### PR TITLE
Add pandas.DataFrame support to proper_repr and json serialization

### DIFF
--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any, Callable, Optional, Dict, Tuple
 
 import numpy as np
+import pandas as pd
 import sympy
 
 
@@ -40,6 +41,15 @@ def proper_repr(value: Any) -> str:
 
     if isinstance(value, np.ndarray):
         return 'np.array({!r}, dtype=np.{})'.format(value.tolist(), value.dtype)
+
+    if isinstance(value, pd.DataFrame):
+        cols = [value[col].tolist() for col in value.columns]
+        rows = list(zip(*cols))
+        return (f'pd.DataFrame.from_records('
+                f'columns={repr(list(value.columns))}, '
+                f'index={repr(list(value.index))}, '
+                f'data={repr(rows)})')
+
     return repr(value)
 
 

--- a/cirq/_compat_test.py
+++ b/cirq/_compat_test.py
@@ -16,6 +16,7 @@ import logging
 from typing import ContextManager, List
 
 import numpy as np
+import pandas as pd
 import sympy
 
 from cirq._compat import proper_repr, deprecated, deprecated_parameter
@@ -30,6 +31,16 @@ def test_proper_repr():
     v2 = eval(proper_repr(v))
     np.testing.assert_array_equal(v2, v)
     assert v2.dtype == v.dtype
+
+
+def test_proper_repr_data_frame():
+    df = pd.DataFrame(index=[1, 2, 3],
+                      data=[[11, 21.0], [12, 22.0], [13, 23.0]],
+                      columns=['a', 'b'])
+    df2 = eval(proper_repr(df))
+    assert df2['a'].dtype == np.int64
+    assert df2['b'].dtype == np.float
+    assert df2.equals(df)
 
 
 def test_deprecated():

--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -17,6 +17,7 @@ from typing import Union, Any, Dict, Optional, List, Callable, Type, cast, \
     TYPE_CHECKING, Iterable
 
 import numpy as np
+import pandas as pd
 import sympy
 from typing_extensions import Protocol
 
@@ -74,6 +75,7 @@ class _ResolverCache:
                 cirq.SingleQubitPauliStringGateOperation,
                 'SwapPowGate': cirq.SwapPowGate,
                 'sympy.Symbol': sympy.Symbol,
+                'pandas.DataFrame': pd.DataFrame,
                 '_UnconstrainedDevice':
                 cirq.devices.unconstrained_device._UnconstrainedDevice,
                 '_QubitAsQid': raw_types._QubitAsQid,
@@ -201,6 +203,17 @@ class CirqEncoder(json.JSONEncoder):
         #       https://github.com/quantumlib/Cirq/issues/2014
         if isinstance(o, sympy.Symbol):
             return obj_to_dict_helper(o, ['name'], namespace='sympy')
+
+        if isinstance(o, pd.DataFrame):
+            cols = [o[col].tolist() for col in o.columns]
+            rows = list(zip(*cols))
+            return {
+                'cirq_type': 'pandas.DataFrame',
+                'data': rows,
+                'columns': list(o.columns),
+                'index': list(o.index),
+            }
+
         return super().default(o)  # coverage: ignore
 
 

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -17,10 +17,12 @@ import inspect
 import io
 import os
 import textwrap
+from typing import Tuple, Any, Iterator, Type
 
 import pytest
 
 import numpy as np
+import pandas as pd
 import sympy
 
 import cirq
@@ -40,6 +42,8 @@ def assert_roundtrip(obj, text_should_be=None):
     obj2 = cirq.protocols.read_json(buffer)
     if isinstance(obj, np.ndarray):
         np.testing.assert_equal(obj, obj2)
+    elif isinstance(obj, pd.DataFrame):
+        pd.testing.assert_frame_equal(obj, obj2)
     else:
         assert obj == obj2
 
@@ -113,6 +117,19 @@ QUBITS = cirq.LineQubit.range(5)
 Q0, Q1, Q2, Q3, Q4 = QUBITS
 
 TEST_OBJECTS = {
+    '[builtin]complex': [1 + 2j],
+    '[builtin]dict': {
+        'test': [123, 5.5],
+        'key2': 'asdf'
+    },
+    '[external]numpy.ndarray': [np.ones((11, 5)),
+                                np.arange(3)],
+    '[external]pandas.DataFrame':
+    pd.DataFrame(data=[[1, 2, 3], [4, 5, 6]],
+                 columns=['x', 'y', 'z'],
+                 index=[2, 5]),
+    '[external]sympy.Symbol':
+    sympy.Symbol('theta'),
     'Bristlecone':
     cirq.google.Bristlecone,
     'CCNOT':
@@ -170,8 +187,6 @@ TEST_OBJECTS = {
         cirq.CSWAP(*cirq.LineQubit.range(3)),
         cirq.CZ(*cirq.LineQubit.range(2))
     ],
-    'GivensRotation':
-    cirq.GivensRotation,
     'GlobalPhaseOperation':
     cirq.GlobalPhaseOperation(-1j),
     'GridQubit':
@@ -244,8 +259,6 @@ TEST_OBJECTS = {
     'SingleQubitPauliStringGateOperation':
     cirq.X(Q0),
     'SwapPowGate': [cirq.SwapPowGate(), cirq.SWAP**0.5],
-    'Symbol':
-    sympy.Symbol('theta'),
     'T':
     cirq.T,
     'TOFFOLI':
@@ -271,12 +284,6 @@ TEST_OBJECTS = {
     'ZZ':
     cirq.ZZ,
     'ZZPowGate': [cirq.ZZPowGate(), cirq.ZZ**0.789],
-    'complex': [1 + 2j],
-    'ndarray': [np.ones((11, 5)), np.arange(3)],
-    'dict': {
-        'test': [123, 5.5],
-        'key2': 'asdf'
-    }
 }
 
 SHOULDNT_BE_SERIALIZED = [
@@ -359,7 +366,7 @@ SHOULDNT_BE_SERIALIZED = [
 ]
 
 
-def _get_all_public_classes(module):
+def _get_all_public_classes(module) -> Iterator[Tuple[str, Type]]:
     for name, obj in inspect.getmembers(module):
         if inspect.isfunction(obj) or inspect.ismodule(obj):
             continue
@@ -381,7 +388,7 @@ def _get_all_public_classes(module):
         yield name, obj
 
 
-def _get_all_names():
+def _get_all_names() -> Iterator[str]:
 
     def not_module_or_function(x):
         return not (inspect.ismodule(x) or inspect.isfunction(x))
@@ -487,17 +494,31 @@ NOT_YET_SERIALIZABLE = [
 ]
 
 
-def _roundtrip_test_classes():
+def _roundtrip_test_classes() -> Iterator[Tuple[str, Type]]:
     yield from _get_all_public_classes(cirq)
     yield from _get_all_public_classes(cirq.google)
 
-    # extra
-    yield 'complex', complex
-    yield 'ndarray', np.ndarray
-    yield 'Symbol', sympy.Symbol
+    # Objects not listed at top level.
+    yield '_QubitAsQid', type(cirq.NamedQubit('a').with_dimension(5))
 
     # test coverage for `default` paths
-    yield 'dict', dict
+    yield '[builtin]dict', dict
+
+    # extra
+    yield '[builtin]complex', complex
+    yield '[external]numpy.ndarray', np.ndarray
+    yield '[external]sympy.Symbol', sympy.Symbol
+    yield '[external]pandas.DataFrame', pd.DataFrame
+
+
+def test_no_missed_test_objects():
+    seen = {name for name, _ in _roundtrip_test_classes()}
+    missed = TEST_OBJECTS.keys() - seen
+    assert not missed, (
+        "An entry in cirq.protocols.json_test.TEST_OBJECTS was not used when "
+        "checking the serializability of all objects yielded by "
+        "cirq.protocols.json_test._roundtrip_test_classes."
+        f"\n\nMissed keys: {repr(missed)}")
 
 
 @pytest.mark.parametrize('cirq_obj_name,cls', _roundtrip_test_classes())


### PR DESCRIPTION
- Fix json serialization tests allowing accidentally unused TEST_OBJECTS entries
- Prefix non-cirq TEST_OBJECTS entries with a tag, so they group together at the start
- Remove GivensRotation entry, because it's not a serializable object
- Fix _QubitAsQid entry not being checked