### PR TITLE
Fix logo on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: docs/Cirq_logo_color.svg
+.. image:: https://github.com/quantumlib/cirq/blob/master/docs/Cirq_logo_color.svg
   :alt: Cirq
   :width: 500px
 


### PR DESCRIPTION
Change the Cirq logo to an absolute URL so it isn't a broken link on PyPI.