### PR TITLE
Fix FutureWarning from numpy 1.16

### DIFF
--- a/cirq/google/programs.py
+++ b/cirq/google/programs.py
@@ -212,7 +212,7 @@ def pack_results(measurements: Sequence[Tuple[str, np.ndarray]]) -> bytes:
         raise ValueError(
             "Expected same reps for all keys: shapes={}".format(shapes))
 
-    bits = np.hstack(np.asarray(data, dtype=bool) for _, data in measurements)
+    bits = np.hstack([np.asarray(data, dtype=bool) for _, data in measurements])
     bits = bits.reshape(-1)
 
     # Pad length to multiple of 8 if needed.


### PR DESCRIPTION
Numpy 1.16.0 is now released and raises the following warning:
`cirq/google/programs_test.py::test_pack_results
  /home/andbe/Cirq/cirq/google/programs.py:215: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
    bits = np.hstack(np.asarray(data, dtype=bool) for _, data in measurements)`

This PR fixes that.