### PR TITLE
Add `install: requirements` section in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,3 +4,7 @@ build:
 python:
   version: 3.6
   pip_install: true
+
+  install:
+      - requirements: contrib/contrib-requirements.txt
+      - requirements: requirements.txt


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/1204