### PR TITLE
Add spaces to dev string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ if 'CIRQ_DEV_VERSION' in os.environ:
     long_description = (
         "**This is a development version of Cirq and may be "
         "unstable.**\n\n**For the latest stable release of Cirq "
-        "see**\n`here <https://pypi.org/project/cirq>`__.\n\n" + long_description)
+        "see**\n`here <https://pypi.org/project/cirq>`__.\n\n" +
+        long_description)
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ if 'CIRQ_DEV_VERSION' in os.environ:
     long_description = (
         "**This is a development version of Cirq and may be "
         "unstable.**\n\n**For the latest stable release of Cirq "
-        "see **\n`here <https://pypi.org/project/cirq>`__.\n\n" + long_description)
+        "see**\n`here <https://pypi.org/project/cirq>`__.\n\n" + long_description)
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ if 'CIRQ_DEV_VERSION' in os.environ:
         "**This is a development version of Cirq and may be "
         "unstable.**\n\n**For the latest stable release of Cirq "
         "see **\n`here <https://pypi.org/project/cirq>`__.\n\n" + long_description)
-print(long_description)
-assert False
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ if 'CIRQ_DEV_VERSION' in os.environ:
     long_description = (
         "**This is a development version of Cirq and may be "
         "unstable.**\n\n**For the latest stable release of Cirq "
-        "see ** `here <https://pypi.org/project/cirq>`__.\n" + long_description)
+        "see **\n`here <https://pypi.org/project/cirq>`__.\n\n" + long_description)
+print(long_description)
+assert False
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()


### PR DESCRIPTION
Deploy failed.  Printing the long description out gives
```**This is a development version of Cirq and may be unstable.**

**For the latest stable release of Cirq see ** `here <https://pypi.org/project/cirq>`__.
.. image:: https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/Cirq_logo_color.png
  :target: https://github.com/quantumlib/cirq
  :alt: Cirq
  :width: 500px
```
Which I believe has a problem because of the lack of newline before the image.
