### PR TITLE
Give PauliStringPhasor nonzero default atol (Fixes last broken Windows tests)

### DIFF
--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
@@ -40,7 +40,7 @@ class ConvertToPauliStringPhasors(PointOptimizer):
     def __init__(self,
                  ignore_failures: bool = False,
                  keep_clifford: bool = False,
-                 atol: float = 0) -> None:
+                 atol: float = 1e-14) -> None:
         """
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded


### PR DESCRIPTION
Fixes #1667. The issue was that a default value of 0 for atol in PauliStringPhasor meant that some machines didn't failed to recognize gate sequence simplifications. @vtomole Feel free to verify in your Windows build PR.