### PR TITLE
[Qudits] Add support to IdentityGate, MeasurementGate, several protocols

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -175,6 +175,7 @@ from cirq.ops import (
     H,
     HPowGate,
     I,
+    identity,
     IdentityGate,
     InterchangeableQubitsGate,
     ISWAP,

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -48,6 +48,7 @@ from cirq.ops.common_gates import (
     H,
     HPowGate,
     I,
+    identity,
     IdentityGate,
     ISWAP,
     ISwapPowGate,

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -439,7 +439,7 @@ class MeasurementGate(raw_types.Gate):
     """
 
     def __init__(self,
-                 num_qubits: int,
+                 num_qubits: Optional[int] = None,
                  key: str = '',
                  invert_mask: Tuple[bool, ...] = (),
                  qid_shape: Tuple[int, ...] = None) -> None:
@@ -458,10 +458,15 @@ class MeasurementGate(raw_types.Gate):
             ValueError: If the length of invert_mask is greater than num_qubits.
                 or if the length of qid_shape doesn't equal num_qubits.
         """
+        if qid_shape is None:
+            if num_qubits is None:
+                raise ValueError(
+                    'Specify either the num_qubits or qid_shape argument.')
+            qid_shape = (2,) * num_qubits
+        elif num_qubits is None:
+            num_qubits = len(qid_shape)
         if num_qubits == 0:
             raise ValueError('Measuring an empty set of qubits.')
-        if qid_shape is None:
-            qid_shape = (2,) * num_qubits
         self._qid_shape = qid_shape
         if len(self._qid_shape) != num_qubits:
             raise ValueError('len(qid_shape) != num_qubits')
@@ -656,7 +661,9 @@ class IdentityGate(raw_types.Gate):
     `cirq.I` is the single qubit identity gate.
     """
 
-    def __init__(self, num_qubits: int, qid_shape: Tuple[int, ...] = None):
+    def __init__(self,
+                 num_qubits: Optional[int] = None,
+                 qid_shape: Tuple[int, ...] = None):
         """
         Args:
             num_qubits:
@@ -667,7 +674,12 @@ class IdentityGate(raw_types.Gate):
             ValueError: If the length of qid_shape doesn't equal num_qubits.
         """
         if qid_shape is None:
+            if num_qubits is None:
+                raise ValueError(
+                    'Specify either the num_qubits or qid_shape argument.')
             qid_shape = (2,) * num_qubits
+        elif num_qubits is None:
+            num_qubits = len(qid_shape)
         self._qid_shape = qid_shape
         if len(self._qid_shape) != num_qubits:
             raise ValueError('len(qid_shape) != num_qubits')

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -471,7 +471,7 @@ class MeasurementGate(raw_types.Gate):
             len(self.invert_mask) > self.num_qubits()):
             raise ValueError('len(invert_mask) > num_qubits')
 
-    def _qid_shape_(self) -> int:
+    def _qid_shape_(self) -> Tuple[int, ...]:
         return self._qid_shape
 
     def with_bits_flipped(self, *bit_positions: int) -> 'MeasurementGate':
@@ -554,10 +554,7 @@ class MeasurementGate(raw_types.Gate):
         if not all(d == 2 for d in self._qid_shape):
             other = ', {!r}'.format(self._qid_shape)
         return 'cirq.MeasurementGate({!r}, {!r}, {!r}{})'.format(
-            self.num_qubits(),
-            self.key,
-            self.invert_mask,
-            other)
+            self.num_qubits(), self.key, self.invert_mask, other)
 
     def _value_equality_values_(self):
         return self.key, self.invert_mask, self._qid_shape
@@ -575,7 +572,11 @@ class MeasurementGate(raw_types.Gate):
         }
 
     @classmethod
-    def _from_json_dict_(cls, num_qubits, key, invert_mask, qid_shape=None,
+    def _from_json_dict_(cls,
+                         num_qubits,
+                         key,
+                         invert_mask,
+                         qid_shape=None,
                          **kwargs):
         return cls(num_qubits=num_qubits,
                    key=key,
@@ -639,8 +640,10 @@ def measure_each(*qubits: raw_types.Qid,
     Returns:
         A list of operations individually measuring the given qubits.
     """
-    return [MeasurementGate(1, key_func(q), qid_shape=(q.dimension,)).on(q)
-            for q in qubits]
+    return [
+        MeasurementGate(1, key_func(q), qid_shape=(q.dimension,)).on(q)
+        for q in qubits
+    ]
 
 
 @value.value_equality
@@ -669,7 +672,7 @@ class IdentityGate(raw_types.Gate):
         if len(self._qid_shape) != num_qubits:
             raise ValueError('len(qid_shape) != num_qubits')
 
-    def _qid_shape_(self) -> int:
+    def _qid_shape_(self) -> Tuple[int, ...]:
         return self._qid_shape
 
     def on_each(self, *targets: Union[raw_types.Qid, Iterable[Any]]

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -438,13 +438,11 @@ class MeasurementGate(raw_types.Gate):
     of measurements.
     """
 
-    def num_qubits(self) -> int:
-        return self._num_qubits
-
     def __init__(self,
                  num_qubits: int,
                  key: str = '',
-                 invert_mask: Tuple[bool, ...] = ()) -> None:
+                 invert_mask: Tuple[bool, ...] = (),
+                 qid_shape: Tuple[int, ...] = None) -> None:
         """
         Args:
             num_qubits: The number of qubits to act upon.
@@ -453,18 +451,28 @@ class MeasurementGate(raw_types.Gate):
                 qubits should be flipped. The list's length must not be longer
                 than the number of qubits, but it is permitted to be shorter.
                 Qubits with indices past the end of the mask are not flipped.
+            qid_shape: Specifies the dimension of each qid the measurement
+                applies to.  The default is 2 for every qubit.
 
         Raises:
-            ValueError if the length of invert_mask is greater than num_qubits.
+            ValueError: If the length of invert_mask is greater than num_qubits.
+                or if the length of qid_shape doesn't equal num_qubits.
         """
         if num_qubits == 0:
             raise ValueError('Measuring an empty set of qubits.')
-        self._num_qubits = num_qubits
+        if qid_shape is None:
+            qid_shape = (2,) * num_qubits
+        self._qid_shape = qid_shape
+        if len(self._qid_shape) != num_qubits:
+            raise ValueError('len(qid_shape) != num_qubits')
         self.key = key
         self.invert_mask = invert_mask or ()
         if (self.invert_mask is not None and
             len(self.invert_mask) > self.num_qubits()):
             raise ValueError('len(invert_mask) > num_qubits')
+
+    def _qid_shape_(self) -> int:
+        return self._qid_shape
 
     def with_bits_flipped(self, *bit_positions: int) -> 'MeasurementGate':
         """Toggles whether or not the measurement inverts various outputs."""
@@ -494,7 +502,7 @@ class MeasurementGate(raw_types.Gate):
         return self.key
 
     def _channel_(self):
-        size = 2**self.num_qubits()
+        size = np.prod(self._qid_shape, dtype=int)
 
         def delta(i):
             result = np.zeros((size, size))
@@ -525,6 +533,8 @@ class MeasurementGate(raw_types.Gate):
 
     def _qasm_(self, args: 'protocols.QasmArgs',
                qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+        if not all(d == 2 for d in self._qid_shape):
+            return NotImplemented
         args.validate_version('2.0')
         invert_mask = self.invert_mask
         if len(invert_mask) < len(qubits):
@@ -540,27 +550,37 @@ class MeasurementGate(raw_types.Gate):
         return ''.join(lines)
 
     def __repr__(self):
-        return 'cirq.MeasurementGate({}, {}, {})'.format(
-            repr(self.num_qubits()),
-            repr(self.key),
-            repr(self.invert_mask))
+        other = ''
+        if not all(d == 2 for d in self._qid_shape):
+            other = ', {!r}'.format(self._qid_shape)
+        return 'cirq.MeasurementGate({!r}, {!r}, {!r}{})'.format(
+            self.num_qubits(),
+            self.key,
+            self.invert_mask,
+            other)
 
     def _value_equality_values_(self):
-        return self.num_qubits(), self.key, self.invert_mask
+        return self.key, self.invert_mask, self._qid_shape
 
     def _json_dict_(self):
+        other = {}
+        if not all(d == 2 for d in self._qid_shape):
+            other['qid_shape'] = self._qid_shape
         return {
             'cirq_type': self.__class__.__name__,
-            'num_qubits': self.num_qubits(),
+            'num_qubits': len(self._qid_shape),
             'key': self.key,
-            'invert_mask': self.invert_mask
+            'invert_mask': self.invert_mask,
+            **other,
         }
 
     @classmethod
-    def _from_json_dict_(cls, num_qubits, key, invert_mask, **kwargs):
+    def _from_json_dict_(cls, num_qubits, key, invert_mask, qid_shape=None,
+                         **kwargs):
         return cls(num_qubits=num_qubits,
                    key=key,
-                   invert_mask=tuple(invert_mask))
+                   invert_mask=tuple(invert_mask),
+                   qid_shape=None if qid_shape is None else tuple(qid_shape))
 
 
 def _default_measurement_key(qubits: Iterable[raw_types.Qid]) -> str:
@@ -600,7 +620,8 @@ def measure(*qubits: raw_types.Qid,
 
     if key is None:
         key = _default_measurement_key(qubits)
-    return MeasurementGate(len(qubits), key, invert_mask).on(*qubits)
+    qid_shape = protocols.qid_shape(qubits)
+    return MeasurementGate(len(qubits), key, invert_mask, qid_shape).on(*qubits)
 
 
 def measure_each(*qubits: raw_types.Qid,
@@ -618,8 +639,8 @@ def measure_each(*qubits: raw_types.Qid,
     Returns:
         A list of operations individually measuring the given qubits.
     """
-    return [MeasurementGate(1, key_func(q)).on(q) for q in qubits]
-
+    return [MeasurementGate(1, key_func(q), qid_shape=(q.dimension,)).on(q)
+            for q in qubits]
 
 
 @value.value_equality
@@ -632,11 +653,24 @@ class IdentityGate(raw_types.Gate):
     `cirq.I` is the single qubit identity gate.
     """
 
-    def __init__(self, num_qubits):
-        self._num_qubits = num_qubits
+    def __init__(self, num_qubits: int, qid_shape: Tuple[int, ...] = None):
+        """
+        Args:
+            num_qubits:
+            qid_shape: Specifies the dimension of each qid the measurement
+                applies to.  The default is 2 for every qubit.
 
-    def num_qubits(self) -> int:
-        return self._num_qubits
+        Raises:
+            ValueError: If the length of qid_shape doesn't equal num_qubits.
+        """
+        if qid_shape is None:
+            qid_shape = (2,) * num_qubits
+        self._qid_shape = qid_shape
+        if len(self._qid_shape) != num_qubits:
+            raise ValueError('len(qid_shape) != num_qubits')
+
+    def _qid_shape_(self) -> int:
+        return self._qid_shape
 
     def on_each(self, *targets: Union[raw_types.Qid, Iterable[Any]]
                ) -> List[raw_types.Operation]:
@@ -654,7 +688,7 @@ class IdentityGate(raw_types.Gate):
             the gate from which this is applied is not a single qubit identity
             gate.
         """
-        if self._num_qubits != 1:
+        if len(self._qid_shape) != 1:
             raise ValueError(
                 'IdentityGate only supports on_each when it is a one qubit '
                 'gate.')
@@ -671,22 +705,27 @@ class IdentityGate(raw_types.Gate):
         return operations
 
     def _unitary_(self):
-        return np.identity(2 ** self.num_qubits())
+        return np.identity(np.prod(self._qid_shape, dtype=int))
 
     def _apply_unitary_(self, args: 'protocols.ApplyUnitaryArgs'
                        ) -> Optional[np.ndarray]:
         return args.target_tensor
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
+        if not all(d == 2 for d in self._qid_shape):
+            return NotImplemented
         return value.LinearDict({'I' * self.num_qubits(): 1.0})
 
     def _trace_distance_bound_(self) -> float:
         return 0.0
 
     def __repr__(self):
-        if self.num_qubits() == 1:
+        if self._qid_shape == (2,):
             return 'cirq.I'
-        return 'cirq.IdentityGate({!r})'.format(self.num_qubits())
+        other = ''
+        if not all(d == 2 for d in self._qid_shape):
+            other = ', {!r}'.format(self._qid_shape)
+        return 'cirq.IdentityGate({!r}{})'.format(self.num_qubits(), other)
 
     def __str__(self):
         if (self.num_qubits() == 1):
@@ -701,17 +740,47 @@ class IdentityGate(raw_types.Gate):
 
     def _qasm_(self, args: 'protocols.QasmArgs',
                qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+        if not all(d == 2 for d in self._qid_shape):
+            return NotImplemented
         args.validate_version('2.0')
         return ''.join([args.format('id {0};\n', qubit) for qubit in qubits])
 
     def _value_equality_values_(self):
-        return self.num_qubits(),
+        return self._qid_shape
 
     def _json_dict_(self):
+        other = {}
+        if not all(d == 2 for d in self._qid_shape):
+            other['qid_shape'] = self._qid_shape
         return {
             'cirq_type': self.__class__.__name__,
-            'num_qubits': self.num_qubits(),
+            'num_qubits': len(self._qid_shape),
+            **other,
         }
+
+    @classmethod
+    def _from_json_dict_(cls, num_qubits, qid_shape=None, **kwargs):
+        return cls(num_qubits=num_qubits,
+                   qid_shape=None if qid_shape is None else tuple(qid_shape))
+
+
+def identity(*qubits: raw_types.Qid) -> raw_types.Operation:
+    """Returns a single IdentityGate applied to all the given qubits.
+
+    Args:
+        *qubits: The qubits that the identity gate will apply to.
+
+    Returns:
+        An identity operation on the given qubits.
+
+    Raises:
+        ValueError if the qubits are not instances of Qid.
+    """
+    if not all(isinstance(qubit, raw_types.Qid) for qubit in qubits):
+        raise ValueError('identity() was called with type different than Qid.')
+
+    qid_shape = protocols.qid_shape(qubits)
+    return IdentityGate(len(qubits), qid_shape).on(*qubits)
 
 
 class HPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -379,6 +379,12 @@ def test_measurement_full_invert_mask():
         2, 'a', invert_mask=(True,)).full_invert_mask() == (True, False))
 
 
+def test_qudit_measure_qasm():
+    assert cirq.qasm(cirq.measure(cirq.LineQid(0, 3), key='a'),
+                     args=cirq.QasmArgs(),
+                     default='not implemented') == 'not implemented'
+
+
 def test_interchangeable_qubit_eq():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -60,6 +60,10 @@ def test_consistent_protocols(gate_type, num_qubits):
     cirq.testing.assert_implements_consistent_protocols(
         gate, qubit_count=num_qubits)
 
+    gate = gate_type(num_qubits=num_qubits, qid_shape=(3,) * num_qubits)
+    cirq.testing.assert_implements_consistent_protocols(
+        gate, qubit_count=num_qubits)
+
 
 def test_cz_init():
     assert cirq.CZPowGate(exponent=0.5).exponent == 0.5
@@ -214,6 +218,10 @@ def test_x_unitary():
 @pytest.mark.parametrize('num_qubits', [1, 2, 4])
 def test_identity_init(num_qubits):
     assert cirq.IdentityGate(num_qubits).num_qubits() == num_qubits
+    assert cirq.qid_shape(cirq.IdentityGate(num_qubits)) == (2,) * num_qubits
+    assert cirq.qid_shape(cirq.IdentityGate(3, (1, 2, 3))) == (1, 2, 3)
+    with pytest.raises(ValueError, match='len.* !='):
+        cirq.IdentityGate(5, qid_shape=(1, 2))
 
 
 def test_identity_on_each():
@@ -233,6 +241,12 @@ def test_identity_on_each():
 
 def test_identity_on_each_only_single_qubit():
     q0, q1 = cirq.LineQubit.range(2)
+    q0_3, q1_3 = q0.with_dimension(3), q1.with_dimension(3)
+    assert cirq.I.on_each(q0, q1) == [cirq.I.on(q0), cirq.I.on(q1)]
+    assert cirq.IdentityGate(1, (3,)).on_each(q0_3, q1_3) == [
+        cirq.IdentityGate(1, (3,)).on(q0_3),
+        cirq.IdentityGate(1, (3,)).on(q1_3),
+    ]
     with pytest.raises(ValueError, match='one qubit'):
         cirq.IdentityGate(num_qubits=2).on_each(q0, q1)
 
@@ -241,15 +255,21 @@ def test_identity_on_each_only_single_qubit():
 def test_identity_unitary(num_qubits):
     i = cirq.IdentityGate(num_qubits)
     assert np.allclose(cirq.unitary(i), np.identity(2 ** num_qubits))
+    i3 = cirq.IdentityGate(num_qubits, (3,) * num_qubits)
+    assert np.allclose(cirq.unitary(i3), np.identity(3 ** num_qubits))
 
 
 def test_identity_str():
     assert str(cirq.IdentityGate(1)) == 'I'
     assert str(cirq.IdentityGate(2)) == 'I(2)'
+    # Qid shape is not included in str
+    assert str(cirq.IdentityGate(1, (3,))) == 'I'
+    assert str(cirq.IdentityGate(2, (1, 2))) == 'I(2)'
 
 
 def test_identity_repr():
     assert repr(cirq.IdentityGate(2)) == 'cirq.IdentityGate(2)'
+    assert repr(cirq.IdentityGate(2, (2, 3))) == 'cirq.IdentityGate(2, (2, 3))'
 
 
 def test_identity_apply_unitary():
@@ -258,12 +278,34 @@ def test_identity_apply_unitary():
         cirq.I, cirq.ApplyUnitaryArgs(v, np.array([0, 1]), (0,)))
     assert result is v
 
+    v = np.array([1, 0, 0])
+    result = cirq.apply_unitary(
+        cirq.IdentityGate(1, (3,)),
+        cirq.ApplyUnitaryArgs(v, np.array([0, 1, 2]), (0,)))
+    assert result is v
+
 
 def test_identity_eq():
     equals_tester = cirq.testing.EqualsTester()
-    equals_tester.add_equality_group(cirq.I, cirq.IdentityGate(1))
-    equals_tester.add_equality_group(cirq.IdentityGate(2))
+    equals_tester.make_equality_group(
+        lambda: cirq.I,
+        lambda: cirq.IdentityGate(1),
+        lambda: cirq.IdentityGate(1, (2,)))
+    equals_tester.add_equality_group(
+        cirq.IdentityGate(2),
+        cirq.IdentityGate(2, (2, 2)))
     equals_tester.add_equality_group(cirq.IdentityGate(4))
+    equals_tester.add_equality_group(cirq.IdentityGate(1, (3,)))
+    equals_tester.add_equality_group(cirq.IdentityGate(4, (1, 2, 3, 4)))
+
+
+def test_identity_global():
+    qubits = cirq.LineQubit.range(3)
+    assert cirq.identity(*qubits) == cirq.IdentityGate(3).on(*qubits)
+    qids = cirq.LineQid.for_qid_shape((1, 2, 3))
+    assert cirq.identity(*qids) == cirq.IdentityGate(3, (1, 2, 3)).on(*qids)
+    with pytest.raises(ValueError, match='type different'):
+        cirq.identity(qubits)  # The user forgot to expand the list for example.
 
 
 def test_h_unitary():
@@ -298,17 +340,38 @@ def test_runtime_types_of_rot_gates():
         assert cirq.inverse(c) == gate_type(-0.5)
 
 
+@pytest.mark.parametrize('num_qubits', [1, 2, 4])
+def test_measure_init(num_qubits):
+    assert cirq.MeasurementGate(num_qubits).num_qubits() == num_qubits
+    assert cirq.MeasurementGate(num_qubits, key='a').key == 'a'
+    assert cirq.MeasurementGate(num_qubits, invert_mask=(True,)
+        ).invert_mask == (True,)
+    assert cirq.qid_shape(cirq.MeasurementGate(num_qubits)) == (2,) * num_qubits
+    assert cirq.qid_shape(cirq.MeasurementGate(3, qid_shape=(1, 2, 3))
+        ) == (1, 2, 3)
+    with pytest.raises(ValueError, match='len.* >'):
+        cirq.MeasurementGate(5, invert_mask=(True,) * 6)
+    with pytest.raises(ValueError, match='len.* !='):
+        cirq.MeasurementGate(5, qid_shape=(1, 2))
+
+
 def test_measurement_eq():
     eq = cirq.testing.EqualsTester()
-    eq.add_equality_group(cirq.MeasurementGate(1, ''),
-                          cirq.MeasurementGate(1, '', invert_mask=()))
+    eq.make_equality_group(
+        lambda: cirq.MeasurementGate(1, ''),
+        lambda: cirq.MeasurementGate(1, '', invert_mask=()),
+        lambda: cirq.MeasurementGate(1, '', qid_shape=(2,)))
     eq.add_equality_group(cirq.MeasurementGate(1, 'a'))
     eq.add_equality_group(cirq.MeasurementGate(1, 'a', invert_mask=(True,)))
     eq.add_equality_group(cirq.MeasurementGate(1, 'a', invert_mask=(False,)))
     eq.add_equality_group(cirq.MeasurementGate(1, 'b'))
     eq.add_equality_group(cirq.MeasurementGate(2, 'a'))
     eq.add_equality_group(cirq.MeasurementGate(2, ''))
-    eq.add_equality_group(cirq.MeasurementGate(3, 'a'))
+    eq.add_equality_group(
+        cirq.MeasurementGate(3, 'a'),
+        cirq.MeasurementGate(3, 'a', qid_shape=(2,2,2)))
+    eq.add_equality_group(
+        cirq.MeasurementGate(3, 'a', qid_shape=(1,2,3)))
 
 
 def test_measurement_full_invert_mask():
@@ -579,6 +642,9 @@ def test_measure():
                                                             key='b').on(a)
     assert cirq.measure(a, invert_mask=(True,)) == cirq.MeasurementGate(
         num_qubits=1, key='a', invert_mask=(True,)).on(a)
+    assert cirq.measure(*cirq.LineQid.for_qid_shape((1, 2, 3)), key='a'
+        ) == cirq.MeasurementGate(num_qubits=3, key='a', qid_shape=(1, 2, 3)
+        ).on(*cirq.LineQid.for_qid_shape((1, 2, 3)))
 
     with pytest.raises(ValueError, match='ndarray'):
         _ = cirq.measure(np.ndarray([1, 0]))
@@ -610,6 +676,44 @@ def test_measurement_channel():
                        [0, 0, 0, 0],
                        [0, 0, 0, 0],
                        [0, 0, 0, 1]])))
+    np.testing.assert_allclose(
+            cirq.channel(cirq.MeasurementGate(2, qid_shape=(2, 3))),
+            (np.array([[1, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0]]),
+             np.array([[0, 0, 0, 0, 0, 0],
+                       [0, 1, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0]]),
+             np.array([[0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 1, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0]]),
+             np.array([[0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 1, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0]]),
+             np.array([[0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 1, 0],
+                       [0, 0, 0, 0, 0, 0]]),
+             np.array([[0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 0],
+                       [0, 0, 0, 0, 0, 1]])))
     # yapf: enable
 
 
@@ -636,6 +740,8 @@ def test_measure_each():
     assert cirq.measure_each() == []
     assert cirq.measure_each(a) == [cirq.measure(a)]
     assert cirq.measure_each(a, b) == [cirq.measure(a), cirq.measure(b)]
+    assert cirq.measure_each(a.with_dimension(3), b.with_dimension(3)) == [
+        cirq.measure(a.with_dimension(3)), cirq.measure(b.with_dimension(3))]
 
     assert cirq.measure_each(a, b, key_func=lambda e: e.name + '!') == [
         cirq.measure(a, key='a!'),

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -220,8 +220,11 @@ def test_identity_init(num_qubits):
     assert cirq.IdentityGate(num_qubits).num_qubits() == num_qubits
     assert cirq.qid_shape(cirq.IdentityGate(num_qubits)) == (2,) * num_qubits
     assert cirq.qid_shape(cirq.IdentityGate(3, (1, 2, 3))) == (1, 2, 3)
+    assert cirq.qid_shape(cirq.IdentityGate(qid_shape=(1, 2, 3))) == (1, 2, 3)
     with pytest.raises(ValueError, match='len.* !='):
         cirq.IdentityGate(5, qid_shape=(1, 2))
+    with pytest.raises(ValueError, match='Specify either'):
+        cirq.IdentityGate()
 
 
 def test_identity_on_each():
@@ -349,10 +352,14 @@ def test_measure_init(num_qubits):
     assert cirq.qid_shape(cirq.MeasurementGate(num_qubits)) == (2,) * num_qubits
     assert cirq.qid_shape(cirq.MeasurementGate(3, qid_shape=(1, 2,
                                                              3))) == (1, 2, 3)
+    assert cirq.qid_shape(cirq.MeasurementGate(qid_shape=(1, 2, 3))) == (1, 2,
+                                                                         3)
     with pytest.raises(ValueError, match='len.* >'):
         cirq.MeasurementGate(5, invert_mask=(True,) * 6)
     with pytest.raises(ValueError, match='len.* !='):
         cirq.MeasurementGate(5, qid_shape=(1, 2))
+    with pytest.raises(ValueError, match='Specify either'):
+        cirq.MeasurementGate()
 
 
 def test_measurement_eq():
@@ -682,42 +689,12 @@ def test_measurement_channel():
                        [0, 0, 0, 1]])))
     np.testing.assert_allclose(
             cirq.channel(cirq.MeasurementGate(2, qid_shape=(2, 3))),
-            (np.array([[1, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0]]),
-             np.array([[0, 0, 0, 0, 0, 0],
-                       [0, 1, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0]]),
-             np.array([[0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 1, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0]]),
-             np.array([[0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 1, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0]]),
-             np.array([[0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 1, 0],
-                       [0, 0, 0, 0, 0, 0]]),
-             np.array([[0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 0],
-                       [0, 0, 0, 0, 0, 1]])))
+            (np.diag([1, 0, 0, 0, 0, 0]),
+             np.diag([0, 1, 0, 0, 0, 0]),
+             np.diag([0, 0, 1, 0, 0, 0]),
+             np.diag([0, 0, 0, 1, 0, 0]),
+             np.diag([0, 0, 0, 0, 1, 0]),
+             np.diag([0, 0, 0, 0, 0, 1])))
     # yapf: enable
 
 

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -61,8 +61,8 @@ def test_consistent_protocols(gate_type, num_qubits):
         gate, qubit_count=num_qubits)
 
     gate = gate_type(num_qubits=num_qubits, qid_shape=(3,) * num_qubits)
-    cirq.testing.assert_implements_consistent_protocols(
-        gate, qubit_count=num_qubits)
+    cirq.testing.assert_implements_consistent_protocols(gate,
+                                                        qubit_count=num_qubits)
 
 
 def test_cz_init():
@@ -256,7 +256,7 @@ def test_identity_unitary(num_qubits):
     i = cirq.IdentityGate(num_qubits)
     assert np.allclose(cirq.unitary(i), np.identity(2 ** num_qubits))
     i3 = cirq.IdentityGate(num_qubits, (3,) * num_qubits)
-    assert np.allclose(cirq.unitary(i3), np.identity(3 ** num_qubits))
+    assert np.allclose(cirq.unitary(i3), np.identity(3**num_qubits))
 
 
 def test_identity_str():
@@ -290,10 +290,10 @@ def test_identity_eq():
     equals_tester.make_equality_group(
         lambda: cirq.I,
         lambda: cirq.IdentityGate(1),
-        lambda: cirq.IdentityGate(1, (2,)))
-    equals_tester.add_equality_group(
-        cirq.IdentityGate(2),
-        cirq.IdentityGate(2, (2, 2)))
+        lambda: cirq.IdentityGate(1, (2,)),
+    )
+    equals_tester.add_equality_group(cirq.IdentityGate(2),
+                                     cirq.IdentityGate(2, (2, 2)))
     equals_tester.add_equality_group(cirq.IdentityGate(4))
     equals_tester.add_equality_group(cirq.IdentityGate(1, (3,)))
     equals_tester.add_equality_group(cirq.IdentityGate(4, (1, 2, 3, 4)))
@@ -344,11 +344,11 @@ def test_runtime_types_of_rot_gates():
 def test_measure_init(num_qubits):
     assert cirq.MeasurementGate(num_qubits).num_qubits() == num_qubits
     assert cirq.MeasurementGate(num_qubits, key='a').key == 'a'
-    assert cirq.MeasurementGate(num_qubits, invert_mask=(True,)
-        ).invert_mask == (True,)
+    assert cirq.MeasurementGate(num_qubits,
+                                invert_mask=(True,)).invert_mask == (True,)
     assert cirq.qid_shape(cirq.MeasurementGate(num_qubits)) == (2,) * num_qubits
-    assert cirq.qid_shape(cirq.MeasurementGate(3, qid_shape=(1, 2, 3))
-        ) == (1, 2, 3)
+    assert cirq.qid_shape(cirq.MeasurementGate(3, qid_shape=(1, 2,
+                                                             3))) == (1, 2, 3)
     with pytest.raises(ValueError, match='len.* >'):
         cirq.MeasurementGate(5, invert_mask=(True,) * 6)
     with pytest.raises(ValueError, match='len.* !='):
@@ -357,21 +357,18 @@ def test_measure_init(num_qubits):
 
 def test_measurement_eq():
     eq = cirq.testing.EqualsTester()
-    eq.make_equality_group(
-        lambda: cirq.MeasurementGate(1, ''),
-        lambda: cirq.MeasurementGate(1, '', invert_mask=()),
-        lambda: cirq.MeasurementGate(1, '', qid_shape=(2,)))
+    eq.make_equality_group(lambda: cirq.MeasurementGate(
+        1, ''), lambda: cirq.MeasurementGate(1, '', invert_mask=()), lambda:
+                           cirq.MeasurementGate(1, '', qid_shape=(2,)))
     eq.add_equality_group(cirq.MeasurementGate(1, 'a'))
     eq.add_equality_group(cirq.MeasurementGate(1, 'a', invert_mask=(True,)))
     eq.add_equality_group(cirq.MeasurementGate(1, 'a', invert_mask=(False,)))
     eq.add_equality_group(cirq.MeasurementGate(1, 'b'))
     eq.add_equality_group(cirq.MeasurementGate(2, 'a'))
     eq.add_equality_group(cirq.MeasurementGate(2, ''))
-    eq.add_equality_group(
-        cirq.MeasurementGate(3, 'a'),
-        cirq.MeasurementGate(3, 'a', qid_shape=(2,2,2)))
-    eq.add_equality_group(
-        cirq.MeasurementGate(3, 'a', qid_shape=(1,2,3)))
+    eq.add_equality_group(cirq.MeasurementGate(3, 'a'),
+                          cirq.MeasurementGate(3, 'a', qid_shape=(2, 2, 2)))
+    eq.add_equality_group(cirq.MeasurementGate(3, 'a', qid_shape=(1, 2, 3)))
 
 
 def test_measurement_full_invert_mask():
@@ -642,9 +639,10 @@ def test_measure():
                                                             key='b').on(a)
     assert cirq.measure(a, invert_mask=(True,)) == cirq.MeasurementGate(
         num_qubits=1, key='a', invert_mask=(True,)).on(a)
-    assert cirq.measure(*cirq.LineQid.for_qid_shape((1, 2, 3)), key='a'
-        ) == cirq.MeasurementGate(num_qubits=3, key='a', qid_shape=(1, 2, 3)
-        ).on(*cirq.LineQid.for_qid_shape((1, 2, 3)))
+    assert cirq.measure(*cirq.LineQid.for_qid_shape(
+        (1, 2, 3)), key='a') == cirq.MeasurementGate(
+            num_qubits=3, key='a',
+            qid_shape=(1, 2, 3)).on(*cirq.LineQid.for_qid_shape((1, 2, 3)))
 
     with pytest.raises(ValueError, match='ndarray'):
         _ = cirq.measure(np.ndarray([1, 0]))
@@ -741,7 +739,9 @@ def test_measure_each():
     assert cirq.measure_each(a) == [cirq.measure(a)]
     assert cirq.measure_each(a, b) == [cirq.measure(a), cirq.measure(b)]
     assert cirq.measure_each(a.with_dimension(3), b.with_dimension(3)) == [
-        cirq.measure(a.with_dimension(3)), cirq.measure(b.with_dimension(3))]
+        cirq.measure(a.with_dimension(3)),
+        cirq.measure(b.with_dimension(3))
+    ]
 
     assert cirq.measure_each(a, b, key_func=lambda e: e.name + '!') == [
         cirq.measure(a, key='a!'),

--- a/cirq/protocols/apply_channel.py
+++ b/cirq/protocols/apply_channel.py
@@ -22,6 +22,7 @@ from typing_extensions import Protocol
 from cirq import linalg
 from cirq.protocols.apply_unitary import apply_unitary, ApplyUnitaryArgs
 from cirq.protocols.channel import channel
+from cirq.protocols import qid_shape_protocol
 from cirq.type_workarounds import NotImplementedType
 
 
@@ -205,8 +206,28 @@ def apply_channel(val: Any,
 
     Raises:
         TypeError: `val` doesn't have a channel and `default` wasn't specified.
-        AssertionError: if the
+        ValueError: Different left and right shapes of `args.target_tensor`
+            selected by `left_axes` and `right_axes` or `qid_shape(val)` doesn't
+            equal the left and right shapes.
+        AssertionError: `_apply_channel_` returned an auxiliary buffer.
     """
+    # Verify that val has the same qid shape as the selected axes of the density
+    # matrix tensor.
+    val_qid_shape = qid_shape_protocol.qid_shape(val,
+                                                 (2,) * len(args.left_axes))
+    left_shape = tuple(args.target_tensor.shape[i] for i in args.left_axes)
+    right_shape = tuple(args.target_tensor.shape[i] for i in args.right_axes)
+    if left_shape != right_shape:
+        raise ValueError('Invalid target_tensor shape or selected axes. '
+                         'The selected left and right shape of target_tensor '
+                         'are not equal. Got {!r} and {!r}.'.format(
+                            left_shape, right_shape))
+    if val_qid_shape != left_shape:
+        raise ValueError('Invalid channel qid shape is not equal to the '
+                         'selected left and right shape of target_tensor. '
+                         'Got {!r} but expected {!r}.'.format(
+                            val_qid_shape, left_shape))
+
     # Check if the specialized method is present.
     func = getattr(val, '_apply_channel_', None)
     if func is not None:
@@ -216,7 +237,7 @@ def apply_channel(val: Any,
                 return (
                     "Object of type '{}' returned a result object equal to "
                     "auxiliary_buffer{}. This type violates the contract "
-                    "that appears in apply_unitary's documentation.".format(
+                    "that appears in apply_channel's documentation.".format(
                         type(val), buf_num_str))
             assert result is not args.auxiliary_buffer0, err_str('0')
             assert result is not args.auxiliary_buffer1, err_str('1')
@@ -270,7 +291,7 @@ def _apply_krauss(krauss: Union[Tuple[np.ndarray], Sequence[Any]],
     np.copyto(dst=args.auxiliary_buffer0, src=args.target_tensor)
 
     # Special case for single-qubit operations.
-    if krauss[0].shape == (2, 2):
+    if len(args.left_axes) == 1 and krauss[0].shape == (2, 2):
         return _apply_krauss_single_qubit(krauss, args)
     # Fallback to np.einsum for the general case.
     return _apply_krauss_multi_qubit(krauss, args)
@@ -278,7 +299,7 @@ def _apply_krauss(krauss: Union[Tuple[np.ndarray], Sequence[Any]],
 
 def _apply_krauss_single_qubit(krauss: Union[Tuple[Any], Sequence[Any]],
         args: 'ApplyChannelArgs') -> np.ndarray:
-    """Use slicing to apply single qubit channel."""
+    """Use slicing to apply single qubit channel.  Only for two-level qubits."""
     zero_left = linalg.slice_for_qubits_equal_to(args.left_axes, 0)
     one_left = linalg.slice_for_qubits_equal_to(args.left_axes, 1)
     zero_right = linalg.slice_for_qubits_equal_to(args.right_axes, 0)
@@ -305,11 +326,12 @@ def _apply_krauss_single_qubit(krauss: Union[Tuple[Any], Sequence[Any]],
 def _apply_krauss_multi_qubit(krauss: Union[Tuple[Any], Sequence[Any]],
         args: 'ApplyChannelArgs') -> np.ndarray:
     """Use numpy's einsum to apply a multi-qubit channel."""
+    qid_shape = tuple(args.target_tensor.shape[i] for i in args.left_axes)
     for krauss_op in krauss:
         np.copyto(dst=args.target_tensor, src=args.auxiliary_buffer0)
         krauss_tensor = np.reshape(
                 krauss_op.astype(args.target_tensor.dtype),
-                (2,) * len(args.left_axes) * 2)
+                qid_shape * 2)
         linalg.targeted_left_multiply(
                 krauss_tensor,
                 args.target_tensor,

--- a/cirq/protocols/apply_channel.py
+++ b/cirq/protocols/apply_channel.py
@@ -221,12 +221,12 @@ def apply_channel(val: Any,
         raise ValueError('Invalid target_tensor shape or selected axes. '
                          'The selected left and right shape of target_tensor '
                          'are not equal. Got {!r} and {!r}.'.format(
-                            left_shape, right_shape))
+                             left_shape, right_shape))
     if val_qid_shape != left_shape:
         raise ValueError('Invalid channel qid shape is not equal to the '
                          'selected left and right shape of target_tensor. '
                          'Got {!r} but expected {!r}.'.format(
-                            val_qid_shape, left_shape))
+                             val_qid_shape, left_shape))
 
     # Check if the specialized method is present.
     func = getattr(val, '_apply_channel_', None)
@@ -234,11 +234,11 @@ def apply_channel(val: Any,
         result = func(args)
         if result is not NotImplemented and result is not None:
             def err_str(buf_num_str):
-                return (
-                    "Object of type '{}' returned a result object equal to "
-                    "auxiliary_buffer{}. This type violates the contract "
-                    "that appears in apply_channel's documentation.".format(
-                        type(val), buf_num_str))
+                return ("Object of type '{}' returned a result object equal to "
+                        "auxiliary_buffer{}. This type violates the contract "
+                        "that appears in apply_channel's documentation.".format(
+                            type(val), buf_num_str))
+
             assert result is not args.auxiliary_buffer0, err_str('0')
             assert result is not args.auxiliary_buffer1, err_str('1')
             return result
@@ -329,9 +329,8 @@ def _apply_krauss_multi_qubit(krauss: Union[Tuple[Any], Sequence[Any]],
     qid_shape = tuple(args.target_tensor.shape[i] for i in args.left_axes)
     for krauss_op in krauss:
         np.copyto(dst=args.target_tensor, src=args.auxiliary_buffer0)
-        krauss_tensor = np.reshape(
-                krauss_op.astype(args.target_tensor.dtype),
-                qid_shape * 2)
+        krauss_tensor = np.reshape(krauss_op.astype(args.target_tensor.dtype),
+                                   qid_shape * 2)
         linalg.targeted_left_multiply(
                 krauss_tensor,
                 args.target_tensor,

--- a/cirq/protocols/apply_channel_test.py
+++ b/cirq/protocols/apply_channel_test.py
@@ -43,6 +43,23 @@ def apply_channel(val, rho, left_axes, right_axes,
     return result
 
 
+def test_apply_channel_bad_args():
+    target = np.zeros((3,) + (1, 2, 3) + (3, 1, 2) + (3,))
+    with pytest.raises(ValueError, match='Invalid target_tensor shape'):
+        cirq.apply_channel(
+            cirq.IdentityGate(3, (1, 2, 3)),
+            cirq.ApplyChannelArgs(target, np.zeros_like(target),
+                                  np.zeros_like(target), np.zeros_like(target),
+                                  (1, 2, 3), (4, 5, 6)))
+    target = np.zeros((2, 3, 2, 3))
+    with pytest.raises(ValueError, match='Invalid channel qid shape'):
+        cirq.apply_channel(
+            cirq.IdentityGate(2, (2, 9)),
+            cirq.ApplyChannelArgs(target, np.zeros_like(target),
+                                  np.zeros_like(target), np.zeros_like(target),
+                                  (0, 1), (2, 3)))
+
+
 def test_apply_channel_simple():
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -172,7 +172,11 @@ TEST_OBJECTS = {
     'ISWAP':
     cirq.ISWAP,
     'ISwapPowGate': [cirq.ISwapPowGate(exponent=-8), cirq.ISWAP**0.123],
-    'IdentityGate': [cirq.I, cirq.IdentityGate(num_qubits=5), cirq.IdentityGate(num_qubits=5, qid_shape=(3,)*5)],
+    'IdentityGate': [
+        cirq.I,
+        cirq.IdentityGate(num_qubits=5),
+        cirq.IdentityGate(num_qubits=5, qid_shape=(3,) * 5)
+    ],
     'LineQubit': [cirq.LineQubit(0), cirq.LineQubit(123)],
     'LineQid': [cirq.LineQid(0, 1),
                 cirq.LineQid(123, 2),
@@ -184,8 +188,8 @@ TEST_OBJECTS = {
                              invert_mask=(True, False, True)),
         cirq.MeasurementGate(num_qubits=3,
                              key='z',
-                             invert_mask=(True, False,),
-                             qid_shape=(1,2,3)),
+                             invert_mask=(True, False),
+                             qid_shape=(1, 2, 3)),
     ],
     'Moment': [
         cirq.Moment(operations=[cirq.X(Q0), cirq.Y(Q1),

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -172,7 +172,7 @@ TEST_OBJECTS = {
     'ISWAP':
     cirq.ISWAP,
     'ISwapPowGate': [cirq.ISwapPowGate(exponent=-8), cirq.ISWAP**0.123],
-    'IdentityGate': [cirq.I, cirq.IdentityGate(num_qubits=5)],
+    'IdentityGate': [cirq.I, cirq.IdentityGate(num_qubits=5), cirq.IdentityGate(num_qubits=5, qid_shape=(3,)*5)],
     'LineQubit': [cirq.LineQubit(0), cirq.LineQubit(123)],
     'LineQid': [cirq.LineQid(0, 1),
                 cirq.LineQid(123, 2),
@@ -182,6 +182,10 @@ TEST_OBJECTS = {
         cirq.MeasurementGate(num_qubits=3,
                              key='z',
                              invert_mask=(True, False, True)),
+        cirq.MeasurementGate(num_qubits=3,
+                             key='z',
+                             invert_mask=(True, False,),
+                             qid_shape=(1,2,3)),
     ],
     'Moment': [
         cirq.Moment(operations=[cirq.X(Q0), cirq.Y(Q1),

--- a/cirq/protocols/pauli_expansion.py
+++ b/cirq/protocols/pauli_expansion.py
@@ -18,6 +18,7 @@ from typing import Any, TypeVar, Union
 
 from cirq import value
 from cirq.linalg import operator_spaces
+from cirq.protocols import qid_shape_protocol
 from cirq.protocols.unitary import unitary
 
 TDefault = TypeVar('TDefault')
@@ -58,6 +59,13 @@ def pauli_expansion(
 
     if expansion is not NotImplemented:
         return expansion.clean(atol=atol)
+
+    # Don't attempt to derive the pauli expansion if this is a qudit gate
+    if not all(d == 2 for d in qid_shape_protocol.qid_shape(val, default=())):
+        if default is RaiseTypeErrorIfNotProvided:
+            raise TypeError('No Pauli expansion for object {} of type {}'
+                    .format(val, type(val)))
+        return default
 
     matrix = unitary(val, default=None)
     if matrix is None:

--- a/cirq/protocols/pauli_expansion.py
+++ b/cirq/protocols/pauli_expansion.py
@@ -63,8 +63,9 @@ def pauli_expansion(
     # Don't attempt to derive the pauli expansion if this is a qudit gate
     if not all(d == 2 for d in qid_shape_protocol.qid_shape(val, default=())):
         if default is RaiseTypeErrorIfNotProvided:
-            raise TypeError('No Pauli expansion for object {} of type {}'
-                    .format(val, type(val)))
+            raise TypeError(
+                'No Pauli expansion for object {} of type {}'.format(
+                    val, type(val)))
         return default
 
     matrix = unitary(val, default=None)

--- a/cirq/protocols/pauli_expansion_test.py
+++ b/cirq/protocols/pauli_expansion_test.py
@@ -43,9 +43,19 @@ class HasUnitary:
         return self._unitary
 
 
+class HasQuditUnitary:
+
+    def _qid_shape_(self):
+        return (3,)
+
+    def _unitary_(self) -> np.ndarray:
+        raise NotImplementedError
+
+
 @pytest.mark.parametrize('val', (
     NoMethod(),
     ReturnsNotImplemented(),
+    HasQuditUnitary(),
     123,
     np.eye(2),
     object(),
@@ -53,7 +63,7 @@ class HasUnitary:
 ))
 def test_raises_no_pauli_expansion(val):
     assert cirq.pauli_expansion(val, default=None) is None
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match='No Pauli expansion'):
         cirq.pauli_expansion(val)
 
 

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -264,7 +264,10 @@ def assert_has_consistent_apply_unitary(
 
     qubit_counts = [
         qubit_count,
-        expected.shape[0].bit_length() - 1 if expected is not None else None,
+        # Only fall back to using the unitary size if num_qubits or qid_shape
+        # protocols are not defined.
+        protocols.num_qubits(val, default=expected.shape[0].bit_length() - 1
+                                  if expected is not None else None),
         _infer_qubit_count(val)
     ]
     qubit_counts = [e for e in qubit_counts if e is not None]
@@ -276,8 +279,9 @@ def assert_has_consistent_apply_unitary(
         'Inconsistent qubit counts from different methods: {}'.format(
             qubit_counts))
     n = cast(int, qubit_counts[0])
+    qid_shape = protocols.qid_shape(val, default=(2,) * n)
 
-    eye = np.eye(2 << n, dtype=np.complex128).reshape((2,) * (2 * n + 2))
+    eye = linalg.eye_tensor((2,) + qid_shape, dtype=np.complex128)
     actual = protocols.apply_unitary(
         unitary_value=val,
         args=protocols.ApplyUnitaryArgs(
@@ -295,7 +299,7 @@ def assert_has_consistent_apply_unitary(
     # If you applied a unitary, it should match the one you say you have.
     if actual is not None:
         np.testing.assert_allclose(
-            actual.reshape(2 << n, 2 << n),
+            actual.reshape((np.prod((2,) + qid_shape, dtype=int),) * 2),
             expected,
             atol=atol)
 

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -266,8 +266,9 @@ def assert_has_consistent_apply_unitary(
         qubit_count,
         # Only fall back to using the unitary size if num_qubits or qid_shape
         # protocols are not defined.
-        protocols.num_qubits(val, default=expected.shape[0].bit_length() - 1
-                                  if expected is not None else None),
+        protocols.num_qubits(val,
+                             default=expected.shape[0].bit_length() -
+                             1 if expected is not None else None),
         _infer_qubit_count(val)
     ]
     qubit_counts = [e for e in qubit_counts if e is not None]
@@ -298,10 +299,10 @@ def assert_has_consistent_apply_unitary(
 
     # If you applied a unitary, it should match the one you say you have.
     if actual is not None:
-        np.testing.assert_allclose(
-            actual.reshape((np.prod((2,) + qid_shape, dtype=int),) * 2),
-            expected,
-            atol=atol)
+        np.testing.assert_allclose(actual.reshape((np.prod(
+            (2,) + qid_shape, dtype=int),) * 2),
+                                   expected,
+                                   atol=atol)
 
 
 def assert_eigen_gate_has_consistent_apply_unitary(

--- a/cirq/testing/circuit_compare_test.py
+++ b/cirq/testing/circuit_compare_test.py
@@ -364,6 +364,22 @@ def test_assert_has_consistent_apply_unitary():
     cirq.testing.assert_has_consistent_apply_unitary(
         SameEffect())
 
+    class SameQuditEffect:
+        def _qid_shape_(self):
+            return (3,)
+
+        def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> np.ndarray:
+            args.available_buffer[..., 0] = args.target_tensor[..., 2]
+            args.available_buffer[..., 1] = args.target_tensor[..., 0]
+            args.available_buffer[..., 2] = args.target_tensor[..., 1]
+            return args.available_buffer
+
+        def _unitary_(self):
+            return np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
+
+    cirq.testing.assert_has_consistent_apply_unitary(
+        SameQuditEffect())
+
     class BadExponent:
         def __init__(self, power):
             self.power = power

--- a/cirq/testing/circuit_compare_test.py
+++ b/cirq/testing/circuit_compare_test.py
@@ -365,6 +365,7 @@ def test_assert_has_consistent_apply_unitary():
         SameEffect())
 
     class SameQuditEffect:
+
         def _qid_shape_(self):
             return (3,)
 
@@ -377,8 +378,7 @@ def test_assert_has_consistent_apply_unitary():
         def _unitary_(self):
             return np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
 
-    cirq.testing.assert_has_consistent_apply_unitary(
-        SameQuditEffect())
+    cirq.testing.assert_has_consistent_apply_unitary(SameQuditEffect())
 
     class BadExponent:
         def __init__(self, power):

--- a/cirq/testing/consistent_pauli_expansion.py
+++ b/cirq/testing/consistent_pauli_expansion.py
@@ -36,7 +36,8 @@ def assert_pauli_expansion_is_consistent_with_unitary(val: Any) -> None:
     if unitary is None:
         return
 
-    num_qubits = unitary.shape[0].bit_length() - 1
+    num_qubits = protocols.num_qubits(val,
+        default=unitary.shape[0].bit_length() - 1)
     basis = operator_spaces.kron_bases(operator_spaces.PAULI_BASIS,
                                        repeat=num_qubits)
 

--- a/cirq/testing/consistent_pauli_expansion.py
+++ b/cirq/testing/consistent_pauli_expansion.py
@@ -37,7 +37,7 @@ def assert_pauli_expansion_is_consistent_with_unitary(val: Any) -> None:
         return
 
     num_qubits = protocols.num_qubits(val,
-        default=unitary.shape[0].bit_length() - 1)
+                                      default=unitary.shape[0].bit_length() - 1)
     basis = operator_spaces.kron_bases(operator_spaces.PAULI_BASIS,
                                        repeat=num_qubits)
 

--- a/cirq/testing/consistent_phase_by.py
+++ b/cirq/testing/consistent_phase_by.py
@@ -29,7 +29,8 @@ def assert_phase_by_is_consistent_with_unitary(val: Any):
         # If there's no unitary, it's vacuously consistent.
         return
     qid_shape = protocols.qid_shape(val,
-        default=(2,) * (len(original).bit_length() - 1))
+                                    default=(2,) *
+                                    (len(original).bit_length() - 1))
     original = original.reshape(qid_shape * 2)
 
     for t in [0.125, -0.25, 1, sympy.Symbol('a'), sympy.Symbol('a') + 1]:

--- a/cirq/testing/consistent_phase_by.py
+++ b/cirq/testing/consistent_phase_by.py
@@ -28,25 +28,26 @@ def assert_phase_by_is_consistent_with_unitary(val: Any):
     if original is None:
         # If there's no unitary, it's vacuously consistent.
         return
-    qubit_count = len(original).bit_length() - 1
-    original = original.reshape((2, 2) * qubit_count)
+    qid_shape = protocols.qid_shape(val,
+        default=(2,) * (len(original).bit_length() - 1))
+    original = original.reshape(qid_shape * 2)
 
     for t in [0.125, -0.25, 1, sympy.Symbol('a'), sympy.Symbol('a') + 1]:
         p = 1j**(t*4)
         p = protocols.resolve_parameters(p, {'a': -0.125})
-        for i in range(qubit_count):
+        for i in range(len(qid_shape)):
             phased = protocols.phase_by(val, t, i, default=None)
             if phased is None:
                 # If not phaseable, then phase_by is vacuously consistent.
                 continue
 
             phased = protocols.resolve_parameters(phased, {'a': -0.125})
-            actual = protocols.unitary(phased).reshape((2, 2) * qubit_count)
+            actual = protocols.unitary(phased).reshape(qid_shape * 2)
 
             expected = np.array(original)
             s = linalg.slice_for_qubits_equal_to([i], 1)
             expected[s] *= p
-            s = linalg.slice_for_qubits_equal_to([qubit_count + i], 1)
+            s = linalg.slice_for_qubits_equal_to([len(qid_shape) + i], 1)
             expected[s] *= np.conj(p)
 
             lin_alg_utils.assert_allclose_up_to_global_phase(

--- a/cirq/testing/consistent_phase_by_test.py
+++ b/cirq/testing/consistent_phase_by_test.py
@@ -37,6 +37,7 @@ class GoodPhaser:
 
 
 class GoodQuditPhaser:
+
     def __init__(self, e):
         self.e = e
 
@@ -51,7 +52,7 @@ class GoodQuditPhaser:
         ])
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
-        return GoodQuditPhaser(self.e + phase_turns*4)
+        return GoodQuditPhaser(self.e + phase_turns * 4)
 
     def _resolve_parameters_(self, param_resolver):
         return GoodQuditPhaser(param_resolver.value_of(self.e))

--- a/cirq/testing/consistent_phase_by_test.py
+++ b/cirq/testing/consistent_phase_by_test.py
@@ -36,6 +36,27 @@ class GoodPhaser:
         return GoodPhaser(param_resolver.value_of(self.e))
 
 
+class GoodQuditPhaser:
+    def __init__(self, e):
+        self.e = e
+
+    def _qid_shape_(self):
+        return (3,)
+
+    def _unitary_(self):
+        return np.array([
+            [0, 1j**-self.e, 0],
+            [0, 0, 1j**self.e],
+            [1, 0, 0],
+        ])
+
+    def _phase_by_(self, phase_turns: float, qubit_index: int):
+        return GoodQuditPhaser(self.e + phase_turns*4)
+
+    def _resolve_parameters_(self, param_resolver):
+        return GoodQuditPhaser(param_resolver.value_of(self.e))
+
+
 class BadPhaser:
     def __init__(self, e):
         self.e = e
@@ -85,6 +106,9 @@ class SemiBadPhaser:
 def test_assert_phase_by_is_consistent_with_unitary():
     cirq.testing.assert_phase_by_is_consistent_with_unitary(
         GoodPhaser(0.5))
+
+    cirq.testing.assert_phase_by_is_consistent_with_unitary(
+        GoodQuditPhaser(0.5))
 
     with pytest.raises(AssertionError,
                        match='Phased unitary was incorrect for index #0'):

--- a/cirq/testing/consistent_qasm.py
+++ b/cirq/testing/consistent_qasm.py
@@ -37,17 +37,18 @@ def assert_qasm_is_consistent_with_unitary(val: Any):
         # Vacuous consistency.
         return
 
-    controls = getattr(val, 'control_qubits', None)
-    if controls is None:
-        qubit_count = len(unitary).bit_length() - 1
-    else:
-        qubit_count = len(unitary).bit_length() - 1 - (len(controls) -
-                                                       controls.count(None))
     if isinstance(val, ops.Operation):
         qubits = val.qubits
         op = val
     elif isinstance(val, ops.Gate):
-        qubits = tuple(devices.LineQubit.range(qubit_count))
+        qid_shape = protocols.qid_shape(val)
+        remaining_shape = list(qid_shape)
+        controls = getattr(val, 'control_qubits', None)
+        if controls is not None:
+            for i, q in zip(reversed(range(len(controls))), reversed(controls)):
+                if q is not None:
+                    remaining_shape.pop(i)
+        qubits = devices.LineQid.for_qid_shape(remaining_shape)
         op = val.on(*qubits)
     else:
         raise NotImplementedError("Don't know how to test {!r}".format(val))

--- a/cirq/testing/consistent_qasm.py
+++ b/cirq/testing/consistent_qasm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-from typing import Any, List
+from typing import Any, List, Sequence
 
 import numpy as np
 
@@ -38,7 +38,7 @@ def assert_qasm_is_consistent_with_unitary(val: Any):
         return
 
     if isinstance(val, ops.Operation):
-        qubits = val.qubits
+        qubits: Sequence[ops.Qid] = val.qubits
         op = val
     elif isinstance(val, ops.Gate):
         qid_shape = protocols.qid_shape(val)

--- a/cirq/testing/consistent_qasm_test.py
+++ b/cirq/testing/consistent_qasm_test.py
@@ -40,6 +40,25 @@ class Fixed(cirq.Operation):
         return args.format(self.qasm, *self.qubits)
 
 
+class QuditOp(cirq.Operation):
+
+    def _qid_shape_(self):
+        return (3, 3)
+
+    @property
+    def qubits(self):
+        return cirq.LineQid.for_qid_shape((3, 3))
+
+    def with_qubits(self, *new_qubits):
+        raise NotImplementedError
+
+    def _unitary_(self):
+        return np.eye(9)
+
+    def _qasm_(self, args: cirq.QasmArgs):
+        return NotImplemented
+
+
 def test_assert_qasm_is_consistent_with_unitary():
     try:
         import qiskit as _
@@ -70,3 +89,6 @@ def test_assert_qasm_is_consistent_with_unitary():
     with pytest.raises(AssertionError, match='Illegal character'):
         cirq.testing.assert_qasm_is_consistent_with_unitary(
             Fixed(np.array([[1, 0], [0, -1]]), 'JUNK'))
+
+    # Checks that the test handles qudits
+    cirq.testing.assert_qasm_is_consistent_with_unitary(QuditOp())

--- a/cirq/testing/consistent_qasm_test.py
+++ b/cirq/testing/consistent_qasm_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from typing import Tuple
+
 import warnings
-
-import pytest
-
 import numpy as np
+import pytest
 
 import cirq
 
@@ -40,22 +41,15 @@ class Fixed(cirq.Operation):
         return args.format(self.qasm, *self.qubits)
 
 
-class QuditOp(cirq.Operation):
+class QuditGate(cirq.Gate):
 
-    def _qid_shape_(self):
+    def _qid_shape_(self) -> Tuple[int, ...]:
         return (3, 3)
-
-    @property
-    def qubits(self):
-        return cirq.LineQid.for_qid_shape((3, 3))
-
-    def with_qubits(self, *new_qubits):
-        raise NotImplementedError
 
     def _unitary_(self):
         return np.eye(9)
 
-    def _qasm_(self, args: cirq.QasmArgs):
+    def _qasm_(self, args: cirq.QasmArgs, qubits: Tuple[cirq.Qid, ...]):
         return NotImplemented
 
 
@@ -91,4 +85,4 @@ def test_assert_qasm_is_consistent_with_unitary():
             Fixed(np.array([[1, 0], [0, -1]]), 'JUNK'))
 
     # Checks that the test handles qudits
-    cirq.testing.assert_qasm_is_consistent_with_unitary(QuditOp())
+    cirq.testing.assert_qasm_is_consistent_with_unitary(QuditGate())


### PR DESCRIPTION
Part of #933.

Support added:
- IdentityGate and Measurement can be applied to qudits.
- Protocols apply_channel, pauli_expansion, phase_by, and qasm either support qudits or don't crash when given qudit values.
- `testing.assert_implements_consistent_protocols()` correctly tests qudit values.