### PR TITLE
Add EngineProgram to QuantumEngineSampler

### DIFF
--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -739,11 +739,10 @@ class EngineProgram:
     """A program created via the Quantum Engine API.
 
     This program wraps a Circuit or Schedule with additional metadata used to
-    schedule againt devices maintained by Google.
+    schedule against the devices managed by Quantum Engine.
 
     Attributes:
       name: The full resource name of the engine program.
-      code: A serialized version of the Circuit or Schedule
     """
 
     def __init__(self, resource_name: str, engine: Engine) -> None:

--- a/cirq/google/engine/engine_sampler.py
+++ b/cirq/google/engine/engine_sampler.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 class QuantumEngineSampler(work.Sampler):
-    """A sampler that samples from processor managed by the Quantum Engine.
+    """A sampler that samples from processors managed by the Quantum Engine.
 
     Exposes a `cirq.google.Engine` instance as a `cirq.Sampler`.
     """

--- a/cirq/google/engine/engine_sampler.py
+++ b/cirq/google/engine/engine_sampler.py
@@ -12,18 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Union
 
 from cirq import work
+from cirq.google import engine
 
 if TYPE_CHECKING:
     import cirq
 
 
-class QuantumEngineSampler(work.Sampler):
-    """A sampler that samples from real hardware on the quantum engine.
 
-    Exposes a `cirq.google.Engine` instance as a `cirq.Sampler`."""
+class QuantumEngineSampler(work.Sampler):
+    """A sampler that samples from processor managed by the Quantum Engine.
+
+    Exposes a `cirq.google.Engine` instance as a `cirq.Sampler`.
+    """
 
     def __init__(self, *, engine: 'cirq.google.Engine',
                  processor_id: Union[str, List[str]],
@@ -43,15 +46,19 @@ class QuantumEngineSampler(work.Sampler):
 
     def run_sweep(
             self,
-            program: Union['cirq.Circuit', 'cirq.Schedule'],
+            program: Union['cirq.Circuit', 'cirq.Schedule',
+                           'cirq.google.EngineProgram'],
             params: 'cirq.Sweepable',
             repetitions: int = 1,
     ) -> List['cirq.TrialResult']:
-
-        job = self._engine.run_sweep(program=program,
-                                     params=params,
-                                     repetitions=repetitions,
-                                     processor_ids=self._processor_ids,
-                                     gate_set=self._gate_set)
-
+        if isinstance(program, engine.EngineProgram):
+            job = program.run_sweep(params=params,
+                                    repetitions=repetitions,
+                                    processor_ids=self._processor_ids)
+        else:
+            job = self._engine.run_sweep(program=program,
+                                         params=params,
+                                         repetitions=repetitions,
+                                         processor_ids=self._processor_ids,
+                                         gate_set=self._gate_set)
         return job.results()

--- a/cirq/google/engine/engine_sampler_test.py
+++ b/cirq/google/engine/engine_sampler_test.py
@@ -23,11 +23,25 @@ def test_run_circuit():
     sampler = cg.QuantumEngineSampler(engine=engine,
                                       processor_id='tmp',
                                       gate_set=cg.XMON)
-    c = cirq.Circuit()
+    circuit = cirq.Circuit()
     params = [cirq.ParamResolver({'a': 1})]
-    sampler.run_sweep(c, params, 5)
+    sampler.run_sweep(circuit, params, 5)
     engine.run_sweep.assert_called_with(gate_set=cg.XMON,
                                         params=params,
                                         processor_ids=['tmp'],
-                                        program=c,
+                                        program=circuit,
                                         repetitions=5)
+
+
+def test_run_engine_program():
+    engine = mock.Mock()
+    sampler = cg.QuantumEngineSampler(engine=engine,
+                                      processor_id='tmp',
+                                      gate_set=cg.XMON)
+    program = mock.Mock(spec=cg.EngineProgram)
+    params = [cirq.ParamResolver({'a': 1})]
+    sampler.run_sweep(program, params, 5)
+    program.run_sweep.assert_called_with(params=params,
+                                         processor_ids=['tmp'],
+                                         repetitions=5)
+    engine.run_sweep.assert_not_called()


### PR DESCRIPTION
Note that I chose not to validate that the `EngineProgram` was created from the same `Engine` as the sampler.  We could add this.

Alternatively we could add another type of `Sampler`.