### PR TITLE
Implement dev_tools/profile_with_pyflame.sh

### DIFF
--- a/dev_tools/clean_up_pyflame_json_for_chrome.py
+++ b/dev_tools/clean_up_pyflame_json_for_chrome.py
@@ -1,0 +1,173 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prettifies output from pyflame, so that it looks clearer in Chrome."""
+
+from typing import Dict, Any, Sequence, List
+
+import json
+import sys
+
+
+def main():
+    root = json.load(sys.stdin)
+
+    # Ensure all nodes have 'children' list.
+    for node in root['nodes']:
+        if 'children' not in node:
+            node['children'] = []
+
+    # Prettify.
+    clean_out_idles(root)
+    merge_redundant_nodes(root)
+    shorten_names(root)
+
+    json.dump(root, sys.stdout)
+
+
+def id_of_node_with_name(root: Dict[str, Any], name: str) -> int:
+    nodes = root['nodes']
+    for node in nodes:
+        func_name = node['callFrame']['functionName']
+        if func_name == name:
+            return node['id']
+    raise ValueError('no such node')
+
+
+def determine_merge_rewrites(root: Dict[str, Any]) -> Dict[int, int]:
+    """Figures out which nodes should be merged by 'merge_identicals'."""
+
+    root_id = id_of_node_with_name(root, '(root)')
+    idle_id = id_of_node_with_name(root, '(idle)')
+    id_rewrites = {idle_id: root_id}
+
+    # Determine the parent of each node. (Note: assumes single parents.)
+    nodes = root['nodes']
+    parents = {node['id']: None for node in nodes}
+    for node in nodes:
+        parent_id = node['id']
+        parent_id = id_rewrites.get(parent_id, parent_id)
+        for child in node['children']:
+            parents[child] = parent_id
+
+    # Compute the ancestry of every node as a grand|parent|child string.
+    # (Ignore line information when doing so; only care about the function.)
+    def ancestry_key(node):
+        child_id = node['id']
+        if child_id not in ancestries:
+            p = parents.get(child_id, None)
+            leaf = name_without_line_number(node['callFrame']['functionName'])
+            if p is None:
+                ancestries[child_id] = leaf
+            else:
+                ancestries[child_id] = ancestries[p] + '|' + leaf
+        return ancestries[child_id]
+    ancestries = {}
+
+    # Nodes with identical ancestries should be merged.
+    name_to_id = {}
+    for node in nodes:
+        node_id = node['id']
+        key = ancestry_key(node)
+        if key in name_to_id:
+            id_rewrites[node_id] = name_to_id[key]
+        else:
+            name_to_id[key] = node_id
+
+    return id_rewrites
+
+
+def merge_redundant_nodes(root: Dict[str, Any]) -> None:
+    """Merges nodes that refer to the same stack state.
+
+    pyflame likes to generate multiple nodes for single stack states, but
+    this makes the flame chart view in Chrome useless. We have to figure out
+    which nodes should be merged, to make the chart look nice.
+    """
+
+    rewrites = determine_merge_rewrites(root)
+
+    nodes = root['nodes']
+    id_to_index = {node['id']: i for i, node in enumerate(nodes)}
+
+    # Transfer profiler hits from merge-source to merge-destination.
+    for node in nodes:
+        node_id = node['id']
+        if node_id in rewrites:
+            new_id = rewrites[node_id]
+            new_node = nodes[id_to_index[new_id]]
+            new_node['hitCount'] += node['hitCount']
+            new_node['children'].extend(node['children'])
+
+    # Delete nodes that have now been merged into other nodes.
+    nodes[:] = [node for node in nodes if node['id'] not in rewrites]
+
+    # Rewrite references to now-deleted nodes to point at the correct targets.
+    samples = root['samples']
+    samples[:] = rewritten_list(samples, rewrites)
+    for node in nodes:
+        node_id = node['id']
+        children = node['children']
+        children[:] = sorted(set(c
+                                 for c in rewritten_list(children, rewrites)
+                                 if c != node_id))
+
+
+def clean_out_idles(root: Dict[str, Any]) -> None:
+    """Removes '(idle)' spam by extending preceeding samples.
+
+    pyflame is supposed to do this automatically when you pass the '-x' switch,
+    but as far as I can tell it simply doesn't.
+    """
+    idle_id = id_of_node_with_name(root, '(idle)')
+    samples = root['samples']
+    prev_sample = 0
+    for i, sample in enumerate(samples):
+        if sample == idle_id:
+            samples[i] = prev_sample
+        else:
+            prev_sample = sample
+
+
+def shorten_names(root: Dict[str, Any]) -> None:
+    """Replaces overly-specific function names with shorter ones.
+
+    pyflame likes to be very specific, listing full path and function name and
+    line number information. But this is really overly specific; we reduce it
+    to just the file and function.
+    """
+    nodes = root['nodes']
+    for node in nodes:
+        frame = node['callFrame']
+        func_name = frame['functionName']
+        lineless_name = name_without_line_number(func_name)
+        frame['functionName'] = lineless_name.split('/')[-1]
+
+
+def rewritten_list(target: Sequence[int],
+                   rewrites: Dict[int, int]
+                   ) -> List[int]:
+    return [rewrites.get(e, e) for e in target]
+
+
+def name_without_line_number(name: str) -> str:
+    """Removes the trailing line number from a node name."""
+    parts = name.split(':')
+    if len(parts) > 1:
+        return ':'.join(parts[:-1])
+    return name
+
+
+if __name__ == '__main__':
+    main()

--- a/dev_tools/profile_with_pyflame.sh
+++ b/dev_tools/profile_with_pyflame.sh
@@ -55,7 +55,6 @@ else
     exit 1
 fi
 
-
 if [ -z "$1" ]; then
     echo -e "\e[31mSpecify a python file to invoke.\nUSAGE\n    dev_tools/profile_with_pyflame.sh FILE_TO_PROFILE.py [custom-flags-for-pyflame] > OUTPUT_FILE.cpuprofile\e[0m" >&2
     exit 1

--- a/dev_tools/profile_with_pyflame.sh
+++ b/dev_tools/profile_with_pyflame.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# Profiles a python file, producing output that can be viewed in Chrome's
+# JavaScript Profiler.
+#
+# The profile output is printed to stdout. Any output from the python file will
+# be redirected to stderr to avoid cross-contamination.
+#
+# Usage:
+#     dev_tools/profile_with_pyflame.sh FILE_TO_PROFILE.py [custom-flags-for-pyflame] > OUTPUT_FILE.cpuprofile
+#
+# Requires:
+#     pyflame
+#         https://github.com/uber/pyflame
+#         https://pyflame.readthedocs.io/en/latest/index.html
+#     chrome
+#         to view the output
+#
+# Viewing output:
+#    Open Chrome to about:blank
+#    Open Chrome's console (CTRL+SHIFT+J)
+#    DON'T go to the performance tab. It silently fails at opening the file.
+#    At the top right of the conolse, hit the 'three dots' next to the X.
+#    Select 'More Tools -> Javascript Profiler'.
+#    Hit the 'Load' button and select the file this script generated.
+################################################################################
+
+# Check dependencies.
+if which pyflame > /dev/null; then
+    true
+else
+    echo -e "\e[31mpyflame not found. Follow instructions at https://pyflame.readthedocs.io/en/latest/installation.html and make sure the pyflame directory is in your path.\e[0m" >&2
+    exit 1
+fi
+
+if which flame-chart-json > /dev/null; then
+    true
+else
+    echo -e "\e[31mflame-chart-json not found. Make sure the pyflame utils directory is in your path.\e[0m" >&2
+    exit 1
+fi
+
+
+if [ -z "$1" ]; then
+    echo -e "\e[31mSpecify a python file to invoke.\nUSAGE\n    dev_tools/profile_with_pyflame.sh FILE_TO_PROFILE.py [custom-flags-for-pyflame] > OUTPUT_FILE.cpuprofile\e[0m" >&2
+    exit 1
+fi
+if [ -e "$1" ]; then
+    true
+else
+    echo -e "\e[31mExpected a python file but got '${1}', which doesn't exist.\nUSAGE\n    dev_tools/profile_with_pyflame.sh FILE_TO_PROFILE.py [custom-flags-for-pyflame] > OUTPUT_FILE.cpuprofile\e[0m" >&2
+    exit 1
+fi
+
+# Find repo root.
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+repo_dir=$(git rev-parse --show-toplevel)
+PYTHONPATH="${PYTHONPATH}":"${repo_dir}"
+cd - > /dev/null
+
+tmp_out=$(mktemp "/tmp/pyflame.XXXXXXXXXXXXXXXX")
+trap "{ rm ${tmp_out}; }" EXIT
+
+pyflame -x --flamechart "${@:2}" -o "${tmp_out}" -t python "$1" 1>&2
+cat "${tmp_out}" | flame-chart-json | python "${repo_dir}/dev_tools/clean_up_pyflame_json_for_chrome.py"


### PR DESCRIPTION
Example profiled code:

```python
n = 10000
unitary = cirq.testing.random_unitary(4)
decomps = [cirq.kak_decomposition(unitary) for _ in range(n)]
```

Screenshot of chart view in Chrome:

![image](https://user-images.githubusercontent.com/79941/47897347-9f766b00-de2e-11e8-8fc6-a90d90b52c70.png)

Zoomed in:

![image](https://user-images.githubusercontent.com/79941/47897369-b3ba6800-de2e-11e8-9f87-9e8a4f4f53b4.png)

I tested out what happens if I go around commenting out input and output checks in the kak decomposition (without keeping the tests passing in general) and profiled that. It gets about 4x faster even with those simple changes:

![image](https://user-images.githubusercontent.com/79941/47897399-d8aedb00-de2e-11e8-9777-42e18045154c.png)

