### PR TITLE
Allow bools to be parsed by the serializer

### DIFF
--- a/cirq/google/api/v1/programs.py
+++ b/cirq/google/api/v1/programs.py
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
     from cirq.google import xmon_device
 
 
+def _load_json_bool(b: Any):
+    """Converts a json field to bool.  If already a bool, pass through."""
+    if isinstance(b, bool):
+        return b
+    return json.loads(b)
+
+
 def gate_to_proto_dict(gate: 'cirq.Gate',
                        qubits: Tuple['cirq.Qid', ...]) -> Dict:
     if isinstance(gate, ops.MeasurementGate):
@@ -327,7 +334,7 @@ def xmon_op_from_proto_dict(proto_dict: Dict) -> 'cirq.Operation':
         meas = proto_dict['measurement']
         invert_mask = cast(Tuple[Any, ...], ())
         if 'invert_mask' in meas:
-            invert_mask = tuple(json.loads(x) for x in meas['invert_mask'])
+            invert_mask = tuple(_load_json_bool(x) for x in meas['invert_mask'])
         if 'key' not in meas or 'targets' not in meas:
             raise_missing_fields('Measurement')
         return ops.MeasurementGate(

--- a/cirq/google/api/v1/programs_test.py
+++ b/cirq/google/api/v1/programs_test.py
@@ -191,6 +191,22 @@ def test_single_qubit_measurement_to_proto_dict_convert_invert_mask():
     assert_proto_dict_convert(gate, proto_dict, cirq.GridQubit(2, 3))
 
 
+def test_proto_dict_convert_invert_mask_bools():
+    gate = cirq.MeasurementGate(1, 'test', invert_mask=(True,))
+    proto_dict = {
+        'measurement': {
+            'targets': [{
+                'row': 2,
+                'col': 3
+            }],
+            'key': 'test',
+            'invert_mask': [True]
+        }
+    }
+    # Conversion only works one way, since the reverse converts True to string
+    assert cg.xmon_op_from_proto_dict(proto_dict) == gate(cirq.GridQubit(2, 3))
+
+
 def test_single_qubit_measurement_to_proto_dict_pad_invert_mask():
     gate = cirq.MeasurementGate(2, 'test', invert_mask=(True,))
     proto_dict = {


### PR DESCRIPTION
- Currently, the json serializer for v1 protos only accepts strings.  If you pass a naked bool, the serializer crashes.  This allows it to handle both.