### PR TITLE
 Add cirq.value_equality class decorator

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -201,6 +201,7 @@ from cirq.value import (
     Duration,
     Symbol,
     Timestamp,
+    value_equality,
 )
 
 # pylint: disable=redefined-builtin

--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -22,6 +22,7 @@ from cirq.contrib.paulistring.pauli_string_raw_types import (
 from cirq.ops.pauli_string import PauliString
 
 
+@value.value_equality
 class PauliStringPhasor(PauliStringGateOperation):
     """An operation that phases a Pauli string."""
     def __init__(self,
@@ -53,19 +54,8 @@ class PauliStringPhasor(PauliStringGateOperation):
         super().__init__(pauli_string)
         self.half_turns = half_turns
 
-    def _eq_tuple(self) -> Tuple[Hashable, ...]:
-        return (PauliStringPhasor, self.pauli_string, self.half_turns)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._eq_tuple())
+    def _value_equality_values_(self):
+        return self.pauli_string, self.half_turns
 
     def map_qubits(self, qubit_map: Dict[ops.QubitId, ops.QubitId]):
         ps = self.pauli_string.map_qubits(qubit_map)

--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import (
-    Dict, Hashable, Iterable, Optional, Tuple, Union, cast
+    Dict, Iterable, Optional, Union, cast
 )
 
 from cirq import ops, value, study, protocols

--- a/cirq/contrib/qcircuit/qcircuit_diagram.py
+++ b/cirq/contrib/qcircuit/qcircuit_diagram.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import cast
 
-from cirq import circuits, ops, protocols
+from cirq import circuits, ops, protocols, value
 from cirq.contrib.qcircuit.qcircuit_diagrammable import (
     QCircuitDiagrammable,
     fallback_qcircuit_extensions,
@@ -22,6 +22,7 @@ from cirq.contrib.qcircuit.qcircuit_diagrammable import (
 )
 
 
+@value.value_equality
 class _QCircuitQubit(ops.QubitId):
     def __init__(self, sub: ops.QubitId) -> None:
         self.sub = sub
@@ -36,16 +37,8 @@ class _QCircuitQubit(ops.QubitId):
         # TODO: If qubit name ends with digits, turn them into subscripts.
         return '\\lstick{\\text{' + str(self.sub) + '}}&'
 
-    def __eq__(self, other):
-        if not isinstance(other, _QCircuitQubit):
-            return NotImplemented
-        return self.sub == other.sub
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((_QCircuitQubit, self.sub))
+    def _value_equality_values_(self):
+        return self.sub
 
 
 class _QCircuitOperation(ops.Operation):

--- a/cirq/ops/clifford_gate.py
+++ b/cirq/ops/clifford_gate.py
@@ -17,7 +17,7 @@ from typing import (Any, Dict, NamedTuple, Optional, Sequence, Tuple, Union,
 
 import numpy as np
 
-from cirq import protocols
+from cirq import protocols, value
 from cirq.ops import raw_types, common_gates, op_tree, \
     named_qubit
 from cirq.ops.pauli import Pauli
@@ -32,6 +32,7 @@ def _pretend_initialized() -> 'SingleQubitCliffordGate':
     pass
 
 
+@value.value_equality
 class SingleQubitCliffordGate(raw_types.Gate):
     """Any single qubit Clifford rotation."""
     I = _pretend_initialized()
@@ -196,22 +197,10 @@ class SingleQubitCliffordGate(raw_types.Gate):
     def transform(self, pauli: Pauli) -> PauliTransform:
         return self._rotation_map[pauli]
 
-    def _eq_tuple(self) -> Tuple[Any, ...]:
-        return (SingleQubitCliffordGate,
-                self.transform(Pauli.X),
+    def _value_equality_values_(self):
+        return (self.transform(Pauli.X),
                 self.transform(Pauli.Y),
                 self.transform(Pauli.Z))
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._eq_tuple())
 
     def __pow__(self, exponent) -> 'SingleQubitCliffordGate':
         if exponent != -1:

--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -18,10 +18,11 @@ from typing import Iterable
 
 import numpy as np
 
-from cirq import protocols
+from cirq import protocols, value
 from cirq.ops import raw_types
 
 
+@value.value_equality
 class AsymmetricDepolarizingChannel(raw_types.Gate):
     """A channel that depolarizes asymmetrically along different directions."""
 
@@ -67,17 +68,8 @@ class AsymmetricDepolarizingChannel(raw_types.Gate):
             np.sqrt(self._p_z) * np.array([[1, 0], [0, -1]])
         )
 
-    def _eq_tuple(self):
-        return (AsymmetricDepolarizingChannel,
-                self._p_x, self._p_y, self._p_z)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
+    def _value_equality_values_(self):
+        return self._p_x, self._p_y, self._p_z
 
     def __repr__(self) -> str:
         return (

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -395,6 +395,7 @@ class ZPowGate(eigen_gate.EigenGate,
         ).format(self._exponent, self._global_shift)
 
 
+@value.value_equality
 class MeasurementGate(raw_types.Gate):
     """Indicates that qubits should be measured plus a key to identify results.
 
@@ -476,16 +477,8 @@ class MeasurementGate(raw_types.Gate):
         return 'cirq.MeasurementGate({}, {})'.format(repr(self.key),
                                                      repr(self.invert_mask))
 
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self.key == other.key and self.invert_mask == other.invert_mask
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((MeasurementGate, self.key, self.invert_mask))
+    def _value_equality_values_(self):
+        return self.key, self.invert_mask
 
 
 def _default_measurement_key(qubits: Iterable[raw_types.QubitId]) -> str:

--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -16,11 +16,12 @@ from typing import Union, Sequence, Any
 
 import numpy as np
 
-from cirq import linalg, protocols
+from cirq import linalg, protocols, value
 from cirq.ops import raw_types
 from cirq.type_workarounds import NotImplementedType
 
 
+@value.value_equality
 class ControlledGate(raw_types.Gate):
     """Augments existing gates with a control qubit."""
 
@@ -37,16 +38,8 @@ class ControlledGate(raw_types.Gate):
             raise ValueError('No control qubit specified.')
         self.sub_gate.validate_args(qubits[1:])
 
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self.sub_gate == other.sub_gate
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((ControlledGate, self.sub_gate))
+    def _value_equality_values_(self):
+        return self.sub_gate
 
     def _apply_unitary_to_tensor_(self,
                                   target_tensor: np.ndarray,

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -45,6 +45,7 @@ EigenComponent = NamedTuple(
 )
 
 
+@value.value_equality(distinct_child_types=True)
 class EigenGate(raw_types.Gate):
     """A gate with a known eigendecomposition.
 
@@ -261,21 +262,8 @@ class EigenGate(raw_types.Gate):
                 self._canonical_exponent_cached = self._exponent % period
         return self._canonical_exponent_cached
 
-    def _identity_tuple(self):
-        return (type(self),
-                self._canonical_exponent,
-                self._global_shift)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._identity_tuple() == other._identity_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._identity_tuple())
+    def _value_equality_values_(self):
+        return self._canonical_exponent, self._global_shift
 
     def _trace_distance_bound_(self):
         if isinstance(self._exponent, value.Symbol):

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -20,7 +20,7 @@ from typing import (
 
 import numpy as np
 
-from cirq import extension, protocols
+from cirq import extension, protocols, value
 from cirq.ops import raw_types, gate_features
 from cirq.type_workarounds import NotImplementedType
 
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from typing import Dict, List
 
 
+@value.value_equality
 class GateOperation(raw_types.Operation):
     """An application of a gate to a collection of qubits.
 
@@ -90,20 +91,8 @@ class GateOperation(raw_types.Operation):
             groups[k].append(q)
         return tuple(sorted((k, frozenset(v)) for k, v in groups.items()))
 
-    def _eq_tuple(self):
-        grouped_qubits = self._group_interchangeable_qubits()
-        return raw_types.Operation, self.gate, grouped_qubits
-
-    def __hash__(self):
-        return hash(self._eq_tuple())
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
+    def _value_equality_values_(self):
+        return self.gate, self._group_interchangeable_qubits()
 
     def _decompose_(self):
         return protocols.decompose_once_with_qubits(self.gate,

--- a/cirq/ops/pauli.py
+++ b/cirq/ops/pauli.py
@@ -14,11 +14,14 @@
 
 from typing import Union, overload, TYPE_CHECKING
 
+from cirq import value
+
 if TYPE_CHECKING:
     # pylint: disable=unused-import
     from typing import Tuple
 
 
+@value.value_equality
 class Pauli:
     """Represents the X, Y, or Z axis of the Bloch sphere."""
     X = None  # type: Pauli
@@ -39,13 +42,8 @@ class Pauli:
     def difference(self, second: 'Pauli') -> int:
         return (self._index - second._index + 1) % 3 - 1
 
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._index == other._index
-
-    def __ne__(self, other):
-        return not self == other
+    def _value_equality_values_(self):
+        return self._index
 
     def __gt__(self, other):
         if not isinstance(other, type(self)):
@@ -59,9 +57,6 @@ class Pauli:
 
     def __add__(self, shift: int) -> 'Pauli':
         return Pauli.XYZ[(self._index + shift) % 3]
-
-    def __hash__(self):
-        return hash(self._index)
 
     # pylint: disable=function-redefined
     @overload

--- a/cirq/ops/pauli_interaction_gate.py
+++ b/cirq/ops/pauli_interaction_gate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Hashable, List, Optional, Sequence, Tuple, Union
+from typing import List, Sequence, Tuple, Union
 
 import numpy as np
 

--- a/cirq/ops/pauli_interaction_gate.py
+++ b/cirq/ops/pauli_interaction_gate.py
@@ -32,6 +32,7 @@ pauli_eigen_map = {
 }
 
 
+@value.value_equality
 class PauliInteractionGate(eigen_gate.EigenGate,
                            gate_features.InterchangeableQubitsGate):
     CZ = None  # type: PauliInteractionGate
@@ -59,22 +60,10 @@ class PauliInteractionGate(eigen_gate.EigenGate,
         self.pauli1 = pauli1
         self.invert1 = invert1
 
-    def _eq_tuple(self) -> Tuple[Hashable, ...]:
-        return (PauliInteractionGate,
-                self.pauli0, self.invert0,
+    def _value_equality_values_(self):
+        return (self.pauli0, self.invert0,
                 self.pauli1, self.invert1,
                 self._canonical_exponent)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._eq_tuple())
 
     def qubit_index_to_equivalence_group_key(self, index: int) -> int:
         if self.pauli0 == self.pauli1 and self.invert0 == self.invert1:

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -15,6 +15,7 @@
 from typing import (Any, Dict, ItemsView, Iterable, Iterator, KeysView, Mapping,
                     Tuple, TypeVar, Union, ValuesView, overload)
 
+from cirq import value
 from cirq.ops import (
     raw_types, gate_operation, common_gates, op_tree
 )
@@ -24,6 +25,8 @@ from cirq.ops.pauli_interaction_gate import PauliInteractionGate
 
 TDefault = TypeVar('TDefault')
 
+
+@value.value_equality
 class PauliString:
     def __init__(self,
                  qubit_pauli_map: Mapping[raw_types.QubitId, Pauli],
@@ -36,21 +39,9 @@ class PauliString:
         """Creates a PauliString with a single qubit."""
         return PauliString({qubit: pauli})
 
-    def _eq_tuple(self) -> Tuple[Any, ...]:
-        return (PauliString,
-                self._qubit_pauli_map,
+    def _value_equality_values_(self):
+        return (frozenset(self._qubit_pauli_map.items()),
                 self.negated)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((PauliString, self.negated, frozenset(self.items())))
 
     def equal_up_to_sign(self, other: 'PauliString') -> bool:
         return self._qubit_pauli_map == other._qubit_pauli_map

--- a/cirq/ops/phased_x_gate.py
+++ b/cirq/ops/phased_x_gate.py
@@ -26,6 +26,7 @@ from cirq.type_workarounds import NotImplementedType
 import cirq.ops.common_gates
 
 
+@value.value_equality
 class PhasedXPowGate(gate_features.SingleQubitGate):
     """A gate equivalent to the circuit ───Z^-p───X^t───Z^p───.
 
@@ -188,19 +189,5 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         else:
             return self._exponent % period
 
-    def _identity_tuple(self):
-        return (PhasedXPowGate,
-                self.phase_exponent,
-                self._canonical_exponent,
-                self._global_shift)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._identity_tuple() == other._identity_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._identity_tuple())
+    def _value_equality_values_(self):
+        return self.phase_exponent, self._canonical_exponent, self._global_shift

--- a/cirq/protocols/circuit_diagram_info.py
+++ b/cirq/protocols/circuit_diagram_info.py
@@ -17,11 +17,14 @@ from typing import Any, TYPE_CHECKING, Optional, Union, Tuple, TypeVar, Dict, \
 
 from typing_extensions import Protocol
 
+from cirq import value
+
 if TYPE_CHECKING:
     # pylint: disable=unused-import
     import cirq
 
 
+@value.value_equality
 class CircuitDiagramInfo:
     """Describes how to draw an operation in a circuit diagram."""
 
@@ -48,20 +51,8 @@ class CircuitDiagramInfo:
         self.exponent = exponent
         self.connected = connected
 
-    def _eq_tuple(self):
-        return (CircuitDiagramInfo, self.wire_symbols,
-                self.exponent, self.connected)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._eq_tuple())
+    def _value_equality_values_(self):
+        return self.wire_symbols, self.exponent, self.connected
 
     def __repr__(self):
         return ('cirq.CircuitDiagramInfo(' +
@@ -71,6 +62,7 @@ class CircuitDiagramInfo:
                 )
 
 
+@value.value_equality
 class CircuitDiagramInfoArgs:
     """A request for information on drawing an operation in a circuit diagram.
 
@@ -105,26 +97,14 @@ class CircuitDiagramInfoArgs:
         self.precision = precision
         self.qubit_map = qubit_map
 
-    def _eq_tuple(self):
-        return (CircuitDiagramInfoArgs,
-                self.known_qubits,
+    def _value_equality_values_(self):
+        return (self.known_qubits,
                 self.known_qubit_count,
                 self.use_unicode_characters,
                 self.precision,
                 None
                 if self.qubit_map is None else
                 tuple(sorted(self.qubit_map.items(), key=lambda e: e[0])))
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash(self._eq_tuple())
 
     def __repr__(self):
         return (

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -26,7 +26,7 @@ from typing import Dict, Iterator, List, Union
 
 import numpy as np
 
-from cirq import circuits, ops, schedules, study
+from cirq import circuits, ops, schedules, study, value
 from cirq.sim import wavefunction
 
 
@@ -184,6 +184,7 @@ class SimulatesFinalWaveFunction:
         raise NotImplementedError()
 
 
+@value.value_equality(unhashable=True)
 class SimulationTrialResult:
     """Results of a simulation by a SimulatesFinalWaveFunction.
 
@@ -227,19 +228,11 @@ class SimulationTrialResult:
     def dirac_notation(self, decimals=2):
         return wavefunction.dirac_notation(self.final_state, decimals)
 
-    def _eq_tuple(self):
+    def _value_equality_values_(self):
         measurements = {k: v.tolist() for k, v in
                         sorted(self.measurements.items())}
         return (SimulationTrialResult, self.params, measurements,
                 self.final_state.tolist())
-
-    def __eq__(self, other):
-        if not isinstance(other, SimulationTrialResult):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
 
 
 class SimulatesIntermediateWaveFunction(SimulatesFinalWaveFunction):

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -19,6 +19,7 @@ from typing import Iterable, Callable, Tuple, TypeVar, Dict, Any
 import collections
 import numpy as np
 
+from cirq import value
 from cirq.study import resolver
 
 T = TypeVar('T')
@@ -74,6 +75,7 @@ def _keyed_repeated_bitstrings(vals: Dict[str, np.ndarray]
     return '\n'.join(keyed_bitstrings)
 
 
+@value.value_equality(unhashable=True)
 class TrialResult:
     """The results of multiple executions of a circuit with fixed parameters.
 
@@ -224,13 +226,5 @@ class TrialResult:
     def __str__(self):
         return _keyed_repeated_bitstrings(self.measurements)
 
-    def _eq_tuple(self):
-        return (TrialResult, self.measurements, self.repetitions, self.params)
-
-    def __eq__(self, other):
-        if not isinstance(other, TrialResult):
-            return NotImplemented
-        return self._eq_tuple() == other._eq_tuple()
-
-    def __ne__(self, other):
-        return not self == other
+    def _value_equality_values_(self):
+        return self.measurements, self.repetitions, self.params

--- a/cirq/value/__init__.py
+++ b/cirq/value/__init__.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from cirq.value.angle import (
+    canonicalize_half_turns,
+    chosen_angle_to_canonical_half_turns,
+    chosen_angle_to_half_turns,
+)
 from cirq.value.duration import (
     Duration,
 )
@@ -20,8 +26,6 @@ from cirq.value.symbol import (
 from cirq.value.timestamp import (
     Timestamp,
 )
-from cirq.value.angle import (
-    canonicalize_half_turns,
-    chosen_angle_to_canonical_half_turns,
-    chosen_angle_to_half_turns,
+from cirq.value.value_equality import (
+    value_equality,
 )

--- a/cirq/value/symbol.py
+++ b/cirq/value/symbol.py
@@ -15,14 +15,20 @@
 import json
 import re
 
+from cirq.value.value_equality import value_equality
+
 _identifier_pattern = '[a-zA-Z_][a-zA-Z0-9_]*$'
+
 
 def _is_valid_identifier(text):
     return re.match(_identifier_pattern, text)
 
+
 def _encode(text):
     return json.JSONEncoder().encode(text)
 
+
+@value_equality
 class Symbol:
     """A constant plus the runtime value of a parameter with a given key.
 
@@ -47,16 +53,8 @@ class Symbol:
     def __repr__(self):
         return 'cirq.Symbol({!r})'.format(self.name)
 
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self.name == other.name
-
-    def __ne__(self, other):
-        return not self == other
-
-    def __hash__(self):
-        return hash((Symbol, self.name))
+    def _value_equality_values_(self):
+        return self.name
 
     def __mul__(self, other):
         return self if other == 1 else NotImplemented

--- a/cirq/value/value_equality.py
+++ b/cirq/value/value_equality.py
@@ -1,0 +1,79 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def _value_equality_eq(self, other):
+    cls_self = self._value_equality_values_cls_()
+    if not isinstance(other, cls_self):
+        return NotImplemented
+    cls_other = other._value_equality_values_cls_()
+    if cls_self != cls_other:
+        return False
+    return self._value_equality_values_() == other._value_equality_values_()
+
+
+def _value_equality_ne(self, other):
+    return not self == other
+
+
+def _value_equality_hash(self):
+    return hash((self._value_equality_values_cls_(),
+                 self._value_equality_values_()))
+
+
+def value_equality(*args,
+                   unhashable: bool = False,
+                   distinct_child_types: bool = False):
+    """Implements __eq__, __ne__, and __hash__ via _value_equality_values_.
+
+    Note that a type is appended to the equality values. By default this is the
+    class type of the decorated class (so child types will be considered equal),
+    but it can be changed to the type of the receiving value (so child type are
+    all distinct). This logic is encoded by adding an appropriate
+    `_value_equality_values_cls_` method to the class.
+
+    Args:
+        unhashable: When set, the __hash__ method will be set to None instead of
+            to a hash of the equality class and equality values. Useful for
+            mutable types such as dictionaries.
+        distinct_child_types: When set, classes that inherit from the decorated
+            class will not be considered equal to it. Also, different child
+            classes will not be considered equal to each other. Useful for when
+            the decorated class is an abstract class or trait that is helping to
+            define equality for many conceptually distinct concrete classes.
+    """
+
+    # If `unhashable` was specified, the cls argument has not been passed yet.
+    if len(args) == 0:
+        return lambda cls: value_equality(
+            cls,
+            unhashable=unhashable,
+            distinct_child_types=distinct_child_types)
+    assert len(args) == 1
+
+    cls = args[0]
+    getter = getattr(cls, '_value_equality_values_', None)
+    if getter is None:
+        raise ValueError('The @cirq.value_equality decorator requires a '
+                         '_value_equality_values_ method to be defined.')
+
+    if distinct_child_types:
+        setattr(cls, '_value_equality_values_cls_', lambda self: type(self))
+    else:
+        setattr(cls, '_value_equality_values_cls_', lambda self: cls)
+    setattr(cls, '__hash__', None if unhashable else _value_equality_hash)
+    setattr(cls, '__eq__', _value_equality_eq)
+    setattr(cls, '__ne__', _value_equality_ne)
+
+    return cls

--- a/cirq/value/value_equality_test.py
+++ b/cirq/value/value_equality_test.py
@@ -1,0 +1,124 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import cirq
+
+
+def test_value_equality_basic():
+    @cirq.value_equality
+    class C:
+        def __init__(self, x):
+            self.x = x
+
+        def _value_equality_values_(self):
+            return self.x
+
+    @cirq.value_equality
+    class D:
+        def __init__(self, x):
+            self.x = x
+
+        def _value_equality_values_(self):
+            return self.x
+
+    class Ca(C):
+        pass
+
+    class Cb(C):
+        pass
+
+    # Lookup works across equivalent types.
+    v = {C(1): 4, Ca(2): 5}
+    assert v[Ca(1)] == v[C(1)] == 4
+    assert v[Ca(2)] == 5
+
+    # Equality works as expected.
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(C(1), C(1), Ca(1), Cb(1))
+    eq.add_equality_group(D(1))
+    eq.add_equality_group(C(2))
+    eq.add_equality_group(Ca(3))
+
+
+def test_value_equality_unhashable():
+    @cirq.value_equality(unhashable=True)
+    class C:
+        def __init__(self, x):
+            self.x = x
+
+        def _value_equality_values_(self):
+            return self.x
+
+    @cirq.value_equality(unhashable=True)
+    class D:
+        def __init__(self, x):
+            self.x = x
+
+        def _value_equality_values_(self):
+            return self.x
+
+    class Ca(C):
+        pass
+
+    class Cb(C):
+        pass
+
+    # Not possible to use as a dictionary key.
+    with pytest.raises(TypeError, match='unhashable'):
+        _ = {C(1): 4}
+
+    # Equality works as expected.
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(C(1), C(1), Ca(1), Cb(1))
+    eq.add_equality_group(C(2))
+    eq.add_equality_group(D(1))
+
+
+def test_value_equality_distinct_child_types():
+    @cirq.value_equality(distinct_child_types=True)
+    class C:
+        def __init__(self, x):
+            self.x = x
+
+        def _value_equality_values_(self):
+            return self.x
+
+    @cirq.value_equality(distinct_child_types=True)
+    class D:
+        def __init__(self, x):
+            self.x = x
+
+        def _value_equality_values_(self):
+            return self.x
+
+    class Ca(C):
+        pass
+
+    class Cb(C):
+        pass
+
+    # Lookup is distinct across child types.
+    v = {C(1): 4, Ca(1): 5, Cb(1): 6}
+    assert v[C(1)] == 4
+    assert v[Ca(1)] == 5
+    assert v[Cb(1)] == 6
+
+    # Equality works as expected.
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(C(1), C(1))
+    eq.add_equality_group(Ca(1), Ca(1))
+    eq.add_equality_group(Cb(1), Cb(1))
+    eq.add_equality_group(C(2))
+    eq.add_equality_group(D(1))


### PR DESCRIPTION
- Implements `__eq__`, `__ne__`, and `__hash__` in terms of `_value_equality_values_` method
- Many classes were using this pattern (e.g. by defining an `_eq_tuple` method)