### PR TITLE
Add qubits property

### DIFF
--- a/cirq/ops/linear_combinations.py
+++ b/cirq/ops/linear_combinations.py
@@ -280,6 +280,11 @@ class PauliSum:
             termdict[key] += pstring.coefficient
         return cls(linear_dict=value.LinearDict(termdict))
 
+    @property
+    def qubits(self) -> Tuple[raw_types.Qid, ...]:
+        qs = {q for k in self._linear_dict.keys() for q, _ in k}
+        return tuple(sorted(qs))
+
     def copy(self) -> 'PauliSum':
         factory = type(self)
         return factory(self._linear_dict.copy())

--- a/cirq/ops/linear_combinations_test.py
+++ b/cirq/ops/linear_combinations_test.py
@@ -579,6 +579,16 @@ def test_pauli_sum_construction():
     assert len(zero) == 0
 
 
+@pytest.mark.parametrize('psum, expected_qubits', (
+    (cirq.Z(q1), (q1,)),
+    (cirq.X(q0) + cirq.Y(q0), (q0,)),
+    (cirq.X(q0) + cirq.Y(q2), (q0, q2)),
+    (cirq.X(q0) * cirq.Y(q1) + cirq.Y(q1) * cirq.Z(q3), (q0, q1, q3)),
+))
+def test_pauli_sum_qubits(psum, expected_qubits):
+    assert psum.qubits == expected_qubits
+
+
 def test_pauli_sum_from_single_pauli():
     q = cirq.LineQubit.range(2)
     psum1 = cirq.X(q[0]) + cirq.Y(q[1])


### PR DESCRIPTION
This is analogous to a similar property on PauliString and other gates. It's useful on the commandline and simplifies some conditions (e.g. checking whether the PauliString is single-qubit).