### PR TITLE
Add type annotations for Circuit.__iter__ and Moment.__iter__

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -189,13 +189,13 @@ class Circuit:
             atol=atol
         ) and self._device == other._device
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not self == other
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._moments)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator['cirq.Moment']:
         return iter(self._moments)
 
     def _decompose_(self) -> 'cirq.OP_TREE':

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -51,8 +51,10 @@ def rectify_acquaintance_strategy(circuit: 'cirq.Circuit',
         gate_type_to_ops: Dict[bool, List[
             ops.GateOperation]] = collections.defaultdict(list)
         for op in moment.operations:
-            gate_type_to_ops[isinstance(op.gate, AcquaintanceOpportunityGate)
-                    ].append(op)
+            if not isinstance(op, ops.GateOperation):
+                raise TypeError(f'expected GateOperation, got: {op}')
+            is_acquaintance = isinstance(op.gate, AcquaintanceOpportunityGate)
+            gate_type_to_ops[is_acquaintance].append(op)
         if len(gate_type_to_ops) == 1:
             rectified_moments.append(moment)
             continue
@@ -98,7 +100,9 @@ def replace_acquaintance_with_swap_network(circuit: 'cirq.Circuit',
     for moment_index, moment in enumerate(circuit):
         if reflected:
             moment = moment.transform_qubits(reverse_map.__getitem__)
-        if all(isinstance(op.gate, AcquaintanceOpportunityGate)
+        if all(
+                isinstance(op, ops.GateOperation) and
+                isinstance(op.gate, AcquaintanceOpportunityGate)
                 for op in moment.operations):
             swap_network_gate = SwapNetworkGate.from_operations(
                     qubit_order, moment.operations,

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -51,9 +51,8 @@ def rectify_acquaintance_strategy(circuit: 'cirq.Circuit',
         gate_type_to_ops: Dict[bool, List[
             ops.GateOperation]] = collections.defaultdict(list)
         for op in moment.operations:
-            if not isinstance(op, ops.GateOperation):
-                raise TypeError(f'expected GateOperation, got: {op}')
-            is_acquaintance = isinstance(op.gate, AcquaintanceOpportunityGate)
+            is_acquaintance = ops.op_gate_isinstance(
+                op, AcquaintanceOpportunityGate)
             gate_type_to_ops[is_acquaintance].append(op)
         if len(gate_type_to_ops) == 1:
             rectified_moments.append(moment)
@@ -101,8 +100,7 @@ def replace_acquaintance_with_swap_network(circuit: 'cirq.Circuit',
         if reflected:
             moment = moment.transform_qubits(reverse_map.__getitem__)
         if all(
-                isinstance(op, ops.GateOperation) and
-                isinstance(op.gate, AcquaintanceOpportunityGate)
+                ops.op_gate_isinstance(op, AcquaintanceOpportunityGate)
                 for op in moment.operations):
             swap_network_gate = SwapNetworkGate.from_operations(
                     qubit_order, moment.operations,

--- a/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq/contrib/acquaintance/mutation_utils.py
@@ -14,7 +14,7 @@
 
 import collections
 
-from typing import Dict, List, Optional, Sequence, Union, TYPE_CHECKING
+from typing import cast, Dict, List, Optional, Sequence, Union, TYPE_CHECKING
 
 from cirq import circuits, ops, optimizers
 
@@ -51,9 +51,10 @@ def rectify_acquaintance_strategy(circuit: 'cirq.Circuit',
         gate_type_to_ops: Dict[bool, List[
             ops.GateOperation]] = collections.defaultdict(list)
         for op in moment.operations:
-            is_acquaintance = ops.op_gate_isinstance(
-                op, AcquaintanceOpportunityGate)
-            gate_type_to_ops[is_acquaintance].append(op)
+            gate_op = cast(ops.GateOperation, op)
+            is_acquaintance = isinstance(gate_op.gate,
+                                         AcquaintanceOpportunityGate)
+            gate_type_to_ops[is_acquaintance].append(gate_op)
         if len(gate_type_to_ops) == 1:
             rectified_moments.append(moment)
             continue

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -14,10 +14,14 @@
 
 """A simplified time-slice of operations within a sequenced circuit."""
 
-from typing import Any, Callable, Iterable, Sequence, TypeVar, Union
+from typing import (Any, Callable, Iterable, Iterator, Sequence, TypeVar,
+                    TYPE_CHECKING, Union)
 
 from cirq import protocols
 from cirq.ops import raw_types
+
+if TYPE_CHECKING:
+    import cirq
 
 TSelf_Moment = TypeVar('TSelf_Moment', bound='Moment')
 
@@ -106,10 +110,10 @@ class Moment:
     def __copy__(self):
         return type(self)(self.operations)
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return bool(self.operations)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, type(self)):
             return NotImplemented
 
@@ -127,14 +131,14 @@ class Moment:
                                           key=lambda op: op.qubits),
                                    atol=atol)
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not self == other
 
     def __hash__(self):
         return hash(
             (Moment, tuple(sorted(self.operations, key=lambda op: op.qubits))))
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator['cirq.Operation']:
         return iter(self.operations)
 
     def __pow__(self, power):

--- a/cirq/protocols/inverse_protocol.py
+++ b/cirq/protocols/inverse_protocol.py
@@ -39,12 +39,12 @@ def inverse(val: 'cirq.Operation') -> 'cirq.Operation':
 
 
 @overload
-def inverse(val: 'cirq.OP_TREE') -> 'cirq.OP_TREE':
+def inverse(val: 'cirq.Circuit') -> 'cirq.Circuit':
     pass
 
 
 @overload
-def inverse(val: 'cirq.Circuit') -> 'cirq.Circuit':
+def inverse(val: 'cirq.OP_TREE') -> 'cirq.OP_TREE':
     pass
 
 
@@ -61,14 +61,14 @@ def inverse(val: 'cirq.Operation',
 
 
 @overload
-def inverse(val: 'cirq.OP_TREE',
-            default: TDefault) -> Union[TDefault, 'cirq.OP_TREE']:
+def inverse(val: 'cirq.Circuit',
+            default: TDefault) -> Union[TDefault, 'cirq.Circuit']:
     pass
 
 
 @overload
-def inverse(val: 'cirq.Circuit',
-            default: TDefault) -> Union[TDefault, 'cirq.Circuit']:
+def inverse(val: 'cirq.OP_TREE',
+            default: TDefault) -> Union[TDefault, 'cirq.OP_TREE']:
     pass
 
 


### PR DESCRIPTION
Also had to fix up a few type errors in other places resulting from this change. I find dealing with `cirq.Operation` versus `cirq.GateOperation` to be a persistent source of annoyance; is there some way we can make this simpler? For example have a `gate` field on all operations but type it as `Optional[cirq.Gate]`?