### PR TITLE
Use LinearDict for Pauli expansions

### DIFF
--- a/cirq/linalg/operator_spaces.py
+++ b/cirq/linalg/operator_spaces.py
@@ -18,6 +18,8 @@ from typing import Dict
 
 import numpy as np
 
+from cirq import value
+
 PAULI_BASIS = {
     'I': np.eye(2),
     'X': np.array([[0., 1.], [1., 0.]]),
@@ -50,21 +52,21 @@ def hilbert_schmidt_inner_product(m1: np.ndarray, m2: np.ndarray) -> complex:
 def expand_matrix_in_orthogonal_basis(
         m: np.ndarray,
         basis: Dict[str, np.ndarray],
-) -> Dict[str, complex]:
+) -> value.LinearDict[str]:
     """Computes coefficients of expansion of m in basis.
 
     We require that basis be orthogonal w.r.t. the Hilbert-Schmidt inner
     product. We do not require that basis be orthonormal. Note that Pauli
     basis (I, X, Y, Z) is orthogonal, but not orthonormal.
     """
-    return {
+    return value.LinearDict({
         name: (hilbert_schmidt_inner_product(b, m) /
                hilbert_schmidt_inner_product(b, b))
         for name, b in basis.items()
-    }
+    })
 
 
-def matrix_from_basis_coefficients(expansion: Dict[str, complex],
+def matrix_from_basis_coefficients(expansion: value.LinearDict[str],
                                    basis: Dict[str, np.ndarray]) -> np.ndarray:
     """Computes linear combination of basis vectors with given coefficients."""
     some_element = next(iter(basis.values()))

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -92,15 +92,15 @@ class XPowGate(eigen_gate.EigenGate,
             (1, np.array([[0.5, -0.5], [-0.5, 0.5]])),
         ]
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         phase = 1j**(2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return {
+        return value.LinearDict({
             'I': phase * np.cos(angle),
             'X': -1j * phase * np.sin(angle),
-        }
+        })
 
     def _circuit_diagram_info_(self, args: protocols.CircuitDiagramInfoArgs
                                ) -> Union[str, protocols.CircuitDiagramInfo]:
@@ -188,15 +188,15 @@ class YPowGate(eigen_gate.EigenGate,
             (1, np.array([[0.5, 0.5j], [-0.5j, 0.5]])),
         ]
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         phase = 1j**(2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return {
+        return value.LinearDict({
             'I': phase * np.cos(angle),
             'Y': -1j * phase * np.sin(angle),
-        }
+        })
 
     def _circuit_diagram_info_(self, args: protocols.CircuitDiagramInfoArgs
                                ) -> Union[str, protocols.CircuitDiagramInfo]:
@@ -295,15 +295,15 @@ class ZPowGate(eigen_gate.EigenGate,
             (1, np.diag([0, 1])),
         ]
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         phase = 1j**(2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return {
+        return value.LinearDict({
             'I': phase * np.cos(angle),
             'Z': -1j * phase * np.sin(angle),
-        }
+        })
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return self
@@ -564,8 +564,8 @@ class IdentityGate(gate_features.MultiQubitGate):
         self, args: protocols.ApplyUnitaryArgs) -> Optional[np.ndarray]:
         return args.target_tensor
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
-        return {'I' * self.num_qubits(): 1.0}
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
+        return value.LinearDict({'I' * self.num_qubits(): 1.0})
 
     def __repr__(self):
         if self.num_qubits() == 1:
@@ -621,16 +621,16 @@ class HPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
 
         return [(0, component0), (1, component1)]
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         phase = 1j**(2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return {
+        return value.LinearDict({
             'I': phase * np.cos(angle),
             'X': -1j * phase * np.sin(angle) / np.sqrt(2),
             'Z': -1j * phase * np.sin(angle) / np.sqrt(2),
-        }
+        })
 
     def _apply_unitary_(self, args: protocols.ApplyUnitaryArgs
                         ) -> Optional[np.ndarray]:
@@ -729,18 +729,18 @@ class CZPowGate(eigen_gate.EigenGate,
             args.target_tensor *= p
         return args.target_tensor
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j**(2 * self._exponent * self._global_shift)
         z_phase = 1j**self._exponent
         c = -1j * z_phase * np.sin(np.pi * self._exponent / 2) / 2
-        return {
+        return value.LinearDict({
             'II': global_phase * (1 - c),
             'IZ': global_phase * c,
             'ZI': global_phase * c,
             'ZZ': global_phase * -c,
-        }
+        })
 
     def _phase_by_(self, phase_turns, qubit_index):
         return self
@@ -852,18 +852,18 @@ class CNotPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
             args.target_tensor *= p
         return args.target_tensor
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j**(2 * self._exponent * self._global_shift)
         cnot_phase = 1j**self._exponent
         c = -1j * cnot_phase * np.sin(np.pi * self._exponent / 2) / 2
-        return {
+        return value.LinearDict({
             'II': global_phase * (1 - c),
             'IX': global_phase * c,
             'ZI': global_phase * c,
             'ZX': global_phase * -c,
-        }
+        })
 
     def _qasm_(self,
                args: protocols.QasmArgs,
@@ -956,18 +956,18 @@ class SwapPowGate(eigen_gate.EigenGate,
             args.target_tensor *= p
         return args.target_tensor
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j**(2 * self._exponent * self._global_shift)
         swap_phase = 1j**self._exponent
         c = -1j * swap_phase * np.sin(np.pi * self._exponent / 2) / 2
-        return {
+        return value.LinearDict({
             'II': global_phase * (1 - c),
             'XX': global_phase * c,
             'YY': global_phase * c,
             'ZZ': global_phase * c,
-        }
+        })
 
     def _circuit_diagram_info_(self, args: protocols.CircuitDiagramInfoArgs
                                ) -> protocols.CircuitDiagramInfo:
@@ -1071,18 +1071,18 @@ class ISwapPowGate(eigen_gate.EigenGate,
             args.target_tensor *= p
         return args.target_tensor
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j**(2 * self._exponent * self._global_shift)
         angle = np.pi * self._exponent / 4
         c, s = np.cos(angle), np.sin(angle)
-        return {
+        return value.LinearDict({
             'II': global_phase * c * c,
             'XX': global_phase * c * s * 1j,
             'YY': global_phase * s * c * 1j,
             'ZZ': global_phase * s * s,
-        }
+        })
 
     def _circuit_diagram_info_(self, args: protocols.CircuitDiagramInfoArgs
                                ) -> protocols.CircuitDiagramInfo:

--- a/cirq/ops/phased_x_gate.py
+++ b/cirq/ops/phased_x_gate.py
@@ -144,17 +144,17 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         p = np.exp(1j * np.pi * self._global_shift * self._exponent)
         return np.dot(np.dot(z, x), np.conj(z)) * p
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if self._is_parameterized_():
             return NotImplemented
         phase_angle = np.pi * self._phase_exponent / 2
         angle = np.pi * self._exponent / 2
         phase = 1j**(2 * self._exponent * (self._global_shift + 0.5))
-        return {
+        return value.LinearDict({
             'I': phase * np.cos(angle),
             'X': -1j * phase * np.sin(angle) * np.cos(2 * phase_angle),
             'Y': -1j * phase * np.sin(angle) * np.sin(2 * phase_angle),
-        }
+        })
 
     def _is_parameterized_(self) -> bool:
         """See `cirq.SupportsParameterization`."""

--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -18,7 +18,7 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 
-from cirq import linalg, protocols
+from cirq import linalg, protocols, value
 from cirq._compat import proper_repr
 from cirq.ops import (
     common_gates,
@@ -45,13 +45,13 @@ class CCZPowGate(eigen_gate.EigenGate,
             (1, np.diag([0, 0, 0, 0, 0, 0, 0, 1])),
         ]
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j**(2 * self._exponent * self._global_shift)
         z_phase = 1j**self._exponent
         c = -1j * z_phase * np.sin(np.pi * self._exponent / 2) / 4
-        return {
+        return value.LinearDict({
             'III': global_phase * (1 - c),
             'IIZ': global_phase * c,
             'IZI': global_phase * c,
@@ -60,7 +60,7 @@ class CCZPowGate(eigen_gate.EigenGate,
             'ZIZ': global_phase * -c,
             'IZZ': global_phase * -c,
             'ZZZ': global_phase * c,
-        }
+        })
 
     def _decompose_(self, qubits):
         """An adjacency-respecting decomposition.
@@ -162,13 +162,13 @@ class CCXPowGate(eigen_gate.EigenGate,
                                   np.array([[0.5, -0.5], [-0.5, 0.5]]))),
         ]
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j**(2 * self._exponent * self._global_shift)
         z_phase = 1j**self._exponent
         c = -1j * z_phase * np.sin(np.pi * self._exponent / 2) / 4
-        return {
+        return value.LinearDict({
             'III': global_phase * (1 - c),
             'IIX': global_phase * c,
             'IZI': global_phase * c,
@@ -177,7 +177,7 @@ class CCXPowGate(eigen_gate.EigenGate,
             'ZIX': global_phase * -c,
             'IZX': global_phase * -c,
             'ZZX': global_phase * c,
-        }
+        })
 
     def qubit_index_to_equivalence_group_key(self, index):
         return index < 2
@@ -243,8 +243,8 @@ class CSwapGate(gate_features.ThreeQubitGate,
     def qubit_index_to_equivalence_group_key(self, index):
         return 0 if index == 0 else 1
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
-        return {
+    def _pauli_expansion_(self) -> value.LinearDict[str]:
+        return value.LinearDict({
             'III': 3/4,
             'IXX': 1/4,
             'IYY': 1/4,
@@ -253,7 +253,7 @@ class CSwapGate(gate_features.ThreeQubitGate,
             'ZXX': -1/4,
             'ZYY': -1/4,
             'ZZZ': -1/4,
-        }
+        })
 
     def _decompose_(self, qubits):
         c, t1, t2 = qubits

--- a/cirq/protocols/pauli_expansion_test.py
+++ b/cirq/protocols/pauli_expansion_test.py
@@ -30,10 +30,10 @@ class ReturnsNotImplemented:
 
 
 class ReturnsExpansion:
-    def __init__(self, expansion: Dict[str, complex]) -> None:
+    def __init__(self, expansion: cirq.LinearDict[str]) -> None:
         self._expansion = expansion
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> cirq.LinearDict[str]:
         return self._expansion
 
 
@@ -60,17 +60,21 @@ def test_raises_no_pauli_expansion(val):
 
 
 @pytest.mark.parametrize('val, expected_expansion', (
-    (ReturnsExpansion({'X': 1, 'Y': 2, 'Z': 3}), {'X': 1, 'Y': 2, 'Z': 3}),
-    (HasUnitary(np.eye(2)), {'I': 1}),
-    (HasUnitary(np.array([[1, -1j], [1j, -1]])), {'Y': 1, 'Z': 1}),
-    (HasUnitary(np.array([[0., 1.], [0., 0.]])), {'X': 0.5, 'Y': 0.5j}),
-    (HasUnitary(np.eye(16)), {'IIII': 1.0}),
-    (cirq.H, {'X': np.sqrt(0.5), 'Z': np.sqrt(0.5)}),
-    (cirq.Ry(np.pi / 2),
-        {'I': np.cos(np.pi / 4), 'Y': -1j * np.sin(np.pi / 4)}),
+    (ReturnsExpansion(cirq.LinearDict({'X': 1, 'Y': 2, 'Z': 3})),
+        cirq.LinearDict({'X': 1, 'Y': 2, 'Z': 3})),
+    (HasUnitary(np.eye(2)), cirq.LinearDict({'I': 1})),
+    (HasUnitary(np.array([[1, -1j], [1j, -1]])),
+        cirq.LinearDict({'Y': 1, 'Z': 1})),
+    (HasUnitary(np.array([[0., 1.], [0., 0.]])),
+        cirq.LinearDict({'X': 0.5, 'Y': 0.5j})),
+    (HasUnitary(np.eye(16)), cirq.LinearDict({'IIII': 1.0})),
+    (cirq.H, cirq.LinearDict({'X': np.sqrt(0.5), 'Z': np.sqrt(0.5)})),
+    (cirq.Ry(np.pi / 2), cirq.LinearDict({'I': np.cos(np.pi / 4),
+                                          'Y': -1j * np.sin(np.pi / 4)})),
 ))
 def test_pauli_expansion(val, expected_expansion):
     actual_expansion = cirq.pauli_expansion(val)
+    assert cirq.approx_eq(actual_expansion, expected_expansion, atol=1e-12)
     assert set(actual_expansion.keys()) == set(expected_expansion.keys())
     for name in actual_expansion.keys():
         assert np.abs(actual_expansion[name] - expected_expansion[name]) < 1e-12

--- a/cirq/testing/consistent_pauli_expansion_test.py
+++ b/cirq/testing/consistent_pauli_expansion_test.py
@@ -28,8 +28,10 @@ class GoodGateExplicitPauliExpansion(cirq.SingleQubitGate):
     def _unitary_(self) -> np.ndarray:
         return np.sqrt(1/2) * X + np.sqrt(1/3) * Y + np.sqrt(1/6) * Z
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
-        return {'X': np.sqrt(1/2), 'Y': np.sqrt(1/3), 'Z': np.sqrt(1/6)}
+    def _pauli_expansion_(self) -> cirq.LinearDict[str]:
+        return cirq.LinearDict({'X': np.sqrt(1/2),
+                                'Y': np.sqrt(1/3),
+                                'Z': np.sqrt(1/6)})
 
 
 class GoodGateImplicitPauliExpansion(cirq.SingleQubitGate):
@@ -46,8 +48,8 @@ class GoodGateNoPauliExpansion(cirq.MultiQubitGate):
 
 
 class GoodGateNoUnitary(cirq.SingleQubitGate):
-    def _pauli_expansion_(self) -> Dict[str, complex]:
-        return {'X': np.sqrt(1/2), 'Y': np.sqrt(1/2)}
+    def _pauli_expansion_(self) -> cirq.LinearDict[str]:
+        return cirq.LinearDict({'X': np.sqrt(1/2), 'Y': np.sqrt(1/2)})
 
 
 class GoodGateNoPauliExpansionNoUnitary(cirq.SingleQubitGate):
@@ -58,8 +60,10 @@ class BadGateInconsistentPauliExpansion(cirq.SingleQubitGate):
     def _unitary_(self) -> np.ndarray:
         return np.sqrt(1/2) * X + np.sqrt(1/3) * Y + np.sqrt(1/6) * Z
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
-        return {'X': np.sqrt(1/6), 'Y': np.sqrt(1/3), 'Z': np.sqrt(1/2)}
+    def _pauli_expansion_(self) -> cirq.LinearDict[str]:
+        return cirq.LinearDict({'X': np.sqrt(1/6),
+                                'Y': np.sqrt(1/3),
+                                'Z': np.sqrt(1/2)})
 
 
 def test_assert_pauli_expansion_is_consistent_with_unitary():

--- a/cirq/testing/consistent_protocols_test.py
+++ b/cirq/testing/consistent_protocols_test.py
@@ -66,17 +66,17 @@ class GoodGate(cirq.SingleQubitGate):
             return NotImplemented
         return z**-1, x, z
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
+    def _pauli_expansion_(self) -> cirq.LinearDict[str]:
         if self._is_parameterized_():
             return NotImplemented
         phase_angle = np.pi * self.phase_exponent / 2
         angle = np.pi * self.exponent / 2
         global_phase = np.exp(1j * angle)
-        return {
+        return cirq.LinearDict({
             'I': global_phase * np.cos(angle),
             'X': -1j * global_phase * np.sin(angle) * np.cos(2 * phase_angle),
             'Y': -1j * global_phase * np.sin(angle) * np.sin(2 * phase_angle),
-        }
+        })
 
     def _phase_by_(self, phase_turns, qubit_index):
         assert qubit_index == 0
@@ -149,8 +149,8 @@ class BadGateDecompose(GoodGate):
 
 class BadGatePauliExpansion(GoodGate):
 
-    def _pauli_expansion_(self) -> Dict[str, complex]:
-        return {'I': 10}
+    def _pauli_expansion_(self) -> cirq.LinearDict[str]:
+        return cirq.LinearDict({'I': 10})
 
 
 class BadGatePhaseBy(GoodGate):


### PR DESCRIPTION
Follow-up to #1439.

Removes cleanup logic duplicated between LinearDict and Pauli expansion protocol and allows Pauli expansions to be added together and multiplied by scalars. This in turn simplifies implementation of linear combinations of gates (coming up next).