### PR TITLE
TESTING: Github Actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,27 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -21,7 +21,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r dev_tools/conf/pip-list-dev-tools.txt
+        pip install -r cirq/contrib/contrib-requirements.txt
     - name: Test with pytest
       run: |
-        pip install pytest
-        pytest
+        check/pytest-and-incremental-coverage master --actually-quiet

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,4 +25,4 @@ jobs:
         pip install -r cirq/contrib/contrib-requirements.txt
     - name: Test with pytest
       run: |
-        check/pytest-and-incremental-coverage master --actually-quiet
+        check/pytest-and-incremental-coverage --actually-quiet


### PR DESCRIPTION
Background: https://developer.github.com/actions/

Adopting Github actions to replace Travis will require a `Cirq/.github/workflows/pythonpackage.yml`. 

This could make implementing nightly builds like https://github.com/quantumlib/Cirq/pull/1938 easier.