### PR TITLE
Add __bool__ to cirq.PauliString

### DIFF
--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -144,6 +144,9 @@ class PauliString(raw_types.Operation):
     def __iter__(self) -> Iterator[raw_types.Qid]:
         return iter(self._qubit_pauli_map.keys())
 
+    def __bool__(self):
+        return bool(self._qubit_pauli_map)
+
     def __len__(self) -> int:
         return len(self._qubit_pauli_map)
 

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -616,3 +616,8 @@ def test_with_qubits():
     for q in new_qubits:
         assert new_pauli_string[q] == cirq.Pauli.by_index(q.x)
     assert new_pauli_string.coefficient == -1
+
+
+def test_bool():
+    assert not bool(cirq.PauliString({}))
+    assert bool(cirq.PauliString({a: cirq.X}))

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -619,5 +619,6 @@ def test_with_qubits():
 
 
 def test_bool():
+    a = cirq.LineQubit(0)
     assert not bool(cirq.PauliString({}))
     assert bool(cirq.PauliString({a: cirq.X}))


### PR DESCRIPTION
Matches the behavior of other collections: empty is false, non-empty is true.