### PR TITLE
Allow adding OP_TREEs into Circuit

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -221,6 +221,8 @@ class Circuit:
         return self
 
     def __add__(self, other):
+        if isinstance(other, list):
+            other = self.from_ops(other)
         if not isinstance(other, type(self)):
             return NotImplemented
         device = (self._device
@@ -232,13 +234,8 @@ class Circuit:
         if device != device_2:
             raise ValueError("Can't add circuits with incompatible devices.")
 
-        for moment in self:
-            device.validate_moment(moment)
-        for moment in other:
-            device.validate_moment(moment)
-
-        return Circuit(self._moments + other._moments,
-                       device=device)
+        result = Circuit(moments=self._moments, device=device)
+        return result.__iadd__(other)
 
     def __imul__(self, repetitions: int):
         if not isinstance(repetitions, int):

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -212,6 +212,16 @@ def test_append_moments():
     ])
 
 
+def test_add_op_tree():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+
+    c = cirq.Circuit()
+    assert c + [cirq.X(a), cirq.Y(b)] == cirq.Circuit([
+        cirq.Moment([cirq.X(a), cirq.Y(b)]),
+    ])
+
+
 def test_bool():
     assert not cirq.Circuit()
     assert cirq.Circuit.from_ops(cirq.X(cirq.NamedQubit('a')))


### PR DESCRIPTION
The method now delegates to `__iadd__` and `__init__` for validation of moments.

Fixes https://github.com/quantumlib/Cirq/issues/1698
