### PR TITLE
Use apply_channel in DensityMatrixSimulator

### DIFF
--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -30,6 +30,14 @@ if TYPE_CHECKING:
     from typing import Any, Hashable
 
 
+class _StateAndBuffers:
+
+    def __init__(self, n: int, state: np.ndarray):
+        self.n = n
+        self.state = state
+        self.buffers = [np.empty_like(state) for _ in range(3)]
+
+
 class DensityMatrixSimulator(simulator.SimulatesSamples,
                              simulator.SimulatesIntermediateState):
     """A simulator for density matrices and noisy quantum circuits.
@@ -194,6 +202,23 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                                    qubit_order,
                                    actual_initial_state)
 
+    def _apply_op_channel(self, op: ops.Operation, state: _StateAndBuffers,
+                          indices: List[int]) -> None:
+        """Apply channel to state."""
+        result = protocols.apply_channel(
+            op,
+            args=protocols.ApplyChannelArgs(
+                target_tensor=state.state,
+                out_buffer=state.buffers[0],
+                auxiliary_buffer0=state.buffers[1],
+                auxiliary_buffer1=state.buffers[2],
+                left_axes=indices,
+                right_axes=[e + state.n for e in indices]))
+        for i in range(3):
+            if result is state.buffers[i]:
+                state.buffers[i] = state.state
+        state.state = result
+
     def _base_iterator(
             self,
             circuit: circuits.Circuit,
@@ -204,11 +229,15 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
             circuit.all_qubits())
         num_qubits = len(qubits)
         qubit_map = {q: i for i, q in enumerate(qubits)}
-        matrix = density_matrix_utils.to_valid_density_matrix(
+        initial_matrix = density_matrix_utils.to_valid_density_matrix(
             initial_state, num_qubits, self._dtype)
         if len(circuit) == 0:
-            yield DensityMatrixStepResult(matrix, {}, qubit_map, self._dtype)
-        matrix = np.reshape(matrix, (2,) * num_qubits * 2)
+            yield DensityMatrixStepResult(initial_matrix, {}, qubit_map,
+                                          self._dtype)
+            return
+
+        state = _StateAndBuffers(num_qubits,
+                                 initial_matrix.reshape((2,) * num_qubits * 2))
 
         def on_stuck(bad_op: ops.Operation):
             return TypeError(
@@ -226,7 +255,6 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                                    ops.DensityMatrixDisplay))
                     )
 
-        matrix = np.reshape(matrix, (2,) * num_qubits * 2)
         noisy_moments = self.noise.noisy_moments(circuit,
                                                  sorted(circuit.all_qubits()))
 
@@ -251,34 +279,18 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                         invert_mask = meas.invert_mask or num_qubits * (False,)
                         # Measure updates inline.
                         bits, _ = density_matrix_utils.measure_density_matrix(
-                            matrix, indices, matrix)
+                            state.state, indices, out=state.state)
                         corrected = [bit ^ mask for bit, mask in
                                      zip(bits, invert_mask)]
                         key = protocols.measurement_key(meas)
                         measurements[key].extend(corrected)
                 else:
                     # TODO: Use apply_channel similar to apply_unitary.
-                    gate = cast(ops.GateOperation, op).gate
-                    channel = protocols.channel(gate)
-                    sum_buffer = np.zeros((2,) * 2 * num_qubits,
+                    self._apply_op_channel(op, state, indices)
+            yield DensityMatrixStepResult(density_matrix=state.state,
+                                          measurements=measurements,
+                                          qubit_map=qubit_map,
                                           dtype=self._dtype)
-                    buffer = np.empty((2,) * 2 * num_qubits, dtype=self._dtype)
-                    out = np.empty((2,) * 2 * num_qubits, dtype=self._dtype)
-                    for krauss in channel:
-                        krauss_tensor = np.reshape(krauss.astype(self._dtype),
-                                                   (2,) * gate.num_qubits() * 2)
-                        result = linalg.targeted_conjugate_about(krauss_tensor,
-                                                                 matrix,
-                                                                 indices,
-                                                                 buffer=buffer,
-                                                                 out=out)
-                        sum_buffer += result
-                    np.copyto(dst=matrix, src=sum_buffer)
-            yield DensityMatrixStepResult(
-                    density_matrix=matrix,
-                    measurements=measurements,
-                    qubit_map=qubit_map,
-                    dtype=self._dtype)
 
     def _create_simulator_trial_result(self,
             params: study.ParamResolver,

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -622,6 +622,7 @@ def test_works_on_operation():
             return self.q,
 
         def with_qubits(self, *new_qubits):
+            # coverage: ignore
             return XAsOp(new_qubits[0])
 
         def _channel_(self):

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -608,3 +608,38 @@ def test_compute_samples_displays(dtype):
                                atol=1e-7)
     np.testing.assert_allclose(result.display_values['approx_z1x3'], 1,
                                atol=1e-7)
+
+
+def test_works_on_operation():
+
+    class XAsOp(cirq.Operation):
+
+        def __init__(self, q):
+            self.q = q
+
+        @property
+        def qubits(self):
+            return self.q,
+
+        def with_qubits(self, *new_qubits):
+            return XAsOp(new_qubits[0])
+
+        def _channel_(self):
+            return cirq.channel(cirq.X)
+
+    s = cirq.DensityMatrixSimulator()
+    c = cirq.Circuit.from_ops(XAsOp(cirq.LineQubit(0)))
+    np.testing.assert_allclose(
+        s.simulate(c).final_simulator_state.density_matrix,
+        np.diag([0, 1]),
+        atol=1e-8)
+
+
+def test_works_on_pauli_string_phasor():
+    a, b = cirq.LineQubit.range(2)
+    c = cirq.Circuit.from_ops(np.exp(1j * np.pi * cirq.X(a) * cirq.X(b)))
+    sim = cirq.DensityMatrixSimulator()
+    result = sim.simulate(c).final_simulator_state.density_matrix
+    np.testing.assert_allclose(result.reshape(4, 4),
+                               np.diag([0, 0, 0, 1]),
+                               atol=1e-8)

--- a/cirq/sim/wave_function.py
+++ b/cirq/sim/wave_function.py
@@ -322,7 +322,7 @@ def to_valid_state_vector(state_rep: Union[int, np.ndarray],
                 'initial state was {} but expected state for {} qubits'.format(
                     state_rep, num_qubits))
         else:
-            state = np.zeros(2 ** num_qubits, dtype=dtype)
+            state = np.zeros(2**num_qubits, dtype=dtype)
             state[state_rep] = 1.0
     else:
         raise TypeError('initial_state was not of type int or ndarray')


### PR DESCRIPTION
And make it work on operations, not just gate operations.

Fixes https://github.com/quantumlib/Cirq/issues/1630