### PR TITLE
Use just '*' to force keyword arguments

### DIFF
--- a/cirq/google/xmon_gates.py
+++ b/cirq/google/xmon_gates.py
@@ -124,7 +124,7 @@ class Exp11Gate(XmonGate,
     so the half_turn corresponds to half of a full rotation in U(4).
     """
 
-    def __init__(self, *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -135,14 +135,10 @@ class Exp11Gate(XmonGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: The amount of phasing of the 11 state, in half_turns.
             rads: The amount of phasing of the 11 state, in radians.
             degs: The amount of phasing of the 11 state, in degrees.
         """
-        assert not positional_args
         self.half_turns = value.chosen_angle_to_canonical_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -237,7 +233,7 @@ class ExpWGate(XmonGate,
     an operator pointing along the Y direction.
     """
 
-    def __init__(self, *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  axis_half_turns: Optional[Union[value.Symbol, float]] = None,
                  axis_rads: Optional[float] = None,
                  axis_degs: Optional[float] = None,
@@ -255,9 +251,6 @@ class ExpWGate(XmonGate,
         being positive-ward along X and 90 degrees being positive-ward along Y.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             axis_half_turns: The axis angle in the XY plane, in half_turns.
             axis_rads: The axis angle in the XY plane, in radians.
             axis_degs: The axis angle in the XY plane, in degrees.
@@ -265,7 +258,6 @@ class ExpWGate(XmonGate,
             rads: The amount to rotate, in radians.
             degs: The amount to rotate, in degrees.
         """
-        assert not positional_args
         self.half_turns = value.chosen_angle_to_canonical_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -411,7 +403,7 @@ class ExpZGate(XmonGate,
     bloch sphere of 360 degrees.
     """
 
-    def __init__(self, *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -422,14 +414,10 @@ class ExpZGate(XmonGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: The relative phasing of Z's eigenstates, in half_turns.
             rads: The relative phasing of Z's eigenstates, in radians.
             degs: The relative phasing of Z's eigenstates, in degrees.
         """
-        assert not positional_args
         self.half_turns = value.chosen_angle_to_canonical_half_turns(
             half_turns=half_turns,
             rads=rads,

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -32,8 +32,7 @@ class Rot11Gate(eigen_gate.EigenGate,
     A ParameterizedCZGate guaranteed to not be using the parameter key field.
     """
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -44,14 +43,10 @@ class Rot11Gate(eigen_gate.EigenGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: Relative phasing of CZ's eigenstates, in half_turns.
             rads: Relative phasing of CZ's eigenstates, in radians.
             degs: Relative phasing of CZ's eigenstates, in degrees.
         """
-        assert not positional_args
         super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -97,8 +92,7 @@ class RotXGate(eigen_gate.EigenGate,
                gate_features.SingleQubitGate):
     """Fixed rotation around the X axis of the Bloch sphere."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -109,14 +103,10 @@ class RotXGate(eigen_gate.EigenGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: The relative phasing of X's eigenstates, in half_turns.
             rads: The relative phasing of X's eigenstates, in radians.
             degs: The relative phasing of X's eigenstates, in degrees.
         """
-        assert not positional_args
         super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -159,8 +149,7 @@ class RotYGate(eigen_gate.EigenGate,
                gate_features.SingleQubitGate):
     """Fixed rotation around the Y axis of the Bloch sphere."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -171,14 +160,10 @@ class RotYGate(eigen_gate.EigenGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: The relative phasing of Y's eigenstates, in half_turns.
             rads: The relative phasing of Y's eigenstates, in radians.
             degs: The relative phasing of Y's eigenstates, in degrees.
         """
-        assert not positional_args
         super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -221,8 +206,7 @@ class RotZGate(eigen_gate.EigenGate,
                gate_features.SingleQubitGate):
     """Fixed rotation around the Z axis of the Bloch sphere."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -233,14 +217,10 @@ class RotZGate(eigen_gate.EigenGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: The relative phasing of Z's eigenstates, in half_turns.
             rads: The relative phasing of Z's eigenstates, in radians.
             degs: The relative phasing of Z's eigenstates, in degrees.
         """
-        assert not positional_args
         super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -408,8 +388,7 @@ class CNotGate(eigen_gate.EigenGate,
                gate_features.TwoQubitGate):
     """A controlled-NOT. Toggle the second qubit when the first qubit is on."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -420,14 +399,10 @@ class CNotGate(eigen_gate.EigenGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: Relative phasing of CNOT's eigenstates, in half_turns.
             rads: Relative phasing of CNOT's eigenstates, in radians.
             degs: Relative phasing of CNOT's eigenstates, in degrees.
         """
-        assert not positional_args
         super().__init__(exponent=value.chosen_angle_to_half_turns(
             half_turns=half_turns,
             rads=rads,
@@ -487,10 +462,8 @@ class SwapGate(eigen_gate.EigenGate,
                raw_types.InterchangeableQubitsGate):
     """Swaps two qubits."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Union[value.Symbol, float] = 1.0) -> None:
-        assert not positional_args
         super().__init__(exponent=half_turns)
 
     def default_decompose(self, qubits):

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -36,10 +36,8 @@ class EigenGate(gate_features.BoundedEffectGate,
     method.
     """
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  exponent: Union[Symbol, float] = 1.0) -> None:
-        assert not positional_args
 
         # Canonicalize the exponent.
         period = self._canonical_exponent_period()

--- a/cirq/ops/partial_reflection_gate.py
+++ b/cirq/ops/partial_reflection_gate.py
@@ -39,8 +39,7 @@ class PartialReflectionGate(gate_features.BoundedEffectGate,
     with half_turns=1 corresponding to the point where U is a reflection
     operation (i.e., the relative phase is exactly -1).
     """
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  half_turns: Optional[Union[value.Symbol, float]] = None,
                  rads: Optional[float] = None,
                  degs: Optional[float] = None) -> None:
@@ -51,14 +50,10 @@ class PartialReflectionGate(gate_features.BoundedEffectGate,
         argument is given, the default value of one half turn is used.
 
         Args:
-            *positional_args: Not an actual argument. Forces all arguments to
-                be keyword arguments. Prevents angle unit confusion by forcing
-                "rads=", "degs=", or "half_turns=".
             half_turns: The relative phasing of the eigenstates, in half_turns.
             rads: The relative phasing of the eigenstates, in radians.
             degs: The relative phasing of the eigenstates, in degrees.
         """
-        assert not positional_args
         self.half_turns = value.chosen_angle_to_canonical_half_turns(
             half_turns=half_turns,
             rads=rads,

--- a/cirq/schedules/schedule.py
+++ b/cirq/schedules/schedule.py
@@ -70,13 +70,12 @@ class Schedule:
 
     __hash__ = None  # type: ignore
 
-    def query(self,
-        *positional_args,
-        time: Timestamp,
-        duration: Duration = Duration(),
-        qubits: Iterable[QubitId] = None,
-        include_query_end_time=False,
-        include_op_end_times=False) -> List[ScheduledOperation]:
+    def query(self, *,  # Forces keyword args.
+              time: Timestamp,
+              duration: Duration = Duration(),
+              qubits: Iterable[QubitId] = None,
+              include_query_end_time=False,
+              include_op_end_times=False) -> List[ScheduledOperation]:
         """Finds operations by time and qubit.
 
         Args:
@@ -93,7 +92,6 @@ class Schedule:
         Returns:
             A list of scheduled operations meeting the specified conditions.
         """
-        assert not positional_args
         earliest_time = time - self._max_duration
         end_time = time + duration
         qubits = None if qubits is None else frozenset(qubits)

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -88,14 +88,12 @@ class TrialResult:
             results.
     """
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  params: resolver.ParamResolver,
                  measurements: Dict[str, np.ndarray],
                  repetitions: int) -> None:
         """
         Args:
-            positional_args: Never specified. Forces keyword arguments.
             params: A ParamResolver of settings used for this result.
             measurements: A dictionary from measurement gate key to measurement
                 results. The value for each key is a 2-D array of booleans,
@@ -104,15 +102,13 @@ class TrialResult:
                 measurements.
             repetitions: The number of times the circuit was sampled.
         """
-        assert not positional_args
         self.params = params
         self.measurements = measurements
         self.repetitions = repetitions
 
     # Reason for 'type: ignore': https://github.com/python/mypy/issues/5273
     def multi_measurement_histogram(  # type: ignore
-            self,
-            *positional_args,
+            self, *,  # Forces keyword args.
             keys: Iterable[str],
             fold_func: Callable[[Tuple[np.ndarray, ...]],
                                 T] = _tuple_of_big_endian_int
@@ -149,7 +145,6 @@ class TrialResult:
         first measured qubit determining the highest-value bit.
 
         Args:
-            positional_args: Never specified. Forces keyword arguments.
             fold_func: A function used to convert sampled measurement results
                 into countable values. The input is a tuple containing the
                 list of bits measured by each measurement specified by the
@@ -162,7 +157,6 @@ class TrialResult:
             A counter indicating how often measurements sampled various
             results.
         """
-        assert not positional_args
         fixed_keys = tuple(keys)
         samples = zip(*[self.measurements[sub_key]
                         for sub_key in fixed_keys])
@@ -175,7 +169,7 @@ class TrialResult:
 
     # Reason for 'type: ignore': https://github.com/python/mypy/issues/5273
     def histogram(self,  # type: ignore
-                  *positional_args,
+                  *,  # Forces keyword args.
                   key: str,
                   fold_func: Callable[[np.ndarray], T] = _big_endian_int
                   ) -> collections.Counter:
@@ -216,7 +210,6 @@ class TrialResult:
             A counter indicating how often a measurement sampled various
             results.
         """
-        assert not positional_args
         return self.multi_measurement_histogram(
             keys=[key],
             fold_func=lambda e: fold_func(e[0]))

--- a/cirq/value/duration.py
+++ b/cirq/value/duration.py
@@ -19,8 +19,7 @@ from typing import Union
 class Duration:
     """A time delta that supports picosecond accuracy."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  picos: Union[int, float] = 0,
                  nanos: Union[int, float] = 0) -> None:
         """Initializes a Duration with a time specified in ns and/or ps.
@@ -31,8 +30,6 @@ class Duration:
             picos: A number of picoseconds to add to the time delta.
             nanos: A number of nanoseconds to add to the time delta.
         """
-
-        assert not positional_args
 
         if picos and nanos:
             self._picos = picos + nanos * 1000

--- a/cirq/value/timestamp.py
+++ b/cirq/value/timestamp.py
@@ -23,8 +23,7 @@ class Timestamp:
 
     Supports affine operations against Duration."""
 
-    def __init__(self,
-                 *positional_args,
+    def __init__(self, *,  # Forces keyword args.
                  picos: Union[int, float] = 0,
                  nanos: Union[int, float] = 0) -> None:
         """Initializes a Timestamp with a time specified in ns and/or ps.
@@ -36,8 +35,6 @@ class Timestamp:
             picos: How many picoseconds away from time zero?
             nanos: How many nanoseconds away from time zero?
         """
-
-        assert not positional_args
 
         if picos and nanos:
             self._picos = picos + nanos * 1000


### PR DESCRIPTION
Casey pointed this out to me. It's significantly better because:
- it doesn't require a docstring for the argument
- it doesn't need an assert line
- it gives a better error message to the user