### PR TITLE
 Remove many obsoleted pylint directives

### DIFF
--- a/cirq/circuits/_bucket_priority_queue.py
+++ b/cirq/circuits/_bucket_priority_queue.py
@@ -54,9 +54,8 @@ class BucketPriorityQueue(Generic[TItem]):
         self._buckets: List[List[TItem]] = []
         self._offset = 0
         self._len = 0
-        self._drop_set: Optional[Set[Tuple[int, TItem]]] = (set()
-                                                            if drop_duplicate_entries
-                                                            else None)
+        self._drop_set: Optional[Set[Tuple[int, TItem]]] = (
+            set() if drop_duplicate_entries else None)
 
         for p, e in entries:
             self.enqueue(p, e)

--- a/cirq/circuits/_bucket_priority_queue.py
+++ b/cirq/circuits/_bucket_priority_queue.py
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, List, TypeVar, Generic, Iterable, Iterator, Any, \
-    TYPE_CHECKING
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Set, Optional
+from typing import (Any, Generic, Iterable, Iterator, List, Optional, Set,
+                    Tuple, TypeVar)
 
 
 TItem = TypeVar('TItem')
@@ -55,12 +51,12 @@ class BucketPriorityQueue(Generic[TItem]):
                 in the priority queue. Note that duplicates of an item may still
                 be enqueued, as long as they have different priorities.
         """
-        self._buckets = []  # type: List[List[TItem]]
+        self._buckets: List[List[TItem]] = []
         self._offset = 0
         self._len = 0
-        self._drop_set = (set()
-                          if drop_duplicate_entries
-                          else None)  # type: Optional[Set[Tuple[int, TItem]]]
+        self._drop_set: Optional[Set[Tuple[int, TItem]]] = (set()
+                                                            if drop_duplicate_entries
+                                                            else None)
 
         for p, e in entries:
             self.enqueue(p, e)

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -24,9 +24,9 @@ from fractions import Fraction
 from itertools import groupby
 import math
 
-from typing import (
-    List, Any, Dict, FrozenSet, Callable, Iterable, Iterator, Optional,
-    Sequence, Union, Set, Type, Tuple, cast, TypeVar, overload)
+from typing import (List, Any, Dict, FrozenSet, Callable, Iterable, Iterator,
+                    Optional, Sequence, Union, Set, Type, Tuple, cast, TypeVar,
+                    overload)
 
 import re
 import numpy as np

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -26,7 +26,7 @@ import math
 
 from typing import (
     List, Any, Dict, FrozenSet, Callable, Iterable, Iterator, Optional,
-    Sequence, Union, Type, Tuple, cast, TypeVar, overload, TYPE_CHECKING)
+    Sequence, Union, Set, Type, Tuple, cast, TypeVar, overload)
 
 import re
 import numpy as np
@@ -39,10 +39,6 @@ from cirq.circuits.text_diagram_drawer import TextDiagramDrawer
 from cirq.circuits.qasm_output import QasmOutput
 from cirq.type_workarounds import NotImplementedType
 import cirq._version
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Set
 
 
 T_DESIRED_GATE_TYPE = TypeVar('T_DESIRED_GATE_TYPE', bound='ops.Gate')
@@ -572,7 +568,7 @@ class Circuit:
             where i is the moment index, q is the qubit, and end_frontier is the
             result of this method.
         """
-        active = set()  # type: Set[ops.Qid]
+        active: Set[ops.Qid] = set()
         end_frontier = {}
         queue = BucketPriorityQueue[ops.Operation](drop_duplicate_entries=True)
 

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -14,7 +14,7 @@
 
 """Defines the OptimizationPass type."""
 from typing import (
-    Callable, Iterable, Optional, Sequence, TYPE_CHECKING, Tuple, cast)
+    Dict, Callable, Iterable, Optional, Sequence, TYPE_CHECKING, Tuple, cast)
 
 import abc
 from collections import defaultdict
@@ -23,9 +23,7 @@ from cirq import ops
 from cirq.circuits.circuit import Circuit
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.ops import Qid
-    from typing import Dict
 
 
 class PointOptimizationSummary:
@@ -116,7 +114,7 @@ class PointOptimizer:
         """
 
     def optimize_circuit(self, circuit: Circuit):
-        frontier = defaultdict(lambda: 0)  # type: Dict[Qid, int]
+        frontier: Dict['Qid', int] = defaultdict(lambda: 0)
         i = 0
         while i < len(circuit):  # Note: circuit may mutate as we go.
             for op in circuit[i].operations:

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Defines the OptimizationPass type."""
-from typing import (
-    Dict, Callable, Iterable, Optional, Sequence, TYPE_CHECKING, Tuple, cast)
+from typing import (Dict, Callable, Iterable, Optional, Sequence, TYPE_CHECKING,
+                    Tuple, cast)
 
 import abc
 from collections import defaultdict

--- a/cirq/circuits/qasm_output.py
+++ b/cirq/circuits/qasm_output.py
@@ -14,9 +14,8 @@
 
 """Utility classes for representing QASM."""
 
-from typing import Set, Any  # pylint: disable=unused-import
 from typing import (
-    Callable, Dict, Optional, Sequence, Tuple, Union
+    Callable, Dict, Optional, Sequence, Set, Tuple, Union
 )
 
 import re
@@ -242,7 +241,7 @@ class QasmOutput:
             output('qreg q[{}];\n'.format(len(self.qubits)))
         # Classical registers
         # Pick an id for the creg that will store each measurement
-        already_output_keys = set()  # type: Set[str]
+        already_output_keys: Set[str] = set()
         for meas in self.measurements:
             key = protocols.measurement_key(meas)
             if key in already_output_keys:

--- a/cirq/circuits/qasm_output.py
+++ b/cirq/circuits/qasm_output.py
@@ -14,9 +14,7 @@
 
 """Utility classes for representing QASM."""
 
-from typing import (
-    Callable, Dict, Optional, Sequence, Set, Tuple, Union
-)
+from typing import (Callable, Dict, Optional, Sequence, Set, Tuple, Union)
 
 import re
 import numpy as np

--- a/cirq/circuits/text_diagram_drawer.py
+++ b/cirq/circuits/text_diagram_drawer.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, NamedTuple, Tuple, TYPE_CHECKING, cast, Union
+from typing import (Callable, cast, Dict, List, Optional, NamedTuple, Tuple,
+                    Union)
 
 import numpy as np
 
@@ -22,12 +23,6 @@ from cirq.circuits._box_drawing_character_data import (
     BOLD_BOX_CHARS,
     ASCII_BOX_CHARS,
 )
-
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Tuple, Dict, Optional
-
 
 _HorizontalLine = NamedTuple('HorizontalLine', [
     ('y', Union[int, float]),
@@ -60,17 +55,17 @@ class TextDiagramDrawer:
     """
 
     def __init__(self):
-        self.entries = dict()  # type: Dict[Tuple[int, int], _DiagramText]
-        self.vertical_lines = []  # type: List[_VerticalLine]
-        self.horizontal_lines = []  # type: List[_HorizontalLine]
-        self.horizontal_padding = {}  # type: Dict[int, Union[int, float]]
-        self.vertical_padding = {}  # type: Dict[int, Union[int, float]]
+        self.entries: Dict[Tuple[int, int], _DiagramText] = dict()
+        self.vertical_lines: List[_VerticalLine] = []
+        self.horizontal_lines: List[_HorizontalLine] = []
+        self.horizontal_padding: Dict[int, Union[int, float]] = {}
+        self.vertical_padding: Dict[int, Union[int, float]] = {}
 
     def write(self,
               x: int,
               y: int,
               text: str,
-              transposed_text: 'Optional[str]' = None):
+              transposed_text: Optional[str] = None):
         """Adds text to the given location.
 
         Args:

--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Sequence, TYPE_CHECKING
+from typing import DefaultDict, Dict, List, Sequence
 
 import abc
 from collections import defaultdict
@@ -29,11 +29,6 @@ from cirq.contrib.acquaintance.permutation import (
         LogicalGates, LogicalMapping)
 from cirq.contrib.acquaintance.mutation_utils import (
         expose_acquaintance_gates)
-
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Callable, List, DefaultDict
 
 
 class ExecutionStrategy(metaclass=abc.ABCMeta):
@@ -122,7 +117,7 @@ class AcquaintanceOperation(ops.GateOperation):
             raise ValueError('len(logical_indices) != len(qubits)')
         super().__init__(AcquaintanceOpportunityGate(num_qubits=len(qubits)),
                          qubits)
-        self.logical_indices = logical_indices # type: LogicalIndexSequence
+        self.logical_indices: LogicalIndexSequence = logical_indices
 
     def _circuit_diagram_info_(self,
             args: protocols.CircuitDiagramInfoArgs
@@ -188,8 +183,8 @@ class GreedyExecutionStrategy(ExecutionStrategy):
         Takes a set of gates specified by ordered sequences of logical
         indices, and groups those that act on the same qubits regardless of
         order."""
-        canonicalized_gates = defaultdict(dict
-            ) # type: DefaultDict[frozenset, LogicalGates]
+        canonicalized_gates: DefaultDict[frozenset,
+                                         LogicalGates] = defaultdict(dict)
         for indices, gate in gates.items():
             indices = tuple(indices)
             canonicalized_gates[frozenset(indices)][indices] = gate

--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -183,8 +183,8 @@ class GreedyExecutionStrategy(ExecutionStrategy):
         Takes a set of gates specified by ordered sequences of logical
         indices, and groups those that act on the same qubits regardless of
         order."""
-        canonicalized_gates: DefaultDict[frozenset,
-                                         LogicalGates] = defaultdict(dict)
+        canonicalized_gates: DefaultDict[frozenset, LogicalGates] = defaultdict(
+            dict)
         for indices, gate in gates.items():
             indices = tuple(indices)
             canonicalized_gates[frozenset(indices)][indices] = gate

--- a/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq/contrib/acquaintance/gates_test.py
@@ -15,7 +15,7 @@
 from itertools import combinations, product
 from random import randint
 from string import ascii_lowercase as alphabet
-from typing import Sequence, Tuple, TYPE_CHECKING
+from typing import Optional, Sequence, Tuple
 
 from numpy.random import poisson
 import pytest
@@ -23,10 +23,6 @@ import pytest
 import cirq
 import cirq.testing as ct
 import cirq.contrib.acquaintance as cca
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Optional
 
 
 def test_acquaintance_gate_repr():
@@ -145,7 +141,7 @@ def test_acquaint_part_pairs(part_lens):
     expected_opps = set(frozenset(s + t) for s, t in combinations(parts, 2))
     assert expected_opps == actual_opps
 
-acquaintance_sizes = (None,) # type: Tuple[Optional[int], ...]
+acquaintance_sizes: Tuple[Optional[int], ...] = (None,)
 acquaintance_sizes += tuple(range(5))
 @pytest.mark.parametrize('part_lens, acquaintance_size',
     list(((part_len,) * n_parts, acquaintance_size) for

--- a/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq/contrib/acquaintance/gates_test.py
@@ -141,6 +141,7 @@ def test_acquaint_part_pairs(part_lens):
     expected_opps = set(frozenset(s + t) for s, t in combinations(parts, 2))
     assert expected_opps == actual_opps
 
+
 acquaintance_sizes: Tuple[Optional[int], ...] = (None,)
 acquaintance_sizes += tuple(range(5))
 @pytest.mark.parametrize('part_lens, acquaintance_size',

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -14,7 +14,7 @@
 
 import collections
 
-from typing import Optional, Sequence, TYPE_CHECKING, Union
+from typing import Dict, List, Optional, Sequence, Type, Union, TYPE_CHECKING
 
 from cirq import circuits, ops, optimizers
 
@@ -26,9 +26,7 @@ from cirq.contrib.acquaintance.permutation import (
     PermutationGate)
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.ops import Gate
-    from typing import Dict, List, Type
 
 STRATEGY_GATE = Union[AcquaintanceOpportunityGate, PermutationGate]
 
@@ -52,8 +50,8 @@ def rectify_acquaintance_strategy(
 
     rectified_moments = []
     for moment in circuit:
-        gate_type_to_ops = collections.defaultdict(list
-                ) # type: Dict[bool, List[ops.GateOperation]]
+        gate_type_to_ops: Dict[bool, List[
+            ops.GateOperation]] = collections.defaultdict(list)
         for op in moment.operations:
             gate_type_to_ops[isinstance(op.gate, AcquaintanceOpportunityGate)
                     ].append(op)

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -14,7 +14,7 @@
 
 import collections
 
-from typing import Dict, List, Optional, Sequence, Type, Union, TYPE_CHECKING
+from typing import Dict, List, Optional, Sequence, Union, TYPE_CHECKING
 
 from cirq import circuits, ops, optimizers
 

--- a/cirq/contrib/acquaintance/optimizers.py
+++ b/cirq/contrib/acquaintance/optimizers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, Sequence, TYPE_CHECKING
+from typing import cast, FrozenSet, List, Sequence, Set
 
 from cirq import circuits, ops
 
@@ -22,10 +22,6 @@ from cirq.contrib.acquaintance.gates import acquaint
 from cirq.contrib.acquaintance.executor import AcquaintanceOperation
 from cirq.contrib.acquaintance.mutation_utils import expose_acquaintance_gates
 from cirq.contrib.acquaintance.inspection_utils import LogicalAnnotator
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import FrozenSet, List, Set
 
 
 def remove_redundant_acquaintance_opportunities(

--- a/cirq/contrib/graph_device/uniform_graph_device.py
+++ b/cirq/contrib/graph_device/uniform_graph_device.py
@@ -32,8 +32,7 @@ def uniform_undirected_graph_device(
     """
 
     labelled_edges: Dict[Iterable[Hashable], Any] = {
-        frozenset(edge): edge_label
-        for edge in edges
+        frozenset(edge): edge_label for edge in edges
     }
     device_graph = UndirectedHypergraph(labelled_edges=labelled_edges)
     return UndirectedGraphDevice(device_graph=device_graph)

--- a/cirq/contrib/graph_device/uniform_graph_device.py
+++ b/cirq/contrib/graph_device/uniform_graph_device.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Hashable, Iterable, Mapping, Optional, TYPE_CHECKING
+from typing import Any, Dict, Hashable, Iterable, Mapping, Optional
 
 from cirq import line, ops
 from cirq.contrib.graph_device.graph_device import (UndirectedGraphDevice,
                                                     UndirectedGraphDeviceEdge)
 from cirq.contrib.graph_device.hypergraph import UndirectedHypergraph
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Any, Dict
 
 
 def uniform_undirected_graph_device(
@@ -35,8 +31,10 @@ def uniform_undirected_graph_device(
         edge_label: The label to apply to all edges. Defaults to None.
     """
 
-    labelled_edges = {frozenset(edge): edge_label for edge in edges
-                     }  # type: Dict[Iterable[Hashable], Any]
+    labelled_edges: Dict[Iterable[Hashable], Any] = {
+        frozenset(edge): edge_label
+        for edge in edges
+    }
     device_graph = UndirectedHypergraph(labelled_edges=labelled_edges)
     return UndirectedGraphDevice(device_graph=device_graph)
 

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, cast, TYPE_CHECKING
+from typing import List, Optional, cast
 
 import numpy as np
 
@@ -22,10 +22,6 @@ from cirq.circuits.optimization_pass import (
     PointOptimizationSummary,
     PointOptimizer,
 )
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import List
 
 
 class ConvertToPauliStringPhasors(PointOptimizer):

--- a/cirq/devices/device.py
+++ b/cirq/devices/device.py
@@ -20,7 +20,6 @@ from cirq.value import Duration
 
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 # Note: circuit/schedule types specified by name to avoid circular references.

--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Iterable, Sequence, Union
+from typing import TYPE_CHECKING, Sequence
 
 from cirq import ops, value
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
+    from typing import Iterable
     import cirq
 
 

--- a/cirq/google/api/v1/programs.py
+++ b/cirq/google/api/v1/programs.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-from typing import (Any, cast, Dict, Iterable, Sequence, Tuple, TYPE_CHECKING,
-                    Union)
+from typing import (Any, cast, Dict, Iterable, Optional, Sequence, Tuple,
+                    TYPE_CHECKING, Union)
 import numpy as np
 import sympy
 
@@ -22,8 +22,6 @@ from cirq.schedules import Schedule, ScheduledOperation
 from cirq.value import Timestamp
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Optional
     from cirq.google import xmon_device
 
 
@@ -141,7 +139,7 @@ def schedule_to_proto_dicts(schedule: Schedule) -> Iterable[Dict]:
     Yields:
         A proto dictionary corresponding to an Operation proto.
     """
-    last_time_picos = None  # type: Optional[int]
+    last_time_picos: Optional[int] = None
     for so in schedule.scheduled_operations:
         op = gate_to_proto_dict(
             cast(ops.GateOperation, so.operation).gate, so.operation.qubits)

--- a/cirq/google/engine/engine_sampler.py
+++ b/cirq/google/engine/engine_sampler.py
@@ -17,7 +17,6 @@ from typing import Union, List, TYPE_CHECKING
 from cirq import work
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 

--- a/cirq/google/line/placement/anneal.py
+++ b/cirq/google/line/placement/anneal.py
@@ -30,7 +30,6 @@ from cirq.google.line.placement.sequence import (
 )
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq.google
 
 _STATE = Tuple[List[List[GridQubit]], Set[EDGE]]

--- a/cirq/google/line/placement/chip.py
+++ b/cirq/google/line/placement/chip.py
@@ -17,7 +17,6 @@ from typing import Dict, List, Tuple, TYPE_CHECKING
 from cirq.devices import GridQubit
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq.google
 
 

--- a/cirq/google/line/placement/greedy.py
+++ b/cirq/google/line/placement/greedy.py
@@ -23,7 +23,6 @@ from cirq.google.line.placement.chip import chip_as_adjacency_list
 from cirq.google.line.placement.sequence import GridQubitLineTuple
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.google.line.placement.sequence import LineSequence
     import cirq.google
 

--- a/cirq/google/line/placement/line.py
+++ b/cirq/google/line/placement/line.py
@@ -18,7 +18,6 @@ from cirq.google.line.placement.place_strategy import LinePlacementStrategy
 from cirq.google.line.placement.sequence import GridQubitLineTuple
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq.google
 
 

--- a/cirq/google/line/placement/place_strategy.py
+++ b/cirq/google/line/placement/place_strategy.py
@@ -18,7 +18,6 @@ import abc
 from cirq.google.line.placement.sequence import GridQubitLineTuple
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq.google
 
 

--- a/cirq/google/optimize.py
+++ b/cirq/google/optimize.py
@@ -36,7 +36,6 @@ _OPTIMIZERS: List[Callable[[circuits.Circuit], None]] = [
     optimizers.DropNegligible(tolerance=_TOLERANCE).optimize_circuit,
 ]
 
-
 _OPTIMIZERS_PART_CZ: List[Callable[[circuits.Circuit], None]] = [
     convert_to_xmon_gates.ConvertToXmonGates().optimize_circuit,
     optimizers.MergeInteractions(tolerance=_TOLERANCE,

--- a/cirq/google/optimize.py
+++ b/cirq/google/optimize.py
@@ -13,14 +13,10 @@
 # limitations under the License.
 
 """A combination of several optimizations targeting XmonDevice."""
-from typing import Optional, Callable, cast, TYPE_CHECKING
+from typing import Callable, cast, List, Optional
 
 from cirq import circuits, devices, ops, optimizers
 from cirq.google import convert_to_xmon_gates, xmon_device
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import List
 
 
 _TOLERANCE = 1e-5
@@ -30,7 +26,7 @@ def _merge_rots(c: circuits.Circuit):
     return optimizers.merge_single_qubit_gates_into_phased_x_z(c, _TOLERANCE)
 
 
-_OPTIMIZERS = [
+_OPTIMIZERS: List[Callable[[circuits.Circuit], None]] = [
     convert_to_xmon_gates.ConvertToXmonGates().optimize_circuit,
     optimizers.MergeInteractions(tolerance=_TOLERANCE,
                                  allow_partial_czs=False).optimize_circuit,
@@ -38,10 +34,10 @@ _OPTIMIZERS = [
     optimizers.EjectPhasedPaulis(tolerance=_TOLERANCE).optimize_circuit,
     optimizers.EjectZ(tolerance=_TOLERANCE).optimize_circuit,
     optimizers.DropNegligible(tolerance=_TOLERANCE).optimize_circuit,
-]  # type: List[Callable[[circuits.Circuit], None]]
+]
 
 
-_OPTIMIZERS_PART_CZ = [
+_OPTIMIZERS_PART_CZ: List[Callable[[circuits.Circuit], None]] = [
     convert_to_xmon_gates.ConvertToXmonGates().optimize_circuit,
     optimizers.MergeInteractions(tolerance=_TOLERANCE,
                                  allow_partial_czs=True).optimize_circuit,
@@ -49,7 +45,7 @@ _OPTIMIZERS_PART_CZ = [
     optimizers.EjectPhasedPaulis(tolerance=_TOLERANCE).optimize_circuit,
     optimizers.EjectZ(tolerance=_TOLERANCE).optimize_circuit,
     optimizers.DropNegligible(tolerance=_TOLERANCE).optimize_circuit,
-]  # type: List[Callable[[circuits.Circuit], None]]
+]
 
 
 def optimized_for_xmon(

--- a/cirq/google/sim/mem_manager.py
+++ b/cirq/google/sim/mem_manager.py
@@ -47,8 +47,8 @@ class SharedMemManager(object):
         self._lock = Lock()
         self._current = 0
         self._count = 0
-        self._arrays = SharedMemManager._INITIAL_SIZE * [
-            None]  # type: List[Optional[Tuple[Any, Tuple[int, ...]]]]
+        self._arrays: List[Optional[Tuple[
+            Any, Tuple[int, ...]]]] = SharedMemManager._INITIAL_SIZE * [None]
 
     def _create_array(self, arr: np.ndarray) -> int:
         """Returns the handle of a RawArray created from the given numpy array.

--- a/cirq/google/sim/xmon_simulator.py
+++ b/cirq/google/sim/xmon_simulator.py
@@ -35,8 +35,7 @@ via.
 """
 import math
 import collections
-from typing import cast, Dict, Iterator, List, Set, Union
-from typing import Tuple  # pylint: disable=unused-import
+from typing import cast, Dict, Iterator, List, Set, Tuple, Union
 
 import numpy as np
 
@@ -162,8 +161,7 @@ class XmonSimulator(sim.SimulatesSamples,
                           circuit: circuits.Circuit,
                           repetitions: int) -> Dict[str, np.ndarray]:
         keys = find_measurement_keys(circuit)
-        measurements = {k: [] for k in
-                        keys}  # type: Dict[str, List[np.ndarray]]
+        measurements: Dict[str, List[np.ndarray]] = {k: [] for k in keys}
         for _ in range(repetitions):
             all_step_results = self._base_iterator(
                 circuit,
@@ -240,9 +238,9 @@ class XmonSimulator(sim.SimulatesSamples,
             if len(circuit) == 0:
                 yield XmonStepResult(stepper, qubit_map, {})
             for moment in circuit:
-                measurements = collections.defaultdict(
-                    list)  # type: Dict[str, List[bool]]
-                phase_map = {}  # type: Dict[Tuple[int, ...], float]
+                measurements: Dict[str, List[bool]] = collections.defaultdict(
+                    list)
+                phase_map: Dict[Tuple[int, ...], float] = {}
                 for op in moment.operations:
                     gate = cast(ops.GateOperation, op).gate
                     if isinstance(gate, ops.ZPowGate):
@@ -291,7 +289,7 @@ class XmonSimulator(sim.SimulatesSamples,
 
 
 def find_measurement_keys(circuit: circuits.Circuit) -> Set[str]:
-    keys = set()  # type: Set[str]
+    keys: Set[str] = set()
     for _, _, gate in circuit.findall_operations_with_gate_type(
             ops.MeasurementGate):
         key = protocols.measurement_key(gate)

--- a/cirq/google/xmon_device.py
+++ b/cirq/google/xmon_device.py
@@ -13,16 +13,11 @@
 # limitations under the License.
 
 from datetime import timedelta
-from typing import Iterable, cast, Optional, List, Union, TYPE_CHECKING
+from typing import cast, Iterable, List, Optional, Set, Union
 
 from cirq import circuits, devices, ops, protocols, value
 from cirq.google import convert_to_xmon_gates
 from cirq.devices.grid_qubit import GridQubit
-
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Set
 
 
 @value.value_equality
@@ -222,7 +217,7 @@ class XmonDevice(devices.Device):
 
 
 def _verify_unique_measurement_keys(operations: Iterable[ops.Operation]):
-    seen = set()  # type: Set[str]
+    seen: Set[str] = set()
     for op in operations:
         if protocols.is_measurement(op):
             key = protocols.measurement_key(op)

--- a/cirq/ion/ion_device.py
+++ b/cirq/ion/ion_device.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 
 from datetime import timedelta
-from typing import cast, Iterable, Optional, Union, TYPE_CHECKING
+from typing import cast, Iterable, Optional, Set, Union
 
 from cirq import circuits, value, devices, ops, protocols
 from cirq.line import LineQubit
 from cirq.ion import convert_to_ion_gates
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Set
 
 
 @value.value_equality
@@ -187,7 +183,7 @@ class IonDevice(devices.Device):
 
 
 def _verify_unique_measurement_keys(operations: Iterable[ops.Operation]):
-    seen = set()  # type: Set[str]
+    seen: Set[str] = set()
     for op in operations:
         meas = ops.op_gate_of_type(op, ops.MeasurementGate)
         if meas:

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -15,8 +15,7 @@
 
 """Utility methods for breaking matrices into useful pieces."""
 
-from typing import Set, NamedTuple, Union  # pylint: disable=unused-import
-from typing import Callable, List, Tuple, TypeVar
+from typing import Callable, List, Set, Tuple, TypeVar, Union
 
 import math
 import cmath
@@ -85,8 +84,8 @@ def _group_similar(items: List[T],
   Returns:
     A list of groups of items.
   """
-    groups = []  # type: List[List[T]]
-    used = set()  # type: Set[int]
+    groups: List[List[T]] = []
+    used: Set[int] = set()
     for i in range(len(items)):
         if i not in used:
             group = [items[i]]

--- a/cirq/linalg/predicates.py
+++ b/cirq/linalg/predicates.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 
 """Utility methods for checking properties of matrices."""
-from typing import Sequence, Union, Tuple, TYPE_CHECKING
+from typing import List, Sequence, Union, Tuple
 
 import numpy as np
 
 from cirq.linalg import tolerance, transformations
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import List
 
 
 def is_diagonal(matrix: np.ndarray, *, atol: float = 1e-8) -> bool:
@@ -256,8 +252,8 @@ def slice_for_qubits_equal_to(target_qubit_axes: Sequence[int],
     """
     n = num_qubits if num_qubits is not None else (
         max(target_qubit_axes) if target_qubit_axes else -1)
-    result = [slice(None)] * (n + 2 * (
-            num_qubits is None))  # type: List[Union[slice, int, ellipsis]]
+    result: List[Union[slice, int, 'ellipsis']] = [slice(None)] * (n + 2 * (
+            num_qubits is None))
     for k, axis in enumerate(target_qubit_axes):
         result[axis] = (little_endian_qureg_value >> k) & 1
     if num_qubits is None:

--- a/cirq/linalg/predicates.py
+++ b/cirq/linalg/predicates.py
@@ -252,8 +252,9 @@ def slice_for_qubits_equal_to(target_qubit_axes: Sequence[int],
     """
     n = num_qubits if num_qubits is not None else (
         max(target_qubit_axes) if target_qubit_axes else -1)
-    result: List[Union[slice, int, 'ellipsis']] = [slice(None)] * (n + 2 * (
-            num_qubits is None))
+    result: List[Union[slice, int, 'ellipsis']] = [slice(None)
+                                                  ] * (n + 2 *
+                                                       (num_qubits is None))
     for k, axis in enumerate(target_qubit_axes):
         result[axis] = (little_endian_qureg_value >> k) & 1
     if num_qubits is None:

--- a/cirq/ops/display.py
+++ b/cirq/ops/display.py
@@ -31,7 +31,6 @@ from cirq import protocols, value
 from cirq.ops import op_tree, raw_types
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.ops import pauli_string
 
 

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -15,8 +15,7 @@
 """Basic types defining qubits, gates, and operations."""
 
 from typing import (
-    Any, FrozenSet, Optional, Sequence, Tuple, Type, TypeVar, TYPE_CHECKING,
-    Union
+    Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 )
 
 import numpy as np
@@ -24,10 +23,6 @@ import numpy as np
 from cirq import protocols, value
 from cirq.ops import raw_types, gate_features, op_tree
 from cirq.type_workarounds import NotImplementedType
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Dict, List
 
 
 @value.value_equality(approximate=True)
@@ -85,7 +80,7 @@ class GateOperation(raw_types.Operation):
         if not isinstance(self.gate, gate_features.InterchangeableQubitsGate):
             return self.qubits
 
-        groups = {}  # type: Dict[int, List[raw_types.Qid]]
+        groups: Dict[int, List[raw_types.Qid]] = {}
         for i, q in enumerate(self.qubits):
             k = self.gate.qubit_index_to_equivalence_group_key(i)
             if k not in groups:

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -14,9 +14,8 @@
 
 """Basic types defining qubits, gates, and operations."""
 
-from typing import (
-    Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Type, TypeVar, Union
-)
+from typing import (Any, Dict, FrozenSet, List, Optional, Sequence, Tuple, Type,
+                    TypeVar, Union)
 
 import numpy as np
 

--- a/cirq/ops/parallel_gate_operation.py
+++ b/cirq/ops/parallel_gate_operation.py
@@ -13,17 +13,13 @@
 # limitations under the License.
 
 
-from typing import Sequence, Tuple, Union, TYPE_CHECKING, Any
+from typing import Sequence, Tuple, Union, Any
 
 import numpy as np
 
 from cirq import protocols, value
 from cirq.ops import raw_types, op_tree
 from cirq.type_workarounds import NotImplementedType
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Dict, List
 
 
 @value.value_equality

--- a/cirq/ops/pauli_gates.py
+++ b/cirq/ops/pauli_gates.py
@@ -18,7 +18,6 @@ import sympy
 from cirq.ops import common_gates, raw_types
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.ops.pauli_string import SingleQubitPauliStringGateOperation
 
 

--- a/cirq/ops/qubit_order.py
+++ b/cirq/ops/qubit_order.py
@@ -26,7 +26,6 @@ from typing import (
 from cirq.ops import raw_types
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.ops import qubit_order_or_list
 
 

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -22,9 +22,7 @@ from cirq import value
 from cirq.protocols import decompose, inverse, qid_shape_protocol
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from cirq.ops import gate_operation, linear_combinations
-    # pylint: enable=unused-import
 
 
 class Qid(metaclass=abc.ABCMeta):

--- a/cirq/optimizers/drop_negligible.py
+++ b/cirq/optimizers/drop_negligible.py
@@ -14,14 +14,12 @@
 
 """An optimization pass that removes operations with tiny effects."""
 
-from typing import TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING
 
 from cirq import protocols
 from cirq.circuits import circuit as _circuit
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import List, Tuple
     from cirq import ops
 
 
@@ -35,7 +33,7 @@ class DropNegligible():
         self.optimize_circuit(circuit)
 
     def optimize_circuit(self, circuit: _circuit.Circuit) -> None:
-        deletions = []  # type: List[Tuple[int, ops.Operation]]
+        deletions: List[Tuple[int, ops.Operation]] = []
         for moment_index, moment in enumerate(circuit):
             for op in moment.operations:
                 if (op is not None and

--- a/cirq/optimizers/eject_phased_paulis.py
+++ b/cirq/optimizers/eject_phased_paulis.py
@@ -22,7 +22,6 @@ from cirq import circuits, ops, value, protocols
 from cirq.optimizers import decompositions
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     from typing import Dict, List
 
 

--- a/cirq/optimizers/eject_z.py
+++ b/cirq/optimizers/eject_z.py
@@ -14,17 +14,13 @@
 
 """An optimization pass that pushes Z gates later and later in the circuit."""
 
-from typing import Optional, cast, TYPE_CHECKING, Iterable
+from typing import cast, Dict, Iterable, List, Optional, Tuple
 from collections import defaultdict
 import numpy as np
 import sympy
 
 from cirq import circuits, ops, protocols
 from cirq.optimizers import decompositions
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Dict, List, Tuple
 
 
 def _is_integer(n):

--- a/cirq/optimizers/merge_interactions_test.py
+++ b/cirq/optimizers/merge_interactions_test.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+from typing import Callable, List
 
 import pytest
 import sympy
 
 import cirq
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Callable, List
 
 
 def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit):
@@ -30,13 +26,13 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit):
     opt.optimize_circuit(actual)
 
     # Ignore differences that would be caught by follow-up optimizations.
-    followup_optimizations = [
+    followup_optimizations: List[Callable[[cirq.Circuit], None]] = [
         cirq.merge_single_qubit_gates_into_phased_x_z,
         cirq.EjectPhasedPaulis().optimize_circuit,
         cirq.EjectZ().optimize_circuit,
         cirq.DropNegligible().optimize_circuit,
         cirq.DropEmptyMoments().optimize_circuit
-    ]  # type: List[Callable[[cirq.Circuit], None]]
+    ]
     for post in followup_optimizations:
         post(actual)
         post(expected)

--- a/cirq/protocols/circuit_diagram_info.py
+++ b/cirq/protocols/circuit_diagram_info.py
@@ -20,7 +20,6 @@ from typing_extensions import Protocol
 from cirq import value
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 

--- a/cirq/protocols/control.py
+++ b/cirq/protocols/control.py
@@ -17,7 +17,6 @@ from typing import Any, TYPE_CHECKING, TypeVar, Union, Sequence, Iterable
 from cirq.ops import op_tree
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 # This is a special indicator value used by the control method to determine

--- a/cirq/protocols/decompose.py
+++ b/cirq/protocols/decompose.py
@@ -21,7 +21,6 @@ from typing_extensions import Protocol
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 
@@ -31,7 +30,7 @@ TDefault = TypeVar('TDefault')
 
 TError = TypeVar('TError', bound=Exception)
 
-RaiseTypeErrorIfNotProvided = ([],)  # type: Any
+RaiseTypeErrorIfNotProvided: Any = ([],)
 
 
 def _value_error_describing_bad_operation(op: 'cirq.Operation') -> ValueError:
@@ -238,7 +237,7 @@ def decompose(
         return NotImplemented
 
     output = []
-    queue = [val]  # type: List[Any]
+    queue: List[Any] = [val]
     while queue:
         item = queue.pop(0)
 

--- a/cirq/protocols/has_unitary.py
+++ b/cirq/protocols/has_unitary.py
@@ -30,7 +30,6 @@ from typing_extensions import Protocol
 from cirq.protocols import qid_shape_protocol
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 TDefault = TypeVar('TDefault')

--- a/cirq/protocols/inverse.py
+++ b/cirq/protocols/inverse.py
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, overload, TYPE_CHECKING, TypeVar, Union, Iterable
+from typing import (Any, List, overload, Tuple, TYPE_CHECKING, TypeVar,
+                    Union, Iterable)
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
-    from typing import Tuple, List
 
 # This is a special indicator value used by the inverse method to determine
 # whether or not the caller provided a 'default' argument.
-RaiseTypeErrorIfNotProvided = ([],)  # type: Tuple[List[Any]]
+RaiseTypeErrorIfNotProvided: Tuple[List[Any]] = ([],)
 
 
 TDefault = TypeVar('TDefault')
@@ -115,7 +114,7 @@ def inverse(val: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
     # Note: we avoid str because 'a'[0] == 'a', which creates an infinite loop.
     if (isinstance(val, Iterable) and not isinstance(val,
                                                      (str, ops.Operation))):
-        unique_indicator = []  # type: List[Any]
+        unique_indicator: List[Any] = []
         results = tuple(inverse(e, unique_indicator) for e in val)
         if all(e is not unique_indicator for e in results):
             return results[::-1]

--- a/cirq/protocols/inverse.py
+++ b/cirq/protocols/inverse.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (Any, List, overload, Tuple, TYPE_CHECKING, TypeVar,
-                    Union, Iterable)
+from typing import (Any, List, overload, Tuple, TYPE_CHECKING, TypeVar, Union,
+                    Iterable)
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq/protocols/pow.py
+++ b/cirq/protocols/pow.py
@@ -15,12 +15,11 @@
 from typing import Any, overload, TYPE_CHECKING, TypeVar, Union
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 # This is a special indicator value used by the pow method to determine
 # whether or not the caller provided a 'default' argument.
-RaiseTypeErrorIfNotProvided = ([],)  # type: Any
+RaiseTypeErrorIfNotProvided: Any = ([],)
 
 
 TDefault = TypeVar('TDefault')

--- a/cirq/protocols/qasm.py
+++ b/cirq/protocols/qasm.py
@@ -21,7 +21,6 @@ from typing_extensions import Protocol
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 TDefault = TypeVar('TDefault')

--- a/cirq/protocols/qid_shape_protocol.py
+++ b/cirq/protocols/qid_shape_protocol.py
@@ -19,7 +19,6 @@ from typing_extensions import Protocol
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 # This is a special indicator value used by the methods to determine whether or

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -18,7 +18,6 @@ from typing_extensions import Protocol
 import sympy
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 TDefault = TypeVar('TDefault')

--- a/cirq/protocols/unitary.py
+++ b/cirq/protocols/unitary.py
@@ -28,7 +28,6 @@ from cirq.protocols import qid_shape_protocol
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 # This is a special indicator value used by the unitary method to determine

--- a/cirq/schedules/schedule.py
+++ b/cirq/schedules/schedule.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from datetime import timedelta
-from typing import Iterable, List, TYPE_CHECKING, Union, cast
+from typing import Iterable, List, Optional, Union, cast
 
 from sortedcontainers import SortedListWithKey
 
@@ -24,11 +24,6 @@ from cirq.devices import Device
 from cirq.ops import Qid
 from cirq.schedules.scheduled_operation import ScheduledOperation
 from cirq.value import Duration, Timestamp
-
-if TYPE_CHECKING:
-    from typing import Optional  # pylint: disable=unused-import
-
-    from cirq.ops import Operation  # pylint: disable=unused-import
 
 
 class Schedule:
@@ -197,7 +192,7 @@ class Schedule:
         operations that are scheduled at the same time in the same Moment.
         """
         circuit = Circuit(device=self.device)
-        time = None  # type: Optional[Timestamp]
+        time: Optional[Timestamp] = None
         for so in self.scheduled_operations:
             if so.time != time:
                 circuit.append(so.operation,

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -17,17 +17,13 @@
 import collections
 
 from typing import (
-        cast, Dict, Iterator, List, Optional, TYPE_CHECKING, Type, Union)
+        Any, cast, Dict, Hashable, Iterator, List, Optional, Type, Union)
 
 import numpy as np
 
 from cirq import (circuits, linalg, ops, protocols, schedules, study, value,
                   devices)
 from cirq.sim import density_matrix_utils, simulator
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Any, Hashable
 
 
 class _StateAndBuffers:
@@ -367,9 +363,9 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
         qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)
         qubits = qubit_order.order_for(circuit.all_qubits())
 
-        compute_displays_results = []  # type: List[study.ComputeDisplaysResult]
+        compute_displays_results: List[study.ComputeDisplaysResult] = []
         for param_resolver in param_resolvers:
-            display_values = {}  # type: Dict[Hashable, Any]
+            display_values: Dict[Hashable, Any] = {}
 
             # Compute the displays in the first Moment
             moment = circuit[0]

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -16,8 +16,8 @@
 
 import collections
 
-from typing import (
-        Any, cast, Dict, Hashable, Iterator, List, Optional, Type, Union)
+from typing import (Any, cast, Dict, Hashable, Iterator, List, Optional, Type,
+                    Union)
 
 import numpy as np
 

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -19,7 +19,6 @@ from typing import Dict, Union, TYPE_CHECKING, cast
 import sympy
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -26,7 +26,6 @@ from cirq._compat import proper_repr
 from cirq.study import resolver
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 T = TypeVar('T')

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterable, Optional, Sequence, TYPE_CHECKING, Type, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Type, cast
 
 from collections import defaultdict
 import itertools
@@ -20,10 +20,6 @@ import numpy as np
 import sympy
 
 from cirq import circuits, ops, linalg, protocols, EigenGate
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Dict, List
 
 
 def highlight_text_differences(actual: str, expected: str) -> str:
@@ -77,7 +73,7 @@ def _measurement_subspaces(
         measurement_mask |= 1 << i
 
     # Keyed by computational basis state with lowest index.
-    measurement_subspaces = defaultdict(list)  # type: Dict[int, List[int]]
+    measurement_subspaces: Dict[int, List[int]] = defaultdict(list)
     computational_basis = range(1 << n_qubits)
 
     for basis_state in computational_basis:

--- a/cirq/testing/random_circuit.py
+++ b/cirq/testing/random_circuit.py
@@ -13,16 +13,12 @@
 # limitations under the License.
 
 from random import choice, sample, random
-from typing import Union, Sequence, TYPE_CHECKING, Dict, Optional
+from typing import List, Union, Sequence, Dict, Optional
 
 from cirq import ops
 from cirq.circuits import Circuit
 
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import List
-
-DEFAULT_GATE_DOMAIN = {
+DEFAULT_GATE_DOMAIN: Dict[ops.Gate, int] = {
     ops.CNOT: 2,
     ops.CZ: 2,
     ops.H: 1,
@@ -34,7 +30,7 @@ DEFAULT_GATE_DOMAIN = {
     ops.X: 1,
     ops.Y: 1,
     ops.Z: 1
-}  # type: Dict[ops.Gate, int]
+}
 
 
 def random_circuit(qubits: Union[Sequence[ops.Qid], int],
@@ -76,7 +72,7 @@ def random_circuit(qubits: Union[Sequence[ops.Qid], int],
     if n_qubits < 1:
         raise ValueError('At least one qubit must be specified.')
 
-    moments = [] # type: List[ops.Moment]
+    moments: List[ops.Moment] = []
     for _ in range(n_moments):
         operations = []
         free_qubits = set(q for q in qubits)

--- a/cirq/work/collector.py
+++ b/cirq/work/collector.py
@@ -22,7 +22,6 @@ from cirq import circuits, study, value
 from cirq.work import work_pool
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 

--- a/cirq/work/sampler.py
+++ b/cirq/work/sampler.py
@@ -21,7 +21,6 @@ import threading
 from cirq import study
 
 if TYPE_CHECKING:
-    # pylint: disable=unused-import
     import cirq
 
 

--- a/dev_tools/shell_tools.py
+++ b/dev_tools/shell_tools.py
@@ -16,7 +16,14 @@ import asyncio
 import subprocess
 import sys
 from typing import (
-    List, Optional, Tuple, Union, IO, Any, cast, NamedTuple,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    IO,
+    Any,
+    cast,
+    NamedTuple,
 )
 
 from collections.abc import AsyncIterable

--- a/dev_tools/shell_tools.py
+++ b/dev_tools/shell_tools.py
@@ -16,7 +16,7 @@ import asyncio
 import subprocess
 import sys
 from typing import (
-    Optional, Tuple, Union, IO, Any, cast, TYPE_CHECKING, NamedTuple,
+    List, Optional, Tuple, Union, IO, Any, cast, NamedTuple,
 )
 
 from collections.abc import AsyncIterable
@@ -29,10 +29,6 @@ CommandOutput = NamedTuple(
         ('exit_code', int),
     ]
 )
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import List
 
 
 BOLD = 1
@@ -85,7 +81,7 @@ async def _async_forward(async_chunks: AsyncIterable,
     capture = isinstance(out, TeeCapture)
     out_pipe = out.out_pipe if isinstance(out, TeeCapture) else out
 
-    chunks = [] if capture else None  # type: Optional[List[str]]
+    chunks: Optional[List[str]] = [] if capture else None
     async for chunk in async_chunks:
         if not isinstance(chunk, str):
             chunk = chunk.decode()

--- a/docs/snippets_test.py
+++ b/docs/snippets_test.py
@@ -55,7 +55,7 @@ In addition to checking that the code executes:
 """
 import inspect
 import sys
-from typing import Dict, List, Pattern, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Pattern, Tuple
 
 import os
 import re
@@ -63,10 +63,6 @@ import re
 import pytest
 
 import cirq
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from typing import Any
 
 
 def test_can_run_readme_code_snippets():
@@ -368,7 +364,7 @@ def assert_code_snippets_run_in_sequence(snippets: List[Tuple[str, int]],
     snippet will be visible in later snippets.
     """
 
-    state = {}  # type: Dict[str, Any]
+    state: Dict[str, Any] = {}
 
     if assume_import:
         exec('import cirq', state)


### PR DESCRIPTION
This is made possible by `pylint` recently starting to automatically ignore unused imports inside `if typing.TYPE_CHECKING`, and by the use of variable type annotations (instead of commented type annotations).