### PR TITLE
Add google.api protos to packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,4 +72,6 @@ setup(name=name,
       package_data={
           'cirq.api.google.v1': ['*.proto'],
           'cirq.api.google.v2': ['*.proto'],
+          'cirq.google.api.v1': ['*.proto'],
+          'cirq.google.api.v2': ['*.proto'],
       })


### PR DESCRIPTION
- Needed so that we can start pulling them for cirq-dev packages
and transition over to the new packages.