### PR TITLE
Fix ParamResolver.param_dict type

### DIFF
--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-ParamDictType = Dict[Union[str, sympy.Basic], Union[float, str, sympy.Symbol]]
+ParamDictType = Dict[Union[str, sympy.Symbol], Union[float, str, sympy.Symbol]]
 document(
     ParamDictType,  # type: ignore
     """Dictionary from symbols to values.""")

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -57,9 +57,8 @@ class ParamResolver(object):
             return  # Already initialized. Got wrapped as part of the __new__.
 
         self._param_hash = None
-        self.param_dict = cast(
-            Dict[Union[str, sympy.Symbol], Union[float, str, sympy.Symbol]],
-            {} if param_dict is None else param_dict)
+        self.param_dict = cast(ParamDictType,
+                               {} if param_dict is None else param_dict)
 
     def value_of(self,
                  value: Union[sympy.Basic, float, str]) -> 'cirq.TParamVal':

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-ParamDictType = Dict[Union[str, sympy.Symbol], Union[float, str, sympy.Symbol]]
+ParamDictType = Dict[Union[str, sympy.Symbol], Union[float, str, sympy.Basic]]
 document(
     ParamDictType,  # type: ignore
     """Dictionary from symbols to values.""")


### PR DESCRIPTION
Is this correct? The new type allows keys that are sympy.Basic, not just sympy.Symbol.