### PR TITLE
Add `cirq.scatter_plot_normalized_kak_interaction_coefficients`

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -128,6 +128,7 @@ from cirq.linalg import (
     one_hot,
     partial_trace,
     PAULI_BASIS,
+    plot_normalized_kak_interaction_coefficients,
     pow_pauli_combination,
     reflection_matrix_pow,
     slice_for_qubits_equal_to,

--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -128,7 +128,7 @@ from cirq.linalg import (
     one_hot,
     partial_trace,
     PAULI_BASIS,
-    plot_normalized_kak_interaction_coefficients,
+    scatter_plot_normalized_kak_interaction_coefficients,
     pow_pauli_combination,
     reflection_matrix_pow,
     slice_for_qubits_equal_to,

--- a/cirq/linalg/__init__.py
+++ b/cirq/linalg/__init__.py
@@ -35,6 +35,7 @@ from cirq.linalg.decompositions import (
     KakDecomposition,
     kron_factor_4x4_to_2x2s,
     map_eigenvalues,
+    plot_normalized_kak_interaction_coefficients,
     so4_to_magic_su2s,
 )
 

--- a/cirq/linalg/__init__.py
+++ b/cirq/linalg/__init__.py
@@ -35,7 +35,7 @@ from cirq.linalg.decompositions import (
     KakDecomposition,
     kron_factor_4x4_to_2x2s,
     map_eigenvalues,
-    plot_normalized_kak_interaction_coefficients,
+    scatter_plot_normalized_kak_interaction_coefficients,
     so4_to_magic_su2s,
 )
 

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -595,8 +595,8 @@ def scatter_plot_normalized_kak_interaction_coefficients(
         ...         include_frame=ax is None,
         ...         label=f'y={y:0.2f}')
         >>> _ = ax.legend()
-        >>> # import matplotlib.pyplot as plt
-        >>> # plt.show()
+        >>> import matplotlib.pyplot as plt
+        >>> plt.show()
     """
     if ax is None:
         fig = plt.figure()

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -526,13 +526,14 @@ class KakDecomposition:
             before)
 
 
-def scatter_plot_normalized_kak_interaction_coefficients(interactions: Iterable[
-        Union[np.ndarray, 'cirq.SupportsUnitary', 'KakDecomposition']],
-                                                         *,
-                                                         include_frame: bool = True,
-                                                         ax: Optional[plt.Axes] = None,
-                                                         show: bool = False,
-                                                         **kwargs):
+def scatter_plot_normalized_kak_interaction_coefficients(
+        interactions: Iterable[
+            Union[np.ndarray, 'cirq.SupportsUnitary', 'KakDecomposition']],
+        *,
+        include_frame: bool = True,
+        ax: Optional[plt.Axes] = None,
+        show: bool = False,
+        **kwargs):
     """Plots the interaction coefficients of many two-qubit operations.
 
     Plots:

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -24,6 +24,7 @@ from typing import (
     Union,
     Iterable,
     Optional,
+    TYPE_CHECKING,
 )
 
 import math
@@ -32,10 +33,12 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 
-import cirq
 from cirq import value, protocols
 from cirq._compat import proper_repr
 from cirq.linalg import combinators, diagonalize, predicates
+
+if TYPE_CHECKING:
+    import cirq
 
 
 T = TypeVar('T')
@@ -570,13 +573,37 @@ def scatter_plot_normalized_kak_interaction_coefficients(
 
     Returns:
         The matplotlib 3d axes object that was plotted into.
+
+    Examples:
+        >>> ax = None
+        >>> for y in np.linspace(0, 0.5, 4):
+        ...     a, b = cirq.LineQubit.range(2)
+        ...     circuits = [
+        ...         cirq.Circuit.from_ops(
+        ...             cirq.CZ(a, b)**0.5,
+        ...             cirq.X(a)**y, cirq.X(b)**x,
+        ...             cirq.CZ(a, b)**0.5,
+        ...             cirq.X(a)**x, cirq.X(b)**y,
+        ...             cirq.CZ(a, b) ** 0.5,
+        ...         )
+        ...         for x in np.linspace(0, 1, 25)
+        ...     ]
+        ...     ax = cirq.scatter_plot_normalized_kak_interaction_coefficients(
+        ...         circuits,
+        ...         s=1,
+        ...         ax=ax,
+        ...         include_frame=ax is None,
+        ...         label=f'y={y:0.2f}')
+        >>> _ = ax.legend()
+        >>> # import matplotlib.pyplot as plt
+        >>> # plt.show()
     """
     if ax is None:
         fig = plt.figure()
         ax = fig.add_subplot(projection='3d')
 
     def coord_transform(
-            pts: List[Tuple[float, float, float]]
+            pts: Iterable[Tuple[float, float, float]]
     ) -> Tuple[Iterable[float], Iterable[float], Iterable[float]]:
         xs, ys, zs = zip(*pts)
         return xs, zs, ys

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -536,7 +536,7 @@ def scatter_plot_normalized_kak_interaction_coefficients(
         ax: Optional[plt.Axes] = None,
         show: bool = False,
         **kwargs):
-    """Plots the interaction coefficients of many two-qubit operations.
+    f"""Plots the interaction coefficients of many two-qubit operations.
 
     Plots:
         A point for the (x, y, z) normalized interaction coefficients of
@@ -552,6 +552,19 @@ def scatter_plot_normalized_kak_interaction_coefficients(
 
         The wireframe includes lines along the surface of the space at z=0.
 
+        The space is a prism with the identity at the origin, a crease along
+        y=z=0 leading to the CZ/CNOT at x=1 and a vertical triangular face that
+        contains the iswap at x=y=1,z=0 and the swap at x=y=z=1:
+
+                                 (x=1,y=1,z=0)
+                             swap___iswap___swap (x=1,y=1,z=+-1)
+                               _/\    |    /
+                             _/   \   |   /
+                           _/      \  |  /
+                         _/         \ | /
+                       _/            \|/
+        (x=0,y=0,z=0) I---------------CZ (x=1,y=0,z=0)
+
     Args:
         interactions: An iterable of two qubit unitary interactions. Each
             interaction can be specified as a raw 4x4 unitary matrix, or an
@@ -559,7 +572,7 @@ def scatter_plot_normalized_kak_interaction_coefficients(
             (e.g. `cirq.CZ` or a `cirq.KakDecomposition` or a `cirq.Circuit`
             over two qubits).
         include_frame: Determines whether or not to draw the kak space
-            wireframe. If not set. Defaults to `True`.
+            wireframe. Defaults to `True`.
         ax: A matplotlib 3d axes object to plot into. If not specified, a new
             figure is created.
         show: Whether or not to call `matplotlib.pyplot.show()`. Defaults to

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -526,27 +526,28 @@ class KakDecomposition:
             before)
 
 
-def plot_normalized_kak_interaction_coefficients(interactions: Iterable[
+def scatter_plot_normalized_kak_interaction_coefficients(interactions: Iterable[
         Union[np.ndarray, 'cirq.SupportsUnitary', 'KakDecomposition']],
-                                                 *,
-                                                 ax: Optional[plt.Axes] = None,
-                                                 show: bool = False):
+                                                         *,
+                                                         include_frame: bool = True,
+                                                         ax: Optional[plt.Axes] = None,
+                                                         show: bool = False,
+                                                         **kwargs):
     """Plots the interaction coefficients of many two-qubit operations.
 
     Plots:
-        An orange point for the (x, y, z) normalized interaction coefficients of
+        A point for the (x, y, z) normalized interaction coefficients of
         each interaction from the given interactions. The (x, y, z) coordinates
         are normalized so that the maximum value is at 1 instead of at pi/4.
 
-        A blue wireframe outline of the canonicalized normalized KAK
-        coefficient space, which is defined by the following two
-        constraints:
+        If frame is set to True or ax is set to None, then a black wireframe
+        outline of the canonicalized normalized KAK coefficient space. The space
+        is defined by the following two constraints:
 
             0 <= abs(z) <= y <= x <= 1
             if x = 1 then z >= 0
 
-        In addition to the wireframe, there are guide lines along the z=0
-        surface of the space.
+        The wireframe has guide lines along the surface of the space at z=0.
 
     Args:
         interactions: An iterable of two qubit unitary interactions. Each
@@ -554,8 +555,17 @@ def plot_normalized_kak_interaction_coefficients(interactions: Iterable[
             object with a 4x4 unitary matrix according to `cirq.unitary` (
             (e.g. `cirq.CZ` or a `cirq.KakDecomposition` or a `cirq.Circuit`
             over two qubits).
-        ax: A matplotlib 3d axes object to plot into.
-        show: Whether or not to call `matplotlib.pyplot.show()`.
+        include_frame: Determines whether or not to draw the kak space wireframe. If not
+            set. Defaults to `True`.
+        ax: A matplotlib 3d axes object to plot into. If not specified, a new
+            figure is created.
+        show: Whether or not to call `matplotlib.pyplot.show()`. Defaults to
+            `False`.
+        kwargs: Arguments forwarded into the call to `scatter` that plots the
+            points. Working arguments include color `c='blue'`, scale `s=2`,
+            labelling `label="theta=pi/4"`, etc. For reference see the
+            `matplotlib.pyplot.scatter` documentation:
+            https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.scatter.html
 
     Returns:
         The matplotlib 3d axes object that was plotted into.
@@ -570,22 +580,23 @@ def plot_normalized_kak_interaction_coefficients(interactions: Iterable[
         xs, ys, zs = zip(*pts)
         return xs, zs, ys
 
-    envelope = [
-        (0, 0, 0),
-        (1, 1, 1),
-        (1, 1, -1),
-        (0, 0, 0),
-        (1, 1, 1),
-        (1, 0, 0),
-        (0, 0, 0),
-        (1, 1, -1),
-        (1, 0, 0),
-        (0, 0, 0),
-        (1, 0, 0),
-        (1, 1, 0),
-        (0, 0, 0),
-    ]
-    ax.plot(*coord_transform(envelope), c='C0', linewidth=1)
+    if include_frame:
+        envelope = [
+            (0, 0, 0),
+            (1, 1, 1),
+            (1, 1, -1),
+            (0, 0, 0),
+            (1, 1, 1),
+            (1, 0, 0),
+            (0, 0, 0),
+            (1, 1, -1),
+            (1, 0, 0),
+            (0, 0, 0),
+            (1, 0, 0),
+            (1, 1, 0),
+            (0, 0, 0),
+        ]
+        ax.plot(*coord_transform(envelope), c='black', linewidth=1)
 
     points = []
     for obj in interactions:
@@ -598,7 +609,7 @@ def plot_normalized_kak_interaction_coefficients(interactions: Iterable[
         normalized = np.array(kak.interaction_coefficients) * 4 / np.pi
         points.append(normalized)
 
-    ax.scatter(*coord_transform(points), c='C1', s=1)
+    ax.scatter(*coord_transform(points), **kwargs)
     ax.set_xlim(0, +1)
     ax.set_ylim(-1, +1)
     ax.set_zlim(0, +1)

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -541,14 +541,14 @@ def scatter_plot_normalized_kak_interaction_coefficients(
         each interaction from the given interactions. The (x, y, z) coordinates
         are normalized so that the maximum value is at 1 instead of at pi/4.
 
-        If frame is set to True or ax is set to None, then a black wireframe
-        outline of the canonicalized normalized KAK coefficient space. The space
-        is defined by the following two constraints:
+        If `include_frame` is set to True, then a black wireframe outline of the
+        canonicalized normalized KAK coefficient space. The space is defined by
+        the following two constraints:
 
             0 <= abs(z) <= y <= x <= 1
             if x = 1 then z >= 0
 
-        The wireframe has guide lines along the surface of the space at z=0.
+        The wireframe includes lines along the surface of the space at z=0.
 
     Args:
         interactions: An iterable of two qubit unitary interactions. Each
@@ -556,8 +556,8 @@ def scatter_plot_normalized_kak_interaction_coefficients(
             object with a 4x4 unitary matrix according to `cirq.unitary` (
             (e.g. `cirq.CZ` or a `cirq.KakDecomposition` or a `cirq.Circuit`
             over two qubits).
-        include_frame: Determines whether or not to draw the kak space wireframe. If not
-            set. Defaults to `True`.
+        include_frame: Determines whether or not to draw the kak space
+            wireframe. If not set. Defaults to `True`.
         ax: A matplotlib 3d axes object to plot into. If not specified, a new
             figure is created.
         show: Whether or not to call `matplotlib.pyplot.show()`. Defaults to

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -40,7 +40,6 @@ from cirq.linalg import combinators, diagonalize, predicates
 if TYPE_CHECKING:
     import cirq
 
-
 T = TypeVar('T')
 MAGIC = np.array([[1, 0, 0, 1j],
                   [0, 1j, 1, 0],
@@ -770,10 +769,9 @@ KAK_GAMMA = np.array([[1, 1, 1, 1],
 # yapf: enable
 
 
-def kak_decomposition(
-        unitary_object: Union[np.ndarray, 'cirq.SupportsUnitary'],
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> KakDecomposition:
+def kak_decomposition(unitary_object: Union[np.ndarray, 'cirq.SupportsUnitary'],
+                      rtol: float = 1e-5,
+                      atol: float = 1e-8) -> KakDecomposition:
     """Decomposes a 2-qubit unitary into 1-qubit ops and XX/YY/ZZ interactions.
 
     Args:

--- a/cirq/linalg/decompositions_test.py
+++ b/cirq/linalg/decompositions_test.py
@@ -231,7 +231,7 @@ def test_kak_canonicalize_vector(x, y, z):
     SWAP * 1j,
     CZ,
     CNOT,
-    SWAP.dot(CZ),
+    SWAP @ CZ,
 ] + [
     cirq.testing.random_unitary(4)
     for _ in range(10)
@@ -239,6 +239,13 @@ def test_kak_canonicalize_vector(x, y, z):
 def test_kak_decomposition(target):
     kak = cirq.kak_decomposition(target)
     np.testing.assert_allclose(cirq.unitary(kak), target, atol=1e-8)
+
+
+def test_kak_decomposition_unitary_object():
+    op = cirq.ISWAP(*cirq.LineQubit.range(2))**0.5
+    kak = cirq.kak_decomposition(op)
+    np.testing.assert_allclose(cirq.unitary(kak), cirq.unitary(op), atol=1e-8)
+    assert cirq.kak_decomposition(kak) is kak
 
 
 def test_kak_decomposition_eq():

--- a/cirq/linalg/decompositions_test.py
+++ b/cirq/linalg/decompositions_test.py
@@ -478,3 +478,23 @@ def test_axis_angle_init():
 
     with pytest.raises(ValueError, match='normalize'):
         cirq.AxisAngleDecomposition(angle=1, axis=(0, 0.5, 0), global_phase=1)
+
+
+def test_scatter_plot_normalized_kak_interaction_coefficients():
+    a, b = cirq.LineQubit.range(2)
+    data = [
+        cirq.kak_decomposition(cirq.unitary(cirq.CZ)),
+        cirq.unitary(cirq.CZ),
+        cirq.CZ,
+        cirq.Circuit.from_ops(cirq.H(a), cirq.CNOT(a, b)),
+    ]
+    ax = cirq.scatter_plot_normalized_kak_interaction_coefficients(data)
+    assert ax is not None
+    ax2 = cirq.scatter_plot_normalized_kak_interaction_coefficients(
+        data,
+        s=1,
+        c='blue',
+        ax=ax,
+        include_frame=False,
+        label=f'test')
+    assert ax2 is ax

--- a/cirq/linalg/decompositions_test.py
+++ b/cirq/linalg/decompositions_test.py
@@ -232,10 +232,7 @@ def test_kak_canonicalize_vector(x, y, z):
     CZ,
     CNOT,
     SWAP @ CZ,
-] + [
-    cirq.testing.random_unitary(4)
-    for _ in range(10)
-])
+] + [cirq.testing.random_unitary(4) for _ in range(10)])
 def test_kak_decomposition(target):
     kak = cirq.kak_decomposition(target)
     np.testing.assert_allclose(cirq.unitary(kak), target, atol=1e-8)
@@ -497,10 +494,5 @@ def test_scatter_plot_normalized_kak_interaction_coefficients():
     ax = cirq.scatter_plot_normalized_kak_interaction_coefficients(data)
     assert ax is not None
     ax2 = cirq.scatter_plot_normalized_kak_interaction_coefficients(
-        data,
-        s=1,
-        c='blue',
-        ax=ax,
-        include_frame=False,
-        label=f'test')
+        data, s=1, c='blue', ax=ax, include_frame=False, label=f'test')
     assert ax2 is ax

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -339,8 +339,8 @@ class PauliString(raw_types.Operation):
                                               axes=(qubit_map[qubit],))
             ket = protocols.apply_unitary(pauli, args)
 
-        return self.coefficient * np.asscalar(
-            np.tensordot(state.conj(), ket, axes=len(ket.shape)))
+        return self.coefficient * (
+            np.tensordot(state.conj(), ket, axes=len(ket.shape)).item())
 
     def expectation_from_density_matrix(self, state: np.ndarray,
                                         qubit_map: Mapping[raw_types.Qid, int]

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -339,8 +339,8 @@ class PauliString(raw_types.Operation):
                                               axes=(qubit_map[qubit],))
             ket = protocols.apply_unitary(pauli, args)
 
-        return self.coefficient * (
-            np.tensordot(state.conj(), ket, axes=len(ket.shape)).item())
+        return self.coefficient * (np.tensordot(
+            state.conj(), ket, axes=len(ket.shape)).item())
 
     def expectation_from_density_matrix(self, state: np.ndarray,
                                         qubit_map: Mapping[raw_types.Qid, int]

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -41,6 +41,8 @@ IGNORED_LINE_PATTERNS = [
     r'^assert False.*$',
     # Code testing if libraries are present.
     r'except ImportError',
+    # Plotting code.
+    r'plt\.show\(\)',
 ]
 EXPLICIT_OPT_OUT_COMMENT = '#coverage:ignore'
 

--- a/dev_tools/run_doctest.py
+++ b/dev_tools/run_doctest.py
@@ -69,9 +69,15 @@ def run_tests(file_paths: Iterable[str],
         include_local: If True, the file under test is imported as a python
             module (only if the file extension is .py) and all globals defined
             in the file may be used by the snippets.
+        quiet: Determines if progress output is shown.
 
     Returns: A tuple with the results: (# tests failed, # tests attempted)
     """
+
+    # Ignore calls to `plt.show()`.
+    import matplotlib.pyplot as plt
+    plt.switch_backend('pdf')
+
     tests = load_tests(file_paths,
                        include_modules=include_modules,
                        include_local=include_local,


### PR DESCRIPTION
This PR also:

- Marks `plt.show()` lines as not needing to be covered
- Fixes a deprecation warning w.r.t. `np.asscalar`
- Allows `plt.show()` to be called in doctested example code
- Allows `cirq.kak_decompose` to be called on objects with a `_unitary_` method, such as `cirq.Circuit`.

Plotting KAK interaction coefficients visually is something I've found really handy for understanding two qubit operation decomposition. I put together this flexible method for doing so.

Example:

```python
import cirq
import numpy as np
import matplotlib.pyplot as plt

ax = None
for y in np.linspace(0, 0.5, 10):
    a, b = cirq.LineQubit.range(2)
    circuits = [
        cirq.Circuit.from_ops(
            cirq.CZ(a, b)**0.5,
            cirq.X(a)**y, cirq.X(b)**x,
            cirq.CZ(a, b)**0.5,
            cirq.X(a)**x, cirq.X(b)**y,
            cirq.CZ(a, b) ** 0.5,
        )
        for x in np.linspace(0, 1, 100)
    ]

    ax = cirq.scatter_plot_normalized_kak_interaction_coefficients(
        circuits,
        s=1,
        ax=ax,
        include_frame=ax is None,
        label=f'y={y:0.2f}')
ax.legend()
plt.show()
```

![image](https://user-images.githubusercontent.com/79941/65005029-5c40b180-d8b3-11e9-8393-25a5c5bde871.png)

![image](https://user-images.githubusercontent.com/79941/65005043-64005600-d8b3-11e9-9b05-efd8c7155cde.png)
