### PR TITLE
Add contrib requirements to dev install

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,7 @@ See the previous section for instructions.
     pip install --upgrade pip
     pip install -r requirements.txt
     pip install -r dev_tools/conf/pip-list-dev-tools.txt
+    pip install -r cirq/contrib/contrib-requirements.txt
     ```
 
     (When you later open another terminal, you can activate the virtualenv with `workon cirq-py3`.)


### PR DESCRIPTION
If you don't do this then `pytest .` fails due to tensorflow not being installed.