### PR TITLE
Fix tensorflow version since tensorflow 2.0 was just released

### DIFF
--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -2,4 +2,4 @@
 
 ply>=3.4
 pylatex~=1.3.0
-tensorflow
+tensorflow~=1.14


### PR DESCRIPTION
`pip install tensorflow` now gives tensorflow 2.0 which will break us. 