### PR TITLE
Update numpy version for python2 from 1.13 to 1.14 and remove "docs/" path for relative links.

### DIFF
--- a/docs/gates.md
+++ b/docs/gates.md
@@ -27,7 +27,7 @@ For example, one feature is ``ReversibleEffect``.
 A ``Gate`` that inherits this class is required to implement the method ``inverse`` which returns the inverse gate.
 Algorithms that operate on gates can use ``isinstance(gate, ReversibleEffect)`` to determine whether gates implements ``inverse`` method, and then use it.
 (Note that, even if the gate is not reversible, the algorithm may have been given an ``Extension`` with a cast from the gate to ``ReversibleEffect``.
-See the [extensions documentation](docs/extensions.md) for more information.)
+See the [extensions documentation](extensions.md) for more information.)
 
 We describe some gate features below.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -201,7 +201,7 @@ Here we see that we can iterate over a `Circuit`'s `Moment`s. The reason
 that two `Moment`s were created was that the `append` method uses an
 `InsertStrategy` of `NEW_THEN_INLINE`. `InsertStrategy`s describe
 how new insertions into `Circuit`s place their gates. Details of these
-strategies can be found in the [circuit documentation](/docs/circuits.md).  If
+strategies can be found in the [circuit documentation](circuits.md).  If
 we wanted to insert the gates so that they form one `Moment`, we could 
 instead use the `EARLIEST` insertion strategy:
 ```python

--- a/python2.7-requirements.txt
+++ b/python2.7-requirements.txt
@@ -3,7 +3,7 @@
 google-api-python-client~=1.6
 matplotlib~=2.1
 networkx~=2.1
-numpy~=1.13
+numpy~=1.14
 protobuf~=3.5
 sortedcontainers~=1.5
 typing~=3.6


### PR DESCRIPTION
Addressing: https://github.com/quantumlib/Cirq/issues/823 and https://github.com/quantumlib/Cirq/issues/857. While we are at it, should we update both versions to the latest numpy (1.15)?