### PR TITLE
Fix setup.py requirements and add setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='0.1',
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
-    install_requirements=requirements,
+    install_requires=requirements,
     license='Apache 2',
     packages=find_packages(),
     package_data={'cirq.api.google.v1': ['*.proto']})


### PR DESCRIPTION
The `install_requires` keyword was misspelled. Also, adding the `setup.cfg` metadata is apparently the only way to ensure that the license file gets included if packaging as a wheel (https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file).