### PR TITLE
Fix missing dependency for google-api-python-client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ google-api-python-client
 mypy==0.590
 matplotlib
 numpy
+oauth2client
 pylint
 pytest
 pytest-cov


### PR DESCRIPTION
You would think that a package manager could include dependencies automatically, but here we are. --Craig