### PR TITLE
Fix bugs in publish-dev-package and verify-published-package

### DIFF
--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -41,6 +41,11 @@
 #
 #     pip install -r requirements.txt
 #     pip install --index-url https://test.pypi.org/simple/ cirq==VERSION_YOU_UPLOADED
+#
+# Package verification:
+#
+#     dev_tools/packaging/verify-dev-package.sh VERSION_YOU_UPLOADED [--test|--prod]
+#
 ################################################################################
 
 PROJECT_NAME=cirq
@@ -108,7 +113,7 @@ tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 
 # Configure to push to cirq-dev and not cirq.
-export CIRQ_DEV_VERSION=$(dev_tools/packaging/set-dev-version.sh)
+export CIRQ_DEV_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ################################################################################
-# Downloads and tests cirq wheels from the pypi package repository. Uses the
+# Downloads and tests cirq-dev wheels from the pypi package repository. Uses the
 # prod pypi repository unless the --test switch is added.
 #
 # CAUTION: when targeting the test pypi repository, this script assumes that the
@@ -32,6 +32,7 @@ trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 
 PROJECT_NAME=cirq
+PROJECT_NAME_DEV=cirq-dev
 PROJECT_VERSION=$1
 PROD_SWITCH=$2
 
@@ -75,8 +76,8 @@ for PYTHON_VERSION in python3; do
         echo "Pre-installing dependencies since they don't all exist in TEST pypi"
         "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${RUNTIME_DEPS_FILE}"
     fi
-    echo Installing "${PROJECT_NAME}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi"
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet ${PYPI_REPOSITORY_FLAG} "${PROJECT_NAME}==${PROJECT_VERSION}"
+    echo Installing "${PROJECT_NAME_DEV}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi"
+    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet ${PYPI_REPOSITORY_FLAG} "${PROJECT_NAME_DEV}==${PROJECT_VERSION}"
 
     # Check that code runs without dev deps.
     echo Checking that code executes


### PR DESCRIPTION
- publish-dev-package had a missed script rename
- verify-published-package was using cirq instead of cirq-dev