### PR TITLE
Remove redundant multiplication in random_unitary

### DIFF
--- a/cirq/testing/lin_alg_utils.py
+++ b/cirq/testing/lin_alg_utils.py
@@ -50,7 +50,7 @@ def random_unitary(dim: int) -> np.ndarray:
         http://arxiv.org/abs/math-ph/0609050
     """
     z = (np.random.randn(dim, dim) +
-         1j * np.random.randn(dim, dim)) * np.sqrt(0.5)
+         1j * np.random.randn(dim, dim))
     q, r = np.linalg.qr(z)
     d = np.diag(r)
     return q * (d / abs(d))

--- a/cirq/testing/lin_alg_utils.py
+++ b/cirq/testing/lin_alg_utils.py
@@ -49,8 +49,7 @@ def random_unitary(dim: int) -> np.ndarray:
         'How to generate random matrices from the classical compact groups'
         http://arxiv.org/abs/math-ph/0609050
     """
-    z = (np.random.randn(dim, dim) +
-         1j * np.random.randn(dim, dim))
+    z = (np.random.randn(dim, dim) + 1j * np.random.randn(dim, dim))
     q, r = np.linalg.qr(z)
     d = np.diag(r)
     return q * (d / abs(d))


### PR DESCRIPTION
The re-scaling of d by (d/abs(d)) undoes the effect of this multiplication so there is no use in having it.