### PR TITLE
Reduce minimum required python version to 3.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,21 @@ matrix:
   include:
   - os: linux
     env: NAME=mypy
-    python: "3.5"
+    python: "3.5.2"
     install:
       - cat dev_tools/conf/pip-list-dev-tools.txt | grep mypy | xargs pip install
     script: check/mypy
 
   - os: linux
     env: NAME=pylint
-    python: "3.5"
+    python: "3.5.2"
     install:
       - cat dev_tools/conf/pip-list-dev-tools.txt | grep pylint | xargs pip install
     script: check/pylint
 
   - os: linux
     env: NAME=pytest-and-incremental-coverage
-    python: "3.5"
+    python: "3.5.2"
     install:
       - pip install -r requirements.txt
       - pip install -r dev_tools/conf/pip-list-dev-tools.txt

--- a/python2.7-generate.sh
+++ b/python2.7-generate.sh
@@ -83,8 +83,8 @@ cp "${in_dir}/LICENSE" "${out_dir}/LICENSE"
 cp "${in_dir}/setup.py" "${out_dir}/setup.py"
 
 # Substitute versions (failing via grep triggering -e if not present.)
-grep "python_requires='>=3.5.3'" "${out_dir}/setup.py" > /dev/null
-sed -i "s/python_requires='>=3.5.3'/python_requires='==2.7.*'/" "${out_dir}/setup.py"
+grep "python_requires='>=3.5.2'" "${out_dir}/setup.py" > /dev/null
+sed -i "s/python_requires='>=3.5.2'/python_requires='==2.7.*'/" "${out_dir}/setup.py"
 
 # Mark every file as using utf8 encoding.
 files_to_update=$(find ${out_dir} | grep "\.py$" | grep -v "_pb2\.py$")

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq@googlegroups.com',
-    python_requires='>=3.5.3',
+    python_requires='>=3.5.2',
     install_requires=requirements,
     license='Apache 2',
     description=description,


### PR DESCRIPTION
This is the version included in Ubuntu 16.04, so a fairly common thing
that we should support if possible. See #710.