### PR TITLE
Fix precision in decomposition_test.py

### DIFF
--- a/cirq/decompositions_test.py
+++ b/cirq/decompositions_test.py
@@ -15,7 +15,7 @@
 import cmath
 import math
 import random
-from typing import List, Sequence, cast
+from typing import Sequence, cast
 
 import numpy as np
 import pytest

--- a/cirq/decompositions_test.py
+++ b/cirq/decompositions_test.py
@@ -187,21 +187,18 @@ def test_single_qubit_op_to_framed_phase_form_equivalent_on_known_and_random(
 def test_controlled_op_to_operations_concrete_case():
     c = cirq.NamedQubit('c')
     t = cirq.NamedQubit('t')
+    expected = [cirq.Y(t)**-0.5, cirq.CZ(c, t)**1.5,
+                cirq.Z(c)**0.25, cirq.Y(t)**0.5]
     operations = cirq.controlled_op_to_operations(
         control=c,
         target=t,
         operation=np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5),
         tolerance=0.0001)
     # Test closeness as opposed to equality to avoid precision errors
-    assert cirq.allclose_up_to_global_phase(operations[0].matrix(),
-                                            (cirq.Y(t)**-0.5).matrix())
-    assert cirq.allclose_up_to_global_phase(operations[1].matrix(),
-                                            (cirq.CZ(c, t)**1.5).matrix())
-    assert cirq.allclose_up_to_global_phase(operations[2].matrix(),
-                                            (cirq.Z(t)**0.25).matrix())
-    assert cirq.allclose_up_to_global_phase(operations[3].matrix(),
-                                            (cirq.Y(t)**0.5).matrix())
-
+    for actual_op, expected_op in zip(operations, expected):
+        assert cirq.allclose_up_to_global_phase(actual_op.matrix(),
+                                              expected_op.matrix(),
+                                              atol=1e-8)
 
 def test_controlled_op_to_operations_omits_negligible_global_phase():
     qc = cirq.QubitId()

--- a/cirq/decompositions_test.py
+++ b/cirq/decompositions_test.py
@@ -197,8 +197,8 @@ def test_controlled_op_to_operations_concrete_case():
     # Test closeness as opposed to equality to avoid precision errors
     for actual_op, expected_op in zip(operations, expected):
         assert cirq.allclose_up_to_global_phase(actual_op.matrix(),
-                                              expected_op.matrix(),
-                                              atol=1e-8)
+                                                expected_op.matrix(),
+                                                atol=1e-8)
 
 def test_controlled_op_to_operations_omits_negligible_global_phase():
     qc = cirq.QubitId()

--- a/cirq/decompositions_test.py
+++ b/cirq/decompositions_test.py
@@ -15,13 +15,12 @@
 import cmath
 import math
 import random
-from typing import Sequence, cast
+from typing import List, Sequence, cast
 
 import numpy as np
 import pytest
 
 import cirq
-
 
 def _operations_to_matrix(operations, qubits):
     return cirq.Circuit.from_ops(operations).to_unitary_matrix(
@@ -34,7 +33,6 @@ def _gates_to_matrix(gates: Sequence[cirq.KnownMatrix]) -> np.ndarray:
     for gate in gates[1:]:
         m = gate.matrix().dot(m)
     return m
-
 
 def assert_gates_implement_unitary(gates: Sequence[cirq.SingleQubitGate],
                                    intended_effect: np.ndarray,
@@ -194,9 +192,15 @@ def test_controlled_op_to_operations_concrete_case():
         target=t,
         operation=np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5),
         tolerance=0.0001)
-
-    assert operations == [cirq.Y(t)**-0.5, cirq.CZ(c, t)**1.5,
-                          cirq.Z(c)**0.25, cirq.Y(t)**0.5]
+    # Test closeness as opposed to equality to avoid precision errors
+    assert cirq.allclose_up_to_global_phase(operations[0].matrix(),
+                                            (cirq.Y(t)**-0.5).matrix())
+    assert cirq.allclose_up_to_global_phase(operations[1].matrix(),
+                                            (cirq.CZ(c, t)**1.5).matrix())
+    assert cirq.allclose_up_to_global_phase(operations[2].matrix(),
+                                            (cirq.Z(t)**0.25).matrix())
+    assert cirq.allclose_up_to_global_phase(operations[3].matrix(),
+                                            (cirq.Y(t)**0.5).matrix())
 
 
 def test_controlled_op_to_operations_omits_negligible_global_phase():

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,9 +1,9 @@
 # Tutorial
 
 In this tutorial we will go from knowing nothing about Cirq to creating a
-[quantum variational algorithm](https://arxiv.org/abs/1304.3061). 
-Note that this tutorial isn't a quantum computing 101 tutorial, 
-we assume familiarity of quantum computing at about the level of 
+[quantum variational algorithm](https://arxiv.org/abs/1304.3061).
+Note that this tutorial isn't a quantum computing 101 tutorial,
+we assume familiarity of quantum computing at about the level of
 the textbook "Quantum Computation and Quantum Information" by
 Nielsen and Chuang. For a more conceptual overview see the
 [conceptual documentation](table_of_contents.md).
@@ -13,23 +13,23 @@ To begin, please follow the instructions for [installing Cirq](install.md).
 ### Background: Variational quantum algorithms
 
 The [variational method](https://en.wikipedia.org/wiki/Variational_method_(quantum_mechanics))
-in quantum theory is a classical method for finding low energy states 
-of a quantum system. The rough idea of this method is that one defines 
-a trial wave function (sometimes called an ansatz) as a function 
-of some parameters, and then one finds the values of these 
-parameters that minimize the expectation value of the energy 
-with respect to these parameters. This minimized anstaz is then 
-an approximation to the lowest energy eigenstate, and 
+in quantum theory is a classical method for finding low energy states
+of a quantum system. The rough idea of this method is that one defines
+a trial wave function (sometimes called an ansatz) as a function
+of some parameters, and then one finds the values of these
+parameters that minimize the expectation value of the energy
+with respect to these parameters. This minimized ansatz is then
+an approximation to the lowest energy eigenstate, and
 the expectation value serves as an upper bound on the energy of the
 ground state.
 
 In the last few years (see [arXiv:1304.3061](https://arxiv.org/abs/1304.3061)
-and [arXiv:1507.08969](https://arxiv.org/abs/1507.08969) for example), it 
+and [arXiv:1507.08969](https://arxiv.org/abs/1507.08969) for example), it
 has been realized that quantum computers can mimic the
 classical technique and that a quantum computer does so with certain
 advantages.  In particular, when one applies the classical variational
 method to a system of `n` qubits, an exponential number (in `n`)
-of complex numbers are necessary to generically represent the 
+of complex numbers are necessary to generically represent the
 wave function of the system.  However with a quantum computer one
 can directly produce this state using a parameterized quantum
 circuit, and then by repeated measurements estimate the expectation
@@ -38,16 +38,16 @@ value of the energy.
 This idea has led to a class of algorithms known as variational quantum
 algorithms. Indeed this approach is not just limited to finding low
 energy eigenstates, but minimizing any objective function that can
-be expressed as a quantum observable. It is an open question to identify 
-under what conditions these quantum variataional algorithms will succeed, 
-and exploring this class of algorithms is a key part of research 
+be expressed as a quantum observable. It is an open question to identify
+under what conditions these quantum variataional algorithms will succeed,
+and exploring this class of algorithms is a key part of research
 for [noisy intermediate scale quantum computers](https://arxiv.org/abs/1801.00862).
 
 The classical problem we will focus on is the 2D +/- Ising model with
 transverse field ([ISING](http://iopscience.iop.org/article/10.1088/0305-4470/15/10/028/meta)).
-This problem is NP-complete so it is highly unlikely that 
+This problem is NP-complete.  So it is highly unlikely that
 quantum computers will be able to efficiently solve it
-across all instances.  Yet this type of problem is illustrative of 
+across all instances.  Yet this type of problem is illustrative of
 the general class of problems that Cirq is designed to tackle.
 
 Consider the energy function
@@ -61,7 +61,7 @@ The problem we would like to solve is, given J<sub>i,j</sub>, and h<sub>i</sub>,
 find an assignment of s<sub>i</sub> values that minimize E.
 
 How does a variational quantum algorithm work for this? One approach is
-to consider `n` qubits and associate them with each of the bits in the 
+to consider `n` qubits and associate them with each of the bits in the
 classical problem.  This maps the classical problem onto the quantum problem
 of minimizing the expectation value of the observable
 
@@ -85,7 +85,7 @@ given ansatz state by
 3. Goto 1.
 
 Note that one cannot always measure H directly (without
-the use of quantum phase estimation), so one often relies
+the use of quantum phase estimation).  So one often relies
 on the linearity of expectation values to measure parts of
 H in step 2. One always needs to repeat the measurements to
 obtain an estimate of the expectation value. How many measurements
@@ -103,19 +103,19 @@ lowest possible value of the objective function.
 
 ### Create a circuit on a Grid
 
-To build the above variational quantum algorithm using Cirq, 
+To build the above variational quantum algorithm using Cirq,
 one begins by building the appropriate [circuit](circuits.md).
 In Cirq circuits are represented either by a `Circuit` object
-or a `Schedule` object.  `Schedule`s offer more control over 
-quantum gates and circuits at the timing level, which we do not 
+or a `Schedule` object.  `Schedule`s offer more control over
+quantum gates and circuits at the timing level, which we do not
 need, so here we will work with `Circuit`s instead.
 
 Conceptually: a `Circuit` is a collection of ``Moments``. A
 `Moment` is a collection of ``Operations`` that all act during
 the same abstract time slice. An `Operation` is a an effect
 that operates on a specific subset of ``Qubits``.
-The most common type of `Operation` is a `Gate` applied 
-to several qubits (a `GateOperation`). The following diagram 
+The most common type of `Operation` is a `Gate` applied
+to several qubits (a `GateOperation`). The following diagram
 should help illustrate these concepts.
 
 ![Circuits and Moments](CircuitMomentOperation.png)
@@ -125,8 +125,8 @@ details on these classes. Because the problem we have
 defined has a natural structure on a grid, we will use 
 Cirq's built in `GridQubit`s as our qubits.
 We will demonstrate some of how this works in an 
-interactive python environment, the following code can
-be run in series in a python environment where you have
+interactive Python environment, the following code can
+be run in series in a Python environment where you have
 Cirq installed.
 
 Let's begin by talking about our qubits. In an interactive
@@ -145,7 +145,7 @@ print(qubits)
 Here we see that we've created a bunch of `GridQubit`s. 
 `GridQubit`s implement the `QubitId` class, which just means
 that they are equatable and hashable. `GridQubit`s in addition
-have a row and column, indicating their position on a grid. 
+have a row and column, indicating their position on a grid.
 
 Now that we have some qubits, let us construct a `Circuit` on these qubits.
 For example, suppose we want to apply the Hadamard gate `H` to
@@ -184,12 +184,12 @@ and a gate object (which is an instantiation of a class).  The second is that ga
 objects are transformed into `Operation`s (technically `GateOperation`s)
 via either the method `on(qubit)` or, as we see for the `X` gates, via simply
 applying the gate to the qubits `(qubit)`. Here we only apply single
-qubit gates, but a similar pattern applies for multiple qubits, but now a 
-sequence of qubits should be supplied as parameters. 
+qubit gates, but a similar pattern applies for multiple qubit gates with a 
+sequence of qubits as parameters.
 
 Another thing one notices about the above circuit is that the circuit has
 staggered gates. This is because the way in which we have applied the
-gates has created two `Moment`s.  
+gates has created two `Moment`s.
 ```python
 for i, m in enumerate(circuit):
     print('Moment {}: {}'.format(i, m))
@@ -236,11 +236,11 @@ over to act at the earliest `Moment` they can.
 
 If you look closely at the circuit creation code above you will see that
 we applied the `append` method to both a `generator` and a `list` (recall that
-in python one can use generator comprehensions in method calls).
+in Python one can use generator comprehensions in method calls).
 Inspecting the [code](/cirq/circuits/circuit.py) for append one sees that
 the append method generally takes an `OP_TREE` (or a `Moment`).  What is
-an `OP_TREE`?  It is not a class but a contract.  Roughly an `OP_TREE` 
-is anything that can be flattened, perhaps recursively, into a list 
+an `OP_TREE`?  It is not a class but a contract.  Roughly an `OP_TREE`
+is anything that can be flattened, perhaps recursively, into a list
 of operations, or into a single operation. Examples of an `OP_TREE` are
 * A single `Operation`.
 * A list of `Operation`s.
@@ -248,7 +248,7 @@ of operations, or into a single operation. Examples of an `OP_TREE` are
 * A list of a list of `Operations`s.
 * A generator yielding `Operations`. 
 
-This last case yields a nice pattern for defining sub-circuits / layers,
+This last case yields a nice pattern for defining sub-circuits / layers:
 define a function that takes in the relevant parameters and then
 yields the operations for the sub circuit and then this can be appended
 to the Circuit: 
@@ -272,18 +272,18 @@ print(circuit)
 #
 # (1, 1): ───X^0.1───
 ```
-Another important concept here is that the rotation gate is 
+Another important concept here is that the rotation gate is
 specified in "half turns". For a rotation about X this is the
-gate cos(half_turns * pi) I + i sin(half_turns * pi) X. 
+gate cos(half_turns * pi) I + i sin(half_turns * pi) X.
 
-There is a lot of freedom defining a variational ansatz. 
+There is a lot of freedom defining a variational ansatz.
 Here we will do a variation on a [QOAO strategy](https://arxiv.org/abs/1411.4028)
-and define an anstaz related to he problem we are trying to solve. 
+and define an anstaz related to he problem we are trying to solve.
 
-First we need to choose how the instances of the 
+First we need to choose how the instances of the
 problem are represented.  These are the values J and h in the
 Hamiltonian definition.  We will represent these as two dimensional
-arrays (lists of lists).  For J we will use two such lists, 
+arrays (lists of lists).  For J we will use two such lists,
 one for the row links and one for the column links.
 
 Here is code that we can use to generate random problem
@@ -314,9 +314,9 @@ print('column j fields: {}'.format(jc))
 where the actual values will be different for an individual
 run because they are using `random.choice`.
 
-Given this definition of the problem instance we can 
-now introduce our ansatz.  Our ansatz will consist 
-of one steps of a circuit made up of 
+Given this definition of the problem instance we can
+now introduce our ansatz.  Our ansatz will consist
+of one step of a circuit made up of
 1. Apply a RotXGate for the same parameter for all qubits.
 This is the method we have written above.
 2. Apply a RotZGate for the same parameter for all qubits
@@ -398,34 +398,34 @@ print(circuit)
 #                                                            │                           │
 # (2, 2): ───X^0.1───Z^0.2───────────────────────────────────@^0.3───────────────────────@^0.3───────────────
 ```
-Where here we see that we have chosen particular parameter
+Here we see that we have chosen particular parameter
 values (0.1, 0.2, 0.3).
 
 ### Simulation
 
-Now lets see how simulate the circuit corresponding
+Now let's see how to simulate the circuit corresponding
 to creating our ansatz.  In Cirq the simulators make a distinction
-between a "run" and a "simulation". A "run" only allows for a 
+between a "run" and a "simulation". A "run" only allows for a
 simulation that mimics the actual quantum hardware.  For example,
 it does not allow for access to the amplitudes of the wave function
 of the system, since that is not experimentally accessible.
 "Simulate" commands, however, are more broad and allow different forms
-of simulation.  When prototyping small circuits it is useful to 
+of simulation.  When prototyping small circuits it is useful to
 execute "simulate" methods, but one should be wary of relying on
 them when run against actual hardware.
 
 Currently Cirq ships with a simulator tied strongly to the gate
-set of the Google xmon architecture.  However, for convenience, 
-the simulator attempts to automatically convert unknown 
-operations into XmonGates (as long as the operation specifies 
-a matrix or a decomposition into XmonGates). This can in 
-principle allows us to simulate any circuit that has gates 
-that implement one and two qubit  `KnownMatrix` gates. 
+set of the Google xmon architecture.  However, for convenience,
+the simulator attempts to automatically convert unknown
+operations into XmonGates (as long as the operation specifies
+a matrix or a decomposition into XmonGates). This can in
+principle allows us to simulate any circuit that has gates
+that implement one and two qubit  `KnownMatrix` gates.
 Future releases of Cirq will expand these simulators.
 
 Because the simulator is tied to the xmon gate set, the simulator
 lives, in contrast to core Cirq, in the `cirq.google` module.
-To run a simulation of the full circuit we simply create a 
+To run a simulation of the full circuit we simply create a
 simulator, and pass the circuit to the simulator.
 
 ```python
@@ -438,14 +438,14 @@ print(results.histogram(key='x'))
 # prints something like
 # Counter({0: 85, 128: 5, 32: 3, 1: 2, 4: 1, 2: 1, 8: 1, 18: 1, 20: 1})
 ```
-Note that we have run the simulation 100 times and produced a 
+Note that we have run the simulation 100 times and produced a
 histogram of the counts of the measurement results.  What are the
-keys in the histogram counter? Note that we have passed in 
-the order of the qubits. This ordering is then used to translate 
-the order of the measurement results to a register using a 
+keys in the histogram counter? Note that we have passed in
+the order of the qubits. This ordering is then used to translate
+the order of the measurement results to a register using a
 [big endian](https://en.wikipedia.org/wiki/Endianness) representation.
 
-For our optimization problem we will want to calculate the 
+For our optimization problem we will want to calculate the
 value of the objective function for a given result run. One
 way to do this is use the raw measurement data from the result
 of `simulator.run`. Another way to do this is to provide to
@@ -487,16 +487,16 @@ print('Value of the objective function {}'.format(obj_func(results)))
 
 ### Parameterizing the Ansatz
 
-Now that we have constructed a variational ansatz, and shown how to simulate
-it using Cirq, we can now think about optimizing the value. On quantum 
+Now that we have constructed a variational ansatz and shown how to simulate
+it using Cirq, we can now think about optimizing the value. On quantum
 hardware one would most likely want to have the optimization code as close
 to the hardware as possible.  As the classical hardware that is allowed to
 inter-operate with the quantum hardware becomes better specified, this
 language will be better defined.  Without this specification, however,
 Cirq also provides a useful concept for optimizing the looping in many
-optimization algorithms.  This is the fact that many of the value in 
+optimization algorithms.  This is the fact that many of the value in
 the gate sets can, instead of being specified by a float, be specified
-by a `Symbol` and this `Symbol` can be substituted for a value specified 
+by a `Symbol` and this `Symbol` can be substituted for a value specified
 at execution time.
 
 Luckily for us, we have written our code so that using parameterized
@@ -545,7 +545,7 @@ is very useful when one wants to run many circuits for many different
 parameter values.  Sweeps can be created to specify values directly
 (this is one way to get classical information into a circuit), or
 a variety of helper methods.  For example suppose we want to evaluate
-our circuit over an equally spaced grid of parameter values.  We 
+our circuit over an equally spaced grid of parameter values.  We
 can easily create this using `LinSpace`.
 ```python
 sweep = (cirq.Linspace(key='alpha', start=0.1, stop=0.9, length=5)
@@ -595,4 +595,4 @@ Where to go next?  Perhaps you can play around with the above code
 and work on analyzing the algorithms performance.  Add new parameterized
 circuits and build an end to end program for analyzing these circuits.
 Finally a good place to learn more about features of Cirq is to read
-through the [conceptual documentation](table_of_contents.md). 
+through the [conceptual documentation](table_of_contents.md).


### PR DESCRIPTION
This test is flaky in the google repository, since the matrix decomposition could be something not exactly 0.5 (such as 0.500001).  Changed the test to use an allclose method rather than test equality.