### PR TITLE
Speed up randomized bench-marking

### DIFF
--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -402,10 +402,10 @@ def two_qubit_state_tomography(sampler: sim.Sampler,
         prob_list = [results_hist[0], results_hist[1], results_hist[2]]
         return np.asarray(prob_list) / repetitions
 
-    sigma_0 = np.eye(2) / 2.0
-    sigma_1 = np.array([[0.0, 1.0], [1.0, 0.0]]) / 2.0
-    sigma_2 = np.array([[0.0, -1.0j], [1.0j, 0.0]]) / 2.0
-    sigma_3 = np.array([[1.0, 0.0], [0.0, -1.0]]) / 2.0
+    sigma_0 = np.eye(2) * 0.5
+    sigma_1 = np.array([[0.0, 1.0], [1.0, 0.0]]) * 0.5
+    sigma_2 = np.array([[0.0, -1.0j], [1.0j, 0.0]]) * 0.5
+    sigma_3 = np.array([[1.0, 0.0], [0.0, -1.0]]) * 0.5
     sigmas = [sigma_0, sigma_1, sigma_2, sigma_3]
 
     # Stores all 27 measured probabilities (P_00, P_01, P_10 after 9

--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -6,9 +6,7 @@ import sympy
 
 from matplotlib import pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # type: ignore
-
-from cirq import circuits, protocols, devices, ops, sim, study
-
+from cirq import circuits, devices, ops, protocols, sim, study
 
 Cliffords = NamedTuple('Cliffords',
                        [('c1_in_xy', List[List[ops.Gate]]),

--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -7,7 +7,7 @@ import sympy
 from matplotlib import pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # type: ignore
 
-from cirq import circuits, devices, ops, protocols, sim, study
+from cirq import circuits, devices, ops, sim, study
 import cirq
 
 Cliffords = NamedTuple('Cliffords',
@@ -270,7 +270,7 @@ def two_qubit_randomized_benchmarking(
         gnd_probs_l = []
         for _ in range(num_circuits):
             circuit = _random_two_q_clifford(first_qubit, second_qubit,
-                                             num_cfds,  cliffords)
+                                             num_cfds, cliffords)
             circuit.append(ops.measure(first_qubit, second_qubit, key='z'))
             results = sampler.run(circuit, repetitions=repetitions)
             gnds = [(not r[0] and not r[1]) for r in results.measurements['z']]
@@ -457,7 +457,7 @@ def _indices_after_basis_rot(i: int, j: int) -> Tuple[int, Sequence[int],
 
 def _random_single_q_clifford(qubit: devices.GridQubit, num_cfds: int,
                               cfds: Sequence[Sequence[ops.Gate]]
-                              ) -> circuits.Circuit:
+                             ) -> circuits.Circuit:
     clifford_group_size = 24
     gate_ids = list(np.random.choice(clifford_group_size, num_cfds))
     gate_sequence = []  # type: List[ops.Gate]
@@ -469,8 +469,8 @@ def _random_single_q_clifford(qubit: devices.GridQubit, num_cfds: int,
 
 
 def _random_two_q_clifford(q_0: devices.GridQubit, q_1: devices.GridQubit,
-                           num_cfds: int, cliffords: Cliffords
-                           ) -> circuits.Circuit:
+                           num_cfds: int,
+                           cliffords: Cliffords) -> circuits.Circuit:
     clifford_group_size = 11520
     idx_list = list(np.random.choice(clifford_group_size, num_cfds))
     circuit = circuits.Circuit()

--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -7,8 +7,8 @@ import sympy
 from matplotlib import pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # type: ignore
 
-from cirq import circuits, devices, ops, sim, study
-import cirq
+from cirq import circuits, protocols, devices, ops, sim, study
+
 
 Cliffords = NamedTuple('Cliffords',
                        [('c1_in_xy', List[List[ops.Gate]]),
@@ -463,7 +463,7 @@ def _random_single_q_clifford(qubit: devices.GridQubit, num_cfds: int,
     gate_sequence = []  # type: List[ops.Gate]
     for gate_id in gate_ids:
         gate_sequence.extend(cfds[gate_id])
-    gate_sequence.extend(cirq.inverse(gate_sequence))
+    gate_sequence.extend(protocols.inverse(gate_sequence))
     circuit = circuits.Circuit.from_ops(gate(qubit) for gate in gate_sequence)
     return circuit
 
@@ -476,7 +476,7 @@ def _random_two_q_clifford(q_0: devices.GridQubit, q_1: devices.GridQubit,
     circuit = circuits.Circuit()
     for idx in idx_list:
         circuit.append(_two_qubit_clifford(q_0, q_1, idx, cliffords))
-    circuit.append(cirq.inverse(circuit))
+    circuit.append(protocols.inverse(circuit))
     return circuit
 
 

--- a/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq/experiments/qubit_characterizations_test.py
@@ -14,7 +14,7 @@ def test_rabi_oscillations():
     # small statistical error.
     simulator = sim.Simulator()
     qubit = GridQubit(0, 0)
-    results = rabi_oscillations(simulator, qubit, np.pi, repetitions=10000)
+    results = rabi_oscillations(simulator, qubit, np.pi, repetitions=1000)
     data = np.asarray(results.data)
     angles = data[:, 0]
     actual_pops = data[:, 1]
@@ -30,7 +30,8 @@ def test_single_qubit_randomized_benchmarking():
     qubit = GridQubit(0, 0)
     num_cfds = range(5, 20, 5)
     results = single_qubit_randomized_benchmarking(simulator, qubit,
-                                                   num_clifford_range=num_cfds)
+                                                   num_clifford_range=num_cfds,
+                                                   repetitions=100)
     g_pops = np.asarray(results.data)[:, 1]
     assert np.isclose(np.mean(g_pops), 1.0)
 
@@ -43,7 +44,8 @@ def test_two_qubit_randomized_benchmarking():
     q_1 = GridQubit(0, 1)
     num_cfds = range(5, 20, 5)
     results = two_qubit_randomized_benchmarking(simulator, q_0, q_1,
-                                                num_clifford_range=num_cfds)
+                                                num_clifford_range=num_cfds,
+                                                repetitions=100)
     g_pops = np.asarray(results.data)[:, 1]
     assert np.isclose(np.mean(g_pops), 1.0)
 
@@ -59,11 +61,11 @@ def test_single_qubit_state_tomography():
     circuit_3 = circuits.Circuit.from_ops(ops.H(qubit), ops.Y(qubit))
 
     act_rho_1 = single_qubit_state_tomography(simulator, qubit, circuit_1,
-                                              100000).data
+                                              1000).data
     act_rho_2 = single_qubit_state_tomography(simulator, qubit, circuit_2,
-                                              100000).data
+                                              1000).data
     act_rho_3 = single_qubit_state_tomography(simulator, qubit, circuit_3,
-                                              100000).data
+                                              1000).data
 
     tar_rho_1 = np.array([[0.5, 0.5j], [-0.5j, 0.5]])
     tar_rho_2 = np.array([[0.5, 0.5], [0.5, 0.5]])
@@ -96,24 +98,24 @@ def test_two_qubit_state_tomography():
     circuit_yx = circuits.Circuit.from_ops(ops.Y(q_0)**0.5, ops.X(q_1)**0.5)
 
     act_rho_00 = two_qubit_state_tomography(simulator, q_0, q_1, circuit_00,
-                                            100000).data
+                                            1000).data
     act_rho_01 = two_qubit_state_tomography(simulator, q_0, q_1, circuit_01,
-                                            100000).data
+                                            1000).data
     act_rho_10 = two_qubit_state_tomography(simulator, q_0, q_1, circuit_10,
-                                            100000).data
+                                            1000).data
     act_rho_11 = two_qubit_state_tomography(simulator, q_0, q_1, circuit_11,
-                                            100000).data
+                                            1000).data
     act_rho_hh = two_qubit_state_tomography(simulator, q_0, q_1, circuit_hh,
-                                            100000).data
+                                            1000).data
     act_rho_xy = two_qubit_state_tomography(simulator, q_0, q_1, circuit_xy,
-                                            100000).data
+                                            1000).data
     act_rho_yx = two_qubit_state_tomography(simulator, q_0, q_1, circuit_yx,
-                                            100000).data
+                                            1000).data
 
-    tar_rho_00 = np.outer([1.0, 0, 0, 1.0], [1.0, 0, 0, 1.0]) / 2.0
-    tar_rho_01 = np.outer([0, 1.0, 1.0, 0], [0, 1.0, 1.0, 0]) / 2.0
-    tar_rho_10 = np.outer([1.0, 0, 0, -1.0], [1.0, 0, 0, -1.0]) / 2.0
-    tar_rho_11 = np.outer([0, 1.0, -1.0, 0], [0, 1.0, -1.0, 0]) / 2.0
+    tar_rho_00 = np.outer([1.0, 0, 0, 1.0], [1.0, 0, 0, 1.0]) * 0.5
+    tar_rho_01 = np.outer([0, 1.0, 1.0, 0], [0, 1.0, 1.0, 0]) * 0.5
+    tar_rho_10 = np.outer([1.0, 0, 0, -1.0], [1.0, 0, 0, -1.0]) * 0.5
+    tar_rho_11 = np.outer([0, 1.0, -1.0, 0], [0, 1.0, -1.0, 0]) * 0.5
     tar_rho_hh = np.outer([0.5, 0.5, 0.5, 0.5], [0.5, 0.5, 0.5, 0.5])
     tar_rho_xy = np.outer([0.5, 0.5, -0.5j, -0.5j], [0.5, 0.5, 0.5j, 0.5j])
     tar_rho_yx = np.outer([0.5, -0.5j, 0.5, -0.5j], [0.5, 0.5j, 0.5, 0.5j])

--- a/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq/experiments/qubit_characterizations_test.py
@@ -29,7 +29,8 @@ def test_single_qubit_randomized_benchmarking():
     simulator = sim.Simulator()
     qubit = GridQubit(0, 0)
     num_cfds = range(5, 20, 5)
-    results = single_qubit_randomized_benchmarking(simulator, qubit,
+    results = single_qubit_randomized_benchmarking(simulator,
+                                                   qubit,
                                                    num_clifford_range=num_cfds,
                                                    repetitions=100)
     g_pops = np.asarray(results.data)[:, 1]
@@ -43,7 +44,9 @@ def test_two_qubit_randomized_benchmarking():
     q_0 = GridQubit(0, 0)
     q_1 = GridQubit(0, 1)
     num_cfds = range(5, 20, 5)
-    results = two_qubit_randomized_benchmarking(simulator, q_0, q_1,
+    results = two_qubit_randomized_benchmarking(simulator,
+                                                q_0,
+                                                q_1,
                                                 num_clifford_range=num_cfds,
                                                 repetitions=100)
     g_pops = np.asarray(results.data)[:, 1]

--- a/examples/qubit_characterizations_example.py
+++ b/examples/qubit_characterizations_example.py
@@ -14,14 +14,16 @@ def main():
     rabi_results = cirq.experiments.rabi_oscillations(simulator, q_0, 4 * np.pi)
     rabi_results.plot()
 
+    num_cfds = range(5, 20, 5)
+
     # Clifford-based randomized benchmarking of single-qubit gates on q_0.
     rb_result_1q = cirq.experiments.single_qubit_randomized_benchmarking(
-        simulator, q_0)
+        simulator, q_0, num_clifford_range=num_cfds, repetitions=100)
     rb_result_1q.plot()
 
     # Clifford-based randomized benchmarking of two-qubit gates on q_0 and q_1.
     rb_result_2q = cirq.experiments.two_qubit_randomized_benchmarking(
-        simulator, q_0, q_1)
+        simulator, q_0, q_1, num_clifford_range=num_cfds, repetitions=100)
     rb_result_2q.plot()
 
     # State-tomography of q_0 after application of an X/2 rotation.


### PR DESCRIPTION
Currently we generate the matrices for all 11520 elements of the 2 qubit Clifford group and in order to identify the inverse of a specific element we multiply it by all 11520 elements to find a candidate for the inverse. We have cirq.inverse() and should be using that instead. This shaved ~35 seconds off my pytest runs. Fixes #1476 