### PR TITLE
_unitary_() init for qasm_output.py

### DIFF
--- a/cirq/circuits/qasm_output.py
+++ b/cirq/circuits/qasm_output.py
@@ -62,9 +62,9 @@ class QasmUGate(ops.SingleQubitGate):
                                                    self.phi)
 
     def _unitary_(self) -> np.ndarray:
-        rz_phi_matrix = cirq.unitary(cirq.Rz(self.phi))
-        ry_theta_matrix = cirq.unitary(cirq.Ry(self.theta))
-        rz_lmda_matrix = cirq.unitary(cirq.Rz(self.lmda))
+        rz_phi_matrix = cirq.unitary(cirq.Rz(self.phi * np.pi))
+        ry_theta_matrix = cirq.unitary(cirq.Ry(self.theta * np.pi))
+        rz_lmda_matrix = cirq.unitary(cirq.Rz(self.lmda * np.pi))
         return rz_phi_matrix.dot(ry_theta_matrix.dot(rz_lmda_matrix))
 
 

--- a/cirq/circuits/qasm_output_test.py
+++ b/cirq/circuits/qasm_output_test.py
@@ -35,6 +35,18 @@ def test_qasm_two_qubit_gate_repr():
         cirq.testing.random_unitary(4)))
 
 
+def test_qasm_u_qubit_gate_unitary():
+    u = cirq.testing.random_unitary(2)
+    g = QasmUGate.from_matrix(u)
+    np.testing.assert_allclose(cirq.unitary(g), u)
+
+
+def test_qasm_two_qubit_gate_unitary():
+    u = cirq.testing.random_unitary(4)
+    g = QasmTwoQubitGate.from_matrix(u)
+    np.testing.assert_allclose(cirq.unitary(g), u)
+
+
 def test_empty_circuit():
     q0, = _make_qubits(1)
     output = cirq.QasmOutput((), (q0,))
@@ -464,9 +476,3 @@ measure q[3] -> m_multi[2];
 // Operation: DummyCompositeOperation()
 x q[0];
 """))
-
-
-def test_qasm_two_qubit_gate_unitary():
-    u = cirq.testing.random_unitary(4)
-    g = QasmTwoQubitGate.from_matrix(u)
-    np.testing.assert_allclose(cirq.unitary(g), u)


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/1139

@Strilanc I don't think my implementation of `_unitary_` for QasmTwoQubitGate is correct as I tried to implement a test for CNOT, but it's not passing. Used: https://arxiv.org/pdf/quant-ph/0507171.pdf as a reference. Is it the test or the implementation?