### PR TITLE
Refactor PauliString.negated into complex PauliString.coefficient

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -27,7 +27,6 @@ from typing import (
     List, Any, Dict, FrozenSet, Callable, Iterable, Iterator, Optional,
     Sequence, Union, Type, Tuple, cast, TypeVar, overload, TYPE_CHECKING)
 
-import json
 import re
 import numpy as np
 
@@ -1529,12 +1528,10 @@ def _get_operation_circuit_diagram_info_with_fallback(
 
     return protocols.CircuitDiagramInfo(wire_symbols=symbols)
 
-def _is_exposed_formula(text):
-    return re.match('[a-zA-Z_][a-zA-Z0-9_]*$', text)
 
+def _is_exposed_formula(text: str) -> bool:
+    return re.match('[a-zA-Z_][a-zA-Z0-9_]*$', text) is None
 
-def _encode(text):
-    return json.JSONEncoder().encode(text)
 
 def _formatted_exponent(info: protocols.CircuitDiagramInfo,
                         args: protocols.CircuitDiagramInfoArgs
@@ -1542,9 +1539,9 @@ def _formatted_exponent(info: protocols.CircuitDiagramInfo,
 
     if protocols.is_parameterized(info.exponent):
         name = str(info.exponent)
-        return (name
+        return ('({})'.format(name)
                 if _is_exposed_formula(name)
-                else '({})'.format(_encode(name)))
+                else name)
 
     if info.exponent == 0:
         return '0'

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -298,6 +298,7 @@ a b
         use_unicode_characters=False,
         transpose=True)
 
+
 def test_symbol_addition_in_gate_exponent():
     # 1-qubit test
     qubit = cirq.NamedQubit('a')
@@ -307,7 +308,7 @@ def test_symbol_addition_in_gate_exponent():
             exponent=sympy.Symbol('a') + sympy.Symbol('b')).on(qubit)
     )
     cirq.testing.assert_has_diagram(circuit,
-                                    'a: ───X^0.5───Y^("a + b")───',
+                                    'a: ───X^0.5───Y^(a + b)───',
                                     use_unicode_characters=True)
 
 
@@ -317,14 +318,14 @@ a
 │
 X^0.5
 │
-Y^("a + b")
+Y^(a + b)
 │
 """,
                                     use_unicode_characters=True,
      transpose=True)
 
     cirq.testing.assert_has_diagram(circuit,
-                                    'a: ---X^0.5---Y^("a + b")---',
+                                    'a: ---X^0.5---Y^(a + b)---',
                                     use_unicode_characters=False)
 
     cirq.testing.assert_has_diagram(circuit,
@@ -333,7 +334,7 @@ a
 |
 X^0.5
 |
-Y^("a + b")
+Y^(a + b)
 |
 
 """,
@@ -1417,7 +1418,7 @@ def test_to_text_diagram_parameterized_value():
         PGate(sympy.Symbol('a')).on(q),
         PGate(sympy.Symbol('%$&#*(')).on(q),
     )
-    assert str(c).strip() == 'cube: ───P───P^2───P^a───P^("%$&#*(")───'
+    assert str(c).strip() == 'cube: ───P───P^2───P^a───P^(%$&#*()───'
 
 
 def test_to_text_diagram_custom_order():

--- a/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq/contrib/paulistring/clifford_optimize.py
@@ -100,7 +100,8 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
 
             qubit, pauli = next(iter(merge_op.pauli_string.items()))
             quarter_turns = round(merge_op.half_turns * 2)
-            assert merge_op.pauli_string.coefficient in [1, -1]
+            if merge_op.pauli_string.coefficient not in [1, -1]:
+                raise NotImplementedError("TODO: handle all coefficients.")
             quarter_turns *= int(merge_op.pauli_string.coefficient.real)
             quarter_turns %= 4
             part_cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(

--- a/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq/contrib/paulistring/clifford_optimize.py
@@ -100,7 +100,8 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
 
             qubit, pauli = next(iter(merge_op.pauli_string.items()))
             quarter_turns = round(merge_op.half_turns * 2)
-            quarter_turns *= (1, -1)[merge_op.pauli_string.negated]
+            assert merge_op.pauli_string.coefficient in [1, -1]
+            quarter_turns *= int(merge_op.pauli_string.coefficient.real)
             quarter_turns %= 4
             part_cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(
                                         pauli, quarter_turns)

--- a/cirq/contrib/paulistring/pauli_string_optimize.py
+++ b/cirq/contrib/paulistring/pauli_string_optimize.py
@@ -66,7 +66,7 @@ def merge_equal_strings(string_dag: circuits.CircuitDag) -> None:
                            - set(networkx.dag.descendants(string_dag, node))
                            - set([node]))
         for other_node in commuting_nodes:
-            if node.val.pauli_string.equal_up_to_sign(
+            if node.val.pauli_string.equal_up_to_coefficient(
                                         other_node.val.pauli_string):
                 string_dag.remove_node(other_node)
                 node.val = node.val.merged_with(other_node.val)

--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -15,6 +15,7 @@
 from typing import (
     Dict, Iterable, Optional, Union, cast
 )
+
 import sympy
 
 from cirq import ops, value, study, protocols
@@ -79,30 +80,26 @@ class PauliStringPhasor(PauliStringGateOperation):
     def merged_with(self, op: 'PauliStringPhasor') -> 'PauliStringPhasor':
         if not self.can_merge_with(op):
             raise ValueError('Cannot merge operations: {}, {}'.format(self, op))
-        neg_sign = (1, -1)[op.pauli_string.negated ^ self.pauli_string.negated]
+        coef = op.pauli_string.coefficient * self.pauli_string.coefficient
+        if coef not in [-1, 1]:
+            raise NotImplementedError("TODO: merge phased pauli operations.")
         half_turns = (cast(float, self.half_turns)
-                      + cast(float, op.half_turns) * neg_sign)
+                      + cast(float, op.half_turns) * int(coef.real))
         return PauliStringPhasor(self.pauli_string, half_turns=half_turns)
 
     def _decompose_(self) -> ops.OP_TREE:
         if len(self.pauli_string) <= 0:
             return
+        if self.pauli_string.coefficient not in [-1, +1]:
+            raise NotImplementedError("TODO: arbitrary coefficients.")
         qubits = self.qubits
         any_qubit = qubits[0]
         to_z_ops = ops.freeze_op_tree(self.pauli_string.to_z_basis_ops())
         xor_decomp = tuple(xor_nonlocal_decompose(qubits, any_qubit))
         yield to_z_ops
         yield xor_decomp
-        if protocols.is_parameterized(self.half_turns):
-            if self.pauli_string.negated:
-                yield ops.X(any_qubit)
-            yield ops.Z(any_qubit)**self.half_turns
-            if self.pauli_string.negated:
-                yield ops.X(any_qubit)
-        else:
-            half_turns = self.half_turns * (-1 if self.pauli_string.negated
-                                               else 1)
-            yield ops.Z(any_qubit) ** half_turns
+        sign = self.pauli_string.coefficient.real
+        yield ops.Z(any_qubit)**protocols.mul(self.half_turns, sign)
         yield protocols.inverse(xor_decomp)
         yield protocols.inverse(to_z_ops)
 

--- a/cirq/contrib/paulistring/pauli_string_phasor.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor.py
@@ -75,7 +75,7 @@ class PauliStringPhasor(PauliStringGateOperation):
         return self._with_half_turns(new_exponent)
 
     def can_merge_with(self, op: 'PauliStringPhasor') -> bool:
-        return self.pauli_string.equal_up_to_sign(op.pauli_string)
+        return self.pauli_string.equal_up_to_coefficient(op.pauli_string)
 
     def merged_with(self, op: 'PauliStringPhasor') -> 'PauliStringPhasor':
         if not self.can_merge_with(op):

--- a/cirq/contrib/paulistring/pauli_string_phasor_test.py
+++ b/cirq/contrib/paulistring/pauli_string_phasor_test.py
@@ -35,22 +35,22 @@ def test_eq_ne_hash():
         lambda: PauliStringPhasor(cirq.PauliString({}), half_turns=-1.5),
         lambda: PauliStringPhasor(cirq.PauliString({}), half_turns=2.5))
     eq.make_equality_group(
-        lambda: PauliStringPhasor(cirq.PauliString({}, True),
-                                       half_turns=-0.5))
+        lambda: PauliStringPhasor(cirq.PauliString({}, -1),
+                                  half_turns=-0.5))
     eq.add_equality_group(
         PauliStringPhasor(ps1),
         PauliStringPhasor(ps1, half_turns=1))
     eq.add_equality_group(
-        PauliStringPhasor(ps1.negate(), half_turns=1))
+        PauliStringPhasor(-ps1, half_turns=1))
     eq.add_equality_group(
         PauliStringPhasor(ps2),
         PauliStringPhasor(ps2, half_turns=1))
     eq.add_equality_group(
-        PauliStringPhasor(ps2.negate(), half_turns=1))
+        PauliStringPhasor(-ps2, half_turns=1))
     eq.add_equality_group(
         PauliStringPhasor(ps2, half_turns=0.5))
     eq.add_equality_group(
-        PauliStringPhasor(ps2.negate(), half_turns=-0.5))
+        PauliStringPhasor(-ps2, half_turns=-0.5))
     eq.add_equality_group(
         PauliStringPhasor(ps1, half_turns=sympy.Symbol('a')))
 
@@ -71,8 +71,8 @@ def test_pass_operations_over():
     q0, q1 = _make_qubits(2)
     op = cirq.SingleQubitCliffordGate.from_double_map(
             {cirq.Z: (cirq.X, False), cirq.X: (cirq.Z, False)})(q0)
-    ps_before = cirq.PauliString({q0: cirq.X, q1: cirq.Y}, True)
-    ps_after = cirq.PauliString({q0: cirq.Z, q1: cirq.Y}, True)
+    ps_before = cirq.PauliString({q0: cirq.X, q1: cirq.Y}, -1)
+    ps_after = cirq.PauliString({q0: cirq.Z, q1: cirq.Y}, -1)
     before = PauliStringPhasor(ps_before, half_turns=0.1)
     after = PauliStringPhasor(ps_after, half_turns=0.1)
     assert before.pass_operations_over([op]) == after
@@ -124,15 +124,15 @@ def test_can_merge_with():
     assert op1.can_merge_with(op2)
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=0.75)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=0.75)
     assert op1.can_merge_with(op2)
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.Y}, True), half_turns=0.75)
+            cirq.PauliString({q0: cirq.Y}, -1), half_turns=0.75)
     assert not op1.can_merge_with(op2)
 
 
@@ -145,41 +145,41 @@ def test_merge_with():
     assert op1.merged_with(op2) == op12
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.75)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.75)
     op12 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=1.0)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=1.0)
     assert op1.merged_with(op2) == op12
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=0.75)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=0.75)
     op12 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=-0.5)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=-0.5)
     assert op1.merged_with(op2) == op12
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.75)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.75)
     op12 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=-0.5)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=-0.5)
     assert op1.merged_with(op2) == op12
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=0.75)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=0.75)
     op12 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, True), half_turns=1.0)
+            cirq.PauliString({q0: cirq.X}, -1), half_turns=1.0)
     assert op1.merged_with(op2) == op12
 
     op1 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.X}, False), half_turns=0.25)
+            cirq.PauliString({q0: cirq.X}, +1), half_turns=0.25)
     op2 = PauliStringPhasor(
-            cirq.PauliString({q0: cirq.Y}, True), half_turns=0.75)
+            cirq.PauliString({q0: cirq.Y}, -1), half_turns=0.75)
     with pytest.raises(ValueError):
         op1.merged_with(op2)
 
@@ -264,17 +264,18 @@ def test_manual_default_decompose():
         rtol=1e-7, atol=1e-7)
 
 
-@pytest.mark.parametrize('paulis,half_turns,neg',
+@pytest.mark.parametrize('paulis,half_turns,sign',
     itertools.product(
         itertools.product((cirq.X, cirq.Y, cirq.Z, None), repeat=3),
         (0, 0.1, 0.5, 1, -0.25),
-        (False, True)))
-def test_default_decompose(paulis, half_turns, neg):
+        (+1, -1)))
+def test_default_decompose(paulis, half_turns: float, sign: int):
     paulis = [pauli for pauli in paulis if pauli is not None]
     qubits = _make_qubits(len(paulis))
 
     # Get matrix from decomposition
-    pauli_string = cirq.PauliString({q: p for q, p in zip(qubits, paulis)}, neg)
+    pauli_string = cirq.PauliString({q: p for q, p in zip(qubits, paulis)},
+                                    sign)
     actual = cirq.Circuit.from_ops(
         PauliStringPhasor(pauli_string, half_turns=half_turns)
     ).to_unitary_matrix()
@@ -286,7 +287,7 @@ def test_default_decompose(paulis, half_turns, neg):
     expected_convert = np.eye(1)
     for pauli in paulis:
         expected_convert = np.kron(expected_convert, to_z_mats[pauli])
-    t = 1j ** (half_turns * 2 * (-1 if neg else 1))
+    t = 1j ** (half_turns * 2 * sign)
     expected_z = np.diag([1, t, t, 1, t, 1, 1, t][:2**len(paulis)])
     expected = expected_convert.T.conj().dot(expected_z).dot(expected_convert)
 
@@ -302,12 +303,12 @@ def test_decompose_with_symbol():
     cirq.ExpandComposite().optimize_circuit(circuit)
     cirq.testing.assert_has_diagram(circuit, "q0: ───X^0.5───Z^a───X^-0.5───")
 
-    ps = cirq.PauliString({q0: cirq.Y}, True)
+    ps = cirq.PauliString({q0: cirq.Y}, -1)
     op = PauliStringPhasor(ps, half_turns=sympy.Symbol('a'))
     circuit = cirq.Circuit.from_ops(op)
     cirq.ExpandComposite().optimize_circuit(circuit)
     cirq.testing.assert_has_diagram(
-        circuit, "q0: ───X^0.5───X───Z^a───X───X^-0.5───")
+        circuit, "q0: ───X^0.5───Z^(-a)───X^-0.5───")
 
 
 def test_text_diagram():
@@ -320,22 +321,22 @@ def test_text_diagram():
                                             q2: cirq.Z})),
         PauliStringPhasor(cirq.PauliString({q0: cirq.Z,
                                             q1: cirq.Y,
-                                            q2: cirq.X}, True)) ** 0.5,
+                                            q2: cirq.X}, -1)) ** 0.5,
         PauliStringPhasor(cirq.PauliString({q0: cirq.Z,
                                             q1: cirq.Y,
                                             q2: cirq.X}),
                           half_turns=sympy.Symbol('a')),
         PauliStringPhasor(cirq.PauliString({q0: cirq.Z,
                                             q1: cirq.Y,
-                                            q2: cirq.X}, True),
+                                            q2: cirq.X}, -1),
                           half_turns=sympy.Symbol('b')))
 
     cirq.testing.assert_has_diagram(circuit, """
-q0: ───[Z]───[Y]^0.25───[Z]───[Z]────────[Z]─────[Z]──────
+q0: ───[Z]───[Y]^0.25───[Z]───[Z]────────[Z]─────[Z]────────
                         │     │          │       │
-q1: ────────────────────[Z]───[Y]────────[Y]─────[Y]──────
+q1: ────────────────────[Z]───[Y]────────[Y]─────[Y]────────
                         │     │          │       │
-q2: ────────────────────[Z]───[X]^-0.5───[X]^a───[X]^-b───
+q2: ────────────────────[Z]───[X]^-0.5───[X]^a───[X]^(-b)───
 """)
 
 
@@ -349,28 +350,28 @@ def test_repr():
             "PauliStringPhasor("
             "cirq.PauliString({cirq.NamedQubit('q0'): cirq.X, "
             "cirq.NamedQubit('q1'): cirq.Y, "
-            "cirq.NamedQubit('q2'): cirq.Z}, False), half_turns=0.5)")
+            "cirq.NamedQubit('q2'): cirq.Z}, (1+0j)), half_turns=0.5)")
 
     ps = PauliStringPhasor(cirq.PauliString({q2: cirq.Z,
                                              q1: cirq.Y,
-                                             q0: cirq.X}, True)
+                                             q0: cirq.X}, -1)
                                 ) ** -0.5
     assert (repr(ps) ==
             "PauliStringPhasor("
             "cirq.PauliString({cirq.NamedQubit('q0'): cirq.X, "
             "cirq.NamedQubit('q1'): cirq.Y, "
-            "cirq.NamedQubit('q2'): cirq.Z}, True), half_turns=-0.5)")
+            "cirq.NamedQubit('q2'): cirq.Z}, (-1+0j)), half_turns=-0.5)")
 
 
 def test_str():
     q0, q1, q2 = _make_qubits(3)
     ps = PauliStringPhasor(cirq.PauliString({q2: cirq.Z,
                                              q1: cirq.Y,
-                                             q0: cirq.X}, False)
+                                             q0: cirq.X}, +1)
                                 ) ** 0.5
     assert str(ps) == '(X(q0)*Y(q1)*Z(q2))**0.5'
 
     ps = PauliStringPhasor(cirq.PauliString({q2: cirq.Z,
                                              q1: cirq.Y,
-                                             q0: cirq.X}, True)) ** -0.5
+                                             q0: cirq.X}, -1)) ** -0.5
     assert str(ps) == '(-X(q0)*Y(q1)*Z(q2))**-0.5'

--- a/cirq/contrib/paulistring/pauli_string_raw_types.py
+++ b/cirq/contrib/paulistring/pauli_string_raw_types.py
@@ -63,10 +63,7 @@ class PauliStringGateOperation(ops.Operation,
         qubits = self.qubits if args.known_qubits is None else args.known_qubits
         syms = tuple('[{}]'.format(self.pauli_string[qubit])
                      for qubit in qubits)
-        if exponent_absorbs_sign and self.pauli_string.negated:
-            if isinstance(exponent, float):
-                exponent = -exponent
-            else:
-                exponent = '-{!s}'.format(exponent)
+        if exponent_absorbs_sign and self.pauli_string.coefficient == -1:
+            exponent = -exponent
         return protocols.CircuitDiagramInfo(wire_symbols=syms,
                                             exponent=exponent)

--- a/cirq/contrib/paulistring/pauli_string_raw_types.py
+++ b/cirq/contrib/paulistring/pauli_string_raw_types.py
@@ -64,6 +64,7 @@ class PauliStringGateOperation(ops.Operation,
         syms = tuple('[{}]'.format(self.pauli_string[qubit])
                      for qubit in qubits)
         if exponent_absorbs_sign and self.pauli_string.coefficient == -1:
+            # TODO: generalize to other coefficients.
             exponent = -exponent
         return protocols.CircuitDiagramInfo(wire_symbols=syms,
                                             exponent=exponent)

--- a/cirq/contrib/paulistring/pauli_string_raw_types_test.py
+++ b/cirq/contrib/paulistring/pauli_string_raw_types_test.py
@@ -80,7 +80,7 @@ def test_default_text_diagram():
 
     circuit = cirq.Circuit.from_ops(
         DiagramGate(ps),
-        DiagramGate(ps.negate()),
+        DiagramGate(-ps),
     )
     cirq.testing.assert_has_diagram(circuit, """
 q0: ───[X]───[X]───

--- a/cirq/ops/display_test.py
+++ b/cirq/ops/display_test.py
@@ -124,7 +124,7 @@ def test_approx_pauli_string_expectation_value(measurements, value):
 def test_properties():
     qubits = cirq.LineQubit.range(9)
     qubit_pauli_map = {q: cirq.Pauli.by_index(q.x) for q in qubits}
-    pauli_string = cirq.PauliString(qubit_pauli_map, negated=True)
+    pauli_string = cirq.PauliString(qubit_pauli_map, -1)
 
     pauli_string_expectation = cirq.PauliStringExpectation(
         pauli_string, key='a')
@@ -142,7 +142,7 @@ def test_with_qubits():
     old_qubits = cirq.LineQubit.range(9)
     new_qubits = cirq.LineQubit.range(9, 18)
     qubit_pauli_map = {q: cirq.Pauli.by_index(q.x) for q in old_qubits}
-    pauli_string = cirq.PauliString(qubit_pauli_map, negated=True)
+    pauli_string = cirq.PauliString(qubit_pauli_map, -1)
 
     assert (
         cirq.PauliStringExpectation(pauli_string).with_qubits(*new_qubits)
@@ -158,7 +158,7 @@ def test_with_qubits():
 def test_pauli_string_expectation_helper():
     qubits = cirq.LineQubit.range(9)
     qubit_pauli_map = {q: cirq.Pauli.by_index(q.x) for q in qubits}
-    pauli_string = cirq.PauliString(qubit_pauli_map, negated=True)
+    pauli_string = cirq.PauliString(qubit_pauli_map, -1)
 
     assert (cirq.pauli_string_expectation(pauli_string, key='a')
             == cirq.PauliStringExpectation(pauli_string, key='a'))

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -31,11 +31,8 @@ class PauliString(raw_types.Operation):
     def __init__(self,
                  qubit_pauli_map: Mapping[raw_types.Qid, Pauli],
                  coefficient: Union[int, float, complex] = 1) -> None:
-        assert coefficient is not False
-        assert coefficient is not True
-        assert isinstance(coefficient, (int, float, complex))
         self._qubit_pauli_map = dict(qubit_pauli_map)
-        self._coef = complex(coefficient)
+        self._coefficient = complex(coefficient)
 
     @staticmethod
     def from_single(qubit: raw_types.Qid, pauli: Pauli) -> 'PauliString':
@@ -44,13 +41,13 @@ class PauliString(raw_types.Operation):
 
     @property
     def coefficient(self) -> complex:
-        return self._coef
+        return self._coefficient
 
     def _value_equality_values_(self):
         return (frozenset(self._qubit_pauli_map.items()),
-                self._coef)
+                self._coefficient)
 
-    def equal_up_to_sign(self, other: 'PauliString') -> bool:
+    def equal_up_to_coefficient(self, other: 'PauliString') -> bool:
         return self._qubit_pauli_map == other._qubit_pauli_map
 
     def __getitem__(self, key: raw_types.Qid) -> Pauli:
@@ -72,12 +69,12 @@ class PauliString(raw_types.Operation):
 
     def __mul__(self, other):
         if isinstance(other, (int, float, complex)):
-            return PauliString(self._qubit_pauli_map, self._coef * other)
+            return PauliString(self._qubit_pauli_map, self._coefficient * other)
         return NotImplemented
 
     def __rmul__(self, other):
         if isinstance(other, (int, float, complex)):
-            return PauliString(self._qubit_pauli_map, self._coef * other)
+            return PauliString(self._qubit_pauli_map, self._coefficient * other)
         return NotImplemented
 
     def __contains__(self, key: raw_types.Qid) -> bool:
@@ -93,7 +90,7 @@ class PauliString(raw_types.Operation):
     def with_qubits(self, *new_qubits: raw_types.Qid) -> 'PauliString':
         return PauliString(dict(zip(new_qubits,
                                     (self[q] for q in self.qubits))),
-                           self._coef)
+                           self._coefficient)
 
     def values(self) -> ValuesView[Pauli]:
         return self._qubit_pauli_map.values()
@@ -110,14 +107,14 @@ class PauliString(raw_types.Operation):
     def __repr__(self):
         map_str = ', '.join(('{!r}: {!r}'.format(qubit, self[qubit])
                              for qubit in sorted(self.qubits)))
-        return 'cirq.PauliString({{{}}}, {})'.format(map_str, self._coef)
+        return 'cirq.PauliString({{{}}}, {})'.format(map_str, self._coefficient)
 
     def __str__(self):
         ordered_qubits = sorted(self.qubits)
         prefix = (
-            '-' if self._coef == -1
-            else '' if self._coef == 1
-            else '{}*'.format(self._coef)
+            '-' if self._coefficient == -1
+            else '' if self._coefficient == 1
+            else '{}*'.format(self._coefficient)
         )
         if not ordered_qubits:
             return '{}{}'.format(prefix, 'I')
@@ -141,7 +138,7 @@ class PauliString(raw_types.Operation):
                    ) % 2 == 0
 
     def __neg__(self) -> 'PauliString':
-        return PauliString(self._qubit_pauli_map, -self._coef)
+        return PauliString(self._qubit_pauli_map, -self._coefficient)
 
     def __pos__(self) -> 'PauliString':
         return self
@@ -150,7 +147,7 @@ class PauliString(raw_types.Operation):
                    ) -> 'PauliString':
         new_qubit_pauli_map = {qubit_map[qubit]: pauli
                                for qubit, pauli in self.items()}
-        return PauliString(new_qubit_pauli_map, self._coef)
+        return PauliString(new_qubit_pauli_map, self._coefficient)
 
     def to_z_basis_ops(self) -> op_tree.OP_TREE:
         """Returns operations to convert the qubits to the computational basis.
@@ -199,7 +196,7 @@ class PauliString(raw_types.Operation):
             should_negate ^= PauliString._pass_operation_over(pauli_map,
                                                               op,
                                                               after_to_before)
-        coef = self._coef * (-1 if should_negate else +1)
+        coef = -self._coefficient if should_negate else self.coefficient
         return PauliString(pauli_map, coef)
 
     @staticmethod
@@ -242,10 +239,11 @@ class PauliString(raw_types.Operation):
                                           qubit1: raw_types.Qid,
                                           after_to_before: bool = False
                                           ) -> bool:
-        def merge_and_kickback(qubit,
+        def merge_and_kickback(qubit: raw_types.Qid,
                                pauli_left: Optional[pauli_gates.Pauli],
                                pauli_right: Optional[pauli_gates.Pauli],
                                inv: bool) -> int:
+            assert pauli_left is not None or pauli_right is not None
             if pauli_left is None or pauli_right is None:
                 pauli_map[qubit] = cast(pauli_gates.Pauli,
                                         pauli_left or pauli_right)
@@ -261,14 +259,14 @@ class PauliString(raw_types.Operation):
                     return int(inv) * 2 - 1
 
         quarter_kickback = 0
-        if (qubit0 in pauli_map
-            and not pauli_map[qubit0].commutes_with(gate.pauli0)):
+        if (qubit0 in pauli_map and
+                not pauli_map[qubit0].commutes_with(gate.pauli0)):
             quarter_kickback += merge_and_kickback(qubit1,
                                                    gate.pauli1,
                                                    pauli_map.get(qubit1),
                                                    gate.invert1)
-        if (qubit1 in pauli_map
-            and not pauli_map[qubit1].commutes_with(gate.pauli1)):
+        if (qubit1 in pauli_map and
+                not pauli_map[qubit1].commutes_with(gate.pauli1)):
             quarter_kickback += merge_and_kickback(qubit0,
                                                    pauli_map.get(qubit0),
                                                    gate.pauli0,

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -267,6 +267,18 @@ def test_negate():
     assert -neg_ps1 == ps1
 
 
+def test_mul():
+    a, b = cirq.LineQubit.range(2)
+    p = cirq.PauliString({a: cirq.X, b: cirq.Y})
+    assert -p == -1 * p == -1.0 * p == p * -1 == p * complex(-1)
+    assert -p != 1j * p
+    assert +p == 1 * p
+    with pytest.raises(TypeError):
+        _ = p * 'test'
+    with pytest.raises(TypeError):
+        _ = 'test' * p
+
+
 def test_pos():
     q0, q1 = _make_qubits(2)
     qubit_pauli_map = {q0: cirq.X, q1: cirq.Y}

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import itertools
+from typing import List
+
 import numpy as np
 import pytest
 from cirq.testing import (
@@ -39,45 +41,45 @@ def test_eq_ne_hash():
     eq = EqualsTester()
     eq.make_equality_group(
         lambda: cirq.PauliString({}),
-        lambda: cirq.PauliString({}, False))
-    eq.add_equality_group(cirq.PauliString({}, True))
+        lambda: cirq.PauliString({}, +1))
+    eq.add_equality_group(cirq.PauliString({}, -1))
     for q, pauli in itertools.product((q0, q1), (cirq.X, cirq.Y, cirq.Z)):
-        eq.add_equality_group(cirq.PauliString({q: pauli}, False))
-        eq.add_equality_group(cirq.PauliString({q: pauli}, True))
+        eq.add_equality_group(cirq.PauliString({q: pauli}, +1))
+        eq.add_equality_group(cirq.PauliString({q: pauli}, -1))
     for q, p0, p1 in itertools.product((q0, q1), (cirq.X, cirq.Y, cirq.Z),
                                        (cirq.X, cirq.Y, cirq.Z)):
-        eq.add_equality_group(cirq.PauliString({q: p0, q2: p1}, False))
+        eq.add_equality_group(cirq.PauliString({q: p0, q2: p1}, +1))
 
 
 def test_equal_up_to_sign():
     q0, = _make_qubits(1)
-    assert cirq.PauliString({}, False).equal_up_to_sign(
-           cirq.PauliString({}, False))
-    assert cirq.PauliString({}, True).equal_up_to_sign(
-           cirq.PauliString({}, True))
-    assert cirq.PauliString({}, False).equal_up_to_sign(
-           cirq.PauliString({}, True))
+    assert cirq.PauliString({}, +1).equal_up_to_sign(
+           cirq.PauliString({}, +1))
+    assert cirq.PauliString({}, -1).equal_up_to_sign(
+           cirq.PauliString({}, -1))
+    assert cirq.PauliString({}, +1).equal_up_to_sign(
+           cirq.PauliString({}, -1))
 
-    assert cirq.PauliString({q0: cirq.X}, False).equal_up_to_sign(
-           cirq.PauliString({q0: cirq.X}, False))
-    assert cirq.PauliString({q0: cirq.X}, True).equal_up_to_sign(
-           cirq.PauliString({q0: cirq.X}, True))
-    assert cirq.PauliString({q0: cirq.X}, False).equal_up_to_sign(
-           cirq.PauliString({q0: cirq.X}, True))
+    assert cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+           cirq.PauliString({q0: cirq.X}, +1))
+    assert cirq.PauliString({q0: cirq.X}, -1).equal_up_to_sign(
+           cirq.PauliString({q0: cirq.X}, -1))
+    assert cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+           cirq.PauliString({q0: cirq.X}, -1))
 
-    assert not cirq.PauliString({q0: cirq.X}, False).equal_up_to_sign(
-               cirq.PauliString({q0: cirq.Y}, False))
-    assert not cirq.PauliString({q0: cirq.X}, True).equal_up_to_sign(
-               cirq.PauliString({q0: cirq.Y}, True))
-    assert not cirq.PauliString({q0: cirq.X}, False).equal_up_to_sign(
-               cirq.PauliString({q0: cirq.Y}, True))
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+               cirq.PauliString({q0: cirq.Y}, +1))
+    assert not cirq.PauliString({q0: cirq.X}, -1).equal_up_to_sign(
+               cirq.PauliString({q0: cirq.Y}, -1))
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+               cirq.PauliString({q0: cirq.Y}, -1))
 
-    assert not cirq.PauliString({q0: cirq.X}, False).equal_up_to_sign(
-               cirq.PauliString({}, False))
-    assert not cirq.PauliString({q0: cirq.X}, True).equal_up_to_sign(
-               cirq.PauliString({}, True))
-    assert not cirq.PauliString({q0: cirq.X}, False).equal_up_to_sign(
-               cirq.PauliString({}, True))
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+               cirq.PauliString({}, +1))
+    assert not cirq.PauliString({q0: cirq.X}, -1).equal_up_to_sign(
+               cirq.PauliString({}, -1))
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+               cirq.PauliString({}, -1))
 
 
 
@@ -157,19 +159,11 @@ def test_iter(qubit_pauli_map):
     assert set(tuple(qubit_pauli_map)) == set(tuple(pauli_string))
 
 
-# NamedQubit name repr in Python2 is different: u'q0' vs 'q0'
-@cirq.testing.only_test_in_python3
 def test_repr():
     q0, q1, q2 = _make_qubits(3)
     pauli_string = cirq.PauliString({q2: cirq.X, q1: cirq.Y, q0: cirq.Z})
-    assert (repr(pauli_string) ==
-            "cirq.PauliString({cirq.NamedQubit('q0'): cirq.Z, "
-            "cirq.NamedQubit('q1'): cirq.Y, cirq.NamedQubit('q2'): "
-            "cirq.X}, False)")
-    assert (repr(pauli_string.negate()) ==
-            "cirq.PauliString({cirq.NamedQubit('q0'): cirq.Z, "
-            "cirq.NamedQubit('q1'): cirq.Y, cirq.NamedQubit('q2'): "
-            "cirq.X}, True)")
+    cirq.testing.assert_equivalent_repr(pauli_string)
+    cirq.testing.assert_equivalent_repr(-pauli_string)
 
 
 def test_str():
@@ -178,7 +172,9 @@ def test_str():
     assert str(cirq.PauliString({})) == 'I'
     assert str(-cirq.PauliString({})) == '-I'
     assert str(pauli_string) == 'Z(q0)*Y(q1)*X(q2)'
-    assert str(pauli_string.negate()) == '-Z(q0)*Y(q1)*X(q2)'
+    assert str(-pauli_string) == '-Z(q0)*Y(q1)*X(q2)'
+    assert str(1j*pauli_string) == '1j*Z(q0)*Y(q1)*X(q2)'
+    assert str(pauli_string*-1j) == '-1j*Z(q0)*Y(q1)*X(q2)'
 
 
 @pytest.mark.parametrize('map1,map2,out', (lambda q0, q1, q2: (
@@ -264,10 +260,11 @@ def test_negate():
     q0, q1 = _make_qubits(2)
     qubit_pauli_map = {q0: cirq.X, q1: cirq.Y}
     ps1 = cirq.PauliString(qubit_pauli_map)
-    ps2 = cirq.PauliString(qubit_pauli_map, True)
-    assert ps1.negate() == -ps1 == ps2
-    assert ps1 == ps2.negate() == -ps2
-    assert ps1.negate().negate() == ps1
+    ps2 = cirq.PauliString(qubit_pauli_map, -1)
+    assert -ps1 == ps2
+    assert ps1 == -ps2
+    neg_ps1 = -ps1
+    assert -neg_ps1 == ps1
 
 
 def test_pos():
@@ -313,81 +310,85 @@ def test_to_z_basis_ops():
                     z_basis_state, expected_state, rtol=1e-7, atol=1e-7)
 
 
-def _assert_pass_over(ops, before, after):
+def _assert_pass_over(ops: List[cirq.Operation],
+                      before: cirq.PauliString,
+                      after: cirq.PauliString):
     assert before.pass_operations_over(ops[::-1]) == after
-    assert (after.pass_operations_over(ops, after_to_before=True)
-            == before)
+    assert after.pass_operations_over(ops, after_to_before=True) == before
 
 
-@pytest.mark.parametrize('shift,t_or_f',
-        itertools.product(range(3), (True, False)))
-def test_pass_operations_over_single(shift, t_or_f):
+@pytest.mark.parametrize('shift,sign',
+                         itertools.product(range(3), (-1, +1)))
+def test_pass_operations_over_single(shift: int, sign: int):
     q0, q1 = _make_qubits(2)
     X, Y, Z = (cirq.Pauli.by_relative_index(pauli, shift)
                for pauli in (cirq.X, cirq.Y, cirq.Z))
 
     op0 = cirq.SingleQubitCliffordGate.from_pauli(Y)(q1)
-    ps_before = cirq.PauliString({q0: X}, t_or_f)
+    ps_before = cirq.PauliString({q0: X}, sign)
     ps_after = ps_before
     _assert_pass_over([op0], ps_before, ps_after)
 
     op0 = cirq.SingleQubitCliffordGate.from_pauli(X)(q0)
     op1 = cirq.SingleQubitCliffordGate.from_pauli(Y)(q1)
-    ps_before = cirq.PauliString({q0: X, q1: Y}, t_or_f)
+    ps_before = cirq.PauliString({q0: X, q1: Y}, sign)
     ps_after = ps_before
     _assert_pass_over([op0, op1], ps_before, ps_after)
 
-    op0 = cirq.SingleQubitCliffordGate.from_double_map({Z: (X,False),
-                                                        X: (Z,False)})(q0)
-    ps_before = cirq.PauliString({q0: X, q1: Y}, t_or_f)
-    ps_after = cirq.PauliString({q0: Z, q1: Y}, t_or_f)
+    op0 = cirq.SingleQubitCliffordGate.from_double_map({Z: (X, False),
+                                                        X: (Z, False)})(q0)
+    ps_before = cirq.PauliString({q0: X, q1: Y}, sign)
+    ps_after = cirq.PauliString({q0: Z, q1: Y}, sign)
     _assert_pass_over([op0], ps_before, ps_after)
 
     op1 = cirq.SingleQubitCliffordGate.from_pauli(X)(q1)
-    ps_before = cirq.PauliString({q0: X, q1: Y}, t_or_f)
-    ps_after = ps_before.negate()
+    ps_before = cirq.PauliString({q0: X, q1: Y}, sign)
+    ps_after = -ps_before
     _assert_pass_over([op1], ps_before, ps_after)
 
-    ps_after = cirq.PauliString({q0: Z, q1: Y}, not t_or_f)
+    ps_after = cirq.PauliString({q0: Z, q1: Y}, -sign)
     _assert_pass_over([op0, op1], ps_before, ps_after)
 
     op0 = cirq.SingleQubitCliffordGate.from_pauli(Z, True)(q0)
     op1 = cirq.SingleQubitCliffordGate.from_pauli(X, True)(q0)
-    ps_before = cirq.PauliString({q0: X}, t_or_f)
-    ps_after = cirq.PauliString({q0: Y}, not t_or_f)
+    ps_before = cirq.PauliString({q0: X}, sign)
+    ps_after = cirq.PauliString({q0: Y}, -sign)
     _assert_pass_over([op0, op1], ps_before, ps_after)
 
 
 @pytest.mark.parametrize('shift,t_or_f1, t_or_f2,neg',
         itertools.product(range(3), *((True, False),)*3))
 def test_pass_operations_over_double(shift, t_or_f1, t_or_f2, neg):
+    sign = -1 if neg else +1
     q0, q1, q2 = _make_qubits(3)
     X, Y, Z = (cirq.Pauli.by_relative_index(pauli, shift)
                for pauli in (cirq.X, cirq.Y, cirq.Z))
 
     op0 = cirq.PauliInteractionGate(Z, t_or_f1, X, t_or_f2)(q0, q1)
-    ps_before = cirq.PauliString({q0: Z, q2: Y}, neg)
-    ps_after = cirq.PauliString({q0: Z, q2: Y}, neg)
+    ps_before = cirq.PauliString({q0: Z, q2: Y}, sign)
+    ps_after = cirq.PauliString({q0: Z, q2: Y}, sign)
     _assert_pass_over([op0], ps_before, ps_after)
 
     op0 = cirq.PauliInteractionGate(Y, t_or_f1, X, t_or_f2)(q0, q1)
-    ps_before = cirq.PauliString({q0: Z, q2: Y}, neg)
-    ps_after = cirq.PauliString({q0: Z, q2: Y, q1: X}, neg)
+    ps_before = cirq.PauliString({q0: Z, q2: Y}, sign)
+    ps_after = cirq.PauliString({q0: Z, q2: Y, q1: X}, sign)
     _assert_pass_over([op0], ps_before, ps_after)
 
     op0 = cirq.PauliInteractionGate(Z, t_or_f1, X, t_or_f2)(q0, q1)
-    ps_before = cirq.PauliString({q0: Z, q1: Y}, neg)
-    ps_after = cirq.PauliString({q1: Y}, neg)
+    ps_before = cirq.PauliString({q0: Z, q1: Y}, sign)
+    ps_after = cirq.PauliString({q1: Y}, sign)
     _assert_pass_over([op0], ps_before, ps_after)
 
     op0 = cirq.PauliInteractionGate(Y, t_or_f1, X, t_or_f2)(q0, q1)
-    ps_before = cirq.PauliString({q0: Z, q1: Y}, neg)
-    ps_after = cirq.PauliString({q0: X, q1: Z}, neg ^ t_or_f1 ^ t_or_f2)
+    ps_before = cirq.PauliString({q0: Z, q1: Y}, sign)
+    ps_after = cirq.PauliString({q0: X, q1: Z},
+                                -1 if neg ^ t_or_f1 ^ t_or_f2 else +1)
     _assert_pass_over([op0], ps_before, ps_after)
 
     op0 = cirq.PauliInteractionGate(X, t_or_f1, X, t_or_f2)(q0, q1)
-    ps_before = cirq.PauliString({q0: Z, q1: Y}, neg)
-    ps_after = cirq.PauliString({q0: Y, q1: Z}, not neg ^ t_or_f1 ^ t_or_f2)
+    ps_before = cirq.PauliString({q0: Z, q1: Y}, sign)
+    ps_after = cirq.PauliString({q0: Y, q1: Z},
+                                +1 if neg ^ t_or_f1 ^ t_or_f2 else -1)
     _assert_pass_over([op0], ps_before, ps_after)
 
 
@@ -421,10 +422,10 @@ def test_with_qubits():
     old_qubits = cirq.LineQubit.range(9)
     new_qubits = cirq.LineQubit.range(9, 18)
     qubit_pauli_map = {q: cirq.Pauli.by_index(q.x) for q in old_qubits}
-    pauli_string = cirq.PauliString(qubit_pauli_map, negated=True)
+    pauli_string = cirq.PauliString(qubit_pauli_map, -1)
     new_pauli_string = pauli_string.with_qubits(*new_qubits)
 
     assert new_pauli_string.qubits == tuple(new_qubits)
     for q in new_qubits:
         assert new_pauli_string[q] == cirq.Pauli.by_index(q.x)
-    assert new_pauli_string.negated is True
+    assert new_pauli_string.coefficient == -1

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -51,34 +51,38 @@ def test_eq_ne_hash():
         eq.add_equality_group(cirq.PauliString({q: p0, q2: p1}, +1))
 
 
-def test_equal_up_to_sign():
+def test_equal_up_to_coefficient():
     q0, = _make_qubits(1)
-    assert cirq.PauliString({}, +1).equal_up_to_sign(
+    assert cirq.PauliString({}, +1).equal_up_to_coefficient(
            cirq.PauliString({}, +1))
-    assert cirq.PauliString({}, -1).equal_up_to_sign(
+    assert cirq.PauliString({}, -1).equal_up_to_coefficient(
            cirq.PauliString({}, -1))
-    assert cirq.PauliString({}, +1).equal_up_to_sign(
+    assert cirq.PauliString({}, +1).equal_up_to_coefficient(
            cirq.PauliString({}, -1))
+    assert cirq.PauliString({}, +1).equal_up_to_coefficient(
+           cirq.PauliString({}, 2j))
 
-    assert cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+    assert cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
            cirq.PauliString({q0: cirq.X}, +1))
-    assert cirq.PauliString({q0: cirq.X}, -1).equal_up_to_sign(
+    assert cirq.PauliString({q0: cirq.X}, -1).equal_up_to_coefficient(
            cirq.PauliString({q0: cirq.X}, -1))
-    assert cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+    assert cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
            cirq.PauliString({q0: cirq.X}, -1))
 
-    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
                cirq.PauliString({q0: cirq.Y}, +1))
-    assert not cirq.PauliString({q0: cirq.X}, -1).equal_up_to_sign(
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
+               cirq.PauliString({q0: cirq.Y}, 1j))
+    assert not cirq.PauliString({q0: cirq.X}, -1).equal_up_to_coefficient(
                cirq.PauliString({q0: cirq.Y}, -1))
-    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
                cirq.PauliString({q0: cirq.Y}, -1))
 
-    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
                cirq.PauliString({}, +1))
-    assert not cirq.PauliString({q0: cirq.X}, -1).equal_up_to_sign(
+    assert not cirq.PauliString({q0: cirq.X}, -1).equal_up_to_coefficient(
                cirq.PauliString({}, -1))
-    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_sign(
+    assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(
                cirq.PauliString({}, -1))
 
 

--- a/cirq/protocols/mul.py
+++ b/cirq/protocols/mul.py
@@ -54,10 +54,14 @@ def mul(lhs: Any, rhs: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
         result = NotImplemented if right_mul is None else right_mul(lhs)
 
     # Don't build up factors of 1.0 vs sympy Symbols.
-    if lhs == 1.0 and is_parameterized(rhs):
+    if lhs == 1 and is_parameterized(rhs):
         result = rhs
-    if rhs == 1.0 and is_parameterized(lhs):
+    if rhs == 1 and is_parameterized(lhs):
         result = lhs
+    if lhs == -1 and is_parameterized(rhs):
+        result = -rhs
+    if rhs == -1 and is_parameterized(lhs):
+        result = -lhs
 
     # Output.
     if result is not NotImplemented:


### PR DESCRIPTION
- Work around sympy not folding -1.0 * symbol into -symbol
- Don't quote circuit symbol equations like "-a" and "a*2". Just bracket them.
- Drop 'negate' method (redundant with unary negation)
- Leave some TODOs work in contrib
- Fix PauliStringGateOperation avoiding negating sympy expressions
- Add support for multiplying pauli strings by complex coefficients