### PR TITLE
Force keyword-only args for ZGate/CZGate/XYGate constructors

### DIFF
--- a/cirq/circuits/eject_z.py
+++ b/cirq/circuits/eject_z.py
@@ -153,7 +153,7 @@ class EjectZ(OptimizationPass):
         # Drain type: end of circuit.
         if drain == len(circuit.moments):
             circuit.append(
-                ops.ZGate(accumulated_phase).on(qubit),
+                ops.ZGate(turns=accumulated_phase).on(qubit),
                 InsertStrategy.INLINE)
             return
 

--- a/cirq/circuits/util.py
+++ b/cirq/circuits/util.py
@@ -141,7 +141,7 @@ def single_qubit_matrix_to_native_gates(
     # Build the intended operation out of non-negligible XY and Z rotations.
     result = [
         ops.XYGate(turns=xy_turn, axis_phase_turns=xy_phase_turn),
-        ops.ZGate(total_z_turn)
+        ops.ZGate(turns=total_z_turn)
     ]
     result = [g for g in result if g.trace_distance_bound() > tolerance]
 

--- a/cirq/circuits/util_test.py
+++ b/cirq/circuits/util_test.py
@@ -131,8 +131,10 @@ def test_single_qubit_matrix_to_native_gates_cases(intended_effect):
                           for _ in range(10)])
 def test_single_qubit_matrix_to_native_gates_fuzz_half_turns_always_one_gate(
         pre_turns, post_turns):
-    intended_effect = ops.ZGate(pre_turns).matrix().dot(
-        ops.XYGate(turns=0.5).matrix()).dot(ops.ZGate(post_turns).matrix())
+    intended_effect = linalg.dot(
+        ops.ZGate(turns=pre_turns).matrix(),
+        ops.XYGate(turns=0.5).matrix(),
+        ops.ZGate(turns=post_turns).matrix())
 
     gates = circuits.single_qubit_matrix_to_native_gates(
         intended_effect, tolerance=0.0001)

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -32,12 +32,13 @@ class CZGate(native_gates.ParameterizedCZGate,
   A ParameterizedCZGate guaranteed to not be using the parameter key field.
   """
 
-    def __init__(self, turns=0.5):
+    def __init__(self, *positional_args, turns=0.5):
+        assert not positional_args
         super(CZGate, self).__init__(turns_offset=turns)
 
     def extrapolate_effect(self, factor) -> 'CZGate':
         """See base class."""
-        return CZGate(self.turns * factor)
+        return CZGate(turns=self.turns * factor)
 
     def ascii_exponent(self):
         return self.turns * 2
@@ -67,12 +68,14 @@ class XYGate(native_gates.ParameterizedXYGate,
              gate_features.PhaseableGate):
     """Fixed rotation around an axis in the XY plane of the Bloch sphere."""
 
-    def __init__(self, axis_phase_turns=0.0, turns=0.5):
+    def __init__(self, *positional_args, axis_phase_turns=0.0, turns=0.5):
+        assert not positional_args
         super(XYGate, self).__init__(
             axis_phase_turns_offset=axis_phase_turns, turns_offset=turns)
 
     def phase_by(self, phase_turns, qubit_index):
-        return XYGate(self.axis_phase_turns + phase_turns, self.turns)
+        return XYGate(axis_phase_turns=self.axis_phase_turns + phase_turns,
+                      turns=self.turns)
 
     def ascii_exponent(self):
         return self.turns * 2
@@ -90,11 +93,12 @@ class XYGate(native_gates.ParameterizedXYGate,
 
     def extrapolate_effect(self, factor) -> 'XYGate':
         """See base class."""
-        return XYGate(self.axis_phase_turns, self.turns * factor)
+        return XYGate(axis_phase_turns=self.axis_phase_turns,
+                      turns=self.turns * factor)
 
     def matrix(self):
         """See base class."""
-        phase = ZGate(self.axis_phase_turns).matrix()
+        phase = ZGate(turns=self.axis_phase_turns).matrix()
         c = np.exp(2j * np.pi * self.turns)
         rot = np.array([[1 + c, 1 - c], [1 - c, 1 + c]]) / 2
         return phase.dot(rot).dot(np.conj(phase))
@@ -121,7 +125,8 @@ class ZGate(native_gates.ParameterizedZGate,
             gate_features.AsciiDiagrammableGate):
     """Fixed rotation around the Z axis of the Bloch sphere."""
 
-    def __init__(self, turns=0.5):
+    def __init__(self, *positional_args, turns=0.5):
+        assert not positional_args
         super(ZGate, self).__init__(turns_offset=turns)
 
     def ascii_exponent(self):
@@ -136,7 +141,7 @@ class ZGate(native_gates.ParameterizedZGate,
 
     def extrapolate_effect(self, factor) -> 'ZGate':
         """See base class."""
-        return ZGate(self.turns * factor)
+        return ZGate(turns=self.turns * factor)
 
     def matrix(self):
         """See base class."""

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -33,22 +33,22 @@ def proto_matches_text(proto: message, expected_as_text: str):
 
 
 def test_cz_init():
-    cz = ops.CZGate(2.5)
+    cz = ops.CZGate(turns=2.5)
     assert cz.turns == 0.5
     assert cz.turns_param_key == ''
 
 
 def test_cz_eq():
     eq = EqualsTester()
-    eq.add_equality_group(ops.CZGate(), ops.CZGate(0.5), ops.CZ)
-    eq.add_equality_group(ops.CZGate(1.75), ops.CZGate(-0.25))
-    eq.make_equality_pair(lambda: ops.CZGate(0))
-    eq.make_equality_pair(lambda: ops.CZGate(0.25))
+    eq.add_equality_group(ops.CZGate(), ops.CZGate(turns=0.5), ops.CZ)
+    eq.add_equality_group(ops.CZGate(turns=1.75), ops.CZGate(turns=-0.25))
+    eq.make_equality_pair(lambda: ops.CZGate(turns=0))
+    eq.make_equality_pair(lambda: ops.CZGate(turns=0.25))
 
 
 def test_cz_to_proto():
     assert proto_matches_text(
-        ops.CZGate(0.25).to_proto(ops.QubitId(2, 3), ops.QubitId(4, 5)),
+        ops.CZGate(turns=0.25).to_proto(ops.QubitId(2, 3), ops.QubitId(4, 5)),
         """
         cz {
             target1 {
@@ -67,30 +67,31 @@ def test_cz_to_proto():
 
 
 def test_cz_extrapolate():
-    assert ops.CZGate(0.5).extrapolate_effect(0.5) == ops.CZGate(0.25)
+    assert ops.CZGate(
+        turns=0.5).extrapolate_effect(0.5) == ops.CZGate(turns=0.25)
     assert ops.CZ**-0.25 == ops.CZGate(turns=1.75 / 2)
 
 
 def test_cz_matrix():
-    assert np.allclose(ops.CZGate(0.5).matrix(),
+    assert np.allclose(ops.CZGate(turns=0.5).matrix(),
                        np.array([[1, 0, 0, 0],
                                [0, 1, 0, 0],
                                [0, 0, 1, 0],
                                [0, 0, 0, -1]]))
 
-    assert np.allclose(ops.CZGate(0.25).matrix(),
+    assert np.allclose(ops.CZGate(turns=0.25).matrix(),
                        np.array([[1, 0, 0, 0],
                                [0, 1, 0, 0],
                                [0, 0, 1, 0],
                                [0, 0, 0, 1j]]))
 
-    assert np.allclose(ops.CZGate(0).matrix(),
+    assert np.allclose(ops.CZGate(turns=0).matrix(),
                        np.array([[1, 0, 0, 0],
                                [0, 1, 0, 0],
                                [0, 0, 1, 0],
                                [0, 0, 0, 1]]))
 
-    assert np.allclose(ops.CZGate(-0.25).matrix(),
+    assert np.allclose(ops.CZGate(turns=-0.25).matrix(),
                        np.array([[1, 0, 0, 0],
                                [0, 1, 0, 0],
                                [0, 0, 1, 0],
@@ -98,27 +99,28 @@ def test_cz_matrix():
 
 
 def test_z_init():
-    z = ops.ZGate(2.5)
+    z = ops.ZGate(turns=2.5)
     assert z.turns == 0.5
     assert z.turns_param_key == ''
 
 
 def test_z_eq():
     eq = EqualsTester()
-    eq.add_equality_group(ops.ZGate(), ops.ZGate(0.5), ops.Z)
-    eq.add_equality_group(ops.ZGate(1.75), ops.ZGate(-0.25))
-    eq.make_equality_pair(lambda: ops.ZGate(0))
-    eq.make_equality_pair(lambda: ops.ZGate(0.25))
+    eq.add_equality_group(ops.ZGate(), ops.ZGate(turns=0.5), ops.Z)
+    eq.add_equality_group(ops.ZGate(turns=1.75), ops.ZGate(turns=-0.25))
+    eq.make_equality_pair(lambda: ops.ZGate(turns=0))
+    eq.make_equality_pair(lambda: ops.ZGate(turns=0.25))
 
 
 def test_z_extrapolate():
-    assert ops.ZGate(0.5).extrapolate_effect(0.5) == ops.ZGate(0.25)
+    assert ops.ZGate(
+        turns=0.5).extrapolate_effect(0.5) == ops.ZGate(turns=0.25)
     assert ops.Z**-0.25 == ops.ZGate(turns=1.75 / 2)
 
 
 def test_z_to_proto():
     assert proto_matches_text(
-        ops.ZGate(0.25).to_proto(ops.QubitId(2, 3)),
+        ops.ZGate(turns=0.25).to_proto(ops.QubitId(2, 3)),
         """
         z {
             target {
@@ -133,10 +135,14 @@ def test_z_to_proto():
 
 
 def test_z_matrix():
-    assert np.allclose(ops.ZGate(0.5).matrix(), np.array([[1, 0], [0, -1]]))
-    assert np.allclose(ops.ZGate(0.25).matrix(), np.array([[1, 0], [0, 1j]]))
-    assert np.allclose(ops.ZGate(0).matrix(), np.array([[1, 0], [0, 1]]))
-    assert np.allclose(ops.ZGate(-0.25).matrix(), np.array([[1, 0], [0, -1j]]))
+    assert np.allclose(ops.ZGate(turns=0.5).matrix(),
+                       np.array([[1, 0], [0, -1]]))
+    assert np.allclose(ops.ZGate(turns=0.25).matrix(),
+                       np.array([[1, 0], [0, 1j]]))
+    assert np.allclose(ops.ZGate(turns=0).matrix(),
+                       np.array([[1, 0], [0, 1]]))
+    assert np.allclose(ops.ZGate(turns=-0.25).matrix(),
+                       np.array([[1, 0], [0, -1j]]))
 
 
 def test_xy_init():
@@ -149,13 +155,15 @@ def test_xy_init():
 
 def test_xy_eq():
     eq = EqualsTester()
-    eq.add_equality_group(ops.XYGate(), ops.XYGate(0, 0.5), ops.X)
-    eq.add_equality_group(ops.XYGate(1.75, 1.125),
-                          ops.XYGate(-0.25, 0.125))
-    eq.add_equality_group(ops.XYGate(0.25, 0.375),
-                          ops.XYGate(-0.25, -0.375))
-    eq.make_equality_pair(lambda: ops.XYGate(0, 0))
-    eq.make_equality_pair(lambda: ops.XYGate(0.25, 0.25))
+    eq.add_equality_group(ops.XYGate(), ops.XYGate(axis_phase_turns=0,
+                                                   turns=0.5), ops.X)
+    eq.add_equality_group(ops.XYGate(axis_phase_turns=1.75, turns=1.125),
+                          ops.XYGate(axis_phase_turns=-0.25, turns=0.125))
+    eq.add_equality_group(ops.XYGate(axis_phase_turns=0.25, turns=0.375),
+                          ops.XYGate(axis_phase_turns=-0.25, turns=-0.375))
+    eq.make_equality_pair(lambda: ops.XYGate(axis_phase_turns=0, turns=0))
+    eq.make_equality_pair(lambda: ops.XYGate(axis_phase_turns=0.25,
+                                             turns=0.25))
 
 
 def test_xy_extrapolate():


### PR DESCRIPTION
- This is step 1 in converting to different argument units