### PR TITLE
Fix links in docs/install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -2,9 +2,9 @@
 
 Choose your operating system:
 
-- [Installing on Linux](#Installing-on-linux)
-- [Installing on Mac OS X](#Installing-on-mac-os-x)
-- [Installing on Windows](#Installing-on-windows)
+- [Installing on Linux](#installing-on-linux)
+- [Installing on Mac OS X](#installing-on-mac-os-x)
+- [Installing on Windows](#installing-on-windows)
 
 If you want to create a development environment, see [docs/development.md](/docs/development.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,9 +2,9 @@
 
 Choose your operating system:
 
-- [Installing on Linux](#Installing-on-Linux)
-- [Installing on Mac OS X](#Installing-on-Mac-OS-X)
-- [Installing on Windows](#Installing-on-Windows)
+- [Installing on Linux](#Installing-on-linux)
+- [Installing on Mac OS X](#Installing-on-mac-os-x)
+- [Installing on Windows](#Installing-on-windows)
 
 If you want to create a development environment, see [docs/development.md](/docs/development.md).
 


### PR DESCRIPTION
Fix broken anchor links on [docs/install](https://cirq.readthedocs.io/en/latest/install.html).