### PR TITLE
Fix dataclasses package being installed for python 3.7+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-dataclasses
+dataclasses; python_version < '3.7'
 google-api-python-client~=1.6
 matplotlib~=3.0
 networkx==2.3


### PR DESCRIPTION
Python 3.7 has a built-in dataclasses module. This was causing a failure when verifying v0.6.0's package, because the dataclasses shim package was accessing private properties from typing that no longer existed in 3.7.