### PR TITLE
Remove remaining references to 'python 2'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # ignore compiled python files
 __pycache__
 *.pyc
-python2.7-output/*
 
 # ignore idea SDK
 .idea/*

--- a/cirq/schedules/schedule_test.py
+++ b/cirq/schedules/schedule_test.py
@@ -178,8 +178,6 @@ def test_query_overlapping_operations_exclusive():
     assert schedule.query(time=zero + 3.5 * ps, duration=ps) == []
 
 
-# In python 2, timedelta doesn't support multiplication with floats
-
 def test_query_timedelta():
     q = cirq.NamedQubit('q')
     zero = cirq.Timestamp(picos=0)

--- a/cirq/type_workarounds.py
+++ b/cirq/type_workarounds.py
@@ -15,7 +15,6 @@
 from typing import Any
 
 # At the moment there's no reliable way to say 'NotImplementedType'.
-# - There is a NotImplementedType in python 2, but not python 3.
 # - type(NotImplemented) causes mypy to error.
 # - Just NotImplemented causes runtime errors (it's not a type).
 # - The string "NotImplemented" causes runtime errors (in some python versions).

--- a/cirq/value/duration_test.py
+++ b/cirq/value/duration_test.py
@@ -84,10 +84,6 @@ def test_cmp():
     assert (Duration() != 0)
 
 
-# In python 2, comparisons fallback to __cmp__ and don't fail.
-# But a custom __cmp__ that does fail would result in == failing.
-# So we throw up our hands and let it be.
-
 def test_cmp_vs_other_type():
     with pytest.raises(TypeError):
         _ = Duration() < 0

--- a/cirq/value/timestamp_test.py
+++ b/cirq/value/timestamp_test.py
@@ -66,11 +66,6 @@ def test_cmp():
     assert not (Timestamp() == Duration())
     assert Timestamp() != Duration()
 
-
-# In python 2, comparisons fallback to __cmp__ and don't fail.
-# But a custom __cmp__ that does fail would result in == failing.
-# So we throw up our hands and let it be.
-
 def test_cmp_vs_other_type():
     with pytest.raises(TypeError):
         _ = Timestamp() < Duration()


### PR DESCRIPTION
Part of: https://github.com/quantumlib/Cirq/issues/1372
I don't remove the `_cmp_` tests because i think they are nice to have documentation (they don't affect coverage). 

With regards to the circular dependency issue, after tinkering with it, it seems to me like it's not specific to Python 2. Please let me know otherwise.