### PR TITLE
Remove whitespace in density simulator test

### DIFF
--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -667,6 +667,9 @@ def test_density_matrix_trial_result_str():
         measurements={},
         final_simulator_state=final_simulator_state)
 
-    assert str(result) == ('measurements: (no measurements)\n'
-                           'final density matrix:\n'
-                           '[[0.5 0.5]\n [0.5 0.5]]')
+    # numpy varies whitespace in its representation for differnt versions
+    # Eliminate whitespace to harden tests against this variation
+    result_no_whitespace = str(result).replace('\n','').replace(' ','')
+    assert result_no_whitespace == ('measurements:(nomeasurements)'
+                           'finaldensitymatrix:'
+                           '[[0.50.5][0.50.5]]')

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -667,7 +667,7 @@ def test_density_matrix_trial_result_str():
         measurements={},
         final_simulator_state=final_simulator_state)
 
-    # numpy varies whitespace in its representation for differnt versions
+    # numpy varies whitespace in its representation for different versions
     # Eliminate whitespace to harden tests against this variation
     result_no_whitespace = str(result).replace('\n', '').replace(' ', '')
     assert result_no_whitespace == ('measurements:(nomeasurements)'

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -669,7 +669,7 @@ def test_density_matrix_trial_result_str():
 
     # numpy varies whitespace in its representation for differnt versions
     # Eliminate whitespace to harden tests against this variation
-    result_no_whitespace = str(result).replace('\n','').replace(' ','')
+    result_no_whitespace = str(result).replace('\n', '').replace(' ', '')
     assert result_no_whitespace == ('measurements:(nomeasurements)'
-                           'finaldensitymatrix:'
-                           '[[0.50.5][0.50.5]]')
+                                    'finaldensitymatrix:'
+                                    '[[0.50.5][0.50.5]]')


### PR DESCRIPTION
- Numpy does not have a consistent whitespace across
versions, so this test can fail in other contexts