### PR TITLE
Add pip package configurations for contrib and dev tools

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -89,9 +89,7 @@ See the previous section for instructions.
     ```bash
     mkvirtualenv cirq-py3 --python=/usr/bin/python3
     python -m pip install --upgrade pip
-    python -m pip install -r requirements.txt
-    python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    python -m pip install -r cirq/contrib/contrib-requirements.txt
+    python -m pip install -e .[dev,contrib]
     ```
 
     (When you later open another terminal, you can activate the virtualenv with `workon cirq-py3`.)

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,15 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. (Optional) install system dependencies that pip can't handle.
+3. (Optional) install other dependencies.
+
+    Install dependencies of features in `cirq.contrib`.
+
+    ```bash
+    python -m pip install cirq[contrib]
+    ```
+
+    Install system dependencies that pip can't handle.
 
     ```bash
     sudo apt-get install texlive-latex-base latexmk
@@ -69,7 +77,13 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. Check that it works!
+3. (Optional) install dependencies of features in `cirq.contrib`.
+
+    ```bash
+    python -m pip install cirq[contrib]
+    ```
+
+4. Check that it works!
 
     ```bash
     python -c 'import cirq; print(cirq.google.Foxtail)'
@@ -96,7 +110,13 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. Check that it works!
+3. (Optional) install dependencies of features in `cirq.contrib`.
+
+    ```bash
+    python -m pip install cirq[contrib]
+    ```
+
+4. Check that it works!
 
     ```bash
     python -c "import cirq; print(cirq.google.Foxtail)"

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,15 +34,7 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. (Optional) install other dependencies.
-
-    Install dependencies of features in `cirq.contrib`.
-
-    ```bash
-    python -m pip install cirq[contrib]
-    ```
-
-    Install system dependencies that pip can't handle.
+3. (Optional) install system dependencies that pip can't handle.
 
     ```bash
     sudo apt-get install texlive-latex-base latexmk
@@ -77,13 +69,7 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. (Optional) install dependencies of features in `cirq.contrib`.
-
-    ```bash
-    python -m pip install cirq[contrib]
-    ```
-
-4. Check that it works!
+3. Check that it works!
 
     ```bash
     python -c 'import cirq; print(cirq.google.Foxtail)'
@@ -110,13 +96,7 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. (Optional) install dependencies of features in `cirq.contrib`.
-
-    ```bash
-    python -m pip install cirq[contrib]
-    ```
-
-4. Check that it works!
+3. Check that it works!
 
     ```bash
     python -c "import cirq; print(cirq.google.Foxtail)"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ long_description = io.open('README.rst', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
+contrib_requirements = open('cirq/contrib/contrib-requirements.txt').readlines()
+contrib_requirements = [r.strip() for r in contrib_requirements]
 
 cirq_packages = ['cirq'] + [
     'cirq.' + package for package in find_packages(where='cirq')
@@ -40,6 +42,9 @@ setup(name='cirq',
       author_email='cirq@googlegroups.com',
       python_requires=('>=3.6.0'),
       install_requires=requirements,
+      extras_require = {
+          'contrib': contrib_requirements,
+      },
       license='Apache 2',
       description=description,
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='cirq',
       author_email='cirq@googlegroups.com',
       python_requires=('>=3.6.0'),
       install_requires=requirements,
-      extras_require = {
+      extras_require={
           'contrib': contrib_requirements,
       },
       license='Apache 2',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
 contrib_requirements = open('cirq/contrib/contrib-requirements.txt').readlines()
 contrib_requirements = [r.strip() for r in contrib_requirements]
+dev_requirements = open('dev_tools/conf/pip-list-dev-tools.txt').readlines()
+dev_requirements = [r.strip() for r in dev_requirements]
 
 cirq_packages = ['cirq'] + [
     'cirq.' + package for package in find_packages(where='cirq')
@@ -44,6 +46,7 @@ setup(name='cirq',
       install_requires=requirements,
       extras_require={
           'contrib': contrib_requirements,
+          'dev': dev_requirements,
       },
       license='Apache 2',
       description=description,


### PR DESCRIPTION
Fixes #843.

This allows users to easily install Cirq with the contrib dependencies:
```
$ pip install cirq[contrib]
```

To install Cirq in editable mode for development:
```
$ pip install -e .[dev,contrib]
```