### PR TITLE
Define cirq.PAULI_GATE_LIKE

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -218,6 +218,7 @@ from cirq.ops import (
     Operation,
     ParallelGateOperation,
     Pauli,
+    PAULI_GATE_LIKE,
     PAULI_STRING_LIKE,
     PauliInteractionGate,
     PauliString,

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -172,6 +172,7 @@ from cirq.ops.pauli_interaction_gate import (
     PauliInteractionGate,)
 
 from cirq.ops.pauli_string import (
+    PAULI_GATE_LIKE,
     PAULI_STRING_LIKE,
     PauliString,
     SingleQubitPauliStringGateOperation,

--- a/cirq/ops/dense_pauli_string.py
+++ b/cirq/ops/dense_pauli_string.py
@@ -49,10 +49,11 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
     Y_VAL = 2
     Z_VAL = 3
 
-    def __init__(self,
-                 pauli_mask: Union[str, Iterable[int], np.ndarray],
-                 *,
-                 coefficient: Union[sympy.Basic, int, float, complex] = 1):
+    def __init__(
+            self,
+            pauli_mask: Union[Iterable['cirq.PAULI_GATE_LIKE'], np.ndarray],
+            *,
+            coefficient: Union[sympy.Basic, int, float, complex] = 1):
         """Initializes a new dense pauli string.
 
         Args:
@@ -94,14 +95,15 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
 
     @classmethod
     def one_hot(cls: Type[TCls], *, index: int, length: int,
-                pauli: Union[str, 'cirq.Gate']) -> TCls:
+                pauli: 'cirq.PAULI_GATE_LIKE') -> TCls:
         """Creates a dense pauli string with only one non-identity Pauli.
 
         Args:
             index: The index of the Pauli that is not an identity.
             pauli: The pauli gate to put at the hot index. Can be set to either
-                a string ('X', 'Y', 'Z', 'I') or a cirq gate (`cirq.X`,
-                `cirq.Y`, `cirq.Z`, or `cirq.I`).
+                a string ('X', 'Y', 'Z', 'I'), a cirq gate (`cirq.X`,
+                `cirq.Y`, `cirq.Z`, or `cirq.I`), or an integer (0=I, 1=X, 2=Y,
+                3=Z).
         """
         mask = np.zeros(length, dtype=np.uint8)
         mask[index] = _pauli_index(pauli)
@@ -477,38 +479,21 @@ class MutableDensePauliString(BaseDensePauliString):
                 next_row += 1
 
 
-def _pauli_index(val: Any):
-    if isinstance(val, str):
-        return PAULI_CHARS.index(val)
-    if isinstance(val, raw_types.Gate):
-        return PAULI_GATES.index(val)
-    if isinstance(val, int) and 0 <= val < 4:
-        return val
-    raise TypeError(f'Expected a Pauli character (IXYZ), gate, or index but '
-                    f'got {repr(val)}.')
+def _pauli_index(val: 'cirq.PAULI_GATE_LIKE') -> int:
+    m = pauli_string.PAULI_GATE_LIKE_TO_INDEX_MAP
+    if val not in m:
+        raise TypeError(
+            f'Expected a cirq.PAULI_GATE_LIKE (any of cirq.I cirq.X, cirq.Y, '
+            f'cirq.Z, "I", "X", "Y", "Z", "i", "x", "y", "z", 0, 1, 2, 3) but '
+            f'got {repr(val)}.')
+    return m[val]
 
 
-def _as_pauli_mask(val: Union[str, Iterable[int], np.ndarray]) -> np.ndarray:
+def _as_pauli_mask(val: Union[Iterable['cirq.PAULI_GATE_LIKE'], np.ndarray]
+                  ) -> np.ndarray:
     if isinstance(val, np.ndarray):
         return np.asarray(val, dtype=np.uint8)
-
-    if isinstance(val, str):
-        return _str_to_pauli_mask(val)
-
     return np.array([_pauli_index(v) for v in val], dtype=np.uint8)
-
-
-def _str_to_pauli_mask(text: str) -> np.ndarray:
-    result = np.zeros(len(text), dtype=np.uint8)
-    for i in range(len(text)):
-        c = text[i]
-        try:
-            result[i] = PAULI_CHARS.index(c)
-        except ValueError:
-            raise ValueError(
-                f'Not a Pauli character: {repr(c)}. Valid Pauli characters are '
-                f'upper case IXYZ.\ntext={repr(text)}.')
-    return result
 
 
 def _attempt_value_to_pauli_index(v: Any) -> Optional[Tuple[int, int]]:
@@ -525,7 +510,7 @@ def _attempt_value_to_pauli_index(v: Any) -> Optional[Tuple[int, int]]:
             'Got a Pauli operation, but it was applied to a qubit type '
             'other than `cirq.LineQubit` so its dense index is ambiguous.\n'
             f'v={repr(v)}.')
-    return PAULI_GATES.index(v.gate), q.x
+    return pauli_string.PAULI_GATE_LIKE_TO_INDEX_MAP[v.gate], q.x
 
 
 def _vectorized_pauli_mul_phase(lhs: Union[int, np.ndarray],

--- a/cirq/ops/dense_pauli_string_test.py
+++ b/cirq/ops/dense_pauli_string_test.py
@@ -47,7 +47,7 @@ def test_init():
     # Mixed types.
     assert cirq.DensePauliString([1, 'X',
                                   cirq.X]) == cirq.DensePauliString('XXX')
-    with pytest.raises(TypeError, match='Expected a Pauli'):
+    with pytest.raises(TypeError, match='Expected a cirq.PAULI_GATE_LIKE'):
         _ = cirq.DensePauliString([object()])
 
 
@@ -79,7 +79,9 @@ def test_from_text():
     assert d('XYZI') == d([1, 2, 3, 0])
     assert d('III', coefficient=-1) == d([0, 0, 0], coefficient=-1)
     assert d('XXY', coefficient=1j) == d([1, 1, 2], coefficient=1j)
-    with pytest.raises(ValueError, match='Not a Pauli character'):
+    assert d('ixyz') == d([0, 1, 2, 3])
+    assert d(['i', 'x', 'y', 'z']) == d([0, 1, 2, 3])
+    with pytest.raises(TypeError, match='Expected a cirq.PAULI_GATE_LIKE'):
         _ = d('2')
 
 

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -1052,26 +1052,6 @@ _x = cast(pauli_gates.Pauli, pauli_gates.X)  # type: ignore
 _y = cast(pauli_gates.Pauli, pauli_gates.Y)  # type: ignore
 _z = cast(pauli_gates.Pauli, pauli_gates.Z)  # type: ignore
 
-PAULI_GATE_LIKE_TO_GATE_MAP: Dict['cirq.PAULI_GATE_LIKE',
-                                  Union['cirq.Pauli', 'cirq.IdentityGate']] = {
-                                      _i: _i,
-                                      _x: _x,
-                                      _y: _y,
-                                      _z: _z,
-                                      'I': _i,
-                                      'X': _x,
-                                      'Y': _y,
-                                      'Z': _z,
-                                      'i': _i,
-                                      'x': _x,
-                                      'y': _y,
-                                      'z': _z,
-                                      0: _i,
-                                      1: _x,
-                                      2: _y,
-                                      3: _z,
-                                  }
-
 PAULI_GATE_LIKE_TO_INDEX_MAP: Dict['cirq.PAULI_GATE_LIKE', int] = {
     _i: 0,
     _x: 1,
@@ -1090,3 +1070,10 @@ PAULI_GATE_LIKE_TO_INDEX_MAP: Dict['cirq.PAULI_GATE_LIKE', int] = {
     2: 2,
     3: 3,
 }
+
+_INT_TO_PAULI = [_i, _x, _y, _z]
+
+PAULI_GATE_LIKE_TO_GATE_MAP: Dict[
+    'cirq.PAULI_GATE_LIKE', Union['cirq.Pauli', 'cirq.IdentityGate']] = {
+        k: _INT_TO_PAULI[v] for k, v in PAULI_GATE_LIKE_TO_INDEX_MAP.items()
+    }

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -1071,7 +1071,7 @@ PAULI_GATE_LIKE_TO_INDEX_MAP: Dict['cirq.PAULI_GATE_LIKE', int] = {
     3: 3,
 }
 
-_INT_TO_PAULI = [_i, _x, _y, _z]
+_INT_TO_PAULI: List[Union['cirq.Pauli', 'cirq.IdentityGate']] = [_i, _x, _y, _z]
 
 PAULI_GATE_LIKE_TO_GATE_MAP: Dict[
     'cirq.PAULI_GATE_LIKE', Union['cirq.Pauli', 'cirq.IdentityGate']] = {

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import (Dict, ItemsView, Iterable, Iterator, KeysView, Mapping,
                     Tuple, TypeVar, Union, ValuesView, overload, Optional, cast,
-                    TYPE_CHECKING, SupportsComplex, List, Sequence)
+                    TYPE_CHECKING, SupportsComplex, List, Sequence, Any)
 
 import cmath
 import math
@@ -44,7 +43,7 @@ if TYPE_CHECKING:
 
 PAULI_STRING_LIKE = Union[
     complex, 'cirq.OP_TREE',
-    Mapping['cirq.Qid', Union['cirq.Pauli', 'cirq.IdentityGate']],
+    Mapping['cirq.Qid', 'cirq.PAULI_GATE_LIKE'],
     Iterable,  # of PAULI_STRING_LIKE, but mypy doesn't do recursive types yet.
 ]
 document(
@@ -54,9 +53,23 @@ document(
     Complex numbers turn into the coefficient of an empty Pauli string.
 
     Dictionaries from qubit to Pauli operation are wrapped into a Pauli string.
+    Each Pauli operation can be specified as a cirq object (e.g. `cirq.X`) or as
+    a string (e.g. `"X"`) or as an integer where 0=I, 1=X, 2=Y, 3=Z.
 
     Collections of Pauli operations are recrusively multiplied into a single
     Pauli string.
+    """)
+
+PAULI_GATE_LIKE = Union['cirq.Pauli', 'cirq.IdentityGate', str, int,]
+document(
+    PAULI_GATE_LIKE,  # type: ignore
+    """An object that can be interpreted as a Pauli gate.
+
+    Allowed values are:
+
+    1. Cirq gates: `cirq.I`, `cirq.X`, `cirq.Y`, `cirq.Z`.
+    2. Strings: "I", "X", "Y", "Z". Equivalently "i", "x", "y", "z".
+    3. Integers from 0 to 3, with the convention 0=I, 1=X, 2=Y, 3=Z.
     """)
 
 TDefault = TypeVar('TDefault')
@@ -271,6 +284,14 @@ class PauliString(raw_types.Operation):
 
     def __len__(self) -> int:
         return len(self._qubit_pauli_map)
+
+    def _repr_pretty_(self, p: Any, cycle: bool) -> None:
+        """Print ASCII diagram in Jupyter."""
+        if cycle:
+            # There should never be a cycle.  This is just in case.
+            p.text('cirq.PauliString(...)')
+        else:
+            p.text(str(self))
 
     def __repr__(self):
         ordered_qubits = sorted(self.qubits)
@@ -661,7 +682,7 @@ class PauliString(raw_types.Operation):
             $$
 
         For example, conjugating a +Y operation by an S operation results in a
-        +X operation.
+        +X operation (as opposed to a -X operation).
 
         In a circuit diagram where `P` is a pauli string observable immediately
         after a Clifford operation `C`, the pauli string `P.conjugated_by(C)` is
@@ -965,15 +986,16 @@ class _MutablePauliString:
 
     def _inline_times_mapping(
             self, mapping: Mapping['cirq.Qid',
-                                   Union['cirq.Pauli', 'cirq.IdentityGate']]):
-        for qubit, pauli in mapping.items():
+                                   'cirq.PAULI_GATE_LIKE']):
+        for qubit, pauli_like in mapping.items():
+            pauli = PAULI_GATE_LIKE_TO_GATE_MAP.get(pauli_like, None)
+            if pauli is None:
+                raise TypeError(f'{pauli_like!r} is not '
+                                f'cirq.I, cirq.X, cirq.Y, cirq.Z, '
+                                f'"I", "X", "Y", "Z", '
+                                f'0, 1, 2, or 3.')
             if isinstance(pauli, identity.IdentityGate):
                 continue
-
-            if not isinstance(pauli, pauli_gates.Pauli):
-                raise TypeError(
-                    f'{repr(pauli)} is not a Pauli or identity gate.')
-
             self._inline_times_pauli(qubit, pauli)
 
     def inline_times_pauli_string_like(self,
@@ -1024,3 +1046,43 @@ def _decompose_into_cliffords(op: 'cirq.Operation') -> List['cirq.Operation']:
 
     raise TypeError(f'Operation is not a known Clifford and did not decompose '
                     f'into known Cliffords: {op!r}')
+
+
+PAULI_GATE_LIKE_TO_GATE_MAP: Dict['cirq.PAULI_GATE_LIKE',
+                                  Union['cirq.Pauli', 'cirq.IdentityGate']] = {
+                                      identity.I: identity.I,
+                                      pauli_gates.X: pauli_gates.X,
+                                      pauli_gates.Y: pauli_gates.Y,
+                                      pauli_gates.Z: pauli_gates.Z,
+                                      'I': identity.I,
+                                      'X': pauli_gates.X,
+                                      'Y': pauli_gates.Y,
+                                      'Z': pauli_gates.Z,
+                                      'i': identity.I,
+                                      'x': pauli_gates.X,
+                                      'y': pauli_gates.Y,
+                                      'z': pauli_gates.Z,
+                                      0: identity.I,
+                                      1: pauli_gates.X,
+                                      2: pauli_gates.Y,
+                                      3: pauli_gates.Z,
+                                  }
+
+PAULI_GATE_LIKE_TO_INDEX_MAP: Dict['cirq.PAULI_GATE_LIKE', int] = {
+    identity.I: 0,
+    pauli_gates.X: 1,
+    pauli_gates.Y: 2,
+    pauli_gates.Z: 3,
+    'I': 0,
+    'X': 1,
+    'Y': 2,
+    'Z': 3,
+    'i': 0,
+    'x': 1,
+    'y': 2,
+    'z': 3,
+    0: 0,
+    1: 1,
+    2: 2,
+    3: 3,
+}

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -42,8 +42,7 @@ if TYPE_CHECKING:
 # A value that can be unambiguously converted into a `cirq.PauliString`.
 
 PAULI_STRING_LIKE = Union[
-    complex, 'cirq.OP_TREE',
-    Mapping['cirq.Qid', 'cirq.PAULI_GATE_LIKE'],
+    complex, 'cirq.OP_TREE', Mapping['cirq.Qid', 'cirq.PAULI_GATE_LIKE'],
     Iterable,  # of PAULI_STRING_LIKE, but mypy doesn't do recursive types yet.
 ]
 document(
@@ -985,8 +984,7 @@ class _MutablePauliString:
         self.coef *= other.coefficient
 
     def _inline_times_mapping(
-            self, mapping: Mapping['cirq.Qid',
-                                   'cirq.PAULI_GATE_LIKE']):
+            self, mapping: Mapping['cirq.Qid', 'cirq.PAULI_GATE_LIKE']):
         for qubit, pauli_like in mapping.items():
             pauli = PAULI_GATE_LIKE_TO_GATE_MAP.get(pauli_like, None)
             if pauli is None:

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -1047,10 +1047,10 @@ def _decompose_into_cliffords(op: 'cirq.Operation') -> List['cirq.Operation']:
 
 
 # Mypy has extreme difficulty with these constants for some reason.
-_i = cast(cirq.IdentityGate, identity.I)  # type: ignore
-_x = cast(cirq.IdentityGate, pauli_gates.X)  # type: ignore
-_y = cast(cirq.IdentityGate, pauli_gates.Y)  # type: ignore
-_z = cast(cirq.IdentityGate, pauli_gates.Z)  # type: ignore
+_i = cast(identity.IdentityGate, identity.I)  # type: ignore
+_x = cast(pauli_gates.Pauli, pauli_gates.X)  # type: ignore
+_y = cast(pauli_gates.Pauli, pauli_gates.Y)  # type: ignore
+_z = cast(pauli_gates.Pauli, pauli_gates.Z)  # type: ignore
 
 PAULI_GATE_LIKE_TO_GATE_MAP: Dict['cirq.PAULI_GATE_LIKE',
                                   Union['cirq.Pauli', 'cirq.IdentityGate']] = {

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -1046,31 +1046,37 @@ def _decompose_into_cliffords(op: 'cirq.Operation') -> List['cirq.Operation']:
                     f'into known Cliffords: {op!r}')
 
 
+# Mypy has extreme difficulty with these constants for some reason.
+_i = cast(cirq.IdentityGate, identity.I)  # type: ignore
+_x = cast(cirq.IdentityGate, pauli_gates.X)  # type: ignore
+_y = cast(cirq.IdentityGate, pauli_gates.Y)  # type: ignore
+_z = cast(cirq.IdentityGate, pauli_gates.Z)  # type: ignore
+
 PAULI_GATE_LIKE_TO_GATE_MAP: Dict['cirq.PAULI_GATE_LIKE',
                                   Union['cirq.Pauli', 'cirq.IdentityGate']] = {
-                                      identity.I: identity.I,
-                                      pauli_gates.X: pauli_gates.X,
-                                      pauli_gates.Y: pauli_gates.Y,
-                                      pauli_gates.Z: pauli_gates.Z,
-                                      'I': identity.I,
-                                      'X': pauli_gates.X,
-                                      'Y': pauli_gates.Y,
-                                      'Z': pauli_gates.Z,
-                                      'i': identity.I,
-                                      'x': pauli_gates.X,
-                                      'y': pauli_gates.Y,
-                                      'z': pauli_gates.Z,
-                                      0: identity.I,
-                                      1: pauli_gates.X,
-                                      2: pauli_gates.Y,
-                                      3: pauli_gates.Z,
+                                      _i: _i,
+                                      _x: _x,
+                                      _y: _y,
+                                      _z: _z,
+                                      'I': _i,
+                                      'X': _x,
+                                      'Y': _y,
+                                      'Z': _z,
+                                      'i': _i,
+                                      'x': _x,
+                                      'y': _y,
+                                      'z': _z,
+                                      0: _i,
+                                      1: _x,
+                                      2: _y,
+                                      3: _z,
                                   }
 
 PAULI_GATE_LIKE_TO_INDEX_MAP: Dict['cirq.PAULI_GATE_LIKE', int] = {
-    identity.I: 0,
-    pauli_gates.X: 1,
-    pauli_gates.Y: 2,
-    pauli_gates.Z: 3,
+    _i: 0,
+    _x: 1,
+    _y: 2,
+    _z: 3,
     'I': 0,
     'X': 1,
     'Y': 2,

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -1388,6 +1388,13 @@ def test_conjugated_by_common_single_qubit_gates():
     a, b = cirq.LineQubit.range(2)
 
     base_single_qubit_gates = [
+        cirq.I,
+        cirq.X,
+        cirq.Y,
+        cirq.Z,
+        cirq.X**-0.5,
+        cirq.Y**-0.5,
+        cirq.Z**-0.5,
         cirq.X**0.5,
         cirq.Y**0.5,
         cirq.Z**0.5,
@@ -1421,13 +1428,20 @@ def test_conjugated_by_common_two_qubit_gates():
         cirq.CNOT,
         cirq.CZ,
         cirq.ISWAP,
+        cirq.ISWAP**-1,
         cirq.SWAP,
         cirq.XX**0.5,
         cirq.YY**0.5,
         cirq.ZZ**0.5,
+        cirq.XX**-0.5,
+        cirq.YY**-0.5,
+        cirq.ZZ**-0.5,
     ]
     two_qubit_gates = [g**i for i in range(4) for g in base_two_qubit_gates]
-    two_qubit_gates.append(OrderSensitiveGate())
+    two_qubit_gates.extend([
+        OrderSensitiveGate(),
+        cirq.Y.controlled(),
+    ])
     for p1 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
         for p2 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
             for g in two_qubit_gates:

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -1440,7 +1440,6 @@ def test_conjugated_by_common_two_qubit_gates():
     two_qubit_gates = [g**i for i in range(4) for g in base_two_qubit_gates]
     two_qubit_gates.extend([
         OrderSensitiveGate(),
-        cirq.Y.controlled(),
     ])
     for p1 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
         for p2 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
@@ -1512,3 +1511,26 @@ def test_pass_operations_over_ordering_reversed():
                                     after_to_before=True).pass_operations_over(
                                         [cirq.CNOT(a, b)], after_to_before=True)
     assert out1 == out2 == out3 == cirq.Z(b)
+
+
+def test_pretty_print():
+    a, b, c = cirq.LineQubit.range(3)
+    result = cirq.PauliString({a: 'x', b: 'y', c: 'z'})
+
+    # Test Jupyter console output from
+    class FakePrinter:
+
+        def __init__(self):
+            self.text_pretty = ''
+
+        def text(self, to_print):
+            self.text_pretty += to_print
+
+    p = FakePrinter()
+    result._repr_pretty_(p, False)
+    assert p.text_pretty == 'X(0)*Y(1)*Z(2)'
+
+    # Test cycle handling
+    p = FakePrinter()
+    result._repr_pretty_(p, True)
+    assert p.text_pretty == 'cirq.PauliString(...)'

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -186,6 +186,7 @@ SHOULDNT_BE_SERIALIZED = [
     'DURATION_LIKE',
     'NOISE_MODEL_LIKE',
     'OP_TREE',
+    'PAULI_GATE_LIKE',
     'PAULI_STRING_LIKE',
     'ParamResolverOrSimilarType',
     'PauliSumLike',

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,6 +146,7 @@ and products of Pauli operations.
     :toctree: generated/
 
     cirq.PAULI_BASIS
+    cirq.PAULI_GATE_LIKE
     cirq.PAULI_STRING_LIKE
     cirq.pow_pauli_combination
     cirq.BaseDensePauliString


### PR DESCRIPTION
- Use in `cirq.PauliString` and `cirq.DensePauliString`
- Generalize to allow lower case "ixyz"
- Make it consistent to allow integers 0=I, 1=X, 2=Y, 3=Z

Example:

```python
cirq.PauliString({
    cirq.GridQubit(0, 0): 0,
    cirq.GridQubit(0, 1): 1,
    cirq.GridQubit(0, 2): 2,
    cirq.GridQubit(0, 3): 3,
})
```

```
X((0, 1))*Y((0, 2))*Z((0, 3))
```