### PR TITLE
Fix bug in PhaseXPowGate is_parameterized protocol

### DIFF
--- a/cirq/ops/phased_x_gate.py
+++ b/cirq/ops/phased_x_gate.py
@@ -156,8 +156,8 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
 
     def _is_parameterized_(self) -> bool:
         """See `cirq.SupportsParameterization`."""
-        return (isinstance(self._exponent, sympy.Symbol) or
-                isinstance(self._phase_exponent, sympy.Symbol))
+        return (protocols.is_parameterized(self._exponent) or
+                protocols.is_parameterized(self._phase_exponent))
 
     def _resolve_parameters_(self, param_resolver) -> 'PhasedXPowGate':
         """See `cirq.SupportsParameterization`."""

--- a/cirq/ops/phased_x_gate_test.py
+++ b/cirq/ops/phased_x_gate_test.py
@@ -170,10 +170,15 @@ def test_parameterize():
     ) is NotImplemented
     assert cirq.unitary(parameterized_gate, default=None) is None
     assert cirq.is_parameterized(parameterized_gate)
+
     resolver = cirq.ParamResolver({'a': 0.1, 'b': 0.2})
     resolved_gate = cirq.resolve_parameters(parameterized_gate, resolver)
     assert resolved_gate == cirq.PhasedXPowGate(exponent=0.1,
                                                 phase_exponent=0.2)
+
+    unparameterized_gate = cirq.PhasedXPowGate(exponent=0.1, phase_exponent=0.2)
+    assert not cirq.is_parameterized(unparameterized_gate)
+    assert cirq.is_parameterized(unparameterized_gate**sympy.Symbol('a'))
 
 
 def test_trace_bound():

--- a/cirq/value/periodic_value.py
+++ b/cirq/value/periodic_value.py
@@ -16,8 +16,8 @@ from typing import Any, Union
 
 import sympy
 
+from cirq import protocols
 from cirq._compat import proper_repr
-import cirq.protocols
 
 
 class PeriodicValue:
@@ -75,12 +75,13 @@ class PeriodicValue:
         if high - low > self.period / 2:
             low += self.period
 
-        return cirq.protocols.approx_eq(low, high, atol=atol)
+        return protocols.approx_eq(low, high, atol=atol)
 
     def __repr__(self):
         return 'cirq.PeriodicValue({}, {})'.format(proper_repr(self.value),
                                                    proper_repr(self.period))
 
     def _is_parameterized_(self):
-        return any(isinstance(val, sympy.Basic)
-                   for val in (self.value, self.period))
+        return any(
+            protocols.is_parameterized(val)
+            for val in (self.value, self.period))


### PR DESCRIPTION
Fixes #1713 and moves periodic_value over to use protocol method to future proof it.