### PR TITLE
Add _unitary_ for PauliString

### DIFF
--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -20,7 +20,7 @@ import math
 
 import numpy as np
 
-from cirq import value
+from cirq import protocols, value
 from cirq.ops import (
     raw_types,
     gate_operation,
@@ -178,6 +178,12 @@ class PauliString(raw_types.Operation):
             factors.append(str(cast(raw_types.Gate, self[q]).on(q)))
 
         return prefix + '*'.join(factors)
+
+    def _unitary_(self) -> np.ndarray:
+        u = np.array([self.coefficient], dtype=np.complex128)
+        for pauli in self.values():
+            u = np.kron(u, protocols.unitary(pauli))
+        return u
 
     def zip_items(self, other: 'PauliString') -> Iterator[
             Tuple[raw_types.Qid, Tuple[pauli_gates.Pauli, pauli_gates.Pauli]]]:

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -616,3 +616,27 @@ def test_with_qubits():
     for q in new_qubits:
         assert new_pauli_string[q] == cirq.Pauli.by_index(q.x)
     assert new_pauli_string.coefficient == -1
+
+
+@pytest.mark.parametrize('paulis, coefficient, expected_unitary', (
+    ((cirq.Z,), -3j, np.diag([-3j, 3j])),
+    ((cirq.Z, cirq.X), 2, np.array([[0, 2, 0, 0],
+                                    [2, 0, 0, 0],
+                                    [0, 0, 0, -2],
+                                    [0, 0, -2, 0]])),
+    ((cirq.X, cirq.Y), 0.5, np.array([[0, 0, 0, -0.5j],
+                                      [0, 0, 0.5j, 0],
+                                      [0, -0.5j, 0, 0],
+                                      [0.5j, 0, 0, 0]])),
+    ((cirq.X, cirq.X, cirq.X), 3, np.rot90(np.diag([3] * 8))),
+))  # yapf: disable
+def test_unitary(paulis, coefficient, expected_unitary):
+    qubits = _make_qubits(len(paulis))
+    pauli_string = cirq.PauliString(dict(zip(qubits, paulis)), coefficient)
+    assert np.all(expected_unitary == cirq.unitary(pauli_string))
+
+
+@pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
+def test_consistency(qubit_pauli_map):
+    pauli_string = cirq.PauliString(qubit_pauli_map)
+    cirq.testing.assert_implements_consistent_protocols(pauli_string)


### PR DESCRIPTION
Found it was missing when trying to use PauliString as an Operation in unit tests for #1612.