### PR TITLE
Generalize read/to_json to work with pathlib.Path and raw json text

### DIFF
--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -11,10 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import io
 import json
-from typing import Union, Any, Dict, Optional, List, Callable, Type, cast, \
-    TYPE_CHECKING, Iterable
+import pathlib
+from typing import (
+    Union,
+    Any,
+    Dict,
+    Optional,
+    List,
+    Callable,
+    Type,
+    cast,
+    TYPE_CHECKING,
+    Iterable,
+    overload,
+    IO,
+)
 
 import numpy as np
 import pandas as pd
@@ -294,7 +307,24 @@ def _cirq_object_hook(d, resolvers: List[Callable[[str], Union[None, Type]]]):
     return cls(**d)
 
 
-def to_json(obj: Any, file_or_fn, *, indent=2, cls=CirqEncoder):
+# pylint: disable=function-redefined
+@overload
+def to_json(obj: Any, file_or_fn: Union[IO, str], *, indent=2,
+            cls=CirqEncoder) -> None:
+    pass
+
+
+@overload
+def to_json(obj: Any, file_or_fn: None = None, *, indent=2,
+            cls=CirqEncoder) -> str:
+    pass
+
+
+def to_json(obj: Any,
+            file_or_fn: Union[None, IO, pathlib.Path, str] = None,
+            *,
+            indent: int = 2,
+            cls: Type[json.JSONEncoder] = CirqEncoder) -> Optional[str]:
     """Write a JSON file containing a representation of obj.
 
     The object may be a cirq object or have data members that are cirq
@@ -302,8 +332,10 @@ def to_json(obj: Any, file_or_fn, *, indent=2, cls=CirqEncoder):
 
     Args:
         obj: An object which can be serialized to a JSON representation.
-        file_or_fn: A filename (if a string), otherwise a file-like
-            object to serve as the destination for `obj`.
+        file_or_fn: A filename (if a string or `pathlib.Path`) to write to, or
+            an IO object (such as a file or buffer) to write to, or `None` to
+            indicate that the method should return the JSON text as its result.
+            Defaults to `None`.
         indent: Pretty-print the resulting file with this indent level.
             Passed to json.dump.
         cls: Passed to json.dump; the default value of CirqEncoder
@@ -312,21 +344,39 @@ def to_json(obj: Any, file_or_fn, *, indent=2, cls=CirqEncoder):
             party classes, prefer adding the _json_dict_ magic method
             to your classes rather than overriding this default.
     """
+    if file_or_fn is None:
+        buffer = io.StringIO()
+        to_json(obj, buffer)
+        buffer.seek(0)
+        return buffer.read()
+
     if isinstance(file_or_fn, str):
         with open(file_or_fn, 'w') as actually_a_file:
             return json.dump(obj, actually_a_file, indent=indent, cls=cls)
 
+    if isinstance(file_or_fn, pathlib.Path):
+        with file_or_fn.open('w') as actually_a_file:
+            return json.dump(obj, actually_a_file, indent=indent, cls=cls)
+
     return json.dump(obj, file_or_fn, indent=indent, cls=cls)
+# pylint: enable=function-redefined
 
 
 def read_json(
-        file_or_fn,
+        file_or_fn: Union[None, IO, pathlib.Path, str] = None,
+        *,
+        json_text: Optional[str] = None,
         resolvers: Optional[List[Callable[[str], Union[None, Type]]]] = None):
     """Read a JSON file that optionally contains cirq objects.
 
     Args:
-        file_or_fn: A filename (if a string), otherwise a file-like
-            object from which we read in a representation of an object.
+        file_or_fn: A filename (if a string or `pathlib.Path`) to read from, or
+            an IO object (such as a file or buffer) to read from, or `None` to
+            indicate that `json_text` argument should be used. Defaults to
+            `None`.
+        json_text: A string representation of the JSON to parse the object from,
+            or else `None` indicating `file_or_fn` should be used. Defaults to
+            `None`.
         resolvers: A list of functions that are called in order to turn
             the serialized `cirq_type` string into a constructable class.
             By default, top-level cirq objects that implement the SupportsJSON
@@ -335,6 +385,14 @@ def read_json(
             to indicate that it cannot resolve the given cirq_type and that
             the next resolver should be tried.
     """
+    if (file_or_fn is None) == (json_text is None):
+        raise ValueError('Must specify ONE of "file_or_fn" or "json".')
+
+    if json_text is not None:
+        file_or_fn = io.StringIO()
+        file_or_fn.write(json_text)
+        file_or_fn.seek(0)
+
     if resolvers is None:
         # This cast is required because mypy does not accept
         # assigning an expression of type T to a variable of type
@@ -347,6 +405,10 @@ def read_json(
 
     if isinstance(file_or_fn, str):
         with open(file_or_fn, 'r') as file:
+            return json.load(file, object_hook=obj_hook)
+
+    if isinstance(file_or_fn, pathlib.Path):
+        with file_or_fn.open('r') as file:
             return json.load(file, object_hook=obj_hook)
 
     return json.load(file_or_fn, object_hook=obj_hook)

--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -350,15 +350,15 @@ def to_json(obj: Any,
         buffer.seek(0)
         return buffer.read()
 
-    if isinstance(file_or_fn, str):
+    if isinstance(file_or_fn, (str, pathlib.Path)):
         with open(file_or_fn, 'w') as actually_a_file:
-            return json.dump(obj, actually_a_file, indent=indent, cls=cls)
+            json.dump(obj, actually_a_file, indent=indent, cls=cls)
+            return None
 
-    if isinstance(file_or_fn, pathlib.Path):
-        with file_or_fn.open('w') as actually_a_file:
-            return json.dump(obj, actually_a_file, indent=indent, cls=cls)
+    json.dump(obj, file_or_fn, indent=indent, cls=cls)
+    return None
 
-    return json.dump(obj, file_or_fn, indent=indent, cls=cls)
+
 # pylint: enable=function-redefined
 
 
@@ -403,12 +403,8 @@ def read_json(
     def obj_hook(x):
         return _cirq_object_hook(x, resolvers)
 
-    if isinstance(file_or_fn, str):
+    if isinstance(file_or_fn, (str, pathlib.Path)):
         with open(file_or_fn, 'r') as file:
             return json.load(file, object_hook=obj_hook)
 
-    if isinstance(file_or_fn, pathlib.Path):
-        with file_or_fn.open('r') as file:
-            return json.load(file, object_hook=obj_hook)
-
-    return json.load(file_or_fn, object_hook=obj_hook)
+    return json.load(cast(IO, file_or_fn), object_hook=obj_hook)

--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -347,10 +347,7 @@ def to_json(obj: Any,
             to your classes rather than overriding this default.
     """
     if file_or_fn is None:
-        buffer = io.StringIO()
-        to_json(obj, buffer)
-        buffer.seek(0)
-        return buffer.read()
+        return json.dumps(obj, indent=indent, cls=cls)
 
     if isinstance(file_or_fn, (str, pathlib.Path)):
         with open(file_or_fn, 'w') as actually_a_file:
@@ -390,11 +387,6 @@ def read_json(
     if (file_or_fn is None) == (json_text is None):
         raise ValueError('Must specify ONE of "file_or_fn" or "json".')
 
-    if json_text is not None:
-        file_or_fn = io.StringIO()
-        file_or_fn.write(json_text)
-        file_or_fn.seek(0)
-
     if resolvers is None:
         # This cast is required because mypy does not accept
         # assigning an expression of type T to a variable of type
@@ -404,6 +396,9 @@ def read_json(
 
     def obj_hook(x):
         return _cirq_object_hook(x, resolvers)
+
+    if json_text is not None:
+        return json.loads(json_text, object_hook=obj_hook)
 
     if isinstance(file_or_fn, (str, pathlib.Path)):
         with open(file_or_fn, 'r') as file:

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -16,6 +16,7 @@ import inspect
 
 import io
 import os
+import pathlib
 import textwrap
 from typing import Tuple, Iterator, Type
 
@@ -623,3 +624,22 @@ def test_all_roundtrip(cirq_obj_name: str, cls):
         # more strict: must be exact (no subclasses)
         assert type(obj) == cls
         assert_roundtrip(obj)
+
+
+def test_to_from_strings():
+    x_json_text = """{
+  "cirq_type": "_PauliX",
+  "exponent": 1.0,
+  "global_shift": 0.0
+}"""
+    assert cirq.to_json(cirq.X) == x_json_text
+    assert cirq.read_json(json_text=x_json_text) == cirq.X
+
+    with pytest.raises(ValueError, match='specify ONE'):
+        cirq.read_json(io.StringIO(), json_text=x_json_text)
+
+
+def test_pathlib_paths(tmpdir):
+    path = pathlib.Path(tmpdir) / 'op.json'
+    cirq.to_json(cirq.X, path)
+    assert cirq.read_json(path) == cirq.X


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/2422

Example serialize:

```python
cirq.to_json(cirq.X)
```

```
'{\n  "cirq_type": "_PauliX",\n  "exponent": 1.0,\n  "global_shift": 0.0\n}'
```

Example deserialize:

```python
cirq.read_json(json_text='{\n  "cirq_type": "_PauliX",\n  "exponent": 1.0,\n  "global_shift": 0.0\n}')
```

```
cirq.X
```