### PR TITLE
Fix __str__ methods of X/Y/ZPowGate not printing Rx/Ry/Rz when global shift is -0.5 

### DIFF
--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -133,9 +133,16 @@ class XPowGate(eigen_gate.EigenGate,
             phase_exponent=phase_turns * 2)
 
     def __str__(self) -> str:
-        if self._exponent == 1:
-            return 'X'
-        return 'X**{!r}'.format(self._exponent)
+        if self._global_shift == -0.5:
+            if self._exponent == 1:
+                return 'Rx(π)'
+            return 'Rx({}π)'.format(self._exponent)
+        if self._global_shift == 0:
+            if self._exponent == 1:
+                return 'X'
+            return 'X**{}'.format(self._exponent)
+        return ('XPowGate(exponent={}, '
+                'global_shift={!r})').format(self._exponent, self._global_shift)
 
     def __repr__(self) -> str:
         if self._global_shift == -0.5:
@@ -229,9 +236,16 @@ class YPowGate(eigen_gate.EigenGate,
             phase_exponent=0.5 + phase_turns * 2)
 
     def __str__(self) -> str:
-        if self._exponent == 1:
-            return 'Y'
-        return 'Y**{}'.format(self._exponent)
+        if self._global_shift == -0.5:
+            if self._exponent == 1:
+                return 'Ry(π)'
+            return 'Ry({}π)'.format(self._exponent)
+        if self._global_shift == 0:
+            if self._exponent == 1:
+                return 'Y'
+            return 'Y**{}'.format(self._exponent)
+        return ('YPowGate(exponent={}, '
+                'global_shift={!r})').format(self._exponent, self._global_shift)
 
     def __repr__(self) -> str:
         if self._global_shift == -0.5:
@@ -340,17 +354,24 @@ class ZPowGate(eigen_gate.EigenGate,
                                self._exponent, qubits[0])
 
     def __str__(self) -> str:
-        if self._exponent == 0.25:
-            return 'T'
-        if self._exponent == -0.25:
-            return 'T**-1'
-        if self._exponent == 0.5:
-            return 'S'
-        if self._exponent == -0.5:
-            return 'S**-1'
-        if self._exponent == 1:
-            return 'Z'
-        return 'Z**{}'.format(self._exponent)
+        if self._global_shift == -0.5:
+            if self._exponent == 1:
+                return 'Rz(π)'
+            return 'Rz({}π)'.format(self._exponent)
+        if self._global_shift == 0:
+            if self._exponent == 0.25:
+                return 'T'
+            if self._exponent == -0.25:
+                return 'T**-1'
+            if self._exponent == 0.5:
+                return 'S'
+            if self._exponent == -0.5:
+                return 'S**-1'
+            if self._exponent == 1:
+                return 'Z'
+            return 'Z**{}'.format(self._exponent)
+        return ('ZPowGate(exponent={}, '
+                'global_shift={!r})').format(self._exponent, self._global_shift)
 
     def __repr__(self) -> str:
         if self._global_shift == -0.5:

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -429,13 +429,31 @@ def test_repr():
 def test_str():
     assert str(cirq.X) == 'X'
     assert str(cirq.X**0.5) == 'X**0.5'
+    assert str(cirq.Rx(np.pi)) == 'Rx(π)'
+    assert str(cirq.Rx(0.5 * np.pi)) == 'Rx(0.5π)'
+    assert str(cirq.XPowGate(
+        global_shift=-0.25)) == 'XPowGate(exponent=1.0, global_shift=-0.25)'
 
     assert str(cirq.Z) == 'Z'
     assert str(cirq.Z**0.5) == 'S'
     assert str(cirq.Z**0.125) == 'Z**0.125'
+    assert str(cirq.Rz(np.pi)) == 'Rz(π)'
+    assert str(cirq.Rz(1.4 * np.pi)) == 'Rz(1.4π)'
+    assert str(cirq.ZPowGate(
+        global_shift=0.25)) == 'ZPowGate(exponent=1.0, global_shift=0.25)'
+
+    assert str(cirq.S) == 'S'
+    assert str(cirq.S**-1) == 'S**-1'
+    assert str(cirq.T) == 'T'
+    assert str(cirq.T**-1) == 'T**-1'
 
     assert str(cirq.Y) == 'Y'
     assert str(cirq.Y**0.5) == 'Y**0.5'
+    assert str(cirq.Ry(np.pi)) == 'Ry(π)'
+    assert str(cirq.Ry(3.14 * np.pi)) == 'Ry(3.14π)'
+    assert str(cirq.YPowGate(
+        exponent=2,
+        global_shift=-0.25)) == 'YPowGate(exponent=2, global_shift=-0.25)'
 
     assert str(cirq.CNOT) == 'CNOT'
     assert str(cirq.CNOT**0.5) == 'CNOT**0.5'
@@ -445,7 +463,6 @@ def test_str():
 
     assert str(cirq.ISWAP) == 'ISWAP'
     assert str(cirq.ISWAP**0.5) == 'ISWAP**0.5'
-
 
 def test_measurement_gate_diagram():
     # Shows key.


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/1507