### PR TITLE
pow magic methods for symbols

### DIFF
--- a/cirq/value/symbol.py
+++ b/cirq/value/symbol.py
@@ -67,3 +67,9 @@ class Symbol:
 
     def __radd__(self, other):
         return self if other == 0 else NotImplemented
+
+    def __pow__(self, other):
+        return 1 if other == 0 else NotImplemented
+
+    def __rpow__(self, other):
+        return 1 if other == 1 else NotImplemented

--- a/cirq/value/symbol_test.py
+++ b/cirq/value/symbol_test.py
@@ -48,6 +48,8 @@ def test_identity_operations():
     s = cirq.Symbol('s')
     assert s == s * 1 == 1 * s == 1.0 * s * 1.0
     assert s == s + 0 == 0 + s == 0.0 + s + 0.0
+    assert 1 == 1 ** s == 1.0 ** s
+    assert 1 == s ** 0 == s ** 0.0
 
     with pytest.raises(TypeError):
         _ = s + s
@@ -61,3 +63,7 @@ def test_identity_operations():
         _ = s * 2
     with pytest.raises(TypeError):
         _ = 2 * s
+    with pytest.raises(TypeError):
+        _ = 2 ** s
+    with pytest.raises(TypeError):
+        _ = s ** 2


### PR DESCRIPTION
Rationale:
- simplification of calculations where result is known without evaluating the symbol,
- consistency with existing magic methods,
- happy mypy.

The last reason is why I do this now. In particular, when writing code like `1j**self._exponent` in various gates, mypy is unhappy about the power operation. OTOH, it does allow things like `2 * self._exponent` and even `1j**(self._exponent + 0)`.