### PR TITLE
Moving duration keyword for angles in from OpenFermion-Cirq

### DIFF
--- a/cirq/value/angle.py
+++ b/cirq/value/angle.py
@@ -23,32 +23,38 @@ def chosen_angle_to_half_turns(
         half_turns: Optional[Union[symbol.Symbol, float]] = None,
         rads: Optional[float] = None,
         degs: Optional[float] = None,
+        duration: Optional[float] = None,
         default: float = 1.0,
 ) -> Union[symbol.Symbol, float]:
     """Returns a half_turns value based on the given arguments.
 
-    At most one of half_turns, rads, degs must be specified. If none are
-    specified, the output defaults to half_turns=1.
+    At most one of half_turns, rads, degs, or duration must be specified. If
+    none are specified, the output defaults to half_turns=1.
 
     Args:
         half_turns: The number of half turns to rotate by.
         rads: The number of radians to rotate by.
-        degs: The number of degrees to rotate by
+        degs: The number of degrees to rotate by.
+        duration: The exponent as a duration of time.
         default: The half turns angle to use if nothing else is specified.
 
     Returns:
         A number of half turns.
     """
 
-    if len([1 for e in [half_turns, rads, degs] if e is not None]) > 1:
+    if len([1 for e in [half_turns, rads, degs, duration]
+            if e is not None]) > 1:
         raise ValueError('Redundant angle specification. '
-                         'Use ONE of half_turns, rads, or degs.')
+                         'Use ONE of half_turns, rads, degs, or duration.')
 
     if rads is not None:
         return rads / np.pi
 
     if degs is not None:
         return degs / 180
+
+    if duration is not None:
+        return 2 * duration / np.pi
 
     if half_turns is not None:
         return half_turns
@@ -60,28 +66,31 @@ def chosen_angle_to_canonical_half_turns(
         half_turns: Optional[Union[symbol.Symbol, float]] = None,
         rads: Optional[float] = None,
         degs: Optional[float] = None,
+        duration: Optional[float] = None,
         default: float = 1.0,
 ) -> Union[symbol.Symbol, float]:
     """Returns a canonicalized half_turns based on the given arguments.
 
-    At most one of half_turns, rads, degs must be specified. If none are
-    specified, the output defaults to half_turns=1.
+    At most one of half_turns, rads, degs, or duration must be specified. If
+    none are specified, the output defaults to half_turns=1.
 
     Args:
         half_turns: The number of half turns to rotate by.
         rads: The number of radians to rotate by.
-        degs: The number of degrees to rotate by
+        degs: The number of degrees to rotate by.
+        duration: The exponent as a duration of time.
         default: The half turns angle to use if nothing else is specified.
 
     Returns:
         A number of half turns.
     """
     return canonicalize_half_turns(
-            chosen_angle_to_half_turns(
-                half_turns=half_turns,
-                rads=rads,
-                degs=degs,
-                default=default))
+        chosen_angle_to_half_turns(
+            half_turns=half_turns,
+            rads=rads,
+            degs=degs,
+            duration=duration,
+            default=default))
 
 
 def canonicalize_half_turns(
@@ -94,5 +103,3 @@ def canonicalize_half_turns(
     if half_turns > 1:
         half_turns -= 2
     return half_turns
-
-

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -33,13 +33,21 @@ def test_chosen_angle_to_half_turns():
     assert cirq.chosen_angle_to_half_turns() == 1
     assert cirq.chosen_angle_to_half_turns(default=0.5) == 0.5
     assert cirq.chosen_angle_to_half_turns(half_turns=0.25,
-                                                     default=0.75) == 0.25
+                                           default=0.75) == 0.25
     np.testing.assert_allclose(
         cirq.chosen_angle_to_half_turns(rads=np.pi/2),
         0.5,
         atol=1e-8)
     np.testing.assert_allclose(
         cirq.chosen_angle_to_half_turns(rads=-np.pi/4),
+        -0.25,
+        atol=1e-8)
+    np.testing.assert_allclose(
+        cirq.chosen_angle_to_half_turns(duration=3*np.pi/4),
+        1.5,
+        atol=1e-8)
+    np.testing.assert_allclose(
+        cirq.chosen_angle_to_half_turns(duration=-np.pi/8),
         -0.25,
         atol=1e-8)
     assert cirq.chosen_angle_to_half_turns(degs=90) == 0.5
@@ -53,9 +61,18 @@ def test_chosen_angle_to_half_turns():
     with pytest.raises(ValueError):
         _ = cirq.chosen_angle_to_half_turns(degs=0, rads=0)
     with pytest.raises(ValueError):
-        _ = cirq.chosen_angle_to_half_turns(half_turns=0,
-                                                      rads=0,
-                                                      degs=0)
+        _ = cirq.chosen_angle_to_half_turns(half_turns=0, rads=0, degs=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(duration=0, half_turns=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(degs=0, duration=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(duration=0, rads=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(duration=0, degs=0, half_turns=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_half_turns(rads=0, duration=0,
+                                            degs=0, half_turns=0)
 
 
 def test_chosen_angle_to_canonical_half_turns():
@@ -71,6 +88,14 @@ def test_chosen_angle_to_canonical_half_turns():
         cirq.chosen_angle_to_canonical_half_turns(rads=-np.pi/4),
         -0.25,
         atol=1e-8)
+    np.testing.assert_allclose(
+        cirq.chosen_angle_to_canonical_half_turns(duration=-np.pi/4),
+        -0.5,
+        atol=1e-8)
+    np.testing.assert_allclose(
+        cirq.chosen_angle_to_canonical_half_turns(duration=3*np.pi/8),
+        0.75,
+        atol=1e-8)
     assert cirq.chosen_angle_to_canonical_half_turns(degs=90) == 0.5
     assert cirq.chosen_angle_to_canonical_half_turns(degs=1080) == 0
     assert cirq.chosen_angle_to_canonical_half_turns(degs=990) == -0.5
@@ -85,3 +110,15 @@ def test_chosen_angle_to_canonical_half_turns():
         _ = cirq.chosen_angle_to_canonical_half_turns(half_turns=0,
                                                       rads=0,
                                                       degs=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_canonical_half_turns(duration=0,
+                                                      half_turns=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_canonical_half_turns(duration=0, degs=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_canonical_half_turns(rads=0, duration=0)
+    with pytest.raises(ValueError):
+        _ = cirq.chosen_angle_to_canonical_half_turns(half_turns=0,
+                                                      rads=0,
+                                                      degs=0,
+                                                      duration=0)


### PR DESCRIPTION
Added `duration` (time-based) keyword to `chosen_angle_to_half_turns` and `chosen_angle_to_canonical_half_turns` from OpenFermion-Cirq. Should allow a fair amount of boilerplate removal from OpenFermion-Cirq.