### PR TITLE
Change old references to SupportsApplyUnitary

### DIFF
--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -241,8 +241,9 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
         def on_stuck(bad_op: ops.Operation):
             return TypeError(
                 "Can't simulate operations that don't implement "
-                "SupportsUnitary, SupportsConsistentApplyUnitary, SupportsMixture, "
-                "SupportsChannel or is a measurement: {!r}".format(bad_op))
+                "SupportsUnitary, SupportsConsistentApplyUnitary, "
+                "SupportsMixture, SupportsChannel or is a measurement: {!r}"
+                .format(bad_op))
 
         def keep(potential_op: ops.Operation) -> bool:
             return (protocols.has_channel(potential_op)

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -53,7 +53,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
     That is, the circuit must have elements that follow on of the protocols:
         * `cirq.SupportsChannel`
         * `cirq.SupportsMixture`
-        * `cirq.SupportsApplyUnitary`
+        * `cirq.SupportsConsistentApplyUnitary`
         * `cirq.SupportsUnitary`
         * `cirq.SupportsDecompose`
     or is a measurement.
@@ -241,7 +241,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
         def on_stuck(bad_op: ops.Operation):
             return TypeError(
                 "Can't simulate operations that don't implement "
-                "SupportsUnitary, SupportsApplyUnitary, SupportsMixture, "
+                "SupportsUnitary, SupportsConsistentApplyUnitary, SupportsMixture, "
                 "SupportsChannel or is a measurement: {!r}".format(bad_op))
 
         def keep(potential_op: ops.Operation) -> bool:

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -242,8 +242,8 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
             return TypeError(
                 "Can't simulate operations that don't implement "
                 "SupportsUnitary, SupportsConsistentApplyUnitary, "
-                "SupportsMixture, SupportsChannel or is a measurement: {!r}"
-                .format(bad_op))
+                "SupportsMixture, SupportsChannel or is a measurement: {!r}".
+                format(bad_op))
 
         def keep(potential_op: ops.Operation) -> bool:
             return (protocols.has_channel(potential_op)

--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -40,11 +40,11 @@ class Simulator(simulator.SimulatesSamples,
     `_apply_unitary_`, `_mixture_` methods, are measurements, or support a
     `_decompose_` method that returns operations satisfying these same
     conditions. That is to say, the operations should follow the
-    `cirq.SupportsApplyUnitary` protocol, the `cirq.SupportsUnitary` protocol,
-    the `cirq.SupportsMixture` protocol, or the `cirq.CompositeOperation`
-    protocol. It is also permitted for the circuit to contain measurements
-    which are operations that support `cirq.SupportsChannel` and
-    `cirq.SupportsMeasurementKey`
+    `cirq.SupportsConsistentApplyUnitary` protocol, the `cirq.SupportsUnitary`
+    protocol, the `cirq.SupportsMixture` protocol, or the
+    `cirq.CompositeOperation` protocol. It is also permitted for the circuit
+    to contain measurements which are operations that support
+    `cirq.SupportsChannel` and `cirq.SupportsMeasurementKey`
 
     This simulator supports three types of simulation.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -331,7 +331,7 @@ Classes defining and used by the magic method protocols.
     QasmArgs
     QasmOutput
     SupportsApplyChannel
-    SupportsApplyUnitary
+    SupportsConsistentApplyUnitary
     SupportsApproximateEquality
     SupportsChannel
     SupportsCircuitDiagramInfo


### PR DESCRIPTION
I found some old references to `SupportsApplyUnitary` after #1790. 