### PR TITLE
 Add Require n_rows > 1 in generate_boixo_2018_supremacy_circuits_v2_…

### DIFF
--- a/cirq/experiments/google_v2_supremacy_circuit_test.py
+++ b/cirq/experiments/google_v2_supremacy_circuit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from cirq import GridQubit
 from cirq import ops
 import cirq.experiments.google_v2_supremacy_circuit as supremacy_v2
@@ -69,3 +71,9 @@ def test_google_v2_supremacy_bristlecone():
     assert isinstance(c.operation_at(qubits[7], 3).gate, ops.YPowGate)
     assert len(list(c.findall_operations_with_gate_type(ops.CZPowGate))) == 79
     assert len(list(c.findall_operations_with_gate_type(ops.XPowGate))) == 32
+
+
+def test_n_rows_less_than_2():
+    with pytest.raises(AssertionError):
+        supremacy_v2.generate_boixo_2018_supremacy_circuits_v2_bristlecone(
+            n_rows=1, cz_depth=0, seed=0)


### PR DESCRIPTION
…bristlecone test.

I should have asked for this in my review of https://github.com/quantumlib/Cirq/pull/2296.