### PR TITLE
Fix timings for Google devices

### DIFF
--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -201,7 +201,7 @@ _DURATIONS_FOR_XMON = {
     'cz': 50_000,
     'xy': 20_000,
     'z': 0,
-    'meas': 4_000_000,  # 1000 ms for readout, 3000ns for "ring down"
+    'meas': 4_000_000,  # 1000ns for readout, 3000ns for "ring down"
 }
 
 FOXTAIL_PROTO = create_device_proto_from_diagram(_FOXTAIL_GRID,

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -183,12 +183,11 @@ class _NamedConstantXmonDevice(XmonDevice):
         }
 
 
-Foxtail = _NamedConstantXmonDevice(
-    'cirq.google.Foxtail',
-    measurement_duration=Duration(nanos=4000),
-    exp_w_duration=Duration(nanos=20),
-    exp_11_duration=Duration(nanos=50),
-    qubits=_parse_device(_FOXTAIL_GRID)[0])
+Foxtail = _NamedConstantXmonDevice('cirq.google.Foxtail',
+                                   measurement_duration=Duration(nanos=4000),
+                                   exp_w_duration=Duration(nanos=20),
+                                   exp_11_duration=Duration(nanos=50),
+                                   qubits=_parse_device(_FOXTAIL_GRID)[0])
 document(Foxtail, f"""72 xmon qubit device.
 
 **Qubit grid**:
@@ -229,7 +228,8 @@ Bristlecone = _NamedConstantXmonDevice(
     exp_w_duration=Duration(nanos=20),
     exp_11_duration=Duration(nanos=50),
     qubits=_parse_device(_BRISTLECONE_GRID)[0])
-document(Bristlecone, f"""72 xmon qubit device.
+document(
+    Bristlecone, f"""72 xmon qubit device.
 
 **Qubit grid**:
 ```

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -184,7 +184,7 @@ class _NamedConstantXmonDevice(XmonDevice):
 
 
 Foxtail = _NamedConstantXmonDevice('cirq.google.Foxtail',
-                                   measurement_duration=Duration(nanos=1000),
+                                   measurement_duration=Duration(nanos=4000),
                                    exp_w_duration=Duration(nanos=20),
                                    exp_11_duration=Duration(nanos=50),
                                    qubits=_parse_device(_FOXTAIL_GRID)[0])
@@ -201,7 +201,7 @@ _DURATIONS_FOR_XMON = {
     'cz': 50_000,
     'xy': 20_000,
     'z': 0,
-    'meas': 1_000_000,
+    'meas': 4_000_000, # 1000 ms for readout, 3000ns for "ring down"
 }
 
 FOXTAIL_PROTO = create_device_proto_from_diagram(_FOXTAIL_GRID,
@@ -224,7 +224,7 @@ ABCDEFGHIJKL
 
 Bristlecone = _NamedConstantXmonDevice(
     'cirq.google.Bristlecone',
-    measurement_duration=Duration(nanos=1000),
+    measurement_duration=Duration(nanos=4000),
     exp_w_duration=Duration(nanos=20),
     exp_11_duration=Duration(nanos=50),
     qubits=_parse_device(_BRISTLECONE_GRID)[0])
@@ -262,7 +262,7 @@ _SYCAMORE_DURATIONS_PICOS = {
     'inv_fsim_pi_4': 32_000,
     'syc': 12_000,
     'z': 0,
-    'meas': 1_000_000,
+    'meas': 4_000_000, # 1000 ns for readout, 3000ns for ring_down
 }
 
 SYCAMORE_PROTO = create_device_proto_from_diagram(

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -183,25 +183,27 @@ class _NamedConstantXmonDevice(XmonDevice):
         }
 
 
-Foxtail = _NamedConstantXmonDevice('cirq.google.Foxtail',
-                                   measurement_duration=Duration(nanos=4000),
-                                   exp_w_duration=Duration(nanos=20),
-                                   exp_11_duration=Duration(nanos=50),
-                                   qubits=_parse_device(_FOXTAIL_GRID)[0])
+Foxtail = _NamedConstantXmonDevice(
+    'cirq.google.Foxtail',
+    measurement_duration=Duration(nanos=4000),
+    exp_w_duration=Duration(nanos=20),
+    exp_11_duration=Duration(nanos=50),
+    qubits=_parse_device(_FOXTAIL_GRID)[0])
 document(Foxtail, f"""72 xmon qubit device.
 
 **Qubit grid**:
 ```
 {str(Foxtail)}
 ```
-""")
+"""
+   )
 
 # Duration dict in picoseconds
 _DURATIONS_FOR_XMON = {
     'cz': 50_000,
     'xy': 20_000,
     'z': 0,
-    'meas': 4_000_000, # 1000 ms for readout, 3000ns for "ring down"
+    'meas': 4_000_000,  # 1000 ms for readout, 3000ns for "ring down"
 }
 
 FOXTAIL_PROTO = create_device_proto_from_diagram(_FOXTAIL_GRID,
@@ -235,7 +237,8 @@ document(
 ```
 {str(Bristlecone)}
 ```
-""")
+"""
+   )
 
 BRISTLECONE_PROTO = create_device_proto_from_diagram(_BRISTLECONE_GRID,
                                                      [gate_sets.XMON],
@@ -262,7 +265,7 @@ _SYCAMORE_DURATIONS_PICOS = {
     'inv_fsim_pi_4': 32_000,
     'syc': 12_000,
     'z': 0,
-    'meas': 4_000_000, # 1000 ns for readout, 3000ns for ring_down
+    'meas': 4_000_000,  # 1000 ns for readout, 3000ns for ring_down
 }
 
 SYCAMORE_PROTO = create_device_proto_from_diagram(

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -195,8 +195,7 @@ document(Foxtail, f"""72 xmon qubit device.
 ```
 {str(Foxtail)}
 ```
-"""
-   )
+""")
 
 # Duration dict in picoseconds
 _DURATIONS_FOR_XMON = {
@@ -230,15 +229,13 @@ Bristlecone = _NamedConstantXmonDevice(
     exp_w_duration=Duration(nanos=20),
     exp_11_duration=Duration(nanos=50),
     qubits=_parse_device(_BRISTLECONE_GRID)[0])
-document(
-    Bristlecone, f"""72 xmon qubit device.
+document(Bristlecone, f"""72 xmon qubit device.
 
 **Qubit grid**:
 ```
 {str(Bristlecone)}
 ```
-"""
-   )
+""")
 
 BRISTLECONE_PROTO = create_device_proto_from_diagram(_BRISTLECONE_GRID,
                                                      [gate_sets.XMON],

--- a/cirq/google/devices/known_devices_test.py
+++ b/cirq/google/devices/known_devices_test.py
@@ -75,7 +75,7 @@ valid_gate_sets {
       name: "invert_mask"
       type: REPEATED_BOOLEAN
     }
-    gate_duration_picos: 1000000
+    gate_duration_picos: 4000000
     valid_targets: "meas_targets"
   }
 }
@@ -377,7 +377,7 @@ def test_json_dict():
     assert cg.Foxtail._json_dict_() == {
         'cirq_type': '_NamedConstantXmonDevice',
         'constant': 'cirq.google.Foxtail',
-        'measurement_duration': cirq.Duration(nanos=1000),
+        'measurement_duration': cirq.Duration(nanos=4000),
         'exp_w_duration': cirq.Duration(nanos=20),
         'exp_11_duration': cirq.Duration(nanos=50),
         'qubits': sorted(cirq.google.Foxtail.qubits)
@@ -386,7 +386,7 @@ def test_json_dict():
     assert cirq.google.Bristlecone._json_dict_() == {
         'cirq_type': '_NamedConstantXmonDevice',
         'constant': 'cirq.google.Bristlecone',
-        'measurement_duration': cirq.Duration(nanos=1000),
+        'measurement_duration': cirq.Duration(nanos=4000),
         'exp_w_duration': cirq.Duration(nanos=20),
         'exp_11_duration': cirq.Duration(nanos=50),
         'qubits': sorted(cirq.google.Bristlecone.qubits)


### PR DESCRIPTION
- 1000ns is just for read-out.  If we want to use this timing for
non-terminal measurements, there is also a 3000ns "ring down" for
signals to depopulate.