### PR TITLE
ISwapRotation

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -195,6 +195,7 @@ from cirq.ops import (
     InterchangeableQubitsGate,
     ISWAP,
     ISwapPowGate,
+    ISwapRotation,
     LinearCombinationOfGates,
     LinearCombinationOfOperations,
     measure,

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -200,6 +200,7 @@ from cirq.ops.raw_types import (
 from cirq.ops.swap_gates import (
     ISWAP,
     ISwapPowGate,
+    ISwapRotation,
     SWAP,
     SwapPowGate,
 )

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -23,6 +23,7 @@ raised to a power (i.e. cirq.ISWAP**0.5). See the definition in EigenGate.
 from typing import Optional, Tuple
 
 import numpy as np
+import sympy
 
 from cirq import protocols, value
 from cirq._compat import proper_repr
@@ -245,6 +246,12 @@ class ISwapPowGate(eigen_gate.EigenGate,
         return ('cirq.ISwapPowGate(exponent={}, '
                 'global_shift={!r})').format(proper_repr(self._exponent),
                                              self._global_shift)
+
+
+def ISwapRotation(angle_rads: value.TParamVal) -> ISwapPowGate:
+    """Returns gate with matrix exp(+i angle_rads (X⊗X + Y⊗Y) / 2)."""
+    pi = sympy.pi if protocols.is_parameterized(angle_rads) else np.pi
+    return ISwapPowGate()**(2 * angle_rads / pi)
 
 
 SWAP = SwapPowGate()


### PR DESCRIPTION
Many gates in cirq and OpenFermion-Cirq have utilities associated with them that take the rotation angle associated with the gate and convert it to the parameters needed to instantiate the gate.

In particular, XXYY and YXXY in OpenFermion-Cirq have such utilities: Rxxyy and Ryxxy. When PhasedISwapPowGate was added to cirq in order to eventually replace OpenFermion-Cirq's YXXY it was added together with GivensRotation to replace Ryxxy. However, cirq's replacement for XXYY, i.e. ISwapPowGate, lacks a corresponding utility to replace Rxxyy. This PR implements the missing function.