### PR TITLE
Fix `cirq.Circuit._has_unitary_` false positives

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1547,13 +1547,16 @@ def _apply_unitary_circuit(circuit: Circuit,
     qubit_map = {q: i for i, q in enumerate(qubits)}
     buffer = np.zeros(state.shape, dtype=dtype)
 
+    def on_stuck(bad_op):
+        return TypeError(
+            'Operation without a known matrix or decomposition: {!r}'.format(
+                bad_op))
+
     unitary_ops = protocols.decompose(
         circuit.all_operations(),
         keep=protocols.has_unitary,
         intercepting_decomposer=_decompose_measurement_inversions,
-        on_stuck_raise=lambda bad_op: TypeError(
-            'Operation without a known matrix or decomposition: {!r}'.format(
-                bad_op)))
+        on_stuck_raise=on_stuck)
 
     for op in unitary_ops:
         indices = [qubit_map[q] for q in op.qubits]

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -438,8 +438,8 @@ def test_insert_at_frontier_init():
         frontier = {x: 2}
         circuit.insert_at_frontier(op, 0, frontier)
 
-def test_insert_at_frontier():
 
+def test_insert_at_frontier():
     class Replacer(PointOptimizer):
         def __init__(self, replacer=(lambda x: x)):
             super().__init__()
@@ -458,9 +458,9 @@ def test_insert_at_frontier():
     a, b, c = qubits[:3]
 
     circuit = Circuit([
-              Moment([cirq.CZ(a, b)]),
-              Moment([cirq.CZ(b, c)]),
-              Moment([cirq.CZ(a, b)])
+        Moment([cirq.CZ(a, b)]),
+        Moment([cirq.CZ(b, c)]),
+        Moment([cirq.CZ(a, b)])
     ])
 
     prepend_two_Xs_append_one_Y.optimize_circuit(circuit)
@@ -491,8 +491,8 @@ c: ─────────────────────────�
 
     duplicate = Replacer(lambda op: (op,) * 2)
     circuit = Circuit([
-        Moment([cirq.CZ(qubits[j], qubits[j+1])
-                     for j in range(i % 2, 5, 2)])
+        Moment([cirq.CZ(qubits[j], qubits[j + 1])
+                for j in range(i % 2, 5, 2)])
         for i in range(4)])
 
     duplicate.optimize_circuit(circuit)
@@ -513,7 +513,7 @@ f: ───@───@───────────@───@────�
     circuit = Circuit([
         Moment([cirq.CZ(*qubits[2:4]), cirq.CNOT(*qubits[:2])]),
         Moment([cirq.CNOT(*qubits[1::-1])])
-        ])
+    ])
 
     duplicate.optimize_circuit(circuit)
     cirq.testing.assert_has_diagram(circuit, """
@@ -939,12 +939,12 @@ def test_all_operations():
     assert list(c.all_operations()) == [cirq.CZ(a, b), cirq.X(a)]
 
     c = Circuit([
-            Moment([]),
-            Moment([cirq.X(a), cirq.Y(b)]),
-            Moment([]),
-            Moment([cirq.CNOT(a, b)]),
-            Moment([cirq.Z(b), cirq.H(a)]),  # Different qubit order
-            Moment([])])
+        Moment([]),
+        Moment([cirq.X(a), cirq.Y(b)]),
+        Moment([]),
+        Moment([cirq.CNOT(a, b)]),
+        Moment([cirq.Z(b), cirq.H(a)]),  # Different qubit order
+        Moment([])])
 
     assert list(c.all_operations()) == [
         cirq.X(a),
@@ -1166,7 +1166,7 @@ def test_to_text_diagram_custom_order():
 
 2: ---X---
 """, qubit_order=cirq.QubitOrder.sorted_by(lambda e: int(str(e)) % 3),
-use_unicode_characters=False)
+                                    use_unicode_characters=False)
 
 
 def test_overly_precise_diagram():
@@ -1213,6 +1213,30 @@ def test_diagram_wgate_none_precision():
     cirq.testing.assert_has_diagram(c, """
 a: ---W(0.43214321)^0.12341234---
 """, use_unicode_characters=False, precision=None)
+
+
+def test_has_unitary():
+
+    class NonUnitary(cirq.Gate):
+        pass
+
+    class EventualUnitary(cirq.Gate):
+        def _decompose_(self, qubits):
+            return cirq.X.on_each(qubits)
+
+    q = cirq.NamedQubit('q')
+
+    # Non-unitary operations cause a non-unitary circuit.
+    assert cirq.has_unitary(cirq.Circuit.from_ops(cirq.X(q)))
+    assert not cirq.has_unitary(cirq.Circuit.from_ops(NonUnitary().on(q)))
+
+    # Terminal measurements are ignored, though.
+    assert cirq.has_unitary(cirq.Circuit.from_ops(cirq.measure(q)))
+    assert not cirq.has_unitary(cirq.Circuit.from_ops(cirq.measure(q),
+                                                      cirq.measure(q)))
+
+    # Still unitary if operations decompose into unitary operations.
+    assert cirq.has_unitary(cirq.Circuit.from_ops(EventualUnitary().on(q)))
 
 
 def test_text_diagram_jupyter():
@@ -1293,7 +1317,7 @@ def test_circuit_to_unitary_matrix():
             [1j, -1j, -1j, 1j],
             [1, 1, 1, 1],
             [1, -1, 1, -1],
-        ])*np.sqrt(0.25),
+        ]) * np.sqrt(0.25),
         atol=1e-8)
 
     # Measurement gate has no corresponding matrix.
@@ -1332,9 +1356,9 @@ def test_circuit_to_unitary_matrix():
 
     # Non-terminal measurements are not ignored (multiple qubits).
     c = Circuit.from_ops(
-            cirq.measure(a),
-            cirq.measure(b),
-            cirq.CNOT(a, b))
+        cirq.measure(a),
+        cirq.measure(b),
+        cirq.CNOT(a, b))
     with pytest.raises(ValueError):
         _ = c.to_unitary_matrix()
 
@@ -1380,8 +1404,8 @@ def test_simple_circuits_to_unitary_matrix():
 
     # Phase parity.
     c = Circuit.from_ops(cirq.CNOT(a, b), cirq.Z(b), cirq.CNOT(a, b))
+    assert cirq.has_unitary(c)
     m = c.to_unitary_matrix()
-    assert cirq.has_unitary(c) is True
     cirq.testing.assert_allclose_up_to_global_phase(
         m,
         np.array([
@@ -1414,14 +1438,14 @@ def test_composite_gate_to_unitary_matrix():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = Circuit.from_ops(
-            cirq.X(a),
-            CnotComposite()(a, b),
-            cirq.X(a),
-            cirq.measure(a),
-            cirq.X(b),
-            cirq.measure(b))
+        cirq.X(a),
+        CnotComposite()(a, b),
+        cirq.X(a),
+        cirq.measure(a),
+        cirq.X(b),
+        cirq.measure(b))
+    assert cirq.has_unitary(c)
 
-    assert cirq.has_unitary(c) is True
     mat = c.to_unitary_matrix()
     mat_expected = cirq.unitary(cirq.CNOT)
 
@@ -1661,22 +1685,32 @@ def test_items():
     m4 = cirq.Moment([cirq.CZ(a, b)])
 
     c[:] = [m1, m2]
-    assert c == cirq.Circuit([m1, m2])
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([m1, m2]))
 
     assert c[0] == m1
     del c[0]
-    assert c == cirq.Circuit([m2])
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([m2]))
 
     c.append(m1)
     c.append(m3)
-    assert c == cirq.Circuit([m2, m1, m3])
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([m2, m1, m3]))
 
     assert c[0:2] == Circuit([m2, m1])
     c[0:2] = [m4]
-    assert c == cirq.Circuit([m4, m3])
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([m4, m3]))
 
     c[:] = [m1]
-    assert c == cirq.Circuit([m1])
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([m1]))
 
     with pytest.raises(TypeError):
         c[:] = [m1, 1]
@@ -1873,10 +1907,12 @@ def test_batch_insert_multiple_same_index():
     c.batch_insert([(0, cirq.Z(a)),
                     (0, cirq.Z(b)),
                     (0, cirq.Z(a))])
-    assert c == cirq.Circuit([
-        cirq.Moment([cirq.Z(a), cirq.Z(b)]),
-        cirq.Moment([cirq.Z(a)]),
-    ])
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([
+            cirq.Moment([cirq.Z(a), cirq.Z(b)]),
+            cirq.Moment([cirq.Z(a)]),
+        ]))
 
 
 def test_batch_insert_reverses_order_for_same_index_inserts():
@@ -1975,7 +2011,7 @@ def test_pick_inserted_ops_moment_indices():
         expected_circuit._moments += [Moment() for _ in
                 range(len(circuit) - len(expected_circuit))]
         insert_indices, _ = circuit._pick_inserted_ops_moment_indices(
-                operations, start)
+            operations, start)
         actual_circuit = Circuit(first_half._moments +
             [Moment() for _ in range(n_moments - start)])
         for op, insert_index in zip(operations, insert_indices):
@@ -2001,13 +2037,13 @@ def test_push_frontier_random_circuit():
         early_frontier = {q: randint(0, n_moments) for q in
                           sample(qubits, randint(0, len(qubits)))}
         late_frontier = {q: randint(0, n_moments) for q in
-                          sample(qubits, randint(0, len(qubits)))}
+                         sample(qubits, randint(0, len(qubits)))}
         update_qubits = sample(qubits, randint(0, len(qubits)))
 
         orig_early_frontier = {q: f for q, f in early_frontier.items()}
-        orig_moments = [m for m  in circuit._moments]
+        orig_moments = [m for m in circuit._moments]
         insert_index, n_new_moments = circuit._push_frontier(
-                early_frontier, late_frontier, update_qubits)
+            early_frontier, late_frontier, update_qubits)
 
         assert set(early_frontier.keys()) == set(orig_early_frontier.keys())
         for q in set(early_frontier).difference(update_qubits):
@@ -2064,6 +2100,7 @@ def test_insert_operations_errors():
         insertion_indices = []
         circuit._insert_operations(operations, insertion_indices)
 
+
 def test_validates_while_editing():
     c = cirq.Circuit(device=cg.Foxtail)
 
@@ -2082,42 +2119,46 @@ def test_validates_while_editing():
                                     cirq.GridQubit(1, 2))])
 
     c.insert(0, cirq.CZ(cirq.GridQubit(0, 0),
-                                           cirq.GridQubit(1, 0)))
+                        cirq.GridQubit(1, 0)))
 
 
 def test_respects_additional_adjacency_constraints():
     c = cirq.Circuit(device=cg.Foxtail)
     c.append(cirq.CZ(cirq.GridQubit(0, 0),
-                               cirq.GridQubit(0, 1)))
+                     cirq.GridQubit(0, 1)))
     c.append(cirq.CZ(cirq.GridQubit(1, 0),
-                               cirq.GridQubit(1, 1)),
+                     cirq.GridQubit(1, 1)),
              strategy=cirq.InsertStrategy.EARLIEST)
-    assert c == cirq.Circuit([
-        cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
-                                       cirq.GridQubit(0, 1))]),
-        cirq.Moment([cirq.CZ(cirq.GridQubit(1, 0),
-                                       cirq.GridQubit(1, 1))]),
-    ], device=cg.Foxtail)
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([
+            cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
+                                 cirq.GridQubit(0, 1))]),
+            cirq.Moment([cirq.CZ(cirq.GridQubit(1, 0),
+                                 cirq.GridQubit(1, 1))]),
+        ], device=cg.Foxtail))
 
 
 def test_commutes_past_adjacency_constraints():
     c = cirq.Circuit([
-            cirq.Moment(),
-            cirq.Moment(),
-            cirq.Moment([
-                cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))])
-        ],
+        cirq.Moment(),
+        cirq.Moment(),
+        cirq.Moment([
+            cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))])
+    ],
         device=cg.Foxtail)
     c.append(cirq.CZ(cirq.GridQubit(1, 0),
-                               cirq.GridQubit(1, 1)),
+                     cirq.GridQubit(1, 1)),
              strategy=cirq.InsertStrategy.EARLIEST)
-    assert c == cirq.Circuit([
-        cirq.Moment([cirq.CZ(cirq.GridQubit(1, 0),
-                                       cirq.GridQubit(1, 1))]),
-        cirq.Moment(),
-        cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
-                                       cirq.GridQubit(0, 1))]),
-    ], device=cg.Foxtail)
+    cirq.testing.assert_same_circuits(
+        c,
+        cirq.Circuit([
+            cirq.Moment([cirq.CZ(cirq.GridQubit(1, 0),
+                                 cirq.GridQubit(1, 1))]),
+            cirq.Moment(),
+            cirq.Moment([cirq.CZ(cirq.GridQubit(0, 0),
+                                 cirq.GridQubit(0, 1))]),
+        ], device=cg.Foxtail))
 
 
 def test_decomposes_while_appending():


### PR DESCRIPTION
- Was returning True when there were non-unitary non-measurement operations in the circuit
- Also did some reformating
- Now using `cirq.decompose` to extract unitary gates from circuits