### PR TITLE
Make matrix gates text diagrammable

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1034,15 +1034,14 @@ class Circuit(ops.ParameterizableEffect):
             use_unicode_characters=use_unicode_characters,
             qubit_name_suffix='' if transpose else ': ',
             precision=precision,
-            qubit_order=qubit_order)
+            qubit_order=qubit_order,
+            transpose=transpose)
 
-        if transpose:
-            return diagram.transpose().render(
-                crossing_char='┼' if use_unicode_characters else '-',
-                use_unicode_characters=use_unicode_characters)
         return diagram.render(
-            crossing_char='┼' if use_unicode_characters else '|',
-            horizontal_spacing=3,
+            crossing_char=(None
+                           if use_unicode_characters
+                           else ('-' if transpose else '|')),
+            horizontal_spacing=1 if transpose else 3,
             use_unicode_characters=use_unicode_characters)
 
     def to_text_diagram_drawer(
@@ -1050,6 +1049,7 @@ class Circuit(ops.ParameterizableEffect):
             ext: extension.Extensions = None,
             use_unicode_characters: bool = True,
             qubit_name_suffix: str = '',
+            transpose: bool = False,
             precision: Optional[int] = 3,
             qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> TextDiagramDrawer:
@@ -1060,6 +1060,7 @@ class Circuit(ops.ParameterizableEffect):
             use_unicode_characters: Determines if unicode characters are
                 allowed (as opposed to ascii-only diagrams).
             qubit_name_suffix: Appended to qubit names in the diagram.
+            transpose: Arranges qubit wires vertically instead of horizontally.
             precision: Number of digits to use when representing numbers.
             qubit_order: Determines how qubits are ordered in the diagram.
 
@@ -1083,11 +1084,15 @@ class Circuit(ops.ParameterizableEffect):
                                     use_unicode_characters,
                                     qubit_map,
                                     diagram,
-                                    precision)
+                                    precision,
+                                    transpose)
 
         w = diagram.width()
         for i in qubit_map.values():
             diagram.horizontal_line(i, 0, w)
+
+        if transpose:
+            diagram = diagram.transpose()
 
         return diagram
 
@@ -1250,7 +1255,8 @@ def _draw_moment_in_diagram(moment: Moment,
                             use_unicode_characters: bool,
                             qubit_map: Dict[ops.QubitId, int],
                             out_diagram: TextDiagramDrawer,
-                            precision: Optional[int]):
+                            precision: Optional[int],
+                            is_transposed: bool):
     x0 = out_diagram.width()
     for op in moment.operations:
         indices = [qubit_map[q] for q in op.qubits]

--- a/cirq/circuits/text_diagram_drawer.py
+++ b/cirq/circuits/text_diagram_drawer.py
@@ -11,6 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import List, NamedTuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from typing import Tuple, Dict
+
+_HorizontalLine = NamedTuple('HorizontalLine', [
+    ('y', int),
+    ('x1', int),
+    ('x2', int),
+    ('emphasize', bool),
+])
+_VerticalLine = NamedTuple('VerticalLine', [
+    ('x', int),
+    ('y1', int),
+    ('y2', int),
+    ('emphasize', bool),
+])
 
 
 class TextDiagramDrawer:
@@ -18,9 +36,9 @@ class TextDiagramDrawer:
     """
 
     def __init__(self):
-        self.entries = dict()
-        self.vertical_lines = []
-        self.horizontal_lines = []
+        self.entries = dict()  # type: Dict[Tuple[int, int], str]
+        self.vertical_lines = []  # type: List[_VerticalLine]
+        self.horizontal_lines = []  # type: List[_HorizontalLine]
 
     def write(self, x: int, y: int, text: str):
         """Adds text to the given location."""
@@ -37,8 +55,7 @@ class TextDiagramDrawer:
             return True
 
         # Vertical line?
-        if any(line_x == x and y1 < y < y2
-               for line_x, y1, y2, _ in self.vertical_lines):
+        if any(v.x == x and v.y1 < y < v.y2 for v in self.vertical_lines):
             return True
 
         # Horizontal line?
@@ -65,44 +82,48 @@ class TextDiagramDrawer:
         else:
             raise ValueError("Line is neither horizontal nor vertical")
 
-    def vertical_line(self, x: int, y1: int, y2: int, emphasize: bool = False):
+    def vertical_line(self, x: int, y1: int, y2: int, emphasize: bool = False
+                      ) -> None:
         """Adds a line from (x, y1) to (x, y2)."""
         y1, y2 = sorted([y1, y2])
-        self.vertical_lines.append((x, y1, y2, emphasize))
+        self.vertical_lines.append(_VerticalLine(x, y1, y2, emphasize))
 
-    def horizontal_line(self, y, x1, x2, emphasize: bool = False):
+    def horizontal_line(self, y, x1, x2, emphasize: bool = False
+                      ) -> None:
         """Adds a line from (x1, y) to (x2, y)."""
         x1, x2 = sorted([x1, x2])
-        self.horizontal_lines.append((y, x1, x2, emphasize))
+        self.horizontal_lines.append(_HorizontalLine(y, x1, x2, emphasize))
 
-    def transpose(self):
+    def transpose(self) -> 'TextDiagramDrawer':
         """Returns the same diagram, but mirrored across its diagonal."""
         out = TextDiagramDrawer()
         out.entries = {(y, x): v for (x, y), v in self.entries.items()}
-        out.vertical_lines = list(self.horizontal_lines)
-        out.horizontal_lines = list(self.vertical_lines)
+        out.vertical_lines = [_VerticalLine(*e)
+                              for e in self.horizontal_lines]
+        out.horizontal_lines = [_HorizontalLine(*e)
+                                for e in self.vertical_lines]
         return out
 
-    def width(self):
+    def width(self) -> int:
         """Determines how many entry columns are in the diagram."""
         max_x = -1
         for x, _ in self.entries.keys():
             max_x = max(max_x, x)
-        for x, _, _, _ in self.vertical_lines:
-            max_x = max(max_x, x)
-        for _, x1, x2, _ in self.horizontal_lines:
-            max_x = max(max_x, x1, x2)
+        for v in self.vertical_lines:
+            max_x = max(max_x, v.x)
+        for h in self.horizontal_lines:
+            max_x = max(max_x, h.x1, h.x2)
         return 1 + max_x
 
-    def height(self):
+    def height(self) -> int:
         """Determines how many entry rows are in the diagram."""
         max_y = -1
         for _, y in self.entries.keys():
             max_y = max(max_y, y)
-        for y, _, _, _ in self.horizontal_lines:
-            max_y = max(max_y, y)
-        for _, y1, y2, _ in self.vertical_lines:
-            max_y = max(max_y, y1, y2)
+        for h in self.horizontal_lines:
+            max_y = max(max_y, h.y)
+        for v in self.vertical_lines:
+            max_y = max(max_y, v.y1, v.y2)
         return 1 + max_y
 
     def render(self,
@@ -112,49 +133,138 @@ class TextDiagramDrawer:
                use_unicode_characters: bool = True) -> str:
         """Outputs text containing the diagram."""
 
-        pipe = '│' if use_unicode_characters else '|'
-        dash = '─' if use_unicode_characters else '-'
-        if crossing_char is None:
-            crossing_char = '┼' if use_unicode_characters else '+'
+        char = _normal_char if use_unicode_characters else _ascii_char
 
-        emp_pipe = '┃' if use_unicode_characters else '#'
-        emp_dash = '━' if use_unicode_characters else '#'
-
-        dx = 1 + horizontal_spacing
-        dy = 1 + vertical_spacing
-        w = self.width() * dx - horizontal_spacing
-        h = self.height() * dy - vertical_spacing
+        w = self.width()
+        h = self.height()
 
         grid = [[''] * w for _ in range(h)]
-        extend_char = [[' '] * w for _ in range(h)]
+        horizontal_separator = [[' '] * w for _ in range(h)]
+        vertical_separator = [[' '] * w for _ in range(h)]
 
-        for x, y1, y2, emphasize in self.vertical_lines:
-            x *= dx
-            y1 *= dy
-            y2 *= dy
-            for y in range(y1, y2):
-                grid[y][x] = emp_pipe if emphasize else pipe
+        # Place lines.
+        verticals = {
+            (v.x, y): v.emphasize
+            for v in self.vertical_lines
+            for y in range(v.y1, v.y2)
+        }
+        horizontals = {
+            (x, h.y): h.emphasize
+            for h in self.horizontal_lines
+            for x in range(h.x1, h.x2)
+        }
+        for (x, y), emph in verticals.items():
+            c = char('│', emph)
+            grid[y][x] = c
+            vertical_separator[y][x] = c
+        for (x, y), emph in horizontals.items():
+            c = char('─', emph)
+            grid[y][x] = c
+            horizontal_separator[y][x] = c
+        for x, y in set(horizontals.keys()) & set(verticals.keys()):
+            grid[y][x] = crossing_char or _cross_char(
+                not use_unicode_characters,
+                horizontals[(x, y)],
+                verticals[(x, y)])
 
-        for y, x1, x2, emphasize in self.horizontal_lines:
-            y *= dy
-            x1 *= dx
-            x2 *= dx
-            for x in range(x1, x2):
-                if grid[y][x] == pipe:
-                    grid[y][x] = crossing_char
-                else:
-                    grid[y][x] = emp_dash if emphasize else dash
-                extend_char[y][x] = emp_dash if emphasize else dash
-
+        # Place entries.
         for (x, y), v in self.entries.items():
-            x *= dx
-            y *= dy
             grid[y][x] = v
 
-        for col in range(w):
-            col_width = max(1, max(len(grid[y][col]) for y in range(h)))
-            for row in range(h):
-                missing = col_width - len(grid[row][col])
-                grid[row][col] += extend_char[row][col] * missing
+        # Pad rows and columns to fit contents with desired spacing.
+        multiline_grid = _pad_into_multiline(w,
+                                             grid,
+                                             horizontal_separator,
+                                             vertical_separator,
+                                             horizontal_spacing,
+                                             vertical_spacing)
 
-        return '\n'.join(''.join(row).rstrip() for row in grid)
+        # Concatenate it all together.
+        return '\n'.join(''.join(sub_row).rstrip()
+                         for row in multiline_grid
+                         for sub_row in row).rstrip()
+
+
+_BoxChars = [
+    ('─', '━', '-'),
+    ('│', '┃', '|'),
+    ('┌', '┏', '/'),
+    ('└', '┗', '\\'),
+    ('┐', '┓', '\\'),
+    ('┘', '┛', '/'),
+    ('├', '┣', '>'),
+    ('┼', '╋', '+'),
+    ('┤', '┫', '<'),
+    ('┬', '┳', 'v'),
+    ('┴', '┻', '^'),
+]  # type: List[Tuple[str, ...]]
+
+_EmphasisMap = {k: v for k, v, _ in _BoxChars}
+_AsciiMap = {k: v for k, _, v in _BoxChars}
+
+
+def _normal_char(k: str, emphasize: bool = False) -> str:
+    if not emphasize:
+        return k
+    r = _EmphasisMap.get(k)
+    return r if r is not None else k
+
+
+def _ascii_char(k: str, emphasize: bool = False) -> str:
+    del emphasize
+    r = _AsciiMap.get(k)
+    return r if r is not None else k
+
+
+def _cross_char(use_ascii: bool, horizontal_emph: bool, vertical_emph: bool
+                ) -> str:
+    if use_ascii:
+        return '+'
+    if horizontal_emph != vertical_emph:
+        return '┿' if horizontal_emph else '╂'
+    return _normal_char('┼', horizontal_emph)
+
+
+def _pad_into_multiline(width: int,
+                        grid: List[List[str]],
+                        horizontal_separator: List[List[str]],
+                        vertical_separator: List[List[str]],
+                        horizontal_spacing: int,
+                        vertical_spacing: int
+                        ) -> List[List[List[str]]]:
+    multiline_grid = []  # type: List[List[List[str]]]
+
+    # Vertical padding.
+    for row in range(len(grid)):
+        multiline_cells = [cell.split('\n') for cell in grid[row]]
+        row_height = max(1, max(len(cell) for cell in multiline_cells))
+        row_height += vertical_spacing
+
+        multiline_row = []
+        for sub_row in range(row_height):
+            sub_row_cells = []
+            for col in range(width):
+                cell_lines = multiline_cells[col]
+                sub_row_cells.append(cell_lines[sub_row]
+                                     if sub_row < len(cell_lines)
+                                     else vertical_separator[row][col])
+            multiline_row.append(sub_row_cells)
+
+        multiline_grid.append(multiline_row)
+
+    # Horizontal padding.
+    for col in range(width):
+        col_width = max(1, max(len(sub_row[col])
+                               for row in multiline_grid
+                               for sub_row in row))
+        col_width += horizontal_spacing
+        for row in range(len(multiline_grid)):
+            for sub_row in range(len(multiline_grid[row])):
+                sub_row_contents = multiline_grid[row][sub_row]
+                pad_char = (horizontal_separator[row][col]
+                            if sub_row == 0
+                            else ' ')
+                sub_row_contents[col] = sub_row_contents[col].ljust(
+                    col_width, pad_char)
+
+    return multiline_grid

--- a/cirq/circuits/text_diagram_drawer_test.py
+++ b/cirq/circuits/text_diagram_drawer_test.py
@@ -80,18 +80,25 @@ def test_draw_entries_and_lines_with_emphasize():
     d = TextDiagramDrawer()
     d.write(0, 0, '!')
     d.write(6, 2, 'span')
-    d.grid_line(2, 3, 8, 3, True)
-    d.grid_line(7, 1, 7, 4, True)
-    print(d.render().strip())
+    d.horizontal_line(y=3, x1=2, x2=8, emphasize=True)
+    d.horizontal_line(y=5, x1=2, x2=9, emphasize=False)
+    d.vertical_line(x=7, y1=1, y2=6, emphasize=True)
+    d.vertical_line(x=5, y1=1, y2=7, emphasize=False)
     assert d.render().strip() == """
 !
 
-                 ┃
-                 ┃
-            span ┃
-                 ┃
-    ━━━━━━━━━━━━━━━
-                 ┃
+          │      ┃
+          │      ┃
+          │ span ┃
+          │      ┃
+    ━━━━━━┿━━━━━━╋━
+          │      ┃
+          │      ┃
+          │      ┃
+    ──────┼──────╂───
+          │      ┃
+          │
+          │
     """.strip()
 
 

--- a/cirq/ops/matrix_gates.py
+++ b/cirq/ops/matrix_gates.py
@@ -27,6 +27,7 @@ def _phase_matrix(turns: float) -> np.ndarray:
 
 
 class SingleQubitMatrixGate(raw_types.Gate,
+                            gate_features.TextDiagrammable,
                             gate_features.KnownMatrix,
                             gate_features.PhaseableEffect,
                             gate_features.ExtrapolatableEffect,
@@ -78,6 +79,11 @@ class SingleQubitMatrixGate(raw_types.Gate,
                 'method.'.format(type(self)))
         return self._matrix
 
+    def text_diagram_info(self, args: gate_features.TextDiagramInfoArgs
+                          ) -> gate_features.TextDiagramInfo:
+        return gate_features.TextDiagramInfo(
+            wire_symbols=(_matrix_to_diagram_symbol(self.matrix(), args),))
+
     def __hash__(self):
         vals = tuple(v for _, v in np.ndenumerate(self.matrix()))
         return hash((SingleQubitMatrixGate, vals))
@@ -105,6 +111,7 @@ class SingleQubitMatrixGate(raw_types.Gate,
 
 
 class TwoQubitMatrixGate(raw_types.Gate,
+                         gate_features.TextDiagrammable,
                          gate_features.KnownMatrix,
                          gate_features.PhaseableEffect,
                          gate_features.ExtrapolatableEffect):
@@ -160,6 +167,11 @@ class TwoQubitMatrixGate(raw_types.Gate,
                 'method.'.format(type(self)))
         return self._matrix
 
+    def text_diagram_info(self, args: gate_features.TextDiagramInfoArgs
+                          ) -> gate_features.TextDiagramInfo:
+        return gate_features.TextDiagramInfo(
+            wire_symbols=(_matrix_to_diagram_symbol(self.matrix(), args), '#2'))
+
     def __hash__(self):
         vals = tuple(v for _, v in np.ndenumerate(self.matrix()))
         return hash((SingleQubitMatrixGate, vals))
@@ -177,3 +189,23 @@ class TwoQubitMatrixGate(raw_types.Gate,
 
     def __str__(self):
         return str(self.matrix().round(3))
+
+
+def _matrix_to_diagram_symbol(matrix: np.ndarray,
+                              args: gate_features.TextDiagramInfoArgs) -> str:
+    if args.precision is not None:
+        matrix = matrix.round(args.precision)
+    result = str(matrix)
+    if args.use_unicode_characters:
+        lines = result.split('\n')
+        for i in range(len(lines)):
+            lines[i] = lines[i].replace('[[', '')
+            lines[i] = lines[i].replace(' [', '')
+            lines[i] = lines[i].replace(']', '')
+        w = max(len(line) for line in lines)
+        for i in range(len(lines)):
+            lines[i] = '│' + lines[i].ljust(w) + '│'
+        lines.insert(0, '┌' + ' ' * w + '┐')
+        lines.append('└' + ' ' * w + '┘')
+        result = '\n'.join(lines)
+    return result

--- a/cirq/ops/matrix_gates_test.py
+++ b/cirq/ops/matrix_gates_test.py
@@ -135,3 +135,77 @@ def test_two_qubit_extrapolate():
     assert cz2.extrapolate_effect(0).approx_eq(i)
     assert cz4.extrapolate_effect(0).approx_eq(i)
     assert cz2.extrapolate_effect(0.5).approx_eq(cz4)
+
+
+def test_single_qubit_diagram():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
+    c = cirq.Circuit.from_ops(
+        cirq.SingleQubitMatrixGate(m).on(a),
+        cirq.CZ(a, b))
+    assert c.to_text_diagram() == """
+a: ───┌                         ┐───@───
+      │0.707+0.j    0.   +0.707j│   │
+      │0.   +0.707j 0.707+0.j   │   │
+      └                         ┘   │
+                                    │
+b: ─────────────────────────────────@───
+    """.strip()
+
+    assert c.to_text_diagram(transpose=True) == """
+a                           b
+│                           │
+┌                         ┐ │
+│0.707+0.j    0.   +0.707j│ │
+│0.   +0.707j 0.707+0.j   │ │
+└                         ┘ │
+│                           │
+@───────────────────────────@
+│                           │
+    """.strip()
+
+
+def test_two_qubit_diagram():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    c = cirq.NamedQubit('c')
+    c = cirq.Circuit.from_ops(
+        cirq.TwoQubitMatrixGate(cirq.CZ.matrix()).on(a, b),
+        cirq.TwoQubitMatrixGate(cirq.CZ.matrix()).on(c, a))
+    assert c.to_text_diagram() == """
+a: ───┌                               ┐───#2──────────────────────────────────
+      │ 1.+0.j  0.+0.j  0.+0.j  0.+0.j│   │
+      │ 0.+0.j  1.+0.j  0.+0.j  0.+0.j│   │
+      │ 0.+0.j  0.+0.j  1.+0.j  0.+0.j│   │
+      │ 0.+0.j  0.+0.j  0.+0.j -1.+0.j│   │
+      └                               ┘   │
+      │                                   │
+b: ───#2──────────────────────────────────┼───────────────────────────────────
+                                          │
+c: ───────────────────────────────────────┌                               ┐───
+                                          │ 1.+0.j  0.+0.j  0.+0.j  0.+0.j│
+                                          │ 0.+0.j  1.+0.j  0.+0.j  0.+0.j│
+                                          │ 0.+0.j  0.+0.j  1.+0.j  0.+0.j│
+                                          │ 0.+0.j  0.+0.j  0.+0.j -1.+0.j│
+                                          └                               ┘
+    """.strip()
+
+    assert c.to_text_diagram(transpose=True) == """
+a                                 b  c
+│                                 │  │
+┌                               ┐─#2 │
+│ 1.+0.j  0.+0.j  0.+0.j  0.+0.j│ │  │
+│ 0.+0.j  1.+0.j  0.+0.j  0.+0.j│ │  │
+│ 0.+0.j  0.+0.j  1.+0.j  0.+0.j│ │  │
+│ 0.+0.j  0.+0.j  0.+0.j -1.+0.j│ │  │
+└                               ┘ │  │
+│                                 │  │
+#2────────────────────────────────┼──┌                               ┐
+│                                 │  │ 1.+0.j  0.+0.j  0.+0.j  0.+0.j│
+│                                 │  │ 0.+0.j  1.+0.j  0.+0.j  0.+0.j│
+│                                 │  │ 0.+0.j  0.+0.j  1.+0.j  0.+0.j│
+│                                 │  │ 0.+0.j  0.+0.j  0.+0.j -1.+0.j│
+│                                 │  └                               ┘
+│                                 │  │
+    """.strip()


### PR DESCRIPTION
- Add support for multi-line gate symbols
- Fix emphasized lines not crossing properly
- Polish text diagram drawing code
    - Merge spacing code into padding code
    - Add transpose arg to Circuit.to_text_diagram_drawer
    - Consolidate character choices into one place
- Implement _matrix_to_diagram_symbol method to clean up numpy output

Previously, text diagrams defaulted to the matrix gate's `__str__` and didn't support multi-line stuff, so it messed up the entire layout.

Fixes https://github.com/quantumlib/Cirq/issues/766