### PR TITLE
Rename cirq.CliffordGate to cirq.SingleQubitCliffordGate (#964)

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -110,7 +110,7 @@ from cirq.ops import (
     BoundedEffect,
     CCX,
     CCZ,
-    CliffordGate,
+    SingleQubitCliffordGate,
     CNOT,
     CNotGate,
     CompositeGate,

--- a/cirq/contrib/paulistring/__init__.py
+++ b/cirq/contrib/paulistring/__init__.py
@@ -22,7 +22,7 @@ from cirq.contrib.paulistring.convert_to_pauli_string_phasors import (
     ConvertToPauliStringPhasors,
 )
 from cirq.contrib.paulistring.convert_to_clifford_gates import (
-    ConvertToCliffordGates,
+    ConvertToSingleQubitCliffordGates,
 )
 from cirq.contrib.paulistring.convert_gate_set import (
     converted_gate_set,

--- a/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq/contrib/paulistring/clifford_optimize.py
@@ -24,7 +24,8 @@ from cirq.contrib.paulistring.convert_gate_set import (
 def clifford_optimized_circuit(circuit: circuits.Circuit,
                                tolerance: float = 1e-8
                                ) -> circuits.Circuit:
-    # Convert to a circuit with CliffordGates, CZs and other ignored gates
+    # Convert to a circuit with SingleQubitCliffordGates,
+    # CZs and other ignored gates
     c_cliff = converted_gate_set(circuit, no_clifford_gates=False,
                                  tolerance=tolerance)
 
@@ -41,7 +42,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
                                current_string: PauliStringPhasor,
                                is_first: bool) -> int:
             if (isinstance(op, ops.GateOperation)
-                and isinstance(op.gate, ops.CliffordGate)):
+                and isinstance(op.gate, ops.SingleQubitCliffordGate)):
                 return (CONTINUE if len(current_string.pauli_string) != 1
                                  else STOP)
             if (isinstance(op, ops.GateOperation)
@@ -81,9 +82,10 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
 
     def try_merge_clifford(cliff_op: ops.GateOperation, start_i: int) -> bool:
         orig_qubit, = cliff_op.qubits
-        remaining_cliff_gate = ops.CliffordGate.I
+        remaining_cliff_gate = ops.SingleQubitCliffordGate.I
         for pauli, quarter_turns in reversed(
-                cast(ops.CliffordGate, cliff_op.gate).decompose_rotation()):
+                cast(ops.SingleQubitCliffordGate,
+                     cliff_op.gate).decompose_rotation()):
             trans = remaining_cliff_gate.transform(pauli)
             pauli = trans.to
             quarter_turns *= -1 if trans.flip else 1
@@ -100,7 +102,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
             quarter_turns = round(merge_op.half_turns * 2)
             quarter_turns *= (1, -1)[merge_op.pauli_string.negated]
             quarter_turns %= 4
-            part_cliff_gate = ops.CliffordGate.from_quarter_turns(
+            part_cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(
                                         pauli, quarter_turns)
 
             other_op = all_ops[merge_i] if merge_i < len(all_ops) else None
@@ -108,8 +110,8 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
                 other_op = None
 
             if (isinstance(other_op, ops.GateOperation)
-                and isinstance(other_op.gate, ops.CliffordGate)):
-                # Merge with another CliffordGate
+                and isinstance(other_op.gate, ops.SingleQubitCliffordGate)):
+                # Merge with another SingleQubitCliffordGate
                 new_op = part_cliff_gate.merged_with(other_op.gate
                                                      )(qubit)
                 all_ops[merge_i] = new_op
@@ -122,7 +124,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
                     other_qubit = other_op.qubits[
                                     other_op.qubits.index(qubit)-1]
                     all_ops.insert(merge_i+1,
-                                   ops.CliffordGate.Z(other_qubit))
+                                   ops.SingleQubitCliffordGate.Z(other_qubit))
                 all_ops.insert(merge_i+1, part_cliff_gate(qubit))
             elif isinstance(other_op, PauliStringPhasor):
                 # Pass over a non-Clifford gate
@@ -138,7 +140,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
                 remaining_cliff_gate = remaining_cliff_gate.merged_with(
                                             part_cliff_gate)
 
-        if remaining_cliff_gate == ops.CliffordGate.I:
+        if remaining_cliff_gate == ops.SingleQubitCliffordGate.I:
             all_ops.pop(start_i)
             return True
         else:
@@ -175,7 +177,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
     while i < len(all_ops):
         op = all_ops[i]
         if (isinstance(op, ops.GateOperation)
-            and isinstance(op.gate, ops.CliffordGate)):
+            and isinstance(op.gate, ops.SingleQubitCliffordGate)):
             if try_merge_clifford(op, i):
                 i -= 1
         elif (isinstance(op, ops.GateOperation)

--- a/cirq/contrib/paulistring/convert_gate_set.py
+++ b/cirq/contrib/paulistring/convert_gate_set.py
@@ -22,7 +22,8 @@ def converted_gate_set(circuit: circuits.Circuit,
                        no_clifford_gates: bool = False,
                        tolerance: float = 1e-8,
                        ) -> circuits.Circuit:
-    """Returns a new, equivalent circuit using the gate set {CliffordGate,
+    """Returns a new, equivalent circuit using the gate set
+    {SingleQubitCliffordGate,
     CZ/PauliInteractionGate, PauliStringPhasor}.
     """
     conv_circuit = circuits.Circuit(circuit)

--- a/cirq/contrib/paulistring/convert_gate_set_test.py
+++ b/cirq/contrib/paulistring/convert_gate_set_test.py
@@ -21,15 +21,15 @@ from cirq.contrib.paulistring import converted_gate_set
 
 
 @pytest.mark.parametrize('op,expected_ops', (lambda q0, q1: (
-    (cirq.X(q0), cirq.CliffordGate.X(q0)),
-    (cirq.Y(q0), cirq.CliffordGate.Y(q0)),
-    (cirq.Z(q0), cirq.CliffordGate.Z(q0)),
-    (cirq.X(q0) ** 0.5, cirq.CliffordGate.X_sqrt(q0)),
-    (cirq.Y(q0) ** 0.5, cirq.CliffordGate.Y_sqrt(q0)),
-    (cirq.Z(q0) ** 0.5, cirq.CliffordGate.Z_sqrt(q0)),
-    (cirq.X(q0) ** -0.5, cirq.CliffordGate.X_nsqrt(q0)),
-    (cirq.Y(q0) ** -0.5, cirq.CliffordGate.Y_nsqrt(q0)),
-    (cirq.Z(q0) ** -0.5, cirq.CliffordGate.Z_nsqrt(q0)),
+    (cirq.X(q0), cirq.SingleQubitCliffordGate.X(q0)),
+    (cirq.Y(q0), cirq.SingleQubitCliffordGate.Y(q0)),
+    (cirq.Z(q0), cirq.SingleQubitCliffordGate.Z(q0)),
+    (cirq.X(q0) ** 0.5, cirq.SingleQubitCliffordGate.X_sqrt(q0)),
+    (cirq.Y(q0) ** 0.5, cirq.SingleQubitCliffordGate.Y_sqrt(q0)),
+    (cirq.Z(q0) ** 0.5, cirq.SingleQubitCliffordGate.Z_sqrt(q0)),
+    (cirq.X(q0) ** -0.5, cirq.SingleQubitCliffordGate.X_nsqrt(q0)),
+    (cirq.Y(q0) ** -0.5, cirq.SingleQubitCliffordGate.Y_nsqrt(q0)),
+    (cirq.Z(q0) ** -0.5, cirq.SingleQubitCliffordGate.Z_nsqrt(q0)),
 
     (cirq.X(q0) ** 0.25,
      PauliStringPhasor(cirq.PauliString.from_single(q0, cirq.Pauli.X)) ** 0.25),
@@ -71,7 +71,7 @@ def test_degenerate_single_qubit_decompose():
         cirq.Z(q0) ** 0.1,
     )
     expected = cirq.Circuit.from_ops(
-        cirq.CliffordGate.X(q0),
+        cirq.SingleQubitCliffordGate.X(q0),
     )
 
     after = converted_gate_set(before)

--- a/cirq/contrib/paulistring/convert_to_clifford_gates.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates.py
@@ -24,13 +24,14 @@ from cirq.circuits.optimization_pass import (
 )
 
 
-class ConvertToCliffordGates(PointOptimizer):
+class ConvertToSingleQubitCliffordGates(PointOptimizer):
     """Attempts to convert single-qubit gates into single-qubit
-    CliffordGates.
+    SingleQubitCliffordGates.
 
     First, checks if the operation has a known unitary effect. If so, and the
         gate is a 1-qubit gate, then decomposes it and tries to make a
-        CliffordGate. It fails if the operation is not in the Clifford group.
+        SingleQubitCliffordGate. It fails if the operation is not in the
+    Clifford group.
 
     Second, checks if the given extensions are able to cast the operation into a
         CompositeOperation. If so, recurses on the decomposition.
@@ -57,22 +58,22 @@ class ConvertToCliffordGates(PointOptimizer):
         self._tol = linalg.Tolerance(atol=tolerance)
 
     def _rotation_to_clifford_gate(self, pauli: ops.Pauli, half_turns: float
-                                   ) -> ops.CliffordGate:
+                                   ) -> ops.SingleQubitCliffordGate:
         quarter_turns = round(half_turns * 2) % 4
         if quarter_turns == 1:
-            return ops.CliffordGate.from_pauli(pauli, True)
+            return ops.SingleQubitCliffordGate.from_pauli(pauli, True)
         elif quarter_turns == 2:
-            return ops.CliffordGate.from_pauli(pauli)
+            return ops.SingleQubitCliffordGate.from_pauli(pauli)
         elif quarter_turns == 3:
-            return ops.CliffordGate.from_pauli(pauli, True).inverse()
+            return ops.SingleQubitCliffordGate.from_pauli(pauli, True).inverse()
         else:
-            return ops.CliffordGate.I
+            return ops.SingleQubitCliffordGate.I
 
     def _matrix_to_clifford_op(self, mat: np.ndarray, qubit: ops.QubitId
                                ) -> Optional[ops.Operation]:
         rotations = decompositions.single_qubit_matrix_to_pauli_rotations(
                                        mat, self.tolerance)
-        clifford_gate = ops.CliffordGate.I
+        clifford_gate = ops.SingleQubitCliffordGate.I
         for pauli, half_turns in rotations:
             if self._tol.all_near_zero_mod(half_turns, 0.5):
                 clifford_gate = clifford_gate.merged_with(
@@ -82,9 +83,9 @@ class ConvertToCliffordGates(PointOptimizer):
         return clifford_gate(qubit)
 
     def _convert_one(self, op: ops.Operation) -> ops.OP_TREE:
-        # Don't change if it's already a CliffordGate
+        # Don't change if it's already a SingleQubitCliffordGate
         if (isinstance(op, ops.GateOperation) and
-                isinstance(op.gate, ops.CliffordGate)):
+                isinstance(op.gate, ops.SingleQubitCliffordGate)):
             return op
 
         # Single qubit gate with known matrix?

--- a/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
@@ -16,7 +16,7 @@ import pytest
 
 import cirq
 from cirq.contrib.paulistring import (
-    ConvertToCliffordGates,
+    ConvertToSingleQubitCliffordGates,
 )
 
 
@@ -30,9 +30,9 @@ def test_convert():
         cirq.H(q0),
     )
     c_orig = cirq.Circuit(circuit)
-    ConvertToCliffordGates().optimize_circuit(circuit)
+    ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 
-    assert all(isinstance(op.gate, cirq.CliffordGate)
+    assert all(isinstance(op.gate, cirq.SingleQubitCliffordGate)
                for op in circuit.all_operations())
 
     cirq.testing.assert_allclose_up_to_global_phase(
@@ -54,22 +54,23 @@ def test_non_clifford_known_matrix():
     )
     c_orig = cirq.Circuit(circuit)
 
-    ConvertToCliffordGates(ignore_failures=True).optimize_circuit(circuit)
+    ConvertToSingleQubitCliffordGates(ignore_failures=True) \
+        .optimize_circuit(circuit)
     assert circuit == c_orig
 
     circuit2 = cirq.Circuit(c_orig)
     with pytest.raises(ValueError):
-        ConvertToCliffordGates().optimize_circuit(circuit2)
+        ConvertToSingleQubitCliffordGates().optimize_circuit(circuit2)
 
 
 
 def test_already_converted():
     q0 = cirq.LineQubit(0)
     circuit = cirq.Circuit.from_ops(
-        cirq.CliffordGate.H(q0),
+        cirq.SingleQubitCliffordGate.H(q0),
     )
     c_orig = cirq.Circuit(circuit)
-    ConvertToCliffordGates().optimize_circuit(circuit)
+    ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 
     assert circuit == c_orig
 
@@ -87,9 +88,9 @@ def test_convert_composite():
         CompositeDummy()(q0, q1)
     )
     c_orig = cirq.Circuit(circuit)
-    ConvertToCliffordGates().optimize_circuit(circuit)
+    ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 
-    assert all(isinstance(op.gate, cirq.CliffordGate)
+    assert all(isinstance(op.gate, cirq.SingleQubitCliffordGate)
                for op in circuit.all_operations())
 
     cirq.testing.assert_allclose_up_to_global_phase(
@@ -113,7 +114,8 @@ def test_ignore_unsupported_gate():
         UnsupportedDummy()(q0, q1),
     )
     c_orig = cirq.Circuit(circuit)
-    ConvertToCliffordGates(ignore_failures=True).optimize_circuit(circuit)
+    ConvertToSingleQubitCliffordGates(ignore_failures=True) \
+        .optimize_circuit(circuit)
 
     assert circuit == c_orig
 
@@ -127,17 +129,17 @@ def test_fail_unsupported_gate():
         UnsupportedDummy()(q0, q1),
     )
     with pytest.raises(TypeError):
-        ConvertToCliffordGates().optimize_circuit(circuit)
+        ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 
 
 def test_rotation_to_clifford_gate():
-    conv = ConvertToCliffordGates()
+    conv = ConvertToSingleQubitCliffordGates()
 
     assert (conv._rotation_to_clifford_gate(cirq.Pauli.X, 0.0)
-            == cirq.CliffordGate.I)
+            == cirq.SingleQubitCliffordGate.I)
     assert (conv._rotation_to_clifford_gate(cirq.Pauli.X, 0.5)
-            == cirq.CliffordGate.X_sqrt)
+            == cirq.SingleQubitCliffordGate.X_sqrt)
     assert (conv._rotation_to_clifford_gate(cirq.Pauli.X, 1.0)
-            == cirq.CliffordGate.X)
+            == cirq.SingleQubitCliffordGate.X)
     assert (conv._rotation_to_clifford_gate(cirq.Pauli.X, -0.5)
-            == cirq.CliffordGate.X_nsqrt)
+            == cirq.SingleQubitCliffordGate.X_nsqrt)

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
@@ -48,7 +48,7 @@ class ConvertToPauliStringPhasors(PointOptimizer):
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.
             keep_clifford: If set, single qubit rotations in the Clifford group
-                are converted to CliffordGates.
+                are converted to SingleQubitCliffordGates.
             tolerance: Maximum absolute error tolerance. The optimization is
                 permitted to round angles with a threshold determined by this
                 tolerance.
@@ -71,11 +71,11 @@ class ConvertToPauliStringPhasors(PointOptimizer):
         for pauli, half_turns in rotations:
             if (self.keep_clifford
                     and self._tol.all_near_zero_mod(half_turns, 0.5)):
-                cliff_gate = ops.CliffordGate.from_quarter_turns(
+                cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(
                     pauli, round(half_turns * 2))
                 if out_ops and not isinstance(out_ops[-1], PauliStringPhasor):
                     op = cast(ops.GateOperation, out_ops[-1])
-                    gate = cast(ops.CliffordGate, op.gate)
+                    gate = cast(ops.SingleQubitCliffordGate, op.gate)
                     out_ops[-1] = gate.merged_with(cliff_gate)(qubit)
                 else:
                     out_ops.append(
@@ -94,7 +94,7 @@ class ConvertToPauliStringPhasors(PointOptimizer):
 
         if (self.keep_clifford
             and isinstance(op, ops.GateOperation)
-                and isinstance(op.gate, ops.CliffordGate)):
+                and isinstance(op.gate, ops.SingleQubitCliffordGate)):
             return op
 
         # Single qubit gate with known matrix?

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
@@ -48,7 +48,7 @@ def test_convert_keep_clifford():
         cirq.X(q0),
         cirq.Y(q1) ** 0.25,
         cirq.Z(q0) ** 0.125,
-        cirq.CliffordGate.H(q1),
+        cirq.SingleQubitCliffordGate.H(q1),
     )
     c_orig = cirq.Circuit(circuit)
     ConvertToPauliStringPhasors(keep_clifford=True).optimize_circuit(circuit)

--- a/cirq/contrib/paulistring/pauli_string_phasor_test.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor_test.py
@@ -71,7 +71,8 @@ def test_map_qubits():
 def test_pass_operations_over():
     q0, q1 = _make_qubits(2)
     X, Y, Z = cirq.Pauli.XYZ
-    op = cirq.CliffordGate.from_double_map({Z: (X,False), X: (Z,False)})(q0)
+    op = cirq.SingleQubitCliffordGate.from_double_map({Z: (X,False),
+                                                       X: (Z,False)})(q0)
     ps_before = cirq.PauliString({q0: X, q1: Y}, True)
     ps_after = cirq.PauliString({q0: Z, q1: Y}, True)
     before = PauliStringPhasor(ps_before, half_turns=0.1)

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -45,7 +45,7 @@ def _possible_string_placements(
                 # Pass through another Pauli string if they commute
                 continue
             if not (isinstance(out_op, ops.GateOperation) and
-                    isinstance(out_op.gate, (ops.CliffordGate,
+                    isinstance(out_op.gate, (ops.SingleQubitCliffordGate,
                                              ops.PauliInteractionGate,
                                              ops.Rot11Gate))):
                 # This is as far through as this Pauli string can move

--- a/cirq/contrib/paulistring/separate.py
+++ b/cirq/contrib/paulistring/separate.py
@@ -37,8 +37,9 @@ def convert_and_separate_circuit(circuit: circuits.Circuit,
 
         circuit_left contains only PauliStringPhasor operations.
 
-        circuit_right is a Clifford circuit which contains only CliffordGate and
-        PauliInteractionGate gates.  It also contains MeasurementGates if the
+        circuit_right is a Clifford circuit which contains only
+        SingleQubitCliffordGate and PauliInteractionGate gates.
+        It also contains MeasurementGates if the
         given circuit contains measurements.
     """
     circuit = converted_gate_set(circuit,
@@ -52,12 +53,13 @@ def regular_half(circuit: circuits.Circuit) -> circuits.Circuit:
     convert_and_separate_circuit().
 
     Args:
-        circuit: A Circuit with the gate set {CliffordGate,
+        circuit: A Circuit with the gate set {SingleQubitCliffordGate,
             PauliInteractionGate, PauliStringPhasor}.
 
     Returns:
-        A Circuit with CliffordGate and PauliInteractionGate gates.  It also
-        contains MeasurementGates if the given circuit contains measurements.
+        A Circuit with SingleQubitCliffordGate and PauliInteractionGate gates.
+        It also contains MeasurementGates if the given
+        circuit contains measurements.
     """
     return circuits.Circuit(
                 circuits.Moment(op for op in moment.operations
@@ -70,7 +72,7 @@ def pauli_string_half(circuit: circuits.Circuit) -> circuits.Circuit:
     convert_and_separate_circuit().
 
     Args:
-        circuit: A Circuit with the gate set {CliffordGate,
+        circuit: A Circuit with the gate set {SingleQubitCliffordGate,
             PauliInteractionGate, PauliStringPhasor}.
 
     Returns:

--- a/cirq/contrib/paulistring/separate_test.py
+++ b/cirq/contrib/paulistring/separate_test.py
@@ -34,7 +34,7 @@ def test_toffoli_separate():
     assert all(isinstance(op, PauliStringPhasor)
                for op in c_left.all_operations())
     assert all(isinstance(op, cirq.GateOperation) and
-               isinstance(op.gate, (cirq.CliffordGate,
+               isinstance(op.gate, (cirq.SingleQubitCliffordGate,
                                     cirq.Rot11Gate))
                for op in c_right.all_operations())
 

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -86,7 +86,7 @@ from cirq.ops.pauli import (
     Pauli,
 )
 from cirq.ops.clifford_gate import (
-    CliffordGate,
+    SingleQubitCliffordGate,
     PauliTransform,
 )
 from cirq.ops.pauli_interaction_gate import (

--- a/cirq/ops/clifford_gate.py
+++ b/cirq/ops/clifford_gate.py
@@ -25,22 +25,22 @@ from cirq.ops.pauli import Pauli
 PauliTransform = NamedTuple('PauliTransform', [('to', Pauli), ('flip', bool)])
 
 
-class CliffordGate(raw_types.Gate,
+class SingleQubitCliffordGate(raw_types.Gate,
                    gate_features.CompositeGate,
                    gate_features.ReversibleEffect,
                    gate_features.TextDiagrammable):
     """Any single qubit Clifford rotation."""
-    I = None  # type: CliffordGate
-    H = None  # type: CliffordGate
-    X = None  # type: CliffordGate
-    Y = None  # type: CliffordGate
-    Z = None  # type: CliffordGate
-    X_sqrt  = None  # type: CliffordGate
-    X_nsqrt = None  # type: CliffordGate
-    Y_sqrt  = None  # type: CliffordGate
-    Y_nsqrt = None  # type: CliffordGate
-    Z_sqrt  = None  # type: CliffordGate
-    Z_nsqrt = None  # type: CliffordGate
+    I = None  # type: SingleQubitCliffordGate
+    H = None  # type: SingleQubitCliffordGate
+    X = None  # type: SingleQubitCliffordGate
+    Y = None  # type: SingleQubitCliffordGate
+    Z = None  # type: SingleQubitCliffordGate
+    X_sqrt  = None  # type: SingleQubitCliffordGate
+    X_nsqrt = None  # type: SingleQubitCliffordGate
+    Y_sqrt  = None  # type: SingleQubitCliffordGate
+    Y_nsqrt = None  # type: SingleQubitCliffordGate
+    Z_sqrt  = None  # type: SingleQubitCliffordGate
+    Z_nsqrt = None  # type: SingleQubitCliffordGate
 
     def __init__(self, *,
                  _rotation_map: Dict[Pauli, PauliTransform],
@@ -50,15 +50,15 @@ class CliffordGate(raw_types.Gate,
 
     @staticmethod
     def from_xz_map(x_to: Tuple[Pauli, bool],
-                    z_to: Tuple[Pauli, bool]) -> 'CliffordGate':
-        """Returns a CliffordGate for the specified transforms.  The Y
-        transform is derived from the X and Z.
+                    z_to: Tuple[Pauli, bool]) -> 'SingleQubitCliffordGate':
+        """Returns a SingleQubitCliffordGate for the specified transforms.
+        The Y transform is derived from the X and Z.
 
         Args:
             x_to: Which Pauli to transform X to and if it should negate.
             z_to: Which Pauli to transform Z to and if it should negate.
         """
-        return CliffordGate.from_double_map(x_to=x_to, z_to=z_to)
+        return SingleQubitCliffordGate.from_double_map(x_to=x_to, z_to=z_to)
 
     @staticmethod
     def from_single_map(pauli_map_to: Optional[Dict[Pauli, Tuple[Pauli, bool]]]
@@ -67,9 +67,9 @@ class CliffordGate(raw_types.Gate,
                         x_to: Optional[Tuple[Pauli, bool]] = None,
                         y_to: Optional[Tuple[Pauli, bool]] = None,
                         z_to: Optional[Tuple[Pauli, bool]] = None
-                        ) -> 'CliffordGate':
-        """Returns a CliffordGate for the specified transform with a 90 or 180
-        degree rotation.
+                        ) -> 'SingleQubitCliffordGate':
+        """Returns a SingleQubitCliffordGate for the
+        specified transform with a 90 or 180 degree rotation.
 
         The arguments are exclusive, only one may be specified.
 
@@ -80,7 +80,7 @@ class CliffordGate(raw_types.Gate,
             y_to: The transform from Pauli.Y
             z_to: The transform from Pauli.Z
         """
-        rotation_map = CliffordGate._validate_map_input(
+        rotation_map = SingleQubitCliffordGate._validate_map_input(
                                         1,
                                         pauli_map_to,
                                         x_to=x_to, y_to=y_to, z_to=z_to)
@@ -94,7 +94,7 @@ class CliffordGate(raw_types.Gate,
             trans_to2 = trans_from
             flip2 = not flip
         rotation_map[trans_from2] = PauliTransform(trans_to2, flip2)
-        return CliffordGate.from_double_map(
+        return SingleQubitCliffordGate.from_double_map(
                         cast(Dict[Pauli, Tuple[Pauli, bool]], rotation_map))
 
     @staticmethod
@@ -104,9 +104,9 @@ class CliffordGate(raw_types.Gate,
                         x_to: Optional[Tuple[Pauli, bool]] = None,
                         y_to: Optional[Tuple[Pauli, bool]] = None,
                         z_to: Optional[Tuple[Pauli, bool]] = None
-                        ) -> 'CliffordGate':
-        """Returns a CliffordGate for the specified transform with a 90 or 180
-        degree rotation.
+                        ) -> 'SingleQubitCliffordGate':
+        """Returns a SingleQubitCliffordGate for the
+        specified transform with a 90 or 180 degree rotation.
 
         Either pauli_map_to or two of (x_to, y_to, z_to) may be specified.
 
@@ -117,7 +117,7 @@ class CliffordGate(raw_types.Gate,
             y_to: The transform from Pauli.Y
             z_to: The transform from Pauli.Z
         """
-        rotation_map = CliffordGate._validate_map_input(
+        rotation_map = SingleQubitCliffordGate._validate_map_input(
                                         2,
                                         pauli_map_to,
                                         x_to=x_to, y_to=y_to, z_to=z_to)
@@ -129,11 +129,12 @@ class CliffordGate(raw_types.Gate,
         rotation_map[from3] = PauliTransform(to3, flip3)
         inverse_map = {to: PauliTransform(frm, flip)
                        for frm, (to, flip) in rotation_map.items()}
-        return CliffordGate(_rotation_map=rotation_map,
+        return SingleQubitCliffordGate(_rotation_map=rotation_map,
                             _inverse_map=inverse_map)
 
     @staticmethod
-    def from_pauli(pauli: Pauli, sqrt: bool = False) -> 'CliffordGate':
+    def from_pauli(pauli: Pauli,
+                   sqrt: bool = False) -> 'SingleQubitCliffordGate':
         if sqrt:
             rotation_map = {pauli:   PauliTransform(pauli, False),
                             pauli+1: PauliTransform(pauli+2, False),
@@ -144,20 +145,21 @@ class CliffordGate(raw_types.Gate,
                             pauli+2: PauliTransform(pauli+2, True)}
         inverse_map = {to: PauliTransform(frm, flip)
                        for frm, (to, flip) in rotation_map.items()}
-        return CliffordGate(_rotation_map=rotation_map,
+        return SingleQubitCliffordGate(_rotation_map=rotation_map,
                             _inverse_map=inverse_map)
 
     @staticmethod
-    def from_quarter_turns(pauli: Pauli, quarter_turns: int) -> 'CliffordGate':
+    def from_quarter_turns(pauli: Pauli,
+                           quarter_turns: int) -> 'SingleQubitCliffordGate':
         quarter_turns = quarter_turns % 4
         if quarter_turns == 0:
-            return CliffordGate.I
+            return SingleQubitCliffordGate.I
         elif quarter_turns == 1:
-            return CliffordGate.from_pauli(pauli, True)
+            return SingleQubitCliffordGate.from_pauli(pauli, True)
         elif quarter_turns == 2:
-            return CliffordGate.from_pauli(pauli)
+            return SingleQubitCliffordGate.from_pauli(pauli)
         else:
-            return CliffordGate.from_pauli(pauli, True).inverse()
+            return SingleQubitCliffordGate.from_pauli(pauli, True).inverse()
 
     @staticmethod
     def _validate_map_input(required_transform_count: int,
@@ -191,7 +193,7 @@ class CliffordGate(raw_types.Gate,
         return self._rotation_map[pauli]
 
     def _eq_tuple(self) -> Tuple[Any, ...]:
-        return (CliffordGate,
+        return (SingleQubitCliffordGate,
                 self.transform(Pauli.X),
                 self.transform(Pauli.Y),
                 self.transform(Pauli.Z))
@@ -207,21 +209,23 @@ class CliffordGate(raw_types.Gate,
     def __hash__(self):
         return hash(self._eq_tuple())
 
-    def inverse(self) -> 'CliffordGate':
-        return CliffordGate(_rotation_map=self._inverse_map,
+    def inverse(self) -> 'SingleQubitCliffordGate':
+        return SingleQubitCliffordGate(_rotation_map=self._inverse_map,
                             _inverse_map=self._rotation_map)
 
     def commutes_with(self,
-                      gate_or_pauli: Union['CliffordGate', Pauli]
+                      gate_or_pauli: Union['SingleQubitCliffordGate', Pauli]
                       ) -> bool:
-        if isinstance(gate_or_pauli, CliffordGate):
+        if isinstance(gate_or_pauli, SingleQubitCliffordGate):
             gate = gate_or_pauli
             return self.commutes_with_single_qubit_gate(gate)
         else:
             pauli = gate_or_pauli
             return self.commutes_with_pauli(pauli)
 
-    def commutes_with_single_qubit_gate(self, gate: 'CliffordGate') -> bool:
+    def commutes_with_single_qubit_gate(self,
+                                        gate: 'SingleQubitCliffordGate') \
+                                        -> bool:
         """Tests if the two circuits would be equivalent up to global phase:
             --self--gate-- and --gate--self--"""
         for pauli0 in (Pauli.X, Pauli.Z):
@@ -237,16 +241,19 @@ class CliffordGate(raw_types.Gate,
         to, flip = self.transform(pauli)
         return (to == pauli and not flip)
 
-    def merged_with(self, second: 'CliffordGate') -> 'CliffordGate':
-        """Returns a CliffordGate such that the circuits
+    def merged_with(self,
+                    second: 'SingleQubitCliffordGate') \
+                    -> 'SingleQubitCliffordGate':
+        """Returns a SingleQubitCliffordGate such that the circuits
             --output-- and --self--second--
         are equivalent up to global phase."""
         x_intermediate_pauli, x_flip1 = self.transform(Pauli.X)
         x_final_pauli, x_flip2 = second.transform(x_intermediate_pauli)
         z_intermediate_pauli, z_flip1 = self.transform(Pauli.Z)
         z_final_pauli, z_flip2 = second.transform(z_intermediate_pauli)
-        return CliffordGate.from_xz_map((x_final_pauli, x_flip1 ^ x_flip2),
-                                          (z_final_pauli, z_flip1 ^ z_flip2))
+        return SingleQubitCliffordGate.from_xz_map(
+            (x_final_pauli, x_flip1 ^ x_flip2),
+            (z_final_pauli, z_flip1 ^ z_flip2))
 
     def _unitary_(self) -> np.ndarray:
         mat = np.eye(2)
@@ -258,7 +265,7 @@ class CliffordGate(raw_types.Gate,
     def default_decompose(self, qubits: Sequence[raw_types.QubitId]
                           ) -> op_tree.OP_TREE:
         qubit, = qubits
-        if self == CliffordGate.H:
+        if self == SingleQubitCliffordGate.H:
             return common_gates.H(qubit),
         rotations = self.decompose_rotation()
         pauli_gate_map = {Pauli.X: common_gates.X,
@@ -318,14 +325,16 @@ class CliffordGate(raw_types.Gate,
         assert False, ('Impossible condition where this gate only rotates one'
                        ' Pauli to a different Pauli.')
 
-    def equivalent_gate_before(self, after: 'CliffordGate') -> 'CliffordGate':
-        """Returns a CliffordGate such that the circuits
+    def equivalent_gate_before(self, after: 'SingleQubitCliffordGate') \
+        -> 'SingleQubitCliffordGate':
+        """Returns a SingleQubitCliffordGate such that the circuits
             --output--self-- and --self--gate--
         are equivalent up to global phase."""
         return self.merged_with(after).merged_with(self.inverse())
 
     def __repr__(self):
-        return 'cirq.CliffordGate(X:{}{!s}, Y:{}{!s}, Z:{}{!s})'.format(
+        return 'cirq.SingleQubitCliffordGate(X:{}{!s}, Y:{}{!s}, Z:{}{!s})' \
+            .format(
                 '+-'[self.transform(Pauli.X).flip], self.transform(Pauli.X).to,
                 '+-'[self.transform(Pauli.Y).flip], self.transform(Pauli.Y).to,
                 '+-'[self.transform(Pauli.Z).flip], self.transform(Pauli.Z).to)
@@ -333,17 +342,17 @@ class CliffordGate(raw_types.Gate,
     def text_diagram_info(self, args: gate_features.TextDiagramInfoArgs
                           ) -> gate_features.TextDiagramInfo:
         well_known_map = {
-            CliffordGate.I: 'I',
-            CliffordGate.H: 'H',
-            CliffordGate.X: 'X',
-            CliffordGate.Y: 'Y',
-            CliffordGate.Z: 'Z',
-            CliffordGate.X_sqrt: 'X',
-            CliffordGate.Y_sqrt: 'Y',
-            CliffordGate.Z_sqrt: 'Z',
-            CliffordGate.X_nsqrt: 'X',
-            CliffordGate.Y_nsqrt: 'Y',
-            CliffordGate.Z_nsqrt: 'Z',
+            SingleQubitCliffordGate.I: 'I',
+            SingleQubitCliffordGate.H: 'H',
+            SingleQubitCliffordGate.X: 'X',
+            SingleQubitCliffordGate.Y: 'Y',
+            SingleQubitCliffordGate.Z: 'Z',
+            SingleQubitCliffordGate.X_sqrt: 'X',
+            SingleQubitCliffordGate.Y_sqrt: 'Y',
+            SingleQubitCliffordGate.Z_sqrt: 'Z',
+            SingleQubitCliffordGate.X_nsqrt: 'X',
+            SingleQubitCliffordGate.Y_nsqrt: 'Y',
+            SingleQubitCliffordGate.Z_nsqrt: 'Z',
         }
         if self in well_known_map:
             symbol = well_known_map[self]
@@ -356,29 +365,34 @@ class CliffordGate(raw_types.Gate,
         return gate_features.TextDiagramInfo(
             wire_symbols=(symbol,),
             exponent={
-                CliffordGate.X_sqrt: 0.5,
-                CliffordGate.Y_sqrt: 0.5,
-                CliffordGate.Z_sqrt: 0.5,
-                CliffordGate.X_nsqrt: -0.5,
-                CliffordGate.Y_nsqrt: -0.5,
-                CliffordGate.Z_nsqrt: -0.5,
+                SingleQubitCliffordGate.X_sqrt: 0.5,
+                SingleQubitCliffordGate.Y_sqrt: 0.5,
+                SingleQubitCliffordGate.Z_sqrt: 0.5,
+                SingleQubitCliffordGate.X_nsqrt: -0.5,
+                SingleQubitCliffordGate.Y_nsqrt: -0.5,
+                SingleQubitCliffordGate.Z_nsqrt: -0.5,
             }.get(self, 1))
 
 
-CliffordGate.I = CliffordGate.from_xz_map((Pauli.X, False), (Pauli.Z, False))
-CliffordGate.H = CliffordGate.from_xz_map((Pauli.Z, False), (Pauli.X, False))
-CliffordGate.X = CliffordGate.from_xz_map((Pauli.X, False), (Pauli.Z, True))
-CliffordGate.Y = CliffordGate.from_xz_map((Pauli.X, True),  (Pauli.Z, True))
-CliffordGate.Z = CliffordGate.from_xz_map((Pauli.X, True),  (Pauli.Z, False))
-CliffordGate.X_sqrt  = CliffordGate.from_xz_map((Pauli.X, False),
-                                                  (Pauli.Y, True))
-CliffordGate.X_nsqrt = CliffordGate.from_xz_map((Pauli.X, False),
-                                                  (Pauli.Y, False))
-CliffordGate.Y_sqrt  = CliffordGate.from_xz_map((Pauli.Z, True),
-                                                  (Pauli.X, False))
-CliffordGate.Y_nsqrt = CliffordGate.from_xz_map((Pauli.Z, False),
-                                                  (Pauli.X, True))
-CliffordGate.Z_sqrt  = CliffordGate.from_xz_map((Pauli.Y, False),
-                                                  (Pauli.Z, False))
-CliffordGate.Z_nsqrt = CliffordGate.from_xz_map((Pauli.Y, True),
-                                                  (Pauli.Z, False))
+SingleQubitCliffordGate.I = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.X, False), (Pauli.Z, False))
+SingleQubitCliffordGate.H = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.Z, False), (Pauli.X, False))
+SingleQubitCliffordGate.X = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.X, False), (Pauli.Z, True))
+SingleQubitCliffordGate.Y = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.X, True), (Pauli.Z, True))
+SingleQubitCliffordGate.Z = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.X, True), (Pauli.Z, False))
+SingleQubitCliffordGate.X_sqrt  = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.X, False), (Pauli.Y, True))
+SingleQubitCliffordGate.X_nsqrt = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.X, False), (Pauli.Y, False))
+SingleQubitCliffordGate.Y_sqrt  = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.Z, True), (Pauli.X, False))
+SingleQubitCliffordGate.Y_nsqrt = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.Z, False), (Pauli.X, True))
+SingleQubitCliffordGate.Z_sqrt  = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.Y, False), (Pauli.Z, False))
+SingleQubitCliffordGate.Z_nsqrt = SingleQubitCliffordGate.from_xz_map(
+    (Pauli.Y, True), (Pauli.Z, False))

--- a/cirq/ops/pauli_interaction_gate.py
+++ b/cirq/ops/pauli_interaction_gate.py
@@ -19,7 +19,7 @@ import numpy as np
 from cirq import value
 from cirq.ops import raw_types, gate_features, common_gates, eigen_gate, op_tree
 from cirq.ops.pauli import Pauli
-from cirq.ops.clifford_gate import CliffordGate
+from cirq.ops.clifford_gate import SingleQubitCliffordGate
 
 
 pauli_eigen_map = {
@@ -106,9 +106,9 @@ class PauliInteractionGate(eigen_gate.EigenGate,
     def default_decompose(self, qubits: Sequence[raw_types.QubitId]
                           ) -> op_tree.OP_TREE:
         q0, q1 = qubits
-        right_gate0 = CliffordGate.from_single_map(
+        right_gate0 = SingleQubitCliffordGate.from_single_map(
                                     z_to=(self.pauli0, self.invert0))
-        right_gate1 = CliffordGate.from_single_map(
+        right_gate1 = SingleQubitCliffordGate.from_single_map(
                                     z_to=(self.pauli1, self.invert1))
         left_gate0 = right_gate0.inverse()
         left_gate1 = right_gate1.inverse()

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -19,7 +19,7 @@ from cirq.ops import (
     raw_types, gate_operation, common_gates, qubit_order, op_tree
 )
 from cirq.ops.pauli import Pauli
-from cirq.ops.clifford_gate import CliffordGate
+from cirq.ops.clifford_gate import SingleQubitCliffordGate
 from cirq.ops.pauli_interaction_gate import PauliInteractionGate
 
 
@@ -127,7 +127,8 @@ class PauliString:
         """Returns operations to convert the qubits to the computational basis.
         """
         for qubit, pauli in self.items():
-            yield CliffordGate.from_single_map({pauli: (Pauli.Z, False)})(qubit)
+            yield SingleQubitCliffordGate.from_single_map(
+                {pauli: (Pauli.Z, False)})(qubit)
 
     def pass_operations_over(self,
                              ops: Iterable[raw_types.Operation],
@@ -169,7 +170,7 @@ class PauliString:
                              after_to_before: bool = False) -> bool:
         if isinstance(op, gate_operation.GateOperation):
             gate = op.gate
-            if isinstance(gate, CliffordGate):
+            if isinstance(gate, SingleQubitCliffordGate):
                 return PauliString._pass_single_clifford_gate_over(
                     pauli_map, gate, op.qubits[0],
                     after_to_before=after_to_before)
@@ -184,7 +185,7 @@ class PauliString:
     @staticmethod
     def _pass_single_clifford_gate_over(pauli_map: Dict[raw_types.QubitId,
                                                         Pauli],
-                                        gate: CliffordGate,
+                                        gate: SingleQubitCliffordGate,
                                         qubit: raw_types.QubitId,
                                         after_to_before: bool = False) -> bool:
         if qubit not in pauli_map:

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -342,23 +342,24 @@ def test_pass_operations_over_single(shift, t_or_f):
     q0, q1 = _make_qubits(2)
     X, Y, Z = (pauli+shift for pauli in cirq.Pauli.XYZ)
 
-    op0 = cirq.CliffordGate.from_pauli(Y)(q1)
+    op0 = cirq.SingleQubitCliffordGate.from_pauli(Y)(q1)
     ps_before = cirq.PauliString({q0: X}, t_or_f)
     ps_after = ps_before
     _assert_pass_over([op0], ps_before, ps_after)
 
-    op0 = cirq.CliffordGate.from_pauli(X)(q0)
-    op1 = cirq.CliffordGate.from_pauli(Y)(q1)
+    op0 = cirq.SingleQubitCliffordGate.from_pauli(X)(q0)
+    op1 = cirq.SingleQubitCliffordGate.from_pauli(Y)(q1)
     ps_before = cirq.PauliString({q0: X, q1: Y}, t_or_f)
     ps_after = ps_before
     _assert_pass_over([op0, op1], ps_before, ps_after)
 
-    op0 = cirq.CliffordGate.from_double_map({Z: (X,False), X: (Z,False)})(q0)
+    op0 = cirq.SingleQubitCliffordGate.from_double_map({Z: (X,False),
+                                                        X: (Z,False)})(q0)
     ps_before = cirq.PauliString({q0: X, q1: Y}, t_or_f)
     ps_after = cirq.PauliString({q0: Z, q1: Y}, t_or_f)
     _assert_pass_over([op0], ps_before, ps_after)
 
-    op1 = cirq.CliffordGate.from_pauli(X)(q1)
+    op1 = cirq.SingleQubitCliffordGate.from_pauli(X)(q1)
     ps_before = cirq.PauliString({q0: X, q1: Y}, t_or_f)
     ps_after = ps_before.negate()
     _assert_pass_over([op1], ps_before, ps_after)
@@ -366,8 +367,8 @@ def test_pass_operations_over_single(shift, t_or_f):
     ps_after = cirq.PauliString({q0: Z, q1: Y}, not t_or_f)
     _assert_pass_over([op0, op1], ps_before, ps_after)
 
-    op0 = cirq.CliffordGate.from_pauli(Z, True)(q0)
-    op1 = cirq.CliffordGate.from_pauli(X, True)(q0)
+    op0 = cirq.SingleQubitCliffordGate.from_pauli(Z, True)(q0)
+    op1 = cirq.SingleQubitCliffordGate.from_pauli(X, True)(q0)
     ps_before = cirq.PauliString({q0: X}, t_or_f)
     ps_after = cirq.PauliString({q0: Y}, not t_or_f)
     _assert_pass_over([op0, op1], ps_before, ps_after)


### PR DESCRIPTION
Curious. Where is `TwoQubitCliffordGate`?