### PR TITLE
Remove edit button from documentation

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,0 +1,3 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+{% block breadcrumbs_aside %}
+{% endblock %}


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/1197
Reference: https://github.com/rtfd/readthedocs.org/blob/master/docs/guides/remove-edit-buttons.rst