### PR TITLE
Fix deprecation warning for np.sum with generator.

### DIFF
--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -134,8 +134,8 @@ class EigenGate(raw_types.Gate,
         if self.is_parameterized():
             raise ValueError("Parameterized. Don't have a known matrix.")
         e = cast(float, self._exponent)
-        return np.sum(1j**(half_turns * e * 2) * component
-                      for half_turns, component in self._eigen_components())
+        return sum(1j**(half_turns * e * 2) * component
+                   for half_turns, component in self._eigen_components())
 
     def extrapolate_effect(self: TSelf,
                            factor: Union[float, value.Symbol]) -> TSelf:

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -134,8 +134,8 @@ class EigenGate(raw_types.Gate,
         if self.is_parameterized():
             raise ValueError("Parameterized. Don't have a known matrix.")
         e = cast(float, self._exponent)
-        return sum(1j**(half_turns * e * 2) * component
-                   for half_turns, component in self._eigen_components())
+        return np.sum([1j**(half_turns * e * 2) * component for half_turns,
+                       component in self._eigen_components()], axis=0)
 
     def extrapolate_effect(self: TSelf,
                            factor: Union[float, value.Symbol]) -> TSelf:


### PR DESCRIPTION
Background:
https://docs.scipy.org/doc/numpy/release.html#numpy-1-15-0-release-notes
"Giving a generator to numpy.sum is now deprecated. This was undocumented behavior, but worked. Previously, it would calculate the sum of the generator expression. In the future, it might return a different result. Use np.sum(np.from_iter(generator)) or the built-in Python sum instead."