### PR TITLE
Disable post-computation verification tasks

### DIFF
--- a/cirq/linalg/decompositions_test.py
+++ b/cirq/linalg/decompositions_test.py
@@ -35,7 +35,28 @@ CNOT = np.array([[1, 0, 0, 0],
                  [0, 0, 0, 1],
                  [0, 0, 1, 0]])
 CZ = np.diag([1, 1, 1, -1])
+TOL = cirq.Tolerance.DEFAULT
 
+
+def assert_kronecker_factorization_within_tolerance(matrix, g, f1, f2):
+    restored = g * cirq.linalg.combinators.kron(f1, f2)
+    assert not np.any(np.isnan(restored)), "NaN in kronecker product."
+    assert TOL.all_close(restored, matrix), "Can't factor kronecker product."
+
+
+def assert_kronecker_factorization_not_within_tolerance(matrix, g, f1, f2):
+    restored = g * cirq.linalg.combinators.kron(f1, f2)
+    assert (np.any(np.isnan(restored) or
+                   not TOL.all_close(restored, matrix)))
+
+def assert_magic_su2_within_tolerance(mat, a, b):
+    M = cirq.linalg.decompositions.MAGIC
+    MT = cirq.linalg.decompositions.MAGIC_CONJ_T
+    recon = cirq.linalg.combinators.dot(
+        MT,
+        cirq.linalg.combinators.kron(a, b),
+        M)
+    assert TOL.all_close(recon, mat), "Failed to decompose within tolerance."
 
 @pytest.mark.parametrize('matrix', [
     X,
@@ -83,6 +104,8 @@ def test_kron_factor(f1, f2):
     assert abs(np.linalg.det(g1) - 1) < 0.00001
     assert abs(np.linalg.det(g2) - 1) < 0.00001
     assert np.allclose(g * cirq.kron(g1, g2), p)
+    assert_kronecker_factorization_within_tolerance(
+        p, g, g1, g2)
 
 
 @pytest.mark.parametrize('f1,f2', [
@@ -97,15 +120,20 @@ def test_kron_factor_special_unitaries(f1, f2):
     assert abs(g - 1) < 0.000001
     assert cirq.is_special_unitary(g1)
     assert cirq.is_special_unitary(g2)
+    assert_kronecker_factorization_within_tolerance(
+        p, g, g1, g2)
 
 
 def test_kron_factor_fail():
+    mat = cirq.kron_with_controls(cirq.CONTROL_TAG, X)
+    g, f1, f2 = cirq.kron_factor_4x4_to_2x2s(mat)
     with pytest.raises(ValueError):
-        _ = cirq.kron_factor_4x4_to_2x2s(
-            cirq.kron_with_controls(cirq.CONTROL_TAG, X))
-
+        assert_kronecker_factorization_not_within_tolerance(
+            mat, g, f1, f2)
+    mat = cirq.kron_factor_4x4_to_2x2s(np.diag([1, 1, 1, 1j]))
     with pytest.raises(ValueError):
-        _ = cirq.kron_factor_4x4_to_2x2s(np.diag([1, 1, 1, 1j]))
+        assert_kronecker_factorization_not_within_tolerance(
+            mat, g, f1, f2)
 
 
 def recompose_so4(a: np.ndarray, b: np.ndarray) -> np.ndarray:
@@ -130,8 +158,9 @@ def recompose_so4(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     for _ in range(10)
 ])
 def test_so4_to_magic_su2s(m):
-    a, b = cirq.so4_to_magic_su2s(m)
+    a, b = cirq.so4_to_magic_su2s(m, cirq.Tolerance.DEFAULT)
     m2 = recompose_so4(a, b)
+    assert_magic_su2_within_tolerance(m2, a, b)
     assert np.allclose(m, m2)
 
 
@@ -164,7 +193,7 @@ def test_so4_to_magic_su2s_known_factors(a, b):
 ])
 def test_so4_to_magic_su2s_fail(mat):
     with pytest.raises(ValueError):
-        cirq.so4_to_magic_su2s(mat)
+        _ = cirq.so4_to_magic_su2s(mat)
 
 
 @pytest.mark.parametrize('x,y,z', [

--- a/cirq/linalg/diagonalize.py
+++ b/cirq/linalg/diagonalize.py
@@ -38,19 +38,12 @@ def diagonalize_real_symmetric_matrix(
 
     Raises:
         ValueError: Matrix isn't real symmetric.
-        ArithmeticError: Failed to meet specified tolerance.
     """
 
     if np.any(np.imag(matrix) != 0) or not predicates.is_hermitian(matrix):
         raise ValueError('Input must be real and symmetric.')
 
     _, result = np.linalg.eigh(matrix)
-
-    # Check acceptability vs tolerances.
-    if (not predicates.is_orthogonal(result, tolerance) or
-            not predicates.is_diagonal(result.T.dot(matrix).dot(result),
-                                        tolerance)):
-        raise ArithmeticError('Failed to diagonalize to specified tolerance.')
 
     return result
 
@@ -103,7 +96,6 @@ def diagonalize_real_symmetric_and_sorted_diagonal_matrices(
 
     Raises:
         ValueError: Matrices don't meet preconditions (e.g. not symmetric).
-        ArithmeticError: Failed to meet specified tolerance.
     """
 
     # Verify preconditions.
@@ -133,13 +125,6 @@ def diagonalize_real_symmetric_and_sorted_diagonal_matrices(
     for start, end in ranges:
         block = symmetric_matrix[start:end, start:end]
         p[start:end, start:end] = diagonalize_real_symmetric_matrix(block)
-
-    # Check acceptability vs tolerances.
-    if (not predicates.is_diagonal(p.T.dot(symmetric_matrix).dot(p),
-                                    tolerance) or
-            not tolerance.all_close(diagonal_matrix,
-                                    p.T.dot(diagonal_matrix).dot(p))):
-        raise ArithmeticError('Failed to diagonalize to specified tolerance.')
 
     return p
 
@@ -174,7 +159,6 @@ def bidiagonalize_real_matrix_pair_with_symmetric_products(
 
     Raises:
         ValueError: Matrices don't meet preconditions (e.g. not real).
-        ArithmeticError: Failed to meet specified tolerance.
     """
 
     if np.any(np.imag(mat1) != 0):
@@ -219,11 +203,6 @@ def bidiagonalize_real_matrix_pair_with_symmetric_products(
     left = left_adjust.T.dot(base_left.T)
     right = base_right.T.dot(right_adjust.T)
 
-    # Check acceptability vs tolerances.
-    if any(not predicates.is_diagonal(left.dot(mat).dot(right), tolerance)
-           for mat in [mat1, mat2]):
-        raise ArithmeticError('Failed to diagonalize to specified tolerance.')
-
     return left, right
 
 
@@ -243,7 +222,6 @@ def bidiagonalize_unitary_with_special_orthogonals(
 
     Raises:
         ValueError: Matrices don't meet preconditions (e.g. not real).
-        ArithmeticError: Failed to meet specified tolerance.
     """
 
     if not predicates.is_unitary(mat, tolerance):
@@ -263,9 +241,5 @@ def bidiagonalize_unitary_with_special_orthogonals(
         right[:, 0] *= -1
 
     diag = combinators.dot(left, mat, right)
-
-    # Check acceptability vs tolerances.
-    if not predicates.is_diagonal(diag, tolerance):
-        raise ArithmeticError('Failed to diagonalize to specified tolerance.')
 
     return left, np.diag(diag), right


### PR DESCRIPTION
- Disable verification tasks for decomposition and diagonalization.
- Computation for the code in issue #1071 has decreased by another
10-20% or so.

The cumulative savings of this change, in combination with the previous
fixes has decreased conversion from 2.7 seconds to 1.25 seconds and
optimization from 12.6 seconds to 5.4 seconds.