### PR TITLE
Add eq, ne, and hash to Pauli

### DIFF
--- a/cirq/ops/pauli.py
+++ b/cirq/ops/pauli.py
@@ -39,6 +39,14 @@ class Pauli:
     def difference(self, second: 'Pauli') -> int:
         return (self._index - second._index + 1) % 3 - 1
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self._index == other._index
+
+    def __ne__(self, other):
+        return not self == other
+
     def __gt__(self, other):
         if not isinstance(other, type(self)):
             return NotImplemented
@@ -51,6 +59,9 @@ class Pauli:
 
     def __add__(self, shift: int) -> 'Pauli':
         return Pauli.XYZ[(self._index + shift) % 3]
+
+    def __hash__(self):
+        return hash(self._index)
 
     # pylint: disable=function-redefined
     @overload

--- a/cirq/ops/pauli_test.py
+++ b/cirq/ops/pauli_test.py
@@ -18,9 +18,9 @@ import cirq
 
 def test_equals():
     eq = cirq.testing.EqualsTester()
-    eq.add_equality_group(cirq.Pauli.X)
-    eq.add_equality_group(cirq.Pauli.Y)
-    eq.add_equality_group(cirq.Pauli.Z)
+    eq.add_equality_group(cirq.Pauli.X, cirq.Pauli(_index=0, _name='X'))
+    eq.add_equality_group(cirq.Pauli.Y, cirq.Pauli(_index=1, _name='Y'))
+    eq.add_equality_group(cirq.Pauli.Z, cirq.Pauli(_index=2, _name='Z'))
 
 
 def test_singletons():


### PR DESCRIPTION
Equality test was passing because it was falling back to object equals and equality groups only had one element.  