### PR TITLE
Delete repeated `Product` import in `study/__init__.py`

### DIFF
--- a/cirq/study/__init__.py
+++ b/cirq/study/__init__.py
@@ -40,7 +40,6 @@ from cirq.study.sweepable import (
 from cirq.study.sweeps import (
     Linspace,
     ListSweep,
-    Product,
     Points,
     Product,
     Sweep,


### PR DESCRIPTION
Remove a repeated import for the `Product` class defined in `study/sweeps.py`. 