### PR TITLE
Implement repr() for JobConfig

### DIFF
--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -104,6 +104,19 @@ class JobConfig:
             gcs_program=self.gcs_program,
             gcs_results=self.gcs_results)
 
+    def __repr__(self):
+        return ('JobConfig(project_id={!r}, '
+                'program_id={!r}, '
+                'job_id={!r}, '
+                'gcs_prefix={!r}, '
+                'gcs_program={!r}, '
+                'gcs_results={!r}) ').format(self.project_id,
+                                             self.program_id,
+                                             self.job_id,
+                                             self.gcs_prefix,
+                                             self.gcs_program,
+                                             self.gcs_results)
+
 
 class Engine:
     """Runs programs via the Quantum Engine API.
@@ -176,7 +189,7 @@ class Engine:
             repetitions: int = 1,
             priority: int = 50,
             target_route: str = '/xmonsim'
-    ) -> TrialResult:
+            ) -> TrialResult:
         """Runs the supplied Circuit or Schedule via Quantum Engine.
 
         Args:
@@ -304,7 +317,7 @@ class Engine:
                   repetitions: int = 1,
                   priority: int = 500,
                   target_route: str = '/xmonsim'
-    ) -> 'EngineJob':
+                  ) -> 'EngineJob':
         """Runs the supplied Circuit or Schedule via Quantum Engine.
 
         In contrast to run, this runs across multiple parameter sweeps, and
@@ -593,7 +606,7 @@ def _sweepable_to_sweeps(sweepable: Sweepable) -> List[Sweep]:
             resolvers = iterable
             return [_resolver_to_sweep(p) for p in resolvers]
     else:
-        raise TypeError('Unexpected Sweepable.') # coverage: ignore
+        raise TypeError('Unexpected Sweepable.')  # coverage: ignore
 
 
 def _resolver_to_sweep(resolver: ParamResolver) -> Sweep:

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -110,7 +110,7 @@ class JobConfig:
                 'job_id={!r}, '
                 'gcs_prefix={!r}, '
                 'gcs_program={!r}, '
-                'gcs_results={!r}) ').format(self.project_id,
+                'gcs_results={!r})').format(self.project_id,
                                              self.program_id,
                                              self.job_id,
                                              self.gcs_prefix,

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -33,9 +33,9 @@ def test_repr():
                               job_id='my-job-id')
 
     assert repr(v) == ("JobConfig(project_id='my-project-id', "
-                         "program_id='my-program-id', "
-                         "job_id='my-job-id', gcs_prefix=None, "
-                         "gcs_program=None, gcs_results=None)")
+                       "program_id='my-program-id', "
+                       "job_id='my-job-id', gcs_prefix=None, "
+                       "gcs_program=None, gcs_results=None)")
 
 
 

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -26,28 +26,41 @@ import cirq.google as cg
 from cirq.api.google.v1 import operations_pb2, params_pb2, program_pb2
 from cirq.testing.mock import mock
 
+
+@cirq.testing.only_test_in_python3
+def test_repr():
+    v = cirq.google.JobConfig(project_id='my-project-id',
+                              program_id='my-program-id',
+                              job_id='my-job-id')
+
+    assert repr(options) == ("JobConfig(project_id='my-project-id', "
+                             "program_id='my-program-id', "
+                             "job_id='my-job-id', gcs_prefix=None, "
+                             "gcs_program=None, gcs_results=None)")
+
+
 _A_RESULT = program_pb2.Result(
     sweep_results=[program_pb2.SweepResult(repetitions=1, measurement_keys=[
         program_pb2.MeasurementKey(
             key='q',
             qubits=[operations_pb2.Qubit(row=1, col=1)])],
-            parameterized_results=[
-                program_pb2.ParameterizedResult(
-                    params=params_pb2.ParameterDict(assignments={'a': 1}),
-                    measurement_results=b'01')])])
+        parameterized_results=[
+        program_pb2.ParameterizedResult(
+            params=params_pb2.ParameterDict(assignments={'a': 1}),
+            measurement_results=b'01')])])
 
 _RESULTS = program_pb2.Result(
     sweep_results=[program_pb2.SweepResult(repetitions=1, measurement_keys=[
         program_pb2.MeasurementKey(
             key='q',
             qubits=[operations_pb2.Qubit(row=1, col=1)])],
-            parameterized_results=[
-                program_pb2.ParameterizedResult(
-                    params=params_pb2.ParameterDict(assignments={'a': 1}),
-                    measurement_results=b'01'),
-                program_pb2.ParameterizedResult(
-                    params=params_pb2.ParameterDict(assignments={'a': 2}),
-                    measurement_results=b'01')])])
+        parameterized_results=[
+        program_pb2.ParameterizedResult(
+            params=params_pb2.ParameterDict(assignments={'a': 1}),
+            measurement_results=b'01'),
+        program_pb2.ParameterizedResult(
+            params=params_pb2.ParameterDict(assignments={'a': 2}),
+            measurement_results=b'01')])])
 
 
 @mock.patch.object(discovery, 'build')
@@ -79,7 +92,7 @@ def test_run_circuit(build):
                                                   '{apiVersion}&key=key'))
     assert programs.create.call_args[1]['parent'] == 'projects/project-id'
     assert jobs.create.call_args[1][
-               'parent'] == 'projects/project-id/programs/test'
+        'parent'] == 'projects/project-id/programs/test'
     assert jobs.get().execute.call_count == 1
     assert jobs.getResult().execute.call_count == 1
 
@@ -197,6 +210,7 @@ def test_default_prefix(build):
     assert programs.create.call_args[1]['body']['gcs_code_location'][
         'uri'].startswith('gs://gqe-project-id/programs/')
 
+
 @mock.patch.object(discovery, 'build')
 def test_run_sweep_params(build):
     service = mock.Mock()
@@ -235,9 +249,9 @@ def test_run_sweep_params(build):
     for i, v in enumerate([1, 2]):
         assert sweeps[i]['repetitions'] == 1
         assert sweeps[i]['sweep']['factors'][0]['sweeps'][0]['points'][
-                   'points'] == [v]
+            'points'] == [v]
     assert jobs.create.call_args[1][
-               'parent'] == 'projects/project-id/programs/test'
+        'parent'] == 'projects/project-id/programs/test'
     assert jobs.get().execute.call_count == 1
     assert jobs.getResult().execute.call_count == 1
 
@@ -279,9 +293,9 @@ def test_run_sweep_sweeps(build):
     assert len(sweeps) == 1
     assert sweeps[0]['repetitions'] == 1
     assert sweeps[0]['sweep']['factors'][0]['sweeps'][0]['points'][
-               'points'] == [1, 2]
+        'points'] == [1, 2]
     assert jobs.create.call_args[1][
-               'parent'] == 'projects/project-id/programs/test'
+        'parent'] == 'projects/project-id/programs/test'
     assert jobs.get().execute.call_count == 1
     assert jobs.getResult().execute.call_count == 1
 
@@ -319,7 +333,7 @@ def test_cancel(build):
                                      'jobs/test')
     assert job.status() == 'CANCELLED'
     assert jobs.cancel.call_args[1][
-               'name'] == 'projects/project-id/programs/test/jobs/test'
+        'name'] == 'projects/project-id/programs/test/jobs/test'
 
 
 @mock.patch.object(discovery, 'build')

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -26,17 +26,17 @@ import cirq.google as cg
 from cirq.api.google.v1 import operations_pb2, params_pb2, program_pb2
 from cirq.testing.mock import mock
 
-
 @cirq.testing.only_test_in_python3
 def test_repr():
     v = cirq.google.JobConfig(project_id='my-project-id',
                               program_id='my-program-id',
                               job_id='my-job-id')
 
-    assert repr(options) == ("JobConfig(project_id='my-project-id', "
-                             "program_id='my-program-id', "
-                             "job_id='my-job-id', gcs_prefix=None, "
-                             "gcs_program=None, gcs_results=None)")
+    assert repr(v) == ("JobConfig(project_id='my-project-id', "
+                         "program_id='my-program-id', "
+                         "job_id='my-job-id', gcs_prefix=None, "
+                         "gcs_program=None, gcs_results=None)")
+
 
 
 _A_RESULT = program_pb2.Result(


### PR DESCRIPTION
Addressing: https://github.com/quantumlib/Cirq/issues/776. I was thinking about implementing an `__str__`, but  I don't know what that would look like. I think `__repr__` is enough for this class.