### PR TITLE
Fix some shellcheck warnings in 'get to repo root' script code

### DIFF
--- a/check/bazel
+++ b/check/bazel
@@ -9,7 +9,7 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 bazel build //cirq/api/google/v1:operations_proto
 bazel build //cirq/api/google/v1:params_proto

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -31,7 +31,7 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 # Parse arguments.
 only_print=1

--- a/check/mypy
+++ b/check/mypy
@@ -9,7 +9,7 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 echo -e -n "\e[31m"
 mypy --config-file=dev_tools/conf/mypy.ini $@ .

--- a/check/performance
+++ b/check/performance
@@ -9,7 +9,7 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 # Test will fail if Mean is 0.1 seconds slower for any test.
 pytest --benchmark-autosave --benchmark-only --benchmark-compare --benchmark-compare-fail=mean:0.1  \

--- a/check/pylint
+++ b/check/pylint
@@ -9,6 +9,6 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 pylint --rcfile=dev_tools/conf/.pylintrc $@ cirq dev_tools examples

--- a/check/pytest
+++ b/check/pytest
@@ -13,6 +13,6 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 pytest $@

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -24,7 +24,7 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 # Figure out which revision to compare against.
 if [ ! -z "$1" ] && [[ $1 != -* ]]; then

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -29,7 +29,7 @@
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 # Figure out which branch to compare against.
 rest=$@

--- a/continuous-integration/check.sh
+++ b/continuous-integration/check.sh
@@ -42,11 +42,9 @@
 
 
 set -e
-own_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-cd ${own_directory}
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cirq_dir=$(git rev-parse --show-toplevel)
-cd ${cirq_dir}
+cd "${cirq_dir}"
 export PYTHONPATH=${cirq_dir}
 
 python3 ${cirq_dir}/dev_tools/run_checks.py $@

--- a/continuous-integration/simple_check.sh
+++ b/continuous-integration/simple_check.sh
@@ -26,10 +26,9 @@
 
 
 # Get the working directory to the repo root.
-own_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd ${own_directory}
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 repo_dir=$(git rev-parse --show-toplevel)
-cd ${repo_dir}
+cd "${repo_dir}"
 
 # Run the checks.
 export PYTHONPATH=${repo_dir}:${PYTHONPATH}

--- a/dev_tools/auto_merge.sh
+++ b/dev_tools/auto_merge.sh
@@ -32,10 +32,9 @@
 
 
 # Get the working directory to the repo root.
-own_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd ${own_directory}
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 repo_dir=$(git rev-parse --show-toplevel)
-cd ${repo_dir}
+cd "${repo_dir}"
 
 # Do the thing.
 export PYTHONPATH=${repo_dir}

--- a/dev_tools/build-docs.sh
+++ b/dev_tools/build-docs.sh
@@ -32,7 +32,7 @@ trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 docs_conf_dir="docs"
 out_dir="docs/_build"

--- a/dev_tools/build-protos.sh
+++ b/dev_tools/build-protos.sh
@@ -26,7 +26,7 @@ trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 
 # Build protos for each protobuf package.
 for package in cirq/api/google/v1 cirq/api/google/v2

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -41,7 +41,7 @@ SPECIFIED_VERSION="${2}"
 # Get the working directory to the repo root.
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 repo_dir=$(git rev-parse --show-toplevel)
-cd ${repo_dir}
+cd "${repo_dir}"
 
 # Make a clean copy of HEAD, without files ignored by git (but potentially kept by setup.py).
 if [ ! -z "$(git status --short)" ]; then
@@ -51,7 +51,7 @@ tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_git_dir}; }" EXIT
 cd "${tmp_git_dir}"
 git init --quiet
-git fetch ${repo_dir} HEAD --quiet --depth=1
+git fetch "${repo_dir}" HEAD --quiet --depth=1
 git checkout FETCH_HEAD -b work --quiet
 if [ ! -z "${SPECIFIED_VERSION}" ]; then
     echo '__version__ = "'"${SPECIFIED_VERSION}"'"' > "${tmp_git_dir}/${PROJECT_NAME}/_version.py"


### PR DESCRIPTION
@fvkg mentioned this tool [shellcheck](https://www.shellcheck.net/). It produces a lot of useful warnings about our scripts, mostly related to undesired word splitting if strings happen to contain spaces.