### PR TITLE
Rename cirq-dev to cirq-unstable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,14 +114,14 @@ matrix:
     os: linux
     env: NAME=dev-release
     python: '3.7'
-    script: export CIRQ_DEV_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
+    script: export CIRQ_UNSTABLE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 before_deploy:
-- echo "Deploying dev version '$CIRQ_DEV_VERSION'"
+- echo "Deploying dev version '$CIRQ_UNSTABLE_VERSION'"
 deploy:
 - provider: pypi
   user: quantumlibdev
   on:
-    condition: '"$CIRQ_DEV_VERSION" == *dev*'
+    condition: '"$CIRQ_UNSTABLE_VERSION" == *dev*'
   distributions: bdist_wheel
   password:
     secure: KO3RuwLvjb5/J7akv2v/a9tEIbmErp7El6S+ZfMvDRlx8qpUfav1w4nvSGw6sfn837++2+F2Tb22wbJkjefpFMzg9mOdhFGwtOpiHSOnYlY2mnxVN9XdQnMS7F+8IMFas4J3EhqrlsZxoqyMy122S3pjtE/d6YSG+3YzmCu3rLsFl4EV6I5U8MgWJY8LDFqMIxuxgmEkJfPe5z9Sqqwtneelj39jobg4q1uZc0JD3rkI0hj/uhBvBoTTLQjPiZk3ZIkgkMmPVB8tDGK9eXqVuDK7U1ZoDWvTKNebZ94g46YuKVNY6tEJpgpacti6mMalva6wX8zYpWOrY0PPo34e5d/kfwkttnrMk+sPXJnvn5eM7tEWxF+PHz4ejcLEYpehgdbWksHaUVdPog7UrYXnertHDY42ukxF17JlU9rlf60IXJVmeYHTfB1p8V7Yfllgmfa49yGDnR68Y3iIR9NtT26ZoJnMAkrxvlTgz6poBbTKj+Gyr0pkTHLzniEo3D/C8xeVcD30yZPlXxCojcM4s2dM2h5IiQU//ubptP/TE0idG2AJiooEfGUsXZ+IbN4Zxvkoa4YzYCvYFlr42ZBnv0H5/xZc4uFK6rLcVtysZqWAj3QjVGIUX3G1sxy8ik+RSQun1Dhzov8v5RVtb6aShDWT6l6paAAEwrQNt0T44yo=

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ################################################################################
-# Produces and uploads dev-version wheels to a pypi package repository cirq-dev
+# Produces and uploads dev-version wheels to a pypi package 'cirq-unstable'
 # Note that this is not the dev-version for cirq, whose use is deprecated.
 #
 # Uploads to the test pypi repository unless the --prod switch is added.
@@ -112,8 +112,8 @@ cd "$(git rev-parse --show-toplevel)"
 tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap "{ rm -rf ${tmp_package_dir}; }" EXIT
 
-# Configure to push to cirq-dev and not cirq.
-export CIRQ_DEV_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
+# Configure to push to cirq-unstable and not cirq.
+export CIRQ_UNSTABLE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ description = ('A framework for creating, editing, and invoking '
 # README file as long_description.
 long_description = io.open('README.rst', encoding='utf-8').read()
 
-# If CIRQ_DEV_VERSION is set then we use cirq-dev as the name of the package
+# If CIRQ_UNSTABLE_VERSION is set then we use cirq-unstable as the name of the package
 # and update the version to this value.
-if 'CIRQ_DEV_VERSION' in os.environ:
-    name = 'cirq-dev'
-    __version__ = os.environ['CIRQ_DEV_VERSION']
+if 'CIRQ_UNSTABLE_VERSION' in os.environ:
+    name = 'cirq-unstable'
+    __version__ = os.environ['CIRQ_UNSTABLE_VERSION']
     long_description = (
         "**This is a development version of Cirq and may be "
         "unstable.**\n\n**For the latest stable release of Cirq "


### PR DESCRIPTION
- Refactor verify-published-package to have an --unstable flag.
- Refactor verify-published-package to require --prod/--test/--unstable be specified
- Rename various CIRQ_DEV type things to CIRQ_UNSTABLE type things

Fixes https://github.com/quantumlib/Cirq/issues/2431