### PR TITLE
Add parameter resolution protocol

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -124,7 +124,6 @@ from cirq.ops import (
     NamedQubit,
     OP_TREE,
     Operation,
-    ParameterizableEffect,
     Pauli,
     PauliInteractionGate,
     PauliString,
@@ -195,6 +194,9 @@ from cirq.protocols import (
     SupportsApplyUnitaryToTensor,
     SupportsCircuitDiagramInfo,
     SupportsUnitary,
+    SupportsParameterization,
+    is_parameterized,
+    resolve_parameters,
     unitary,
 )
 

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1128,10 +1128,7 @@ class Circuit:
         return diagram
 
     def is_parameterized(self) -> bool:
-        for op in self.all_operations():
-            if cirq.is_parameterized(op):
-                return True
-        return False
+        return any(cirq.is_parameterized(op) for op in self.all_operations())
 
     def with_parameters_resolved_by(self,
                                     param_resolver: study.ParamResolver,

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -27,7 +27,6 @@ from typing import (
 )
 
 import numpy as np
-import cirq
 
 from cirq import devices, ops, extension, study, protocols
 from cirq.circuits.insert_strategy import InsertStrategy
@@ -1128,7 +1127,8 @@ class Circuit:
         return diagram
 
     def is_parameterized(self) -> bool:
-        return any(cirq.is_parameterized(op) for op in self.all_operations())
+        return any(protocols.is_parameterized(op)
+                   for op in self.all_operations())
 
     def with_parameters_resolved_by(self,
                                     param_resolver: study.ParamResolver,
@@ -1140,8 +1140,7 @@ class Circuit:
         for moment in self:
             resolved_circuit.append(_resolve_operations(
                 moment.operations,
-                param_resolver,
-                ext))
+                param_resolver))
         return resolved_circuit
 
     def to_qasm(self,
@@ -1202,11 +1201,11 @@ class Circuit:
 
 def _resolve_operations(
         operations: Iterable[ops.Operation],
-        param_resolver: study.ParamResolver,
-        ext: extension.Extensions) -> List[ops.Operation]:
+        param_resolver: study.ParamResolver) -> List[ops.Operation]:
     resolved_operations = []  # type: List[ops.Operation]
     for op in operations:
-        resolved_operations.append(cirq.resolve_parameters(op, param_resolver))
+        resolved_operations.append(protocols.resolve_parameters(
+            op, param_resolver))
     return resolved_operations
 
 

--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -29,7 +29,6 @@ T_DESIRED = TypeVar('T_DESIRED')
 class PauliStringPhasor(PauliStringGateOperation,
                         ops.CompositeOperation,
                         ops.BoundedEffect,
-                        ops.ParameterizableEffect,
                         ops.TextDiagrammable,
                         extension.PotentialImplementation[Union[
                             ops.ExtrapolatableEffect,
@@ -91,7 +90,7 @@ class PauliStringPhasor(PauliStringGateOperation,
         return self._with_half_turns(self.half_turns * factor)  # type: ignore
 
     def __pow__(self, power: Union[float, value.Symbol]) -> 'PauliStringPhasor':
-        if power != 1 and self.is_parameterized():
+        if power != 1 and self._is_parameterized_():
             return NotImplemented
         return self.extrapolate_effect(power)
 
@@ -146,14 +145,14 @@ class PauliStringPhasor(PauliStringGateOperation,
                     ) -> Optional[T_DESIRED]:
         if (desired_type in [ops.ExtrapolatableEffect,
                              ops.ReversibleEffect] and
-                not self.is_parameterized()):
+                not self._is_parameterized_()):
             return cast(T_DESIRED, self)
         return super().try_cast_to(desired_type, ext)
 
-    def is_parameterized(self) -> bool:
+    def _is_parameterized_(self) -> bool:
         return isinstance(self.half_turns, value.Symbol)
 
-    def with_parameters_resolved_by(self, param_resolver: study.ParamResolver
+    def _resolve_parameters_(self, param_resolver: study.ParamResolver
                                     ) -> 'PauliStringPhasor':
         return self._with_half_turns(
                         param_resolver.value_of(self.half_turns))

--- a/cirq/contrib/paulistring/pauli_string_phasor_test.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor_test.py
@@ -192,7 +192,6 @@ def test_try_cast_to():
     ext = cirq.Extensions()
     assert not op.try_cast_to(cirq.CompositeOperation, ext) is None
     assert not op.try_cast_to(cirq.BoundedEffect, ext) is None
-    assert not op.try_cast_to(cirq.ParameterizableEffect, ext) is None
     assert not op.try_cast_to(cirq.ExtrapolatableEffect, ext) is None
     assert not op.try_cast_to(cirq.ReversibleEffect, ext) is None
     assert op.try_cast_to(Dummy, ext) is None
@@ -202,7 +201,6 @@ def test_try_cast_to():
     ext = cirq.Extensions()
     assert not op.try_cast_to(cirq.CompositeOperation, ext) is None
     assert not op.try_cast_to(cirq.BoundedEffect, ext) is None
-    assert not op.try_cast_to(cirq.ParameterizableEffect, ext) is None
     assert op.try_cast_to(cirq.ExtrapolatableEffect, ext) is None
     assert op.try_cast_to(cirq.ReversibleEffect, ext) is None
     assert op.try_cast_to(Dummy, ext) is None
@@ -211,16 +209,16 @@ def test_try_cast_to():
 
 def test_is_parametrized():
     op = PauliStringPhasor(cirq.PauliString({}))
-    assert not op.is_parameterized()
-    assert not (op ** 0.1).is_parameterized()
-    assert (op ** cirq.Symbol('a')).is_parameterized()
+    assert not cirq.is_parameterized(op)
+    assert not cirq.is_parameterized(op ** 0.1)
+    assert cirq.is_parameterized(op ** cirq.Symbol('a'))
 
 
 def test_with_parameters_resolved_by():
     op = PauliStringPhasor(cirq.PauliString({}),
                            half_turns=cirq.Symbol('a'))
     resolver = cirq.ParamResolver({'a': 0.1})
-    actual = op.with_parameters_resolved_by(resolver)
+    actual = cirq.resolve_parameters(op, resolver)
     expected = PauliStringPhasor(cirq.PauliString({}), half_turns=0.1)
     assert actual == expected
 

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -1092,23 +1092,3 @@ def test_simulator_implied_measurement_key():
     assert str(result) == "(0, 0)=11111\nother=11111"
 
 
-def test_supports_extensions_for_parameter_resolving():
-    class DummyGate(cirq.Gate):
-        pass
-
-    ext = cirq.Extensions()
-    ext.add_cast(cirq.ParameterizableEffect,
-                 DummyGate,
-                 lambda _: cg.ExpWGate(half_turns=cirq.Symbol('x')))
-
-    a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit.from_ops(
-        DummyGate().on(a),
-        cg.XmonMeasurementGate('a').on(a)
-    )
-    results = cirq.google.XmonSimulator().run(
-        circuit=circuit,
-        param_resolver=cirq.ParamResolver({'x': 1}),
-        extensions=ext)
-
-    assert str(results) == 'a=1'

--- a/cirq/google/xmon_gates.py
+++ b/cirq/google/xmon_gates.py
@@ -164,7 +164,6 @@ class Exp11Gate(XmonGate,
                 ops.TextDiagrammable,
                 ops.InterchangeableQubitsGate,
                 ops.PhaseableEffect,
-                ops.ParameterizableEffect,
                 ops.QasmConvertibleGate):
     """A two-qubit interaction that phases the amplitude of the 11 state.
 
@@ -251,10 +250,10 @@ class Exp11Gate(XmonGate,
     def __hash__(self):
         return hash((Exp11Gate, self.half_turns))
 
-    def is_parameterized(self) -> bool:
+    def _is_parameterized_(self) -> bool:
         return isinstance(self.half_turns, value.Symbol)
 
-    def with_parameters_resolved_by(self, param_resolver) -> 'Exp11Gate':
+    def _resolve_parameters_(self, param_resolver) -> 'Exp11Gate':
         return Exp11Gate(half_turns=param_resolver.value_of(self.half_turns))
 
 
@@ -263,7 +262,6 @@ class ExpWGate(XmonGate,
                ops.TextDiagrammable,
                ops.PhaseableEffect,
                ops.BoundedEffect,
-               ops.ParameterizableEffect,
                PotentialImplementation[Union[
                    ops.ReversibleEffect]]):
     """A rotation around an axis in the XY plane of the Bloch sphere.
@@ -434,11 +432,11 @@ class ExpWGate(XmonGate,
             return hash((ops.RotYGate, self.half_turns))
         return hash((ExpWGate, self.half_turns, self.axis_half_turns))
 
-    def is_parameterized(self) -> bool:
+    def _is_parameterized_(self) -> bool:
         return (isinstance(self.half_turns, value.Symbol) or
                 isinstance(self.axis_half_turns, value.Symbol))
 
-    def with_parameters_resolved_by(self, param_resolver) -> 'ExpWGate':
+    def _resolve_parameters_(self, param_resolver) -> 'ExpWGate':
         return ExpWGate(
                 half_turns=param_resolver.value_of(self.half_turns),
                 axis_half_turns=param_resolver.value_of(self.axis_half_turns))
@@ -447,7 +445,6 @@ class ExpWGate(XmonGate,
 class ExpZGate(XmonGate,
                ops.SingleQubitGate,
                ops.TextDiagrammable,
-               ops.ParameterizableEffect,
                ops.PhaseableEffect,
                ops.BoundedEffect,
                ops.QasmConvertibleGate,
@@ -575,8 +572,8 @@ class ExpZGate(XmonGate,
     def __hash__(self):
         return hash((ExpZGate, self.half_turns))
 
-    def is_parameterized(self) -> bool:
+    def _is_parameterized_(self) -> bool:
         return isinstance(self.half_turns, value.Symbol)
 
-    def with_parameters_resolved_by(self, param_resolver) -> 'ExpZGate':
+    def _resolve_parameters_(self, param_resolver) -> 'ExpZGate':
         return ExpZGate(half_turns=param_resolver.value_of(self.half_turns))

--- a/cirq/google/xmon_gates.py
+++ b/cirq/google/xmon_gates.py
@@ -343,7 +343,7 @@ class ExpWGate(XmonGate,
         return {'exp_w': exp_w}
 
     def __pow__(self, power):
-        if self.is_parameterized() and power != 1:
+        if protocols.is_parameterized(self) and power != 1:
             return NotImplemented
         return ExpWGate(half_turns=self.half_turns * power,
                         axis_half_turns=self.axis_half_turns)

--- a/cirq/google/xmon_gates_test.py
+++ b/cirq/google/xmon_gates_test.py
@@ -230,10 +230,10 @@ def test_z_matrix():
 
 def test_z_parameterize():
     parameterized_gate = cg.ExpZGate(half_turns=cirq.Symbol('a'))
-    assert parameterized_gate.is_parameterized()
+    assert cirq.is_parameterized(parameterized_gate)
     assert cirq.unitary(parameterized_gate, None) is None
     resolver = cirq.ParamResolver({'a': 0.1})
-    resolved_gate = parameterized_gate.with_parameters_resolved_by(resolver)
+    resolved_gate = cirq.resolve_parameters(parameterized_gate, resolver)
     assert resolved_gate == cg.ExpZGate(half_turns=0.1)
 
 
@@ -348,10 +348,10 @@ def test_cz_potential_implementation():
 
 def test_cz_parameterize():
     parameterized_gate = cg.Exp11Gate(half_turns=cirq.Symbol('a'))
-    assert parameterized_gate.is_parameterized()
+    assert cirq.is_parameterized(parameterized_gate)
     assert cirq.unitary(parameterized_gate, None) is None
     resolver = cirq.ParamResolver({'a': 0.1})
-    resolved_gate = parameterized_gate.with_parameters_resolved_by(resolver)
+    resolved_gate = cirq.resolve_parameters(parameterized_gate, resolver)
     assert resolved_gate == cg.Exp11Gate(half_turns=0.1)
 
 
@@ -514,10 +514,10 @@ def test_w_inverse():
 def test_w_parameterize():
     parameterized_gate = cg.ExpWGate(half_turns=cirq.Symbol('a'),
                                      axis_half_turns=cirq.Symbol('b'))
-    assert parameterized_gate.is_parameterized()
+    assert cirq.is_parameterized(parameterized_gate)
     assert cirq.unitary(parameterized_gate, None) is None
     resolver = cirq.ParamResolver({'a': 0.1, 'b': 0.2})
-    resolved_gate = parameterized_gate.with_parameters_resolved_by(resolver)
+    resolved_gate = cirq.resolve_parameters(parameterized_gate, resolver)
     assert resolved_gate == cg.ExpWGate(half_turns=0.1, axis_half_turns=0.2)
 
 

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -50,7 +50,6 @@ from cirq.ops.gate_features import (
     CompositeOperation,
     ExtrapolatableEffect,
     InterchangeableQubitsGate,
-    ParameterizableEffect,
     PhaseableEffect,
     QasmConvertibleGate,
     QasmConvertibleOperation,

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -65,7 +65,7 @@ class Rot11Gate(eigen_gate.EigenGate,
                                   available_buffer: np.ndarray,
                                   axes: Sequence[int],
                                   ) -> Union[np.ndarray, type(NotImplemented)]:
-        if cirq.is_parameterized(self):
+        if protocols.is_parameterized(self):
             return NotImplemented
 
         c = np.exp(1j * np.pi * self.half_turns)
@@ -305,7 +305,7 @@ class RotZGate(eigen_gate.EigenGate,
                                   available_buffer: np.ndarray,
                                   axes: Sequence[int],
                                   ) -> Union[np.ndarray, type(NotImplemented)]:
-        if cirq.is_parameterized(self):
+        if protocols.is_parameterized(self):
             return NotImplemented
 
         one = linalg.slice_for_qubits_equal_to(axes, 1)

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -18,9 +18,8 @@ from typing import (
 )
 
 import numpy as np
-import cirq
 
-from cirq import value, linalg
+from cirq import value, linalg, protocols
 from cirq.ops import gate_features, eigen_gate, raw_types, gate_operation
 
 

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -18,6 +18,7 @@ from typing import (
 )
 
 import numpy as np
+import cirq
 
 from cirq import value, linalg
 from cirq.ops import gate_features, eigen_gate, raw_types, gate_operation
@@ -65,7 +66,7 @@ class Rot11Gate(eigen_gate.EigenGate,
                                   available_buffer: np.ndarray,
                                   axes: Sequence[int],
                                   ) -> Union[np.ndarray, type(NotImplemented)]:
-        if self.is_parameterized():
+        if cirq.is_parameterized(self):
             return NotImplemented
 
         c = np.exp(1j * np.pi * self.half_turns)
@@ -297,7 +298,7 @@ class RotZGate(eigen_gate.EigenGate,
                                   available_buffer: np.ndarray,
                                   axes: Sequence[int],
                                   ) -> Union[np.ndarray, type(NotImplemented)]:
-        if self.is_parameterized():
+        if cirq.is_parameterized(self):
             return NotImplemented
 
         one = linalg.slice_for_qubits_equal_to(axes, 1)

--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -145,10 +145,11 @@ class ControlledGate(raw_types.Gate,
                               self.default_extensions)
 
     def _is_parameterized_(self):
-        return cirq.is_parameterized(self.sub_gate)
+        return protocols.is_parameterized(self.sub_gate)
 
     def _resolve_parameters_(self, param_resolver):
-        new_sub_gate = cirq.resolve_parameters(self.sub_gate, param_resolver)
+        new_sub_gate = protocols.resolve_parameters(self.sub_gate,
+                                                    param_resolver)
         return ControlledGate(new_sub_gate, self.default_extensions)
 
     def trace_distance_bound(self):

--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -15,7 +15,6 @@
 from typing import Optional, TypeVar, Type, cast, Union, Sequence
 
 import numpy as np
-import cirq
 
 from cirq import linalg, extension, protocols
 from cirq.ops import raw_types, gate_features

--- a/cirq/ops/controlled_gate_test.py
+++ b/cirq/ops/controlled_gate_test.py
@@ -122,14 +122,12 @@ def test_try_cast_to():
     assert CRestricted.try_cast_to(cirq.ExtrapolatableEffect, ext) is None
     assert CRestricted.try_cast_to(cirq.TextDiagrammable, ext) is None
     assert CRestricted.try_cast_to(cirq.BoundedEffect, ext) is None
-    assert CRestricted.try_cast_to(cirq.ParameterizableEffect, ext) is None
 
     # Supported sub features that are present on sub gate.
     assert cirq.inverse(CY, None) is not None
     assert CY.try_cast_to(cirq.ExtrapolatableEffect, ext) is not None
     assert CY.try_cast_to(cirq.TextDiagrammable, ext) is not None
     assert CY.try_cast_to(cirq.BoundedEffect, ext) is not None
-    assert CY.try_cast_to(cirq.ParameterizableEffect, ext) is not None
 
 
 def test_extrapolatable_effect():
@@ -171,21 +169,9 @@ def test_parameterizable():
     a = cirq.Symbol('a')
     cz = cirq.ControlledGate(cirq.RotYGate(half_turns=1))
     cza = cirq.ControlledGate(cirq.RotYGate(half_turns=a))
-    assert cza.is_parameterized()
-    assert not cz.is_parameterized()
-    assert cza.with_parameters_resolved_by(cirq.ParamResolver({'a': 1})) == cz
-
-
-def test_parameterizable_via_extension():
-    ext = cirq.Extensions()
-    ext.add_cast(cirq.ParameterizableEffect, RestrictedGate, lambda _: cirq.S)
-    without_ext = cirq.ControlledGate(RestrictedGate())
-    with_ext = cirq.ControlledGate(RestrictedGate(), ext)
-
-    with pytest.raises(TypeError):
-        _ = without_ext.is_parameterized()
-
-    assert not with_ext.is_parameterized()
+    assert cirq.is_parameterized(cza)
+    assert not cirq.is_parameterized(cz)
+    assert cirq.resolve_parameters(cza, cirq.ParamResolver({'a': 1})) == cz
 
 
 def test_text_diagram_info():

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -43,7 +43,6 @@ EigenComponent = NamedTuple(
 
 class EigenGate(raw_types.Gate,
                 gate_features.BoundedEffect,
-                gate_features.ParameterizableEffect,
                 extension.PotentialImplementation[Union[
                     gate_features.ExtrapolatableEffect,
                     gate_features.ReversibleEffect]]):
@@ -148,7 +147,7 @@ class EigenGate(raw_types.Gate,
         pass
 
     def __pow__(self: TSelf, power: float) -> TSelf:
-        if power != 1 and self.is_parameterized():
+        if power != 1 and self._is_parameterized_():
             return NotImplemented
         return self.extrapolate_effect(power)
 
@@ -178,12 +177,12 @@ class EigenGate(raw_types.Gate,
     def try_cast_to(self, desired_type, ext):
         if (desired_type in [gate_features.ExtrapolatableEffect,
                              gate_features.ReversibleEffect] and
-                not self.is_parameterized()):
+                not self._is_parameterized_()):
             return self
         return super().try_cast_to(desired_type, ext)
 
     def _unitary_(self) -> Union[np.ndarray, type(NotImplemented)]:
-        if self.is_parameterized():
+        if self._is_parameterized_():
             return NotImplemented
         e = cast(float, self._exponent)
         return np.sum([1j**(half_turns * e * 2) * component for half_turns,
@@ -194,9 +193,9 @@ class EigenGate(raw_types.Gate,
         return self._with_exponent(
             exponent=self._exponent * factor)  # type: ignore
 
-    def is_parameterized(self) -> bool:
+    def _is_parameterized_(self) -> bool:
         return isinstance(self._exponent, value.Symbol)
 
-    def with_parameters_resolved_by(self: TSelf, param_resolver) -> TSelf:
+    def _resolve_parameters_(self: TSelf, param_resolver) -> TSelf:
         return self._with_exponent(
                 exponent=param_resolver.value_of(self._exponent))

--- a/cirq/ops/eigen_gate_test.py
+++ b/cirq/ops/eigen_gate_test.py
@@ -157,15 +157,15 @@ def test_matrix_is_exact_for_quarter_turn():
 
 
 def test_is_parameterized():
-    assert not CExpZinGate(0).is_parameterized()
-    assert not CExpZinGate(1).is_parameterized()
-    assert not CExpZinGate(3).is_parameterized()
-    assert CExpZinGate(cirq.Symbol('a')).is_parameterized()
+    assert not cirq.is_parameterized(CExpZinGate(0))
+    assert not cirq.is_parameterized(CExpZinGate(1))
+    assert not cirq.is_parameterized(CExpZinGate(3))
+    assert cirq.is_parameterized(CExpZinGate(cirq.Symbol('a')))
 
 
-def test_with_parameters_resolved_by():
-    assert CExpZinGate(cirq.Symbol('a')).with_parameters_resolved_by(
+def test_resolve_parameters():
+    assert cirq.resolve_parameters(CExpZinGate(cirq.Symbol('a')),
         cirq.ParamResolver({'a': 0.5})) == CExpZinGate(0.5)
 
-    assert CExpZinGate(0.25).with_parameters_resolved_by(
+    assert cirq.resolve_parameters(CExpZinGate(0.25),
         cirq.ParamResolver({})) == CExpZinGate(0.25)

--- a/cirq/ops/gate_features.py
+++ b/cirq/ops/gate_features.py
@@ -25,7 +25,6 @@ import string
 
 from cirq import abc, value
 from cirq.ops import op_tree, raw_types
-from cirq.study import ParamResolver
 
 
 class InterchangeableQubitsGate(metaclass=abc.ABCMeta):
@@ -303,31 +302,6 @@ class ThreeQubitGate(raw_types.Gate, metaclass=abc.ABCMeta):
             raise ValueError(
                 'Three-qubit gate not applied to three qubits: {}({})'.
                 format(self, qubits))
-
-
-TSelf_ParameterizableEffect = TypeVar('TSelf_ParameterizableEffect',
-                                      bound='ParameterizableEffect')
-
-
-class ParameterizableEffect(metaclass=abc.ABCMeta):
-    """An effect that can be parameterized by Symbols."""
-
-    @abc.abstractmethod
-    def is_parameterized(self) -> bool:
-        """Whether the effect is parameterized.
-
-        Returns True if the gate has any unresolved Symbols and False otherwise.
-        """
-
-    @abc.abstractmethod
-    def with_parameters_resolved_by(self: TSelf_ParameterizableEffect,
-                                    param_resolver: ParamResolver
-                                    ) -> TSelf_ParameterizableEffect:
-        """Resolve the parameters in the effect.
-
-        Returns a gate or operation of the same type, but with all Symbols
-        replaced with floats according to the given ParamResolver.
-        """
 
 
 class QasmOutputArgs(string.Formatter):

--- a/cirq/ops/gate_features_test.py
+++ b/cirq/ops/gate_features_test.py
@@ -162,43 +162,6 @@ def test_three_qubit_gate_validate():
         g.validate_args([a, b, c, d])
 
 
-def test_parameterizable_gate_is_abstract_cant_instantiate():
-    with pytest.raises(TypeError):
-        _ = gate_features.ParameterizableEffect()
-
-
-def test_parameterizable_gate_is_abstract_must_implement():
-    # noinspection PyAbstractClass
-    class MissingBoth(gate_features.ParameterizableEffect):
-        pass
-    # noinspection PyAbstractClass
-    class MissingOne(gate_features.ParameterizableEffect):
-        def is_parameterized(self):
-            pass
-    # noinspection PyAbstractClass
-    class MissingOtherOne(gate_features.ParameterizableEffect):
-        def with_parameters_resolved_by(self, param_resolver):
-            pass
-
-    with pytest.raises(TypeError):
-        _ = MissingBoth()
-    with pytest.raises(TypeError):
-        _ = MissingOne()
-    with pytest.raises(TypeError):
-        _ = MissingOtherOne()
-
-
-def test_parameterizable_gate_is_abstract_can_implement():
-    class Included(gate_features.ParameterizableEffect):
-        def is_parameterized(self):
-            pass
-
-        def with_parameters_resolved_by(self, param_resolver):
-            pass
-
-    assert isinstance(Included(), gate_features.ParameterizableEffect)
-
-
 def test_on_each():
     class CustomGate(gate_features.SingleQubitGate):
         pass

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 LIFTED_POTENTIAL_TYPES = {t: t for t in [
     gate_features.BoundedEffect,
     gate_features.ExtrapolatableEffect,
-    gate_features.ParameterizableEffect,
     gate_features.PhaseableEffect,
     gate_features.ReversibleEffect,
     gate_features.TextDiagrammable,
@@ -49,7 +48,6 @@ class GateOperation(raw_types.Operation,
                         gate_features.BoundedEffect,
                         gate_features.CompositeOperation,
                         gate_features.ExtrapolatableEffect,
-                        gate_features.ParameterizableEffect,
                         gate_features.PhaseableEffect,
                         gate_features.ReversibleEffect,
                         gate_features.TextDiagrammable,
@@ -157,6 +155,13 @@ class GateOperation(raw_types.Operation,
     def _unitary_(self) -> Union[np.ndarray, type(NotImplemented)]:
         return protocols.unitary(self._gate, NotImplemented)
 
+    def _is_parameterized_(self) -> bool:
+        return protocols.is_parameterized(self._gate)
+
+    def _resolve_parameters_(self, resolver):
+        resolved_gate = protocols.resolve_parameters(self._gate, resolver)
+        return GateOperation(resolved_gate, self._qubits)
+
     def text_diagram_info(self, args: gate_features.TextDiagramInfoArgs
                           ) -> gate_features.TextDiagramInfo:
         cast_gate = extension.cast(gate_features.TextDiagrammable, self.gate)
@@ -205,18 +210,6 @@ class GateOperation(raw_types.Operation,
             return self.with_gate(inv_gate)
         return self.extrapolate_effect(power)
 
-    def is_parameterized(self) -> bool:
-        cast_gate = extension.cast(gate_features.ParameterizableEffect,
-                                   self.gate)
-        return cast_gate.is_parameterized()
-
-    def with_parameters_resolved_by(self,
-                                    param_resolver: 'study.ParamResolver',
-                                    ) -> 'GateOperation':
-        cast_gate = extension.cast(gate_features.ParameterizableEffect,
-                                   self.gate)
-        new_gate = cast_gate.with_parameters_resolved_by(param_resolver)
-        return self.with_gate(cast(raw_types.Gate, new_gate))
 
     def known_qasm_output(self,
                           args: gate_features.QasmOutputArgs) -> Optional[str]:

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -146,19 +146,10 @@ def test_parameterizable_effect():
     q = cirq.NamedQubit('q')
     r = cirq.ParamResolver({'a': 0.5})
 
-    # If the gate isn't parameterizable, you get a type error.
-    op0 = cirq.GateOperation(cirq.Gate(), [q])
-    assert not cirq.can_cast(cirq.ParameterizableEffect, op0)
-    with pytest.raises(TypeError):
-        _ = op0.is_parameterized()
-    with pytest.raises(TypeError):
-        _ = op0.with_parameters_resolved_by(r)
-
     op1 = cirq.GateOperation(cirq.RotZGate(half_turns=cirq.Symbol('a')), [q])
-    assert cirq.can_cast(cirq.ParameterizableEffect, op1)
-    assert op1.is_parameterized()
-    op2 = op1.with_parameters_resolved_by(r)
-    assert not op2.is_parameterized()
+    assert cirq.is_parameterized(op1)
+    op2 = cirq.resolve_parameters(op1, r)
+    assert not cirq.is_parameterized(op2)
     assert op2 == cirq.S.on(q)
 
 

--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -92,7 +92,7 @@ class _CCZPowerGate(eigen_gate.EigenGate,
                                   available_buffer: np.ndarray,
                                   axes: Sequence[int],
                                   ) -> np.ndarray:
-        if self.is_parameterized():
+        if protocols.is_parameterized(self):
             return NotImplemented
         ooo = linalg.slice_for_qubits_equal_to(axes, 0b111)
         target_tensor[ooo] *= np.exp(1j * self.exponent * np.pi)

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -30,3 +30,8 @@ from cirq.protocols.unitary import (
     SupportsUnitary,
     unitary,
 )
+from cirq.protocols.resolve_parameters import (
+    SupportsParameterization,
+    is_parameterized,
+    resolve_parameters,
+)

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -1,0 +1,69 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, TypeVar
+from typing_extensions import Protocol
+from cirq.study import ParamResolver
+
+TDefault = TypeVar('TDefault')
+
+class SupportsParameterization(Protocol):
+    """An object that may be describable by a unitary matrix."""
+
+    def _is_parameterized_(self: Any) -> bool:
+        """Whether the gate is parameterized by any Symbols that require
+        resolution.  Returns True if the gate has any unresolved Symbols
+        and False otherwise."""
+
+    def _resolve_parameters_(self: Any, param_resolver: ParamResolver):
+        """Resolve the parameters in the effect."""
+
+
+
+def is_parameterized(val: Any) -> bool:
+    """Returns whether a gate is parameterizable.
+
+    Returns:
+        True if the gate has any unresolved Symbols
+        and False otherwise.
+    """
+    getter = getattr(val, '_is_parameterized_', None)
+    result = NotImplemented if getter is None else getter()
+
+    if result is not NotImplemented:
+        return result
+    else:
+        return False
+
+
+def resolve_parameters(val: Any, param_resolver: ParamResolver) -> Any:
+    """Resolve the parameters in the effect.
+
+    Args:
+        val: The gate to resolve
+        param_resolver: the object to use for resolving all symbols
+
+    Returns:
+        a gate or operation of the same type, but with all Symbols
+        replaced with floats according to the given ParamResolver.
+        If no implementation exists, this will return the input
+        unmodified.
+    """
+    getter = getattr(val, '_resolve_parameters_', None)
+    result = NotImplemented if getter is None else getter(param_resolver)
+
+    if result is not NotImplemented:
+        return result
+    else:
+        return val

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -33,11 +33,14 @@ class SupportsParameterization(Protocol):
 
 
 def is_parameterized(val: Any) -> bool:
-    """Returns whether a gate is parameterizable.
+    """Returns whether the object is parameterized with any Symbols.
+    This function uses the magic method "_is_parameterized_" of the
+    passed in object to determine the result.
 
     Returns:
         True if the gate has any unresolved Symbols
-        and False otherwise.
+        and False otherwise. If no implementation of the magic
+        method above exists, will default to False.
     """
     getter = getattr(val, '_is_parameterized_', None)
     result = NotImplemented if getter is None else getter()
@@ -49,17 +52,20 @@ def is_parameterized(val: Any) -> bool:
 
 
 def resolve_parameters(val: Any, param_resolver: ParamResolver) -> Any:
-    """Resolve the parameters in the effect.
+    """Resolve the parameters in the effect by returning a copy of the
+    given value, but with symbols replaced by concrete values from the
+    given parameter resolver. This function uses the magic method
+    "_resolve_parameters_" of the passed in object to determine the result.
 
     Args:
-        val: The gate to resolve
+        val: The object to resolve (e.g. the gate, operation, etc)
         param_resolver: the object to use for resolving all symbols
 
     Returns:
         a gate or operation of the same type, but with all Symbols
         replaced with floats according to the given ParamResolver.
-        If no implementation exists, this will return the input
-        unmodified.
+        If no implementation of the above magic method exists,
+        this will return the input unmodified.
     """
     getter = getattr(val, '_resolve_parameters_', None)
     result = NotImplemented if getter is None else getter(param_resolver)

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -35,7 +35,7 @@ class SupportsParameterization(Protocol):
 def is_parameterized(val: Any) -> bool:
     """Returns whether the object is parameterized with any Symbols.
 
-    A value is parameterized when it has an is_parameterized method and
+    A value is parameterized when it has an `_is_parameterized_` method and
     that method returns a truthy value.
 
     Returns:

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -34,13 +34,15 @@ class SupportsParameterization(Protocol):
 
 def is_parameterized(val: Any) -> bool:
     """Returns whether the object is parameterized with any Symbols.
-    This function uses the magic method "_is_parameterized_" of the
-    passed in object to determine the result.
+
+    A value is parameterized when it has an is_parameterized method and
+    that method returns a truthy value.
 
     Returns:
         True if the gate has any unresolved Symbols
         and False otherwise. If no implementation of the magic
-        method above exists, will default to False.
+        method above exists or if that method returns NotImplemented,
+        this will default to False.
     """
     getter = getattr(val, '_is_parameterized_', None)
     result = NotImplemented if getter is None else getter()
@@ -52,10 +54,11 @@ def is_parameterized(val: Any) -> bool:
 
 
 def resolve_parameters(val: Any, param_resolver: ParamResolver) -> Any:
-    """Resolve the parameters in the effect by returning a copy of the
-    given value, but with symbols replaced by concrete values from the
-    given parameter resolver. This function uses the magic method
-    "_resolve_parameters_" of the passed in object to determine the result.
+    """Resolves symbol parameters in the effect using the param resolver.
+
+    This function will use the `_resolve_parameters_` magic method
+    of `val` to resolve any Symbols with concrete values from the given
+    parameter resolver.
 
     Args:
         val: The object to resolve (e.g. the gate, operation, etc)
@@ -64,8 +67,8 @@ def resolve_parameters(val: Any, param_resolver: ParamResolver) -> Any:
     Returns:
         a gate or operation of the same type, but with all Symbols
         replaced with floats according to the given ParamResolver.
-        If no implementation of the above magic method exists,
-        this will return the input unmodified.
+        If `val` has no `_resolve_parameters_` method or if it returns
+        NotImplemented, `val` itself is returned.
     """
     getter = getattr(val, '_resolve_parameters_', None)
     result = NotImplemented if getter is None else getter(param_resolver)

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -19,7 +19,8 @@ from cirq.study import ParamResolver
 TDefault = TypeVar('TDefault')
 
 class SupportsParameterization(Protocol):
-    """An object that may be describable by a unitary matrix."""
+    """An object that can be parameterized by Symbols and resolved
+    via a ParamResolver"""
 
     def _is_parameterized_(self: Any) -> bool:
         """Whether the gate is parameterized by any Symbols that require

--- a/cirq/protocols/resolve_parameters_test.py
+++ b/cirq/protocols/resolve_parameters_test.py
@@ -1,0 +1,53 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+from cirq.study import ParamResolver
+
+def test_resolve_parameters():
+
+    class NoMethod:
+        pass
+
+    class ReturnsNotImplemented:
+        def _is_parameterized_(self) -> type(NotImplemented):
+            return NotImplemented
+
+        def _resolve_parameters_(self, resolver) -> type(NotImplemented):
+            return NotImplemented
+
+    class SimpleParameterSwitch:
+        def __init__(self, var):
+            self.parameter = var
+
+        def _is_parameterized_(self) -> bool:
+            return self.parameter == 0
+
+        def _resolve_parameters_(self, resolver: ParamResolver):
+            self.parameter = resolver.value_of(self.parameter)
+            return self
+
+
+    assert not cirq.is_parameterized(NoMethod())
+    assert not cirq.is_parameterized(ReturnsNotImplemented())
+    assert not cirq.is_parameterized(SimpleParameterSwitch('a'))
+    assert cirq.is_parameterized(SimpleParameterSwitch(0))
+
+    ni = ReturnsNotImplemented()
+    r = cirq.ParamResolver({'a': 0})
+    no = NoMethod()
+    assert cirq.resolve_parameters(no, r) == no
+    assert cirq.resolve_parameters(ni, r) == ni
+    assert cirq.resolve_parameters(SimpleParameterSwitch(0), r).parameter == 0
+    assert cirq.resolve_parameters(SimpleParameterSwitch('a'), r).parameter == 0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,7 +53,6 @@ Gate Features and Effects
 .. autosummary::
     :toctree: generated
 
-    ParameterizableEffect
     CompositeGate
     ExtrapolatableEffect
     ReversibleEffect


### PR DESCRIPTION
    - Add cirq.is_parameterized() and cirq.resolve_parameters() in Protocols
    - Add _is_parameterized_() and _resolve_parameters_() magic methods to
    several gate and operation classes
    - Remove ParameterizableEffect and its references and a few references
    to extensions.
