### PR TITLE
Add default parameters for add_subplot

### DIFF
--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -610,7 +610,7 @@ def scatter_plot_normalized_kak_interaction_coefficients(
     """
     if ax is None:
         fig = plt.figure()
-        ax = fig.add_subplot(projection='3d')
+        ax = fig.add_subplot(1, 1, 1, projection='3d')
 
     def coord_transform(
             pts: Iterable[Tuple[float, float, float]]


### PR DESCRIPTION
- cirq only requires matplotlib 3.0
- add_subplot() with no positional arguments was not added until 3.1

See:

https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.figure.Figure.html#matplotlib.figure.Figure.add_subplot
https://matplotlib.org/3.0.3/api/_as_gen/matplotlib.figure.Figure.html#matplotlib.figure.Figure.add_subplot