### PR TITLE
eigvals -> eigvalsh

### DIFF
--- a/cirq/sim/density_matrix_utils.py
+++ b/cirq/sim/density_matrix_utils.py
@@ -350,5 +350,5 @@ def von_neumann_entropy(density_matrix: np.ndarray) -> float:
     Returns:
         The calculated von Neumann entropy.
     """
-    eigenvalues = np.linalg.eigvals(density_matrix)
+    eigenvalues = np.linalg.eigvalsh(density_matrix)
     return entropy(abs(eigenvalues), base=2)


### PR DESCRIPTION
if the input is known to be Hermitian, eigvalsh is generally higher precision (e.g. see http://www.netlib.org/lapack/lug/node89.html vs. http://www.netlib.org/lapack/lug/node91.html) and more performant:

```
>>> timeit.timeit('np.linalg.eigvalsh(b)', setup='import numpy as np; a = np.random.random((128,128)).astype(np.complex6
4); b = (a + a.T); b = b / np.trace(b)', number=1000)
6.555085600004531
>>> timeit.timeit('np.linalg.eigvals(b)', setup='import numpy as np; a = np.random.random((128,128)).astype(np.complex64
); b = (a + a.T); b = b / np.trace(b)', number=1000)
61.79538379999576
>>>
```