### PR TITLE
identity operation -> gate property

### DIFF
--- a/cirq/ops/identity.py
+++ b/cirq/ops/identity.py
@@ -179,6 +179,10 @@ class IdentityOperation(raw_types.Operation):
         """The qubits targeted by the operation."""
         return self._qubits
 
+    @property
+    def gate(self) -> raw_types.Gate:
+        return IdentityGate(num_qubits=len(self.qubits))
+
     def with_qubits(self, *new_qubits: raw_types.Qid) -> 'raw_types.Operation':
         return IdentityOperation(new_qubits)
 


### PR DESCRIPTION
Sometime before the v06 release the `gate` property of `IdentityOperation` was removed. This leads to a sort of confusing interface with operations
```
cirq.X(qubit).gate 
>>> cirq.X
cirq.I(qubit).gate
>>> None
```
was there a reason for this change?