### PR TITLE
Optimize recombination step in paulistring optimizer

### DIFF
--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -80,10 +80,10 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
     while rightmost_nodes:
         # Pick the Pauli string that can be moved furthest through the Clifford
         # circuit
-        frontier = _sorted_best_string_placements(rightmost_nodes, output_ops)
+        placements = _sorted_best_string_placements(rightmost_nodes, output_ops)
         last_index = len(output_ops)
-        while frontier:
-            best_string_op, best_index, best_node = frontier.pop()
+        while placements:
+            best_string_op, best_index, best_node = placements.pop()
             # Place the best one into the output circuit
             assert best_index <= last_index, "{} >= {}, len: {}".format(
                 best_index, last_index, len(output_ops))

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (Any, Callable, Iterable, Iterator, Sequence, Tuple, Union,
+from typing import (Any, Callable, Iterable, Sequence, Tuple, Union,
                     cast, List)
 
 from cirq import ops, circuits

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (Any, Callable, Iterable, Sequence, Tuple, Union,
-                    cast, List)
+from typing import (Any, Callable, Iterable, Sequence, Tuple, Union, cast, List)
 
 from cirq import ops, circuits
 
@@ -85,8 +84,10 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
         while placements:
             best_string_op, best_index, best_node = placements.pop()
             # Place the best one into the output circuit
-            assert best_index <= last_index, "{} >= {}, len: {}".format(
-                best_index, last_index, len(output_ops))
+            assert (best_index <= last_index,
+                    "Unexpected insertion index order,"
+                    " {} >= {}, len: {}".format(best_index, last_index,
+                                                len(output_ops)))
 
             last_index = best_index
             output_ops.insert(best_index, best_string_op)

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -77,13 +77,15 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
                        - set(before for before, _ in string_dag.edges()))
 
     while rightmost_nodes:
-        # Pick the Pauli string that can be moved furthest through the Clifford
-        # circuit
+        # Sort the pauli string placements based on paulistring length and
+        # furthest possible distance in circuit_right
         placements = _sorted_best_string_placements(rightmost_nodes, output_ops)
         last_index = len(output_ops)
         while placements:
+            # Pick the Pauli string that can be moved furthest through
+            # the Clifford circuit
             best_string_op, best_index, best_node = placements.pop()
-            # Place the best one into the output circuit
+
             assert (best_index <= last_index,
                     "Unexpected insertion index order,"
                     " {} >= {}, len: {}".format(best_index, last_index,

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -86,10 +86,10 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
             # the Clifford circuit
             best_string_op, best_index, best_node = placements.pop()
 
-            assert (best_index <= last_index,
-                    "Unexpected insertion index order,"
-                    " {} >= {}, len: {}".format(best_index, last_index,
-                                                len(output_ops)))
+            assert best_index <= last_index, (
+                "Unexpected insertion index order,"
+                " {} >= {}, len: {}".format(best_index, last_index,
+                                            len(output_ops)))
 
             last_index = best_index
             output_ops.insert(best_index, best_string_op)

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -58,7 +58,7 @@ def _sorted_best_string_placements(
 
         node_maxes.append(node_max)
 
-    return sorted(node_maxes, key=sort_key)
+    return sorted(node_maxes, key=sort_key, reverse=True)
 
 
 def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
@@ -81,10 +81,10 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
         # furthest possible distance in circuit_right
         placements = _sorted_best_string_placements(rightmost_nodes, output_ops)
         last_index = len(output_ops)
-        while placements:
-            # Pick the Pauli string that can be moved furthest through
-            # the Clifford circuit
-            best_string_op, best_index, best_node = placements.pop()
+
+        # Pick the Pauli string that can be moved furthest through
+        # the Clifford circuit
+        for best_string_op, best_index, best_node in placements:
 
             assert best_index <= last_index, (
                 "Unexpected insertion index order,"

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (
-    Any, Callable, Iterable, Iterator, Sequence, Tuple, Union, cast
-)
+from typing import (Any, Callable, Iterable, Iterator, Sequence, Tuple, Union,
+                    cast, List)
 
 from cirq import ops, circuits
 
@@ -23,16 +22,20 @@ from cirq.contrib.paulistring.pauli_string_dag import (
     pauli_string_dag_from_circuit)
 
 
-def _possible_string_placements(
+def _sorted_best_string_placements(
         possible_nodes: Iterable[Any],
         output_ops: Sequence[ops.Operation],
         key: Callable[[Any], ops.PauliStringPhasor] = lambda node: node.val,
-) -> Iterator[Tuple[ops.PauliStringPhasor, int, circuits.
-                    Unique[ops.PauliStringPhasor]]]:
+) -> List[Tuple[ops.PauliStringPhasor, int, circuits.
+                Unique[ops.PauliStringPhasor]]]:
+
+    sort_key = lambda placement: (-len(placement[0].pauli_string), placement[1])
+
+    node_maxes = []
     for possible_node in possible_nodes:
         string_op = key(possible_node)
         # Try moving the Pauli string through, stop at measurements
-        yield string_op, 0, possible_node
+        node_max = (string_op, 0, possible_node)
 
         for i, out_op in enumerate(output_ops):
             if not set(out_op.qubits) & set(string_op.qubits):
@@ -50,13 +53,13 @@ def _possible_string_placements(
                 break
             string_op = string_op.pass_operations_over([out_op],
                                                        after_to_before=True)
-            yield string_op, i+1, possible_node
+            curr = (string_op, i + 1, possible_node)
+            if sort_key(curr) > sort_key(node_max):
+                node_max = curr
 
-        if len(string_op.pauli_string) == 1:
-            # This is as far as any Pauli string can go on this qubit
-            # and this Pauli string can be moved here.
-            # Stop searching to save time.
-            return
+        node_maxes.append(node_max)
+
+    return sorted(node_maxes, key=sort_key)
 
 
 def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
@@ -77,20 +80,22 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
     while rightmost_nodes:
         # Pick the Pauli string that can be moved furthest through the Clifford
         # circuit
-        best_string_op, best_index, best_node = max(
-            _possible_string_placements(rightmost_nodes, output_ops),
-            key=lambda placement: (-len(placement[0].pauli_string),
-                                   placement[1]))
+        frontier = _sorted_best_string_placements(rightmost_nodes, output_ops)
+        last_index = len(output_ops)
+        while frontier:
+            best_string_op, best_index, best_node = frontier.pop()
+            # Place the best one into the output circuit
+            assert best_index <= last_index, "{} >= {}, len: {}".format(
+                best_index, last_index, len(output_ops))
 
-        # Place the best one into the output circuit
-        output_ops.insert(best_index, best_string_op)
-        # Remove the best one from the dag and update rightmost_nodes
-        rightmost_nodes.remove(best_node)
-        rightmost_nodes.update(
-            pred_node
-            for pred_node in string_dag.predecessors(best_node)
-            if len(string_dag.succ[pred_node]) <= 1)
-        string_dag.remove_node(best_node)
+            last_index = best_index
+            output_ops.insert(best_index, best_string_op)
+            # Remove the best one from the dag and update rightmost_nodes
+            rightmost_nodes.remove(best_node)
+            rightmost_nodes.update(
+                pred_node for pred_node in string_dag.predecessors(best_node)
+                if len(string_dag.succ[pred_node]) <= 1)
+            string_dag.remove_node(best_node)
 
     assert not string_dag.nodes(), 'There was a cycle in the CircuitDag'
 


### PR DESCRIPTION
Before optimization: 

```bash
2019-07-16 09:16:20,584 - INFO - reading qasm file...
2019-07-16 09:16:25,140 - INFO - parsed qasm file: 13392 ops
2019-07-16 09:18:24,564 - INFO - optimized circuit: 1854 ops in 119.42398381233215 
2019-07-16 09:18:24,654 - INFO - stats: misses 74115, dupes: 6505723
```
which means that 98.87% of comparisons has been done at least twice.

Insight: we can  just sort the nodes of the frontier _once_, based on the best placement possible for a given paulistring instead of repeatedly reevaluating them. Why? 

1.) because the nodes of the frontier (rightmost nodes in the DAG) are commuting with each other, so they can be sorted independently of each other and each other's predecessors in the DAG and we can insert all the nodes in the frontier first.
2.)  sorting the nodes seems to guarantee the insertion indices to be sorted _as well_ , which is great, because then we don't have to worry about recalculating the best insertion spot for a node (as a previous insertion might have changed the circuit?) as I start with the furthest one, that leaves the circuit the same before, where the next node can come in...- why does sorting guarantee the insertion indices to be sorted? Because the best placements are where the paulistrings become of length one - and within those placements the insertion index is sorted. 

Thus, we can just insert the nodes in the sorted frontier to their best placements and only then draw the new frontier. 

This gives us: 

```bash
2019-07-16 10:00:49,046 - INFO - reading qasm file...
2019-07-16 10:00:53,691 - INFO - parsed qasm file: 13392 ops
2019-07-16 10:01:46,964 - INFO - optimized circuit: 1854 ops in 53.273059129714966 
2019-07-16 10:01:47,044 - INFO - stats: misses 843915, dupes: 31864
```

which is 3% duplication and >50% time reduction. 
