### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -91,7 +91,7 @@ If you want to create a development environment, see [docs/development.md](/docs
 3. Check that it works!
 
     ```bash
-    python -c 'import cirq; print(cirq.google.Foxtail)'
+    python -c "import cirq; print(cirq.google.Foxtail)"
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │


### PR DESCRIPTION
Use double quotes on windows for those getting "SyntaxError: EOL while scanning string literal python".