### PR TITLE
Support symbols in EjectPhasedPaulis optimizer

### DIFF
--- a/cirq/ops/pauli_gates.py
+++ b/cirq/ops/pauli_gates.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-from typing import Union, TYPE_CHECKING, Tuple, Optional
+from typing import Union, TYPE_CHECKING, Tuple
 
 import sympy
 from cirq.ops import common_gates, raw_types

--- a/cirq/optimizers/decompositions.py
+++ b/cirq/optimizers/decompositions.py
@@ -25,7 +25,9 @@ from cirq.linalg.tolerance import near_zero_mod
 
 def is_negligible_turn(turns: float, tolerance: float) -> bool:
     if isinstance(turns, sympy.Basic):
-        return False
+        if not turns.is_constant():
+            return False
+        turns = float(turns)
     return abs(_signed_mod_1(turns)) <= tolerance
 
 

--- a/cirq/optimizers/decompositions_test.py
+++ b/cirq/optimizers/decompositions_test.py
@@ -49,7 +49,10 @@ def test_is_negligible_turn():
     assert not cirq.is_negligible_turn(-0.5, 1e-5)
     assert not cirq.is_negligible_turn(0.5, 1e-5)
     assert not cirq.is_negligible_turn(4.5, 1e-5)
+    # Variable sympy expression
     assert not cirq.is_negligible_turn(sympy.Symbol('a'), 1e-5)
+    assert not cirq.is_negligible_turn(sympy.Symbol('a') + 1, 1e-5)
+    assert not cirq.is_negligible_turn(sympy.Symbol('a') * 1e-10, 1e-5)
     # Sympy expression for a constant
     assert cirq.is_negligible_turn(sympy.Symbol('a') * 0 + 3 + 1e-6, 1e-5)
     assert not cirq.is_negligible_turn(sympy.Symbol('a') * 0 + 1.5 - 1e-6, 1e-5)

--- a/cirq/optimizers/decompositions_test.py
+++ b/cirq/optimizers/decompositions_test.py
@@ -36,13 +36,13 @@ def test_is_negligible_turn():
     assert cirq.is_negligible_turn(0, 1e-5)
     assert cirq.is_negligible_turn(1e-6, 1e-5)
     assert cirq.is_negligible_turn(1, 1e-5)
-    assert cirq.is_negligible_turn(1+1e-6, 1e-5)
-    assert cirq.is_negligible_turn(1-1e-6, 1e-5)
+    assert cirq.is_negligible_turn(1 + 1e-6, 1e-5)
+    assert cirq.is_negligible_turn(1 - 1e-6, 1e-5)
     assert cirq.is_negligible_turn(-1, 1e-5)
-    assert cirq.is_negligible_turn(-1+1e-6, 1e-5)
-    assert cirq.is_negligible_turn(-1-1e-6, 1e-5)
+    assert cirq.is_negligible_turn(-1 + 1e-6, 1e-5)
+    assert cirq.is_negligible_turn(-1 - 1e-6, 1e-5)
     assert cirq.is_negligible_turn(3, 1e-5)
-    assert cirq.is_negligible_turn(3+1e-6, 1e-5)
+    assert cirq.is_negligible_turn(3 + 1e-6, 1e-5)
     assert not cirq.is_negligible_turn(1e-4, 1e-5)
     assert not cirq.is_negligible_turn(-1e-4, 1e-5)
     assert not cirq.is_negligible_turn(0.5, 1e-5)
@@ -51,8 +51,8 @@ def test_is_negligible_turn():
     assert not cirq.is_negligible_turn(4.5, 1e-5)
     assert not cirq.is_negligible_turn(sympy.Symbol('a'), 1e-5)
     # Sympy expression for a constant
-    assert cirq.is_negligible_turn(sympy.Symbol('a')*0+3+1e-6, 1e-5)
-    assert not cirq.is_negligible_turn(sympy.Symbol('a')*0+1.5-1e-6, 1e-5)
+    assert cirq.is_negligible_turn(sympy.Symbol('a') * 0 + 3 + 1e-6, 1e-5)
+    assert not cirq.is_negligible_turn(sympy.Symbol('a') * 0 + 1.5 - 1e-6, 1e-5)
 
 
 def test_single_qubit_matrix_to_gates_known_x():

--- a/cirq/optimizers/decompositions_test.py
+++ b/cirq/optimizers/decompositions_test.py
@@ -18,6 +18,7 @@ from typing import Sequence
 
 import numpy as np
 import pytest
+import sympy
 
 import cirq
 
@@ -29,6 +30,29 @@ def assert_gates_implement_unitary(gates: Sequence[cirq.SingleQubitGate],
     cirq.testing.assert_allclose_up_to_global_phase(actual_effect,
                                                     intended_effect,
                                                     atol=atol)
+
+
+def test_is_negligible_turn():
+    assert cirq.is_negligible_turn(0, 1e-5)
+    assert cirq.is_negligible_turn(1e-6, 1e-5)
+    assert cirq.is_negligible_turn(1, 1e-5)
+    assert cirq.is_negligible_turn(1+1e-6, 1e-5)
+    assert cirq.is_negligible_turn(1-1e-6, 1e-5)
+    assert cirq.is_negligible_turn(-1, 1e-5)
+    assert cirq.is_negligible_turn(-1+1e-6, 1e-5)
+    assert cirq.is_negligible_turn(-1-1e-6, 1e-5)
+    assert cirq.is_negligible_turn(3, 1e-5)
+    assert cirq.is_negligible_turn(3+1e-6, 1e-5)
+    assert not cirq.is_negligible_turn(1e-4, 1e-5)
+    assert not cirq.is_negligible_turn(-1e-4, 1e-5)
+    assert not cirq.is_negligible_turn(0.5, 1e-5)
+    assert not cirq.is_negligible_turn(-0.5, 1e-5)
+    assert not cirq.is_negligible_turn(0.5, 1e-5)
+    assert not cirq.is_negligible_turn(4.5, 1e-5)
+    assert not cirq.is_negligible_turn(sympy.Symbol('a'), 1e-5)
+    # Sympy expression for a constant
+    assert cirq.is_negligible_turn(sympy.Symbol('a')*0+3+1e-6, 1e-5)
+    assert not cirq.is_negligible_turn(sympy.Symbol('a')*0+1.5-1e-6, 1e-5)
 
 
 def test_single_qubit_matrix_to_gates_known_x():

--- a/cirq/optimizers/decompositions_test.py
+++ b/cirq/optimizers/decompositions_test.py
@@ -53,7 +53,7 @@ def test_is_negligible_turn():
     assert not cirq.is_negligible_turn(sympy.Symbol('a'), 1e-5)
     assert not cirq.is_negligible_turn(sympy.Symbol('a') + 1, 1e-5)
     assert not cirq.is_negligible_turn(sympy.Symbol('a') * 1e-10, 1e-5)
-    # Sympy expression for a constant
+    # Constant sympy expression
     assert cirq.is_negligible_turn(sympy.Symbol('a') * 0 + 3 + 1e-6, 1e-5)
     assert not cirq.is_negligible_turn(sympy.Symbol('a') * 0 + 1.5 - 1e-6, 1e-5)
 

--- a/cirq/optimizers/eject_phased_paulis.py
+++ b/cirq/optimizers/eject_phased_paulis.py
@@ -48,7 +48,9 @@ class EjectPhasedPaulis():
     then be removed by the EjectZ optimization).
     """
 
-    def __init__(self, tolerance: float = 1e-8, eject_parameterized: bool = False) -> None:
+    def __init__(self,
+                 tolerance: float = 1e-8,
+                 eject_parameterized: bool = False) -> None:
         """
         Args:
             tolerance: Maximum absolute error tolerance. The optimization is
@@ -69,7 +71,8 @@ class EjectPhasedPaulis():
                 affected = [q for q in op.qubits if q in state.held_w_phases]
 
                 # Collect, phase, and merge Ws.
-                w = _try_get_known_phased_pauli(op, no_symbolic=not self.eject_parameterized)
+                w = _try_get_known_phased_pauli(
+                    op, no_symbolic=not self.eject_parameterized)
                 if w is not None:
                     if decompositions.is_negligible_turn(
                             w[0] - 1,
@@ -86,7 +89,8 @@ class EjectPhasedPaulis():
                     continue
 
                 # Absorb Z rotations.
-                t = _try_get_known_z_half_turns(op, no_symbolic=not self.eject_parameterized)
+                t = _try_get_known_z_half_turns(
+                    op, no_symbolic=not self.eject_parameterized)
                 if t is not None:
                     _absorb_z_into_w(moment_index, op, state)
                     continue
@@ -96,7 +100,9 @@ class EjectPhasedPaulis():
                     _dump_into_measurement(moment_index, op, state)
 
                 # Cross CZs using kickback.
-                if _try_get_known_cz_half_turns(op, no_symbolic=not self.eject_parameterized) is not None:
+                if _try_get_known_cz_half_turns(
+                        op,
+                        no_symbolic=not self.eject_parameterized) is not None:
                     if len(affected) == 1:
                         _single_cross_over_cz(moment_index,
                                               op,
@@ -155,8 +161,8 @@ def _dump_into_measurement(moment_index: int,
                            state: _OptimizerState) -> None:
     measurement = cast(ops.MeasurementGate, cast(ops.GateOperation, op).gate)
     new_measurement = measurement.with_bits_flipped(
-        *[i for i, q in enumerate(op.qubits) if q in state.held_w_phases]
-    ).on(*op.qubits)
+        *[i for i, q in enumerate(op.qubits) if q in state.held_w_phases]).on(
+            *op.qubits)
     for q in op.qubits:
         state.held_w_phases.pop(q, None)
     state.deletions.append((moment_index, op))
@@ -180,8 +186,7 @@ def _potential_cross_whole_w(moment_index: int,
     """
     state.deletions.append((moment_index, op))
 
-    _, phase_exponent = cast(Tuple[TVal, TVal],
-                             _try_get_known_phased_pauli(op))
+    _, phase_exponent = cast(Tuple[TVal, TVal], _try_get_known_phased_pauli(op))
     q = op.qubits[0]
     a = state.held_w_phases.get(q, None)
     b = phase_exponent
@@ -311,8 +316,8 @@ def _double_cross_over_cz(op: ops.Operation,
         state.held_w_phases[q] = cast(TVal, state.held_w_phases[q]) + t / 2
 
 
-def _try_get_known_cz_half_turns(op: ops.Operation, no_symbolic: bool = False
-                                ) -> Optional[TVal]:
+def _try_get_known_cz_half_turns(op: ops.Operation,
+                                 no_symbolic: bool = False) -> Optional[TVal]:
     if (not isinstance(op, ops.GateOperation) or
             not isinstance(op.gate, ops.CZPowGate)):
         return None
@@ -324,8 +329,8 @@ def _try_get_known_cz_half_turns(op: ops.Operation, no_symbolic: bool = False
 
 def _try_get_known_phased_pauli(op: ops.Operation, no_symbolic: bool = False
                                ) -> Optional[Tuple[TVal, TVal]]:
-    if ((no_symbolic and protocols.is_parameterized(op))
-        or not isinstance(op, ops.GateOperation)):
+    if ((no_symbolic and protocols.is_parameterized(op)) or
+            not isinstance(op, ops.GateOperation)):
         return None
     gate = op.gate
 
@@ -343,8 +348,8 @@ def _try_get_known_phased_pauli(op: ops.Operation, no_symbolic: bool = False
     return value.canonicalize_half_turns(e), value.canonicalize_half_turns(p)
 
 
-def _try_get_known_z_half_turns(op: ops.Operation, no_symbolic: bool = False
-                               ) -> Optional[TVal]:
+def _try_get_known_z_half_turns(op: ops.Operation,
+                                no_symbolic: bool = False) -> Optional[TVal]:
     if (not isinstance(op, ops.GateOperation) or
             not isinstance(op.gate, ops.ZPowGate)):
         return None

--- a/cirq/optimizers/eject_phased_paulis.py
+++ b/cirq/optimizers/eject_phased_paulis.py
@@ -15,7 +15,7 @@
 """Pushes 180 degree rotations around axes in the XY plane later in the circuit.
 """
 
-from typing import Optional, cast, TYPE_CHECKING, Iterable, Tuple
+from typing import Optional, cast, TYPE_CHECKING, Iterable, Tuple, Union
 import sympy
 
 from cirq import circuits, ops, value, protocols
@@ -25,10 +25,13 @@ if TYPE_CHECKING:
     from typing import Dict, List
 
 
+TVal = Union[float, sympy.Basic]
+
+
 class _OptimizerState:
     def __init__(self):
         # The phases of the W gates currently being pushed along each qubit.
-        self.held_w_phases = {}  # type: Dict[ops.Qid, Optional[float]]
+        self.held_w_phases = {}  # type: Dict[ops.Qid, TVal]
 
         # Accumulated commands to batch-apply to the circuit later.
         self.deletions = []  # type: List[Tuple[int, ops.Operation]]
@@ -45,25 +48,28 @@ class EjectPhasedPaulis():
     then be removed by the EjectZ optimization).
     """
 
-    def __init__(self, tolerance: float = 1e-8) -> None:
+    def __init__(self, tolerance: float = 1e-8, eject_parameterized: bool = False) -> None:
         """
         Args:
             tolerance: Maximum absolute error tolerance. The optimization is
-                 permitted to simply drop negligible combinations of Z gates,
-                 with a threshold determined by this tolerance.
+                 permitted to simply drop negligible combinations gates with a
+                 threshold determined by this tolerance.
+            eject_parameterized: If True, the optimization will attempt to eject
+                parametrized gates as well.  This may result in other gates
+                parameterized by symbolic expressions.
         """
         self.tolerance = tolerance
+        self.eject_parameterized = eject_parameterized
 
     def optimize_circuit(self, circuit: circuits.Circuit):
         state = _OptimizerState()
 
         for moment_index, moment in enumerate(circuit):
             for op in moment.operations:
-                affected = [q for q in op.qubits
-                            if state.held_w_phases.get(q) is not None]
+                affected = [q for q in op.qubits if q in state.held_w_phases]
 
                 # Collect, phase, and merge Ws.
-                w = _try_get_known_phased_pauli(op)
+                w = _try_get_known_phased_pauli(op, no_symbolic=not self.eject_parameterized)
                 if w is not None:
                     if decompositions.is_negligible_turn(
                             w[0] - 1,
@@ -80,7 +86,7 @@ class EjectPhasedPaulis():
                     continue
 
                 # Absorb Z rotations.
-                t = _try_get_known_z_half_turns(op)
+                t = _try_get_known_z_half_turns(op, no_symbolic=not self.eject_parameterized)
                 if t is not None:
                     _absorb_z_into_w(moment_index, op, state)
                     continue
@@ -90,7 +96,7 @@ class EjectPhasedPaulis():
                     _dump_into_measurement(moment_index, op, state)
 
                 # Cross CZs using kickback.
-                if _try_get_known_cz_half_turns(op) is not None:
+                if _try_get_known_cz_half_turns(op, no_symbolic=not self.eject_parameterized) is not None:
                     if len(affected) == 1:
                         _single_cross_over_cz(moment_index,
                                               op,
@@ -126,9 +132,9 @@ def _absorb_z_into_w(moment_index: int,
         ≡ ────────────────────────W(a+t/2)───────── (cancel Ws)
         ≡ ───W(a+t/2)───
     """
-    t = cast(float, _try_get_known_z_half_turns(op))
+    t = cast(TVal, _try_get_known_z_half_turns(op))
     q = op.qubits[0]
-    state.held_w_phases[q] = cast(float, state.held_w_phases[q]) + t / 2
+    state.held_w_phases[q] += t / 2
     state.deletions.append((moment_index, op))
 
 
@@ -141,7 +147,7 @@ def _dump_held(qubits: Iterable[ops.Qid],
         if p is not None:
             dump_op = ops.PhasedXPowGate(phase_exponent=p).on(q)
             state.insertions.append((moment_index, dump_op))
-        state.held_w_phases[q] = None
+        state.held_w_phases.pop(q, None)
 
 
 def _dump_into_measurement(moment_index: int,
@@ -149,12 +155,10 @@ def _dump_into_measurement(moment_index: int,
                            state: _OptimizerState) -> None:
     measurement = cast(ops.MeasurementGate, cast(ops.GateOperation, op).gate)
     new_measurement = measurement.with_bits_flipped(
-        *[i
-          for i, q in enumerate(op.qubits)
-          if state.held_w_phases.get(q) is not None]
+        *[i for i, q in enumerate(op.qubits) if q in state.held_w_phases]
     ).on(*op.qubits)
     for q in op.qubits:
-        state.held_w_phases[q] = None
+        state.held_w_phases.pop(q, None)
     state.deletions.append((moment_index, op))
     state.inline_intos.append((moment_index, new_measurement))
 
@@ -176,10 +180,10 @@ def _potential_cross_whole_w(moment_index: int,
     """
     state.deletions.append((moment_index, op))
 
-    _, phase_exponent = cast(Tuple[float, float],
+    _, phase_exponent = cast(Tuple[TVal, TVal],
                              _try_get_known_phased_pauli(op))
     q = op.qubits[0]
-    a = state.held_w_phases.get(q)
+    a = state.held_w_phases.get(q, None)
     b = phase_exponent
 
     if a is None:
@@ -187,7 +191,7 @@ def _potential_cross_whole_w(moment_index: int,
         state.held_w_phases[q] = b
     else:
         # Cancel the gate.
-        state.held_w_phases[q] = None
+        del state.held_w_phases[q]
         t = 2*(b - a)
         if not decompositions.is_negligible_turn(t / 2, tolerance):
             leftover_phase = ops.Z(q)**t
@@ -209,10 +213,10 @@ def _potential_cross_partial_w(moment_index: int,
         ≡ ───W(2a-b)^t───Z^-a───X───Z^a─── (move Z^-a across, phasing axis)
         ≡ ───W(2a-b)^t───W(a)───
     """
-    a = state.held_w_phases.get(op.qubits[0])
+    a = state.held_w_phases.get(op.qubits[0], None)
     if a is None:
         return
-    exponent, phase_exponent = cast(Tuple[float, float],
+    exponent, phase_exponent = cast(Tuple[TVal, TVal],
                                     _try_get_known_phased_pauli(op))
     new_op = ops.PhasedXPowGate(
         exponent=exponent,
@@ -256,7 +260,7 @@ def _single_cross_over_cz(moment_index: int,
                    │
           ─────────@^-t───W(a)────
     """
-    t = cast(float, _try_get_known_cz_half_turns(op))
+    t = cast(TVal, _try_get_known_cz_half_turns(op))
     other_qubit = op.qubits[0] if qubit_with_w == op.qubits[1] else op.qubits[1]
     negated_cz = ops.CZ(*op.qubits)**-t
     kickback = ops.Z(other_qubit)**t
@@ -302,24 +306,26 @@ def _double_cross_over_cz(op: ops.Operation,
              │
           ───@^t───W(b+t/2)───
     """
-    t = cast(float, _try_get_known_cz_half_turns(op))
+    t = cast(TVal, _try_get_known_cz_half_turns(op))
     for q in op.qubits:
-        state.held_w_phases[q] = cast(float, state.held_w_phases[q]) + t / 2
+        state.held_w_phases[q] = cast(TVal, state.held_w_phases[q]) + t / 2
 
 
-def _try_get_known_cz_half_turns(op: ops.Operation) -> Optional[float]:
+def _try_get_known_cz_half_turns(op: ops.Operation, no_symbolic: bool = False
+                                ) -> Optional[TVal]:
     if (not isinstance(op, ops.GateOperation) or
             not isinstance(op.gate, ops.CZPowGate)):
         return None
     h = op.gate.exponent
-    if isinstance(h, sympy.Basic):
+    if no_symbolic and isinstance(h, sympy.Basic):
         return None
     return h
 
 
-def _try_get_known_phased_pauli(op: ops.Operation
-                                ) -> Optional[Tuple[float, float]]:
-    if protocols.is_parameterized(op) or not isinstance(op, ops.GateOperation):
+def _try_get_known_phased_pauli(op: ops.Operation, no_symbolic: bool = False
+                               ) -> Optional[Tuple[TVal, TVal]]:
+    if ((no_symbolic and protocols.is_parameterized(op))
+        or not isinstance(op, ops.GateOperation)):
         return None
     gate = op.gate
 
@@ -334,16 +340,15 @@ def _try_get_known_phased_pauli(op: ops.Operation
         p = 0.0
     else:
         return None
-    return cast(Tuple[float, float],
-                (value.canonicalize_half_turns(e),
-                 value.canonicalize_half_turns(p)))
+    return value.canonicalize_half_turns(e), value.canonicalize_half_turns(p)
 
 
-def _try_get_known_z_half_turns(op: ops.Operation) -> Optional[float]:
+def _try_get_known_z_half_turns(op: ops.Operation, no_symbolic: bool = False
+                               ) -> Optional[TVal]:
     if (not isinstance(op, ops.GateOperation) or
             not isinstance(op.gate, ops.ZPowGate)):
         return None
     h = op.gate.exponent
-    if isinstance(h, sympy.Basic):
+    if no_symbolic and isinstance(h, sympy.Basic):
         return None
     return h

--- a/cirq/optimizers/eject_phased_paulis_test.py
+++ b/cirq/optimizers/eject_phased_paulis_test.py
@@ -15,22 +15,32 @@ from typing import Iterable, cast
 
 import pytest
 import sympy
+import numpy as np
 
 import cirq
 
 
 def assert_optimizes(before: cirq.Circuit,
                      expected: cirq.Circuit,
-                     compare_unitaries: bool = True):
-    opt = cirq.EjectPhasedPaulis()
+                     compare_unitaries: bool = True,
+                     eject_parameterized: bool = False):
+    opt = cirq.EjectPhasedPaulis(eject_parameterized=eject_parameterized)
 
     circuit = before.copy()
     opt.optimize_circuit(circuit)
 
     # They should have equivalent effects.
     if compare_unitaries:
-        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-            circuit, expected, 1e-8)
+        if cirq.is_parameterized(circuit):
+            for a in (0, 0.1, 0.5, -1.0, np.pi, np.pi/2):
+                params = {'x': a, 'y': a/2, 'z': -2*a}
+                (cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+                     cirq.resolve_parameters(circuit, params),
+                     cirq.resolve_parameters(expected, params),
+                     1e-8))
+        else:
+            cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+                circuit, expected, 1e-8)
 
     # And match the expected circuit.
     assert circuit == expected, (
@@ -63,6 +73,7 @@ def quick_circuit(*moments: Iterable[cirq.OP_TREE]) -> cirq.Circuit:
 
 def test_absorbs_z():
     q = cirq.NamedQubit('q')
+    x = sympy.Symbol('x')
 
     # Full Z.
     assert_optimizes(
@@ -86,6 +97,28 @@ def test_absorbs_z():
             [],
         ))
 
+    # Parametrized Z.
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=0.125).on(q)],
+            [cirq.Z(q) ** x],
+        ),
+        expected=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=0.125+x/2).on(q)],
+            [],
+        ),
+        eject_parameterized=True)
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=0.125).on(q)],
+            [cirq.Z(q) ** (x+1)],
+        ),
+        expected=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=0.625+x/2).on(q)],
+            [],
+        ),
+        eject_parameterized=True)
+
     # Multiple Zs.
     assert_optimizes(
         before=quick_circuit(
@@ -99,10 +132,39 @@ def test_absorbs_z():
             [],
         ))
 
+    # Multiple Parameterized Zs.
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=0.125).on(q)],
+            [cirq.S(q) ** x],
+            [cirq.T(q) ** -x],
+        ),
+        expected=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=0.125+x/8).on(q)],
+            [],
+            [],
+        ),
+        eject_parameterized=True)
+
+    # Parameterized Phase and Partial Z
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+            [cirq.S(q)],
+        ),
+        expected=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x+0.25).on(q)],
+            [],
+        ),
+        eject_parameterized=True)
+
 
 def test_crosses_czs():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
+    x = sympy.Symbol('x')
+    y = sympy.Symbol('y')
+    z = sympy.Symbol('z')
 
     # Full CZ.
     assert_optimizes(
@@ -125,6 +187,17 @@ def test_crosses_czs():
             [cirq.CZ(a, b)],
             [cirq.PhasedXPowGate(phase_exponent=0.125).on(a)],
         ))
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
+            [cirq.CZ(b, a)],
+        ),
+        expected=quick_circuit(
+            [cirq.Z(b)],
+            [cirq.CZ(a, b)],
+            [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
+        ),
+        eject_parameterized=True)
 
     # Partial CZ.
     assert_optimizes(
@@ -137,6 +210,17 @@ def test_crosses_czs():
             [cirq.CZ(a, b)**-0.25],
             [cirq.X(a)],
         ))
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.X(a)],
+            [cirq.CZ(a, b)**x],
+        ),
+        expected=quick_circuit(
+            [cirq.Z(b)**x],
+            [cirq.CZ(a, b)**-x],
+            [cirq.X(a)],
+        ),
+        eject_parameterized=True)
 
     # Double cross.
     assert_optimizes(
@@ -152,11 +236,26 @@ def test_crosses_czs():
             [cirq.PhasedXPowGate(phase_exponent=0.5).on(b),
              cirq.PhasedXPowGate(phase_exponent=0.25).on(a)],
         ))
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
+            [cirq.PhasedXPowGate(phase_exponent=y).on(b)],
+            [cirq.CZ(a, b)**z],
+        ),
+        expected=quick_circuit(
+            [],
+            [],
+            [cirq.CZ(a, b)**z],
+            [cirq.PhasedXPowGate(phase_exponent=y+z/2).on(b),
+             cirq.PhasedXPowGate(phase_exponent=x+z/2).on(a)],
+        ),
+        eject_parameterized=True)
 
 
 def test_toggles_measurements():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
+    x = sympy.Symbol('x')
 
     # Single.
     assert_optimizes(
@@ -177,6 +276,16 @@ def test_toggles_measurements():
             [],
             [cirq.measure(a, b, invert_mask=(False, True))],
         ))
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(b)],
+            [cirq.measure(a, b)],
+        ),
+        expected=quick_circuit(
+            [],
+            [cirq.measure(a, b, invert_mask=(False, True))],
+        ),
+        eject_parameterized=True)
 
     # Multiple.
     assert_optimizes(
@@ -205,6 +314,8 @@ def test_toggles_measurements():
 
 def test_cancels_other_full_w():
     q = cirq.NamedQubit('q')
+    x = sympy.Symbol('x')
+    y = sympy.Symbol('y')
 
     assert_optimizes(
         before=quick_circuit(
@@ -215,6 +326,17 @@ def test_cancels_other_full_w():
             [],
             [],
         ))
+
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+        ),
+        expected=quick_circuit(
+            [],
+            [],
+        ),
+        eject_parameterized=True)
 
     assert_optimizes(
         before=quick_circuit(
@@ -246,9 +368,23 @@ def test_cancels_other_full_w():
             [cirq.Z(q)**-0.5],
         ))
 
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=y).on(q)],
+        ),
+        expected=quick_circuit(
+            [],
+            [cirq.Z(q)**(2*(y-x))],
+        ),
+        eject_parameterized=True)
+
 
 def test_phases_partial_ws():
     q = cirq.NamedQubit('q')
+    x = sympy.Symbol('x')
+    y = sympy.Symbol('y')
+    z = sympy.Symbol('z')
 
     assert_optimizes(
         before=quick_circuit(
@@ -294,10 +430,22 @@ def test_phases_partial_ws():
             [cirq.X(q)],
         ))
 
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=y, exponent=z).on(q)],
+        ),
+        expected=quick_circuit(
+            [],
+            [cirq.PhasedXPowGate(phase_exponent=2*x-y, exponent=z).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+        ),
+        eject_parameterized=True)
+
 
 @pytest.mark.parametrize('sym', [
-    sympy.Symbol('a'),
-    sympy.Symbol('a') + 1,
+    sympy.Symbol('x'),
+    sympy.Symbol('x') + 1,
 ])
 def test_blocked_by_unknown_and_symbols(sym):
     a = cirq.NamedQubit('a')

--- a/cirq/optimizers/eject_phased_paulis_test.py
+++ b/cirq/optimizers/eject_phased_paulis_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 from typing import Iterable, cast
 
+import numpy as np
 import pytest
 import sympy
-import numpy as np
 
 import cirq
 
@@ -39,8 +39,9 @@ def assert_optimizes(before: cirq.Circuit,
                      cirq.resolve_parameters(circuit, params),
                      cirq.resolve_parameters(expected, params), 1e-8))
         else:
-            cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-                circuit, expected, 1e-8)
+            (cirq.testing.
+             assert_circuits_with_terminal_measurements_are_equivalent(
+                 circuit, expected, 1e-8))
 
     # And match the expected circuit.
     assert circuit == expected, (

--- a/cirq/optimizers/eject_phased_paulis_test.py
+++ b/cirq/optimizers/eject_phased_paulis_test.py
@@ -32,12 +32,12 @@ def assert_optimizes(before: cirq.Circuit,
     # They should have equivalent effects.
     if compare_unitaries:
         if cirq.is_parameterized(circuit):
-            for a in (0, 0.1, 0.5, -1.0, np.pi, np.pi/2):
-                params = {'x': a, 'y': a/2, 'z': -2*a}
-                (cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+            for a in (0, 0.1, 0.5, -1.0, np.pi, np.pi / 2):
+                params = {'x': a, 'y': a / 2, 'z': -2 * a}
+                (cirq.testing.
+                 assert_circuits_with_terminal_measurements_are_equivalent(
                      cirq.resolve_parameters(circuit, params),
-                     cirq.resolve_parameters(expected, params),
-                     1e-8))
+                     cirq.resolve_parameters(expected, params), 1e-8))
         else:
             cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
                 circuit, expected, 1e-8)
@@ -101,20 +101,20 @@ def test_absorbs_z():
     assert_optimizes(
         before=quick_circuit(
             [cirq.PhasedXPowGate(phase_exponent=0.125).on(q)],
-            [cirq.Z(q) ** x],
+            [cirq.Z(q)**x],
         ),
         expected=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=0.125+x/2).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=0.125 + x / 2).on(q)],
             [],
         ),
         eject_parameterized=True)
     assert_optimizes(
         before=quick_circuit(
             [cirq.PhasedXPowGate(phase_exponent=0.125).on(q)],
-            [cirq.Z(q) ** (x+1)],
+            [cirq.Z(q)**(x + 1)],
         ),
         expected=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=0.625+x/2).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=0.625 + x / 2).on(q)],
             [],
         ),
         eject_parameterized=True)
@@ -136,27 +136,26 @@ def test_absorbs_z():
     assert_optimizes(
         before=quick_circuit(
             [cirq.PhasedXPowGate(phase_exponent=0.125).on(q)],
-            [cirq.S(q) ** x],
-            [cirq.T(q) ** -x],
+            [cirq.S(q)**x],
+            [cirq.T(q)**-x],
         ),
         expected=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=0.125+x/8).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=0.125 + x / 8).on(q)],
             [],
             [],
         ),
         eject_parameterized=True)
 
     # Parameterized Phase and Partial Z
-    assert_optimizes(
-        before=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
-            [cirq.S(q)],
-        ),
-        expected=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=x+0.25).on(q)],
-            [],
-        ),
-        eject_parameterized=True)
+    assert_optimizes(before=quick_circuit(
+        [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+        [cirq.S(q)],
+    ),
+                     expected=quick_circuit(
+                         [cirq.PhasedXPowGate(phase_exponent=x + 0.25).on(q)],
+                         [],
+                     ),
+                     eject_parameterized=True)
 
 
 def test_crosses_czs():
@@ -187,17 +186,16 @@ def test_crosses_czs():
             [cirq.CZ(a, b)],
             [cirq.PhasedXPowGate(phase_exponent=0.125).on(a)],
         ))
-    assert_optimizes(
-        before=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
-            [cirq.CZ(b, a)],
-        ),
-        expected=quick_circuit(
-            [cirq.Z(b)],
-            [cirq.CZ(a, b)],
-            [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
-        ),
-        eject_parameterized=True)
+    assert_optimizes(before=quick_circuit(
+        [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
+        [cirq.CZ(b, a)],
+    ),
+                     expected=quick_circuit(
+                         [cirq.Z(b)],
+                         [cirq.CZ(a, b)],
+                         [cirq.PhasedXPowGate(phase_exponent=x).on(a)],
+                     ),
+                     eject_parameterized=True)
 
     # Partial CZ.
     assert_optimizes(
@@ -210,17 +208,16 @@ def test_crosses_czs():
             [cirq.CZ(a, b)**-0.25],
             [cirq.X(a)],
         ))
-    assert_optimizes(
-        before=quick_circuit(
-            [cirq.X(a)],
-            [cirq.CZ(a, b)**x],
-        ),
-        expected=quick_circuit(
-            [cirq.Z(b)**x],
-            [cirq.CZ(a, b)**-x],
-            [cirq.X(a)],
-        ),
-        eject_parameterized=True)
+    assert_optimizes(before=quick_circuit(
+        [cirq.X(a)],
+        [cirq.CZ(a, b)**x],
+    ),
+                     expected=quick_circuit(
+                         [cirq.Z(b)**x],
+                         [cirq.CZ(a, b)**-x],
+                         [cirq.X(a)],
+                     ),
+                     eject_parameterized=True)
 
     # Double cross.
     assert_optimizes(
@@ -246,8 +243,10 @@ def test_crosses_czs():
             [],
             [],
             [cirq.CZ(a, b)**z],
-            [cirq.PhasedXPowGate(phase_exponent=y+z/2).on(b),
-             cirq.PhasedXPowGate(phase_exponent=x+z/2).on(a)],
+            [
+                cirq.PhasedXPowGate(phase_exponent=y + z / 2).on(b),
+                cirq.PhasedXPowGate(phase_exponent=x + z / 2).on(a)
+            ],
         ),
         eject_parameterized=True)
 
@@ -276,16 +275,15 @@ def test_toggles_measurements():
             [],
             [cirq.measure(a, b, invert_mask=(False, True))],
         ))
-    assert_optimizes(
-        before=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=x).on(b)],
-            [cirq.measure(a, b)],
-        ),
-        expected=quick_circuit(
-            [],
-            [cirq.measure(a, b, invert_mask=(False, True))],
-        ),
-        eject_parameterized=True)
+    assert_optimizes(before=quick_circuit(
+        [cirq.PhasedXPowGate(phase_exponent=x).on(b)],
+        [cirq.measure(a, b)],
+    ),
+                     expected=quick_circuit(
+                         [],
+                         [cirq.measure(a, b, invert_mask=(False, True))],
+                     ),
+                     eject_parameterized=True)
 
     # Multiple.
     assert_optimizes(
@@ -327,16 +325,15 @@ def test_cancels_other_full_w():
             [],
         ))
 
-    assert_optimizes(
-        before=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
-            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
-        ),
-        expected=quick_circuit(
-            [],
-            [],
-        ),
-        eject_parameterized=True)
+    assert_optimizes(before=quick_circuit(
+        [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+        [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+    ),
+                     expected=quick_circuit(
+                         [],
+                         [],
+                     ),
+                     eject_parameterized=True)
 
     assert_optimizes(
         before=quick_circuit(
@@ -368,16 +365,15 @@ def test_cancels_other_full_w():
             [cirq.Z(q)**-0.5],
         ))
 
-    assert_optimizes(
-        before=quick_circuit(
-            [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
-            [cirq.PhasedXPowGate(phase_exponent=y).on(q)],
-        ),
-        expected=quick_circuit(
-            [],
-            [cirq.Z(q)**(2*(y-x))],
-        ),
-        eject_parameterized=True)
+    assert_optimizes(before=quick_circuit(
+        [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
+        [cirq.PhasedXPowGate(phase_exponent=y).on(q)],
+    ),
+                     expected=quick_circuit(
+                         [],
+                         [cirq.Z(q)**(2 * (y - x))],
+                     ),
+                     eject_parameterized=True)
 
 
 def test_phases_partial_ws():
@@ -437,7 +433,7 @@ def test_phases_partial_ws():
         ),
         expected=quick_circuit(
             [],
-            [cirq.PhasedXPowGate(phase_exponent=2*x-y, exponent=z).on(q)],
+            [cirq.PhasedXPowGate(phase_exponent=2 * x - y, exponent=z).on(q)],
             [cirq.PhasedXPowGate(phase_exponent=x).on(q)],
         ),
         eject_parameterized=True)

--- a/cirq/value/angle.py
+++ b/cirq/value/angle.py
@@ -106,5 +106,3 @@ def canonicalize_half_turns(
         half_turns -= 2
     return half_turns
 # pylint: enable=function-redefined
-
-

--- a/cirq/value/angle.py
+++ b/cirq/value/angle.py
@@ -98,7 +98,9 @@ def canonicalize_half_turns(
 ) -> Union[sympy.Basic, float]:
     """Wraps the input into the range (-1, +1]."""
     if isinstance(half_turns, sympy.Basic):
-        return half_turns
+        if not half_turns.is_constant():
+            return half_turns
+        half_turns = float(half_turns)
     half_turns %= 2
     if half_turns > 1:
         half_turns -= 2

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -28,6 +28,8 @@ def test_canonicalize_half_turns():
     assert cirq.canonicalize_half_turns(-0.5) == -0.5
     assert cirq.canonicalize_half_turns(101.5) == -0.5
     assert cirq.canonicalize_half_turns(sympy.Symbol('a')) == sympy.Symbol('a')
+    # Sympy expression for a constant
+    assert cirq.canonicalize_half_turns(sympy.Symbol('a')*0+3) == 1
 
 
 def test_chosen_angle_to_half_turns():

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -29,7 +29,7 @@ def test_canonicalize_half_turns():
     assert cirq.canonicalize_half_turns(101.5) == -0.5
     assert cirq.canonicalize_half_turns(sympy.Symbol('a')) == sympy.Symbol('a')
     # Sympy expression for a constant
-    assert cirq.canonicalize_half_turns(sympy.Symbol('a')*0+3) == 1
+    assert cirq.canonicalize_half_turns(sympy.Symbol('a') * 0 + 3) == 1
 
 
 def test_chosen_angle_to_half_turns():

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -27,8 +27,11 @@ def test_canonicalize_half_turns():
     assert cirq.canonicalize_half_turns(1.5) == -0.5
     assert cirq.canonicalize_half_turns(-0.5) == -0.5
     assert cirq.canonicalize_half_turns(101.5) == -0.5
+    # Variable sympy expression
     assert cirq.canonicalize_half_turns(sympy.Symbol('a')) == sympy.Symbol('a')
-    # Sympy expression for a constant
+    assert (cirq.canonicalize_half_turns(sympy.Symbol('a') + 1) ==
+            sympy.Symbol('a') + 1)
+    # Constant sympy expression
     assert cirq.canonicalize_half_turns(sympy.Symbol('a') * 0 + 3) == 1
 
 

--- a/cirq/value/angle_test.py
+++ b/cirq/value/angle_test.py
@@ -29,8 +29,8 @@ def test_canonicalize_half_turns():
     assert cirq.canonicalize_half_turns(101.5) == -0.5
     # Variable sympy expression
     assert cirq.canonicalize_half_turns(sympy.Symbol('a')) == sympy.Symbol('a')
-    assert (cirq.canonicalize_half_turns(sympy.Symbol('a') + 1) ==
-            sympy.Symbol('a') + 1)
+    assert (cirq.canonicalize_half_turns(sympy.Symbol('a') +
+                                         1) == sympy.Symbol('a') + 1)
     # Constant sympy expression
     assert cirq.canonicalize_half_turns(sympy.Symbol('a') * 0 + 3) == 1
 


### PR DESCRIPTION
For #1930.  Independent of #1963.