### PR TITLE
Add dev system dependency requirements file

### DIFF
--- a/apt-dev-requirements.txt
+++ b/apt-dev-requirements.txt
@@ -1,0 +1,1 @@
+protobuf-compiler


### PR DESCRIPTION
I tried to run the continuous integration on a fresh machine, and it choked on `protoc` not being present. Installing the package listed in this file fixes that issue. We can make it part of some unified getting started process later.