### PR TITLE
[WIP] Drop empty moments

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -24,6 +24,7 @@ from cirq.circuits import (
     InsertStrategy,
     PointOptimizationSummary,
     PointOptimizer,
+    Optimizer,
     QasmOutput,
     TextDiagramDrawer,
     Unique,

--- a/cirq/circuits/__init__.py
+++ b/cirq/circuits/__init__.py
@@ -31,6 +31,7 @@ from cirq.circuits.insert_strategy import (
     InsertStrategy,
 )
 from cirq.circuits.optimization_pass import (
+    Optimizer,
     PointOptimizer,
     PointOptimizationSummary,
 )

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -91,6 +91,7 @@ class Optimizer:
     def drop_empty_moments(self, drop_empty_moments: bool):
         self._drop_empty_moments = drop_empty_moments
 
+
     @abc.abstractmethod
     def _optimize_circuit(self, circuit: Circuit):
         """Optimizes a circuit via mutating the operations and Moments of the
@@ -101,9 +102,17 @@ class Optimizer:
         """
         pass
 
-    def optimize_circuit(self, circuit: Circuit):
+    def __call__(self, circuit: Circuit,
+                 drop_empty_moments: bool = None):
+        return self.optimize_circuit(circuit, drop_empty_moments)
+
+    def optimize_circuit(self, circuit: Circuit,
+                         drop_empty_moments: bool = None):
         self._optimize_circuit(circuit)
-        if self._drop_empty_moments:
+        drop_empty = drop_empty_moments \
+            if drop_empty_moments is not None else \
+            self._drop_empty_moments
+        if drop_empty:
             circuit[:] = (m for m in circuit if m.operations)
 
 
@@ -122,10 +131,6 @@ class PointOptimizer(Optimizer):
         """
         super().__init__(drop_empty_moments)
         self.post_clean_up = post_clean_up
-        self._drop_empty_moments = drop_empty_moments
-
-    def __call__(self, circuit: Circuit):
-        return self.optimize_circuit(circuit)
 
     @abc.abstractmethod
     def optimization_at(self,

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -84,14 +84,6 @@ class Optimizer:
         """
         self._drop_empty_moments = drop_empty_moments
 
-    def __call__(self, circuit: Circuit):
-        return self.optimize_circuit(circuit)
-
-    @property
-    def drop_empty_moments(self, drop_empty_moments: bool):
-        self._drop_empty_moments = drop_empty_moments
-
-
     @abc.abstractmethod
     def _optimize_circuit(self, circuit: Circuit):
         """Optimizes a circuit via mutating the operations and Moments of the

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from cirq.ops import QubitId
     from typing import Dict
 
+
 class PointOptimizationSummary:
     """A description of a local optimization to perform."""
 
@@ -76,7 +77,7 @@ class PointOptimizer():
 
     def __init__(self,
                  post_clean_up: Callable[[Sequence[ops.Operation]], ops.OP_TREE
-                                ] = lambda op_list: op_list
+                 ] = lambda op_list: op_list
                  ) -> None:
         """
         Args:
@@ -115,7 +116,8 @@ class PointOptimizer():
         """
         pass
 
-    def optimize_circuit(self, circuit: Circuit):
+    def optimize_circuit(self, circuit: Circuit,
+                         drop_empty_moments: bool = True):
         frontier = defaultdict(lambda: 0)  # type: Dict[QubitId, int]
         i = 0
         while i < len(circuit):  # Note: circuit may mutate as we go.
@@ -144,3 +146,7 @@ class PointOptimizer():
                 circuit.insert_at_frontier(new_operations, i, frontier)
 
             i += 1
+        if drop_empty_moments:
+            print("DROPPING {} ".format(circuit))
+            circuit[:] = (m for m in circuit if m.operations)
+            print("AFTER: {} ".format(circuit))

--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -183,7 +183,7 @@ class GreedyExecutionStrategy(ExecutionStrategy):
         indices, and groups those that act on the same qubits regardless of
         order."""
         canonicalized_gates = defaultdict(dict
-                                          )  # type: DefaultDict[frozenset, LogicalGates]
+            ) # type: DefaultDict[frozenset, LogicalGates]
         for indices, gate in gates.items():
             indices = tuple(indices)
             canonicalized_gates[frozenset(indices)][indices] = gate

--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -77,12 +77,16 @@ class StrategyExecutor(circuits.PointOptimizer):
         self.execution_strategy = execution_strategy
         self.mapping = execution_strategy.initial_mapping.copy()
 
-    def __call__(self, strategy: circuits.Circuit):
+    def __call__(self, strategy: circuits.Circuit,
+                 drop_empty_moments: bool = None):
         if not is_acquaintance_strategy(strategy):
             raise TypeError('not is_acquaintance_strategy(strategy)')
-        expose_acquaintance_gates(strategy, self._drop_empty_moments)
+        drop_empty = drop_empty_moments \
+            if drop_empty_moments is not None else \
+            self._drop_empty_moments
+        expose_acquaintance_gates(strategy, drop_empty)
         strategy.device = self.execution_strategy.device
-        super().optimize_circuit(strategy)
+        super().optimize_circuit(strategy, drop_empty)
         return self.mapping.copy()
 
     def optimization_at(self,

--- a/cirq/contrib/acquaintance/inspection_utils.py
+++ b/cirq/contrib/acquaintance/inspection_utils.py
@@ -28,12 +28,14 @@ class LogicalAnnotator(ExecutionStrategy):
     """
 
     def __init__(self,
-                 initial_mapping: LogicalMapping
+                 initial_mapping: LogicalMapping,
+                 drop_empty_moments: bool = True
                  ) -> None:
         """
         Args:
             initial_mapping: The initial mapping of qubits to logical indices.
         """
+        super().__init__(drop_empty_moments=drop_empty_moments)
         self._initial_mapping = initial_mapping.copy()
 
     @property

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -35,8 +35,8 @@ STRATEGY_GATE = Union[AcquaintanceOpportunityGate, PermutationGate]
 
 def rectify_acquaintance_strategy(
         circuit: circuits.Circuit,
-        acquaint_first: bool = True
-) -> None:
+        acquaint_first: bool=True
+        ) -> None:
     """Splits moments so that they contain either only acquaintance gates
     or only permutation gates. Orders resulting moments so that the first one
     is of the same type as the previous one.
@@ -53,25 +53,25 @@ def rectify_acquaintance_strategy(
     rectified_moments = []
     for moment in circuit:
         gate_type_to_ops = collections.defaultdict(list
-                                                   )  # type: Dict[bool, List[ops.GateOperation]]
+                ) # type: Dict[bool, List[ops.GateOperation]]
         for op in moment.operations:
             gate_type_to_ops[isinstance(op.gate, AcquaintanceOpportunityGate)
-            ].append(op)
+                    ].append(op)
         if len(gate_type_to_ops) == 1:
             rectified_moments.append(moment)
             continue
         for acquaint_first in sorted(gate_type_to_ops.keys(),
                                      reverse=acquaint_first):
             rectified_moments.append(
-                ops.Moment(gate_type_to_ops[acquaint_first]))
+                    ops.Moment(gate_type_to_ops[acquaint_first]))
     circuit._moments = rectified_moments
 
 
 def replace_acquaintance_with_swap_network(
         circuit: circuits.Circuit,
         qubit_order: Sequence[ops.QubitId],
-        acquaintance_size: int = 0
-) -> bool:
+        acquaintance_size: int=0
+        ) -> bool:
     """
     Replace every moment containing acquaintance gates (after
     rectification) with a generalized swap network, with the partition
@@ -102,9 +102,9 @@ def replace_acquaintance_with_swap_network(
         if reflected:
             moment = moment.transform_qubits(reverse_map.__getitem__)
         if all(isinstance(op.gate, AcquaintanceOpportunityGate)
-               for op in moment.operations):
+                for op in moment.operations):
             swap_network_gate = SwapNetworkGate.from_operations(
-                qubit_order, moment.operations, acquaintance_size)
+                    qubit_order, moment.operations, acquaintance_size)
             swap_network_op = swap_network_gate(*qubit_order)
             moment = ops.Moment([swap_network_op])
             reflected = not reflected

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -35,8 +35,8 @@ STRATEGY_GATE = Union[AcquaintanceOpportunityGate, PermutationGate]
 
 def rectify_acquaintance_strategy(
         circuit: circuits.Circuit,
-        acquaint_first: bool=True
-        ) -> None:
+        acquaint_first: bool = True
+) -> None:
     """Splits moments so that they contain either only acquaintance gates
     or only permutation gates. Orders resulting moments so that the first one
     is of the same type as the previous one.
@@ -53,25 +53,25 @@ def rectify_acquaintance_strategy(
     rectified_moments = []
     for moment in circuit:
         gate_type_to_ops = collections.defaultdict(list
-                ) # type: Dict[bool, List[ops.GateOperation]]
+                                                   )  # type: Dict[bool, List[ops.GateOperation]]
         for op in moment.operations:
             gate_type_to_ops[isinstance(op.gate, AcquaintanceOpportunityGate)
-                    ].append(op)
+            ].append(op)
         if len(gate_type_to_ops) == 1:
             rectified_moments.append(moment)
             continue
         for acquaint_first in sorted(gate_type_to_ops.keys(),
                                      reverse=acquaint_first):
             rectified_moments.append(
-                    ops.Moment(gate_type_to_ops[acquaint_first]))
+                ops.Moment(gate_type_to_ops[acquaint_first]))
     circuit._moments = rectified_moments
 
 
 def replace_acquaintance_with_swap_network(
         circuit: circuits.Circuit,
         qubit_order: Sequence[ops.QubitId],
-        acquaintance_size: int=0
-        ) -> bool:
+        acquaintance_size: int = 0
+) -> bool:
     """
     Replace every moment containing acquaintance gates (after
     rectification) with a generalized swap network, with the partition
@@ -102,9 +102,9 @@ def replace_acquaintance_with_swap_network(
         if reflected:
             moment = moment.transform_qubits(reverse_map.__getitem__)
         if all(isinstance(op.gate, AcquaintanceOpportunityGate)
-                for op in moment.operations):
+               for op in moment.operations):
             swap_network_gate = SwapNetworkGate.from_operations(
-                    qubit_order, moment.operations, acquaintance_size)
+                qubit_order, moment.operations, acquaintance_size)
             swap_network_op = swap_network_gate(*qubit_order)
             moment = ops.Moment([swap_network_op])
             reflected = not reflected
@@ -115,12 +115,13 @@ def replace_acquaintance_with_swap_network(
 class ExposeAcquaintanceGates(optimizers.ExpandComposite):
     """Decomposes any permutation gates that provide acquaintance opportunities
     in order to make them explicit."""
-    def __init__(self):
-        circuits.PointOptimizer.__init__(self)
-        self.no_decomp = lambda op: (
+
+    def __init__(self, drop_empty_moments: bool = True):
+        super().__init__(no_decomp=lambda op: (
                 not get_acquaintance_size(op) or
                 (isinstance(op, ops.GateOperation) and
-                 isinstance(op.gate, AcquaintanceOpportunityGate)))
+                 isinstance(op.gate, AcquaintanceOpportunityGate))),
+                         drop_empty_moments=drop_empty_moments)
 
 
 expose_acquaintance_gates = ExposeAcquaintanceGates()

--- a/cirq/contrib/acquaintance/optimizers.py
+++ b/cirq/contrib/acquaintance/optimizers.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 
 def remove_redundant_acquaintance_opportunities(
-        strategy: circuits.Circuit) -> None:
+        strategy: circuits.Circuit, drop_empty_moments: bool = True) -> None:
     """Removes redundant acquaintance opportunities."""
     if not is_acquaintance_strategy(strategy):
         raise TypeError('not is_acquaintance_strategy(circuit)')
@@ -37,14 +37,15 @@ def remove_redundant_acquaintance_opportunities(
     qubits = tuple(strategy.all_qubits())
     mapping = {q: i for i, q in enumerate(qubits)}
 
-    expose_acquaintance_gates(strategy)
+    expose_acquaintance_gates(strategy, drop_empty_moments)
     annotated_strategy = strategy.copy()
-    LogicalAnnotator(mapping)(annotated_strategy)
+    LogicalAnnotator(mapping,
+                     drop_empty_moments=drop_empty_moments)(annotated_strategy)
 
-    new_moments = [] # type: List[ops.Moment]
-    acquaintance_opps = set() # type: Set[FrozenSet[int]]
+    new_moments = []  # type: List[ops.Moment]
+    acquaintance_opps = set()  # type: Set[FrozenSet[int]]
     for moment in annotated_strategy:
-        new_moment = [] # type: List[ops.Operation]
+        new_moment = []  # type: List[ops.Operation]
         for op in moment:
             if isinstance(op, AcquaintanceOperation):
                 opp = frozenset(cast(Sequence[int], op.logical_indices))

--- a/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq/contrib/acquaintance/optimizers_test.py
@@ -39,9 +39,9 @@ def test_remove_redundant_acquaintance_opportunities():
     cca.remove_redundant_acquaintance_opportunities(strategy)
     cca.remove_redundant_acquaintance_opportunities(strategy)
     diagram_after = """
-0: ───█───────
+0: ───█───
       │
-1: ───█───────
+1: ───█───
     """
     ct.assert_has_diagram(strategy, diagram_after)
 

--- a/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq/contrib/acquaintance/optimizers_test.py
@@ -39,9 +39,9 @@ def test_remove_redundant_acquaintance_opportunities():
     cca.remove_redundant_acquaintance_opportunities(strategy)
     cca.remove_redundant_acquaintance_opportunities(strategy)
     diagram_after = """
-0: ───█───
+0: ───█───────
       │
-1: ───█───
+1: ───█───────
     """
     ct.assert_has_diagram(strategy, diagram_after)
 

--- a/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq/contrib/acquaintance/optimizers_test.py
@@ -26,7 +26,7 @@ def test_remove_redundant_acquaintance_opportunities():
     with pytest.raises(TypeError):
         ops = [cca.acquaint(a, b)]
         strategy = cirq.Circuit.from_ops(ops)
-        cca.remove_redundant_acquaintance_opportunities(strategy)
+        cca.remove_redundant_acquaintance_opportunities(strategy, False)
 
     ops = [cca.acquaint(a, b), cca.acquaint(a, b)]
     strategy = cirq.Circuit.from_ops(ops, device=device)
@@ -36,15 +36,21 @@ def test_remove_redundant_acquaintance_opportunities():
 1: ───█───█───
     """
     ct.assert_has_diagram(strategy, diagram_before)
-    cca.remove_redundant_acquaintance_opportunities(strategy)
-    cca.remove_redundant_acquaintance_opportunities(strategy)
+    cca.remove_redundant_acquaintance_opportunities(strategy, False)
+    cca.remove_redundant_acquaintance_opportunities(strategy, False)
     diagram_after = """
 0: ───█───────
       │
 1: ───█───────
     """
     ct.assert_has_diagram(strategy, diagram_after)
-
+    cca.remove_redundant_acquaintance_opportunities(strategy)
+    diagram_after = """
+0: ───█───
+      │
+1: ───█───
+        """
+    ct.assert_has_diagram(strategy, diagram_after)
 
     ops = [
             cca.acquaint(a, b), cca.acquaint(c, d),

--- a/cirq/contrib/paulistring/convert_to_clifford_gates.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates.py
@@ -38,7 +38,8 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
 
     def __init__(self,
                  ignore_failures: bool = False,
-                 atol: float = 0) -> None:
+                 atol: float = 0,
+                 drop_empty_moments: bool = True) -> None:
         """
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
@@ -47,7 +48,7 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
                 permitted to round angles with a threshold determined by this
                 tolerance.
         """
-        super().__init__()
+        super().__init__(drop_empty_moments=drop_empty_moments)
         self.ignore_failures = ignore_failures
         self.atol = atol
 
@@ -59,7 +60,7 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
         elif quarter_turns == 2:
             return ops.SingleQubitCliffordGate.from_pauli(pauli)
         elif quarter_turns == 3:
-            return ops.SingleQubitCliffordGate.from_pauli(pauli, True)**-1
+            return ops.SingleQubitCliffordGate.from_pauli(pauli, True) ** -1
         else:
             return ops.SingleQubitCliffordGate.I
 
@@ -95,7 +96,7 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
     def _on_stuck_raise(self, op: ops.Operation):
         if len(op.qubits) == 1 and protocols.has_unitary(op):
             raise ValueError('Single qubit operation is not in the '
-                              'Clifford group: {!r}'.format(op))
+                             'Clifford group: {!r}'.format(op))
 
         raise TypeError("Don't know how to work with {!r}. "
                         "It isn't composite or a 1-qubit operation "

--- a/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
@@ -29,9 +29,9 @@ def test_convert():
         cirq.Z(q1) ** 0,
         cirq.H(q0),
     )
+    circuit.insert(1, cirq.Moment())
     c_orig = cirq.Circuit(circuit)
-    ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
-
+    ConvertToSingleQubitCliffordGates(drop_empty_moments=True).optimize_circuit(circuit)
     assert all(isinstance(op.gate, cirq.SingleQubitCliffordGate)
                for op in circuit.all_operations())
 
@@ -39,12 +39,12 @@ def test_convert():
         circuit.to_unitary_matrix(),
         c_orig.to_unitary_matrix(),
         atol=1e-7)
-
     cirq.testing.assert_has_diagram(circuit, """
 0: ───X───────Z^-0.5───H───
 
 1: ───Y^0.5───I────────────
 """)
+
 
 
 def test_non_clifford_known_matrix():

--- a/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
@@ -31,7 +31,8 @@ def test_convert():
     )
     circuit.insert(1, cirq.Moment())
     c_orig = cirq.Circuit(circuit)
-    ConvertToSingleQubitCliffordGates(drop_empty_moments=True).optimize_circuit(circuit)
+    ConvertToSingleQubitCliffordGates(drop_empty_moments=True)\
+        .optimize_circuit(circuit)
     assert all(isinstance(op.gate, cirq.SingleQubitCliffordGate)
                for op in circuit.all_operations())
 
@@ -44,7 +45,6 @@ def test_convert():
 
 1: ───Y^0.5───I────────────
 """)
-
 
 
 def test_non_clifford_known_matrix():
@@ -61,7 +61,6 @@ def test_non_clifford_known_matrix():
     circuit2 = cirq.Circuit(c_orig)
     with pytest.raises(ValueError):
         ConvertToSingleQubitCliffordGates().optimize_circuit(circuit2)
-
 
 
 def test_already_converted():

--- a/cirq/contrib/paulistring/pauli_string_phasor_test.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor_test.py
@@ -213,7 +213,6 @@ def test_drop_negligible():
         PauliStringPhasor(cirq.PauliString({q0: cirq.Z})) ** sym,
     )
     cirq.DropNegligible().optimize_circuit(circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
     assert circuit == expected
 
 

--- a/cirq/optimizers/convert_to_cz_and_single_gates.py
+++ b/cirq/optimizers/convert_to_cz_and_single_gates.py
@@ -34,7 +34,8 @@ class ConvertToCzAndSingleGates(circuits.PointOptimizer):
 
     def __init__(self,
                  ignore_failures: bool = False,
-                 allow_partial_czs: bool = False) -> None:
+                 allow_partial_czs: bool = False,
+                 drop_empty_moments: bool = True) -> None:
         """
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
@@ -42,7 +43,7 @@ class ConvertToCzAndSingleGates(circuits.PointOptimizer):
             allow_partial_czs: If set, the decomposition is permitted to use
                 gates of the form `cirq.CZ**t`, instead of only `cirq.CZ`.
         """
-        super().__init__()
+        super().__init__(drop_empty_moments=drop_empty_moments)
         self.ignore_failures = ignore_failures
         self.allow_partial_czs = allow_partial_czs
 

--- a/cirq/optimizers/drop_empty_moments.py
+++ b/cirq/optimizers/drop_empty_moments.py
@@ -15,7 +15,7 @@
 """An optimization pass that removes empty moments from a circuit."""
 
 from cirq import Circuit
-from cirq.circuits import circuit as _circuit, Optimizer
+from cirq.circuits import Optimizer
 
 
 class DropEmptyMoments(Optimizer):
@@ -23,13 +23,3 @@ class DropEmptyMoments(Optimizer):
 
     def _optimize_circuit(self, circuit: Circuit):
         pass
-
-    def drop_empty_moments(self, drop_empty_moments: bool):
-        """
-        This is a noop implementation - for this optimization does not make
-        sense anything else than drop_empty_moments = True
-        """
-        pass
-
-    def __call__(self, circuit: _circuit.Circuit):
-        self.optimize_circuit(circuit)

--- a/cirq/optimizers/drop_empty_moments.py
+++ b/cirq/optimizers/drop_empty_moments.py
@@ -13,18 +13,22 @@
 # limitations under the License.
 
 """An optimization pass that removes empty moments from a circuit."""
-from typing import Optional
 
-from cirq import Circuit, ops, PointOptimizationSummary
-from cirq.circuits import circuit as _circuit, PointOptimizer
+from cirq import Circuit
+from cirq.circuits import circuit as _circuit, Optimizer
 
 
-class DropEmptyMoments(PointOptimizer):
+class DropEmptyMoments(Optimizer):
     """Removes empty moments from a circuit."""
 
-    def optimization_at(self, circuit: Circuit, index: int,
-                        op: ops.Operation) -> Optional[
-        PointOptimizationSummary]:
+    def _optimize_circuit(self, circuit: Circuit):
+        pass
+
+    def drop_empty_moments(self, drop_empty_moments: bool):
+        """
+        This is a noop implementation - for this optimization does not make
+        sense anything else than drop_empty_moments = True
+        """
         pass
 
     def __call__(self, circuit: _circuit.Circuit):

--- a/cirq/optimizers/drop_empty_moments.py
+++ b/cirq/optimizers/drop_empty_moments.py
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 """An optimization pass that removes empty moments from a circuit."""
+from typing import Optional
 
-from cirq.circuits.circuit import Circuit
-from cirq.circuits import circuit as _circuit
+from cirq import Circuit, ops, PointOptimizationSummary
+from cirq.circuits import circuit as _circuit, PointOptimizer
 
 
-class DropEmptyMoments():
+class DropEmptyMoments(PointOptimizer):
     """Removes empty moments from a circuit."""
+
+    def optimization_at(self, circuit: Circuit, index: int,
+                        op: ops.Operation) -> Optional[
+        PointOptimizationSummary]:
+        pass
 
     def __call__(self, circuit: _circuit.Circuit):
         self.optimize_circuit(circuit)
-
-    def optimize_circuit(self, circuit: Circuit):
-        circuit[:] = (m for m in circuit if m.operations)

--- a/cirq/optimizers/drop_empty_moments_test.py
+++ b/cirq/optimizers/drop_empty_moments_test.py
@@ -18,7 +18,7 @@ import cirq
 def assert_optimizes(before, after):
     opt = cirq.DropEmptyMoments()
     opt.optimize_circuit(before)
-    assert before == after
+    cirq.testing.assert_same_circuits(after, before)
 
 
 def test_drop():

--- a/cirq/optimizers/drop_negligible.py
+++ b/cirq/optimizers/drop_negligible.py
@@ -33,9 +33,6 @@ class DropNegligible(Optimizer):
         super().__init__(drop_empty_moments)
         self.tolerance = tolerance
 
-    def __call__(self, circuit: _circuit.Circuit):
-        self.optimize_circuit(circuit)
-
     def _optimize_circuit(self, circuit: _circuit.Circuit) -> None:
         deletions = []  # type: List[Tuple[int, ops.Operation]]
         for moment_index, moment in enumerate(circuit):

--- a/cirq/optimizers/drop_negligible.py
+++ b/cirq/optimizers/drop_negligible.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from cirq import protocols
 from cirq.circuits import circuit as _circuit
+from cirq.optimizers import DropEmptyMoments
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -31,10 +32,12 @@ class DropNegligible():
     def __init__(self, tolerance: float = 1e-8) -> None:
         self.tolerance = tolerance
 
-    def __call__(self, circuit: _circuit.Circuit):
-        self.optimize_circuit(circuit)
+    def __call__(self, circuit: _circuit.Circuit,
+                 drop_empty_moments: bool = True):
+        self.optimize_circuit(circuit, drop_empty_moments)
 
-    def optimize_circuit(self, circuit: _circuit.Circuit) -> None:
+    def optimize_circuit(self, circuit: _circuit.Circuit,
+                         drop_empty_moments: bool = True) -> None:
         deletions = []  # type: List[Tuple[int, ops.Operation]]
         for moment_index, moment in enumerate(circuit):
             for op in moment.operations:
@@ -42,3 +45,5 @@ class DropNegligible():
                         protocols.trace_distance_bound(op) <= self.tolerance):
                     deletions.append((moment_index, op))
         circuit.batch_remove(deletions)
+        if drop_empty_moments:
+            DropEmptyMoments()(circuit)

--- a/cirq/optimizers/drop_negligible_test.py
+++ b/cirq/optimizers/drop_negligible_test.py
@@ -14,19 +14,19 @@
 
 import cirq
 
-
+#TODO(test drop empty)
 def assert_optimizes(optimizer,
                      initial_circuit: cirq.Circuit,
                      expected_circuit: cirq.Circuit):
     circuit = cirq.Circuit(initial_circuit)
     optimizer.optimize_circuit(circuit)
-    assert circuit == expected_circuit
+    cirq.testing.assert_same_circuits(circuit, expected_circuit)
 
 
 def test_leaves_big():
     drop = cirq.DropNegligible(0.001)
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit([cirq.Moment([cirq.Z(a)**0.1])])
+    circuit = cirq.Circuit([cirq.Moment([cirq.Z(a) ** 0.1])])
 
     assert_optimizes(optimizer=drop,
                      initial_circuit=circuit,
@@ -34,9 +34,9 @@ def test_leaves_big():
 
 
 def test_clears_small():
-    drop = cirq.DropNegligible(0.001)
+    drop = cirq.DropNegligible(0.001, False)
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit([cirq.Moment([cirq.Z(a)**0.000001])])
+    circuit = cirq.Circuit([cirq.Moment([cirq.Z(a) ** 0.000001])])
 
     assert_optimizes(optimizer=drop,
                      initial_circuit=circuit,
@@ -46,20 +46,22 @@ def test_clears_small():
 def test_clears_known_empties_even_at_zero_tolerance():
     a, b = cirq.LineQubit.range(2)
     circuit = cirq.Circuit.from_ops(
-        cirq.Z(a)**0,
-        cirq.Y(a)**0.0000001,
-        cirq.X(a)**-0.0000001,
-        cirq.CZ(a, b)**0
+        cirq.Z(a) ** 0,
+        cirq.Y(a) ** 0.0000001,
+        cirq.X(a) ** -0.0000001,
+        cirq.CZ(a, b) ** 0
     )
-    assert_optimizes(optimizer=cirq.DropNegligible(tolerance=0.001),
+    assert_optimizes(optimizer=cirq.DropNegligible(tolerance=0.001,
+                                                   drop_empty_moments=False),
                      initial_circuit=circuit,
                      expected_circuit=cirq.Circuit([cirq.Moment()] * 4))
-    assert_optimizes(optimizer=cirq.DropNegligible(tolerance=0),
-                     initial_circuit=circuit,
-                     expected_circuit=cirq.Circuit(
-                         [
-                             cirq.Moment(),
-                             cirq.Moment([cirq.Y(a)**0.0000001]),
-                             cirq.Moment([cirq.X(a)**-0.0000001]),
-                             cirq.Moment(),
-                         ]))
+    assert_optimizes(
+        optimizer=cirq.DropNegligible(tolerance=0, drop_empty_moments=False),
+        initial_circuit=circuit,
+        expected_circuit=cirq.Circuit(
+            [
+                cirq.Moment(),
+                cirq.Moment([cirq.Y(a) ** 0.0000001]),
+                cirq.Moment([cirq.X(a) ** -0.0000001]),
+                cirq.Moment(),
+            ]))

--- a/cirq/optimizers/eject_phased_paulis_test.py
+++ b/cirq/optimizers/eject_phased_paulis_test.py
@@ -21,7 +21,7 @@ import cirq
 def assert_optimizes(before: cirq.Circuit,
                      expected: cirq.Circuit,
                      compare_unitaries: bool = True):
-    opt = cirq.EjectPhasedPaulis()
+    opt = cirq.EjectPhasedPaulis(drop_empty_moments=False)
 
     circuit = before.copy()
     opt.optimize_circuit(circuit)
@@ -30,28 +30,11 @@ def assert_optimizes(before: cirq.Circuit,
     if compare_unitaries:
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
             circuit, expected, 1e-8)
-
-    # And match the expected circuit.
-    assert circuit == expected, (
-        "Circuit wasn't optimized as expected.\n"
-        "INPUT:\n"
-        "{}\n"
-        "\n"
-        "EXPECTED OUTPUT:\n"
-        "{}\n"
-        "\n"
-        "ACTUAL OUTPUT:\n"
-        "{}\n"
-        "\n"
-        "EXPECTED OUTPUT (detailed):\n"
-        "{!r}\n"
-        "\n"
-        "ACTUAL OUTPUT (detailed):\n"
-        "{!r}").format(before, expected, circuit, expected, circuit)
-
+    #TODO(test drop empty)
+    cirq.testing.assert_same_circuits(circuit, expected)
     # And it should be idempotent.
     opt.optimize_circuit(circuit)
-    assert circuit == expected
+    cirq.testing.assert_same_circuits(circuit, expected)
 
 
 def quick_circuit(*moments: Iterable[cirq.OP_TREE]) -> cirq.Circuit:

--- a/cirq/optimizers/eject_z.py
+++ b/cirq/optimizers/eject_z.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 import sympy
 
 from cirq import circuits, ops, protocols
-from cirq.optimizers import decompositions
+from cirq.optimizers import decompositions, DropEmptyMoments
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -42,7 +42,8 @@ class EjectZ():
         """
         self.tolerance = tolerance
 
-    def optimize_circuit(self, circuit: circuits.Circuit):
+    def optimize_circuit(self, circuit: circuits.Circuit,
+                         drop_empty_moments=True):
         # Tracks qubit phases (in half turns; multiply by pi to get radians).
         qubit_phase = defaultdict(lambda: 0)  # type: Dict[ops.QubitId, float]
 
@@ -97,6 +98,8 @@ class EjectZ():
         circuit.batch_remove(deletions)
         circuit.batch_insert_into(inline_intos)
         circuit.batch_insert(insertions)
+        if drop_empty_moments:
+            DropEmptyMoments().optimize_circuit(circuit)
 
 
 def _try_get_known_z_half_turns(op: ops.Operation) -> Optional[float]:

--- a/cirq/optimizers/eject_z_test.py
+++ b/cirq/optimizers/eject_z_test.py
@@ -19,7 +19,8 @@ from cirq.optimizers.eject_z import _try_get_known_z_half_turns
 
 def assert_optimizes(before: cirq.Circuit,
                      expected: cirq.Circuit):
-    opt = cirq.EjectZ()
+    # TODO(test drop empty)
+    opt = cirq.EjectZ(drop_empty_moments=False)
 
     if cirq.has_unitary(before):
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
@@ -92,6 +93,8 @@ def test_early_z():
         ]),
         expected=cirq.Circuit([
             cirq.Moment([cirq.Z(q)**0.5]),
+            cirq.Moment(),
+            cirq.Moment(),
         ]))
 
 
@@ -146,6 +149,8 @@ def test_measurement_consumes_zs():
             cirq.Moment([cirq.measure(q)]),
         ]),
         expected=cirq.Circuit([
+            cirq.Moment(),
+            cirq.Moment(),
             cirq.Moment([cirq.measure(q)]),
         ]))
 
@@ -171,7 +176,9 @@ def test_unphaseable_causes_earlier_merge_without_size_increase():
         expected=cirq.Circuit([
             cirq.Moment([cirq.Z(q)]),
             cirq.Moment([u(q)]),
+            cirq.Moment(),
             cirq.Moment([cirq.Y(q)**-1.0]),
+            cirq.Moment(),
             cirq.Moment([cirq.PhasedXPowGate(phase_exponent=-0.75).on(q)]),
             cirq.Moment([cirq.Z(q)**0.75]),
             cirq.Moment([u(q)]),

--- a/cirq/optimizers/eject_z_test.py
+++ b/cirq/optimizers/eject_z_test.py
@@ -92,8 +92,6 @@ def test_early_z():
         ]),
         expected=cirq.Circuit([
             cirq.Moment([cirq.Z(q)**0.5]),
-            cirq.Moment(),
-            cirq.Moment(),
         ]))
 
 
@@ -148,8 +146,6 @@ def test_measurement_consumes_zs():
             cirq.Moment([cirq.measure(q)]),
         ]),
         expected=cirq.Circuit([
-            cirq.Moment(),
-            cirq.Moment(),
             cirq.Moment([cirq.measure(q)]),
         ]))
 
@@ -175,9 +171,7 @@ def test_unphaseable_causes_earlier_merge_without_size_increase():
         expected=cirq.Circuit([
             cirq.Moment([cirq.Z(q)]),
             cirq.Moment([u(q)]),
-            cirq.Moment(),
             cirq.Moment([cirq.Y(q)**-1.0]),
-            cirq.Moment(),
             cirq.Moment([cirq.PhasedXPowGate(phase_exponent=-0.75).on(q)]),
             cirq.Moment([cirq.Z(q)**0.75]),
             cirq.Moment([u(q)]),

--- a/cirq/optimizers/expand_composite.py
+++ b/cirq/optimizers/expand_composite.py
@@ -32,7 +32,8 @@ class ExpandComposite(PointOptimizer):
     """
 
     def __init__(self,
-                 no_decomp: Callable[[ops.Operation], bool]=(lambda _: False)
+                 no_decomp: Callable[[ops.Operation], bool]=(lambda _: False),
+                 drop_empty_moments: bool = True
                  ) -> None:
         """Construct the optimization pass.
 
@@ -40,7 +41,7 @@ class ExpandComposite(PointOptimizer):
             no_decomp: A predicate that determines whether an operation should
                 be decomposed or not. Defaults to decomposing everything.
         """
-        super().__init__()
+        super().__init__(drop_empty_moments=drop_empty_moments)
         self.no_decomp = no_decomp
 
     def optimization_at(self, circuit, index, op):

--- a/cirq/optimizers/expand_composite_test.py
+++ b/cirq/optimizers/expand_composite_test.py
@@ -16,30 +16,18 @@
 import cirq
 
 
-def assert_equal_mod_empty(expected, actual):
-    drop_empty = cirq.DropEmptyMoments()
-    drop_empty.optimize_circuit(actual)
-    if expected != actual:
-        # coverage: ignore
-        print('EXPECTED')
-        print(expected)
-        print('ACTUAL')
-        print(actual)
-    assert expected == actual
-
-
 def test_empty_circuit():
     circuit = cirq.Circuit()
     opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    assert_equal_mod_empty(cirq.Circuit(), circuit)
+    cirq.testing.assert_same_circuits(cirq.Circuit(), circuit)
 
 
 def test_empty_moment():
     circuit = cirq.Circuit([])
     opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    assert_equal_mod_empty(cirq.Circuit([]), circuit)
+    cirq.testing.assert_same_circuits(cirq.Circuit([]), circuit)
 
 
 def test_ignore_non_composite():
@@ -49,7 +37,7 @@ def test_ignore_non_composite():
     expected = circuit.copy()
     opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
-    assert_equal_mod_empty(expected, circuit)
+    cirq.testing.assert_same_circuits(expected, circuit)
 
 
 def test_composite_default():
@@ -61,7 +49,7 @@ def test_composite_default():
     opt.optimize_circuit(circuit)
     expected = cirq.Circuit()
     expected.append([cirq.Y(q1) ** -0.5, cirq.CZ(q0, q1), cirq.Y(q1) ** 0.5])
-    assert_equal_mod_empty(expected, circuit)
+    cirq.testing.assert_same_circuits(expected, circuit)
 
 
 def test_multiple_composite_default():
@@ -74,7 +62,7 @@ def test_multiple_composite_default():
     expected = cirq.Circuit()
     decomp = [cirq.Y(q1) ** -0.5, cirq.CZ(q0, q1), cirq.Y(q1) ** 0.5]
     expected.append([decomp, decomp])
-    assert_equal_mod_empty(expected, circuit)
+    cirq.testing.assert_same_circuits(expected, circuit)
 
 
 def test_mix_composite_non_composite():
@@ -90,7 +78,7 @@ def test_mix_composite_non_composite():
                                      cirq.Y(q1) ** 0.5,
                                      cirq.X(q1),
                                      strategy=cirq.InsertStrategy.NEW)
-    assert_equal_mod_empty(expected, actual)
+    cirq.testing.assert_same_circuits(expected, actual)
 
 
 def test_recursive_composite():
@@ -110,7 +98,7 @@ def test_recursive_composite():
                                        cirq.Y(q1) ** -0.5,
                                        cirq.CZ(q0, q1),
                                        cirq.Y(q1) ** 0.5)
-    assert_equal_mod_empty(expected, circuit)
+    cirq.testing.assert_same_circuits(expected, circuit)
 
 
 def test_decompose_returns_not_flat_op_tree():
@@ -126,7 +114,7 @@ def test_decompose_returns_not_flat_op_tree():
     opt = cirq.ExpandComposite()
     opt.optimize_circuit(circuit)
     expected = cirq.Circuit().from_ops(cirq.X(q0))
-    assert_equal_mod_empty(expected, circuit)
+    cirq.testing.assert_same_circuits(expected, circuit)
 
 
 def test_decompose_returns_deep_op_tree():
@@ -158,7 +146,7 @@ def test_decompose_returns_deep_op_tree():
         cirq.X(q0), cirq.X(q0),
         cirq.CZ(q0, q1), cirq.Y(q0),
         cirq.Z(q0), cirq.Z(q0))
-    assert_equal_mod_empty(expected, circuit)
+    cirq.testing.assert_same_circuits(expected, circuit)
 
 
 def test_nonrecursive_expansion():

--- a/cirq/optimizers/merge_interactions.py
+++ b/cirq/optimizers/merge_interactions.py
@@ -31,8 +31,9 @@ class MergeInteractions(circuits.PointOptimizer):
                  allow_partial_czs: bool = True,
                  post_clean_up: Callable[
                      [Sequence[ops.Operation]], ops.OP_TREE
-                 ] = lambda op_list: op_list) -> None:
-        super().__init__(post_clean_up=post_clean_up)
+                 ] = lambda op_list: op_list,
+                 drop_empty_moments: bool = True) -> None:
+        super().__init__(post_clean_up,  drop_empty_moments)
         self.tolerance = tolerance
         self.allow_partial_czs = allow_partial_czs
 

--- a/cirq/optimizers/merge_interactions_test.py
+++ b/cirq/optimizers/merge_interactions_test.py
@@ -35,19 +35,12 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit):
         cirq.EjectPhasedPaulis().optimize_circuit,
         cirq.EjectZ().optimize_circuit,
         cirq.DropNegligible().optimize_circuit,
-        cirq.DropEmptyMoments().optimize_circuit
     ]  # type: List[Callable[[cirq.Circuit], None]]
     for post in followup_optimizations:
         post(actual)
         post(expected)
 
-    if actual != expected:
-        # coverage: ignore
-        print('ACTUAL')
-        print(actual)
-        print('EXPECTED')
-        print(expected)
-    assert actual == expected
+    cirq.testing.assert_same_circuits(actual, expected)
 
 
 def assert_optimization_not_broken(circuit):
@@ -214,7 +207,6 @@ def test_post_clean_up():
     optimizer = cirq.MergeInteractions(allow_partial_czs=False,
                                        post_clean_up=clean_up)
     optimizer.optimize_circuit(circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
 
     assert isinstance(circuit[0].operations[0].gate, Marker)
     assert isinstance(circuit[-1].operations[0].gate, Marker)

--- a/cirq/optimizers/merge_interactions_test.py
+++ b/cirq/optimizers/merge_interactions_test.py
@@ -26,15 +26,15 @@ if TYPE_CHECKING:
 
 def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit):
     actual = cirq.Circuit(before)
-    opt = cirq.MergeInteractions()
+    opt = cirq.MergeInteractions(drop_empty_moments=False)
     opt.optimize_circuit(actual)
 
     # Ignore differences that would be caught by follow-up optimizations.
     followup_optimizations = [
         cirq.merge_single_qubit_gates_into_phased_x_z,
-        cirq.EjectPhasedPaulis().optimize_circuit,
-        cirq.EjectZ().optimize_circuit,
-        cirq.DropNegligible().optimize_circuit,
+        cirq.EjectPhasedPaulis(drop_empty_moments=False).optimize_circuit,
+        cirq.EjectZ(drop_empty_moments=False).optimize_circuit,
+        cirq.DropNegligible(drop_empty_moments=False).optimize_circuit,
     ]  # type: List[Callable[[cirq.Circuit], None]]
     for post in followup_optimizations:
         post(actual)

--- a/cirq/optimizers/merge_single_qubit_gates_test.py
+++ b/cirq/optimizers/merge_single_qubit_gates_test.py
@@ -30,21 +30,12 @@ def assert_optimizes(
     # Ignore differences that would be caught by follow-up optimizations.
     followup_optimizations = [
         cirq.DropNegligible(),
-        cirq.DropEmptyMoments()
     ]
     for post in followup_optimizations:
         post(before)  # type: ignore #  error: "object" not callable
         post(expected)  # type: ignore #  error: "object" not callable
 
-    try:
-        assert before == expected
-    except AssertionError:  # coverage: ignore
-        # coverage: ignore
-        print("BEFORE")
-        print(before)
-        print("EXPECTED")
-        print(expected)
-        raise
+    cirq.testing.assert_same_circuits(before, expected)
 
 
 def test_leaves_singleton():

--- a/cirq/optimizers/merge_single_qubit_gates_test.py
+++ b/cirq/optimizers/merge_single_qubit_gates_test.py
@@ -157,7 +157,6 @@ def test_rewrite():
     cirq.MergeSingleQubitGates(
         rewriter=lambda ops: cirq.H(ops[0].qubits[0])
     ).optimize_circuit(circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
 
     cirq.testing.assert_same_circuits(circuit, cirq.Circuit.from_ops(
         cirq.H(q0),


### PR DESCRIPTION
Fixes #1316. 

However, I am not yet convinced that this is the best direction to go as the implicit empty moment removal gets a bit tricky to reason about - it could be that leaving empty moment removal an explicit post-operation is what the pattern should be that we support - that is, we should just close #1316 and leave things as they are.

Having said that, if we decide that we like this superclass direction, I can clean up this PR further with more unit tests and docs as needed. 

Feedback, thoughts more than welcome! 