### PR TITLE
Use same type for measurement results everywhere

### DIFF
--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -487,13 +487,13 @@ def test_simulate_moment_steps_sample():
     simulator = cg.XmonSimulator()
     for step in simulator.simulate_moment_steps(circuit, qubit_order=[Q1, Q2]):
         pass
-    assert [[True]] == step.sample([Q1])
-    assert [[True, False]] == step.sample([Q1, Q2])
-    assert [[False]] == step.sample([Q2])
+    np.testing.assert_equal([[True]], step.sample([Q1]))
+    np.testing.assert_equal([[True, False]], step.sample([Q1, Q2]))
+    np.testing.assert_equal([[False]], step.sample([Q2]))
 
-    assert [[True]] * 3 == step.sample([Q1], 3)
-    assert [[True, False]] * 3 == step.sample([Q1, Q2], 3)
-    assert [[False]] * 3 == step.sample([Q2], 3)
+    np.testing.assert_equal([[True]] * 3, step.sample([Q1], 3))
+    np.testing.assert_equal([[True, False]] * 3, step.sample([Q1, Q2], 3))
+    np.testing.assert_equal([[False]] * 3, step.sample([Q2], 3))
 
 
 def compute_gate(circuit, resolver, num_qubits=1):

--- a/cirq/google/sim/xmon_stepper_test.py
+++ b/cirq/google/sim/xmon_stepper_test.py
@@ -510,9 +510,10 @@ def test_sample_little_endian(num_prefix_qubits):
             # We ask for ordering of most significant bit first. This is
             # easier to test against the natural order of itertools.product.
             results.append(s.sample_measurements([2, 1, 0]))
-        expected = [[list(x)] for x in
-                    list(itertools.product([False, True], repeat=3))]
-        assert results == expected
+        expecteds = [[list(x)] for x in
+                     list(itertools.product([False, True], repeat=3))]
+        for result, expected in zip(results, expecteds):
+            np.testing.assert_equal(result, expected)
 
 
 @pytest.mark.parametrize('num_prefix_qubits', (0, 2))
@@ -523,8 +524,8 @@ def test_sample_partial_indices(num_prefix_qubits):
         for index in range(3):
             for x in range(8):
                 s.reset_state(x)
-                assert s.sample_measurements([index]) == [[
-                    bool(1 & (x >> index))]]
+                np.testing.assert_equal(s.sample_measurements([index]),
+                                        [[bool(1 & (x >> index))]])
 
 
 @pytest.mark.parametrize('num_prefix_qubits', (0, 2))
@@ -535,7 +536,7 @@ def test_sample_partial_indices_order(num_prefix_qubits):
         for x in range(8):
             s.reset_state(x)
             expected = [[bool(1 & (x >> 2)), bool(1 & (x >> 1))]]
-            assert s.sample_measurements([2, 1]) == expected
+            np.testing.assert_equal(s.sample_measurements([2, 1]), expected)
 
 
 
@@ -548,7 +549,7 @@ def test_sample_partial_indices_all_orders(num_prefix_qubits):
             for x in range(8):
                 s.reset_state(x)
                 expected = [[bool(1 & (x >> p)) for p in perm]]
-                assert s.sample_measurements(perm) == expected
+                np.testing.assert_equal(s.sample_measurements(perm), expected)
 
 
 @pytest.mark.parametrize('num_prefix_qubits', (0, 2))
@@ -562,12 +563,13 @@ def test_sample(num_prefix_qubits):
         s.reset_state(initial_state)
         # Full sample only returns non-zero terms.
         for _ in range(10):
-            assert s.sample_measurements([2, 1, 0]) in [[[False, False, False]],
-                                                        [[False, True, False]]]
+            sample = s.sample_measurements([2, 1, 0])
+            assert (np.array_equal(sample, [[False, False, False]])
+                    or np.array_equal(sample, [[False, True, False]]))
         # Partial sample is correct.
         for _ in range(10):
-            assert s.sample_measurements([2]) == [[False]]
-            assert s.sample_measurements([0]) == [[False]]
+            np.testing.assert_equal(s.sample_measurements([2]), [[False]])
+            np.testing.assert_equal(s.sample_measurements([0]), [[False]])
 
 
 @pytest.mark.parametrize('num_prefix_qubits', (0, 2))
@@ -580,7 +582,7 @@ def test_sample_repetitions(num_prefix_qubits):
                 s.reset_state(x)
                 expected = [[bool(1 & (x >> p)) for p in perm]] * 3
                 result = s.sample_measurements(perm, repetitions=3)
-                assert result == expected
+                np.testing.assert_equal(result, expected)
 
 
 @pytest.mark.parametrize('num_prefix_qubits', (0, 2))

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -83,10 +83,9 @@ class SimulatesSamples:
             measurements = self._run(circuit=circuit,
                                      param_resolver=param_resolver,
                                      repetitions=repetitions)
-            as_array = dict((k, np.array(v)) for k, v in measurements.items())
             trial_results.append(study.TrialResult(params=param_resolver,
                                                    repetitions=repetitions,
-                                                   measurements=as_array))
+                                                   measurements=measurements))
         return trial_results
 
     @abc.abstractmethod
@@ -95,7 +94,7 @@ class SimulatesSamples:
         circuit: circuits.Circuit,
         param_resolver: study.ParamResolver,
         repetitions: int
-    ) -> Dict[str, List[np.ndarray]]:
+    ) -> Dict[str, np.ndarray]:
         """Run a simulation, mimicking quantum hardware.
 
         Args:
@@ -104,11 +103,11 @@ class SimulatesSamples:
             repetitions: Number of times to repeat the run.
 
         Returns:
-            A dictionary from measurement key to a list of lists representing
-            the results. Measurement results are a list of lists (a numpy
-            ndarray), the first list corresponding to the repetition, and the
-            second is the actual boolean measurement results (ordered by
-            the qubits acted upon by the measurement gate.)
+            A dictionary from measurement gate key to measurement
+            results. Measurement results are stored in a 2-dimensional
+            numpy array, the first dimension corresponding to the repetition
+            and the second to the actual boolean measurement results (ordered
+            by the qubits being measured.)
         """
         raise NotImplementedError()
 
@@ -531,7 +530,7 @@ class StepResult:
     def sample_measurement_ops(
             self,
             measurement_ops: List[ops.GateOperation],
-            repetitions: int = 1) -> Dict[str, List[List[bool]]]:
+            repetitions: int = 1) -> Dict[str, np.ndarray]:
         """Samples from the wave function at this point in the computation.
 
         Note that this does not collapse the wave function.
@@ -547,11 +546,11 @@ class StepResult:
                 `MeasurementGate` instances to be sampled form.
             repetitions: The number of samples to take.
 
-        Returns: A dictionary from the measurement gate keys to the measurement
-            results. These results are lists of lists, with the outer list
-            corresponding to repetitions and the inner list corresponding
-            to the qubits acted upon by the measurement operation with the
-            given key.
+        Returns: A dictionary from measurement gate key to measurement
+            results. Measurement results are stored in a 2-dimensional
+            numpy array, the first dimension corresponding to the repetition
+            and the second to the actual boolean measurement results (ordered
+            by the qubits being measured.)
 
         Raises:
             ValueError: If the operation's gates are not `MeasurementGate`
@@ -572,7 +571,7 @@ class StepResult:
             all_qubits.extend(op.qubits)
             current_index += len(op.qubits)
         indexed_sample = self.sample(all_qubits, repetitions)
-        return {k: [x[s:e] for x in indexed_sample] for k, (s, e) in
+        return {k: np.array([x[s:e] for x in indexed_sample]) for k, (s, e) in
                 bounds.items()}
 
     def dirac_notation(self, decimals: int = 2) -> str:

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -509,7 +509,7 @@ class StepResult:
     @abc.abstractmethod
     def sample(self,
                qubits: List[ops.QubitId],
-               repetitions: int = 1) -> List[List[bool]]:
+               repetitions: int = 1) -> np.ndarray:
         """Samples from the wave function at this point in the computation.
 
         Note that this does not collapse the wave function.

--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -261,7 +261,7 @@ class SimulatorStep(simulator.StepResult):
         np.copyto(self._state, update_state)
 
     def sample(self, qubits: List[ops.QubitId],
-               repetitions: int = 1) -> List[List[bool]]:
+               repetitions: int = 1) -> np.ndarray:
         indices = [self.qubit_map[qubit] for qubit in qubits]
         return wave_function.sample_state_vector(self._state, indices,
                                                  repetitions)

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -352,12 +352,13 @@ def test_simulate_moment_steps_sample(dtype):
         if i == 0:
             samples = step.sample([q0, q1], repetitions=10)
             for sample in samples:
-                assert sample == [True, False] or sample == [False, False]
+                assert (np.array_equal(sample, [True, False])
+                        or np.array_equal(sample, [False, False]))
         else:
             samples = step.sample([q0, q1], repetitions=10)
             for sample in samples:
-                assert sample == [True, True] or sample == [False, False]
-
+                assert (np.array_equal(sample, [True, True])
+                        or np.array_equal(sample, [False, False]))
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])

--- a/cirq/sim/wave_function.py
+++ b/cirq/sim/wave_function.py
@@ -230,7 +230,7 @@ def validate_normalized_state(state: np.ndarray,
 
 def sample_state_vector(state: np.ndarray,
                         indices: List[int],
-                        repetitions: int=1) -> List[List[bool]]:
+                        repetitions: int=1) -> np.ndarray:
     """Samples repeatedly from measurements in the computational basis.
 
     Note that this does not modify the passed in state.
@@ -248,7 +248,8 @@ def sample_state_vector(state: np.ndarray,
     Returns:
         Measurement results with True corresponding to the ``|1⟩`` state.
         The outer list is for repetitions, and the inner corresponds to
-        measurements ordered by the input indices.
+        measurements ordered by the supplied qubits. These lists
+        are wrapped as an numpy ndarray.
 
     Raises:
         ValueError: ``repetitions`` is less than one or size of ``state`` is not
@@ -276,7 +277,7 @@ def sample_state_vector(state: np.ndarray,
     result = np.random.choice(len(probs), size=repetitions, p=probs)
     # Convert to bools and rearrange to match repetition being the outer list.
     return np.transpose([(1 & (result >> i)).astype(np.bool) for i in
-                         range(len(indices))]).tolist()
+                         range(len(indices))])
 
 
 def measure_state_vector(

--- a/cirq/sim/wave_function_test.py
+++ b/cirq/sim/wave_function_test.py
@@ -257,23 +257,25 @@ def test_sample_state_big_endian():
         state = cirq.to_valid_state_vector(x, 3)
         sample = cirq.sample_state_vector(state, [2, 1, 0])
         results.append(sample)
-    expected = [[list(reversed(x))] for x in
-                list(itertools.product([False, True], repeat=3))]
-    assert results == expected
+    expecteds = [[list(reversed(x))] for x in
+                 list(itertools.product([False, True], repeat=3))]
+    for result, expected in zip(results, expecteds):
+        np.testing.assert_equal(result, expected)
 
 
 def test_sample_state_partial_indices():
     for index in range(3):
         for x in range(8):
             state = cirq.to_valid_state_vector(x, 3)
-            assert (cirq.sample_state_vector(state, [index])
-                    == [[bool(1 & (x >> (2 - index)))]])
+            np.testing.assert_equal(cirq.sample_state_vector(state, [index]),
+                                    [[bool(1 & (x >> (2 - index)))]])
 
 def test_sample_state_partial_indices_oder():
     for x in range(8):
         state = cirq.to_valid_state_vector(x, 3)
         expected = [[bool(1 & (x >> 0)), bool(1 & (x >> 1))]]
-        assert cirq.sample_state_vector(state, [2, 1]) == expected
+        np.testing.assert_equal(cirq.sample_state_vector(state, [2, 1]),
+                                expected)
 
 
 def test_sample_state_partial_indices_all_orders():
@@ -281,7 +283,8 @@ def test_sample_state_partial_indices_all_orders():
         for x in range(8):
             state = cirq.to_valid_state_vector(x, 3)
             expected = [[bool(1 & (x >> (2 - p))) for p in perm]]
-            assert cirq.sample_state_vector(state, perm) == expected
+            np.testing.assert_equal(cirq.sample_state_vector(state, perm),
+                                    expected)
 
 
 def test_sample_state():
@@ -289,13 +292,13 @@ def test_sample_state():
     state[0] = 1 / np.sqrt(2)
     state[2] = 1 / np.sqrt(2)
     for _ in range(10):
-        assert cirq.sample_state_vector(state, [2, 1, 0]) in [
-            [[False, False, False]],
-            [[False, True, False]]]
+        sample = cirq.sample_state_vector(state, [2, 1, 0])
+        assert (np.array_equal(sample, [[False, False, False]])
+                or np.array_equal(sample, [[False, True, False]]))
     # Partial sample is correct.
     for _ in range(10):
-        assert cirq.sample_state_vector(state, [2]) == [[False]]
-        assert cirq.sample_state_vector(state, [0]) == [[False]]
+        np.testing.assert_equal(cirq.sample_state_vector(state, [2]), [[False]])
+        np.testing.assert_equal(cirq.sample_state_vector(state, [0]), [[False]])
 
 
 def test_sample_empty_state():
@@ -315,7 +318,7 @@ def test_sample_state_repetitions():
             expected = [[bool(1 & (x >> (2 - p))) for p in perm]] * 3
 
             result = cirq.sample_state_vector(state, perm, repetitions=3)
-            assert result == expected
+            np.testing.assert_equal(result, expected)
 
 
 def test_sample_state_negative_repetitions():

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -82,10 +82,10 @@ class TrialResult:
     Attributes:
         params: A ParamResolver of settings used when sampling result.
         measurements: A dictionary from measurement gate key to measurement
-            results. Measurement results are a list of lists (a numpy ndarray),
-            the first list corresponding to the repetition, and the second is
-            the actual boolean measurement results (ordered by the qubits acted
-            the measurement gate.)
+            results. Measurement results are stored in a 2-dimensional
+            numpy array, the first dimension corresponding to the repetition
+            and the second to the actual boolean measurement results (ordered
+            by the qubits being measured.)
         repetitions: The number of times a circuit was sampled to get these
             results.
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,10 @@
 #
 from typing import List, Any
 
-import pypandoc
 import os
 import sys
+
+import pypandoc
 
 cirq_root_path = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, cirq_root_path)


### PR DESCRIPTION
Fixes #1052 

I thought it was confusing that the same concept is being represented in different places as `Dict[str, np.ndarray]`, `Dict[str, List[np.ndarray]]`, and `Dict[str, List[List[bool]]]`. Is there a reason for this?