### PR TITLE
Fix import of SimulatorTrialResult

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -55,7 +55,7 @@ from cirq.google.sim import (
     Options,
     Simulator,
     StepResult,
-    TrialResult,
+    SimulatorTrialResult,
 )
 from cirq.google.engine import (
     Engine,

--- a/cirq/google/sim/__init__.py
+++ b/cirq/google/sim/__init__.py
@@ -19,7 +19,7 @@ from cirq.google.sim.xmon_simulator import (
     Options,
     Simulator,
     StepResult,
-    TrialResult,
+    SimulatorTrialResult,
 )
 from cirq.google.sim.xmon_stepper import (
     Stepper,


### PR DESCRIPTION
Appears that TrialResult from `cirq.study` was imported instead by mistake.