### PR TITLE
Swap deprecation flag with comment in Program proto.

### DIFF
--- a/cirq/api/google/v1/program.proto
+++ b/cirq/api/google/v1/program.proto
@@ -17,7 +17,7 @@ message Program {
 
   // The circuit parameters for the operations above will be evaluated for
   // each parameter in parameter sweeps.
-  repeated ParameterSweep parameter_sweeps = 2 [deprecated = true];
+  repeated ParameterSweep parameter_sweeps = 2;  // Deprecated.
 }
 
 // The context for running a quantum program.


### PR DESCRIPTION
Until we get `RunContext`s plumbed through Cirq, we'll rely on implementers to handle deprecation warnings, as the current compile-time deprecations are causing hard errors in our build system.