### PR TITLE
Add method to get half_turns without canonicalizing

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -153,6 +153,7 @@ from cirq.study.visualize import (
 from cirq.value import (
     canonicalize_half_turns,
     chosen_angle_to_canonical_half_turns,
+    chosen_angle_to_half_turns,
     Duration,
     Symbol,
     Timestamp,

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -52,7 +52,7 @@ class Rot11Gate(eigen_gate.EigenGate,
             degs: Relative phasing of CZ's eigenstates, in degrees.
         """
         assert not positional_args
-        super().__init__(exponent=value.chosen_angle_to_canonical_half_turns(
+        super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
             degs=degs))
@@ -117,7 +117,7 @@ class RotXGate(eigen_gate.EigenGate,
             degs: The relative phasing of X's eigenstates, in degrees.
         """
         assert not positional_args
-        super().__init__(exponent=value.chosen_angle_to_canonical_half_turns(
+        super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
             degs=degs))
@@ -179,7 +179,7 @@ class RotYGate(eigen_gate.EigenGate,
             degs: The relative phasing of Y's eigenstates, in degrees.
         """
         assert not positional_args
-        super().__init__(exponent=value.chosen_angle_to_canonical_half_turns(
+        super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
             degs=degs))
@@ -241,7 +241,7 @@ class RotZGate(eigen_gate.EigenGate,
             degs: The relative phasing of Z's eigenstates, in degrees.
         """
         assert not positional_args
-        super().__init__(exponent=value.chosen_angle_to_canonical_half_turns(
+        super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
             degs=degs))
@@ -428,7 +428,7 @@ class CNotGate(eigen_gate.EigenGate,
             degs: Relative phasing of CNOT's eigenstates, in degrees.
         """
         assert not positional_args
-        super().__init__(exponent=value.chosen_angle_to_canonical_half_turns(
+        super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
             degs=degs))

--- a/cirq/value/__init__.py
+++ b/cirq/value/__init__.py
@@ -23,4 +23,5 @@ from cirq.value.timestamp import (
 from cirq.value.angle import (
     canonicalize_half_turns,
     chosen_angle_to_canonical_half_turns,
+    chosen_angle_to_half_turns,
 )

--- a/cirq/value/angle.py
+++ b/cirq/value/angle.py
@@ -19,6 +19,43 @@ import numpy as np
 from cirq.value import symbol
 
 
+def chosen_angle_to_half_turns(
+        half_turns: Optional[Union[symbol.Symbol, float]] = None,
+        rads: Optional[float] = None,
+        degs: Optional[float] = None,
+        default: float = 1.0,
+) -> Union[symbol.Symbol, float]:
+    """Returns a half_turns value based on the given arguments.
+
+    At most one of half_turns, rads, degs must be specified. If none are
+    specified, the output defaults to half_turns=1.
+
+    Args:
+        half_turns: The number of half turns to rotate by.
+        rads: The number of radians to rotate by.
+        degs: The number of degrees to rotate by
+        default: The half turns angle to use if nothing else is specified.
+
+    Returns:
+        A number of half turns.
+    """
+
+    if len([1 for e in [half_turns, rads, degs] if e is not None]) > 1:
+        raise ValueError('Redundant angle specification. '
+                         'Use ONE of half_turns, rads, or degs.')
+
+    if rads is not None:
+        return rads / np.pi
+
+    if degs is not None:
+        return degs / 180
+
+    if half_turns is not None:
+        return half_turns
+
+    return default
+
+
 def chosen_angle_to_canonical_half_turns(
         half_turns: Optional[Union[symbol.Symbol, float]] = None,
         rads: Optional[float] = None,
@@ -39,21 +76,12 @@ def chosen_angle_to_canonical_half_turns(
     Returns:
         A number of half turns.
     """
-
-    if len([1 for e in [half_turns, rads, degs] if e is not None]) > 1:
-        raise ValueError('Redundant angle specification. '
-                         'Use ONE of half_turns, rads, or degs.')
-
-    if rads is not None:
-        return canonicalize_half_turns(rads / np.pi)
-
-    if degs is not None:
-        return canonicalize_half_turns(degs / 180)
-
-    if half_turns is not None:
-        return canonicalize_half_turns(half_turns)
-
-    return default
+    return canonicalize_half_turns(
+            chosen_angle_to_half_turns(
+                half_turns=half_turns,
+                rads=rads,
+                degs=degs,
+                default=default))
 
 
 def canonicalize_half_turns(

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -29,6 +29,33 @@ def test_canonicalize_half_turns():
     assert cirq.canonicalize_half_turns(cirq.Symbol('a')) == cirq.Symbol('a')
 
 
+def test_chosen_angle_to_half_turns():
+    assert cirq.chosen_angle_to_half_turns() == 1
+    assert cirq.chosen_angle_to_half_turns(default=0.5) == 0.5
+    assert cirq.chosen_angle_to_half_turns(half_turns=0.25,
+                                                     default=0.75) == 0.25
+    np.testing.assert_allclose(
+        cirq.chosen_angle_to_half_turns(rads=np.pi/2),
+        0.5)
+    np.testing.assert_allclose(
+        cirq.chosen_angle_to_half_turns(rads=-np.pi/4),
+        -0.25)
+    assert cirq.chosen_angle_to_half_turns(degs=90) == 0.5
+    assert cirq.chosen_angle_to_half_turns(degs=1080) == 6.0
+    assert cirq.chosen_angle_to_half_turns(degs=990) == 5.5
+
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(half_turns=0, rads=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(half_turns=0, degs=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(degs=0, rads=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(half_turns=0,
+                                                      rads=0,
+                                                      degs=0)
+
+
 def test_chosen_angle_to_canonical_half_turns():
     assert cirq.chosen_angle_to_canonical_half_turns() == 1
     assert cirq.chosen_angle_to_canonical_half_turns(default=0.5) == 0.5


### PR DESCRIPTION
This lets you defer canonicalizing to EigenGate. In fact, once XmonGates are switched over to EigenGate I don't think there will be a need for `chosen_angle_to_canonical_half_turns` anymore.