### PR TITLE
Deprecate-rename Circuit.to_unitary_matrix to Circuit.unitary

### DIFF
--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -17,6 +17,7 @@
 from typing import Any
 import numpy as np
 import sympy
+import sys
 
 
 def proper_repr(value: Any) -> str:
@@ -38,3 +39,36 @@ def proper_repr(value: Any) -> str:
     if isinstance(value, np.ndarray):
         return 'np.array({!r})'.format(value.tolist())
     return repr(value)
+
+
+def deprecated(*, deadline: str, fix: str):
+    """Marks a function as deprecated.
+
+    Args:
+        deadline: The version where the function will be deleted (e.g. "v0.7").
+        fix: A complete sentence describing what the user should be using
+            instead of this particular function (e.g. "Use cos instead.")
+
+    Returns:
+        A decorator that decorates functions with a deprecation warning.
+    """
+
+    def decorator(func):
+        used = False
+
+        def decorated_func(*args, **kwargs):
+            nonlocal used
+            if not used:
+                used = True
+                print(
+                    f'\nThe function "{func.__qualname__}" was used '
+                    f'but is being DEPRECATED.\n'
+                    f'It will be removed in cirq {deadline}.\n'
+                    f'{fix}\n',
+                    file=sys.stderr)
+
+            return func(*args, **kwargs)
+
+        return decorated_func
+
+    return decorator

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -15,9 +15,10 @@
 """Workarounds for sympy issues"""
 
 from typing import Any
+import sys
+
 import numpy as np
 import sympy
-import sys
 
 
 def proper_repr(value: Any) -> str:
@@ -53,6 +54,7 @@ def deprecated(*, deadline: str, fix: str):
         A decorator that decorates functions with a deprecation warning.
     """
 
+    # coverage: ignore
     def decorator(func):
         used = False
 

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Workarounds for sympy issues"""
+"""Workarounds for compatibility issues between versions and libraries."""
+
 from typing import Any, Callable
 import contextlib
 import os

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -64,10 +64,7 @@ def deprecated(*, deadline: str, fix: str) -> Callable[[Callable], Callable]:
                     'DEPRECATION\n'
                     'The function %s was used but is being deprecated.\n'
                     'It will be removed in cirq %s.\n'
-                    '%s\n',
-                    func.__qualname__,
-                    deadline,
-                    fix)
+                    '%s\n', func.__qualname__, deadline, fix)
 
             return func(*args, **kwargs)
 

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 """Workarounds for compatibility issues between versions and libraries."""
-
+import logging
 from typing import Any, Callable
-import contextlib
-import os
-import sys
 
 import numpy as np
 import sympy
@@ -63,26 +60,17 @@ def deprecated(*, deadline: str, fix: str) -> Callable[[Callable], Callable]:
             nonlocal used
             if not used:
                 used = True
-                print(
-                    f'\nThe function "{func.__qualname__}" was used '
-                    f'but is being DEPRECATED.\n'
-                    f'It will be removed in cirq {deadline}.\n'
-                    f'{fix}\n',
-                    file=sys.stderr)
+                logging.warning(
+                    'DEPRECATION\n'
+                    'The function %s was used but is being deprecated.\n'
+                    'It will be removed in cirq %s.\n'
+                    '%s\n',
+                    func.__qualname__,
+                    deadline,
+                    fix)
 
             return func(*args, **kwargs)
 
         return decorated_func
 
     return decorator
-
-
-def deprecated_test(test_func: Callable) -> Callable:
-    """Temporarily redirects stderr to /dev/null during the test."""
-
-    def decorated_test_func():
-        with open(os.devnull, 'w') as devnull:
-            with contextlib.redirect_stderr(devnull):
-                return test_func()
-
-    return decorated_test_func

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -80,6 +80,7 @@ def deprecated(*, deadline: str, fix: str) -> Callable[[Callable], Callable]:
 def deprecated_test(test_func: Callable) -> Callable:
     """Temporarily redirects stderr to /dev/null during the test."""
     def decorated_test_func():
-        with contextlib.redirect_stderr(open(os.devnull, 'w')):
-            return test_func()
+        with open(os.devnull, 'w') as devnull:
+            with contextlib.redirect_stderr(devnull):
+                return test_func()
     return decorated_test_func

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -79,8 +79,10 @@ def deprecated(*, deadline: str, fix: str) -> Callable[[Callable], Callable]:
 
 def deprecated_test(test_func: Callable) -> Callable:
     """Temporarily redirects stderr to /dev/null during the test."""
+
     def decorated_test_func():
         with open(os.devnull, 'w') as devnull:
             with contextlib.redirect_stderr(devnull):
                 return test_func()
+
     return decorated_test_func

--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 """Workarounds for sympy issues"""
-
-from typing import Any
+from typing import Any, Callable
+import contextlib
+import os
 import sys
 
 import numpy as np
@@ -42,7 +43,7 @@ def proper_repr(value: Any) -> str:
     return repr(value)
 
 
-def deprecated(*, deadline: str, fix: str):
+def deprecated(*, deadline: str, fix: str) -> Callable[[Callable], Callable]:
     """Marks a function as deprecated.
 
     Args:
@@ -54,11 +55,10 @@ def deprecated(*, deadline: str, fix: str):
         A decorator that decorates functions with a deprecation warning.
     """
 
-    # coverage: ignore
-    def decorator(func):
+    def decorator(func: Callable) -> Callable:
         used = False
 
-        def decorated_func(*args, **kwargs):
+        def decorated_func(*args, **kwargs) -> Any:
             nonlocal used
             if not used:
                 used = True
@@ -74,3 +74,11 @@ def deprecated(*, deadline: str, fix: str):
         return decorated_func
 
     return decorator
+
+
+def deprecated_test(test_func: Callable) -> Callable:
+    """Temporarily redirects stderr to /dev/null during the test."""
+    def decorated_test_func():
+        with contextlib.redirect_stderr(open(os.devnull, 'w')):
+            return test_func()
+    return decorated_test_func

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1254,12 +1254,11 @@ class Circuit:
             return NotImplemented
         return self.unitary(ignore_terminal_measurements=True)
 
-    def unitary(
-            self,
-            qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
-            qubits_that_should_be_present: Iterable[ops.Qid] = (),
-            ignore_terminal_measurements: bool = True,
-            dtype: Type[np.number] = np.complex128) -> np.ndarray:
+    def unitary(self,
+                qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+                qubits_that_should_be_present: Iterable[ops.Qid] = (),
+                ignore_terminal_measurements: bool = True,
+                dtype: Type[np.number] = np.complex128) -> np.ndarray:
         """Converts the circuit into a unitary matrix, if possible.
 
         Returns the same result as `cirq.unitary`, but provides more options.

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1262,6 +1262,7 @@ class Circuit:
             qubits_that_should_be_present: Iterable[ops.Qid] = (),
             ignore_terminal_measurements: bool = True,
             dtype: Type[np.number] = np.complex128) -> np.ndarray:
+        # coverage: ignore
         return self.unitary(qubit_order, qubits_that_should_be_present,
                             ignore_terminal_measurements, dtype)
 

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1262,7 +1262,6 @@ class Circuit:
             qubits_that_should_be_present: Iterable[ops.Qid] = (),
             ignore_terminal_measurements: bool = True,
             dtype: Type[np.number] = np.complex128) -> np.ndarray:
-        # coverage: ignore
         return self.unitary(qubit_order, qubits_that_should_be_present,
                             ignore_terminal_measurements, dtype)
 

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -31,6 +31,7 @@ import re
 import numpy as np
 
 from cirq import devices, ops, study, protocols
+from cirq._compat import deprecated
 from cirq.circuits._bucket_priority_queue import BucketPriorityQueue
 from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.circuits.text_diagram_drawer import TextDiagramDrawer
@@ -1253,6 +1254,16 @@ class Circuit:
         if not self._has_unitary_():
             return NotImplemented
         return self.unitary(ignore_terminal_measurements=True)
+
+    @deprecated(deadline='v0.7.0', fix='Use Circuit.unitary instead.')
+    def to_unitary_matrix(
+            self,
+            qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
+            qubits_that_should_be_present: Iterable[ops.Qid] = (),
+            ignore_terminal_measurements: bool = True,
+            dtype: Type[np.number] = np.complex128) -> np.ndarray:
+        return self.unitary(qubit_order, qubits_that_should_be_present,
+                            ignore_terminal_measurements, dtype)
 
     def unitary(self,
                 qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -61,7 +61,7 @@ class Circuit:
         findall_operations_with_gate_type
         are_all_matches_terminal
         are_all_measurements_terminal
-        to_unitary_matrix
+        unitary
         apply_unitary_effect_to_state
         to_text_diagram
         to_text_diagram_drawer
@@ -1252,15 +1252,17 @@ class Circuit:
         """
         if not self._has_unitary_():
             return NotImplemented
-        return self.to_unitary_matrix(ignore_terminal_measurements=True)
+        return self.unitary(ignore_terminal_measurements=True)
 
-    def to_unitary_matrix(
+    def unitary(
             self,
             qubit_order: ops.QubitOrderOrList = ops.QubitOrder.DEFAULT,
             qubits_that_should_be_present: Iterable[ops.Qid] = (),
             ignore_terminal_measurements: bool = True,
             dtype: Type[np.number] = np.complex128) -> np.ndarray:
         """Converts the circuit into a unitary matrix, if possible.
+
+        Returns the same result as `cirq.unitary`, but provides more options.
 
         Args:
             qubit_order: Determines how qubits are ordered when passing matrices

--- a/cirq/circuits/circuit_dag_test.py
+++ b/cirq/circuits/circuit_dag_test.py
@@ -148,8 +148,8 @@ def test_to_circuit():
     assert circuit == dag.to_circuit()
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        dag.to_circuit().to_unitary_matrix(),
+        circuit.unitary(),
+        dag.to_circuit().unitary(),
         atol=1e-7)
 
 
@@ -241,6 +241,6 @@ def test_larger_circuit():
     cirq.testing.assert_has_diagram(dag.to_circuit(), desired)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        dag.to_circuit().to_unitary_matrix(),
+        circuit.unitary(),
+        dag.to_circuit().unitary(),
         atol=1e-7)

--- a/cirq/circuits/circuit_dag_test.py
+++ b/cirq/circuits/circuit_dag_test.py
@@ -147,10 +147,9 @@ def test_to_circuit():
     # Only one possible output circuit for this simple case
     assert circuit == dag.to_circuit()
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        dag.to_circuit().unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    dag.to_circuit().unitary(),
+                                                    atol=1e-7)
 
 
 def test_equality():
@@ -240,7 +239,6 @@ def test_larger_circuit():
     cirq.testing.assert_has_diagram(circuit, desired)
     cirq.testing.assert_has_diagram(dag.to_circuit(), desired)
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        dag.to_circuit().unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    dag.to_circuit().unitary(),
+                                                    atol=1e-7)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import Tuple
 
 from collections import defaultdict
@@ -22,6 +23,7 @@ import sympy
 
 import cirq
 import cirq.google as cg
+from cirq._compat import deprecated_test
 
 
 class _MomentAndOpTypeValidatingDeviceType(cirq.Device):
@@ -3069,6 +3071,7 @@ def test_device_propagates():
     c = cirq.Circuit(device=moment_and_op_type_validating_device)
     assert c[:].device is moment_and_op_type_validating_device
 
+
 def test_moment_groups():
     qubits = [cirq.GridQubit(x, y) for x in range(8) for y in range(8)]
     c0 = cirq.H(qubits[0])
@@ -3100,3 +3103,10 @@ def test_moment_groups():
 (0, 7): ────H──────H─────────────────────
            └──┘   └───┘   └───┘   └──┘
 """, use_unicode_characters=True)
+
+
+@deprecated_test
+def test_deprecated_to_unitary_matrix():
+    np.testing.assert_allclose(
+        cirq.Circuit().to_unitary_matrix(),
+        cirq.Circuit().unitary())

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1810,22 +1810,18 @@ def test_circuit_to_unitary_matrix():
 
     # Ignoring terminal measurements.
     c = cirq.Circuit.from_ops(cirq.measure(a))
-    cirq.testing.assert_allclose_up_to_global_phase(
-        c.unitary(),
-        np.eye(2),
-        atol=1e-8)
+    cirq.testing.assert_allclose_up_to_global_phase(c.unitary(),
+                                                    np.eye(2),
+                                                    atol=1e-8)
 
     # Ignoring terminal measurements with further cirq.
     c = cirq.Circuit.from_ops(cirq.Z(a), cirq.measure(a), cirq.Z(b))
-    cirq.testing.assert_allclose_up_to_global_phase(
-        c.unitary(),
-        np.array([
-            [1, 0, 0, 0],
-            [0, -1, 0, 0],
-            [0, 0, -1, 0],
-            [0, 0, 0, 1]
-        ]),
-        atol=1e-8)
+    cirq.testing.assert_allclose_up_to_global_phase(c.unitary(),
+                                                    np.array([[1, 0, 0, 0],
+                                                              [0, -1, 0, 0],
+                                                              [0, 0, -1, 0],
+                                                              [0, 0, 0, 1]]),
+                                                    atol=1e-8)
 
     # Optionally don't ignoring terminal measurements.
     c = cirq.Circuit.from_ops(cirq.measure(a))
@@ -1851,12 +1847,10 @@ def test_circuit_to_unitary_matrix():
         _ = c.unitary()
 
     # Accounts for measurement bit flipping.
-    cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.Circuit.from_ops(
-            cirq.measure(a, invert_mask=(True,))
-        ).unitary(),
-        cirq.unitary(cirq.X),
-        atol=1e-8)
+    cirq.testing.assert_allclose_up_to_global_phase(cirq.Circuit.from_ops(
+        cirq.measure(a, invert_mask=(True,))).unitary(),
+                                                    cirq.unitary(cirq.X),
+                                                    atol=1e-8)
 
     # dtype
     c = cirq.Circuit.from_ops(cirq.X(a))
@@ -2682,10 +2676,9 @@ def test_decomposes_while_appending():
     c.append(cirq.TOFFOLI(cirq.GridQubit(0, 0),
                           cirq.GridQubit(0, 1),
                           cirq.GridQubit(0, 2)))
-    cirq.testing.assert_allclose_up_to_global_phase(
-        c.unitary(),
-        cirq.unitary(cirq.TOFFOLI),
-        atol=1e-8)
+    cirq.testing.assert_allclose_up_to_global_phase(c.unitary(),
+                                                    cirq.unitary(cirq.TOFFOLI),
+                                                    atol=1e-8)
 
     # But you still have to respect adjacency constraints!
     with pytest.raises(ValueError):

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -23,7 +23,6 @@ import sympy
 
 import cirq
 import cirq.google as cg
-from cirq._compat import deprecated_test
 
 
 class _MomentAndOpTypeValidatingDeviceType(cirq.Device):
@@ -3105,7 +3104,6 @@ def test_moment_groups():
 """, use_unicode_characters=True)
 
 
-@deprecated_test
 def test_deprecated_to_unitary_matrix():
     np.testing.assert_allclose(cirq.Circuit().to_unitary_matrix(),
                                cirq.Circuit().unitary())

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1761,18 +1761,18 @@ def test_circuit_to_unitary_matrix():
 
     # Single qubit gates.
     cirq.testing.assert_allclose_up_to_global_phase(cirq.Circuit.from_ops(
-        cirq.X(a)**0.5).to_unitary_matrix(),
+        cirq.X(a)**0.5).unitary(),
                                                     np.array([
                                                         [1j, 1],
                                                         [1, 1j],
                                                     ]) * np.sqrt(0.5),
                                                     atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.Circuit.from_ops(cirq.Y(a)**0.25).to_unitary_matrix(),
+        cirq.Circuit.from_ops(cirq.Y(a)**0.25).unitary(),
         cirq.unitary(cirq.Y(a)**0.25),
         atol=1e-8)
     cirq.testing.assert_allclose_up_to_global_phase(cirq.Circuit.from_ops(
-        cirq.Z(a), cirq.X(b)).to_unitary_matrix(),
+        cirq.Z(a), cirq.X(b)).unitary(),
                                                     np.array([
                                                         [0, 1, 0, 0],
                                                         [1, 0, 0, 0],
@@ -1783,7 +1783,7 @@ def test_circuit_to_unitary_matrix():
 
     # Single qubit gates and two qubit gate.
     cirq.testing.assert_allclose_up_to_global_phase(cirq.Circuit.from_ops(
-        cirq.Z(a), cirq.X(b), cirq.CNOT(a, b)).to_unitary_matrix(),
+        cirq.Z(a), cirq.X(b), cirq.CNOT(a, b)).unitary(),
                                                     np.array([
                                                         [0, 1, 0, 0],
                                                         [1, 0, 0, 0],
@@ -1794,7 +1794,7 @@ def test_circuit_to_unitary_matrix():
     cirq.testing.assert_allclose_up_to_global_phase(cirq.Circuit.from_ops(
         cirq.H(b),
         cirq.CNOT(b, a)**0.5,
-        cirq.Y(a)**0.5).to_unitary_matrix(),
+        cirq.Y(a)**0.5).unitary(),
                                                     np.array([
                                                         [1, 1, -1, -1],
                                                         [1j, -1j, -1j, 1j],
@@ -1806,19 +1806,19 @@ def test_circuit_to_unitary_matrix():
     # Measurement gate has no corresponding matrix.
     c = cirq.Circuit.from_ops(cirq.measure(a))
     with pytest.raises(ValueError):
-        _ = c.to_unitary_matrix(ignore_terminal_measurements=False)
+        _ = c.unitary(ignore_terminal_measurements=False)
 
     # Ignoring terminal measurements.
     c = cirq.Circuit.from_ops(cirq.measure(a))
     cirq.testing.assert_allclose_up_to_global_phase(
-        c.to_unitary_matrix(),
+        c.unitary(),
         np.eye(2),
         atol=1e-8)
 
     # Ignoring terminal measurements with further cirq.
     c = cirq.Circuit.from_ops(cirq.Z(a), cirq.measure(a), cirq.Z(b))
     cirq.testing.assert_allclose_up_to_global_phase(
-        c.to_unitary_matrix(),
+        c.unitary(),
         np.array([
             [1, 0, 0, 0],
             [0, -1, 0, 0],
@@ -1830,17 +1830,17 @@ def test_circuit_to_unitary_matrix():
     # Optionally don't ignoring terminal measurements.
     c = cirq.Circuit.from_ops(cirq.measure(a))
     with pytest.raises(ValueError, match="measurement"):
-        _ = c.to_unitary_matrix(ignore_terminal_measurements=False),
+        _ = c.unitary(ignore_terminal_measurements=False),
 
     # Non-terminal measurements are not ignored.
     c = cirq.Circuit.from_ops(cirq.measure(a), cirq.X(a))
     with pytest.raises(ValueError):
-        _ = c.to_unitary_matrix()
+        _ = c.unitary()
 
     # Non-terminal measurements are not ignored (multiple qubits).
     c = cirq.Circuit.from_ops(cirq.measure(a), cirq.measure(b), cirq.CNOT(a, b))
     with pytest.raises(ValueError):
-        _ = c.to_unitary_matrix()
+        _ = c.unitary()
 
     # Gates without matrix or decomposition raise exception
     class MysteryGate(cirq.TwoQubitGate):
@@ -1848,21 +1848,21 @@ def test_circuit_to_unitary_matrix():
 
     c = cirq.Circuit.from_ops(MysteryGate()(a, b))
     with pytest.raises(TypeError):
-        _ = c.to_unitary_matrix()
+        _ = c.unitary()
 
     # Accounts for measurement bit flipping.
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.Circuit.from_ops(
             cirq.measure(a, invert_mask=(True,))
-        ).to_unitary_matrix(),
+        ).unitary(),
         cirq.unitary(cirq.X),
         atol=1e-8)
 
     # dtype
     c = cirq.Circuit.from_ops(cirq.X(a))
-    assert c.to_unitary_matrix(dtype=np.complex64).dtype == np.complex64
-    assert c.to_unitary_matrix(dtype=np.complex128).dtype == np.complex128
-    assert c.to_unitary_matrix(dtype=np.float64).dtype == np.float64
+    assert c.unitary(dtype=np.complex64).dtype == np.complex64
+    assert c.unitary(dtype=np.complex128).dtype == np.complex128
+    assert c.unitary(dtype=np.float64).dtype == np.float64
 
 
 def test_circuit_unitary():
@@ -1891,7 +1891,7 @@ def test_simple_circuits_to_unitary_matrix():
     # Phase parity.
     c = cirq.Circuit.from_ops(cirq.CNOT(a, b), cirq.Z(b), cirq.CNOT(a, b))
     assert cirq.has_unitary(c)
-    m = c.to_unitary_matrix()
+    m = c.unitary()
     cirq.testing.assert_allclose_up_to_global_phase(
         m,
         np.array([
@@ -1911,7 +1911,7 @@ def test_simple_circuits_to_unitary_matrix():
                 return expected
 
         c = cirq.Circuit.from_ops(Passthrough()(a, b))
-        m = c.to_unitary_matrix()
+        m = c.unitary()
         cirq.testing.assert_allclose_up_to_global_phase(m, expected, atol=1e-8)
 
 
@@ -1928,7 +1928,7 @@ def test_composite_gate_to_unitary_matrix():
                               cirq.X(b), cirq.measure(b))
     assert cirq.has_unitary(c)
 
-    mat = c.to_unitary_matrix()
+    mat = c.unitary()
     mat_expected = cirq.unitary(cirq.CNOT)
 
     cirq.testing.assert_allclose_up_to_global_phase(mat, mat_expected,
@@ -2683,7 +2683,7 @@ def test_decomposes_while_appending():
                           cirq.GridQubit(0, 1),
                           cirq.GridQubit(0, 2)))
     cirq.testing.assert_allclose_up_to_global_phase(
-        c.to_unitary_matrix(),
+        c.unitary(),
         cirq.unitary(cirq.TOFFOLI),
         atol=1e-8)
 

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3107,6 +3107,5 @@ def test_moment_groups():
 
 @deprecated_test
 def test_deprecated_to_unitary_matrix():
-    np.testing.assert_allclose(
-        cirq.Circuit().to_unitary_matrix(),
-        cirq.Circuit().unitary())
+    np.testing.assert_allclose(cirq.Circuit().to_unitary_matrix(),
+                               cirq.Circuit().unitary())

--- a/cirq/circuits/qasm_output_test.py
+++ b/cirq/circuits/qasm_output_test.py
@@ -316,7 +316,7 @@ def test_output_unitary_same_as_qiskit():
         return
 
     circuit = cirq.Circuit.from_ops(operations)
-    cirq_unitary = circuit.to_unitary_matrix(qubit_order=qubits)
+    cirq_unitary = circuit.unitary(qubit_order=qubits)
 
     result = qiskit.execute(
         qiskit.load_qasm_string(text),

--- a/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq/contrib/acquaintance/executor_test.py
@@ -166,13 +166,13 @@ def test_executor_random(num_qubits: int,
     circuit = cca.complete_acquaintance_strategy(qubits, acquaintance_size)
 
     logical_circuit = cirq.Circuit.from_ops([g(*Q) for Q, g in gates.items()])
-    expected_unitary = logical_circuit.to_unitary_matrix()
+    expected_unitary = logical_circuit.unitary()
 
     initial_mapping = {q: q for q in qubits}
     final_mapping = cca.GreedyExecutionStrategy(gates, initial_mapping)(circuit)
     permutation = {q.x: qq.x for q, qq in final_mapping.items()}
     circuit.append(cca.LinearPermutationGate(num_qubits, permutation)(*qubits))
-    actual_unitary = circuit.to_unitary_matrix()
+    actual_unitary = circuit.unitary()
 
     np.testing.assert_allclose(
             actual=actual_unitary,

--- a/cirq/contrib/paulistring/clifford_optimize_test.py
+++ b/cirq/contrib/paulistring/clifford_optimize_test.py
@@ -42,8 +42,8 @@ def test_optimize():
     c_opt = clifford_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 
@@ -71,8 +71,8 @@ def test_remove_czs():
     c_opt = clifford_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(qubits_that_should_be_present=(q0, q1)),
+        c_orig.unitary(),
+        c_opt.unitary(qubits_that_should_be_present=(q0, q1)),
         atol=1e-7,
     )
 
@@ -98,8 +98,8 @@ def test_remove_staggered_czs():
     c_opt = clifford_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(qubits_that_should_be_present=(q0, q1, q2)),
+        c_orig.unitary(),
+        c_opt.unitary(qubits_that_should_be_present=(q0, q1, q2)),
         atol=1e-7,
     )
 
@@ -130,8 +130,8 @@ def test_with_measurements():
     c_opt = clifford_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 
@@ -151,7 +151,7 @@ def test_optimize_large_circuit():
     c_opt = clifford_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )

--- a/cirq/contrib/paulistring/convert_gate_set_test.py
+++ b/cirq/contrib/paulistring/convert_gate_set_test.py
@@ -47,12 +47,12 @@ def test_converts_various_ops(op, expected_ops):
     after = converted_gate_set(before)
     assert after == expected
     cirq.testing.assert_allclose_up_to_global_phase(
-            before.to_unitary_matrix(),
-            after.to_unitary_matrix(qubits_that_should_be_present=op.qubits),
+            before.unitary(),
+            after.unitary(qubits_that_should_be_present=op.qubits),
             atol=1e-7)
     cirq.testing.assert_allclose_up_to_global_phase(
-            after.to_unitary_matrix(qubits_that_should_be_present=op.qubits),
-            expected.to_unitary_matrix(qubits_that_should_be_present=op.qubits),
+            after.unitary(qubits_that_should_be_present=op.qubits),
+            expected.unitary(qubits_that_should_be_present=op.qubits),
             atol=1e-7)
 
 
@@ -71,12 +71,12 @@ def test_degenerate_single_qubit_decompose():
     after = converted_gate_set(before)
     assert after == expected
     cirq.testing.assert_allclose_up_to_global_phase(
-            before.to_unitary_matrix(),
-            after.to_unitary_matrix(),
+            before.unitary(),
+            after.unitary(),
             atol=1e-7)
     cirq.testing.assert_allclose_up_to_global_phase(
-            after.to_unitary_matrix(),
-            expected.to_unitary_matrix(),
+            after.unitary(),
+            expected.unitary(),
             atol=1e-7)
 
 
@@ -100,8 +100,8 @@ def test_converts_single_qubit_series():
 
     after = converted_gate_set(before)
     cirq.testing.assert_allclose_up_to_global_phase(
-            before.to_unitary_matrix(),
-            after.to_unitary_matrix(),
+            before.unitary(),
+            after.unitary(),
             atol=1e-7)
 
 
@@ -116,8 +116,8 @@ def test_converts_single_qubit_then_two():
 
     after = converted_gate_set(before)
     cirq.testing.assert_allclose_up_to_global_phase(
-            before.to_unitary_matrix(),
-            after.to_unitary_matrix(),
+            before.unitary(),
+            after.unitary(),
             atol=1e-7)
 
 
@@ -146,8 +146,8 @@ def test_converts_large_circuit():
     after = converted_gate_set(before)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-            before.to_unitary_matrix(),
-            after.to_unitary_matrix(),
+            before.unitary(),
+            after.unitary(),
             atol=1e-7)
 
     cirq.testing.assert_has_diagram(after, '''

--- a/cirq/contrib/paulistring/convert_gate_set_test.py
+++ b/cirq/contrib/paulistring/convert_gate_set_test.py
@@ -47,13 +47,13 @@ def test_converts_various_ops(op, expected_ops):
     after = converted_gate_set(before)
     assert after == expected
     cirq.testing.assert_allclose_up_to_global_phase(
-            before.unitary(),
-            after.unitary(qubits_that_should_be_present=op.qubits),
-            atol=1e-7)
+        before.unitary(),
+        after.unitary(qubits_that_should_be_present=op.qubits),
+        atol=1e-7)
     cirq.testing.assert_allclose_up_to_global_phase(
-            after.unitary(qubits_that_should_be_present=op.qubits),
-            expected.unitary(qubits_that_should_be_present=op.qubits),
-            atol=1e-7)
+        after.unitary(qubits_that_should_be_present=op.qubits),
+        expected.unitary(qubits_that_should_be_present=op.qubits),
+        atol=1e-7)
 
 
 def test_degenerate_single_qubit_decompose():
@@ -70,14 +70,12 @@ def test_degenerate_single_qubit_decompose():
 
     after = converted_gate_set(before)
     assert after == expected
-    cirq.testing.assert_allclose_up_to_global_phase(
-            before.unitary(),
-            after.unitary(),
-            atol=1e-7)
-    cirq.testing.assert_allclose_up_to_global_phase(
-            after.unitary(),
-            expected.unitary(),
-            atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(before.unitary(),
+                                                    after.unitary(),
+                                                    atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(after.unitary(),
+                                                    expected.unitary(),
+                                                    atol=1e-7)
 
 
 def test_converts_single_qubit_series():
@@ -99,10 +97,9 @@ def test_converts_single_qubit_series():
     )
 
     after = converted_gate_set(before)
-    cirq.testing.assert_allclose_up_to_global_phase(
-            before.unitary(),
-            after.unitary(),
-            atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(before.unitary(),
+                                                    after.unitary(),
+                                                    atol=1e-7)
 
 
 def test_converts_single_qubit_then_two():
@@ -115,10 +112,9 @@ def test_converts_single_qubit_then_two():
     )
 
     after = converted_gate_set(before)
-    cirq.testing.assert_allclose_up_to_global_phase(
-            before.unitary(),
-            after.unitary(),
-            atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(before.unitary(),
+                                                    after.unitary(),
+                                                    atol=1e-7)
 
 
 def test_converts_large_circuit():
@@ -145,10 +141,9 @@ def test_converts_large_circuit():
 
     after = converted_gate_set(before)
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-            before.unitary(),
-            after.unitary(),
-            atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(before.unitary(),
+                                                    after.unitary(),
+                                                    atol=1e-7)
 
     cirq.testing.assert_has_diagram(after, '''
 0: ───Y^0.5───@───[Z]^-0.304───[X]^(1/3)───[Z]^0.446───@───

--- a/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
@@ -36,8 +36,8 @@ def test_convert():
                for op in circuit.all_operations())
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)
 
     cirq.testing.assert_has_diagram(circuit, """
@@ -94,8 +94,8 @@ def test_convert_composite():
                for op in circuit.all_operations())
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)
 
     cirq.testing.assert_has_diagram(circuit, """

--- a/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
@@ -35,10 +35,9 @@ def test_convert():
     assert all(isinstance(op.gate, cirq.SingleQubitCliffordGate)
                for op in circuit.all_operations())
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)
 
     cirq.testing.assert_has_diagram(circuit, """
 0: ───X───────Z^-0.5───H───
@@ -93,10 +92,9 @@ def test_convert_composite():
     assert all(isinstance(op.gate, cirq.SingleQubitCliffordGate)
                for op in circuit.all_operations())
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)
 
     cirq.testing.assert_has_diagram(circuit, """
 0: ───X───────H───

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
@@ -30,8 +30,8 @@ def test_convert():
     ConvertToPauliStringPhasors().optimize_circuit(circuit)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)
     cirq.testing.assert_has_diagram(circuit, """
 0: ───[X]────────[Z]^(1/8)─────────
@@ -52,8 +52,8 @@ def test_convert_keep_clifford():
     ConvertToPauliStringPhasors(keep_clifford=True).optimize_circuit(circuit)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)
     cirq.testing.assert_has_diagram(circuit, """
 0: ───X──────────[Z]^(1/8)───

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
@@ -29,10 +29,9 @@ def test_convert():
     c_orig = cirq.Circuit(circuit)
     ConvertToPauliStringPhasors().optimize_circuit(circuit)
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)
     cirq.testing.assert_has_diagram(circuit, """
 0: ───[X]────────[Z]^(1/8)─────────
 
@@ -51,10 +50,9 @@ def test_convert_keep_clifford():
     c_orig = cirq.Circuit(circuit)
     ConvertToPauliStringPhasors(keep_clifford=True).optimize_circuit(circuit)
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)
     cirq.testing.assert_has_diagram(circuit, """
 0: ───X──────────[Z]^(1/8)───
 

--- a/cirq/contrib/paulistring/optimize_test.py
+++ b/cirq/contrib/paulistring/optimize_test.py
@@ -48,8 +48,8 @@ def test_optimize():
     c_opt = optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 
@@ -69,8 +69,8 @@ def test_optimize_large_circuit():
     c_opt = optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 
@@ -86,8 +86,8 @@ def test_repeat_limit():
     c_opt = optimized_circuit(c_orig, repeat=1)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 

--- a/cirq/contrib/paulistring/pauli_string_dag_test.py
+++ b/cirq/contrib/paulistring/pauli_string_dag_test.py
@@ -32,6 +32,6 @@ def test_pauli_string_dag_from_circuit(repetition):
     c_left_reordered = c_left_dag.to_circuit()
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_left.to_unitary_matrix(),
-        c_left_reordered.to_unitary_matrix(),
+        c_left.unitary(),
+        c_left_reordered.unitary(),
         atol=1e-7)

--- a/cirq/contrib/paulistring/pauli_string_dag_test.py
+++ b/cirq/contrib/paulistring/pauli_string_dag_test.py
@@ -31,7 +31,6 @@ def test_pauli_string_dag_from_circuit(repetition):
     c_left_dag = pauli_string_dag_from_circuit(c_left)
     c_left_reordered = c_left_dag.to_circuit()
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        c_left.unitary(),
-        c_left_reordered.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(c_left.unitary(),
+                                                    c_left_reordered.unitary(),
+                                                    atol=1e-7)

--- a/cirq/contrib/paulistring/pauli_string_optimize_test.py
+++ b/cirq/contrib/paulistring/pauli_string_optimize_test.py
@@ -43,8 +43,8 @@ def test_optimize():
     c_opt = pauli_string_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 
@@ -71,8 +71,8 @@ def test_handles_measurement_gate():
     c_opt = pauli_string_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )
 
@@ -90,7 +90,7 @@ def test_optimize_large_circuit():
     c_opt = pauli_string_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        c_orig.to_unitary_matrix(),
-        c_opt.to_unitary_matrix(),
+        c_orig.unitary(),
+        c_opt.unitary(),
         atol=1e-7,
     )

--- a/cirq/contrib/paulistring/separate_test.py
+++ b/cirq/contrib/paulistring/separate_test.py
@@ -24,8 +24,8 @@ def test_toffoli_separate():
     c_left, c_right = convert_and_separate_circuit(circuit)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        (c_left + c_right).to_unitary_matrix(),
+        circuit.unitary(),
+        (c_left + c_right).unitary(),
         atol=1e-7,
     )
 

--- a/cirq/google/sim/xmon_simulator_test.py
+++ b/cirq/google/sim/xmon_simulator_test.py
@@ -947,7 +947,7 @@ def test_circuit_param_and_reps():
 
 def assert_simulated_states_match_circuit_matrix_by_basis(circuit):
     basis = [Q1, Q2]
-    matrix = circuit.to_unitary_matrix(qubit_order=basis)
+    matrix = circuit.unitary(qubit_order=basis)
     simulator = cg.XmonSimulator()
     for i in range(matrix.shape[0]):
         col = matrix[:, i]

--- a/cirq/ion/ion_decomposition_test.py
+++ b/cirq/ion/ion_decomposition_test.py
@@ -7,7 +7,7 @@ import cirq
 
 
 def _operations_to_matrix(operations, qubits):
-    return cirq.Circuit.from_ops(operations).to_unitary_matrix(
+    return cirq.Circuit.from_ops(operations).unitary(
         qubit_order=cirq.QubitOrder.explicit(qubits),
         qubits_that_should_be_present=qubits)
 

--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -361,10 +361,10 @@ def test_decompose(gate, gate_equiv):
     q0 = cirq.NamedQubit('q0')
     mat = cirq.Circuit.from_ops(
                     gate(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     mat_check = cirq.Circuit.from_ops(
                     gate_equiv(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     assert_allclose_up_to_global_phase(mat, mat_check, rtol=1e-7, atol=1e-7)
 
 
@@ -395,8 +395,8 @@ def test_inverse(gate):
 @pytest.mark.parametrize('gate', _all_clifford_gates())
 def test_inverse_matrix(gate):
     q0 = cirq.NamedQubit('q0')
-    mat = cirq.Circuit.from_ops(gate(q0)).to_unitary_matrix()
-    mat_inv = cirq.Circuit.from_ops(cirq.inverse(gate)(q0)).to_unitary_matrix()
+    mat = cirq.Circuit.from_ops(gate(q0)).unitary()
+    mat_inv = cirq.Circuit.from_ops(cirq.inverse(gate)(q0)).unitary()
     assert_allclose_up_to_global_phase(mat, mat_inv.T.conj(),
                                        rtol=1e-7, atol=1e-7)
 
@@ -409,11 +409,11 @@ def test_commutes_with_single_qubit_gate(gate, other):
     mat = cirq.Circuit.from_ops(
                     gate(q0),
                     other(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     mat_swap = cirq.Circuit.from_ops(
                     other(q0),
                     gate(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     commutes = gate.commutes_with(other)
     commutes_check = cirq.allclose_up_to_global_phase(mat, mat_swap)
     assert commutes == commutes_check
@@ -429,11 +429,11 @@ def test_commutes_with_pauli(gate, pauli, half_turns):
     mat = cirq.Circuit.from_ops(
                     gate(q0),
                     pauli_gate(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     mat_swap = cirq.Circuit.from_ops(
                     pauli_gate(q0),
                     gate(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     commutes = gate.commutes_with(pauli)
     commutes_check = cirq.allclose_up_to_global_phase(mat, mat_swap)
     assert commutes == commutes_check
@@ -447,11 +447,11 @@ def test_single_qubit_gate_after_switching_order(gate, other):
     mat = cirq.Circuit.from_ops(
                     gate(q0),
                     other(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     mat_swap = cirq.Circuit.from_ops(
                     gate.equivalent_gate_before(other)(q0),
                     gate(q0),
-                ).to_unitary_matrix()
+                ).unitary()
     assert_allclose_up_to_global_phase(mat, mat_swap, rtol=1e-7, atol=1e-7)
 
 

--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -359,7 +359,7 @@ def test_y_rotation(gate, trans_y):
     (cirq.SingleQubitCliffordGate.Z_nsqrt, cirq.Z ** -0.5)))
 def test_decompose(gate, gate_equiv):
     q0 = cirq.NamedQubit('q0')
-    mat = cirq.Circuit.from_ops(gate(q0),).unitary()
+    mat = cirq.Circuit.from_ops(gate(q0)).unitary()
     mat_check = cirq.Circuit.from_ops(gate_equiv(q0),).unitary()
     assert_allclose_up_to_global_phase(mat, mat_check, rtol=1e-7, atol=1e-7)
 

--- a/cirq/ops/clifford_gate_test.py
+++ b/cirq/ops/clifford_gate_test.py
@@ -359,12 +359,8 @@ def test_y_rotation(gate, trans_y):
     (cirq.SingleQubitCliffordGate.Z_nsqrt, cirq.Z ** -0.5)))
 def test_decompose(gate, gate_equiv):
     q0 = cirq.NamedQubit('q0')
-    mat = cirq.Circuit.from_ops(
-                    gate(q0),
-                ).unitary()
-    mat_check = cirq.Circuit.from_ops(
-                    gate_equiv(q0),
-                ).unitary()
+    mat = cirq.Circuit.from_ops(gate(q0),).unitary()
+    mat_check = cirq.Circuit.from_ops(gate_equiv(q0),).unitary()
     assert_allclose_up_to_global_phase(mat, mat_check, rtol=1e-7, atol=1e-7)
 
 
@@ -407,13 +403,13 @@ def test_inverse_matrix(gate):
 def test_commutes_with_single_qubit_gate(gate, other):
     q0 = cirq.NamedQubit('q0')
     mat = cirq.Circuit.from_ops(
-                    gate(q0),
-                    other(q0),
-                ).unitary()
+        gate(q0),
+        other(q0),
+    ).unitary()
     mat_swap = cirq.Circuit.from_ops(
-                    other(q0),
-                    gate(q0),
-                ).unitary()
+        other(q0),
+        gate(q0),
+    ).unitary()
     commutes = gate.commutes_with(other)
     commutes_check = cirq.allclose_up_to_global_phase(mat, mat_swap)
     assert commutes == commutes_check
@@ -427,13 +423,13 @@ def test_commutes_with_pauli(gate, pauli, half_turns):
     pauli_gate = pauli ** half_turns
     q0 = cirq.NamedQubit('q0')
     mat = cirq.Circuit.from_ops(
-                    gate(q0),
-                    pauli_gate(q0),
-                ).unitary()
+        gate(q0),
+        pauli_gate(q0),
+    ).unitary()
     mat_swap = cirq.Circuit.from_ops(
-                    pauli_gate(q0),
-                    gate(q0),
-                ).unitary()
+        pauli_gate(q0),
+        gate(q0),
+    ).unitary()
     commutes = gate.commutes_with(pauli)
     commutes_check = cirq.allclose_up_to_global_phase(mat, mat_swap)
     assert commutes == commutes_check
@@ -445,13 +441,13 @@ def test_commutes_with_pauli(gate, pauli, half_turns):
 def test_single_qubit_gate_after_switching_order(gate, other):
     q0 = cirq.NamedQubit('q0')
     mat = cirq.Circuit.from_ops(
-                    gate(q0),
-                    other(q0),
-                ).unitary()
+        gate(q0),
+        other(q0),
+    ).unitary()
     mat_swap = cirq.Circuit.from_ops(
-                    gate.equivalent_gate_before(other)(q0),
-                    gate(q0),
-                ).unitary()
+        gate.equivalent_gate_before(other)(q0),
+        gate(q0),
+    ).unitary()
     assert_allclose_up_to_global_phase(mat, mat_swap, rtol=1e-7, atol=1e-7)
 
 

--- a/cirq/ops/display_test.py
+++ b/cirq/ops/display_test.py
@@ -168,7 +168,7 @@ def test_approx_pauli_string_expectation_measurement_basis_change(paulis):
     matrix = np.kron(cirq.unitary(paulis[0]), cirq.unitary(paulis[1]))
 
     circuit = cirq.Circuit.from_ops(display.measurement_basis_change())
-    unitary = circuit.to_unitary_matrix(qubit_order=qubits)
+    unitary = circuit.unitary(qubit_order=qubits)
 
     ZZ = np.diag([1, -1, -1, 1])
     np.testing.assert_allclose(

--- a/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq/ops/pauli_interaction_gate_test.py
@@ -62,8 +62,8 @@ def test_interchangeable_qubits(gate):
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')
     op0 = gate(q0, q1)
     op1 = gate(q1, q0)
-    mat0 = cirq.Circuit.from_ops(op0,).unitary()
-    mat1 = cirq.Circuit.from_ops(op1,).unitary()
+    mat0 = cirq.Circuit.from_ops(op0).unitary()
+    mat1 = cirq.Circuit.from_ops(op1).unitary()
     same = op0 == op1
     same_check = cirq.allclose_up_to_global_phase(mat0, mat1)
     assert same == same_check

--- a/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq/ops/pauli_interaction_gate_test.py
@@ -62,12 +62,8 @@ def test_interchangeable_qubits(gate):
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')
     op0 = gate(q0, q1)
     op1 = gate(q1, q0)
-    mat0 = cirq.Circuit.from_ops(
-                    op0,
-                ).unitary()
-    mat1 = cirq.Circuit.from_ops(
-                    op1,
-                ).unitary()
+    mat0 = cirq.Circuit.from_ops(op0,).unitary()
+    mat1 = cirq.Circuit.from_ops(op1,).unitary()
     same = op0 == op1
     same_check = cirq.allclose_up_to_global_phase(mat0, mat1)
     assert same == same_check

--- a/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq/ops/pauli_interaction_gate_test.py
@@ -64,10 +64,10 @@ def test_interchangeable_qubits(gate):
     op1 = gate(q1, q0)
     mat0 = cirq.Circuit.from_ops(
                     op0,
-                ).to_unitary_matrix()
+                ).unitary()
     mat1 = cirq.Circuit.from_ops(
                     op1,
-                ).to_unitary_matrix()
+                ).unitary()
     same = op0 == op1
     same_check = cirq.allclose_up_to_global_phase(mat0, mat1)
     assert same == same_check

--- a/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq/ops/pauli_string_phasor_test.py
@@ -357,9 +357,8 @@ def test_default_decompose(paulis, phase_exponent_negative: float, sign: int):
     pauli_string = cirq.PauliString({q: p for q, p in zip(qubits, paulis)},
                                     sign)
     actual = cirq.Circuit.from_ops(
-        cirq.PauliStringPhasor(
-            pauli_string,
-            exponent_neg=phase_exponent_negative)).unitary()
+        cirq.PauliStringPhasor(pauli_string,
+                               exponent_neg=phase_exponent_negative)).unitary()
 
     # Calculate expected matrix
     to_z_mats = {

--- a/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq/ops/pauli_string_phasor_test.py
@@ -296,7 +296,7 @@ def test_manual_default_decompose():
     mat = cirq.Circuit.from_ops(
         cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Z}))**0.25,
         cirq.Z(q0)**-0.25,
-    ).to_unitary_matrix()
+    ).unitary()
     cirq.testing.assert_allclose_up_to_global_phase(mat,
                                                     np.eye(2),
                                                     rtol=1e-7,
@@ -305,7 +305,7 @@ def test_manual_default_decompose():
     mat = cirq.Circuit.from_ops(
         cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Y}))**0.25,
         cirq.Y(q0)**-0.25,
-    ).to_unitary_matrix()
+    ).unitary()
     cirq.testing.assert_allclose_up_to_global_phase(mat,
                                                     np.eye(2),
                                                     rtol=1e-7,
@@ -317,7 +317,7 @@ def test_manual_default_decompose():
                 q0: cirq.Z,
                 q1: cirq.Z,
                 q2: cirq.Z
-            }))).to_unitary_matrix()
+            }))).unitary()
     cirq.testing.assert_allclose_up_to_global_phase(
         mat, np.diag([1, -1, -1, 1, -1, 1, 1, -1]), rtol=1e-7, atol=1e-7)
 
@@ -327,7 +327,7 @@ def test_manual_default_decompose():
                 q0: cirq.Z,
                 q1: cirq.Y,
                 q2: cirq.X
-            }))**0.5).to_unitary_matrix()
+            }))**0.5).unitary()
     cirq.testing.assert_allclose_up_to_global_phase(
         mat,
         np.array([
@@ -359,7 +359,7 @@ def test_default_decompose(paulis, phase_exponent_negative: float, sign: int):
     actual = cirq.Circuit.from_ops(
         cirq.PauliStringPhasor(
             pauli_string,
-            exponent_neg=phase_exponent_negative)).to_unitary_matrix()
+            exponent_neg=phase_exponent_negative)).unitary()
 
     # Calculate expected matrix
     to_z_mats = {

--- a/cirq/optimizers/convert_to_cz_and_single_gates_test.py
+++ b/cirq/optimizers/convert_to_cz_and_single_gates_test.py
@@ -57,8 +57,8 @@ def test_kak_decomposes_unknown_two_qubit_gate():
                for op in circuit.all_operations()
                if cirq.op_gate_of_type(op, cirq.CZPowGate))
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)
 
 
@@ -89,12 +89,12 @@ def test_composite_gates_without_matrix():
     cirq.ConvertToCzAndSingleGates().optimize_circuit(circuit)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        expected.to_unitary_matrix(),
+        circuit.unitary(),
+        expected.unitary(),
         atol=1e-7)
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)
 
 
@@ -179,6 +179,6 @@ def test_dont_allow_partial_czs():
                for op in circuit.all_operations()
                if cirq.op_gate_of_type(op, cirq.CZPowGate))
     cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.to_unitary_matrix(),
-        c_orig.to_unitary_matrix(),
+        circuit.unitary(),
+        c_orig.unitary(),
         atol=1e-7)

--- a/cirq/optimizers/convert_to_cz_and_single_gates_test.py
+++ b/cirq/optimizers/convert_to_cz_and_single_gates_test.py
@@ -56,10 +56,9 @@ def test_kak_decomposes_unknown_two_qubit_gate():
     assert all(op.gate.exponent == 1
                for op in circuit.all_operations()
                if cirq.op_gate_of_type(op, cirq.CZPowGate))
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)
 
 
 def test_composite_gates_without_matrix():
@@ -88,14 +87,12 @@ def test_composite_gates_without_matrix():
     c_orig = cirq.Circuit(circuit)
     cirq.ConvertToCzAndSingleGates().optimize_circuit(circuit)
 
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        expected.unitary(),
-        atol=1e-7)
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    expected.unitary(),
+                                                    atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)
 
 
 def test_ignore_unsupported_gate():
@@ -178,7 +175,6 @@ def test_dont_allow_partial_czs():
     assert all(op.gate.exponent % 2 == 1
                for op in circuit.all_operations()
                if cirq.op_gate_of_type(op, cirq.CZPowGate))
-    cirq.testing.assert_allclose_up_to_global_phase(
-        circuit.unitary(),
-        c_orig.unitary(),
-        atol=1e-7)
+    cirq.testing.assert_allclose_up_to_global_phase(circuit.unitary(),
+                                                    c_orig.unitary(),
+                                                    atol=1e-7)

--- a/cirq/optimizers/merge_interactions_test.py
+++ b/cirq/optimizers/merge_interactions_test.py
@@ -48,9 +48,9 @@ def assert_optimization_not_broken(circuit):
     """Check that the unitary matrix for the input circuit is the same (up to
     global phase and rounding error) as the unitary matrix of the optimized
     circuit."""
-    u_before = circuit.to_unitary_matrix()
+    u_before = circuit.unitary()
     cirq.MergeInteractions().optimize_circuit(circuit)
-    u_after = circuit.to_unitary_matrix()
+    u_after = circuit.unitary()
 
     cirq.testing.assert_allclose_up_to_global_phase(
         u_before, u_after, atol=1e-8)
@@ -213,7 +213,7 @@ def test_post_clean_up():
     assert isinstance(circuit[0].operations[0].gate, Marker)
     assert isinstance(circuit[-1].operations[0].gate, Marker)
 
-    u_before = c_orig.to_unitary_matrix()
-    u_after = circuit[1:-1].to_unitary_matrix()
+    u_before = c_orig.unitary()
+    u_after = circuit[1:-1].unitary()
     cirq.testing.assert_allclose_up_to_global_phase(
         u_before, u_after, atol=1e-8)

--- a/cirq/optimizers/two_qubit_decompositions_test.py
+++ b/cirq/optimizers/two_qubit_decompositions_test.py
@@ -51,7 +51,7 @@ def test_is_trivial_angle(rad, expected):
 
 
 def _operations_to_matrix(operations, qubits):
-    return cirq.Circuit.from_ops(operations).to_unitary_matrix(
+    return cirq.Circuit.from_ops(operations).unitary(
         qubit_order=cirq.QubitOrder.explicit(qubits),
         qubits_that_should_be_present=qubits)
 

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -209,7 +209,7 @@ def test_simulate_random_unitary(dtype):
             circuit_unitary.append(result.final_state)
         np.testing.assert_almost_equal(
             np.transpose(circuit_unitary),
-            random_circuit.to_unitary_matrix(qubit_order=[q0, q1]),
+            random_circuit.unitary(qubit_order=[q0, q1]),
             decimal=6)
 
 

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -129,10 +129,9 @@ def assert_circuits_with_terminal_measurements_are_equivalent(
 
     all_qubits = actual.all_qubits().union(reference.all_qubits())
 
-    matrix_actual = actual.unitary(
-            qubits_that_should_be_present=all_qubits)
+    matrix_actual = actual.unitary(qubits_that_should_be_present=all_qubits)
     matrix_reference = reference.unitary(
-            qubits_that_should_be_present=all_qubits)
+        qubits_that_should_be_present=all_qubits)
 
     n_qubits = len(all_qubits)
     n = matrix_actual.shape[0]

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -129,9 +129,9 @@ def assert_circuits_with_terminal_measurements_are_equivalent(
 
     all_qubits = actual.all_qubits().union(reference.all_qubits())
 
-    matrix_actual = actual.to_unitary_matrix(
+    matrix_actual = actual.unitary(
             qubits_that_should_be_present=all_qubits)
-    matrix_reference = reference.to_unitary_matrix(
+    matrix_reference = reference.unitary(
             qubits_that_should_be_present=all_qubits)
 
     n_qubits = len(all_qubits)

--- a/cirq/testing/circuit_compare_test.py
+++ b/cirq/testing/circuit_compare_test.py
@@ -198,7 +198,7 @@ def test_measuring_qubits():
 def test_random_same_matrix(circuit):
     a, b = cirq.LineQubit.range(2)
     same = cirq.Circuit.from_ops(
-        cirq.TwoQubitMatrixGate(circuit.to_unitary_matrix(
+        cirq.TwoQubitMatrixGate(circuit.unitary(
             qubits_that_should_be_present=[a, b])).on(a, b))
 
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(

--- a/cirq/testing/circuit_compare_test.py
+++ b/cirq/testing/circuit_compare_test.py
@@ -198,8 +198,8 @@ def test_measuring_qubits():
 def test_random_same_matrix(circuit):
     a, b = cirq.LineQubit.range(2)
     same = cirq.Circuit.from_ops(
-        cirq.TwoQubitMatrixGate(circuit.unitary(
-            qubits_that_should_be_present=[a, b])).on(a, b))
+        cirq.TwoQubitMatrixGate(
+            circuit.unitary(qubits_that_should_be_present=[a, b])).on(a, b))
 
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
         circuit, same, atol=1e-8)

--- a/cirq/testing/consistent_decomposition.py
+++ b/cirq/testing/consistent_decomposition.py
@@ -40,8 +40,7 @@ def assert_decompose_is_consistent_with_unitary(
         # If there's no decomposition, it's vacuously consistent.
         return
 
-    actual = circuits.Circuit.from_ops(dec).unitary(
-        qubit_order=qubits)
+    actual = circuits.Circuit.from_ops(dec).unitary(qubit_order=qubits)
 
     if ignoring_global_phase:
         lin_alg_utils.assert_allclose_up_to_global_phase(actual,

--- a/cirq/testing/consistent_decomposition.py
+++ b/cirq/testing/consistent_decomposition.py
@@ -40,7 +40,7 @@ def assert_decompose_is_consistent_with_unitary(
         # If there's no decomposition, it's vacuously consistent.
         return
 
-    actual = circuits.Circuit.from_ops(dec).to_unitary_matrix(
+    actual = circuits.Circuit.from_ops(dec).unitary(
         qubit_order=qubits)
 
     if ignoring_global_phase:

--- a/cirq/testing/sample_circuits_test.py
+++ b/cirq/testing/sample_circuits_test.py
@@ -18,6 +18,6 @@ import cirq
 def test_nonoptimal_toffoli_circuit():
     q0, q1, q2 = cirq.LineQubit.range(3)
     cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2).to_unitary_matrix(),
+        cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2).unitary(),
         cirq.unitary(cirq.TOFFOLI(q0, q1, q2)),
         atol=1e-7)


### PR DESCRIPTION
This makes the circuit method consistent with the global `cirq.unitary` method name.