### PR TITLE
YPowGate docstring fix

### DIFF
--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -174,8 +174,8 @@ class YPowGate(eigen_gate.EigenGate,
 
     The unitary matrix of ``YPowGate(exponent=t)`` is:
 
-        [[g·c, g·s],
-         [-g·s, g·c]]
+        [[g·c, -g·s],
+         [g·s, g·c]]
 
     where:
 


### PR DESCRIPTION
Modified the `YPowGate` docstring to:

> 
> [[g·c, -g·s],
>  [g·s, g·c]]
> 
> where:
> 
> c = cos(π·t/2)
> s = sin(π·t/2)
> g = exp(i·π·t/2).

For t=1, g= i and s = 1 so this matrix evaluates to:
[[0, -i],
[i, 0]]

which is consistent with `cirq.unitary(cirq.YPowGate(exponent=1)).