### PR TITLE
Optimize three qubit gate decompositions

### DIFF
--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -19,7 +19,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 from cirq import linalg
-from cirq.ops import gate_features, common_gates, raw_types
+from cirq.ops import gate_features, common_gates, raw_types, op_tree
 
 
 class _CCZGate(gate_features.ThreeQubitGate,
@@ -31,6 +31,14 @@ class _CCZGate(gate_features.ThreeQubitGate,
     """A doubly-controlled-Z."""
 
     def default_decompose(self, qubits):
+        """An adjacency-respecting decomposition.
+
+        0: ───T───@──────────────@───────@──────────@──────────
+                  │              │       │          │
+        1: ───T───X───@───T^-1───X───@───X──────@───X──────@───
+                      │              │          │          │
+        2: ───T───────X───T──────────X───T^-1───X───T^-1───X───
+        """
         a, b, c = qubits
 
         # Hacky magic: avoid the non-adjacent edge.
@@ -40,26 +48,18 @@ class _CCZGate(gate_features.ThreeQubitGate,
             elif not b.is_adjacent(c):
                 a, b = b, a
 
-        yield common_gates.T.on_each([a, b, c])  # Phase a, b, and c.
-        yield common_gates.CNOT(c, b)
-        yield common_gates.T(b)**-1  # Counter-phase b ⊕ c.
-        yield common_gates.CNOT(a, b)
-        yield common_gates.T(b)  # Phase a ⊕ b ⊕ c.
-        yield common_gates.CNOT(c, b)
-        yield common_gates.T(b)**-1  # Counter-phase a ⊕ b.
-        yield common_gates.CNOT(a, b)
+        t = common_gates.T
+        sweep_abc = [common_gates.CNOT(a, b),
+                     common_gates.CNOT(b, c)]
 
-        # If a then toggle b and c.
-        yield common_gates.CNOT(b, c)
-        yield common_gates.CNOT(a, b)
-        yield common_gates.CNOT(b, c)
-
-        yield common_gates.T(c)**-1  # Counter-phase a ⊕ c.
-
-        # If a then un-toggle b and c.
-        yield common_gates.CNOT(b, c)
-        yield common_gates.CNOT(a, b)
-        yield common_gates.CNOT(b, c)
+        yield t(a), t(b), t(c)
+        yield sweep_abc
+        yield t(b)**-1, t(c)
+        yield sweep_abc
+        yield t(c)**-1
+        yield sweep_abc
+        yield t(c)**-1
+        yield sweep_abc
 
     def matrix(self):
         return np.diag([1, 1, 1, 1, 1, 1, 1, -1])
@@ -132,18 +132,89 @@ class _CSwapGate(gate_features.ThreeQubitGate,
     def default_decompose(self, qubits):
         c, t1, t2 = qubits
 
-        # Hacky magic: cross the non-adjacent edge.
-        need_hop = hasattr(t1, 'is_adjacent') and not t1.is_adjacent(t2)
+        # Hacky magic: special case based on adjacency.
+        if hasattr(t1, 'is_adjacent'):
+            if not t1.is_adjacent(t2):
+                # Targets separated by control.
+                return self._decompose_inside_control(t1, c, t2)
+            if not t1.is_adjacent(c):
+                # Control separated from t1 by t2.
+                return self._decompose_outside_control(c, t2, t1)
 
-        cnot = common_gates.CNOT(t2, t1) if not need_hop else [
-            common_gates.CNOT(t2, c),
-            common_gates.CNOT(c, t1),
-            common_gates.CNOT(t2, c),
-            common_gates.CNOT(c, t1),
-        ]
-        yield cnot
-        yield TOFFOLI(c, t1, t2)
-        yield cnot
+        return self._decompose_outside_control(c, t1, t2)
+
+    def _decompose_inside_control(self,
+                                  target1: raw_types.QubitId,
+                                  control: raw_types.QubitId,
+                                  target2: raw_types.QubitId
+                                  ) -> op_tree.OP_TREE:
+        """A decomposition assuming the control separates the targets.
+
+        target1: ─@─X───────T──────@────────@─────────X───@─────X^-0.5─
+                  │ │              │        │         │   │
+        control: ─X─@─X─────@─T^-1─X─@─T────X─@─X^0.5─@─@─X─@──────────
+                      │     │        │        │         │   │
+        target2: ─────@─H─T─X─T──────X─T^-1───X─T^-1────X───X─H─S^-1───
+        """
+        a, b, c = target1, control, target2
+        yield common_gates.CNOT(a, b)
+        yield common_gates.CNOT(b, a)
+        yield common_gates.CNOT(c, b)
+        yield common_gates.H(c)
+        yield common_gates.T(c)
+        yield common_gates.CNOT(b, c)
+        yield common_gates.T(a)
+        yield common_gates.T(b)**-1
+        yield common_gates.T(c)
+        yield common_gates.CNOT(a, b)
+        yield common_gates.CNOT(b, c)
+        yield common_gates.T(b)
+        yield common_gates.T(c)**-1
+        yield common_gates.CNOT(a, b)
+        yield common_gates.CNOT(b, c)
+        yield common_gates.X(b)**0.5
+        yield common_gates.T(c)**-1
+        yield common_gates.CNOT(b, a)
+        yield common_gates.CNOT(b, c)
+        yield common_gates.CNOT(a, b)
+        yield common_gates.CNOT(b, c)
+        yield common_gates.H(c)
+        yield common_gates.S(c)**-1
+        yield common_gates.X(a)**-0.5
+
+    def _decompose_outside_control(self,
+                                   control: raw_types.QubitId,
+                                   near_target: raw_types.QubitId,
+                                   far_target: raw_types.QubitId
+                                   ) -> op_tree.OP_TREE:
+        """A decomposition assuming one of the targets is in the middle.
+
+        control: ───T──────@────────@───@────────────@────────────────
+                           │        │   │            │
+           near: ─X─T──────X─@─T^-1─X─@─X────@─X^0.5─X─@─X^0.5────────
+                  │          │        │      │         │
+            far: ─@─Y^-0.5─T─X─T──────X─T^-1─X─T^-1────X─S─────X^-0.5─
+        """
+        a, b, c = control, near_target, far_target
+
+        t = common_gates.T
+        sweep_abc = [common_gates.CNOT(a, b),
+                     common_gates.CNOT(b, c)]
+
+        yield common_gates.CNOT(c, b)
+        yield common_gates.Y(c)**-0.5
+        yield t(a), t(b), t(c)
+        yield sweep_abc
+        yield t(b) ** -1, t(c)
+        yield sweep_abc
+        yield t(c) ** -1
+        yield sweep_abc
+        yield t(c) ** -1
+        yield common_gates.X(b)**0.5
+        yield sweep_abc
+        yield common_gates.S(c)
+        yield common_gates.X(b)**0.5
+        yield common_gates.X(c)**-0.5
 
     def matrix(self):
         return linalg.block_diag(np.diag([1, 1, 1, 1, 1]),

--- a/cirq/ops/three_qubit_gates_test.py
+++ b/cirq/ops/three_qubit_gates_test.py
@@ -76,16 +76,41 @@ def test_eq():
     eq.add_equality_group(cirq.CSWAP(b, a, c), cirq.CSWAP(b, c, a))
 
 
+@pytest.mark.parametrize('op,max_two_cost', [
+    (cirq.CCZ(*cirq.LineQubit.range(3)), 8),
+    (cirq.CCX(*cirq.LineQubit.range(3)), 8),
+    (cirq.CCZ(cirq.LineQubit(0),
+              cirq.LineQubit(2),
+              cirq.LineQubit(1)), 8),
+    (cirq.CSWAP(*cirq.LineQubit.range(3)), 9),
+    (cirq.CSWAP(*reversed(cirq.LineQubit.range(3))), 9),
+    (cirq.CSWAP(cirq.LineQubit(1),
+                cirq.LineQubit(0),
+                cirq.LineQubit(2)), 12),
+])
+def test_decomposition_cost(op: cirq.Operation, max_two_cost: int):
+    ops = tuple(
+        cirq.flatten_op_tree(cirq.google.ConvertToXmonGates().convert(op)))
+    two_cost = len([e for e in ops if len(e.qubits) == 2])
+    over_cost = len([e for e in ops if len(e.qubits) > 2])
+    assert over_cost == 0
+    assert two_cost == max_two_cost
+
+
 @pytest.mark.parametrize('gate', [
     cirq.CCX, cirq.CSWAP, cirq.CCZ,
 ])
 def test_decomposition_matches_matrix(gate):
-    cirq.testing.assert_allclose_up_to_global_phase(
-        gate.matrix(),
-        cirq.Circuit.from_ops(
-            gate.default_decompose(cirq.LineQubit.range(3))
-        ).to_unitary_matrix(),
-        atol=1e-8)
+    a, b, c = cirq.LineQubit.range(3)
+    for x, y, z in itertools.permutations([a, b, c]):
+        cirq.testing.assert_allclose_up_to_global_phase(
+            cirq.Circuit.from_ops(
+                gate(x, y, z)
+            ).to_unitary_matrix(),
+            cirq.Circuit.from_ops(
+                gate.default_decompose((x, y, z))
+            ).to_unitary_matrix(),
+            atol=1e-8)
 
 
 @pytest.mark.parametrize('gate', [


### PR DESCRIPTION
- Improve CCZ and Toffoli's two-cost from 10 to 8
- Improve CSWAP's two-cost from 14 to 9 for outside controls and 12 for inside controls
- Check all qubit permutations when testing matrix equivalence