### PR TITLE
Fix produce-package.sh including spurious files

### DIFF
--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -17,8 +17,12 @@
 ################################################################################
 # Produces wheels that can be uploaded to the pypi package repository.
 #
+# First argument must be the output directory. Second argument is an optional
+# version specifier. If not set, the version from `cirq/_version.py` is used.
+# If set, it overwrites `cirq/_version.py`.
+#
 # Usage:
-#     dev_tools/packaging/produce-package.sh output_dir
+#     dev_tools/packaging/produce-package.sh output_dir [version]
 ################################################################################
 
 set -e
@@ -29,23 +33,39 @@ if [ -z "${1}" ]; then
 fi
 out_dir=$(realpath "${1}")
 
+SPECIFIED_VERSION="${2}"
+
 # Get the working directory to the repo root.
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 repo_dir=$(git rev-parse --show-toplevel)
 cd ${repo_dir}
 
+# Make a clean copy of HEAD, without files ignored by git (but potentially kept by setup.py).
+if [ ! -z "$(git status --short)" ]; then
+    echo -e "\e[31mWARNING: You have uncommitted changes. They won't be included in the package.\e[0m"
+fi
+tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
+trap "{ rm -rf ${tmp_git_dir}; }" EXIT
+cd "${tmp_git_dir}"
+git init --quiet
+git fetch ${repo_dir} HEAD --quiet --depth=1
+git checkout FETCH_HEAD -b work --quiet
+if [ ! -z "${SPECIFIED_VERSION}" ]; then
+    echo '__version__ = "'"${SPECIFIED_VERSION}"'"' > "${tmp_git_dir}/cirq/_version.py"
+fi
+
+# Python 3 wheel.
 echo "Producing python 3 package files..."
 python3 setup.py -q bdist_wheel -d "${out_dir}"
 
+# Python 2 wheel.
 echo "Generating python 2.7 source..."
 tmp_py2_dir=$(mktemp -d "/tmp/produce-package-py2.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_py2_dir}; }" EXIT
-rmdir "${tmp_py2_dir}"
-bash dev_tools/python2.7-generate.sh "${tmp_py2_dir}" "${repo_dir}"
-
+"${tmp_git_dir}/dev_tools/python2.7-generate.sh" "${tmp_py2_dir}/py2" "${tmp_git_dir}"
 echo "Producing python 2.7 package files..."
-export PYTHONPATH=${tmp_py2_dir}
-cd "${tmp_py2_dir}"
+export PYTHONPATH="${tmp_py2_dir}/py2"
+cd "${tmp_py2_dir}/py2"
 python2 setup.py -q bdist_wheel -d "${out_dir}"
 
 ls "${out_dir}"

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -104,17 +104,11 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd "$(git rev-parse --show-toplevel)"
 
 # Temporary workspace.
-tmp_src_dir=$(mktemp -d "/tmp/publish-dev-package_source.XXXXXXXXXXXXXXXX")
 tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
-trap "{ rm -rf ${tmp_src_dir}; }" EXIT
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 
-# Make a temporary copy of the source with an updated version.
-cp -r . "${tmp_src_dir}/src"
-echo '__version__ = "'"${UPLOAD_VERSION}"'"' > "${tmp_src_dir}/src/cirq/_version.py"
-
 # Produce packages.
-"${tmp_src_dir}/src/dev_tools/packaging/produce-package.sh" "${tmp_package_dir}"
+dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"
 twine upload --username="${USERNAME}" --password="${PASSWORD}" ${PYPI_REPOSITORY_FLAG} "${tmp_package_dir}/*"
 
 echo -e "\e[32mUploaded package with version ${UPLOAD_VERSION} to ${PYPI_REPO_NAME} pypi repository\e[0m"


### PR DESCRIPTION
- In particular, python setup.py was producing a 'BUILD' directory and later runs were including those old build files
- Version changing shenanigans are now done in produce-package instead of in publish-dev-package