### PR TITLE
[Qudits] Fix qudit result with invert mask in simulators

### DIFF
--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -290,8 +290,10 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                             indices,
                             qid_shape=qid_shape,
                             out=state.tensor)
-                        corrected = [bit ^ mask for bit, mask in
-                                     zip(bits, invert_mask)]
+                        corrected = [
+                            bit ^ (bit < 2 and mask)
+                            for bit, mask in zip(bits, invert_mask)
+                        ]
                         key = protocols.measurement_key(meas)
                         measurements[key].extend(corrected)
                 else:

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -558,7 +558,8 @@ class StepResult(metaclass=abc.ABCMeta):
         results = {}
         for k, (s, e) in bounds.items():
             before_invert_mask = np.array([x[s:e] for x in indexed_sample])
-            results[k] = before_invert_mask ^ meas_ops[k].full_invert_mask()
+            results[k] = before_invert_mask ^ (np.logical_and(
+                before_invert_mask < 2, meas_ops[k].full_invert_mask()))
         return results
 
 

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -46,7 +46,9 @@ def _tuple_of_big_endian_int(bit_groups: Iterable[Any]) -> Tuple[int, ...]:
 
 
 def _bitstring(vals: Iterable[Any]) -> str:
-    return ''.join('1' if v else '0' for v in vals)
+    str_list = [str(int(v)) for v in vals]
+    separator = '' if all(len(s) == 1 for s in str_list) else ' '
+    return separator.join(str_list)
 
 
 def _keyed_repeated_bitstrings(vals: Dict[str, np.ndarray]) -> str:

--- a/cirq/study/trial_result_test.py
+++ b/cirq/study/trial_result_test.py
@@ -36,6 +36,14 @@ def test_str():
         })
     assert str(result) == 'ab=00010, 11101\nc=00101'
 
+    result = cirq.TrialResult.from_single_parameter_set(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'ab': np.array([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]),
+            'c': np.array([[0], [1], [2], [3], [4]])
+        })
+    assert str(result) == 'ab=13579, 2 4 6 8 10\nc=01234'
+
 
 def test_df():
     result = cirq.TrialResult.from_single_parameter_set(


### PR DESCRIPTION
Part of #933.

Where the invert mask is True, switches the measurements of |0> and |1> without modifying |2> and above.

Also fix `str(TrialResult)` for qudits.