### PR TITLE
Remove implicit dependence on mock library

### DIFF
--- a/cirq/circuits/text_diagram_drawer_test.py
+++ b/cirq/circuits/text_diagram_drawer_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import pytest
 
 from cirq.circuits import TextDiagramDrawer

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -15,7 +15,7 @@
 """Tests for engine."""
 import base64
 import re
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 

--- a/cirq/google/engine/env_config_test.py
+++ b/cirq/google/engine/env_config_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-import mock
+from unittest import mock
 import pytest
 from apiclient import discovery
 

--- a/cirq/google/line/placement/anneal_test.py
+++ b/cirq/google/line/placement/anneal_test.py
@@ -14,7 +14,7 @@
 
 from typing import Iterable, List
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 

--- a/cirq/google/line/placement/greedy_test.py
+++ b/cirq/google/line/placement/greedy_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import Iterable
-import mock
+from unittest import mock
 import pytest
 
 import cirq

--- a/cirq/google/line/placement/line_test.py
+++ b/cirq/google/line/placement/line_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import cirq
 import cirq.google as cg
 

--- a/cirq/google/line/placement/optimization_test.py
+++ b/cirq/google/line/placement/optimization_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-import mock
+from unittest import mock
 import pytest
 
 from cirq.google.line.placement import optimization

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 import sympy

--- a/cirq/sim/simulator_test.py
+++ b/cirq/sim/simulator_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for simulator.py"""
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 import numpy as np
 import pytest
 import sympy


### PR DESCRIPTION
The mock library was being secretly installed via one of the dev or contrib dependencies. This was causing the package verification, which limits itself to the main dependencies plus pytest, to fail. We want to depend on the builtin one.