### PR TITLE
Add JSON resolver decorator

### DIFF
--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -390,6 +390,7 @@ def generalized_amplitude_damp(
 
 
 @value.value_equality
+@protocols.json.AddJson(key='AmplitudeDampingChannel')
 class AmplitudeDampingChannel(gate_features.SingleQubitGate):
     """Dampen qubit amplitudes through dissipation.
 

--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -21,6 +21,7 @@ import numpy as np
 from cirq import protocols, value
 from cirq.ops import (raw_types, common_gates, pauli_gates, gate_features,
                       identity)
+from cirq.protocols.json import AddJson
 
 
 @value.value_equality
@@ -390,7 +391,7 @@ def generalized_amplitude_damp(
 
 
 @value.value_equality
-@protocols.json.AddJson(key='AmplitudeDampingChannel')
+@AddJson(key='AmplitudeDampingChannel')
 class AmplitudeDampingChannel(gate_features.SingleQubitGate):
     """Dampen qubit amplitudes through dissipation.
 

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -59,6 +59,7 @@ from cirq.protocols.json import (
     to_json,
     read_json,
     obj_to_dict_helper,
+    AddJson,
 )
 from cirq.protocols.measurement_key_protocol import (
     is_measurement,


### PR DESCRIPTION
Will help to resolve #2445.

The idea here is to move away from the model for the json.py file has to reference all of the other classes, and instead have a Plug-In model where all of the classes can register themselves with the json resolver. That way, code in contrib/ can also use this decorator, and json.py will not need to reference it directly.

This PR is just a proof of concept - if it makes sense, I will add the decorator to all the other classes in Cirq. Any input is appreciated :) @mpharrigan @Strilanc  