### PR TITLE
cirq.google.api is the new cirq.api.google

### DIFF
--- a/check/bazel
+++ b/check/bazel
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ################################################################################
-# Runs bazel build for proto files in Cirq/cirq/api/google/*
+# Runs bazel build for proto files in Cirq/cirq/google/api/*
 #
 # Usage:
 #     check/bazel
@@ -11,11 +11,11 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-bazel build //cirq/api/google/v1:operations_proto
-bazel build //cirq/api/google/v1:params_proto
-bazel build //cirq/api/google/v1:program_proto
+bazel build //cirq/google/api/v1:operations_proto
+bazel build //cirq/google/api/v1:params_proto
+bazel build //cirq/google/api/v1:program_proto
 
-bazel build //cirq/api/google/v2:metrics_proto
-bazel build //cirq/api/google/v2:program_proto
-bazel build //cirq/api/google/v2:run_context_proto
-bazel build //cirq/api/google/v2:result_proto
+bazel build //cirq/google/api/v2:metrics_proto
+bazel build //cirq/google/api/v2:program_proto
+bazel build //cirq/google/api/v2:run_context_proto
+bazel build //cirq/google/api/v2:result_proto

--- a/cirq/google/api/v2/results.py
+++ b/cirq/google/api/v2/results.py
@@ -4,12 +4,12 @@ from typing import (Dict, Iterable, Iterator, List, NamedTuple, Optional, Set,
 from collections import OrderedDict
 import numpy as np
 
-from cirq.api.google.v2 import result_pb2
 from cirq import circuits
 from cirq import devices
 from cirq import ops
 from cirq import schedules
 from cirq import study
+from cirq.google.api.v2 import result_pb2
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq/google/api/v2/results_test.py
+++ b/cirq/google/api/v2/results_test.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq.api.google.v2 import result_pb2
 from cirq.google.api import v2
+from cirq.google.api.v2 import result_pb2
 
 
 @pytest.mark.parametrize('reps', range(1, 100, 7))

--- a/cirq/google/api/v2/sweeps.py
+++ b/cirq/google/api/v2/sweeps.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from cirq.api.google.v2 import run_context_pb2
+from cirq.google.api.v2 import run_context_pb2
 from cirq.study import sweeps
 
 

--- a/cirq/google/api/v2/sweeps_test.py
+++ b/cirq/google/api/v2/sweeps_test.py
@@ -17,8 +17,8 @@ from typing import Iterator
 import pytest
 
 import cirq
-from cirq.api.google.v2 import run_context_pb2
 from cirq.google.api import v2
+from cirq.google.api.v2 import run_context_pb2
 from cirq.study import sweeps
 
 

--- a/cirq/google/engine/calibration_test.py
+++ b/cirq/google/engine/calibration_test.py
@@ -21,7 +21,7 @@ import cirq.google as cg
 
 _CALIBRATION_DATA = {
     '@type':
-    'type.googleapis.com/cirq.api.google.v2.MetricsSnapshot',
+    'type.googleapis.com/cirq.google.api.v2.MetricsSnapshot',
     'timestampMs':
     '1562544000021',
     'metrics': [{

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -396,8 +396,7 @@ class Engine:
             context_dict = {}  # type: Dict[str, Any]
             context_dict['@type'] = TYPE_PREFIX + context_descriptor.full_name
             context_dict['parameter_sweeps'] = [
-                v1.sweep_to_proto_dict(sweep, repetitions)
-                for sweep in sweeps
+                v1.sweep_to_proto_dict(sweep, repetitions) for sweep in sweeps
             ]
             return context_dict
         elif proto_version == ProtoVersion.V2:
@@ -519,10 +518,10 @@ class Engine:
         result_type = result['@type'][len(TYPE_PREFIX):]
 
         if (result_type == 'cirq.api.google.v1.Result' or
-            result_type == 'cirq.google.api.v1.Result'):
+                result_type == 'cirq.google.api.v1.Result'):
             return self._get_job_results_v1(response['result'])
         if (result_type == 'cirq.api.google.v2.Result' or
-            result_type == 'cirq.google.api.v2.Result'):
+                result_type == 'cirq.google.api.v2.Result'):
             return self._get_job_results_v2(response['result'])
         raise ValueError('invalid result proto version: {}'.format(
             self.proto_version))
@@ -537,7 +536,7 @@ class Engine:
             for result in sweep_result['parameterizedResults']:
                 data = base64.standard_b64decode(result['measurementResults'])
                 measurements = v1.unpack_results(data, sweep_repetitions,
-                                                     key_sizes)
+                                                 key_sizes)
 
                 trial_results.append(
                     study.TrialResult.from_single_parameter_set(

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -37,10 +37,8 @@ import google.protobuf as gp
 from google.protobuf import any_pb2
 
 from cirq import circuits, optimizers, schedules, study, value
-from cirq.api.google import v1, v2
 from cirq.google import gate_sets, serializable_gate_set
-from cirq.google.api import v1 as api_v1
-from cirq.google.api import v2 as api_v2
+from cirq.google.api import v1, v2
 from cirq.google.engine import calibration, engine_job, engine_program
 
 gcs_prefix_pattern = re.compile('gs://[a-z0-9._/-]+')
@@ -398,7 +396,7 @@ class Engine:
             context_dict = {}  # type: Dict[str, Any]
             context_dict['@type'] = TYPE_PREFIX + context_descriptor.full_name
             context_dict['parameter_sweeps'] = [
-                api_v1.sweep_to_proto_dict(sweep, repetitions)
+                v1.sweep_to_proto_dict(sweep, repetitions)
                 for sweep in sweeps
             ]
             return context_dict
@@ -407,7 +405,7 @@ class Engine:
             for sweep in sweeps:
                 sweep_proto = run_context.parameter_sweeps.add()
                 sweep_proto.repetitions = repetitions
-                api_v2.sweep_to_proto(sweep, out=sweep_proto.sweep)
+                v2.sweep_to_proto(sweep, out=sweep_proto.sweep)
 
             return _any_dict_from_msg(run_context)
         else:
@@ -460,7 +458,7 @@ class Engine:
             program_dict = {}  # type: Dict[str, Any]
             program_dict['@type'] = TYPE_PREFIX + program_descriptor.full_name
             program_dict['operations'] = [
-                op for op in api_v1.schedule_to_proto_dicts(schedule)
+                op for op in v1.schedule_to_proto_dicts(schedule)
             ]
             return program_dict
         elif self.proto_version == ProtoVersion.V2:
@@ -520,9 +518,11 @@ class Engine:
         result = response['result']
         result_type = result['@type'][len(TYPE_PREFIX):]
 
-        if result_type == 'cirq.api.google.v1.Result':
+        if (result_type == 'cirq.api.google.v1.Result' or
+            result_type == 'cirq.google.api.v1.Result'):
             return self._get_job_results_v1(response['result'])
-        if result_type == 'cirq.api.google.v2.Result':
+        if (result_type == 'cirq.api.google.v2.Result' or
+            result_type == 'cirq.google.api.v2.Result'):
             return self._get_job_results_v2(response['result'])
         raise ValueError('invalid result proto version: {}'.format(
             self.proto_version))
@@ -536,7 +536,7 @@ class Engine:
                          for m in sweep_result['measurementKeys']]
             for result in sweep_result['parameterizedResults']:
                 data = base64.standard_b64decode(result['measurementResults'])
-                measurements = api_v1.unpack_results(data, sweep_repetitions,
+                measurements = v1.unpack_results(data, sweep_repetitions,
                                                      key_sizes)
 
                 trial_results.append(
@@ -553,7 +553,7 @@ class Engine:
         result = v2.result_pb2.Result()
         result_any.Unpack(result)
 
-        sweep_results = api_v2.results_from_proto(result)
+        sweep_results = v2.results_from_proto(result)
         # Flatten to single list to match to sampler api.
         return [
             trial_result for sweep_result in sweep_results

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -137,7 +137,6 @@ _RESULTS_V2 = {
     ],
 }
 
-
 _CALIBRATION = {
     'name': 'projects/foo/processors/xmonsim/calibrations/1562715599',
     'timestamp': '2019-07-09T23:39:59Z',

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -29,7 +29,7 @@ _SCHEDULE = cirq.moment_by_moment_schedule(cirq.UNCONSTRAINED_DEVICE, _CIRCUIT)
 
 _A_RESULT = {
     '@type':
-    'type.googleapis.com/cirq.api.google.v1.Result',
+    'type.googleapis.com/cirq.google.api.v1.Result',
     'sweepResults': [{
         'repetitions':
         1,
@@ -53,7 +53,7 @@ _A_RESULT = {
 
 _RESULTS = {
     '@type':
-    'type.googleapis.com/cirq.api.google.v1.Result',
+    'type.googleapis.com/cirq.google.api.v1.Result',
     'sweepResults': [{
         'repetitions':
         1,
@@ -84,7 +84,7 @@ _RESULTS = {
 
 _RESULTS_V2 = {
     '@type':
-    'type.googleapis.com/cirq.api.google.v2.Result',
+    'type.googleapis.com/cirq.google.api.v2.Result',
     'sweepResults': [
         {
             'repetitions':
@@ -143,7 +143,7 @@ _CALIBRATION = {
     'timestamp': '2019-07-09T23:39:59Z',
     'data': {
         '@type':
-        'type.googleapis.com/cirq.api.google.v2.MetricsSnapshot',
+        'type.googleapis.com/cirq.google.api.v2.MetricsSnapshot',
         'timestampMs':
         '1562544000021',
         'metrics': [{
@@ -241,7 +241,7 @@ def test_run_circuit(build):
                 }
             },
             'run_context': {
-                '@type': 'type.googleapis.com/cirq.api.google.v1.RunContext',
+                '@type': 'type.googleapis.com/cirq.google.api.v1.RunContext',
                 'parameter_sweeps': [{
                     'repetitions': 1
                 }]

--- a/cirq/google/op_deserializer.py
+++ b/cirq/google/op_deserializer.py
@@ -19,8 +19,8 @@ import sympy
 from google.protobuf import json_format
 
 from cirq import devices
-from cirq.api.google import v2
 from cirq.google import arg_func_langs
+from cirq.google.api import v2
 
 if TYPE_CHECKING:
     import cirq
@@ -95,14 +95,14 @@ class GateOpDeserializer:
         self.num_qubits_param = num_qubits_param
 
     def from_proto_dict(self, proto: Dict) -> 'cirq.GateOperation':
-        """Turns a cirq.api.google.v2.Operation proto into a GateOperation."""
+        """Turns a cirq.google.api.v2.Operation proto into a GateOperation."""
         msg = v2.program_pb2.Operation()
         json_format.ParseDict(proto, msg)
         return self.from_proto(msg)
 
     def from_proto(self,
                    proto: v2.program_pb2.Operation) -> 'cirq.GateOperation':
-        """Turns a cirq.api.google.v2.Operation proto into a GateOperation."""
+        """Turns a cirq.google.api.v2.Operation proto into a GateOperation."""
         qubits = [devices.GridQubit.from_proto_id(q.id) for q in proto.qubits]
         args = self._args_from_proto(proto)
         if self.num_qubits_param is not None:

--- a/cirq/google/op_serializer.py
+++ b/cirq/google/op_serializer.py
@@ -20,8 +20,8 @@ import sympy
 from google.protobuf import json_format
 
 from cirq import devices, ops
-from cirq.api.google import v2
 from cirq.google import arg_func_langs
+from cirq.google.api import v2
 
 if TYPE_CHECKING:
     import cirq
@@ -119,7 +119,7 @@ class GateOpSerializer:
                  op: 'cirq.GateOperation',
                  msg: Optional[v2.program_pb2.Operation] = None
                 ) -> Optional[v2.program_pb2.Operation]:
-        """Returns the cirq.api.google.v2.Operation message as a proto dict."""
+        """Returns the cirq.google.api.v2.Operation message as a proto dict."""
         if not all(isinstance(qubit, devices.GridQubit) for qubit in op.qubits):
             raise ValueError('All qubits must be GridQubits')
         gate = op.gate

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Support for serializing and deserializing cirq.api.google.v2 protos."""
+"""Support for serializing and deserializing cirq.google.api.v2 protos."""
 
 from collections import defaultdict
 
@@ -21,8 +21,8 @@ from typing import cast, Dict, Iterable, List, Optional, Tuple, Type, Union, \
 from google.protobuf import json_format
 
 from cirq import circuits, ops, schedules, value
-from cirq.api.google import v2
 from cirq.google import op_deserializer, op_serializer
+from cirq.google.api import v2
 
 if TYPE_CHECKING:
     import cirq
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 class SerializableGateSet:
     """A class for serializing and deserializing programs and operations.
 
-    This class is for cirq.api.google.v2. protos.
+    This class is for cirq.google.api.v2. protos.
     """
 
     def __init__(self, gate_set_name: str,
@@ -72,13 +72,13 @@ class SerializableGateSet:
     def serialize_dict(self,
                        program: Union[circuits.Circuit, schedules.Schedule]
                       ) -> Dict:
-        """Serialize a Circuit or Schedule to cirq.api.google.v2.Program proto.
+        """Serialize a Circuit or Schedule to cirq.google.api.v2.Program proto.
 
         Args:
             program: The Circuit or Schedule to serialize.
 
         Returns:
-            A dictionary corresponding to the cirq.api.google.v2.Program proto.
+            A dictionary corresponding to the cirq.google.api.v2.Program proto.
         """
         return json_format.MessageToDict(self.serialize(program),
                                          including_default_value_fields=True,
@@ -89,7 +89,7 @@ class SerializableGateSet:
                   program: Union[circuits.Circuit, schedules.Schedule],
                   msg: Optional[v2.program_pb2.Program] = None
                  ) -> v2.program_pb2.Program:
-        """Serialize a Circuit or Schedule to cirq.api.google.v2.Program proto.
+        """Serialize a Circuit or Schedule to cirq.google.api.v2.Program proto.
 
         Args:
             program: The Circuit or Schedule to serialize.
@@ -104,13 +104,13 @@ class SerializableGateSet:
         return msg
 
     def serialize_op_dict(self, op: 'cirq.Operation') -> Dict:
-        """Serialize an Operation to cirq.api.google.v2.Operation proto.
+        """Serialize an Operation to cirq.google.api.v2.Operation proto.
 
         Args:
             op: The operation to serialize.
 
         Returns:
-            A dictionary corresponds to the cirq.api.google.v2.Operation proto.
+            A dictionary corresponds to the cirq.google.api.v2.Operation proto.
         """
         return json_format.MessageToDict(self.serialize_op(op),
                                          including_default_value_fields=True,
@@ -121,13 +121,13 @@ class SerializableGateSet:
                      op: 'cirq.Operation',
                      msg: Optional[v2.program_pb2.Operation] = None
                     ) -> v2.program_pb2.Operation:
-        """Serialize an Operation to cirq.api.google.v2.Operation proto.
+        """Serialize an Operation to cirq.google.api.v2.Operation proto.
 
         Args:
             op: The operation to serialize.
 
         Returns:
-            A dictionary corresponds to the cirq.api.google.v2.Operation proto.
+            A dictionary corresponds to the cirq.google.api.v2.Operation proto.
         """
         gate_op = cast(ops.GateOperation, op)
         gate_type = type(gate_op.gate)
@@ -147,10 +147,10 @@ class SerializableGateSet:
                          proto: Dict,
                          device: Optional['cirq.Device'] = None
                         ) -> Union[circuits.Circuit, schedules.Schedule]:
-        """Deserialize a Circuit or Schedule from a cirq.api.google.v2.Program.
+        """Deserialize a Circuit or Schedule from a cirq.google.api.v2.Program.
 
         Args:
-            proto: A dictionary representing a cirq.api.google.v2.Program proto.
+            proto: A dictionary representing a cirq.google.api.v2.Program proto.
             device: If the proto is for a schedule, a device is required
                 Otherwise optional.
 
@@ -166,10 +166,10 @@ class SerializableGateSet:
                     proto: v2.program_pb2.Program,
                     device: Optional['cirq.Device'] = None
                    ) -> Union[circuits.Circuit, schedules.Schedule]:
-        """Deserialize a Circuit or Schedule from a cirq.api.google.v2.Program.
+        """Deserialize a Circuit or Schedule from a cirq.google.api.v2.Program.
 
         Args:
-            proto: A dictionary representing a cirq.api.google.v2.Program proto.
+            proto: A dictionary representing a cirq.google.api.v2.Program proto.
             device: If the proto is for a schedule, a device is required
                 Otherwise optional.
 
@@ -197,11 +197,11 @@ class SerializableGateSet:
             'Program proto does not contain a circuit or schedule.')
 
     def deserialize_op_dict(self, operation_proto: Dict) -> 'cirq.Operation':
-        """Deserialize an Operation from a cirq.api.google.v2.Operation.
+        """Deserialize an Operation from a cirq.google.api.v2.Operation.
 
         Args:
             operation_proto: A dictionary representing a
-                cirq.api.google.v2.Operation proto.
+                cirq.google.api.v2.Operation proto.
 
         Returns:
             The deserialized Operation.
@@ -212,11 +212,11 @@ class SerializableGateSet:
 
     def deserialize_op(self, operation_proto: v2.program_pb2.Operation
                       ) -> 'cirq.Operation':
-        """Deserialize an Operation from a cirq.api.google.v2.Operation.
+        """Deserialize an Operation from a cirq.google.api.v2.Operation.
 
         Args:
             operation_proto: A dictionary representing a
-                cirq.api.google.v2.Operation proto.
+                cirq.google.api.v2.Operation proto.
 
         Returns:
             The deserialized Operation.


### PR DESCRIPTION
- Exterminate all cirq.api.google references
- Welcome to our new cirq.google.api