### PR TITLE
Install contrib deps in dev virtualenvs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,7 @@ See the previous section for instructions.
     pip install --upgrade pip
     pip install -r requirements.txt
     pip install -r dev_tools/conf/pip-list-dev-tools.txt
+    pip install -r cirq/contrib/contrib-requirements.txt
     ```
 
     (When you later open another terminal, you can activate the virtualenv with `workon cirq-py3`.)


### PR DESCRIPTION
Without these, pytest fails in a fresh virtualenv complaining about missing tensorflow:

```
Traceback:
cirq/contrib/tpu/__init__.py:75: in <module>
    from cirq.contrib.tpu.circuit_to_tensorflow import (
cirq/contrib/tpu/circuit_to_tensorflow.py:20: in <module>
    import tensorflow as tf
E   ImportError: No module named 'tensorflow'
```