### PR TITLE
Turn on flag to parallelize build docs

### DIFF
--- a/dev_tools/build-docs.sh
+++ b/dev_tools/build-docs.sh
@@ -44,7 +44,7 @@ rm -rf "${docs_conf_dir}/generated"
 rm -rf "${out_dir}"
 
 # Regenerate docs.
-sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W
+sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W -j auto
 
 # Cleanup newly generated temporary files.
 rm -rf "${docs_conf_dir}/generated"

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -21,7 +21,7 @@ pypandoc
 recommonmark >= 0.4.0
 Sphinx
 sphinx_rtd_theme
-sphinx-markdown-tables
+git+git://github.com/ryanfox/sphinx-markdown-tables@b5ec89bfcc8f5117f47c71881869feae13d8f0e7
 
 # Need to pin pylint's parser to 2.1 instead of 2.2 until https://github.com/PyCQA/astroid/issues/650 is fixed
 astroid~=2.1.0


### PR DESCRIPTION
-j auto uses the number of cpus.  

On my box this sped up the test by a factor of 2.

