### PR TITLE
[AFTER #609] Refactor CompositeOperation out of CompositeGate

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -97,6 +97,7 @@ from cirq.ops import (
     CNOT,
     CNotGate,
     CompositeGate,
+    CompositeOperation,
     ControlledGate,
     CSWAP,
     CZ,

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -702,10 +702,10 @@ def _flatten_to_known_matrix_ops(iter_ops: Iterable[ops.Operation],
             continue
 
         # If not, check if it has a decomposition
-        composite_gate = ext.try_cast(ops.CompositeGate, op.gate)
-        if composite_gate is not None:
+        composite_op = ext.try_cast(ops.CompositeOperation, op)
+        if composite_op is not None:
             # Recurse decomposition to get known matrix gates.
-            op_tree = composite_gate.default_decompose(op.qubits)
+            op_tree = composite_op.default_decompose()
             op_list = ops.flatten_op_tree(op_tree)
             for op in _flatten_to_known_matrix_ops(op_list, ext):
                 yield op

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1198,7 +1198,7 @@ def test_simple_circuits_to_unitary_matrix():
 
 
 def test_composite_gate_to_unitary_matrix():
-    class CNOT_composite(cirq.CompositeGate):
+    class CNOT_composite(cirq.Gate, cirq.CompositeGate):
         def default_decompose(self, qubits):
             q0, q1 = qubits
             return cirq.Y(q1)**-0.5, cirq.CZ(q0, q1), cirq.Y(q1)**0.5

--- a/cirq/circuits/expand_composite.py
+++ b/cirq/circuits/expand_composite.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""An optimizer that expands CompositeGates into their constituent gates."""
+"""An optimizer that expands CompositeOperation instances."""
 
 from cirq import ops
 from cirq.circuits.optimization_pass import (
@@ -23,13 +23,12 @@ from cirq.extension import Extensions
 
 
 class ExpandComposite(PointOptimizer):
-    """An optimization pass that expands CompositeGates.
+    """An optimization pass that expands CompositeOperation instances.
 
-    For each operation in the circuit, this pass examines if the operation's
-    gate is a CompositeGate, or is composite according to a supplied Extension,
-    and if it is, clears the operation and replaces it with the composite
-    gate elements using a fixed insertion strategy.
-
+    For each operation in the circuit, this pass examines if the operation is a
+    CompositeOperation, or is composite according to a supplied Extension,
+    and if it is, clears the operation and replaces it with its decomposition
+    using a fixed insertion strategy.
     """
 
     def __init__(self,
@@ -38,7 +37,7 @@ class ExpandComposite(PointOptimizer):
 
         Args:
             composite_gate_extension: An extension that that can be used
-                to supply or override a CompositeGate decomposition.
+                to supply or override a CompositeOperation decomposition.
         """
         self.extension = composite_gate_extension or Extensions()
 
@@ -54,9 +53,8 @@ class ExpandComposite(PointOptimizer):
 
     def _decompose(self, op: ops.Operation) -> ops.OP_TREE:
         """Recursively decompose composite gates into an OP_TREE of gates."""
-        composite_gate = self.extension.try_cast(ops.CompositeGate, op.gate)
-        if composite_gate is None:
+        composite_op = self.extension.try_cast(ops.CompositeOperation, op)
+        if composite_op is None:
             return op
-        op_iter = ops.flatten_op_tree(
-                        composite_gate.default_decompose(op.qubits))
+        op_iter = ops.flatten_op_tree(composite_op.default_decompose())
         return (self._decompose(op) for op in op_iter)

--- a/cirq/circuits/expand_composite_test.py
+++ b/cirq/circuits/expand_composite_test.py
@@ -13,19 +13,12 @@
 # limitations under the License.
 
 """Tests for the expand composite optimization pass."""
-
-from cirq.circuits import (
-    Circuit,
-    DropEmptyMoments,
-    ExpandComposite,
-    InsertStrategy,
-)
-from cirq.extension import Extensions
-from cirq.ops import CNOT, CNotGate, CompositeGate, CZ, QubitId, SWAP, X, Y, Z
+import cirq
+from cirq.ops import CNOT, CNotGate, CZ, QubitId, SWAP, X, Y, Z
 
 
 def assert_equal_mod_empty(expected, actual):
-    drop_empty = DropEmptyMoments()
+    drop_empty = cirq.DropEmptyMoments()
     drop_empty.optimize_circuit(actual)
     if expected != actual:
         # coverage: ignore
@@ -37,25 +30,25 @@ def assert_equal_mod_empty(expected, actual):
 
 
 def test_empty_circuit():
-    circuit = Circuit()
-    opt = ExpandComposite()
+    circuit = cirq.Circuit()
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    assert_equal_mod_empty(Circuit(), circuit)
+    assert_equal_mod_empty(cirq.Circuit(), circuit)
 
 
 def test_empty_moment():
-    circuit = Circuit([])
-    opt = ExpandComposite()
+    circuit = cirq.Circuit([])
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    assert_equal_mod_empty(Circuit([]), circuit)
+    assert_equal_mod_empty(cirq.Circuit([]), circuit)
 
 
 def test_ignore_non_composite():
     q0, q1 = QubitId(), QubitId()
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     circuit.append([X(q0), Y(q1), CZ(q0, q1), Z(q0)])
-    expected = Circuit(circuit.moments)
-    opt = ExpandComposite()
+    expected = cirq.Circuit(circuit.moments)
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
     assert_equal_mod_empty(expected, circuit)
 
@@ -63,11 +56,11 @@ def test_ignore_non_composite():
 def test_composite_default():
     q0, q1 = QubitId(), QubitId()
     cnot = CNOT(q0, q1)
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     circuit.append(cnot)
-    opt = ExpandComposite()
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    expected = Circuit()
+    expected = cirq.Circuit()
     expected.append([Y(q1) ** -0.5, CZ(q0, q1), Y(q1) ** 0.5])
     assert_equal_mod_empty(expected, circuit)
 
@@ -75,11 +68,11 @@ def test_composite_default():
 def test_multiple_composite_default():
     q0, q1 = QubitId(), QubitId()
     cnot = CNOT(q0, q1)
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     circuit.append([cnot, cnot])
-    opt = ExpandComposite()
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    expected = Circuit()
+    expected = cirq.Circuit()
     decomp = [Y(q1) ** -0.5, CZ(q0, q1), Y(q1) ** 0.5]
     expected.append([decomp, decomp])
     assert_equal_mod_empty(expected, circuit)
@@ -88,57 +81,57 @@ def test_multiple_composite_default():
 def test_mix_composite_non_composite():
     q0, q1 = QubitId(), QubitId()
 
-    actual = Circuit.from_ops(X(q0), CNOT(q0, q1), X(q1))
-    opt = ExpandComposite()
+    actual = cirq.Circuit.from_ops(X(q0), CNOT(q0, q1), X(q1))
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(actual)
 
-    expected = Circuit.from_ops(X(q0),
-                                Y(q1) ** -0.5,
-                                CZ(q0, q1),
-                                Y(q1) ** 0.5,
-                                X(q1),
-                                strategy=InsertStrategy.NEW)
+    expected = cirq.Circuit.from_ops(X(q0),
+                                     Y(q1) ** -0.5,
+                                     CZ(q0, q1),
+                                     Y(q1) ** 0.5,
+                                     X(q1),
+                                     strategy=cirq.InsertStrategy.NEW)
     assert_equal_mod_empty(expected, actual)
 
 
 def test_recursive_composite():
     q0, q1 = QubitId(), QubitId()
     swap = SWAP(q0, q1)
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     circuit.append(swap)
 
-    opt = ExpandComposite()
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    expected = Circuit().from_ops(Y(q1) ** -0.5,
-                                  CZ(q0, q1),
-                                  Y(q1) ** 0.5,
-                                  Y(q0) ** -0.5,
-                                  CZ(q1, q0),
-                                  Y(q0) ** 0.5,
-                                  Y(q1) ** -0.5,
-                                  CZ(q0, q1),
-                                  Y(q1) ** 0.5)
+    expected = cirq.Circuit().from_ops(Y(q1) ** -0.5,
+                                       CZ(q0, q1),
+                                       Y(q1) ** 0.5,
+                                       Y(q0) ** -0.5,
+                                       CZ(q1, q0),
+                                       Y(q0) ** 0.5,
+                                       Y(q1) ** -0.5,
+                                       CZ(q0, q1),
+                                       Y(q1) ** 0.5)
     assert_equal_mod_empty(expected, circuit)
 
 
 def test_decompose_returns_not_flat_op_tree():
-    class DummyGate(CompositeGate):
+    class DummyGate(cirq.Gate, cirq.CompositeGate):
         def default_decompose(self, qubits):
             q0, = qubits
             # Yield a tuple of gates instead of yielding a gate
             yield X(q0),
 
     q0 = QubitId()
-    circuit = Circuit.from_ops(DummyGate()(q0))
+    circuit = cirq.Circuit.from_ops(DummyGate()(q0))
 
-    opt = ExpandComposite()
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    expected = Circuit().from_ops(X(q0))
+    expected = cirq.Circuit().from_ops(X(q0))
     assert_equal_mod_empty(expected, circuit)
 
 
 def test_decompose_returns_deep_op_tree():
-    class DummyGate(CompositeGate):
+    class DummyGate(cirq.Gate, cirq.CompositeGate):
         def default_decompose(self, qubits):
             q0, q1 = qubits
             # Yield a tuple
@@ -155,16 +148,16 @@ def test_decompose_returns_deep_op_tree():
             yield generator(2)
 
     q0, q1 = QubitId(), QubitId()
-    circuit = Circuit.from_ops(DummyGate()(q0, q1))
+    circuit = cirq.Circuit.from_ops(DummyGate()(q0, q1))
 
-    opt = ExpandComposite()
+    opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    expected = Circuit().from_ops(X(q0), Y(q0), Z(q0),  # From tuple
-                                  X(q0), Y(q0), Z(q0),  # From nested lists
-                                  # From nested generators
-                                  X(q0), X(q0),
-                                  CZ(q0, q1), Y(q0),
-                                  Z(q0), Z(q0))
+    expected = cirq.Circuit().from_ops(X(q0), Y(q0), Z(q0),  # From tuple
+                                       X(q0), Y(q0), Z(q0),  # From nested lists
+                                       # From nested generators
+                                       X(q0), X(q0),
+                                       CZ(q0, q1), Y(q0),
+                                       Z(q0), Z(q0))
     assert_equal_mod_empty(expected, circuit)
 
 
@@ -182,13 +175,13 @@ class OtherCNot(CNotGate):
 def test_composite_extension_overrides():
     q0, q1 = QubitId(), QubitId()
     cnot = CNOT(q0, q1)
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     circuit.append(cnot)
-    opt = ExpandComposite(composite_gate_extension=Extensions({
-        CompositeGate: {CNotGate: lambda e: OtherCNot()}
+    opt = cirq.ExpandComposite(composite_gate_extension=cirq.Extensions({
+        cirq.CompositeGate: {CNotGate: lambda e: OtherCNot()}
     }))
     opt.optimize_circuit(circuit)
-    expected = Circuit()
+    expected = cirq.Circuit()
     expected.append([Z(q0), Y(q1) ** -0.5, CZ(q0, q1), Y(q1) ** 0.5, Z(q0)])
     assert_equal_mod_empty(expected, circuit)
 
@@ -196,16 +189,16 @@ def test_composite_extension_overrides():
 def test_recursive_composite_extension_overrides():
     q0, q1 = QubitId(), QubitId()
     swap = SWAP(q0, q1)
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     circuit.append(swap)
-    opt = ExpandComposite(composite_gate_extension=Extensions({
-        CompositeGate: {CNotGate: lambda e: OtherCNot()}
+    opt = cirq.ExpandComposite(composite_gate_extension=cirq.Extensions({
+        cirq.CompositeGate: {CNotGate: lambda e: OtherCNot()}
     }))
     opt.optimize_circuit(circuit)
-    expected = Circuit()
+    expected = cirq.Circuit()
     expected.append([Z(q0), Y(q1) ** -0.5, CZ(q0, q1), Y(q1) ** 0.5, Z(q0)])
     expected.append([Z(q1), Y(q0) ** -0.5, CZ(q1, q0), Y(q0) ** 0.5, Z(q1)],
-                    strategy=InsertStrategy.INLINE)
+                    strategy=cirq.InsertStrategy.INLINE)
     expected.append([Z(q0), Y(q1) ** -0.5, CZ(q0, q1), Y(q1) ** 0.5, Z(q0)],
-                    strategy=InsertStrategy.INLINE)
+                    strategy=cirq.InsertStrategy.INLINE)
     assert_equal_mod_empty(expected, circuit)

--- a/cirq/contrib/paulistring/clifford_gate.py
+++ b/cirq/contrib/paulistring/clifford_gate.py
@@ -23,7 +23,8 @@ from cirq.contrib.paulistring.pauli import Pauli
 PauliTransform = NamedTuple('PauliTransform', [('to', Pauli), ('flip', bool)])
 
 
-class CliffordGate(ops.CompositeGate,
+class CliffordGate(ops.Gate,
+                   ops.CompositeGate,
                    ops.ReversibleEffect,
                    ops.TextDiagrammable):
     """Any single qubit Clifford rotation."""

--- a/cirq/google/convert_to_xmon_gates.py
+++ b/cirq/google/convert_to_xmon_gates.py
@@ -33,11 +33,11 @@ class ConvertToXmonGates(PointOptimizer):
         XmonGate instance.
 
     Second, checks if the given extensions are able to cast the operation into a
-        KnownMatrix instance. If so, and the gate is a 1-qubit or 2-qubit
+        KnownMatrix. If so, and the gate is a 1-qubit or 2-qubit
         gate, then performs circuit synthesis of the operation.
 
-    Third, checks if the given extensions are able to cast the gate into a
-        CompositeGate instance. If so, recurses on the decomposition.
+    Third, checks if the given extensions are able to cast the operation into a
+        CompositeOperation. If so, recurses on the decomposition.
 
     Fourth, if ignore_failures is set, gives up and returns the gate unchanged.
         Otherwise raises a TypeError.
@@ -80,19 +80,19 @@ class ConvertToXmonGates(PointOptimizer):
                 allow_partial_czs=True)
 
         # Provides a decomposition?
-        composite = self.extensions.try_cast(ops.CompositeGate, op.gate)
-        if composite is not None:
-            return composite.default_decompose(op.qubits)
+        composite_op = self.extensions.try_cast(ops.CompositeOperation, op)
+        if composite_op is not None:
+            return composite_op.default_decompose()
 
         # Just let it be?
         if self.ignore_failures:
             return op
 
         raise TypeError("Don't know how to work with {!r}. "
-                        "It isn't an XmonGate, "
-                        "1-qubit KnownMatrix, "
-                        "2-qubit KnownMatrix, "
-                        "or CompositeGate.".format(op))
+                        "It isn't a GateOperation with an XmonGate, "
+                        "a 1-qubit KnownMatrix, "
+                        "a 2-qubit KnownMatrix, "
+                        "or a CompositeOperation.".format(op))
 
     def convert(self, op: ops.Operation) -> ops.OP_TREE:
         converted = self._convert_one(op)

--- a/cirq/google/sim/xmon_simulator.py
+++ b/cirq/google/sim/xmon_simulator.py
@@ -16,8 +16,9 @@
 
 The simulator can be used to run all of a Circuit or to step through the
 simulation Moment by Moment. The simulator requires that all gates used in
-the circuit are either an XmonGate or are CompositeGate which can be
-decomposed into XmonGates. Measurement gates must all have unique string keys.
+the circuit are either an XmonGate or are CompositionOperations or have a
+KnownNatrix which can be decomposed into XmonGates. Measurement gates must all
+have unique string keys.
 
 A simple example:
     circuit = Circuit([Moment([X(q1), X(q2)]), Moment([CZ(q1, q2)])])

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -675,7 +675,7 @@ def test_extensions():
     # We test that an extension is being applied, by created an incorrect
     # gate with an extension.
 
-    class WrongH(CompositeGate):
+    class WrongH(cirq.Gate, cirq.CompositeGate):
         def default_decompose(self,
                               qubits: Sequence[cirq.QubitId]
                               ) -> cirq.OP_TREE:

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -47,6 +47,7 @@ from cirq.ops.eigen_gate import (
 from cirq.ops.gate_features import (
     BoundedEffect,
     CompositeGate,
+    CompositeOperation,
     ExtrapolatableEffect,
     InterchangeableQubitsGate,
     KnownMatrix,

--- a/cirq/ops/gate_features_test.py
+++ b/cirq/ops/gate_features_test.py
@@ -106,34 +106,6 @@ def test_composite_gate_is_abstract_can_implement():
     assert isinstance(Included(), gate_features.CompositeGate)
 
 
-def test_composite_gate_from_gates():
-    class G1(raw_types.Gate):
-        pass
-    class G2(raw_types.Gate):
-        pass
-
-    gates = [G1(), G2()]
-    composite = gate_features.CompositeGate.from_gates(gates)
-
-    q1 = raw_types.QubitId()
-    assert [gates[0](q1), gates[1](q1)] == composite.default_decompose([q1])
-
-
-def test_composite_gate_from_gate_tuples():
-    class G1(raw_types.Gate):
-        pass
-    class G2(raw_types.Gate):
-        pass
-
-    gates = [(G1(), (0,)), (G2(), (0, 1))]
-    composite = gate_features.CompositeGate.from_gates(gates)
-
-    q1 = raw_types.QubitId()
-    q2 = raw_types.QubitId()
-    assert ([gates[0][0](q1), gates[1][0](q1, q2)]
-            == composite.default_decompose([q1, q2]))
-
-
 def test_single_qubit_gate_validate_args():
     class Dummy(gate_features.SingleQubitGate):
         def matrix(self):

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -27,19 +27,23 @@ if TYPE_CHECKING:
     from typing import Dict, List
 
 
-LIFTED_POTENTIAL_TYPES = [
+LIFTED_POTENTIAL_TYPES = {t: t for t in [
     gate_features.BoundedEffect,
     gate_features.ExtrapolatableEffect,
     gate_features.KnownMatrix,
     gate_features.ParameterizableEffect,
     gate_features.ReversibleEffect,
     gate_features.TextDiagrammable,
-]
+]}
+
+LIFTED_POTENTIAL_TYPES[
+    gate_features.CompositeOperation] = gate_features.CompositeGate
 
 
 class GateOperation(raw_types.Operation,
                     extension.PotentialImplementation[Union[
                         gate_features.BoundedEffect,
+                        gate_features.CompositeOperation,
                         gate_features.ExtrapolatableEffect,
                         gate_features.KnownMatrix,
                         gate_features.ParameterizableEffect,
@@ -114,11 +118,16 @@ class GateOperation(raw_types.Operation,
         return not self == other
 
     def try_cast_to(self, desired_type, extensions):
-        if desired_type in LIFTED_POTENTIAL_TYPES:
-            cast_gate = extensions.try_cast(desired_type, self.gate)
+        desired_gate_type = LIFTED_POTENTIAL_TYPES.get(desired_type)
+        if desired_gate_type is not None:
+            cast_gate = extensions.try_cast(desired_gate_type, self.gate)
             if cast_gate is not None:
                 return self.with_gate(cast_gate)
         return None
+
+    def default_decompose(self):
+        cast_gate = extension.cast(gate_features.CompositeGate, self.gate)
+        return cast_gate.default_decompose(self.qubits)
 
     def matrix(self) -> np.ndarray:
         cast_gate = extension.cast(gate_features.KnownMatrix, self.gate)

--- a/cirq/ops/reversible_composite_gate.py
+++ b/cirq/ops/reversible_composite_gate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implements the inverse() method of a CompositeGate & ReversibleEffect."""
+"""Implements the inverse method of a CompositeOperation & ReversibleEffect."""
 from typing import TypeVar, Generic, cast
 
 from cirq import abc

--- a/docs/gates.md
+++ b/docs/gates.md
@@ -73,7 +73,7 @@ We've seen this above.
 These are ``Gate`` or ``Operation`` instances which implement the ``matrix`` method.
 This returns a numpy ``ndarray`` matrix which is the unitary gate for the gate/operation.
 
-#### CompositeGate
+#### CompositeGate and CompositeOperation
 
 A ``CompositeGate`` is a gate which consists of multiple gates
 that can be applied to a given set of qubits.  This is a manner
@@ -89,6 +89,8 @@ take an ``Extension`` which allows for overriding the
 ``CompositeGate``.  An example of this is for in 
 ``Simulators`` where an optional extension can be supplied
 that can be used to override the CompositeGate.
+
+A ``CompositeOperation`` is just like a ``CompositeGate``, except it already knows the qubits it should be applied to.
 
 #### TextDiagrammable
 

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -189,12 +189,10 @@ for the binary expansion of the passed integer.
 
 ### Gate sets
 
-The xmon simulator is designed to work with ``Gates`` that
-are either ``XmonGates`` or are ``CompositeGates`` that
-decompose (recursively) to ``XmonGates``.  By default the
-xmon simulator uses an ``Extension`` defined in 
-``xgate_gate_extensions`` to try to resolve gates that 
-are not ``XmonGates`` to ``XmonGates``.  
+The xmon simulator is designed to work with operations that are either a ``GateOperation`` applying an ``XmonGate``,
+a ``CompositeOperation`` that decomposes (recursively) to ``XmonGates``,
+or a 1-qubit or 2-qubit operation with a ``KnownMatrix``.
+By default the xmon simulator uses an ``Extension`` defined in ``xgate_gate_extensions`` to try to resolve gates that are not ``XmonGates`` to ``XmonGates``.
 
 So if you are using a custom gate, there are multiple options
 for getting it to work with the simulator:


### PR DESCRIPTION
- CompositeGate no longer inherits from Gate
- GateOperation now has CompositeOperation as a potential implementation
- Code casting op.gate to CompositeGate now instead casts op to CompositeOperation
- Deleted CompositeGate.from_gates and _CompositeGateImpl, which were not used anywhere

Part of https://github.com/quantumlib/Cirq/issues/475