### PR TITLE
PointOptimizerSummary option to avoid flattening

### DIFF
--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -31,7 +31,7 @@ class PointOptimizationSummary:
     """A description of a local optimization to perform."""
 
     def __init__(self, clear_span: int, clear_qubits: Iterable['cirq.Qid'],
-                 new_operations: 'cirq.OP_TREE') -> None:
+                 new_operations: 'cirq.OP_TREE', preserve_moments: bool = False) -> None:
         """
         Args:
             clear_span: Defines the range of moments to affect. Specifically,
@@ -41,8 +41,11 @@ class PointOptimizationSummary:
                 with each affected moment.
             new_operations: The operations to replace the cleared out
                 operations with.
+            preserve_moments: Whether to keep Moments intact instead of
+                flattening them
         """
-        self.new_operations = tuple(ops.flatten_op_tree(new_operations))
+        self.new_operations = tuple(ops.flatten_op_tree(
+            new_operations, preserve_moments=preserve_moments))
         self.clear_span = clear_span
         self.clear_qubits = tuple(clear_qubits)
 

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -42,7 +42,9 @@ class PointOptimizationSummary:
             new_operations: The operations to replace the cleared out
                 operations with.
             preserve_moments: Whether to keep Moments intact instead of
-                flattening them
+                flattening them in this summary. Please be advised that
+                a PointOptimizer consuming this summary will flatten
+                operations no matter what, see gh-2406.
         """
         self.new_operations = tuple(ops.flatten_op_tree(
             new_operations, preserve_moments=preserve_moments))

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -44,10 +44,13 @@ class PointOptimizationSummary:
                 with each affected moment.
             new_operations: The operations to replace the cleared out
                 operations with.
-            preserve_moments: Whether to keep Moments intact instead of
-                flattening them in this summary. Please be advised that
-                a PointOptimizer consuming this summary will flatten
-                operations no matter what, see gh-2406.
+            preserve_moments: If set, `cirq.Moment` instances within
+                `new_operations` will be preserved exactly. Normally the
+                operations would be repacked to fit better into the
+                target space, which may move them between moments.
+                Please be advised that a PointOptimizer consuming this
+                summary will flatten operations no matter what,
+                see https://github.com/quantumlib/Cirq/issues/2406.
         """
         self.new_operations = tuple(
             ops.flatten_op_tree(new_operations,

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -30,8 +30,11 @@ if TYPE_CHECKING:
 class PointOptimizationSummary:
     """A description of a local optimization to perform."""
 
-    def __init__(self, clear_span: int, clear_qubits: Iterable['cirq.Qid'],
-                 new_operations: 'cirq.OP_TREE', preserve_moments: bool = False) -> None:
+    def __init__(self,
+                 clear_span: int,
+                 clear_qubits: Iterable['cirq.Qid'],
+                 new_operations: 'cirq.OP_TREE',
+                 preserve_moments: bool = False) -> None:
         """
         Args:
             clear_span: Defines the range of moments to affect. Specifically,
@@ -46,8 +49,9 @@ class PointOptimizationSummary:
                 a PointOptimizer consuming this summary will flatten
                 operations no matter what, see gh-2406.
         """
-        self.new_operations = tuple(ops.flatten_op_tree(
-            new_operations, preserve_moments=preserve_moments))
+        self.new_operations = tuple(
+            ops.flatten_op_tree(new_operations,
+                                preserve_moments=preserve_moments))
         self.clear_span = clear_span
         self.clear_qubits = tuple(clear_qubits)
 


### PR DESCRIPTION
This isn't actually enough as the point optimizer will flatten it (again). But this *does* make it so I can write my own PointOptimizer replacement that can respect it

xref #2406 