### PR TITLE
Remove implicit imports from tests by adding global_vals argument to test routine

### DIFF
--- a/cirq/testing/consistent_protocols.py
+++ b/cirq/testing/consistent_protocols.py
@@ -62,8 +62,9 @@ def assert_eigengate_implements_consistent_protocols(
             0, 1, -1, 0.5, 0.25, -0.5, 0.1, value.Symbol('s')),
         global_shifts: Sequence[float] = (0, 0.5, -0.5, 0.1),
         qubit_count: Optional[int] = None,
-        setup_code: str = 'import cirq\nimport numpy as np'
-        ) -> None:
+        setup_code: str = 'import cirq\nimport numpy as np',
+        global_vals: Optional[Dict[str, Any]] = None,
+        local_vals: Optional[Dict[str, Any]] = None) -> None:
     """Checks that an EigenGate subclass is internally consistent and has a
     good __repr__."""
     for exponent in exponents:
@@ -71,7 +72,9 @@ def assert_eigengate_implements_consistent_protocols(
             _assert_meets_standards_helper(
                     eigen_gate_type(exponent=exponent, global_shift=shift),
                     qubit_count,
-                    setup_code)
+                    setup_code,
+                    global_vals,
+                    local_vals)
 
 
 def assert_eigen_shifts_is_consistent_with_eigen_components(
@@ -83,8 +86,8 @@ def _assert_meets_standards_helper(
         val: Any,
         qubit_count: Optional[int],
         setup_code: str,
-        global_vals: Optional[Dict[str, Any]] = None,
-        local_vals: Optional[Dict[str, Any]] = None) -> None:
+        global_vals: Optional[Dict[str, Any]],
+        local_vals: Optional[Dict[str, Any]]) -> None:
     assert_has_consistent_apply_unitary(val, qubit_count=qubit_count)
     assert_qasm_is_consistent_with_unitary(val)
     assert_decompose_is_consistent_with_unitary(val)

--- a/cirq/testing/consistent_protocols.py
+++ b/cirq/testing/consistent_protocols.py
@@ -34,10 +34,13 @@ def assert_implements_consistent_protocols(
         qubit_count: Optional[int] = None,
         setup_code: str = 'import cirq\nimport numpy as np',
         global_vals: Optional[Dict[str, Any]] = None,
-        local_vals: Optional[Dict[str, Any]] = None) -> None:
+        local_vals: Optional[Dict[str, Any]] = None
+        ) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
-    global_vals = global_vals or {}  # type: Dict[str, Any]
-    local_vals = local_vals or {}  # type: Dict[str, Any]
+    if global_vals is None:
+        global_vals = {}  # type: Dict[str, Any]
+    if local_vals is None:
+        local_vals = {}  # type: Dict[str, Any]
 
     _assert_meets_standards_helper(val,
                                    qubit_count,

--- a/cirq/testing/consistent_protocols.py
+++ b/cirq/testing/consistent_protocols.py
@@ -37,10 +37,8 @@ def assert_implements_consistent_protocols(
         local_vals: Optional[Dict[str, Any]] = None
         ) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
-    if global_vals is None:
-        global_vals = {}  # type: Dict[str, Any]
-    if local_vals is None:
-        local_vals = {}  # type: Dict[str, Any]
+    global_vals = global_vals or {}
+    local_vals = local_vals or {}
 
     _assert_meets_standards_helper(val,
                                    qubit_count,

--- a/cirq/testing/consistent_protocols.py
+++ b/cirq/testing/consistent_protocols.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Sequence, Type, Union
+from typing import Any, Dict, Optional, Sequence, Type, Union
 
 from cirq import ops, protocols, value
 from cirq.testing.circuit_compare import (
@@ -32,17 +32,27 @@ def assert_implements_consistent_protocols(
         exponents: Sequence[Any] = (
             0, 1, -1, 0.5, 0.25, -0.5, 0.1, value.Symbol('s')),
         qubit_count: Optional[int] = None,
-        setup_code: str = 'import cirq\nimport numpy as np'
-        ) -> None:
+        setup_code: str = 'import cirq\nimport numpy as np',
+        global_vals: Optional[Dict[str, Any]] = None,
+        local_vals: Optional[Dict[str, Any]] = None) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
+    global_vals = global_vals or {}  # type: Dict[str, Any]
+    local_vals = local_vals or {}  # type: Dict[str, Any]
 
-    _assert_meets_standards_helper(val, qubit_count, setup_code)
+    _assert_meets_standards_helper(val,
+                                   qubit_count,
+                                   setup_code,
+                                   global_vals,
+                                   local_vals)
 
     for exponent in exponents:
         p = protocols.pow(val, exponent, None)
         if p is not None:
-            _assert_meets_standards_helper(
-                    val**exponent, qubit_count, setup_code)
+            _assert_meets_standards_helper(val**exponent,
+                                           qubit_count,
+                                           setup_code,
+                                           global_vals,
+                                           local_vals)
 
 
 def assert_eigengate_implements_consistent_protocols(
@@ -69,13 +79,19 @@ def assert_eigen_shifts_is_consistent_with_eigen_components(
     assert val._eigen_shifts() == [e[0] for e in val._eigen_components()]
 
 
-def _assert_meets_standards_helper(val: Any,
-                                   qubit_count: Optional[int],
-                                   setup_code: str) -> None:
+def _assert_meets_standards_helper(
+        val: Any,
+        qubit_count: Optional[int],
+        setup_code: str,
+        global_vals: Optional[Dict[str, Any]] = None,
+        local_vals: Optional[Dict[str, Any]] = None) -> None:
     assert_has_consistent_apply_unitary(val, qubit_count=qubit_count)
     assert_qasm_is_consistent_with_unitary(val)
     assert_decompose_is_consistent_with_unitary(val)
     assert_phase_by_is_consistent_with_unitary(val)
-    assert_equivalent_repr(val, setup_code=setup_code)
+    assert_equivalent_repr(val,
+                           setup_code=setup_code,
+                           global_vals=global_vals,
+                           local_vals=local_vals)
     if isinstance(val, ops.EigenGate):
         assert_eigen_shifts_is_consistent_with_eigen_components(val)

--- a/cirq/testing/consistent_protocols_test.py
+++ b/cirq/testing/consistent_protocols_test.py
@@ -82,8 +82,7 @@ class GoodGate(cirq.SingleQubitGate):
         args = ['phase_exponent={!r}'.format(self.phase_exponent)]
         if self.exponent != 1:
             args.append('exponent={!r}'.format(self.exponent))
-        return 'cirq.testing.consistent_protocols_test.GoodGate({})'.format(
-                ', '.join(args))
+        return 'GoodGate({})'.format(', '.join(args))
 
     def _is_parameterized_(self) -> bool:
         return (isinstance(self.exponent, cirq.Symbol) or
@@ -150,8 +149,7 @@ class BadGateRepr(GoodGate):
         if self.exponent != 1:
             # coverage: ignore
             args.append('exponent={!r}'.format(self.exponent))
-        return 'cirq.testing.consistent_protocols_test.BadGateRepr({})'.format(
-                ', '.join(args))
+        return 'BadGateRepr({})'.format(', '.join(args))
 
 
 class GoodEigenGate(cirq.EigenGate, cirq.SingleQubitGate):
@@ -163,7 +161,7 @@ class GoodEigenGate(cirq.EigenGate, cirq.SingleQubitGate):
         ]
 
     def __repr__(self):
-        return ('cirq.testing.consistent_protocols_test.GoodEigenGate'
+        return ('GoodEigenGate'
                 '(exponent={!r}, global_shift={!r})'.format(
                     self._exponent, self._global_shift))
 
@@ -174,18 +172,20 @@ class BadEigenGate(GoodEigenGate):
         return [0, 0]
 
     def __repr__(self):
-        return ('cirq.testing.consistent_protocols_test.BadEigenGate'
+        return ('BadEigenGate'
                 '(exponent={!r}, global_shift={!r})'.format(
                     self._exponent, self._global_shift))
 
 
 def test_assert_implements_consistent_protocols():
     cirq.testing.assert_implements_consistent_protocols(
-            GoodGate(phase_exponent=0.0)
+            GoodGate(phase_exponent=0.0),
+            global_vals={'GoodGate': GoodGate}
     )
 
     cirq.testing.assert_implements_consistent_protocols(
-            GoodGate(phase_exponent=0.25)
+            GoodGate(phase_exponent=0.25),
+            global_vals={'GoodGate': GoodGate}
     )
 
     with pytest.raises(AssertionError):
@@ -205,14 +205,17 @@ def test_assert_implements_consistent_protocols():
 
     with pytest.raises(AssertionError):
         cirq.testing.assert_implements_consistent_protocols(
-                BadGateRepr(phase_exponent=0.25)
+                BadGateRepr(phase_exponent=0.25),
+                global_vals={'BadGateRepr': BadGateRepr}
         )
 
 
 def test_assert_eigengate_implements_consistent_protocols():
     cirq.testing.assert_eigengate_implements_consistent_protocols(
-            GoodEigenGate)
+            GoodEigenGate,
+            global_vals={'GoodEigenGate': GoodEigenGate})
 
     with pytest.raises(AssertionError):
         cirq.testing.assert_eigengate_implements_consistent_protocols(
-                BadEigenGate)
+            BadEigenGate,
+            global_vals={'BadEigenGate': BadEigenGate})

--- a/cirq/testing/equivalent_repr_eval.py
+++ b/cirq/testing/equivalent_repr_eval.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional
 
 
 def assert_equivalent_repr(
@@ -29,9 +29,11 @@ def assert_equivalent_repr(
         setup_code: Code that must be executed before the repr can be evaluated.
             Ideally this should just be a series of 'import' lines.
     """
+    if global_vals is None:
+        global_vals = {}  # type: Dict[str, Any]
+    if local_vals is None:
+        local_vals = {}  # type: Dict[str, Any]
 
-    global_vals = global_vals or {}  # type: Dict[str, Any]
-    local_vals = local_vals or {}  # type: Dict[str, Any]
     exec(setup_code, global_vals, local_vals)
 
     try:

--- a/cirq/testing/equivalent_repr_eval.py
+++ b/cirq/testing/equivalent_repr_eval.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Dict
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 
 def assert_equivalent_repr(
         value: Any,
         *,
-        setup_code: str = 'import cirq\nimport numpy as np') -> None:
+        setup_code: str = 'import cirq\nimport numpy as np',
+        global_vals: Optional[Dict[str, Any]] = None,
+        local_vals: Optional[Dict[str, Any]] = None) -> None:
     """Checks that eval(repr(v)) == v.
 
     Args:
@@ -32,8 +30,8 @@ def assert_equivalent_repr(
             Ideally this should just be a series of 'import' lines.
     """
 
-    global_vals = {}  # type: Dict[str, Any]
-    local_vals = {}  # type: Dict[str, Any]
+    global_vals = global_vals or {}  # type: Dict[str, Any]
+    local_vals = local_vals or {}  # type: Dict[str, Any]
     exec(setup_code, global_vals, local_vals)
 
     try:

--- a/cirq/testing/equivalent_repr_eval.py
+++ b/cirq/testing/equivalent_repr_eval.py
@@ -29,10 +29,8 @@ def assert_equivalent_repr(
         setup_code: Code that must be executed before the repr can be evaluated.
             Ideally this should just be a series of 'import' lines.
     """
-    if global_vals is None:
-        global_vals = {}  # type: Dict[str, Any]
-    if local_vals is None:
-        local_vals = {}  # type: Dict[str, Any]
+    global_vals = global_vals or {}
+    local_vals = local_vals or {}
 
     exec(setup_code, global_vals, local_vals)
 


### PR DESCRIPTION
Fixes #1235 