### PR TITLE
Simplify 'requires' for python3 versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,7 @@ setup(
     # wheels, ensure that their names encode the version they are targeting. For
     # example, a wheel named 'cirq-#.#.#-py27-none-any.whl' will only be
     # installed in python 2.7.
-    python_requires=('>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*, !=3.5.0, '
-                     '!=3.5.1'),
+    python_requires=('>=2.7, >=3.5.2'),
 
     install_requires=requirements,
     license='Apache 2',


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/1478