### PR TITLE
[Qudits] Allow argument of Gate._decompose_ to not just be 'qubits'

### DIFF
--- a/cirq/protocols/decompose.py
+++ b/cirq/protocols/decompose.py
@@ -312,10 +312,10 @@ def decompose_once(val: Any,
             `val`.
 
     Returns:
-        The result of `val._decompose_(*args, **kwargs)`, if `val` has a `_decompose_`
-        method and it didn't return `NotImplemented` or `None`. Otherwise
-        `default` is returned, if it was specified. Otherwise an error is
-        raised.
+        The result of `val._decompose_(*args, **kwargs)`, if `val` has a
+        `_decompose_` method and it didn't return `NotImplemented` or `None`.
+        Otherwise `default` is returned, if it was specified. Otherwise an error
+        is raised.
 
     TypeError:
         `val` didn't have a `_decompose_` method (or that method returned

--- a/cirq/protocols/decompose.py
+++ b/cirq/protocols/decompose.py
@@ -285,15 +285,14 @@ def decompose_once(val: Any, **kwargs) -> List['cirq.Operation']:
 
 
 @overload
-def decompose_once(val: Any,
-                   default: TDefault,
-                   **kwargs
-                   ) -> Union[TDefault, List['cirq.Operation']]:
+def decompose_once(val: Any, default: TDefault, *args,
+                   **kwargs) -> Union[TDefault, List['cirq.Operation']]:
     pass
 
 
 def decompose_once(val: Any,
                    default=RaiseTypeErrorIfNotProvided,
+                   *args,
                    **kwargs):
     """Decomposes a value into operations, if possible.
 
@@ -306,12 +305,14 @@ def decompose_once(val: Any,
         default: A default result to use if the value doesn't have a
             `_decompose_` method or that method returns `NotImplemented` or
             `None`. If not specified, undecomposable values cause a `TypeError`.
-        kwargs: Arguments to forward into the `_decompose_` method of `val`.
-            For example, this is used to tell gates what qubits they are being
-            applied to.
+        args: Positional arguments to forward into the `_decompose_` method of
+            `val`.  For example, this is used to tell gates what qubits they are
+            being applied to.
+        kwargs: Keyword arguments to forward into the `_decompose_` method of
+            `val`.
 
     Returns:
-        The result of `val._decompose_(**kwargs)`, if `val` has a `_decompose_`
+        The result of `val._decompose_(*args, **kwargs)`, if `val` has a `_decompose_`
         method and it didn't return `NotImplemented` or `None`. Otherwise
         `default` is returned, if it was specified. Otherwise an error is
         raised.
@@ -321,7 +322,7 @@ def decompose_once(val: Any,
         `NotImplemented` or `None`) and `default` wasn't set.
     """
     method = getattr(val, '_decompose_', None)
-    decomposed = NotImplemented if method is None else method(**kwargs)
+    decomposed = NotImplemented if method is None else method(*args, **kwargs)
 
     if decomposed is not NotImplemented and decomposed is not None:
         return list(ops.flatten_op_tree(decomposed))
@@ -364,7 +365,7 @@ def decompose_once_with_qubits(val: Any,
     operations recursively until some criteria is met.
 
     Args:
-        val: The value to call `._decompose_(qubits=qubits)` on, if possible.
+        val: The value to call `._decompose_(qubits)` on, if possible.
         qubits: The value to pass into the named `qubits` parameter of
             `val._decompose_`.
         default: A default result to use if the value doesn't have a
@@ -372,7 +373,7 @@ def decompose_once_with_qubits(val: Any,
             `None`. If not specified, undecomposable values cause a `TypeError`.
 
     Returns:
-        The result of `val._decompose_(qubits=qubits)`, if `val` has a
+        The result of `val._decompose_(qubits)`, if `val` has a
         `_decompose_` method and it didn't return `NotImplemented` or `None`.
         Otherwise `default` is returned, if it was specified. Otherwise an error
         is raised.
@@ -381,7 +382,7 @@ def decompose_once_with_qubits(val: Any,
         `val` didn't have a `_decompose_` method (or that method returned
         `NotImplemented` or `None`) and `default` wasn't set.
     """
-    return decompose_once(val, default, qubits=tuple(qubits))
+    return decompose_once(val, default, tuple(qubits))
 # pylint: enable=function-redefined
 
 

--- a/cirq/protocols/decompose_test.py
+++ b/cirq/protocols/decompose_test.py
@@ -21,12 +21,14 @@ class NoMethod:
 
 
 class DecomposeNotImplemented:
-    def _decompose_(self, **kwargs):
+
+    def _decompose_(self, qubits=None):
         return NotImplemented
 
 
 class DecomposeNone:
-    def _decompose_(self, **kwargs):
+
+    def _decompose_(self, qubits=None):
         return None
 
 
@@ -50,6 +52,12 @@ class DecomposeGenerated:
     def _decompose_(self):
         yield cirq.X(cirq.LineQubit(0))
         yield cirq.Y(cirq.LineQubit(1))
+
+
+class DecomposeQuditGate:
+
+    def _decompose_(self, qids):
+        yield cirq.identity(*qids)
 
 
 def test_decompose_once():
@@ -112,6 +120,12 @@ def test_decompose_once_with_qubits():
         qs) == [cirq.Y(cirq.LineQubit(0)),
                 cirq.Y(cirq.LineQubit(1)),
                 cirq.Y(cirq.LineQubit(2))]
+
+    # Qudits, _decompose_ argument name is not 'qubits'.
+    assert cirq.decompose_once_with_qubits(
+        DecomposeQuditGate(), cirq.LineQid.for_qid_shape(
+            (1, 2,
+             3))) == [cirq.identity(*cirq.LineQid.for_qid_shape((1, 2, 3)))]
 
     # Works when qubits are generated.
     def use_qubits_twice(*qubits):


### PR DESCRIPTION
Part of #933.

This is a minor API change.
- `def _decompose_(self, qids):` will now work.
- `def _decompose_(self, **kwargs):` will no longer work.
- `def _decompose_(self, something_else=5, qubits=None):` will no longer work.