### PR TITLE
Improve types in decompose protocol

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1961,8 +1961,7 @@ def _apply_unitary_circuit(circuit: Circuit, state: np.ndarray,
 
 
 def _decompose_measurement_inversions(op: 'cirq.Operation') -> 'cirq.OP_TREE':
-    if (isinstance(op, ops.Operation) and
-            isinstance(op.gate, ops.MeasurementGate)):
+    if isinstance(op.gate, ops.MeasurementGate):
         return [ops.X(q) for q, b in zip(op.qubits, op.gate.invert_mask) if b]
     return NotImplemented
 

--- a/cirq/contrib/tpu/circuit_to_tensorflow.py
+++ b/cirq/contrib/tpu/circuit_to_tensorflow.py
@@ -185,12 +185,7 @@ class _QubitGrouping:
 
         return False
 
-    def intercept_decompose_func(self,
-                                 op: Union[ops.Operation, circuits.Circuit]
-                                 ) -> ops.OP_TREE:
-        if not isinstance(op, ops.Operation):
-            return NotImplemented
-
+    def intercept_decompose_func(self, op: ops.Operation) -> ops.OP_TREE:
         # Drop measurements.
         if protocols.is_measurement(op):
             return []


### PR DESCRIPTION
Also ensure that intercepting and fallback decomposers, which are
documented as taking cirq.Operation, are in fact only called with
Operations and not other op trees.