### PR TITLE
Update publish dev pypi script to use cirq-dev

### DIFF
--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -15,17 +15,21 @@
 # limitations under the License.
 
 ################################################################################
-# If cirq's version is a dev release, this script can be used to set
-# the CIRQ_DEV_VERSION variable to a string that is the dev version
-# plus an increasing date string.
+# This script prints a new dev version id if the current cirq version
+# is a dev release.
 #
-# This is used by travis during deployment and by published-dev-package.sh.
+# If version in Cirq's _version.py file contains 'dev' this
+# prints a dev version appended by an id given by the time the
+# script was run. This can be used to ensure later releases
+# have increasing numerical release numbers.
 #
-# The variable can be set using
+# This script is used by publish-dev-package and can also be
+# used to set a bash variable for use by travis ci to deploy
+# a new dev version on successful merge.
 #
-#     export CIRQ_DEV_VERSION=`dev_tools/packaging/set-dev-version.sh`
-#
-# Which, for example sets $CIRQ_DEV_VERSION to 0.6.0.dev20190813193556.
+# Example:
+#     > echo `generate-dev-version-id.sh`
+#     0.6.0.dev20190829135619
 ################################################################################
 
 set -e

--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -50,5 +50,3 @@ else
   echo "Version doesn't end in dev: ${ACTUAL_VERSION_LINE}" >&2
   exit 1
 fi
-
-exit 0

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -108,7 +108,7 @@ tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 
 # Configure to push to cirq-dev and not cirq.
-export CIRQ_DEV_VERSION=`dev_tools/packaging/set-dev-version.sh`
+export CIRQ_DEV_VERSION=$(dev_tools/packaging/set-dev-version.sh)
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -108,7 +108,7 @@ tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 
 # Configure to push to cirq-dev and not cirq.
-source dev_tools/packaging/set-dev-version.sh
+export CIRQ_DEV_VERSION=`dev_tools/packaging/set-dev-version.sh`
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -108,7 +108,7 @@ tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 
 # Configure to push to cirq-dev and not cirq.
-source ./set-dev-version.
+source dev_tools/packaging/set-dev-version.sh
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 ################################################################################
-# Produces and uploads dev-version wheels to a pypi package repository. Uploads
-# to the test pypi repository unless the --prod switch is added.
+# Produces and uploads dev-version wheels to a pypi package repository cirq-dev
+# Note that this is not the dev-version for cirq, whose use is deprecated.
+#
+# Uploads to the test pypi repository unless the --prod switch is added.
 #
 # The pypi credentials given to twine are specified via environment variables.
 #
@@ -104,6 +106,9 @@ cd "$(git rev-parse --show-toplevel)"
 # Temporary workspace.
 tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
+
+# Configure to push to cirq-dev and not cirq.
+source ./set-dev-version.
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/dev_tools/packaging/set-dev-version.sh
+++ b/dev_tools/packaging/set-dev-version.sh
@@ -19,9 +19,7 @@
 # the CIRQ_DEV_VERSION variable to a string that is the dev version
 # plus an increasing date string.
 #
-# This is used by travis during deployment, and should not be run as
-# part of a deployment from a local branch. When travis uses this it
-# pushes to the cirq-dev pypi package, not the cirq package.
+# This is used by travis during deployment and by published-dev-package.sh.
 #
 # The variable is set by sourcing this file
 #

--- a/dev_tools/packaging/set-dev-version.sh
+++ b/dev_tools/packaging/set-dev-version.sh
@@ -21,45 +21,30 @@
 #
 # This is used by travis during deployment and by published-dev-package.sh.
 #
-# The variable is set by sourcing this file
+# The variable can be set using
 #
-#     source set-dev-version.sh
+#     export CIRQ_DEV_VERSION=`dev_tools/packaging/set-dev-version.sh`
 #
 # Which, for example sets $CIRQ_DEV_VERSION to 0.6.0.dev20190813193556.
 ################################################################################
 
-export CIRQ_DEV_VERSION="$(
-  set -e
+set -e
 
-  if ! (return 0 2>/dev/null); then
-    echo "Usage:" >&2
-    echo "  source set-dev-version.sh" >&2
-    echo >&2
-    echo "This script sets the environment variable \$CIRQ_DEV_VERSION." >&2
-    exit 1
-  fi
+# Get the working directory to the repo root.
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+repo_dir=$(git rev-parse --show-toplevel)
+cd "${repo_dir}"
 
-  # Get the working directory to the repo root.
-  cd "$( dirname "${BASH_SOURCE[0]}" )"
-  repo_dir=$(git rev-parse --show-toplevel)
-  cd "${repo_dir}"
+PROJECT_NAME=cirq
 
-  PROJECT_NAME=cirq
+ACTUAL_VERSION_LINE=$(cat "${PROJECT_NAME}/_version.py" | tail -n 1)
+ACTUAL_VERSION=`echo $ACTUAL_VERSION_LINE | cut -d'"' -f 2`
 
-  ACTUAL_VERSION_LINE=$(cat "${PROJECT_NAME}/_version.py" | tail -n 1)
-  ACTUAL_VERSION=`echo $ACTUAL_VERSION_LINE | cut -d'"' -f 2`
-
-  if [[ ${ACTUAL_VERSION} == *"dev" ]]; then
-    echo "${ACTUAL_VERSION}$(date "+%Y%m%d%H%M%S")"
-  else
-    echo "Version doesn't end in dev: ${ACTUAL_VERSION_LINE}" >&2
-    exit 1
-  fi
-
-  exit 0
-)"
-
-if [ $? -ne 0 ]; then
-  unset CIRQ_DEV_VERSION
-  echo -e '\033[31mFAILED\033[0m'
+if [[ ${ACTUAL_VERSION} == *"dev" ]]; then
+  echo "${ACTUAL_VERSION}$(date "+%Y%m%d%H%M%S")"
+else
+  echo "Version doesn't end in dev: ${ACTUAL_VERSION_LINE}" >&2
+  exit 1
 fi
+
+exit 0


### PR DESCRIPTION
I'm keeping the set-dev-version script in the case that we can go back to using travis's deploy.  