### PR TITLE
Fix types on Sampler.run_async

### DIFF
--- a/cirq/work/sampler.py
+++ b/cirq/work/sampler.py
@@ -70,7 +70,7 @@ class Sampler(metaclass=abc.ABCMeta):
 
     async def run_async(self,
                         program: Union[circuits.Circuit, schedules.Schedule], *,
-                        repetitions: int) -> Awaitable[study.TrialResult]:
+                        repetitions: int) -> study.TrialResult:
         """Asynchronously samples from the given Circuit or Schedule.
 
         By default, this method calls `run` on another thread and yields the
@@ -85,7 +85,7 @@ class Sampler(metaclass=abc.ABCMeta):
             An awaitable TrialResult.
         """
         loop = asyncio.get_event_loop()
-        done = loop.create_future()  # type: asyncio.Future
+        done = loop.create_future()  # type: asyncio.Future[study.TrialResult]
 
         def run():
             try:

--- a/cirq/work/sampler.py
+++ b/cirq/work/sampler.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Abstract base class for things sampling quantum circuits."""
 
-from typing import Awaitable, List, Union
+from typing import List, Union
 import abc
 import asyncio
 import threading


### PR DESCRIPTION
`async` methods should be annotated with the type you get when `await`-ing the coroutine; mypy knows to wrap this with `Awaitable` when checking callsites. See https://mypy.readthedocs.io/en/stable/more_types.html#async-and-await.