### PR TITLE
Fix tests for sympy versions below 1.4

### DIFF
--- a/cirq/study/flatten_expressions_test.py
+++ b/cirq/study/flatten_expressions_test.py
@@ -18,8 +18,9 @@ from cirq.study import flatten_expressions
 
 
 # None of the following tests use expressions of the form
-# <constant term> - <other term> because the string of these expressions is not
-# consistent for sympy versions <1.4 vs >=1.4.
+# <constant term> - <other term> because the string of expressions containing
+# exactly two terms, one constant term and one non-constant term with a negative
+# factor, is not consistent between sympy versions <1.4 and >=1.4.
 
 
 def test_expr_map_names():


### PR DESCRIPTION
Sympy version 1.4 added a special case for expression term ordering to avoid making the first term negative.  This change makes the tests succeed on earlier versions of sympy.

Sympy 1.4:
```
>>> 1 - sympy.Symbol('a')
1 - a
```
Sympy 1.3 and 1.2:
```
>>> 1 - sympy.Symbol('a')
-a + 1
```

Note this doesn't change:
```
>>> -sympy.Symbol('a')+sympy.Symbol('b')
-a + b
```