### PR TITLE
Refactor `assert_apply_unitary_to_tensor_is_consistent_with_unitary` into three methods

### DIFF
--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -64,7 +64,7 @@ class CZPowGate(eigen_gate.EigenGate,
         if protocols.is_parameterized(self):
             return NotImplemented
 
-        c = np.exp(1j * np.pi * self._exponent)
+        c = 1j**(2 * self._exponent)
         one_one = linalg.slice_for_qubits_equal_to(axes, 0b11)
         target_tensor[one_one] *= c
         return target_tensor
@@ -149,6 +149,9 @@ class XPowGate(eigen_gate.EigenGate,
         one = linalg.slice_for_qubits_equal_to(axes, 1)
         available_buffer[zero] = target_tensor[one]
         available_buffer[one] = target_tensor[zero]
+        p = 1j**(2 * self._exponent * self._global_shift)
+        if p != 1:
+            available_buffer *= p
         return available_buffer
 
     def _eigen_components(self):
@@ -315,8 +318,12 @@ class ZPowGate(eigen_gate.EigenGate,
             return NotImplemented
 
         one = linalg.slice_for_qubits_equal_to(axes, 1)
-        c = np.exp(1j * np.pi * self._exponent)
+        c = 1j**(self._exponent * 2)
+        one_one = linalg.slice_for_qubits_equal_to(axes, 0b11)
         target_tensor[one] *= c
+        p = 1j**(2 * self._exponent * self._global_shift)
+        if p != 1:
+            target_tensor *= p
         return target_tensor
 
     def _eigen_components(self):

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -74,9 +74,8 @@ def test_cz_matrix():
                                  [0, 0, 1, 0],
                                  [0, 0, 0, -1j]]))
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.CZ,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.CZ)
 
 
 def test_z_init():
@@ -141,9 +140,7 @@ def test_z_matrix():
     assert np.allclose(cirq.unitary(cirq.Z**-0.5),
                        np.array([[1, 0], [0, -1j]]))
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.Z,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_eigen_gate_has_consistent_apply_unitary(cirq.ZPowGate)
 
 
 def test_y_matrix():
@@ -159,9 +156,7 @@ def test_y_matrix():
     assert np.allclose(cirq.unitary(cirq.Y**-0.5),
                        np.array([[1 - 1j, 1 - 1j], [-1 + 1j, 1 - 1j]]) / 2)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.Y,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_eigen_gate_has_consistent_apply_unitary(cirq.YPowGate)
 
 
 def test_x_matrix():
@@ -177,9 +172,7 @@ def test_x_matrix():
     assert np.allclose(cirq.unitary(cirq.X**-0.5),
                        np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]]) / 2)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.X,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_eigen_gate_has_consistent_apply_unitary(cirq.XPowGate)
 
 
 def test_h_matrix():
@@ -187,9 +180,8 @@ def test_h_matrix():
     m = np.dot(sqrt, sqrt)
     assert np.allclose(m, cirq.unitary(cirq.H), atol=1e-8)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.H,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.H)
 
 
 def test_h_init():
@@ -300,9 +292,8 @@ def test_cnot_power():
     cirq.testing.assert_decompose_is_consistent_with_unitary(cirq.CNOT**0.5)
     cirq.testing.assert_decompose_is_consistent_with_unitary(cirq.CNOT**0.1)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.CNOT,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.CNOT)
 
 
 def test_cnot_keyword_arguments():
@@ -378,9 +369,8 @@ def test_swap_power():
     cirq.testing.assert_decompose_is_consistent_with_unitary(cirq.SWAP**0.5)
     cirq.testing.assert_decompose_is_consistent_with_unitary(cirq.SWAP**0.1)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.SWAP,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.SWAP)
 
 
 def test_xyz_repr():
@@ -556,9 +546,8 @@ def test_iswap_matrix():
                   [0, 0, 0, 1]]),
         atol=1e-8)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val=cirq.ISWAP,
-        exponents=[1, -0.5, 0.5, 0.25, -0.25, 0.1, cirq.Symbol('s')])
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.ISWAP)
 
 
 def test_iswap_decompose():

--- a/cirq/ops/controlled_gate_test.py
+++ b/cirq/ops/controlled_gate_test.py
@@ -143,6 +143,9 @@ class GateAllocatingNewSpaceForResult(cirq.SingleQubitGate):
 
 @pytest.mark.parametrize('gate', [
     cirq.X,
+    cirq.X**0.5,
+    cirq.Rx(np.pi),
+    cirq.Rx(np.pi / 2),
     cirq.Z,
     cirq.H,
     cirq.CNOT,
@@ -153,9 +156,8 @@ class GateAllocatingNewSpaceForResult(cirq.SingleQubitGate):
     GateAllocatingNewSpaceForResult(),
 ])
 def test_apply_unitary_to_tensor(gate: cirq.Gate):
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        cirq.ControlledGate(gate),
-        exponents=[1, 0.5, cirq.Symbol('s')])
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.ControlledGate(gate))
 
 
 def test_pow_inverse():

--- a/cirq/ops/three_qubit_gates_test.py
+++ b/cirq/ops/three_qubit_gates_test.py
@@ -73,14 +73,11 @@ def test_matrix():
         [0, 0, 0, 0, 0, 0, 0, 1],
     ]), atol=1e-8)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        cirq.CCZ,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        cirq.CCX,
-        exponents=[1, 0.5, -0.25, cirq.Symbol('s')])
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        cirq.CSWAP)
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.CCX)
+    cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
+        cirq.CCZ)
+    cirq.testing.assert_has_consistent_apply_unitary(cirq.CSWAP)
 
 
 def test_str():

--- a/cirq/testing/__init__.py
+++ b/cirq/testing/__init__.py
@@ -15,8 +15,10 @@
 """Utilities for testing code."""
 
 from cirq.testing.circuit_compare import (
-    assert_apply_unitary_to_tensor_is_consistent_with_unitary,
     assert_circuits_with_terminal_measurements_are_equivalent,
+    assert_eigen_gate_has_consistent_apply_unitary,
+    assert_has_consistent_apply_unitary_for_various_exponents,
+    assert_has_consistent_apply_unitary,
     assert_has_diagram,
     assert_same_circuits,
     highlight_text_differences,

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterable, Optional, Sequence, TYPE_CHECKING
+from typing import Any, Iterable, Optional, Sequence, TYPE_CHECKING, Type
 
 from collections import defaultdict
 import itertools
 import numpy as np
 
-from cirq import circuits, ops, linalg, protocols
+from cirq import circuits, ops, linalg, protocols, value, EigenGate
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -245,6 +245,113 @@ def assert_has_diagram(
     )
 
 
+def assert_has_consistent_apply_unitary(
+        val: Any,
+        *,
+        qubit_count: Optional[int] = None) -> None:
+    """Tests whether a value's _apply_unitary_to_tensor_ is correct.
+
+    Contrasts the effects of the value's `_apply_unitary_to_tensor_` with the
+    matrix returned by the value's `_unitary_` method.
+
+    Args:
+        val: The value under test. Should have a `__pow__` method.
+        qubit_count: Usually inferred. The number of qubits the value acts on.
+            This argument isn't needed if the gate has a unitary matrix or
+            implements `cirq.SingleQubitGate`/`cirq.TwoQubitGate`/
+            `cirq.ThreeQubitGate`.
+    """
+
+    expected = protocols.unitary(val, default=None)
+    if qubit_count is not None:
+        n = qubit_count
+    elif expected is not None:
+        n = expected.shape[0].bit_length() - 1
+    else:
+        n = _infer_qubit_count(val)
+
+    eye = np.eye(2 << n, dtype=np.complex128).reshape((2,) * (2 * n + 2))
+    actual = protocols.apply_unitary_to_tensor(
+        val=val,
+        target_tensor=eye,
+        available_buffer=np.ones_like(eye) * float('nan'),
+        axes=list(range(1, n + 1)),
+        default=None)
+
+    # If you don't have a unitary, you shouldn't be able to apply a unitary.
+    if expected is None:
+        assert actual is None
+    else:
+        expected = np.kron(np.eye(2), expected)
+
+    # If you applied a unitary, it should match the one you say you have.
+    if actual is not None:
+        np.testing.assert_allclose(
+            actual.reshape(2 << n, 2 << n),
+            expected)
+
+
+def assert_eigen_gate_has_consistent_apply_unitary(
+        eigen_gate_type: Type[EigenGate],
+        *,
+        exponents=(1, -0.5, 0.5, 0.25, -0.25, 0.1, -1, value.Symbol('s')),
+        global_shifts=(0, 0.5, -0.5),
+        qubit_count: Optional[int] = None) -> None:
+    """Tests whether an EigenGate type's _apply_unitary_to_tensor_ is correct.
+
+    Contrasts the effects of the gate's `_apply_unitary_to_tensor_` with the
+    matrix returned by the gate's `_unitary_` method, trying various values for
+    the gate exponent and global shift.
+
+    Args:
+        eigen_gate_type: The type of gate to test. The type must have an
+            __init__ method that takes an exponent and a global_shift.
+        exponents: The exponents to try. Defaults to a variety of special and
+            arbitrary angles, as well as a parameterized angle (a symbol).
+        global_shifts: The global shifts to try. Defaults to a variety of
+            special angles.
+        qubit_count: The qubit count to use for the gate. This argument isn't
+            needed if the gate has a unitary matrix or implements
+            `cirq.SingleQubitGate`/`cirq.TwoQubitGate`/`cirq.ThreeQubitGate`; it
+            will be inferred.
+    """
+    for exponent in exponents:
+        for shift in global_shifts:
+            assert_has_consistent_apply_unitary(
+                eigen_gate_type(exponent=exponent, global_shift=shift),
+                qubit_count=qubit_count)
+
+
+def assert_has_consistent_apply_unitary_for_various_exponents(
+        val: Any,
+        *,
+        exponents=(1, -0.5, 0.5, 0.25, -0.25, 0.1, value.Symbol('s')),
+        qubit_count: Optional[int] = None) -> None:
+    """Tests whether a value's _apply_unitary_to_tensor_ is correct.
+
+    Contrasts the effects of the value's `_apply_unitary_to_tensor_` with the
+    matrix returned by the value's `_unitary_` method. Attempts this after
+    attempting to raise the value to several exponents.
+
+    Args:
+        val: The value under test. Should have a `__pow__` method.
+        exponents: The exponents to try. Defaults to a variety of special and
+            arbitrary angles, as well as a parameterized angle (a symbol). If
+            the value's `__pow__` returns `NotImplemented` for any of these,
+            they are skipped.
+        qubit_count: A minimum qubit count for the test system. This argument
+            isn't needed if the gate has a unitary matrix or implements
+            `cirq.SingleQubitGate`/`cirq.TwoQubitGate`/`cirq.ThreeQubitGate`; it
+            will be inferred.
+    """
+    for exponent in exponents:
+        gate = protocols.pow(val, exponent, default=None)
+        if gate is not None:
+            assert_has_consistent_apply_unitary(
+                gate,
+                qubit_count=qubit_count)
+
+
 def _infer_qubit_count(val: Any) -> int:
     if isinstance(val, ops.Operation):
         return len(val.qubits)
@@ -257,35 +364,5 @@ def _infer_qubit_count(val: Any) -> int:
     if isinstance(val, ops.ControlledGate):
         return 1 + _infer_qubit_count(val.sub_gate)
     raise NotImplementedError(
-        'Failed to infer qubit count of <{!r}>. Specify it.'.format(val))
-
-
-def assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        val: Any,
-        exponents: Sequence[Any] = (1,),
-        qubit_count: Optional[int] = None) -> None:
-
-    n = qubit_count if qubit_count is not None else _infer_qubit_count(val)
-
-    for exponent in exponents:
-        val_exp = val if exponent == 1 else val**exponent
-        eye = np.eye(2 << n, dtype=np.complex128).reshape((2,) * (2 * n + 2))
-        actual = protocols.apply_unitary_to_tensor(
-            val=val_exp,
-            target_tensor=eye,
-            available_buffer=np.ones_like(eye) * float('nan'),
-            axes=list(range(n)),
-            default=None)
-        expected = protocols.unitary(val_exp, default=None)
-
-        # If you don't have a unitary, you shouldn't be able to apply a unitary.
-        if expected is None:
-            assert actual is None
-        else:
-            expected = np.kron(expected, np.eye(2))
-
-        # If you applied a unitary, it should match the one you say you have.
-        if actual is not None:
-            np.testing.assert_allclose(
-                actual.reshape(2 << n, 2 << n),
-                expected)
+        'Failed to infer qubit count of <{!r}>. Specify it.'.format(
+            val))

--- a/cirq/testing/circuit_compare_test.py
+++ b/cirq/testing/circuit_compare_test.py
@@ -327,9 +327,8 @@ def test_assert_apply_unitary_to_tensor_is_consistent_with_unitary():
             return np.eye(2)
 
     with pytest.raises(AssertionError):
-        cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-            IdentityReturningUnalteredWorkspace(),
-            qubit_count=1)
+        cirq.testing.assert_has_consistent_apply_unitary(
+            IdentityReturningUnalteredWorkspace())
 
     class DifferentEffect:
         def _apply_unitary_to_tensor_(self,
@@ -344,11 +343,10 @@ def test_assert_apply_unitary_to_tensor_is_consistent_with_unitary():
             return np.eye(2, dtype=np.complex128)
 
     with pytest.raises(AssertionError):
-        cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-            DifferentEffect(),
-            qubit_count=1)
+        cirq.testing.assert_has_consistent_apply_unitary(
+            DifferentEffect())
 
-    class SameEffect:
+    class IgnoreAxisEffect:
         def _apply_unitary_to_tensor_(self,
                                       target_tensor: np.ndarray,
                                       available_buffer: np.ndarray,
@@ -360,9 +358,26 @@ def test_assert_apply_unitary_to_tensor_is_consistent_with_unitary():
         def _unitary_(self):
             return np.array([[0, 1], [1, 0]])
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        SameEffect(),
-        qubit_count=1)
+    with pytest.raises(AssertionError, match='Not equal'):
+        cirq.testing.assert_has_consistent_apply_unitary(
+            IgnoreAxisEffect())
+
+    class SameEffect:
+        def _apply_unitary_to_tensor_(self,
+                                      target_tensor: np.ndarray,
+                                      available_buffer: np.ndarray,
+                                      axes: Sequence[int]) -> np.ndarray:
+            o = cirq.slice_for_qubits_equal_to(axes, 0)
+            i = cirq.slice_for_qubits_equal_to(axes, 1)
+            available_buffer[o] = target_tensor[i]
+            available_buffer[i] = target_tensor[o]
+            return available_buffer
+
+        def _unitary_(self):
+            return np.array([[0, 1], [1, 0]])
+
+    cirq.testing.assert_has_consistent_apply_unitary(
+        SameEffect())
 
     class BadExponent:
         def __init__(self, power):
@@ -375,18 +390,18 @@ def test_assert_apply_unitary_to_tensor_is_consistent_with_unitary():
                                       target_tensor: np.ndarray,
                                       available_buffer: np.ndarray,
                                       axes: Sequence[int]) -> np.ndarray:
-            target_tensor[1] *= self.power * 2
+            i = cirq.slice_for_qubits_equal_to(axes, 1)
+            target_tensor[i] *= self.power * 2
             return target_tensor
 
         def _unitary_(self):
             return np.array([[1, 0], [0, 2]])
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
-        BadExponent(1),
-        qubit_count=1)
+    cirq.testing.assert_has_consistent_apply_unitary(
+        BadExponent(1))
 
     with pytest.raises(AssertionError):
-        cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+        cirq.testing.assert_has_consistent_apply_unitary_for_various_exponents(
             BadExponent(1),
             exponents=[1, 2],
             qubit_count=1)
@@ -399,7 +414,7 @@ def test_assert_apply_unitary_to_tensor_is_consistent_with_unitary():
             return target_tensor
 
     with pytest.raises(AssertionError):
-        cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+        cirq.testing.assert_has_consistent_apply_unitary(
             EffectWithoutUnitary(),
             qubit_count=1)
 
@@ -410,23 +425,23 @@ def test_assert_apply_unitary_to_tensor_is_consistent_with_unitary():
                                       axes: Sequence[int]) -> np.ndarray:
             return NotImplemented
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+    cirq.testing.assert_has_consistent_apply_unitary(
         NoEffect(),
         qubit_count=1)
 
     class UnknownCountEffect:
         pass
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+    cirq.testing.assert_has_consistent_apply_unitary(
         UnknownCountEffect(),
         qubit_count=1)
 
     with pytest.raises(NotImplementedError):
-        cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+        cirq.testing.assert_has_consistent_apply_unitary(
             UnknownCountEffect())
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+    cirq.testing.assert_has_consistent_apply_unitary(
         cirq.X)
 
-    cirq.testing.assert_apply_unitary_to_tensor_is_consistent_with_unitary(
+    cirq.testing.assert_has_consistent_apply_unitary(
         cirq.X.on(cirq.NamedQubit('q')))


### PR DESCRIPTION
- the variant `assert_has_consistent_apply_unitary` with no 'try multiple values' arguments
- the variant `assert_has_consistent_apply_unitary_for_various_exponents` that raises the value under test to various powers while testing
- the variant `assert_eigen_gate_has_consistent_apply_unitary` which raises to various exponents and adds various global shifts while testing
- fixed XPowGate and ZPowGate not accounting for global shift when applying their unitaries

Fixes https://github.com/quantumlib/Cirq/issues/1135