### PR TITLE
Remove lazy imports from protocols

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -31,11 +31,11 @@ with _import.delay_import('cirq.protocols'):
         value,
         linalg,
         ops,
+        devices,
+        study,
     )
 from cirq import (
     # Core
-    devices,
-    study,
     circuits,
     schedules,
     # Optimize and run

--- a/cirq/protocols/decompose.py
+++ b/cirq/protocols/decompose.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Callable, Union, Any, Tuple, Iterable, \
 
 from typing_extensions import Protocol
 
+from cirq import ops
 
 from cirq.type_workarounds import NotImplementedType
 
@@ -214,7 +215,6 @@ def decompose(
             Custom type of error raised if there's an undecomposable operation
             that doesn't satisfy the given `keep` predicate.
     """
-    from cirq import ops  # HACK: Avoids circular dependencies.
 
     if (on_stuck_raise is not _value_error_describing_bad_operation and
             keep is None):
@@ -312,7 +312,6 @@ def decompose_once(val: Any,
     decomposed = NotImplemented if method is None else method(**kwargs)
 
     if decomposed is not NotImplemented and decomposed is not None:
-        from cirq import ops  # HACK: Avoids circular dependencies.
         return list(ops.flatten_op_tree(decomposed))
 
     if default is not RaiseTypeErrorIfNotProvided:

--- a/cirq/protocols/equal_up_to_global_phase.py
+++ b/cirq/protocols/equal_up_to_global_phase.py
@@ -19,7 +19,7 @@ import numpy as np
 from typing_extensions import Protocol
 
 from cirq import linalg
-from cirq.protocols import approximate_equality
+from cirq.protocols.approximate_equality import approx_eq
 
 
 class SupportsEqualUpToGlobalPhase(Protocol):
@@ -94,10 +94,9 @@ def equal_up_to_global_phase(val: Any,
 
     # Fall back to approx_eq for compare the magnitude of two numbers.
     if isinstance(val, numbers.Number) and isinstance(other, numbers.Number):
-        result = approximate_equality.approx_eq(abs(val), abs(other),
-                                                atol=atol)  # type: ignore
+        result = approx_eq(abs(val), abs(other), atol=atol)  # type: ignore
         if result is not NotImplemented:
             return result
 
     # Fall back to cirq approx_eq for remaining types.
-    return approximate_equality.approx_eq(val, other, atol=atol)
+    return approx_eq(val, other, atol=atol)

--- a/cirq/protocols/equal_up_to_global_phase.py
+++ b/cirq/protocols/equal_up_to_global_phase.py
@@ -16,10 +16,10 @@ from collections.abc import Iterable
 import numbers
 from typing import Any, Union
 
+from cirq import linalg
+import cirq
 import numpy as np
 from typing_extensions import Protocol
-
-import cirq
 
 
 class SupportsEqualUpToGlobalPhase(Protocol):
@@ -90,13 +90,14 @@ def equal_up_to_global_phase(val: Any,
         a = np.asarray(val)
         b = np.asarray(other)
         if a.dtype.kind in 'uifc' and b.dtype.kind in 'uifc':
-            return cirq.linalg.allclose_up_to_global_phase(a, b, atol=atol)
+            return linalg.allclose_up_to_global_phase(a, b, atol=atol)
 
     # Fall back to approx_eq for compare the magnitude of two numbers.
+    from cirq.protocols.approximate_equality import approx_eq
     if isinstance(val, numbers.Number) and isinstance(other, numbers.Number):
-        result = cirq.approx_eq(abs(val), abs(other), atol=atol)  # type: ignore
+        result = approx_eq(abs(val), abs(other), atol=atol)  # type: ignore
         if result is not NotImplemented:
             return result
 
     # Fall back to cirq approx_eq for remaining types.
-    return cirq.approx_eq(val, other, atol=atol)
+    return approx_eq(val, other, atol=atol)

--- a/cirq/protocols/equal_up_to_global_phase.py
+++ b/cirq/protocols/equal_up_to_global_phase.py
@@ -15,11 +15,10 @@
 from collections.abc import Iterable
 import numbers
 from typing import Any, Union
-
-from cirq import linalg
-
 import numpy as np
 from typing_extensions import Protocol
+
+from cirq import linalg
 
 
 class SupportsEqualUpToGlobalPhase(Protocol):

--- a/cirq/protocols/equal_up_to_global_phase.py
+++ b/cirq/protocols/equal_up_to_global_phase.py
@@ -19,6 +19,7 @@ import numpy as np
 from typing_extensions import Protocol
 
 from cirq import linalg
+from cirq.protocols import approximate_equality
 
 
 class SupportsEqualUpToGlobalPhase(Protocol):
@@ -92,11 +93,11 @@ def equal_up_to_global_phase(val: Any,
             return linalg.allclose_up_to_global_phase(a, b, atol=atol)
 
     # Fall back to approx_eq for compare the magnitude of two numbers.
-    from cirq.protocols.approximate_equality import approx_eq
     if isinstance(val, numbers.Number) and isinstance(other, numbers.Number):
-        result = approx_eq(abs(val), abs(other), atol=atol)  # type: ignore
+        result = approximate_equality.approx_eq(abs(val), abs(other),
+                                                atol=atol)  # type: ignore
         if result is not NotImplemented:
             return result
 
     # Fall back to cirq approx_eq for remaining types.
-    return approx_eq(val, other, atol=atol)
+    return approximate_equality.approx_eq(val, other, atol=atol)

--- a/cirq/protocols/equal_up_to_global_phase.py
+++ b/cirq/protocols/equal_up_to_global_phase.py
@@ -17,7 +17,7 @@ import numbers
 from typing import Any, Union
 
 from cirq import linalg
-import cirq
+
 import numpy as np
 from typing_extensions import Protocol
 

--- a/cirq/protocols/has_unitary.py
+++ b/cirq/protocols/has_unitary.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 import numpy as np
 from typing_extensions import Protocol
 
-from cirq.protocols import qid_shape_protocol
+from cirq.protocols import decompose, qid_shape_protocol
 from cirq import devices, linalg, ops
 
 if TYPE_CHECKING:
@@ -164,21 +164,20 @@ def _try_decompose_into_operations_and_qubits(val: Any) -> Tuple[Optional[
         List['cirq.Operation']], Sequence['cirq.Qid'], Tuple[int, ...]]:
     """Returns the value's decomposition (if any) and the qubits it applies to.
     """
-    from cirq.protocols.decompose import (decompose_once,
-                                          decompose_once_with_qubits)
 
     if isinstance(val, ops.Gate):
         # Gates don't specify qubits, and so must be handled specially.
         qid_shape = qid_shape_protocol.qid_shape(val)
         qubits = devices.LineQid.for_qid_shape(
             qid_shape)  # type: Sequence[cirq.Qid]
-        return decompose_once_with_qubits(val, qubits, None), qubits, qid_shape
+        return decompose.decompose_once_with_qubits(val, qubits,
+                                                    None), qubits, qid_shape
 
     if isinstance(val, ops.Operation):
         qid_shape = qid_shape_protocol.qid_shape(val)
-        return decompose_once(val, None), val.qubits, qid_shape
+        return decompose.decompose_once(val, None), val.qubits, qid_shape
 
-    result = decompose_once(val, None)
+    result = decompose.decompose_once(val, None)
     if result is not None:
         qubit_set = set()
         qid_shape_dict = defaultdict(lambda: 1)  # type: Dict[cirq.Qid, int]

--- a/cirq/protocols/has_unitary.py
+++ b/cirq/protocols/has_unitary.py
@@ -27,7 +27,8 @@ from collections import defaultdict
 import numpy as np
 from typing_extensions import Protocol
 
-from cirq.protocols import decompose, qid_shape_protocol
+from cirq.protocols import qid_shape_protocol
+from cirq.protocols.decompose import decompose_once, decompose_once_with_qubits
 from cirq import devices, linalg, ops
 
 if TYPE_CHECKING:
@@ -170,14 +171,13 @@ def _try_decompose_into_operations_and_qubits(val: Any) -> Tuple[Optional[
         qid_shape = qid_shape_protocol.qid_shape(val)
         qubits = devices.LineQid.for_qid_shape(
             qid_shape)  # type: Sequence[cirq.Qid]
-        return decompose.decompose_once_with_qubits(val, qubits,
-                                                    None), qubits, qid_shape
+        return decompose_once_with_qubits(val, qubits, None), qubits, qid_shape
 
     if isinstance(val, ops.Operation):
         qid_shape = qid_shape_protocol.qid_shape(val)
-        return decompose.decompose_once(val, None), val.qubits, qid_shape
+        return decompose_once(val, None), val.qubits, qid_shape
 
-    result = decompose.decompose_once(val, None)
+    result = decompose_once(val, None)
     if result is not None:
         qubit_set = set()
         qid_shape_dict = defaultdict(lambda: 1)  # type: Dict[cirq.Qid, int]

--- a/cirq/protocols/has_unitary.py
+++ b/cirq/protocols/has_unitary.py
@@ -28,6 +28,7 @@ import numpy as np
 from typing_extensions import Protocol
 
 from cirq.protocols import qid_shape_protocol
+from cirq import devices, linalg, ops
 
 if TYPE_CHECKING:
     import cirq
@@ -143,7 +144,6 @@ def _strat_has_unitary_from_apply_unitary(val: Any) -> Optional[bool]:
     """Attempts to infer a value's unitary-ness via its _apply_unitary_ method.
     """
     from cirq.protocols.apply_unitary import ApplyUnitaryArgs
-    from cirq import linalg
 
     method = getattr(val, '_apply_unitary_', None)
     if method is None:
@@ -166,15 +166,15 @@ def _try_decompose_into_operations_and_qubits(val: Any) -> Tuple[Optional[
     """
     from cirq.protocols.decompose import (decompose_once,
                                           decompose_once_with_qubits)
-    from cirq import LineQid, Gate, Operation
 
-    if isinstance(val, Gate):
+    if isinstance(val, ops.Gate):
         # Gates don't specify qubits, and so must be handled specially.
         qid_shape = qid_shape_protocol.qid_shape(val)
-        qubits = LineQid.for_qid_shape(qid_shape)  # type: Sequence[cirq.Qid]
+        qubits = devices.LineQid.for_qid_shape(
+            qid_shape)  # type: Sequence[cirq.Qid]
         return decompose_once_with_qubits(val, qubits, None), qubits, qid_shape
 
-    if isinstance(val, Operation):
+    if isinstance(val, ops.Operation):
         qid_shape = qid_shape_protocol.qid_shape(val)
         return decompose_once(val, None), val.qubits, qid_shape
 

--- a/cirq/protocols/inverse.py
+++ b/cirq/protocols/inverse.py
@@ -15,6 +15,8 @@
 from typing import (Any, List, overload, Tuple, TYPE_CHECKING, TypeVar, Union,
                     Iterable)
 
+from cirq import ops
+
 if TYPE_CHECKING:
     import cirq
 
@@ -102,7 +104,6 @@ def inverse(val: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
             iterable containing invertible items. Also, no `default` argument
             was specified.
     """
-    from cirq import ops  # HACK: avoid circular import
 
     # Check if object defines an inverse via __pow__.
     raiser = getattr(val, '__pow__', None)

--- a/cirq/protocols/qasm.py
+++ b/cirq/protocols/qasm.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Union, Any, Tuple, TypeVar, Optional, Dict, \
 
 from typing_extensions import Protocol
 
+from cirq import ops
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
@@ -53,7 +54,7 @@ class QasmArgs(string.Formatter):
 
     def format_field(self, value: Any, spec: str) -> str:
         """Method of string.Formatter that specifies the output of format()."""
-        from cirq import ops  # HACK: avoids cyclic dependency.
+
         if isinstance(value, (float, int)):
             if isinstance(value, float):
                 value = round(value, self.precision)

--- a/cirq/protocols/qasm.py
+++ b/cirq/protocols/qasm.py
@@ -54,7 +54,6 @@ class QasmArgs(string.Formatter):
 
     def format_field(self, value: Any, spec: str) -> str:
         """Method of string.Formatter that specifies the output of format()."""
-
         if isinstance(value, (float, int)):
             if isinstance(value, float):
                 value = round(value, self.precision)

--- a/cirq/protocols/qid_shape_protocol.py
+++ b/cirq/protocols/qid_shape_protocol.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Sequence, Tuple, TypeVar, Union
 
 from typing_extensions import Protocol
 
+from cirq import ops
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
@@ -107,7 +108,6 @@ def qid_shape(val: Any, default: TDefault = RaiseTypeErrorIfNotProvided
         return result
 
     # Check if val is a list of qids
-    from cirq import ops  # Avoid circular dependency
     if isinstance(val, Sequence) and all(isinstance(q, ops.Qid) for q in val):
         return tuple(q.dimension for q in val)
 
@@ -165,7 +165,6 @@ def num_qubits(val: Any, default: TDefault = RaiseTypeErrorIfNotProvidedInt
         return len(shape)
 
     # Check if val is a list of qids
-    from cirq import ops  # Avoid circular dependency
     if isinstance(val, Sequence) and all(isinstance(q, ops.Qid) for q in val):
         return len(val)
 

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -14,10 +14,9 @@
 
 from typing import Any, TypeVar, TYPE_CHECKING
 from typing_extensions import Protocol
+import sympy
 
 from cirq import study
-
-import sympy
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -15,6 +15,8 @@
 from typing import Any, TypeVar, TYPE_CHECKING
 from typing_extensions import Protocol
 
+from cirq import study
+
 import sympy
 
 if TYPE_CHECKING:
@@ -82,7 +84,7 @@ def resolve_parameters(
         If `val` has no `_resolve_parameters_` method or if it returns
         NotImplemented, `val` itself is returned.
     """
-    from cirq import study  # HACK: break cycle.
+
     if not param_resolver:
         return val
 

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -83,7 +83,6 @@ def resolve_parameters(
         If `val` has no `_resolve_parameters_` method or if it returns
         NotImplemented, `val` itself is returned.
     """
-
     if not param_resolver:
         return val
 


### PR DESCRIPTION
Closes #2055 

Moved lazy imports to module level.

Moved the imports of `study` and `device` so that they can be imported at module level  in `protocols`.

I also found one `import cirq` at module level which I turned into a lazy import in ` cirq/protocols/equal_up_to_global_phase.py`.