### PR TITLE
Make param_resolver and params argument default to None

### DIFF
--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -39,7 +39,7 @@ class SimulatesSamples:
     def run(
         self,
         circuit: circuits.Circuit,
-        param_resolver: study.ParamResolver = study.ParamResolver({}),
+        param_resolver: Optional[study.ParamResolver] = None,
         repetitions: int = 1,
     ) -> study.TrialResult:
         """Runs the entire supplied Circuit, mimicking the quantum hardware.
@@ -52,12 +52,14 @@ class SimulatesSamples:
         Returns:
             TrialResult for a run.
         """
-        return self.run_sweep(circuit, [param_resolver], repetitions)[0]
+        return self.run_sweep(circuit,
+                              [param_resolver or study.ParamResolver({})],
+                              repetitions)[0]
 
     def run_sweep(
         self,
         program: Union[circuits.Circuit, schedules.Schedule],
-        params: study.Sweepable = study.ParamResolver({}),
+        params: Optional[study.Sweepable] = None,
         repetitions: int = 1,
     ) -> List[study.TrialResult]:
         """Runs the entire supplied Circuit, mimicking the quantum hardware.
@@ -124,7 +126,7 @@ class SimulatesFinalWaveFunction:
     def simulate(
         self,
         circuit: circuits.Circuit,
-        param_resolver: study.ParamResolver = study.ParamResolver({}),
+        param_resolver: Optional[study.ParamResolver] = None,
         qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Union[int, np.ndarray] = 0,
     ) -> 'SimulationTrialResult':
@@ -148,14 +150,16 @@ class SimulatesFinalWaveFunction:
             SimulateTrialResults for the simulation. Includes the final wave
             function.
         """
-        return self.simulate_sweep(circuit, [param_resolver], qubit_order,
+        return self.simulate_sweep(circuit,
+                                   [param_resolver or study.ParamResolver({})],
+                                   qubit_order,
                                    initial_state)[0]
 
     @abc.abstractmethod
     def simulate_sweep(
         self,
         program: Union[circuits.Circuit, schedules.Schedule],
-        params: study.Sweepable = study.ParamResolver({}),
+        params: Optional[study.Sweepable] = None,
         qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Union[int, np.ndarray] = 0,
     ) -> List['SimulationTrialResult']:
@@ -334,7 +338,7 @@ class SimulatesIntermediateWaveFunction(SimulatesFinalWaveFunction):
     def simulate_sweep(
         self,
         program: Union[circuits.Circuit, schedules.Schedule],
-        params: study.Sweepable = study.ParamResolver({}),
+        params: Optional[study.Sweepable] = None,
         qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Union[int, np.ndarray] = 0,
     ) -> List['SimulationTrialResult']:
@@ -393,7 +397,7 @@ class SimulatesIntermediateWaveFunction(SimulatesFinalWaveFunction):
     def simulate_moment_steps(
         self,
         circuit: circuits.Circuit,
-        param_resolver: study.ParamResolver = None,
+        param_resolver: Optional[study.ParamResolver] = None,
         qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Union[int, np.ndarray] = 0
     ) -> Iterator['StepResult']:


### PR DESCRIPTION
ParamResolvers are mutable so they shouldn't be used as default arguments. This was already anticipated by existing lines such as
```
        param_resolvers = study.to_resolvers(params or study.ParamResolver({}))
```
which are present even though `params` already defaulted to `study.ParamResolver({})`.

Actually, shouldn't `params` be mandatory when using the `sweep` methods?