### PR TITLE
Fix deprecation warning in arithmetic_operation.py

### DIFF
--- a/cirq/ops/arithmetic_operation.py
+++ b/cirq/ops/arithmetic_operation.py
@@ -221,7 +221,7 @@ class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
             # Copy amplitude to new location.
             cast(List[Union[int, slice]], outputs).append(slice(None))
             cast(List[Union[int, slice]], inputs).append(slice(None))
-            dst[outputs] = src[inputs]
+            dst[tuple(outputs)] = src[tuple(inputs)]
 
         # In case the reshaped arrays were copies instead of views.
         dst.shape = transposed_args.available_buffer.shape


### PR DESCRIPTION
- There was a lot of "FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result."