### PR TITLE
Loosen precision requirement on some tests

### DIFF
--- a/cirq/ops/linear_combinations_test.py
+++ b/cirq/ops/linear_combinations_test.py
@@ -1155,26 +1155,38 @@ def test_expectation_from_wavefunction_two_qubit_states():
     psum2 = -1 * cirq.X(q[0]) + 2 * cirq.X(q[1])
     wf1 = np.array([0, 1, 0, 0], dtype=np.complex)
     for state in [wf1, wf1.reshape(2, 2)]:
-        np.testing.assert_allclose(
-            psum1.expectation_from_wavefunction(state, qubit_map=q_map), -2.2)
-        np.testing.assert_allclose(
-            psum2.expectation_from_wavefunction(state, qubit_map=q_map), 0)
+        np.testing.assert_allclose(psum1.expectation_from_wavefunction(
+            state, qubit_map=q_map),
+                                   -2.2,
+                                   atol=1e-7)
+        np.testing.assert_allclose(psum2.expectation_from_wavefunction(
+            state, qubit_map=q_map),
+                                   0,
+                                   atol=1e-7)
 
     wf2 = np.array([1, 1, 1, 1], dtype=np.complex) / 2
     for state in [wf2, wf2.reshape(2, 2)]:
-        np.testing.assert_allclose(
-            psum1.expectation_from_wavefunction(state, qubit_map=q_map), 0)
-        np.testing.assert_allclose(
-            psum2.expectation_from_wavefunction(state, qubit_map=q_map), 1)
+        np.testing.assert_allclose(psum1.expectation_from_wavefunction(
+            state, qubit_map=q_map),
+                                   0,
+                                   atol=1e-7)
+        np.testing.assert_allclose(psum2.expectation_from_wavefunction(
+            state, qubit_map=q_map),
+                                   1,
+                                   atol=1e-7)
 
     psum3 = cirq.Z(q[0]) + cirq.X(q[1])
     wf3 = np.array([1, 1, 0, 0], dtype=np.complex) / np.sqrt(2)
     q_map_2 = {q0: 1, q1: 0}
     for state in [wf3, wf3.reshape(2, 2)]:
-        np.testing.assert_allclose(
-            psum3.expectation_from_wavefunction(state, qubit_map=q_map), 2)
-        np.testing.assert_allclose(
-            psum3.expectation_from_wavefunction(state, qubit_map=q_map_2), 0)
+        np.testing.assert_allclose(psum3.expectation_from_wavefunction(
+            state, qubit_map=q_map),
+                                   2,
+                                   atol=1e-7)
+        np.testing.assert_allclose(psum3.expectation_from_wavefunction(
+            state, qubit_map=q_map_2),
+                                   0,
+                                   atol=1e-7)
 
 
 def test_expectation_from_density_matrix_invalid_input():

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -834,32 +834,40 @@ def test_expectation_from_wavefunction_basis_states():
     x0 = cirq.PauliString({q0: cirq.X})
     q_map = {q0: 0}
 
-    np.testing.assert_allclose(
-        x0.expectation_from_wavefunction(np.array([1, 0], dtype=np.complex),
-                                         q_map), 0)
-    np.testing.assert_allclose(
-        x0.expectation_from_wavefunction(np.array([0, 1], dtype=np.complex),
-                                         q_map), 0)
-    np.testing.assert_allclose(
-        x0.expectation_from_wavefunction(
-            np.array([1, 1], dtype=np.complex) / np.sqrt(2), q_map), 1)
-    np.testing.assert_allclose(
-        x0.expectation_from_wavefunction(
-            np.array([1, -1], dtype=np.complex) / np.sqrt(2), q_map), -1)
+    np.testing.assert_allclose(x0.expectation_from_wavefunction(
+        np.array([1, 0], dtype=np.complex), q_map),
+                               0,
+                               atol=1e-7)
+    np.testing.assert_allclose(x0.expectation_from_wavefunction(
+        np.array([0, 1], dtype=np.complex), q_map),
+                               0,
+                               atol=1e-7)
+    np.testing.assert_allclose(x0.expectation_from_wavefunction(
+        np.array([1, 1], dtype=np.complex) / np.sqrt(2), q_map),
+                               1,
+                               atol=1e-7)
+    np.testing.assert_allclose(x0.expectation_from_wavefunction(
+        np.array([1, -1], dtype=np.complex) / np.sqrt(2), q_map),
+                               -1,
+                               atol=1e-7)
 
     y0 = cirq.PauliString({q0: cirq.Y})
-    np.testing.assert_allclose(
-        y0.expectation_from_wavefunction(
-            np.array([1, 1j], dtype=np.complex) / np.sqrt(2), q_map), 1)
-    np.testing.assert_allclose(
-        y0.expectation_from_wavefunction(
-            np.array([1, -1j], dtype=np.complex) / np.sqrt(2), q_map), -1)
-    np.testing.assert_allclose(
-        y0.expectation_from_wavefunction(
-            np.array([1, 1], dtype=np.complex) / np.sqrt(2), q_map), 0)
-    np.testing.assert_allclose(
-        y0.expectation_from_wavefunction(
-            np.array([1, -1], dtype=np.complex) / np.sqrt(2), q_map), 0)
+    np.testing.assert_allclose(y0.expectation_from_wavefunction(
+        np.array([1, 1j], dtype=np.complex) / np.sqrt(2), q_map),
+                               1,
+                               atol=1e-7)
+    np.testing.assert_allclose(y0.expectation_from_wavefunction(
+        np.array([1, -1j], dtype=np.complex) / np.sqrt(2), q_map),
+                               -1,
+                               atol=1e-7)
+    np.testing.assert_allclose(y0.expectation_from_wavefunction(
+        np.array([1, 1], dtype=np.complex) / np.sqrt(2), q_map),
+                               0,
+                               atol=1e-7)
+    np.testing.assert_allclose(y0.expectation_from_wavefunction(
+        np.array([1, -1], dtype=np.complex) / np.sqrt(2), q_map),
+                               0,
+                               atol=1e-7)
 
 
 def test_expectation_from_wavefunction_entangled_states():


### PR DESCRIPTION
This fixes 2 of the test failures listed at #2455 . I couldn't fix the third one this way though; that seems to be a separate issue.