### PR TITLE
DOC: move reference/ to generated/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ __pycache__
 *.egg-info/
 # Sphinx
 _build
-docs/reference
+docs/generated

--- a/continuous-integration/build-docs.sh
+++ b/continuous-integration/build-docs.sh
@@ -24,6 +24,12 @@ if [ -d "$repo_root/docs/_build" ] ; then
   exit 1
 fi
 
+if [ -d "$repo_root/docs/generated" ] ; then
+  echo "'$repo_root/docs/generated' directory still exists." >&2
+  echo "Remove the generated directory before continuing." >&2
+  exit 1
+fi
+
 cd "$repo_root/docs"
 pip install -r requirements.txt
 make html

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,7 @@ Single Qubit Gates
 ~~~~~~~~~~~~~~~~~~
 
 .. autosummary::
-    :toctree: reference/
+    :toctree: generated/
 
     H
     X
@@ -21,6 +21,6 @@ Two Quibit Gates
 ~~~~~~~~~~~~~~~~
 
 .. autosummary::
-    :toctree: reference/
+    :toctree: generated/
 
     CNOT


### PR DESCRIPTION
`generated/` is consistent with what we do in the Google Cloud client libraries and also in Pandas docs.

This move makes it clearer that the API reference Sphinx sources should
not be hand-edited. They are generated from the docstrings in the source
Python files.

Also, add a check for the generated/ directory in the build-docs.sh.
Just as with _build, we want to ensure that generated/ is created by
Sphinx so that the API reference stays fresh.