### PR TITLE
Get rid of warnings when building readthedocs

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -792,7 +792,7 @@ class Circuit:
             predicate: A predicate on ops.Operations which is being checked.
 
         Returns:
-            Whether or not all `Operation`s in a circuit that satisfy the
+            Whether or not all `Operation` s in a circuit that satisfy the
             given predicate are terminal.
         """
         return all(

--- a/cirq/google/sim/xmon_simulator.py
+++ b/cirq/google/sim/xmon_simulator.py
@@ -375,7 +375,7 @@ class XmonStepResult(sim.StateVectorMixin, sim.WaveFunctionStepResult):
         Note that this does not collapse the wave function.
 
         Returns:
-            Measurement results with True corresponding to the |1> state.
+            Measurement results with True corresponding to the `|1>` state.
             The outer list is for repetitions, and the inner corresponds to
             measurements ordered by the supplied qubits.
         """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -540,7 +540,6 @@ waiting area.
     :toctree: generated/
 
     contrib.acquaintance
-    contrib.jobs
     contrib.paulistring
     contrib.qcircuit
     contrib.quirk

--- a/docs/development.md
+++ b/docs/development.md
@@ -128,7 +128,7 @@ mypy --config-file=dev_tools/conf/mypy.ini .
 ```
 
 This can be a bit tedious, because you have to specify the configuration files each time.
-A more convenient way to run checks is to via the scripts in the [check/](/check) directory, which specify configuration arguments for you and cover more use cases:
+A more convenient way to run checks is to via the scripts in the [check/](https://github.com/quantumlib/Cirq/tree/master/check) directory, which specify configuration arguments for you and cover more use cases:
 
 ```bash
 # Run all tests in the repository.
@@ -152,7 +152,7 @@ A more convenient way to run checks is to via the scripts in the [check/](/check
 
 The above scripts are convenient and reasonably fast, but they often won't exactly match the results computed by the continuous integration builds run on travis.
 For example, you may be running an older version of `pylint` or `numpy`.
-In order to run a check that is significantly more likely to agree with the travis builds, you can use the [continuous-integration/check.sh](/continuous-integration/check.sh) script:
+In order to run a check that is significantly more likely to agree with the travis builds, you can use the [continuous-integration/check.sh](https://github.com/quantumlib/Cirq/blob/master/continuous-integration/check.sh) script:
 
 ```bash
 ./continuous-integration/check.sh
@@ -166,7 +166,7 @@ This flag value can be `pylint`, `typecheck`, `pytest`, `pytest2`, or `increment
 
 ### Producing the Python 2.7 code
 
-Run [dev_tools/python2.7-generate.sh](/dev_tools/python2.7-generate.sh) to transpile cirq's python 3 code into python 2.7 code:
+Run [dev_tools/python2.7-generate.sh](https://github.com/quantumlib/Cirq/blob/master/dev_tools/python2.7-generate.sh) to transpile cirq's python 3 code into python 2.7 code:
 
 ```bash
 ./dev_tools/python2.7-generate.sh [output_dir] [input_dir] [virtual_env_with_3to2]
@@ -276,13 +276,13 @@ The HTML output will go into the `docs/_build` directory.
 
     If everything goes smoothly, the script will finish by printing `VERIFIED`.
 
-3. Set the version number in [cirq/_version.py](/cirq/_version.py).
+3. Set the version number in [cirq/_version.py](https://github.com/quantumlib/Cirq/blob/master/cirq/_version.py).
 
     Development versions end with `.dev` or `.dev#`.
     For example, `0.0.4.dev500` is a development version of the release version `0.0.4`.
     For a release, create a pull request turning `#.#.#.dev*` into `#.#.#` and a follow up pull request turning `#.#.#` into `(#+1).#.#.dev`.
 
-4. Run [dev_tools/packaging/produce-package.sh](/dev_tools/packaging/produce-package.sh) to produce pypi artifacts.
+4. Run [dev_tools/packaging/produce-package.sh](https://github.com/quantumlib/Cirq/blob/master/dev_tools/packaging/produce-package.sh) to produce pypi artifacts.
 
     ```bash
     dev_tools/packaging/produce-package.sh dist

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -77,7 +77,7 @@ can call `cirq.mixture_channel`.
 ### Common Channels
 
 Cirq supports many commonly used quantum channels out of the box, see
-[`ops/common_channels.py`](/cirq/ops/common_channels.py).
+[`ops/common_channels.py`](https://github.com/quantumlib/Cirq/blob/master/cirq/ops/common_channels.py).
 
 #### AsymmetricDepolarizingChannel, DepolarizingChannel, BitFlipChannel, and PhaseFlipChannel
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -237,7 +237,7 @@ Here we see that we can iterate over a `Circuit`'s `Moment`s.
 If you look closely at the circuit creation code above you will see that
 we applied the `append` method to both a `generator` and a `list` (recall that
 in Python one can use generator comprehensions in method calls).
-Inspecting the [code](/cirq/circuits/circuit.py) for append one sees that
+Inspecting the [code](https://github.com/quantumlib/Cirq/blob/master/cirq/circuits/circuit.py) for append one sees that
 the append method generally takes an `OP_TREE` (or a `Moment`).  What is
 an `OP_TREE`?  It is not a class but a contract.  Roughly an `OP_TREE`
 is anything that can be flattened, perhaps recursively, into a list

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -174,7 +174,7 @@ print(circuit)
 ```
 One thing to notice here.  First `cirq.X` is a `Gate` object. There
 are many different gates supported by Cirq. A good place to look
-at gates that are defined is in [common_gates.py](/cirq/ops/common_gates.py).
+at gates that are defined is in [common_gates.py](https://github.com/quantumlib/Cirq/blob/master/cirq/ops/common_gates.py).
 One common confusion to avoid is the difference between a gate class 
 and a gate object (which is an instantiation of a class).  The second is that gate
 objects are transformed into `Operation`s (technically `GateOperation`s)


### PR DESCRIPTION
This gets rid of all the warnings and
Fixes: https://github.com/quantumlib/Cirq/issues/1535

We've been through the relative vs absolute link wringer before (https://github.com/quantumlib/Cirq/issues/857), but this is a temporary solution until I figure out how to display sourcefiles in readthedocs; if it's possible.

