### PR TITLE
Store ParamResolver keys as strings

### DIFF
--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -93,20 +93,16 @@ class ParamResolver:
         if isinstance(value, float):
             return value
 
-        # Handles 2 cases:
-        # Input is a string and maps to a number in the dictionary
-        # Input is a symbol and maps to a number in the dictionary
-        # In both cases, return it directly.
+        # Input is a string and maps to a number in the dictionary.
+        # Return it directly.
         if value in self.param_dict:
             param_value = self.param_dict[value]
             if isinstance(param_value, (float, int)):
                 return param_value
 
-        # Input is a string and is not in the dictionary.
+        # Input is a string and did not map to a number in the dictionary.
         # Treat it as a symbol instead.
         if isinstance(value, str):
-            # If the string is in the param_dict as a value, return it.
-            # Otherwise, try using the symbol instead.
             return self.value_of(sympy.Symbol(value))
 
         # Input is a symbol (sympy.Symbol('a')) and its string maps to a number

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-ParamDictType = Dict[Union[str, sympy.Basic], Union[float, str, sympy.Symbol]]
+ParamDictType = Dict[Union[str, sympy.Symbol], Union[float, str, sympy.Basic]]
 document(
     ParamDictType,  # type: ignore
     """Dictionary from symbols to values.""")
@@ -33,7 +33,7 @@ document(
     """Something that can be used to turn parameters into values.""")
 
 
-class ParamResolver(object):
+class ParamResolver:
     """Resolves sympy.Symbols to actual values.
 
     A Symbol is a wrapped parameter name (str). A ParamResolver is an object
@@ -58,8 +58,11 @@ class ParamResolver(object):
 
         self._param_hash = None
         self.param_dict = cast(
-            Dict[Union[str, sympy.Symbol], Union[float, str, sympy.Symbol]],
-            {} if param_dict is None else param_dict)
+            Dict[str, Union[float, str, sympy.Symbol]],
+            {} if param_dict is None else {
+                param.name if isinstance(param, sympy.Symbol) else param: value
+                for param, value in param_dict.items()
+            })
 
     def value_of(self,
                  value: Union[sympy.Basic, float, str]) -> 'cirq.TParamVal':

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -61,7 +61,7 @@ class ParamResolver:
             Dict[str, Union[float, str, sympy.Symbol]],
             {} if param_dict is None else {
                 param.name if isinstance(param, sympy.Symbol) else param: value
-                for param, value in param_dict.items()
+                for param, value in cast(ParamDictType, param_dict).items()
             })
 
     def value_of(self,

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -70,10 +70,9 @@ def test_formulas_in_param_dict():
     b = sympy.Symbol('b')
     c = sympy.Symbol('c')
     e = sympy.Symbol('e')
-    r = cirq.ParamResolver({a: b + 1, b: 2, b + c: 101, 'd': 2 * e})
+    r = cirq.ParamResolver({a: b + 1, b: 2, 'd': 2 * e})
     assert r.value_of('a') == 3
     assert r.value_of('b') == 2
-    assert r.value_of(b + c) == 101
     assert r.value_of('c') == c
     assert r.value_of('d') == 2 * e
 


### PR DESCRIPTION
The reason I want to do this is to make JSON serialization simple; in JSON, dictionary keys need to be strings or something simple like that. Note that I didn't actually need to change the test; it still passed but was incorrect because keys are not supposed to be Sympy formulas.

We could avoid modifying the input dictionary by adjusting `ParamDictType` to only allow string keys, but that wouldn't be backwards compatible.