### PR TITLE
Add static TrialResult.from_single_parameter_set factory method

### DIFF
--- a/cirq/google/api/v2/results.py
+++ b/cirq/google/api/v2/results.py
@@ -199,7 +199,7 @@ def _trial_sweep_from_proto(
                 ordered_results = list(qubit_results.values())
             m_data[mr.key] = np.array(ordered_results).transpose()
         trial_sweep.append(
-            study.TrialResult(
+            study.TrialResult.from_single_parameter_set_reps(
                 params=study.ParamResolver(dict(pr.params.assignments)),
                 measurements=m_data,
             ))

--- a/cirq/google/api/v2/results.py
+++ b/cirq/google/api/v2/results.py
@@ -199,7 +199,7 @@ def _trial_sweep_from_proto(
                 ordered_results = list(qubit_results.values())
             m_data[mr.key] = np.array(ordered_results).transpose()
         trial_sweep.append(
-            study.TrialResult.from_single_parameter_set_reps(
+            study.TrialResult.from_single_parameter_set(
                 params=study.ParamResolver(dict(pr.params.assignments)),
                 measurements=m_data,
             ))

--- a/cirq/google/api/v2/results_test.py
+++ b/cirq/google/api/v2/results_test.py
@@ -104,29 +104,32 @@ def test_results_to_proto():
     measurements = [v2.MeasureInfo('foo', [q(0, 0)], slot=0)]
     trial_results = [
         [
-            cirq.TrialResult(params=cirq.ParamResolver({'i': 0}),
-                             measurements={
-                                 'foo': np.array([[0], [1], [0], [1]],
-                                                 dtype=bool),
-                             }),
-            cirq.TrialResult(params=cirq.ParamResolver({'i': 1}),
-                             measurements={
-                                 'foo': np.array([[0], [1], [1], [0]],
-                                                 dtype=bool),
-                             }),
+            cirq.TrialResult.from_single_parameter_set_reps(
+                params=cirq.ParamResolver({'i': 0}),
+                measurements={
+                    'foo': np.array([[0], [1], [0], [1]],
+                                    dtype=bool),
+                }),
+            cirq.TrialResult.from_single_parameter_set_reps(
+                params=cirq.ParamResolver({'i': 1}),
+                measurements={
+                    'foo': np.array([[0], [1], [1], [0]],
+                                    dtype=bool),
+                }),
         ],
         [
-            cirq.TrialResult(
+            cirq.TrialResult.from_single_parameter_set_reps(
                 params=cirq.ParamResolver({'i': 0}),
                 measurements={
                     'foo': np.array([[0], [1], [0], [1]], dtype=bool),
                 },
             ),
-            cirq.TrialResult(params=cirq.ParamResolver({'i': 1}),
-                             measurements={
-                                 'foo': np.array([[0], [1], [1], [0]],
-                                                 dtype=bool),
-                             }),
+            cirq.TrialResult.from_single_parameter_set_reps(
+                params=cirq.ParamResolver({'i': 1}),
+                measurements={
+                    'foo': np.array([[0], [1], [1], [0]],
+                                    dtype=bool),
+                }),
         ],
     ]
     proto = v2.results_to_proto(trial_results, measurements)
@@ -147,14 +150,16 @@ def test_results_to_proto():
 def test_results_to_proto_sweep_repetitions():
     measurements = [v2.MeasureInfo('foo', [q(0, 0)], slot=0)]
     trial_results = [[
-        cirq.TrialResult(params=cirq.ParamResolver({'i': 0}),
-                         measurements={
-                             'foo': np.array([[0]], dtype=bool),
-                         }),
-        cirq.TrialResult(params=cirq.ParamResolver({'i': 1}),
-                         measurements={
-                             'foo': np.array([[0], [1]], dtype=bool),
-                         }),
+        cirq.TrialResult.from_single_parameter_set_reps(
+            params=cirq.ParamResolver({'i': 0}),
+            measurements={
+                'foo': np.array([[0]], dtype=bool),
+            }),
+        cirq.TrialResult.from_single_parameter_set_reps(
+            params=cirq.ParamResolver({'i': 1}),
+            measurements={
+                'foo': np.array([[0], [1]], dtype=bool),
+            }),
     ]]
     with pytest.raises(ValueError, match='different numbers of repetitions'):
         v2.results_to_proto(trial_results, measurements)

--- a/cirq/google/api/v2/results_test.py
+++ b/cirq/google/api/v2/results_test.py
@@ -104,13 +104,13 @@ def test_results_to_proto():
     measurements = [v2.MeasureInfo('foo', [q(0, 0)], slot=0)]
     trial_results = [
         [
-            cirq.TrialResult.from_single_parameter_set_reps(
+            cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 0}),
                 measurements={
                     'foo': np.array([[0], [1], [0], [1]],
                                     dtype=bool),
                 }),
-            cirq.TrialResult.from_single_parameter_set_reps(
+            cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 1}),
                 measurements={
                     'foo': np.array([[0], [1], [1], [0]],
@@ -118,13 +118,13 @@ def test_results_to_proto():
                 }),
         ],
         [
-            cirq.TrialResult.from_single_parameter_set_reps(
+            cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 0}),
                 measurements={
                     'foo': np.array([[0], [1], [0], [1]], dtype=bool),
                 },
             ),
-            cirq.TrialResult.from_single_parameter_set_reps(
+            cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 1}),
                 measurements={
                     'foo': np.array([[0], [1], [1], [0]],
@@ -150,12 +150,12 @@ def test_results_to_proto():
 def test_results_to_proto_sweep_repetitions():
     measurements = [v2.MeasureInfo('foo', [q(0, 0)], slot=0)]
     trial_results = [[
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             params=cirq.ParamResolver({'i': 0}),
             measurements={
                 'foo': np.array([[0]], dtype=bool),
             }),
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             params=cirq.ParamResolver({'i': 1}),
             measurements={
                 'foo': np.array([[0], [1]], dtype=bool),

--- a/cirq/google/api/v2/results_test.py
+++ b/cirq/google/api/v2/results_test.py
@@ -107,14 +107,12 @@ def test_results_to_proto():
             cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 0}),
                 measurements={
-                    'foo': np.array([[0], [1], [0], [1]],
-                                    dtype=bool),
+                    'foo': np.array([[0], [1], [0], [1]], dtype=bool),
                 }),
             cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 1}),
                 measurements={
-                    'foo': np.array([[0], [1], [1], [0]],
-                                    dtype=bool),
+                    'foo': np.array([[0], [1], [1], [0]], dtype=bool),
                 }),
         ],
         [
@@ -127,8 +125,7 @@ def test_results_to_proto():
             cirq.TrialResult.from_single_parameter_set(
                 params=cirq.ParamResolver({'i': 1}),
                 measurements={
-                    'foo': np.array([[0], [1], [1], [0]],
-                                    dtype=bool),
+                    'foo': np.array([[0], [1], [1], [0]], dtype=bool),
                 }),
         ],
     ]
@@ -150,16 +147,20 @@ def test_results_to_proto():
 def test_results_to_proto_sweep_repetitions():
     measurements = [v2.MeasureInfo('foo', [q(0, 0)], slot=0)]
     trial_results = [[
-        cirq.TrialResult.from_single_parameter_set(
-            params=cirq.ParamResolver({'i': 0}),
-            measurements={
-                'foo': np.array([[0]], dtype=bool),
-            }),
-        cirq.TrialResult.from_single_parameter_set(
-            params=cirq.ParamResolver({'i': 1}),
-            measurements={
-                'foo': np.array([[0], [1]], dtype=bool),
-            }),
+        cirq.TrialResult.from_single_parameter_set(params=cirq.ParamResolver(
+            {'i': 0}),
+                                                   measurements={
+                                                       'foo':
+                                                       np.array([[0]],
+                                                                dtype=bool),
+                                                   }),
+        cirq.TrialResult.from_single_parameter_set(params=cirq.ParamResolver(
+            {'i': 1}),
+                                                   measurements={
+                                                       'foo':
+                                                       np.array([[0], [1]],
+                                                                dtype=bool),
+                                                   }),
     ]]
     with pytest.raises(ValueError, match='different numbers of repetitions'):
         v2.results_to_proto(trial_results, measurements)

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -518,9 +518,10 @@ class Engine:
                                               key_sizes)
 
                 trial_results.append(
-                    TrialResult(params=ParamResolver(
-                        result.get('params', {}).get('assignments', {})),
-                                measurements=measurements))
+                    TrialResult.from_single_parameter_set_reps(
+                        params=ParamResolver(
+                            result.get('params', {}).get('assignments', {})),
+                        measurements=measurements))
         return trial_results
 
     def _get_job_results_v2(self,

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -518,7 +518,7 @@ class Engine:
                                               key_sizes)
 
                 trial_results.append(
-                    TrialResult.from_single_parameter_set_reps(
+                    TrialResult.from_single_parameter_set(
                         params=ParamResolver(
                             result.get('params', {}).get('assignments', {})),
                         measurements=measurements))

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -81,7 +81,7 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
                                      param_resolver=param_resolver,
                                      repetitions=repetitions)
             trial_results.append(
-                study.TrialResult.from_single_parameter_set_reps(
+                study.TrialResult.from_single_parameter_set(
                     params=param_resolver,
                     measurements=measurements))
         return trial_results

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -81,8 +81,9 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
                                      param_resolver=param_resolver,
                                      repetitions=repetitions)
             trial_results.append(
-                study.TrialResult(params=param_resolver,
-                                  measurements=measurements))
+                study.TrialResult.from_single_parameter_set_reps(
+                    params=param_resolver,
+                    measurements=measurements))
         return trial_results
 
     @abc.abstractmethod

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -82,8 +82,7 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
                                      repetitions=repetitions)
             trial_results.append(
                 study.TrialResult.from_single_parameter_set(
-                    params=param_resolver,
-                    measurements=measurements))
+                    params=param_resolver, measurements=measurements))
         return trial_results
 
     @abc.abstractmethod

--- a/cirq/sim/simulator_test.py
+++ b/cirq/sim/simulator_test.py
@@ -30,7 +30,7 @@ def test_run_simulator_run():
     simulator._run.return_value = expected_measurements
     circuit = mock.Mock(cirq.Circuit)
     param_resolver = mock.Mock(cirq.ParamResolver)
-    expected_result = cirq.TrialResult.from_single_parameter_set_reps(
+    expected_result = cirq.TrialResult.from_single_parameter_set(
         measurements=expected_measurements,
         params=param_resolver)
     assert expected_result == simulator.run(program=circuit,
@@ -52,10 +52,10 @@ def test_run_simulator_sweeps():
     param_resolvers = [mock.Mock(cirq.ParamResolver),
                        mock.Mock(cirq.ParamResolver)]
     expected_results = [
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             measurements=expected_measurements,
             params=param_resolvers[0]),
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             measurements=expected_measurements,
             params=param_resolvers[1])
     ]

--- a/cirq/sim/simulator_test.py
+++ b/cirq/sim/simulator_test.py
@@ -31,8 +31,7 @@ def test_run_simulator_run():
     circuit = mock.Mock(cirq.Circuit)
     param_resolver = mock.Mock(cirq.ParamResolver)
     expected_result = cirq.TrialResult.from_single_parameter_set(
-        measurements=expected_measurements,
-        params=param_resolver)
+        measurements=expected_measurements, params=param_resolver)
     assert expected_result == simulator.run(program=circuit,
                                             repetitions=10,
                                             param_resolver=param_resolver)
@@ -53,11 +52,9 @@ def test_run_simulator_sweeps():
                        mock.Mock(cirq.ParamResolver)]
     expected_results = [
         cirq.TrialResult.from_single_parameter_set(
-            measurements=expected_measurements,
-            params=param_resolvers[0]),
+            measurements=expected_measurements, params=param_resolvers[0]),
         cirq.TrialResult.from_single_parameter_set(
-            measurements=expected_measurements,
-            params=param_resolvers[1])
+            measurements=expected_measurements, params=param_resolvers[1])
     ]
     assert expected_results == simulator.run_sweep(program=circuit,
                                                    repetitions=10,

--- a/cirq/sim/simulator_test.py
+++ b/cirq/sim/simulator_test.py
@@ -30,8 +30,9 @@ def test_run_simulator_run():
     simulator._run.return_value = expected_measurements
     circuit = mock.Mock(cirq.Circuit)
     param_resolver = mock.Mock(cirq.ParamResolver)
-    expected_result = cirq.TrialResult(measurements=expected_measurements,
-                                       params=param_resolver)
+    expected_result = cirq.TrialResult.from_single_parameter_set_reps(
+        measurements=expected_measurements,
+        params=param_resolver)
     assert expected_result == simulator.run(program=circuit,
                                             repetitions=10,
                                             param_resolver=param_resolver)
@@ -51,10 +52,12 @@ def test_run_simulator_sweeps():
     param_resolvers = [mock.Mock(cirq.ParamResolver),
                        mock.Mock(cirq.ParamResolver)]
     expected_results = [
-        cirq.TrialResult(measurements=expected_measurements,
-                         params=param_resolvers[0]),
-        cirq.TrialResult(measurements=expected_measurements,
-                         params=param_resolvers[1])
+        cirq.TrialResult.from_single_parameter_set_reps(
+            measurements=expected_measurements,
+            params=param_resolvers[0]),
+        cirq.TrialResult.from_single_parameter_set_reps(
+            measurements=expected_measurements,
+            params=param_resolvers[1])
     ]
     assert expected_results == simulator.run_sweep(program=circuit,
                                                    repetitions=10,

--- a/cirq/study/compute_displays_result_test.py
+++ b/cirq/study/compute_displays_result_test.py
@@ -29,8 +29,9 @@ def test_compute_displays_result_eq():
     w = cirq.ComputeDisplaysResult(
         params=cirq.ParamResolver({'b': 2}),
         display_values={'k': 1.0})
-    x = cirq.TrialResult(params=cirq.ParamResolver({'a': 2}),
-                         measurements={'k': np.array([[1]])})
+    x = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({'a': 2}),
+        measurements={'k': np.array([[1]])})
 
     eq.add_equality_group(u, v)
     eq.add_equality_group(w)

--- a/cirq/study/compute_displays_result_test.py
+++ b/cirq/study/compute_displays_result_test.py
@@ -29,7 +29,7 @@ def test_compute_displays_result_eq():
     w = cirq.ComputeDisplaysResult(
         params=cirq.ParamResolver({'b': 2}),
         display_values={'k': 1.0})
-    x = cirq.TrialResult.from_single_parameter_set_reps(
+    x = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({'a': 2}),
         measurements={'k': np.array([[1]])})
 

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 
 from cirq import value, ops
+from cirq._compat import proper_repr
 from cirq.study import resolver
 
 if TYPE_CHECKING:
@@ -136,10 +137,10 @@ class TrialResult:
         self.data = pd.DataFrame(converted_dict)
 
     @staticmethod
-    def from_single_parameter_set_reps(
+    def from_single_parameter_set(
             *,  # Forces keyword args.
             params: resolver.ParamResolver,
-            measurements: Dict[str, np.ndarray]) -> None:
+            measurements: Dict[str, np.ndarray]) -> 'TrialResult':
         """Packages runs of a single parameterized circuit into a TrialResult.
 
         Args:
@@ -266,11 +267,17 @@ class TrialResult:
             keys=[key], fold_func=lambda e: fold_func(e.iloc[0]))
 
     def __repr__(self):
-        return ('cirq.TrialResult(params={!r}, '
-                'repetitions={!r}, '
-                'measurements={!r})').format(self.params,
-                                             self.repetitions,
-                                             self.measurements)
+        def item_repr(entry):
+            key, val = entry
+            return '{!r}: {}'.format(key, proper_repr(val))
+
+        measurement_dict_repr = (
+                '{' +
+                ', '.join([item_repr(e) for e in self.measurements.items()]) +
+                '}')
+
+        return 'cirq.TrialResult(params={!r}, measurements={})'.format(
+            self.params, measurement_dict_repr)
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:
         """Output to show in ipython and Jupyter notebooks."""

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -135,6 +135,23 @@ class TrialResult:
             converted_dict[key] = [pd.Series(m_vals) for m_vals in val]
         self.data = pd.DataFrame(converted_dict)
 
+    @staticmethod
+    def from_single_parameter_set_reps(
+            *,  # Forces keyword args.
+            params: resolver.ParamResolver,
+            measurements: Dict[str, np.ndarray]) -> None:
+        """Packages runs of a single parameterized circuit into a TrialResult.
+
+        Args:
+            params: A ParamResolver of settings used for this result.
+            measurements: A dictionary from measurement gate key to measurement
+                results. The value for each key is a 2-D array of booleans,
+                with the first index running over the repetitions, and the
+                second index running over the qubits for the corresponding
+                measurements.
+        """
+        return TrialResult(params=params, measurements=measurements)
+
     # Keep the old instance variables for test compatibility.
     @property
     def measurements(self) -> Dict[str, np.ndarray]:

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -267,14 +267,14 @@ class TrialResult:
             keys=[key], fold_func=lambda e: fold_func(e.iloc[0]))
 
     def __repr__(self):
+
         def item_repr(entry):
             key, val = entry
             return '{!r}: {}'.format(key, proper_repr(val))
 
         measurement_dict_repr = (
-                '{' +
-                ', '.join([item_repr(e) for e in self.measurements.items()]) +
-                '}')
+            '{' + ', '.join([item_repr(e) for e in self.measurements.items()]) +
+            '}')
 
         return 'cirq.TrialResult(params={!r}, measurements={})'.format(
             self.params, measurement_dict_repr)

--- a/cirq/study/trial_result_test.py
+++ b/cirq/study/trial_result_test.py
@@ -31,11 +31,8 @@ def test_str():
     result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
-            'ab':
-            np.array([[0, 1], [0, 1], [0, 1], [1, 0],
-                      [0, 1]]),
-            'c':
-            np.array([[0], [0], [1], [0], [1]])
+            'ab': np.array([[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]]),
+            'c': np.array([[0], [0], [1], [0], [1]])
         })
     assert str(result) == 'ab=00010, 11101\nc=00101'
 
@@ -44,13 +41,9 @@ def test_df():
     result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
-            'ab':
-            np.array(
-                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                dtype=np.bool),
-            'c':
-            np.array([[0], [0], [1], [0], [1]],
-                     dtype=np.bool)
+            'ab': np.array([[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                           dtype=np.bool),
+            'c': np.array([[0], [0], [1], [0], [1]], dtype=np.bool)
         })
     remove_end_measurements = pd.DataFrame(data={
         'ab': [
@@ -79,13 +72,9 @@ def test_histogram():
     result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
-            'ab':
-            np.array(
-                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                dtype=np.bool),
-            'c':
-            np.array([[0], [0], [1], [0], [1]],
-                     dtype=np.bool)
+            'ab': np.array([[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                           dtype=np.bool),
+            'c': np.array([[0], [0], [1], [0], [1]], dtype=np.bool)
         })
 
     assert result.histogram(key='ab') == collections.Counter({
@@ -110,13 +99,9 @@ def test_multi_measurement_histogram():
     result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
-            'ab':
-            np.array(
-                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                dtype=np.bool),
-            'c':
-            np.array([[0], [0], [1], [0], [1]],
-                     dtype=np.bool)
+            'ab': np.array([[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                           dtype=np.bool),
+            'c': np.array([[0], [0], [1], [0], [1]], dtype=np.bool)
         })
 
     assert result.multi_measurement_histogram(keys=[]) == collections.Counter({
@@ -202,13 +187,9 @@ def test_text_diagram_jupyter():
     result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
-            'ab':
-            np.array(
-                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                dtype=np.bool),
-            'c':
-            np.array([[0], [0], [1], [0], [1]],
-                     dtype=np.bool)
+            'ab': np.array([[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                           dtype=np.bool),
+            'c': np.array([[0], [0], [1], [0], [1]], dtype=np.bool)
         })
 
     # Test Jupyter console output from

--- a/cirq/study/trial_result_test.py
+++ b/cirq/study/trial_result_test.py
@@ -20,39 +20,38 @@ import pandas as pd
 import cirq
 
 
-
 def test_repr():
-    v = cirq.TrialResult(params=cirq.ParamResolver({'a': 2}),
-                         measurements={'xy': np.array([[1, 0], [0, 1]])})
-
-    assert repr(v) == ("cirq.TrialResult(params=cirq.ParamResolver({'a': 2}), "
-                       "repetitions=2, measurements={'xy': array([[1, 0],\n"
-                       "       [0, 1]])})")
+    v = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({'a': 2}),
+        measurements={'xy': np.array([[1, 0], [0, 1]])})
+    cirq.testing.assert_equivalent_repr(v)
 
 
 def test_str():
-    result = cirq.TrialResult(params=cirq.ParamResolver({}),
-                              measurements={
-                                  'ab':
-                                  np.array([[0, 1], [0, 1], [0, 1], [1, 0],
-                                            [0, 1]]),
-                                  'c':
-                                  np.array([[0], [0], [1], [0], [1]])
-                              })
+    result = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'ab':
+            np.array([[0, 1], [0, 1], [0, 1], [1, 0],
+                      [0, 1]]),
+            'c':
+            np.array([[0], [0], [1], [0], [1]])
+        })
     assert str(result) == 'ab=00010, 11101\nc=00101'
 
 
 def test_df():
-    result = cirq.TrialResult(params=cirq.ParamResolver({}),
-                              measurements={
-                                  'ab':
-                                  np.array(
-                                      [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                                      dtype=np.bool),
-                                  'c':
-                                  np.array([[0], [0], [1], [0], [1]],
-                                           dtype=np.bool)
-                              })
+    result = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'ab':
+            np.array(
+                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                dtype=np.bool),
+            'c':
+            np.array([[0], [0], [1], [0], [1]],
+                     dtype=np.bool)
+        })
     remove_end_measurements = pd.DataFrame(data={
         'ab': [
             pd.Series([False, True]),
@@ -77,16 +76,17 @@ def test_df():
 
 
 def test_histogram():
-    result = cirq.TrialResult(params=cirq.ParamResolver({}),
-                              measurements={
-                                  'ab':
-                                  np.array(
-                                      [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                                      dtype=np.bool),
-                                  'c':
-                                  np.array([[0], [0], [1], [0], [1]],
-                                           dtype=np.bool)
-                              })
+    result = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'ab':
+            np.array(
+                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                dtype=np.bool),
+            'c':
+            np.array([[0], [0], [1], [0], [1]],
+                     dtype=np.bool)
+        })
 
     assert result.histogram(key='ab') == collections.Counter({
         1: 4,
@@ -107,16 +107,17 @@ def test_histogram():
 
 
 def test_multi_measurement_histogram():
-    result = cirq.TrialResult(params=cirq.ParamResolver({}),
-                              measurements={
-                                  'ab':
-                                  np.array(
-                                      [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                                      dtype=np.bool),
-                                  'c':
-                                  np.array([[0], [0], [1], [0], [1]],
-                                           dtype=np.bool)
-                              })
+    result = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'ab':
+            np.array(
+                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                dtype=np.bool),
+            'c':
+            np.array([[0], [0], [1], [0], [1]],
+                     dtype=np.bool)
+        })
 
     assert result.multi_measurement_histogram(keys=[]) == collections.Counter({
         ():
@@ -168,14 +169,17 @@ def test_multi_measurement_histogram():
 def test_trial_result_equality():
     et = cirq.testing.EqualsTester()
     et.add_equality_group(
-        cirq.TrialResult(params=cirq.ParamResolver({}),
-                         measurements={'a': np.array([[0]] * 5)}))
+        cirq.TrialResult.from_single_parameter_set_reps(
+            params=cirq.ParamResolver({}),
+            measurements={'a': np.array([[0]] * 5)}))
     et.add_equality_group(
-        cirq.TrialResult(params=cirq.ParamResolver({}),
-                         measurements={'a': np.array([[0]] * 6)}))
+        cirq.TrialResult.from_single_parameter_set_reps(
+            params=cirq.ParamResolver({}),
+            measurements={'a': np.array([[0]] * 6)}))
     et.add_equality_group(
-        cirq.TrialResult(params=cirq.ParamResolver({}),
-                         measurements={'a': np.array([[1]] * 5)}))
+        cirq.TrialResult.from_single_parameter_set_reps(
+            params=cirq.ParamResolver({}),
+            measurements={'a': np.array([[1]] * 5)}))
 
 
 def test_qubit_keys_for_histogram():
@@ -195,16 +199,17 @@ def test_qubit_keys_for_histogram():
 
 
 def test_text_diagram_jupyter():
-    result = cirq.TrialResult(params=cirq.ParamResolver({}),
-                              measurements={
-                                  'ab':
-                                  np.array(
-                                      [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
-                                      dtype=np.bool),
-                                  'c':
-                                  np.array([[0], [0], [1], [0], [1]],
-                                           dtype=np.bool)
-                              })
+    result = cirq.TrialResult.from_single_parameter_set_reps(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'ab':
+            np.array(
+                [[0, 1], [0, 1], [0, 1], [1, 0], [0, 1]],
+                dtype=np.bool),
+            'c':
+            np.array([[0], [0], [1], [0], [1]],
+                     dtype=np.bool)
+        })
 
     # Test Jupyter console output from
     class FakePrinter:

--- a/cirq/study/trial_result_test.py
+++ b/cirq/study/trial_result_test.py
@@ -21,14 +21,14 @@ import cirq
 
 
 def test_repr():
-    v = cirq.TrialResult.from_single_parameter_set_reps(
+    v = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({'a': 2}),
         measurements={'xy': np.array([[1, 0], [0, 1]])})
     cirq.testing.assert_equivalent_repr(v)
 
 
 def test_str():
-    result = cirq.TrialResult.from_single_parameter_set_reps(
+    result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
             'ab':
@@ -41,7 +41,7 @@ def test_str():
 
 
 def test_df():
-    result = cirq.TrialResult.from_single_parameter_set_reps(
+    result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
             'ab':
@@ -76,7 +76,7 @@ def test_df():
 
 
 def test_histogram():
-    result = cirq.TrialResult.from_single_parameter_set_reps(
+    result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
             'ab':
@@ -107,7 +107,7 @@ def test_histogram():
 
 
 def test_multi_measurement_histogram():
-    result = cirq.TrialResult.from_single_parameter_set_reps(
+    result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
             'ab':
@@ -169,15 +169,15 @@ def test_multi_measurement_histogram():
 def test_trial_result_equality():
     et = cirq.testing.EqualsTester()
     et.add_equality_group(
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             params=cirq.ParamResolver({}),
             measurements={'a': np.array([[0]] * 5)}))
     et.add_equality_group(
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             params=cirq.ParamResolver({}),
             measurements={'a': np.array([[0]] * 6)}))
     et.add_equality_group(
-        cirq.TrialResult.from_single_parameter_set_reps(
+        cirq.TrialResult.from_single_parameter_set(
             params=cirq.ParamResolver({}),
             measurements={'a': np.array([[1]] * 5)}))
 
@@ -199,7 +199,7 @@ def test_qubit_keys_for_histogram():
 
 
 def test_text_diagram_jupyter():
-    result = cirq.TrialResult.from_single_parameter_set_reps(
+    result = cirq.TrialResult.from_single_parameter_set(
         params=cirq.ParamResolver({}),
         measurements={
             'ab':


### PR DESCRIPTION
- The goal here is to gradually refactor TrialResult into something that can also represent sweep results.