### PR TITLE
Use helper to simplify seeding

### DIFF
--- a/cirq/sim/__init__.py
+++ b/cirq/sim/__init__.py
@@ -34,6 +34,9 @@ from cirq.sim.mux import (
     sample_sweep,
 )
 
+from cirq.sim.random import (
+    prng_from_seed,)
+
 from cirq.sim.simulator import (
     SimulatesAmplitudes,
     SimulatesFinalState,

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -135,13 +135,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
 
         self._dtype = dtype
         self.noise = devices.NoiseModel.from_noise_model_like(noise)
-
-        if seed is None:
-            self.prng = None
-        elif isinstance(seed, np.random.RandomState):
-            self.prng = seed
-        else:
-            self.prng = np.random.RandomState(seed)
+        self._seed = seed
 
     def _run(self, circuit: circuits.Circuit,
              param_resolver: study.ParamResolver,
@@ -170,7 +164,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                                ops.MeasurementGate)]
         return step_result.sample_measurement_ops(measurement_ops,
                                                   repetitions,
-                                                  seed=self.prng)
+                                                  seed=self._seed)
 
     def _run_sweep_repeat(self,
                           circuit: circuits.Circuit,
@@ -285,7 +279,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
                             indices,
                             qid_shape=qid_shape,
                             out=state.tensor,
-                            seed=self.prng)
+                            seed=self._seed)
                         corrected = [
                             bit ^ (bit < 2 and mask)
                             for bit, mask in zip(bits, invert_mask)

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -21,7 +21,7 @@ from typing import Dict, Iterator, List, Optional, Type, Union, TYPE_CHECKING
 import numpy as np
 
 from cirq import circuits, ops, protocols, study, value, devices
-from cirq.sim import density_matrix_utils, simulator
+from cirq.sim import density_matrix_utils, random, simulator
 
 if TYPE_CHECKING:
     import cirq
@@ -127,7 +127,11 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
             dtype: The `numpy.dtype` used by the simulation. One of
                 `numpy.complex64` or `numpy.complex128`
             noise: A noise model to apply while simulating.
-            seed: The random seed to use for this simulator.
+            seed: The random seed to use for this simulator. If this is None,
+                the default prng `np.random` with no seed set will be used. If
+                this is an int, an `np.random.RandomState` initialized with
+                this seed will be used. If it is an `np.random.RandomState`,
+                this will be used.
         """
         if dtype not in {np.complex64, np.complex128}:
             raise ValueError(
@@ -135,7 +139,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
 
         self._dtype = dtype
         self.noise = devices.NoiseModel.from_noise_model_like(noise)
-        self._seed = seed
+        self._seed = random.prng_from_seed(seed)
 
     def _run(self, circuit: circuits.Circuit,
              param_resolver: study.ParamResolver,

--- a/cirq/sim/density_matrix_utils.py
+++ b/cirq/sim/density_matrix_utils.py
@@ -19,7 +19,7 @@ import numpy as np
 from scipy.stats import entropy
 
 from cirq import linalg, value
-from cirq.sim import wave_function
+from cirq.sim import random, wave_function
 
 
 def to_valid_density_matrix(
@@ -136,12 +136,7 @@ def sample_density_matrix(
     if repetitions == 0 or len(indices) == 0:
         return np.zeros(shape=(repetitions, len(indices)), dtype=np.int8)
 
-    if seed is None:
-        prng = np.random
-    elif isinstance(seed, np.random.RandomState):
-        prng = seed
-    else:
-        prng = np.random.RandomState(seed)
+    prng = random.prng_from_seed(seed)
 
     # Calculate the measurement probabilities.
     probs = _probs(density_matrix, indices, qid_shape)
@@ -218,12 +213,7 @@ def measure_density_matrix(
         return ([], out)
         # Final else: if out is matrix then matrix will be modified in place.
 
-    if seed is None:
-        prng = np.random
-    elif isinstance(seed, np.random.RandomState):
-        prng = seed
-    else:
-        prng = np.random.RandomState(seed)
+    prng = random.prng_from_seed(seed)
 
     # Cache initial shape.
     initial_shape = density_matrix.shape

--- a/cirq/sim/random.py
+++ b/cirq/sim/random.py
@@ -31,7 +31,7 @@ def prng_from_seed(seed: Optional[Union[int, np.random.RandomState]]):
     """
     if seed is None:
         return np.random
-    elif isinstance(seed, np.random.RandomState):
+    elif seed == np.random or isinstance(seed, np.random.RandomState):
         return seed
     elif isinstance(seed, int):
         return np.random.RandomState(seed)

--- a/cirq/sim/random.py
+++ b/cirq/sim/random.py
@@ -1,0 +1,41 @@
+# Copyright 2019 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for helping with randomness in simulations."""
+
+from typing import Optional, Union
+
+import numpy as np
+
+
+def prng_from_seed(seed: Optional[Union[int, np.random.RandomState]]):
+    """Return a numpy pseudo-random number generator.
+
+    Args:
+        seed: If None, will use `np.random`. If an instance of
+            `np.random.RandomState`, returns this. If an integer, this will use
+            `np.RandomState` seeded by this integer.
+
+    Raises:
+        ValueError if the type supplied is not correct.
+    """
+    if seed is None:
+        return np.random
+    elif isinstance(seed, np.random.RandomState):
+        return seed
+    elif isinstance(seed, int):
+        return np.random.RandomState(seed)
+    else:
+        raise ValueError('Pseudo-random number seed can only be an integer, '
+                         'None, or an numpy RandomState. Instead was {}'.format(
+                             type(seed)))

--- a/cirq/sim/random_test.py
+++ b/cirq/sim/random_test.py
@@ -1,0 +1,34 @@
+# Copyright 2019 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import numpy as np
+
+from cirq.sim import random
+
+
+def test_prng_from_seed():
+    assert random.prng_from_seed(None) == np.random
+
+    prng = random.prng_from_seed(10)
+    np.testing.assert_equal(prng.randint(0, 10, 3), [9, 4, 0])
+
+    prng = random.prng_from_seed(np.random.RandomState(seed=4))
+    np.testing.assert_equal(prng.randint(0, 10, 3), [7, 5, 1])
+
+
+def test_prng_wrong_type():
+    with pytest.raises(ValueError, match='float'):
+        _ = random.prng_from_seed(1.0)

--- a/cirq/sim/random_test.py
+++ b/cirq/sim/random_test.py
@@ -21,6 +21,7 @@ from cirq.sim import random
 
 def test_prng_from_seed():
     assert random.prng_from_seed(None) == np.random
+    assert random.prng_from_seed(np.random) == np.random
 
     prng = random.prng_from_seed(10)
     np.testing.assert_equal(prng.randint(0, 10, 3), [9, 4, 0])

--- a/cirq/sim/simulator.py
+++ b/cirq/sim/simulator.py
@@ -460,7 +460,11 @@ class StepResult(metaclass=abc.ABCMeta):
             measurement_ops: `GateOperation` instances whose gates are
                 `MeasurementGate` instances to be sampled form.
             repetitions: The number of samples to take.
-            seed: A seed for the pseudorandom number generator.
+        seed: The random seed to use for this simulator. If this is None,
+            the default prng `np.random` with no seed set will be used. If
+            this is an int, an `np.random.RandomState` initialized with
+            this seed will be used. If it is an `np.random.RandomState`,
+            this will be used.
 
         Returns: A dictionary from measurement gate key to measurement
             results. Measurement results are stored in a 2-dimensional

--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -141,13 +141,17 @@ class Simulator(simulator.SimulatesSamples,
         Args:
             dtype: The `numpy.dtype` used by the simulation. One of
                 `numpy.complex64` or `numpy.complex128`.
-            seed: The random seed to use for this simulator.
+            seed: The random seed to use for this simulator. If this is None,
+                the default prng `np.random` with no seed set will be used. If
+                this is an int, an `np.random.RandomState` initialized with
+                this seed will be used. If it is an `np.random.RandomState`,
+                this will be used.
         """
         if np.dtype(dtype).kind != 'c':
             raise ValueError(
                 'dtype must be a complex type but was {}'.format(dtype))
         self._dtype = dtype
-        self._seed = seed
+        self._seed = random.prng_from_seed(seed)
 
     def _run(
         self,
@@ -349,8 +353,7 @@ class Simulator(simulator.SimulatesSamples,
         # We work around numpy barfing on choosing from a list of
         # numpy arrays (which is not `one-dimensional`) by selecting
         # the index of the unitary.
-        prng = random.prng_from_seed(self._seed)
-        index = prng.choice(range(len(unitaries)), p=probs)
+        index = self._seed.choice(range(len(unitaries)), p=probs)
         shape = protocols.qid_shape(op) * 2
         unitary = unitaries[index].astype(self._dtype).reshape(shape)
         result = linalg.targeted_left_multiply(unitary, data.state, indices,

--- a/cirq/sim/wave_function.py
+++ b/cirq/sim/wave_function.py
@@ -21,7 +21,7 @@ import abc
 import numpy as np
 
 from cirq import linalg, ops, value
-from cirq.sim import simulator
+from cirq.sim import random, simulator
 
 
 class StateVectorMixin():
@@ -443,12 +443,7 @@ def sample_state_vector(
     if repetitions == 0 or len(indices) == 0:
         return np.zeros(shape=(repetitions, len(indices)), dtype=np.uint8)
 
-    if seed is None:
-        prng = np.random
-    elif isinstance(seed, np.random.RandomState):
-        prng = seed
-    else:
-        prng = np.random.RandomState(seed)
+    prng = random.prng_from_seed(seed)
 
     # Calculate the measurement probabilities.
     probs = _probs(state, indices, qid_shape)
@@ -519,12 +514,7 @@ def measure_state_vector(
         # Final else: if out is state then state will be modified in place.
         return ([], out)
 
-    if seed is None:
-        prng = np.random
-    elif isinstance(seed, np.random.RandomState):
-        prng = seed
-    else:
-        prng = np.random.RandomState(seed)
+    prng = random.prng_from_seed(seed)
 
     # Cache initial shape.
     initial_shape = state.shape

--- a/cirq/sim/wave_function.py
+++ b/cirq/sim/wave_function.py
@@ -419,7 +419,11 @@ def sample_state_vector(
         qid_shape: The qid shape of the state vector.  Specify this argument
             when using qudits.
         repetitions: The number of times to sample the state.
-        seed: A seed for the pseudorandom number generator.
+        seed: The random seed to use for this simulator. If this is None,
+            the default prng `np.random` with no seed set will be used. If
+            this is an int, an `np.random.RandomState` initialized with
+            this seed will be used. If it is an `np.random.RandomState`,
+            this will be used.
 
     Returns:
         Measurement results with True corresponding to the ``|1⟩`` state.
@@ -489,7 +493,11 @@ def measure_state_vector(
             same as the returned ndarray of the method. The shape and dtype of
             `out` will match that of state if `out` is None, otherwise it will
             match the shape and dtype of `out`.
-        seed: A seed for the pseudorandom number generator.
+        seed: The random seed to use for this simulator. If this is None,
+            the default prng `np.random` with no seed set will be used. If
+            this is an int, an `np.random.RandomState` initialized with
+            this seed will be used. If it is an `np.random.RandomState`,
+            this will be used.
 
     Returns:
         A tuple of a list and an numpy array. The list is an array of booleans


### PR DESCRIPTION
This adds a method `prng_from_seed` which is only used on the sim module.  This is only used when the prng is actually needed, making it easier to understand what this is when you read the code where it is used (by doing these conversion higher in the call chain one doesn't quite see why one is doing this).