### PR TITLE
Make circuit rendering of PhasedISwapPowGate consistent with other gates

### DIFF
--- a/cirq/ops/phased_iswap_gate.py
+++ b/cirq/ops/phased_iswap_gate.py
@@ -156,6 +156,17 @@ class PhasedISwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
             'ZZ': expansion['ZZ'],
         })
 
+    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
+                              ) -> 'protocols.CircuitDiagramInfo':
+        if (isinstance(self._phase_exponent, (sympy.Basic, int)) or
+                args.precision is None):
+            s = 'PhISwap({})'.format(self._phase_exponent)
+        else:
+            s = 'PhISwap({{:.{}}})'.format(args.precision).format(
+                self._phase_exponent)
+        return protocols.CircuitDiagramInfo(
+            wire_symbols=(s, s), exponent=self._diagram_exponent(args))
+
     def __str__(self) -> str:
         if self.exponent == 1:
             return 'PhasedISWAP'

--- a/cirq/ops/phased_iswap_gate_test.py
+++ b/cirq/ops/phased_iswap_gate_test.py
@@ -108,6 +108,24 @@ def test_phased_iswap_has_consistent_protocols(phase_exponent, exponent):
         ignoring_global_phase=False)
 
 
+def test_diagram():
+    q0, q1 = cirq.LineQubit.range(2)
+    c = cirq.Circuit(
+        cirq.PhasedISwapPowGate(phase_exponent=sympy.Symbol('p'),
+                                exponent=sympy.Symbol('t')).on(q0, q1),
+        cirq.PhasedISwapPowGate(phase_exponent=2 * sympy.Symbol('p'),
+                                exponent=1 - sympy.Symbol('t')).on(q0, q1),
+        cirq.PhasedISwapPowGate(phase_exponent=0.2, exponent=1).on(q0, q1),
+        cirq.PhasedISwapPowGate(phase_exponent=0.3, exponent=0.4).on(q0, q1),
+    )
+    cirq.testing.assert_has_diagram(
+        c, """
+0: ───PhISwap(p)─────PhISwap(2*p)───────────PhISwap(0.2)───PhISwap(0.3)───────
+      │              │                      │              │
+1: ───PhISwap(p)^t───PhISwap(2*p)^(1 - t)───PhISwap(0.2)───PhISwap(0.3)^0.4───
+""")
+
+
 @pytest.mark.parametrize('angle_rads', (-np.pi, -np.pi / 3, -0.1, np.pi / 5))
 def test_givens_rotation_unitary(angle_rads):
     actual = cirq.unitary(cirq.GivensRotation(angle_rads))


### PR DESCRIPTION
Before:

```
In [3]: cirq.Circuit([cirq.PhasedXPowGate(phase_exponent=0.1, exponent=0.2).on(q0), cirq.ISWAP(q0, q1)**0.3, cirq.PhasedISwapPowGate(phase_exponent=0.4, exponent=0.5).on(q0, q1)])

Out[3]: 
0: ───PhX(0.1)^0.2───iSwap───────PhasedISWAP**0.5───
                     │           │
1: ──────────────────iSwap^0.3───#2─────────────────
```

After:

```
In [3]: cirq.Circuit([cirq.PhasedXPowGate(phase_exponent=0.1, exponent=0.2).on(q0), cirq.ISWAP(q0, q1)**0.3, cirq.PhasedISwapPowGate(phase_exponent=0.4, exponent=0.5).on(q0, q1)])

Out[3]: 
0: ───PhX(0.1)^0.2───iSwap───────PhISwap(0.4)───────
                     │           │
1: ──────────────────iSwap^0.3───PhISwap(0.4)^0.5───
```