### PR TITLE
Optimize TrialResult.data

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -270,6 +270,10 @@ from cirq.study import (
 from cirq.value import (
     ABCMetaImplementAnyOneOf,
     alternative,
+    big_endian_bits_to_int,
+    big_endian_digits_to_int,
+    big_endian_int_to_bits,
+    big_endian_int_to_digits,
     canonicalize_half_turns,
     chosen_angle_to_canonical_half_turns,
     chosen_angle_to_half_turns,

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -55,7 +55,7 @@ def _keyed_repeated_bitstrings(vals: Dict[str, np.ndarray]) -> str:
     for key in sorted(vals.keys()):
         reps = vals[key]
         n = 0 if len(reps) == 0 else len(reps[0])
-        all_bits = ', '.join([_bitstring(reps[:, i]) for i in range(n)])
+        all_bits = ', '.join(_bitstring(reps[:, i]) for i in range(n))
         keyed_bitstrings.append('{}={}'.format(key, all_bits))
     return '\n'.join(keyed_bitstrings)
 

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -14,9 +14,8 @@
 
 """Defines trial results."""
 
-from typing import (
-    Iterable, Callable, Tuple, TypeVar, Dict, Any, TYPE_CHECKING, Union,
-    List, Optional)
+from typing import (Iterable, Callable, Tuple, TypeVar, Dict, Any,
+                    TYPE_CHECKING, Union, List, Optional)
 
 import collections
 import numpy as np
@@ -86,14 +85,12 @@ def _bitstring(vals: Iterable[Any]) -> str:
     return ''.join('1' if v else '0' for v in vals)
 
 
-def _keyed_repeated_bitstrings(vals: Dict[str, np.ndarray]
-                               ) -> str:
+def _keyed_repeated_bitstrings(vals: Dict[str, np.ndarray]) -> str:
     keyed_bitstrings = []
     for key in sorted(vals.keys()):
         reps = vals[key]
         n = 0 if len(reps) == 0 else len(reps[0])
-        all_bits = ', '.join([_bitstring(reps[:, i])
-                              for i in range(n)])
+        all_bits = ', '.join([_bitstring(reps[:, i]) for i in range(n)])
         keyed_bitstrings.append('{}={}'.format(key, all_bits))
     return '\n'.join(keyed_bitstrings)
 
@@ -148,8 +145,9 @@ class TrialResult:
             # repetitions and a big endian integer for individual measurements.
             converted_dict = {}
             for key, val in self._measurements.items():
-                converted_dict[key] = [_big_endian_int(m_vals) for m_vals in
-                                       val]
+                converted_dict[key] = [
+                    _big_endian_int(m_vals) for m_vals in val
+                ]
             self._data = pd.DataFrame(converted_dict)
         return self._data
 
@@ -213,8 +211,8 @@ class TrialResult:
             results.
         """
         fixed_keys = tuple(_key_to_str(key) for key in keys)
-        samples = zip(*[self.measurements[sub_key]
-                        for sub_key in fixed_keys])  # type: Iterable[Any]
+        samples = zip(*[self.measurements[sub_key] for sub_key in fixed_keys
+                       ])  # type: Iterable[Any]
         if len(fixed_keys) == 0:
             samples = [()] * self.repetitions
         c = collections.Counter()  # type: collections.Counter

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -15,7 +15,7 @@
 """Defines trial results."""
 
 from typing import (Iterable, Callable, Tuple, TypeVar, Dict, Any,
-                    TYPE_CHECKING, Union, List, Optional)
+                    TYPE_CHECKING, Union, Optional)
 
 import collections
 import numpy as np
@@ -43,43 +43,7 @@ def _tuple_of_big_endian_int(bit_groups: Iterable[Any]) -> Tuple[int, ...]:
     Returns:
         A tuple containing the integer for each group.
     """
-    return tuple(_big_endian_int(bits) for bits in bit_groups)
-
-
-def _big_endian_int(bits: Iterable[Any]) -> int:
-    """Returns the big-endian integer specified by the given bits.
-
-    For example, [True, False, False, True, False] becomes binary 10010 which
-    is 18 in decimal.
-
-    Args:
-        bits: Descending bits of the integer, with the 1s bit at the end.
-
-    Returns:
-        The integer.
-    """
-    result = 0
-    for e in bits:
-        result <<= 1
-        if e:
-            result |= 1
-    return result
-
-
-def _big_endian_bits(val: int, bit_count: int) -> List[bool]:
-    """Returns the big-endian bits of an integer.
-
-    For example, 18 becomes [True, False, False, True, False] when `bit_count`
-    is five.
-
-    Args:
-        val: The integer to get bits from.
-        bit_count: The number of desired bits in the result.
-
-    Returns:
-        The bits.
-    """
-    return [bool(val & (1 << i)) for i in range(bit_count)[::-1]]
+    return tuple(value.big_endian_bits_to_int(bits) for bits in bit_groups)
 
 
 def _bitstring(vals: Iterable[Any]) -> str:
@@ -147,7 +111,7 @@ class TrialResult:
             converted_dict = {}
             for key, val in self._measurements.items():
                 converted_dict[key] = [
-                    _big_endian_int(m_vals) for m_vals in val
+                    value.big_endian_bits_to_int(m_vals) for m_vals in val
                 ]
             self._data = pd.DataFrame(converted_dict)
         return self._data
@@ -243,7 +207,7 @@ class TrialResult:
             self,
             *,  # Forces keyword args.
             key: TMeasurementKey,
-            fold_func: Callable[[pd.Series], T] = _big_endian_int
+            fold_func: Callable[[pd.Series], T] = value.big_endian_bits_to_int
     ) -> collections.Counter:
         """Counts the number of times a measurement result occurred.
 

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -104,7 +104,7 @@ class TrialResult:
         self._measurements = measurements
 
     @property
-    def data(self):
+    def data(self) -> pd.DataFrame:
         if self._data is None:
             # Convert to a DataFrame with columns as measurement keys, rows as
             # repetitions and a big endian integer for individual measurements.
@@ -193,8 +193,8 @@ class TrialResult:
             results.
         """
         fixed_keys = tuple(_key_to_str(key) for key in keys)
-        samples = zip(*[self.measurements[sub_key] for sub_key in fixed_keys
-                       ])  # type: Iterable[Any]
+        samples = zip(*(self.measurements[sub_key]
+                        for sub_key in fixed_keys))  # type: Iterable[Any]
         if len(fixed_keys) == 0:
             samples = [()] * self.repetitions
         c = collections.Counter()  # type: collections.Counter

--- a/cirq/study/trial_result_test.py
+++ b/cirq/study/trial_result_test.py
@@ -53,12 +53,11 @@ def test_df():
                                   np.array([[0], [0], [1], [0], [1]],
                                            dtype=np.bool)
                               })
-    remove_end_measurements = pd.DataFrame(
-        data={
-            'ab': [1, 1, 2],
-            'c': [0, 1, 0]
-        },
-        index=[1, 2, 3])
+    remove_end_measurements = pd.DataFrame(data={
+        'ab': [1, 1, 2],
+        'c': [0, 1, 0]
+    },
+                                           index=[1, 2, 3])
 
     pd.testing.assert_frame_equal(result.data.iloc[1:-1],
                                   remove_end_measurements)

--- a/cirq/study/trial_result_test.py
+++ b/cirq/study/trial_result_test.py
@@ -53,27 +53,20 @@ def test_df():
                                   np.array([[0], [0], [1], [0], [1]],
                                            dtype=np.bool)
                               })
-    remove_end_measurements = pd.DataFrame(data={
-        'ab': [
-            pd.Series([False, True]),
-            pd.Series([False, True]),
-            pd.Series([True, False])
-        ],
-        'c': [pd.Series([False]),
-              pd.Series([True]),
-              pd.Series([False])]
-    },
-                                           index=[1, 2, 3])
+    remove_end_measurements = pd.DataFrame(
+        data={
+            'ab': [1, 1, 2],
+            'c': [0, 1, 0]
+        },
+        index=[1, 2, 3])
 
     pd.testing.assert_frame_equal(result.data.iloc[1:-1],
                                   remove_end_measurements)
 
-    ab = result.data['ab']
-    c = result.data['c']
-    # Count number of ab repitiions with measurements [False, True]
-    assert ab.apply(lambda x: x.equals(pd.Series([False, True]))).sum() == 4
-    # Count number of c repitiions with measurements [False]
-    assert c.apply(lambda x: x.equals(pd.Series([False]))).sum() == 3
+    # Frequency counting.
+    df = result.data
+    assert len(df[df['ab'] == 1]) == 4
+    assert df.c.value_counts().to_dict() == {0: 3, 1: 2}
 
 
 def test_histogram():

--- a/cirq/value/__init__.py
+++ b/cirq/value/__init__.py
@@ -23,6 +23,13 @@ from cirq.value.angle import (
     chosen_angle_to_half_turns,
 )
 
+from cirq.value.digits import (
+    big_endian_bits_to_int,
+    big_endian_digits_to_int,
+    big_endian_int_to_bits,
+    big_endian_int_to_digits,
+)
+
 from cirq.value.duration import (
     Duration,)
 

--- a/cirq/value/digits.py
+++ b/cirq/value/digits.py
@@ -1,7 +1,5 @@
 from typing import List, Iterable, Any, Union, Optional, overload
 
-import numpy as np
-
 
 def big_endian_bits_to_int(bits: Iterable[Any]) -> int:
     """Returns the big-endian integer specified by the given bits.
@@ -111,21 +109,22 @@ def big_endian_digits_to_int(digits: Iterable[int], *,
     return result
 
 
+# pylint: disable=function-redefined
 @overload
 def big_endian_int_to_digits(val: int, *, digit_count: int,
-                             base: int) -> List[bool]:
+                             base: int) -> List[int]:
     pass
 
 
 @overload
-def big_endian_int_to_digits(val: int, *, base: Iterable[int]) -> List[bool]:
+def big_endian_int_to_digits(val: int, *, base: Iterable[int]) -> List[int]:
     pass
 
 
 def big_endian_int_to_digits(val: int,
                              *,
                              digit_count: Optional[int] = None,
-                             base: Union[int, Iterable[int]]) -> List[bool]:
+                             base: Union[int, Iterable[int]]) -> List[int]:
     """Separates an integer into big-endian digits.
 
     Examples:
@@ -176,8 +175,10 @@ def big_endian_int_to_digits(val: int,
             raise ValueError(
                 'No digit count. Provide `digit_count` when base is an int.')
         base = (base,) * digit_count
-    elif digit_count is None:
-        digit_count = len(base)
+    else:
+        base = tuple(base)
+        if digit_count is None:
+            digit_count = len(base)
 
     if len(base) != digit_count:
         raise ValueError('Inconsistent digit count. len(base) != digit_count')
@@ -193,3 +194,4 @@ def big_endian_int_to_digits(val: int,
                          'left behind {!r} instead of 0.'.format(result, val))
 
     return result[::-1]
+# pylint: enable=function-redefined

--- a/cirq/value/digits.py
+++ b/cirq/value/digits.py
@@ -32,18 +32,15 @@ def big_endian_bits_to_int(bits: Iterable[Any]) -> int:
     return result
 
 
-def big_endian_int_to_bits(val: int, *, bit_count: int) -> List[bool]:
+def big_endian_int_to_bits(val: int, *, bit_count: int) -> List[int]:
     """Returns the big-endian bits of an integer.
 
     Examples:
-        >>> big_endian_int_to_bits(2, bit_count=4)
-        [0, 0, 1, 0]
+        >>> big_endian_int_to_bits(19, bit_count=8)
+        [0, 0, 0, 1, 0, 0, 1, 1]
 
-        >>> big_endian_int_to_bits(18, bit_count=8)
-        [0, 0, 0, 1, 0, 0, 1, 0]
-
-        >>> big_endian_int_to_bits(18, bit_count=4)
-        [0, 0, 1, 0]
+        >>> big_endian_int_to_bits(19, bit_count=4)
+        [0, 0, 1, 1]
 
         >>> big_endian_int_to_bits(-3, bit_count=4)
         [1, 1, 0, 1]
@@ -58,7 +55,7 @@ def big_endian_int_to_bits(val: int, *, bit_count: int) -> List[bool]:
     Returns:
         The bits.
     """
-    return [bool(val & (1 << i)) for i in range(bit_count)[::-1]]
+    return [(val >> i) & 1 for i in range(bit_count)[::-1]]
 
 
 def big_endian_digits_to_int(digits: Iterable[int], *,
@@ -131,23 +128,8 @@ def big_endian_int_to_digits(val: int,
         >>> big_endian_int_to_digits(11, digit_count=4, base=10)
         [0, 0, 1, 1]
 
-        >>> big_endian_int_to_digits(11, digit_count=4, base=[2, 3, 4])
-        [0, 0, 1, 1]
-
-        >>> big_endian_int_to_digits(11, digit_count=4, base=3)
-        [0, 1, 0, 2]
-
         >>> big_endian_int_to_digits(11, base=[2, 3, 4])
-        [0, 1, 0, 2]
-
-        >>> big_endian_int_to_digits(18, bit_count=8)
-        [0, 0, 0, 1, 0, 0, 1, 0]
-
-        >>> big_endian_int_to_digits(18, bit_count=4)
-        [0, 0, 1, 0]
-
-        >>> big_endian_int_to_digits(-3, bit_count=4)
-        [1, 1, 0, 1]
+        [0, 2, 3]
 
     Args:
         val: The integer to get digits from. Must be non-negative and less than

--- a/cirq/value/digits.py
+++ b/cirq/value/digits.py
@@ -176,4 +176,6 @@ def big_endian_int_to_digits(val: int,
                          'left behind {!r} instead of 0.'.format(result, val))
 
     return result[::-1]
+
+
 # pylint: enable=function-redefined

--- a/cirq/value/digits.py
+++ b/cirq/value/digits.py
@@ -166,7 +166,7 @@ def big_endian_int_to_digits(val: int,
         raise ValueError('Inconsistent digit count. len(base) != digit_count')
 
     result = []
-    for b in base[::-1]:
+    for b in reversed(base):
         result.append(val % b)
         val //= b
 

--- a/cirq/value/digits.py
+++ b/cirq/value/digits.py
@@ -1,0 +1,195 @@
+from typing import List, Iterable, Any, Union, Optional, overload
+
+import numpy as np
+
+
+def big_endian_bits_to_int(bits: Iterable[Any]) -> int:
+    """Returns the big-endian integer specified by the given bits.
+
+    Examples:
+
+        >>> big_endian_bits_to_int([0, 1])
+        1
+
+        >>> big_endian_bits_to_int([1, 0])
+        2
+
+        >>> big_endian_bits_to_int([0, 1, 0])
+        2
+
+        >>> big_endian_bits_to_int([1, 0, 0, 1, 0])
+        18
+
+    Args:
+        bits: Descending bits of the integer, with the 1s bit at the end.
+
+    Returns:
+        The integer.
+    """
+    result = 0
+    for e in bits:
+        result <<= 1
+        if e:
+            result |= 1
+    return result
+
+
+def big_endian_int_to_bits(val: int, *, bit_count: int) -> List[bool]:
+    """Returns the big-endian bits of an integer.
+
+    Examples:
+        >>> big_endian_int_to_bits(2, bit_count=4)
+        [0, 0, 1, 0]
+
+        >>> big_endian_int_to_bits(18, bit_count=8)
+        [0, 0, 0, 1, 0, 0, 1, 0]
+
+        >>> big_endian_int_to_bits(18, bit_count=4)
+        [0, 0, 1, 0]
+
+        >>> big_endian_int_to_bits(-3, bit_count=4)
+        [1, 1, 0, 1]
+
+    Args:
+        val: The integer to get bits from. This integer is permitted to be
+            larger than `2**bit_count` (in which case the high bits of the
+            result are dropped) or to be negative (in which case the bits come
+            from the 2s complement signed representation).
+        bit_count: The number of desired bits in the result.
+
+    Returns:
+        The bits.
+    """
+    return [bool(val & (1 << i)) for i in range(bit_count)[::-1]]
+
+
+def big_endian_digits_to_int(digits: Iterable[int], *,
+                             base: Union[int, Iterable[int]]) -> int:
+    """Returns the big-endian integer specified by the given digits and base.
+
+    Examples:
+
+        >>> big_endian_digits_to_int([0, 1], base=10)
+        1
+
+        >>> big_endian_digits_to_int([1, 0], base=10)
+        10
+
+        >>> big_endian_digits_to_int([1, 2, 3], base=[2, 3, 4])
+        23
+
+    Args:
+        digits: Digits of the integer, with the least significant digit at the
+            end.
+        base: The base, or list of per-digit bases, to use when combining the
+            digits into an integer. When a list of bases is specified, the last
+            entry in the list is the base for the last entry of the digits list
+            (i.e. the least significant digit). That is to say, the bases are
+            also specified in big endian order.
+
+    Returns:
+        The integer.
+
+    Raises:
+        ValueError:
+            One of the digits is out of range for its base.
+            The base was specified per-digit (as a list) but the length of the
+                bases list is different from the number of digits.
+    """
+    digits = tuple(digits)
+    base = (base,) * len(digits) if isinstance(base, int) else tuple(base)
+    if len(digits) != len(base):
+        raise ValueError('len(digits) != len(base)')
+
+    result = 0
+    for d, b in zip(digits, base):
+        if not (0 <= d < b):
+            raise ValueError(
+                'Out of range digit. Digit: {!r}, base: {!r}'.format(d, b))
+        result *= b
+        result += d
+    return result
+
+
+@overload
+def big_endian_int_to_digits(val: int, *, digit_count: int,
+                             base: int) -> List[bool]:
+    pass
+
+
+@overload
+def big_endian_int_to_digits(val: int, *, base: Iterable[int]) -> List[bool]:
+    pass
+
+
+def big_endian_int_to_digits(val: int,
+                             *,
+                             digit_count: Optional[int] = None,
+                             base: Union[int, Iterable[int]]) -> List[bool]:
+    """Separates an integer into big-endian digits.
+
+    Examples:
+        >>> big_endian_int_to_digits(11, digit_count=4, base=10)
+        [0, 0, 1, 1]
+
+        >>> big_endian_int_to_digits(11, digit_count=4, base=[2, 3, 4])
+        [0, 0, 1, 1]
+
+        >>> big_endian_int_to_digits(11, digit_count=4, base=3)
+        [0, 1, 0, 2]
+
+        >>> big_endian_int_to_digits(11, base=[2, 3, 4])
+        [0, 1, 0, 2]
+
+        >>> big_endian_int_to_digits(18, bit_count=8)
+        [0, 0, 0, 1, 0, 0, 1, 0]
+
+        >>> big_endian_int_to_digits(18, bit_count=4)
+        [0, 0, 1, 0]
+
+        >>> big_endian_int_to_digits(-3, bit_count=4)
+        [1, 1, 0, 1]
+
+    Args:
+        val: The integer to get digits from. Must be non-negative and less than
+            the maximum representable value, given the specified base(s) and
+            digit count.
+        base: The base, or list of per-digit bases, to separate `val` into. When
+             a list of bases is specified, the last entry in the list is the
+             base for the last entry of the result (i.e. the least significant
+             digit). That is to say, the bases are also specified in big endian
+             order.
+        digit_count: The length of the desired result.
+
+    Returns:
+        The list of digits.
+
+    Raises:
+        ValueError:
+            Unknown digit count. The `base` was specified as an integer and a
+                `digit_count` was not provided.
+            Inconsistent digit count. The `base` was specified as a per-digit
+                list, and `digit_count` was also provided, but they disagree.
+    """
+    if isinstance(base, int):
+        if digit_count is None:
+            raise ValueError(
+                'No digit count. Provide `digit_count` when base is an int.')
+        base = (base,) * digit_count
+    elif digit_count is None:
+        digit_count = len(base)
+
+    if len(base) != digit_count:
+        raise ValueError('Inconsistent digit count. len(base) != digit_count')
+
+    result = []
+    for b in base[::-1]:
+        result.append(val % b)
+        val //= b
+
+    if val:
+        raise ValueError('Out of range. '
+                         'Extracted digits {!r} but the long division process '
+                         'left behind {!r} instead of 0.'.format(result, val))
+
+    return result[::-1]

--- a/cirq/value/digits_test.py
+++ b/cirq/value/digits_test.py
@@ -1,0 +1,61 @@
+import pytest
+
+import cirq
+
+
+def test_big_endian_bits_to_int():
+    assert cirq.big_endian_bits_to_int([0, 1]) == 1
+    assert cirq.big_endian_bits_to_int([1, 0]) == 2
+    assert cirq.big_endian_bits_to_int([0, 1, 0]) == 2
+    assert cirq.big_endian_bits_to_int([1, 0, 0, 1, 0]) == 18
+
+    assert cirq.big_endian_bits_to_int([]) == 0
+    assert cirq.big_endian_bits_to_int([0]) == 0
+    assert cirq.big_endian_bits_to_int([0, 0]) == 0
+    assert cirq.big_endian_bits_to_int([0, 0, 0]) == 0
+
+    assert cirq.big_endian_bits_to_int([1]) == 1
+    assert cirq.big_endian_bits_to_int([0, 1]) == 1
+    assert cirq.big_endian_bits_to_int([0, 0, 1]) == 1
+
+
+def test_big_endian_digits_to_int():
+    with pytest.raises(ValueError, match=r'len\(base\)'):
+        _ = cirq.big_endian_digits_to_int([1, 2, 3], base=[2, 3, 5, 7])
+    with pytest.raises(ValueError, match='Out of range'):
+        _ = cirq.big_endian_digits_to_int([105, 106, 107], base=4)
+
+    assert cirq.big_endian_digits_to_int([0, 1], base=102) == 1
+    assert cirq.big_endian_digits_to_int([1, 0], base=102) == 102
+    assert cirq.big_endian_digits_to_int([1, 0], base=[5, 7]) == 7
+    assert cirq.big_endian_digits_to_int([0, 1], base=[5, 7]) == 1
+    assert cirq.big_endian_digits_to_int([1, 2, 3, 4], base=[2, 3, 5, 7]) == 200
+    assert cirq.big_endian_digits_to_int([1, 2, 3, 4], base=10) == 1234
+
+
+def test_big_endian_int_to_bits():
+    assert cirq.big_endian_int_to_bits(2, bit_count=4) == [0, 0, 1, 0]
+    assert cirq.big_endian_int_to_bits(18,
+                                       bit_count=8) == [0, 0, 0, 1, 0, 0, 1, 0]
+    assert cirq.big_endian_int_to_bits(18, bit_count=4) == [0, 0, 1, 0]
+    assert cirq.big_endian_int_to_bits(-3, bit_count=4) == [1, 1, 0, 1]
+
+
+def test_big_endian_int_to_digits():
+    with pytest.raises(ValueError, match='Inconsistent digit count'):
+        _ = cirq.big_endian_int_to_digits(0, base=[], digit_count=1)
+    with pytest.raises(ValueError, match='Inconsistent digit count'):
+        _ = cirq.big_endian_int_to_digits(0, base=[2, 3], digit_count=20)
+    with pytest.raises(ValueError, match='Out of range'):
+        assert cirq.big_endian_int_to_digits(101, base=[], digit_count=0) == []
+    with pytest.raises(ValueError, match='Out of range'):
+        _ = cirq.big_endian_int_to_digits(10**100, base=[2, 3, 4, 5, 6])
+
+    assert cirq.big_endian_int_to_digits(0, base=[], digit_count=0) == []
+    assert cirq.big_endian_int_to_digits(0, base=[]) == []
+    assert cirq.big_endian_int_to_digits(11, base=3,
+                                         digit_count=4) == [0, 1, 0, 2]
+    assert cirq.big_endian_int_to_digits(11, base=[3, 3, 3, 3],
+                                         digit_count=4) == [0, 1, 0, 2]
+    assert cirq.big_endian_int_to_digits(11, base=[2, 3, 4],
+                                         digit_count=3) == [0, 2, 3]

--- a/cirq/value/digits_test.py
+++ b/cirq/value/digits_test.py
@@ -32,6 +32,11 @@ def test_big_endian_digits_to_int():
     assert cirq.big_endian_digits_to_int([1, 2, 3, 4], base=[2, 3, 5, 7]) == 200
     assert cirq.big_endian_digits_to_int([1, 2, 3, 4], base=10) == 1234
 
+    # Use-once digit and base iterators.
+    assert cirq.big_endian_digits_to_int((e for e in [1, 2, 3, 4]),
+                                         base=(e for e in [2, 3, 5, 7])
+                                         ) == 200
+
 
 def test_big_endian_int_to_bits():
     assert cirq.big_endian_int_to_bits(2, bit_count=4) == [0, 0, 1, 0]
@@ -42,6 +47,8 @@ def test_big_endian_int_to_bits():
 
 
 def test_big_endian_int_to_digits():
+    with pytest.raises(ValueError, match='No digit count'):
+        _ = cirq.big_endian_int_to_digits(0, base=10)
     with pytest.raises(ValueError, match='Inconsistent digit count'):
         _ = cirq.big_endian_int_to_digits(0, base=[], digit_count=1)
     with pytest.raises(ValueError, match='Inconsistent digit count'):
@@ -59,3 +66,9 @@ def test_big_endian_int_to_digits():
                                          digit_count=4) == [0, 1, 0, 2]
     assert cirq.big_endian_int_to_digits(11, base=[2, 3, 4],
                                          digit_count=3) == [0, 2, 3]
+
+    # Use-once base iterators.
+    assert cirq.big_endian_int_to_digits(11, base=(e for e in [2, 3, 4]),
+                                         digit_count=3) == [0, 2, 3]
+    assert cirq.big_endian_int_to_digits(11, base=(e for e in [2, 3, 4])
+                                         ) == [0, 2, 3]

--- a/cirq/value/digits_test.py
+++ b/cirq/value/digits_test.py
@@ -34,8 +34,7 @@ def test_big_endian_digits_to_int():
 
     # Use-once digit and base iterators.
     assert cirq.big_endian_digits_to_int((e for e in [1, 2, 3, 4]),
-                                         base=(e for e in [2, 3, 5, 7])
-                                         ) == 200
+                                         base=(e for e in [2, 3, 5, 7])) == 200
 
 
 def test_big_endian_int_to_bits():
@@ -68,7 +67,8 @@ def test_big_endian_int_to_digits():
                                          digit_count=3) == [0, 2, 3]
 
     # Use-once base iterators.
-    assert cirq.big_endian_int_to_digits(11, base=(e for e in [2, 3, 4]),
+    assert cirq.big_endian_int_to_digits(11,
+                                         base=(e for e in [2, 3, 4]),
                                          digit_count=3) == [0, 2, 3]
-    assert cirq.big_endian_int_to_digits(11, base=(e for e in [2, 3, 4])
-                                         ) == [0, 2, 3]
+    assert cirq.big_endian_int_to_digits(
+        11, base=(e for e in [2, 3, 4])) == [0, 2, 3]


### PR DESCRIPTION
- Lazily compute the dataframe when it is needed
- Flatten bits into ints, instead of a series