### PR TITLE
Replace usage of cirq.Circuit.from_ops(...) with cirq.Circuit(...) in contrib

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -93,19 +93,44 @@ class Circuit:
         circuit[1:7] = [Moment(...)]
     """
 
+    @deprecated_parameter(
+        deadline='v0.8',
+        fix='Pass contents positionally or using the "contents=" keyword.',
+        func_name='cirq.Circuit',
+        parameter_desc='moments keyword',
+        match=lambda args, kwargs: 'moments' in kwargs,
+        rewrite=lambda args, kwargs: (args + (kwargs[
+            'moments'],), {k: v for k, v in kwargs.items() if k != 'moments'}))
+    @deprecated_parameter(
+        deadline='v0.8',
+        fix='Pass the device using the "device=" keyword.',
+        func_name='cirq.Circuit',
+        parameter_desc='positional device',
+        match=lambda args, kwargs: len(args) == 3 and isinstance(
+            args[2], devices.Device),
+        rewrite=lambda args, kwargs: (
+            args[:2], dict(list(kwargs.items()) + [('device', args[2])])))
     def __init__(self,
-                 moments: Iterable['cirq.Moment'] = (),
-                 device: devices.Device = devices.UNCONSTRAINED_DEVICE) -> None:
+                 *contents: 'cirq.OP_TREE',
+                 strategy: 'cirq.InsertStrategy' = InsertStrategy.EARLIEST,
+                 device: 'cirq.Device' = devices.UNCONSTRAINED_DEVICE) -> None:
         """Initializes a circuit.
 
         Args:
-            moments: The initial list of moments defining the circuit.
+            contents: The initial list of moments and operations defining the
+                circuit. You can also pass in operations, lists of operations,
+                or generally anything meeting the `cirq.OP_TREE` contract.
+                Non-moment entries will be inserted according to the specified
+                insertion strategy.
+            strategy: When initializing the circuit with operations and moments
+                from `contents`, this determines how the operations are packed
+                together. This option does not affect later insertions into the
+                circuit.
             device: Hardware that the circuit should be able to run on.
         """
-        self._moments = list(moments)
+        self._moments: List['cirq.Moment'] = []
         self._device = device
-        self._device.validate_circuit(self)
-        self._validate_op_tree_qids(self)
+        self.append(contents, strategy=strategy)
 
     @property
     def device(self) -> devices.Device:
@@ -139,7 +164,7 @@ class Circuit:
         return self.copy()
 
     def copy(self) -> 'Circuit':
-        return Circuit(self._moments, self._device)
+        return Circuit(self._moments, device=self._device)
 
     def __bool__(self):
         return bool(self._moments)
@@ -183,7 +208,7 @@ class Circuit:
 
     def __getitem__(self, key):
         if isinstance(key, slice):
-            return Circuit(self._moments[key], self.device)
+            return Circuit(self._moments[key], device=self.device)
         if isinstance(key, int):
             return self._moments[key]
 
@@ -234,7 +259,7 @@ class Circuit:
         if device != device_2:
             raise ValueError("Can't add circuits with incompatible devices.")
 
-        result = Circuit(moments=self._moments, device=device)
+        result = Circuit(self._moments, device=device)
         return result.__iadd__(other)
 
     def __imul__(self, repetitions: int):
@@ -283,10 +308,9 @@ class Circuit:
 
         moment_str = _list_repr_with_indented_item_lines(self._moments)
         if self._device == devices.UNCONSTRAINED_DEVICE:
-            return 'cirq.Circuit(moments={})'.format(moment_str)
+            return 'cirq.Circuit({})'.format(moment_str)
 
-        return 'cirq.Circuit(moments={}, device={!r})'.format(moment_str,
-                                                              self._device)
+        return 'cirq.Circuit({}, device={!r})'.format(moment_str, self._device)
 
     def __str__(self):
         return self.to_text_diagram()
@@ -308,12 +332,13 @@ class Circuit:
         Returns:
             The translated circuit.
         """
-        return Circuit(
-            moments=[ops.Moment(operation.transform_qubits(qubit_mapping)
-                            for operation in moment.operations)
-                     for moment in self._moments],
-            device=new_device
-        )
+        return Circuit([
+            ops.Moment(
+                operation.transform_qubits(qubit_mapping)
+                for operation in moment.operations)
+            for moment in self._moments
+        ],
+                       device=new_device)
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:
         """Print ASCII diagram in Jupyter."""
@@ -1621,6 +1646,10 @@ class Circuit:
 
     def _json_dict_(self):
         return protocols.obj_to_dict_helper(self, ['moments', 'device'])
+
+    @classmethod
+    def _from_json_dict_(cls, moments, device, **kwargs):
+        return cls(moments, device=device)
 
     def with_noise(self, noise: devices.NoiseModel) -> 'cirq.Circuit':
         """Make a noisy version of the circuit.

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -255,7 +255,7 @@ def test_repr():
         cirq.Moment([cirq.CZ(a, b)]),
     ])
     cirq.testing.assert_equivalent_repr(c)
-    assert repr(c) == """cirq.Circuit(moments=[
+    assert repr(c) == """cirq.Circuit([
     cirq.Moment(operations=[
         cirq.H.on(cirq.NamedQubit('a')),
         cirq.H.on(cirq.NamedQubit('b')),
@@ -272,7 +272,7 @@ def test_repr():
 
     c = cirq.Circuit.from_ops(cirq.Z(cirq.GridQubit(0, 0)), device=cg.Foxtail)
     cirq.testing.assert_equivalent_repr(c)
-    assert repr(c) == """cirq.Circuit(moments=[
+    assert repr(c) == """cirq.Circuit([
     cirq.Moment(operations=[
         cirq.Z.on(cirq.GridQubit(0, 0)),
     ]),
@@ -1520,6 +1520,17 @@ def test_qid_shape_qudit():
     assert circuit.qid_shape()
     with pytest.raises(ValueError, match='extra qubits'):
         _ = circuit.qid_shape(qubit_order=[b, c])
+
+
+def test_deprecated_circuit_init_parameter_positional_device():
+    c = cirq.Circuit([], cirq.UNCONSTRAINED_DEVICE)
+    assert c == cirq.Circuit(device=cirq.UNCONSTRAINED_DEVICE)
+
+
+def test_deprecated_circuit_init_parameter_moments_keywords():
+    a = cirq.LineQubit(0)
+    c = cirq.Circuit(moments=[cirq.X(a)])
+    assert c == cirq.Circuit(cirq.X(a))
 
 
 def test_from_ops():

--- a/cirq/contrib/acquaintance/bipartite_test.py
+++ b/cirq/contrib/acquaintance/bipartite_test.py
@@ -225,7 +225,7 @@ circuit_diagrams = {
 def test_circuit_diagrams(part_size, subgraph):
     qubits = cirq.LineQubit.range(2 * part_size)
     gate = cca.BipartiteSwapNetworkGate(subgraph, part_size)
-    circuit = cirq.Circuit.from_ops(gate(*qubits))
+    circuit = cirq.Circuit(gate(*qubits))
     diagram = circuit_diagrams['undecomposed', subgraph, part_size]
     cirq.testing.assert_has_diagram(circuit, diagram)
 

--- a/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq/contrib/acquaintance/executor_test.py
@@ -57,12 +57,12 @@ def test_executor_explicit():
         executor(cirq.Circuit())
 
     with pytest.raises(TypeError):
-        bad_strategy = cirq.Circuit.from_ops(cirq.X(qubits[0]))
+        bad_strategy = cirq.Circuit(cirq.X(qubits[0]))
         executor(bad_strategy)
 
     with pytest.raises(TypeError):
         op = cirq.X(qubits[0])
-        bad_strategy = cirq.Circuit.from_ops(op)
+        bad_strategy = cirq.Circuit(op)
         executor.optimization_at(bad_strategy, 0, op)
 
     executor(circuit)
@@ -130,7 +130,7 @@ def test_diagonal_gate():
 
     qubits = cirq.LineQubit.range(2)
     gate = DiagonalGate.random(2)
-    circuit = cirq.Circuit.from_ops([gate(*qubits)])
+    circuit = cirq.Circuit([gate(*qubits)])
     actual_text_diagram = circuit.to_text_diagram()
     expected_text_diagram = """
 0: ───Diag───
@@ -165,7 +165,7 @@ def test_executor_random(num_qubits: int,
     qubits = cirq.LineQubit.range(num_qubits)
     circuit = cca.complete_acquaintance_strategy(qubits, acquaintance_size)
 
-    logical_circuit = cirq.Circuit.from_ops([g(*Q) for Q, g in gates.items()])
+    logical_circuit = cirq.Circuit([g(*Q) for Q, g in gates.items()])
     expected_unitary = logical_circuit.unitary()
 
     initial_mapping = {q: q for q in qubits}

--- a/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq/contrib/acquaintance/gates_test.py
@@ -58,7 +58,7 @@ def test_swap_network_gate():
     n_qubits = sum(part_lens)
     swap_network_op = cca.SwapNetworkGate(part_lens,
         acquaintance_size=acquaintance_size)(*qubits[:n_qubits])
-    swap_network = cirq.Circuit.from_ops(swap_network_op)
+    swap_network = cirq.Circuit(swap_network_op)
     expected_text_diagram = """
 a: ───×(0,0)───
       │
@@ -102,7 +102,7 @@ f: ─────────────────█───────�
     n_qubits = sum(part_lens)
     swap_network_op = cca.SwapNetworkGate(part_lens,
         acquaintance_size=acquaintance_size)(*qubits[:n_qubits])
-    swap_network = cirq.Circuit.from_ops(swap_network_op)
+    swap_network = cirq.Circuit(swap_network_op)
 
     expander(swap_network)
     expected_text_diagram = """
@@ -132,8 +132,8 @@ def test_acquaint_part_pairs(part_lens):
     qubits = cirq.LineQubit.range(n_qubits)
     swap_network_op = cca.SwapNetworkGate(
         part_lens, acquaintance_size=None)(*qubits)
-    swap_network = cirq.Circuit.from_ops(
-            swap_network_op, device=cca.UnconstrainedAcquaintanceDevice)
+    swap_network = cirq.Circuit(swap_network_op,
+                                device=cca.UnconstrainedAcquaintanceDevice)
     initial_mapping = {q: i for i, q in enumerate(qubits)}
 
     actual_opps = cca.get_logical_acquaintance_opportunities(
@@ -177,7 +177,7 @@ def test_swap_network_gate_from_ops():
     swap_network = cca.SwapNetworkGate.from_operations(qubits, operations,
                                                        acquaintance_size,
                                                        cirq.ZZ)
-    circuit = cirq.Circuit.from_ops(swap_network(*qubits))
+    circuit = cirq.Circuit(swap_network(*qubits))
     cca.DECOMPOSE_PERMUTATION_GATES(circuit)
 
     expected_diagram = """
@@ -198,7 +198,7 @@ def test_swap_network_decomposition():
     qubits = cirq.LineQubit.range(8)
     swap_network_gate = cca.SwapNetworkGate((4, 4), 5)
     operations = cirq.decompose_once_with_qubits(swap_network_gate, qubits)
-    circuit = cirq.Circuit.from_ops(operations)
+    circuit = cirq.Circuit(operations)
     expected_text_diagram = """
 0: ───█─────────────█─────────────╲0╱─────────────█─────────█───────0↦2───
       │             │             │               │         │       │

--- a/cirq/contrib/acquaintance/mutation_utils_test.py
+++ b/cirq/contrib/acquaintance/mutation_utils_test.py
@@ -149,8 +149,8 @@ def test_rectification():
         cca.acquaint(*qubits[:2]), perm_gate(*qubits[2:])
         ]
 
-    strategy = cirq.Circuit.from_ops(
-            operations, device=cca.UnconstrainedAcquaintanceDevice)
+    strategy = cirq.Circuit(operations,
+                            device=cca.UnconstrainedAcquaintanceDevice)
     cca.rectify_acquaintance_strategy(strategy)
     actual_text_diagram = strategy.to_text_diagram().strip()
     expected_text_diagram = """
@@ -164,8 +164,8 @@ def test_rectification():
     """.strip()
     assert actual_text_diagram == expected_text_diagram
 
-    strategy = cirq.Circuit.from_ops(
-            operations, device=cca.UnconstrainedAcquaintanceDevice)
+    strategy = cirq.Circuit(operations,
+                            device=cca.UnconstrainedAcquaintanceDevice)
     cca.rectify_acquaintance_strategy(strategy, False)
     actual_text_diagram = strategy.to_text_diagram()
     expected_text_diagram = """

--- a/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq/contrib/acquaintance/optimizers_test.py
@@ -25,11 +25,11 @@ def test_remove_redundant_acquaintance_opportunities():
 
     with pytest.raises(TypeError):
         ops = [cca.acquaint(a, b)]
-        strategy = cirq.Circuit.from_ops(ops)
+        strategy = cirq.Circuit(ops)
         cca.remove_redundant_acquaintance_opportunities(strategy)
 
     ops = [cca.acquaint(a, b), cca.acquaint(a, b)]
-    strategy = cirq.Circuit.from_ops(ops, device=device)
+    strategy = cirq.Circuit(ops, device=device)
     diagram_before = """
 0: ───█───█───
       │   │
@@ -49,7 +49,7 @@ def test_remove_redundant_acquaintance_opportunities():
     ops = [
             cca.acquaint(a, b), cca.acquaint(c, d),
             swap(d, e), swap(c, d), cca.acquaint(d, e)]
-    strategy = cirq.Circuit.from_ops(ops, device=device)
+    strategy = cirq.Circuit(ops, device=device)
     diagram_before = """
 0: ───█───────────────────
       │

--- a/cirq/contrib/acquaintance/permutation_test.py
+++ b/cirq/contrib/acquaintance/permutation_test.py
@@ -28,7 +28,7 @@ def test_swap_permutation_gate():
     expander = cirq.ExpandComposite(no_decomp=no_decomp)
     gate = cca.SwapPermutationGate()
     assert gate.num_qubits() == 2
-    circuit = cirq.Circuit.from_ops(gate(a, b))
+    circuit = cirq.Circuit(gate(a, b))
     expander(circuit)
     assert tuple(circuit.all_operations()) == (cirq.SWAP(a, b),)
 
@@ -36,7 +36,7 @@ def test_swap_permutation_gate():
     no_decomp = lambda op: (isinstance(op, cirq.GateOperation) and
                             op.gate == cirq.CZ)
     expander = cirq.ExpandComposite(no_decomp=no_decomp)
-    circuit = cirq.Circuit.from_ops(cca.SwapPermutationGate(cirq.CZ)(a, b))
+    circuit = cirq.Circuit(cca.SwapPermutationGate(cirq.CZ)(a, b))
     expander(circuit)
     assert tuple(circuit.all_operations()) == (cirq.CZ(a, b),)
 
@@ -63,7 +63,7 @@ def test_validate_permutation_errors():
 def test_diagram():
     gate = cca.SwapPermutationGate()
     a, b = cirq.NamedQubit('a'), cirq.NamedQubit('b')
-    circuit = cirq.Circuit.from_ops([gate(a, b)])
+    circuit = cirq.Circuit([gate(a, b)])
     actual_text_diagram = circuit.to_text_diagram()
     expected_text_diagram = """
 a: ───0↦1───
@@ -270,7 +270,7 @@ def test_display_mapping():
 
 
 @pytest.mark.parametrize('circuit', [
-    cirq.Circuit.from_ops(
+    cirq.Circuit(
         cca.SwapPermutationGate()(*qubit_pair)
         for qubit_pair in
         [random.sample(cirq.LineQubit.range(10), 2)
@@ -288,18 +288,18 @@ def test_return_to_initial_mapping(circuit):
 
 def test_uses_consistent_swap_gate():
     a, b = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         [cca.SwapPermutationGate()(a, b),
          cca.SwapPermutationGate()(a, b)])
     assert cca.uses_consistent_swap_gate(circuit, cirq.SWAP)
     assert not cca.uses_consistent_swap_gate(circuit, cirq.CZ)
-    circuit = cirq.Circuit.from_ops([
+    circuit = cirq.Circuit([
         cca.SwapPermutationGate(cirq.CZ)(a, b),
         cca.SwapPermutationGate(cirq.CZ)(a, b)
     ])
     assert cca.uses_consistent_swap_gate(circuit, cirq.CZ)
     assert not cca.uses_consistent_swap_gate(circuit, cirq.SWAP)
-    circuit = cirq.Circuit.from_ops([
+    circuit = cirq.Circuit([
         cca.SwapPermutationGate()(a, b),
         cca.SwapPermutationGate(cirq.CZ)(a, b)
     ])

--- a/cirq/contrib/acquaintance/shift_swap_network_test.py
+++ b/cirq/contrib/acquaintance/shift_swap_network_test.py
@@ -34,8 +34,8 @@ def test_shift_swap_network_gate_acquaintance_opps(
     gate = cca.ShiftSwapNetworkGate(left_part_lens, right_part_lens)
     n_qubits = gate.qubit_count()
     qubits = cirq.LineQubit.range(n_qubits)
-    strategy = cirq.Circuit.from_ops(gate(*qubits),
-            device=cca.UnconstrainedAcquaintanceDevice)
+    strategy = cirq.Circuit(gate(*qubits),
+                            device=cca.UnconstrainedAcquaintanceDevice)
 
     # actual_opps
     initial_mapping = {q: i for i, q in enumerate(qubits)}
@@ -184,7 +184,7 @@ def test_shift_swap_network_gate_diagrams(
     gate = cca.ShiftSwapNetworkGate(left_part_lens, right_part_lens)
     n_qubits = gate.qubit_count()
     qubits = cirq.LineQubit.range(n_qubits)
-    circuit = cirq.Circuit.from_ops(gate(*qubits))
+    circuit = cirq.Circuit(gate(*qubits))
 
     diagram = circuit_diagrams['undecomposed', left_part_lens, right_part_lens]
     cirq.testing.assert_has_diagram(circuit, diagram)

--- a/cirq/contrib/acquaintance/shift_test.py
+++ b/cirq/contrib/acquaintance/shift_test.py
@@ -57,7 +57,7 @@ def test_circular_shift_gate_decomposition():
 
     expander = cirq.ExpandComposite()
     circular_shift = cca.CircularShiftGate(2, 1, cirq.CZ)(*qubits[:2])
-    circuit = cirq.Circuit.from_ops(circular_shift)
+    circuit = cirq.Circuit(circular_shift)
     expander.optimize_circuit(circuit)
     expected_circuit = cirq.Circuit(
             (cirq.Moment((cirq.CZ(*qubits[:2]),)),))
@@ -68,7 +68,7 @@ def test_circular_shift_gate_decomposition():
     expander = cirq.ExpandComposite(no_decomp=no_decomp)
 
     circular_shift = cca.CircularShiftGate(6, 3)(*qubits)
-    circuit = cirq.Circuit.from_ops(circular_shift)
+    circuit = cirq.Circuit(circular_shift)
     expander.optimize_circuit(circuit)
     actual_text_diagram = circuit.to_text_diagram().strip()
     expected_text_diagram = """
@@ -87,7 +87,7 @@ f: ───────────×───────────
     assert actual_text_diagram == expected_text_diagram
 
     circular_shift = cca.CircularShiftGate(6, 2)(*qubits)
-    circuit = cirq.Circuit.from_ops(circular_shift)
+    circuit = cirq.Circuit(circular_shift)
     expander.optimize_circuit(circuit)
     actual_text_diagram = circuit.to_text_diagram().strip()
     expected_text_diagram = """
@@ -108,7 +108,7 @@ f: ───────────────×───────
 
 def test_circular_shift_gate_wire_symbols():
     qubits = [cirq.NamedQubit(q) for q in 'xyz']
-    circuit = cirq.Circuit.from_ops(cca.CircularShiftGate(3, 2)(*qubits))
+    circuit = cirq.Circuit(cca.CircularShiftGate(3, 2)(*qubits))
     actual_text_diagram = circuit.to_text_diagram().strip()
     expected_text_diagram = """
 x: ───╲0╱───
@@ -128,5 +128,3 @@ y: ---\1/---
 z: ---/2\---
     """.strip()
     assert actual_text_diagram.strip() == expected_text_diagram
-
-

--- a/cirq/contrib/acquaintance/strategies/complete.py
+++ b/cirq/contrib/acquaintance/strategies/complete.py
@@ -51,12 +51,11 @@ def complete_acquaintance_strategy(qubit_order: Sequence['cirq.Qid'],
     if acquaintance_size > len(qubit_order):
         return circuits.Circuit(device=UnconstrainedAcquaintanceDevice)
     if acquaintance_size == len(qubit_order):
-        return circuits.Circuit.from_ops(
-                acquaint(*qubit_order), device=UnconstrainedAcquaintanceDevice)
+        return circuits.Circuit(acquaint(*qubit_order),
+                                device=UnconstrainedAcquaintanceDevice)
 
-    strategy = circuits.Circuit.from_ops(
-            (acquaint(q) for q in qubit_order),
-            device=UnconstrainedAcquaintanceDevice)
+    strategy = circuits.Circuit((acquaint(q) for q in qubit_order),
+                                device=UnconstrainedAcquaintanceDevice)
     for size_to_acquaint in range(2, acquaintance_size + 1):
         expose_acquaintance_gates(strategy)
         replace_acquaintance_with_swap_network(strategy, qubit_order,

--- a/cirq/contrib/acquaintance/strategies/quartic_paired.py
+++ b/cirq/contrib/acquaintance/strategies/quartic_paired.py
@@ -62,8 +62,8 @@ def quartic_paired_acquaintance_strategy(
     qubits = qubit_pairs_to_qubit_order(qubit_pairs)
     n_qubits = len(qubits)
     swap_network = SwapNetworkGate((1,) * n_qubits, 2)(*qubits)
-    strategy = circuits.Circuit.from_ops(swap_network,
-            device=UnconstrainedAcquaintanceDevice)
+    strategy = circuits.Circuit(swap_network,
+                                device=UnconstrainedAcquaintanceDevice)
     expose_acquaintance_gates(strategy)
     for i in reversed(range(0, n_qubits, 2)):
         moment = ops.Moment([acquaint(*qubits[j: j + 4])

--- a/cirq/contrib/graph_device/graph_device_test.py
+++ b/cirq/contrib/graph_device/graph_device_test.py
@@ -158,7 +158,7 @@ def test_graph_device():
         [cirq.CNOT(qubits[0], qubits[3]),
          cirq.CZ(qubits[1], qubits[2])])
     graph_device.validate_moment(moment)
-    circuit = cirq.Circuit([moment], graph_device)
+    circuit = cirq.Circuit(moment, device=graph_device)
     schedule = cirq.moment_by_moment_schedule(graph_device, circuit)
     assert graph_device.validate_schedule(schedule) is None
 

--- a/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq/contrib/paulistring/clifford_optimize.py
@@ -185,6 +185,4 @@ def clifford_optimized_circuit(circuit: circuits.Circuit,
             i -= num_rm
         i += 1
 
-    return circuits.Circuit.from_ops(
-                all_ops,
-                strategy=circuits.InsertStrategy.EARLIEST)
+    return circuits.Circuit(all_ops, strategy=circuits.InsertStrategy.EARLIEST)

--- a/cirq/contrib/paulistring/clifford_optimize_test.py
+++ b/cirq/contrib/paulistring/clifford_optimize_test.py
@@ -23,19 +23,19 @@ from cirq.contrib.paulistring import (
 
 def test_optimize():
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit.from_ops(
-        cirq.X(q1) ** 0.5,
+    c_orig = cirq.Circuit(
+        cirq.X(q1)**0.5,
         cirq.CZ(q0, q1),
-        cirq.Z(q0) ** 0.25,
-        cirq.X(q1) ** 0.25,
+        cirq.Z(q0)**0.25,
+        cirq.X(q1)**0.25,
         cirq.CZ(q0, q1),
-        cirq.X(q1) ** -0.5,
+        cirq.X(q1)**-0.5,
     )
     c_expected = converted_gate_set(
-        cirq.Circuit.from_ops(
+        cirq.Circuit(
             cirq.CZ(q0, q1),
-            cirq.Z(q0) ** 0.25,
-            cirq.X(q1) ** 0.25,
+            cirq.Z(q0)**0.25,
+            cirq.X(q1)**0.25,
             cirq.CZ(q0, q1),
         ))
 
@@ -58,15 +58,12 @@ def test_optimize():
 
 def test_remove_czs():
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit.from_ops(
+    c_orig = cirq.Circuit(
         cirq.CZ(q0, q1),
-        cirq.Z(q0) ** 0.5,
+        cirq.Z(q0)**0.5,
         cirq.CZ(q0, q1),
     )
-    c_expected = converted_gate_set(
-        cirq.Circuit.from_ops(
-            cirq.Z(q0) ** 0.5,
-        ))
+    c_expected = converted_gate_set(cirq.Circuit(cirq.Z(q0)**0.5,))
 
     c_opt = clifford_optimized_circuit(c_orig)
 
@@ -85,15 +82,12 @@ def test_remove_czs():
 
 def test_remove_staggered_czs():
     q0, q1, q2 = cirq.LineQubit.range(3)
-    c_orig = cirq.Circuit.from_ops(
+    c_orig = cirq.Circuit(
         cirq.CZ(q0, q1),
         cirq.CZ(q1, q2),
         cirq.CZ(q0, q1),
     )
-    c_expected = converted_gate_set(
-        cirq.Circuit.from_ops(
-            cirq.CZ(q1, q2),
-        ))
+    c_expected = converted_gate_set(cirq.Circuit(cirq.CZ(q1, q2),))
 
     c_opt = clifford_optimized_circuit(c_orig)
 
@@ -114,13 +108,13 @@ def test_remove_staggered_czs():
 
 def test_with_measurements():
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit.from_ops(
+    c_orig = cirq.Circuit(
         cirq.X(q0),
         cirq.CZ(q0, q1),
         cirq.measure(q0, q1, key='m'),
     )
     c_expected = converted_gate_set(
-        cirq.Circuit.from_ops(
+        cirq.Circuit(
             cirq.CZ(q0, q1),
             cirq.X(q0),
             cirq.Z(q1),

--- a/cirq/contrib/paulistring/convert_gate_set_test.py
+++ b/cirq/contrib/paulistring/convert_gate_set_test.py
@@ -40,9 +40,8 @@ from cirq.contrib.paulistring import converted_gate_set
     (cirq.measure(q0, q1, key='key'), cirq.measure(q0, q1, key='key')),
 ))(cirq.LineQubit(0), cirq.LineQubit(1)))
 def test_converts_various_ops(op, expected_ops):
-    before = cirq.Circuit.from_ops(op)
-    expected = cirq.Circuit.from_ops(expected_ops,
-                                     strategy=cirq.InsertStrategy.EARLIEST)
+    before = cirq.Circuit(op)
+    expected = cirq.Circuit(expected_ops, strategy=cirq.InsertStrategy.EARLIEST)
 
     after = converted_gate_set(before)
     assert after == expected
@@ -59,14 +58,12 @@ def test_converts_various_ops(op, expected_ops):
 def test_degenerate_single_qubit_decompose():
     q0 = cirq.LineQubit(0)
 
-    before = cirq.Circuit.from_ops(
-        cirq.Z(q0) ** 0.1,
-        cirq.X(q0) ** 1.0000000001,
-        cirq.Z(q0) ** 0.1,
+    before = cirq.Circuit(
+        cirq.Z(q0)**0.1,
+        cirq.X(q0)**1.0000000001,
+        cirq.Z(q0)**0.1,
     )
-    expected = cirq.Circuit.from_ops(
-        cirq.SingleQubitCliffordGate.X(q0),
-    )
+    expected = cirq.Circuit(cirq.SingleQubitCliffordGate.X(q0),)
 
     after = converted_gate_set(before)
     assert after == expected
@@ -81,19 +78,19 @@ def test_degenerate_single_qubit_decompose():
 def test_converts_single_qubit_series():
     q0 = cirq.LineQubit(0)
 
-    before = cirq.Circuit.from_ops(
+    before = cirq.Circuit(
         cirq.X(q0),
         cirq.Y(q0),
         cirq.Z(q0),
-        cirq.X(q0) ** 0.5,
-        cirq.Y(q0) ** 0.5,
-        cirq.Z(q0) ** 0.5,
-        cirq.X(q0) ** -0.5,
-        cirq.Y(q0) ** -0.5,
-        cirq.Z(q0) ** -0.5,
-        cirq.X(q0) ** 0.25,
-        cirq.Y(q0) ** 0.25,
-        cirq.Z(q0) ** 0.25,
+        cirq.X(q0)**0.5,
+        cirq.Y(q0)**0.5,
+        cirq.Z(q0)**0.5,
+        cirq.X(q0)**-0.5,
+        cirq.Y(q0)**-0.5,
+        cirq.Z(q0)**-0.5,
+        cirq.X(q0)**0.25,
+        cirq.Y(q0)**0.25,
+        cirq.Z(q0)**0.25,
     )
 
     after = converted_gate_set(before)
@@ -105,7 +102,7 @@ def test_converts_single_qubit_series():
 def test_converts_single_qubit_then_two():
     q0, q1 = cirq.LineQubit.range(2)
 
-    before = cirq.Circuit.from_ops(
+    before = cirq.Circuit(
         cirq.X(q0),
         cirq.Y(q0),
         cirq.CZ(q0, q1),
@@ -120,22 +117,22 @@ def test_converts_single_qubit_then_two():
 def test_converts_large_circuit():
     q0, q1, q2 = cirq.LineQubit.range(3)
 
-    before = cirq.Circuit.from_ops(
+    before = cirq.Circuit(
         cirq.X(q0),
         cirq.Y(q0),
         cirq.Z(q0),
-        cirq.X(q0) ** 0.5,
-        cirq.Y(q0) ** 0.5,
-        cirq.Z(q0) ** 0.5,
-        cirq.X(q0) ** -0.5,
-        cirq.Y(q0) ** -0.5,
-        cirq.Z(q0) ** -0.5,
+        cirq.X(q0)**0.5,
+        cirq.Y(q0)**0.5,
+        cirq.Z(q0)**0.5,
+        cirq.X(q0)**-0.5,
+        cirq.Y(q0)**-0.5,
+        cirq.Z(q0)**-0.5,
         cirq.H(q0),
         cirq.CZ(q0, q1),
         cirq.CZ(q1, q2),
-        cirq.X(q0) ** 0.25,
-        cirq.Y(q0) ** 0.25,
-        cirq.Z(q0) ** 0.25,
+        cirq.X(q0)**0.25,
+        cirq.Y(q0)**0.25,
+        cirq.Z(q0)**0.25,
         cirq.CZ(q0, q1),
     )
 

--- a/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates_test.py
@@ -22,11 +22,11 @@ from cirq.contrib.paulistring import (
 
 def test_convert():
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.X(q0),
-        cirq.Y(q1) ** 0.5,
-        cirq.Z(q0) ** -0.5,
-        cirq.Z(q1) ** 0,
+        cirq.Y(q1)**0.5,
+        cirq.Z(q0)**-0.5,
+        cirq.Z(q1)**0,
         cirq.H(q0),
     )
     c_orig = cirq.Circuit(circuit)
@@ -48,9 +48,7 @@ def test_convert():
 
 def test_non_clifford_known_matrix():
     q0 = cirq.LineQubit(0)
-    circuit = cirq.Circuit.from_ops(
-        cirq.Z(q0) ** 0.25,
-    )
+    circuit = cirq.Circuit(cirq.Z(q0)**0.25,)
     c_orig = cirq.Circuit(circuit)
 
     ConvertToSingleQubitCliffordGates(ignore_failures=True) \
@@ -65,9 +63,7 @@ def test_non_clifford_known_matrix():
 
 def test_already_converted():
     q0 = cirq.LineQubit(0)
-    circuit = cirq.Circuit.from_ops(
-        cirq.SingleQubitCliffordGate.H(q0),
-    )
+    circuit = cirq.Circuit(cirq.SingleQubitCliffordGate.H(q0),)
     c_orig = cirq.Circuit(circuit)
     ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 
@@ -83,9 +79,7 @@ def test_convert_composite():
             yield cirq.H(q0)
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
-        CompositeDummy()(q0, q1)
-    )
+    circuit = cirq.Circuit(CompositeDummy()(q0, q1))
     c_orig = cirq.Circuit(circuit)
     ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 
@@ -108,9 +102,7 @@ def test_ignore_unsupported_gate():
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
-        UnsupportedDummy()(q0, q1),
-    )
+    circuit = cirq.Circuit(UnsupportedDummy()(q0, q1),)
     c_orig = cirq.Circuit(circuit)
     ConvertToSingleQubitCliffordGates(ignore_failures=True) \
         .optimize_circuit(circuit)
@@ -123,9 +115,7 @@ def test_fail_unsupported_gate():
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
-        UnsupportedDummy()(q0, q1),
-    )
+    circuit = cirq.Circuit(UnsupportedDummy()(q0, q1),)
     with pytest.raises(TypeError):
         ConvertToSingleQubitCliffordGates().optimize_circuit(circuit)
 

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors_test.py
@@ -20,10 +20,10 @@ from cirq.contrib.paulistring import ConvertToPauliStringPhasors
 
 def test_convert():
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.X(q0),
-        cirq.Y(q1) ** 0.25,
-        cirq.Z(q0) ** 0.125,
+        cirq.Y(q1)**0.25,
+        cirq.Z(q0)**0.125,
         cirq.H(q1),
     )
     c_orig = cirq.Circuit(circuit)
@@ -41,10 +41,10 @@ def test_convert():
 
 def test_convert_keep_clifford():
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.X(q0),
-        cirq.Y(q1) ** 0.25,
-        cirq.Z(q0) ** 0.125,
+        cirq.Y(q1)**0.25,
+        cirq.Z(q0)**0.125,
         cirq.SingleQubitCliffordGate.H(q1),
     )
     c_orig = cirq.Circuit(circuit)
@@ -62,7 +62,7 @@ def test_convert_keep_clifford():
 
 def test_already_converted():
     q0 = cirq.LineQubit(0)
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.PauliStringPhasor(cirq.PauliString.from_single(q0, cirq.X)),)
     c_orig = cirq.Circuit(circuit)
     ConvertToPauliStringPhasors().optimize_circuit(circuit)
@@ -75,9 +75,7 @@ def test_ignore_unsupported_gate():
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
-        UnsupportedDummy()(q0, q1),
-    )
+    circuit = cirq.Circuit(UnsupportedDummy()(q0, q1),)
     c_orig = cirq.Circuit(circuit)
     ConvertToPauliStringPhasors(ignore_failures=True
                                      ).optimize_circuit(circuit)
@@ -90,8 +88,6 @@ def test_fail_unsupported_gate():
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(
-        UnsupportedDummy()(q0, q1),
-    )
+    circuit = cirq.Circuit(UnsupportedDummy()(q0, q1),)
     with pytest.raises(TypeError):
         ConvertToPauliStringPhasors().optimize_circuit(circuit)

--- a/cirq/contrib/paulistring/optimize.py
+++ b/cirq/contrib/paulistring/optimize.py
@@ -51,7 +51,7 @@ def optimized_circuit(circuit: circuits.Circuit,
 def _optimized_ops(ops: Sequence[ops.Operation],
                    atol: float = 1e-8,
                    repeat: int = 10) -> ops.OP_TREE:
-    c = circuits.Circuit.from_ops(ops)
+    c = circuits.Circuit(ops)
     c_opt = optimized_circuit(c, atol, repeat, merge_interactions=False)
     return c_opt.all_operations()
 

--- a/cirq/contrib/paulistring/optimize_test.py
+++ b/cirq/contrib/paulistring/optimize_test.py
@@ -22,20 +22,20 @@ from cirq.contrib.paulistring import (
 
 def test_optimize():
     q0, q1, q2 = cirq.LineQubit.range(3)
-    c_orig = cirq.Circuit.from_ops(
-        cirq.X(q0) ** 0.5,
+    c_orig = cirq.Circuit(
+        cirq.X(q0)**0.5,
         cirq.X(q1),
         cirq.CZ(q1, q2),
-        cirq.X(q2) ** 0.125,
-        cirq.Z(q1) ** 0.5,
-        cirq.Y(q1) ** 0.5,
+        cirq.X(q2)**0.125,
+        cirq.Z(q1)**0.5,
+        cirq.Y(q1)**0.5,
         cirq.CZ(q0, q1),
-        cirq.Z(q1) ** 0.5,
+        cirq.Z(q1)**0.5,
         cirq.CZ(q1, q2),
-        cirq.Z(q1) ** 0.5,
-        cirq.X(q2) ** 0.875,
+        cirq.Z(q1)**0.5,
+        cirq.X(q2)**0.875,
         cirq.CZ(q1, q2),
-        cirq.X(q2) ** 0.125,
+        cirq.X(q2)**0.125,
     )
     cirq.testing.assert_has_diagram(c_orig, """
 0: ───X^0.5─────────────────────────@───────────────────────────────────

--- a/cirq/contrib/paulistring/pauli_string_optimize_test.py
+++ b/cirq/contrib/paulistring/pauli_string_optimize_test.py
@@ -23,22 +23,21 @@ from cirq.contrib.paulistring import (
 
 def test_optimize():
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit.from_ops(
-        cirq.X(q0) ** 0.25,
+    c_orig = cirq.Circuit(
+        cirq.X(q0)**0.25,
         cirq.H(q0),
         cirq.CZ(q0, q1),
         cirq.H(q0),
-        cirq.X(q0) ** 0.125,
+        cirq.X(q0)**0.125,
     )
-    c_expected = converted_gate_set(
-        cirq.Circuit.from_ops(
-            cirq.Y(q0) ** -0.5,
-            cirq.CZ(q0, q1),
-            cirq.Z(q0) ** -0.125,
-            cirq.X(q0) ** 0.5,
-            cirq.Z(q0) ** 0.5,
-        ),
-        no_clifford_gates=True)
+    c_expected = converted_gate_set(cirq.Circuit(
+        cirq.Y(q0)**-0.5,
+        cirq.CZ(q0, q1),
+        cirq.Z(q0)**-0.125,
+        cirq.X(q0)**0.5,
+        cirq.Z(q0)**0.5,
+    ),
+                                    no_clifford_gates=True)
 
     c_opt = pauli_string_optimized_circuit(c_orig)
 
@@ -59,15 +58,10 @@ def test_optimize():
 
 def test_handles_measurement_gate():
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit.from_ops(
-        cirq.X(q0) ** 0.25,
-        cirq.H(q0),
-        cirq.CZ(q0, q1),
-        cirq.H(q0),
-        cirq.X(q0) ** 0.125,
-        cirq.measure(q1, key='m1'),
-        cirq.measure(q0, key='m0')
-    )
+    c_orig = cirq.Circuit(
+        cirq.X(q0)**0.25, cirq.H(q0), cirq.CZ(q0, q1), cirq.H(q0),
+        cirq.X(q0)**0.125, cirq.measure(q1, key='m1'), cirq.measure(q0,
+                                                                    key='m0'))
     c_opt = pauli_string_optimized_circuit(c_orig)
 
     cirq.testing.assert_allclose_up_to_global_phase(

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -102,7 +102,6 @@ def move_pauli_strings_into_circuit(circuit_left: Union[circuits.Circuit,
 
     assert not string_dag.nodes(), 'There was a cycle in the CircuitDag'
 
-    return circuits.Circuit.from_ops(
-            output_ops,
-            strategy=circuits.InsertStrategy.EARLIEST,
-            device=circuit_right.device)
+    return circuits.Circuit(output_ops,
+                            strategy=circuits.InsertStrategy.EARLIEST,
+                            device=circuit_right.device)

--- a/cirq/contrib/paulistring/separate.py
+++ b/cirq/contrib/paulistring/separate.py
@@ -78,9 +78,8 @@ def pauli_string_half(circuit: circuits.Circuit) -> circuits.Circuit:
     Returns:
         A Circuit with only PauliStringPhasor operations.
     """
-    return circuits.Circuit.from_ops(
-            _pull_non_clifford_before(circuit),
-            strategy=circuits.InsertStrategy.EARLIEST)
+    return circuits.Circuit(_pull_non_clifford_before(circuit),
+                            strategy=circuits.InsertStrategy.EARLIEST)
 
 
 def _pull_non_clifford_before(circuit: circuits.Circuit) -> ops.OP_TREE:

--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -940,7 +940,7 @@ def test_single_qubit_gates(qasm_gate: str, cirq_gate: cirq.SingleQubitGate):
     q0 = cirq.NamedQubit('q_0')
     q1 = cirq.NamedQubit('q_1')
 
-    expected_circuit = Circuit.from_ops([
+    expected_circuit = Circuit([
         cirq_gate.on(q0),
         cirq_gate.on(q0),
         cirq_gate.on(q1),

--- a/cirq/contrib/qasm_import/qasm_test.py
+++ b/cirq/contrib/qasm_import/qasm_test.py
@@ -22,7 +22,7 @@ from cirq.contrib.qasm_import import circuit_from_qasm
 def test_consistency_with_qasm_output_and_qiskit():
     qubits = [cirq.NamedQubit('q_{}'.format(i)) for i in range(4)]
     a, b, c, d = qubits
-    circuit1 = cirq.Circuit.from_ops(
+    circuit1 = cirq.Circuit(
         cirq.Rx(np.pi / 2).on(a),
         cirq.Ry(np.pi / 2).on(b),
         cirq.Rz(np.pi / 2).on(b),

--- a/cirq/contrib/qcircuit/qcircuit_test.py
+++ b/cirq/contrib/qcircuit/qcircuit_test.py
@@ -69,10 +69,9 @@ def test_fallback_diagram():
         def __str__(self):
             return 'MagicOperate'
 
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         MagicOp(cirq.NamedQubit('b')),
-        MagicGate().on(cirq.NamedQubit('b'),
-                       cirq.NamedQubit('a'),
+        MagicGate().on(cirq.NamedQubit('b'), cirq.NamedQubit('a'),
                        cirq.NamedQubit('c')))
     expected_diagram = r"""
 \Qcircuit @R=1em @C=0.75em {
@@ -90,14 +89,10 @@ def test_teleportation_diagram():
     car = cirq.NamedQubit('carrier')
     bob = cirq.NamedQubit('bob')
 
-    circuit = cirq.Circuit.from_ops(
-        cirq.H(car),
-        cirq.CNOT(car, bob),
-        cirq.X(ali)**0.5,
-        cirq.CNOT(ali, car),
-        cirq.H(ali),
-        [cirq.measure(ali), cirq.measure(car)],
-        cirq.CNOT(car, bob),
+    circuit = cirq.Circuit(
+        cirq.H(car), cirq.CNOT(car, bob),
+        cirq.X(ali)**0.5, cirq.CNOT(ali, car), cirq.H(ali),
+        [cirq.measure(ali), cirq.measure(car)], cirq.CNOT(car, bob),
         cirq.CZ(ali, bob))
 
     expected_diagram = r"""
@@ -115,10 +110,7 @@ def test_teleportation_diagram():
 def test_other_diagram():
     a, b, c = cirq.LineQubit.range(3)
 
-    circuit = cirq.Circuit.from_ops(
-        cirq.X(a),
-        cirq.Y(b),
-        cirq.Z(c))
+    circuit = cirq.Circuit(cirq.X(a), cirq.Y(b), cirq.Z(c))
 
     expected_diagram = r"""
 \Qcircuit @R=1em @C=0.75em {

--- a/cirq/contrib/quirk/export_to_quirk_test.py
+++ b/cirq/contrib/quirk/export_to_quirk_test.py
@@ -30,7 +30,7 @@ def assert_links_to(circuit: cirq.Circuit, expected: str, **kwargs):
 def test_x_z_same_col():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
-    circuit = cirq.Circuit.from_ops(cirq.X(a), cirq.Z(b))
+    circuit = cirq.Circuit(cirq.X(a), cirq.Z(b))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["X","Z"]]}
     """, escape_url=False)
@@ -44,7 +44,7 @@ def test_x_cnot_split_cols():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
-    circuit = cirq.Circuit.from_ops(cirq.CNOT(a, b), cirq.X(c))
+    circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.X(c))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","X"],[1,1,"X"]]}
     """, escape_url=False)
@@ -54,7 +54,7 @@ def test_cz_cnot_split_cols():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
-    circuit = cirq.Circuit.from_ops(cirq.CNOT(a, b), cirq.CZ(b, c))
+    circuit = cirq.Circuit(cirq.CNOT(a, b), cirq.CZ(b, c))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","X"],[1,"•","Z"]]}
     """, escape_url=False)
@@ -63,7 +63,7 @@ def test_cz_cnot_split_cols():
 def test_various_known_gate_types():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.X(a),
         cirq.X(a)**0.25,
         cirq.X(a)**-0.5,
@@ -119,20 +119,19 @@ class MysteryGate(cirq.SingleQubitGate):
 def test_various_unknown_gate_types():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         MysteryOperation(b),
         cirq.SWAP(a, b)**0.5,
         cirq.H(a)**0.5,
         cirq.SingleQubitCliffordGate.X_sqrt.merged_with(
             cirq.SingleQubitCliffordGate.Z_sqrt).on(a),
-        cirq.X(a)**(1/5),
-        cirq.Y(a)**(1/5),
-        cirq.Z(a)**(1/5),
-        cirq.CZ(a, b)**(1/5),
+        cirq.X(a)**(1 / 5),
+        cirq.Y(a)**(1 / 5),
+        cirq.Z(a)**(1 / 5),
+        cirq.CZ(a, b)**(1 / 5),
         cirq.PhasedXPowGate(phase_exponent=0.25)(a),
         cirq.PhasedXPowGate(exponent=1, phase_exponent=sympy.Symbol('r'))(a),
-        cirq.PhasedXPowGate(exponent=0.001, phase_exponent=0.1)(a)
-    )
+        cirq.PhasedXPowGate(exponent=0.001, phase_exponent=0.1)(a))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[
             [1,"UNKNOWN"],
@@ -163,9 +162,7 @@ def test_various_unknown_gate_types():
 
 def test_unrecognized_single_qubit_gate_with_matrix():
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit.from_ops(
-        cirq.X(a)**0.2731,
-    )
+    circuit = cirq.Circuit(cirq.X(a)**0.2731,)
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[[{
             "id":"?",
@@ -180,7 +177,7 @@ def test_unknown_gate():
     class UnknownGate(cirq.SingleQubitGate):
         pass
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit.from_ops(UnknownGate()(a))
+    circuit = cirq.Circuit(UnknownGate()(a))
     with pytest.raises(TypeError):
         _ = circuit_to_quirk_url(circuit)
     with pytest.raises(TypeError):
@@ -192,14 +189,14 @@ def test_unknown_gate():
 
 def test_controlled_gate():
     a, b, c, d = cirq.LineQubit.range(4)
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.ControlledGate(cirq.ControlledGate(cirq.CZ)).on(a, d, c, b))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","Z","•", "•"]]}
     """, escape_url=False)
 
     # Doesn't merge.
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.ControlledGate(cirq.X).on(a, b),
         cirq.ControlledGate(cirq.Z).on(c, d))
     assert_links_to(circuit, """
@@ -207,8 +204,7 @@ def test_controlled_gate():
     """, escape_url=False)
 
     # Unknown sub-gate.
-    circuit = cirq.Circuit.from_ops(
-        cirq.ControlledGate(MysteryGate()).on(a, b))
+    circuit = cirq.Circuit(cirq.ControlledGate(MysteryGate()).on(a, b))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["UNKNOWN","UNKNOWN"]]}
     """, escape_url=False, prefer_unknown_gate_to_failure=True)
@@ -218,24 +214,20 @@ def test_toffoli():
     a, b, c, d = cirq.LineQubit.range(4)
 
     # Raw.
-    circuit = cirq.Circuit.from_ops(
-        cirq.TOFFOLI(a, b, c))
+    circuit = cirq.Circuit(cirq.TOFFOLI(a, b, c))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","•","X"]]}
     """, escape_url=False)
 
     # With exponent. Doesn't merge with other operation.
-    circuit = cirq.Circuit.from_ops(
-        cirq.CCX(a, b, c)**0.5,
-        cirq.H(d))
+    circuit = cirq.Circuit(cirq.CCX(a, b, c)**0.5, cirq.H(d))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[
             ["•","•","X^½"],[1,1,1,"H"]]}
     """, escape_url=False)
 
     # Unknown exponent.
-    circuit = cirq.Circuit.from_ops(
-        cirq.CCX(a, b, c)**0.01)
+    circuit = cirq.Circuit(cirq.CCX(a, b, c)**0.01)
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[
             ["UNKNOWN","UNKNOWN","UNKNOWN"]
@@ -245,17 +237,14 @@ def test_toffoli():
 
 def test_fredkin():
     a, b, c = cirq.LineQubit.range(3)
-    circuit = cirq.Circuit.from_ops(
-        cirq.FREDKIN(a, b, c))
+    circuit = cirq.Circuit(cirq.FREDKIN(a, b, c))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","Swap","Swap"]]}
     """, escape_url=False)
 
     # Doesn't merge.
     x, y, z = cirq.LineQubit.range(3, 6)
-    circuit = cirq.Circuit.from_ops(
-        cirq.CSWAP(a, b, c),
-        cirq.CSWAP(x, y, z))
+    circuit = cirq.Circuit(cirq.CSWAP(a, b, c), cirq.CSWAP(x, y, z))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[
             ["•","Swap","Swap"],
@@ -268,22 +257,19 @@ def test_ccz():
     a, b, c, d = cirq.LineQubit.range(4)
 
     # Raw.
-    circuit = cirq.Circuit.from_ops(
-        cirq.CCZ(a, b, c))
+    circuit = cirq.Circuit(cirq.CCZ(a, b, c))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","•","Z"]]}
     """, escape_url=False)
 
     # Symbolic exponent.
-    circuit = cirq.Circuit.from_ops(
-        cirq.CCZ(a, b, c)**sympy.Symbol('t'))
+    circuit = cirq.Circuit(cirq.CCZ(a, b, c)**sympy.Symbol('t'))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[["•","•","Z^t"]]}
     """, escape_url=False)
 
     # Unknown exponent.
-    circuit = cirq.Circuit.from_ops(
-        cirq.CCZ(a, b, c)**0.01)
+    circuit = cirq.Circuit(cirq.CCZ(a, b, c)**0.01)
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[
             ["UNKNOWN","UNKNOWN","UNKNOWN"]
@@ -291,9 +277,7 @@ def test_ccz():
     """, escape_url=False, prefer_unknown_gate_to_failure=True)
 
     # With exponent. Doesn't merge with other operation.
-    circuit = cirq.Circuit.from_ops(
-        cirq.CCZ(a, b, c)**0.5,
-        cirq.H(d))
+    circuit = cirq.Circuit(cirq.CCZ(a, b, c)**0.5, cirq.H(d))
     assert_links_to(circuit, """
         http://algassert.com/quirk#circuit={"cols":[
             ["•","•","Z^½"],[1,1,1,"H"]]}

--- a/cirq/contrib/routing/greedy.py
+++ b/cirq/contrib/routing/greedy.py
@@ -73,7 +73,7 @@ def route_circuit_greedily(circuit: circuits.Circuit, device_graph: nx.Graph,
     router.route()
 
     swap_network = router.swap_network
-    swap_network.circuit = circuits.Circuit.from_ops(
+    swap_network.circuit = circuits.Circuit(
         swap_network.circuit.all_operations(), device=swap_network.device)
     return swap_network
 
@@ -214,7 +214,7 @@ class _GreedyRouter:
 
     @property
     def swap_network(self) -> SwapNetwork:
-        return SwapNetwork(circuits.Circuit.from_ops(self.physical_ops),
+        return SwapNetwork(circuits.Circuit(self.physical_ops),
                            self.initial_mapping)
 
     def distance(self, edge: QidPair) -> int:

--- a/cirq/contrib/routing/router_test.py
+++ b/cirq/contrib/routing/router_test.py
@@ -78,11 +78,11 @@ def test_router_bad_args():
                           algo_name=algo_name,
                           router=ccr.ROUTERS[algo_name])
 
-    circuit = cirq.Circuit.from_ops(cirq.CCZ(*cirq.LineQubit.range(3)))
+    circuit = cirq.Circuit(cirq.CCZ(*cirq.LineQubit.range(3)))
     with pytest.raises(ValueError):
         ccr.route_circuit(circuit, device_graph, algo_name=algo_name)
 
-    circuit = cirq.Circuit.from_ops(
+    circuit = cirq.Circuit(
         cirq.CZ(cirq.LineQubit(i), cirq.LineQubit(i + 1)) for i in range(5))
     with pytest.raises(ValueError):
         ccr.route_circuit(circuit, device_graph, algo_name=algo_name)

--- a/cirq/contrib/routing/utils.py
+++ b/cirq/contrib/routing/utils.py
@@ -36,7 +36,7 @@ def get_time_slices(dag: circuits.CircuitDag) -> List[nx.Graph]:
     second slice correspond to the nodes of the DAG whose only predecessors are
     in the first time slice, and so on.
     """
-    circuit = circuits.Circuit.from_ops(
+    circuit = circuits.Circuit(
         op for op in dag.all_operations() if len(op.qubits) > 1)
     return [
         nx.Graph(op.qubits for op in moment.operations) for moment in circuit

--- a/cirq/contrib/routing/utils_test.py
+++ b/cirq/contrib/routing/utils_test.py
@@ -19,7 +19,7 @@ import cirq.contrib.routing as ccr
 def test_ops_are_consistent_with_device_graph():
     device_graph = ccr.get_linear_device_graph(3)
     qubits = cirq.LineQubit.range(3)
-    circuit = cirq.Circuit.from_ops(cirq.ZZ(qubits[0], qubits[2]))
+    circuit = cirq.Circuit(cirq.ZZ(qubits[0], qubits[2]))
     assert not ccr.ops_are_consistent_with_device_graph(
         circuit.all_operations(), device_graph)
     assert not ccr.ops_are_consistent_with_device_graph(

--- a/cirq/contrib/tpu/circuit_to_tensorflow.py
+++ b/cirq/contrib/tpu/circuit_to_tensorflow.py
@@ -342,7 +342,7 @@ class _TensorCircuit:
                  circuit: circuits.Circuit,
                  initial_state: Union[int, np.ndarray]):
         self.grouping = _QubitGrouping(circuit)
-        self.circuit = circuits.Circuit.from_ops(
+        self.circuit = circuits.Circuit(
             protocols.decompose(
                 circuit,
                 intercepting_decomposer=self.grouping.intercept_decompose_func,

--- a/cirq/contrib/tpu/circuit_to_tensorflow_test.py
+++ b/cirq/contrib/tpu/circuit_to_tensorflow_test.py
@@ -39,20 +39,16 @@ def _assert_evaluates_correctly(circuit: cirq.Circuit,
 @pytest.mark.parametrize('n', range(10))
 def test_circuit_to_compute_and_feed_dict_small(n: int):
     qs = cirq.LineQubit.range(n)
-    c = cirq.Circuit.from_ops(
-        [cirq.X(q)**(0.13 * i + 0.1) for i, q in enumerate(qs)],
-        [[cirq.CZ(a, b), cirq.X(a)**0.5, cirq.H(b)]
-         for a in qs
-         for b in qs
-         if a < b]
-    )
+    c = cirq.Circuit([cirq.X(q)**(0.13 * i + 0.1) for i, q in enumerate(qs)],
+                     [[cirq.CZ(a, b), cirq.X(a)**0.5,
+                       cirq.H(b)] for a in qs for b in qs if a < b])
     _assert_evaluates_correctly(c)
 
 
 def test_circuit_to_compute_and_feed_dict_big():
     n = 16
     qs = cirq.LineQubit.range(n)
-    c = cirq.Circuit.from_ops(
+    c = cirq.Circuit(
         [cirq.H(q) for i, q in enumerate(qs)],
         cirq.CZ(qs[1], qs[3]),
         cirq.CZ(qs[1], qs[10]),
@@ -66,7 +62,7 @@ def test_circuit_to_compute_and_feed_dict_big():
 
 def test_circuit_to_compute_and_feed_dict_vector_custom_start_state():
     a, b = cirq.LineQubit.range(2)
-    c = cirq.Circuit.from_ops(cirq.CZ(a, b))
+    c = cirq.Circuit(cirq.CZ(a, b))
 
     tf.reset_default_graph()
     r = circuit_to_tensorflow_runnable(c, initial_state=0)
@@ -102,11 +98,11 @@ def test_circuit_to_compute_and_feed_dict_vector_custom_start_state():
 
 def test_circuit_to_compute_and_feed_dict_allows_terminal_measurements():
     q = cirq.NamedQubit('q')
-    c = cirq.Circuit.from_ops(cirq.H(q), cirq.measure(q), cirq.H(q))
+    c = cirq.Circuit(cirq.H(q), cirq.measure(q), cirq.H(q))
     with pytest.raises(ValueError):
         _ = circuit_to_tensorflow_runnable(c)
 
-    c = cirq.Circuit.from_ops(cirq.H(q), cirq.measure(q))
+    c = cirq.Circuit(cirq.H(q), cirq.measure(q))
     _assert_evaluates_correctly(c)
 
 
@@ -124,11 +120,8 @@ def test_circuit_to_compute_and_feed_dict_works_on_unknown_ops():
 
     phased_swap = PhasedSwapGate()
 
-    c = cirq.Circuit.from_ops(
-        [cirq.Y(q)**(0.13 * i + 0.1) for i, q in enumerate(qs)],
-        cirq.CCX(qs[0], qs[4], qs[8])**0.5,
-        phased_swap(qs[0], qs[1]),
-        phased_swap(qs[3], qs[9]),
-        phased_swap(qs[0], qs[6]),
-        phased_swap(qs[9], qs[8]))
+    c = cirq.Circuit([cirq.Y(q)**(0.13 * i + 0.1) for i, q in enumerate(qs)],
+                     cirq.CCX(qs[0], qs[4], qs[8])**0.5,
+                     phased_swap(qs[0], qs[1]), phased_swap(qs[3], qs[9]),
+                     phased_swap(qs[0], qs[6]), phased_swap(qs[9], qs[8]))
     _assert_evaluates_correctly(c, up_to_global_phase=True)


### PR DESCRIPTION
Part of #1787

This should be nothing but basically a search-replace of `Circuit.from_ops(` with `Circuit(`, followed by formatting, followed by tiny manual tweaks.