### PR TITLE
Json serialization of ControlledGate and ControlledOperation

### DIFF
--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -32,7 +32,7 @@ class ControlledGate(raw_types.Gate):
             num_controls: int = None,
             control_values: Optional[Sequence[
                 Union[int, Collection[int]]]] = None,
-            control_qid_shape: Optional[Tuple[int, ...]] = None,
+            control_qid_shape: Optional[Sequence[int]] = None,
     ) -> None:
         """Initializes the controlled gate. If no arguments are specified for
            the controls, defaults to a single qubit control.
@@ -229,3 +229,11 @@ class ControlledGate(raw_types.Gate):
                 'control_qid_shape={!r})'.format(self.sub_gate,
                                                  self.control_values,
                                                  self.control_qid_shape))
+
+    def _json_dict_(self):
+        return {
+            'cirq_type': self.__class__.__name__,
+            'control_values': self.control_values,
+            'control_qid_shape': self.control_qid_shape,
+            'sub_gate': self.sub_gate,
+        }

--- a/cirq/ops/controlled_operation_test.py
+++ b/cirq/ops/controlled_operation_test.py
@@ -339,10 +339,10 @@ def test_controlled_operation_gate():
 
         @property
         def qubits(self):
-            return ()
+            return ()  # coverage: ignore
 
         def with_qubits(self, *new_qubits):
-            return self
+            return self  # coverage: ignore
 
     op = Gateless().controlled_by(cirq.LineQubit(0))
     assert op.gate is None

--- a/cirq/ops/controlled_operation_test.py
+++ b/cirq/ops/controlled_operation_test.py
@@ -328,3 +328,21 @@ def test_bounded_effect():
     assert cirq.approx_eq(cirq.trace_distance_bound(cy), 1.0)
     mock = cirq.ControlledOperation(qubits[:1], MockGate().on(*qubits[1:]))
     assert cirq.approx_eq(cirq.trace_distance_bound(mock), 1)
+
+
+def test_controlled_operation_gate():
+    gate = cirq.X.controlled(control_values=[0, 1], control_qid_shape=[2, 3])
+    op = gate.on(cirq.LineQubit(0), cirq.LineQid(1, 3), cirq.LineQubit(2))
+    assert op.gate == gate
+
+    class Gateless(cirq.Operation):
+
+        @property
+        def qubits(self):
+            return ()
+
+        def with_qubits(self, *new_qubits):
+            return self
+
+    op = Gateless().controlled_by(cirq.LineQubit(0))
+    assert op.gate is None

--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -51,6 +51,8 @@ class _ResolverCache:
                 'CCXPowGate': cirq.CCXPowGate,
                 'CCZPowGate': cirq.CCZPowGate,
                 'CNotPowGate': cirq.CNotPowGate,
+                'ControlledGate': cirq.ControlledGate,
+                'ControlledOperation': cirq.ControlledOperation,
                 'CSwapGate': cirq.CSwapGate,
                 'CZPowGate': cirq.CZPowGate,
                 'Circuit': cirq.Circuit,

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -142,6 +142,15 @@ TEST_OBJECTS = {
     cirq.CNOT,
     'CNotPowGate':
     cirq.CNotPowGate(exponent=0.123, global_shift=0.456),
+    'ControlledOperation':
+    cirq.ControlledOperation(sub_operation=cirq.Y(cirq.NamedQubit('target')),
+                             controls=cirq.LineQubit.range(2),
+                             control_values=[0, 1]),
+    'ControlledGate':
+    cirq.ControlledGate(sub_gate=cirq.Y,
+                        num_controls=2,
+                        control_values=[0, 1],
+                        control_qid_shape=(3, 2)),
     'CX':
     cirq.CX,
     'CSWAP':
@@ -457,8 +466,6 @@ NOT_YET_SERIALIZABLE = [
     'CliffordTableau',
     'CliffordTrialResult',
     'ConstantQubitNoiseModel',
-    'ControlledGate',
-    'ControlledOperation',
     'DensityMatrixSimulator',
     'DensityMatrixSimulatorState',
     'DensityMatrixStepResult',


### PR DESCRIPTION
- Also override 'gate' property of ControlledOperation
- Also fix overly-specific type annotation of control_qid_shape

Fixes https://github.com/quantumlib/Cirq/issues/2422