### PR TITLE
Workaround windows builds suddenly failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
     language: sh
     python: '3.7.3'
     before_install:
-      - powershell -command 'Set-MpPreference -DisableArchiveScanning $true'
       - powershell -command 'Set-MpPreference -DisableBehaviorMonitoring $true'
       - powershell -command 'Set-MpPreference -DisableRealtimeMonitoring $true'
       - choco install python --version 3.7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     language: sh
     python: '3.7.3'
     before_install:
+      - # TODO(craiggidney): re-enable after https://github.com/quantumlib/Cirq/issues/2283 is resolved
+      - # powershell -command 'Set-MpPreference -DisableArchiveScanning $true'
       - powershell -command 'Set-MpPreference -DisableBehaviorMonitoring $true'
       - powershell -command 'Set-MpPreference -DisableRealtimeMonitoring $true'
       - choco install python --version 3.7.3


### PR DESCRIPTION
I'm going to temporarily comment the line in the travis.yml file causing the problem. We can later re-enable it when whatever is causing the breakage is actually fixed. The line relates to turning off antivirus slowdown.

Part of https://github.com/quantumlib/Cirq/issues/2283