### PR TITLE
fixes bug in Circuit.findall_operations_until_blocked

### DIFF
--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1183,6 +1183,16 @@ def test_findall_operations_until_blocked():
             start_frontier={a: idx},
             is_blocker=stop_if_h) == [(11, cirq.CZ.on(a,b))]
 
+    circuit = cirq.Circuit.from_ops(
+        [cirq.CZ(a, b), cirq.CZ(a, b),
+         cirq.CZ(b, c)])
+
+    start = {a: 0, b: 0}
+    is_blocker = lambda next_op: sorted(next_op.qubits) != [a, b]
+    assert (circuit.findall_operations_until_blocked(start, is_blocker) == [
+        (i, cirq.CZ(a, b)) for i in (0, 1)
+    ])
+
 
 def test_has_measurements():
     a = cirq.NamedQubit('a')

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1190,7 +1190,7 @@ def test_findall_operations_until_blocked():
     start = {a: 0, b: 0}
     is_blocker = lambda next_op: sorted(next_op.qubits) != [a, b]
     assert (circuit.findall_operations_until_blocked(start, is_blocker) == [
-        (i, cirq.CZ(a, b)) for i in (0, 1)
+        (0, cirq.CZ(a, b)), (1, cirq.CZ(a, b))
     ])
 
 


### PR DESCRIPTION
Prior implementation double-counted operations because it iterated over qubits rather than moments.