### PR TITLE
Use loop counter for bad case in mem_manager

### DIFF
--- a/cirq/google/sim/mem_manager.py
+++ b/cirq/google/sim/mem_manager.py
@@ -67,7 +67,6 @@ class SharedMemManager(object):
                 'Array has unsupported dtype {}.'.format(arr.dtype))
 
         with self._lock:
-
             if self._count >= len(self._arrays):
                 self._arrays += len(self._arrays) * [None]
 
@@ -82,10 +81,11 @@ class SharedMemManager(object):
         return self._current
 
     def _get_next_free(self):
-        previous_current = self._current
+        loop_count = 0
         while self._arrays[self._current] is not None:
             self._current = (self._current + 1) % len(self._arrays)
-            if previous_current == self._current:
+            loop_count += 1
+            if loop_count == len(self._arrays):
                 raise RuntimeError(
                     'Cannot find free space to allocate new array.')
 


### PR DESCRIPTION
This is a safer way to detect the error case when not being able to get the memory.  This may fix #244 but I have been unable to reproduce that bug.