### PR TITLE
Verified and documented methods sampling from Haar measure.

### DIFF
--- a/cirq/testing/lin_alg_utils.py
+++ b/cirq/testing/lin_alg_utils.py
@@ -42,19 +42,46 @@ def random_unitary(dim: int) -> np.ndarray:
 
 
 def random_orthogonal(dim: int) -> np.ndarray:
-    # TODO(craiggidney): Distribute with Haar measure.
-    m = np.random.randn(dim, dim) * 2 - 1
+    """Returns a random orthogonal matrix distributed with Haar measure.
+
+    Args:
+      dim: The width and height of the matrix.
+
+    Returns:
+      The sampled orthogonal matrix.
+
+    References:
+        'How to generate random matrices from the classical compact groups'
+        http://arxiv.org/abs/math-ph/0609050
+    """
+    m = np.random.randn(dim, dim)
     q, _ = np.linalg.qr(m)
     return q
 
 
 def random_special_unitary(dim: int) -> np.ndarray:
+    """Returns a random special unitary distributed with Haar measure.
+
+    Args:
+      dim: The width and height of the matrix.
+
+    Returns:
+      The sampled special unitary.
+    """
     r = random_unitary(dim)
     r[0, :] /= np.linalg.det(r)
     return r
 
 
 def random_special_orthogonal(dim: int) -> np.ndarray:
+    """Returns a random special orthogonal matrix distributed with Haar measure.
+
+    Args:
+      dim: The width and height of the matrix.
+
+    Returns:
+      The sampled special orthogonal matrix.
+    """
     m = random_orthogonal(dim)
     if np.linalg.det(m) < 0:
         m[0, :] *= -1

--- a/cirq/testing/lin_alg_utils_test.py
+++ b/cirq/testing/lin_alg_utils_test.py
@@ -17,9 +17,13 @@ import pytest
 
 from cirq.testing import (
     random_unitary,
+    random_orthogonal,
+    random_special_unitary,
+    random_special_orthogonal,
     assert_allclose_up_to_global_phase,
 )
-from cirq.linalg import is_unitary
+from cirq.linalg import (is_unitary, is_orthogonal,
+                         is_special_unitary, is_special_orthogonal)
 
 
 def test_random_unitary():
@@ -29,6 +33,26 @@ def test_random_unitary():
     assert is_unitary(u2)
     assert not np.allclose(u1, u2)
 
+def test_random_orthogonal():
+    o1 = random_orthogonal(2)
+    o2 = random_orthogonal(2)
+    assert is_orthogonal(o1)
+    assert is_orthogonal(o2)
+    assert not np.allclose(o1, o2)
+
+def test_random_special_unitary():
+    u1 = random_special_unitary(2)
+    u2 = random_special_unitary(2)
+    assert is_special_unitary(u1)
+    assert is_special_unitary(u2)
+    assert not np.allclose(u1, u2)
+
+def test_random_special_orthgonal():
+    o1 = random_special_orthogonal(2)
+    o2 = random_special_orthogonal(2)
+    assert is_special_orthogonal(o1)
+    assert is_special_orthogonal(o2)
+    assert not np.allclose(o1, o2)
 
 def test_assert_allclose_up_to_global_phase():
     assert_allclose_up_to_global_phase(

--- a/cirq/testing/random_superposition.py
+++ b/cirq/testing/random_superposition.py
@@ -3,7 +3,7 @@ import numpy as np
 def random_superposition(dim: int) -> np.ndarray:
     """
     Args:
-        dim: Specified size returns a 2^dim length array.
+        dim: Specified size returns a dim length array.
     Returns:
         Normalized random array.
     """


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/1451

- Checked to make sure methods in `cirq.testing.linalg` is sampling from the Haar measure.
- Added a few more simple tests in `cirq.testing.linalg.lin_alg_utils_test.py`