### PR TITLE
[Qudits] Add support to cirq.channel, cirq.apply_channel, and cirq.mixture

### DIFF
--- a/cirq/protocols/apply_channel.py
+++ b/cirq/protocols/apply_channel.py
@@ -20,8 +20,8 @@ import numpy as np
 from typing_extensions import Protocol
 
 from cirq import linalg
-from cirq.protocols.apply_unitary import (
-    apply_unitary, ApplyUnitaryArgs, _incorporate_result_into_buffer)
+from cirq.protocols.apply_unitary import (apply_unitary, ApplyUnitaryArgs,
+                                          _incorporate_result_into_buffer)
 from cirq.protocols.channel import channel
 from cirq.protocols import qid_shape_protocol
 from cirq.type_workarounds import NotImplementedType
@@ -193,18 +193,19 @@ class ApplyChannelArgs:
         ordered_axes = (*other_axes, *sub_left_axes, *sub_right_axes)
         # Transpose sub_left_axes+sub_right_axes to the end of the shape and
         # slice them.
-        target_tensor = self.target_tensor.transpose(*ordered_axes)[(
-            ..., *slices, *slices)]
-        out_buffer = self.out_buffer.transpose(*ordered_axes)[(
-            ..., *slices, *slices)]
-        aux0 = self.auxiliary_buffer0.transpose(*ordered_axes)[(
-            ..., *slices, *slices)]
-        aux1 = self.auxiliary_buffer1.transpose(*ordered_axes)[(
-            ..., *slices, *slices)]
+        target_tensor = self.target_tensor.transpose(*ordered_axes)[(...,
+                                                                     *slices,
+                                                                     *slices)]
+        out_buffer = self.out_buffer.transpose(*ordered_axes)[(..., *slices,
+                                                               *slices)]
+        aux0 = self.auxiliary_buffer0.transpose(*ordered_axes)[(..., *slices,
+                                                                *slices)]
+        aux1 = self.auxiliary_buffer1.transpose(*ordered_axes)[(..., *slices,
+                                                                *slices)]
         new_left_axes = range(len(other_axes),
-                              len(other_axes)+len(sub_left_axes))
-        new_right_axes = range(len(other_axes)+len(sub_left_axes),
-                               len(ordered_axes))
+                              len(other_axes) + len(sub_left_axes))
+        new_right_axes = range(
+            len(other_axes) + len(sub_left_axes), len(ordered_axes))
         return ApplyChannelArgs(target_tensor, out_buffer, aux0, aux1,
                                 new_left_axes, new_right_axes)
 
@@ -326,25 +327,24 @@ def apply_channel(val: Any,
             "NotImplemented).".format(type(val)))
 
 
-def _strat_apply_channel_from_apply_channel(val: Any,
-                                            args: ApplyChannelArgs
+def _strat_apply_channel_from_apply_channel(val: Any, args: ApplyChannelArgs
                                            ) -> Optional[np.ndarray]:
     func = getattr(val, '_apply_channel_', None)
     if func is None:
         return NotImplemented
-    op_qid_shape = qid_shape_protocol.qid_shape(val,
-                                                (2,) * len(args.left_axes))
+    op_qid_shape = qid_shape_protocol.qid_shape(val, (2,) * len(args.left_axes))
     sub_args = args._for_channel_with_qid_shape(range(len(op_qid_shape)),
                                                 op_qid_shape)
     sub_result = func(sub_args)
     if sub_result is NotImplemented or sub_result is None:
         return sub_result
+
     def err_str(buf_num_str):
-        return (
-            "Object of type '{}' returned a result object equal to "
-            "auxiliary_buffer{}. This type violates the contract "
-            "that appears in apply_channel's documentation.".format(
-                type(val), buf_num_str))
+        return ("Object of type '{}' returned a result object equal to "
+                "auxiliary_buffer{}. This type violates the contract "
+                "that appears in apply_channel's documentation.".format(
+                    type(val), buf_num_str))
+
     assert sub_result is not sub_args.auxiliary_buffer0, err_str('0')
     assert sub_result is not sub_args.auxiliary_buffer1, err_str('1')
     return _incorporate_result_into_target(args, sub_args, sub_result)
@@ -453,8 +453,6 @@ def _incorporate_result_into_target(args: 'ApplyChannelArgs',
     Returns: The full result tensor after applying the channel.  Either
         `args.target_tensor` or `args.out_buffer`.
     """
-    return _incorporate_result_into_buffer(args.target_tensor,
-                                           args.out_buffer,
+    return _incorporate_result_into_buffer(args.target_tensor, args.out_buffer,
                                            sub_args.target_tensor,
-                                           sub_args.out_buffer,
-                                           sub_result)
+                                           sub_args.out_buffer, sub_result)

--- a/cirq/protocols/apply_channel_test.py
+++ b/cirq/protocols/apply_channel_test.py
@@ -95,20 +95,21 @@ def test_apply_channel_inline():
 
 
 def test_apply_channel_not_implemented():
+
     class NotImplementedChannel():
 
         def _apply_channel_(self, args: cirq.ApplyChannelArgs):
             return NotImplemented
 
-    result = cirq.apply_channel(
-            NotImplementedChannel(),
-            args=cirq.ApplyChannelArgs(target_tensor=np.zeros(()),
-                                       left_axes=[],
-                                       right_axes=[],
-                                       out_buffer=np.zeros(()),
-                                       auxiliary_buffer0=np.zeros(()),
-                                       auxiliary_buffer1=np.zeros(())),
-            default=None)
+    result = cirq.apply_channel(NotImplementedChannel(),
+                                args=cirq.ApplyChannelArgs(
+                                    target_tensor=np.zeros(()),
+                                    left_axes=[],
+                                    right_axes=[],
+                                    out_buffer=np.zeros(()),
+                                    auxiliary_buffer0=np.zeros(()),
+                                    auxiliary_buffer1=np.zeros(())),
+                                default=None)
     assert result is None
 
 
@@ -330,4 +331,3 @@ def test_assign_args_properties():
         args.auxiliary_buffer0 = np.zeros(())
     with pytest.raises(AttributeError, match="can't set attribute"):
         args.auxiliary_buffer1 = np.zeros(())
-

--- a/cirq/protocols/apply_channel_test.py
+++ b/cirq/protocols/apply_channel_test.py
@@ -94,6 +94,24 @@ def test_apply_channel_inline():
     np.testing.assert_almost_equal(result, x)
 
 
+def test_apply_channel_not_implemented():
+    class NotImplementedChannel():
+
+        def _apply_channel_(self, args: cirq.ApplyChannelArgs):
+            return NotImplemented
+
+    result = cirq.apply_channel(
+            NotImplementedChannel(),
+            args=cirq.ApplyChannelArgs(target_tensor=np.zeros(()),
+                                       left_axes=[],
+                                       right_axes=[],
+                                       out_buffer=np.zeros(()),
+                                       auxiliary_buffer0=np.zeros(()),
+                                       auxiliary_buffer1=np.zeros(())),
+            default=None)
+    assert result is None
+
+
 def test_apply_channel_returns_aux_buffer():
     rho = np.array([[1, 0], [0, 0]], dtype=np.complex128)
 
@@ -299,3 +317,17 @@ def test_apply_channel_apply_unitary_not_implemented():
                                            out_buffer=out_buf,
                                            auxiliary_buffer0=aux_buf0,
                                            auxiliary_buffer1=aux_buf1))
+
+
+def test_assign_args_properties():
+    args = cirq.ApplyChannelArgs(np.zeros(()), np.zeros(()), np.zeros(()),
+                                 np.zeros(()), [], [])
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        args.target_tensor = np.zeros(())
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        args.out_buffer = np.zeros(())
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        args.auxiliary_buffer0 = np.zeros(())
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        args.auxiliary_buffer1 = np.zeros(())
+

--- a/cirq/protocols/apply_channel_test.py
+++ b/cirq/protocols/apply_channel_test.py
@@ -85,7 +85,7 @@ def test_apply_channel_inline():
     class HasApplyChannel():
 
         def _apply_channel_(self, args: cirq.ApplyChannelArgs):
-            args.target_tensor = 0.5 * args.target_tensor + 0.5 * np.dot(
+            args.target_tensor[...] = 0.5 * args.target_tensor + 0.5 * np.dot(
                 np.dot(x, args.target_tensor), x)
             return args.target_tensor
 

--- a/cirq/protocols/apply_unitary.py
+++ b/cirq/protocols/apply_unitary.py
@@ -537,8 +537,7 @@ def _incorporate_result_into_target(args: 'ApplyUnitaryArgs',
                                            sub_result)
 
 
-def _incorporate_result_into_buffer(target: np.ndarray,
-                                    other: np.ndarray,
+def _incorporate_result_into_buffer(target: np.ndarray, other: np.ndarray,
                                     sub_target: np.ndarray,
                                     sub_other: np.ndarray,
                                     sub_result: np.ndarray) -> np.ndarray:

--- a/cirq/protocols/apply_unitary_test.py
+++ b/cirq/protocols/apply_unitary_test.py
@@ -459,3 +459,11 @@ def test_incorporate_result_not_view():
 def test_default_method_arguments():
     with pytest.raises(TypeError, match='exactly one of'):
         cirq.ApplyUnitaryArgs.default(1, qid_shape=(2,))
+
+
+def test_assign_args_properties():
+    args = cirq.ApplyUnitaryArgs(np.zeros(()), np.zeros(()), [])
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        args.target_tensor = np.zeros(())
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        args.available_buffer = np.zeros(())

--- a/cirq/protocols/channel.py
+++ b/cirq/protocols/channel.py
@@ -108,7 +108,7 @@ def channel(val: Any,
     Returns:
         If `val` has a `_channel_` method and its result is not NotImplemented,
         that result is returned. Otherwise, if `val` has a `_mixture_` method
-        and its results is not NotImplement a tuple made up of channel
+        and its results is not NotImplemented a tuple made up of channels
         corresponding to that mixture being a probabilistic mixture of unitaries
         is returned.  Otherwise, if `val` has a `_unitary_` method and
         its result is not NotImplemented a tuple made up of that result is


### PR DESCRIPTION
For #933. Part 3 after #1771.

- `cirq.apply_channel` checks for the `qid_shape` protocol and use properly sized numpy arrays.
- `cirq.channel` and `cirq.mixture` should just work.

Qudit features not in this PR are simulators, measurements, optimizers.