### PR TITLE
Update example for INLINE InsertStrategy

### DIFF
--- a/docs/circuits.md
+++ b/docs/circuits.md
@@ -227,7 +227,7 @@ circuit.append([H(q0), H(q1), H(q2)], strategy=InsertStrategy.INLINE)
 print(circuit)
 # prints
 # (0, 0): ───────H───────
-#                │
+#                
 # (1, 0): ───@───@───H───
 #            │   │
 # (2, 0): ───@───@───H───


### PR DESCRIPTION
Change the example so as to distinguish it from EARLIEST and NEW_THEN_INLINE. The current example may as well have been for either of these strategies.
Need at least 2 empty moments on a qubit to demonstrate this.