### PR TITLE
Removes expensive executor test

### DIFF
--- a/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq/contrib/acquaintance/executor_test.py
@@ -155,8 +155,8 @@ def random_diagonal_gates(n_qubits: int,
       for acquaintance_size, n_qubits in
       ([(2, n) for n in range(2, 9)] +
        [(3, n) for n in range(3, 9)] +
-       [(4, n) for n in (4, 7)] +
-       [(5, n) for n in (5, 8)])
+       [(4, n) for n in (4, 7)] + 
+       [(5, n) for n in (5, 6)])
       for _ in range(2)
       ])
 def test_executor_random(n_qubits: int,

--- a/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq/contrib/acquaintance/executor_test.py
@@ -155,7 +155,7 @@ def random_diagonal_gates(n_qubits: int,
       for acquaintance_size, n_qubits in
       ([(2, n) for n in range(2, 9)] +
        [(3, n) for n in range(3, 9)] +
-       [(4, n) for n in (4, 7)] + 
+       [(4, n) for n in (4, 7)] +
        [(5, n) for n in (5, 6)])
       for _ in range(2)
       ])


### PR DESCRIPTION
Addresses #880.

The costly test was creating two 8-qubit unitaries to compare. Would using the simulator (and comparing only a sample of states) be significantly faster (i.e. fast enough)?