### PR TITLE
Fix tests using assert_allclose without setting atol

### DIFF
--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1322,7 +1322,8 @@ def test_circuit_to_unitary_matrix():
     c = Circuit.from_ops(cirq.measure(a))
     cirq.testing.assert_allclose_up_to_global_phase(
         c.to_unitary_matrix(),
-        np.eye(2))
+        np.eye(2),
+        atol=1e-8)
 
     # Ignoring terminal measurements with further cirq.
     c = Circuit.from_ops(cirq.Z(a), cirq.measure(a), cirq.Z(b))
@@ -1333,7 +1334,8 @@ def test_circuit_to_unitary_matrix():
             [0, -1, 0, 0],
             [0, 0, -1, 0],
             [0, 0, 0, 1]
-        ]))
+        ]),
+        atol=1e-8)
 
     # Optionally don't ignoring terminal measurements.
     c = Circuit.from_ops(cirq.measure(a))
@@ -1365,7 +1367,8 @@ def test_circuit_to_unitary_matrix():
         cirq.Circuit.from_ops(
             cirq.measure(a, invert_mask=(True,))
         ).to_unitary_matrix(),
-        cirq.X.matrix())
+        cirq.X.matrix(),
+        atol=1e-8)
 
 
 def test_simple_circuits_to_unitary_matrix():
@@ -1394,7 +1397,7 @@ def test_simple_circuits_to_unitary_matrix():
 
         c = Circuit.from_ops(Passthrough()(a, b))
         m = c.to_unitary_matrix()
-        cirq.testing.assert_allclose_up_to_global_phase(m, expected)
+        cirq.testing.assert_allclose_up_to_global_phase(m, expected, atol=1e-8)
 
 
 def test_composite_gate_to_unitary_matrix():
@@ -1415,7 +1418,8 @@ def test_composite_gate_to_unitary_matrix():
     mat = c.to_unitary_matrix()
     mat_expected = cirq.CNOT.matrix()
 
-    cirq.testing.assert_allclose_up_to_global_phase(mat, mat_expected)
+    cirq.testing.assert_allclose_up_to_global_phase(mat, mat_expected,
+                                                    atol=1e-8)
 
 
 def test_expanding_gate_symbols():
@@ -1501,84 +1505,101 @@ def test_apply_unitary_effect_to_state():
     # State ordering.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.X(a)**0.5).apply_unitary_effect_to_state(),
-        np.array([1j, 1]) * np.sqrt(0.5))
+        np.array([1j, 1]) * np.sqrt(0.5),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.X(a)**0.5).apply_unitary_effect_to_state(
             initial_state=0),
-        np.array([1j, 1]) * np.sqrt(0.5))
+        np.array([1j, 1]) * np.sqrt(0.5),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.X(a)**0.5).apply_unitary_effect_to_state(
             initial_state=1),
-        np.array([1, 1j]) * np.sqrt(0.5))
+        np.array([1, 1j]) * np.sqrt(0.5),
+        atol=1e-8)
 
     # Vector state.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.X(a)**0.5).apply_unitary_effect_to_state(
             initial_state=np.array([1j, 1]) * np.sqrt(0.5)),
-        np.array([0, 1]))
+        np.array([0, 1]),
+        atol=1e-8)
 
     # Qubit ordering.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.CNOT(a, b)).apply_unitary_effect_to_state(
             initial_state=0),
-        np.array([1, 0, 0, 0]))
+        np.array([1, 0, 0, 0]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.CNOT(a, b)).apply_unitary_effect_to_state(
             initial_state=1),
-        np.array([0, 1, 0, 0]))
+        np.array([0, 1, 0, 0]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.CNOT(a, b)).apply_unitary_effect_to_state(
             initial_state=2),
-        np.array([0, 0, 0, 1]))
+        np.array([0, 0, 0, 1]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.CNOT(a, b)).apply_unitary_effect_to_state(
             initial_state=3),
-        np.array([0, 0, 1, 0]))
+        np.array([0, 0, 1, 0]),
+        atol=1e-8)
 
     # Measurements.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.measure(a)).apply_unitary_effect_to_state(),
-        np.array([1, 0]))
+        np.array([1, 0]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.X(a), cirq.measure(a)
                               ).apply_unitary_effect_to_state(),
-        np.array([0, 1]))
+        np.array([0, 1]),
+        atol=1e-8)
     with pytest.raises(ValueError):
         cirq.testing.assert_allclose_up_to_global_phase(
             cirq.Circuit.from_ops(cirq.measure(a), cirq.X(a)
                                   ).apply_unitary_effect_to_state(),
-            np.array([1, 0]))
+            np.array([1, 0]),
+            atol=1e-8)
     with pytest.raises(ValueError):
         cirq.testing.assert_allclose_up_to_global_phase(
             cirq.Circuit.from_ops(
                 cirq.measure(a)).apply_unitary_effect_to_state(
                     ignore_terminal_measurements=False),
-            np.array([1, 0]))
+            np.array([1, 0]),
+            atol=1e-8)
 
     # Extra qubits.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops().apply_unitary_effect_to_state(),
-        np.array([1]))
+        np.array([1]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops().apply_unitary_effect_to_state(
             qubits_that_should_be_present=[a]),
-        np.array([1, 0]))
+        np.array([1, 0]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(cirq.X(b)).apply_unitary_effect_to_state(
             qubits_that_should_be_present=[a]),
-        np.array([0, 1, 0, 0]))
+        np.array([0, 1, 0, 0]),
+        atol=1e-8)
 
     # Qubit order.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(
             cirq.Z(a), cirq.X(b)).apply_unitary_effect_to_state(
                 qubit_order=[a, b]),
-        np.array([0, 1, 0, 0]))
+        np.array([0, 1, 0, 0]),
+        atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(
             cirq.Z(a), cirq.X(b)).apply_unitary_effect_to_state(
                 qubit_order=[b, a]),
-        np.array([0, 0, 1, 0]))
+        np.array([0, 0, 1, 0]),
+        atol=1e-8)
 
 
 def test_is_parameterized():

--- a/cirq/circuits/qasm_output_test.py
+++ b/cirq/circuits/qasm_output_test.py
@@ -286,7 +286,7 @@ def test_output_unitary_same_as_qiskit():
     qiskit_unitary = result.get_unitary()
 
     cirq.testing.assert_allclose_up_to_global_phase(
-                    cirq_unitary, qiskit_unitary, rtol=1e-10, atol=1e-10)
+                    cirq_unitary, qiskit_unitary, rtol=1e-8, atol=1e-8)
 
 
 def test_output_format():

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -339,8 +339,8 @@ def test_initial_state_consistency(scheduler):
                                 initial_state=blip(i, 8),
                                 qubit_order=[Q1, Q2, Q3]).final_state
 
-        np.testing.assert_allclose(int_result, blip(i, 8))
-        np.testing.assert_allclose(int_result, array_result)
+        np.testing.assert_allclose(int_result, blip(i, 8), atol=1e-8)
+        np.testing.assert_allclose(int_result, array_result, atol=1e-8)
 
 
 @pytest.mark.parametrize('scheduler', SCHEDULERS)

--- a/cirq/linalg/transformations_test.py
+++ b/cirq/linalg/transformations_test.py
@@ -64,8 +64,8 @@ def test_match_global_phase():
     a = np.array([[5, 4], [3, -2]])
     b = np.array([[0.000001, 0], [0, 1j]])
     c, d = match_global_phase(a, b)
-    np.testing.assert_allclose(c, -a)
-    np.testing.assert_allclose(d, b * -1j)
+    np.testing.assert_allclose(c, -a, atol=1e-10)
+    np.testing.assert_allclose(d, b * -1j, atol=1e-10)
 
 
 def test_match_global_phase_zeros():
@@ -73,16 +73,16 @@ def test_match_global_phase_zeros():
     b = np.array([[1, 1], [1, 1]])
 
     z1, b1 = match_global_phase(z, b)
-    np.testing.assert_allclose(z, z1)
-    np.testing.assert_allclose(b, b1)
+    np.testing.assert_allclose(z, z1, atol=1e-10)
+    np.testing.assert_allclose(b, b1, atol=1e-10)
 
     z2, b2 = match_global_phase(z, b)
-    np.testing.assert_allclose(z, z2)
-    np.testing.assert_allclose(b, b2)
+    np.testing.assert_allclose(z, z2, atol=1e-10)
+    np.testing.assert_allclose(b, b2, atol=1e-10)
 
     z3, z4 = match_global_phase(z, z)
-    np.testing.assert_allclose(z, z3)
-    np.testing.assert_allclose(z, z4)
+    np.testing.assert_allclose(z, z3, atol=1e-10)
+    np.testing.assert_allclose(z, z4, atol=1e-10)
 
 
 def test_match_global_no_float_error_when_axis_aligned():

--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -275,7 +275,7 @@ def test_decompose(gate, gate_equiv):
     mat_check = cirq.Circuit.from_ops(
                     gate_equiv(q0),
                 ).to_unitary_matrix()
-    assert_allclose_up_to_global_phase(mat, mat_check)
+    assert_allclose_up_to_global_phase(mat, mat_check, rtol=1e-7, atol=1e-7)
 
 
 @pytest.mark.parametrize('gate', _all_clifford_gates())
@@ -288,7 +288,8 @@ def test_inverse_matrix(gate):
     q0 = cirq.NamedQubit('q0')
     mat = cirq.Circuit.from_ops(gate(q0)).to_unitary_matrix()
     mat_inv = cirq.Circuit.from_ops(gate.inverse()(q0)).to_unitary_matrix()
-    assert_allclose_up_to_global_phase(mat, mat_inv.T.conj())
+    assert_allclose_up_to_global_phase(mat, mat_inv.T.conj(),
+                                       rtol=1e-7, atol=1e-7)
 
 
 @pytest.mark.parametrize('gate,other',
@@ -345,7 +346,7 @@ def test_single_qubit_gate_after_switching_order(gate, other):
                     gate.equivalent_gate_before(other)(q0),
                     gate(q0),
                 ).to_unitary_matrix()
-    assert_allclose_up_to_global_phase(mat, mat_swap)
+    assert_allclose_up_to_global_phase(mat, mat_swap, rtol=1e-7, atol=1e-7)
 
 
 @pytest.mark.parametrize('gate,sym,exp', (

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -424,7 +424,8 @@ def test_iswap_matrix():
         np.array([[1, 0, 0, 0],
                   [0, 0, 1j, 0],
                   [0, 1j, 0, 0],
-                  [0, 0, 0, 1]]))
+                  [0, 0, 0, 1]]),
+        atol=1e-8)
 
 
 def test_iswap_decompose():

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -178,8 +178,9 @@ def test_known_matrix():
     op1 = cirq.X(a)
     assert cirq.can_cast(cirq.KnownMatrix, op1)
     np.testing.assert_allclose(op1.matrix(),
-                               np.array([[0, 1], [1, 0]]))
+                               np.array([[0, 1], [1, 0]]),
+                               atol=1e-8)
     op2 = cirq.CNOT(a, b)
     op3 = cirq.CNOT(a, b)
-    np.testing.assert_allclose(op2.matrix(), cirq.CNOT.matrix())
-    np.testing.assert_allclose(op3.matrix(), cirq.CNOT.matrix())
+    np.testing.assert_allclose(op2.matrix(), cirq.CNOT.matrix(), atol=1e-8)
+    np.testing.assert_allclose(op3.matrix(), cirq.CNOT.matrix(), atol=1e-8)

--- a/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq/ops/pauli_interaction_gate_test.py
@@ -73,7 +73,8 @@ def test_decompose(gate):
     cirq.circuits.ExpandComposite().optimize_circuit(circuit)
     decompose_mat = circuit.to_unitary_matrix()
     gate_mat = gate.matrix()
-    assert_allclose_up_to_global_phase(decompose_mat, gate_mat)
+    assert_allclose_up_to_global_phase(decompose_mat, gate_mat,
+                                       rtol=1e-7, atol=1e-7)
 
 def test_exponent():
     cnot = cirq.PauliInteractionGate(cirq.Pauli.Z, False, cirq.Pauli.X, False)
@@ -93,7 +94,7 @@ def test_exponent():
         g.matrix(),
         cirq.Circuit.from_ops(g.default_decompose([q0, q1])
                               ).to_unitary_matrix(),
-        atol=1e-8)
+        rtol=1e-7, atol=1e-7)
 
 def test_decomposes_despite_symbol():
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')

--- a/cirq/ops/three_qubit_gates_test.py
+++ b/cirq/ops/three_qubit_gates_test.py
@@ -29,7 +29,7 @@ def test_matrix():
         [0, 0, 0, 0, 0, 1, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 1],
         [0, 0, 0, 0, 0, 0, 1, 0],
-    ]))
+    ]), atol=1e-8)
 
     np.testing.assert_allclose(cirq.CCZ.matrix(), np.array([
         [1, 0, 0, 0, 0, 0, 0, 0],
@@ -40,7 +40,7 @@ def test_matrix():
         [0, 0, 0, 0, 0, 1, 0, 0],
         [0, 0, 0, 0, 0, 0, 1, 0],
         [0, 0, 0, 0, 0, 0, 0, -1],
-    ]))
+    ]), atol=1e-8)
 
     np.testing.assert_allclose(cirq.CSWAP.matrix(), np.array([
         [1, 0, 0, 0, 0, 0, 0, 0],
@@ -51,7 +51,7 @@ def test_matrix():
         [0, 0, 0, 0, 0, 0, 1, 0],
         [0, 0, 0, 0, 0, 1, 0, 0],
         [0, 0, 0, 0, 0, 0, 0, 1],
-    ]))
+    ]), atol=1e-8)
 
 
 def test_str():

--- a/cirq/testing/lin_alg_utils.py
+++ b/cirq/testing/lin_alg_utils.py
@@ -64,8 +64,9 @@ def random_special_orthogonal(dim: int) -> np.ndarray:
 def assert_allclose_up_to_global_phase(
         actual: np.ndarray,
         desired: np.ndarray,
+        *,  # Forces keyword args.
         rtol: float = 1e-7,
-        atol: float = 0,
+        atol: float,  # Require atol to be specified
         equal_nan: bool = True,
         err_msg: Optional[str] = '',
         verbose: bool = True) -> None:

--- a/cirq/testing/lin_alg_utils_test.py
+++ b/cirq/testing/lin_alg_utils_test.py
@@ -33,12 +33,14 @@ def test_random_unitary():
 def test_assert_allclose_up_to_global_phase():
     assert_allclose_up_to_global_phase(
         np.array([[1]]),
-        np.array([[1j]]))
+        np.array([[1j]]),
+        atol=0)
 
     with pytest.raises(AssertionError):
         assert_allclose_up_to_global_phase(
             np.array([[1]]),
-            np.array([[2]]))
+            np.array([[2]]),
+            atol=0)
 
     assert_allclose_up_to_global_phase(
         np.array([[1e-8, -1, 1e-8]]),
@@ -53,4 +55,5 @@ def test_assert_allclose_up_to_global_phase():
 
     assert_allclose_up_to_global_phase(
         np.array([[1, 2], [3, 4]]),
-        np.array([[-1, -2], [-3, -4]]))
+        np.array([[-1, -2], [-3, -4]]),
+        atol=0)

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -36,10 +36,12 @@ def test_chosen_angle_to_half_turns():
                                                      default=0.75) == 0.25
     np.testing.assert_allclose(
         cirq.chosen_angle_to_half_turns(rads=np.pi/2),
-        0.5)
+        0.5,
+        atol=1e-8)
     np.testing.assert_allclose(
         cirq.chosen_angle_to_half_turns(rads=-np.pi/4),
-        -0.25)
+        -0.25,
+        atol=1e-8)
     assert cirq.chosen_angle_to_half_turns(degs=90) == 0.5
     assert cirq.chosen_angle_to_half_turns(degs=1080) == 6.0
     assert cirq.chosen_angle_to_half_turns(degs=990) == 5.5
@@ -63,10 +65,12 @@ def test_chosen_angle_to_canonical_half_turns():
                                                      default=0.75) == 0.25
     np.testing.assert_allclose(
         cirq.chosen_angle_to_canonical_half_turns(rads=np.pi/2),
-        0.5)
+        0.5,
+        atol=1e-8)
     np.testing.assert_allclose(
         cirq.chosen_angle_to_canonical_half_turns(rads=-np.pi/4),
-        -0.25)
+        -0.25,
+        atol=1e-8)
     assert cirq.chosen_angle_to_canonical_half_turns(degs=90) == 0.5
     assert cirq.chosen_angle_to_canonical_half_turns(degs=1080) == 0
     assert cirq.chosen_angle_to_canonical_half_turns(degs=990) == -0.5


### PR DESCRIPTION
This should make the tests robust to numerical error.