### PR TITLE
Add pandoc to dev apt-list

### DIFF
--- a/dev_tools/conf/apt-list-dev-tools.txt
+++ b/dev_tools/conf/apt-list-dev-tools.txt
@@ -1,1 +1,2 @@
 virtualenvwrapper
+pandoc


### PR DESCRIPTION
Fixes #1920 

Tested that removing pandoc mails buid-docs.sh fail and that installing after made it succeed.