### PR TITLE
Reorder travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,28 +14,23 @@ stages:
   if: type = push AND branch = master
 matrix:
   include:
-  - stage: test
-    os: linux
-    env: NAME=mypy
-    python: '3.6'
-    install:
-    - cat dev_tools/conf/pip-list-dev-tools.txt | grep mypy | xargs pip install
-    script: check/mypy
-  - stage: test
-    os: linux
-    env: NAME=pylint
-    python: '3.6'
-    install:
-    - cat dev_tools/conf/pip-list-dev-tools.txt | grep "pylint\|astroid" | grep -v
-      "#" | xargs pip install
-    script: check/pylint
-  - stage: test
-    os: linux
-    env: NAME=format
-    python: '3.6'
-    install:
-    - cat dev_tools/conf/pip-list-dev-tools.txt | grep yapf | xargs pip install
-    script: check/format-incremental
+    - stage: test
+      os: windows
+      env: NAME=pytest (Windows)
+      language: sh
+      python: '3.7.3'
+      before_install:
+        - powershell -command 'Set-MpPreference -DisableArchiveScanning $true'
+        - powershell -command 'Set-MpPreference -DisableBehaviorMonitoring $true'
+        - powershell -command 'Set-MpPreference -DisableRealtimeMonitoring $true'
+        - choco install python --version 3.7.3
+        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - python -m pip install --upgrade pip wheel
+      install:
+        - python -m pip install -r requirements.txt
+        - python -m pip install -r cirq/contrib/contrib-requirements.txt
+        - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
+      script: check/pytest --benchmark-skip --actually-quiet
   - stage: test
     os: linux
     env: NAME=pytest-and-incremental-coverage
@@ -47,29 +42,22 @@ matrix:
     script: check/pytest-and-incremental-coverage master --actually-quiet
   - stage: test
     os: linux
+    env: NAME=build-docs
+    python: '3.6'
+    install:
+      - pip install -r requirements.txt
+      - pip install -r cirq/contrib/contrib-requirements.txt
+      - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
+      - sudo apt-get install pandoc
+    script: dev_tools/build-docs.sh
+  - stage: test
+    os: linux
     env: NAME=pytest (without contrib)
     python: '3.7'
     install:
     - pip install -r requirements.txt
     - pip install -r dev_tools/conf/pip-list-dev-tools.txt
     script: check/pytest --ignore=cirq/contrib --benchmark-skip --actually-quiet
-  - stage: test
-    os: windows
-    env: NAME=pytest (Windows)
-    language: sh
-    python: '3.7.3'
-    before_install:
-    - powershell -command 'Set-MpPreference -DisableArchiveScanning $true'
-    - powershell -command 'Set-MpPreference -DisableBehaviorMonitoring $true'
-    - powershell -command 'Set-MpPreference -DisableRealtimeMonitoring $true'
-    - choco install python --version 3.7.3
-    - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-    - python -m pip install --upgrade pip wheel
-    install:
-    - python -m pip install -r requirements.txt
-    - python -m pip install -r cirq/contrib/contrib-requirements.txt
-    - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest --benchmark-skip --actually-quiet
   - stage: test
     os: linux
     env: NAME=doctest
@@ -80,14 +68,26 @@ matrix:
     script: check/doctest -q
   - stage: test
     os: linux
-    env: NAME=build-docs
+    env: NAME=pylint
     python: '3.6'
     install:
-    - pip install -r requirements.txt
-    - pip install -r cirq/contrib/contrib-requirements.txt
-    - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    - sudo apt-get install pandoc
-    script: dev_tools/build-docs.sh
+      - cat dev_tools/conf/pip-list-dev-tools.txt | grep "pylint\|astroid" | grep -v
+        "#" | xargs pip install
+    script: check/pylint
+  - stage: test
+    os: linux
+    env: NAME=mypy
+    python: '3.6'
+    install:
+      - cat dev_tools/conf/pip-list-dev-tools.txt | grep mypy | xargs pip install
+    script: check/mypy
+  - stage: test
+    os: linux
+    env: NAME=format
+    python: '3.6'
+    install:
+      - cat dev_tools/conf/pip-list-dev-tools.txt | grep yapf | xargs pip install
+    script: check/format-incremental
   - stage: deploy
     os: linux
     env: NAME=dev-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,23 +14,23 @@ stages:
   if: type = push AND branch = master
 matrix:
   include:
-    - stage: test
-      os: windows
-      env: NAME=pytest (Windows)
-      language: sh
-      python: '3.7.3'
-      before_install:
-        - powershell -command 'Set-MpPreference -DisableArchiveScanning $true'
-        - powershell -command 'Set-MpPreference -DisableBehaviorMonitoring $true'
-        - powershell -command 'Set-MpPreference -DisableRealtimeMonitoring $true'
-        - choco install python --version 3.7.3
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-        - python -m pip install --upgrade pip wheel
-      install:
-        - python -m pip install -r requirements.txt
-        - python -m pip install -r cirq/contrib/contrib-requirements.txt
-        - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-      script: check/pytest --benchmark-skip --actually-quiet
+  - stage: test
+    os: windows
+    env: NAME=pytest (Windows)
+    language: sh
+    python: '3.7.3'
+    before_install:
+      - powershell -command 'Set-MpPreference -DisableArchiveScanning $true'
+      - powershell -command 'Set-MpPreference -DisableBehaviorMonitoring $true'
+      - powershell -command 'Set-MpPreference -DisableRealtimeMonitoring $true'
+      - choco install python --version 3.7.3
+      - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+      - python -m pip install --upgrade pip wheel
+    install:
+      - python -m pip install -r requirements.txt
+      - python -m pip install -r cirq/contrib/contrib-requirements.txt
+      - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
+    script: check/pytest --benchmark-skip --actually-quiet
   - stage: test
     os: linux
     env: NAME=pytest-and-incremental-coverage

--- a/style.md
+++ b/style.md
@@ -48,8 +48,9 @@ from cirq import contrib
 contrib.circuit_to_latex_using_qcircuit(cirq.Circuit())
 ``` 
 
-Of course, if this import style fundamentally cannot be used, do not let this block submitting
-a pull request for the code as we will definitely grant exceptions.
+Of course, if this import style fundamentally cannot be used, do not let this
+block submitting a pull request for the code as we will definitely grant
+exceptions.
 
 #### Typing based import cycles
 


### PR DESCRIPTION
This reorders the travis tests from longest to shortest in duration.  Because travis runs with 5 concurrent jobs that pick up test in this order putting a long test like build docs or windows later can lead to slower overall testing time. 