### PR TITLE
Implement Circuit.reachable_frontier_from and Circuit.findall_operations_between

### DIFF
--- a/cirq/circuits/_bucket_priority_queue.py
+++ b/cirq/circuits/_bucket_priority_queue.py
@@ -1,0 +1,156 @@
+from typing import Tuple, List, TypeVar, Generic, Iterable, Iterator, Any
+
+TItem = TypeVar('TItem')
+
+
+class BucketPriorityQueue(Generic[TItem]):
+    """A priority queue for when priorities are integers over a small range.
+
+    Items are dequeued in ascending priority order. Items with the same priority
+    are dequeued in FIFO order.
+
+    Works by having an explicit list for each priority (from the current min
+    priority to the current max priority). Enqueued items are placed into the
+    list corresponding to their bucket (after adding more buckets if necessary).
+    Dequeued items come from the lowest list containing items, and result in
+    empty buckets at the bottom end of the range being removed.
+
+    Let P be the length of the priority range, and N be the number of items that
+    are enqueued and dequeued. If the priority of items being enqueued is never
+    smaller than the priority of previously dequeued items (the "monotonic use
+    case"), then the worst case runtime complexity is O(N+P). In more general
+    use the worst case runtime complexity is O(N*P).
+    """
+
+    def __init__(self,
+                 items: Iterable[Tuple[int, TItem]] = (),
+                 *,
+                 drop_duplicates: bool=False):
+        """Initializes a new priority queue."""
+        self._buckets = []  # type: List[List[TItem]]
+        self._offset = 0
+        self._len = 0
+        self._drop_set = set() if drop_duplicates else None
+
+        for p, e in items:
+            self.enqueue(p, e)
+
+    @property
+    def drop_duplicates(self) -> bool:
+        return self._drop_set is not None
+
+    def __bool__(self) -> bool:
+        """Returns whether or not the priority queue contains any items."""
+        return bool(self._len)
+
+    def __len__(self) -> int:
+        """Returns how many items are in the priority queue."""
+        return self._len
+
+    def __iter__(self) -> Iterator[Tuple[int, TItem]]:
+        for i, bucket in enumerate(self._buckets):
+            for item in bucket:
+                yield i + self._offset, item
+
+    def enqueue(self, priority: int, item: TItem) -> bool:
+        """Adds an item to the priority queue.
+
+        Args:
+            priority: The priority of the item. Lower priorities dequeue before
+                higher priorities.
+            item: The item associated with the given priority.
+
+        Returns:
+            True if the item was enqueued. False if drop_duplicates is
+            set and the item is already in the queue.
+        """
+        if self.drop_duplicates:
+            if (priority, item) in self._drop_set:
+                return False
+            self._drop_set.add((priority, item))
+
+        # First enqueue initializes self._offset.
+        if not self._buckets:
+            self._buckets.append([item])
+            self._offset = priority
+            self._len = 1
+            return True
+
+        # Where is the bucket this item is supposed to go into?
+        i = priority - self._offset
+
+        # Extend bucket list backwards if needed.
+        if i < 0:
+            self._buckets[:0] = [[] for _ in range(-i)]
+            self._offset = priority
+            i = 0
+
+        # Extend bucket list forwards if needed.
+        while i >= len(self._buckets):
+            self._buckets.append([])
+
+        # Finish by adding item to the intended bucket's list.
+        self._buckets[i].append(item)
+        self._len += 1
+        return True
+
+    def dequeue(self) -> Tuple[int, TItem]:
+        """Removes and returns an item from the priority queue.
+
+        Returns:
+            A tuple whose first element is the priority of the dequeued item
+            and whose second element is the dequeued item.
+
+        Raises:
+            ValueError:
+                The queue is empty.
+        """
+        if self._len == 0:
+            raise ValueError('BucketPriorityQueue is empty.')
+
+        # Drop empty buckets at the front of the queue.
+        while self._buckets and not self._buckets[0]:
+            self._buckets.pop(0)
+            self._offset += 1
+
+        # Pull item out of the front bucket.
+        item = self._buckets[0].pop(0)
+        priority = self._offset
+        self._len -= 1
+        if self.drop_duplicates:
+            self._drop_set.remove((priority, item))
+
+        # Note: do not eagerly clear out empty buckets after pulling the item!
+        # Doing so increases the worst case complexity of "monotonic" use from
+        # O(N+P) to O(N*P).
+
+        return priority, item
+
+    def __str__(self):
+        lines = [
+            '{}: {},'.format(p, e)
+            for p, e in self
+        ]
+        return 'BucketPriorityQueue {' + _indent(lines) + '\n}'
+
+    def __repr__(self):
+        return '{!r}(items={!r}, drop_duplicates={!r})'.format(
+            type(self),
+            list(self),
+            self._drop_set is not None)
+
+    __hash__ = None
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return (self.drop_duplicates == other.drop_duplicates and
+                list(self) == list(other))
+
+    def __ne__(self, other):
+        return not self == other
+
+
+def _indent(lines: List[Any]) -> str:
+    paragraph = ''.join('\n' + str(line) for line in lines)
+    return paragraph.replace('\n', '\n    ')

--- a/cirq/circuits/_bucket_priority_queue_test.py
+++ b/cirq/circuits/_bucket_priority_queue_test.py
@@ -1,0 +1,151 @@
+import pytest
+
+from cirq.circuits._bucket_priority_queue import BucketPriorityQueue
+import cirq
+
+
+def test_init():
+    q = BucketPriorityQueue()
+    assert not q.drop_duplicates
+    assert list(q) == []
+    assert len(q) == 0
+    assert not bool(q)
+    with pytest.raises(ValueError, match='empty'):
+        _ = q.dequeue()
+
+    q = BucketPriorityQueue(items=[(5, 'a')])
+    assert not q.drop_duplicates
+    assert list(q) == [(5, 'a')]
+    assert len(q) == 1
+    assert bool(q)
+
+    q = BucketPriorityQueue(items=[(5, 'a'), (6, 'b')], drop_duplicates=True)
+    assert q.drop_duplicates
+    assert list(q) == [(5, 'a'), (6, 'b')]
+    assert len(q) == 2
+    assert bool(q)
+
+
+def test_eq():
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(
+        BucketPriorityQueue(),
+        BucketPriorityQueue(drop_duplicates=False),
+        BucketPriorityQueue(items=[]),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(drop_duplicates=True),
+        BucketPriorityQueue(items=[], drop_duplicates=True),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(0, 'a')], drop_duplicates=True),
+        BucketPriorityQueue(items=[(0, 'a'), (0, 'a')], drop_duplicates=True),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(0, 'a')]),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(0, 'a'), (0, 'a')]),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(1, 'a')]),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(0, 'b')]),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(0, 'a'), (1, 'b')]),
+        BucketPriorityQueue(items=[(1, 'b'), (0, 'a')]),
+    )
+    eq.add_equality_group(
+        BucketPriorityQueue(items=[(0, 'a'), (1, 'b'), (0, 'a')]),
+        BucketPriorityQueue(items=[(1, 'b'), (0, 'a'), (0, 'a')]),
+    )
+
+
+def test_enqueue_dequeue():
+    q = BucketPriorityQueue()
+    q.enqueue(5, 'a')
+    assert q == BucketPriorityQueue([(5, 'a')])
+    q.enqueue(4, 'b')
+    assert q == BucketPriorityQueue([(4, 'b'), (5, 'a')])
+    assert q.dequeue() == (4, 'b')
+    assert q == BucketPriorityQueue([(5, 'a')])
+    assert q.dequeue() == (5, 'a')
+    assert q == BucketPriorityQueue()
+    with pytest.raises(ValueError, match='empty'):
+        _ = q.dequeue()
+
+
+def test_drop_duplicates_enqueue():
+    q0 = BucketPriorityQueue()
+    q1 = BucketPriorityQueue(drop_duplicates=False)
+    q2 = BucketPriorityQueue(drop_duplicates=True)
+    for q in [q0, q1, q2]:
+        for _ in range(2):
+            q.enqueue(0, 'a')
+
+    assert q0 == q1 == BucketPriorityQueue([(0, 'a'), (0, 'a')])
+    assert q2 == BucketPriorityQueue([(0, 'a')], drop_duplicates=True)
+
+
+def test_drop_duplicates_dequeue():
+    q0 = BucketPriorityQueue()
+    q1 = BucketPriorityQueue(drop_duplicates=False)
+    q2 = BucketPriorityQueue(drop_duplicates=True)
+    for q in [q0, q1, q2]:
+        q.enqueue(0, 'a')
+        q.enqueue(0, 'b')
+        q.enqueue(0, 'a')
+        q.dequeue()
+        q.enqueue(0, 'b')
+        q.enqueue(0, 'a')
+
+    assert q0 == q1 == BucketPriorityQueue(
+        [(0, 'b'), (0, 'a'), (0, 'b'), (0, 'a')])
+    assert q2 == BucketPriorityQueue([(0, 'b'), (0, 'a')], drop_duplicates=True)
+
+
+def test_same_priority_fifo():
+    a = (5, 'a')
+    b = (5, 'b')
+    for x, y in [(a, b), (b, a)]:
+        q = BucketPriorityQueue()
+        q.enqueue(*x)
+        q.enqueue(*y)
+        assert q
+        assert q.dequeue() == x
+        assert q
+        assert q.dequeue() == y
+        assert not q
+
+
+def test_supports_arbitrary_offsets():
+    m = 1 << 60
+
+    q_neg = BucketPriorityQueue()
+    q_neg.enqueue(-m + 0, 'b')
+    q_neg.enqueue(-m - 4, 'a')
+    q_neg.enqueue(-m + 4, 'c')
+    assert list(q_neg) == [(-m-4, 'a'), (-m, 'b'), (-m+4, 'c')]
+
+    q_pos = BucketPriorityQueue()
+    q_pos.enqueue(m + 0, 'b')
+    q_pos.enqueue(m + 4, 'c')
+    q_pos.enqueue(m - 4, 'a')
+    assert list(q_pos) == [(m-4, 'a'), (m, 'b'), (m+4, 'c')]
+
+
+def test_repr():
+    r = repr(BucketPriorityQueue(items=[(1, 2), (3, 4)], drop_duplicates=True))
+    assert r.endswith('BucketPriorityQueue(items=[(1, 2), (3, 4)], '
+                      'drop_duplicates=True)')
+
+
+def test_str():
+    s = str(BucketPriorityQueue(items=[(1, 2), (3, 4)], drop_duplicates=True))
+    assert s == """
+BucketPriorityQueue {
+    1: 2,
+    3: 4,
+}""".strip()

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -29,6 +29,7 @@ from typing import (
 import numpy as np
 
 from cirq import devices, ops, extension, study, protocols
+from cirq.circuits._bucket_priority_queue import BucketPriorityQueue
 from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.circuits.moment import Moment
 from cirq.circuits.text_diagram_drawer import TextDiagramDrawer
@@ -406,6 +407,210 @@ class Circuit(ops.ParameterizableEffect):
             if self._can_add_op_at(k, op):
                 last_available = k
         return last_available
+
+    def reachable_frontier_from(
+            self,
+            start_frontier: Dict[ops.QubitId, int],
+            *,
+            is_blocker: Callable[[ops.Operation], bool] = lambda op: False
+    ) -> Dict[ops.QubitId, int]:
+        """Determines how far can be reached into a circuit under certain rules.
+
+        The location L = (qubit, moment_index) is *reachable* if and only if:
+
+            a) L is one of the items in `start_frontier`.
+
+            OR
+
+            b) There is no operation at L and prev(L) = (qubit, moment_index-1) is
+                reachable and L is within the bounds of the circuit.
+
+            OR
+
+            c) There is an operation P covering L and, for every location
+                M = (q', moment_index) that P covers, the location
+                prev(M) = (q', moment_index-1) is reachable. Also, P must not be
+                classified as a blocker by the given `is_blocker` argument.
+
+        In other words, the reachable region extends horizontally along each qubit
+        until it hits a blocked operation or an operation that crosses into the
+        set of not-involved-at-the-moment qubits.
+
+        For each qubit q in `start_frontier`, the reachable locations will
+        correspond to a contiguous range starting at start_frontier[q] and ending
+        just before some index end_q. The result of this method is a dictionary, and
+        that dictionary maps each qubit q to its end_q.
+
+        Examples:
+
+            If start_frontier is {
+                cirq.LineQubit(0): 6,
+                cirq.LineQubit(1): 2,
+                cirq.LineQubit(2): 2,
+            } then the reachable wire locations in the following circuit are
+            highlighted with '█' characters:
+
+                0   1   2   3   4   5   6   7   8   9   10  11  12  13
+            0: ───H───@─────────────────█████████████████████─@───H───
+                      │                                       │
+            1: ───────@─██H███@██████████████████████─@───H───@───────
+                              │                       │
+            2: ─────────██████@███H██─@───────@───H───@───────────────
+                                      │       │
+            3: ───────────────────────@───H───@───────────────────────
+
+            And the computed end_frontier is {
+                cirq.LineQubit(0): 11,
+                cirq.LineQubit(1): 9,
+                cirq.LineQubit(2): 6,
+            }
+
+            Note that the frontier indices (shown above the circuit) are
+            best thought of (and shown) as happening *between* moment indices.
+
+            If we specify a blocker as follows:
+
+                is_blocker=lambda: op == cirq.CZ(cirq.LineQubit(1),
+                                                 cirq.LineQubit(2))
+
+            and use this start_frontier:
+
+                {
+                    cirq.LineQubit(0): 0,
+                    cirq.LineQubit(1): 0,
+                    cirq.LineQubit(2): 0,
+                    cirq.LineQubit(3): 0,
+                }
+
+            Then this is the reachable area:
+
+                0   1   2   3   4   5   6   7   8   9   10  11  12  13
+            0: ─██H███@██████████████████████████████████████─@───H───
+                      │                                       │
+            1: ─██████@███H██─@───────────────────────@───H───@───────
+                              │                       │
+            2: ─█████████████─@───H───@───────@───H───@───────────────
+                                      │       │
+            3: ─█████████████████████─@───H───@───────────────────────
+
+            and the computed end_frontier is:
+
+                {
+                    cirq.LineQubit(0): 11,
+                    cirq.LineQubit(1): 3,
+                    cirq.LineQubit(2): 3,
+                    cirq.LineQubit(3): 5,
+                }
+
+        Args:
+            start_frontier: A starting set of reachable locations.
+            is_blocker: A predicate that determines if operations block
+                reachability. Any location covered by an operation that causes
+                `is_blocker` to return True is considered to be an unreachable
+                location.
+
+        Returns:
+            An end_frontier dictionary, containing an end index for each qubit q
+            mapped to a start index by the given `start_frontier` dictionary.
+
+            To determine if a location (q, i) was reachable, you can use
+            this expression:
+
+                q in start_frontier and start_frontier[q] <= i < end_frontier[q]
+
+            where i is the moment index, q is the qubit, and end_frontier is the
+            result of this method.
+        """
+        active = set()
+        end_frontier = {}
+        queue = BucketPriorityQueue(
+            drop_duplicates=True)  # type: BucketPriorityQueue[ops.Operation]
+
+        def enqueue_next(qubit: ops.QubitId, moment: int) -> None:
+            next_moment = self.next_moment_operating_on([qubit], moment)
+            if next_moment is None:
+                end_frontier[qubit] = max(len(self), start_frontier[qubit])
+                if qubit in active:
+                    active.remove(qubit)
+            else:
+                next_op = self.operation_at(qubit, next_moment)
+                queue.enqueue(next_moment, next_op)
+
+        for start_qubit, start_moment in start_frontier.items():
+            enqueue_next(start_qubit, start_moment)
+
+        while queue:
+            cur_moment, cur_op = queue.dequeue()
+            for q in cur_op.qubits:
+                if (q in start_frontier and
+                        cur_moment >= start_frontier[q] and
+                        q not in end_frontier):
+                    active.add(q)
+
+            continue_past = (
+                    cur_op is not None and
+                    active.issuperset(cur_op.qubits) and
+                    not is_blocker(cur_op)
+            )
+            if continue_past:
+                for q in cur_op.qubits:
+                    enqueue_next(q, cur_moment + 1)
+            else:
+                for q in cur_op.qubits:
+                    if q in active:
+                        end_frontier[q] = cur_moment
+                        active.remove(q)
+
+        return end_frontier
+
+    def findall_operations_between(self,
+                                   start_frontier: Dict[ops.QubitId, int],
+                                   end_frontier: Dict[ops.QubitId, int],
+                                   omit_crossing_operations: bool = False
+                                   ) -> List[Tuple[int, ops.Operation]]:
+        """Finds operations between the two given frontiers.
+
+        If a qubit is in `start_frontier` but not `end_frontier`, its end index
+        defaults to the end of the circuit. If a qubit is in `end_frontier` but
+        not `start_frontier`, its start index defaults to the start of the
+        circuit. Operations on qubits not mentioned in either frontier are not
+        included in the results.
+
+        Args:
+            start_frontier: Just before where to start searching for operations,
+                for each qubit of interest. Start frontier indices are
+                inclusive.
+            end_frontier: Just before where to stop searching for operations,
+                for each qubit of interest. End frontier indices are exclusive.
+            omit_crossing_operations: Determines whether or not operations that
+                cross from a location between the two frontiers to a location
+                outside the two frontiers are included or excluded. (Operations
+                completely inside are always included, and operations completely
+                outside are always excluded.)
+
+        Returns:
+            A list of tuples. Each tuple describes an operation found between
+            the two frontiers. The first item of each tuple is the index of the
+            moment containing the operation, and the second item is the
+            operation itself. The list is sorted so that the moment index
+            increases monotonically.
+        """
+        result = BucketPriorityQueue(
+            drop_duplicates=True)  # type: BucketPriorityQueue[ops.Operation]
+
+        involved_qubits = set(start_frontier.keys()) | set(end_frontier.keys())
+        for q in ops.QubitOrder.DEFAULT.order_for(involved_qubits):
+            for i in range(start_frontier.get(q, 0),
+                           end_frontier.get(q, len(self))):
+                op = self.operation_at(q, i)
+                if op is None:
+                    continue
+                if (omit_crossing_operations and
+                        not involved_qubits.issuperset(op.qubits)):
+                    continue
+                result.enqueue(i, op)
+
+        return list(result)
 
     def operation_at(self,
                      qubit: ops.QubitId,

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -2169,3 +2169,207 @@ qreg q[1];
 
 x q[0];
 """)
+
+
+def test_findall_operations_between():
+    a, b, c, d = cirq.LineQubit.range(4)
+
+    #    0: ───H───@───────────────────────────────────────@───H───
+    #              │                                       │
+    #    1: ───────@───H───@───────────────────────@───H───@───────
+    #                      │                       │
+    #    2: ───────────────@───H───@───────@───H───@───────────────
+    #                              │       │
+    #    3: ───────────────────────@───H───@───────────────────────
+    #
+    # moments: 0   1   2   3   4   5   6   7   8   9   10  11  12
+    circuit = cirq.Circuit.from_ops(
+        cirq.H(a),
+        cirq.CZ(a, b),
+        cirq.H(b),
+        cirq.CZ(b, c),
+        cirq.H(c),
+        cirq.CZ(c, d),
+        cirq.H(d),
+        cirq.CZ(c, d),
+        cirq.H(c),
+        cirq.CZ(b, c),
+        cirq.H(b),
+        cirq.CZ(a, b),
+        cirq.H(a))
+
+    # Empty frontiers means no results.
+    actual = circuit.findall_operations_between(
+        start_frontier={},
+        end_frontier={})
+    assert actual == []
+
+    # Empty range is empty.
+    actual = circuit.findall_operations_between(
+        start_frontier={a: 5},
+        end_frontier={a: 5})
+    assert actual == []
+
+    # Default end_frontier value is len(circuit.
+    actual = circuit.findall_operations_between(
+        start_frontier={a: 5},
+        end_frontier={})
+    assert actual == [
+        (11, cirq.CZ(a, b)),
+        (12, cirq.H(a)),
+    ]
+
+    # Default start_frontier value is 0.
+    actual = circuit.findall_operations_between(
+        start_frontier={},
+        end_frontier={a: 5})
+    assert actual == [
+        (0, cirq.H(a)),
+        (1, cirq.CZ(a, b))
+    ]
+
+    # omit_crossing_operations omits crossing operations.
+    actual = circuit.findall_operations_between(
+        start_frontier={a: 5},
+        end_frontier={},
+        omit_crossing_operations=True)
+    assert actual == [
+        (12, cirq.H(a)),
+    ]
+
+    # omit_crossing_operations keeps operations across included regions.
+    actual = circuit.findall_operations_between(
+        start_frontier={a: 5, b: 5},
+        end_frontier={},
+        omit_crossing_operations=True)
+    assert actual == [
+        (10, cirq.H(b)),
+        (11, cirq.CZ(a, b)),
+        (12, cirq.H(a)),
+    ]
+
+    # Regions are OR'd together, not AND'd together.
+    actual = circuit.findall_operations_between(
+        start_frontier={a: 5},
+        end_frontier={b: 5})
+    assert actual == [
+        (1, cirq.CZ(a, b)),
+        (2, cirq.H(b)),
+        (3, cirq.CZ(b, c)),
+        (11, cirq.CZ(a, b)),
+        (12, cirq.H(a)),
+    ]
+
+    # Regions are OR'd together, not AND'd together (2).
+    actual = circuit.findall_operations_between(
+        start_frontier={a: 5},
+        end_frontier={a: 5, b: 5})
+    assert actual == [
+        (1, cirq.CZ(a, b)),
+        (2, cirq.H(b)),
+        (3, cirq.CZ(b, c)),
+    ]
+
+    # Inclusive start, exclusive end.
+    actual = circuit.findall_operations_between(
+        start_frontier={c: 4},
+        end_frontier={c: 8})
+    assert actual == [
+        (4, cirq.H(c)),
+        (5, cirq.CZ(c, d)),
+        (7, cirq.CZ(c, d)),
+    ]
+
+    # Out of range is clamped.
+    actual = circuit.findall_operations_between(
+        start_frontier={a: -100},
+        end_frontier={a: +100})
+    assert actual == [
+        (0, cirq.H(a)),
+        (1, cirq.CZ(a, b)),
+        (11, cirq.CZ(a, b)),
+        (12, cirq.H(a)),
+    ]
+
+
+def test_reachable_frontier_from():
+    a, b, c, d = cirq.LineQubit.range(4)
+
+    #    0: ───H───@───────────────────────────────────────@───H───
+    #              │                                       │
+    #    1: ───────@───H───@───────────────────────@───H───@───────
+    #                      │                       │
+    #    2: ───────────────@───H───@───────@───H───@───────────────
+    #                              │       │
+    #    3: ───────────────────────@───H───@───────────────────────
+    #
+    # moments: 0   1   2   3   4   5   6   7   8   9   10  11  12
+    circuit = cirq.Circuit.from_ops(
+        cirq.H(a),
+        cirq.CZ(a, b),
+        cirq.H(b),
+        cirq.CZ(b, c),
+        cirq.H(c),
+        cirq.CZ(c, d),
+        cirq.H(d),
+        cirq.CZ(c, d),
+        cirq.H(c),
+        cirq.CZ(b, c),
+        cirq.H(b),
+        cirq.CZ(a, b),
+        cirq.H(a))
+
+    # Empty cases.
+    assert cirq.Circuit().reachable_frontier_from(start_frontier={}) == {}
+    assert circuit.reachable_frontier_from(start_frontier={}) == {}
+
+    # Clamped input cases.
+    assert cirq.Circuit().reachable_frontier_from(
+        start_frontier={a: 5}) == {a: 5}
+    assert cirq.Circuit().reachable_frontier_from(
+        start_frontier={a: -100}) == {a: 0}
+    assert circuit.reachable_frontier_from(
+        start_frontier={a: 100}) == {a: 100}
+
+    # Stopped by crossing outside case.
+    assert circuit.reachable_frontier_from({a: -1}) == {a: 1}
+    assert circuit.reachable_frontier_from({a: 0}) == {a: 1}
+    assert circuit.reachable_frontier_from({a: 1}) == {a: 1}
+    assert circuit.reachable_frontier_from({a: 2}) == {a: 11}
+    assert circuit.reachable_frontier_from({a: 5}) == {a: 11}
+    assert circuit.reachable_frontier_from({a: 10}) == {a: 11}
+    assert circuit.reachable_frontier_from({a: 11}) == {a: 11}
+    assert circuit.reachable_frontier_from({a: 12}) == {a: 13}
+    assert circuit.reachable_frontier_from({a: 13}) == {a: 13}
+    assert circuit.reachable_frontier_from({a: 14}) == {a: 14}
+
+    # Inside crossing works only before blocked case.
+    assert circuit.reachable_frontier_from({a: 0, b: 0}) == {a: 11, b: 3}
+    assert circuit.reachable_frontier_from({a: 2, b: 2}) == {a: 11, b: 3}
+    assert circuit.reachable_frontier_from({a: 0, b: 4}) == {a: 1, b: 9}
+    assert circuit.reachable_frontier_from({a: 3, b: 4}) == {a: 11, b: 9}
+    assert circuit.reachable_frontier_from({a: 3, b: 9}) == {a: 11, b: 9}
+    assert circuit.reachable_frontier_from({a: 3, b: 10}) == {a: 13, b: 13}
+
+    # Travelling shadow.
+    assert circuit.reachable_frontier_from({a: 0, b: 0, c: 0}) == {a: 11,
+                                                                   b: 9,
+                                                                   c: 5}
+
+    # Full circuit
+    assert circuit.reachable_frontier_from({a: 0, b: 0, c: 0, d: 0}) == {
+        a: 13,
+        b: 13,
+        c: 13,
+        d: 13
+    }
+
+    # Blocker.
+    assert circuit.reachable_frontier_from(
+        {a: 0, b: 0, c: 0, d: 0},
+        is_blocker=lambda op: op == cirq.CZ(b, c)) == {
+            a: 11,
+            b: 3,
+            c: 3,
+            d: 5
+        }


### PR DESCRIPTION
- Implemented a private priority queue (BuckerPriorityQueue) specialized to the needs of these methods

These methods are useful when attempting to find "spacelike-separated light cones" within a circuit. For example, if you want to grab as many operations as possible to fold into one big 8 qubit operation, you would do the following:

```python
start_frontier = {q: start_index for q in group_of_8_qubits}
end_frontier = circuit.reachable_frontier_from(start_frontier)
merged_operations = circuit.findall_operations_between(start_frontier, end_frontier)
```