### PR TITLE
Define circuit_diagram_info magic method protocol

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -199,7 +199,11 @@ from cirq.value import (
 )
 
 from cirq.protocols import (
+    CircuitDiagramInfo,
+    CircuitDiagramInfoArgs,
+    circuit_diagram_info,
     inverse,
+    SupportsCircuitDiagramInfo,
     SupportsUnitary,
     unitary,
 )

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -20,3 +20,9 @@ from cirq.protocols.unitary import (
     SupportsUnitary,
     unitary,
 )
+from cirq.protocols.circuit_diagram_info import (
+    CircuitDiagramInfo,
+    CircuitDiagramInfoArgs,
+    circuit_diagram_info,
+    SupportsCircuitDiagramInfo,
+)

--- a/cirq/protocols/circuit_diagram_info.py
+++ b/cirq/protocols/circuit_diagram_info.py
@@ -1,0 +1,193 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, TYPE_CHECKING, Optional, Union, Tuple, TypeVar, Dict
+
+from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    import cirq
+
+
+class CircuitDiagramInfo:
+    """Describes how to draw an operation in a circuit diagram."""
+
+    def __init__(self,
+                 wire_symbols: Tuple[str, ...],
+                 exponent: Any = 1,
+                 connected: bool = True) -> None:
+        """
+        Args:
+            wire_symbols: The symbols that should be shown on the qubits
+                affected by this operation. Must match the number of qubits that
+                the operation is applied to.
+            exponent: An optional convenience value that will be appended onto
+                an operation's final gate symbol with a caret in front
+                (unless it's equal to 1). For example, the square root of X gate
+                has a text diagram exponent of 0.5 and symbol of 'X' so it is
+                drawn as 'X^0.5'.
+            connected: Whether or not to draw a line connecting the qubits.
+        """
+        if isinstance(wire_symbols, str):
+            raise ValueError(
+                'Expected a Tuple[str] for wire_symbols but got a str.')
+        self.wire_symbols = wire_symbols
+        self.exponent = exponent
+        self.connected = connected
+
+    def _eq_tuple(self):
+        return (CircuitDiagramInfo, self.wire_symbols,
+                self.exponent, self.connected)
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self._eq_tuple() == other._eq_tuple()
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return hash(self._eq_tuple())
+
+    def __repr__(self):
+        return ('cirq.DiagramInfo(' +
+                'wire_symbols={!r}, '.format(self.wire_symbols) +
+                'exponent={!r}, '.format(self.exponent) +
+                'connected={!r})'.format(self.connected)
+                )
+
+
+class CircuitDiagramInfoArgs:
+    """A request for information on drawing an operation in a circuit diagram.
+
+    Attributes:
+        known_qubits: The qubits the gate is being applied to. None means this
+            information is not known by the caller.
+        known_qubit_count: The number of qubits the gate is being applied to
+            None means this information is not known by the caller.
+        use_unicode_characters: If true, the wire symbols are permitted to
+            include unicode characters (as long as they work well in fixed
+            width fonts). If false, use only ascii characters. ASCII is
+            preferred in cases where UTF8 support is done poorly, or where
+            the fixed-width font being used to show the diagrams does not
+            properly handle unicode characters.
+        precision: The number of digits after the decimal to show for numbers in
+            the text diagram. None means use full precision.
+        qubit_map: The map from qubits to diagram positions.
+    """
+
+    UNINFORMED_DEFAULT = None  # type: CircuitDiagramInfoArgs
+
+    def __init__(self,
+                 known_qubits: Optional[Tuple['cirq.QubitId', ...]],
+                 known_qubit_count: Optional[int],
+                 use_unicode_characters: bool,
+                 precision: Optional[int],
+                 qubit_map: Optional[Dict['cirq.QubitId', int]]) -> None:
+        self.known_qubits = known_qubits
+        self.known_qubit_count = known_qubit_count
+        self.use_unicode_characters = use_unicode_characters
+        self.precision = precision
+        self.qubit_map = qubit_map
+
+
+CircuitDiagramInfoArgs.UNINFORMED_DEFAULT = CircuitDiagramInfoArgs(
+    known_qubits=None,
+    known_qubit_count=None,
+    use_unicode_characters=True,
+    precision=3,
+    qubit_map=None)
+
+
+class SupportsCircuitDiagramInfo(Protocol):
+    """A diagrammable operation on qubits."""
+
+    def _circuit_diagram_info_(self, args: CircuitDiagramInfoArgs
+                               ) -> Union[str,
+                                          Tuple[str, ...],
+                                          CircuitDiagramInfo]:
+        """Describes how to draw an operation in a circuit diagram.
+
+        This method is used by the global `cirq.diagram_info` method. If this
+        method is not present, or returns NotImplemented, it is assumed that the
+        receiving object doesn't specify diagram info.
+
+        Args:
+            args: A DiagramInfoArgs instance encapsulating various pieces of
+                information (e.g. how many qubits are we being applied to) as
+                well as user options (e.g. whether to avoid unicode characters).
+
+        Returns:
+            A DiagramInfo instance describing what to show.
+        """
+
+
+TDefault = TypeVar('TDefault')
+RaiseTypeErrorIfNotProvided = CircuitDiagramInfo(())
+
+
+def circuit_diagram_info(val: Any,
+                         args: Optional[CircuitDiagramInfoArgs] = None,
+                         default: TDefault = RaiseTypeErrorIfNotProvided,
+                         ) -> Union[CircuitDiagramInfo, TDefault]:
+    """Requests information on drawing an operation in a circuit diagram.
+
+    Calls _circuit_diagram_info_ on `val`. If `val` doesn't have
+    _circuit_diagram_info_, or it returns NotImplemented, that indicates that
+    diagram information is not available.
+
+    Args:
+        val: The operation or gate that will need to be drawn.
+        args: A CircuitDiagramInfoArgs describing the desired drawing style.
+        default: A default result to return if the value doesn't have circuit
+            diagram information. If not specified, a TypeError is raised
+            instead.
+
+    Returns:
+        If `val` has no _circuit_diagram_info_ method or it returns
+        NotImplemented, then `default` is returned (or a TypeError is
+        raised if no `default` is specified).
+
+        Otherwise, the value returned by _circuit_diagram_info_ is returned.
+
+    Raises:
+        TypeError:
+            `val` doesn't have circuit diagram information and `default` was
+            not specified.
+    """
+
+    # Attempt.
+    if args is None:
+        args = CircuitDiagramInfoArgs.UNINFORMED_DEFAULT
+    getter = getattr(val, '_circuit_diagram_info_', None)
+    result = NotImplemented if getter is None else getter(args)
+
+    # Success?
+    if isinstance(result, str):
+        return CircuitDiagramInfo(wire_symbols=(result,))
+    if isinstance(result, tuple):
+        return CircuitDiagramInfo(wire_symbols=result)
+    if result is not NotImplemented:
+        return result
+
+    # Failure.
+    if default is not RaiseTypeErrorIfNotProvided:
+        return default
+    if getter is None:
+        raise TypeError(
+            "object of type '{}' "
+            "has no _circuit_diagram_info_ method.".format(type(val)))
+    raise TypeError("object of type '{}' does have a _circuit_diagram_info_ "
+                    "method, but it returned NotImplemented.".format(type(val)))

--- a/cirq/protocols/circuit_diagram_info_test.py
+++ b/cirq/protocols/circuit_diagram_info_test.py
@@ -16,6 +16,41 @@ import pytest
 import cirq
 
 
+def test_circuit_diagram_info_value_wrapping():
+    single_info = cirq.CircuitDiagramInfo(('Single',))
+
+    class ReturnInfo:
+        def _circuit_diagram_info_(self, args):
+            return single_info
+
+    class ReturnTuple:
+        def _circuit_diagram_info_(self, args):
+            return 'Single',
+
+    class ReturnString:
+        def _circuit_diagram_info_(self, args):
+            return 'Single'
+
+    assert (cirq.circuit_diagram_info(ReturnInfo()) ==
+            cirq.circuit_diagram_info(ReturnTuple()) ==
+            cirq.circuit_diagram_info(ReturnString()) ==
+            single_info)
+
+    double_info = cirq.CircuitDiagramInfo(('Single', 'Double',))
+
+    class ReturnDoubleInfo:
+        def _circuit_diagram_info_(self, args):
+            return double_info
+
+    class ReturnDoubleTuple:
+        def _circuit_diagram_info_(self, args):
+            return 'Single', 'Double'
+
+    assert (cirq.circuit_diagram_info(ReturnDoubleInfo()) ==
+            cirq.circuit_diagram_info(ReturnDoubleTuple()) ==
+            double_info)
+
+
 def test_circuit_diagram_info_validate():
     with pytest.raises(ValueError):
         _ = cirq.CircuitDiagramInfo('X')

--- a/cirq/protocols/circuit_diagram_info_test.py
+++ b/cirq/protocols/circuit_diagram_info_test.py
@@ -1,0 +1,62 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import cirq
+
+
+def test_circuit_diagram_info_validate():
+    with pytest.raises(ValueError):
+        _ = cirq.CircuitDiagramInfo('X')
+
+
+@cirq.testing.only_test_in_python3
+def test_circuit_diagram_info_repr():
+    info = cirq.CircuitDiagramInfo(('X', 'Y'), 2)
+    assert repr(info) == ("cirq.DiagramInfo(wire_symbols=('X', 'Y')"
+                          ", exponent=2, connected=True)")
+
+
+def test_circuit_diagram_info_eq():
+    eq = cirq.testing.EqualsTester()
+    eq.make_equality_group(lambda: cirq.CircuitDiagramInfo(('X',)))
+    eq.add_equality_group(cirq.CircuitDiagramInfo(('X', 'Y')),
+                          cirq.CircuitDiagramInfo(('X', 'Y'), 1))
+    eq.add_equality_group(cirq.CircuitDiagramInfo(('Z',), 2))
+    eq.add_equality_group(cirq.CircuitDiagramInfo(('Z', 'Z'), 2))
+    eq.add_equality_group(cirq.CircuitDiagramInfo(('Z',), 3))
+
+
+def test_circuit_diagram_info_pass_fail():
+    class C:
+        pass
+
+    class D:
+        def _circuit_diagram_info_(self, args):
+            return NotImplemented
+
+    class E:
+        def _circuit_diagram_info_(self, args):
+            return cirq.CircuitDiagramInfo(('X',))
+
+    assert cirq.circuit_diagram_info(C(), default=None) is None
+    assert cirq.circuit_diagram_info(D(), default=None) is None
+    assert cirq.circuit_diagram_info(
+        E(), default=None) == cirq.CircuitDiagramInfo(('X',))
+
+    with pytest.raises(TypeError, match='no _circuit_diagram_info'):
+        _ = cirq.circuit_diagram_info(C())
+    with pytest.raises(TypeError, match='returned NotImplemented'):
+        _ = cirq.circuit_diagram_info(D())
+    assert cirq.circuit_diagram_info(E()) == cirq.CircuitDiagramInfo(('X',))


### PR DESCRIPTION
- This will eventually replace cirq.TextDiagrammable

Part of https://github.com/quantumlib/Cirq/issues/946