### PR TITLE
Allow cirq.* in docstring code snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,4 +74,4 @@ matrix:
     install:
       - pip install -r requirements.txt
       - pip install -r cirq/contrib/contrib-requirements.txt
-    script: check/doctest
+    script: check/doctest -q

--- a/check/doctest
+++ b/check/doctest
@@ -8,6 +8,9 @@
 #
 # Usage:
 #     check/doctest [-q]
+#
+# The -q argument suppresses all output except the final result line and any
+# error messages.
 ################################################################################
 
 # Get the working directory to the repo root.

--- a/check/doctest
+++ b/check/doctest
@@ -14,4 +14,4 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-python dev_tools/run_doctest.py
+python dev_tools/run_doctest.py -q

--- a/check/doctest
+++ b/check/doctest
@@ -14,4 +14,4 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-find cirq -type f -iname '*.py' | xargs python -m doctest
+python dev_tools/run_doctest.py

--- a/check/doctest
+++ b/check/doctest
@@ -7,11 +7,11 @@
 #     https://docs.python.org/3/library/doctest.html
 #
 # Usage:
-#     check/doctest
+#     check/doctest [-q]
 ################################################################################
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-python dev_tools/run_doctest.py -q
+python dev_tools/run_doctest.py $@

--- a/check/doctest
+++ b/check/doctest
@@ -14,4 +14,4 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-python dev_tools/run_doctest.py $@
+PYTHONPATH="$(pwd)" python dev_tools/run_doctest.py $@

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -27,10 +27,10 @@ class GridQubit(ops.Qid):
 
     New GridQubits can be constructed by adding or subtracting tuples
 
-        >>> GridQubit(2, 3) + (3, 1)
+        >>> cirq.GridQubit(2, 3) + (3, 1)
         cirq.GridQubit(5, 4)
 
-        >>> GridQubit(2, 3) - (1, 2)
+        >>> cirq.GridQubit(2, 3) - (1, 2)
         cirq.GridQubit(1, 1)
     """
 

--- a/cirq/line/line_qubit.py
+++ b/cirq/line/line_qubit.py
@@ -27,10 +27,10 @@ class LineQubit(ops.Qid):
 
     One can construct new LineQubits by adding or subtracting integers:
 
-        >>> LineQubit(1) + 3
+        >>> cirq.LineQubit(1) + 3
         cirq.LineQubit(4)
 
-        >>> LineQubit(2) - 1
+        >>> cirq.LineQubit(2) - 1
         cirq.LineQubit(1)
     """
 

--- a/cirq/value/digits.py
+++ b/cirq/value/digits.py
@@ -6,16 +6,16 @@ def big_endian_bits_to_int(bits: Iterable[Any]) -> int:
 
     Examples:
 
-        >>> big_endian_bits_to_int([0, 1])
+        >>> cirq.big_endian_bits_to_int([0, 1])
         1
 
-        >>> big_endian_bits_to_int([1, 0])
+        >>> cirq.big_endian_bits_to_int([1, 0])
         2
 
-        >>> big_endian_bits_to_int([0, 1, 0])
+        >>> cirq.big_endian_bits_to_int([0, 1, 0])
         2
 
-        >>> big_endian_bits_to_int([1, 0, 0, 1, 0])
+        >>> cirq.big_endian_bits_to_int([1, 0, 0, 1, 0])
         18
 
     Args:
@@ -36,13 +36,13 @@ def big_endian_int_to_bits(val: int, *, bit_count: int) -> List[int]:
     """Returns the big-endian bits of an integer.
 
     Examples:
-        >>> big_endian_int_to_bits(19, bit_count=8)
+        >>> cirq.big_endian_int_to_bits(19, bit_count=8)
         [0, 0, 0, 1, 0, 0, 1, 1]
 
-        >>> big_endian_int_to_bits(19, bit_count=4)
+        >>> cirq.big_endian_int_to_bits(19, bit_count=4)
         [0, 0, 1, 1]
 
-        >>> big_endian_int_to_bits(-3, bit_count=4)
+        >>> cirq.big_endian_int_to_bits(-3, bit_count=4)
         [1, 1, 0, 1]
 
     Args:
@@ -64,13 +64,13 @@ def big_endian_digits_to_int(digits: Iterable[int], *,
 
     Examples:
 
-        >>> big_endian_digits_to_int([0, 1], base=10)
+        >>> cirq.big_endian_digits_to_int([0, 1], base=10)
         1
 
-        >>> big_endian_digits_to_int([1, 0], base=10)
+        >>> cirq.big_endian_digits_to_int([1, 0], base=10)
         10
 
-        >>> big_endian_digits_to_int([1, 2, 3], base=[2, 3, 4])
+        >>> cirq.big_endian_digits_to_int([1, 2, 3], base=[2, 3, 4])
         23
 
     Args:
@@ -125,10 +125,10 @@ def big_endian_int_to_digits(val: int,
     """Separates an integer into big-endian digits.
 
     Examples:
-        >>> big_endian_int_to_digits(11, digit_count=4, base=10)
+        >>> cirq.big_endian_int_to_digits(11, digit_count=4, base=10)
         [0, 0, 1, 1]
 
-        >>> big_endian_int_to_digits(11, base=[2, 3, 4])
+        >>> cirq.big_endian_int_to_digits(11, base=[2, 3, 4])
         [0, 2, 3]
 
     Args:

--- a/dev_tools/output_capture.py
+++ b/dev_tools/output_capture.py
@@ -18,6 +18,7 @@ import io
 
 class OutputCapture:
     """A context manager that captures stdout and stderr."""
+
     def __init__(self):
         self.buffer = io.StringIO()
         self._cache = None

--- a/dev_tools/output_capture.py
+++ b/dev_tools/output_capture.py
@@ -1,0 +1,34 @@
+# Copyright 2019 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import io
+
+
+class OutputCapture:
+    """A context manager that captures stdout and stderr."""
+    def __init__(self):
+        self.buffer = io.StringIO()
+        self._cache = None
+
+    def __enter__(self):
+        self._cache = sys.stdout, sys.stderr
+        sys.stdout, sys.stderr = self.buffer, self.buffer
+        return None
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        sys.stdout, sys.stderr = self._cache
+
+    def content(self) -> str:
+        return self.buffer.getvalue()

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -25,12 +25,12 @@ import doctest
 from dev_tools import shell_tools
 from dev_tools.output_capture import OutputCapture
 
-
 # Bug workaround: https://github.com/python/mypy/issues/1498
 ModuleType = Any
 
 
 class Doctest:
+
     def __init__(self, file_name: str, mod: ModuleType,
                  test_globals: Dict[str, Any]):
         self.file_name = file_name
@@ -38,11 +38,14 @@ class Doctest:
         self.test_globals = test_globals
 
     def run(self) -> doctest.TestResults:
-        return doctest.testmod(self.mod, globs=self.test_globals, report=False,
+        return doctest.testmod(self.mod,
+                               globs=self.test_globals,
+                               report=False,
                                verbose=False)
 
 
-def run_tests(file_paths: Iterable[str], include_cirq: bool = True,
+def run_tests(file_paths: Iterable[str],
+              include_cirq: bool = True,
               include_local: bool = True) -> doctest.TestResults:
     """Runs code snippets from docstrings found in each file.
 
@@ -56,7 +59,8 @@ def run_tests(file_paths: Iterable[str], include_cirq: bool = True,
 
     Returns: A tuple with the results: (# tests failed, # tests attempted)
     """
-    tests = load_tests(file_paths, include_cirq=include_cirq,
+    tests = load_tests(file_paths,
+                       include_cirq=include_cirq,
                        include_local=include_local)
     print()
     results, error_messages = exec_tests(tests)
@@ -65,7 +69,9 @@ def run_tests(file_paths: Iterable[str], include_cirq: bool = True,
         print(error)
     return results
 
-def load_tests(file_paths: Iterable[str], include_cirq: bool = True,
+
+def load_tests(file_paths: Iterable[str],
+               include_cirq: bool = True,
                include_local: bool = True) -> List[Doctest]:
     """Prepares tests for code snippets from docstrings found in each file.
 
@@ -86,11 +92,13 @@ def load_tests(file_paths: Iterable[str], include_cirq: bool = True,
         base_globals = {}
 
     print('Loading tests   ', end='')
+
     def make_test(file_path: str) -> Doctest:
         print('.', end='')
         mod = import_file(file_path)
         glob = make_globals(mod)
         return Doctest(file_path, mod, glob)
+
     def make_globals(mod: ModuleType) -> Dict[str, Any]:
         sys.stdout.flush()
         if include_local:
@@ -99,12 +107,14 @@ def load_tests(file_paths: Iterable[str], include_cirq: bool = True,
             return glob
         else:
             return dict(base_globals)
+
     tests = [make_test(file_path) for file_path in file_paths]
     print()
     return tests
 
-def exec_tests(tests: Iterable[Doctest]) -> Tuple[doctest.TestResults,
-                                                  List[str]]:
+
+def exec_tests(tests: Iterable[Doctest]
+              ) -> Tuple[doctest.TestResults, List[str]]:
     """Runs a list of `Doctest`s and collects and returns any error messages.
 
     Args:
@@ -127,9 +137,8 @@ def exec_tests(tests: Iterable[Doctest]) -> Tuple[doctest.TestResults,
             print('F', end='')
             error = shell_tools.highlight(
                 '{}\n{} failed, {} passed, {} total\n'.format(
-                    test.file_name, r.failed, r.attempted-r.failed,
-                    r.attempted),
-                shell_tools.RED)
+                    test.file_name, r.failed, r.attempted - r.failed,
+                    r.attempted), shell_tools.RED)
             error += out.content()
             error_messages.append(error)
         else:
@@ -137,8 +146,9 @@ def exec_tests(tests: Iterable[Doctest]) -> Tuple[doctest.TestResults,
         sys.stdout.flush()
     print()
 
-    return (doctest.TestResults(failed=failed, attempted=attempted),
-            error_messages)
+    return doctest.TestResults(failed=failed,
+                               attempted=attempted), error_messages
+
 
 def import_file(file_path: str) -> ModuleType:
     """Finds and runs a python file as if were imported with an `import`
@@ -162,20 +172,22 @@ def import_file(file_path: str) -> ModuleType:
 
 def main():
     file_names = glob.glob('cirq/**/*.py', recursive=True)
-    failed, attempted = run_tests(file_names, include_cirq=True,
+    failed, attempted = run_tests(file_names,
+                                  include_cirq=True,
                                   include_local=True)
 
     if failed != 0:
-        print(shell_tools.highlight(
-            'Failed: {} failed, {} passed, {} total'.format(
-                failed, attempted-failed, attempted),
-            shell_tools.RED))
+        print(
+            shell_tools.highlight(
+                'Failed: {} failed, {} passed, {} total'.format(
+                    failed, attempted - failed, attempted), shell_tools.RED))
         sys.exit(1)
     else:
-        print(shell_tools.highlight(
-            'Passed: {}'.format(attempted),
-            shell_tools.GREEN))
+        print(
+            shell_tools.highlight('Passed: {}'.format(attempted),
+                                  shell_tools.GREEN))
         sys.exit(0)
+
 
 if __name__ == '__main__':
     main()

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -45,13 +45,13 @@ class Doctest:
 
 
 def run_tests(file_paths: Iterable[str],
-              include_cirq: bool = True,
+              include_modules: bool = True,
               include_local: bool = True) -> doctest.TestResults:
     """Runs code snippets from docstrings found in each file.
 
     Args:
         file_paths: The list of files to test.
-        include_cirq: If True, the snippets can use `cirq` without explicitly
+        include_modules: If True, the snippets can use `cirq` without explicitly
             importing it.  E.g. `>>> cirq.LineQubit(0)`
         include_local: If True, the file under test is imported as a python
             module (only if the file extension is .py) and all globals defined
@@ -60,7 +60,7 @@ def run_tests(file_paths: Iterable[str],
     Returns: A tuple with the results: (# tests failed, # tests attempted)
     """
     tests = load_tests(file_paths,
-                       include_cirq=include_cirq,
+                       include_modules=include_modules,
                        include_local=include_local)
     print()
     results, error_messages = exec_tests(tests)
@@ -71,13 +71,13 @@ def run_tests(file_paths: Iterable[str],
 
 
 def load_tests(file_paths: Iterable[str],
-               include_cirq: bool = True,
+               include_modules: bool = True,
                include_local: bool = True) -> List[Doctest]:
     """Prepares tests for code snippets from docstrings found in each file.
 
     Args:
         file_paths: The list of files to test.
-        include_cirq: If True, the snippets can use `cirq` without explicitly
+        include_modules: If True, the snippets can use `cirq` without explicitly
             importing it.  E.g. `>>> cirq.LineQubit(0)`
         include_local: If True, the file under test is imported as a python
             module (only if the file extension is .py) and all globals defined
@@ -85,9 +85,15 @@ def load_tests(file_paths: Iterable[str],
 
     Returns: A list of `Doctest` objects.
     """
-    if include_cirq:
+    if include_modules:
         import cirq
-        base_globals = {'cirq': cirq}
+        import numpy
+        import sympy
+        import pandas
+        base_globals = {'cirq': cirq,
+                        'np': numpy,
+                        'sympy': sympy,
+                        'pd': pandas}
     else:
         base_globals = {}
 
@@ -173,8 +179,8 @@ def import_file(file_path: str) -> ModuleType:
 def main():
     file_names = glob.glob('cirq/**/*.py', recursive=True)
     failed, attempted = run_tests(file_names,
-                                  include_cirq=True,
-                                  include_local=True)
+                                  include_modules=True,
+                                  include_local=False)
 
     if failed != 0:
         print(

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, Iterable, List, Tuple
 import sys
 import os
 import glob
-import io
 import importlib.util
 import doctest
 
@@ -157,7 +156,7 @@ def import_file(file_path: str) -> ModuleType:
     spec = importlib.util.spec_from_file_location(mod_name, file_path)
     mod = importlib.util.module_from_spec(spec)
     # Run the code in the module (but not with __name__ == '__main__')
-    spec.loader.exec_module(mod)
+    spec.loader.exec_module(mod)  # type: ignore
     return mod
 
 

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Iterable, List, Tuple
+
+import sys
+import os
+import glob
+import io
+import importlib.util
+import doctest
+
+from dev_tools import shell_tools
+from dev_tools.output_capture import OutputCapture
+
+
+# Bug workaround: https://github.com/python/mypy/issues/1498
+ModuleType = Any
+
+
+class Doctest:
+    def __init__(self, file_name: str, mod: ModuleType,
+                 test_globals: Dict[str, Any]):
+        self.file_name = file_name
+        self.mod = mod
+        self.test_globals = test_globals
+
+    def run(self) -> doctest.TestResults:
+        return doctest.testmod(self.mod, globs=self.test_globals, report=False,
+                               verbose=False)
+
+
+def run_tests(file_paths: Iterable[str], include_cirq: bool = True,
+              include_local: bool = True) -> doctest.TestResults:
+    """Runs code snippets from docstrings found in each file.
+
+    Args:
+        file_paths: The list of files to test.
+        include_cirq: If True, the snippets can use `cirq` without explicitly
+            importing it.  E.g. `>>> cirq.LineQubit(0)`
+        include_local: If True, the file under test is imported as a python
+            module (only if the file extension is .py) and all globals defined
+            in the file may be used by the snippets.
+
+    Returns: A tuple with the results: (# tests failed, # tests attempted)
+    """
+    tests = load_tests(file_paths, include_cirq=include_cirq,
+                       include_local=include_local)
+    print()
+    results, error_messages = exec_tests(tests)
+    print()
+    for error in error_messages:
+        print(error)
+    return results
+
+def load_tests(file_paths: Iterable[str], include_cirq: bool = True,
+               include_local: bool = True) -> List[Doctest]:
+    """Prepares tests for code snippets from docstrings found in each file.
+
+    Args:
+        file_paths: The list of files to test.
+        include_cirq: If True, the snippets can use `cirq` without explicitly
+            importing it.  E.g. `>>> cirq.LineQubit(0)`
+        include_local: If True, the file under test is imported as a python
+            module (only if the file extension is .py) and all globals defined
+            in the file may be used by the snippets.
+
+    Returns: A list of `Doctest` objects.
+    """
+    if include_cirq:
+        import cirq
+        base_globals = {'cirq': cirq}
+    else:
+        base_globals = {}
+
+    print('Loading tests   ', end='')
+    def make_test(file_path: str) -> Doctest:
+        print('.', end='')
+        mod = import_file(file_path)
+        glob = make_globals(mod)
+        return Doctest(file_path, mod, glob)
+    def make_globals(mod: ModuleType) -> Dict[str, Any]:
+        sys.stdout.flush()
+        if include_local:
+            glob = dict(mod.__dict__)
+            glob.update(base_globals)
+            return glob
+        else:
+            return dict(base_globals)
+    tests = [make_test(file_path) for file_path in file_paths]
+    print()
+    return tests
+
+def exec_tests(tests: Iterable[Doctest]) -> Tuple[doctest.TestResults,
+                                                  List[str]]:
+    """Runs a list of `Doctest`s and collects and returns any error messages.
+
+    Args:
+        tests: The tests to run
+
+    Returns: A tuple containing the results (# failures, # attempts) and a list
+        of the error outputs from each failing test.
+    """
+    print('Executing tests ', end='')
+
+    failed, attempted = 0, 0
+    error_messages = []
+    for test in tests:
+        out = OutputCapture()
+        with out:
+            r = test.run()
+        failed += r.failed
+        attempted += r.attempted
+        if r.failed != 0:
+            print('F', end='')
+            error = shell_tools.highlight(
+                '{}\n{} failed, {} passed, {} total\n'.format(
+                    test.file_name, r.failed, r.attempted-r.failed,
+                    r.attempted),
+                shell_tools.RED)
+            error += out.content()
+            error_messages.append(error)
+        else:
+            print('.', end='')
+        sys.stdout.flush()
+    print()
+
+    return (doctest.TestResults(failed=failed, attempted=attempted),
+            error_messages)
+
+def import_file(file_path: str) -> ModuleType:
+    """Finds and runs a python file as if were imported with an `import`
+    statement.
+
+    Args:
+        file_path: The file to import.
+
+    Returns: The imported module.
+    """
+    mod_name = os.path.basename(file_path)
+    if mod_name.endswith('.py'):
+        mod_name = mod_name[:-3]
+    # Find and create the module
+    spec = importlib.util.spec_from_file_location(mod_name, file_path)
+    mod = importlib.util.module_from_spec(spec)
+    # Run the code in the module (but not with __name__ == '__main__')
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main():
+    file_names = glob.glob('cirq/**/*.py', recursive=True)
+    failed, attempted = run_tests(file_names, include_cirq=True,
+                                  include_local=True)
+
+    if failed != 0:
+        print(shell_tools.highlight(
+            'Failed: {} failed, {} passed, {} total'.format(
+                failed, attempted-failed, attempted),
+            shell_tools.RED))
+        sys.exit(1)
+    else:
+        print(shell_tools.highlight(
+            'Passed: {}'.format(attempted),
+            shell_tools.GREEN))
+        sys.exit(0)
+
+if __name__ == '__main__':
+    main()

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -99,8 +99,10 @@ def load_tests(file_paths: Iterable[str],
 
     Returns: A list of `Doctest` objects.
     """
-    if quiet:
-        print = lambda *args, **kwargs: None
+    if not quiet:
+        try_print = print
+    else:
+        try_print = lambda *args, **kwargs: None
     if include_modules:
         import cirq
         import numpy
@@ -110,10 +112,10 @@ def load_tests(file_paths: Iterable[str],
     else:
         base_globals = {}
 
-    print('Loading tests   ', end='')
+    try_print('Loading tests   ', end='')
 
     def make_test(file_path: str) -> Doctest:
-        print('.', end='', flush=True)
+        try_print('.', end='', flush=True)
         mod = import_file(file_path)
         glob = make_globals(mod)
         return Doctest(file_path, mod, glob)
@@ -127,7 +129,7 @@ def load_tests(file_paths: Iterable[str],
             return dict(base_globals)
 
     tests = [make_test(file_path) for file_path in file_paths]
-    print()
+    try_print()
     return tests
 
 
@@ -141,9 +143,11 @@ def exec_tests(tests: Iterable[Doctest],
     Returns: A tuple containing the results (# failures, # attempts) and a list
         of the error outputs from each failing test.
     """
-    if quiet:
-        print = lambda *args, **kwargs: None
-    print('Executing tests ', end='')
+    if not quiet:
+        try_print = print
+    else:
+        try_print = lambda *args, **kwargs: None
+    try_print('Executing tests ', end='')
 
     failed, attempted = 0, 0
     error_messages = []
@@ -154,7 +158,7 @@ def exec_tests(tests: Iterable[Doctest],
         failed += r.failed
         attempted += r.attempted
         if r.failed != 0:
-            print('F', end='', flush=True)
+            try_print('F', end='', flush=True)
             error = shell_tools.highlight(
                 '{}\n{} failed, {} passed, {} total\n'.format(
                     test.file_name, r.failed, r.attempted - r.failed,
@@ -162,9 +166,9 @@ def exec_tests(tests: Iterable[Doctest],
             error += out.content()
             error_messages.append(error)
         else:
-            print('.', end='', flush=True)
+            try_print('.', end='', flush=True)
 
-    print()
+    try_print()
 
     return doctest.TestResults(failed=failed,
                                attempted=attempted), error_messages

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -21,6 +21,9 @@ See also:
 
 Usage:
     python run_doctest.py [-q]
+
+The -q argument suppresses all output except the final result line and any error
+messages.
 """
 
 from typing import Any, Dict, Iterable, List, Tuple

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -106,10 +106,7 @@ def load_tests(file_paths: Iterable[str],
         import numpy
         import sympy
         import pandas
-        base_globals = {'cirq': cirq,
-                        'np': numpy,
-                        'sympy': sympy,
-                        'pd': pandas}
+        base_globals = {'cirq': cirq, 'np': numpy, 'sympy': sympy, 'pd': pandas}
     else:
         base_globals = {}
 
@@ -135,8 +132,7 @@ def load_tests(file_paths: Iterable[str],
 
 
 def exec_tests(tests: Iterable[Doctest],
-               quiet: bool = True
-              ) -> Tuple[doctest.TestResults, List[str]]:
+               quiet: bool = True) -> Tuple[doctest.TestResults, List[str]]:
     """Runs a list of `Doctest`s and collects and returns any error messages.
 
     Args:


### PR DESCRIPTION
This was a problem in https://github.com/quantumlib/Cirq/pull/1836#discussion_r305040210.

Before this PR you had to write this:
```python
>>> GridQubit(2, 3) + (3, 1)
cirq.GridQubit(5, 4)
```

Now you can only write this:
```python
>>> cirq.GridQubit(2, 3) + (3, 1)
cirq.GridQubit(5, 4)
```

./check/doctest now has useful pretty output too (with color).  The dots don't show on Travis.

```
Loading tests   ............................................................................................................................................................................................................................................................................................................................................................................................................................................

Executing tests ............................................................................................................................................................................................................................................................................................................................................................................................................................................

Passed: 16
```
```
Loading tests   ............................................................................................................................................................................................................................................................................................................................................................................................................................................

Executing tests ................................................F..................F........................................................................................................................................................................................................................................................................................................................................................................

cirq/value/digits.py
1 failed, 11 passed, 12 total
**********************************************************************
File "cirq/value/digits.py", line 45, in digits.big_endian_int_to_bits
Failed example:
    big_endian_int_to_bits(-3, bit_count=4)
Expected:
    [1, 1, 0, 1]???
Got:
    [1, 1, 0, 1]

cirq/circuits/_block_diagram_drawer_test.py
1 failed, 0 passed, 1 total
**********************************************************************
File "cirq/circuits/_block_diagram_drawer_test.py", line 420, in _block_diagram_drawer_test.test_indices
Failed example:
    cirq.X(cirq.LineQubit(1))
Expected:
    'Wrong result'
Got:
    cirq.X.on(cirq.LineQubit(1))

Failed: 2 failed, 11 passed, 13 total
```