### PR TITLE
Speed up circuit creation

### DIFF
--- a/cirq/contrib/quirk/cells/arithmetic_cells.py
+++ b/cirq/contrib/quirk/cells/arithmetic_cells.py
@@ -49,10 +49,10 @@ class QuirkArithmeticOperation(ops.ArithmeticOperation):
         self.target = target
         self.inputs = inputs
 
-        for input in self.inputs:
-            if isinstance(input, int):
+        for input_register in self.inputs:
+            if isinstance(input_register, int):
                 continue
-            if set(self.target) & set(input):
+            if set(self.target) & set(input_register):
                 raise ValueError(f'Overlapping registers: '
                                  f'{self.target} {self.inputs}')
 

--- a/cirq/contrib/quirk/cells/arithmetic_cells.py
+++ b/cirq/contrib/quirk/cells/arithmetic_cells.py
@@ -49,6 +49,13 @@ class QuirkArithmeticOperation(ops.ArithmeticOperation):
         self.target = target
         self.inputs = inputs
 
+        for input in self.inputs:
+            if isinstance(input, int):
+                continue
+            if set(self.target) & set(input):
+                raise ValueError(f'Overlapping registers: '
+                                 f'{self.target} {self.inputs}')
+
         if self.operation.is_modular:
             r = inputs[-1]
             if isinstance(r, int):

--- a/cirq/contrib/quirk/cells/input_cells_test.py
+++ b/cirq/contrib/quirk/cells/input_cells_test.py
@@ -41,7 +41,7 @@ def test_input_cell():
         })
 
     # Overlaps with effect.
-    with pytest.raises(ValueError, match='Overlapping operations'):
+    with pytest.raises(ValueError, match='Overlapping registers'):
         _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":['
                                  '["+=A3","inputA3"]]}')
 
@@ -64,7 +64,7 @@ def test_reversed_input_cell():
         })
 
     # Overlaps with effect.
-    with pytest.raises(ValueError, match='Overlapping operations'):
+    with pytest.raises(ValueError, match='Overlapping registers'):
         _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":['
                                  '["+=A3","revinputA3"]]}')
 

--- a/cirq/devices/unconstrained_device.py
+++ b/cirq/devices/unconstrained_device.py
@@ -29,6 +29,9 @@ class _UnconstrainedDevice(device.Device):
     def validate_scheduled_operation(self, schedule, scheduled_operation):
         pass
 
+    def validate_moment(self, moment):
+        pass
+
     def validate_circuit(self, circuit):
         pass
 

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -81,7 +81,7 @@ class Moment:
         Returns:
             Whether this moment has operations involving the qubits.
         """
-        return any(q in self.qubits for q in qubits)
+        return bool(set(qubits) & self.qubits)
 
     def with_operation(self, operation: raw_types.Operation):
         """Returns an equal moment, but with the given op added.
@@ -93,7 +93,7 @@ class Moment:
             The new moment.
         """
         if any(q in self._qubits for q in operation.qubits):
-            raise ValueError('Overlapping operation: {}'.format(operation))
+            raise ValueError('Overlapping operations: {}'.format(operation))
 
         # Use private variables to facilitate a quick copy
         m = Moment()

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -49,7 +49,7 @@ class Moment:
 
         self._operations = tuple(operations)
         # Check that operations don't overlap.
-        affected_qubits = [q for op in operations for q in op.qubits]
+        affected_qubits = [q for op in self.operations for q in op.qubits]
         self._qubits = frozenset(affected_qubits)
         if len(affected_qubits) != len(self._qubits):
             raise ValueError(


### PR DESCRIPTION
- Reorganize qubit check so that containment is checked on a set.
- Moment.with_operation() cheats and uses private variables so that it
changes from O(n) to O(1).
- Overload validate_moment in unconstrained device so we don't iterate
over all moments.
- Perf improvement is like 100x for example code listed in comments
below.