### PR TITLE
Implement test-pull-request.sh for manual continuous integration

### DIFF
--- a/cirq/testing/equals_tester_test.py
+++ b/cirq/testing/equals_tester_test.py
@@ -139,7 +139,6 @@ def test_fails_hash_is_default_and_inconsistent():
             return not self == other
 
     with pytest.raises(AssertionError):
-
         eq.make_equality_pair(DefaultHashImplementation)
 
 


### PR DESCRIPTION
You use this to run tests locally, or against a PR number (and set the status on github).

Run locally (working directory must be inside the repository):

    bash continuous-integration/test-pull-request.sh

Run against PR number 100:

    export CIRQ_GITHUB_ACCESS_TOKEN=#################
    bash continuous-integration/test-pull-request.sh 100

or

    bash continuous-integration/test-pull-request.sh 100 #################

If the access token isn't given, it will still fetch the PR and run the tests but it won't update the status.