### PR TITLE
Hide simulator_state

### DIFF
--- a/cirq/google/sim/xmon_simulator.py
+++ b/cirq/google/sim/xmon_simulator.py
@@ -321,7 +321,7 @@ class XmonStepResult(sim.StateVectorMixin, sim.WaveFunctionStepResult):
         self.measurements = measurements or collections.defaultdict(list)
         self._stepper = stepper
 
-    def simulator_state(self) -> sim.WaveFunctionSimulatorState:
+    def _simulator_state(self) -> sim.WaveFunctionSimulatorState:
         return sim.WaveFunctionSimulatorState(
             state_vector=self._stepper.current_state, qubit_map=self.qubit_map)
 

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -475,7 +475,7 @@ class DensityMatrixStepResult(simulator.StepResult):
         self._qubit_map = qubit_map
         self._dtype = dtype
 
-    def simulator_state(self) -> 'DensityMatrixSimulatorState':
+    def _simulator_state(self) -> 'DensityMatrixSimulatorState':
         return DensityMatrixSimulatorState(self._density_matrix,
                                            self._qubit_map)
 
@@ -494,9 +494,11 @@ class DensityMatrixStepResult(simulator.StepResult):
         """
         density_matrix = density_matrix_utils.to_valid_density_matrix(
             density_matrix_repr, len(self._qubit_map), self._dtype)
-        density_matrix = np.reshape(density_matrix,
-                                    self.simulator_state().density_matrix.shape)
-        np.copyto(dst=self.simulator_state().density_matrix, src=density_matrix)
+        density_matrix = np.reshape(
+            density_matrix,
+            self._simulator_state().density_matrix.shape)
+        np.copyto(dst=self._simulator_state().density_matrix,
+                  src=density_matrix)
 
     def density_matrix(self):
         """Returns the density matrix at this step in the simulation.
@@ -534,8 +536,7 @@ class DensityMatrixStepResult(simulator.StepResult):
             repetitions: int = 1) -> np.ndarray:
         indices = [self._qubit_map[q] for q in qubits]
         return density_matrix_utils.sample_density_matrix(
-            self.simulator_state().density_matrix,
-            indices, repetitions)
+            self._simulator_state().density_matrix, indices, repetitions)
 
 
 @value.value_equality(unhashable=True)
@@ -618,10 +619,10 @@ class DensityMatrixTrialResult(simulator.SimulationTrialResult):
     def _value_equality_values_(self):
         measurements = {k: v.tolist() for k, v in
                         sorted(self.measurements.items())}
-        return (self.params, measurements, self.final_simulator_state)
+        return (self.params, measurements, self._final_simulator_state)
 
     def __repr__(self):
         return ("cirq.DensityMatrixTrialResult(params={!r}, measurements={!r}, "
-                "final_simulator_state={!r})"
-                .format(self.params, self.measurements,
-                        self.final_simulator_state))
+                "final_simulator_state={!r})".format(
+                    self.params, self.measurements,
+                    self._final_simulator_state))

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -267,6 +267,7 @@ def test_simulate_compare_to_wave_function_simulator(dtype):
         mixed_result = (cirq.DensityMatrixSimulator(dtype=dtype)
                         .simulate(circuit,qubit_order=qubits)
                         .final_density_matrix)
+        assert mixed_result.shape == (16, 16)
         np.testing.assert_almost_equal(mixed_result, pure_result)
 
 
@@ -394,7 +395,7 @@ def test_simulate_moment_steps_empty_circuit(dtype):
     step = None
     for step in simulator.simulate_moment_steps(circuit):
         pass
-    assert step.simulator_state() == cirq.DensityMatrixSimulatorState(
+    assert step._simulator_state() == cirq.DensityMatrixSimulatorState(
         density_matrix=np.array([[1]]), qubit_map={})
 
 
@@ -630,17 +631,16 @@ def test_works_on_operation():
 
     s = cirq.DensityMatrixSimulator()
     c = cirq.Circuit.from_ops(XAsOp(cirq.LineQubit(0)))
-    np.testing.assert_allclose(
-        s.simulate(c).final_simulator_state.density_matrix,
-        np.diag([0, 1]),
-        atol=1e-8)
+    np.testing.assert_allclose(s.simulate(c).final_density_matrix,
+                               np.diag([0, 1]),
+                               atol=1e-8)
 
 
 def test_works_on_pauli_string_phasor():
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit.from_ops(np.exp(1j * np.pi * cirq.X(a) * cirq.X(b)))
     sim = cirq.DensityMatrixSimulator()
-    result = sim.simulate(c).final_simulator_state.density_matrix
+    result = sim.simulate(c).final_density_matrix
     np.testing.assert_allclose(result.reshape(4, 4),
                                np.diag([0, 0, 0, 1]),
                                atol=1e-8)
@@ -650,7 +650,7 @@ def test_works_on_pauli_string():
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit.from_ops(cirq.X(a) * cirq.X(b))
     sim = cirq.DensityMatrixSimulator()
-    result = sim.simulate(c).final_simulator_state.density_matrix
+    result = sim.simulate(c).final_density_matrix
     np.testing.assert_allclose(result.reshape(4, 4),
                                np.diag([0, 0, 0, 1]),
                                atol=1e-8)

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -300,7 +300,7 @@ class SimulatesIntermediateState(SimulatesFinalState, metaclass=abc.ABCMeta):
                 self._create_simulator_trial_result(
                     params=param_resolver,
                     measurements=measurements,
-                    final_simulator_state=step_result.simulator_state()))
+                    final_simulator_state=step_result._simulator_state()))
         return trial_results
 
     def simulate_moment_steps(
@@ -397,8 +397,12 @@ class StepResult(metaclass=abc.ABCMeta):
         self.measurements = measurements or collections.defaultdict(list)
 
     @abc.abstractmethod
-    def simulator_state(self) -> Any:
-        """Returns the simulator_state of the simulator after this step.
+    def _simulator_state(self) -> Any:
+        """Returns the simulator state of the simulator after this step.
+
+        This method starts with an underscore to indicate that it is private.
+        State that should be exposed should exposed on the child StepResult
+        class.
 
         The form of the simulator_state depends on the implementation of the
         simulation,see documentation for the implementing class for the form of
@@ -490,8 +494,6 @@ class SimulationTrialResult:
             results. Measurement results are a numpy ndarray of actual boolean
             measurement results (ordered by the qubits acted on by the
             measurement gate.)
-        final_simulator_state: The final simulator state of the system after the
-            trial finishes.
     """
 
     def __init__(self,
@@ -500,14 +502,13 @@ class SimulationTrialResult:
         final_simulator_state: Any) -> None:
         self.params = params
         self.measurements = measurements
-        self.final_simulator_state = final_simulator_state
+        self._final_simulator_state = final_simulator_state
 
     def __repr__(self):
-        return (
-            'cirq.SimulationTrialResult(params={!r}, '
-            'measurements={!r}, '
-            'final_simulator_state={!r})').format(
-                self.params, self.measurements, self.final_simulator_state)
+        return ('cirq.SimulationTrialResult(params={!r}, '
+                'measurements={!r}, '
+                'final_simulator_state={!r})').format(
+                    self.params, self.measurements, self._final_simulator_state)
 
     def __str__(self):
         def bitstring(vals):
@@ -531,4 +532,4 @@ class SimulationTrialResult:
     def _value_equality_values_(self):
         measurements = {k: v.tolist() for k, v in
                         sorted(self.measurements.items())}
-        return (self.params, measurements, self.final_simulator_state)
+        return (self.params, measurements, self._final_simulator_state)

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -401,8 +401,7 @@ class StepResult(metaclass=abc.ABCMeta):
         """Returns the simulator state of the simulator after this step.
 
         This method starts with an underscore to indicate that it is private.
-        State that should be exposed should exposed on the child StepResult
-        class.
+        To access public state, see public methods on StepResult.
 
         The form of the simulator_state depends on the implementation of the
         simulation,see documentation for the implementing class for the form of

--- a/cirq/sim/simulator_test.py
+++ b/cirq/sim/simulator_test.py
@@ -79,7 +79,7 @@ def test_intermediate_simulator():
         yield result
         result = mock.Mock()
         result.measurements = {'b': [True, False]}
-        result.simulator_state.return_value = final_simulator_state
+        result._simulator_state.return_value = final_simulator_state
         yield result
 
     simulator._simulator_iterator.side_effect = steps
@@ -94,7 +94,8 @@ def test_intermediate_simulator():
     np.testing.assert_equal(result.measurements['b'], [True, False])
     assert set(result.measurements.keys()) == {'a', 'b'}
     assert result.params == param_resolver
-    np.testing.assert_equal(result.final_simulator_state, final_simulator_state)
+    np.testing.assert_equal(result._final_simulator_state,
+                            final_simulator_state)
 
 
 @mock.patch.multiple(cirq.SimulatesIntermediateState,
@@ -107,7 +108,7 @@ def test_intermediate_sweeps():
     def steps(*args, **kwargs):
         result = mock.Mock()
         result.measurements = {'a': np.array([True, True])}
-        result.simulator_state.return_value = final_state
+        result._simulator_state.return_value = final_state
         yield result
 
     simulator._simulator_iterator.side_effect = steps
@@ -137,7 +138,7 @@ class FakeStepResult(cirq.StepResult):
     def __init__(self, ones_qubits):
         self._ones_qubits = set(ones_qubits)
 
-    def simulator_state(self):
+    def _simulator_state(self):
         pass
 
     def state_vector(self):

--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -339,8 +339,8 @@ class SparseSimulatorStep(wave_function.StateVectorMixin,
         self._dtype = dtype
         self._state_vector = np.reshape(state_vector, 2 ** len(qubit_map))
 
-    def simulator_state(
-        self) -> wave_function_simulator.WaveFunctionSimulatorState:
+    def _simulator_state(self
+                        ) -> wave_function_simulator.WaveFunctionSimulatorState:
         return wave_function_simulator.WaveFunctionSimulatorState(
             qubit_map=self.qubit_map,
             state_vector=self._state_vector)
@@ -371,7 +371,7 @@ class SparseSimulatorStep(wave_function.StateVectorMixin,
                  6  |   1    |   1    |   0
                  7  |   1    |   1    |   1
         """
-        return self.simulator_state().state_vector
+        return self._simulator_state().state_vector
 
     def set_state_vector(self, state: Union[int, np.ndarray]):
         update_state = wave_function.to_valid_state_vector(state,

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -377,7 +377,7 @@ def test_simulate_moment_steps_empty_circuit(dtype):
     step = None
     for step in simulator.simulate_moment_steps(circuit):
         pass
-    assert step.simulator_state() == cirq.WaveFunctionSimulatorState(
+    assert step._simulator_state() == cirq.WaveFunctionSimulatorState(
         state_vector=np.array([1]), qubit_map={})
 
 
@@ -597,7 +597,7 @@ def test_works_on_pauli_string_phasor():
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit.from_ops(np.exp(1j * np.pi * cirq.X(a) * cirq.X(b)))
     sim = cirq.Simulator()
-    result = sim.simulate(c).final_simulator_state.state_vector
+    result = sim.simulate(c).state_vector()
     np.testing.assert_allclose(result.reshape(4),
                                np.array([0, 0, 0, 1j]),
                                atol=1e-8)
@@ -607,7 +607,7 @@ def test_works_on_pauli_string():
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit.from_ops(cirq.X(a) * cirq.X(b))
     sim = cirq.Simulator()
-    result = sim.simulate(c).final_simulator_state.state_vector
+    result = sim.simulate(c).state_vector()
     np.testing.assert_allclose(result.reshape(4),
                                np.array([0, 0, 0, 1]),
                                atol=1e-8)

--- a/cirq/sim/wave_function_simulator.py
+++ b/cirq/sim/wave_function_simulator.py
@@ -194,7 +194,7 @@ def _compute_samples_display_value(display: ops.SamplesDisplay,
 class WaveFunctionStepResult(simulator.StepResult, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
-    def simulator_state(self) -> 'WaveFunctionSimulatorState':
+    def _simulator_state(self) -> 'WaveFunctionSimulatorState':
         """Returns the simulator_state of the simulator after this step.
 
         The form of the simulator_state depends on the implementation of the
@@ -267,14 +267,12 @@ class WaveFunctionTrialResult(wave_function.StateVectorMixin,
                  6  |   1    |   1    |   0
                  7  |   1    |   1    |   1
         """
-        return self.final_simulator_state.state_vector
+        return self._final_simulator_state.state_vector
 
     def _value_equality_values_(self):
         measurements = {k: v.tolist() for k, v in
                         sorted(self.measurements.items())}
-        return (self.params,
-                measurements,
-                self.final_simulator_state)
+        return (self.params, measurements, self._final_simulator_state)
 
     def __str__(self):
         samples = super().__str__()
@@ -297,7 +295,5 @@ class WaveFunctionTrialResult(wave_function.StateVectorMixin,
     def __repr__(self):
         return ('cirq.WaveFunctionTrialResult(params={!r}, '
                 'measurements={!r}, '
-                'final_simulator_state={!r})'
-                ).format(self.params,
-                         self.measurements,
-                         self.final_simulator_state)
+                'final_simulator_state={!r})').format(
+                    self.params, self.measurements, self._final_simulator_state)


### PR DESCRIPTION
The simulator state for simulators is an internal state used by the implementations for simulating state when stepping through a simulation.  It shouldn't be exposed "publically".  See #1658 for where callers where using this state instead of going to the public methods on step result or trial result.  