### PR TITLE
Fix behavior of simulator on empty circuit

### DIFF
--- a/cirq/google/sim/xmon_simulator.py
+++ b/cirq/google/sim/xmon_simulator.py
@@ -38,7 +38,7 @@ from cirq.extension import Extensions
 from cirq.google import xmon_gates
 from cirq.google import xmon_gate_ext
 from cirq.google.convert_to_xmon_gates import ConvertToXmonGates
-from cirq.google.sim.xmon_stepper import Stepper
+from cirq.google.sim import xmon_stepper
 from cirq.ops import raw_types
 from cirq.schedules import Schedule
 from cirq.study import ParamResolver, Sweep, Sweepable, TrialResult
@@ -137,7 +137,7 @@ class Simulator:
                 basis state corresponding corresponding to this state.
                 Otherwise  if this is a np.ndarray it is the full initial
                 state. In this case it must be the correct size, be normalized
-                (an L2 norm of 1), and have a dtype of np.complex64.
+                (an L2 norm of 1), and be safely castable to a np.complex64.
             extensions: Extensions that will be applied while trying to
                 decompose the circuit's gates into XmonGates. If None, this uses
                 the default of xmon_gate_ext.
@@ -173,7 +173,7 @@ class Simulator:
                 basis state corresponding corresponding to this state.
                 Otherwise if this is a np.ndarray it is the full initial state.
                 In this case it must be the correct size, be normalized (an L2
-                norm of 1), and have a dtype of np.complex64.
+                norm of 1), and be safely castable to a np.complex64.
             extensions: Extensions that will be applied while trying to
                 decompose the circuit's gates into XmonGates. If None, this uses
                 the default of xmon_gate_ext.
@@ -207,7 +207,12 @@ class Simulator:
                 if step_result:
                     final_states.append(step_result.state())
                 else:
-                    final_states.append(initial_state)
+                    # Empty circuit, so final state should be initial state.
+                    num_qubits = max(len(circuit.qubits()),
+                                     len(qubits) if qubits else 0)
+                    final_states.append(
+                        xmon_stepper.decode_initial_state(initial_state,
+                                                          num_qubits))
             trial_results.append(SimulatorTrialResult(
                 param_resolver,
                 repetitions,
@@ -247,7 +252,7 @@ class Simulator:
                 basis state corresponding corresponding to this state.
                 Otherwise if this is a np.ndarray it is the full initial state.
                 In this case it must be the correct size, be normalized (an L2
-                norm of 1), and have a dtype of np.complex64.
+                norm of 1), and be safely castable to a np.complex64.
             param_resolver: A ParamResolver for determining values of
                 Symbols.
             extensions: Extensions that will be applied while trying to
@@ -294,6 +299,9 @@ def simulator_iterator(
             is used to define the wave function.
         initial_state: If an int, the state is set to the computational
             basis state corresponding corresponding to this state.
+            Otherwise if this is a np.ndarray it is the full initial state.
+            In this case it must be the correct size, be normalized (an L2
+            norm of 1), and be safely castable to a np.complex64.
         param_resolver: A ParamResolver for determining values ofs
             Symbols.
 
@@ -311,8 +319,10 @@ def simulator_iterator(
     else:
         qubits = list(circuit_qubits)
     qubit_map = {q: i for i, q in enumerate(qubits)}
+    if isinstance(initial_state, np.ndarray):
+        initial_state = initial_state.astype(dtype=np.complex64, casting='safe')
 
-    with Stepper(num_qubits=len(qubits),
+    with xmon_stepper.Stepper(num_qubits=len(qubits),
                  num_prefix_qubits=options.num_prefix_qubits,
                  initial_state=initial_state,
                  min_qubits_before_shard=options.min_qubits_before_shard
@@ -378,7 +388,7 @@ class StepResult:
 
     def __init__(
             self,
-            stepper: Stepper,
+            stepper: xmon_stepper.Stepper,
             qubit_map: Dict,
             measurements: Dict[str, List[bool]]) -> None:
         self.qubit_map = qubit_map or {}

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -126,10 +126,72 @@ def test_run_empty_circuit(scheduler):
 
 
 @pytest.mark.parametrize('scheduler', SCHEDULERS)
-def test_initial_state_empty_circuit(scheduler):
+def test_initial_state_empty_circuit_qubits_specified(scheduler):
     simulator = xmon_simulator.Simulator()
+
     result = run(simulator, Circuit(), scheduler, qubits = [Q1, Q1])
-    assert result.final_states[0] == [1, 0, 0, 0]
+    np.testing.assert_almost_equal(result.final_states[0],
+                                   np.array([1.0, 0.0, 0.0, 0.0]))
+
+    result = run(simulator, Circuit(), scheduler, qubits=[Q1, Q1],
+                 initial_state=1)
+    np.testing.assert_almost_equal(result.final_states[0],
+                                   np.array([0.0, 1.0, 0.0, 0.0]))
+
+    result = run(simulator, Circuit(), scheduler, qubits=[Q1, Q1],
+                 initial_state=np.array([0.0, 1.0, 0.0, 0.0],
+                                        dtype=np.complex64))
+    np.testing.assert_almost_equal(result.final_states[0],
+                                   np.array([0.0, 1.0, 0.0, 0.0]))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_invalid_initial_state_empty_circuit_qubits_specified(scheduler):
+    simulator = xmon_simulator.Simulator()
+
+    with pytest.raises(ValueError):
+        _ = run(simulator, Circuit(), scheduler, qubits=[Q1, Q1],
+                initial_state=-1)
+
+    with pytest.raises(ValueError):
+        _ = run(simulator, Circuit(), scheduler, qubits=[Q1, Q1],
+                initial_state=100)
+
+    with pytest.raises(ValueError):
+        _ = run(simulator, Circuit(), scheduler, qubits=[Q1, Q1],
+                initial_state=np.array([0.0, 1.0], dtype=np.complex64))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_initial_state_empty_circuit_qubits_not_specified(scheduler):
+    simulator = xmon_simulator.Simulator()
+
+    result = run(simulator, Circuit(), scheduler)
+    np.testing.assert_almost_equal(result.final_states[0], np.array([1.0]))
+
+    result = run(simulator, Circuit(), scheduler, initial_state=0)
+    np.testing.assert_almost_equal(result.final_states[0], np.array([1.0]))
+
+    result = run(simulator, Circuit(), scheduler,
+                 initial_state=np.array([1], dtype=np.complex64))
+    np.testing.assert_almost_equal(result.final_states[0], np.array([1.0]))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_invalid_initial_state_empty_circuit_qubits_not_specified(scheduler):
+    simulator = xmon_simulator.Simulator()
+
+    with pytest.raises(ValueError):
+        _ = run(simulator, Circuit(), scheduler, initial_state=2)
+
+    with pytest.raises(ValueError):
+        _ = run(simulator, Circuit(), scheduler,
+                 initial_state=np.array([2], dtype=np.complex64))
+
+    with pytest.raises(ValueError):
+        _ = run(simulator, Circuit(), scheduler,
+                initial_state=np.array([1, 0], dtype=np.complex64))
+
 
 @pytest.mark.parametrize('scheduler', SCHEDULERS)
 def test_run_state(scheduler):
@@ -137,6 +199,45 @@ def test_run_state(scheduler):
     result = run(simulator, basic_circuit(), scheduler, qubits=[Q1, Q2])
     np.testing.assert_almost_equal(result.final_states[0],
                                    np.array([0.5j, -0.5, 0.5, -0.5j]))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_run_initial_state_int(scheduler):
+    simulator = xmon_simulator.Simulator()
+    result = run(simulator, basic_circuit(), scheduler, qubits=[Q1, Q2],
+                 initial_state=1)
+    np.testing.assert_almost_equal(result.final_states[0],
+                                   np.array([0.5, 0.5j, 0.5j, 0.5]))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_run_initial_state_ndarray(scheduler):
+    simulator = xmon_simulator.Simulator()
+    result = run(simulator, basic_circuit(), scheduler, qubits=[Q1, Q2],
+                 initial_state=np.array([0.0, 1.0, 0.0, 0.0],
+                                        dtype=np.complex64))
+    np.testing.assert_almost_equal(result.final_states[0],
+                                   np.array([0.5, 0.5j, 0.5j, 0.5]))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_run_initial_state_ndarray_upconvert(scheduler):
+    simulator = xmon_simulator.Simulator()
+    result = run(simulator, basic_circuit(), scheduler, qubits=[Q1, Q2],
+                 initial_state=np.array([0.0, 1.0, 0.0, 0.0],
+                                        dtype=np.float32))
+    np.testing.assert_almost_equal(result.final_states[0],
+                                   np.array([0.5, 0.5j, 0.5j, 0.5]))
+
+
+@pytest.mark.parametrize('scheduler', SCHEDULERS)
+def test_run_initial_state_ndarray_not_upconvertable(scheduler):
+    simulator = xmon_simulator.Simulator()
+
+    with pytest.raises(TypeError):
+        _ = run(simulator, basic_circuit(), scheduler, qubits=[Q1, Q2],
+                initial_state=np.array([0.0, 1.0, 0.0, 0.0],
+                                       dtype=np.float128))
 
 
 @pytest.mark.parametrize('scheduler', SCHEDULERS)

--- a/cirq/google/sim/xmon_stepper_test.py
+++ b/cirq/google/sim/xmon_stepper_test.py
@@ -607,17 +607,17 @@ def test_shard_for_more_prefix_qubits_than_qubits():
 
 @pytest.mark.parametrize('num_prefix_qubits', (0, 2))
 def test_precision(num_prefix_qubits):
-    # 16 random W's followed by their inverses on five qubits.
+    # 25 random W's followed by their inverses on five qubits.
     # The floating point epsilon for np.float32 is about 1e-7.
     # Floating point epsilon is about 1e-7.
     # Each qubits error will add across gates on that qubit, but it is like a
-    # random walk, so error should be about sqrt(16) per qubit.
-    # The total error should then be about 2e-6.
+    # random walk, so error should be about 2 * sqrt(25) per qubit.
+    # The total error should then be about 5e-6.
     with xmon_stepper.Stepper(num_qubits=5,
                               num_prefix_qubits=num_prefix_qubits,
                               min_qubits_before_shard=0) as s:
-        half_turns_list = [np.random.rand() for _ in range(16)]
-        axis_half_turns_list = [np.random.rand() for _ in range(16)]
+        half_turns_list = [np.random.rand() for _ in range(25)]
+        axis_half_turns_list = [np.random.rand() for _ in range(25)]
 
         for half_turns, axis_half_turns in zip(half_turns_list,
                                                axis_half_turns_list):
@@ -632,4 +632,42 @@ def test_precision(num_prefix_qubits):
         expected = np.zeros(2 ** 5, dtype=np.complex64)
         expected[0] = 1.0
         # asserts that abs value of arrays is < 1.5 * 10^(-decimal)
-        np.testing.assert_almost_equal(expected, s.current_state, decimal=6)
+        np.testing.assert_almost_equal(expected, s.current_state, decimal=5)
+
+
+def test_decode_initial_state():
+    np.testing.assert_almost_equal(xmon_stepper.decode_initial_state(
+        np.array([1.0, 0.0, 0.0, 0.0], dtype=np.complex64), 2),
+        np.array([1.0, 0.0, 0.0, 0.0]))
+    np.testing.assert_almost_equal(xmon_stepper.decode_initial_state(
+        np.array([0.0, 1.0, 0.0, 0.0], dtype=np.complex64), 2),
+        np.array([0.0, 1.0, 0.0, 0.0]))
+    np.testing.assert_almost_equal(xmon_stepper.decode_initial_state(0, 2),
+        np.array([1.0, 0.0, 0.0, 0.0]))
+    np.testing.assert_almost_equal(xmon_stepper.decode_initial_state(1, 2),
+                                   np.array([0.0, 1.0, 0.0, 0.0]))
+
+
+def test_invalid_decode_initial_state():
+    with pytest.raises(ValueError):
+        _ = xmon_stepper.decode_initial_state(
+            np.array([1.0, 0.0], dtype=np.complex64), 2)
+    with pytest.raises(ValueError):
+        _ = xmon_stepper.decode_initial_state(-1, 2)
+    with pytest.raises(ValueError):
+        _ = xmon_stepper.decode_initial_state(5, 2)
+    with pytest.raises(TypeError):
+        _ = xmon_stepper.decode_initial_state('not an int', 2)
+
+
+def test_check_state():
+    xmon_stepper.check_state(np.array([0.5, 0.5, 0.5, 0.5], dtype=np.complex64),
+                             2)
+    with pytest.raises(ValueError):
+        xmon_stepper.check_state(np.array([1, 1], dtype=np.complex64), 2)
+    with pytest.raises(ValueError):
+        xmon_stepper.check_state(
+            np.array([1.0, 0.2, 0.0, 0.0], dtype=np.complex64), 2)
+    with pytest.raises(ValueError):
+        xmon_stepper.check_state(
+            np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64), 2)


### PR DESCRIPTION
Further also allow for initial states that can be safely converted to np.complex64 (so float32,for example).

Also adjust accuracy test to be more lenient and clean up some imports.

