### PR TITLE
Implement wavefunction pretty printer

### DIFF
--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -94,6 +94,31 @@ def simulate(simulator, circuit, scheduler, **kw):
     return simulator.simulate(program, **kw)
 
 
+def test_wavefunction():
+    simulator = cirq.google.XmonSimulator()
+
+    hadamard = cirq.Circuit.from_ops(cirq.H(Q1))
+    result = simulator.simulate(hadamard)
+    assert simulator.wavefunction(result) == "-0.71j|0> + -0.71j|1>"
+
+    bell00 = cirq.Circuit.from_ops(cirq.H(Q1), cirq.CNOT(Q1, Q2))
+    result = simulator.simulate(bell00)
+    assert simulator.wavefunction(result) == "(0.71+0j)|00> + (0.71+0j)|11>"
+
+    bell01 = cirq.Circuit.from_ops(cirq.X(Q2), cirq.H(Q1), cirq.CNOT(Q1, Q2))
+    result = simulator.simulate(bell01)
+    assert simulator.wavefunction(result) == "-0.71j|01> + -0.71j|10>"
+
+    bell10 = cirq.Circuit.from_ops(cirq.X(Q1), cirq.H(Q1), cirq.CNOT(Q1, Q2))
+    result = simulator.simulate(bell10)
+    assert simulator.wavefunction(result) == "-0.71j|00> + 0.71j|11>"
+
+    bell11 = cirq.Circuit.from_ops(
+        cirq.X(Q1), cirq.X(Q2), cirq.H(Q1), cirq.CNOT(Q1, Q2))
+    result = simulator.simulate(bell11)
+    assert simulator.wavefunction(result) == "(-0.71+0j)|01> + (0.71+0j)|10>"
+
+
 SCHEDULERS = [None, cirq.moment_by_moment_schedule]
 
 


### PR DESCRIPTION
The wavefunction vector is sometimes hard to read. This procedure could help for debugging  and quantum programming in general.

Example:

```
import cirq

Q1 = cirq.GridQubit(0, 0)

circuit = cirq.Circuit.from_ops(cirq.H(Q1))
simulator = cirq.google.XmonSimulator()
result = simulator.simulate(circuit)

print(simulator.wavefunction(result))
```