### PR TITLE
Make QuantumEngineSampler engine accessible through property

### DIFF
--- a/cirq/google/engine/engine_sampler.py
+++ b/cirq/google/engine/engine_sampler.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     import cirq
 
 
-
 class QuantumEngineSampler(work.Sampler):
     """A sampler that samples from processors managed by the Quantum Engine.
 
@@ -62,3 +61,7 @@ class QuantumEngineSampler(work.Sampler):
                                          processor_ids=self._processor_ids,
                                          gate_set=self._gate_set)
         return job.results()
+
+    @property
+    def engine(self) -> 'cirq.google.Engine':
+        return self._engine

--- a/cirq/google/engine/engine_sampler_test.py
+++ b/cirq/google/engine/engine_sampler_test.py
@@ -45,3 +45,11 @@ def test_run_engine_program():
                                          processor_ids=['tmp'],
                                          repetitions=5)
     engine.run_sweep.assert_not_called()
+
+
+def test_engine_sampler_engine_property():
+    engine = mock.Mock()
+    sampler = cg.QuantumEngineSampler(engine=engine,
+                                      processor_id='tmp',
+                                      gate_set=cg.XMON)
+    assert sampler.engine is engine


### PR DESCRIPTION
Sometimes you want to get engine information such as the calibration.