### PR TITLE
Fix key sorting in LinearDict.__format__

### DIFF
--- a/cirq/value/linear_dict.py
+++ b/cirq/value/linear_dict.py
@@ -243,7 +243,7 @@ class LinearDict(Dict[TVector, Scalar]):
 
     def __format__(self, format_spec: str) -> str:
         formatted_terms = [self._format_term(format_spec, v, self[v])
-                           for v in sorted(self.keys())]
+                           for v in sorted(self.keys(), key=str)]
         s = ''.join(formatted_terms)
         if not s:
             return '{:{fmt}}'.format(0, fmt=format_spec)

--- a/cirq/value/linear_dict_test.py
+++ b/cirq/value/linear_dict_test.py
@@ -423,6 +423,7 @@ class FakePrinter:
     {}, {'Y': 2}, {'X': 1, 'Y': -1j},
     {'X': np.sqrt(3)/3, 'Y': np.sqrt(3)/3, 'Z': np.sqrt(3)/3},
     {'I': np.sqrt(1j)}, {'X': np.sqrt(-1j)},
+    {cirq.X: 1, cirq.H: -1},
 ))
 def test_repr_pretty(terms):
     printer = FakePrinter()


### PR DESCRIPTION
This allows one to use keys that don't define comparison methods, e.g. `cirq.X` and `cirq.H`.

Before this PR, `__format__` (which is invoked e.g. by `_repr_pretty_`) raises this

```
TypeError: '<' not supported between instances of 'HPowGate' and '_PauliX'
```