### PR TITLE
Add back in extras_require by using compatible versions

### DIFF
--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for contrib.
 
 ply>=3.4
-pylatex~=1.3
+pylatex~=1.3.0
 # Python 3.7 support for Tensorflow is currently only supported in the nightly build.
 tf-nightly

--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for contrib.
 
 ply>=3.4
-pylatex==1.3.*
+pylatex~=1.3
 # Python 3.7 support for Tensorflow is currently only supported in the nightly build.
 tf-nightly

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -24,4 +24,4 @@ sphinx_rtd_theme
 sphinx-markdown-tables
 
 # Need to pin pylint's parser to 2.1 instead of 2.2 until https://github.com/PyCQA/astroid/issues/650 is fixed
-astroid==2.1.0
+astroid~=2.1.0

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -1,27 +1,27 @@
 # For testing and analyzing code.
-mypy==0.701.*
-pylint==2.3.*
-pytest==3.8.*
-pytest-cov==2.5.*
-pytest-benchmark==3.2.*
-yapf==0.27.*
+mypy~=0.701
+pylint~=2.3
+pytest~=3.8
+pytest-cov~=2.5
+pytest-benchmark~=3.2
+yapf~=0.27
 
 # For generating protobufs
-grpcio-tools==1.21.*
+grpcio-tools~=1.21
 mypy-protobuf==1.10
 
 # For uploading packages to pypi.
 twine
 
 # For verifying behavior of qasm output.
-qiskit==0.6.*
+qiskit~=0.6
 
 # For generating documentation.
 pypandoc
-recommonmark >= 0.4.0
+recommonmark ~= 0.4.0
 Sphinx
 sphinx_rtd_theme
 sphinx-markdown-tables
 
 # Need to pin pylint's parser to 2.1 instead of 2.2 until https://github.com/PyCQA/astroid/issues/650 is fixed
-astroid==2.1.*
+astroid~=2.1

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -1,27 +1,27 @@
 # For testing and analyzing code.
-mypy~=0.701
-pylint~=2.3
-pytest~=3.8
-pytest-cov~=2.5
-pytest-benchmark~=3.2
-yapf~=0.27
+mypy~=0.701.0
+pylint~=2.3.0
+pytest~=3.8.0
+pytest-cov~=2.5.0
+pytest-benchmark~=3.2.0
+yapf~=0.27.0
 
 # For generating protobufs
-grpcio-tools~=1.21
+grpcio-tools~=1.21.0
 mypy-protobuf==1.10
 
 # For uploading packages to pypi.
 twine
 
 # For verifying behavior of qasm output.
-qiskit~=0.6
+qiskit~=0.6.0
 
 # For generating documentation.
 pypandoc
-recommonmark ~= 0.4.0
+recommonmark >= 0.4.0
 Sphinx
 sphinx_rtd_theme
 sphinx-markdown-tables
 
 # Need to pin pylint's parser to 2.1 instead of 2.2 until https://github.com/PyCQA/astroid/issues/650 is fixed
-astroid~=2.1
+astroid==2.1.0

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,9 +89,7 @@ See the previous section for instructions.
     ```bash
     mkvirtualenv cirq-py3 --python=/usr/bin/python3
     python -m pip install --upgrade pip
-    python -m pip install -r requirements.txt
-    python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    python -m pip install -r cirq/contrib/contrib-requirements.txt
+    python -m pip install -e .[dev,contrib]
     ```
 
     (When you later open another terminal, you can activate the virtualenv with `workon cirq-py3`.)

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,7 +34,15 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. (Optional) install system dependencies that pip can't handle.
+3. (Optional) install other dependencies.
+
+    Install dependencies of features in `cirq.contrib`.
+
+    ```bash
+    python -m pip install cirq[contrib]
+    ```
+
+    Install system dependencies that pip can't handle.
 
     ```bash
     sudo apt-get install texlive-latex-base latexmk
@@ -69,7 +77,13 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. Check that it works!
+3. (Optional) install dependencies of features in `cirq.contrib`.
+
+    ```bash
+    python -m pip install cirq[contrib]
+    ```
+
+4. Check that it works!
 
     ```bash
     python -c 'import cirq; print(cirq.google.Foxtail)'
@@ -96,7 +110,13 @@ That way you have control over when a breaking change affects you.
     python -m pip install cirq
     ```
 
-3. Check that it works!
+3. (Optional) install dependencies of features in `cirq.contrib`.
+
+    ```bash
+    python -m pip install cirq[contrib]
+    ```
+
+4. Check that it works!
 
     ```bash
     python -c "import cirq; print(cirq.google.Foxtail)"

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ long_description = io.open('README.rst', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
+contrib_requirements = open('cirq/contrib/contrib-requirements.txt').readlines()
+contrib_requirements = [r.strip() for r in contrib_requirements]
+dev_requirements = open('dev_tools/conf/pip-list-dev-tools.txt').readlines()
+dev_requirements = [r.strip() for r in dev_requirements]
 
 cirq_packages = ['cirq'] + [
     'cirq.' + package for package in find_packages(where='cirq')
@@ -40,6 +44,10 @@ setup(name='cirq',
       author_email='cirq@googlegroups.com',
       python_requires=('>=3.6.0'),
       install_requires=requirements,
+      extras_require={
+          'contrib': contrib_requirements,
+          'dev': dev_requirements,
+      },
       license='Apache 2',
       description=description,
       long_description=long_description,


### PR DESCRIPTION
Instead of using `==v.w.*` this uses `~=v.w` the compatibility operator.  Compatibility is `==v.* >=v.w`.  This is nearly the same thing with some sublties about prelease versions that shouldn't hit us.

I've tested this by pushing to test pypi and prod pypi and it works.