### PR TITLE
Avoid warning about log10(0)

### DIFF
--- a/cirq/linalg/diagonalize_test.py
+++ b/cirq/linalg/diagonalize_test.py
@@ -68,12 +68,12 @@ def random_bi_diagonalizable_pair(
     b = cirq.dot(u, z, v)
     return a, b
 
+
 def _get_assert_diagonalized_by_str(m, p, d):
     return 'm.round(3) : {}, p.round(3) : {}, ' \
-        'np.log10(np.abs(p.T @ m @ p)).round(2): {}'.format(np.round(m, 3),
-                                                            np.round(p, 3),
-                                                            np.log10(np.abs(d))\
-                                                            .round(2))
+           'np.abs(p.T @ m @ p).round(2): {}'.format(np.round(m, 3),
+                                                     np.round(p, 3),
+                                                     np.abs(d).round(2))
 
 def assert_diagonalized_by(m, p, atol: float = 1e-8):
     d = p.T.dot(m).dot(p)
@@ -81,13 +81,13 @@ def assert_diagonalized_by(m, p, atol: float = 1e-8):
     assert cirq.is_orthogonal(p) and cirq.is_diagonal(d, atol=atol), \
         _get_assert_diagonalized_by_str(m, p, d)
 
+
 def _get_assert_bidiagonalized_by_str(m, p, q, d):
     return 'm.round(3) : {}, p.round(3) : {}, q.round(3): {}, ' \
-        'np.log10(np.abs(p.T @ m @ p)).round(2): {}'.format(np.round(m, 3),
-                                                            np.round(p, 3),
-                                                            np.round(q, 3),
-                                                            np.log10(np.abs(d) \
-                                                                     .round(2)))
+           'np.abs(p.T @ m @ p).round(2): {}'.format(np.round(m, 3),
+                                                     np.round(p, 3),
+                                                     np.round(q, 3),
+                                                     np.abs(d).round(2))
 
 def assert_bidiagonalized_by(m, p, q, rtol: float = 1e-5,
                              atol: float = 1e-8):


### PR DESCRIPTION
`cirq/linalg/diagonalize_test.py:75: RuntimeWarning: divide by zero encountered in log10
  np.log10(np.abs(d))`

Even though the assert string is never used, this value is evaluated and a log10(0) is encountered.  I don't think returning log10 of the term here gives that much more info, than just returning it directly, so got rid of the log10.