### PR TITLE
Cleanup: remove instances of abstractmethod for properties

### DIFF
--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -40,14 +40,16 @@ class ExecutionStrategy(metaclass=abc.ABCMeta):
 
     keep_acquaintance = False
 
-    @abc.abstractproperty
+    @abc.abstractmethod
+    @property
     def device(self) -> devices.Device:
         """The device for which the executed acquaintance strategy should be
         valid.
         """
 
 
-    @abc.abstractproperty
+    @abc.abstractmethod
+    @property
     def initial_mapping(self) -> LogicalMapping:
         """The initial mapping of logical indices to qubits."""
 

--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -40,16 +40,16 @@ class ExecutionStrategy(metaclass=abc.ABCMeta):
 
     keep_acquaintance = False
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def device(self) -> devices.Device:
         """The device for which the executed acquaintance strategy should be
         valid.
         """
 
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def initial_mapping(self) -> LogicalMapping:
         """The initial mapping of logical indices to qubits."""
 

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -263,7 +263,8 @@ class Operation(metaclass=abc.ABCMeta):
     effect into a qubit-independent Gate and the qubits it should be applied to.
     """
 
-    @abc.abstractproperty
+    @abc.abstractmethod
+    @property
     def qubits(self) -> Tuple[Qid, ...]:
         raise NotImplementedError()
 

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -263,8 +263,8 @@ class Operation(metaclass=abc.ABCMeta):
     effect into a qubit-independent Gate and the qubits it should be applied to.
     """
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def qubits(self) -> Tuple[Qid, ...]:
         raise NotImplementedError()
 

--- a/cirq/study/sweeps.py
+++ b/cirq/study/sweeps.py
@@ -87,8 +87,8 @@ class Sweep(metaclass=abc.ABCMeta):
     def __ne__(self, other):
         return not self == other
 
-    @abc.abstractmethod
     @property
+    @abc.abstractmethod
     def keys(self) -> List[str]:
         """The keys for the all of the sympy.Symbols that are resolved."""
 

--- a/cirq/study/sweeps.py
+++ b/cirq/study/sweeps.py
@@ -87,7 +87,8 @@ class Sweep(metaclass=abc.ABCMeta):
     def __ne__(self, other):
         return not self == other
 
-    @abc.abstractproperty
+    @abc.abstractmethod
+    @property
     def keys(self) -> List[str]:
         """The keys for the all of the sympy.Symbols that are resolved."""
 


### PR DESCRIPTION
@abstractproperty is deprecated after python 3.3