### PR TITLE
[Incomplete] Breaking down jobs.

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -38,6 +38,7 @@ from cirq.google.engine import (
     Engine,
     engine_from_environment,
     EngineJob,
+    EngineJobBatch,
     EngineProgram,
     JobConfig,
     ProtoVersion,

--- a/cirq/google/engine/__init__.py
+++ b/cirq/google/engine/__init__.py
@@ -25,7 +25,8 @@ from cirq.google.engine.engine import (
 )
 
 from cirq.google.engine.engine_job import (
-    EngineJob,)
+    EngineJob,
+    EngineJobBatch,)
 
 from cirq.google.engine.engine_program import (
     EngineProgram,)


### PR DESCRIPTION
In an effort to tackle the second part of #2107 , I introduced a new class for batches of jobs along with some unpolished logic for how it would operate. Since writing the tests would take a lot of time I was wondering if I could get a quick look over from @dabacon or @wcourtney and see if this is roughly what was in mind as a solution to the issue before I go ahead with writing them all. The `results` method has an identical return type as the regular `EngineJob`.