### PR TITLE
Speed up density matrix sampling

### DIFF
--- a/cirq/sim/density_matrix_utils.py
+++ b/cirq/sim/density_matrix_utils.py
@@ -259,7 +259,7 @@ def measure_density_matrix(
 
 
 def _probs(density_matrix: np.ndarray, indices: List[int],
-           qid_shape: Tuple[int, ...]) -> List[float]:
+           qid_shape: Tuple[int, ...]) -> np.ndarray:
     """Returns the probabilities for a measurement on the given indices."""
     # Only diagonal elements matter.
     all_probs = np.diagonal(
@@ -278,7 +278,7 @@ def _probs(density_matrix: np.ndarray, indices: List[int],
     probs = np.sum(probs, axis=tuple(range(1, len(probs.shape))))
 
     # To deal with rounding issues, ensure that the probabilities sum to 1.
-    probs /= np.sum(probs) # type: ignore
+    probs /= np.sum(probs)
     return probs
 
 

--- a/cirq/sim/density_matrix_utils.py
+++ b/cirq/sim/density_matrix_utils.py
@@ -269,12 +269,13 @@ def _probs(density_matrix: np.ndarray, indices: List[int],
 
     # Calculate the probabilities for measuring the particular results.
     meas_shape = tuple(qid_shape[i] for i in indices)
-    probs = [
-        np.sum(
-            np.abs(tensor[linalg.slice_for_qubits_equal_to(
-                indices, big_endian_qureg_value=b, qid_shape=qid_shape)]))
+    probs = np.abs([
+        tensor[linalg.slice_for_qubits_equal_to(indices,
+                                                big_endian_qureg_value=b,
+                                                qid_shape=qid_shape)]
         for b in range(np.prod(meas_shape, dtype=int))
-    ]
+    ])
+    probs = np.sum(probs, axis=tuple(range(1, len(probs.shape))))
 
     # To deal with rounding issues, ensure that the probabilities sum to 1.
     probs /= np.sum(probs) # type: ignore


### PR DESCRIPTION
Gives a ~1.5x using the same method as #2460 .