### PR TITLE
Add __pow__ method on Operation to scale the underlying gate

### DIFF
--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -114,3 +114,19 @@ class Operation:
 
     def __ne__(self, other):
         return not self == other
+
+    def __pow__(self, power: float) -> 'Operation':
+        """Raise gate to a power, then reapply to the same qubits.
+
+        Only works if the gate implements gate_features.ExtrapolatableGate.
+        For extrapolatable gate G this means the following two are equivalent:
+
+            (G ** 1.5)(qubit)  or  G(qubit) ** 1.5
+
+        Args:
+            power: The amount to scale the gate's effect by.
+
+        Returns:
+            A new operation on the same qubits with the scaled gate.
+        """
+        return (self.gate ** power)(*self.qubits)

--- a/cirq/ops/raw_types_test.py
+++ b/cirq/ops/raw_types_test.py
@@ -66,3 +66,9 @@ def test_operation_eq():
     eq.make_equality_pair(lambda: ops.Operation(g1, r21))
     eq.add_equality_group(ops.Operation(ops.CZ, r21),
                           ops.Operation(ops.CZ, r12))
+
+
+def test_operation_pow():
+    Y = ops.Y
+    qubit = ops.QubitId()
+    assert (Y ** 0.5)(qubit) == Y(qubit) ** 0.5


### PR DESCRIPTION
Not sure if this is a good idea or not, but it seems convenient (at least syntactically) to allow exponentiating a gate _after_ turning it into an operation.