### PR TITLE
Break cyclic dependence and remove remaining lazy imports from protocols

### DIFF
--- a/cirq/protocols/apply_unitary.py
+++ b/cirq/protocols/apply_unitary.py
@@ -32,6 +32,7 @@ from typing_extensions import Protocol
 
 from cirq import linalg
 from cirq.protocols import qid_shape_protocol
+from cirq.protocols.decompose import _try_decompose_into_operations_and_qubits
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
@@ -397,8 +398,6 @@ def _strat_apply_unitary_from_unitary(unitary_value: Any, args: ApplyUnitaryArgs
 
 def _strat_apply_unitary_from_decompose(val: Any, args: ApplyUnitaryArgs
                                        ) -> Optional[np.ndarray]:
-    from cirq.protocols.has_unitary import (
-        _try_decompose_into_operations_and_qubits)
     operations, qubits, _ = _try_decompose_into_operations_and_qubits(val)
     if operations is None:
         return NotImplemented

--- a/cirq/protocols/decompose.py
+++ b/cirq/protocols/decompose.py
@@ -12,12 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Callable, Union, Any, Tuple, Iterable, \
-    TypeVar, List, Optional, overload
-
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    overload,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+from collections import defaultdict
 from typing_extensions import Protocol
 
-from cirq import ops
+from cirq import devices, ops
+from cirq.protocols import qid_shape_protocol
 
 from cirq.type_workarounds import NotImplementedType
 
@@ -371,3 +384,33 @@ def decompose_once_with_qubits(val: Any,
     """
     return decompose_once(val, default, qubits=tuple(qubits))
 # pylint: enable=function-redefined
+
+
+def _try_decompose_into_operations_and_qubits(val: Any) -> Tuple[Optional[
+        List['cirq.Operation']], Sequence['cirq.Qid'], Tuple[int, ...]]:
+    """Returns the value's decomposition (if any) and the qubits it applies to.
+    """
+
+    if isinstance(val, ops.Gate):
+        # Gates don't specify qubits, and so must be handled specially.
+        qid_shape = qid_shape_protocol.qid_shape(val)
+        qubits = devices.LineQid.for_qid_shape(
+            qid_shape)  # type: Sequence[cirq.Qid]
+        return decompose_once_with_qubits(val, qubits, None), qubits, qid_shape
+
+    if isinstance(val, ops.Operation):
+        qid_shape = qid_shape_protocol.qid_shape(val)
+        return decompose_once(val, None), val.qubits, qid_shape
+
+    result = decompose_once(val, None)
+    if result is not None:
+        qubit_set = set()
+        qid_shape_dict = defaultdict(lambda: 1)  # type: Dict[cirq.Qid, int]
+        for op in result:
+            for level, q in zip(qid_shape_protocol.qid_shape(op), op.qubits):
+                qubit_set.add(q)
+                qid_shape_dict[q] = max(qid_shape_dict[q], level)
+        qubits = sorted(qubit_set)
+        return result, qubits, tuple(qid_shape_dict[q] for q in qubits)
+
+    return None, (), ()

--- a/cirq/protocols/decompose.py
+++ b/cirq/protocols/decompose.py
@@ -31,7 +31,6 @@ from typing_extensions import Protocol
 
 from cirq import devices, ops
 from cirq.protocols import qid_shape_protocol
-
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:

--- a/cirq/protocols/unitary.py
+++ b/cirq/protocols/unitary.py
@@ -25,6 +25,8 @@ from typing_extensions import Protocol
 
 from cirq import linalg
 from cirq.protocols import qid_shape_protocol
+from cirq.protocols.apply_unitary import ApplyUnitaryArgs, apply_unitaries
+from cirq.protocols.decompose import _try_decompose_into_operations_and_qubits
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
@@ -153,8 +155,6 @@ def _strat_unitary_from_unitary(val: Any) -> Optional[np.ndarray]:
 
 def _strat_unitary_from_apply_unitary(val: Any) -> Optional[np.ndarray]:
     """Attempts to compute a value's unitary via its _apply_unitary_ method."""
-    from cirq.protocols.apply_unitary import ApplyUnitaryArgs
-
     # Check for the magic method.
     method = getattr(val, '_apply_unitary_', None)
     if method is None:
@@ -178,11 +178,7 @@ def _strat_unitary_from_apply_unitary(val: Any) -> Optional[np.ndarray]:
 
 def _strat_unitary_from_decompose(val: Any) -> Optional[np.ndarray]:
     """Attempts to compute a value's unitary via its _decompose_ method."""
-    from cirq.protocols.apply_unitary import ApplyUnitaryArgs, apply_unitaries
-
     # Check if there's a decomposition.
-    from cirq.protocols.has_unitary import (
-        _try_decompose_into_operations_and_qubits)
     operations, qubits, val_qid_shape = (
         _try_decompose_into_operations_and_qubits(val))
     if operations is None:


### PR DESCRIPTION
Follow-up to #2059 
By moving `_try_decompose_into_operations_and_qubits` to `decompose`, the cycling dependence in `unitary/has_unitary/apply_unitary` can be removed.

@cduck PTAL