### PR TITLE
Special case single-qubit unitaries in _apply_unitary_to_tensor_

### DIFF
--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -211,8 +211,9 @@ def apply_matrix_to_slices(
 
     # Apply operation.
     for i, s_i in enumerate(slices):
-        out[s_i] = 0
+        out[s_i] *= matrix[i, i]
         for j, s_j in enumerate(slices):
-            out[s_i] += target[s_j] * matrix[i, j]
+            if i != j:
+                out[s_i] += target[s_j] * matrix[i, j]
 
     return out

--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -149,7 +149,7 @@ def targeted_left_multiply(left_matrix: np.ndarray,
                      **({'out': out} if out is not None else {}))
 
 
-_TSliceAtom = Union[int, slice]
+_TSliceAtom = Union[int, slice, 'ellipsis']
 _TSlice = Union[_TSliceAtom, Sequence[_TSliceAtom]]
 
 

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -75,7 +75,7 @@ def test_cz_matrix():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.CZ,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_z_init():
@@ -138,7 +138,7 @@ def test_z_matrix():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.Z,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_y_matrix():
@@ -156,7 +156,7 @@ def test_y_matrix():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.Y,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_x_matrix():
@@ -174,7 +174,7 @@ def test_x_matrix():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.X,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_h_matrix():
@@ -184,7 +184,7 @@ def test_h_matrix():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.H,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_h_decompose():
@@ -297,7 +297,7 @@ def test_cnot_power():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.CNOT,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_cnot_keyword_arguments():
@@ -371,7 +371,7 @@ def test_swap_power():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.SWAP,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_xyz_repr():
@@ -525,7 +525,7 @@ def test_iswap_matrix():
 
     cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
         val=cirq.ISWAP,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
+        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
 
 
 def test_iswap_decompose():

--- a/cirq/protocols/apply_unitary_to_tensor.py
+++ b/cirq/protocols/apply_unitary_to_tensor.py
@@ -158,6 +158,16 @@ def apply_unitary_to_tensor(val: Any,
     # Fallback to using the object's _unitary_ matrix.
     matrix = unitary(val, None)
     if matrix is not None:
+        # Special case for single-qubit operations.
+        if matrix.shape == (2, 2):
+            zero = linalg.slice_for_qubits_equal_to(axes, 0)
+            one = linalg.slice_for_qubits_equal_to(axes, 1)
+            return linalg.apply_matrix_to_slices(target_tensor,
+                                                 matrix,
+                                                 [zero, one],
+                                                 out=available_buffer)
+
+        # Fallback to np.einsum for the general case.
         return linalg.targeted_left_multiply(
             matrix.astype(target_tensor.dtype).reshape((2,) * (2 * len(axes))),
             target_tensor,


### PR DESCRIPTION
This is 20% faster than using einsum.

Setup:

```
import cirq
import numpy as np
c = cirq.Circuit.from_ops(cirq.X(q)**0.1 for q in cirq.LineQubit.range(24))
```

Before:

```
%time _ = c.apply_unitary_effect_to_state(dtype=np.complex64)
CPU times: user 4.05 s, sys: 611 ms, total: 4.66 s
Wall time: 4.66 s
```

After:

```
%time _ = c.apply_unitary_effect_to_state(dtype=np.complex64)
CPU times: user 3.38 s, sys: 279 ms, total: 3.66 s
Wall time: 3.66 s
```