### PR TITLE
Add option to skip cleanup in two qubit decomposition

### DIFF
--- a/cirq/google/convert_to_xmon_gates.py
+++ b/cirq/google/convert_to_xmon_gates.py
@@ -57,7 +57,8 @@ class ConvertToXmonGates(PointOptimizer):
                 op.qubits[0],
                 op.qubits[1],
                 mat,
-                allow_partial_czs=True)
+                allow_partial_czs=True,
+                clean_operations=False)
 
         return NotImplemented
 

--- a/cirq/optimizers/merge_interactions.py
+++ b/cirq/optimizers/merge_interactions.py
@@ -72,7 +72,8 @@ class MergeInteractions(circuits.PointOptimizer):
                 op.qubits[1],
                 matrix,
                 self.allow_partial_czs,
-                self.tolerance))
+                self.tolerance,
+                False))
         new_interaction_count = len([new_op for new_op in new_operations
                                      if len(new_op.qubits) == 2])
 

--- a/cirq/optimizers/two_qubit_decompositions.py
+++ b/cirq/optimizers/two_qubit_decompositions.py
@@ -31,7 +31,8 @@ def two_qubit_matrix_to_operations(q0: ops.QubitId,
                                    q1: ops.QubitId,
                                    mat: np.ndarray,
                                    allow_partial_czs: bool,
-                                   tolerance: float = 1e-8
+                                   tolerance: float = 1e-8,
+                                   clean_operations: bool = False,
                                    ) -> List[ops.Operation]:
     """Decomposes a two-qubit operation into Z/XY/CZ gates.
 
@@ -42,6 +43,8 @@ def two_qubit_matrix_to_operations(q0: ops.QubitId,
         allow_partial_czs: Enables the use of Partial-CZ gates.
         tolerance: A limit on the amount of error introduced by the
             construction.
+        clean_operations: Enables optimizing resulting operation list by
+            merging operations and ejecting phased Paulis and Z operations.
 
     Returns:
         A list of operations implementing the matrix.
@@ -49,7 +52,10 @@ def two_qubit_matrix_to_operations(q0: ops.QubitId,
     kak = linalg.kak_decomposition(mat, linalg.Tolerance(atol=tolerance))
     operations = _kak_decomposition_to_operations(
         q0, q1, kak, allow_partial_czs, tolerance)
-    return _cleanup_operations(operations)
+    if clean_operations:
+        return _cleanup_operations(operations)
+    else:
+        return operations
 
 
 def _xx_interaction_via_full_czs(q0: ops.QubitId,

--- a/cirq/optimizers/two_qubit_decompositions.py
+++ b/cirq/optimizers/two_qubit_decompositions.py
@@ -32,7 +32,7 @@ def two_qubit_matrix_to_operations(q0: ops.QubitId,
                                    mat: np.ndarray,
                                    allow_partial_czs: bool,
                                    tolerance: float = 1e-8,
-                                   clean_operations: bool = False,
+                                   clean_operations: bool = True,
                                    ) -> List[ops.Operation]:
     """Decomposes a two-qubit operation into Z/XY/CZ gates.
 

--- a/cirq/optimizers/two_qubit_decompositions_test.py
+++ b/cirq/optimizers/two_qubit_decompositions_test.py
@@ -200,7 +200,8 @@ def test_kak_decomposition_depth_full_cz():
 
     # Random.
     u = cirq.testing.random_unitary(4)
-    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, False)
+    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, False,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_full)
     # 3 CZ, 3+1 PhasedX, 1 Z
     assert len(c) <= 8
@@ -208,21 +209,32 @@ def test_kak_decomposition_depth_full_cz():
     # Double-axis interaction.
     u = cirq.unitary(cirq.Circuit.from_ops(cirq.CNOT(a, b),
                                            cirq.CNOT(b, a)))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 2 CZ, 2+1 PhasedX, 1 Z
     assert len(c) <= 6
 
+    # Test unoptimized/un-cleaned length of Double-axis interaction.
+    u = cirq.unitary(cirq.Circuit.from_ops(cirq.CNOT(a, b),
+                                           cirq.CNOT(b, a)))
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
+                                                               1e-8, False)
+    c = cirq.Circuit.from_ops(operations_with_part)
+    assert len(c) > 6 # Length should be 13 with extra Pauli gates
+
     # Partial single-axis interaction.
     u = cirq.unitary(cirq.CNOT**0.1)
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 2 CZ, 2+1 PhasedX, 1 Z
     assert len(c) <= 6
 
     # Full single-axis interaction.
     u = cirq.unitary(cirq.ControlledGate(cirq.Y))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 1 CZ, 1+1 PhasedX, 1 Z
     assert len(c) <= 4
@@ -233,7 +245,8 @@ def test_kak_decomposition_depth_partial_cz():
 
     # Random.
     u = cirq.testing.random_unitary(4)
-    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, True)
+    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, True,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_full)
     # 3 CP, 3+1 PhasedX, 1 Z
     assert len(c) <= 8
@@ -241,21 +254,24 @@ def test_kak_decomposition_depth_partial_cz():
     # Double-axis interaction.
     u = cirq.unitary(cirq.Circuit.from_ops(cirq.CNOT(a, b),
                                            cirq.CNOT(b, a)))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 2 CP, 2+1 PhasedX, 1 Z
     assert len(c) <= 6
 
     # Partial single-axis interaction.
     u = cirq.unitary(cirq.CNOT**0.1)
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 1 CP, 1+1 PhasedX, 1 Z
     assert len(c) <= 4
 
     # Full single-axis interaction.
     u = cirq.unitary(cirq.ControlledGate(cirq.Y))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True,
+                                                               1e-8, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 1 CP, 1+1 PhasedX, 1 Z
     assert len(c) <= 4

--- a/cirq/optimizers/two_qubit_decompositions_test.py
+++ b/cirq/optimizers/two_qubit_decompositions_test.py
@@ -200,8 +200,7 @@ def test_kak_decomposition_depth_full_cz():
 
     # Random.
     u = cirq.testing.random_unitary(4)
-    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, False,
-                                                               1e-8, True)
+    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, False)
     c = cirq.Circuit.from_ops(operations_with_full)
     # 3 CZ, 3+1 PhasedX, 1 Z
     assert len(c) <= 8
@@ -209,8 +208,7 @@ def test_kak_decomposition_depth_full_cz():
     # Double-axis interaction.
     u = cirq.unitary(cirq.Circuit.from_ops(cirq.CNOT(a, b),
                                            cirq.CNOT(b, a)))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
-                                                               1e-8, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 2 CZ, 2+1 PhasedX, 1 Z
     assert len(c) <= 6
@@ -225,16 +223,14 @@ def test_kak_decomposition_depth_full_cz():
 
     # Partial single-axis interaction.
     u = cirq.unitary(cirq.CNOT**0.1)
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
-                                                               1e-8, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 2 CZ, 2+1 PhasedX, 1 Z
     assert len(c) <= 6
 
     # Full single-axis interaction.
     u = cirq.unitary(cirq.ControlledGate(cirq.Y))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False,
-                                                               1e-8, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, False)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 1 CZ, 1+1 PhasedX, 1 Z
     assert len(c) <= 4
@@ -245,8 +241,7 @@ def test_kak_decomposition_depth_partial_cz():
 
     # Random.
     u = cirq.testing.random_unitary(4)
-    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, True,
-                                                               1e-8, True)
+    operations_with_full = cirq.two_qubit_matrix_to_operations(a, b, u, True)
     c = cirq.Circuit.from_ops(operations_with_full)
     # 3 CP, 3+1 PhasedX, 1 Z
     assert len(c) <= 8
@@ -254,24 +249,21 @@ def test_kak_decomposition_depth_partial_cz():
     # Double-axis interaction.
     u = cirq.unitary(cirq.Circuit.from_ops(cirq.CNOT(a, b),
                                            cirq.CNOT(b, a)))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True,
-                                                               1e-8, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 2 CP, 2+1 PhasedX, 1 Z
     assert len(c) <= 6
 
     # Partial single-axis interaction.
     u = cirq.unitary(cirq.CNOT**0.1)
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True,
-                                                               1e-8, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 1 CP, 1+1 PhasedX, 1 Z
     assert len(c) <= 4
 
     # Full single-axis interaction.
     u = cirq.unitary(cirq.ControlledGate(cirq.Y))
-    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True,
-                                                               1e-8, True)
+    operations_with_part = cirq.two_qubit_matrix_to_operations(a, b, u, True)
     c = cirq.Circuit.from_ops(operations_with_part)
     # 1 CP, 1+1 PhasedX, 1 Z
     assert len(c) <= 4


### PR DESCRIPTION
_cleanup_operations seems to take up 30-40% of the time in the conversion to Xmon gates.  However, this does optimizations that are all done by later phases of the Xmon optimizer set. 

This changes the default to skip this step and adds an option to allow you to optimize the operation list if you want to anyway.  This should only affect two qubit decomposition and not the full circuit optimization, but this should be verified.
