### PR TITLE
Merge cirq.google.Exp11Gate into cirq.Rot11Gate

### DIFF
--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -2057,35 +2057,35 @@ def test_insert_operations_errors():
 def test_validates_while_editing():
     c = cirq.Circuit(device=cg.Foxtail)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Unsupported qubit type'):
         # Wrong type of qubit.
         c.append(cg.ExpZGate().on(cirq.NamedQubit('q')))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Qubit not on device'):
         # A qubit that's not on the device.
         c[:] = [cirq.Moment([
             cg.ExpZGate().on(cirq.GridQubit(-5, 100))])]
     c.append(cg.ExpZGate().on(cirq.GridQubit(0, 0)))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Non-local interaction'):
         # Non-adjacent CZ.
-        c[0] = cirq.Moment([cg.Exp11Gate().on(cirq.GridQubit(0, 0),
-                                                       cirq.GridQubit(2, 2))])
+        c[0] = cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
+                                    cirq.GridQubit(1, 2))])
 
-    c.insert(0, cg.Exp11Gate().on(cirq.GridQubit(0, 0),
+    c.insert(0, cirq.CZ(cirq.GridQubit(0, 0),
                                            cirq.GridQubit(1, 0)))
 
 
 def test_respects_additional_adjacency_constraints():
     c = cirq.Circuit(device=cg.Foxtail)
-    c.append(cg.Exp11Gate().on(cirq.GridQubit(0, 0),
+    c.append(cirq.CZ(cirq.GridQubit(0, 0),
                                cirq.GridQubit(0, 1)))
-    c.append(cg.Exp11Gate().on(cirq.GridQubit(1, 0),
+    c.append(cirq.CZ(cirq.GridQubit(1, 0),
                                cirq.GridQubit(1, 1)),
              strategy=cirq.InsertStrategy.EARLIEST)
     assert c == cirq.Circuit([
-        cirq.Moment([cg.Exp11Gate().on(cirq.GridQubit(0, 0),
+        cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
                                        cirq.GridQubit(0, 1))]),
-        cirq.Moment([cg.Exp11Gate().on(cirq.GridQubit(1, 0),
+        cirq.Moment([cirq.CZ(cirq.GridQubit(1, 0),
                                        cirq.GridQubit(1, 1))]),
     ], device=cg.Foxtail)
 
@@ -2095,17 +2095,17 @@ def test_commutes_past_adjacency_constraints():
             cirq.Moment(),
             cirq.Moment(),
             cirq.Moment([
-                cg.Exp11Gate().on(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))])
+                cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))])
         ],
         device=cg.Foxtail)
-    c.append(cg.Exp11Gate().on(cirq.GridQubit(1, 0),
+    c.append(cirq.CZ(cirq.GridQubit(1, 0),
                                cirq.GridQubit(1, 1)),
              strategy=cirq.InsertStrategy.EARLIEST)
     assert c == cirq.Circuit([
-        cirq.Moment([cg.Exp11Gate().on(cirq.GridQubit(1, 0),
+        cirq.Moment([cirq.CZ(cirq.GridQubit(1, 0),
                                        cirq.GridQubit(1, 1))]),
         cirq.Moment(),
-        cirq.Moment([cg.Exp11Gate().on(cirq.GridQubit(0, 0),
+        cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
                                        cirq.GridQubit(0, 1))]),
     ], device=cg.Foxtail)
 

--- a/cirq/circuits/qasm_output_test.py
+++ b/cirq/circuits/qasm_output_test.py
@@ -241,9 +241,6 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurments=True):
         cirq.google.ExpZGate()(q3),
         cirq.google.ExpZGate(half_turns=0.75)(q3),
         cirq.google.ExpWGate(axis_half_turns=0.125, half_turns=0.25)(q1),
-        cirq.google.Exp11Gate()(q0, q1),
-        # Requires 2-qubit decomposition
-        cirq.google.Exp11Gate(half_turns=1.25)(q0, q1),
 
         (
             cirq.MeasurementGate('xX')(q0),
@@ -453,22 +450,6 @@ rz(pi*0.75) q[3];
 
 // Gate: W(0.125)^0.25
 u3(pi*0.25,pi*1.625,pi*0.375) q[1];
-
-cz q[0],q[1];
-
-// Gate: Exp11Gate(half_turns=-0.75)
-u3(pi*0.5,0,pi*1.54081) q[0];
-u3(pi*0.5,pi*1.0,pi*0.04081) q[1];
-rx(pi*0.5) q[0];
-cx q[0],q[1];
-rx(pi*0.125) q[0];
-ry(pi*0.5) q[1];
-cx q[1],q[0];
-rx(pi*-0.5) q[1];
-rz(pi*0.5) q[1];
-cx q[0],q[1];
-u3(pi*0.5,pi*1.08419,pi*1.0) q[0];
-u3(pi*0.5,pi*0.58419,0) q[1];
 
 measure q[0] -> m_xX[0];
 measure q[2] -> m_x_a[0];

--- a/cirq/contrib/jobs/depolarizer_channel_test.py
+++ b/cirq/contrib/jobs/depolarizer_channel_test.py
@@ -108,7 +108,7 @@ def test_depolarizer_parameterized_gates():
     q1 = cirq.QubitId()
     q2 = cirq.QubitId()
     cnot_param = cirq.Symbol('cnot_turns')
-    cnot_gate = xmon_gates.Exp11Gate(half_turns=cnot_param).on(q1, q2)
+    cnot_gate = cirq.CZ(q1, q2)**cnot_param
 
     job_sweep = cirq.Points('cnot_turns', [0.5])
 

--- a/cirq/contrib/quirk/quirk_gate.py
+++ b/cirq/contrib/quirk/quirk_gate.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from cirq import ops, Symbol
 from cirq.extension import Extensions
-from cirq.google.xmon_gates import ExpZGate, Exp11Gate, ExpWGate
+from cirq.google.xmon_gates import ExpZGate, ExpWGate
 
 
 class QuirkOp:
@@ -98,7 +98,7 @@ def y_to_known(gate: Union[ops.RotYGate, ExpWGate]) -> Optional[QuirkOp]:
     return QuirkOp('Y' + e)
 
 
-def cz_to_known(gate: Union[ops.Rot11Gate, Exp11Gate]) -> Optional[QuirkOp]:
+def cz_to_known(gate: ops.Rot11Gate) -> Optional[QuirkOp]:
     e = angle_to_exponent_key(gate.half_turns)
     if e is None:
         return None
@@ -152,7 +152,6 @@ quirk_gate_ext.add_cast(QuirkOp, ops.RotZGate, z_to_known)
 quirk_gate_ext.add_cast(QuirkOp, ExpZGate, z_to_known)
 quirk_gate_ext.add_cast(QuirkOp, ExpWGate, w_to_known)
 quirk_gate_ext.add_cast(QuirkOp, ops.Rot11Gate, cz_to_known)
-quirk_gate_ext.add_cast(QuirkOp, Exp11Gate, cz_to_known)
 quirk_gate_ext.add_cast(QuirkOp,
                         ops.CNotGate,
                         lambda e: QuirkOp('•', 'X',

--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -42,7 +42,6 @@ from cirq.google.optimize import (
     optimized_for_xmon,
 )
 from cirq.google.xmon_gates import (
-    Exp11Gate,
     ExpWGate,
     ExpZGate,
     XmonGate,

--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -58,3 +58,10 @@ from cirq.google.engine import (
     Engine,
     JobConfig,
 )
+from cirq.google.programs import (
+    gate_to_proto_dict,
+    schedule_from_proto_dicts,
+    schedule_to_proto_dicts,
+    pack_results,
+    unpack_results,
+)

--- a/cirq/google/convert_to_xmon_gates.py
+++ b/cirq/google/convert_to_xmon_gates.py
@@ -58,7 +58,8 @@ class ConvertToXmonGates(PointOptimizer):
 
     def _convert_one(self, op: ops.Operation) -> ops.OP_TREE:
         # Already supported?
-        if isinstance(op, ops.GateOperation) and isinstance(op.gate, XmonGate):
+        if (isinstance(op, ops.GateOperation) and
+                isinstance(op.gate, (ops.Rot11Gate, XmonGate))):
             return op
 
         # Maybe we know how to wrap it?

--- a/cirq/google/eject_full_w.py
+++ b/cirq/google/eject_full_w.py
@@ -18,7 +18,7 @@
 from typing import Optional, cast, TYPE_CHECKING, Iterable
 
 from cirq import circuits, ops, extension, value, decompositions
-from cirq.google.xmon_gates import ExpZGate, ExpWGate, Exp11Gate
+from cirq.google.xmon_gates import ExpZGate, ExpWGate
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -256,7 +256,7 @@ def _single_cross_over_cz(moment_index: int,
     """
     t = cast(float, _try_get_known_cz_half_turns(op))
     other_qubit = op.qubits[0] if qubit_with_w == op.qubits[1] else op.qubits[1]
-    negated_cz = Exp11Gate(half_turns=-t).on(*op.qubits)
+    negated_cz = ops.CZ(*op.qubits)**-t
     kickback = ExpZGate(half_turns=t).on(other_qubit)
 
     state.deletions.append((moment_index, op))
@@ -305,7 +305,7 @@ def _double_cross_over_cz(op: ops.Operation,
 
 def _try_get_known_cz_half_turns(op: ops.Operation) -> Optional[float]:
     if (not isinstance(op, ops.GateOperation) or
-            not isinstance(op.gate, (Exp11Gate, ops.Rot11Gate))):
+            not isinstance(op.gate, ops.Rot11Gate)):
         return None
     h = op.gate.half_turns
     if isinstance(h, value.Symbol):

--- a/cirq/google/eject_full_w_test.py
+++ b/cirq/google/eject_full_w_test.py
@@ -108,7 +108,7 @@ def test_crosses_czs():
         ),
         expected=quick_circuit(
             [cg.ExpZGate().on(b)],
-            [cg.Exp11Gate().on(a, b)],
+            [cirq.CZ(a, b)],
             [cg.ExpWGate(axis_half_turns=0.25).on(a)],
         ))
     assert_optimizes(
@@ -118,7 +118,7 @@ def test_crosses_czs():
         ),
         expected=quick_circuit(
             [cg.ExpZGate().on(b)],
-            [cg.Exp11Gate().on(a, b)],
+            [cirq.CZ(a, b)],
             [cg.ExpWGate(axis_half_turns=0.125).on(a)],
         ))
 
@@ -130,7 +130,7 @@ def test_crosses_czs():
         ),
         expected=quick_circuit(
             [cg.ExpZGate(half_turns=0.25).on(b)],
-            [cg.Exp11Gate(half_turns=-0.25).on(a, b)],
+            [cirq.CZ(a, b)**-0.25],
             [cg.ExpWGate().on(a)],
         ))
 
@@ -323,12 +323,12 @@ def test_blocked_by_unknown_and_symbols():
     assert_optimizes(
         before=quick_circuit(
             [cg.ExpWGate().on(a)],
-            [cg.Exp11Gate(half_turns=cirq.Symbol('z')).on(a, b)],
+            [cirq.CZ(a, b)**cirq.Symbol('z')],
             [cg.ExpWGate().on(a)],
         ),
         expected=quick_circuit(
             [cg.ExpWGate().on(a)],
-            [cg.Exp11Gate(half_turns=cirq.Symbol('z')).on(a, b)],
+            [cirq.CZ(a, b)**cirq.Symbol('z')],
             [cg.ExpWGate().on(a)],
         ),
         compare_unitaries=False)

--- a/cirq/google/eject_z_test.py
+++ b/cirq/google/eject_z_test.py
@@ -261,7 +261,7 @@ def test_removes_zs():
         cirq.Z(a),
         cirq.Z(b),
         cirq.CZ(a, b),
-        cirq.google.Exp11Gate().on(a, b),
+        cirq.CZ(a, b),
         cirq.measure(a, b)))
 
 

--- a/cirq/google/merge_rotations.py
+++ b/cirq/google/merge_rotations.py
@@ -42,8 +42,8 @@ class MergeRotations(PointOptimizer):
 
         indices, operations = self._scan_single_qubit_ops(
             circuit, index, op.qubits[0])
-        if not operations or (
-                len(operations) == 1 and XmonGate.is_supported_op(operations[0])):
+        if not operations or (len(operations) == 1 and
+                              XmonGate.is_supported_op(operations[0])):
             return
 
         # Replace the gates with a max-2-op XY + Z construction.

--- a/cirq/google/merge_rotations.py
+++ b/cirq/google/merge_rotations.py
@@ -43,7 +43,7 @@ class MergeRotations(PointOptimizer):
         indices, operations = self._scan_single_qubit_ops(
             circuit, index, op.qubits[0])
         if not operations or (
-                len(operations) == 1 and XmonGate.is_xmon_op(operations[0])):
+                len(operations) == 1 and XmonGate.is_supported_op(operations[0])):
             return
 
         # Replace the gates with a max-2-op XY + Z construction.

--- a/cirq/google/optimize_test.py
+++ b/cirq/google/optimize_test.py
@@ -68,9 +68,9 @@ def test_adjacent_cz_get_split_apart():
 
     assert after == cirq.Circuit([
         cirq.Moment([
-            cg.Exp11Gate().on(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))]),
+            cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))]),
         cirq.Moment([
-            cg.Exp11Gate().on(cirq.GridQubit(1, 0), cirq.GridQubit(1, 1))])],
+            cirq.CZ(cirq.GridQubit(1, 0), cirq.GridQubit(1, 1))])],
         device=cg.Foxtail)
 
 
@@ -84,7 +84,7 @@ def test_remap_qubits():
 
     assert after == cirq.Circuit([
         cirq.Moment([
-            cg.Exp11Gate().on(cirq.GridQubit(0, 0), cirq.GridQubit(1, 0))])],
+            cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(1, 0))])],
         device=cg.Foxtail)
 
 
@@ -95,8 +95,8 @@ def test_dont_allow_partial_czs():
     after = cg.optimized_for_xmon(before, allow_partial_czs=False)
 
     cz_gates = [op.gate for op in after.all_operations()
-                        if cg.XmonGate.is_xmon_op(op) and
-                           isinstance(op.gate, cg.Exp11Gate)]
+                if isinstance(op, cirq.GateOperation) and
+                isinstance(op.gate, cirq.Rot11Gate)]
     num_full_cz = sum(1 for cz in cz_gates if cz.half_turns == 1)
     num_part_cz = sum(1 for cz in cz_gates if cz.half_turns != 1)
     assert num_full_cz == 2
@@ -110,8 +110,8 @@ def test_allow_partial_czs():
     after = cg.optimized_for_xmon(before, allow_partial_czs=True)
 
     cz_gates = [op.gate for op in after.all_operations()
-                        if cg.XmonGate.is_xmon_op(op) and
-                           isinstance(op.gate, cg.Exp11Gate)]
+                if isinstance(op, cirq.GateOperation) and
+                isinstance(op.gate, cirq.Rot11Gate)]
     num_full_cz = sum(1 for cz in cz_gates if cz.half_turns == 1)
     num_part_cz = sum(1 for cz in cz_gates if cz.half_turns != 1)
     assert num_full_cz == 0

--- a/cirq/google/programs.py
+++ b/cirq/google/programs.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
     from typing import Optional  # pylint: disable=unused-import
 
 
-def _gate_to_proto_dict(gate: ops.Gate,
-                        qubits: Tuple[ops.QubitId, ...]) -> Dict:
+def gate_to_proto_dict(gate: ops.Gate,
+                       qubits: Tuple[ops.QubitId, ...]) -> Dict:
     xmon_gate = xmon_gate_ext.try_cast(xmon_gates.XmonGate, gate)
     if xmon_gate is not None:
         return xmon_gate.to_proto_dict(*qubits)
@@ -63,7 +63,7 @@ def schedule_to_proto_dicts(schedule: Schedule) -> Iterable[Dict]:
     """
     last_time_picos = None  # type: Optional[int]
     for so in schedule.scheduled_operations:
-        op = _gate_to_proto_dict(
+        op = gate_to_proto_dict(
             cast(ops.GateOperation, so.operation).gate,
             so.operation.qubits)
         time_picos = so.time.raw_picos()

--- a/cirq/google/programs.py
+++ b/cirq/google/programs.py
@@ -25,6 +25,32 @@ if TYPE_CHECKING:
     from typing import Optional  # pylint: disable=unused-import
 
 
+def _gate_to_proto_dict(gate: ops.Gate,
+                        qubits: Tuple[ops.QubitId, ...]) -> Dict:
+    xmon_gate = xmon_gate_ext.try_cast(xmon_gates.XmonGate, gate)
+    if xmon_gate is not None:
+        return xmon_gate.to_proto_dict(*qubits)
+
+    if isinstance(gate, ops.Rot11Gate):
+        if len(qubits) != 2:
+            raise ValueError('Wrong number of qubits.')
+        return _cz_to_proto_dict(gate, *qubits)
+
+    raise ValueError("Don't know how to serialize this gate: {!r}".format(gate))
+
+
+def _cz_to_proto_dict(gate: ops.Rot11Gate,
+                      p: ops.QubitId,
+                      q: ops.QubitId) -> Dict:
+    exp_11 = {
+        'target1': p.to_proto_dict(),
+        'target2': q.to_proto_dict(),
+        'half_turns': xmon_gates.XmonGate.parameterized_value_to_proto_dict(
+            gate.half_turns)
+    }
+    return {'exp_11': exp_11}
+
+
 def schedule_to_proto_dicts(schedule: Schedule) -> Iterable[Dict]:
     """Convert a schedule into an iterable of proto dictionaries.
 
@@ -37,10 +63,9 @@ def schedule_to_proto_dicts(schedule: Schedule) -> Iterable[Dict]:
     """
     last_time_picos = None  # type: Optional[int]
     for so in schedule.scheduled_operations:
-        gate = xmon_gate_ext.cast(
-            xmon_gates.XmonGate,
-            cast(ops.GateOperation, so.operation).gate)
-        op = gate.to_proto_dict(*so.operation.qubits)
+        op = _gate_to_proto_dict(
+            cast(ops.GateOperation, so.operation).gate,
+            so.operation.qubits)
         time_picos = so.time.raw_picos()
         if last_time_picos is None:
             op['incremental_delay_picoseconds'] = time_picos

--- a/cirq/google/programs_test.py
+++ b/cirq/google/programs_test.py
@@ -27,7 +27,7 @@ def test_protobuf_round_trip():
             for q in device.qubits
         ],
         [
-            cirq.google.Exp11Gate().on(q, q2)
+            cirq.CZ(q, q2)
             for q in [cirq.GridQubit(0, 0)]
             for q2 in device.neighbors_of(q)
         ]

--- a/cirq/google/programs_test.py
+++ b/cirq/google/programs_test.py
@@ -11,16 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Dict
+
 import numpy as np
 import pytest
 
 import cirq
-from cirq.google import Foxtail, programs
+import cirq.google as cg
 from cirq.schedules import moment_by_moment_schedule
 
 
+def assert_proto_dict_convert(gate_cls,
+                              gate: cirq.Gate,
+                              proto_dict: Dict,
+                              *qubits: cirq.QubitId):
+    from cirq.google.programs import gate_to_proto_dict
+    assert gate_to_proto_dict(gate, qubits) == proto_dict
+    assert gate_cls.from_proto_dict(proto_dict) == gate(*qubits)
+
+
 def test_protobuf_round_trip():
-    device = Foxtail
+    device = cg.Foxtail
     circuit = cirq.Circuit.from_ops(
         [
             cirq.google.ExpWGate(half_turns=0.5).on(q)
@@ -34,8 +45,8 @@ def test_protobuf_round_trip():
     )
     s1 = moment_by_moment_schedule(device, circuit)
 
-    protos = list(programs.schedule_to_proto_dicts(s1))
-    s2 = programs.schedule_from_proto_dicts(device, protos)
+    protos = list(cg.schedule_to_proto_dicts(s1))
+    s2 = cg.schedule_from_proto_dicts(device, protos)
 
     assert s2 == s1
 
@@ -87,7 +98,7 @@ def test_pack_results():
             [0, 1],
             [1, 0],])),
     ]
-    data = programs.pack_results(measurements)
+    data = cg.pack_results(measurements)
     expected = make_bytes("""
         000 00
         001 01
@@ -103,7 +114,7 @@ def test_pack_results():
 
 
 def test_pack_results_no_measurements():
-    assert programs.pack_results([]) == b''
+    assert cg.pack_results([]) == b''
 
 
 def test_pack_results_incompatible_shapes():
@@ -111,10 +122,10 @@ def test_pack_results_incompatible_shapes():
         return np.zeros(shape, dtype=bool)
 
     with pytest.raises(ValueError):
-        programs.pack_results([('a', bools(10))])
+        cg.pack_results([('a', bools(10))])
 
     with pytest.raises(ValueError):
-        programs.pack_results([('a', bools(7, 3)), ('b', bools(8, 2))])
+        cg.pack_results([('a', bools(7, 3)), ('b', bools(8, 2))])
 
 
 def test_unpack_results():
@@ -128,7 +139,7 @@ def test_unpack_results():
         110 10
     """)
     assert len(data) == 5  # 35 data bits + 5 padding bits
-    results = programs.unpack_results(data, 7, [('a', 3), ('b', 2)])
+    results = cg.unpack_results(data, 7, [('a', 3), ('b', 2)])
     assert 'a' in results
     assert results['a'].shape == (7, 3)
     assert results['a'].dtype == bool
@@ -154,3 +165,358 @@ def test_unpack_results():
          [0, 0],
          [0, 1],
          [1, 0],])
+
+
+def test_single_qubit_measurement_proto_dict_convert():
+    gate = cg.XmonMeasurementGate('test')
+    proto_dict = {
+        'measurement': {
+            'targets': [
+                {
+                    'row': 2,
+                    'col': 3
+                }
+            ],
+            'key': 'test'
+        }
+    }
+    assert_proto_dict_convert(cg.XmonMeasurementGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3))
+
+
+def test_single_qubit_measurement_to_proto_dict_convert_invert_mask():
+    gate = cg.XmonMeasurementGate('test', invert_mask=(True,))
+    proto_dict = {
+        'measurement': {
+            'targets': [
+                {
+                    'row': 2,
+                    'col': 3
+                }
+            ],
+            'key': 'test',
+            'invert_mask': ['true']
+        }
+    }
+    assert_proto_dict_convert(cg.XmonMeasurementGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3))
+
+
+def test_multi_qubit_measurement_to_proto_dict():
+    gate = cg.XmonMeasurementGate('test')
+    proto_dict = {
+        'measurement': {
+            'targets': [
+                {
+                    'row': 2,
+                    'col': 3
+                },
+                {
+                    'row': 3,
+                    'col': 4
+                }
+            ],
+            'key': 'test'
+        }
+    }
+    assert_proto_dict_convert(cg.XmonMeasurementGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
+
+
+def test_z_proto_dict_convert():
+    gate = cg.ExpZGate(half_turns=cirq.Symbol('k'))
+    proto_dict = {
+        'exp_z': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    assert_proto_dict_convert(cg.ExpZGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3))
+
+    gate = cg.ExpZGate(half_turns=0.5)
+    proto_dict = {
+        'exp_z': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+            'half_turns': {
+                'raw': 0.5
+            }
+        }
+    }
+    assert_proto_dict_convert(cg.ExpZGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3))
+
+
+def test_cz_proto_dict_convert():
+    gate = cirq.CZ**cirq.Symbol('k')
+    proto_dict = {
+        'exp_11': {
+            'target1': {
+                'row': 2,
+                'col': 3
+            },
+            'target2': {
+                'row': 3,
+                'col': 4
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    assert_proto_dict_convert(cg.XmonGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
+
+    gate = cirq.CZ**0.5
+    proto_dict = {
+        'exp_11': {
+            'target1': {
+                'row': 2,
+                'col': 3
+            },
+            'target2': {
+                'row': 3,
+                'col': 4
+            },
+            'half_turns': {
+                'raw': 0.5
+            }
+        }
+    }
+    assert_proto_dict_convert(cg.XmonGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
+
+
+def test_cz_invalid_dict():
+    proto_dict = {
+        'exp_11': {
+            'target2': {
+                'row': 3,
+                'col': 4
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    with pytest.raises(ValueError, match='missing required fields'):
+        cg.XmonGate.from_proto_dict(proto_dict)
+
+    proto_dict = {
+        'exp_11': {
+            'target1': {
+                'row': 2,
+                'col': 3
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    with pytest.raises(ValueError, match='missing required fields'):
+        cg.XmonGate.from_proto_dict(proto_dict)
+
+    proto_dict = {
+        'exp_11': {
+            'target1': {
+                'row': 2,
+                'col': 3
+            },
+            'target2': {
+                'row': 3,
+                'col': 4
+            },
+        }
+    }
+    with pytest.raises(ValueError, match='missing required fields'):
+        cg.XmonGate.from_proto_dict(proto_dict)
+
+
+def test_w_to_proto_dict():
+    gate = cg.ExpWGate(half_turns=cirq.Symbol('k'), axis_half_turns=1)
+    proto_dict = {
+        'exp_w': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+            'axis_half_turns': {
+                'raw': 1
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    assert_proto_dict_convert(cg.ExpWGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3))
+
+    gate = cg.ExpWGate(half_turns=0.5, axis_half_turns=cirq.Symbol('j'))
+    proto_dict = {
+        'exp_w': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+            'axis_half_turns': {
+                'parameter_key': 'j'
+            },
+            'half_turns': {
+                'raw': 0.5
+            }
+        }
+    }
+    assert_proto_dict_convert(cg.ExpWGate, gate, proto_dict,
+                              cirq.GridQubit(2, 3))
+
+
+def test_w_invalid_dict():
+    proto_dict = {
+        'exp_w': {
+            'axis_half_turns': {
+                'raw': 1
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.ExpWGate.from_proto_dict(proto_dict)
+
+    proto_dict = {
+        'exp_w': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.ExpWGate.from_proto_dict(proto_dict)
+
+    proto_dict = {
+        'exp_w': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+            'axis_half_turns': {
+                'raw': 1
+            },
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.ExpWGate.from_proto_dict(proto_dict)
+
+
+def test_unsupported_op():
+    proto_dict = {
+        'not_a_gate': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+        }
+    }
+    with pytest.raises(ValueError, match='invalid operation'):
+        cg.XmonGate.from_proto_dict(proto_dict)
+    with pytest.raises(ValueError, match='know how to serialize'):
+        cg.gate_to_proto_dict(cirq.CCZ, (cirq.GridQubit(0, 0),
+                                         cirq.GridQubit(0, 1),
+                                         cirq.GridQubit(0, 2)))
+
+
+def test_invalid_to_proto_dict_qubit_number():
+    from cirq.google.programs import gate_to_proto_dict
+    with pytest.raises(ValueError, match='Wrong number of qubits'):
+        _ = gate_to_proto_dict(cirq.CZ**0.5, (cirq.GridQubit(2, 3),))
+    with pytest.raises(ValueError, match='Wrong number of qubits'):
+        cg.ExpZGate(half_turns=0.5).to_proto_dict(cirq.GridQubit(2, 3),
+                                                  cirq.GridQubit(3, 4))
+    with pytest.raises(ValueError, match='Wrong number of qubits'):
+        cg.ExpWGate(half_turns=0.5, axis_half_turns=0).to_proto_dict(
+            cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
+
+
+def test_parameterized_value_from_proto():
+    from_proto = cg.XmonGate.parameterized_value_from_proto_dict
+
+    m1 = {'raw': 5}
+    assert from_proto(m1) == 5
+
+    with pytest.raises(ValueError):
+        from_proto({})
+
+    m3 = {'parameter_key': 'rr'}
+    assert from_proto(m3) == cirq.Symbol('rr')
+
+
+def test_single_qubit_measurement_invalid_dict():
+    proto_dict = {
+        'measurement': {
+            'targets': [
+                {
+                    'row': 2,
+                    'col': 3
+                }
+            ],
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.XmonMeasurementGate.from_proto_dict(proto_dict)
+
+    proto_dict = {
+        'measurement': {
+            'targets': [
+                {
+                    'row': 2,
+                    'col': 3
+                }
+            ],
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.XmonMeasurementGate.from_proto_dict(proto_dict)
+
+
+def test_invalid_measurement_gate():
+    with pytest.raises(ValueError, match='length'):
+        cg.XmonMeasurementGate('test', invert_mask=(True,)).to_proto_dict(
+            cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
+    with pytest.raises(ValueError, match='no qubits'):
+        cg.XmonMeasurementGate('test').to_proto_dict()
+
+
+def test_z_invalid_dict():
+    proto_dict = {
+        'exp_z': {
+            'target': {
+                'row': 2,
+                'col': 3
+            },
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.ExpZGate.from_proto_dict(proto_dict)
+
+    proto_dict = {
+        'exp_z': {
+            'half_turns': {
+                'parameter_key': 'k'
+            }
+        }
+    }
+    with pytest.raises(ValueError):
+        cg.ExpZGate.from_proto_dict(proto_dict)

--- a/cirq/google/sim/xmon_simulator.py
+++ b/cirq/google/sim/xmon_simulator.py
@@ -535,7 +535,7 @@ def _simulator_iterator(
                 if isinstance(gate, xmon_gates.ExpZGate):
                     index = qubit_map[op.qubits[0]]
                     phase_map[(index,)] = cast(float, gate.half_turns)
-                elif isinstance(gate, xmon_gates.Exp11Gate):
+                elif isinstance(gate, ops.Rot11Gate):
                     index0 = qubit_map[op.qubits[0]]
                     index1 = qubit_map[op.qubits[1]]
                     phase_map[(index0, index1)] = cast(float, gate.half_turns)

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -35,11 +35,10 @@ Q3 = cirq.GridQubit(2, 0)
 def basic_circuit():
     sqrt_x = cg.ExpWGate(half_turns=-0.5, axis_half_turns=0.0)
     z = cg.ExpZGate()
-    cz = cg.Exp11Gate()
     circuit = cirq.Circuit()
     circuit.append(
         [sqrt_x(Q1), sqrt_x(Q2),
-         cz(Q1, Q2),
+         cirq.CZ(Q1, Q2),
          sqrt_x(Q1), sqrt_x(Q2),
          z(Q1)])
     return circuit
@@ -49,12 +48,11 @@ def large_circuit():
     np.random.seed(0)
     qubits = [cirq.GridQubit(i, 0) for i in range(10)]
     sqrt_x = cg.ExpWGate(half_turns=0.5, axis_half_turns=0.0)
-    cz = cg.Exp11Gate()
     circuit = cirq.Circuit()
     for _ in range(11):
         circuit.append(
             [sqrt_x(qubit) for qubit in qubits if np.random.random() < 0.5])
-        circuit.append([cz(qubits[i], qubits[i + 1]) for i in range(9)])
+        circuit.append([cirq.CZ(qubits[i], qubits[i + 1]) for i in range(9)])
     circuit.append([cg.XmonMeasurementGate(key='meas')(*qubits)])
     return circuit
 
@@ -601,9 +599,8 @@ def test_param_resolver_exp_z_half_turns():
 
 
 def test_param_resolver_exp_11_half_turns():
-    exp_11 = cg.Exp11Gate(half_turns=cirq.Symbol('a'))
     circuit = cirq.Circuit()
-    circuit.append(exp_11(Q1, Q2))
+    circuit.append(cirq.CZ(Q1, Q2)**cirq.Symbol('a'))
     resolver = cirq.ParamResolver({'a': 0.5})
     result = compute_gate(circuit, resolver, num_qubits=2)
     # Slight hack: doesn't depend on order of qubits.
@@ -833,7 +830,7 @@ def test_handedness_of_xmon_exp_z_gate():
 def test_handedness_of_xmon_exp_11_gate():
     circuit = cirq.Circuit.from_ops(cirq.H(Q1),
                                     cirq.H(Q2),
-                                    cg.Exp11Gate(half_turns=0.5).on(Q1, Q2))
+                                    cirq.CZ(Q1, Q2)**0.5)
     simulator = cg.XmonSimulator()
     result = list(simulator.simulate_moment_steps(circuit))[-1]
     print(np.round(result.state(), 3))

--- a/cirq/google/xmon_device.py
+++ b/cirq/google/xmon_device.py
@@ -66,9 +66,9 @@ class XmonDevice(Device):
 
     def duration_of(self, operation):
         if isinstance(operation, ops.GateOperation):
-            g = xmon_gate_ext.try_cast(xmon_gates.XmonGate, operation.gate)
-            if isinstance(g, xmon_gates.Exp11Gate):
+            if isinstance(operation.gate, ops.Rot11Gate):
                 return self._exp_z_duration
+            g = xmon_gate_ext.try_cast(xmon_gates.XmonGate, operation.gate)
             if isinstance(g, xmon_gates.ExpWGate):
                 return self._exp_w_duration
             if isinstance(g, xmon_gates.XmonMeasurementGate):
@@ -84,7 +84,7 @@ class XmonDevice(Device):
         Raises:
             ValueError: Unsupported gate.
         """
-        if not isinstance(gate, (xmon_gates.Exp11Gate,
+        if not isinstance(gate, (ops.Rot11Gate,
                                  xmon_gates.ExpWGate,
                                  xmon_gates.XmonMeasurementGate,
                                  xmon_gates.ExpZGate)):
@@ -135,8 +135,7 @@ class XmonDevice(Device):
     def validate_scheduled_operation(self, schedule, scheduled_operation):
         self.validate_operation(scheduled_operation.operation)
 
-        if isinstance(scheduled_operation.operation.gate,
-                      xmon_gates.Exp11Gate):
+        if isinstance(scheduled_operation.operation.gate, ops.Rot11Gate):
             for other in schedule.operations_happening_at_same_time_as(
                     scheduled_operation):
                 if self._check_if_exp11_operation_interacts(
@@ -154,7 +153,7 @@ class XmonDevice(Device):
         super().validate_moment(moment)
         for op in moment.operations:
             if (isinstance(op, ops.GateOperation) and
-                    isinstance(op.gate, xmon_gates.Exp11Gate)):
+                    isinstance(op.gate, ops.Rot11Gate)):
                 for other in moment.operations:
                     if (other is not op and
                             self._check_if_exp11_operation_interacts(
@@ -171,7 +170,7 @@ class XmonDevice(Device):
         if not super().can_add_operation_into_moment(operation, moment):
             return False
         if (isinstance(operation, ops.GateOperation) and
-                isinstance(operation.gate, xmon_gates.Exp11Gate)):
+                isinstance(operation.gate, ops.Rot11Gate)):
             return not self._check_if_exp11_operation_interacts_with_any(
                 cast(ops.GateOperation, operation),
                 cast(Iterable[ops.GateOperation], moment.operations))

--- a/cirq/google/xmon_device_test.py
+++ b/cirq/google/xmon_device_test.py
@@ -50,7 +50,7 @@ def test_init():
     assert d.duration_of(cirq.measure(q00)) == ns
     assert d.duration_of(cirq.measure(q00, q01)) == ns
     assert d.duration_of(cg.ExpWGate().on(q00)) == 2 * ns
-    assert d.duration_of(cg.Exp11Gate().on(q00, q01)) == 3 * ns
+    assert d.duration_of(cirq.CZ(q00, q01)) == 3 * ns
     with pytest.raises(ValueError):
         _ = d.duration_of(cirq.Gate().on(q00))
 
@@ -74,9 +74,9 @@ def test_can_add_operation_into_moment():
     q01 = cirq.GridQubit(0, 1)
     q10 = cirq.GridQubit(1, 0)
     q11 = cirq.GridQubit(1, 1)
-    m = cirq.Moment([cg.Exp11Gate().on(q00, q01)])
+    m = cirq.Moment([cirq.CZ(q00, q01)])
     assert not d.can_add_operation_into_moment(
-        cg.Exp11Gate().on(q10, q11), m)
+        cirq.CZ(q10, q11), m)
 
 
 def test_validate_moment():
@@ -85,8 +85,8 @@ def test_validate_moment():
     q01 = cirq.GridQubit(0, 1)
     q10 = cirq.GridQubit(1, 0)
     q11 = cirq.GridQubit(1, 1)
-    m = cirq.Moment([cg.Exp11Gate().on(q00, q01),
-                     cg.Exp11Gate().on(q10, q11)])
+    m = cirq.Moment([cirq.CZ(q00, q01),
+                     cirq.CZ(q10, q11)])
     with pytest.raises(ValueError):
         d.validate_moment(m)
 
@@ -95,12 +95,12 @@ def test_validate_operation_adjacent_qubits():
     d = square_device(3, 3)
 
     d.validate_operation(cirq.GateOperation(
-        cg.Exp11Gate(),
+        cirq.CZ,
         (cirq.GridQubit(0, 0), cirq.GridQubit(1, 0))))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Non-local interaction'):
         d.validate_operation(cirq.GateOperation(
-            cg.Exp11Gate(),
+            cirq.CZ,
             (cirq.GridQubit(0, 0), cirq.GridQubit(2, 0))))
 
 
@@ -116,18 +116,18 @@ def test_validate_operation_existing_qubits():
     d = square_device(3, 3, holes=[cirq.GridQubit(1, 1)])
 
     d.validate_operation(cirq.GateOperation(
-        cg.Exp11Gate(),
+        cirq.CZ,
         (cirq.GridQubit(0, 0), cirq.GridQubit(1, 0))))
     d.validate_operation(cg.ExpZGate().on(cirq.GridQubit(0, 0)))
 
     with pytest.raises(ValueError):
         d.validate_operation(
-            cg.Exp11Gate().on(cirq.GridQubit(0, 0), cirq.GridQubit(-1, 0)))
+            cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(-1, 0)))
     with pytest.raises(ValueError):
         d.validate_operation(cg.ExpZGate().on(cirq.GridQubit(-1, 0)))
     with pytest.raises(ValueError):
         d.validate_operation(
-            cg.Exp11Gate().on(cirq.GridQubit(1, 0), cirq.GridQubit(1, 1)))
+            cirq.CZ(cirq.GridQubit(1, 0), cirq.GridQubit(1, 1)))
 
 
 def test_validate_operation_supported_gate():
@@ -154,7 +154,7 @@ def test_validate_scheduled_operation_adjacent_exp_11_exp_w():
         cirq.ScheduledOperation.op_at_on(
             cg.ExpWGate().on(q0), cirq.Timestamp(), d),
         cirq.ScheduledOperation.op_at_on(
-            cg.Exp11Gate().on(q1, q2), cirq.Timestamp(), d),
+            cirq.CZ(q1, q2), cirq.Timestamp(), d),
     ])
     d.validate_schedule(s)
 
@@ -168,7 +168,7 @@ def test_validate_scheduled_operation_adjacent_exp_11_exp_z():
         cirq.ScheduledOperation.op_at_on(
             cg.ExpZGate().on(q0), cirq.Timestamp(), d),
         cirq.ScheduledOperation.op_at_on(
-            cg.Exp11Gate().on(q1, q2), cirq.Timestamp(), d),
+            cirq.CZ(q1, q2), cirq.Timestamp(), d),
     ])
     d.validate_schedule(s)
 
@@ -182,7 +182,7 @@ def test_validate_scheduled_operation_adjacent_exp_11_measure():
         cirq.ScheduledOperation.op_at_on(
             cg.XmonMeasurementGate().on(q0), cirq.Timestamp(), d),
         cirq.ScheduledOperation.op_at_on(
-            cg.Exp11Gate().on(q1, q2), cirq.Timestamp(), d),
+            cirq.CZ(q1, q2), cirq.Timestamp(), d),
     ])
     d.validate_schedule(s)
 
@@ -196,7 +196,7 @@ def test_validate_scheduled_operation_not_adjacent_exp_11_exp_w():
         cirq.ScheduledOperation.op_at_on(
             cg.ExpWGate().on(q0), cirq.Timestamp(), d),
         cirq.ScheduledOperation.op_at_on(
-            cg.Exp11Gate().on(p1, p2), cirq.Timestamp(), d),
+            cirq.CZ(p1, p2), cirq.Timestamp(), d),
     ])
     d.validate_schedule(s)
 

--- a/cirq/google/xmon_gate_extensions.py
+++ b/cirq/google/xmon_gate_extensions.py
@@ -38,11 +38,6 @@ xmon_gate_ext.add_cast(
 
 xmon_gate_ext.add_cast(
     desired_type=xmon_gates.XmonGate,
-    actual_type=ops.Rot11Gate,
-    conversion=lambda e: xmon_gates.Exp11Gate(half_turns=e.half_turns))
-
-xmon_gate_ext.add_cast(
-    desired_type=xmon_gates.XmonGate,
     actual_type=ops.MeasurementGate,
     conversion=lambda e: xmon_gates.XmonMeasurementGate(
         key=e.key,

--- a/cirq/google/xmon_gates.py
+++ b/cirq/google/xmon_gates.py
@@ -15,7 +15,7 @@
 """Gates that can be directly described to the API, without decomposition."""
 
 import json
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 
@@ -98,7 +98,7 @@ class XmonGate(ops.Gate, metaclass=abc.ABCMeta):
                           qubit(exp_11['target2']))**param(exp_11['half_turns'])
         elif 'measurement' in proto_dict:
             meas = proto_dict['measurement']
-            invert_mask = () # type: Tuple
+            invert_mask = ()
             if 'invert_mask' in meas:
                 invert_mask = tuple(json.loads(x) for x in meas['invert_mask'])
             if 'key' not in meas or 'targets' not in meas:

--- a/cirq/google/xmon_gates.py
+++ b/cirq/google/xmon_gates.py
@@ -36,7 +36,10 @@ class XmonGate(ops.Gate, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @staticmethod
-    def is_xmon_op(op: ops.Operation) -> bool:
+    def is_supported_op(op: ops.Operation) -> bool:
+        if (isinstance(op, ops.GateOperation) and
+                isinstance(op.gate, ops.Rot11Gate)):
+            return True
         return XmonGate.try_get_xmon_gate(op) is not None
 
     @staticmethod
@@ -91,9 +94,8 @@ class XmonGate(ops.Gate, metaclass=abc.ABCMeta):
             if ('half_turns' not in exp_11 or 'target1' not in exp_11
                     or 'target2' not in exp_11):
                 raise_missing_fields('Exp11')
-            return Exp11Gate(
-                half_turns=param(exp_11['half_turns'])
-            ).on(qubit(exp_11['target1']), qubit(exp_11['target2']))
+            return ops.CZ(qubit(exp_11['target1']),
+                          qubit(exp_11['target2']))**param(exp_11['half_turns'])
         elif 'measurement' in proto_dict:
             meas = proto_dict['measurement']
             invert_mask = () # type: Tuple
@@ -157,104 +159,6 @@ class XmonMeasurementGate(XmonGate, ops.MeasurementGate):
     def __repr__(self):
         return 'XmonMeasurementGate({}, {})'.format(repr(self.key),
                                                     repr(self.invert_mask))
-
-
-class Exp11Gate(XmonGate,
-                ops.TwoQubitGate,
-                ops.TextDiagrammable,
-                ops.InterchangeableQubitsGate,
-                ops.PhaseableEffect,
-                ops.QasmConvertibleGate):
-    """A two-qubit interaction that phases the amplitude of the 11 state.
-
-    This gate is exp(i * pi * |11><11|  * half_turn).
-
-    Note that this half_turn parameter is such that a full turn is the
-    identity matrix, in contrast to the single qubit gates, where a full
-    turn is minus identity. The single qubit half-turn gates are defined
-    so that a full turn corresponds to a rotation on the Bloch sphere of a
-    360 degree rotation. For two qubit gates, there isn't a Bloch sphere,
-    so the half_turn corresponds to half of a full rotation in U(4).
-    """
-
-    def __init__(self, *,  # Forces keyword args.
-                 half_turns: Optional[Union[value.Symbol, float]] = None,
-                 rads: Optional[float] = None,
-                 degs: Optional[float] = None) -> None:
-        """Initializes the gate.
-
-        At most one angle argument may be specified. If more are specified,
-        the result is considered ambiguous and an error is thrown. If no angle
-        argument is given, the default value of one half turn is used.
-
-        Args:
-            half_turns: The amount of phasing of the 11 state, in half_turns.
-            rads: The amount of phasing of the 11 state, in radians.
-            degs: The amount of phasing of the 11 state, in degrees.
-        """
-        self.half_turns = value.chosen_angle_to_canonical_half_turns(
-            half_turns=half_turns,
-            rads=rads,
-            degs=degs)
-
-    def phase_by(self, phase_turns, qubit_index):
-        return self
-
-    def to_proto_dict(self, *qubits):
-        if len(qubits) != 2:
-            raise ValueError('Wrong number of qubits.')
-        p, q = qubits
-        exp_11 = {
-            'target1': p.to_proto_dict(),
-            'target2': q.to_proto_dict(),
-            'half_turns': self.parameterized_value_to_proto_dict(
-                self.half_turns)
-        }
-        return {'exp_11': exp_11}
-
-    def _unitary_(self) -> Union[np.ndarray, type(NotImplemented)]:
-        if isinstance(self.half_turns, value.Symbol):
-            return NotImplemented
-        return protocols.unitary(
-            ops.Rot11Gate(half_turns=self.half_turns))
-
-    def text_diagram_info(self, args: ops.TextDiagramInfoArgs
-                          ) -> ops.TextDiagramInfo:
-        return ops.TextDiagramInfo(('@', '@'), self.half_turns)
-
-    def known_qasm_output(self,
-                          qubits: Tuple[ops.QubitId, ...],
-                          args: ops.QasmOutputArgs) -> Optional[str]:
-        if self.half_turns != 1:
-            return None  # Don't have an equivalent gate in QASM
-        args.validate_version('2.0')
-        return args.format('cz {0},{1};\n', qubits[0], qubits[1])
-
-    def __str__(self):
-        if self.half_turns == 1:
-            return 'CZ'
-        return self.__repr__()
-
-    def __repr__(self):
-        return 'Exp11Gate(half_turns={})'.format(
-            repr(self.half_turns))
-
-    def __eq__(self, other):
-        if not isinstance(other, (ops.Rot11Gate, type(self))):
-            return NotImplemented
-        return self.half_turns == other.half_turns
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((Exp11Gate, self.half_turns))
-
-    def _is_parameterized_(self) -> bool:
-        return isinstance(self.half_turns, value.Symbol)
-
-    def _resolve_parameters_(self, param_resolver) -> 'Exp11Gate':
-        return Exp11Gate(half_turns=param_resolver.value_of(self.half_turns))
 
 
 class ExpWGate(XmonGate,

--- a/cirq/google/xmon_gates_test.py
+++ b/cirq/google/xmon_gates_test.py
@@ -29,6 +29,16 @@ def test_measurement_eq():
                                                           invert_mask=(False,)))
 
 
+def test_is_supported():
+    a = cirq.GridQubit(0, 0)
+    b = cirq.GridQubit(0, 1)
+    c = cirq.GridQubit(1, 0)
+    assert cg.XmonGate.is_supported_op(cirq.CZ(a, b))
+    assert cg.XmonGate.is_supported_op(cg.ExpZGate(half_turns=1).on(a))
+    assert not cg.XmonGate.is_supported_op(cirq.CCZ(a, b, c))
+    assert not cg.XmonGate.is_supported_op(cirq.SWAP(a, b))
+
+
 def test_z_eq():
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cg.ExpZGate(half_turns=0))

--- a/cirq/google/xmon_gates_test.py
+++ b/cirq/google/xmon_gates_test.py
@@ -12,30 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import numpy as np
 
 import cirq
 import cirq.google as cg
-
-
-def assert_proto_dict_convert(gate_cls, gate, proto_dict, *qubits):
-    from cirq.google.programs import _gate_to_proto_dict
-    assert _gate_to_proto_dict(gate, qubits) == proto_dict
-    assert gate_cls.from_proto_dict(proto_dict) == gate(*qubits)
-
-
-def test_parameterized_value_from_proto():
-    from_proto = cg.XmonGate.parameterized_value_from_proto_dict
-
-    m1 = {'raw': 5}
-    assert from_proto(m1) == 5
-
-    with pytest.raises(ValueError):
-        from_proto({})
-
-    m3 = {'parameter_key': 'rr'}
-    assert from_proto(m3) == cirq.Symbol('rr')
 
 
 def test_measurement_eq():
@@ -47,104 +27,6 @@ def test_measurement_eq():
                                                           invert_mask=(True,)))
     eq.make_equality_group(lambda: cg.XmonMeasurementGate(key='',
                                                           invert_mask=(False,)))
-
-
-def test_single_qubit_measurement_proto_dict_convert():
-    gate = cg.XmonMeasurementGate('test')
-    proto_dict = {
-        'measurement': {
-            'targets': [
-                {
-                    'row': 2,
-                    'col': 3
-                }
-            ],
-            'key': 'test'
-        }
-    }
-    assert_proto_dict_convert(cg.XmonMeasurementGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3))
-
-
-def test_single_qubit_measurement_invalid_dict():
-    proto_dict = {
-        'measurement': {
-            'targets': [
-                {
-                    'row': 2,
-                    'col': 3
-                }
-            ],
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.XmonMeasurementGate.from_proto_dict(proto_dict)
-
-    proto_dict = {
-        'measurement': {
-            'targets': [
-                {
-                    'row': 2,
-                    'col': 3
-                }
-            ],
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.XmonMeasurementGate.from_proto_dict(proto_dict)
-
-
-def test_single_qubit_measurement_to_proto_dict_convert_invert_mask():
-    gate = cg.XmonMeasurementGate('test', invert_mask=(True,))
-    proto_dict = {
-        'measurement': {
-            'targets': [
-                {
-                    'row': 2,
-                    'col': 3
-                }
-            ],
-            'key': 'test',
-            'invert_mask': ['true']
-        }
-    }
-    assert_proto_dict_convert(cg.XmonMeasurementGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3))
-
-
-def test_multi_qubit_measurement_to_proto_dict():
-    gate = cg.XmonMeasurementGate('test')
-    proto_dict = {
-        'measurement': {
-            'targets': [
-                {
-                    'row': 2,
-                    'col': 3
-                },
-                {
-                    'row': 3,
-                    'col': 4
-                }
-            ],
-            'key': 'test'
-        }
-    }
-    assert_proto_dict_convert(cg.XmonMeasurementGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
-
-
-@cirq.testing.only_test_in_python3
-def test_measurement_repr():
-    gate = cg.XmonMeasurementGate('test', invert_mask=(True,))
-    assert repr(gate) == 'XmonMeasurementGate(\'test\', (True,))'
-
-
-def test_invalid_measurement_gate():
-    with pytest.raises(ValueError, match='length'):
-        cg.XmonMeasurementGate('test', invert_mask=(True,)).to_proto_dict(
-            cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
-    with pytest.raises(ValueError, match='no qubits'):
-        cg.XmonMeasurementGate('test').to_proto_dict()
 
 
 def test_z_eq():
@@ -163,59 +45,10 @@ def test_z_eq():
         cg.ExpZGate(half_turns=10.5))
 
 
-def test_z_proto_dict_convert():
-    gate = cg.ExpZGate(half_turns=cirq.Symbol('k'))
-    proto_dict = {
-        'exp_z': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    assert_proto_dict_convert(cg.ExpZGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3))
-
-    gate = cg.ExpZGate(half_turns=0.5)
-    proto_dict = {
-        'exp_z': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-            'half_turns': {
-                'raw': 0.5
-            }
-        }
-    }
-    assert_proto_dict_convert(cg.ExpZGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3))
-
-
-def test_z_invalid_dict():
-    proto_dict = {
-        'exp_z': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.ExpZGate.from_proto_dict(proto_dict)
-
-    proto_dict = {
-        'exp_z': {
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.ExpZGate.from_proto_dict(proto_dict)
+@cirq.testing.only_test_in_python3
+def test_measurement_repr():
+    gate = cg.XmonMeasurementGate('test', invert_mask=(True,))
+    assert repr(gate) == "XmonMeasurementGate('test', (True,))"
 
 
 def test_z_matrix():
@@ -241,91 +74,6 @@ def test_z_parameterize():
 def test_z_repr():
     gate = cg.ExpZGate(half_turns=0.25)
     assert repr(gate) == 'ExpZGate(half_turns=0.25)'
-
-
-def test_cz_proto_dict_convert():
-    gate = cirq.CZ**cirq.Symbol('k')
-    proto_dict = {
-        'exp_11': {
-            'target1': {
-                'row': 2,
-                'col': 3
-            },
-            'target2': {
-                'row': 3,
-                'col': 4
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    assert_proto_dict_convert(cg.XmonGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
-
-    gate = cirq.CZ**0.5
-    proto_dict = {
-        'exp_11': {
-            'target1': {
-                'row': 2,
-                'col': 3
-            },
-            'target2': {
-                'row': 3,
-                'col': 4
-            },
-            'half_turns': {
-                'raw': 0.5
-            }
-        }
-    }
-    assert_proto_dict_convert(cg.XmonGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
-
-
-def test_cz_invalid_dict():
-    proto_dict = {
-        'exp_11': {
-            'target2': {
-                'row': 3,
-                'col': 4
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    with pytest.raises(ValueError, match='missing required fields'):
-        cg.XmonGate.from_proto_dict(proto_dict)
-
-    proto_dict = {
-        'exp_11': {
-            'target1': {
-                'row': 2,
-                'col': 3
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    with pytest.raises(ValueError, match='missing required fields'):
-        cg.XmonGate.from_proto_dict(proto_dict)
-
-    proto_dict = {
-        'exp_11': {
-            'target1': {
-                'row': 2,
-                'col': 3
-            },
-            'target2': {
-                'row': 3,
-                'col': 4
-            },
-        }
-    }
-    with pytest.raises(ValueError, match='missing required fields'):
-        cg.XmonGate.from_proto_dict(proto_dict)
 
 
 def test_w_eq():
@@ -377,87 +125,6 @@ def test_w_str():
     assert str(cg.ExpWGate(axis_half_turns=0.5, half_turns=0.25)) == 'Y^0.25'
     assert str(cg.ExpWGate(axis_half_turns=0.25,
                            half_turns=0.5)) == 'W(0.25)^0.5'
-
-
-def test_w_to_proto_dict():
-    gate = cg.ExpWGate(half_turns=cirq.Symbol('k'), axis_half_turns=1)
-    proto_dict = {
-        'exp_w': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-            'axis_half_turns': {
-                'raw': 1
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    assert_proto_dict_convert(cg.ExpWGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3))
-
-    gate = cg.ExpWGate(half_turns=0.5, axis_half_turns=cirq.Symbol('j'))
-    proto_dict = {
-        'exp_w': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-            'axis_half_turns': {
-                'parameter_key': 'j'
-            },
-            'half_turns': {
-                'raw': 0.5
-            }
-        }
-    }
-    assert_proto_dict_convert(cg.ExpWGate, gate, proto_dict,
-                              cirq.GridQubit(2, 3))
-
-
-def test_w_invalid_dict():
-    proto_dict = {
-        'exp_w': {
-            'axis_half_turns': {
-                'raw': 1
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.ExpWGate.from_proto_dict(proto_dict)
-
-    proto_dict = {
-        'exp_w': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-            'half_turns': {
-                'parameter_key': 'k'
-            }
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.ExpWGate.from_proto_dict(proto_dict)
-
-    proto_dict = {
-        'exp_w': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-            'axis_half_turns': {
-                'raw': 1
-            },
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.ExpWGate.from_proto_dict(proto_dict)
 
 
 def test_w_decomposition():
@@ -518,31 +185,6 @@ def test_measure_key_on():
     assert cg.XmonMeasurementGate(key='a').on(q) == cirq.GateOperation(
         gate=cg.XmonMeasurementGate(key='a'),
         qubits=(q,))
-
-
-def test_unsupported_op():
-    proto_dict = {
-        'not_a_gate': {
-            'target': {
-                'row': 2,
-                'col': 3
-            },
-        }
-    }
-    with pytest.raises(ValueError):
-        cg.XmonGate.from_proto_dict(proto_dict)
-
-
-def test_invalid_to_proto_dict_qubit_number():
-    from cirq.google.programs import _gate_to_proto_dict
-    with pytest.raises(ValueError, match='Wrong number of qubits'):
-        _ = _gate_to_proto_dict(cirq.CZ**0.5, (cirq.GridQubit(2, 3),))
-    with pytest.raises(ValueError, match='Wrong number of qubits'):
-        cg.ExpZGate(half_turns=0.5).to_proto_dict(cirq.GridQubit(2, 3),
-                                                  cirq.GridQubit(3, 4))
-    with pytest.raises(ValueError, match='Wrong number of qubits'):
-        cg.ExpWGate(half_turns=0.5, axis_half_turns=0).to_proto_dict(
-            cirq.GridQubit(2, 3), cirq.GridQubit(3, 4))
 
 
 def test_cirq_symbol_diagrams():

--- a/dev_tools/profiling/benchmark_simulators.py
+++ b/dev_tools/profiling/benchmark_simulators.py
@@ -20,9 +20,8 @@ import timeit
 
 import numpy as np
 
-from cirq import Circuit, InsertStrategy
-from cirq.google import ExpWGate, ExpZGate, Exp11Gate, XmonOptions, \
-    XmonSimulator
+import cirq
+from cirq.google import ExpWGate, ExpZGate, XmonOptions, XmonSimulator
 
 
 _XMON = 'xmon'
@@ -36,22 +35,22 @@ def simulate(
     num_prefix_qubits: int = 0,
     use_processes: bool = False) -> None:
     """"Runs the simulator."""
-    circuit = Circuit()
+    circuit = cirq.Circuit()
     for _ in range(num_gates):
         which = np.random.choice(['expz', 'expw', 'exp11'])
         if which == 'expw':
             circuit.append(ExpWGate(axis_half_turns=np.random.random(),
                                     half_turns=np.random.random()).on(
                 np.random.randint(num_qubits)),
-                strategy=InsertStrategy.EARLIEST)
+                strategy=cirq.InsertStrategy.EARLIEST)
         elif which == 'expz':
             circuit.append(ExpZGate(half_turns=np.random.random()).on(
                 np.random.randint(num_qubits)),
-                strategy=InsertStrategy.EARLIEST)
+                strategy=cirq.InsertStrategy.EARLIEST)
         elif which == 'exp11':
             q1, q2 = np.random.choice(num_qubits, 2, replace=False)
-            circuit.append(Exp11Gate(half_turns=np.random.random()).on(q1, q2),
-                           strategy=InsertStrategy.EARLIEST)
+            circuit.append(cirq.CZ(q1, q2)**np.random.random(),
+                           strategy=cirq.InsertStrategy.EARLIEST)
 
     if sim_type == _XMON:
         XmonSimulator(XmonOptions(num_shards=2 ** num_prefix_qubits,

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -36,9 +36,10 @@ class Xmon10Device(cirq.Device):
       return cirq.Duration(nanos=10)
 
   def validate_operation(self, operation):
-      if (not isinstance(operation, cirq.GateOperation) or
-              not isinstance(operation.gate, XmonGate)):
-          raise ValueError('{!r} is not an XmonGate'.format(operation))
+      if not isinstance(operation, cirq.GateOperation):
+          raise ValueError('{!r} is not a supported operation'.format(operation))
+      if not isinstance(operation.gate, (cirq.Rot11Gate, XmonGate)):
+          raise ValueError('{!r} is not a supported gate'.format(operation.gate))
       if len(operation.qubits) == 2:
           p, q = operation.qubits
           if not p.is_adjacent(q):
@@ -60,17 +61,15 @@ class Xmon10Device(cirq.Device):
 This device, for example, knows that two qubit gates between
 next-nearest-neighbors is not valid:
 ```python
-from cirq.google.xmon_gates import Exp11Gate
 device = Xmon10Device()
 circuit = cirq.Circuit()
-CZ = Exp11Gate(half_turns=1.0)
-circuit.append([CZ(device.qubits[0], device.qubits[2])])
+circuit.append([cirq.CZ(device.qubits[0], device.qubits[2])])
 try: 
   device.validate_circuit(circuit)
 except ValueError as e:
   print(e)
 # prints something like
-# ValueError: Non-local interaction: Operation(Exp11Gate(half_turns=1.0), (GridQubit(0, 0), GridQubit(2, 0)))
+# ValueError: Non-local interaction: Operation(cirq.CZ, (GridQubit(0, 0), GridQubit(2, 0)))
 ```
 
 ### Schedules
@@ -93,9 +92,8 @@ defined above
 ```python
 from cirq.google.xmon_gates import ExpWGate
 circuit = cirq.Circuit()
-CZ = Exp11Gate(half_turns=1.0)
 X = ExpWGate(half_turns=1.0)
-circuit.append([CZ(device.qubits[0], device.qubits[1]), X(device.qubits[0])])
+circuit.append([cirq.CZ(device.qubits[0], device.qubits[1]), X(device.qubits[0])])
 print(circuit)
 # prints:
 # (0, 0): ───Z───X───

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -15,16 +15,15 @@ Here is a simple circuit
 import cirq
 from cirq import Circuit
 from cirq.devices import GridQubit
-from cirq.google import ExpWGate, Exp11Gate, XmonMeasurementGate
+from cirq.google import ExpWGate, XmonMeasurementGate
 
 q0 = GridQubit(0, 0)
 q1 = GridQubit(1, 0)
 
 def basic_circuit(meas=True):
     sqrt_x = ExpWGate(half_turns=0.5, axis_half_turns=0.0)
-    cz = Exp11Gate()
     yield sqrt_x(q0), sqrt_x(q1)
-    yield cz(q0, q1)
+    yield cirq.CZ(q0, q1)
     yield sqrt_x(q0), sqrt_x(q1)
     if meas:
         yield XmonMeasurementGate(key='q0')(q0), XmonMeasurementGate(key='q1')(q1)


### PR DESCRIPTION
- Deleted `cirq.google.Exp11Gate`
- Using `cirq.CZ` as a substitute
- Moved all 'proto serialization' tests from `xmon_gates_test` to `cirq/google/programs_test.py`
- Refactored any code that was assuming a supported gate had to be an XmonGate

Part of https://github.com/quantumlib/Cirq/issues/952