### PR TITLE
Add method for taking channel and returning probabilities and unitaries represent channel if possible

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -205,6 +205,7 @@ from cirq.protocols import (
     inverse,
     mul,
     pow,
+    stochastic_unitary,
     SupportsApplyUnitaryToTensor,
     SupportsCircuitDiagramInfo,
     SupportsUnitary,

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -19,6 +19,7 @@ from cirq.protocols.apply_unitary_to_tensor import (
 )
 from cirq.protocols.channel import (
     channel,
+    stochastic_unitary
 )
 from cirq.protocols.circuit_diagram_info import (
     CircuitDiagramInfo,

--- a/cirq/protocols/channel.py
+++ b/cirq/protocols/channel.py
@@ -128,12 +128,12 @@ def channel(val: Any,
 def stochastic_unitary(
     val: SupportsChannel,
     rtol=1.e-5,
-    atol=1.e-8, ) -> Optional[Tuple[Tuple[float, np.ndarray], ...]]:
+    atol=1.e-8) -> Optional[Tuple[Tuple[float, np.ndarray], ...]]:
     """Gives a stochastic representation of a channel by unitaries, if possible.
 
     If a channel has Krauss operators A_0,A_1,...,A_{r-1} this checks whether
     each A_i is proportional to a unitary matrix, U_i, and if so, returns
-    each each unitary U_i along with the probability of the unitary p_i,
+    each unitary U_i along with the probability of the unitary p_i,
     (i.e. A_i = \sqrt{p_i} U_i). Note that this does NOT check whether
     there is some equivalent channel (under unitary equivalences of channels)
     that supports interpretation as a stochastic unitary, only that the

--- a/cirq/protocols/channel.py
+++ b/cirq/protocols/channel.py
@@ -153,13 +153,16 @@ def stochastic_unitary(
     """
     results = []
     for op in val._channel_():
+        # If polar decomposition has Hermitian part that is proportional to
+        # identity, it does not matter whether we use the left or right polar
+        # decomposition.
         u, p = sp.linalg.polar(op)
         if p[0, 0] == 0:
             return None
         potential_eye = p / p[0, 0]
         if np.allclose(potential_eye, np.eye(op.shape[0]), rtol=rtol,
                        atol=atol):
-            results.append((float(p[0, 0]) ** 2, u))
+            results.append((np.abs(p[0, 0]) ** 2, u))
         else:
             return None
     return tuple(results)

--- a/cirq/protocols/channel_test.py
+++ b/cirq/protocols/channel_test.py
@@ -94,3 +94,61 @@ def test_channel_fallback_to_unitary():
                             (u,))
     np.testing.assert_equal(cirq.channel(ReturnsUnitary(), (1,)), (u,))
     np.testing.assert_equal(cirq.channel(ReturnsUnitary(), LOCAL_DEFAULT), (u,))
+
+
+def call_stochastic_unitary(channel):
+    class ReturnsChannel:
+        def _channel_(self) -> Sequence[np.ndarray]:
+            return channel
+    return cirq.stochastic_unitary(ReturnsChannel())
+
+
+Z = np.array([[1, 0], [0, -1]])
+X = np.array([[0, 1], [1, 0]])
+H = np.sqrt(0.5) * np.array([[1, 1], [1, -1]])
+I = np.eye(2)
+PHASER = np.sqrt(0.5) * (np.kron(I, I) + 1j * np.kron(Z, Z))
+
+
+@pytest.mark.parametrize('channel,expected',(
+    ((Z,) , ((1.0, Z),)),
+    ((np.sqrt(0.5) * Z, np.sqrt(0.5) * X), ((0.5, Z), (0.5, X))),
+    ((np.sqrt(0.3) * H, np.sqrt(0.7) * X), ((0.3, H), (0.7, X))),
+    ((np.sqrt(0.3) * H, np.sqrt(0.7) * H), ((0.3, H), (0.7, H))),
+    ((np.sqrt(0.3) * I, np.sqrt(0.7) * H), ((0.3, I), (0.7, H))),
+    ((np.sqrt(0.3) * Z, np.sqrt(0.7) * H * 1j), ((0.3, Z), (0.7, H * 1j))),
+    ((np.sqrt(0.3) * np.kron(X, Z), np.sqrt(0.7) * np.kron(Z, X)),
+        ((0.3, np.kron(X, Z)), (0.7, np.kron(Z, X)))),
+    ((np.sqrt(0.3) * PHASER, np.sqrt(0.7) * np.kron(Z, X)),
+        ((0.3, PHASER), (0.7, np.kron(Z, X)))),
+))
+def test_stochastic_unitary(channel, expected):
+    actual = call_stochastic_unitary(channel)
+    assert len(actual) == len(expected), ('Actual and expected had differing '
+                                          'numbers of elements.')
+    for a, e in zip(actual, expected):
+        assert len(a) == len(e), 'Tuples had more than two elements.'
+        np.testing.assert_almost_equal(a[0], e[0])
+        np.testing.assert_allclose(a[1], e[1])
+
+
+@pytest.mark.parametrize('channel', (
+    (np.array([[0, 1], [0, 0]]),),
+    (np.array([[0.5, 0], [0, 0]]),),
+    (np.sqrt(0.5) * np.eye(2), np.array([[0, np.sqrt(0.5)], [0, 0]])),
+    (np.array([[0, 0], [0, 0]]),),
+    ((np.sqrt(0.3) * PHASER, np.sqrt(0.35) * (np.kron(I, I) + np.kron(Z, Z)))),
+))
+def test_stochastic_unitary_not_decomposable(channel):
+    assert call_stochastic_unitary(channel) is None
+
+
+
+def test_stochastic_unitary_accuracy():
+    channel = (np.sqrt(0.5) * Z, np.diag([np.sqrt(0.5), np.sqrt(0.5) * 1e-2]))
+    class ReturnsChannel:
+        def _channel_(self) -> Sequence[np.ndarray]:
+            return channel
+    assert cirq.stochastic_unitary(ReturnsChannel(), rtol=1e-4) is None
+
+

--- a/cirq/protocols/channel_test.py
+++ b/cirq/protocols/channel_test.py
@@ -143,7 +143,6 @@ def test_stochastic_unitary_not_decomposable(channel):
     assert call_stochastic_unitary(channel) is None
 
 
-
 def test_stochastic_unitary_accuracy():
     channel = (np.sqrt(0.5) * Z, np.diag([np.sqrt(0.5), np.sqrt(0.5) * 1e-2]))
     class ReturnsChannel:


### PR DESCRIPTION
There is no general way to tell if a channel can be interpreted as a stochastic set of probabilities (under the unitary degree of freedom of the Krauss operators), but this does this decomposition when it is possible.

This method means that we don't have to have noise models that declare they are stochastic unitary maps, which will be useful for the stochastic noise simulator.