### PR TITLE
Add 'dottable' check to assert_equivalent_repr

### DIFF
--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -118,7 +118,7 @@ class _CCZPowerGate(eigen_gate.EigenGate,
     def __repr__(self) -> str:
         if self._exponent == 1:
             return 'cirq.CCZ'
-        return 'cirq.CCZ**{!r}'.format(self._exponent)
+        return '(cirq.CCZ**{!r})'.format(self._exponent)
 
     def __str__(self) -> str:
         if self._exponent == 1:
@@ -199,7 +199,7 @@ class _CCXPowerGate(eigen_gate.EigenGate,
     def __repr__(self) -> str:
         if self._exponent == 1:
             return 'cirq.TOFFOLI'
-        return 'cirq.TOFFOLI**{!r}'.format(self._exponent)
+        return '(cirq.TOFFOLI**{!r})'.format(self._exponent)
 
     def __str__(self) -> str:
         if self._exponent == 1:

--- a/cirq/ops/three_qubit_gates_test.py
+++ b/cirq/ops/three_qubit_gates_test.py
@@ -96,8 +96,14 @@ def test_repr():
     assert repr(cirq.FREDKIN) == 'cirq.FREDKIN'
     assert repr(cirq.CCZ) == 'cirq.CCZ'
 
-    assert repr(cirq.CCX**0.5) == 'cirq.TOFFOLI**0.5'
-    assert repr(cirq.CCZ**0.5) == 'cirq.CCZ**0.5'
+    assert repr(cirq.CCX**0.5) == '(cirq.TOFFOLI**0.5)'
+    assert repr(cirq.CCZ**0.5) == '(cirq.CCZ**0.5)'
+
+    cirq.testing.assert_equivalent_repr(cirq.CCZ)
+    cirq.testing.assert_equivalent_repr(cirq.CSWAP)
+    cirq.testing.assert_equivalent_repr(cirq.TOFFOLI)
+    cirq.testing.assert_equivalent_repr(cirq.CCZ**0.5)
+    cirq.testing.assert_equivalent_repr(cirq.TOFFOLI**0.5)
 
 
 def test_eq():

--- a/cirq/testing/equivalent_repr_eval.py
+++ b/cirq/testing/equivalent_repr_eval.py
@@ -42,7 +42,7 @@ def assert_equivalent_repr(
         raise AssertionError(
             'eval(repr(value)) raised an exception.\n'
             '\n'
-            'setup_code={!r}\n'
+            'setup_code={}\n'
             'type(value): {}\n'
             'value={!r}\n'
             'error={!r}'.format(setup_code, type(value), value, ex))
@@ -69,3 +69,18 @@ def assert_equivalent_repr(
              type(value),
              type(eval_repr_value),
              '    ' + setup_code.replace('\n', '\n    '))
+
+    try:
+        a = eval('{!r}.__class__'.format(value), global_vals, local_vals)
+    except (AttributeError, SyntaxError):
+        raise AssertionError(
+            "The repr of a value of type {} wasn't 'dottable'.\n"
+            "{!r}.XXX must be equivalent to ({!r}).XXX, "
+            "but it raised an error instead.".format(
+                type(value), value, value))
+
+    b = eval('({!r}).__class__'.format(value), global_vals, local_vals)
+    assert a == b, (
+        "The repr of a value of type {} wasn't 'dottable'.\n"
+        "{!r}.XXX must be equivalent to ({!r}).XXX, "
+        "but it wasn't.".format(type(value), value, value))

--- a/cirq/testing/equivalent_repr_eval_test.py
+++ b/cirq/testing/equivalent_repr_eval_test.py
@@ -19,7 +19,7 @@ import cirq
 
 
 def test_external():
-    for t in [1, 2, 3, 'a', 0.5, 2**0.5, 1.1, 1j]:
+    for t in ['a', 1j]:
         cirq.testing.assert_equivalent_repr(t)
         cirq.testing.assert_equivalent_repr(t, setup_code='')
 
@@ -39,6 +39,8 @@ def test_custom_class_repr():
         setup_code = """class CustomRepr:
             def __init__(self, eq_val):
                 self.eq_val = eq_val
+            def __pow__(self, exponent):
+                return self
         """
 
         def __init__(self, eq_val, repr_str: str):
@@ -81,6 +83,13 @@ def test_custom_class_repr():
     with pytest.raises(AssertionError, match='SyntaxError'):
         cirq.testing.assert_equivalent_repr(
             CustomRepr('a', "return 1"))
+
+    # Not dottable.
+    with pytest.raises(AssertionError, match=r'dottable'):
+        cirq.testing.assert_equivalent_repr(
+            CustomRepr(5, "CustomRepr(5)**1"),
+            setup_code=CustomRepr.setup_code)
+
 
 
 def test_imports_cirq_by_default():


### PR DESCRIPTION
- For example, we want `{!r}.on(a)` to work, but `cirq.CCZ**0.5` doesn't have that property. You need to add parens.