### PR TITLE
Add transform_qubits to Circuit

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -473,6 +473,10 @@ class Circuit:
                          new_device: 'cirq.Device' = None) -> 'cirq.Circuit':
         """Returns the same circuit, but with different qubits.
 
+        Note that this method does essentially the same thing as
+        `cirq.Circuit.with_device`. It is included regardless because there are
+        also `transform_qubits` methods on `cirq.Operation` and `cirq.Moment`.
+
         Args:
             func: The function to use to turn each current qubit into a desired
                 new qubit.
@@ -484,8 +488,9 @@ class Circuit:
             The receiving circuit but with qubits transformed by the given
                 function, and with an updated device (if specified).
         """
-        return Circuit([moment.transform_qubits(func) for moment in self],
-                       device=self.device if new_device is None else new_device)
+        return self.with_device(
+            new_device=self.device if new_device is None else new_device,
+            qubit_mapping=func)
 
     def _prev_moment_available(self, op: 'cirq.Operation',
                                end_moment_index: int) -> Optional[int]:

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -467,6 +467,26 @@ class Circuit:
                                                (end_moment_index - k - 1
                                                 for k in range(max_distance)))
 
+    def transform_qubits(self,
+                         func: Callable[['cirq.Qid'], 'cirq.Qid'],
+                         *,
+                         new_device: 'cirq.Device' = None) -> 'cirq.Circuit':
+        """Returns the same circuit, but with different qubits.
+
+        Args:
+            func: The function to use to turn each current qubit into a desired
+                new qubit.
+            new_device: The device to use for the new circuit, if different.
+                If this is not set, the new device defaults to the current
+                device.
+
+        Returns:
+            The receiving circuit but with qubits transformed by the given
+                function, and with an updated device (if specified).
+        """
+        return Circuit([moment.transform_qubits(func) for moment in self],
+                       device=self.device if new_device is None else new_device)
+
     def _prev_moment_available(self, op: 'cirq.Operation',
                                end_moment_index: int) -> Optional[int]:
         last_available = end_moment_index

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3300,3 +3300,19 @@ def test_init_contents():
     )
 
     cirq.Circuit()
+
+
+def test_transform_qubits():
+    a, b, c = cirq.LineQubit.range(3)
+    c = cirq.Circuit(cirq.X(a), cirq.CNOT(a, b), cirq.Moment(),
+                     cirq.Moment([cirq.CNOT(b, c)]))
+    x, y, z = cirq.GridQubit.rect(3, 1, 10, 20)
+    desired = cirq.Circuit(cirq.X(x), cirq.CNOT(x, y), cirq.Moment(),
+                           cirq.Moment([cirq.CNOT(y, z)]))
+    assert c.transform_qubits(lambda q: cirq.GridQubit(10 + q.x, 20)) == desired
+
+    # Device
+    c = cirq.Circuit(device=cg.Foxtail)
+    assert c.transform_qubits(lambda q: q).device is cg.Foxtail
+    assert c.transform_qubits(lambda q: q, new_device=cg.Bristlecone
+                             ).device is cg.Bristlecone

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -163,6 +163,16 @@ class Moment:
     def transform_qubits(self: TSelf_Moment,
                          func: Callable[[raw_types.Qid], raw_types.Qid]
                          ) -> TSelf_Moment:
+        """Returns the same moment, but with different qubits.
+
+        Args:
+            func: The function to use to turn each current qubit into a desired
+                new qubit.
+
+        Returns:
+            The receiving moment but with qubits transformed by the given
+                function.
+        """
         return self.__class__(op.transform_qubits(func)
                 for op in self.operations)
 


### PR DESCRIPTION
- Matches behavior of the method on Operation and Moment
- Includes an optional new_device parameter, since changing qubits is the sort of thing that would be associated with switching devices
- Happens to do the same thing as `with_device`, but with a different flavor. I think it's worth including this variant because of the `transform_qubits` methods on other types.