### PR TITLE
Fix MergeInteractions treating empty space as a break point

### DIFF
--- a/cirq/google/merge_interactions.py
+++ b/cirq/google/merge_interactions.py
@@ -144,6 +144,7 @@ class MergeInteractions(circuits.PointOptimizer):
             op_data = [
                 self._op_to_matrix(op, qubits)
                 for op in operations
+                if op is not None
             ]
 
             # Stop at any non-constant or non-local interaction.


### PR DESCRIPTION
MergeInteractions was not always merging an entire series of operations on two qubits.  It would stop prematurely at any moment with no operation on one of the qubits.