### PR TITLE
Fix `cirq.control` documentation talking about `__control__` instead of `controlled_by`

### DIFF
--- a/cirq/protocols/control.py
+++ b/cirq/protocols/control.py
@@ -35,7 +35,7 @@ def control(controllee: Union['cirq.Gate', op_tree.OP_TREE],
     """Returns a Controlled version of the given value, if defined.
 
     Controllees define how to be controlled by defining a method
-    __control__(self, control_qubits). Note that the method may return
+    controlled_by(self, control_qubits). Note that the method may return
     NotImplemented to indicate a particular controlling can't be done.
 
     Args:
@@ -46,13 +46,13 @@ def control(controllee: Union['cirq.Gate', op_tree.OP_TREE],
             fallback occurs, a TypeError is raised instead.
 
     Returns:
-        If `controllee` has a __control__ method that returns something besides
-        NotImplemented, that result is returned. For an OP_TREE, transformation
-        is applied at the leaf. Otherwise, if a default value was specified,
-        the default value is returned.
+        If `controllee` has a controlled_by method that returns something
+        besides NotImplemented, that result is returned. For an OP_TREE,
+        transformation is applied at the leaf. Otherwise, if a default value
+        was specified, the default value is returned.
 
     Raises:
-        TypeError: `controllee` doesn't have a __control__ method (or that
+        TypeError: `controllee` doesn't have a controlled_by method (or that
             method returned NotImplemented) and no `default` was specified.
     """
     if control_qubits is None:

--- a/cirq/protocols/control_test.py
+++ b/cirq/protocols/control_test.py
@@ -43,7 +43,7 @@ def test_controlless(controllee):
     assert cirq.protocols.control(controllee, [p,q], None) is None
 
 
-def test_control_error():
+def test_controlled_by_error():
     with pytest.raises(TypeError, match="returned NotImplemented"):
         _ = cirq.protocols.control(ReturnsNotImplemented(), [p])
     with pytest.raises(TypeError, match="no controlled_by method"):


### PR DESCRIPTION
Fixes #1501 