### PR TITLE
Make DensityMatrixSimulator work on operations that aren't GateOperation

### DIFF
--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -258,15 +258,14 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                         measurements[key].extend(corrected)
                 else:
                     # TODO: Use apply_channel similar to apply_unitary.
-                    gate = cast(ops.GateOperation, op).gate
-                    channel = protocols.channel(gate)
+                    channel = protocols.channel(op)
                     sum_buffer = np.zeros((2,) * 2 * num_qubits,
                                           dtype=self._dtype)
                     buffer = np.empty((2,) * 2 * num_qubits, dtype=self._dtype)
                     out = np.empty((2,) * 2 * num_qubits, dtype=self._dtype)
                     for krauss in channel:
                         krauss_tensor = np.reshape(krauss.astype(self._dtype),
-                                                   (2,) * gate.num_qubits() * 2)
+                                                   (2,) * len(op.qubits) * 2)
                         result = linalg.targeted_conjugate_about(krauss_tensor,
                                                                  matrix,
                                                                  indices,

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -613,6 +613,7 @@ def test_compute_samples_displays(dtype):
 def test_works_on_operation():
 
     class XAsOp(cirq.Operation):
+
         def __init__(self, q):
             self.q = q
 
@@ -628,4 +629,7 @@ def test_works_on_operation():
 
     s = cirq.DensityMatrixSimulator()
     c = cirq.Circuit.from_ops(XAsOp(cirq.LineQubit(0)))
-    np.testing.assert_allclose(s.simulate(c).final_simulator_state.density_matrix, np.diag([0, 1]), atol=1e-8)
+    np.testing.assert_allclose(
+        s.simulate(c).final_simulator_state.density_matrix,
+        np.diag([0, 1]),
+        atol=1e-8)

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -608,3 +608,24 @@ def test_compute_samples_displays(dtype):
                                atol=1e-7)
     np.testing.assert_allclose(result.display_values['approx_z1x3'], 1,
                                atol=1e-7)
+
+
+def test_works_on_operation():
+
+    class XAsOp(cirq.Operation):
+        def __init__(self, q):
+            self.q = q
+
+        @property
+        def qubits(self):
+            return self.q,
+
+        def with_qubits(self, *new_qubits):
+            return XAsOp(new_qubits[0])
+
+        def _channel_(self):
+            return cirq.channel(cirq.X)
+
+    s = cirq.DensityMatrixSimulator()
+    c = cirq.Circuit.from_ops(XAsOp(cirq.LineQubit(0)))
+    np.testing.assert_allclose(s.simulate(c).final_simulator_state.density_matrix, np.diag([0, 1]), atol=1e-8)


### PR DESCRIPTION
Part of https://github.com/quantumlib/Cirq/issues/1630