### PR TITLE
Allow ParamResolver to resolve values into Symbols

### DIFF
--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -32,7 +32,7 @@ class ParamResolver(object):
             assigned value.
     """
 
-    def __init__(self, param_dict: Dict[str, float]) -> None:
+    def __init__(self, param_dict: Dict[str, Union[float, Symbol]]) -> None:
         self.param_dict = param_dict
         self._param_hash = hash(frozenset(param_dict.items()))
 
@@ -46,8 +46,7 @@ class ParamResolver(object):
         If unable to resolve a name, returns a Symbol with that name.
 
         Args:
-            value: The Symbol or name or float to try to resolve into just
-                a float.
+            value: The Symbol or name or float to try to resolve.
 
         Returns:
             The value of the parameter as resolved by this resolver.


### PR DESCRIPTION
Here is the use case I have in mind. I want to define a parameterized operation. Then, I want to define something which has this parameterized operation repeated a bunch of times, but with each repetition introducing a new set of parameters. Concretely, the parameterized operation could be a Trotter step with angle names of the form `T_j` and I want to define a variational ansatz which has multiple repetitions, so the first repetition would have angles named `T_j-0` and the second angles named `T_j-1`, etc. I think a nice way to do this is to make the Trotter step a ParameterizableEffect and then use ParamResolvers to rename the Symbols as appropriate.