### PR TITLE
Fix dev tool terminal colors on Mac

### DIFF
--- a/check/all
+++ b/check/all
@@ -44,12 +44,12 @@ for arg in $@; do
         apply_arg="--apply"
     elif [ -z "${rev}" ]; then
         if [ "$(git cat-file -t ${arg} 2> /dev/null)" != "commit" ]; then
-            echo -e "\e[31mNo revision '${arg}'.\e[0m" >&2
+            echo -e "\033[31mNo revision '${arg}'.\033[0m" >&2
             exit 1
         fi
         rev="${arg}"
     else
-        echo -e "\e[31mInvalid arguments. Expected [BASE_REVISION] [--only-changed-files] [--apply-format].\e[0m" >&2
+        echo -e "\033[31mInvalid arguments. Expected [BASE_REVISION] [--only-changed-files] [--apply-format].\033[0m" >&2
         exit 1
     fi
 done

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -41,12 +41,12 @@ for arg in $@; do
         only_print=0
     elif [ -z "${rev}" ]; then
         if [ "$(git cat-file -t ${arg} 2> /dev/null)" != "commit" ]; then
-            echo -e "\e[31mNo revision '${arg}'.\e[0m" >&2
+            echo -e "\033[31mNo revision '${arg}'.\033[0m" >&2
             exit 1
         fi
         rev="${arg}"
     else
-        echo -e "\e[31mToo many arguments. Expected [revision] [--apply].\e[0m" >&2
+        echo -e "\033[31mToo many arguments. Expected [revision] [--apply].\033[0m" >&2
         exit 1
     fi
 done
@@ -60,7 +60,7 @@ if [ -z "${rev}" ]; then
     elif [ "$(git cat-file -t master 2> /dev/null)" == "commit" ]; then
         rev=master
     else
-        echo -e "\e[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\e[0m" >&2
+        echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
         exit 1
     fi
 fi
@@ -93,7 +93,7 @@ for changed_file in ${changed_files}; do
             if (( only_print == 0 )); then
                 $(yapf --style=google --in-place "${changed_file}" ${changed_line_ranges})
             else
-                echo -e "\n\e[31mChanges in ${changed_file} require formatting:\e[0m\n${results}" \
+                echo -e "\n\033[31mChanges in ${changed_file} require formatting:\033[0m\n${results}" \
                     | sed "s/^\(+ .*\)$/${esc}[32m\\1${esc}[0m/" \
                     | sed "s/^\(- .*\)$/${esc}[31m\\1${esc}[0m/"
             fi
@@ -102,10 +102,10 @@ for changed_file in ${changed_files}; do
 done
 
 if (( needed_changes == 0 )); then
-    echo -e "\e[32mNo formatting needed on changed lines\e[0m."
+    echo -e "\033[32mNo formatting needed on changed lines\033[0m."
 elif (( only_print == 1 )); then
-    echo -e "\e[31mSome formatting needed on changed lines\e[0m."
+    echo -e "\033[31mSome formatting needed on changed lines\033[0m."
     exit 1
 else
-    echo -e "\e[32mReformatted changed lines\e[0m."
+    echo -e "\033[32mReformatted changed lines\033[0m."
 fi

--- a/check/mypy
+++ b/check/mypy
@@ -11,9 +11,9 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-echo -e -n "\e[31m"
+echo -e -n "\033[31m"
 mypy --config-file=dev_tools/conf/mypy.ini $@ .
 result=$?
-echo -e -n "\e[0m"
+echo -e -n "\033[0m"
 
 exit ${result}

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -29,7 +29,7 @@ cd "$(git rev-parse --show-toplevel)"
 # Figure out which revision to compare against.
 if [ ! -z "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
-        echo -e "\e[31mNo revision '$1'.\e[0m" >&2
+        echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi
     rev=$1
@@ -40,7 +40,7 @@ elif [ "$(git cat-file -t origin/master 2> /dev/null)" == "commit" ]; then
 elif [ "$(git cat-file -t master 2> /dev/null)" == "commit" ]; then
     rev=master
 else
-    echo -e "\e[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\e[0m" >&2
+    echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
 base="$(git merge-base ${rev} HEAD)"

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -35,7 +35,7 @@ cd "$(git rev-parse --show-toplevel)"
 rest=$@
 if [ ! -z "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
-        echo -e "\e[31mNo revision '$1'.\e[0m" >&2
+        echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi
     rev=$1
@@ -47,7 +47,7 @@ elif [ "$(git cat-file -t origin/master 2> /dev/null)" == "commit" ]; then
 elif [ "$(git cat-file -t master 2> /dev/null)" == "commit" ]; then
     rev=master
 else
-    echo -e "\e[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\e[0m" >&2
+    echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
 echo "Comparing against revision '${rev}'." >&2

--- a/dev_tools/build-docs.sh
+++ b/dev_tools/build-docs.sh
@@ -28,7 +28,7 @@
 ################################################################################
 
 set -e
-trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
+trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/dev_tools/build-protos.sh
+++ b/dev_tools/build-protos.sh
@@ -22,7 +22,7 @@
 ################################################################################
 
 set -e
-trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
+trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -28,10 +28,10 @@
 PROJECT_NAME=cirq
 
 set -e
-trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
+trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 if [ -z "${1}" ]; then
-  echo -e "\e[31mNo output directory given.\e[0m"
+  echo -e "\033[31mNo output directory given.\033[0m"
   exit 1
 fi
 out_dir=$(realpath "${1}")
@@ -45,7 +45,7 @@ cd "${repo_dir}"
 
 # Make a clean copy of HEAD, without files ignored by git (but potentially kept by setup.py).
 if [ ! -z "$(git status --short)" ]; then
-    echo -e "\e[31mWARNING: You have uncommitted changes. They won't be included in the package.\e[0m"
+    echo -e "\033[31mWARNING: You have uncommitted changes. They won't be included in the package.\033[0m"
 fi
 tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_git_dir}; }" EXIT

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -43,22 +43,22 @@
 
 PROJECT_NAME=cirq
 set -e
-trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
+trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 EXPECTED_VERSION=$1
 PROD_SWITCH=$2
 
 if [ -z "${EXPECTED_VERSION}" ]; then
-    echo -e "\e[31mFirst argument must be the expected version.\e[0m"
+    echo -e "\033[31mFirst argument must be the expected version.\033[0m"
     exit 1
 fi
 if [[ "${EXPECTED_VERSION}" != *dev* ]]; then
-  echo -e "\e[31mExpected version must include 'dev'.\e[0m"
+  echo -e "\033[31mExpected version must include 'dev'.\033[0m"
   exit 1
 fi
 ACTUAL_VERSION_LINE=$(cat "${PROJECT_NAME}/_version.py" | tail -n 1)
 if [ "${ACTUAL_VERSION_LINE}" != '__version__ = "'"${EXPECTED_VERSION}"'"' ]; then
-  echo -e "\e[31mExpected version (${EXPECTED_VERSION}) didn't match the one in ${PROJECT_NAME}/_version.py (${ACTUAL_VERSION_LINE}).\e[0m"
+  echo -e "\033[31mExpected version (${EXPECTED_VERSION}) didn't match the one in ${PROJECT_NAME}/_version.py (${ACTUAL_VERSION_LINE}).\033[0m"
   exit 1
 fi
 
@@ -68,11 +68,11 @@ if [ -z "${PROD_SWITCH}" ] || [ "${PROD_SWITCH}" = "--test" ]; then
     USERNAME="${TEST_TWINE_USERNAME}"
     PASSWORD="${TEST_TWINE_PASSWORD}"
     if [ -z "${USERNAME}" ]; then
-      echo -e "\e[31mTEST_TWINE_USERNAME environment variable must be set.\e[0m"
+      echo -e "\033[31mTEST_TWINE_USERNAME environment variable must be set.\033[0m"
       exit 1
     fi
     if [ -z "${PASSWORD}" ]; then
-      echo -e "\e[31mTEST_TWINE_PASSWORD environment variable must be set.\e[0m"
+      echo -e "\033[31mTEST_TWINE_PASSWORD environment variable must be set.\033[0m"
       exit 1
     fi
 elif [ "${PROD_SWITCH}" = "--prod" ]; then
@@ -81,21 +81,21 @@ elif [ "${PROD_SWITCH}" = "--prod" ]; then
     USERNAME="${PROD_TWINE_USERNAME}"
     PASSWORD="${PROD_TWINE_PASSWORD}"
     if [ -z "${USERNAME}" ]; then
-      echo -e "\e[31mPROD_TWINE_USERNAME environment variable must be set.\e[0m"
+      echo -e "\033[31mPROD_TWINE_USERNAME environment variable must be set.\033[0m"
       exit 1
     fi
     if [ -z "${PASSWORD}" ]; then
-      echo -e "\e[31mPROD_TWINE_PASSWORD environment variable must be set.\e[0m"
+      echo -e "\033[31mPROD_TWINE_PASSWORD environment variable must be set.\033[0m"
       exit 1
     fi
 else
-    echo -e "\e[31mSecond argument must be empty, '--test' or '--prod'.\e[0m"
+    echo -e "\033[31mSecond argument must be empty, '--test' or '--prod'.\033[0m"
     exit 1
 fi
 
 
 UPLOAD_VERSION="${EXPECTED_VERSION}$(date "+%Y%m%d%H%M%S")"
-echo -e "Producing package with version \e[33m\e[100m${UPLOAD_VERSION}\e[0m to upload to \e[33m\e[100m${PYPI_REPO_NAME}\e[0m pypi repository"
+echo -e "Producing package with version \033[33m\033[100m${UPLOAD_VERSION}\033[0m to upload to \033[33m\033[100m${PYPI_REPO_NAME}\033[0m pypi repository"
 
 # Get the working directory to the repo root.
 cd "$( dirname "${BASH_SOURCE[0]}" )"
@@ -109,4 +109,4 @@ trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"
 twine upload --username="${USERNAME}" --password="${PASSWORD}" ${PYPI_REPOSITORY_FLAG} "${tmp_package_dir}/*"
 
-echo -e "\e[32mUploaded package with version ${UPLOAD_VERSION} to ${PYPI_REPO_NAME} pypi repository\e[0m"
+echo -e "\033[32mUploaded package with version ${UPLOAD_VERSION} to ${PYPI_REPO_NAME} pypi repository\033[0m"

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -28,7 +28,7 @@
 ################################################################################
 
 set -e
-trap "{ echo -e '\e[31mFAILED\e[0m'; }" ERR
+trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 
 PROJECT_NAME=cirq
@@ -36,7 +36,7 @@ PROJECT_VERSION=$1
 PROD_SWITCH=$2
 
 if [ -z "${PROJECT_VERSION}" ]; then
-    echo -e "\e[31mFirst argument must be the package version to test.\e[0m"
+    echo -e "\033[31mFirst argument must be the package version to test.\033[0m"
     exit 1
 fi
 
@@ -47,7 +47,7 @@ elif [ -z "${PROD_SWITCH}" ] || [ "${PROD_SWITCH}" = "--prod" ]; then
     PYPI_REPOSITORY_FLAG=''
     PYPI_REPO_NAME="PROD"
 else
-    echo -e "\e[31mSecond argument must be empty, '--prod' or '--test'.\e[0m"
+    echo -e "\033[31mSecond argument must be empty, '--prod' or '--test'.\033[0m"
     exit 1
 fi
 
@@ -66,7 +66,7 @@ for PYTHON_VERSION in python3; do
     RUNTIME_DEPS_FILE="${REPO_ROOT}/requirements.txt"
     CONTRIB_DEPS_FILE="${REPO_ROOT}/cirq/contrib/contrib-requirements.txt"
 
-    echo -e "\n\e[32m${PYTHON_VERSION}\e[0m"
+    echo -e "\n\033[32m${PYTHON_VERSION}\033[0m"
     echo "Working in a fresh virtualenv at ${tmp_dir}/${PYTHON_VERSION}"
     virtualenv --quiet "--python=/usr/bin/${PYTHON_VERSION}" "${tmp_dir}/${PYTHON_VERSION}"
 
@@ -99,4 +99,4 @@ for PYTHON_VERSION in python3; do
 done
 
 echo
-echo -e '\e[32mVERIFIED\e[0m'
+echo -e '\033[32mVERIFIED\033[0m'


### PR DESCRIPTION
Replace `'\e'` with `'\033'` in all uses of `echo -e`.

The `echo` builtin on Mac bash doesn't support the `'\e'` escape sequence used to set ANSI colors.  This was causing one of the dev tool tests to fail and many of the scripts to output `\e[##m` everywhere.  `'\033'` is equivalent to `'\e'` but has more support.