### PR TITLE
Fix bug when multiple qubits are measured in sparse simulator

### DIFF
--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -200,7 +200,7 @@ class Simulator(simulator.SimulatesSamples,
                                                                      state)
                         corrected = [bit ^ mask for bit, mask in
                                      zip(bits, invert_mask)]
-                        measurements[cast(str, gate.key)].append(*corrected)
+                        measurements[cast(str, gate.key)].extend(corrected)
                 else:
                     result = protocols.apply_unitary_to_tensor(op,
                                                                state,

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -129,6 +129,20 @@ def test_run_correlations(dtype):
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
+def test_run_measure_multiple_qubits(dtype):
+    q0, q1 = cirq.LineQubit.range(2)
+    simulator = cirq.Simulator(dtype=dtype)
+    for b0 in [0, 1]:
+        for b1 in [0, 1]:
+            circuit = cirq.Circuit.from_ops((cirq.X**b0)(q0),
+                                            (cirq.X**b1)(q1),
+                                            cirq.measure(q0, q1))
+            result = simulator.run(circuit, repetitions=3)
+            np.testing.assert_equal(result.measurements,
+                                    {'0,1': [[b0, b1]] * 3})
+
+
+@pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
 def test_run_sweeps_param_resolvers(dtype):
     q0, q1 = cirq.LineQubit.range(2)
     simulator = cirq.Simulator(dtype=dtype)
@@ -253,6 +267,20 @@ def test_simulate_param_resolver(dtype):
                                     np.reshape(expected_state, 4))
             assert result.params == resolver
             assert len(result.measurements) == 0
+
+
+@pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
+def test_simulate_measure_multiple_qubits(dtype):
+    q0, q1 = cirq.LineQubit.range(2)
+    simulator = cirq.Simulator(dtype=dtype)
+    for b0 in [0, 1]:
+        for b1 in [0, 1]:
+            circuit = cirq.Circuit.from_ops((cirq.X**b0)(q0),
+                                            (cirq.X**b1)(q1),
+                                            cirq.measure(q0, q1))
+            result = simulator.simulate(circuit)
+            np.testing.assert_equal(result.measurements,
+                                    {'0,1': [b0, b1]})
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])


### PR DESCRIPTION
Doh: append(*list) works when the list is length one but not really what was wanted.

Fixes https://github.com/quantumlib/Cirq/issues/1152