### PR TITLE
Fix a flaky test in cirq/decompositions_test.py

### DIFF
--- a/cirq/decompositions_test.py
+++ b/cirq/decompositions_test.py
@@ -14,11 +14,11 @@
 
 import cmath
 import math
+import random
 from typing import Sequence, cast
 
 import numpy as np
 import pytest
-import random
 
 import cirq
 


### PR DESCRIPTION
- The decomposition tolerance was looser than the asserted tolerance