### PR TITLE
implements `apply_unitary` for YPowGate

### DIFF
--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -196,6 +196,19 @@ class YPowGate(eigen_gate.EigenGate,
     `cirq.Y`, the Pauli Y gate, is an instance of this gate at exponent=1.
     """
 
+    def _apply_unitary_(self, args: 'protocols.ApplyUnitaryArgs'
+                       ) -> Optional[np.ndarray]:
+        if self._exponent != 1:
+            return NotImplemented
+        zero = args.subspace_index(0)
+        one = args.subspace_index(1)
+        args.available_buffer[zero] = -1j * args.target_tensor[one]
+        args.available_buffer[one] = 1j * args.target_tensor[zero]
+        p = 1j**(2 * self._exponent * self._global_shift)
+        if p != 1:
+            args.available_buffer *= p
+        return args.available_buffer
+
     def in_su2(self) -> 'YPowGate':
         """Returns an equal-up-global-phase gate from the group SU2."""
         return YPowGate(exponent=self._exponent, global_shift=-0.5)


### PR DESCRIPTION
Not sure if there was a reason `_apply_unitary_` was left out of YPowGate? I guess in raw flop counts this should be equivalent to einsum, but I'm guessing numpy has optimizations for scalar multiplication so this is still a faster method. For example:

```
import timeit

# setup code is only run once.
setup = '''
import cirq
import numpy as np
k = 5
c = cirq.Circuit.from_ops([cirq.Y(q) for q in cirq.LineQubit.range(5)])
sim = cirq.Simulator()
init = cirq.testing.random_superposition(2 ** 5).astype(np.complex64)
'''

import numpy as np
out = timeit.Timer('sim.simulate(c, initial_state=np.copy(init))', setup=setup).repeat(100, number=2000)
print("best: {}".format(min(out)))
print("rel. std: {}".format(np.std(out, ddof=1)/ np.mean(out)))
```

on master this yields:
```
>>> best: 1.293166100018425
>>> rel. std: 0.02279256808015728
```
while on this branch I get:
```
>>> best: 0.8134043000172824
>>> rel. std: 0.05712308794562993
```
