### PR TITLE
Refactor cirq.inverse to work on values that define __pow__ or implement ReversibleEffect

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -128,7 +128,6 @@ from cirq.ops import (
     H,
     HGate,
     InterchangeableQubitsGate,
-    inverse,
     ISWAP,
     ISwapGate,
     measure,
@@ -200,6 +199,7 @@ from cirq.value import (
 )
 
 from cirq.protocols import (
+    inverse,
     SupportsUnitary,
     unitary,
 )

--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -16,7 +16,7 @@ from typing import (
     Dict, Hashable, Iterable, Optional, Tuple, Type, TypeVar, Union, cast
 )
 
-from cirq import ops, value, study, extension
+from cirq import ops, value, study, extension, protocols
 
 from cirq.ops.pauli_string import PauliString
 from cirq.contrib.paulistring.pauli_string_raw_types import (
@@ -126,8 +126,8 @@ class PauliStringPhasor(PauliStringGateOperation,
             half_turns = self.half_turns * (-1 if self.pauli_string.negated
                                                else 1)
             yield ops.Z(any_qubit) ** half_turns
-        yield ops.inverse(xor_decomp)
-        yield ops.inverse(to_z_ops)
+        yield protocols.inverse(xor_decomp)
+        yield protocols.inverse(to_z_ops)
 
     def text_diagram_info(self, args: ops.TextDiagramInfoArgs
                           ) -> ops.TextDiagramInfo:

--- a/cirq/decompositions.py
+++ b/cirq/decompositions.py
@@ -20,7 +20,7 @@ import math
 import cmath
 import numpy as np
 
-from cirq import ops, linalg
+from cirq import ops, linalg, protocols
 
 
 def is_negligible_turn(turns: float, tolerance: float) -> bool:
@@ -173,7 +173,7 @@ def controlled_op_to_operations(
         del u_gates[-1]
 
     ops_before = [gate(target) for gate in u_gates]
-    ops_after = ops.inverse(ops_before)
+    ops_after = protocols.inverse(ops_before)
     effect = ops.CZ(control, target) ** (cmath.phase(z_phase) / math.pi)
     kickback = ops.Z(control) ** (cmath.phase(global_phase) / math.pi)
 

--- a/cirq/google/decompositions.py
+++ b/cirq/google/decompositions.py
@@ -20,7 +20,7 @@ from typing import List, Tuple, cast
 
 import numpy as np
 
-from cirq import ops, linalg
+from cirq import ops, linalg, protocols
 from cirq.decompositions import single_qubit_op_to_framed_phase_form
 from cirq.google.xmon_gates import ExpWGate
 
@@ -120,7 +120,7 @@ def controlled_op_to_native_gates(
         del u_gates[-1]
 
     ops_before = [gate(target) for gate in u_gates]
-    ops_after = ops.inverse(ops_before)
+    ops_after = protocols.inverse(ops_before)
     effect = ops.CZ(control, target) ** (cmath.phase(z_phase) / math.pi)
     kickback = ops.Z(control) ** (cmath.phase(global_phase) / math.pi)
 

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -102,7 +102,6 @@ from cirq.ops.raw_types import (
     QubitId,
 )
 from cirq.ops.reversible_composite_gate import (
-    inverse,
     ReversibleCompositeGate,
 )
 from cirq.ops.three_qubit_gates import (

--- a/cirq/ops/reversible_composite_gate.py
+++ b/cirq/ops/reversible_composite_gate.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Implements the inverse method of a CompositeOperation & ReversibleEffect."""
-from typing import TypeVar, Generic, cast
+from typing import TypeVar, Generic
 
 from cirq import abc, protocols
 from cirq.ops import gate_features

--- a/cirq/ops/reversible_composite_gate.py
+++ b/cirq/ops/reversible_composite_gate.py
@@ -15,46 +15,8 @@
 """Implements the inverse method of a CompositeOperation & ReversibleEffect."""
 from typing import TypeVar, Generic, cast
 
-from cirq import abc
-from cirq.extension import Extensions
-from cirq.ops import gate_features, op_tree, raw_types
-
-
-def _reverse_operation(operation: raw_types.Operation,
-                       ext: Extensions) -> raw_types.Operation:
-    """Returns the inverse of an operation, if possible.
-
-    Args:
-        operation: The operation to reverse.
-        ext: Used when casting the operation into a reversible effect.
-
-    Returns:
-        An operation on the same qubits but with the inverse gate.
-
-    Raises:
-        TypeError: The operation isn't reversible.
-    """
-    reversible_op = ext.cast(gate_features.ReversibleEffect, operation)
-    return cast(raw_types.Operation, reversible_op.inverse())
-
-
-def inverse(root: op_tree.OP_TREE,
-            extensions: Extensions = None
-            ) -> op_tree.OP_TREE:
-    """Generates OP_TREE inverses.
-
-    Args:
-        root: An operation tree containing only invertible operations.
-        extensions: For caller-provided implementations of gate inverses.
-
-    Returns:
-        An OP_TREE that performs the inverse operation of the given OP_TREE.
-    """
-    ext = extensions or Extensions()
-    return op_tree.transform_op_tree(
-        root=root,
-        op_transformation=lambda e: _reverse_operation(e, ext),
-        iter_transformation=lambda e: reversed(list(e)))
+from cirq import abc, protocols
+from cirq.ops import gate_features
 
 
 TOriginal = TypeVar('TOriginal', bound='ReversibleCompositeGate')
@@ -82,4 +44,4 @@ class _ReversedReversibleCompositeGate(Generic[TOriginal],
         return self.forward_form
 
     def default_decompose(self, qubits):
-        return inverse(self.forward_form.default_decompose(qubits))
+        return protocols.inverse(self.forward_form.default_decompose(qubits))

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from cirq.protocols.inverse import (
+    inverse,
+)
 from cirq.protocols.unitary import (
     SupportsUnitary,
     unitary,

--- a/cirq/protocols/inverse.py
+++ b/cirq/protocols/inverse.py
@@ -1,0 +1,78 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import collections
+
+from cirq import extension, ops
+
+# This is a special indicator value used by the inverse method to determine
+# whether or not the caller provided a 'default' argument.
+RaiseTypeErrorIfNotProvided = ([],)
+
+
+def inverse(val: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
+    """Returns the inverse `val**-1` of the given value, if defined.
+
+    An object can define an inverse by defining a __pow__(self, exponent) method
+    that returns something besides NotImplemented when given the exponent -1.
+    The inverse of iterables is by default defined to be the iterable's items,
+    each inverted, in reverse order.
+
+    Args:
+        val: The value (or iterable of invertable values) to invert.
+        default: Determines the fallback behavior when `val` doesn't have
+            an inverse defined. If `default` is not set, a TypeError is raised.
+            If `default` is set to a value, that value is returned.
+
+    Returns:
+        If `val` has a __pow__ method that returns something besides
+        NotImplemented when given an exponent of -1, that result is returned.
+        Otherwise, if `val` is iterable, the result is a tuple with the same
+        items as `val` but in reverse order and with each item inverted.
+        Otherwise, if a `default` argument was specified, it is returned.
+
+    Raises:
+        TypeError: `val` doesn't have a __pow__ method, or that method returned
+            NotImplemented when given -1. Furthermore `val` isn't an
+            iterable containing invertible items. Also, no `default` argument
+            was specified.
+    """
+    # TODO: remove this backwards compatibility shim.
+    reversible = extension.try_cast(ops.ReversibleEffect, val)
+    if reversible is not None:
+        return reversible.inverse()
+
+    # Check if object defines an inverse via __pow__.
+    raiser = getattr(val, '__pow__', None)
+    result = NotImplemented if raiser is None else raiser(-1)
+    if result is not NotImplemented:
+        return result
+
+    # Maybe it's an iterable of invertable items?
+    # Note: we avoid str because 'a'[0] == 'a', which creates an infinite loop.
+    if isinstance(val, collections.Iterable) and not isinstance(val, str):
+        unique_indicator = []
+        results = tuple(inverse(e, unique_indicator) for e in val)
+        if all(e is not unique_indicator for e in results):
+            return results[::-1]
+
+    # Can't invert.
+    if default is not RaiseTypeErrorIfNotProvided:
+        return default
+    raise TypeError(
+        "object of type '{}' isn't invertable. "
+        "It has no __pow__ method (or the method returned NotImplemented) "
+        "and it isn't an iterable of invertable objects.".format(type(val)))

--- a/cirq/protocols/inverse.py
+++ b/cirq/protocols/inverse.py
@@ -16,7 +16,6 @@ from typing import Any
 
 import collections
 
-from cirq import extension, ops
 
 # This is a special indicator value used by the inverse method to determine
 # whether or not the caller provided a 'default' argument.
@@ -50,7 +49,8 @@ def inverse(val: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
             iterable containing invertible items. Also, no `default` argument
             was specified.
     """
-    # TODO: remove this backwards compatibility shim.
+    # TODO: remove this compatibility shim when ReversibleEffect is gone.
+    from cirq import extension, ops
     reversible = extension.try_cast(ops.ReversibleEffect, val)
     if reversible is not None:
         return reversible.inverse()

--- a/cirq/protocols/inverse_test.py
+++ b/cirq/protocols/inverse_test.py
@@ -1,0 +1,81 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import cirq
+
+
+class NoMethod:
+    pass
+
+
+class ReturnsNotImplemented:
+    def __pow__(self, exponent) -> type(NotImplemented):
+        return NotImplemented
+
+
+class ReturnsFive:
+    def __pow__(self, exponent) -> int:
+        return 5
+
+
+class SelfInverse:
+    def __pow__(self, exponent) -> 'SelfInverse':
+        return self
+
+
+class ImplementsReversible(cirq.ReversibleEffect):
+    def inverse(self):
+        return 6
+
+
+class IsIterable:
+    def __iter__(self):
+        yield 1
+        yield 2
+
+
+@pytest.mark.parametrize('val', (
+    NoMethod(),
+    'text',
+    object(),
+    ReturnsNotImplemented(),
+    [NoMethod(), 5],
+))
+def test_objects_with_no_inverse(val):
+    with pytest.raises(TypeError, match="isn't invertable"):
+        _ = cirq.inverse(val)
+    assert cirq.inverse(val, None) is None
+    assert cirq.inverse(val, NotImplemented) is NotImplemented
+    assert cirq.inverse(val, 5) == 5
+
+
+@pytest.mark.parametrize('val,inv', (
+    (ReturnsFive(), 5),
+    (ImplementsReversible(), 6),
+    (SelfInverse(),)*2,
+    (1, 1),
+    (2, 0.5),
+    (1j, -1j),
+    ((), ()),
+    ([], ()),
+    ((2,), (0.5,)),
+    ((1, 2), (0.5, 1)),
+    ((2, (4, 8)), ((0.125, 0.25), 0.5)),
+    ((2, [4, 8]), ((0.125, 0.25), 0.5)),
+    (IsIterable(), (0.5, 1)),
+))
+def test_objects_with_inverse(val, inv):
+    assert cirq.inverse(val) == inv


### PR DESCRIPTION
- Moved cirq.inverse into cirq/protocols
- Include temporary compatibility shim for working with ReversibleEffect
- Will eventually delete ReversibleEffect in favor of this method

Part of https://github.com/quantumlib/Cirq/issues/943