### PR TITLE
Add py.typed for type checkers

### DIFF
--- a/cirq/py.typed
+++ b/cirq/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The cirq package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(name=name,
       long_description=long_description,
       packages=cirq_packages,
       package_data={
+          'cirq': ['py.typed'],
           'cirq.api.google.v1': ['*.proto'],
           'cirq.api.google.v2': ['*.proto'],
           'cirq.google.api.v1': ['*.proto'],


### PR DESCRIPTION
Works from local testing.

Fixes #2373 