### PR TITLE
Add Operation.controlled_by method, support multiple controls per ControlledGate/Operation

### DIFF
--- a/cirq/ops/controlled_gate_test.py
+++ b/cirq/ops/controlled_gate_test.py
@@ -144,7 +144,6 @@ def test_unitary():
         atol=1e-8)
 
 
-
 @pytest.mark.parametrize('gate', [
     cirq.X,
     cirq.X**0.5,
@@ -277,11 +276,6 @@ def test_uninformed_circuit_diagram_info():
 
 def test_bounded_effect():
     assert cirq.trace_distance_bound(CY**0.001) < 0.01
-
-
-def test_repr():
-    assert repr(
-        cirq.ControlledGate(cirq.Z)) == 'cirq.ControlledGate(sub_gate=cirq.Z)'
 
 
 def test_str():

--- a/cirq/ops/controlled_operation.py
+++ b/cirq/ops/controlled_operation.py
@@ -11,47 +11,62 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union, Any, Optional
+from typing import Union, Any, Optional, Iterable, List, Sequence
 
 import numpy as np
 
 from cirq import protocols, linalg, value
-from cirq.ops import raw_types
+from cirq.ops import raw_types, gate_operation
 from cirq.type_workarounds import NotImplementedType
 
 
 @value.value_equality
 class ControlledOperation(raw_types.Operation):
+
+    def __new__(cls,
+                controls: Iterable[raw_types.QubitId],
+                sub_operation: raw_types.Operation):
+        """Auto-flatten nested controlled operations."""
+        if isinstance(sub_operation, ControlledOperation):
+            return ControlledOperation(
+                tuple(controls) + sub_operation.controls,
+                sub_operation.sub_operation)
+        return super().__new__(cls)
+
     def __init__(self,
-                 control: raw_types.QubitId,
+                 controls: Iterable[raw_types.QubitId],
                  sub_operation: raw_types.Operation):
-        self.control = control
+        self.controls = tuple(controls)
         self.sub_operation = sub_operation
 
     @property
     def qubits(self):
-        return (self.control,) + self.sub_operation.qubits
+        return self.controls + self.sub_operation.qubits
 
     def with_qubits(self, *new_qubits):
+        n = len(self.controls)
         return ControlledOperation(
-            new_qubits[0],
-            self.sub_operation.with_qubits(*new_qubits[1:]))
+            new_qubits[:n],
+            self.sub_operation.with_qubits(*new_qubits[n:]))
 
     def _decompose_(self):
         result = protocols.decompose_once(self.sub_operation, NotImplemented)
         if result is NotImplemented:
             return NotImplemented
 
-        return [ControlledOperation(self.control, op) for op in result]
+        return [ControlledOperation(self.controls, op) for op in result]
 
     def _value_equality_values_(self):
-        return tuple([self.control, self.sub_operation])
+        return self.controls, self.sub_operation
 
     def _apply_unitary_(self, args: protocols.ApplyUnitaryArgs) -> np.ndarray:
-        control = args.axes[0]
-        rest = args.axes[1:]
-        active = linalg.slice_for_qubits_equal_to([control], 1)
-        sub_axes = [r - int(r > control) for r in rest]
+        n = len(self.controls)
+        control_axes = args.axes[:n]
+        sub_axes = args.axes[n:]
+        active = linalg.slice_for_qubits_equal_to(control_axes, -1)
+        view_axes = _positions_after_removals_at(
+            initial_positions=sub_axes,
+            removals=control_axes)
         target_view = args.target_tensor[active]
         buffer_view = args.available_buffer[active]
         result = protocols.apply_unitary(
@@ -59,7 +74,7 @@ class ControlledOperation(raw_types.Operation):
             protocols.ApplyUnitaryArgs(
                 target_view,
                 buffer_view,
-                sub_axes),
+                view_axes),
             default=NotImplemented)
 
         if result is NotImplemented:
@@ -67,11 +82,6 @@ class ControlledOperation(raw_types.Operation):
 
         if result is target_view:
             return args.target_tensor
-
-        if result is buffer_view:
-            inactive = linalg.slice_for_qubits_equal_to([control], 0)
-            args.available_buffer[inactive] = args.target_tensor[inactive]
-            return args.available_buffer
 
         # HACK: assume they didn't somehow escape the slice view and edit the
         # rest of target_tensor.
@@ -85,21 +95,34 @@ class ControlledOperation(raw_types.Operation):
         sub_matrix = protocols.unitary(self.sub_operation, None)
         if sub_matrix is None:
             return NotImplemented
-        return linalg.block_diag(np.eye(sub_matrix.shape[0]), sub_matrix)
+        return linalg.block_diag(
+            np.eye(sub_matrix.shape[0] << (len(self.controls) - 1)),
+            sub_matrix)
 
     def __str__(self):
-        return 'C({}){}'.format(self.control, str(self.sub_operation))
+        if isinstance(self.sub_operation, gate_operation.GateOperation):
+            return '{}{}({})'.format(
+                'C' * len(self.controls),
+                self.sub_operation.gate,
+                ', '.join(map(str, self.qubits)))
+        return 'C({}, {})'.format(', '.join(str(q) for q in self.controls),
+                                  str(self.sub_operation))
 
     def __repr__(self):
-        return 'cirq.ControlledOperation(control={!r},' \
-               ' sub_operation={!r})'.format(self.control, self.sub_operation)
+        if self.sub_operation.controlled_by(*self.controls) == self:
+            return '{!r}.controlled_by({})'.format(
+                self.sub_operation,
+                ', '.join(map(repr, self.controls)))
+        return 'cirq.ControlledOperation({!r}, {!r})'.format(
+            self.controls,
+            self.sub_operation)
 
     def _is_parameterized_(self) -> bool:
         return protocols.is_parameterized(self.sub_operation)
 
     def _resolve_parameters_(self, resolver):
         new_sub_op = protocols.resolve_parameters(self.sub_operation, resolver)
-        return ControlledOperation(self.control, new_sub_op)
+        return ControlledOperation(self.controls, new_sub_op)
 
     def _trace_distance_bound_(self) -> float:
         return protocols.trace_distance_bound(self.sub_operation)
@@ -110,7 +133,7 @@ class ControlledOperation(raw_types.Operation):
                                    NotImplemented)
         if new_sub_op is NotImplemented:
             return NotImplemented
-        return ControlledOperation(self.control, new_sub_op)
+        return ControlledOperation(self.controls, new_sub_op)
 
     def _circuit_diagram_info_(self,
                                args: protocols.CircuitDiagramInfoArgs
@@ -134,3 +157,13 @@ class ControlledOperation(raw_types.Operation):
         return protocols.CircuitDiagramInfo(
             wire_symbols=('@',) + sub_info.wire_symbols,
             exponent=sub_info.exponent)
+
+
+def _positions_after_removals_at(initial_positions: Sequence[int],
+                                 removals: Sequence[int]) -> List[int]:
+    # TODO: O(n lg n) instead of O(n**2)
+    result = []
+    for p in initial_positions:
+        change = len([1 for r in removals if r < p])
+        result.append(p - change)
+    return result

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -166,3 +166,13 @@ class Operation(metaclass=abc.ABCMeta):
                 function.
         """
         return self.with_qubits(*(func(q) for q in self.qubits))
+
+    def controlled_by(self, *controls: QubitId) -> 'Operation':
+        """Returns a controlled version of the operation.
+
+        Args:
+            controls: The operation will only apply in parts of the
+                superposition where every one of these qubits is in the 1 state.
+        """
+        from cirq import ControlledOperation  # HACK: avoid cyclic dependency.
+        return ControlledOperation(controls, self)

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -298,7 +298,6 @@ def assert_has_consistent_apply_unitary(
 
     # If you applied a unitary, it should match the one you say you have.
     if actual is not None:
-        print("ACTUAL", actual.reshape(2 << n, 2 << n))
         np.testing.assert_allclose(
             actual.reshape(2 << n, 2 << n),
             expected,


### PR DESCRIPTION
- Added a num_controls parameter to ControlledGate
- ControlledOperation now takes an iterable of controls instead of one control
- Added `__new__` methods to ControlledGate and ControlledOperate that auto-unwrap nested instances
- Added controlled_by method to Operation
- assert_has_consistent_apply_unitary now uses Gate.qubit_count and verifies redundant qubit count information sources