### PR TITLE
Fix mem_manager_test hanging sometimes

### DIFF
--- a/cirq/google/sim/mem_manager.py
+++ b/cirq/google/sim/mem_manager.py
@@ -66,6 +66,7 @@ class SharedMemManager(object):
             raise ValueError(
                 'Array has unsupported dtype {}.'.format(arr.dtype))
 
+        # pylint: disable=protected-access
         raw_arr = RawArray(c_arr._type_, c_arr)
 
         with self._lock:
@@ -74,7 +75,6 @@ class SharedMemManager(object):
 
             self._get_next_free()
 
-            # pylint: disable=protected-access
             self._arrays[self._current] = raw_arr
 
             self._count += 1


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/244 (maybe?)

Here's what I think is happening, and why this fix works.

First, we have to cause an XmonStepper instance to be captured in a way that will force the full garbage collector to get involved to clean it up, instead of just the reference counter. This is incredibly finicky:

```python
from cirq.google.sim import mem_manager
exec("""
from cirq.google.sim import xmon_stepper
def a_secret():
    return xmon_stepper.Stepper()
capturee = a_secret()
capturer = lambda: 'ha ha, you are caught!'
""", {})
```

Then we just start allocating memory:

```python
import numpy as np
handles = []
for i in range(200):
    if i % 10 == 0:
        print(i)
    one = np.array([1])
    handles.append(mem_manager.SharedMemManager.create_array(one))
```

On my machine this locks down around iteration 100 or so.

Anyways, now we narrow down where the freeze is by deleting almost the entire codebase while preserving the freeze. Then we use print debugging to figure out the last line to get executed, and print out a traceback:

```
  File "cirq/google/sim/mem_manager_test.py", line 17, in <module>
    handles.append(mem_manager.SharedMemManager.create_array(one))
  File "cirq/google/sim/mem_manager.py", line 65, in create_array
    return SharedMemManager._instance._create_array(arr)
  File "cirq/google/sim/mem_manager.py", line 30, in _create_array
    raw_arr = RawArray(c_arr._type_, c_arr)
  File "/usr/lib/python3.5/multiprocessing/context.py", line 128, in RawArray
    return RawArray(typecode_or_type, size_or_initializer)
  File "/usr/lib/python3.5/multiprocessing/sharedctypes.py", line 65, in RawArray
    result = _new_value(type_)
  File "/usr/lib/python3.5/multiprocessing/sharedctypes.py", line 40, in _new_value
    wrapper = heap.BufferWrapper(size)
  File "/usr/lib/python3.5/multiprocessing/heap.py", line 251, in __init__
    util.Finalize(self, BufferWrapper._heap.free, args=(block,))
  File "cirq/google/sim/xmon_stepper.py", line 13, in __del__
    mem_manager.SharedMemManager.free_array(handle)
  File "cirq/google/sim/mem_manager.py", line 69, in free_array
    SharedMemManager._instance._free_array(handle)
  File "cirq/google/sim/mem_manager.py", line 52, in _free_array
    traceback.print_stack()
```

If you look closely at the stack trace, you'll notice that making the `RawArray` is triggering some kind of heap free method, which is triggering a `__del__` method leading to `_free_array`... which tries to acquire a lock being held by `_create_array`, where the array is being allocated.

Don't play with re-entrancy, kids!

...Maybe we should use a re-entrant lock?