### PR TITLE
Support CircuitDag equality

### DIFF
--- a/cirq/circuits/circuit_dag.py
+++ b/cirq/circuits/circuit_dag.py
@@ -14,6 +14,7 @@
 
 from typing import Any, Callable, Dict, Generic, Iterator, TypeVar
 
+import functools
 import networkx
 
 from cirq import ops, devices
@@ -22,6 +23,7 @@ from cirq.circuits import circuit
 
 T = TypeVar('T')
 
+@functools.total_ordering
 class Unique(Generic[T]):
     """A wrapper for a value that doesn't compare equal to other instances.
 
@@ -41,7 +43,7 @@ class Unique(Generic[T]):
     def __lt__(self, other):
         if not isinstance(other, type(self)):
             return NotImplemented
-        return hash(self) < hash(other)
+        return id(self) < id(other)
 
 
 def _disjoint_qubits(op1: ops.Operation, op2: ops.Operation) -> bool:

--- a/cirq/circuits/circuit_dag_test.py
+++ b/cirq/circuits/circuit_dag_test.py
@@ -28,10 +28,28 @@ def test_wrapper_eq():
     eq.add_equality_group(cirq.CircuitDag.make_node(cirq.X(q1)))
 
 
-def test_wrapper_ordering():
-    # TODO: Use OrderTester when it is finished
+def test_wrapper_cmp():
+    u0 = cirq.Unique(0)
+    u1 = cirq.Unique(1)
+    if u1 < u0:
+        # The ordering of Unique instances is unpredictable
+        u0, u1 = u1, u0
+    assert u0 == u0
+    assert u0 != u1
+    assert u0 <  u1
+    assert u1 >  u0
+    assert u0 <= u0
+    assert u0 <= u1
+    assert u0 >= u0
+    assert u1 >= u0
+
+
+@cirq.testing.only_test_in_python3
+def test_wrapper_cmp_failure():
     with pytest.raises(TypeError):
-        cirq.Unique(5) < object()
+        _ = object() < cirq.Unique(1)
+    with pytest.raises(TypeError):
+        _ = cirq.Unique(1) < object()
 
 
 def test_wrapper_repr():

--- a/cirq/circuits/circuit_dag_test.py
+++ b/cirq/circuits/circuit_dag_test.py
@@ -31,9 +31,8 @@ def test_wrapper_eq():
 def test_wrapper_cmp():
     u0 = cirq.Unique(0)
     u1 = cirq.Unique(1)
-    if u1 < u0:
-        # The ordering of Unique instances is unpredictable
-        u0, u1 = u1, u0
+    # The ordering of Unique instances is unpredictable
+    u0, u1 = (u1, u0) if u1 < u0 else (u0, u1)
     assert u0 == u0
     assert u0 != u1
     assert u0 <  u1

--- a/cirq/circuits/circuit_dag_test.py
+++ b/cirq/circuits/circuit_dag_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import networkx
 
 import cirq
@@ -24,6 +26,12 @@ def test_wrapper_eq():
     eq.add_equality_group(cirq.CircuitDag.make_node(cirq.X(q0)))
     eq.add_equality_group(cirq.CircuitDag.make_node(cirq.Y(q0)))
     eq.add_equality_group(cirq.CircuitDag.make_node(cirq.X(q1)))
+
+
+def test_wrapper_ordering():
+    # TODO: Use OrderTester when it is finished
+    with pytest.raises(TypeError):
+        cirq.Unique(5) < object()
 
 
 def test_wrapper_repr():

--- a/cirq/circuits/circuit_dag_test.py
+++ b/cirq/circuits/circuit_dag_test.py
@@ -128,6 +128,57 @@ def test_to_circuit():
         atol=1e-7)
 
 
+def test_equality():
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit1 = cirq.Circuit.from_ops(
+        cirq.X(q0),
+        cirq.Y(q0),
+        cirq.Z(q1),
+        cirq.CZ(q0, q1),
+        cirq.X(q1),
+        cirq.Y(q1),
+        cirq.Z(q0),
+    )
+    circuit2 = cirq.Circuit.from_ops(
+        cirq.Z(q1),
+        cirq.X(q0),
+        cirq.Y(q0),
+        cirq.CZ(q0, q1),
+        cirq.Z(q0),
+        cirq.X(q1),
+        cirq.Y(q1),
+    )
+    circuit3 = cirq.Circuit.from_ops(
+        cirq.X(q0),
+        cirq.Y(q0),
+        cirq.Z(q1),
+        cirq.CZ(q0, q1),
+        cirq.X(q1),
+        cirq.Y(q1),
+        cirq.Z(q0) ** 0.5,
+    )
+    circuit4 = cirq.Circuit.from_ops(
+        cirq.X(q0),
+        cirq.Y(q0),
+        cirq.Z(q1),
+        cirq.CZ(q0, q1),
+        cirq.X(q1),
+        cirq.Y(q1),
+    )
+
+    eq = cirq.testing.EqualsTester()
+    eq.make_equality_group(
+        lambda: cirq.CircuitDag.from_circuit(circuit1),
+        lambda: cirq.CircuitDag.from_circuit(circuit2),
+    )
+    eq.add_equality_group(
+        cirq.CircuitDag.from_circuit(circuit3),
+    )
+    eq.add_equality_group(
+        cirq.CircuitDag.from_circuit(circuit4),
+    )
+
+
 def test_larger_circuit():
     q0, q1, q2, q3 = cirq.google.Bristlecone.col(5)[:4]
     # This circuit does not have CZ gates on adjacent qubits because the order


### PR DESCRIPTION
Resolves #846.

networkx.is_isomorphic() seems to require that nodes have a total ordering.  Right now I have only implemented `__lt__` for Unique.

Testing the ordering operators on Unique will be much easier once #568 is finished.