### PR TITLE
Add __pow__ to circuit and moments

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -238,6 +238,37 @@ class Circuit:
             return NotImplemented
         return self * repetitions
 
+    def __pow__(self, exponent: float):
+        """See `cirq.pow`.
+
+        For integer exponents, this corresponds to repetitions of the moments
+        of the circuit. When the exponent is negative, these circuits have
+        their moment order reversed and the inverse of each operation in the
+        moment is applied. This means circuit**-1 corresponds to the inverse
+        circuit.
+
+        For non-integer exponents, the integer closest to zero is calculated
+        and this is used as the integer exponent above. The remainder is
+        then applied as a power for each operation, again if the remainder is
+        negative the order is reversed.
+
+        Args:
+            exponent: The exponent to power by.
+
+        Returns:
+            A new circuit of the corresponding power.
+        """
+        d = 1 if exponent > 0 else -1
+        n, r = divmod(exponent, d)
+        result = Circuit()
+        if int(n) != 0:
+            result += int(n) * Circuit(
+                    [protocols.pow(moment, d) for moment in self[::d]])
+        if r != 0:
+            result += Circuit(
+                    [protocols.pow(moment, r) for moment in self[::d]])
+        return result
+
     def __repr__(self):
         if not self._moments and self._device == devices.UnconstrainedDevice:
             return 'cirq.Circuit()'

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -2532,3 +2532,52 @@ def test_decompose():
     assert cirq.decompose(
         cirq.Circuit.from_ops(cirq.X(a), cirq.Y(b), cirq.CZ(a, b))
     ) == [cirq.X(a), cirq.Y(b), cirq.CZ(a, b)]
+
+
+def test_power():
+    a, b = cirq.LineQubit.range(2)
+    base = cirq.Circuit.from_ops((cirq.X ** 0.5)(a), (cirq.Y ** 0.2)(b),
+                                 (cirq.CZ)(a, b))
+    cirq.testing.assert_same_circuits(base ** 0, cirq.Circuit())
+    cirq.testing.assert_same_circuits(base ** 1, base)
+    cirq.testing.assert_same_circuits(base ** 2, base + base)
+    cirq.testing.assert_same_circuits(base ** 2.5, base + base + base ** 0.5)
+    cirq.testing.assert_same_circuits(base ** 0.5, base ** 0.5)
+    cirq.testing.assert_same_circuits(base ** -1, base ** -1)
+    cirq.testing.assert_same_circuits(base ** -2, base ** -1 + base ** -1)
+    cirq.testing.assert_same_circuits(base ** -2.5,
+                                      base ** -1 + base ** -1 + base ** -0.5)
+    cirq.testing.assert_same_circuits(base ** -0.5, base ** -0.5)
+
+
+def test_power_explicit():
+    a, b = cirq.LineQubit.range(2)
+    ops = [(cirq.X ** 0.5)(a), (cirq.Y ** 0.2)(b), cirq.CZ(a, b)]
+    sqrt_ops = [(cirq.X ** 0.25)(a), (cirq.Y ** 0.1)(b), (cirq.CZ**0.5)(a, b)]
+    base = cirq.Circuit.from_ops(ops)
+    expected_ops = ops + ops + sqrt_ops
+    cirq.testing.assert_same_circuits(base ** 2.5,
+                                      cirq.Circuit.from_ops(expected_ops))
+
+    # Note that moment does not reverse order of operations in moment.
+    inverse_ops = [(cirq.CZ ** -1)(a, b), (cirq.X ** -0.5)(a),
+                   (cirq.Y ** -0.2)(b)]
+    inverse_sqrt_ops = [(cirq.CZ ** -0.5)(a, b), (cirq.X ** -0.25)(a),
+                        (cirq.Y ** -0.1)(b)]
+
+    expected_ops = inverse_ops + inverse_ops + inverse_sqrt_ops
+    cirq.testing.assert_same_circuits(base ** (-2.5),
+                                      cirq.Circuit.from_ops(expected_ops))
+
+
+def test_inverse():
+    a, b = cirq.LineQubit.range(2)
+    forward = cirq.Circuit.from_ops((cirq.X ** 0.5)(a), (cirq.Y ** -0.2)(b),
+                                    (cirq.CZ)(a, b))
+    backward = cirq.Circuit.from_ops((cirq.CZ ** (-1.0))(a, b),
+                                     (cirq.X ** (-0.5))(a),
+                                     (cirq.Y ** (0.2))(b))
+    cirq.testing.assert_same_circuits(cirq.inverse(forward), backward)
+
+    cirq.testing.assert_same_circuits(cirq.inverse(cirq.Circuit()),
+                                      cirq.Circuit())

--- a/cirq/circuits/moment.py
+++ b/cirq/circuits/moment.py
@@ -16,7 +16,7 @@
 
 from typing import Any, Iterable, TypeVar, Callable, Sequence
 
-from cirq import ops
+from cirq import ops, protocols
 
 TSelf_Moment = TypeVar('TSelf_Moment', bound='Moment')
 
@@ -115,6 +115,14 @@ class Moment(object):
 
     def __str__(self):
         return ' and '.join(str(op) for op in self.operations)
+
+    def __pow__(self, exponent: float):
+        """See `cirq.pow`. Powers each operation, if possible."""
+        if exponent == 0:
+            return Moment()
+        else:
+            return Moment(protocols.pow(operation, exponent) for operation in
+                          self.operations)
 
     def transform_qubits(self: TSelf_Moment,
                          func: Callable[[ops.QubitId], ops.QubitId]

--- a/cirq/circuits/moment_test.py
+++ b/cirq/circuits/moment_test.py
@@ -184,3 +184,22 @@ def test_qubits():
     assert Moment([cirq.X(a), cirq.X(b)]).qubits == {a , b}
     assert Moment([cirq.X(a)]).qubits == {a}
     assert Moment([cirq.CZ(a, b)]).qubits == {a, b}
+
+
+def test_pow():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    c = cirq.NamedQubit('c')
+    moment = Moment([(cirq.X**0.5)(a), cirq.CZ(b, c)])
+    assert moment ** 2 == Moment([(cirq.X**1)(a), (cirq.CZ**2)(b, c)])
+    assert moment ** 0.5 == Moment([(cirq.X**0.25)(a), (cirq.CZ**0.5)(b, c)])
+    assert moment ** -0.5 == Moment([(cirq.X**-0.25)(a), (cirq.CZ**-0.5)(b, c)])
+    assert moment ** 0 == Moment()
+
+
+def test_inverse():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    c = cirq.NamedQubit('c')
+    moment = Moment([(cirq.X**0.5)(a), cirq.CZ(b, c)])
+    assert cirq.inverse(moment) == Moment([(cirq.X**-0.5)(a), cirq.CZ(b, c)])

--- a/cirq/protocols/inverse.py
+++ b/cirq/protocols/inverse.py
@@ -66,6 +66,16 @@ def inverse(val: 'cirq.OP_TREE',
     pass
 
 
+@overload
+def inverse(val: 'cirq.Moment') -> 'cirq.Moment':
+    pass
+
+
+@overload
+def inverse(val: 'cirq.Circuit') -> 'cirq.Circuit':
+    pass
+
+
 def inverse(val: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
     """Returns the inverse `val**-1` of the given value, if defined.
 

--- a/cirq/protocols/pow.py
+++ b/cirq/protocols/pow.py
@@ -52,6 +52,20 @@ def pow(val: 'cirq.Operation',
 
 
 @overload
+def pow(val: 'cirq.Moment',
+        exponent: Any,
+        default: TDefault) -> Union[TDefault, 'cirq.Moment']:
+    pass
+
+
+@overload
+def pow(val: 'cirq.Circuit',
+        exponent: Any,
+        default: TDefault) -> Union[TDefault, 'cirq.Circuit']:
+    pass
+
+
+@overload
 def pow(val: Any, exponent: Any, default: TDefault) -> Any:
     pass
 


### PR DESCRIPTION
We could restrict to integers if we think
Moment**0.5 shoudn't be defined as all op's raised to 0.5 power.