### PR TITLE
Restore python3-tk as an apt requirement

### DIFF
--- a/apt-system-requirements.txt
+++ b/apt-system-requirements.txt
@@ -1,2 +1,3 @@
 texlive-latex-base
 latexmk
+python3-tk


### PR DESCRIPTION
- I needed to install this to get matplotlib working