### PR TITLE
Remove documentation reference to the deleted class OptimizationPass (see #1248)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -238,7 +238,6 @@ Classes and methods for rewriting circuits.
     merge_single_qubit_gates_into_phased_x_z
     MergeInteractions
     MergeSingleQubitGates
-    OptimizationPass
     PointOptimizationSummary
     PointOptimizer
     single_qubit_matrix_to_gates


### PR DESCRIPTION
OptimizationPass was not removed from the documentation, causing warnings when building the docs.