### PR TITLE
Fix passing 'msg' instead of 'message' args to pytest.raises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # ignore compiled python files
 __pycache__
 *.pyc
-# ignore idea SDK 
+# ignore idea SDK
 .idea/*
 # ignore cache
 .cache/*
+.pytest_cache/*
 # ignore coverage files
 *.py,cover
 *.coverage

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -497,7 +497,7 @@ def test_unsupported_gate(scheduler):
     circuit.append([H(Q1), gate(Q2)])
 
     simulator = xmon_simulator.Simulator()
-    with pytest.raises(TypeError, msg="UnsupportedGate"):
+    with pytest.raises(TypeError, message="UnsupportedGate"):
         _ = run(simulator, circuit, scheduler)
 
 
@@ -523,7 +523,7 @@ def test_unsupported_gate_composite(scheduler):
     circuit.append([H(Q1), gate(Q2)])
 
     simulator = xmon_simulator.Simulator()
-    with pytest.raises(TypeError, msg="UnsupportedGate"):
+    with pytest.raises(TypeError, message="UnsupportedGate"):
         _ = run(simulator, circuit, scheduler)
 
 


### PR DESCRIPTION
The most recent version of pytest started checking for this, causing tests to fail because these were wrong.