### PR TITLE
Add contrib requirements to preparing test environment

### DIFF
--- a/dev_tools/env_tools.py
+++ b/dev_tools/env_tools.py
@@ -117,13 +117,18 @@ def prepare_temporary_test_environment(
     base_path = cast(str, env.destination_directory)
     env_path = os.path.join(base_path, env_name)
     req_path = os.path.join(base_path, 'requirements.txt')
-    req_path_2 = os.path.join(base_path,
-                              'dev_tools',
-                              'conf',
-                              'pip-list-dev-tools.txt')
+    dev_req_path = os.path.join(base_path,
+                                'dev_tools',
+                                'conf',
+                                'pip-list-dev-tools.txt')
+    contrib_rev_path = os.path.join(base_path,
+                                    'cirq',
+                                    'contrib',
+                                    'contrib-requirements.txt')
+    rev_paths = [req_path, dev_req_path, contrib_rev_path]
     create_virtual_env(venv_path=env_path,
                        python_path=python_path,
-                       requirements_paths=[req_path, req_path_2],
+                       requirements_paths=rev_paths,
                        verbose=verbose)
 
     return PreparedEnv(github_repo=env.repository,


### PR DESCRIPTION
Check.sh was not consistent with travis config.

This unfortunately adds an install of tensorflow to check.sh,

Fixes #1168 