### PR TITLE
Fix MatrixGate __pow__ and __repr__ failing for non-qubit shapes

### DIFF
--- a/cirq/ops/matrix_gates.py
+++ b/cirq/ops/matrix_gates.py
@@ -43,8 +43,9 @@ class MatrixGate(raw_types.Gate):
         if qid_shape is None:
             n = int(np.round(np.log2(matrix.shape[0] or 1)))
             if 2**n != matrix.shape[0]:
-                raise ValueError('Matrix width is not a power of 2 and '
-                                 'qid_shape is not specified.')
+                raise ValueError(
+                    f'Matrix width ({matrix.shape[0]}) is not a power of 2 and '
+                    f'qid_shape is not specified.')
             qid_shape = (2,) * n
 
         self._matrix = matrix
@@ -77,7 +78,7 @@ class MatrixGate(raw_types.Gate):
             return NotImplemented
         e = cast(float, exponent)
         new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b**e)
-        return MatrixGate(new_mat)
+        return MatrixGate(new_mat, qid_shape=self._qid_shape)
 
     def _phase_by_(self, phase_turns: float, qubit_index: int) -> 'MatrixGate':
         if not isinstance(phase_turns, (int, float)):
@@ -125,7 +126,10 @@ class MatrixGate(raw_types.Gate):
         return not self == other
 
     def __repr__(self):
-        return 'cirq.MatrixGate({})'.format(proper_repr(self._matrix))
+        if all(e == 2 for e in self._qid_shape):
+            return f'cirq.MatrixGate({proper_repr(self._matrix)})'
+        return (f'cirq.MatrixGate({proper_repr(self._matrix)}, '
+                f'qid_shape={self._qid_shape})')
 
     def __str__(self):
         return str(self._matrix.round(3))

--- a/cirq/ops/matrix_gates_test.py
+++ b/cirq/ops/matrix_gates_test.py
@@ -275,6 +275,9 @@ def test_matrix_gate_pow():
     assert cirq.pow(cirq.MatrixGate(1j * np.eye(1)),
                     2) == cirq.MatrixGate(-np.eye(1))
 
+    m = cirq.MatrixGate(np.diag([1, 1j, -1]), qid_shape=(3,))
+    assert m**3 == cirq.MatrixGate(np.diag([1, -1j, -1]), qid_shape=(3,))
+
 
 def test_phase_by():
     # Single qubit case.
@@ -301,3 +304,10 @@ def test_phase_by():
     m = cirq.MatrixGate(np.eye(3), qid_shape=[3])
     with pytest.raises(TypeError, match='returned NotImplemented'):
         _ = cirq.phase_by(m, 0.25, 0)
+
+
+def test_protocols_and_repr():
+    cirq.testing.assert_implements_consistent_protocols(
+        cirq.MatrixGate(np.diag([1, 1j, 1, -1])))
+    cirq.testing.assert_implements_consistent_protocols(
+        cirq.MatrixGate(np.diag([1, 1j, -1]), qid_shape=(3,)))


### PR DESCRIPTION
- Was not specifying the `qid_shape` correctly.