### PR TITLE
**Proposal** implements `NoiseModel.apply_noise`

### DIFF
--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -122,7 +122,7 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
         """
 
     def apply_noise(self, circuit: 'cirq.Circuit') -> 'cirq.Circuit':
-        """Compose a circuit augmenting the input with defined noise methods.
+        """Compose a circuit applying defined noise methods to the input.
 
         If multiple noise methods are defined, they will be inserted in order
         of finest granularity i.e. `noisy_operation` operations before

--- a/cirq/devices/noise_model_test.py
+++ b/cirq/devices/noise_model_test.py
@@ -113,3 +113,13 @@ def test_constant_qubit_noise():
 
     with pytest.raises(ValueError, match='num_qubits'):
         _ = cirq.ConstantQubitNoiseModel(cirq.CNOT**0.01)
+
+
+class NonMarkovianPulseTrainNoise(cirq.NoiseModel):
+    pass
+
+class MarkovianSpatiallyCorrelatedNoise(cirq.NoiseModel):
+    pass
+
+class OperationSpecificNoise(cirq.NoiseModel):
+    pass

--- a/cirq/devices/noise_model_test.py
+++ b/cirq/devices/noise_model_test.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence
+from typing import Iterable, Sequence, Union
 
+import math
 import pytest
+import numpy as np
 
 import cirq
 
@@ -116,10 +118,82 @@ def test_constant_qubit_noise():
 
 
 class NonMarkovianPulseTrainNoise(cirq.NoiseModel):
-    pass
+    """Apply noise to moments sequentially according to a time series.
 
-class MarkovianSpatiallyCorrelatedNoise(cirq.NoiseModel):
-    pass
+    In this implementation, apply an DFT to a known noise spectrum ("1/f" noise
+    in this case), then approximate evolution by non-commuting operators (noise
+    unitary and circuit unitary) via trotterization.
+    """
+    def __init__(self, epsilon: float, qubit_noise_gate: 'cirq.Gate'):
+        """
+            Args:
+                qubit_noise_gate: The operation representing noise to be applied
+                    to each qubit in the moment.
+                epsilon: Order of magnitude of noise strength to apply.
+        """
+        if qubit_noise_gate.num_qubits() != 1:
+            raise ValueError('noise.num_qubits() != 1')
+        if not cirq.protocols.is_parameterized(qubit_noise_gate):
+            raise ValueError('Gate is not parametrized.')
+        self.qubit_noise_gate = qubit_noise_gate
+        self.epsilon = epsilon
+
+    def noisy_moments(self, moments: 'Iterable[cirq.Moment]',
+                      system_qubits: Sequence['cirq.Qid']):
+        result = []
+        # FT of 1/f spectrum approximates discretized non-Markovian time series.
+        times = np.arange(1, len(moments) + 1)
+        pulse_train = self.epsilon * np.fft.fft(1 / times)
+        for x, moment in zip(pulse_train, moments):
+            result.append([self.qubit_noise_gate(x)(q) for q in system_qubits])
+        # each sublist in `result` corresponds to a moment parametrized
+        # by a single timestep in `pulse_train`
+        return result
+
+
+class MarkovianPairwiseCorrelatedNoise(cirq.NoiseModel):
+    """Apply noise to a moment following a pairwise distribution over qubits.
+
+    In this implementation, apply the same noise parameter to randomly selected
+    pairs of qubits with no interdependence between moments.
+    """
+    def __init__(self,
+                 pairwise_mask: Sequence['cirq.Qid'],
+                 epsilon: float,
+                 qubit_noise_gate: 'cirq.Gate'):
+        """
+            Args:
+                qubit_noise_gate: The operation representing noise to be applied
+                    to each qubit in the moment.
+                epsilon: Order of magnitude of noise strength to apply.
+        """
+        if qubit_noise_gate.num_qubits() != 1:
+            raise ValueError('noise.num_qubits() != 1')
+        if not cirq.protocols.is_parameterized(qubit_noise_gate):
+            raise ValueError('Gate is not parametrized.')
+        self.qubit_noise_gate = qubit_noise_gate
+        self.epsilon = epsilon
+
+        # Persistent mask describing which qubits share noise at each moment.
+        self.pairwise_mask = pairwise_mask
+
+        # np.asarray(
+        #    np.random.shuffle(np.arange(len(system_qubits))), np.int)
+
+    def noisy_moment(self, moment: 'cirq.Moment',
+                     system_qubits: Sequence['cirq.Qid']):
+
+        result = []
+        for index in self.pairwise_mask:
+            shared_param = self.epsilon * np.random.randn()
+            for i in range(2):
+                result.append(
+                    self.qubit_noise_gate(shared_param)(system_qubits[index]))
+        return result
+
 
 class OperationSpecificNoise(cirq.NoiseModel):
+    pass
+
+class AllNoiseModelMethodsExist(cirq.NoiseModel):
     pass


### PR DESCRIPTION
**not ready for merge yet; please just review logic in apply_noise method**

After playing around with noise models a bit, I've implemented `apply_noise` with the following logic in mind:

1.  Users should be able to implement noise models on a circuit-, moment-, and operation- level of specification
2. Invoking separate models that each implement one of `noisy_moments`, `noisy_moment`, `noisy_operation` on a single circuit leads to ambiguity about whether the operations within a given circuit were the original operations intended by the user, or added as noise by one of the intermediate noise models
3. therefore, each `noisy_*` method of `NoiseModel` should append/insert gates that correspond to _different_ realizations of noise in the circuit.

This removes the need for abstraction in the NoiseModel baseclass.

In `noise_model_test.py` I have defined a few semi-realistic noise models that would justify the use of each `noisy_*` method, and also tried to show the difference between how noise models stack with / without the behavior described above.

@Strilanc @c-poole @dabacon Input on this implementation or suggestions are welcome
