### PR TITLE
[Qasm import] rotation gates

### DIFF
--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -287,12 +287,12 @@ class QasmParser:
 
     def _resolve_gate_operation(self, args: List[List[ops.Qid]], gate: str,
                                 p: Any, params: List[float]):
-        helper_text = (", did you forget to include qelib1.inc?"
-                       if not self.qelibinc else "")
         gate_set = (self.basic_gates if not self.qelibinc else self.qelib_gates)
         if gate not in gate_set.keys():
-            raise QasmException('Unknown gate "{}" at line {}{}'.format(
-                gate, p.lineno(1), helper_text))
+            msg = 'Unknown gate "{}" at line {}{}'.format(
+                gate, p.lineno(1), ", did you forget to include qelib1.inc?"
+                if not self.qelibinc else "")
+            raise QasmException(msg)
         p[0] = gate_set[gate].on(args=args, params=params, lineno=p.lineno(1))
 
     # params : parameter ',' params

--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -64,6 +64,9 @@ class QasmGateStatement:
         self.qasm_gate = qasm_gate
         self.cirq_gate = cirq_gate
         self.num_params = num_params
+
+        # at least one quantum argument is mandatory for gates to act on
+        assert num_args >= 1
         self.num_args = num_args
 
     def _validate_args(self, args: List[List[ops.Qid]], lineno: int):
@@ -163,10 +166,27 @@ class QasmParser:
             qasm_gate='U',
             num_params=3,
             num_args=1,
-            # QasmUGate expects half turns and
-            # changes the order of arguments
+            # QasmUGate expects half turns
             cirq_gate=(lambda params: QasmUGate(*[p / np.pi for p in params])))
     }  # type: Dict[str, QasmGateStatement]
+
+    qelib_gates = {
+        'rx':
+        QasmGateStatement(qasm_gate='rx',
+                          cirq_gate=(lambda params: ops.Rx(params[0])),
+                          num_params=1,
+                          num_args=1),
+        'ry':
+        QasmGateStatement(qasm_gate='ry',
+                          cirq_gate=(lambda params: ops.Ry(params[0])),
+                          num_params=1,
+                          num_args=1),
+        'rz':
+        QasmGateStatement(qasm_gate='rz',
+                          cirq_gate=(lambda params: ops.Rz(params[0])),
+                          num_params=1,
+                          num_args=1),
+    }
 
     tokens = QasmLexer.tokens
     start = 'start'
@@ -267,14 +287,13 @@ class QasmParser:
 
     def _resolve_gate_operation(self, args: List[List[ops.Qid]], gate: str,
                                 p: Any, params: List[float]):
-        if gate not in self.basic_gates.keys():
-            raise QasmException('Unknown gate "{}" at line {}, '
-                                'maybe you forgot to include '
-                                'the standard qelib1.inc?'.format(
-                                    gate, p.lineno(1)))
-        p[0] = self.basic_gates[gate].on(args=args,
-                                         params=params,
-                                         lineno=p.lineno(1))
+        helper_text = (", did you forget to include qelib1.inc?"
+                       if not self.qelibinc else "")
+        gate_set = (self.basic_gates if not self.qelibinc else self.qelib_gates)
+        if gate not in gate_set.keys():
+            raise QasmException('Unknown gate "{}" at line {}{}'.format(
+                gate, p.lineno(1), helper_text))
+        p[0] = gate_set[gate].on(args=args, params=params, lineno=p.lineno(1))
 
     # params : parameter ',' params
     #        | parameter

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -124,8 +124,7 @@ def test_already_defined_error(qasm: str):
 def test_zero_length_register(qasm: str):
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=".* zero-length.*'q'.*line 2"):
+    with pytest.raises(QasmException, match=".* zero-length.*'q'.*line 2"):
         parser.parse(qasm)
 
 
@@ -210,8 +209,7 @@ def test_CX_gate_not_enough_args():
 """
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"CX.*takes.*got.*1.*line 3"):
+    with pytest.raises(QasmException, match=r"CX.*takes.*got.*1.*line 3"):
         parser.parse(qasm)
 
 
@@ -236,8 +234,7 @@ def test_CX_gate_bounds():
 """
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"Out of bounds.*4.*q1.*2.*line 4"):
+    with pytest.raises(QasmException, match=r"Out of bounds.*4.*q1.*2.*line 4"):
         parser.parse(qasm)
 
 
@@ -249,8 +246,7 @@ def test_CX_gate_arg_overlap():
 """
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"Overlapping.*at line 4"):
+    with pytest.raises(QasmException, match=r"Overlapping.*at line 4"):
         parser.parse(qasm)
 
 
@@ -304,8 +300,7 @@ def test_U_gate_zero_params_error():
 
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"U takes 3.*got.*0.*line 3"):
+    with pytest.raises(QasmException, match=r"U takes 3.*got.*0.*line 3"):
         parser.parse(qasm)
 
 
@@ -316,8 +311,7 @@ def test_U_gate_too_much_params_error():
 
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"U takes 3.*got.*4.*line 3"):
+    with pytest.raises(QasmException, match=r"U takes 3.*got.*4.*line 3"):
         parser.parse(qasm)
 
 
@@ -450,8 +444,7 @@ def test_rotation_gates_zero_params_error(qasm_gate: str):
 
     with pytest.raises(
             QasmException,
-            match=r".*{}.* takes 1.*got.*0.*line 4".format(
-                qasm_gate)):
+            match=r".*{}.* takes 1.*got.*0.*line 4".format(qasm_gate)):
         parser.parse(qasm)
 
 
@@ -467,8 +460,7 @@ def test_rotation_gates_too_many_params_error(qasm_gate: str):
 
     with pytest.raises(
             QasmException,
-            match=r".*{}.* takes 1.*got.*2.*line 4".format(
-                qasm_gate)):
+            match=r".*{}.* takes 1.*got.*2.*line 4".format(qasm_gate)):
         parser.parse(qasm)
 
 

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -218,7 +218,7 @@ def test_CX_gate_not_enough_args():
         parser.parse(qasm)
 
 
-def test_cx_gate_mismatched_registers():
+def test_CX_gate_mismatched_registers():
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[3];
@@ -232,7 +232,7 @@ def test_cx_gate_mismatched_registers():
         parser.parse(qasm)
 
 
-def test_cx_gate_bounds():
+def test_CX_gate_bounds():
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[3];
@@ -246,7 +246,7 @@ def test_cx_gate_bounds():
         parser.parse(qasm)
 
 
-def test_cx_gate_arg_overlap():
+def test_CX_gate_arg_overlap():
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[3];
@@ -260,7 +260,7 @@ def test_cx_gate_arg_overlap():
         parser.parse(qasm)
 
 
-def test_u_gate():
+def test_U_gate():
     qasm = """
      OPENQASM 2.0;
      qreg q[2];
@@ -290,7 +290,7 @@ def test_u_gate():
     assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_u3_angles():
+def test_U_angles():
     qasm = """
     OPENQASM 2.0;
     qreg q[1];
@@ -301,6 +301,30 @@ def test_u3_angles():
     cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(c),
                                                     cirq.unitary(cirq.H),
                                                     atol=1e-7)
+
+
+def test_U_gate_zero_params_error():
+    qasm = """OPENQASM 2.0;
+     qreg q[2];     
+     U() q[1];"""
+
+    parser = QasmParser()
+
+    with pytest.raises(QasmException,
+                       match=r"U takes 3 parameter\(s\).*got.*0.*line 3"):
+        parser.parse(qasm)
+
+
+def test_U_gate_too_much_params_error():
+    qasm = """OPENQASM 2.0;
+     qreg q[2];     
+     U(pi, pi, pi, pi) q[1];"""
+
+    parser = QasmParser()
+
+    with pytest.raises(QasmException,
+                       match=r"U takes 3 parameter\(s\).*got.*4.*line 3"):
+        parser.parse(qasm)
 
 
 @pytest.mark.parametrize(
@@ -368,39 +392,103 @@ def test_unknown_function():
         parser.parse(qasm)
 
 
-def test_u_gate_zero_params_error():
+rotation_gates = [
+    ('rx', cirq.Rx),
+    ('ry', cirq.Ry),
+    ('rz', cirq.Rz),
+]
+
+
+@pytest.mark.parametrize('qasm_gate,cirq_gate', rotation_gates)
+def test_rotation_gates(qasm_gate: str, cirq_gate: cirq.SingleQubitGate):
     qasm = """OPENQASM 2.0;
-     qreg q[2];     
-     U() q[1];"""
+     include "qelib1.inc";
+     qreg q[2];
+     {0}(pi/2) q[0];
+     {0}(pi) q;
+    """.format(qasm_gate)
 
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"U takes 3 parameter\(s\).*got.*0.*line 3"):
-        parser.parse(qasm)
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq_gate(np.pi / 2).on(q0))
+    expected_circuit.append(
+        cirq.Moment([cirq_gate(np.pi).on(q0),
+                     cirq_gate(np.pi).on(q1)]))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_u_gate_too_much_params_error():
-    qasm = """OPENQASM 2.0;
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
+def test_rotation_gates_wrong_number_of_args(qasm_gate: str):
+    qasm = """
+     OPENQASM 2.0;    
+     include "qelib1.inc";             
      qreg q[2];     
-     U(pi, pi, pi, pi) q[1];"""
+     {}(pi) q[0], q[1];     
+""".format(qasm_gate)
 
     parser = QasmParser()
 
-    with pytest.raises(QasmException,
-                       match=r"U takes 3 parameter\(s\).*got.*4.*line 3"):
+    with pytest.raises(
+            QasmException,
+            match=r".*{}.* takes 1 arg\(s\).*got.*2.*line 5".format(qasm_gate)):
         parser.parse(qasm)
 
 
-def test_unknown_basic_gate():
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
+def test_rotation_gates_zero_params_error(qasm_gate: str):
+    qasm = """OPENQASM 2.0;    
+     include "qelib1.inc";             
+     qreg q[2];     
+     {}() q[1];     
+""".format(qasm_gate)
+
+    parser = QasmParser()
+
+    with pytest.raises(
+            QasmException,
+            match=r".*{}.* takes 1 parameter\(s\).*got.*0.*line 4".format(
+                qasm_gate)):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
+def test_rotation_gates_too_many_params_error(qasm_gate: str):
+    qasm = """OPENQASM 2.0;    
+     include "qelib1.inc";             
+     qreg q[2];     
+     {}(pi, 2*pi) q[1];     
+""".format(qasm_gate)
+
+    parser = QasmParser()
+
+    with pytest.raises(
+            QasmException,
+            match=r".*{}.* takes 1 parameter\(s\).*got.*2.*line 4".format(
+                qasm_gate)):
+        parser.parse(qasm)
+
+
+
+def test_qelib_gate_without_include_statement():
     qasm = """OPENQASM 2.0;
          qreg q[2];
-         foobar q[0];
+         x q[0];
     """
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"""Unknown gate "foobar".* line 3.*forgot.*\?"""):
+                       match=r"""Unknown gate "x".* line 3.*forget.*\?"""):
         parser.parse(qasm)
 
 
@@ -459,8 +547,7 @@ def test_measure_individual_bits():
 
 
 def test_measure_registers():
-    qasm = """
-         OPENQASM 2.0;   
+    qasm = """OPENQASM 2.0;   
          include "qelib1.inc";       
          qreg q1[3];
          creg c1[3];                        

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -431,7 +431,7 @@ def test_rotation_gates(qasm_gate: str, cirq_gate: cirq.SingleQubitGate):
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
 def test_rotation_gates_wrong_number_of_args(qasm_gate: str):
     qasm = """
-     OPENQASM 2.0;    
+     OPENQASM 2.0;
      include "qelib1.inc";             
      qreg q[2];     
      {}(pi) q[0], q[1];     
@@ -447,7 +447,7 @@ def test_rotation_gates_wrong_number_of_args(qasm_gate: str):
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
 def test_rotation_gates_zero_params_error(qasm_gate: str):
-    qasm = """OPENQASM 2.0;    
+    qasm = """OPENQASM 2.0;
      include "qelib1.inc";             
      qreg q[2];     
      {}() q[1];     
@@ -464,7 +464,7 @@ def test_rotation_gates_zero_params_error(qasm_gate: str):
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
 def test_rotation_gates_too_many_params_error(qasm_gate: str):
-    qasm = """OPENQASM 2.0;    
+    qasm = """OPENQASM 2.0;
      include "qelib1.inc";             
      qreg q[2];     
      {}(pi, 2*pi) q[1];     
@@ -477,7 +477,6 @@ def test_rotation_gates_too_many_params_error(qasm_gate: str):
             match=r".*{}.* takes 1 parameter\(s\).*got.*2.*line 4".format(
                 qasm_gate)):
         parser.parse(qasm)
-
 
 
 def test_qelib_gate_without_include_statement():
@@ -517,8 +516,8 @@ def test_undefined_register_from_register_arg():
 
 def test_measure_individual_bits():
     qasm = """
-         OPENQASM 2.0;   
-         include "qelib1.inc";       
+         OPENQASM 2.0;
+         include "qelib1.inc";
          qreg q1[2];
          creg c1[2];                        
          measure q1[0] -> c1[0];
@@ -547,8 +546,8 @@ def test_measure_individual_bits():
 
 
 def test_measure_registers():
-    qasm = """OPENQASM 2.0;   
-         include "qelib1.inc";       
+    qasm = """OPENQASM 2.0;
+         include "qelib1.inc";
          qreg q1[3];
          creg c1[3];                        
          measure q1 -> c1;       
@@ -579,8 +578,7 @@ def test_measure_registers():
 
 
 def test_measure_mismatched_register_size():
-    qasm = """
-         OPENQASM 2.0;   
+    qasm = """OPENQASM 2.0;
          include "qelib1.inc";       
          qreg q1[2];
          creg c1[3];                        
@@ -590,7 +588,7 @@ def test_measure_mismatched_register_size():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r""".*mismatched register sizes 2 -> 3.*line 6"""):
+                       match=r""".*mismatched register sizes 2 -> 3.*line 5"""):
         parser.parse(qasm)
 
 

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -33,8 +33,7 @@ def test_unsupported_format():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match="Unsupported OpenQASM version: 2.1, "
-                       "only 2.0 is supported currently by Cirq"):
+                       match="Unsupported.*2.1.*2.0.*supported.*"):
         parser.parse(qasm)
 
 
@@ -126,7 +125,7 @@ def test_zero_length_register(qasm: str):
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match="Illegal, zero-length register 'q' at line 2"):
+                       match=".* zero-length.*'q'.*line 2"):
         parser.parse(qasm)
 
 
@@ -212,9 +211,7 @@ def test_CX_gate_not_enough_args():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=(r"CX only takes 2 arg\(s\) "
-                              r"\(qubits and/or registers\)"
-                              r", got: 1, at line 3")):
+                       match=r"CX.*takes.*got.*1.*line 3"):
         parser.parse(qasm)
 
 
@@ -227,8 +224,7 @@ def test_CX_gate_mismatched_registers():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"Non matching quantum registers of "
-                       r"length \[2 3\] at line 4"):
+                       match=r"Non matching.*length \[2 3\].*line 4"):
         parser.parse(qasm)
 
 
@@ -241,8 +237,7 @@ def test_CX_gate_bounds():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"Out of bounds qubit index 4"
-                       r" on register q1 of size 2 at line 4"):
+                       match=r"Out of bounds.*4.*q1.*2.*line 4"):
         parser.parse(qasm)
 
 
@@ -255,8 +250,7 @@ def test_CX_gate_arg_overlap():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"Overlapping qubits in arguments"
-                       r" at line 4"):
+                       match=r"Overlapping.*at line 4"):
         parser.parse(qasm)
 
 
@@ -311,7 +305,7 @@ def test_U_gate_zero_params_error():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"U takes 3 parameter\(s\).*got.*0.*line 3"):
+                       match=r"U takes 3.*got.*0.*line 3"):
         parser.parse(qasm)
 
 
@@ -323,7 +317,7 @@ def test_U_gate_too_much_params_error():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"U takes 3 parameter\(s\).*got.*4.*line 3"):
+                       match=r"U takes 3.*got.*4.*line 3"):
         parser.parse(qasm)
 
 
@@ -387,8 +381,7 @@ def test_unknown_function():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"Function not recognized:"
-                       r" 'nonexistent' at line 3"):
+                       match=r".*not recognized.*'nonexistent'.*line 3"):
         parser.parse(qasm)
 
 
@@ -441,7 +434,7 @@ def test_rotation_gates_wrong_number_of_args(qasm_gate: str):
 
     with pytest.raises(
             QasmException,
-            match=r".*{}.* takes 1 arg\(s\).*got.*2.*line 5".format(qasm_gate)):
+            match=r".*{}.* takes 1.*got.*2.*line 5".format(qasm_gate)):
         parser.parse(qasm)
 
 
@@ -457,7 +450,7 @@ def test_rotation_gates_zero_params_error(qasm_gate: str):
 
     with pytest.raises(
             QasmException,
-            match=r".*{}.* takes 1 parameter\(s\).*got.*0.*line 4".format(
+            match=r".*{}.* takes 1.*got.*0.*line 4".format(
                 qasm_gate)):
         parser.parse(qasm)
 
@@ -474,7 +467,7 @@ def test_rotation_gates_too_many_params_error(qasm_gate: str):
 
     with pytest.raises(
             QasmException,
-            match=r".*{}.* takes 1 parameter\(s\).*got.*2.*line 4".format(
+            match=r".*{}.* takes 1.*got.*2.*line 4".format(
                 qasm_gate)):
         parser.parse(qasm)
 
@@ -588,7 +581,7 @@ def test_measure_mismatched_register_size():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r""".*mismatched register sizes 2 -> 3.*line 5"""):
+                       match=r""".*mismatched .* 2 -> 3.*line 5"""):
         parser.parse(qasm)
 
 
@@ -648,6 +641,5 @@ def test_measurement_bounds():
     parser = QasmParser()
 
     with pytest.raises(QasmException,
-                       match=r"Out of bounds bit index 4"
-                       r" on classical register c1 of size 3 at line 4"):
+                       match=r"Out of bounds bit.*4.*c1.*size 3.*line 4"):
         parser.parse(qasm)


### PR DESCRIPTION
Adds support for `rx`, `ry` and `rz` gates in QASM import and as such, the first gates that are defined as part of the "qelib1.inc" file. 

This is PR number 7 for the piecemeal reimplementation of #1602.

4 more PRs are planned: 
- "special" - u3(=`U`), u2, u1 and id gates
- single qubit gates - x,y,z,h,t,tdg,s,sdg
- two qubit gates - cx (=`CX`),cy,cz,ch, swap
- three qubit gates - ccx, cswap