### PR TITLE
Fix issues found syncing openfermioncirq to cirq dev release

### DIFF
--- a/cirq/contrib/acquaintance/bipartite.py
+++ b/cirq/contrib/acquaintance/bipartite.py
@@ -23,6 +23,7 @@ from cirq.contrib.acquaintance.gates import acquaint
 from cirq.contrib.acquaintance.permutation import (
         PermutationGate, SwapPermutationGate)
 
+
 @enum.unique
 class BipartiteGraphType(enum.Enum):
     MATCHING = 1

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -373,6 +373,8 @@ class MeasurementGate(gate_features.MultiQubitGate):
         Raises:
             ValueError if the length of invert_mask is greater than num_qubits.
         """
+        assert isinstance(num_qubits, int)
+
         super().__init__(num_qubits)
         self.key = key
         self.invert_mask = invert_mask or ()

--- a/cirq/testing/equals_tester.py
+++ b/cirq/testing/equals_tester.py
@@ -87,7 +87,8 @@ class EqualsTester:
             example = next(examples)
             raise AssertionError(
                 'Items in the same group produced different hashes. '
-                'Example: hash({}) is {} but hash({}) is {}.'.format(*example))
+                'Example: hash({!r}) is {!r} but hash({!r}) is {!r}.'.format(
+                    *example))
 
     def add_equality_group(self, *group_items: Any):
         """Tries to add a disjoint equivalence group to the equality tester.

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -90,9 +90,9 @@ for PYTHON_VERSION in python2 python3; do
     # Run tests.
     echo Installing pytest requirements
     if [ "${PYTHON_VERSION}" = "python2" ]; then
-        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet pytest mock
+        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet pytest mock pytest-benchmark
     else
-        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet pytest
+        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet pytest pytest-benchmark
     fi
     PY_VER=$(ls "${tmp_dir}/${PYTHON_VERSION}/lib")
     echo Running cirq tests

--- a/dev_tools/python2.7-requirements.txt
+++ b/dev_tools/python2.7-requirements.txt
@@ -8,6 +8,6 @@ numpy~=1.12
 protobuf~=3.5
 sortedcontainers~=1.5
 typing~=3.6
-scipy~=1.1.0
+scipy~=1.1
 sympy
 typing_extensions

--- a/dev_tools/python2.7-requirements.txt
+++ b/dev_tools/python2.7-requirements.txt
@@ -1,5 +1,6 @@
 # Runtime requirements for the transpiled python 2.7 version of cirq.
 
+enum34
 google-api-python-client~=1.6
 matplotlib~=2.1
 networkx~=2.1


### PR DESCRIPTION
- Weaken scipy requirement
- Add pytest-benchmark to verify package script
- Use repr strings when describing hash equivalence failures
- Catch old usage of MeasurementGate
- Add `enum34` python 2.7 requirement (used in acquaintance code)