### PR TITLE
Add --actually-quiet parameter to check/pytest and use it in continuous integration runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       - pip install -r requirements.txt
       - pip install -r cirq/contrib/contrib-requirements.txt
       - pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest-and-incremental-coverage master
+    script: check/pytest-and-incremental-coverage master --actually_quiet
 
   - os: linux
     env: NAME=pytest (without contrib)
@@ -49,7 +49,7 @@ matrix:
     install:
       - pip install -r requirements.txt
       - pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest --ignore=cirq/contrib --benchmark-skip
+    script: check/pytest --ignore=cirq/contrib --benchmark-skip --actually_quiet
 
   - os: linux
     env: NAME=performance tests
@@ -59,7 +59,7 @@ matrix:
       - pip install -r cirq/contrib/contrib-requirements.txt
       - pip install -r dev_tools/conf/pip-list-dev-tools.txt
     script: check/performance
-     
+
   - os: windows
     env: NAME=pytest (Windows)
     language: sh
@@ -75,5 +75,4 @@ matrix:
     - python -m pip install -r requirements.txt
     - python -m pip install -r cirq/contrib/contrib-requirements.txt
     - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest --benchmark-skip
-    
+    script: check/pytest --benchmark-skip --actually_quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       - pip install -r requirements.txt
       - pip install -r cirq/contrib/contrib-requirements.txt
       - pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest-and-incremental-coverage master --actually_quiet
+    script: check/pytest-and-incremental-coverage master --actually-quiet
 
   - os: linux
     env: NAME=pytest (without contrib)
@@ -49,7 +49,7 @@ matrix:
     install:
       - pip install -r requirements.txt
       - pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest --ignore=cirq/contrib --benchmark-skip --actually_quiet
+    script: check/pytest --ignore=cirq/contrib --benchmark-skip --actually-quiet
 
   - os: windows
     env: NAME=pytest (Windows)
@@ -66,7 +66,7 @@ matrix:
     - python -m pip install -r requirements.txt
     - python -m pip install -r cirq/contrib/contrib-requirements.txt
     - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest --benchmark-skip --actually_quiet
+    script: check/pytest --benchmark-skip --actually-quiet
 
   - os: linux
     env: NAME=doctest

--- a/check/pytest
+++ b/check/pytest
@@ -4,9 +4,11 @@
 # Runs pytest on the repository.
 #
 # Usage:
-#     check/pytest [--flags] [file-paths-relative-to-repo-root]
+#     check/pytest [--actually_quiet] [--flags for pytest] [file-paths-relative-to-repo-root]
 #
-# You may specify additional flags or specific files to test. The file paths
+# The --actually_quiet argument filters out any progress output from pytest.
+#
+# You may specify pytest flags and specific files to test. The file paths
 # must be relative to the repository root. If no files are specified, everything
 # is tested.
 ################################################################################
@@ -15,4 +17,20 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-pytest $@
+PYTEST_ARGS=()
+ACTUALLY_QUIET=""
+for arg in $@; do
+    if [[ "${arg}" == "--actually_quiet" ]]; then
+        ACTUALLY_QUIET=1
+    else
+        PYTEST_ARGS+=("${arg}")
+    fi
+done
+
+if [ -z "${ACTUALLY_QUIET}" ]; then
+    pytest "${PYTEST_ARGS[@]}"
+else
+    # Filter out lines like "...F....x...      [ 42%]", with coloring.
+    pytest -q --color=yes "${PYTEST_ARGS[@]}" |
+        grep -Pv '^(.\[0m)?[\.FEsx]+(.\[36m)?\s+\[\s*\d+%\](.\[0m)?$'
+fi

--- a/check/pytest
+++ b/check/pytest
@@ -4,9 +4,9 @@
 # Runs pytest on the repository.
 #
 # Usage:
-#     check/pytest [--actually_quiet] [--flags for pytest] [file-paths-relative-to-repo-root]
+#     check/pytest [--actually-quiet] [--flags for pytest] [file-paths-relative-to-repo-root]
 #
-# The --actually_quiet argument filters out any progress output from pytest.
+# The --actually-quiet argument filters out any progress output from pytest.
 #
 # You may specify pytest flags and specific files to test. The file paths
 # must be relative to the repository root. If no files are specified, everything
@@ -20,7 +20,7 @@ cd "$(git rev-parse --show-toplevel)"
 PYTEST_ARGS=()
 ACTUALLY_QUIET=""
 for arg in $@; do
-    if [[ "${arg}" == "--actually_quiet" ]]; then
+    if [[ "${arg}" == "--actually-quiet" ]]; then
         ACTUALLY_QUIET=1
     else
         PYTEST_ARGS+=("${arg}")

--- a/dev_tools/check_pytest_with_coverage.py
+++ b/dev_tools/check_pytest_with_coverage.py
@@ -39,11 +39,12 @@ class TestAndPrepareCoverageCheck(check.Check):
                                'dev_tools',
                                'conf',
                                '.coveragerc')
+        pytest_path = os.path.join(base_path, 'check', 'pytest')
         target_path = base_path
         result = shell_tools.run_cmd(
-            env.bin('pytest'),
+            pytest_path,
             target_path,
-            None if verbose else '--quiet',
+            None if verbose else '--actually_quiet',
             *([
                 '--cov', '--cov-report=annotate',
                 '--cov-config={}'.format(rc_path), '--benchmark-skip'

--- a/dev_tools/check_pytest_with_coverage.py
+++ b/dev_tools/check_pytest_with_coverage.py
@@ -44,7 +44,7 @@ class TestAndPrepareCoverageCheck(check.Check):
         result = shell_tools.run_cmd(
             pytest_path,
             target_path,
-            None if verbose else '--actually_quiet',
+            None if verbose else '--actually-quiet',
             *([
                 '--cov', '--cov-report=annotate',
                 '--cov-config={}'.format(rc_path), '--benchmark-skip'


### PR DESCRIPTION
- This fixes an annoyance where error output is hidden waaaay down at the bottom of travis-ci logs