### PR TITLE
Begin switch from value.inverse() to value**-1 / cirq.inverse(value)

### DIFF
--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -91,6 +91,8 @@ class PauliStringPhasor(PauliStringGateOperation,
         return self._with_half_turns(self.half_turns * factor)  # type: ignore
 
     def __pow__(self, power: Union[float, value.Symbol]) -> 'PauliStringPhasor':
+        if power != 1 and self.is_parameterized():
+            return NotImplemented
         return self.extrapolate_effect(power)
 
     def inverse(self) -> 'PauliStringPhasor':

--- a/cirq/contrib/paulistring/pauli_string_phasor_test.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor_test.py
@@ -113,7 +113,9 @@ def test_extrapolate_effect_with_symbol():
 def test_inverse():
     op1 = PauliStringPhasor(cirq.PauliString({}), half_turns=0.25)
     op2 = PauliStringPhasor(cirq.PauliString({}), half_turns=-0.25)
-    assert op1.inverse() == op2
+    op3 = PauliStringPhasor(cirq.PauliString({}), half_turns=cirq.Symbol('s'))
+    assert cirq.inverse(op1) == op2
+    assert cirq.inverse(op3, None) is None
 
 
 def test_can_merge_with():

--- a/cirq/google/xmon_gates_test.py
+++ b/cirq/google/xmon_gates_test.py
@@ -506,10 +506,9 @@ def test_w_decomposition():
         atol=1e-8)
 
 
-def test_w_potential_implementation():
-    assert not cirq.can_cast(cirq.ReversibleEffect,
-                             cg.ExpWGate(half_turns=cirq.Symbol('a')))
-    assert cirq.can_cast(cirq.ReversibleEffect, cg.ExpWGate())
+def test_w_inverse():
+    assert cirq.inverse(cg.ExpWGate(half_turns=cirq.Symbol('a')), None) is None
+    assert cirq.inverse(cg.ExpWGate()) == cg.ExpWGate()
 
 
 def test_w_parameterize():
@@ -536,11 +535,9 @@ def test_trace_bound():
         half_turns=cirq.Symbol('a')).trace_distance_bound() >= 1
 
 
-def test_has_inverse():
-    assert cg.ExpZGate(half_turns=.1).has_inverse()
-    assert cg.ExpWGate(half_turns=.1).has_inverse()
-    assert not cg.ExpZGate(half_turns=cirq.Symbol('a')).has_inverse()
-    assert not cg.ExpWGate(half_turns=cirq.Symbol('a')).has_inverse()
+def test_z_inverse():
+    assert cirq.inverse(cg.ExpZGate(half_turns=cirq.Symbol('a')), None) is None
+    assert cirq.inverse(cg.ExpZGate()) == cg.ExpZGate()
 
 
 def test_measure_key_on():

--- a/cirq/ops/clifford_gate.py
+++ b/cirq/ops/clifford_gate.py
@@ -159,7 +159,7 @@ class SingleQubitCliffordGate(raw_types.Gate,
         elif quarter_turns == 2:
             return SingleQubitCliffordGate.from_pauli(pauli)
         else:
-            return SingleQubitCliffordGate.from_pauli(pauli, True).inverse()
+            return SingleQubitCliffordGate.from_pauli(pauli, True)**-1
 
     @staticmethod
     def _validate_map_input(required_transform_count: int,
@@ -209,9 +209,14 @@ class SingleQubitCliffordGate(raw_types.Gate,
     def __hash__(self):
         return hash(self._eq_tuple())
 
+    def __pow__(self, power):
+        if power != -1:
+            return NotImplemented
+        return self.inverse()
+
     def inverse(self) -> 'SingleQubitCliffordGate':
         return SingleQubitCliffordGate(_rotation_map=self._inverse_map,
-                            _inverse_map=self._rotation_map)
+                                       _inverse_map=self._rotation_map)
 
     def commutes_with(self,
                       gate_or_pauli: Union['SingleQubitCliffordGate', Pauli]
@@ -330,7 +335,7 @@ class SingleQubitCliffordGate(raw_types.Gate,
         """Returns a SingleQubitCliffordGate such that the circuits
             --output--self-- and --self--gate--
         are equivalent up to global phase."""
-        return self.merged_with(after).merged_with(self.inverse())
+        return self.merged_with(after).merged_with(self**-1)
 
     def __repr__(self):
         return 'cirq.SingleQubitCliffordGate(X:{}{!s}, Y:{}{!s}, Z:{}{!s})' \

--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -154,7 +154,7 @@ def test_init_90rot_from_single(trans, frm):
     # Check that flipping the transform produces the inverse rotation
     trans_rev = cirq.PauliTransform(trans.to, not trans.flip)
     gate_rev = cirq.SingleQubitCliffordGate.from_single_map({frm: trans_rev})
-    assert gate.inverse() == gate_rev
+    assert gate**-1 == gate_rev
 
 
 @pytest.mark.parametrize('trans,frm',
@@ -367,14 +367,14 @@ def test_known_matrix(gate, gate_equiv):
 
 @pytest.mark.parametrize('gate', _all_clifford_gates())
 def test_inverse(gate):
-    assert gate == gate.inverse().inverse()
+    assert gate == cirq.inverse(cirq.inverse(gate))
 
 
 @pytest.mark.parametrize('gate', _all_clifford_gates())
 def test_inverse_matrix(gate):
     q0 = cirq.NamedQubit('q0')
     mat = cirq.Circuit.from_ops(gate(q0)).to_unitary_matrix()
-    mat_inv = cirq.Circuit.from_ops(gate.inverse()(q0)).to_unitary_matrix()
+    mat_inv = cirq.Circuit.from_ops(cirq.inverse(gate)(q0)).to_unitary_matrix()
     assert_allclose_up_to_global_phase(mat, mat_inv.T.conj(),
                                        rtol=1e-7, atol=1e-7)
 

--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -199,6 +199,18 @@ def test_init_from_pauli(pauli, sqrt, expected):
     assert gate == expected
 
 
+def test_pow():
+    assert cirq.SingleQubitCliffordGate.X**-1 == cirq.SingleQubitCliffordGate.X
+    assert cirq.SingleQubitCliffordGate.H**-1 == cirq.SingleQubitCliffordGate.H
+    assert (cirq.SingleQubitCliffordGate.X_sqrt**-1 ==
+            cirq.SingleQubitCliffordGate.X_nsqrt)
+    assert cirq.inverse(cirq.SingleQubitCliffordGate.X_nsqrt) == (
+        cirq.SingleQubitCliffordGate.X_sqrt
+    )
+    with pytest.raises(TypeError):
+        _ = cirq.SingleQubitCliffordGate.Z**0.25
+
+
 def test_init_from_quarter_turns():
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -44,8 +44,7 @@ def test_cz_repr():
 
 
 def test_cz_extrapolate():
-    assert cirq.Rot11Gate(
-        half_turns=1).extrapolate_effect(0.5) == cirq.Rot11Gate(half_turns=0.5)
+    assert cirq.Rot11Gate(half_turns=1)**0.5 == cirq.Rot11Gate(half_turns=0.5)
     assert cirq.CZ**-0.25 == cirq.Rot11Gate(half_turns=1.75)
 
 
@@ -107,8 +106,7 @@ def test_rot_gates_eq():
 
 
 def test_z_extrapolate():
-    assert cirq.RotZGate(
-        half_turns=1).extrapolate_effect(0.5) == cirq.RotZGate(half_turns=0.5)
+    assert cirq.RotZGate(half_turns=1)**0.5 == cirq.RotZGate(half_turns=0.5)
     assert cirq.Z**-0.25 == cirq.RotZGate(half_turns=1.75)
     assert cirq.RotZGate(half_turns=0.5).phase_by(0.25, 0) == cirq.RotZGate(
         half_turns=0.5)

--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -102,6 +102,11 @@ class ControlledGate(raw_types.Gate,
                               self.default_extensions)
 
     def __pow__(self, power: float) -> 'ControlledGate':
+        if power == -1:
+            inv_gate = protocols.inverse(self.sub_gate, None)
+            if inv_gate is None:
+                return NotImplemented
+            return ControlledGate(inv_gate, self.default_extensions)
         return self.extrapolate_effect(power)
 
     def inverse(self) -> 'ControlledGate':

--- a/cirq/ops/controlled_gate_test.py
+++ b/cirq/ops/controlled_gate_test.py
@@ -117,14 +117,14 @@ def test_try_cast_to():
     assert CRestricted.try_cast_to(cirq.CompositeGate, ext) is None
 
     # Supported sub features that are not present on sub gate.
-    assert CRestricted.try_cast_to(cirq.ReversibleEffect, ext) is None
+    assert cirq.inverse(CRestricted, None) is None
     assert CRestricted.try_cast_to(cirq.ExtrapolatableEffect, ext) is None
     assert CRestricted.try_cast_to(cirq.TextDiagrammable, ext) is None
     assert CRestricted.try_cast_to(cirq.BoundedEffect, ext) is None
     assert CRestricted.try_cast_to(cirq.ParameterizableEffect, ext) is None
 
     # Supported sub features that are present on sub gate.
-    assert CY.try_cast_to(cirq.ReversibleEffect, ext) is not None
+    assert cirq.inverse(CY, None) is not None
     assert CY.try_cast_to(cirq.ExtrapolatableEffect, ext) is not None
     assert CY.try_cast_to(cirq.TextDiagrammable, ext) is not None
     assert CY.try_cast_to(cirq.BoundedEffect, ext) is not None
@@ -162,20 +162,8 @@ def test_extrapolatable_via_extension():
 
 
 def test_reversible():
-    assert (cirq.ControlledGate(cirq.S).inverse() ==
-            cirq.ControlledGate(cirq.S.inverse()))
-
-
-def test_reversible_via_extension():
-    ext = cirq.Extensions()
-    ext.add_cast(cirq.ReversibleEffect, RestrictedGate, lambda _: cirq.S)
-    without_ext = cirq.ControlledGate(RestrictedGate())
-    with_ext = cirq.ControlledGate(RestrictedGate(), ext)
-
-    with pytest.raises(TypeError):
-        _ = without_ext.inverse()
-
-    assert with_ext.inverse() == cirq.ControlledGate(cirq.S.inverse())
+    assert (cirq.inverse(cirq.ControlledGate(cirq.S)) ==
+            cirq.ControlledGate(cirq.S**-1))
 
 
 def test_parameterizable():

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -16,7 +16,7 @@ from typing import Tuple, Union, List, Optional, cast, TypeVar, NamedTuple
 
 import numpy as np
 
-from cirq import abc, extension, value
+from cirq import abc, extension, value, protocols
 from cirq.ops import gate_features, raw_types
 
 
@@ -148,6 +148,8 @@ class EigenGate(raw_types.Gate,
         pass
 
     def __pow__(self: TSelf, power: float) -> TSelf:
+        if power != 1 and self.is_parameterized():
+            return NotImplemented
         return self.extrapolate_effect(power)
 
     def inverse(self: TSelf) -> TSelf:

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -16,7 +16,7 @@ from typing import Tuple, Union, List, Optional, cast, TypeVar, NamedTuple
 
 import numpy as np
 
-from cirq import abc, extension, value, protocols
+from cirq import abc, extension, value
 from cirq.ops import gate_features, raw_types
 
 

--- a/cirq/ops/eigen_gate_test.py
+++ b/cirq/ops/eigen_gate_test.py
@@ -87,9 +87,9 @@ def test_extrapolate_effect():
 
 
 def test_inverse():
-    assert CExpZinGate(0.25).inverse() == CExpZinGate(-0.25)
+    assert cirq.inverse(CExpZinGate(0.25)) == CExpZinGate(-0.25)
     with pytest.raises(TypeError):
-        _ = CExpZinGate(cirq.Symbol('a')).inverse()
+        _ = cirq.inverse(CExpZinGate(cirq.Symbol('a')))
 
 
 def test_trace_distance_bound():
@@ -102,18 +102,18 @@ def test_try_cast_to():
 
     h = CExpZinGate(2)
     assert h.try_cast_to(cirq.ExtrapolatableEffect, ext) is h
-    assert h.try_cast_to(cirq.ReversibleEffect, ext) is h
     assert h.try_cast_to(cirq.SingleQubitGate, ext) is None
+    assert cirq.inverse(h, None) is not None
 
     p = CExpZinGate(0.1)
     assert p.try_cast_to(cirq.ExtrapolatableEffect, ext) is p
-    assert p.try_cast_to(cirq.ReversibleEffect, ext) is p
     assert p.try_cast_to(cirq.SingleQubitGate, ext) is None
+    assert cirq.inverse(p) is not None
 
     s = CExpZinGate(cirq.Symbol('a'))
     assert s.try_cast_to(cirq.ExtrapolatableEffect, ext) is None
-    assert s.try_cast_to(cirq.ReversibleEffect, ext) is None
     assert s.try_cast_to(cirq.SingleQubitGate, ext) is None
+    assert cirq.inverse(s, None) is None
 
 
 def test_matrix():

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -186,6 +186,11 @@ class GateOperation(raw_types.Operation,
         Returns:
             A new operation on the same qubits with the scaled gate.
         """
+        if power == -1:
+            inv_gate = protocols.inverse(self.gate, None)
+            if inv_gate is None:
+                return NotImplemented
+            return self.with_gate(inv_gate)
         return self.extrapolate_effect(power)
 
     def is_parameterized(self) -> bool:

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -103,14 +103,11 @@ def test_inverse():
 
     # If the gate isn't reversible, you get a type error.
     op0 = cirq.GateOperation(cirq.Gate(), [q])
-    assert not cirq.can_cast(cirq.ReversibleEffect, op0)
-    with pytest.raises(TypeError):
-        _ = op0.inverse()
+    assert cirq.inverse(op0, None) is None
 
     op1 = cirq.GateOperation(cirq.S, [q])
-    assert cirq.can_cast(cirq.ReversibleEffect, op1)
-    assert op1.inverse() == cirq.GateOperation(cirq.S.inverse(), [q])
-    assert cirq.S.inverse().on(q) == cirq.S.on(q).inverse()
+    assert cirq.inverse(op1) == op1**-1 == cirq.GateOperation(cirq.S**-1, [q])
+    assert cirq.inverse(cirq.S).on(q) == cirq.inverse(cirq.S.on(q))
 
 
 def test_text_diagrammable():

--- a/cirq/ops/pauli_interaction_gate.py
+++ b/cirq/ops/pauli_interaction_gate.py
@@ -110,8 +110,8 @@ class PauliInteractionGate(eigen_gate.EigenGate,
                                     z_to=(self.pauli0, self.invert0))
         right_gate1 = SingleQubitCliffordGate.from_single_map(
                                     z_to=(self.pauli1, self.invert1))
-        left_gate0 = right_gate0.inverse()
-        left_gate1 = right_gate1.inverse()
+        left_gate0 = right_gate0**-1
+        left_gate1 = right_gate1**-1
         yield left_gate0(q0)
         yield left_gate1(q1)
         yield common_gates.Rot11Gate(half_turns=self._exponent)(q0, q1)

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -191,7 +191,7 @@ class PauliString:
         if qubit not in pauli_map:
             return False
         if not after_to_before:
-            gate = gate.inverse()
+            gate **= -1
         pauli, inv = gate.transform(pauli_map[qubit])
         pauli_map[qubit] = pauli
         return inv

--- a/cirq/ops/reversible_composite_gate.py
+++ b/cirq/ops/reversible_composite_gate.py
@@ -27,6 +27,11 @@ class ReversibleCompositeGate(gate_features.CompositeGate,
                               metaclass=abc.ABCMeta):
     """A composite gate that gets decomposed into reversible gates."""
 
+    def __pow__(self, power):
+        if power != -1:
+            return NotImplemented
+        return self.inverse()
+
     def inverse(self: TOriginal
                 ) -> '_ReversedReversibleCompositeGate[TOriginal]':
         return _ReversedReversibleCompositeGate(self)
@@ -39,6 +44,11 @@ class _ReversedReversibleCompositeGate(Generic[TOriginal],
 
     def __init__(self, forward_form: TOriginal) -> None:
         self.forward_form = forward_form
+
+    def __pow__(self, power):
+        if power != -1:
+            return NotImplemented
+        return self.inverse()
 
     def inverse(self) -> TOriginal:
         return self.forward_form

--- a/cirq/ops/reversible_composite_gate_test.py
+++ b/cirq/ops/reversible_composite_gate_test.py
@@ -80,8 +80,8 @@ def test_child_class():
             yield _FlipGate(2)(*qubits), _FlipGate(3)(*qubits)
 
     gate = Impl()
-    reversed_gate = gate.inverse()
-    assert gate is reversed_gate.inverse()
+    reversed_gate = gate**-1
+    assert gate is reversed_gate**-1
 
     q = cirq.QubitId()
     assert (

--- a/cirq/ops/reversible_composite_gate_test.py
+++ b/cirq/ops/reversible_composite_gate_test.py
@@ -82,6 +82,10 @@ def test_child_class():
     gate = Impl()
     reversed_gate = gate**-1
     assert gate is reversed_gate**-1
+    with pytest.raises(TypeError):
+        _ = gate**0.5
+    with pytest.raises(TypeError):
+        _ = reversed_gate**0.5
 
     q = cirq.QubitId()
     assert (


### PR DESCRIPTION
- Mostly left class implementations alone (except when needed to make tests pass)

Part of https://github.com/quantumlib/Cirq/issues/943