### PR TITLE
Regenerate protobuf code to match proto definitions

### DIFF
--- a/cirq/api/google/v1/params_pb2.py
+++ b/cirq/api/google/v1/params_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='cirq/api/google/v1/params.proto',
   package='cirq.api.google.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x1f\x63irq/api/google/v1/params.proto\x12\x12\x63irq.api.google.v1\"b\n\x0eParameterSweep\x12\x13\n\x0brepetitions\x18\x01 \x01(\x03\x12;\n\x05sweep\x18\x02 \x01(\x0b\x32,.cirq.api.google.v1.ParameterSweepZipProduct\"R\n\x18ParameterSweepZipProduct\x12\x36\n\x07\x66\x61\x63tors\x18\x01 \x03(\x0b\x32%.cirq.api.google.v1.ParameterSweepZip\"M\n\x11ParameterSweepZip\x12\x38\n\x06sweeps\x18\x01 \x03(\x0b\x32(.cirq.api.google.v1.SingleParameterSweep\"\xad\x01\n\x14SingleParameterSweep\x12\x16\n\x0eparameter_name\x18\x01 \x01(\t\x12\x37\n\x0csweep_points\x18\x02 \x01(\x0b\x32\x1f.cirq.api.google.v1.SweepPointsH\x00\x12;\n\x0esweep_linspace\x18\x03 \x01(\x0b\x32!.cirq.api.google.v1.SweepLinspaceH\x00\x42\x07\n\x05sweep\"\x1d\n\x0bSweepPoints\x12\x0e\n\x06points\x18\x01 \x03(\x02\"L\n\rSweepLinspace\x12\x13\n\x0b\x66irst_point\x18\x01 \x01(\x02\x12\x12\n\nlast_point\x18\x02 \x01(\x02\x12\x12\n\nnum_points\x18\x03 \x01(\x03\"\x8c\x01\n\rParameterDict\x12G\n\x0b\x61ssignments\x18\x01 \x03(\x0b\x32\x32.cirq.api.google.v1.ParameterDict.AssignmentsEntry\x1a\x32\n\x10\x41ssignmentsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02:\x02\x38\x01\x42.\n\x1d\x63om.google.cirq.api.google.v1B\x0bParamsProtoP\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x1f\x63irq/api/google/v1/params.proto\x12\x12\x63irq.api.google.v1\"b\n\x0eParameterSweep\x12\x13\n\x0brepetitions\x18\x01 \x01(\x05\x12;\n\x05sweep\x18\x02 \x01(\x0b\x32,.cirq.api.google.v1.ParameterSweepZipProduct\"R\n\x18ParameterSweepZipProduct\x12\x36\n\x07\x66\x61\x63tors\x18\x01 \x03(\x0b\x32%.cirq.api.google.v1.ParameterSweepZip\"M\n\x11ParameterSweepZip\x12\x38\n\x06sweeps\x18\x01 \x03(\x0b\x32(.cirq.api.google.v1.SingleParameterSweep\"\xad\x01\n\x14SingleParameterSweep\x12\x16\n\x0eparameter_name\x18\x01 \x01(\t\x12\x37\n\x0csweep_points\x18\x02 \x01(\x0b\x32\x1f.cirq.api.google.v1.SweepPointsH\x00\x12;\n\x0esweep_linspace\x18\x03 \x01(\x0b\x32!.cirq.api.google.v1.SweepLinspaceH\x00\x42\x07\n\x05sweep\"\x1d\n\x0bSweepPoints\x12\x0e\n\x06points\x18\x01 \x03(\x02\"L\n\rSweepLinspace\x12\x13\n\x0b\x66irst_point\x18\x01 \x01(\x02\x12\x12\n\nlast_point\x18\x02 \x01(\x02\x12\x12\n\nnum_points\x18\x03 \x01(\x03\"\x8c\x01\n\rParameterDict\x12G\n\x0b\x61ssignments\x18\x01 \x03(\x0b\x32\x32.cirq.api.google.v1.ParameterDict.AssignmentsEntry\x1a\x32\n\x10\x41ssignmentsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02:\x02\x38\x01\x42.\n\x1d\x63om.google.cirq.api.google.v1B\x0bParamsProtoP\x01\x62\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -35,7 +35,7 @@ _PARAMETERSWEEP = _descriptor.Descriptor(
   fields=[
     _descriptor.FieldDescriptor(
       name='repetitions', full_name='cirq.api.google.v1.ParameterSweep.repetitions', index=0,
-      number=1, type=3, cpp_type=2, label=1,
+      number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,

--- a/cirq/api/google/v1/program_pb2.py
+++ b/cirq/api/google/v1/program_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='cirq/api/google/v1/program.proto',
   package='cirq.api.google.v1',
   syntax='proto3',
-  serialized_pb=_b('\n cirq/api/google/v1/program.proto\x12\x12\x63irq.api.google.v1\x1a#cirq/api/google/v1/operations.proto\x1a\x1f\x63irq/api/google/v1/params.proto\"y\n\x07Program\x12\x31\n\noperations\x18\x01 \x03(\x0b\x32\x1d.cirq.api.google.v1.Operation\x12;\n\x0fparameter_sweep\x18\x02 \x03(\x0b\x32\".cirq.api.google.v1.ParameterSweep\"e\n\x13ParameterizedResult\x12\x31\n\x06params\x18\x01 \x01(\x0b\x32!.cirq.api.google.v1.ParameterDict\x12\x1b\n\x13measurement_results\x18\x02 \x01(\x0c\"+\n\x0eMeasurementKey\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0c\n\x04size\x18\x02 \x01(\x05\"\xa7\x01\n\x06Result\x12<\n\x10measurement_keys\x18\x01 \x03(\x0b\x32\".cirq.api.google.v1.MeasurementKey\x12\x17\n\x0fnum_repetitions\x18\x02 \x01(\x05\x12\x46\n\x15parameterized_results\x18\x03 \x03(\x0b\x32\'.cirq.api.google.v1.ParameterizedResultB/\n\x1d\x63om.google.cirq.api.google.v1B\x0cProgramProtoP\x01\x62\x06proto3')
+  serialized_pb=_b('\n cirq/api/google/v1/program.proto\x12\x12\x63irq.api.google.v1\x1a#cirq/api/google/v1/operations.proto\x1a\x1f\x63irq/api/google/v1/params.proto\"z\n\x07Program\x12\x31\n\noperations\x18\x01 \x03(\x0b\x32\x1d.cirq.api.google.v1.Operation\x12<\n\x10parameter_sweeps\x18\x02 \x03(\x0b\x32\".cirq.api.google.v1.ParameterSweep\"e\n\x13ParameterizedResult\x12\x31\n\x06params\x18\x01 \x01(\x0b\x32!.cirq.api.google.v1.ParameterDict\x12\x1b\n\x13measurement_results\x18\x02 \x01(\x0c\"+\n\x0eMeasurementKey\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0c\n\x04size\x18\x02 \x01(\x05\"\xa8\x01\n\x0bSweepResult\x12\x13\n\x0brepetitions\x18\x01 \x01(\x05\x12<\n\x10measurement_keys\x18\x02 \x03(\x0b\x32\".cirq.api.google.v1.MeasurementKey\x12\x46\n\x15parameterized_results\x18\x03 \x03(\x0b\x32\'.cirq.api.google.v1.ParameterizedResult\"@\n\x06Result\x12\x36\n\rsweep_results\x18\x01 \x03(\x0b\x32\x1f.cirq.api.google.v1.SweepResultB/\n\x1d\x63om.google.cirq.api.google.v1B\x0cProgramProtoP\x01\x62\x06proto3')
   ,
   dependencies=[cirq_dot_api_dot_google_dot_v1_dot_operations__pb2.DESCRIPTOR,cirq_dot_api_dot_google_dot_v1_dot_params__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -44,7 +44,7 @@ _PROGRAM = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='parameter_sweep', full_name='cirq.api.google.v1.Program.parameter_sweep', index=1,
+      name='parameter_sweeps', full_name='cirq.api.google.v1.Program.parameter_sweeps', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -63,7 +63,7 @@ _PROGRAM = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=126,
-  serialized_end=247,
+  serialized_end=248,
 )
 
 
@@ -100,8 +100,8 @@ _PARAMETERIZEDRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=249,
-  serialized_end=350,
+  serialized_start=250,
+  serialized_end=351,
 )
 
 
@@ -138,34 +138,34 @@ _MEASUREMENTKEY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=352,
-  serialized_end=395,
+  serialized_start=353,
+  serialized_end=396,
 )
 
 
-_RESULT = _descriptor.Descriptor(
-  name='Result',
-  full_name='cirq.api.google.v1.Result',
+_SWEEPRESULT = _descriptor.Descriptor(
+  name='SweepResult',
+  full_name='cirq.api.google.v1.SweepResult',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='measurement_keys', full_name='cirq.api.google.v1.Result.measurement_keys', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='num_repetitions', full_name='cirq.api.google.v1.Result.num_repetitions', index=1,
-      number=2, type=5, cpp_type=1, label=1,
+      name='repetitions', full_name='cirq.api.google.v1.SweepResult.repetitions', index=0,
+      number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='parameterized_results', full_name='cirq.api.google.v1.Result.parameterized_results', index=2,
+      name='measurement_keys', full_name='cirq.api.google.v1.SweepResult.measurement_keys', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='parameterized_results', full_name='cirq.api.google.v1.SweepResult.parameterized_results', index=2,
       number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -183,18 +183,51 @@ _RESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=398,
-  serialized_end=565,
+  serialized_start=399,
+  serialized_end=567,
+)
+
+
+_RESULT = _descriptor.Descriptor(
+  name='Result',
+  full_name='cirq.api.google.v1.Result',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='sweep_results', full_name='cirq.api.google.v1.Result.sweep_results', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=569,
+  serialized_end=633,
 )
 
 _PROGRAM.fields_by_name['operations'].message_type = cirq_dot_api_dot_google_dot_v1_dot_operations__pb2._OPERATION
-_PROGRAM.fields_by_name['parameter_sweep'].message_type = cirq_dot_api_dot_google_dot_v1_dot_params__pb2._PARAMETERSWEEP
+_PROGRAM.fields_by_name['parameter_sweeps'].message_type = cirq_dot_api_dot_google_dot_v1_dot_params__pb2._PARAMETERSWEEP
 _PARAMETERIZEDRESULT.fields_by_name['params'].message_type = cirq_dot_api_dot_google_dot_v1_dot_params__pb2._PARAMETERDICT
-_RESULT.fields_by_name['measurement_keys'].message_type = _MEASUREMENTKEY
-_RESULT.fields_by_name['parameterized_results'].message_type = _PARAMETERIZEDRESULT
+_SWEEPRESULT.fields_by_name['measurement_keys'].message_type = _MEASUREMENTKEY
+_SWEEPRESULT.fields_by_name['parameterized_results'].message_type = _PARAMETERIZEDRESULT
+_RESULT.fields_by_name['sweep_results'].message_type = _SWEEPRESULT
 DESCRIPTOR.message_types_by_name['Program'] = _PROGRAM
 DESCRIPTOR.message_types_by_name['ParameterizedResult'] = _PARAMETERIZEDRESULT
 DESCRIPTOR.message_types_by_name['MeasurementKey'] = _MEASUREMENTKEY
+DESCRIPTOR.message_types_by_name['SweepResult'] = _SWEEPRESULT
 DESCRIPTOR.message_types_by_name['Result'] = _RESULT
 
 Program = _reflection.GeneratedProtocolMessageType('Program', (_message.Message,), dict(
@@ -217,6 +250,13 @@ MeasurementKey = _reflection.GeneratedProtocolMessageType('MeasurementKey', (_me
   # @@protoc_insertion_point(class_scope:cirq.api.google.v1.MeasurementKey)
   ))
 _sym_db.RegisterMessage(MeasurementKey)
+
+SweepResult = _reflection.GeneratedProtocolMessageType('SweepResult', (_message.Message,), dict(
+  DESCRIPTOR = _SWEEPRESULT,
+  __module__ = 'cirq.api.google.v1.program_pb2'
+  # @@protoc_insertion_point(class_scope:cirq.api.google.v1.SweepResult)
+  ))
+_sym_db.RegisterMessage(SweepResult)
 
 Result = _reflection.GeneratedProtocolMessageType('Result', (_message.Message,), dict(
   DESCRIPTOR = _RESULT,


### PR DESCRIPTION
Oops! Need to remember to regenerate the proto code when we make changes to the proto definitions.