### PR TITLE
Remove Pauli addition and subtraction

### DIFF
--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -31,7 +31,7 @@ def _assert_not_mirror(gate) -> None:
     trans_y = gate.transform(cirq.Y)
     trans_z = gate.transform(cirq.Z)
     right_handed = (trans_x.flip ^ trans_y.flip ^ trans_z.flip ^
-                   (trans_x.to - trans_y.to != 1))
+                   (trans_x.to.relative_index(trans_y.to) != 1))
     assert right_handed, 'Mirrors'
 
 
@@ -86,7 +86,7 @@ def test_init_from_xz(trans_x, trans_z):
                                                     _paulis)
      if trans1.to != trans2.to))
 def test_init_from_double_map_vs_kwargs(trans1, trans2, from1):
-    from2 = from1 + 1
+    from2 = cirq.Pauli.by_relative_index(from1, 1)
     from1_str, from2_str = (str(frm).lower()+'_to' for frm in (from1, from2))
     gate_kw = cirq.SingleQubitCliffordGate.from_double_map(**{from1_str: trans1,
                                                    from2_str: trans2})
@@ -103,7 +103,7 @@ def test_init_from_double_map_vs_kwargs(trans1, trans2, from1):
                                                     _paulis)
      if trans1.to == trans2.to))
 def test_init_from_double_invalid(trans1, trans2, from1):
-    from2 = from1 + 1
+    from2 = cirq.Pauli.by_relative_index(from1, 1)
     # Test throws on invalid arguments
     with pytest.raises(ValueError):
         cirq.SingleQubitCliffordGate.from_double_map({from1: trans1,
@@ -117,7 +117,7 @@ def test_init_from_double_invalid(trans1, trans2, from1):
                                                     _paulis)
      if trans1.to != trans2.to))
 def test_init_from_double(trans1, trans2, from1):
-    from2 = from1 + 1
+    from2 = cirq.Pauli.by_relative_index(from1, 1)
     gate = cirq.SingleQubitCliffordGate.from_double_map({from1: trans1,
                                                          from2: trans2})
     # Test initializes what was expected

--- a/cirq/ops/pauli_gates.py
+++ b/cirq/ops/pauli_gates.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-from typing import Any, Union, overload, TYPE_CHECKING
+from typing import Any, Union, TYPE_CHECKING
 
 from cirq import value
 from cirq.ops import common_gates, eigen_gate
@@ -34,6 +34,10 @@ class Pauli(eigen_gate.EigenGate, metaclass=abc.ABCMeta):
     def by_index(index: int) -> 'Pauli':
         return Pauli._XYZ[index % 3]
 
+    @staticmethod
+    def by_relative_index(p: 'Pauli', relative_index: int) -> 'Pauli':
+        return Pauli._XYZ[(p._index + relative_index) % 3]
+
     def __init__(
             self, *args: Any, _index: int, _name: str, **kwargs: Any) -> None:
         super(Pauli, self).__init__(*args, **kwargs)  # type: ignore #4335
@@ -46,7 +50,8 @@ class Pauli(eigen_gate.EigenGate, metaclass=abc.ABCMeta):
     def third(self, second: 'Pauli') -> 'Pauli':
         return Pauli._XYZ[(-self._index - second._index) % 3]
 
-    def _difference(self, second: 'Pauli') -> int:
+    def relative_index(self, second: 'Pauli') -> int:
+        """Relative index of self w.r.t. second in the (X, Y, Z) cycle."""
         return (self._index - second._index + 1) % 3 - 1
 
     def __gt__(self, other):
@@ -58,23 +63,6 @@ class Pauli(eigen_gate.EigenGate, metaclass=abc.ABCMeta):
         if not isinstance(other, Pauli):
             return NotImplemented
         return (other._index - self._index) % 3 == 1
-
-    def __add__(self, shift: int) -> 'Pauli':
-        return Pauli._XYZ[(self._index + shift) % 3]
-
-    # pylint: disable=function-redefined
-    @overload
-    def __sub__(self, other: 'Pauli') -> int: pass
-    @overload
-    def __sub__(self, shift: int) -> 'Pauli': pass
-
-    def __sub__(self, other_or_shift: Union['Pauli', int]
-                ) -> Union[int, 'Pauli']:
-        if isinstance(other_or_shift, int):
-            return self + -other_or_shift
-        else:
-            return self._difference(other_or_shift)
-    # pylint: enable=function-redefined
 
 
 class _PauliX(Pauli, common_gates.XPowGate):

--- a/cirq/ops/pauli_gates_test.py
+++ b/cirq/ops/pauli_gates_test.py
@@ -49,16 +49,41 @@ def test_by_index():
             cirq.Z, *[cirq.Pauli.by_index(i) for i in (-1, 2, 5, 8)])
 
 
-def test_difference():
-    assert cirq.X - cirq.X == 0
-    assert cirq.X - cirq.Y == -1
-    assert cirq.X - cirq.Z == 1
-    assert cirq.Y - cirq.X == 1
-    assert cirq.Y - cirq.Y == 0
-    assert cirq.Y - cirq.Z == -1
-    assert cirq.Z - cirq.X == -1
-    assert cirq.Z - cirq.Y == 1
-    assert cirq.Z - cirq.Z == 0
+def test_relative_index():
+    assert cirq.X.relative_index(cirq.X) == 0
+    assert cirq.X.relative_index(cirq.Y) == -1
+    assert cirq.X.relative_index(cirq.Z) == 1
+    assert cirq.Y.relative_index(cirq.X) == 1
+    assert cirq.Y.relative_index(cirq.Y) == 0
+    assert cirq.Y.relative_index(cirq.Z) == -1
+    assert cirq.Z.relative_index(cirq.X) == -1
+    assert cirq.Z.relative_index(cirq.Y) == 1
+    assert cirq.Z.relative_index(cirq.Z) == 0
+
+
+def test_by_relative_index():
+    assert cirq.Pauli.by_relative_index(cirq.X, -1) == cirq.Z
+    assert cirq.Pauli.by_relative_index(cirq.X, 0) == cirq.X
+    assert cirq.Pauli.by_relative_index(cirq.X, 1) == cirq.Y
+    assert cirq.Pauli.by_relative_index(cirq.X, 2) == cirq.Z
+    assert cirq.Pauli.by_relative_index(cirq.X, 3) == cirq.X
+    assert cirq.Pauli.by_relative_index(cirq.Y, -1) == cirq.X
+    assert cirq.Pauli.by_relative_index(cirq.Y, 0) == cirq.Y
+    assert cirq.Pauli.by_relative_index(cirq.Y, 1) == cirq.Z
+    assert cirq.Pauli.by_relative_index(cirq.Y, 2) == cirq.X
+    assert cirq.Pauli.by_relative_index(cirq.Y, 3) == cirq.Y
+    assert cirq.Pauli.by_relative_index(cirq.Z, -1) == cirq.Y
+    assert cirq.Pauli.by_relative_index(cirq.Z, 0) == cirq.Z
+    assert cirq.Pauli.by_relative_index(cirq.Z, 1) == cirq.X
+    assert cirq.Pauli.by_relative_index(cirq.Z, 2) == cirq.Y
+    assert cirq.Pauli.by_relative_index(cirq.Z, 3) == cirq.Z
+
+
+def test_relative_index_consistency():
+    for pauli_1 in (cirq.X, cirq.Y, cirq.Z):
+        for pauli_2 in (cirq.X, cirq.Y, cirq.Z):
+            shift = pauli_2.relative_index(pauli_1)
+            assert cirq.Pauli.by_relative_index(pauli_1, shift) == pauli_2
 
 
 def test_gt():
@@ -95,44 +120,6 @@ def test_lt():
 def test_lt_other_type():
     with pytest.raises(TypeError):
         _ = cirq.X < object()
-
-
-def test_addition():
-    assert cirq.X + -3 == cirq.X
-    assert cirq.X + -2 == cirq.Y
-    assert cirq.X + -1 == cirq.Z
-    assert cirq.X + 0 == cirq.X
-    assert cirq.X + 1 == cirq.Y
-    assert cirq.X + 2 == cirq.Z
-    assert cirq.X + 3 == cirq.X
-    assert cirq.X + 4 == cirq.Y
-    assert cirq.X + 5 == cirq.Z
-    assert cirq.X + 6 == cirq.X
-    assert cirq.Y + 0 == cirq.Y
-    assert cirq.Y + 1 == cirq.Z
-    assert cirq.Y + 2 == cirq.X
-    assert cirq.Z + 0 == cirq.Z
-    assert cirq.Z + 1 == cirq.X
-    assert cirq.Z + 2 == cirq.Y
-
-
-def test_subtraction():
-    assert cirq.X - -3 == cirq.X
-    assert cirq.X - -2 == cirq.Z
-    assert cirq.X - -1 == cirq.Y
-    assert cirq.X - 0 == cirq.X
-    assert cirq.X - 1 == cirq.Z
-    assert cirq.X - 2 == cirq.Y
-    assert cirq.X - 3 == cirq.X
-    assert cirq.X - 4 == cirq.Z
-    assert cirq.X - 5 == cirq.Y
-    assert cirq.X - 6 == cirq.X
-    assert cirq.Y - 0 == cirq.Y
-    assert cirq.Y - 1 == cirq.X
-    assert cirq.Y - 2 == cirq.Z
-    assert cirq.Z - 0 == cirq.Z
-    assert cirq.Z - 1 == cirq.Y
-    assert cirq.Z - 2 == cirq.X
 
 
 def test_str():

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -321,7 +321,8 @@ def _assert_pass_over(ops, before, after):
         itertools.product(range(3), (True, False)))
 def test_pass_operations_over_single(shift, t_or_f):
     q0, q1 = _make_qubits(2)
-    X, Y, Z = (pauli+shift for pauli in (cirq.X, cirq.Y, cirq.Z))
+    X, Y, Z = (cirq.Pauli.by_relative_index(pauli, shift)
+               for pauli in (cirq.X, cirq.Y, cirq.Z))
 
     op0 = cirq.SingleQubitCliffordGate.from_pauli(Y)(q1)
     ps_before = cirq.PauliString({q0: X}, t_or_f)
@@ -359,7 +360,8 @@ def test_pass_operations_over_single(shift, t_or_f):
         itertools.product(range(3), *((True, False),)*3))
 def test_pass_operations_over_double(shift, t_or_f1, t_or_f2, neg):
     q0, q1, q2 = _make_qubits(3)
-    X, Y, Z = (pauli+shift for pauli in (cirq.X, cirq.Y, cirq.Z))
+    X, Y, Z = (cirq.Pauli.by_relative_index(pauli, shift)
+               for pauli in (cirq.X, cirq.Y, cirq.Z))
 
     op0 = cirq.PauliInteractionGate(Z, t_or_f1, X, t_or_f2)(q0, q1)
     ps_before = cirq.PauliString({q0: Z, q2: Y}, neg)


### PR DESCRIPTION
Before this change, Pauli gates used `__add__()` and `__sub__()` for cycling between the three Pauli gates. This wasn't the most intuitive or appropriate use of addition and subtraction magic methods. More importantly, for #1037 and #491 we need the methods for actual addition/subtraction of linear operators represented by the gates. This change frees the magic methods up for their new role.