### PR TITLE
Show yellow text when lines had to be reformatted

### DIFF
--- a/check/format-incremental
+++ b/check/format-incremental
@@ -107,5 +107,5 @@ elif (( only_print == 1 )); then
     echo -e "\033[31mSome formatting needed on changed lines\033[0m."
     exit 1
 else
-    echo -e "\033[32mReformatted changed lines\033[0m."
+    echo -e "\033[33mReformatted changed lines\033[0m."
 fi


### PR DESCRIPTION
- This makes it clearer at a glance that something happened instead of nothing (shown in green)