### PR TITLE
Bump matplotlib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Runtime requirements for the python 3 version of cirq.
 
 google-api-python-client~=1.6
-matplotlib~=3.1
+matplotlib~=3.0
 networkx~=2.1
 numpy~=1.12
 protobuf~=3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Runtime requirements for the python 3 version of cirq.
 
 google-api-python-client~=1.6
-matplotlib~=2.2
+matplotlib~=3.1
 networkx~=2.1
 numpy~=1.12
 protobuf~=3.5


### PR DESCRIPTION
This fixes a deprecation warning in python 3.7 that shows up everytime you import cirq.