### PR TITLE
Expose cirq.targeted_left_multiply

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -79,7 +79,9 @@ from cirq.linalg import (
     kron_factor_4x4_to_2x2s,
     kron_with_controls,
     map_eigenvalues,
+    reflection_matrix_pow,
     so4_to_magic_su2s,
+    targeted_left_multiply,
     Tolerance,
 )
 

--- a/cirq/linalg/__init__.py
+++ b/cirq/linalg/__init__.py
@@ -55,4 +55,5 @@ from cirq.linalg.tolerance import (
 from cirq.linalg.transformations import (
     match_global_phase,
     reflection_matrix_pow,
+    targeted_left_multiply,
 )

--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -106,8 +106,8 @@ def targeted_left_multiply(left_matrix: np.ndarray,
 
     This method also works when the right hand side is a matrix instead of a
     vector. If a unitary circuit's matrix is `old_effect`, and you append
-    a CNOT(q1, q3) operation onto the circuit, where the control q1 is the qubit
-    at offset 1 and the target q3 is the qubit at offset 4, then the appended
+    a CNOT(q1, q4) operation onto the circuit, where the control q1 is the qubit
+    at offset 1 and the target q4 is the qubit at offset 4, then the appended
     circuit's unitary matrix is computed as follows:
 
         new_effect = cirq.targeted_left_multiply(

--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -14,7 +14,7 @@
 
 """Utility methods for transforming matrices."""
 
-from typing import Tuple
+from typing import Tuple, List, Optional
 
 import numpy as np
 
@@ -86,3 +86,62 @@ def match_global_phase(a: np.ndarray,
 
     # Zero the phase at this entry in both matrices.
     return a * dephase(a[k]), b * dephase(b[k])
+
+
+def targeted_left_multiply(left_matrix: np.ndarray,
+                           right_target: np.ndarray,
+                           target_axes: List[int],
+                           out: Optional[np.ndarray] = None
+                           ) -> np.ndarray:
+    """Left-multiplies the given axes of the target tensor by the given matrix.
+
+    Note that the matrix must have a compatible tensor structure.
+
+    For example, if you have an 6-qubit state vector `input_state` with shape
+    (2, 2, 2, 2, 2, 2), and a 2-qubit unitary operation `op` with shape
+    (2, 2, 2, 2), and you want to apply `op` to the 5'th and 3'rd qubits
+    within `input_state, then the output state vector is computed as follows:
+
+        output_state = cirq.targeted_left_multiply(op, input_state, [5, 3])
+
+    This method also works when the right hand side is a matrix instead of a
+    vector. If a unitary circuit's matrix is `old_effect`, and you append
+    a CNOT(q1, q3) operation onto the circuit, where the control q1 is the qubit
+    at offset 1 and the target q3 is the qubit at offset 4, then the appended
+    circuit's unitary matrix is computed as follows:
+
+        new_effect = cirq.targeted_left_multiply(
+            matrix=cirq.CNOT.matrix().reshape((2, 2, 2, 2)),
+            state=old_effect,
+            target_axes=[1, 4])
+
+    Args:
+        left_matrix: What to left-multiply the target tensor by.
+        right_target: A tensor to carefully broadcast a left-multiply over.
+        target_axes: Which axes of the target are being operated on.
+        out: The buffer to store the results in. If not specified or None, a new
+            buffer is used. Must have the same shape as right_target.
+
+    Returns:
+        The output tensor.
+    """
+    k = len(target_axes)
+    d = len(right_target.shape)
+    work_indices = tuple(range(k))
+    data_indices = tuple(range(k, k + d))
+    used_data_indices = tuple(data_indices[q] for q in target_axes)
+    input_indices = work_indices + used_data_indices
+    output_indices = list(data_indices)
+    for w, t in zip(work_indices, target_axes):
+        output_indices[t] = w
+
+    all_indices = set(input_indices + data_indices + tuple(output_indices))
+
+    return np.einsum(left_matrix, input_indices,
+                     right_target, data_indices,
+                     output_indices,
+                     # Note: this is a workaround for a bug in numpy:
+                     #     https://github.com/numpy/numpy/issues/10926
+                     # Turning optimize on actually makes things slower.
+                     optimize=len(all_indices) >= 26,
+                     **({'out': out} if out is not None else {}))

--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -100,7 +100,7 @@ def targeted_left_multiply(left_matrix: np.ndarray,
     For example, if you have an 6-qubit state vector `input_state` with shape
     (2, 2, 2, 2, 2, 2), and a 2-qubit unitary operation `op` with shape
     (2, 2, 2, 2), and you want to apply `op` to the 5'th and 3'rd qubits
-    within `input_state, then the output state vector is computed as follows:
+    within `input_state`, then the output state vector is computed as follows:
 
         output_state = cirq.targeted_left_multiply(op, input_state, [5, 3])
 

--- a/cirq/linalg/transformations_test.py
+++ b/cirq/linalg/transformations_test.py
@@ -13,24 +13,22 @@
 # limitations under the License.
 
 import numpy as np
+import pytest
 
-from cirq.linalg.transformations import (
-    reflection_matrix_pow,
-    match_global_phase,
-)
+import cirq
 
 
 def test_reflection_matrix_pow_consistent_results():
     x = np.array([[0, 1], [1, 0]])
-    sqrt_x = reflection_matrix_pow(x, 0.5)
+    sqrt_x = cirq.reflection_matrix_pow(x, 0.5)
     np.testing.assert_allclose(np.dot(sqrt_x, sqrt_x), x, atol=1e-10)
 
     ix = x * np.sqrt(1j)
-    sqrt_ix = reflection_matrix_pow(ix, 0.5)
+    sqrt_ix = cirq.reflection_matrix_pow(ix, 0.5)
     np.testing.assert_allclose(np.dot(sqrt_ix, sqrt_ix), ix, atol=1e-10)
 
     h = np.array([[1, 1], [1, -1]]) * np.sqrt(0.5)
-    cube_root_h = reflection_matrix_pow(h, 1/3)
+    cube_root_h = cirq.reflection_matrix_pow(h, 1/3)
     np.testing.assert_allclose(
         np.dot(np.dot(cube_root_h, cube_root_h), cube_root_h),
         h,
@@ -39,14 +37,14 @@ def test_reflection_matrix_pow_consistent_results():
     y = np.array([[0, -1j], [1j, 0]])
     h = np.array([[1, 1], [1, -1]]) * np.sqrt(0.5j)
     yh = np.kron(y, h)
-    sqrt_yh = reflection_matrix_pow(yh, 0.5)
+    sqrt_yh = cirq.reflection_matrix_pow(yh, 0.5)
     np.testing.assert_allclose(np.dot(sqrt_yh, sqrt_yh), yh, atol=1e-10)
 
 
 def test_reflection_matrix_sign_preference_under_perturbation():
     x = np.array([[0, 1], [1, 0]])
     sqrt_x = np.array([[1, -1j], [-1j, 1]]) * (1 + 1j) / 2
-    np.testing.assert_allclose(reflection_matrix_pow(x, 0.5),
+    np.testing.assert_allclose(cirq.reflection_matrix_pow(x, 0.5),
                                sqrt_x,
                                atol=1e-8)
 
@@ -55,7 +53,7 @@ def test_reflection_matrix_sign_preference_under_perturbation():
     for perturbation in [0, 0.1, -0.1, 0.3, -0.3, 0.49, -0.49]:
         px = x * complex(-1)**perturbation
         expected_sqrt_px = sqrt_x * complex(-1)**(perturbation / 2)
-        sqrt_px = reflection_matrix_pow(px, 0.5)
+        sqrt_px = cirq.reflection_matrix_pow(px, 0.5)
         np.testing.assert_allclose(np.dot(sqrt_px, sqrt_px), px, atol=1e-10)
         np.testing.assert_allclose(sqrt_px, expected_sqrt_px, atol=1e-10)
 
@@ -63,7 +61,7 @@ def test_reflection_matrix_sign_preference_under_perturbation():
 def test_match_global_phase():
     a = np.array([[5, 4], [3, -2]])
     b = np.array([[0.000001, 0], [0, 1j]])
-    c, d = match_global_phase(a, b)
+    c, d = cirq.match_global_phase(a, b)
     np.testing.assert_allclose(c, -a, atol=1e-10)
     np.testing.assert_allclose(d, b * -1j, atol=1e-10)
 
@@ -72,27 +70,99 @@ def test_match_global_phase_zeros():
     z = np.array([[0, 0], [0, 0]])
     b = np.array([[1, 1], [1, 1]])
 
-    z1, b1 = match_global_phase(z, b)
+    z1, b1 = cirq.match_global_phase(z, b)
     np.testing.assert_allclose(z, z1, atol=1e-10)
     np.testing.assert_allclose(b, b1, atol=1e-10)
 
-    z2, b2 = match_global_phase(z, b)
+    z2, b2 = cirq.match_global_phase(z, b)
     np.testing.assert_allclose(z, z2, atol=1e-10)
     np.testing.assert_allclose(b, b2, atol=1e-10)
 
-    z3, z4 = match_global_phase(z, z)
+    z3, z4 = cirq.match_global_phase(z, z)
     np.testing.assert_allclose(z, z3, atol=1e-10)
     np.testing.assert_allclose(z, z4, atol=1e-10)
 
 
 def test_match_global_no_float_error_when_axis_aligned():
     a = np.array([[1, 1.1], [-1.3, np.pi]])
-    a2, _ = match_global_phase(a, a)
-    a3, _ = match_global_phase(a * 1j, a * 1j)
-    a4, _ = match_global_phase(-a, -a)
-    a5, _ = match_global_phase(a * -1j, a * -1j)
+    a2, _ = cirq.match_global_phase(a, a)
+    a3, _ = cirq.match_global_phase(a * 1j, a * 1j)
+    a4, _ = cirq.match_global_phase(-a, -a)
+    a5, _ = cirq.match_global_phase(a * -1j, a * -1j)
 
     assert np.all(a2 == a)
     assert np.all(a3 == a)
     assert np.all(a4 == a)
     assert np.all(a5 == a)
+
+
+def test_targeted_left_multiply_matches_kron_then_dot():
+    t = np.array([1, 2, 3, 4, 5, 6, 7, 8])
+    m = np.array([[2, 3], [5, 7]])
+    i = np.eye(2)
+
+    np.testing.assert_allclose(
+        cirq.targeted_left_multiply(left_matrix=m,
+                                    right_target=t.reshape((2, 2, 2)),
+                                    target_axes=[0]),
+        np.dot(cirq.kron(m, i, i), t).reshape((2, 2, 2)),
+        atol=1e-8)
+
+    np.testing.assert_allclose(
+        cirq.targeted_left_multiply(left_matrix=m,
+                                    right_target=t.reshape((2, 2, 2)),
+                                    target_axes=[1]),
+        np.dot(cirq.kron(i, m, i), t).reshape((2, 2, 2)),
+        atol=1e-8)
+
+    np.testing.assert_allclose(
+        cirq.targeted_left_multiply(left_matrix=m,
+                                    right_target=t.reshape((2, 2, 2)),
+                                    target_axes=[2]),
+        np.dot(cirq.kron(i, i, m), t).reshape((2, 2, 2)),
+        atol=1e-8)
+
+
+def test_targeted_left_multiply_reorders_matrices():
+    t = np.eye(4).reshape((2, 2, 2, 2))
+    m = np.array([
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 0, 1,
+        0, 0, 1, 0,
+    ]).reshape((2, 2, 2, 2))
+
+    np.testing.assert_allclose(
+        cirq.targeted_left_multiply(left_matrix=m,
+                                    right_target=t,
+                                    target_axes=[0, 1]),
+        m,
+        atol=1e-8)
+
+    np.testing.assert_allclose(
+        cirq.targeted_left_multiply(left_matrix=m,
+                                    right_target=t,
+                                    target_axes=[1, 0]),
+        np.array([
+            1, 0, 0, 0,
+            0, 0, 0, 1,
+            0, 0, 1, 0,
+            0, 1, 0, 0,
+        ]).reshape((2, 2, 2, 2)),
+        atol=1e-8)
+
+
+def test_targeted_left_multiply_out():
+    left = np.array([[2, 3], [5, 7]])
+    right = np.array([1, -1])
+    out = np.zeros(2)
+
+    result = cirq.targeted_left_multiply(left_matrix=left,
+                                         right_target=right,
+                                         target_axes=[0],
+                                         out=out)
+    assert result is out
+    np.testing.assert_allclose(
+        result,
+        np.array([-1, -2]),
+        atol=1e-8)

--- a/cirq/linalg/transformations_test.py
+++ b/cirq/linalg/transformations_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import pytest
 
 import cirq
 


### PR DESCRIPTION
- Moved from `cirq/circuits/circuit.py:_apply_unitary_operation` to `cirq/linalg/transformations.py:targeted_left_multiply`
- Added some tests of the method
- Fixed `reflection_matrix_pow` not being exported.
- Made `out` optional.

If anyone can think of a better name I'd be happy to hear it.