### PR TITLE
 Refactor Circuit.__init__ to accept an OP_TREE 

### DIFF
--- a/cirq/aqt/aqt_sampler.py
+++ b/cirq/aqt/aqt_sampler.py
@@ -157,8 +157,8 @@ class AQTSampler(Sampler):
             resolver.
         """
         meas_name = 'm'  # TODO: Get measurement name from circuit
-        circuit = (program if isinstance(program, circuits.Circuit) else
-                   program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
         assert isinstance(circuit.device, IonDevice)
         trial_results = []  # type: List[study.TrialResult]
         for param_resolver in study.to_resolvers(params):

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -93,19 +93,44 @@ class Circuit:
         circuit[1:7] = [Moment(...)]
     """
 
+    @deprecated_parameter(
+        deadline='v0.8',
+        fix='Pass contents positionally or using the "contents=" keyword.',
+        func_name='cirq.Circuit',
+        parameter_desc='moments keyword',
+        match=lambda args, kwargs: 'moments' in kwargs,
+        rewrite=lambda args, kwargs: (args + (kwargs[
+            'moments'],), {k: v for k, v in kwargs.items() if k != 'moments'}))
+    @deprecated_parameter(
+        deadline='v0.8',
+        fix='Pass the device using the "device=" keyword.',
+        func_name='cirq.Circuit',
+        parameter_desc='positional device',
+        match=lambda args, kwargs: len(args) == 3 and isinstance(
+            args[2], devices.Device),
+        rewrite=lambda args, kwargs: (
+            args[:2], dict(list(kwargs.items()) + [('device', args[2])])))
     def __init__(self,
-                 moments: Iterable['cirq.Moment'] = (),
-                 device: devices.Device = devices.UNCONSTRAINED_DEVICE) -> None:
+                 *contents: 'cirq.OP_TREE',
+                 strategy: 'cirq.InsertStrategy' = InsertStrategy.EARLIEST,
+                 device: 'cirq.Device' = devices.UNCONSTRAINED_DEVICE) -> None:
         """Initializes a circuit.
 
         Args:
-            moments: The initial list of moments defining the circuit.
+            contents: The initial list of moments and operations defining the
+                circuit. You can also pass in operations, lists of operations,
+                or generally anything meeting the `cirq.OP_TREE` contract.
+                Non-moment entries will be inserted according to the specified
+                insertion strategy.
+            strategy: When initializing the circuit with operations and moments
+                from `contents`, this determines how the operations are packed
+                together. This option does not affect later insertions into the
+                circuit.
             device: Hardware that the circuit should be able to run on.
         """
-        self._moments = list(moments)
+        self._moments: List['cirq.Moment'] = []
         self._device = device
-        self._device.validate_circuit(self)
-        self._validate_op_tree_qids(self)
+        self.append(contents, strategy=strategy)
 
     @property
     def device(self) -> devices.Device:
@@ -139,7 +164,7 @@ class Circuit:
         return self.copy()
 
     def copy(self) -> 'Circuit':
-        return Circuit(self._moments, self._device)
+        return Circuit(self._moments, device=self._device)
 
     def __bool__(self):
         return bool(self._moments)
@@ -183,7 +208,7 @@ class Circuit:
 
     def __getitem__(self, key):
         if isinstance(key, slice):
-            return Circuit(self._moments[key], self.device)
+            return Circuit(self._moments[key], device=self.device)
         if isinstance(key, int):
             return self._moments[key]
 
@@ -234,7 +259,7 @@ class Circuit:
         if device != device_2:
             raise ValueError("Can't add circuits with incompatible devices.")
 
-        result = Circuit(moments=self._moments, device=device)
+        result = Circuit(self._moments, device=device)
         return result.__iadd__(other)
 
     def __imul__(self, repetitions: int):
@@ -283,10 +308,9 @@ class Circuit:
 
         moment_str = _list_repr_with_indented_item_lines(self._moments)
         if self._device == devices.UNCONSTRAINED_DEVICE:
-            return 'cirq.Circuit(moments={})'.format(moment_str)
+            return 'cirq.Circuit({})'.format(moment_str)
 
-        return 'cirq.Circuit(moments={}, device={!r})'.format(moment_str,
-                                                              self._device)
+        return 'cirq.Circuit({}, device={!r})'.format(moment_str, self._device)
 
     def __str__(self):
         return self.to_text_diagram()
@@ -308,12 +332,13 @@ class Circuit:
         Returns:
             The translated circuit.
         """
-        return Circuit(
-            moments=[ops.Moment(operation.transform_qubits(qubit_mapping)
-                            for operation in moment.operations)
-                     for moment in self._moments],
-            device=new_device
-        )
+        return Circuit([
+            ops.Moment(
+                operation.transform_qubits(qubit_mapping)
+                for operation in moment.operations)
+            for moment in self._moments
+        ],
+                       device=new_device)
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:
         """Print ASCII diagram in Jupyter."""
@@ -1621,6 +1646,10 @@ class Circuit:
 
     def _json_dict_(self):
         return protocols.obj_to_dict_helper(self, ['moments', 'device'])
+
+    @classmethod
+    def _from_json_dict_(cls, moments, device, **kwargs):
+        return cls(moments, device=device)
 
     def with_noise(self, noise: devices.NoiseModel) -> 'cirq.Circuit':
         """Make a noisy version of the circuit.

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -255,7 +255,7 @@ def test_repr():
         cirq.Moment([cirq.CZ(a, b)]),
     ])
     cirq.testing.assert_equivalent_repr(c)
-    assert repr(c) == """cirq.Circuit(moments=[
+    assert repr(c) == """cirq.Circuit([
     cirq.Moment(operations=[
         cirq.H.on(cirq.NamedQubit('a')),
         cirq.H.on(cirq.NamedQubit('b')),
@@ -272,7 +272,7 @@ def test_repr():
 
     c = cirq.Circuit.from_ops(cirq.Z(cirq.GridQubit(0, 0)), device=cg.Foxtail)
     cirq.testing.assert_equivalent_repr(c)
-    assert repr(c) == """cirq.Circuit(moments=[
+    assert repr(c) == """cirq.Circuit([
     cirq.Moment(operations=[
         cirq.Z.on(cirq.GridQubit(0, 0)),
     ]),
@@ -1520,6 +1520,17 @@ def test_qid_shape_qudit():
     assert circuit.qid_shape()
     with pytest.raises(ValueError, match='extra qubits'):
         _ = circuit.qid_shape(qubit_order=[b, c])
+
+
+def test_deprecated_circuit_init_parameter_positional_device():
+    c = cirq.Circuit([], cirq.UNCONSTRAINED_DEVICE)
+    assert c == cirq.Circuit(device=cirq.UNCONSTRAINED_DEVICE)
+
+
+def test_deprecated_circuit_init_parameter_moments_keywords():
+    a = cirq.LineQubit(0)
+    c = cirq.Circuit(moments=[cirq.X(a)])
+    assert c == cirq.Circuit(cirq.X(a))
 
 
 def test_from_ops():

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1529,7 +1529,9 @@ def test_deprecated_circuit_init_parameter_positional_device():
 
 def test_deprecated_circuit_init_parameter_moments_keywords():
     a = cirq.LineQubit(0)
+    # pylint: disable=unexpected-keyword-arg
     c = cirq.Circuit(moments=[cirq.X(a)])
+    # pylint: enable=unexpected-keyword-arg
     assert c == cirq.Circuit(cirq.X(a))
 
 

--- a/cirq/contrib/graph_device/graph_device_test.py
+++ b/cirq/contrib/graph_device/graph_device_test.py
@@ -158,7 +158,7 @@ def test_graph_device():
         [cirq.CNOT(qubits[0], qubits[3]),
          cirq.CZ(qubits[1], qubits[2])])
     graph_device.validate_moment(moment)
-    circuit = cirq.Circuit([moment], graph_device)
+    circuit = cirq.Circuit(moment, device=graph_device)
     schedule = cirq.moment_by_moment_schedule(graph_device, circuit)
     assert graph_device.validate_schedule(schedule) is None
 

--- a/cirq/google/api/v2/results.py
+++ b/cirq/google/api/v2/results.py
@@ -49,8 +49,10 @@ def find_measurements(program: Union[circuits.Circuit, schedules.Schedule],
 
     if isinstance(program, circuits.Circuit):
         measure_iter = _circuit_measurements(program)
-    else:
+    elif isinstance(program, schedules.Schedule):
         measure_iter = _schedule_measurements(program)
+    else:
+        raise NotImplementedError(f'Unrecognized program type: {type(program)}')
 
     for m in measure_iter:
         if m.key in keys:

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -99,8 +99,11 @@ class SerializableGateSet:
         msg.language.gate_set = self.gate_set_name
         if isinstance(program, circuits.Circuit):
             self._serialize_circuit(program, msg.circuit)
-        else:
+        elif isinstance(program, schedules.Schedule):
             self._serialize_schedule(program, msg.schedule)
+        else:
+            raise NotImplementedError(
+                f'Unrecognized program type: {type(program)}')
         return msg
 
     def serialize_op_dict(self, op: 'cirq.Operation') -> Dict:

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -173,6 +173,11 @@ def test_deserialize_empty_moment():
     assert MY_GATE_SET.deserialize_dict(proto) == circuit
 
 
+def test_serialize_unrecognized():
+    with pytest.raises(NotImplementedError, match='program type'):
+        MY_GATE_SET.serialize("not quite right")
+
+
 def test_serialize_deserialize_schedule():
     q0 = cirq.GridQubit(1, 1)
     q1 = cirq.GridQubit(1, 2)

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -373,8 +373,8 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
             List of ComputeDisplaysResults for this run, one for each
             possible parameter resolver.
         """
-        circuit = (program if isinstance(program, circuits.Circuit) else
-                   program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
         qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)
         qubits = qubit_order.order_for(circuit.all_qubits())
 

--- a/cirq/sim/mux.py
+++ b/cirq/sim/mux.py
@@ -124,7 +124,7 @@ def final_wavefunction(
             "Program: {!r}".format(program))
 
     result = sparse_simulator.Simulator(dtype=dtype, seed=seed).simulate(
-        program=program,
+        program=cast(Union[circuits.Circuit, schedules.Schedule], program),
         initial_state=initial_state,
         qubit_order=qubit_order,
         param_resolver=param_resolver)
@@ -165,8 +165,8 @@ def sample_sweep(
     """
     if seed:
         np.random.seed(seed)
-    circuit = (program if isinstance(program, circuits.Circuit) else
-               program.to_circuit())
+    circuit = (program.to_circuit()
+               if isinstance(program, schedules.Schedule) else program)
 
     trial_results = []  # type: List[study.TrialResult]
     for param_resolver in study.to_resolvers(params):

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -74,8 +74,8 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
             TrialResult list for this run; one for each possible parameter
             resolver.
         """
-        circuit = (program if isinstance(program, circuits.Circuit)
-                   else program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
         if not circuit.has_measurements():
             raise ValueError("Circuit has no measurements to sample.")
 
@@ -148,8 +148,8 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
             List of ComputeDisplaysResults for this run, one for each
             possible parameter resolver.
         """
-        circuit = (program if isinstance(program, circuits.Circuit) else
-                   program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
 
         compute_displays_results = []  # type: List[study.ComputeDisplaysResult]
         for param_resolver in study.to_resolvers(params):
@@ -359,8 +359,8 @@ class SimulatesIntermediateState(SimulatesFinalState, metaclass=abc.ABCMeta):
             List of SimulationTrialResults for this run, one for each
             possible parameter resolver.
         """
-        circuit = (program if isinstance(program, circuits.Circuit) else
-                   program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
 
         trial_results = []
         qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)

--- a/cirq/sim/wave_function_simulator.py
+++ b/cirq/sim/wave_function_simulator.py
@@ -123,8 +123,8 @@ class SimulatesIntermediateWaveFunction(simulator.SimulatesAmplitudes,
             List of ComputeDisplaysResults for this run, one for each
             possible parameter resolver.
         """
-        circuit = (program if isinstance(program, circuits.Circuit) else
-                   program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
         qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)
         qubits = qubit_order.order_for(circuit.all_qubits())
 
@@ -174,8 +174,8 @@ class SimulatesIntermediateWaveFunction(simulator.SimulatesAmplitudes,
                              '1-dimensional array of ints. Got an array with '
                              f'shape {bitstrings.shape}.')
 
-        circuit = (program if isinstance(program, circuits.Circuit) else
-                   program.to_circuit())
+        circuit = (program.to_circuit()
+                   if isinstance(program, schedules.Schedule) else program)
         trial_results = self.simulate_sweep(circuit, params, qubit_order)
 
         # 1-dimensional tuples don't trigger advanced Numpy array indexing


### PR DESCRIPTION
- Deprecate the moments= keyword and the positional device parameter
- Add a strategy= keyword

To check for deprecated usage within the library, I ran the tests once without the `@deprecated` annotations, which would cause exceptions instead of printed warnings when it was used wrong.

Part of #1787
Will follow up with PRs switching usage of `from_ops` to `Circuit`, then deprecating `from_ops`