### PR TITLE
Add readthedocs build badge and fix requirements file path

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,4 @@
-requirements_file: docs/requirements.txt
+requirements_file: dev_tools/conf/pip-list-dev-tools.txt
 build:
   image: latest
 python:

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ circuits and running them against quantum computers and simulators.
 .. image:: https://badge.fury.io/py/cirq.svg
     :target: https://badge.fury.io/py/cirq
 
+.. image:: https://readthedocs.org/projects/cirq/badge/?version=master
+    :target: https://cirq.readthedocs.io/en/master/?badge=master
+    :alt: Documentation Status
+
 Installation
 ------------
 


### PR DESCRIPTION
Documentation build on readthedocs has been failing for awhile... maybe this badge will help.