### PR TITLE
Add default annotation to heatmap.

### DIFF
--- a/cirq/vis/heatmap.py
+++ b/cirq/vis/heatmap.py
@@ -77,7 +77,7 @@ class Heatmap:
             _get_qubit_row_col(qubit): format(float(value), '.2g')
             for qubit, value in value_map.items()
         }
-        self.annot_kwargs = {}
+        self.annot_kwargs: Dict[str, Any] = {}
         self.unset_url_map()
         self.set_colorbar()
         self.set_colormap()

--- a/cirq/vis/heatmap.py
+++ b/cirq/vis/heatmap.py
@@ -73,7 +73,11 @@ class Heatmap:
 
     def __init__(self, value_map: ValueMap) -> None:
         self.set_value_map(value_map)
-        self.unset_annotation()
+        self.annot_map = {  # Default annotation.
+            _get_qubit_row_col(qubit): format(float(value), '.2g')
+            for qubit, value in value_map.items()
+        }
+        self.annot_kwargs = {}
         self.unset_url_map()
         self.set_colorbar()
         self.set_colormap()
@@ -246,9 +250,9 @@ class Heatmap:
                          **pcolor_options)
         mesh.update_scalarmappable()
         ax.set(xlabel='column', ylabel='row')
-        ax.invert_yaxis()
         ax.xaxis.set_ticks(np.arange(min_col, max_col + 1))
         ax.yaxis.set_ticks(np.arange(min_row, max_row + 1))
+        ax.set_ylim((max_row + 0.5, min_row - 0.5))
 
         if self.plot_colorbar:
             self._plot_colorbar(mesh, ax)

--- a/cirq/vis/heatmap_test.py
+++ b/cirq/vis/heatmap_test.py
@@ -80,6 +80,24 @@ def test_cell_colors(axes, colormap_name):
         assert np.all(np.isclose(facecolor, expected_color))
 
 
+def test_default_annotation(axes):
+    """Tests that the default annotation is '.2g' format on float(value)."""
+    qubits = ((0, 5), (8, 1), (7, 0), (13, 5), (1, 6), (3, 2), (2, 8))
+    values = ['3.752', '42', '-5.27e8', '-7.34e-9', 732, 0.432, 3.9753e28]
+    test_value_map = {qubit: value for qubit, value in zip(qubits, values)}
+    random_heatmap = heatmap.Heatmap(test_value_map)
+    random_heatmap.plot(axes)
+    actual_texts = set()
+    for artist in axes.get_children():
+        if isinstance(artist, mpl.text.Text):
+            col, row = artist.get_position()
+            text = artist.get_text()
+            actual_texts.add(((row, col), text))
+    expected_texts = set((qubit, format(float(value), '.2g'))
+                         for qubit, value in test_value_map.items())
+    assert expected_texts.issubset(actual_texts)
+
+
 @pytest.mark.parametrize('format_string', ['.3e', '.2f', '.4g'])
 def test_annotation_position_and_content(axes, format_string):
     qubits = ((0, 5), (8, 1), (7, 0), (13, 5), (1, 6), (3, 2), (2, 8))


### PR DESCRIPTION
The default annotation is `format(float(value), '.2g')` where `value` is the value in the `value_map` passed to `Heatmap.__init__`. It should work if the value is always `SupportsFloat` specified by the `ValueMap` type.

To remove the annotation, the user can call `unset_annotation()` method afterwards.
```python
cirq.Heatmap(value_map).unset_annotation().plot(ax)
```

Demo:

![nyHFszMgzJo](https://user-images.githubusercontent.com/8291726/63800404-e30cfa80-c8c2-11e9-8801-c41507b92e2b.png)

