### PR TITLE
Add OpTree protocol

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -166,6 +166,8 @@ from cirq.ops import (
     DepolarizingChannel,
     EigenGate,
     flatten_op_tree,
+    flatten_to_ops,
+    flatten_to_ops_or_moments,
     FREDKIN,
     freeze_op_tree,
     FSimGate,

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -911,11 +911,11 @@ class Circuit:
         Raises:
             ValueError: Bad insertion strategy.
         """
-        moments_and_operations = list(ops.flatten_op_tree(
-            ops.transform_op_tree(moment_or_operation_tree,
-                                  self._device.decompose_operation,
-                                  preserve_moments=True),
-            preserve_moments=True))
+        moments_and_operations = list(
+            ops.flatten_to_ops_or_moments(
+                ops.transform_op_tree(moment_or_operation_tree,
+                                      self._device.decompose_operation,
+                                      preserve_moments=True),))
 
         for moment_or_op in moments_and_operations:
             if isinstance(moment_or_op, ops.Moment):
@@ -967,15 +967,15 @@ class Circuit:
             raise IndexError('Bad insert indices: [{}, {})'.format(
                 start, end))
 
-        operations = list(ops.flatten_op_tree(operations))
-        for op in operations:
+        flat_ops = list(ops.flatten_to_ops(operations))
+        for op in flat_ops:
             self._device.validate_operation(op)
-        self._validate_op_tree_qids(operations)
+        self._validate_op_tree_qids(flat_ops)
 
         i = start
         op_index = 0
-        while op_index < len(operations):
-            op = operations[op_index]
+        while op_index < len(flat_ops):
+            op = flat_ops[op_index]
             while i < end and not self._device.can_add_operation_into_moment(
                     op, self._moments[i]):
                 i += 1
@@ -984,10 +984,10 @@ class Circuit:
             self._moments[i] = self._moments[i].with_operation(op)
             op_index += 1
 
-        if op_index >= len(operations):
+        if op_index >= len(flat_ops):
             return end
 
-        return self.insert(end, operations[op_index:])
+        return self.insert(end, flat_ops[op_index:])
 
     @staticmethod
     def _pick_inserted_ops_moment_indices(
@@ -1107,10 +1107,10 @@ class Circuit:
         """
         if frontier is None:
             frontier = defaultdict(lambda: 0)
-        operations = tuple(ops.flatten_op_tree(operations))
-        if not operations:
+        flat_ops = tuple(ops.flatten_to_ops(operations))
+        if not flat_ops:
             return frontier
-        qubits = set(q for op in operations for q in op.qubits)
+        qubits = set(q for op in flat_ops for q in op.qubits)
         if any(frontier[q] > start for q in qubits):
             raise ValueError('The frontier for qubits on which the operations'
                              'to insert act cannot be after start.')
@@ -1118,11 +1118,11 @@ class Circuit:
         next_moments = self.next_moments_operating_on(qubits, start)
 
         insertion_indices, _ = self._pick_inserted_ops_moment_indices(
-            operations, start, frontier)
+            flat_ops, start, frontier)
 
         self._push_frontier(frontier, next_moments)
 
-        self._insert_operations(operations, insertion_indices)
+        self._insert_operations(flat_ops, insertion_indices)
 
         return frontier
 

--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -457,25 +457,20 @@ def _random_single_q_clifford(qubit: devices.GridQubit, num_cfds: int,
                               cfds: Sequence[Sequence[ops.Gate]]
                              ) -> circuits.Circuit:
     clifford_group_size = 24
-    gate_ids = list(np.random.choice(clifford_group_size, num_cfds))
-    gate_sequence = []  # type: List[ops.Gate]
-    for gate_id in gate_ids:
-        gate_sequence.extend(cfds[gate_id])
-    gate_sequence.extend(protocols.inverse(gate_sequence))
-    circuit = circuits.Circuit.from_ops(gate(qubit) for gate in gate_sequence)
-    return circuit
+    idxs = np.random.choice(clifford_group_size, num_cfds)
+    circuit = circuits.Circuit.from_ops(
+        gate(qubit) for idx in idxs for gate in cfds[idx])
+    return circuit + protocols.inverse(circuit)
 
 
 def _random_two_q_clifford(q_0: devices.GridQubit, q_1: devices.GridQubit,
                            num_cfds: int,
                            cliffords: Cliffords) -> circuits.Circuit:
     clifford_group_size = 11520
-    idx_list = list(np.random.choice(clifford_group_size, num_cfds))
-    circuit = circuits.Circuit()
-    for idx in idx_list:
-        circuit.append(_two_qubit_clifford(q_0, q_1, idx, cliffords))
-    circuit.append(protocols.inverse(circuit))
-    return circuit
+    idxs = np.random.choice(clifford_group_size, num_cfds)
+    circuit = circuits.Circuit.from_ops(
+        _two_qubit_clifford(q_0, q_1, idx, cliffords) for idx in idxs)
+    return circuit + protocols.inverse(circuit)
 
 
 def _matrix_bar_plot(mat: np.ndarray,

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -136,6 +136,8 @@ from cirq.ops.named_qubit import (
 from cirq.ops.op_tree import (
     flatten_op_tree,
     freeze_op_tree,
+    flatten_to_ops,
+    flatten_to_ops_or_moments,
     OP_TREE,
     transform_op_tree,
 )

--- a/cirq/ops/op_tree_test.py
+++ b/cirq/ops/op_tree_test.py
@@ -44,11 +44,12 @@ def test_flatten_op_tree():
                                       operations[5:]))) == operations
 
     # Don't flatten moment.
-    assert list(cirq.flatten_op_tree((operations[0],
-                                      cirq.Moment(operations[1:5]),
-                                      operations[5:]), preserve_moments=True)
-                ) == ([operations[0], cirq.Moment(operations[1:5])]
-                      + operations[5:])
+    assert list(
+        cirq.flatten_to_ops_or_moments([
+            operations[0],
+            cirq.Moment(operations[1:5]),
+            operations[5:],
+        ])) == [operations[0], cirq.Moment(operations[1:5])] + operations[5:]
 
     # Bad trees.
     with pytest.raises(TypeError):

--- a/cirq/ops/op_tree_test.py
+++ b/cirq/ops/op_tree_test.py
@@ -43,14 +43,6 @@ def test_flatten_op_tree():
                                       cirq.Moment(operations[1:5]),
                                       operations[5:]))) == operations
 
-    # Don't flatten moment.
-    assert list(
-        cirq.flatten_to_ops_or_moments([
-            operations[0],
-            cirq.Moment(operations[1:5]),
-            operations[5:],
-        ])) == [operations[0], cirq.Moment(operations[1:5])] + operations[5:]
-
     # Bad trees.
     with pytest.raises(TypeError):
         _ = list(cirq.flatten_op_tree(None))
@@ -58,6 +50,29 @@ def test_flatten_op_tree():
         _ = list(cirq.flatten_op_tree(5))
     with pytest.raises(TypeError):
         _ = list(cirq.flatten_op_tree([operations[0], (4,)]))
+
+
+def test_flatten_to_ops_or_moments():
+    operations = [
+        cirq.GateOperation(cirq.SingleQubitGate(), [cirq.NamedQubit(str(i))])
+        for i in range(10)
+    ]
+    op_tree = [
+        operations[0],
+        cirq.Moment(operations[1:5]),
+        operations[5:],
+    ]
+    output = [operations[0], cirq.Moment(operations[1:5])] + operations[5:]
+    assert list(cirq.flatten_to_ops_or_moments(op_tree)) == output
+    assert list(cirq.flatten_op_tree(op_tree, preserve_moments=True)) == output
+
+    # Bad trees.
+    with pytest.raises(TypeError):
+        _ = list(cirq.flatten_to_ops_or_moments(None))
+    with pytest.raises(TypeError):
+        _ = list(cirq.flatten_to_ops_or_moments(5))
+    with pytest.raises(TypeError):
+        _ = list(cirq.flatten_to_ops_or_moments([operations[0], (4,)]))
 
 
 def test_freeze_op_tree():


### PR DESCRIPTION
Defining OP_TREE using a protocol lets us create a recursive type, which is not possible with type aliases alone. This means downstream operations can preserve more type information, which is good but reveals a problem with `flatten_op_tree` returning a Union type due to the `preserve_moments` option. To work around this I've split it up into two functions instead. Another possibility would be to remove the `preserve_moments` option on `flatten_op_tree` and just add a second function for the non-default case (which is a tiny minority of callsites).