### PR TITLE
Support converting to/from proto messages directly in v2 api.

### DIFF
--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -145,11 +145,13 @@ class GridQubit(ops.Qid):
     @staticmethod
     def from_proto_dict(proto_dict: Dict) -> 'GridQubit':
         """Proto dict must have 'row' and 'col' keys."""
-        if 'id' in proto_dict:
-            row, col = proto_dict['id'].split('_')
-            return GridQubit(row=int(row), col=int(col))
         # TODO: Deprecate v1 proto method.
         if 'row' not in proto_dict or 'col' not in proto_dict:
             raise ValueError(
                 'Proto dict does not contain row or col: {}'.format(proto_dict))
         return GridQubit(row=proto_dict['row'], col=proto_dict['col'])
+
+    @staticmethod
+    def from_proto_id(proto_id: str) -> 'GridQubit':
+        row, col = proto_id.split('_')
+        return GridQubit(row=int(row), col=int(col))

--- a/cirq/google/gate_sets_test.py
+++ b/cirq/google/gate_sets_test.py
@@ -20,12 +20,15 @@ import cirq
 import cirq.google as cg
 
 
-@pytest.mark.parametrize(
-    ('gate', 'axis_half_turns', 'half_turns'),
-    ((cirq.X, 0.0, 1.0), (cirq.X**0.2, 0.0, 0.2), (cirq.Y, 0.5, 1.0),
-     (cirq.Y**0.2, 0.5, 0.2),
-     (cirq.PhasedXPowGate(exponent=0.1, phase_exponent=0.2), 0.2, 0.1),
-     (cirq.Rx(0.1 * np.pi), 0.0, 0.1), (cirq.Ry(0.2 * np.pi), 0.5, 0.2)))
+@pytest.mark.parametrize(('gate', 'axis_half_turns', 'half_turns'), [
+    (cirq.X, 0.0, 1.0),
+    (cirq.X**0.25, 0.0, 0.25),
+    (cirq.Y, 0.5, 1.0),
+    (cirq.Y**0.25, 0.5, 0.25),
+    (cirq.PhasedXPowGate(exponent=0.125, phase_exponent=0.25), 0.25, 0.125),
+    (cirq.Rx(0.125 * np.pi), 0.0, 0.125),
+    (cirq.Ry(0.25 * np.pi), 0.5, 0.25),
+])
 def test_serialize_exp_w(gate, axis_half_turns, half_turns):
     q = cirq.GridQubit(1, 2)
     expected = {
@@ -49,15 +52,15 @@ def test_serialize_exp_w(gate, axis_half_turns, half_turns):
         }]
     }
 
-    assert cg.XMON.serialize_op(gate.on(q)) == expected
+    assert cg.XMON.serialize_op_dict(gate.on(q)) == expected
 
 
-@pytest.mark.parametrize(('gate', 'axis_half_turns', 'half_turns'), (
+@pytest.mark.parametrize(('gate', 'axis_half_turns', 'half_turns'), [
     (cirq.X**sympy.Symbol('x'), 0.0, 'x'),
     (cirq.Y**sympy.Symbol('y'), 0.5, 'y'),
     (cirq.PhasedXPowGate(exponent=sympy.Symbol('x'),
-                         phase_exponent=0.2), 0.2, 'x'),
-))
+                         phase_exponent=0.25), 0.25, 'x'),
+])
 def test_serialize_exp_w_parameterized_half_turns(gate, axis_half_turns,
                                                   half_turns):
     q = cirq.GridQubit(1, 2)
@@ -80,11 +83,11 @@ def test_serialize_exp_w_parameterized_half_turns(gate, axis_half_turns,
         }]
     }
 
-    assert cg.XMON.serialize_op(gate.on(q)) == expected
+    assert cg.XMON.serialize_op_dict(gate.on(q)) == expected
 
 
 def test_serialize_exp_w_parameterized_axis_half_turns():
-    gate = cirq.PhasedXPowGate(exponent=0.2, phase_exponent=sympy.Symbol('x'))
+    gate = cirq.PhasedXPowGate(exponent=0.25, phase_exponent=sympy.Symbol('x'))
     q = cirq.GridQubit(1, 2)
     expected = {
         'gate': {
@@ -96,7 +99,7 @@ def test_serialize_exp_w_parameterized_axis_half_turns():
             },
             'half_turns': {
                 'arg_value': {
-                    'float_value': 0.2
+                    'float_value': 0.25
                 }
             },
         },
@@ -105,15 +108,17 @@ def test_serialize_exp_w_parameterized_axis_half_turns():
         }]
     }
 
-    assert cg.XMON.serialize_op(gate.on(q)) == expected
+    assert cg.XMON.serialize_op_dict(gate.on(q)) == expected
 
 
-@pytest.mark.parametrize(
-    ('gate', 'half_turns'),
-    ((cirq.Z, 1.0), (cirq.Z**0.1, 0.1), (cirq.Rz(0.1 * np.pi), 0.1)))
+@pytest.mark.parametrize(('gate', 'half_turns'), [
+    (cirq.Z, 1.0),
+    (cirq.Z**0.125, 0.125),
+    (cirq.Rz(0.125 * np.pi), 0.125),
+])
 def test_serialize_exp_z(gate, half_turns):
     q = cirq.GridQubit(1, 2)
-    assert cg.XMON.serialize_op(gate.on(q)) == {
+    assert cg.XMON.serialize_op_dict(gate.on(q)) == {
         'gate': {
             'id': 'exp_z'
         },
@@ -133,7 +138,7 @@ def test_serialize_exp_z(gate, half_turns):
 def test_serialize_exp_z_parameterized():
     q = cirq.GridQubit(1, 2)
     gate = cirq.Z**sympy.Symbol('x')
-    assert cg.XMON.serialize_op(gate.on(q)) == {
+    assert cg.XMON.serialize_op_dict(gate.on(q)) == {
         'gate': {
             'id': 'exp_z'
         },
@@ -148,12 +153,14 @@ def test_serialize_exp_z_parameterized():
     }
 
 
-@pytest.mark.parametrize(('gate', 'half_turns'),
-                         ((cirq.CZ, 1.0), (cirq.CZ**0.1, 0.1)))
+@pytest.mark.parametrize(('gate', 'half_turns'), [
+    (cirq.CZ, 1.0),
+    (cirq.CZ**0.125, 0.125),
+])
 def test_serialize_exp_11(gate, half_turns):
     c = cirq.GridQubit(1, 2)
     t = cirq.GridQubit(1, 3)
-    assert cg.XMON.serialize_op(gate.on(c, t)) == {
+    assert cg.XMON.serialize_op_dict(gate.on(c, t)) == {
         'gate': {
             'id': 'exp_11'
         },
@@ -176,7 +183,7 @@ def test_serialize_exp_11_parameterized():
     c = cirq.GridQubit(1, 2)
     t = cirq.GridQubit(1, 3)
     gate = cirq.CZ**sympy.Symbol('x')
-    assert cg.XMON.serialize_op(gate.on(c, t)) == {
+    assert cg.XMON.serialize_op_dict(gate.on(c, t)) == {
         'gate': {
             'id': 'exp_11'
         },
@@ -193,12 +200,12 @@ def test_serialize_exp_11_parameterized():
     }
 
 
-@pytest.mark.parametrize(('qubits', 'qubit_ids', 'key', 'invert_mask'), (
+@pytest.mark.parametrize(('qubits', 'qubit_ids', 'key', 'invert_mask'), [
     ([cirq.GridQubit(1, 1)], ['1_1'], 'a', ()),
     ([cirq.GridQubit(1, 2)], ['1_2'], 'b', (True,)),
     ([cirq.GridQubit(1, 1), cirq.GridQubit(1, 2)], ['1_1', '1_2'], 'a',
      (True, False)),
-))
+])
 def test_serialize_meas(qubits, qubit_ids, key, invert_mask):
     op = cirq.measure(*qubits, key=key, invert_mask=invert_mask)
     expected = {
@@ -223,7 +230,7 @@ def test_serialize_meas(qubits, qubit_ids, key, invert_mask):
     }
     for qubit_id in qubit_ids:
         expected['qubits'].append({'id': qubit_id})
-    assert cg.XMON.serialize_op(op) == expected
+    assert cg.XMON.serialize_op_dict(op) == expected
 
 
 def test_serialize_circuit():
@@ -233,24 +240,26 @@ def test_serialize_circuit():
                                     cirq.measure(q1, key='m'))
     expected = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'xmon'
         },
         'circuit': {
             'scheduling_strategy':
             1,
             'moments': [{
-                'operations': [cg.XMON.serialize_op(cirq.CZ(q0, q1))]
+                'operations': [cg.XMON.serialize_op_dict(cirq.CZ(q0, q1))]
             }, {
                 'operations': [
-                    cg.XMON.serialize_op(cirq.X(q0)),
-                    cg.XMON.serialize_op(cirq.Z(q1))
+                    cg.XMON.serialize_op_dict(cirq.X(q0)),
+                    cg.XMON.serialize_op_dict(cirq.Z(q1))
                 ]
             }, {
-                'operations': [cg.XMON.serialize_op(cirq.measure(q1, key='m'))]
+                'operations':
+                [cg.XMON.serialize_op_dict(cirq.measure(q1, key='m'))]
             }]
         },
     }
-    assert cg.XMON.serialize(circuit) == expected
+    assert cg.XMON.serialize_dict(circuit) == expected
 
 
 def test_serialize_schedule():
@@ -274,37 +283,41 @@ def test_serialize_schedule():
                              scheduled_operations=scheduled_ops)
     expected = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'xmon'
         },
         'schedule': {
             'scheduled_operations': [{
                 'operation':
-                cg.XMON.serialize_op(cirq.CZ(q0, q1)),
+                cg.XMON.serialize_op_dict(cirq.CZ(q0, q1)),
                 'start_time_picos':
-                0
+                '0'
             }, {
                 'operation':
-                cg.XMON.serialize_op(cirq.X(q0)),
+                cg.XMON.serialize_op_dict(cirq.X(q0)),
                 'start_time_picos':
-                200000,
+                '200000',
             }, {
                 'operation':
-                cg.XMON.serialize_op(cirq.Z(q1)),
+                cg.XMON.serialize_op_dict(cirq.Z(q1)),
                 'start_time_picos':
-                200000,
+                '200000',
             }, {
                 'operation':
-                cg.XMON.serialize_op(cirq.measure(q0, key='a')),
+                cg.XMON.serialize_op_dict(cirq.measure(q0, key='a')),
                 'start_time_picos':
-                400000,
+                '400000',
             }]
         },
     }
-    assert cg.XMON.serialize(schedule) == expected
+    assert cg.XMON.serialize_dict(schedule) == expected
 
 
-@pytest.mark.parametrize(('axis_half_turns', 'half_turns'),
-                         ((0.2, 0.2), (0, 0.2), (0.5, 0.2)))
+@pytest.mark.parametrize(('axis_half_turns', 'half_turns'), [
+    (0.25, 0.25),
+    (0, 0.25),
+    (0.5, 0.25),
+])
 def test_deserialize_exp_w(axis_half_turns, half_turns):
     serialized_op = {
         'gate': {
@@ -329,7 +342,7 @@ def test_deserialize_exp_w(axis_half_turns, half_turns):
     q = cirq.GridQubit(1, 2)
     expected = cirq.PhasedXPowGate(exponent=half_turns,
                                    phase_exponent=axis_half_turns)(q)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
 def test_deserialize_exp_w_parameterized():
@@ -352,10 +365,10 @@ def test_deserialize_exp_w_parameterized():
     q = cirq.GridQubit(1, 2)
     expected = cirq.PhasedXPowGate(exponent=sympy.Symbol('y'),
                                    phase_exponent=sympy.Symbol('x'))(q)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
-@pytest.mark.parametrize('half_turns', (0, 0.2, 1.0))
+@pytest.mark.parametrize('half_turns', [0, 0.25, 1.0])
 def test_deserialize_exp_z(half_turns):
     serialized_op = {
         'gate': {
@@ -374,7 +387,7 @@ def test_deserialize_exp_z(half_turns):
     }
     q = cirq.GridQubit(1, 2)
     expected = cirq.ZPowGate(exponent=half_turns)(q)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
 def test_deserialize_exp_z_parameterized():
@@ -393,10 +406,10 @@ def test_deserialize_exp_z_parameterized():
     }
     q = cirq.GridQubit(1, 2)
     expected = cirq.ZPowGate(exponent=sympy.Symbol('x'))(q)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
-@pytest.mark.parametrize('half_turns', (0, 0.2, 1.0))
+@pytest.mark.parametrize('half_turns', [0, 0.25, 1.0])
 def test_deserialize_exp_11(half_turns):
     serialized_op = {
         'gate': {
@@ -418,7 +431,7 @@ def test_deserialize_exp_11(half_turns):
     c = cirq.GridQubit(1, 2)
     t = cirq.GridQubit(2, 2)
     expected = cirq.CZPowGate(exponent=half_turns)(c, t)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
 def test_deserialize_exp_11_parameterized():
@@ -440,15 +453,15 @@ def test_deserialize_exp_11_parameterized():
     c = cirq.GridQubit(1, 2)
     t = cirq.GridQubit(2, 2)
     expected = cirq.CZPowGate(exponent=sympy.Symbol('x'))(c, t)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
-@pytest.mark.parametrize(('qubits', 'qubit_ids', 'key', 'invert_mask'), (
+@pytest.mark.parametrize(('qubits', 'qubit_ids', 'key', 'invert_mask'), [
     ([cirq.GridQubit(1, 1)], ['1_1'], 'a', ()),
     ([cirq.GridQubit(1, 2)], ['1_2'], 'b', (True,)),
     ([cirq.GridQubit(1, 1), cirq.GridQubit(1, 2)], ['1_1', '1_2'], 'a',
      (True, False)),
-))
+])
 def test_deserialize_meas(qubits, qubit_ids, key, invert_mask):
     serialized_op = {
         'gate': {
@@ -473,7 +486,7 @@ def test_deserialize_meas(qubits, qubit_ids, key, invert_mask):
         } for id in qubit_ids]
     }
     expected = cirq.measure(*qubits, key=key, invert_mask=invert_mask)
-    assert cg.XMON.deserialize_op(serialized_op) == expected
+    assert cg.XMON.deserialize_op_dict(serialized_op) == expected
 
 
 def test_deserialize_circuit():
@@ -489,18 +502,19 @@ def test_deserialize_circuit():
             'scheduling_strategy':
             1,
             'moments': [{
-                'operations': [cg.XMON.serialize_op(cirq.CZ(q0, q1))]
+                'operations': [cg.XMON.serialize_op_dict(cirq.CZ(q0, q1))]
             }, {
                 'operations': [
-                    cg.XMON.serialize_op(cirq.X(q0)),
-                    cg.XMON.serialize_op(cirq.Z(q1))
+                    cg.XMON.serialize_op_dict(cirq.X(q0)),
+                    cg.XMON.serialize_op_dict(cirq.Z(q1))
                 ]
             }, {
-                'operations': [cg.XMON.serialize_op(cirq.measure(q1, key='m'))]
+                'operations':
+                [cg.XMON.serialize_op_dict(cirq.measure(q1, key='m'))]
             }]
         },
     }
-    assert cg.XMON.deserialize(serialized) == circuit
+    assert cg.XMON.deserialize_dict(serialized) == circuit
 
 
 def test_deserialize_schedule():
@@ -529,25 +543,25 @@ def test_deserialize_schedule():
         'schedule': {
             'scheduled_operations': [{
                 'operation':
-                cg.XMON.serialize_op(cirq.CZ(q0, q1)),
+                cg.XMON.serialize_op_dict(cirq.CZ(q0, q1)),
                 'start_time_picos':
                 0
             }, {
                 'operation':
-                cg.XMON.serialize_op(cirq.X(q0)),
+                cg.XMON.serialize_op_dict(cirq.X(q0)),
                 'start_time_picos':
                 200000,
             }, {
                 'operation':
-                cg.XMON.serialize_op(cirq.Z(q1)),
+                cg.XMON.serialize_op_dict(cirq.Z(q1)),
                 'start_time_picos':
                 200000,
             }, {
                 'operation':
-                cg.XMON.serialize_op(cirq.measure(q0, key='a')),
+                cg.XMON.serialize_op_dict(cirq.measure(q0, key='a')),
                 'start_time_picos':
                 400000,
             }]
         },
     }
-    assert cg.XMON.deserialize(serialized, cg.Bristlecone) == schedule
+    assert cg.XMON.deserialize_dict(serialized, cg.Bristlecone) == schedule

--- a/cirq/google/op_deserializer.py
+++ b/cirq/google/op_deserializer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 from typing import Any, Callable, Dict, NamedTuple, Optional, Sequence
+
 import sympy
+from google.protobuf import json_format
 
 from cirq import devices, ops
+from cirq.api.google import v2
 from cirq.google import arg_func_langs
 
 
@@ -84,42 +87,48 @@ class GateOpDeserializer:
 
     def from_proto_dict(self, proto: Dict) -> ops.GateOperation:
         """Turns a cirq.api.google.v2.Operation proto into a GateOperation."""
-        qubits = [devices.GridQubit.from_proto_dict(x) for x in proto['qubits']]
-        args = self._args_from_proto(proto['args']) if 'args' in proto else {}
+        msg = v2.program_pb2.Operation()
+        json_format.ParseDict(proto, msg)
+        return self.from_proto(msg)
+
+    def from_proto(self, proto: v2.program_pb2.Operation) -> ops.GateOperation:
+        """Turns a cirq.api.google.v2.Operation proto into a GateOperation."""
+        qubits = [devices.GridQubit.from_proto_id(q.id) for q in proto.qubits]
+        args = self._args_from_proto(proto)
         if self.num_qubits_param is not None:
             args[self.num_qubits_param] = len(qubits)
         gate = self.gate_constructor(**args)
         return gate.on(*qubits)
 
-    def _args_from_proto(self, args_proto_dict: Dict
+    def _args_from_proto(self, proto: v2.program_pb2.Operation
                         ) -> Dict[str, arg_func_langs.ArgValue]:
         return_args = {}
         for arg in self.args:
-            if arg.serialized_name not in args_proto_dict and arg.required:
+            if arg.serialized_name not in proto.args and arg.required:
                 raise ValueError(
                     'Argument {} not in deserializing args, but is required.'.
                     format(arg.serialized_name))
 
             value = None  # type: Optional[arg_func_langs.ArgValue]
-            if arg.serialized_name in args_proto_dict:
-                if 'arg_value' in args_proto_dict[arg.serialized_name]:
-                    arg_value = args_proto_dict[
-                        arg.serialized_name]['arg_value']
-                    if 'float_value' in arg_value:
-                        value = float(arg_value['float_value'])
-                    elif 'bool_values' in arg_value:
-                        value = arg_value['bool_values']['values']
-                    elif 'string_value' in arg_value:
-                        value = str(arg_value['string_value'])
-
-                if 'symbol' in args_proto_dict[arg.serialized_name]:
-                    value = sympy.Symbol(
-                        args_proto_dict[arg.serialized_name]['symbol'])
+            if arg.serialized_name in proto.args:
+                arg_proto = proto.args[arg.serialized_name]
+                which = arg_proto.WhichOneof('arg')
+                if which == 'arg_value':
+                    arg_value = arg_proto.arg_value
+                    which = arg_value.WhichOneof('arg_value')
+                    if which == 'float_value':
+                        value = float(arg_value.float_value)
+                    elif which == 'bool_values':
+                        value = arg_value.bool_values.values
+                    elif which == 'string_value':
+                        value = str(arg_value.string_value)
+                elif which == 'symbol':
+                    value = sympy.Symbol(arg_proto.symbol)
 
             if value is None and arg.required:
                 raise ValueError(
                     'Could not get arg {} from arg_proto {}'.format(
-                        arg.serialized_name, args_proto_dict))
+                        arg.serialized_name, args.proto))
 
             if arg.value_func is not None:
                 value = arg.value_func(value)

--- a/cirq/google/op_deserializer.py
+++ b/cirq/google/op_deserializer.py
@@ -128,7 +128,7 @@ class GateOpDeserializer:
             if value is None and arg.required:
                 raise ValueError(
                     'Could not get arg {} from arg_proto {}'.format(
-                        arg.serialized_name, args.proto))
+                        arg.serialized_name, proto.args))
 
             if arg.value_func is not None:
                 value = arg.value_func(value)

--- a/cirq/google/op_deserializer_test.py
+++ b/cirq/google/op_deserializer_test.py
@@ -197,3 +197,36 @@ def test_from_proto_not_required_ok():
     q = cirq.GridQubit(1, 2)
     result = deserializer.from_proto_dict(serialized)
     assert result == GateWithAttribute(0.125)(q)
+
+
+def test_from_proto_missing_required_arg():
+    deserializer = cg.GateOpDeserializer(serialized_gate_id='my_gate',
+                                         gate_constructor=GateWithAttribute,
+                                         args=[
+                                             cg.DeserializingArg(
+                                                 serialized_name='my_val',
+                                                 constructor_arg_name='val',
+                                             ),
+                                             cg.DeserializingArg(
+                                                 serialized_name='not_req',
+                                                 constructor_arg_name='not_req',
+                                                 required=False)
+                                         ])
+    serialized = {
+        'gate': {
+            'id': 'my_gate'
+        },
+        'args': {
+            'not_req': {
+                'arg_value': {
+                    'float_value': 0.125
+                }
+            }
+        },
+        'qubits': [{
+            'id': '1_2'
+        }]
+    }
+    q = cirq.GridQubit(1, 2)
+    with pytest.raises(ValueError):
+        deserializer.from_proto_dict(serialized)

--- a/cirq/google/op_deserializer_test.py
+++ b/cirq/google/op_deserializer_test.py
@@ -227,6 +227,34 @@ def test_from_proto_missing_required_arg():
             'id': '1_2'
         }]
     }
-    q = cirq.GridQubit(1, 2)
+    with pytest.raises(ValueError):
+        deserializer.from_proto_dict(serialized)
+
+
+def test_from_proto_required_arg_not_assigned():
+    deserializer = cg.GateOpDeserializer(serialized_gate_id='my_gate',
+                                         gate_constructor=GateWithAttribute,
+                                         args=[
+                                             cg.DeserializingArg(
+                                                 serialized_name='my_val',
+                                                 constructor_arg_name='val',
+                                             ),
+                                             cg.DeserializingArg(
+                                                 serialized_name='not_req',
+                                                 constructor_arg_name='not_req',
+                                                 required=False)
+                                         ])
+    serialized = {
+        'gate': {
+            'id': 'my_gate'
+        },
+        'args': {
+            'my_val': {
+            }
+        },
+        'qubits': [{
+            'id': '1_2'
+        }]
+    }
     with pytest.raises(ValueError):
         deserializer.from_proto_dict(serialized)

--- a/cirq/google/op_deserializer_test.py
+++ b/cirq/google/op_deserializer_test.py
@@ -249,8 +249,7 @@ def test_from_proto_required_arg_not_assigned():
             'id': 'my_gate'
         },
         'args': {
-            'my_val': {
-            }
+            'my_val': {}
         },
         'qubits': [{
             'id': '1_2'

--- a/cirq/google/op_deserializer_test.py
+++ b/cirq/google/op_deserializer_test.py
@@ -97,7 +97,7 @@ def test_from_proto_required_missing():
         'args': {
             'not_my_val': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             }
         },
@@ -105,7 +105,7 @@ def test_from_proto_required_missing():
             'id': '1_2'
         }]
     }
-    with pytest.raises(ValueError, match='my_val'):
+    with pytest.raises(Exception, match='my_val'):
         deserializer.from_proto_dict(serialized)
 
 
@@ -125,7 +125,7 @@ def test_from_proto_unknown_arg_type():
         'args': {
             'my_val': {
                 'arg_value': {
-                    'what_value': 0.1
+                    'what_value': 0.125
                 }
             }
         },
@@ -133,7 +133,7 @@ def test_from_proto_unknown_arg_type():
             'id': '1_2'
         }]
     }
-    with pytest.raises(ValueError, match='my_val'):
+    with pytest.raises(Exception, match='what_value'):
         deserializer.from_proto_dict(serialized)
 
 
@@ -153,7 +153,7 @@ def test_from_proto_value_func():
         'args': {
             'my_val': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             }
         },
@@ -163,7 +163,7 @@ def test_from_proto_value_func():
     }
     q = cirq.GridQubit(1, 2)
     result = deserializer.from_proto_dict(serialized)
-    assert result == GateWithAttribute(1.1)(q)
+    assert result == GateWithAttribute(1.125)(q)
 
 
 def test_from_proto_not_required_ok():
@@ -186,7 +186,7 @@ def test_from_proto_not_required_ok():
         'args': {
             'my_val': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             }
         },
@@ -196,4 +196,4 @@ def test_from_proto_not_required_ok():
     }
     q = cirq.GridQubit(1, 2)
     result = deserializer.from_proto_dict(serialized)
-    assert result == GateWithAttribute(0.1)(q)
+    assert result == GateWithAttribute(0.125)(q)

--- a/cirq/google/op_serializer.py
+++ b/cirq/google/op_serializer.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, cast, Dict, List, NamedTuple, Type, TypeVar, Union
+from typing import (Callable, cast, Dict, List, NamedTuple, Optional, Type,
+                    TypeVar, Union)
 
 import numpy as np
 import sympy
+from google.protobuf import json_format
 
 from cirq import devices, ops
+from cirq.api.google import v2
 from cirq.google import arg_func_langs
 
 # Type for variables that are subclasses of ops.Gate.
@@ -79,32 +82,36 @@ class GateOpSerializer:
         self.args = args
 
     def to_proto_dict(self, op: ops.GateOperation) -> Dict:
+        return json_format.MessageToDict(self.to_proto(op),
+                                         including_default_value_fields=True,
+                                         preserving_proto_field_name=True,
+                                         use_integers_for_enums=True)
+
+    def to_proto(self,
+                 op: ops.GateOperation,
+                 msg: Optional[v2.program_pb2.Operation] = None
+                ) -> v2.program_pb2.Operation:
         """Returns the cirq.api.google.v2.Operation message as a proto dict."""
         if not all(isinstance(qubit, devices.GridQubit) for qubit in op.qubits):
             raise ValueError('All qubits must be GridQubits')
-        proto_dict = {
-            'gate': {
-                'id': self.serialized_gate_id
-            },
-            'qubits': [{
-                'id': cast(devices.GridQubit, qubit).proto_id()
-            } for qubit in op.qubits]
-        }  # type: Dict
         gate = op.gate
         if not isinstance(gate, self.gate_type):
             raise ValueError(
                 'Gate of type {} but serializer expected type {}'.format(
                     type(gate), self.gate_type))
 
+        if msg is None:
+            msg = v2.program_pb2.Operation()
+
+        msg.gate.id = self.serialized_gate_id
+        for qubit in op.qubits:
+            msg.qubits.add().id = cast(devices.GridQubit, qubit).proto_id()
+
         for arg in self.args:
             value = self._value_from_gate(gate, arg)
             if value is not None:
-                arg_proto = self._arg_value_to_proto(value)
-                if 'args' not in proto_dict:
-                    proto_dict['args'] = {}
-                proto_dict['args'][arg.serialized_name] = arg_proto
-
-        return proto_dict
+                self._arg_value_to_proto(value, msg.args[arg.serialized_name])
+        return msg
 
     def _value_from_gate(self, gate: ops.Gate,
                          arg: SerializingArg) -> arg_func_langs.ArgValue:
@@ -150,16 +157,17 @@ class GateOpSerializer:
                 'Argument {} had type {} but gate returned type {}'.format(
                     arg.serialized_name, arg.serialized_type, type(value)))
 
-    def _arg_value_to_proto(self, value: arg_func_langs.ArgValue) -> Dict:
-        arg_value = lambda x: {'arg_value': x}
+    def _arg_value_to_proto(self, value: arg_func_langs.ArgValue,
+                            msg: v2.program_pb2.Arg) -> None:
         if isinstance(value, (float, int)):
-            return arg_value({'float_value': float(value)})
-        if isinstance(value, str):
-            return arg_value({'string_value': str(value)})
-        if (isinstance(value, (list, tuple, np.ndarray)) and
-                all(isinstance(x, (bool, np.bool_)) for x in value)):
-            return arg_value({'bool_values': {'values': list(value)}})
-        if isinstance(value, sympy.Symbol):
-            return {'symbol': str(value.free_symbols.pop())}
-        raise ValueError('Unsupported type of arg value: {}'.format(
-            type(value)))
+            msg.arg_value.float_value = float(value)
+        elif isinstance(value, str):
+            msg.arg_value.string_value = value
+        elif (isinstance(value, (list, tuple, np.ndarray)) and
+              all(isinstance(x, (bool, np.bool_)) for x in value)):
+            msg.arg_value.bool_values.values.extend(value)
+        elif isinstance(value, sympy.Symbol):
+            msg.symbol = str(value.free_symbols.pop())
+        else:
+            raise ValueError('Unsupported type of arg value: {}'.format(
+                type(value)))

--- a/cirq/google/op_serializer_test.py
+++ b/cirq/google/op_serializer_test.py
@@ -263,7 +263,7 @@ def test_to_proto_not_required_ok():
         'args': {
             'my_val': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             }
         },
@@ -273,13 +273,17 @@ def test_to_proto_not_required_ok():
     }
 
     q = cirq.GridQubit(1, 2)
-    assert serializer.to_proto_dict(GateWithProperty(0.1)(q)) == expected
+    assert serializer.to_proto_dict(GateWithProperty(0.125)(q)) == expected
 
 
-@pytest.mark.parametrize(
-    ('val_type', 'val'),
-    ((float, 's'), (str, 1.0), (sympy.Symbol, 1.0), (List[bool], [1.0]),
-     (List[bool], 'a'), (List[bool], (1.0,))))
+@pytest.mark.parametrize(('val_type', 'val'), (
+    (float, 's'),
+    (str, 1.0),
+    (sympy.Symbol, 1.0),
+    (List[bool], [1.0]),
+    (List[bool], 'a'),
+    (List[bool], (1.0,)),
+))
 def test_to_proto_type_mismatch(val_type, val):
     serializer = cg.GateOpSerializer(gate_type=GateWithProperty,
                                      serialized_gate_id='my_gate',

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -156,14 +156,8 @@ class SerializableGateSet:
                     'given.')
             return self._deserialize_schedule(proto.schedule, device)
         else:
-            # NOTE: this can happen when serializing an empty schedule,
-            if device is None:
-                raise ValueError(
-                    'Deserializing schedule requires a device but None was '
-                    'given.')
-            return self._deserialize_schedule(proto.schedule, device)
-            #raise ValueError(
-            #    'Program proto does not contain a circuit or schedule.')
+            raise ValueError(
+                'Program proto does not contain a circuit or schedule.')
 
     def deserialize_op_dict(self, operation_proto: Dict) -> ops.Operation:
         """Deserialize an Operation from a cirq.api.google.v2.Operation.

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -15,9 +15,11 @@
 
 from typing import cast, Dict, Iterable, Optional, Tuple, Union
 
-from cirq.google import op_deserializer, op_serializer
+from google.protobuf import json_format
 
 from cirq import circuits, devices, ops, schedules, value
+from cirq.api.google import v2
+from cirq.google import op_deserializer, op_serializer
 
 
 class SerializableGateSet:
@@ -36,8 +38,9 @@ class SerializableGateSet:
     def supported_gate_types(self) -> Tuple:
         return tuple(self.serializers.keys())
 
-    def serialize(self,
-                  program: Union[circuits.Circuit, schedules.Schedule]) -> Dict:
+    def serialize_dict(self,
+                       program: Union[circuits.Circuit, schedules.Schedule]
+                      ) -> Dict:
         """Serialize a Circuit or Schedule to cirq.api.google.v2.Program proto.
 
         Args:
@@ -46,14 +49,47 @@ class SerializableGateSet:
         Returns:
             A dictionary corresponding to the cirq.api.google.v2.Program proto.
         """
-        proto = {'language': {'gate_set': self.gate_set_name}}
-        if isinstance(program, circuits.Circuit):
-            proto['circuit'] = self._serialize_circuit(program)
-        else:
-            proto['schedule'] = self._serialize_schedule(program)
-        return proto
+        return json_format.MessageToDict(self.serialize(program),
+                                         including_default_value_fields=True,
+                                         preserving_proto_field_name=True,
+                                         use_integers_for_enums=True)
 
-    def serialize_op(self, op: ops.Operation) -> Dict:
+    def serialize(self,
+                  program: Union[circuits.Circuit, schedules.Schedule],
+                  msg: Optional[v2.program_pb2.Program] = None
+                 ) -> v2.program_pb2.Program:
+        """Serialize a Circuit or Schedule to cirq.api.google.v2.Program proto.
+
+        Args:
+            program: The Circuit or Schedule to serialize.
+        """
+        if msg is None:
+            msg = v2.program_pb2.Program()
+        msg.language.gate_set = self.gate_set_name
+        if isinstance(program, circuits.Circuit):
+            self._serialize_circuit(program, msg.circuit)
+        else:
+            self._serialize_schedule(program, msg.schedule)
+        return msg
+
+    def serialize_op_dict(self, op: ops.Operation) -> Dict:
+        """Serialize an Operation to cirq.api.google.v2.Operation proto.
+
+        Args:
+            op: The operation to serialize.
+
+        Returns:
+            A dictionary corresponds to the cirq.api.google.v2.Operation proto.
+        """
+        return json_format.MessageToDict(self.serialize_op(op),
+                                         including_default_value_fields=True,
+                                         preserving_proto_field_name=True,
+                                         use_integers_for_enums=True)
+
+    def serialize_op(self,
+                     op: ops.Operation,
+                     msg: Optional[v2.program_pb2.Operation] = None
+                    ) -> v2.program_pb2.Operation:
         """Serialize an Operation to cirq.api.google.v2.Operation proto.
 
         Args:
@@ -67,10 +103,31 @@ class SerializableGateSet:
         for gate_type_mro in gate_type.mro():
             # Check all super classes in method resolution order.
             if gate_type_mro in self.serializers:
-                return self.serializers[gate_type_mro].to_proto_dict(gate_op)
+                return self.serializers[gate_type_mro].to_proto(gate_op, msg)
         raise ValueError('Cannot serialize op of type {}'.format(gate_type))
 
-    def deserialize(self, proto: Dict, device: Optional[devices.Device] = None
+    def deserialize_dict(self,
+                         proto: Dict,
+                         device: Optional[devices.Device] = None
+                        ) -> Union[circuits.Circuit, schedules.Schedule]:
+        """Deserialize a Circuit or Schedule from a cirq.api.google.v2.Program.
+
+        Args:
+            proto: A dictionary representing a cirq.api.google.v2.Program proto.
+            device: If the proto is for a schedule, a device is required
+                Otherwise optional.
+
+        Returns:
+            The deserialized Circuit or Schedule, with a device if device was
+            not None.
+        """
+        msg = v2.program_pb2.Program()
+        json_format.ParseDict(proto, msg)
+        return self.deserialize(msg, device)
+
+    def deserialize(self,
+                    proto: v2.program_pb2.Program,
+                    device: Optional[devices.Device] = None
                    ) -> Union[circuits.Circuit, schedules.Schedule]:
         """Deserialize a Circuit or Schedule from a cirq.api.google.v2.Program.
 
@@ -83,25 +140,32 @@ class SerializableGateSet:
             The deserialized Circuit or Schedule, with a device if device was
             not None.
         """
-        if 'language' not in proto or 'gate_set' not in proto['language']:
+        if not proto.HasField('language') or not proto.language.gate_set:
             raise ValueError('Missing gate set specification.')
-        if proto['language']['gate_set'] != self.gate_set_name:
+        if proto.language.gate_set != self.gate_set_name:
             raise ValueError('Gate set in proto was {} but expected {}'.format(
-                proto['language']['gate_set'], self.gate_set_name))
-        if 'circuit' in proto:
-            circuit = self._deserialize_circuit(proto['circuit'])
+                proto.language.gate_set, self.gate_set_name))
+        which = proto.WhichOneof('program')
+        if which == 'circuit':
+            circuit = self._deserialize_circuit(proto.circuit)
             return circuit if device is None else circuit.with_device(device)
-        elif 'schedule' in proto:
+        elif which == 'schedule':
             if device is None:
                 raise ValueError(
                     'Deserializing schedule requires a device but None was '
                     'given.')
-            return self._deserialize_schedule(proto['schedule'], device)
+            return self._deserialize_schedule(proto.schedule, device)
         else:
-            raise ValueError(
-                'Program proto does not contain a circuit or schedule.')
+            # NOTE: this can happen when serializing an empty schedule,
+            if device is None:
+                raise ValueError(
+                    'Deserializing schedule requires a device but None was '
+                    'given.')
+            return self._deserialize_schedule(proto.schedule, device)
+            #raise ValueError(
+            #    'Program proto does not contain a circuit or schedule.')
 
-    def deserialize_op(self, operation_proto) -> ops.Operation:
+    def deserialize_op_dict(self, operation_proto: Dict) -> ops.Operation:
         """Deserialize an Operation from a cirq.api.google.v2.Operation.
 
         Args:
@@ -111,69 +175,67 @@ class SerializableGateSet:
         Returns:
             The deserialized Operation.
         """
-        if 'gate' not in operation_proto or 'id' not in operation_proto['gate']:
+        msg = v2.program_pb2.Operation()
+        json_format.ParseDict(operation_proto, msg)
+        return self.deserialize_op(msg)
+
+    def deserialize_op(self, operation_proto: v2.program_pb2.Operation
+                      ) -> ops.Operation:
+        """Deserialize an Operation from a cirq.api.google.v2.Operation.
+
+        Args:
+            operation_proto: A dictionary representing a
+                cirq.api.google.v2.Operation proto.
+
+        Returns:
+            The deserialized Operation.
+        """
+        if not operation_proto.gate.id:
             raise ValueError('Operation proto does not have a gate.')
 
-        gate_id = operation_proto['gate']['id']
-        if gate_id in self.deserializers.keys():
-            return self.deserializers[gate_id].from_proto_dict(operation_proto)
-        else:
+        gate_id = operation_proto.gate.id
+        if gate_id not in self.deserializers.keys():
             raise ValueError(
                 'Unsupported serialized gate with id {}'.format(gate_id))
 
-    def _serialize_circuit(self, circuit: circuits.Circuit) -> Dict:
-        moment_protos = []
+        return self.deserializers[gate_id].from_proto(operation_proto)
+
+    def _serialize_circuit(self, circuit: circuits.Circuit,
+                           msg: v2.program_pb2.Circuit) -> None:
+        msg.scheduling_strategy = v2.program_pb2.Circuit.MOMENT_BY_MOMENT
         for moment in circuit:
-            moment_proto = {
-                'operations': [self.serialize_op(op) for op in moment]
-            }
-            moment_protos.append(moment_proto)
-        return {
-            'scheduling_strategy': 1,  # MOMENT_BY_MOMENT
-            'moments': moment_protos
-        }
+            moment_proto = msg.moments.add()
+            for op in moment:
+                self.serialize_op(op, moment_proto.operations.add())
 
-    def _serialize_schedule(self, schedule: schedules.Schedule) -> Dict:
-        scheduled_op_protos = []
+    def _serialize_schedule(self, schedule: schedules.Schedule,
+                            msg: v2.program_pb2.Schedule) -> None:
         for scheduled_op in schedule.scheduled_operations:
-            scheduled_op_protos.append({
-                'operation':
-                self.serialize_op(scheduled_op.operation),
-                'start_time_picos':
-                scheduled_op.time.raw_picos()
-            })
-        return {'scheduled_operations': scheduled_op_protos}
+            scheduled_op_proto = msg.scheduled_operations.add()
+            scheduled_op_proto.start_time_picos = scheduled_op.time.raw_picos()
+            self.serialize_op(scheduled_op.operation,
+                              scheduled_op_proto.operation)
 
-    def _deserialize_circuit(self, circuit_proto: Dict) -> circuits.Circuit:
+    def _deserialize_circuit(self, circuit_proto: v2.program_pb2.Circuit
+                            ) -> circuits.Circuit:
         moments = []
-        if 'moments' not in circuit_proto:
-            raise ValueError('Circuit proto has no moments.')
-        for moment_proto in circuit_proto['moments']:
-            if 'operations' not in moment_proto:
-                moments.append(ops.Moment())
-                continue
+        for moment_proto in circuit_proto.moments:
             moment_ops = [
-                self.deserialize_op(o) for o in moment_proto['operations']
+                self.deserialize_op(o) for o in moment_proto.operations
             ]
             moments.append(ops.Moment(moment_ops))
         return circuits.Circuit(moments)
 
-    def _deserialize_schedule(self, schedule_proto: Dict,
+    def _deserialize_schedule(self, schedule_proto: v2.program_pb2.Schedule,
                               device: devices.Device) -> schedules.Schedule:
-        if 'scheduled_operations' not in schedule_proto:
-            raise ValueError('Schedule proto missing scheduled operations.')
         scheduled_ops = []
-        for scheduled_op_proto in schedule_proto['scheduled_operations']:
-            if 'operation' not in scheduled_op_proto:
+        for scheduled_op_proto in schedule_proto.scheduled_operations:
+            if not scheduled_op_proto.HasField('operation'):
                 raise ValueError('Scheduled op missing an operation {}'.format(
                     scheduled_op_proto))
-            if 'start_time_picos' not in scheduled_op_proto:
-                raise ValueError('Scheduled op missing a start time {}'.format(
-                    scheduled_op_proto))
             scheduled_op = schedules.ScheduledOperation.op_at_on(
-                operation=self.deserialize_op(scheduled_op_proto['operation']),
-                time=value.Timestamp(
-                    picos=scheduled_op_proto['start_time_picos']),
+                operation=self.deserialize_op(scheduled_op_proto.operation),
+                time=value.Timestamp(picos=scheduled_op_proto.start_time_picos),
                 device=device)
             scheduled_ops.append(scheduled_op)
         return schedules.Schedule(device, scheduled_ops)

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -190,8 +190,8 @@ def test_serialize_deserialize_empty_schedule():
         }
     }
     assert proto == MY_GATE_SET.serialize_dict(schedule)
-    assert MY_GATE_SET.deserialize_dict(proto,
-                                        cirq.google.Bristlecone) == schedule
+    with pytest.raises(ValueError):
+        MY_GATE_SET.deserialize_dict(proto, cirq.google.Bristlecone)
 
 
 def test_serialize_deserialize_op():

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -50,6 +50,7 @@ def test_serialize_deserialize_circuit():
 
     proto = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'my_gate_set'
         },
         'circuit': {
@@ -68,8 +69,8 @@ def test_serialize_deserialize_circuit():
             ]
         },
     }
-    assert proto == MY_GATE_SET.serialize(circuit)
-    assert MY_GATE_SET.deserialize(proto) == circuit
+    assert proto == MY_GATE_SET.serialize_dict(circuit)
+    assert MY_GATE_SET.deserialize_dict(proto) == circuit
 
 
 def test_serialize_deserialize_empty_circuit():
@@ -77,6 +78,7 @@ def test_serialize_deserialize_empty_circuit():
 
     proto = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'my_gate_set'
         },
         'circuit': {
@@ -84,8 +86,8 @@ def test_serialize_deserialize_empty_circuit():
             'moments': []
         },
     }
-    assert proto == MY_GATE_SET.serialize(circuit)
-    assert MY_GATE_SET.deserialize(proto) == circuit
+    assert proto == MY_GATE_SET.serialize_dict(circuit)
+    assert MY_GATE_SET.deserialize_dict(proto) == circuit
 
 
 def test_deserialize_empty_moment():
@@ -93,6 +95,7 @@ def test_deserialize_empty_moment():
 
     proto = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'my_gate_set'
         },
         'circuit': {
@@ -100,7 +103,7 @@ def test_deserialize_empty_moment():
             'moments': [{}]
         },
     }
-    assert MY_GATE_SET.deserialize(proto) == circuit
+    assert MY_GATE_SET.deserialize_dict(proto) == circuit
 
 
 def test_serialize_deserialize_schedule():
@@ -122,27 +125,29 @@ def test_serialize_deserialize_schedule():
 
     proto = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'my_gate_set'
         },
         'schedule': {
             'scheduled_operations': [
                 {
                     'operation': X_SERIALIZER.to_proto_dict(cirq.X(q0)),
-                    'start_time_picos': 0
+                    'start_time_picos': '0'
                 },
                 {
                     'operation': X_SERIALIZER.to_proto_dict(cirq.X(q1)),
-                    'start_time_picos': 200000,
+                    'start_time_picos': '200000',
                 },
                 {
                     'operation': X_SERIALIZER.to_proto_dict(cirq.X(q0)),
-                    'start_time_picos': 400000,
+                    'start_time_picos': '400000',
                 },
             ]
         },
     }
-    assert proto == MY_GATE_SET.serialize(schedule)
-    assert MY_GATE_SET.deserialize(proto, cirq.google.Bristlecone) == schedule
+    assert proto == MY_GATE_SET.serialize_dict(schedule)
+    assert MY_GATE_SET.deserialize_dict(proto,
+                                        cirq.google.Bristlecone) == schedule
 
 
 def test_serialize_deserialize_empty_schedule():
@@ -151,14 +156,13 @@ def test_serialize_deserialize_empty_schedule():
 
     proto = {
         'language': {
+            'arg_function_language': '',
             'gate_set': 'my_gate_set'
-        },
-        'schedule': {
-            'scheduled_operations': []
-        },
+        }
     }
-    assert proto == MY_GATE_SET.serialize(schedule)
-    assert MY_GATE_SET.deserialize(proto, cirq.google.Bristlecone) == schedule
+    assert proto == MY_GATE_SET.serialize_dict(schedule)
+    assert MY_GATE_SET.deserialize_dict(proto,
+                                        cirq.google.Bristlecone) == schedule
 
 
 def test_serialize_deserialize_op():
@@ -170,7 +174,7 @@ def test_serialize_deserialize_op():
         'args': {
             'half_turns': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             },
         },
@@ -178,8 +182,10 @@ def test_serialize_deserialize_op():
             'id': '1_1'
         }]
     }
-    assert proto == MY_GATE_SET.serialize_op(cirq.XPowGate(exponent=0.1)(q0))
-    assert MY_GATE_SET.deserialize_op(proto) == cirq.XPowGate(exponent=0.1)(q0)
+    assert proto == MY_GATE_SET.serialize_op_dict(
+        cirq.XPowGate(exponent=0.125)(q0))
+    assert MY_GATE_SET.deserialize_op_dict(proto) == cirq.XPowGate(
+        exponent=0.125)(q0)
 
 
 def test_serialize_deserialize_op_subclass():
@@ -200,8 +206,8 @@ def test_serialize_deserialize_op_subclass():
         }]
     }
     # cirq.X is a sublcass of XPowGate.
-    assert proto == MY_GATE_SET.serialize_op(cirq.X(q0))
-    assert MY_GATE_SET.deserialize_op(proto) == cirq.X(q0)
+    assert proto == MY_GATE_SET.serialize_op_dict(cirq.X(q0))
+    assert MY_GATE_SET.deserialize_op_dict(proto) == cirq.X(q0)
 
 
 def test_deserialize_op_invalid_gate():
@@ -210,7 +216,7 @@ def test_deserialize_op_invalid_gate():
         'args': {
             'half_turns': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             },
         },
@@ -219,13 +225,13 @@ def test_deserialize_op_invalid_gate():
         }]
     }
     with pytest.raises(ValueError, match='does not have a gate'):
-        MY_GATE_SET.deserialize_op(proto)
+        MY_GATE_SET.deserialize_op_dict(proto)
 
     proto = {
         'args': {
             'half_turns': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             },
         },
@@ -234,7 +240,7 @@ def test_deserialize_op_invalid_gate():
         }]
     }
     with pytest.raises(ValueError, match='does not have a gate'):
-        MY_GATE_SET.deserialize_op(proto)
+        MY_GATE_SET.deserialize_op_dict(proto)
 
 
 def test_deserialize_unsupported_gate_type():
@@ -245,7 +251,7 @@ def test_deserialize_unsupported_gate_type():
         'args': {
             'half_turns': {
                 'arg_value': {
-                    'float_value': 0.1
+                    'float_value': 0.125
                 }
             },
         },
@@ -254,13 +260,13 @@ def test_deserialize_unsupported_gate_type():
         }]
     }
     with pytest.raises(ValueError, match='no_pow'):
-        MY_GATE_SET.deserialize_op(proto)
+        MY_GATE_SET.deserialize_op_dict(proto)
 
 
 def test_serialize_op_unsupported_type():
     q0 = cirq.GridQubit(1, 1)
     with pytest.raises(ValueError, match='YPowGate'):
-        MY_GATE_SET.serialize_op(cirq.YPowGate()(q0))
+        MY_GATE_SET.serialize_op_dict(cirq.YPowGate()(q0))
 
 
 def test_deserialize_invalid_gate_set():
@@ -274,11 +280,11 @@ def test_deserialize_invalid_gate_set():
         },
     }
     with pytest.raises(ValueError, match='not_my_gate_set'):
-        MY_GATE_SET.deserialize(proto)
+        MY_GATE_SET.deserialize_dict(proto)
 
     proto['language'] = {}
     with pytest.raises(ValueError, match='Missing gate set'):
-        MY_GATE_SET.deserialize(proto)
+        MY_GATE_SET.deserialize_dict(proto)
 
     proto = {
         'circuit': {
@@ -287,7 +293,7 @@ def test_deserialize_invalid_gate_set():
         },
     }
     with pytest.raises(ValueError, match='Missing gate set'):
-        MY_GATE_SET.deserialize(proto)
+        MY_GATE_SET.deserialize_dict(proto)
 
 
 def test_deserialize_schedule_missing_device():
@@ -300,41 +306,7 @@ def test_deserialize_schedule_missing_device():
         },
     }
     with pytest.raises(ValueError, match='device'):
-        MY_GATE_SET.deserialize(proto)
-
-
-def test_deserialize_missing_circuit_or_schedule():
-    proto = {
-        'language': {
-            'gate_set': 'my_gate_set'
-        },
-    }
-    with pytest.raises(ValueError, match='circuit or schedule'):
-        MY_GATE_SET.deserialize(proto)
-
-
-def test_deserialize_no_moments():
-    proto = {
-        'language': {
-            'gate_set': 'my_gate_set'
-        },
-        'circuit': {
-            'scheduling_strategy': 1,
-        },
-    }
-    with pytest.raises(ValueError, match='moments'):
-        MY_GATE_SET.deserialize(proto)
-
-
-def test_deserialize_no_scheduled_ops():
-    proto = {
-        'language': {
-            'gate_set': 'my_gate_set'
-        },
-        'schedule': {},
-    }
-    with pytest.raises(ValueError, match='operations'):
-        MY_GATE_SET.deserialize(proto, cirq.google.Bristlecone)
+        MY_GATE_SET.deserialize_dict(proto)
 
 
 def test_deserialize_no_operation():
@@ -351,22 +323,4 @@ def test_deserialize_no_operation():
         },
     }
     with pytest.raises(ValueError, match='operation'):
-        MY_GATE_SET.deserialize(proto, cirq.google.Bristlecone)
-
-
-def test_deserialize_no_start_time_picos():
-    q0 = cirq.GridQubit(1, 1)
-    proto = {
-        'language': {
-            'gate_set': 'my_gate_set'
-        },
-        'schedule': {
-            'scheduled_operations': [
-                {
-                    'operation': X_SERIALIZER.to_proto_dict(cirq.X(q0)),
-                },
-            ]
-        },
-    }
-    with pytest.raises(ValueError, match='operation'):
-        MY_GATE_SET.deserialize(proto, cirq.google.Bristlecone)
+        MY_GATE_SET.deserialize_dict(proto, cirq.google.Bristlecone)

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -150,6 +150,35 @@ def test_serialize_deserialize_schedule():
                                         cirq.google.Bristlecone) == schedule
 
 
+def test_serialize_deserialize_schedule_no_device():
+    q0 = cirq.GridQubit(1, 1)
+    q1 = cirq.GridQubit(1, 2)
+    proto = {
+        'language': {
+            'arg_function_language': '',
+            'gate_set': 'my_gate_set'
+        },
+        'schedule': {
+            'scheduled_operations': [
+                {
+                    'operation': X_SERIALIZER.to_proto_dict(cirq.X(q0)),
+                    'start_time_picos': '0'
+                },
+                {
+                    'operation': X_SERIALIZER.to_proto_dict(cirq.X(q1)),
+                    'start_time_picos': '200000',
+                },
+                {
+                    'operation': X_SERIALIZER.to_proto_dict(cirq.X(q0)),
+                    'start_time_picos': '400000',
+                },
+            ]
+        },
+    }
+    with pytest.raises(ValueError):
+        MY_GATE_SET.deserialize_dict(proto)
+
+
 def test_serialize_deserialize_empty_schedule():
     schedule = cirq.Schedule(device=cirq.google.Bristlecone,
                              scheduled_operations=[])


### PR DESCRIPTION
Related to the discussion in #1156, this would switch the v2 (de)serializers to use proto message classes, with translation to/from json-compatible dicts using the standard `google.protobuf.json_format` package if desired. This way we can center the discussion around real code. A few notes:

- The protobuf semantics around missing vs. empty fields do not always align with what we've been doing in hand-written code. For example, there's no way to serialize an empty schedule to a protobuf and then deserialize it as an empty schedule, because the protobuf will contain neither a circuit nor schedule field, so we can't tell if this was intended to be an empty schedule or if neither circuit nor schedule was set (which should be an error). I've put in code to assume an empty schedule in this case because there was a test for serializing empty schedules, but I think it might be better to just disallow serializing empty schedules (to do anything you _at least_ need a measurement operation, so empty schedules are not very useful).

- The protos are defined with 32 bit float fields so we lose precision on some numbers. For tests we either need to account for this by checking approximate equality, or we need to use numbers that are exactly representable as 32-bit floats. I've opted for the latter for now to keep the diff smaller.

- The conversion to json format has some options like whether to include default-valued fields, whether to preserve the proto field names or convert to lowerCamelCase, and how to represent enums. The json_format parser for deserialization can handle any of these, but most of the tests were written assuming a specific json output, so I've set the options on `MessageToDict` to be closest to how the tests were written, again to keep the diff smaller.
