### PR TITLE
[QASM import] mathematical expressions for parameters

### DIFF
--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
-from typing import Dict, Optional, List, Any, Iterable, Callable, Tuple, Union
+from typing import (Any, Callable, cast, Dict, Iterable, List, Optional,
+                    Sequence, Union)
+
 import numpy as np
 from ply import yacc
 
@@ -100,8 +102,9 @@ class QasmGateStatement:
         # used as arguments, we generate reg_size GateOperations via iterating
         # through each qubit of the registers 0 to n-1 and use the same one
         # qubit from the "single-qubit registers" for each operation.
-        op_qubits = functools.reduce(np.broadcast, args)  # type: np.broadcast
-        for qubits in op_qubits:  # type: Tuple[cirq.Qid]
+        op_qubits = cast(Sequence[Sequence[cirq.Qid]],
+                         functools.reduce(np.broadcast, args))
+        for qubits in op_qubits:
             if isinstance(qubits, cirq.Qid):
                 yield final_gate.on(qubits)
             elif len(np.unique(qubits)) < len(qubits):

--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -19,8 +19,7 @@ from typing import (Any, Callable, cast, Dict, Iterable, List, Optional,
 import numpy as np
 from ply import yacc
 
-from cirq import ops
-from cirq import Circuit, NamedQubit, CX
+from cirq import ops, Circuit, NamedQubit, CX
 from cirq.circuits.qasm_output import QasmUGate
 from cirq.contrib.qasm_import._lexer import QasmLexer
 from cirq.contrib.qasm_import.exception import QasmException
@@ -132,7 +131,7 @@ class QasmParser:
         self.lexer = QasmLexer()
         self.supported_format = False
         self.parsedQasm = None  # type: Optional[Qasm]
-        self.qubits = {}  # type: Dict[str,ops.NamedQubit]
+        self.qubits = {}  # type: Dict[str,ops.Qid]
         self.functions = {
             'sin': np.sin,
             'cos': np.cos,

--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools
+import operator
 from typing import (Any, Callable, cast, Dict, Iterable, List, Optional,
                     Sequence, Union)
 
 import numpy as np
 from ply import yacc
 
-import cirq
+from cirq import ops
 from cirq import Circuit, NamedQubit, CX
 from cirq.circuits.qasm_output import QasmUGate
 from cirq.contrib.qasm_import._lexer import QasmLexer
@@ -52,7 +53,7 @@ class QasmGateStatement:
 
     def __init__(
             self, qasm_gate: str,
-            cirq_gate: Union[cirq.Gate, Callable[[List[float]], cirq.Gate]],
+            cirq_gate: Union[ops.Gate, Callable[[List[float]], ops.Gate]],
             num_params: int, num_args: int):
         """Initializes a Qasm gate statement.
 
@@ -67,7 +68,7 @@ class QasmGateStatement:
         self.num_params = num_params
         self.num_args = num_args
 
-    def _validate_args(self, args: List[List[cirq.Qid]], lineno: int):
+    def _validate_args(self, args: List[List[ops.Qid]], lineno: int):
         if len(args) != self.num_args:
             raise QasmException(
                 "{} only takes {} arg(s) (qubits and/or registers), "
@@ -80,8 +81,8 @@ class QasmGateStatement:
                 "{} takes {} parameter(s), got: {}, at line {}".format(
                     self.qasm_gate, self.num_params, len(params), lineno))
 
-    def on(self, params: List[float], args: List[List[cirq.Qid]],
-           lineno: int) -> Iterable[cirq.Operation]:
+    def on(self, params: List[float], args: List[List[ops.Qid]],
+           lineno: int) -> Iterable[ops.Operation]:
         self._validate_args(args, lineno)
         self._validate_params(params, lineno)
 
@@ -92,8 +93,8 @@ class QasmGateStatement:
 
         # the actual gate we'll apply the arguments to might be a parameterized
         # or non-parametrized gate
-        final_gate = (self.cirq_gate if isinstance(self.cirq_gate, cirq.Gate)
-                      else self.cirq_gate(params))  # type: cirq.Gate
+        final_gate = (self.cirq_gate if isinstance(self.cirq_gate, ops.Gate)
+                      else self.cirq_gate(params))  # type: ops.Gate
         # OpenQASM gates can be applied on single qubits and qubit registers.
         # We represent single qubits as registers of size 1.
         # Based on the OpenQASM spec (https://arxiv.org/abs/1707.03429),
@@ -102,10 +103,10 @@ class QasmGateStatement:
         # used as arguments, we generate reg_size GateOperations via iterating
         # through each qubit of the registers 0 to n-1 and use the same one
         # qubit from the "single-qubit registers" for each operation.
-        op_qubits = cast(Sequence[Sequence[cirq.Qid]],
+        op_qubits = cast(Sequence[Sequence[ops.Qid]],
                          functools.reduce(np.broadcast, args))
         for qubits in op_qubits:
-            if isinstance(qubits, cirq.Qid):
+            if isinstance(qubits, ops.Qid):
                 yield final_gate.on(qubits)
             elif len(np.unique(qubits)) < len(qubits):
                 raise QasmException("Overlapping qubits in arguments"
@@ -132,7 +133,26 @@ class QasmParser:
         self.lexer = QasmLexer()
         self.supported_format = False
         self.parsedQasm = None  # type: Optional[Qasm]
-        self.qubits = {}  # type: Dict[str,cirq.NamedQubit]
+        self.qubits = {}  # type: Dict[str,ops.NamedQubit]
+        self.functions = {
+            'sin': np.sin,
+            'cos': np.cos,
+            'tan': np.tan,
+            'exp': np.exp,
+            'ln': np.log,
+            'sqrt': np.sqrt,
+            'acos': np.arccos,
+            'atan': np.arctan,
+            'asin': np.arcsin
+        }
+
+        self.binary_operators = {
+            '+': operator.add,
+            '-': operator.sub,
+            '*': operator.mul,
+            '/': operator.truediv,
+            '^': operator.pow
+        }
 
     basic_gates = {
         'CX':
@@ -152,6 +172,12 @@ class QasmParser:
 
     tokens = QasmLexer.tokens
     start = 'start'
+
+    precedence = (
+        ('left', '+', '-'),
+        ('left', '*', '/'),
+        ('right', '^'),
+    )
 
     def p_start(self, p):
         """start : qasm"""
@@ -241,7 +267,7 @@ class QasmParser:
         """gate_op :  ID '(' params ')' qargs"""
         self._resolve_gate_operation(args=p[5], gate=p[1], p=p, params=p[3])
 
-    def _resolve_gate_operation(self, args: List[List[cirq.Qid]], gate: str,
+    def _resolve_gate_operation(self, args: List[List[ops.Qid]], gate: str,
                                 p: Any, params: List[float]):
         if gate not in self.basic_gates.keys():
             raise QasmException('Unknown gate "{}" at line {}, '
@@ -277,6 +303,15 @@ class QasmParser:
         """expr : '(' expr ')'"""
         p[0] = p[2]
 
+    def p_expr_function_call(self, p):
+        """expr : ID '(' expr ')'"""
+        func = p[1]
+        if func not in self.functions.keys():
+            raise QasmException(
+                "Function not recognized: '{}' at line {}".format(
+                    func, p.lineno(1)))
+        p[0] = self.functions[func](p[3])
+
     def p_expr_unary(self, p):
         """expr : '-' expr
                 | '+' expr """
@@ -284,6 +319,15 @@ class QasmParser:
             p[0] = -p[2]
         else:
             p[0] = p[2]
+
+    def p_expr_binary(self, p):
+        """expr : expr '*' expr
+                | expr '/' expr
+                | expr '+' expr
+                | expr '-' expr
+                | expr '^' expr
+        """
+        p[0] = self.binary_operators[p[2]](p[1], p[3])
 
     def p_term(self, p):
         """term : NUMBER
@@ -384,7 +428,7 @@ class QasmParser:
                 'at line {}'.format(len(qreg), len(creg), p.lineno(1)))
 
         p[0] = [
-            cirq.MeasurementGate(num_qubits=1, key=creg[i]).on(qreg[i])
+            ops.MeasurementGate(num_qubits=1, key=creg[i]).on(qreg[i])
             for i in range(len(qreg))
         ]
 

--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -51,10 +51,9 @@ class QasmGateStatement:
     `cirq.GateOperation`s in the `on` method.
     """
 
-    def __init__(
-            self, qasm_gate: str,
-            cirq_gate: Union[ops.Gate, Callable[[List[float]], ops.Gate]],
-            num_params: int, num_args: int):
+    def __init__(self, qasm_gate: str,
+                 cirq_gate: Union[ops.Gate, Callable[[List[float]], ops.Gate]],
+                 num_params: int, num_args: int):
         """Initializes a Qasm gate statement.
 
        Args:

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -34,7 +34,7 @@ def test_unsupported_format():
 
     with pytest.raises(QasmException,
                        match="Unsupported OpenQASM version: 2.1, "
-                             "only 2.0 is supported currently by Cirq"):
+                       "only 2.0 is supported currently by Cirq"):
         parser.parse(qasm)
 
 
@@ -228,7 +228,7 @@ def test_cx_gate_mismatched_registers():
 
     with pytest.raises(QasmException,
                        match=r"Non matching quantum registers of "
-                             r"length \[2 3\] at line 4"):
+                       r"length \[2 3\] at line 4"):
         parser.parse(qasm)
 
 
@@ -242,7 +242,7 @@ def test_cx_gate_bounds():
 
     with pytest.raises(QasmException,
                        match=r"Out of bounds qubit index 4"
-                             r" on register q1 of size 2 at line 4"):
+                       r" on register q1 of size 2 at line 4"):
         parser.parse(qasm)
 
 
@@ -256,7 +256,7 @@ def test_cx_gate_arg_overlap():
 
     with pytest.raises(QasmException,
                        match=r"Overlapping qubits in arguments"
-                             r" at line 4"):
+                       r" at line 4"):
         parser.parse(qasm)
 
 
@@ -304,31 +304,33 @@ def test_u3_angles():
                                                     atol=1e-7)
 
 
-@pytest.mark.parametrize('expr', [
-    '.333 + 4',
-    '1.0 * 2',
-    '0.1 ^ pi',
-    '0.1 / pi',
-    '2.0e-05 ^ (1/2)',
-    '1.2E+05 * (3 + 2)',
-    '123123.2132312 * cos(pi)',
-    '123123.2132312 * sin(2 * pi)',
-    '3 - 4 * 2',  # precedence of *
-    '3 * 4 + 2',  # precedence of *
-    '3 * 4 ^ 2',  # precedence of ^
-    '3 - 4 ^ 2',  # precedence of ^
-    '3^2^(-2)',  # right associativity of ^
-    '(-1) * pi',
-    '(+1) * pi',
-    '-3 * 5 + 2',
-    '(+4 * (-3) ^ 5 - 2)',
-    'tan(123123.2132312)',
-    'ln(pi)',
-    'exp(2*pi)',
-    'sqrt(4)',
-    'acos(1)',
-    'atan(0.2)',
-])
+@pytest.mark.parametrize(
+    'expr',
+    [
+        '.333 + 4',
+        '1.0 * 2',
+        '0.1 ^ pi',
+        '0.1 / pi',
+        '2.0e-05 ^ (1/2)',
+        '1.2E+05 * (3 + 2)',
+        '123123.2132312 * cos(pi)',
+        '123123.2132312 * sin(2 * pi)',
+        '3 - 4 * 2',  # precedence of *
+        '3 * 4 + 2',  # precedence of *
+        '3 * 4 ^ 2',  # precedence of ^
+        '3 - 4 ^ 2',  # precedence of ^
+        '3^2^(-2)',  # right associativity of ^
+        '(-1) * pi',
+        '(+1) * pi',
+        '-3 * 5 + 2',
+        '(+4 * (-3) ^ 5 - 2)',
+        'tan(123123.2132312)',
+        'ln(pi)',
+        'exp(2*pi)',
+        'sqrt(4)',
+        'acos(1)',
+        'atan(0.2)',
+    ])
 def test_expressions(expr: str):
     qasm = """OPENQASM 2.0;
      qreg q[1];
@@ -363,7 +365,7 @@ def test_unknown_function():
 
     with pytest.raises(QasmException,
                        match=r"Function not recognized:"
-                             r" 'nonexistent' at line 3"):
+                       r" 'nonexistent' at line 3"):
         parser.parse(qasm)
 
 
@@ -563,5 +565,5 @@ def test_measurement_bounds():
 
     with pytest.raises(QasmException,
                        match=r"Out of bounds bit index 4"
-                             r" on classical register c1 of size 3 at line 4"):
+                       r" on classical register c1 of size 3 at line 4"):
         parser.parse(qasm)

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -23,7 +23,7 @@ def test_format_header_circuit():
 
     parsed_qasm = parser.parse("OPENQASM 2.0;")
 
-    assert parsed_qasm.supportedFormat is True
+    assert parsed_qasm.supportedFormat
     assert not parsed_qasm.qelib1Include
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
 
@@ -46,8 +46,8 @@ include "qelib1.inc";
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is True
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
 
 
@@ -76,8 +76,8 @@ def test_comments():
     // multiline 
     """)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is True
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
 
 
@@ -91,8 +91,8 @@ def test_multiple_qreg_declaration():
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is True
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
     assert parsed_qasm.qregs == {'a_quantum_register': 1337, 'q': 42}
 
@@ -152,8 +152,8 @@ def test_multiple_creg_declaration():
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is True
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
     assert parsed_qasm.qregs == {'a_quantum_register': 1337}
     assert parsed_qasm.cregs == {'a_classical_register': 1337, 'c': 42}
@@ -197,8 +197,8 @@ def test_CX_gate():
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is False
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.qelib1Include
 
     ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
     assert parsed_qasm.qregs == {'q1': 2, 'q2': 2}
@@ -283,8 +283,8 @@ def test_u_gate():
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is False
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.qelib1Include
 
     ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
     assert parsed_qasm.qregs == {'q': 2}
@@ -346,8 +346,8 @@ def test_expressions(expr: str):
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is False
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.qelib1Include
 
     ct.assert_allclose_up_to_global_phase(cirq.unitary(parsed_qasm.circuit),
                                           cirq.unitary(expected_circuit),
@@ -450,8 +450,8 @@ def test_measure_individual_bits():
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is True
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
 
     ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
     assert parsed_qasm.qregs == {'q1': 2}
@@ -483,8 +483,8 @@ def test_measure_registers():
 
     parsed_qasm = parser.parse(qasm)
 
-    assert parsed_qasm.supportedFormat is True
-    assert parsed_qasm.qelib1Include is True
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
 
     ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
     assert parsed_qasm.qregs == {'q1': 3}

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -294,8 +294,7 @@ def test_u3_angles():
     qasm = """
     OPENQASM 2.0;
     qreg q[1];
-    // TODO: rewrite first param to "pi/2" when we have arithmetics 
-    U(1.5707963267948966,0,pi) q[0];
+    U(pi/2,0,pi) q[0];
     """
 
     c = QasmParser().parse(qasm).circuit


### PR DESCRIPTION
Adds mathematical expressions that are supported by Quantum Experience. 
Also fixes the cirq imports: instead of directly importing cirq, we import `cirq.ops` now.

This is PR number 6 for the piecemeal reimplementation of #1602.


