### PR TITLE
Associate docstrings with public constants

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -22,6 +22,7 @@ from cirq import (
     # Low level
     _version,
     _compat,
+    _doc,
     type_workarounds,
 )
 with _import.delay_import('cirq.protocols'):

--- a/cirq/_doc.py
+++ b/cirq/_doc.py
@@ -1,0 +1,40 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Workaround for associating docstrings with public constants."""
+from typing import Any, Dict, NamedTuple, Optional
+
+DocProperties = NamedTuple(
+    'DocProperties',
+    [
+        ('doc_string', Optional[str]),
+    ],
+)
+
+RECORDED_CONST_DOCS: Dict[int, DocProperties] = {}
+
+
+def document(value: Any, doc_string: str):
+    """Stores documentation details about the given value.
+
+    This method is used to associate a docstring with global constants.
+
+    The given documentation information is filed under `id(value)` in
+    `cirq._doc.RECORDED_CONST_DOCS`.
+
+    Args:
+        value: The value to associate with documentation information.
+        doc_string: The doc string to associate with the value.
+    """
+    docs = DocProperties(doc_string=doc_string)
+    RECORDED_CONST_DOCS[id(value)] = docs

--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -15,6 +15,7 @@
 from typing import TYPE_CHECKING, Sequence, Union
 
 from cirq import ops, protocols, value
+from cirq._doc import document
 
 if TYPE_CHECKING:
     from typing import Iterable
@@ -206,6 +207,22 @@ class ConstantQubitNoiseModel(NoiseModel):
         return protocols.obj_to_dict_helper(self, ['qubit_noise_gate'])
 
 
-NO_NOISE = _NoNoiseModel()  # type: cirq.NoiseModel
-"""An object which can be unambiguously converted into a noise model."""
+NO_NOISE: 'cirq.NoiseModel' = _NoNoiseModel()
+document(
+    NO_NOISE, """The trivial noise model with no effects.
+
+    This is the noise model used when a `NOISE_MODEL_LIKE` noise parameter is
+    set to `None`.
+    """)
+
 NOISE_MODEL_LIKE = Union[None, 'cirq.NoiseModel', 'cirq.SingleQubitGate']
+document(
+    NOISE_MODEL_LIKE,  # type: ignore
+    """A `cirq.NoiseModel` or a value that can be trivially converted into one.
+
+    `None` is a `NOISE_MODEL_LIKE`. It will be replaced by the `cirq.NO_NOISE`
+    noise model.
+
+    A single qubit gate is a `NOISE_MODEL_LIKE`. It will be wrapped inside of a
+    `cirq.ConstantQubitNoiseModel`.
+    """)

--- a/cirq/devices/unconstrained_device.py
+++ b/cirq/devices/unconstrained_device.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from cirq import value, protocols
+from cirq._doc import document
 from cirq.devices import device
 
 
@@ -49,3 +50,5 @@ class _UnconstrainedDevice(device.Device):
 
 
 UNCONSTRAINED_DEVICE: device.Device = _UnconstrainedDevice()
+document(UNCONSTRAINED_DEVICE,
+         """A device with no constraints on operations or qubits.""")

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -14,6 +14,7 @@
 
 from typing import Dict, Optional, Iterable, List, Set, Tuple
 
+from cirq._doc import document
 from cirq.devices import GridQubit
 from cirq.google import gate_sets, serializable_gate_set
 from cirq.google.api import v2
@@ -186,6 +187,13 @@ Foxtail = _NamedConstantXmonDevice('cirq.google.Foxtail',
                                    exp_w_duration=Duration(nanos=20),
                                    exp_11_duration=Duration(nanos=50),
                                    qubits=_parse_device(_FOXTAIL_GRID)[0])
+document(Foxtail, f"""72 xmon qubit device.
+
+**Qubit grid**:
+```
+{str(Foxtail)}
+```
+""")
 
 # Duration dict in picoseconds
 _DURATIONS_FOR_XMON = {
@@ -219,6 +227,14 @@ Bristlecone = _NamedConstantXmonDevice(
     exp_w_duration=Duration(nanos=20),
     exp_11_duration=Duration(nanos=50),
     qubits=_parse_device(_BRISTLECONE_GRID)[0])
+document(
+    Bristlecone, f"""72 xmon qubit device.
+
+**Qubit grid**:
+```
+{str(Bristlecone)}
+```
+""")
 
 BRISTLECONE_PROTO = create_device_proto_from_diagram(_BRISTLECONE_GRID,
                                                      [gate_sets.XMON],

--- a/cirq/google/gate_sets.py
+++ b/cirq/google/gate_sets.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Gate sets supported by Google's apis."""
+from cirq._doc import document
 from cirq.google import serializable_gate_set
 from cirq.google.common_serializers import (
     SINGLE_QUBIT_SERIALIZERS,
@@ -44,6 +45,8 @@ SYC_GATESET = serializable_gate_set.SerializableGateSet(
         MEASUREMENT_DESERIALIZER,
     ],
 )
+document(SYC_GATESET,
+         """Gate set with fsim(pi/4, pi/6) as the core 2 qubit interaction.""")
 
 SQRT_ISWAP_GATESET = serializable_gate_set.SerializableGateSet(
     gate_set_name='sqrt_iswap',
@@ -57,6 +60,8 @@ SQRT_ISWAP_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_DESERIALIZERS,
         MEASUREMENT_DESERIALIZER,
     ])
+document(SQRT_ISWAP_GATESET,
+         """Gate set with sqrt(iswap) as the core 2 qubit interaction.""")
 
 
 # The xmon gate set.
@@ -73,3 +78,5 @@ XMON = serializable_gate_set.SerializableGateSet(
         MEASUREMENT_DESERIALIZER,
     ],
 )
+
+document(XMON, """Gate set for XMON devices.""")

--- a/cirq/google/ops/sycamore_gate.py
+++ b/cirq/google/ops/sycamore_gate.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from cirq import ops, protocols
+from cirq._doc import document
 
 if TYPE_CHECKING:
     import cirq
@@ -57,3 +58,19 @@ class SycamoreGate(ops.FSimGate):
 
 
 SYC = SycamoreGate()
+document(
+    SYC,
+    """The Sycamore gate is a two-qubit gate equivalent to FSimGate(π/2, π/6).
+
+           The unitary of this gate is
+
+               [[1, 0, 0, 0],
+                [0, 0, -1j, 0],
+                [0, -1j, 0, 0],
+                [0, 0, 0, exp(- 1j * π/6)]]
+
+           This gate can be performed on the Google's Sycamore chip and
+           is close to the gates that were used to demonstrate quantum
+           supremacy used in this paper:
+           https://www.nature.com/articles/s41586-019-1666-5
+           """)

--- a/cirq/linalg/combinators.py
+++ b/cirq/linalg/combinators.py
@@ -19,6 +19,8 @@ from typing import Union, Type
 
 import numpy as np
 
+from cirq._doc import document
+
 
 def kron(*factors: Union[np.ndarray, complex, float]) -> np.ndarray:
     """Computes the kronecker product of a sequence of values.
@@ -38,7 +40,13 @@ def kron(*factors: Union[np.ndarray, complex, float]) -> np.ndarray:
     return np.array(product)
 
 
-CONTROL_TAG = np.array([[float('nan'), 0], [0, 1]])  # For kron_with_controls
+CONTROL_TAG = np.array([[float('nan'), 0], [0, 1]])
+document(
+    CONTROL_TAG, """A special indicator value for `cirq.kron_with_controls`.
+
+    This value is a stand-in for "control operations on the other qubits based
+    on the value of this qubit", which otherwise doesn't have a proper matrix.
+    """)
 
 
 def kron_with_controls(*factors: Union[np.ndarray, complex, float]

--- a/cirq/linalg/operator_spaces.py
+++ b/cirq/linalg/operator_spaces.py
@@ -19,6 +19,7 @@ from typing import Dict, Tuple
 import numpy as np
 
 from cirq import value
+from cirq._doc import document
 
 PAULI_BASIS = {
     'I': np.eye(2),
@@ -26,6 +27,9 @@ PAULI_BASIS = {
     'Y': np.array([[0., -1j], [1j, 0.]]),
     'Z': np.diag([1., -1]),
 }
+document(
+    PAULI_BASIS,
+    """The four Pauli matrices (including identity) keyed by character.""")
 
 
 def kron_bases(*bases: Dict[str, np.ndarray],

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -24,7 +24,7 @@ This module creates Gate instances for the following gates:
 Each of these are implemented as EigenGates, which means that they can be
 raised to a power (i.e. cirq.H**0.5). See the definition in EigenGate.
 """
-from typing import Any, cast, Iterable, List, Optional, Tuple, Union
+from typing import Any, cast, Optional, Tuple, Union
 
 import numpy as np
 import sympy
@@ -32,6 +32,7 @@ import sympy
 import cirq
 from cirq import protocols, value
 from cirq._compat import proper_repr
+from cirq._doc import document
 from cirq.ops import gate_features, eigen_gate, raw_types
 
 from cirq.type_workarounds import NotImplementedType
@@ -848,51 +849,64 @@ def Rz(rads: value.TParamVal) -> ZPowGate:
     return ZPowGate(exponent=rads / pi, global_shift=-0.5)
 
 
-# The Hadamard gate.
-#
-# Matrix:
-#
-#     [[s, s],
-#      [s, -s]]
-#     where s = sqrt(0.5).
 H = HPowGate()
+document(
+    H, """The Hadamard gate.
 
-# The Clifford S gate.
-#
-# Matrix:
-#
-#     [[1, 0],
-#      [0, i]]
+    The `exponent=1` instance of `cirq.HPowGate`.
+
+    Matrix:
+        [[s, s],
+         [s, -s]]
+        where s = sqrt(0.5).
+    """)
+
 S = ZPowGate(exponent=0.5)
+document(
+    S, """The Clifford S gate.
 
+    The `exponent=0.5` instance of `cirq.ZPowGate`.
 
-# The non-Clifford T gate.
-#
-# Matrix:
-#
-#     [[1, 0]
-#      [0, exp(i pi / 4)]]
+    Matrix:
+        [[1, 0],
+         [0, i]]
+    """)
+
 T = ZPowGate(exponent=0.25)
+document(
+    T, """The non-Clifford T gate.
 
+    The `exponent=0.25` instance of `cirq.ZPowGate`.
 
-# The controlled Z gate.
-#
-# Matrix:
-#
-#     [[1, 0, 0, 0],
-#      [0, 1, 0, 0],
-#      [0, 0, 1, 0],
-#      [0, 0, 0, -1]]
+    Matrix:
+        [[1, 0]
+         [0, exp(i pi / 4)]]
+    """)
+
 CZ = CZPowGate()
+document(
+    CZ, """The controlled Z gate.
 
+    The `exponent=1` instance of `cirq.CZPowGate`.
 
-# The controlled NOT gate.
-#
-# Matrix:
-#
-#     [[1, 0, 0, 0],
-#      [0, 1, 0, 0],
-#      [0, 0, 0, 1],
-#      [0, 0, 1, 0]]
-CNOT = CNotPowGate()
-CX = CNOT
+    Matrix:
+
+        [[1 . . .],
+         [. 1 . .],
+         [. . 1 .],
+         [. . . -1]]
+    """)
+
+CNOT = CX = CNotPowGate()
+document(
+    CNOT, """The controlled NOT gate.
+
+    The `exponent=1` instance of `cirq.CNotPowGate`.
+
+    Matrix:
+
+        [[1 . . .],
+         [. 1 . .],
+         [. . . 1],
+         [. . 1 .]]
+    """)

--- a/cirq/ops/identity.py
+++ b/cirq/ops/identity.py
@@ -20,6 +20,7 @@ import numpy as np
 import sympy
 
 from cirq import protocols, value
+from cirq._doc import document
 from cirq.ops import raw_types
 
 
@@ -236,13 +237,15 @@ class IdentityOperation(raw_types.Operation):
         return cls(qubits=qubits)
 
 
-# The one qubit identity gate.
-#
-# Matrix:
-#
-#     [[1, 0],
-#      [0, 1]]
 I = IdentityGate(num_qubits=1)
+document(
+    I, """The one qubit identity gate.
+
+    Matrix:
+
+        [[1, 0],
+         [0, 1]]
+    """)
 
 
 def identity_each(*qubits: raw_types.Qid) -> raw_types.Operation:

--- a/cirq/ops/linear_combinations.py
+++ b/cirq/ops/linear_combinations.py
@@ -19,6 +19,7 @@ import numbers
 import numpy as np
 
 from cirq import protocols, value
+from cirq._doc import document
 from cirq.linalg import operator_spaces
 from cirq.ops import identity, raw_types, pauli_gates, pauli_string
 from cirq.ops.pauli_string import PauliString, _validate_qubit_mapping
@@ -27,6 +28,10 @@ from cirq.value.linear_dict import _format_terms
 UnitPauliStringT = FrozenSet[Tuple[raw_types.Qid, pauli_gates.Pauli]]
 PauliSumLike = Union[int, float, complex, PauliString, 'PauliSum', pauli_string.
                      SingleQubitPauliStringGateOperation]
+document(
+    PauliSumLike,  # type: ignore
+    """Any value that can be easily translated into a sum of Pauli products.
+    """)
 
 
 class LinearCombinationOfGates(value.LinearDict[raw_types.Gate]):

--- a/cirq/ops/op_tree.py
+++ b/cirq/ops/op_tree.py
@@ -18,6 +18,7 @@
 from typing import Callable, Iterable, Iterator, NoReturn, Union
 from typing_extensions import Protocol
 
+from cirq._doc import document
 from cirq.ops.moment import Moment
 from cirq.ops.raw_types import Operation
 
@@ -48,6 +49,21 @@ class OpTree(Protocol):
 
 
 OP_TREE = Union[Operation, OpTree]
+document(
+    OP_TREE,  # type: ignore
+    """An operation or nested collections of operations.
+
+    Here are some examples of things that can be given to a method that takes a
+    `cirq.OP_TREE` argument:
+
+    - A single operation (a `cirq.Operation`).
+    - A list of operations (a `List[cirq.Operation]`).
+    - A list of lists of operations (a `List[List[cirq.Operation]]`).
+    - A list mixing operations and generators of operations
+        (a `List[Union[cirq.Operation, Iterator[cirq.Operation]]]`).
+    - Generally anything that can be iterated, and its items iterated, and
+        so forth recursively until a bottom layer of operations is found.
+    """)
 
 
 def flatten_op_tree(root: OP_TREE, preserve_moments: bool = False

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from cirq import protocols
 from cirq._compat import proper_repr
+from cirq._doc import document
 from cirq.ops import gate_features, eigen_gate, common_gates, pauli_gates
 
 
@@ -259,5 +260,20 @@ class ZZPowGate(eigen_gate.EigenGate,
 
 
 XX = XXPowGate()
+document(
+    XX, """The tensor product of two X gates.
+
+    The `exponent=1` instance of `cirq.XXPowGate`.
+    """)
 YY = YYPowGate()
+document(
+    YY, """The tensor product of two Y gates.
+
+    The `exponent=1` instance of `cirq.YYPowGate`.
+    """)
 ZZ = ZZPowGate()
+document(
+    ZZ, """The tensor product of two Z gates.
+
+    The `exponent=1` instance of `cirq.ZZPowGate`.
+    """)

--- a/cirq/ops/pauli_gates.py
+++ b/cirq/ops/pauli_gates.py
@@ -15,6 +15,7 @@ import abc
 from typing import Union, TYPE_CHECKING, Tuple, cast
 
 from cirq import value
+from cirq._doc import document
 from cirq.ops import common_gates, raw_types, identity
 
 
@@ -143,28 +144,34 @@ class _PauliZ(Pauli, common_gates.ZPowGate):
         return cls(exponent=exponent)
 
 
-# The Pauli X gate.
-#
-# Matrix:
-#
-#   [[0, 1],
-#    [1, 0]]
 X = _PauliX()
+document(
+    X, """The Pauli X gate.
 
-# The Pauli Y gate.
-#
-# Matrix:
-#
-#     [[0, -i],
-#      [i, 0]]
+    Matrix:
+
+        [[0, 1],
+         [1, 0]]
+    """)
+
 Y = _PauliY()
+document(
+    Y, """The Pauli Y gate.
 
-# The Pauli Z gate.
-#
-# Matrix:
-#
-#     [[1, 0],
-#      [0, -1]]
+    Matrix:
+
+        [[0, -i],
+         [i, 0]]
+    """)
+
 Z = _PauliZ()
+document(
+    Z, """The Pauli Z gate.
+
+    Matrix:
+
+        [[1, 0],
+         [0, -1]]
+    """)
 
 Pauli._XYZ = (X, Y, Z)

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from cirq import value, protocols, linalg
 from cirq._compat import deprecated
+from cirq._doc import document
 from cirq.ops import (
     global_phase_op,
     raw_types,
@@ -40,11 +41,23 @@ if TYPE_CHECKING:
     import cirq
 
 # A value that can be unambiguously converted into a `cirq.PauliString`.
+
 PAULI_STRING_LIKE = Union[
     complex, 'cirq.OP_TREE',
     Mapping['cirq.Qid', Union['cirq.Pauli', 'cirq.IdentityGate']],
     Iterable,  # of PAULI_STRING_LIKE, but mypy doesn't do recursive types yet.
 ]
+document(
+    PAULI_STRING_LIKE,  # type: ignore
+    """A `cirq.PauliString` or a value that can easily be converted into one.
+
+    Complex numbers turn into the coefficient of an empty Pauli string.
+
+    Dictionaries from qubit to Pauli operation are wrapped into a Pauli string.
+
+    Collections of Pauli operations are recrusively multiplied into a single
+    Pauli string.
+    """)
 
 TDefault = TypeVar('TDefault')
 

--- a/cirq/ops/qubit_order_or_list.py
+++ b/cirq/ops/qubit_order_or_list.py
@@ -20,11 +20,14 @@ mypy.
 
 from typing import Iterable, Union
 
+from cirq._doc import document
 from cirq.ops import qubit_order, raw_types
 
 QubitOrderOrList = Union[qubit_order.QubitOrder, Iterable[raw_types.Qid]]
-"""Specifies a qubit ordering.
+document(
+    QubitOrderOrList,  # type: ignore
+    """Specifies a qubit ordering.
 
-The ordering can either be specified by an iterable (such as a list) with the
-qubits in the desired order, or by a `cirq.QubitOrder` object.
-"""
+    The ordering can either be specified by an iterable (such as a list) with
+    the qubits in the desired order, or by a `cirq.QubitOrder` object.
+    """)

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from cirq import protocols, value
 from cirq._compat import proper_repr
+from cirq._doc import document
 from cirq.ops import common_gates, gate_features, eigen_gate, raw_types
 
 
@@ -246,22 +247,26 @@ class ISwapPowGate(eigen_gate.EigenGate,
                                              self._global_shift)
 
 
-# The swap gate.
-#
-# Matrix:
-#
-#     [[1, 0, 0, 0],
-#      [0, 0, 1, 0],
-#      [0, 1, 0, 0],
-#      [0, 0, 0, 1]]
 SWAP = SwapPowGate()
+document(
+    SWAP, """The swap gate.
 
-# The iswap gate.
-#
-# Matrix:
-#
-#     [[1, 0, 0, 0],
-#      [0, 0, i, 0],
-#      [0, i, 0, 0],
-#      [0, 0, 0, 1]]
+    Matrix:
+
+        [[1, 0, 0, 0],
+         [0, 0, 1, 0],
+         [0, 1, 0, 0],
+         [0, 0, 0, 1]]
+    """)
+
 ISWAP = ISwapPowGate()
+document(
+    ISWAP, """The iswap gate.
+
+    Matrix:
+
+        [[1, 0, 0, 0],
+         [0, 0, i, 0],
+         [0, i, 0, 0],
+         [0, 0, 0, 1]]
+    """)

--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -21,6 +21,7 @@ import sympy
 
 from cirq import linalg, protocols, value
 from cirq._compat import proper_repr
+from cirq._doc import document
 from cirq.ops import (
     common_gates,
     controlled_gate,
@@ -545,12 +546,60 @@ class CSwapGate(gate_features.ThreeQubitGate,
         return 'cirq.FREDKIN'
 
 
-# Explicit names.
 CCZ = CCZPowGate()
-CCX = CCXPowGate()
-CSWAP = CSwapGate()
+document(
+    CCZ, """The Controlled-Controlled-Z gate.
 
-# Common names.
-TOFFOLI = CCX
-CCNOT = TOFFOLI
-FREDKIN = CSWAP
+    The `exponent=1` instance of `cirq.CCZPowGate`.
+
+    Matrix:
+
+    ```
+        [[1 . . . . . . .],
+         [. 1 . . . . . .],
+         [. . 1 . . . . .],
+         [. . . 1 . . . .],
+         [. . . . 1 . . .],
+         [. . . . . 1 . .],
+         [. . . . . . 1 .],
+         [. . . . . . . -1]]
+    ```
+    """)
+
+CCX = TOFFOLI = CCNOT = CCXPowGate()
+document(
+    CCX, """The TOFFOLI gate.
+
+    The `exponent=1` instance of `cirq.CCXPowGate`.
+
+    Matrix:
+    ```
+        [[1 . . . . . . .],
+         [. 1 . . . . . .],
+         [. . 1 . . . . .],
+         [. . . 1 . . . .],
+         [. . . . 1 . . .],
+         [. . . . . 1 . .],
+         [. . . . . . . 1],
+         [. . . . . . 1 .]]
+    ```
+    """)
+
+CSWAP = FREDKIN = CSwapGate()
+document(
+    CSWAP, """The Controlled Swap gate.
+
+    An instance of `cirq.CSwapGate`.
+
+    Matrix:
+    ```
+        [[1 . . . . . . .],
+         [. 1 . . . . . .],
+         [. . 1 . . . . .],
+         [. . . 1 . . . .],
+         [. . . . 1 . . .],
+         [. . . . . . 1 .],
+         [. . . . . 1 . .],
+         [. . . . . . . 1]]
+    ```
+    """)

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -17,14 +17,21 @@
 from typing import Dict, Union, TYPE_CHECKING, cast
 import sympy
 from cirq import value
+from cirq._doc import document
 
 if TYPE_CHECKING:
     import cirq
 
 
-# Things that ParamResolver understands how to wrap.
 ParamDictType = Dict[Union[str, sympy.Basic], Union[float, str, sympy.Symbol]]
+document(
+    ParamDictType,  # type: ignore
+    """Dictionary from symbols to values.""")
+
 ParamResolverOrSimilarType = Union['cirq.ParamResolver', ParamDictType, None]
+document(
+    ParamResolverOrSimilarType,  # type: ignore
+    """Something that can be used to turn parameters into values.""")
 
 
 class ParamResolver(object):

--- a/cirq/study/sweepable.py
+++ b/cirq/study/sweepable.py
@@ -16,12 +16,16 @@
 
 from typing import Dict, Iterable, Iterator, List, Union, cast
 
+from cirq._doc import document
 from cirq.study.resolver import ParamResolver, ParamResolverOrSimilarType
 from cirq.study.sweeps import ListSweep, Points, Sweep, UnitSweep, Zip
 
 
 Sweepable = Union[Dict[str, float], ParamResolver, Sweep, Iterable[
     Union[Dict[str, float], ParamResolver, Sweep]], None]
+document(
+    Sweepable,  # type: ignore
+    """An object or collection of objects representing a parameter sweep.""")
 
 
 def to_resolvers(sweepable: Sweepable) -> Iterator[ParamResolver]:

--- a/cirq/study/sweeps.py
+++ b/cirq/study/sweeps.py
@@ -19,6 +19,7 @@ import collections
 import itertools
 import sympy
 
+from cirq._doc import document
 from cirq.study import resolver
 
 
@@ -186,7 +187,8 @@ class _Unit(Sweep):
         return 'cirq.UnitSweep'
 
 
-UnitSweep = _Unit()  # singleton instance
+UnitSweep = _Unit()
+document(UnitSweep, """The singleton sweep with no parameters.""")
 
 
 class Product(Sweep):

--- a/cirq/value/duration.py
+++ b/cirq/value/duration.py
@@ -20,12 +20,25 @@ import sympy
 
 from cirq import protocols
 from cirq._compat import proper_repr, deprecated
+from cirq._doc import document
 
 if TYPE_CHECKING:
     import cirq
 
-# 0 is also a DURATION_LIKE, but it would be misleading to include `int`.
+
 DURATION_LIKE = Union[None, datetime.timedelta, 'cirq.Duration']
+document(
+    DURATION_LIKE,  # type: ignore
+    """A `cirq.Duration` or value that can trivially converted to one.
+
+    A `datetime.timedelta` is a `cirq.DURATION_LIKE`. It is converted while
+    preserving its duration.
+
+    `None` is a `cirq.DURATION_LIKE` that converts into a zero-length duration.
+
+    Note that 0 is a `DURATION_LIKE`, despite the fact that `int` is not listed,
+    because 0 is the only integer where the physical unit doesn't matter.
+    """)
 
 
 class Duration:

--- a/cirq/value/type_alias.py
+++ b/cirq/value/type_alias.py
@@ -14,7 +14,11 @@
 
 from typing import Union
 import sympy
+
+from cirq._doc import document
 """Supply aliases for commonly used types.
 """
 
 TParamVal = Union[float, sympy.Basic]
+document(TParamVal,
+         """A value that a parameter resolver may return for a symbol.""")

--- a/cirq/value/type_alias.py
+++ b/cirq/value/type_alias.py
@@ -20,5 +20,6 @@ from cirq._doc import document
 """
 
 TParamVal = Union[float, sympy.Basic]
-document(TParamVal,  # type: ignore
-         """A value that a parameter resolver may return for a symbol.""")
+document(
+    TParamVal,  # type: ignore
+    """A value that a parameter resolver may return for a symbol.""")

--- a/cirq/value/type_alias.py
+++ b/cirq/value/type_alias.py
@@ -20,5 +20,5 @@ from cirq._doc import document
 """
 
 TParamVal = Union[float, sympy.Basic]
-document(TParamVal,
+document(TParamVal,  # type: ignore
          """A value that a parameter resolver may return for a symbol.""")


### PR DESCRIPTION
- Add `cirq/_doc.py` with a `document` function
- Pass public constants into `document` when they are initialized
- Fixes the fact that e.g. [`cirq.OP_TREE` was being documented using `typing.Union`'s docstring](https://cirq.readthedocs.io/en/stable/generated/cirq.OP_TREE.html)