### PR TITLE
Refactor OrderTester to detect bad NotImplemented patterns

### DIFF
--- a/cirq/testing/equals_tester.py
+++ b/cirq/testing/equals_tester.py
@@ -31,7 +31,7 @@ class EqualsTester:
     """Tests equality against user-provided disjoint equivalence groups."""
 
     def __init__(self):
-        self.groups = [(_ClassUnknownToSubjects(),)]
+        self._groups = [(_ClassUnknownToSubjects(),)]
 
     @staticmethod
     def _eq_check(v1: Any, v2: Any) -> bool:
@@ -42,7 +42,7 @@ class EqualsTester:
                           "between {!r} and {!r}".format(v1, v2))
         return eq
 
-    def verify_equality_group(self, *group_items: Any):
+    def _verify_equality_group(self, *group_items: Any):
         """Verifies that a group is an equivalence group.
 
         This methods asserts that items within the group must all be equal to
@@ -70,7 +70,7 @@ class EqualsTester:
                 "They're not equal.".format(v1, v2))
 
         # Between-group items must be unequal.
-        for other_group in self.groups:
+        for other_group in self._groups:
             for v1, v2 in itertools.product(group_items, other_group):
                 assert not EqualsTester._eq_check(v1, v2), (
                     "{!r} and {!r} can't be in different equality groups. "
@@ -105,10 +105,10 @@ class EqualsTester:
                 group, or the items violate the equals-implies-same-hash rule.
         """
 
-        self.verify_equality_group(*group_items)
+        self._verify_equality_group(*group_items)
 
         # Remember this group, to enable disjoint checks vs later groups.
-        self.groups.append(group_items)
+        self._groups.append(group_items)
 
     def make_equality_group(self, *factories: Callable[[], Any]):
         """Tries to add a disjoint equivalence group to the equality tester.

--- a/cirq/testing/order_tester_test.py
+++ b/cirq/testing/order_tester_test.py
@@ -91,6 +91,8 @@ def test_add_ordering_group_incorrect():
 
 def test_propagates_internal_errors():
     class UnorderableClass:
+        # coverage: ignore
+
         def __eq__(self, other):
             return NotImplemented
 

--- a/cirq/testing/order_tester_test.py
+++ b/cirq/testing/order_tester_test.py
@@ -15,44 +15,70 @@
 import fractions
 import pytest
 
-from cirq.testing.order_tester import OrderTester
+import cirq
 
 
-class UnorderableClass:
-    """Assume that the element of this class is less than anything else."""
+CMP_OPS = [
+    lambda a, b: a == b,
+    lambda a, b: a != b,
+    lambda a, b: a < b,
+    lambda a, b: a > b,
+    lambda a, b: a <= b,
+    lambda a, b: a >= b
+]
+
+
+class MockValue:
+    def __init__(self, val, eq, ne, lt, gt, le, ge):
+        self.val = val
+        self._eq = eq
+        self._ne = ne
+        self._lt = lt
+        self._gt = gt
+        self._le = le
+        self._ge = ge
+
+    __hash__ = None
 
     def __eq__(self, other):
-        return isinstance(other, UnorderableClass)
+        return self._eq(self, other)
 
     def __ne__(self, other):
-        return not isinstance(other, UnorderableClass)
+        return self._ne(self, other)
 
     def __lt__(self, other):
-        raise TypeError
+        return self._lt(self, other)
 
-    def __cmp__(self, other):   # coverage: ignore
-        raise TypeError         # coverage: ignore
+    def __gt__(self, other):
+        return self._gt(self, other)
 
-    def __hash__(self):
-        return hash(UnorderableClass)
+    def __le__(self, other):
+        return self._le(self, other)
+
+    def __ge__(self, other):
+        return self._ge(self, other)
+
+    def __repr__(self):
+        return 'MockValue(val={!r}, ...)'.format(self.val)
 
 
 def test_add_ordering_group_correct():
-    ot = OrderTester()
+    ot = cirq.testing.OrderTester()
     ot.add_ascending(-4, 0)
     ot.add_ascending(1, 2)
     ot.add_ascending_equivalence_group(fractions.Fraction(6, 2),
                                        fractions.Fraction(12, 4), 3, 3.0)
     ot.add_ascending_equivalence_group(float('inf'), float('inf'))
 
+
 def test_add_ordering_group_incorrect():
-    ot = OrderTester()
+    ot = cirq.testing.OrderTester()
     ot.add_ascending(0)
     with pytest.raises(AssertionError):
         ot.add_ascending_equivalence_group(0, 0)
     ot.add_ascending(1, 2)
     with pytest.raises(AssertionError):
-        ot.add_ascending(object, object)  # not ascending within call
+        ot.add_ascending(20, 20)  # not ascending within call
     with pytest.raises(AssertionError):
         ot.add_ascending(1, 3)  # not ascending w.r.t. previous call
     with pytest.raises(AssertionError):
@@ -62,46 +88,84 @@ def test_add_ordering_group_incorrect():
     with pytest.raises(AssertionError):
         ot.add_ascending(0)
 
-def test_add_ordering_equivalence_group_incorrect():
-    ot = OrderTester()
-    with pytest.raises(AssertionError):
-        ot.add_ascending(UnorderableClass())
-    with pytest.raises(AssertionError):
-        ot.add_ascending_equivalence_group(1, 3)  # not an equivalence group
-    ot.add_ascending(1)
-    with pytest.raises(AssertionError):
-        ot.add_ascending_equivalence_group(0, 0.)  # not ascending w.r.t
-                                                   # previous items
-    with pytest.raises(AssertionError):
-        ot.add_ascending(UnorderableClass())
-    with pytest.raises(AssertionError):
-        ot.add_ascending_equivalence_group(UnorderableClass(),
-            UnorderableClass())                    # incompatible class
 
-def test_add_ordering_equivalence_group_bad_hash():
-    class KeyHash:
-        def __init__(self, k, h):
-            self._k = k
-            self._h = h
-
+def test_propagates_internal_errors():
+    class UnorderableClass:
         def __eq__(self, other):
-            return isinstance(other, KeyHash) and self._k == other._k
+            return NotImplemented
 
         def __ne__(self, other):
-            return not self == other
+            return NotImplemented
 
         def __lt__(self, other):
-            return isinstance(other, KeyHash) and self._k < other._k
+            raise ValueError('oh no')
 
         def __le__(self, other):
-            return isinstance(other, KeyHash) and self._k <= other._k
+            return NotImplemented
 
+        def __ge__(self, other):
+            return NotImplemented
+
+        def __gt__(self, other):
+            return NotImplemented
+
+    ot = cirq.testing.OrderTester()
+    with pytest.raises(ValueError, match='oh no'):
+        ot.add_ascending(UnorderableClass())
+
+
+def test_add_ascending_equivalence_group():
+    ot = cirq.testing.OrderTester()
+    with pytest.raises(AssertionError, match='Expected X=1 to equal Y=3'):
+        ot.add_ascending_equivalence_group(1, 3)
+
+    ot.add_ascending_equivalence_group(2)
+    ot.add_ascending_equivalence_group(4)
+
+    with pytest.raises(AssertionError,
+                       match='Expected X=4 to be less than Y=3'):
+        ot.add_ascending_equivalence_group(3)
+
+    ot.add_ascending_equivalence_group(5)
+
+
+def test_fails_to_return_not_implemented_vs_unknown():
+
+    def make_impls(bad_index: int, bad_result: bool):
+        def make_impl(i, op):
+            def impl(x, y):
+                if isinstance(y, MockValue):
+                    return op(x.val, y.val)
+                if bad_index == i:
+                    return bad_result
+                return NotImplemented
+            return impl
+
+        return [make_impl(i, op) for i, op in enumerate(CMP_OPS)]
+
+    ot = cirq.testing.OrderTester()
+    for k in range(len(CMP_OPS)):
+        for b in [False, True]:
+            item = MockValue(0, *make_impls(bad_index=k, bad_result=b))
+            with pytest.raises(AssertionError, match='return NotImplemented'):
+                ot.add_ascending(item)
+
+    good_impls = make_impls(bad_index=-1, bad_result=NotImplemented)
+    ot.add_ascending(MockValue(0, *good_impls))
+    ot.add_ascending(MockValue(1, *good_impls))
+
+
+def test_fails_on_inconsistent_hashes():
+    class ModifiedHash(tuple):
         def __hash__(self):
-            return self._h
+            return super().__hash__() ^ 1
 
+    ot = cirq.testing.OrderTester()
+    ot.add_ascending((1, 0), (1, 1))
+    ot.add_ascending(ModifiedHash((1, 2)), ModifiedHash((2, 0)))
+    ot.add_ascending_equivalence_group((2, 2), (2, 2))
+    ot.add_ascending_equivalence_group(ModifiedHash((3, 3)),
+                                       ModifiedHash((3, 3)))
 
-    ot = OrderTester()
-    ot.add_ascending_equivalence_group(KeyHash('a', 5), KeyHash('a', 5))
-    ot.add_ascending_equivalence_group(KeyHash('b', 5))
-    with pytest.raises(AssertionError):
-        ot.add_ascending_equivalence_group(KeyHash('c', 2), KeyHash('c', 3))
+    with pytest.raises(AssertionError, match='different hashes'):
+        ot.add_ascending_equivalence_group((4, 4), ModifiedHash((4, 4)))


### PR DESCRIPTION
- Reduced usage of EqualsTester to just verifying hash consistency
- Added clearer error messages when there is a failure
- Add `_EqualToEverything` reference value