### PR TITLE
Extract class equality protocol out of value equality.

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -219,6 +219,8 @@ from cirq.value import (
     canonicalize_half_turns,
     chosen_angle_to_canonical_half_turns,
     chosen_angle_to_half_turns,
+    class_equality,
+    class_equals,
     Duration,
     Symbol,
     Timestamp,

--- a/cirq/value/__init__.py
+++ b/cirq/value/__init__.py
@@ -17,6 +17,10 @@ from cirq.value.angle import (
     chosen_angle_to_canonical_half_turns,
     chosen_angle_to_half_turns,
 )
+from cirq.value.class_equality import (
+    class_equality,
+    class_equals,
+)
 from cirq.value.duration import (
     Duration,
 )

--- a/cirq/value/class_equality.py
+++ b/cirq/value/class_equality.py
@@ -1,0 +1,120 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Defines `@cirq.class_equality`, for `class_euqals` support."""
+
+from typing import Any, Callable, Union, overload
+
+from typing_extensions import Protocol
+
+
+class _SupportsClassEquality(Protocol):
+    """An object decorated with the class equality values decorator."""
+
+    def _class_equality_values_(self) -> Any:
+        """Automatically implemented by the `cirq.class_equality` decorator.
+
+        This method encodes the logic used to determine whether different types
+        are considered to be note equal. By default, this returns the decorated
+        type. But there is an option (`distinct_child_types`) to make it return
+        `type(self)` instead.
+
+        Returns:
+            Type used when determining if the receiving object is equal to
+            another object.
+        """
+        pass
+
+
+def class_equals(a: Any, b: Any) -> bool:
+    """
+    Compares if two classes are type equivalent.
+
+    Both `a` and `b` must implement `_SupportsClassEquality` protocol which is
+    implemented by `class_equality` or `value_equality` decorator.
+
+    Args:
+        a: First value to compare.
+        b: Second value to compare.
+
+    Returns:
+        True if classes are type equivalent, False otherwise. `NotImplemented`
+        is returned if either class does not support `_SupportsClassEquality`
+        protocol.
+    """
+    a_getter = getattr(a, '_class_equality_values_', None)
+    if a_getter is None:
+        return NotImplemented
+    cls_a = a_getter()
+
+    b_getter = getattr(b, '_class_equality_values_', None)
+    if b_getter is None:
+        return NotImplemented
+    cls_b = b_getter()
+
+    return cls_a == cls_b
+
+
+# pylint: disable=function-redefined
+@overload
+def class_equality(cls: type, *, distinct_child_types: bool = False) -> type:
+    pass
+
+
+@overload
+def class_equality(*,
+                   distinct_child_types: bool = False
+                   ) -> Callable[[type], type]:
+    pass
+
+
+def class_equality(cls: type = None,
+                   *,
+                   distinct_child_types: bool = False
+                   ) -> Union[Callable[[type], type], type]:
+    """Implements `_class_equality_values_` method.
+
+    Exposes correct type of the decorated class which can be used as a part of
+    equality check through `class_equals` function.
+
+    Child types of the decorated type will be considered equal to each other,
+    though this behavior can be changed via the `distinct_child_types` argument.
+    The type logic is implemented behind the scenes by a
+    `_class_equality_values_` method added to the class.
+
+    Args:
+        cls: The type to decorate. Automatically passed in by python when using
+            the @cirq.class_equality decorator notation on a class.
+        distinct_child_types: When set, classes that inherit from the decorated
+            class will not be considered equal to it. Also, different child
+            classes will not be considered equal to each other. Useful for when
+            the decorated class is an abstract class or trait that is helping to
+            define equality for many conceptually distinct concrete classes.
+    """
+
+    # If keyword arguments were specified, python invokes the decorator method
+    # without a `cls` argument, then passes `cls` into the result.
+    if cls is None:
+        return lambda deferred_cls: class_equality(
+            deferred_cls,
+            distinct_child_types=distinct_child_types)
+
+    if distinct_child_types:
+        setattr(cls, '_class_equality_values_', lambda self: type(self))
+    else:
+        setattr(cls, '_class_equality_values_', lambda self: cls)
+
+    return cls
+# pylint: enable=function-redefined

--- a/cirq/value/class_equality_test.py
+++ b/cirq/value/class_equality_test.py
@@ -1,0 +1,80 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+
+
+@cirq.class_equality
+class BasicC:
+    pass
+
+
+@cirq.class_equality
+class BasicD:
+    pass
+
+
+class BasicE:
+    pass
+
+
+class BasicCa(BasicC):
+    pass
+
+
+class BasicCb(BasicC):
+    pass
+
+
+def test_class_equality_basic():
+
+    # Class equality works as expected.
+    assert cirq.class_equals(BasicC(), BasicC()) is True
+    assert cirq.class_equals(BasicC(), BasicCa()) is True
+    assert cirq.class_equals(BasicCa(), BasicC()) is True
+    assert cirq.class_equals(BasicCa(), BasicCa()) is True
+    assert cirq.class_equals(BasicCa(), BasicCb()) is True
+    assert cirq.class_equals(BasicC(), BasicD()) is False
+    assert cirq.class_equals(BasicC(), BasicE()) is NotImplemented
+    assert cirq.class_equals(BasicE(), BasicC()) is NotImplemented
+
+
+@cirq.class_equality(distinct_child_types=True)
+class DistinctC:
+    pass
+
+
+@cirq.class_equality(distinct_child_types=True)
+class DistinctD:
+    pass
+
+
+class DistinctCa(DistinctC):
+    pass
+
+
+class DistinctCb(DistinctC):
+    pass
+
+
+def test_value_equality_distinct_child_types():
+
+    # Distinct class equality works as expected.
+    assert cirq.class_equals(DistinctC(), DistinctC()) is True
+    assert cirq.class_equals(DistinctC(), DistinctCa()) is False
+    assert cirq.class_equals(DistinctCa(), DistinctC()) is False
+    assert cirq.class_equals(DistinctCa(), DistinctCa()) is True
+    assert cirq.class_equals(DistinctCa(), DistinctCb()) is False
+    assert cirq.class_equals(DistinctC(), DistinctD()) is False
+


### PR DESCRIPTION
Primarily exposes cirq.class_equals method which works on classes that support `_SupportsClassEquality` protocol that is implemented through `@cirq.class_equality decorator`. This functionality was already present but it was internal to `@cirq.value_equality` decorator.

This refactoring allows the `cirq.class_equals` to be used as an utility function in other comparison operators (like approximate equality) which is external to @cirq.value_equality and custom to the implementing class.

Note that in the process of refactoring an `isinstance` check was dropped. This makes equality comparator symmetric.