### PR TITLE
Add cirq.ArithmeticOperation helper class

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -142,6 +142,7 @@ from cirq.ops import (
     amplitude_damp,
     AmplitudeDampingChannel,
     ApproxPauliStringExpectation,
+    ArithmeticOperation,
     asymmetric_depolarize,
     AsymmetricDepolarizingChannel,
     bit_flip,

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -15,6 +15,9 @@
 """Types for representing and methods for manipulating circuit operation trees.
 """
 
+from cirq.ops.arithmetic_operation import (
+    ArithmeticOperation,)
+
 from cirq.ops.clifford_gate import (
     PauliTransform,
     SingleQubitCliffordGate,

--- a/cirq/ops/arithmetic_operation.py
+++ b/cirq/ops/arithmetic_operation.py
@@ -15,12 +15,14 @@
 
 import abc
 import itertools
-from typing import Union, Iterable, List, Sequence, cast
+from typing import Union, Iterable, List, Sequence, cast, TYPE_CHECKING
 
 import numpy as np
 
-import cirq
 from cirq.ops.raw_types import Operation
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
@@ -32,7 +34,8 @@ class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
     This class handles the details of ensuring that the scaling of implementing
     the operation is O(2^n) instead of O(4^n) where n is the number of qubits
     being acted on, by implementing an `_apply_unitary_` function in terms of
-    the registers and the apply function of the child class.
+    the registers and the apply function of the child class. It also handles the
+    boilerplate of implementing the `qubits` and `with_qubits` methods.
 
     Examples:
         >>> class Add(cirq.ArithmeticOperation):

--- a/cirq/ops/arithmetic_operation.py
+++ b/cirq/ops/arithmetic_operation.py
@@ -1,0 +1,245 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper class for implementing classical arithmetic operations."""
+
+import abc
+import itertools
+from typing import Union, Iterable, List, Sequence, cast
+
+import numpy as np
+
+import cirq
+from cirq.ops.raw_types import Operation
+
+
+class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
+    """A helper class for implementing reversible classical arithmetic.
+
+    Child classes must override the `registers`, `with_registers`, and `apply`
+    methods.
+
+    This class handles the details of ensuring that the scaling of implementing
+    the operation is O(2^n) instead of O(4^n) where n is the number of qubits
+    being acted on, by implementing an `_apply_unitary_` function in terms of
+    the registers and the apply function of the child class.
+
+    Examples:
+        >>> class Add(cirq.ArithmeticOperation):
+        ...     def __init__(self, target_register, input_register):
+        ...         self.target_register = target_register
+        ...         self.input_register = input_register
+        ...
+        ...     def registers(self):
+        ...         return self.target_register, self.input_register
+        ...
+        ...     def with_registers(self, *new_registers):
+        ...         return Add(*new_registers)
+        ...
+        ...     def apply(self, target_value, input_value):
+        ...         return target_value + input_value
+        >>> cirq.unitary(
+        ...     Add(target_register=cirq.LineQubit.range(2),
+        ...         input_register=1)
+        ... ).astype(np.int32)
+        array([[0, 0, 0, 1],
+               [1, 0, 0, 0],
+               [0, 1, 0, 0],
+               [0, 0, 1, 0]], dtype=int32)
+        >>> c = cirq.Circuit.from_ops(
+        ...    cirq.X(cirq.LineQubit(3)),
+        ...    cirq.X(cirq.LineQubit(2)),
+        ...    cirq.X(cirq.LineQubit(6)),
+        ...    cirq.measure(*cirq.LineQubit.range(4, 8), key='before:in'),
+        ...    cirq.measure(*cirq.LineQubit.range(4), key='before:out'),
+        ...
+        ...    Add(target_register=cirq.LineQubit.range(4),
+        ...        input_register=cirq.LineQubit.range(4, 8)),
+        ...
+        ...    cirq.measure(*cirq.LineQubit.range(4, 8), key='after:in'),
+        ...    cirq.measure(*cirq.LineQubit.range(4), key='after:out'),
+        ... )
+        >>> cirq.sample(c).data
+           before:in  before:out  after:in  after:out
+        0          2           3         2          5
+    """
+
+    @abc.abstractmethod
+    def registers(self) -> Sequence[Union[int, Sequence['cirq.Qid']]]:
+        """The data acted upon by the arithmetic operation.
+
+        Each register in the list can either be a classical constant (an `int`),
+        or else a list of qubits/qudits (a `List[cirq.Qid]`). Registers that
+        are set to a classical constant must not be mutated by the arithmetic
+        operation (their value must remain fixed when passed to `apply`).
+
+        Registers are big endian. The first qubit is the most significant, the
+        last qubit is the 1s qubit, the before last qubit is the 2s qubit, etc.
+
+        Returns:
+            A list of constants and qubit groups that the operation will act
+            upon.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def with_registers(self, *new_registers: Union[int, Sequence['cirq.Qid']]
+                      ) -> 'cirq.ArithmeticOperation':
+        """Returns the same operation targeting different registers.
+
+        Args:
+            new_registers: The new values that should be returned by the
+                `registers` method.
+
+        Returns:
+            An instance of the same kind of operation, but acting on different
+            registers.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def apply(self, *register_values: int) -> Union[int, Iterable[int]]:
+        """Returns the result of the operation operating on classical values.
+
+        For example, an addition takes two values (the target and the source),
+        adds the source into the target, then returns the target and source
+        as the new register values.
+
+        The `apply` method is permitted to be sloppy in three ways:
+
+        1. The `apply` method is permitted to return values that have more bits
+            than the registers they will be stored into. The extra bits are
+            simply dropped. For example, if the value 5 is returned for a 2
+            qubit register then 5 % 2**2 = 1 will be used instead. Negative
+            values are also permitted. For example, for a 3 qubit register the
+            value -2 becomes -2 % 2**3 = 6.
+        2. When the value of the last `k` registers is not changed by the
+            operation, the `apply` method is permitted to omit these values
+            from the result. That is to say, when the length of the output is
+            less than the length of the input, it is padded up to the intended
+            length by copying from the same position in the input.
+        3. When only the first register's value changes, the `apply` method is
+            permitted to return an `int` instead of a sequence of ints.
+
+        The `apply` method *must* be reversible. Otherwise the operation will
+        not be unitary, and incorrect behavior will result.
+
+        Examples:
+
+            A fully detailed adder:
+
+            ```
+            def apply(self, target, offset):
+                return (target + offset) % 2**len(self.target_register), offset
+            ```
+
+            The same adder, with less boilerplate due to the details being
+            handled by the `ArithmeticOperation` class:
+
+            ```
+            def apply(self, target, offset):
+                return target + offset
+            ```
+        """
+        raise NotImplementedError()
+
+    @property
+    def qubits(self):
+        return tuple(qubit for register in self.registers()
+                     if not isinstance(register, int) for qubit in register)
+
+    def with_qubits(self, *new_qubits: 'cirq.Qid') -> 'cirq.Operation':
+        new_registers: List[Union[int, Sequence['cirq.Qid']]] = []
+        qs = iter(new_qubits)
+        for register in self.registers():
+            if isinstance(register, int):
+                new_registers.append(register)
+            else:
+                new_registers.append([next(qs) for _ in register])
+        return self.with_registers(*new_registers)
+
+    def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs'):
+        registers = self.registers()
+        input_ranges: List[Sequence[int]] = []
+        shape = []
+        overflow_sizes = []
+        for register in registers:
+            if isinstance(register, int):
+                input_ranges.append([register])
+                shape.append(1)
+                overflow_sizes.append(register + 1)
+            else:
+                size = np.product([q.dimension for q in register]).item()
+                shape.append(size)
+                input_ranges.append(range(size))
+                overflow_sizes.append(size)
+
+        leftover = args.target_tensor.size // np.product(shape).item()
+        new_shape = (*shape, leftover)
+
+        transposed_args = args.with_axes_transposed_to_start()
+        src = transposed_args.target_tensor.reshape(new_shape)
+        dst = transposed_args.available_buffer.reshape(new_shape)
+        for input_seq in itertools.product(*input_ranges):
+            output = self.apply(*input_seq)
+
+            # Wrap into list.
+            inputs: List[int] = list(input_seq)
+            outputs: List[int] = ([output]
+                                  if isinstance(output, int) else list(output))
+
+            # Omitted tail values default to the corresponding input value.
+            if len(outputs) < len(inputs):
+                outputs += inputs[len(outputs) - len(inputs):]
+            # Get indices into range.
+            for i in range(len(outputs)):
+                if isinstance(registers[i], int):
+                    if outputs[i] != registers[i]:
+                        raise ValueError(
+                            _describe_bad_arithmetic_changed_const(
+                                self.registers(), inputs, outputs))
+                    # Classical constants go to zero on a unit axe.
+                    outputs[i] = 0
+                    inputs[i] = 0
+                else:
+                    # Quantum values get wrapped into range.
+                    outputs[i] %= overflow_sizes[i]
+
+            # Copy amplitude to new location.
+            cast(List[Union[int, slice]], outputs).append(slice(None))
+            cast(List[Union[int, slice]], inputs).append(slice(None))
+            dst[outputs] = src[inputs]
+
+        return args.available_buffer
+
+
+def _describe_bad_arithmetic_changed_const(
+        registers: Sequence[Union[int, Sequence['cirq.Qid']]],
+        inputs: List[int], outputs: List[int]) -> str:
+    from cirq.circuits import TextDiagramDrawer
+    drawer = TextDiagramDrawer()
+    drawer.write(0, 0, 'Register Data')
+    drawer.write(1, 0, 'Register Type')
+    drawer.write(2, 0, 'Input Value')
+    drawer.write(3, 0, 'Output Value')
+    for i in range(len(registers)):
+        drawer.write(0, i + 1, str(registers[i]))
+        drawer.write(1, i + 1,
+                     'constant' if isinstance(registers[i], int) else 'qureg')
+        drawer.write(2, i + 1, str(inputs[i]))
+        drawer.write(3, i + 1, str(outputs[i]))
+    return (
+        "A register cannot be set to an int (a classical constant) unless its "
+        "value is not affected by the operation.\n"
+        "\nExample case where a constant changed:\n" +
+        drawer.render(horizontal_spacing=1, vertical_spacing=0))

--- a/cirq/ops/arithmetic_operation_test.py
+++ b/cirq/ops/arithmetic_operation_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools, functools
 import pytest
 import numpy as np
 

--- a/cirq/ops/arithmetic_operation_test.py
+++ b/cirq/ops/arithmetic_operation_test.py
@@ -1,0 +1,152 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools, functools
+import pytest
+import numpy as np
+
+import cirq
+
+
+def shift_matrix(width: int, shift: int) -> np.ndarray:
+    result = np.zeros((width, width))
+    for i in range(width):
+        result[(i + shift) % width, i] = 1
+    return result
+
+
+def adder_matrix(target_width: int, source_width: int) -> np.ndarray:
+    t, s = target_width, source_width
+    result = np.zeros((t, s, t, s))
+    for k in range(s):
+        result[:, k, :, k] = shift_matrix(t, k)
+    result.shape = (t * s, t * s)
+    return result
+
+
+def test_the_tests():
+    np.testing.assert_allclose(shift_matrix(4, 1),
+                               np.array([
+                                   [0, 0, 0, 1],
+                                   [1, 0, 0, 0],
+                                   [0, 1, 0, 0],
+                                   [0, 0, 1, 0],
+                               ]),
+                               atol=1e-8)
+    np.testing.assert_allclose(shift_matrix(8, -1),
+                               np.array([
+                                   [0, 1, 0, 0, 0, 0, 0, 0],
+                                   [0, 0, 1, 0, 0, 0, 0, 0],
+                                   [0, 0, 0, 1, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 1, 0, 0, 0],
+                                   [0, 0, 0, 0, 0, 1, 0, 0],
+                                   [0, 0, 0, 0, 0, 0, 1, 0],
+                                   [0, 0, 0, 0, 0, 0, 0, 1],
+                                   [1, 0, 0, 0, 0, 0, 0, 0],
+                               ]),
+                               atol=1e-8)
+    np.testing.assert_allclose(adder_matrix(4, 2),
+                               np.array([
+                                   [1, 0, 0, 0, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 0, 0, 0, 1],
+                                   [0, 0, 1, 0, 0, 0, 0, 0],
+                                   [0, 1, 0, 0, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 1, 0, 0, 0],
+                                   [0, 0, 0, 1, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 0, 0, 1, 0],
+                                   [0, 0, 0, 0, 0, 1, 0, 0],
+                               ]),
+                               atol=1e-8)
+
+
+def test_arithmetic_operation_apply_unitary():
+
+    class Add(cirq.ArithmeticOperation):
+
+        def __init__(self, target_register, input_register):
+            self.target_register = target_register
+            self.input_register = input_register
+
+        def registers(self):
+            return self.target_register, self.input_register
+
+        def with_registers(self, *new_registers):
+            raise NotImplementedError()
+
+        def apply(self, target_value, input_value):
+            return target_value + input_value
+
+    inc2 = Add(cirq.LineQubit.range(2), 1)
+    np.testing.assert_allclose(cirq.unitary(inc2),
+                               shift_matrix(4, 1),
+                               atol=1e-8)
+
+    dec3 = Add(cirq.LineQubit.range(3), -1)
+    np.testing.assert_allclose(cirq.unitary(dec3),
+                               shift_matrix(8, -1),
+                               atol=1e-8)
+
+    add3from2 = Add(cirq.LineQubit.range(3), cirq.LineQubit.range(2))
+    np.testing.assert_allclose(cirq.unitary(add3from2),
+                               adder_matrix(8, 4),
+                               atol=1e-8)
+
+    add2from3 = Add(cirq.LineQubit.range(2), cirq.LineQubit.range(3))
+    np.testing.assert_allclose(cirq.unitary(add2from3),
+                               adder_matrix(4, 8),
+                               atol=1e-8)
+
+    with pytest.raises(ValueError, match='affected by the operation'):
+        _ = cirq.unitary(Add(1, cirq.LineQubit.range(2)))
+
+    with pytest.raises(ValueError, match='affected by the operation'):
+        _ = cirq.unitary(Add(1, 1))
+
+    np.testing.assert_allclose(cirq.unitary(Add(1, 0)), np.eye(1))
+
+
+def test_arithmetic_operation_qubits():
+
+    class Three(cirq.ArithmeticOperation):
+
+        def __init__(self, a, b, c):
+            self.a = a
+            self.b = b
+            self.c = c
+
+        def registers(self):
+            return self.a, self.b, self.c
+
+        def with_registers(self, *new_registers):
+            return Three(*new_registers)
+
+        def apply(self, target_value, input_value):
+            raise NotImplementedError()
+
+    q0, q1, q2, q3, q4, q5 = cirq.LineQubit.range(6)
+    op = Three([q0], [], [q4, q5])
+    assert op.qubits == (q0, q4, q5)
+    assert op.registers() == ([q0], [], [q4, q5])
+
+    op2 = op.with_qubits(q2, q4, q1)
+    assert op2.qubits == (q2, q4, q1)
+    assert op2.registers() == ([q2], [], [q4, q1])
+
+    op3 = op.with_registers([q0, q1, q3], [q5], 1)
+    assert op3.qubits == (q0, q1, q3, q5)
+    assert op3.registers() == ([q0, q1, q3], [q5], 1)
+
+    op4 = op3.with_qubits(q0, q1, q2, q3)
+    assert op4.registers() == ([q0, q1, q2], [q3], 1)
+    assert op4.qubits == (q0, q1, q2, q3)

--- a/cirq/protocols/apply_unitary.py
+++ b/cirq/protocols/apply_unitary.py
@@ -116,6 +116,27 @@ class ApplyUnitaryArgs:
                                dtype=np.complex128)
         return ApplyUnitaryArgs(state, np.empty_like(state), range(num_qubits))
 
+    def with_axes_transposed_to_start(self) -> 'ApplyUnitaryArgs':
+        """Returns a transposed view of the same arguments.
+
+        Returns:
+            A view over the same target tensor and available workspace, but
+            with the numpy arrays transposed such that the axes field is
+            guaranteed to equal `range(len(result.axes))`. This allows one to
+            say e.g. `result.target_tensor[0, 1, 0, ...]` instead of
+            `result.target_tensor[result.subspace_index(0b010)]`.
+        """
+        axis_set = set(self.axes)
+        other_axes = [
+            axis for axis in range(len(self.target_tensor.shape))
+            if axis not in axis_set
+        ]
+        perm = (*self.axes, *other_axes)
+        target_tensor = self.target_tensor.transpose(*perm)
+        available_buffer = self.available_buffer.transpose(*perm)
+        return ApplyUnitaryArgs(target_tensor, available_buffer,
+                                range(len(self.axes)))
+
     def _for_operation_with_qid_shape(self, indices: Iterable[int],
                                       qid_shape: Tuple[int, ...]
                                      ) -> 'ApplyUnitaryArgs':

--- a/cirq/protocols/apply_unitary_test.py
+++ b/cirq/protocols/apply_unitary_test.py
@@ -459,3 +459,19 @@ def test_incorporate_result_not_view():
 def test_default_method_arguments():
     with pytest.raises(TypeError, match='exactly one of'):
         cirq.ApplyUnitaryArgs.default(1, qid_shape=(2,))
+
+
+def test_apply_unitary_args_with_axes_transposed_to_start():
+    target = np.zeros((2, 3, 4, 5))
+    buffer = np.zeros((2, 3, 4, 5))
+    args = cirq.ApplyUnitaryArgs(target, buffer, [1, 3])
+
+    new_args = args.with_axes_transposed_to_start()
+    assert new_args.target_tensor.shape == (3, 5, 2, 4)
+    assert new_args.available_buffer.shape == (3, 5, 2, 4)
+
+    # Confirm aliasing.
+    new_args.target_tensor[2, 4, 1, 3] = 1
+    assert args.target_tensor[1, 2, 3, 4] == 1
+    new_args.available_buffer[2, 4, 1, 3] = 2
+    assert args.available_buffer[1, 2, 3, 4] == 2


### PR DESCRIPTION
This is a helper class to make it easier to implement arithmetic operations. These operations are not NISQ-y, but people have asked if cirq can do them efficiently a few times in the past. The answer was that it's *possible*, by implementing an `_apply_unitary_` operation, but it's not so convenient to write that method. Now we have a convenient way to do it.

Here is how you would implement an adder using this class:

```python
class Add(cirq.ArithmeticOperation):
    def __init__(self, target_register, input_register):
        self.target_register = target_register
        self.input_register = input_register

    def registers(self):
        return self.target_register, self.input_register

    def with_registers(self, *new_registers):
        return Add(*new_registers)

    def apply(self, target_value, input_value):
        return target_value + input_value
```

The fact that the output is an int instead of a list of two ints, and also that the output may be larger than the register range, is all fixed up automatically. int gets wrapped into List[int], List[int] gets padded up to max length assuming on changes in later registers, and each result gets modded into range. I originally tried a version with all these things explicit, but it was generally quite a pain to have to constantly deal with sizing and remembering to list unchanged values.

A fun feature is that, because the input register is not modified (phase kickback notwithstanding), the input register can be set to a list of qubits *or* to a classical constant:

With a constant:

```python
cirq.unitary(
    Add(target_register=cirq.LineQubit.range(2),
        input_register=1))
```

```
[[0, 0, 0, 1],
 [1, 0, 0, 0],
 [0, 1, 0, 0],
 [0, 0, 1, 0]]
```

With another register:

```python
c = cirq.Circuit.from_ops(
   cirq.X(cirq.LineQubit(3)),
   cirq.X(cirq.LineQubit(2)),
   cirq.X(cirq.LineQubit(6)),
   cirq.measure(*cirq.LineQubit.range(4, 8), key='before:in'),
   cirq.measure(*cirq.LineQubit.range(4), key='before:out'),

   Add(target_register=cirq.LineQubit.range(4),
       input_register=cirq.LineQubit.range(4, 8)),

   cirq.measure(*cirq.LineQubit.range(4, 8), key='after:in'),
   cirq.measure(*cirq.LineQubit.range(4), key='after:out'),
)
print(cirq.sample(c).data)
```

```
   before:in  before:out  after:in  after:out
0          2           3         2          5
```