### PR TITLE
[WIP] Allow specifying params as a plain string

### DIFF
--- a/cirq/contrib/jobs/depolarizer_channel.py
+++ b/cirq/contrib/jobs/depolarizer_channel.py
@@ -21,7 +21,6 @@ from cirq.circuits.circuit import Circuit
 from cirq.circuits.circuit import Moment
 from cirq.contrib.jobs import Job
 from cirq.google import xmon_gates
-from cirq.study.parameterized_value import ParameterizedValue
 from cirq.study.sweeps import Points, Zip
 
 
@@ -100,8 +99,8 @@ class DepolarizerChannel(object):
                 errors = np.random.random(self.realizations) < self.p
                 if any(errors):
                     key = self._parameter_name + str(error_number)
-                    error_gates.append(xmon_gates.ExpZGate(
-                        half_turns=ParameterizedValue(key=key)).on(q))
+                    error_gates.append(
+                        xmon_gates.ExpZGate(half_turns=key).on(q))
                     error_sweep += Points(key, list(errors * 1.0))
                     error_number += 1
 

--- a/cirq/contrib/jobs/depolarizer_channel_test.py
+++ b/cirq/contrib/jobs/depolarizer_channel_test.py
@@ -17,7 +17,6 @@ from cirq import ops
 from cirq.contrib.jobs import DepolarizerChannel
 from cirq.contrib.jobs import Job
 from cirq.google import xmon_gates
-from cirq.study.parameterized_value import ParameterizedValue
 from cirq.study.sweeps import Points
 
 
@@ -39,10 +38,10 @@ def test_depolarizer_all_errors():
         circuits.Moment([ops.CNOT(q1, q2)]),
         ]))
     allerrors = DepolarizerChannel(probability=1.0)
-    p0 = ParameterizedValue(DepolarizerChannel._parameter_name + '0')
-    p1 = ParameterizedValue(DepolarizerChannel._parameter_name + '1')
+    p0 = DepolarizerChannel._parameter_name + '0'
+    p1 = DepolarizerChannel._parameter_name + '1'
 
-    error_sweep = Points(p0.key, [1.0]) + Points(p1.key, [1.0])
+    error_sweep = Points(p0, [1.0]) + Points(p1, [1.0])
 
     cnot_then_z = Job(
         circuits.Circuit([
@@ -62,11 +61,10 @@ def test_depolarizer_multiple_realizations():
         circuits.Moment([ops.CNOT(q1, q2)]),
         ]))
     allerrors3 = DepolarizerChannel(probability=1.0, realizations=3)
-    p0 = ParameterizedValue(DepolarizerChannel._parameter_name + '0')
-    p1 = ParameterizedValue(DepolarizerChannel._parameter_name + '1')
+    p0 = DepolarizerChannel._parameter_name + '0'
+    p1 = DepolarizerChannel._parameter_name + '1'
 
-    error_sweep = (Points(p0.key, [1.0, 1.0, 1.0]) +
-                   Points(p1.key, [1.0, 1.0, 1.0]))
+    error_sweep = Points(p0, [1.0, 1.0, 1.0]) + Points(p1, [1.0, 1.0, 1.0])
 
     cnot_then_z3 = Job(
         circuits.Circuit([
@@ -81,17 +79,16 @@ def test_depolarizer_multiple_realizations():
 def test_depolarizer_parameterized_gates():
     q1 = ops.QubitId()
     q2 = ops.QubitId()
-    cnot_param = ParameterizedValue('cnot_turns')
-    cnot_gate = xmon_gates.Exp11Gate(half_turns=cnot_param).on(q1, q2)
+    cnot_gate = xmon_gates.Exp11Gate(half_turns='cnot_turns').on(q1, q2)
 
     job_sweep = Points('cnot_turns', [0.5])
 
     cnot = Job(circuits.Circuit([circuits.Moment([cnot_gate])]), job_sweep)
     allerrors = DepolarizerChannel(probability=1.0)
-    p0 = ParameterizedValue(DepolarizerChannel._parameter_name + '0')
-    p1 = ParameterizedValue(DepolarizerChannel._parameter_name + '1')
+    p0 = DepolarizerChannel._parameter_name + '0'
+    p1 = DepolarizerChannel._parameter_name + '1'
 
-    error_sweep = Points(p0.key, [1.0]) + Points(p1.key, [1.0])
+    error_sweep = Points(p0, [1.0]) + Points(p1, [1.0])
     cnot_then_z = Job(
         circuits.Circuit([
             circuits.Moment([cnot_gate]),

--- a/cirq/google/merge_interactions_test.py
+++ b/cirq/google/merge_interactions_test.py
@@ -55,14 +55,12 @@ def test_ignores_czs_separated_by_parameterized():
     assert_optimizes(
         before=circuits.Circuit([
             circuits.Moment([ops.CZ(q0, q1)]),
-            circuits.Moment([ExpZGate(
-                half_turns=ParameterizedValue('boo'))(q0)]),
+            circuits.Moment([ExpZGate(half_turns='boo')(q0)]),
             circuits.Moment([ops.CZ(q0, q1)]),
         ]),
         after=circuits.Circuit([
             circuits.Moment([ops.CZ(q0, q1)]),
-            circuits.Moment([ExpZGate(
-                half_turns=ParameterizedValue('boo'))(q0)]),
+            circuits.Moment([ExpZGate(half_turns='boo')(q0)]),
             circuits.Moment([ops.CZ(q0, q1)]),
         ]))
 

--- a/cirq/google/xmon_gates.py
+++ b/cirq/google/xmon_gates.py
@@ -23,7 +23,7 @@ from cirq import ops
 from cirq.api.google.v1 import operations_pb2
 from cirq.extension import PotentialImplementation
 from cirq.google.xmon_qubit import XmonQubit
-from cirq.study.parameterized_value import ParameterizedValue
+from cirq.study.parameterized_value import Parameterizable, ParameterizedValue
 
 
 class XmonGate(ops.Gate, metaclass=abc.ABCMeta):
@@ -65,14 +65,14 @@ class XmonGate(ops.Gate, metaclass=abc.ABCMeta):
     @staticmethod
     def parameterized_value_from_proto(
         message: operations_pb2.ParameterizedFloat
-    ) -> Union[ParameterizedValue, float]:
+    ) -> Parameterizable:
         if not message.parameter_key:
             return message.raw
         return ParameterizedValue(key=message.parameter_key, val=message.raw)
 
     @staticmethod
     def parameterized_value_to_proto(
-        param: Union[ParameterizedValue, float],
+        param: Parameterizable,
         out: operations_pb2.ParameterizedFloat = None
     ) -> operations_pb2.ParameterizedFloat:
         if out is None:
@@ -104,7 +104,7 @@ class Exp11Gate(XmonGate,
     """A two-qubit interaction that phases the amplitude of the 11 state."""
 
     def __init__(self, *positional_args,
-                 half_turns: Union[ParameterizedValue, float]=1):
+                 half_turns: Parameterizable = 1):
         assert not positional_args
         self.half_turns = _canonicalize_half_turns(half_turns)
 
@@ -170,8 +170,8 @@ class ExpWGate(XmonGate,
     """A rotation around an axis in the XY plane of the Bloch sphere."""
 
     def __init__(self, *positional_args,
-                 half_turns: Union[ParameterizedValue, float]=1,
-                 axis_half_turns: Union[ParameterizedValue, float]=0):
+                 half_turns: Parameterizable = 1,
+                 axis_half_turns: Parameterizable = 0):
         assert not positional_args
         self.half_turns = _canonicalize_half_turns(half_turns)
         self.axis_half_turns = _canonicalize_half_turns(axis_half_turns)
@@ -283,7 +283,7 @@ class ExpZGate(XmonGate,
     """A rotation around the Z axis of the Bloch sphere."""
 
     def __init__(self, *positional_args,
-                 half_turns: Union[ParameterizedValue, float]=1):
+                 half_turns: Parameterizable = 1):
         assert not positional_args
         self.half_turns = _canonicalize_half_turns(half_turns)
 
@@ -362,9 +362,7 @@ class ExpZGate(XmonGate,
         return hash((ExpZGate, self.half_turns))
 
 
-def _canonicalize_half_turns(
-        half_turns: Union[ParameterizedValue, float]
-) -> Union[ParameterizedValue, float]:
+def _canonicalize_half_turns(half_turns: Parameterizable) -> Parameterizable:
     v = ParameterizedValue.val_of(half_turns)
     v %= 2
     if v > 1:

--- a/cirq/sim/google/xmon_simulator_test.py
+++ b/cirq/sim/google/xmon_simulator_test.py
@@ -335,7 +335,7 @@ def test_param_resolver_param_dict(offset):
 
 def test_run_study():
     circuit = Circuit.from_ops(
-        ExpWGate(half_turns=ParameterizedValue('a')).on(Q1),
+        ExpWGate(half_turns='a').on(Q1),
         XmonMeasurementGate('m').on(Q1),
     )
 

--- a/cirq/study/__init__.py
+++ b/cirq/study/__init__.py
@@ -15,6 +15,7 @@
 """Types and methods for running studies (repeated trials)."""
 
 from cirq.study.parameterized_value import (
+    Parameterizable,
     ParameterizedValue,
 )
 from cirq.study.resolver import (

--- a/cirq/study/parameterized_value.py
+++ b/cirq/study/parameterized_value.py
@@ -14,6 +14,9 @@
 from typing import Union
 
 
+Parameterizable = Union['ParameterizedValue', float, str]
+
+
 class ParameterizedValue:
     """A constant plus the runtime value of a parameter with a given key.
 
@@ -88,13 +91,17 @@ class ParameterizedValue:
         return ParameterizedValue(self.key, self.val - other)
 
     @staticmethod
-    def val_of(val: Union['ParameterizedValue', float]):
+    def val_of(val: Parameterizable):
         if isinstance(val, ParameterizedValue):
             return float(val.val)
+        elif isinstance(val, str):
+            return 0.0
         return float(val)
 
     @staticmethod
-    def key_of(val: Union['ParameterizedValue', float]):
+    def key_of(val: Parameterizable):
         if isinstance(val, ParameterizedValue):
             return val.key
+        elif isinstance(val, str):
+            return val
         return ''

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Union
 
-from cirq.study import ParameterizedValue
+from cirq.study import Parameterizable, ParameterizedValue
 
 
 class ParamResolver(object):
@@ -35,7 +35,7 @@ class ParamResolver(object):
         self.param_dict = param_dict
         self._param_hash = hash(frozenset(param_dict.items()))
 
-    def value_of(self, parameterized_value: Union[ParameterizedValue, float]):
+    def value_of(self, parameterized_value: Parameterizable):
         """Resolves a ParameterizedValue to its assigned value.
 
         Args:
@@ -52,6 +52,9 @@ class ParamResolver(object):
             return (
                 self.param_dict[ParameterizedValue.key_of(parameterized_value)]
                 + ParameterizedValue.val_of(parameterized_value))
+        elif isinstance(parameterized_value, str):
+            return self.param_dict[
+                ParameterizedValue.key_of(parameterized_value)]
         return parameterized_value
 
     def __hash__(self):


### PR DESCRIPTION
I spoke with @Strilanc about wanting to do this to make it possible to use plain strings for parametrized values with no offset. Especially for constructing gates and circuits, this can reduce a lot of boilerplate. One thing that needs to be resolved is how to store things internally on gates; currently if you pass a string to the constructor it will store a string internally, which would mean that gates `ExpW(half_turns='a')` and `ExpW(half_turns=ParameterizedValue(key='a'))` would not compare equal, which seems a bit surprising to me (though it is already the case right now that `ExpW(half_turns=0.5)` and `ExpW(half_turns=ParameterizedValue(val=0.5))` do not compare equal). Could fix this by modifying the gate classes to convert strings to `ParameterizedValue` internally, or modify `ParameterizedValue` to compare equal to the string key name if it doesn't have a value, or just live with it, as we do now with floats. Thoughts?