### PR TITLE
Split AsyncSampler out of Sampler

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -441,6 +441,7 @@ from cirq.vis import (
     Heatmap,)
 
 from cirq.work import (
+    AsyncSampler,
     CircuitSampleJob,
     PauliSumCollector,
     Sampler,

--- a/cirq/work/__init__.py
+++ b/cirq/work/__init__.py
@@ -5,4 +5,6 @@ from cirq.work.collector import (
 from cirq.work.pauli_sum_collector import (
     PauliSumCollector,)
 from cirq.work.sampler import (
-    Sampler,)
+    AsyncSampler,
+    Sampler,
+)

--- a/cirq/work/collector.py
+++ b/cirq/work/collector.py
@@ -103,7 +103,7 @@ class Collector(metaclass=abc.ABCMeta):
         """
 
     def collect(self,
-                sampler: 'cirq.Sampler',
+                async_sampler: 'cirq.AsyncSampler',
                 *,
                 concurrency: int = 2,
                 max_total_samples: Optional[int] = None) -> None:
@@ -123,7 +123,7 @@ class Collector(metaclass=abc.ABCMeta):
             https://docs.python.org/3/library/asyncio-task.html
 
         Args:
-            sampler: The simulator or service to collect samples from.
+            async_sampler: The simulator or service to collect samples from.
             concurrency: Desired number of sampling jobs to have in flight at
                 any given time.
             max_total_samples: Optional limit on the maximum number of samples
@@ -134,12 +134,12 @@ class Collector(metaclass=abc.ABCMeta):
             collected.
         """
         return asyncio.get_event_loop().run_until_complete(
-            self.collect_async(sampler,
+            self.collect_async(async_sampler,
                                concurrency=concurrency,
                                max_total_samples=max_total_samples))
 
     async def collect_async(self,
-                            sampler: 'cirq.Sampler',
+                            async_sampler: 'cirq.AsyncSampler',
                             *,
                             concurrency: int = 2,
                             max_total_samples: Optional[int] = None) -> None:
@@ -159,7 +159,7 @@ class Collector(metaclass=abc.ABCMeta):
             https://docs.python.org/3/library/asyncio-task.html
 
         Args:
-            sampler: The simulator or service to collect samples from.
+            async_sampler: The simulator or service to collect samples from.
             concurrency: Desired number of sampling jobs to have in flight at
                 any given time.
             max_total_samples: Optional limit on the maximum number of samples
@@ -175,8 +175,8 @@ class Collector(metaclass=abc.ABCMeta):
                              max_total_samples)
 
         async def _start_async_job(job):
-            return job, await sampler.run_async(job.circuit,
-                                                repetitions=job.repetitions)
+            return job, await async_sampler.run_async(
+                job.circuit, repetitions=job.repetitions)
 
         # Keep dispatching and processing work.
         while True:

--- a/cirq/work/pauli_sum_collector_test.py
+++ b/cirq/work/pauli_sum_collector_test.py
@@ -23,7 +23,7 @@ def test_pauli_string_sample_collector():
                                16 * cirq.Y(a) * cirq.Y(b) +
                                4 * cirq.Z(a) * cirq.Z(b),
                                samples_per_term=100)
-    completion = p.collect_async(sampler=cirq.Simulator())
+    completion = p.collect_async(async_sampler=cirq.Simulator())
     cirq.testing.assert_asyncio_will_have_result(completion, None)
     assert p.estimated_energy() == 11
 
@@ -34,7 +34,7 @@ def test_pauli_string_sample_single():
                                                     cirq.X(a), cirq.Z(b)),
                                observable=cirq.X(a) * cirq.X(b),
                                samples_per_term=100)
-    completion = p.collect_async(sampler=cirq.Simulator())
+    completion = p.collect_async(async_sampler=cirq.Simulator())
     cirq.testing.assert_asyncio_will_have_result(completion, None)
     assert p.estimated_energy() == -1
 

--- a/cirq/work/sampler_test.py
+++ b/cirq/work/sampler_test.py
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for cirq.Sampler."""
+import asyncio
 
 import cirq
 
 
-def test_sampler_fail():
+def test_async_sampler_fail():
 
-    class FailingSampler(cirq.Sampler):
+    class FailingSampler(cirq.AsyncSampler):
 
-        def run_sweep(self, program, params, repetitions: int = 1):
+        async def run_sweep_async(self, program, params, repetitions: int = 1):
+            await asyncio.sleep(0.01)
             raise ValueError('test')
 
     cirq.testing.assert_asyncio_will_raise(FailingSampler().run_async(


### PR DESCRIPTION
- Drop auto-threaded run_async (I suspect this will fix the windows build flake)