### PR TITLE
Remove dict.itervalues, which does not exist in python3

### DIFF
--- a/cirq/sim/google/xmon_simulator.py
+++ b/cirq/sim/google/xmon_simulator.py
@@ -148,7 +148,7 @@ class XmonSimulator(object):
         self._shared_mem_dict['state_handle'] = state_handle
 
     def __del__(self):
-        for handle in self._shared_mem_dict.itervalues():
+        for handle in self._shared_mem_dict.values():
             mem_manager.SharedMemManager.free_array(handle)
 
     def __enter__(self):


### PR DESCRIPTION
3to2 doesn't translate this back to `itervalues` for python2, unfortunately, but I don't think that should be too much of a performance hit.