### PR TITLE
Adds default public visibility to the Cirq V2 protos.

### DIFF
--- a/cirq/api/google/v2/BUILD
+++ b/cirq/api/google/v2/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 proto_library(
     name = "metrics_proto",
     srcs = ["metrics.proto"],


### PR DESCRIPTION
This is so external libraries (e.g., TFQuantum) can depend on them when depending on Cirq via a remote archive in blaze.