### PR TITLE
Implement JSON serialization for TrialResult

### DIFF
--- a/cirq/protocols/json.py
+++ b/cirq/protocols/json.py
@@ -112,6 +112,7 @@ class _ResolverCache:
                 cirq.SingleQubitPauliStringGateOperation,
                 'SwapPowGate': cirq.SwapPowGate,
                 'SycamoreGate': cirq.google.SycamoreGate,
+                'TrialResult': cirq.TrialResult,
                 'TwoQubitMatrixGate': cirq.TwoQubitMatrixGate,
                 '_UnconstrainedDevice':
                 cirq.devices.unconstrained_device._UnconstrainedDevice,

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -328,7 +328,6 @@ NOT_YET_SERIALIZABLE = [
     'TextDiagramDrawer',
     'ThreeQubitDiagonalGate',
     'Timestamp',
-    'TrialResult',
     'UnitSweep',
     'WaveFunctionSimulatorState',
     'WaveFunctionTrialResult',

--- a/cirq/protocols/json_test_data/TrialResult.json
+++ b/cirq/protocols/json_test_data/TrialResult.json
@@ -1,0 +1,28 @@
+{
+  "cirq_type": "TrialResult",
+  "params": {
+    "cirq_type": "ParamResolver",
+    "param_dict": [
+      [
+        "a",
+        0.5
+      ]
+    ]
+  },
+  "measurements": {
+    "m": {
+      "packed_bits": "f3c0",
+      "shape": [
+        5,
+        2
+      ]
+    },
+    "n": {
+      "packed_bits": "5bdc",
+      "shape": [
+        5,
+        3
+      ]
+    }
+  }
+}

--- a/cirq/protocols/json_test_data/TrialResult.repr
+++ b/cirq/protocols/json_test_data/TrialResult.repr
@@ -1,0 +1,1 @@
+cirq.TrialResult(params=cirq.ParamResolver({'a': 0.5}), measurements={'m': np.array([[1, 1], [1, 1], [0, 0], [1, 1], [1, 1]], dtype=np.uint8), 'n': np.array([[0, 1, 0], [1, 1, 0], [1, 1, 1], [1, 0, 1], [1, 1, 0]], dtype=np.uint8)})

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -317,7 +317,7 @@ class TrialResult:
                    })
 
 
-def _unpack_bits(bits_hex: str, shape: Sequence[int, ...]):
+def _unpack_bits(bits_hex: str, shape: Sequence[int]):
     bits_bytes = bytes.fromhex(bits_hex)
     bits = np.unpackbits(np.frombuffer(bits_bytes, dtype=np.uint8))
     return bits[:np.prod(shape)].reshape(shape)

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -14,7 +14,7 @@
 
 """Defines trial results."""
 
-from typing import (Iterable, Callable, Tuple, TypeVar, Dict, Any,
+from typing import (Iterable, Callable, Sequence, Tuple, TypeVar, Dict, Any,
                     TYPE_CHECKING, Union, Optional)
 
 import collections
@@ -317,7 +317,7 @@ class TrialResult:
                    })
 
 
-def _unpack_bits(bits_hex: str, shape: Tuple[int, ...]):
+def _unpack_bits(bits_hex: str, shape: Sequence[int, ...]):
     bits_bytes = bytes.fromhex(bits_hex)
     bits = np.unpackbits(np.frombuffer(bits_bytes, dtype=np.uint8))
     return bits[:np.prod(shape)].reshape(shape)


### PR DESCRIPTION
- Packs bits into hex strings to save a factor of 50 or so in space

This scheme is not compatible with higher-dimensional qudit-valued measurements, but TrialResult currently does not support that anyway.