### PR TITLE
Move SycamoreGate to cirq.google

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -240,8 +240,6 @@ from cirq.ops import (
     SingleQubitMatrixGate,
     SWAP,
     SwapPowGate,
-    SYC,
-    SycamoreGate,
     T,
     ThreeQubitGate,
     ThreeQubitDiagonalGate,

--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -61,6 +61,11 @@ from cirq.google.line import (
     LinePlacementStrategy,
 )
 
+from cirq.google.ops.sycamore_gate import (
+    SycamoreGate,
+    SYC,
+)
+
 from cirq.google.optimizers import (
     ConvertToXmonGates,
     optimized_for_xmon,

--- a/cirq/google/gate_sets_test.py
+++ b/cirq/google/gate_sets_test.py
@@ -602,7 +602,7 @@ def test_serialize_deserialize_syc():
 
     q0 = cirq.GridQubit(1, 2)
     q1 = cirq.GridQubit(1, 3)
-    op = cirq.SYC(q0, q1)
+    op = cg.SYC(q0, q1)
     assert cg.SYC_GATESET.serialize_op_dict(op) == proto_dict
     assert cg.SYC_GATESET.deserialize_op_dict(proto_dict) == op
 

--- a/cirq/google/ops/__init__.py
+++ b/cirq/google/ops/__init__.py
@@ -16,4 +16,3 @@ from cirq.google.ops.sycamore_gate import (
     SycamoreGate,
     SYC,
 )
-

--- a/cirq/google/ops/__init__.py
+++ b/cirq/google/ops/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2019 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cirq.google.ops.sycamore_gate import (
+    SycamoreGate,
+    SYC,
+)
+

--- a/cirq/google/ops/sycamore_gate.py
+++ b/cirq/google/ops/sycamore_gate.py
@@ -44,7 +44,7 @@ class SycamoreGate(ops.FSimGate):
         super().__init__(theta=np.pi / 2, phi=np.pi / 6)
 
     def __repr__(self) -> str:
-        return 'cirq.SYC'
+        return 'cirq.google.SYC'
 
     def __str__(self) -> str:
         return 'SYC'

--- a/cirq/google/ops/sycamore_gate_test.py
+++ b/cirq/google/ops/sycamore_gate_test.py
@@ -15,10 +15,11 @@ import numpy as np
 import pytest
 
 import cirq
+import cirq.google as cg
 
 
 @pytest.mark.parametrize('gate_type,qubit_count', (
-    (cirq.SYC, 2),
+    (cg.SYC, 2),
     (cirq.PhasedXPowGate(phase_exponent=0.1), 1),
     (cirq.PhasedXPowGate(exponent=0.5, phase_exponent=0.1), 1),
 ))
@@ -32,13 +33,13 @@ def test_consistent_protocols(gate_type, qubit_count):
 
 
 def test_syc_str_repr():
-    assert str(cirq.SYC) == 'SYC'
-    assert repr(cirq.SYC) == 'cirq.SYC'
+    assert str(cg.SYC) == 'SYC'
+    assert repr(cg.SYC) == 'cirq.google.SYC'
 
 
 def test_syc_circuit_diagram():
     a, b = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit.from_ops(cirq.SYC(a, b))
+    circuit = cirq.Circuit.from_ops(cg.SYC(a, b))
     cirq.testing.assert_has_diagram(circuit, """
 0: ───SYC───
       │
@@ -47,12 +48,12 @@ def test_syc_circuit_diagram():
 
 
 def test_syc_is_specific_fsim():
-    assert cirq.SYC == cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6)
+    assert cg.SYC == cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6)
 
 
 def test_syc_unitary():
     cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(cirq.SYC),
+        cirq.unitary(cg.SYC),
         np.array([
             [1, 0, 0, 0],
             [0, 0, -1j, 0],

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -203,11 +203,6 @@ from cirq.ops.swap_gates import (
     SwapPowGate,
 )
 
-from cirq.ops.sycamore_gate import (
-    SycamoreGate,
-    SYC,
-)
-
 from cirq.ops.three_qubit_gates import (
     CCNOT,
     CCX,

--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -103,7 +103,7 @@ class _ResolverCache:
                 'SingleQubitPauliStringGateOperation':
                 cirq.SingleQubitPauliStringGateOperation,
                 'SwapPowGate': cirq.SwapPowGate,
-                'SycamoreGate': cirq.SycamoreGate,
+                'SycamoreGate': cirq.google.SycamoreGate,
                 'sympy.Symbol': sympy.Symbol,
                 'sympy.Add': lambda args: sympy.Add(*args),
                 'sympy.Mul': lambda args: sympy.Mul(*args),

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -279,9 +279,9 @@ TEST_OBJECTS = {
     cirq.X(Q0),
     'SwapPowGate': [cirq.SwapPowGate(), cirq.SWAP**0.5],
     'SYC':
-    cirq.SYC,
+    cirq.google.SYC,
     'SycamoreGate':
-    cirq.SycamoreGate(),
+    cirq.google.SycamoreGate(),
     'T':
     cirq.T,
     'TOFFOLI':


### PR DESCRIPTION
- This gate is hardware-specific, so moving it to cirq.google.