### PR TITLE
Add BUILD and WORKSPACE files for Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,9 @@
+# proto_library, cc_proto_library, and java_proto_library rules implicitly
+# depend on @com_google_protobuf for protoc and proto runtimes.
+# This statement defines the @com_google_protobuf repo.
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "cef7f1b5a7c5fba672bec2a319246e8feba471f04dcebfe362d55930ee7c1c30",
+    strip_prefix = "protobuf-3.5.0",
+    urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
+)

--- a/cirq/api/google/v1/BUILD
+++ b/cirq/api/google/v1/BUILD
@@ -1,0 +1,18 @@
+proto_library(
+    name = "operations_proto",
+    srcs = ["operations.proto"],
+)
+
+proto_library(
+    name = "params_proto",
+    srcs = ["params.proto"],
+)
+
+proto_library(
+    name = "program_proto",
+    srcs = ["program.proto"],
+    deps = [
+    "operations_proto",
+    "params_proto",
+    ],
+)


### PR DESCRIPTION
All `.protos` compile on Bazel as a result of this commit.

```
vtomole@vtomole:~/Documents/Cirq$ bazel build //cirq/api/google/v1:program_proto 
INFO: Analysed target //cirq/api/google/v1:program_proto (0 packages loaded).
INFO: Found 1 target...
Target //cirq/api/google/v1:program_proto up-to-date:
  bazel-genfiles/cirq/api/google/v1/program_proto-descriptor-set.proto.bin
INFO: Elapsed time: 0.272s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
vtomole@vtomole:~/Documents/Cirq$ bazel build //cirq/api/google/v1:operations_proto 
INFO: Analysed target //cirq/api/google/v1:operations_proto (0 packages loaded).
INFO: Found 1 target...
Target //cirq/api/google/v1:operations_proto up-to-date:
  bazel-genfiles/cirq/api/google/v1/operations_proto-descriptor-set.proto.bin
INFO: Elapsed time: 0.164s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
vtomole@vtomole:~/Documents/Cirq$ bazel build //cirq/api/google/v1:
operations_proto   params_proto       program_proto      
vtomole@vtomole:~/Documents/Cirq$ bazel build //cirq/api/google/v1:
operations_proto   params_proto       program_proto      
vtomole@vtomole:~/Documents/Cirq$ bazel build //cirq/api/google/v1:params_proto 
INFO: Analysed target //cirq/api/google/v1:params_proto (0 packages loaded).
INFO: Found 1 target...
Target //cirq/api/google/v1:params_proto up-to-date:
  bazel-genfiles/cirq/api/google/v1/params_proto-descriptor-set.proto.bin
INFO: Elapsed time: 0.182s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
```