### PR TITLE
Fix several dozen relative type annotations

### DIFF
--- a/cirq/circuits/qasm_output.py
+++ b/cirq/circuits/qasm_output.py
@@ -144,7 +144,7 @@ class QasmOutput:
 
     def __init__(self,
                  operations: 'cirq.OP_TREE',
-                 qubits: Tuple[ops.Qid, ...],
+                 qubits: Tuple['cirq.Qid', ...],
                  header: str = '',
                  precision: int = 10,
                  version: str = '2.0') -> None:
@@ -183,7 +183,7 @@ class QasmOutput:
             meas_key_id_map[key] = meas_id
         return meas_key_id_map, meas_comments
 
-    def _generate_qubit_ids(self) -> Dict[ops.Qid, str]:
+    def _generate_qubit_ids(self) -> Dict['cirq.Qid', str]:
         return {qubit: 'q[{}]'.format(i) for i, qubit in enumerate(self.qubits)}
 
     def is_valid_qasm_id(self, id_str: str) -> bool:

--- a/cirq/contrib/paulistring/convert_to_clifford_gates.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -22,6 +22,9 @@ from cirq.circuits.optimization_pass import (
     PointOptimizationSummary,
     PointOptimizer,
 )
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class ConvertToSingleQubitCliffordGates(PointOptimizer):
@@ -63,8 +66,8 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
 
         return ops.SingleQubitCliffordGate.I
 
-    def _matrix_to_clifford_op(self, mat: np.ndarray, qubit: ops.Qid
-                               ) -> Optional[ops.Operation]:
+    def _matrix_to_clifford_op(self, mat: np.ndarray,
+                               qubit: 'cirq.Qid') -> Optional[ops.Operation]:
         rotations = optimizers.single_qubit_matrix_to_pauli_rotations(
             mat, self.atol)
         clifford_gate = ops.SingleQubitCliffordGate.I

--- a/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
+++ b/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, cast
+from typing import List, Optional, cast, TYPE_CHECKING
 
 import numpy as np
 
@@ -22,6 +22,9 @@ from cirq.circuits.optimization_pass import (
     PointOptimizationSummary,
     PointOptimizer,
 )
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class ConvertToPauliStringPhasors(PointOptimizer):
@@ -52,9 +55,8 @@ class ConvertToPauliStringPhasors(PointOptimizer):
         self.keep_clifford = keep_clifford
         self.atol = atol
 
-    def _matrix_to_pauli_string_phasors(self,
-                                        mat: np.ndarray,
-                                        qubit: ops.Qid) -> ops.OP_TREE:
+    def _matrix_to_pauli_string_phasors(self, mat: np.ndarray,
+                                        qubit: 'cirq.Qid') -> ops.OP_TREE:
         rotations = optimizers.single_qubit_matrix_to_pauli_rotations(
             mat, self.atol)
         out_ops: List[ops.Operation] = []

--- a/cirq/contrib/qcircuit/qcircuit_diagram.py
+++ b/cirq/contrib/qcircuit/qcircuit_diagram.py
@@ -11,13 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import TYPE_CHECKING
 
 from cirq import circuits, ops
 from cirq.contrib.qcircuit.qcircuit_diagram_info import (
     escape_text_for_latex, get_qcircuit_diagram_info)
 
+if TYPE_CHECKING:
+    import cirq
 
-def qcircuit_qubit_namer(qubit: ops.Qid) -> str:
+
+def qcircuit_qubit_namer(qubit: 'cirq.Qid') -> str:
     """Returns the latex code for a QCircuit label of given qubit.
 
         Args:

--- a/cirq/contrib/routing/greedy.py
+++ b/cirq/contrib/routing/greedy.py
@@ -14,7 +14,7 @@
 
 import itertools
 from typing import (Callable, cast, Dict, Iterable, List, Optional, Sequence,
-                    Set, Tuple)
+                    Set, Tuple, TYPE_CHECKING)
 
 import numpy as np
 import networkx as nx
@@ -25,6 +25,9 @@ from cirq.contrib.routing.initialization import get_initial_mapping
 from cirq.contrib.routing.swap_network import SwapNetwork
 from cirq.contrib.routing.utils import (get_time_slices,
                                         ops_are_consistent_with_device_graph)
+
+if TYPE_CHECKING:
+    import cirq
 
 SWAP = cca.SwapPermutationGate()
 QidPair = Tuple[ops.Qid, ops.Qid]
@@ -125,12 +128,12 @@ class _GreedyRouter:
             ]
         return self.edge_sets[edge_set_size]
 
-    def log_to_phys(self, *qubits: ops.Qid) -> Iterable[ops.Qid]:
+    def log_to_phys(self, *qubits: 'cirq.Qid') -> Iterable[ops.Qid]:
         """Returns an iterator over the physical qubits mapped to by the given
         logical qubits."""
         return (self._log_to_phys[q] for q in qubits)
 
-    def phys_to_log(self, *qubits: ops.Qid) -> Iterable[Optional[ops.Qid]]:
+    def phys_to_log(self, *qubits: 'cirq.Qid') -> Iterable[Optional[ops.Qid]]:
         """Returns an iterator over the logical qubits that map to the given
         physical qubits."""
         return (self._phys_to_log[q] for q in qubits)

--- a/cirq/contrib/tpu/circuit_to_tensorflow.py
+++ b/cirq/contrib/tpu/circuit_to_tensorflow.py
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    NamedTuple,
+    Tuple,
+    TypeVar,
+    Union,
+    TYPE_CHECKING,
+)
 
 from collections import namedtuple
 
@@ -20,6 +30,9 @@ import numpy as np
 import tensorflow as tf
 
 from cirq import ops, circuits, linalg, protocols, optimizers
+
+if TYPE_CHECKING:
+    import cirq
 
 
 # We logically divide the qubits into groups of this size, and operate on each
@@ -153,10 +166,10 @@ class _QubitGrouping:
                     for group_id, group in enumerate(self.groups)
                     for item_id, qubit in enumerate(group)}
 
-    def loc(self, q: ops.Qid) -> Tuple[int, int]:
+    def loc(self, q: 'cirq.Qid') -> Tuple[int, int]:
         return self.map[q]
 
-    def ind(self, q: ops.Qid) -> int:
+    def ind(self, q: 'cirq.Qid') -> int:
         g, a = self.loc(q)
         past = sum(len(h) for h in self.groups[:g])
         return self.qubit_count() - 1 - a - past
@@ -170,7 +183,7 @@ class _QubitGrouping:
     def flat_shape(self) -> Tuple[int]:
         return self.system_size(),
 
-    def all_in_same_group(self, *qubits: ops.Qid) -> bool:
+    def all_in_same_group(self, *qubits: 'cirq.Qid') -> bool:
         return len({self.loc(q)[0] for q in qubits}) <= 1
 
     def decompose_keep_func(self, op: ops.Operation) -> bool:

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Iterable, List, Optional, Set, Tuple, TYPE_CHECKING
 
 from cirq import ops, protocols
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class GridQubit(ops.Qid):
@@ -45,7 +48,7 @@ class GridQubit(ops.Qid):
     def dimension(self) -> int:
         return 2
 
-    def is_adjacent(self, other: ops.Qid) -> bool:
+    def is_adjacent(self, other: 'cirq.Qid') -> bool:
         """Determines if two qubits are adjacent qubits."""
         return (isinstance(other, GridQubit) and
                 abs(self.row - other.row) + abs(self.col - other.col) == 1)

--- a/cirq/devices/line_qubit.py
+++ b/cirq/devices/line_qubit.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 
 import functools
-from typing import Any, Iterable, List, Optional, Sequence, Set, TypeVar
+from typing import Any, Iterable, List, Optional, Sequence, Set, TypeVar, \
+    TYPE_CHECKING
 
 import abc
 
 from cirq import ops, protocols
+
+if TYPE_CHECKING:
+    import cirq
 
 TSelf = TypeVar('TSelf', bound='_BaseLineQid')
 
@@ -36,7 +40,7 @@ class _BaseLineQid(ops.Qid):
     def with_dimension(self, dimension: int) -> 'LineQid':
         return LineQid(self.x, dimension)
 
-    def is_adjacent(self, other: ops.Qid) -> bool:
+    def is_adjacent(self, other: 'cirq.Qid') -> bool:
         """Determines if two qubits are adjacent line qubits."""
         return isinstance(other, _BaseLineQid) and abs(self.x - other.x) == 1
 

--- a/cirq/google/api/v2/program.py
+++ b/cirq/google/api/v2/program.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-def qubit_to_proto_id(q: ops.Qid) -> str:
+def qubit_to_proto_id(q: 'cirq.Qid') -> str:
     """Return a proto id for a `cirq.Qid`.
 
     For `cirq.GridQubit`s this id `{row}_{col}` where `{row}` is the integer

--- a/cirq/google/devices/known_devices.py
+++ b/cirq/google/devices/known_devices.py
@@ -14,7 +14,6 @@
 
 from typing import Dict, Optional, Iterable, List, Set, Tuple
 
-from cirq import value
 from cirq._doc import document
 from cirq.devices import GridQubit
 from cirq.google import gate_sets, serializable_gate_set

--- a/cirq/ion/ion_decomposition.py
+++ b/cirq/ion/ion_decomposition.py
@@ -21,19 +21,22 @@ Gate compilation methods implemented here are following the paper below:
     arXiv:1603.07678
 """
 
-from typing import Iterable, List, Optional, cast, Tuple
+from typing import Iterable, List, Optional, cast, Tuple, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import ops, linalg, protocols, optimizers, circuits
 from cirq.ion import ms
 
+if TYPE_CHECKING:
+    import cirq
 
-def two_qubit_matrix_to_ion_operations(q0: ops.Qid,
-                                       q1: ops.Qid,
+
+def two_qubit_matrix_to_ion_operations(q0: 'cirq.Qid',
+                                       q1: 'cirq.Qid',
                                        mat: np.ndarray,
                                        atol: float = 1e-8
-                                       ) -> List[ops.Operation]:
+                                      ) -> List[ops.Operation]:
     """Decomposes a two-qubit operation into MS/single-qubit rotation gates.
 
     Args:
@@ -63,11 +66,10 @@ def _cleanup_operations(operations: List[ops.Operation]):
     return list(circuit.all_operations())
 
 
-def _kak_decomposition_to_operations(q0: ops.Qid,
-                                     q1: ops.Qid,
+def _kak_decomposition_to_operations(q0: 'cirq.Qid',
+                                     q1: 'cirq.Qid',
                                      kak: linalg.KakDecomposition,
-                                     atol: float = 1e-8
-                                     ) -> List[ops.Operation]:
+                                     atol: float = 1e-8) -> List[ops.Operation]:
     """Assumes that the decomposition is canonical."""
     b0, b1 = kak.single_qubit_operations_before
     pre = [_do_single_on(b0, q0, atol), _do_single_on(b1, q1, atol)]
@@ -84,13 +86,13 @@ def _kak_decomposition_to_operations(q0: ops.Qid,
     ])))
 
 
-def _do_single_on(u: np.ndarray, q: ops.Qid, atol: float = 1e-8):
+def _do_single_on(u: np.ndarray, q: 'cirq.Qid', atol: float = 1e-8):
     for gate in optimizers.single_qubit_matrix_to_gates(u, atol):
         yield gate(q)
 
 
-def _parity_interaction(q0: ops.Qid,
-                        q1: ops.Qid,
+def _parity_interaction(q0: 'cirq.Qid',
+                        q1: 'cirq.Qid',
                         rads: float,
                         atol: float,
                         gate: Optional[ops.Gate] = None):
@@ -110,8 +112,8 @@ def _parity_interaction(q0: ops.Qid,
         yield g.on(q0), g.on(q1)
 
 
-def _non_local_part(q0: ops.Qid,
-                    q1: ops.Qid,
+def _non_local_part(q0: 'cirq.Qid',
+                    q1: 'cirq.Qid',
                     interaction_coefficients: Tuple[float, float, float],
                     atol: float = 1e-8):
     """Yields non-local operation of KAK decomposition."""

--- a/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq/neutral_atoms/neutral_atom_devices.py
@@ -400,7 +400,7 @@ class NeutralAtomDevice(devices.Device):
         ]
         return [e for e in possibles if e in self.qubits]
 
-    def distance(self, p: raw_types.Qid, q: raw_types.Qid) -> float:
+    def distance(self, p: 'cirq.Qid', q: 'cirq.Qid') -> float:
         p = cast(GridQubit, p)
         q = cast(GridQubit, q)
         return sqrt((p.row - q.row) ** 2 + (p.col - q.col) ** 2)

--- a/cirq/ops/clifford_gate.py
+++ b/cirq/ops/clifford_gate.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union, cast
+from typing import Dict, NamedTuple, Optional, Sequence, Tuple, Union, cast, \
+    TYPE_CHECKING
 
 import numpy as np
 
 from cirq import protocols, value
 from cirq._doc import document
-from cirq.ops import common_gates, gate_features, named_qubit, op_tree, \
-    pauli_gates, raw_types
+from cirq.ops import common_gates, gate_features, named_qubit, pauli_gates
 from cirq.ops.pauli_gates import Pauli
 
+if TYPE_CHECKING:
+    import cirq
 
 PauliTransform = NamedTuple('PauliTransform', [('to', Pauli), ('flip', bool)])
 document(PauliTransform, """+X, -X, +Y, -Y, +Z, or -Z.""")
@@ -271,8 +273,7 @@ class SingleQubitCliffordGate(gate_features.SingleQubitGate):
             mat = protocols.unitary(op).dot(mat)
         return mat
 
-    def _decompose_(self, qubits: Sequence[raw_types.Qid]
-                          ) -> op_tree.OP_TREE:
+    def _decompose_(self, qubits: Sequence['cirq.Qid']) -> 'cirq.OP_TREE':
         qubit, = qubits
         if self == SingleQubitCliffordGate.H:
             return common_gates.H(qubit),
@@ -348,8 +349,8 @@ class SingleQubitCliffordGate(gate_features.SingleQubitGate):
                 '+-'[self.transform(pauli_gates.Z).flip],
                      self.transform(pauli_gates.Z).to)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         well_known_map = {
             SingleQubitCliffordGate.I: 'I',
             SingleQubitCliffordGate.H: 'H',

--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -14,13 +14,16 @@
 
 """Quantum channels that are commonly used in the literature."""
 
-from typing import Iterable, Optional, Sequence, Tuple, Union
+from typing import Iterable, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import protocols, value
 from cirq.ops import (raw_types, common_gates, pauli_gates, gate_features,
                       identity)
+
+if TYPE_CHECKING:
+    import cirq
 
 
 @value.value_equality
@@ -582,7 +585,7 @@ class ResetChannel(gate_features.SingleQubitGate):
         return protocols.obj_to_dict_helper(self, ['dimension'])
 
 
-def reset(qubit: raw_types.Qid) -> raw_types.Operation:
+def reset(qubit: 'cirq.Qid') -> raw_types.Operation:
     """Returns a `ResetChannel` on the given qubit.
     """
     return ResetChannel(qubit.dimension).on(qubit)

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -125,7 +125,7 @@ class XPowGate(eigen_gate.EigenGate,
             'X': -1j * phase * np.sin(angle),
         })
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
                               ) -> Union[str, 'protocols.CircuitDiagramInfo']:
         if self._global_shift == -0.5:
             return _rads_func_symbol(
@@ -137,8 +137,8 @@ class XPowGate(eigen_gate.EigenGate,
             wire_symbols=('X',),
             exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         args.validate_version('2.0')
         if self._exponent == 1:
             return args.format('x {0};\n', qubits[0])
@@ -264,7 +264,7 @@ class YPowGate(eigen_gate.EigenGate,
             'Y': -1j * phase * np.sin(angle),
         })
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
                               ) -> Union[str, 'protocols.CircuitDiagramInfo']:
         if self._global_shift == -0.5:
             return _rads_func_symbol(
@@ -276,8 +276,8 @@ class YPowGate(eigen_gate.EigenGate,
             wire_symbols=('Y',),
             exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         args.validate_version('2.0')
         if self._exponent == 1:
             return args.format('y {0};\n', qubits[0])
@@ -422,7 +422,7 @@ class ZPowGate(eigen_gate.EigenGate,
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return self
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
                               ) -> Union[str, 'protocols.CircuitDiagramInfo']:
         if self._global_shift == -0.5:
             return _rads_func_symbol(
@@ -445,8 +445,8 @@ class ZPowGate(eigen_gate.EigenGate,
             wire_symbols=('Z',),
             exponent=e)
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         args.validate_version('2.0')
         if self._exponent == 1:
             return args.format('z {0};\n', qubits[0])
@@ -583,14 +583,14 @@ class HPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
         yield XPowGate(exponent=self._exponent).on(q)
         yield YPowGate(exponent=-0.25).on(q)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             wire_symbols=('H',),
             exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         args.validate_version('2.0')
         if self._exponent == 1:
             return args.format('h {0};\n', qubits[0])
@@ -684,14 +684,14 @@ class CZPowGate(eigen_gate.EigenGate,
     def _phase_by_(self, phase_turns, qubit_index):
         return self
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
                 wire_symbols=('@', '@'),
                 exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if self._exponent != 1:
             return None  # Don't have an equivalent gate in QASM
         args.validate_version('2.0')
@@ -781,8 +781,8 @@ class CNotPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
             return None
         return abs(np.sin(self._exponent * 0.5 * np.pi))
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             wire_symbols=('@', 'X'),
             exponent=self._diagram_exponent(args))
@@ -815,8 +815,8 @@ class CNotPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
             'ZX': global_phase * -c,
         })
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if self._exponent != 1:
             return None  # Don't have an equivalent gate in QASM
         args.validate_version('2.0')
@@ -837,8 +837,8 @@ class CNotPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
             'global_shift={!r})'
         ).format(proper_repr(self._exponent), self._global_shift)
 
-    def on(self, *args: raw_types.Qid,
-           **kwargs: raw_types.Qid) -> raw_types.Operation:
+    def on(self, *args: 'cirq.Qid',
+           **kwargs: 'cirq.Qid') -> raw_types.Operation:
         if not kwargs:
             return super().on(*args)
         if not args and set(kwargs.keys()) == {'control', 'target'}:

--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -31,7 +31,7 @@ class ControlledGate(raw_types.Gate):
 
     def __init__(
             self,
-            sub_gate: raw_types.Gate,
+            sub_gate: 'cirq.Gate',
             num_controls: int = None,
             control_values: Optional[Sequence[
                 Union[int, Collection[int]]]] = None,
@@ -113,7 +113,7 @@ class ControlledGate(raw_types.Gate):
                                         self.control_values))
         return decomposed
 
-    def on(self, *qubits: raw_types.Qid) -> cop.ControlledOperation:
+    def on(self, *qubits: 'cirq.Qid') -> cop.ControlledOperation:
         if len(qubits) == 0:
             raise ValueError(
                 "Applied a gate to an empty set of qubits. Gate: {!r}".format(
@@ -180,8 +180,8 @@ class ControlledGate(raw_types.Gate):
         angle_list = np.append(np.angle(np.linalg.eigvals(u)), 0)
         return protocols.trace_distance_from_angle_list(angle_list)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         sub_args = protocols.CircuitDiagramInfoArgs(
             known_qubit_count=(args.known_qubit_count - self.num_controls()
                                if args.known_qubit_count is not None else None),

--- a/cirq/ops/controlled_operation.py
+++ b/cirq/ops/controlled_operation.py
@@ -42,7 +42,7 @@ class ControlledOperation(raw_types.Operation):
 
     def __init__(self,
                  controls: Sequence[raw_types.Qid],
-                 sub_operation: raw_types.Operation,
+                 sub_operation: 'cirq.Operation',
                  control_values: Optional[Sequence[
                      Union[int, Collection[int]]]] = None):
         if control_values is None:
@@ -193,7 +193,7 @@ class ControlledOperation(raw_types.Operation):
         return ControlledOperation(self.controls, new_sub_op,
                                    self.control_values)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
                               ) -> Optional['protocols.CircuitDiagramInfo']:
         n = len(self.controls)
 

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from cirq import protocols, value
 from cirq._compat import deprecated
-from cirq.ops import raw_types, gate_features, op_tree
+from cirq.ops import raw_types, gate_features
 from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
@@ -100,7 +100,7 @@ class GateOperation(raw_types.Operation):
     def _num_qubits_(self):
         return len(self._qubits)
 
-    def _decompose_(self) -> op_tree.OP_TREE:
+    def _decompose_(self) -> 'cirq.OP_TREE':
         return protocols.decompose_once_with_qubits(self.gate,
                                                     self.qubits,
                                                     NotImplemented)
@@ -140,8 +140,8 @@ class GateOperation(raw_types.Operation):
         resolved_gate = protocols.resolve_parameters(self.gate, resolver)
         return GateOperation(resolved_gate, self._qubits)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.circuit_diagram_info(self.gate,
                                               args,
                                               NotImplemented)

--- a/cirq/ops/identity.py
+++ b/cirq/ops/identity.py
@@ -160,7 +160,7 @@ class IdentityGate(raw_types.Gate):
     def _circuit_diagram_info_(self, args):
         return ('I',) * self.num_qubits()
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
+    def _qasm_(self, args: 'cirq.QasmArgs',
                qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         args.validate_version('2.0')
         return ''.join([args.format('id {0};\n', qubit) for qubit in qubits])

--- a/cirq/ops/linear_combinations.py
+++ b/cirq/ops/linear_combinations.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from collections import defaultdict
 from typing import (Mapping, Optional, Tuple, Union, List, FrozenSet,
-                    DefaultDict)
+                    DefaultDict, TYPE_CHECKING)
 import numbers
 
 import numpy as np
@@ -24,6 +24,9 @@ from cirq.linalg import operator_spaces
 from cirq.ops import identity, raw_types, pauli_gates, pauli_string
 from cirq.ops.pauli_string import PauliString, _validate_qubit_mapping
 from cirq.value.linear_dict import _format_terms
+
+if TYPE_CHECKING:
+    import cirq
 
 UnitPauliStringT = FrozenSet[Tuple[raw_types.Qid, pauli_gates.Pauli]]
 PauliSumLike = Union[int, float, complex, PauliString, 'PauliSum', pauli_string.
@@ -73,7 +76,7 @@ class LinearCombinationOfGates(value.LinearDict[raw_types.Gate]):
         any_gate = next(iter(self))
         return any_gate.num_qubits()
 
-    def _is_compatible(self, gate: raw_types.Gate) -> bool:
+    def _is_compatible(self, gate: 'cirq.Gate') -> bool:
         return (self.num_qubits() is None or
                 self.num_qubits() == gate.num_qubits())
 
@@ -190,7 +193,7 @@ class LinearCombinationOfOperations(value.LinearDict[raw_types.Operation]):
         """
         super().__init__(terms, validator=self._is_compatible)
 
-    def _is_compatible(self, operation: raw_types.Operation) -> bool:
+    def _is_compatible(self, operation: 'cirq.Operation') -> bool:
         return isinstance(operation, raw_types.Operation)
 
     @property
@@ -246,17 +249,16 @@ class LinearCombinationOfOperations(value.LinearDict[raw_types.Operation]):
     def _pauli_expansion_(self) -> value.LinearDict[str]:
         """Computes Pauli expansion of self from Pauli expansions of terms."""
 
-        def extend_term(pauli_names: str, qubits: Tuple[raw_types.Qid, ...],
-                        all_qubits: Tuple[raw_types.Qid, ...]) -> str:
+        def extend_term(pauli_names: str, qubits: Tuple['cirq.Qid', ...],
+                        all_qubits: Tuple['cirq.Qid', ...]) -> str:
             """Extends Pauli product on qubits to product on all_qubits."""
             assert len(pauli_names) == len(qubits)
             qubit_to_pauli_name = dict(zip(qubits, pauli_names))
             return ''.join(qubit_to_pauli_name.get(q, 'I') for q in all_qubits)
 
         def extend(expansion: value.LinearDict[str],
-                   qubits: Tuple[raw_types.Qid, ...],
-                   all_qubits: Tuple[raw_types.Qid, ...]
-                  ) -> value.LinearDict[str]:
+                   qubits: Tuple['cirq.Qid', ...],
+                   all_qubits: Tuple['cirq.Qid', ...]) -> value.LinearDict[str]:
             """Extends Pauli expansion on qubits to expansion on all_qubits."""
             return value.LinearDict({
                 extend_term(p, qubits, all_qubits): c

--- a/cirq/ops/matrix_gates.py
+++ b/cirq/ops/matrix_gates.py
@@ -14,13 +14,16 @@
 
 """Quantum gates defined by a matrix."""
 
-from typing import cast, Any, Tuple, Optional, Iterable
+from typing import cast, Any, Tuple, Optional, Iterable, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import linalg, protocols
 from cirq._compat import proper_repr, deprecated
 from cirq.ops import gate_features, raw_types
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class MatrixGate(raw_types.Gate):
@@ -101,8 +104,8 @@ class MatrixGate(raw_types.Gate):
     def _unitary_(self) -> np.ndarray:
         return np.copy(self._matrix)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         main = _matrix_to_diagram_symbol(self._matrix, args)
         rest = [f'#{i+1}' for i in range(1, len(self._qid_shape))]
         return protocols.CircuitDiagramInfo(wire_symbols=[main, *rest])

--- a/cirq/ops/measure_util.py
+++ b/cirq/ops/measure_util.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Iterable, List, Optional, Tuple
+from typing import Callable, Iterable, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 
@@ -20,12 +20,15 @@ from cirq import protocols
 from cirq.ops import raw_types
 from cirq.ops.measurement_gate import MeasurementGate
 
+if TYPE_CHECKING:
+    import cirq
+
 
 def _default_measurement_key(qubits: Iterable[raw_types.Qid]) -> str:
     return ','.join(str(q) for q in qubits)
 
 
-def measure(*target: raw_types.Qid,
+def measure(*target: 'cirq.Qid',
             key: Optional[str] = None,
             invert_mask: Tuple[bool, ...] = ()) -> raw_types.Operation:
     """Returns a single MeasurementGate applied to all the given qubits.
@@ -61,7 +64,7 @@ def measure(*target: raw_types.Qid,
     return MeasurementGate(len(target), key, invert_mask, qid_shape).on(*target)
 
 
-def measure_each(*qubits: raw_types.Qid,
+def measure_each(*qubits: 'cirq.Qid',
                  key_func: Callable[[raw_types.Qid], str] = str
                 ) -> List[raw_types.Operation]:
     """Returns a list of operations individually measuring the given qubits.

--- a/cirq/ops/measurement_gate.py
+++ b/cirq/ops/measurement_gate.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import protocols, value
 from cirq.ops import raw_types
+
+if TYPE_CHECKING:
+    import cirq
 
 
 @value.value_equality
@@ -110,8 +113,8 @@ class MeasurementGate(raw_types.Gate):
     def _has_channel_(self):
         return True
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         symbols = ['M'] * self.num_qubits()
 
         # Show which output bits are negated.
@@ -127,8 +130,8 @@ class MeasurementGate(raw_types.Gate):
 
         return protocols.CircuitDiagramInfo(tuple(symbols))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if not all(d == 2 for d in self._qid_shape):
             return NotImplemented
         args.validate_version('2.0')

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -63,7 +63,7 @@ class Moment:
     def qubits(self) -> FrozenSet[raw_types.Qid]:
         return self._qubits
 
-    def operates_on_single_qubit(self, qubit: raw_types.Qid) -> bool:
+    def operates_on_single_qubit(self, qubit: 'cirq.Qid') -> bool:
         """Determines if the moment has operations touching the given qubit.
         Args:
             qubit: The qubit that may or may not be touched by operations.
@@ -83,7 +83,7 @@ class Moment:
         """
         return bool(set(qubits) & self.qubits)
 
-    def with_operation(self, operation: raw_types.Operation):
+    def with_operation(self, operation: 'cirq.Operation'):
         """Returns an equal moment, but with the given op added.
 
         Args:

--- a/cirq/ops/parallel_gate_operation.py
+++ b/cirq/ops/parallel_gate_operation.py
@@ -13,21 +13,23 @@
 # limitations under the License.
 
 
-from typing import Sequence, Tuple, Union, Any, Optional
+from typing import Sequence, Tuple, Union, Any, Optional, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import protocols, value
-from cirq.ops import raw_types, op_tree
+from cirq.ops import raw_types
 from cirq.type_workarounds import NotImplementedType
+
+if TYPE_CHECKING:
+    import cirq
 
 
 @value.value_equality
 class ParallelGateOperation(raw_types.Operation):
     """An application of several copies of a gate to a group of qubits."""
 
-    def __init__(self,
-                 gate: raw_types.Gate,
+    def __init__(self, gate: 'cirq.Gate',
                  qubits: Sequence[raw_types.Qid]) -> None:
         """
         Args:
@@ -53,12 +55,11 @@ class ParallelGateOperation(raw_types.Operation):
         """The qubits targeted by the operation."""
         return self._qubits
 
-    def with_qubits(self,
-                    *new_qubits: raw_types.Qid) -> 'ParallelGateOperation':
+    def with_qubits(self, *new_qubits: 'cirq.Qid') -> 'ParallelGateOperation':
         """ParallelGateOperation with same the gate but new qubits"""
         return ParallelGateOperation(self.gate, new_qubits)
 
-    def with_gate(self, new_gate: raw_types.Gate) -> 'ParallelGateOperation':
+    def with_gate(self, new_gate: 'cirq.Gate') -> 'ParallelGateOperation':
         """ParallelGateOperation with same qubits but a new gate"""
         return ParallelGateOperation(new_gate, self.qubits)
 
@@ -74,7 +75,7 @@ class ParallelGateOperation(raw_types.Operation):
     def _value_equality_values_(self):
         return self.gate, frozenset(self.qubits)
 
-    def _decompose_(self) -> op_tree.OP_TREE:
+    def _decompose_(self) -> 'cirq.OP_TREE':
         """List of gate operations that correspond to applying the single qubit
            gate to each of the target qubits individually
         """
@@ -123,8 +124,8 @@ class ParallelGateOperation(raw_types.Operation):
             return 1.0
         return np.sin(angle)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         diagram_info = protocols.circuit_diagram_info(self.gate,
                                                       args,
                                                       NotImplemented)

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -14,7 +14,7 @@
 
 """Quantum gates that phase with respect to product-of-pauli observables."""
 
-from typing import Union, Optional
+from typing import Union, Optional, TYPE_CHECKING
 
 import numpy as np
 
@@ -22,6 +22,9 @@ from cirq import protocols
 from cirq._compat import proper_repr
 from cirq._doc import document
 from cirq.ops import gate_features, eigen_gate, common_gates, pauli_gates
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class XXPowGate(eigen_gate.EigenGate,
@@ -81,7 +84,7 @@ class XXPowGate(eigen_gate.EigenGate,
             ]
         return NotImplemented
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
                               ) -> Union[str, 'protocols.CircuitDiagramInfo']:
         if self._global_shift == -0.5:
             # Mølmer–Sørensen gate.
@@ -164,8 +167,8 @@ class YYPowGate(eigen_gate.EigenGate,
             ]
         return NotImplemented
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             wire_symbols=('YY', 'YY'),
             exponent=self._diagram_exponent(args))
@@ -221,8 +224,8 @@ class ZZPowGate(eigen_gate.EigenGate,
             return None
         return abs(np.sin(self._exponent * 0.5 * np.pi))
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             wire_symbols=('ZZ', 'ZZ'),
             exponent=self._diagram_exponent(args))

--- a/cirq/ops/pauli_gates.py
+++ b/cirq/ops/pauli_gates.py
@@ -77,8 +77,7 @@ class Pauli(raw_types.Gate, metaclass=abc.ABCMeta):
             return NotImplemented
         return (other._index - self._index) % 3 == 1
 
-    def on(self,
-           *qubits: raw_types.Qid) -> 'SingleQubitPauliStringGateOperation':
+    def on(self, *qubits: 'cirq.Qid') -> 'SingleQubitPauliStringGateOperation':
         """Returns an application of this gate to the given qubits.
 
         Args:

--- a/cirq/ops/pauli_interaction_gate.py
+++ b/cirq/ops/pauli_interaction_gate.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Sequence, Tuple, cast, Dict
+from typing import List, Sequence, Tuple, cast, Dict, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import value, protocols
 from cirq._compat import proper_repr
-from cirq.ops import raw_types, gate_features, common_gates, eigen_gate, \
-        op_tree, pauli_gates
+from cirq.ops import gate_features, common_gates, eigen_gate, pauli_gates
 from cirq.ops.clifford_gate import SingleQubitCliffordGate
 
+if TYPE_CHECKING:
+    import cirq
 
 pauli_eigen_map = cast(
     Dict[pauli_gates.Pauli, np.ndarray], {
@@ -90,8 +91,7 @@ class PauliInteractionGate(eigen_gate.EigenGate,
         comp0 = np.eye(4) - comp1
         return [(0, comp0), (1, comp1)]
 
-    def _decompose_(self, qubits: Sequence[raw_types.Qid]
-                          ) -> op_tree.OP_TREE:
+    def _decompose_(self, qubits: Sequence['cirq.Qid']) -> 'cirq.OP_TREE':
         q0, q1 = qubits
         right_gate0 = SingleQubitCliffordGate.from_single_map(
             z_to=(self.pauli0, self.invert0))
@@ -106,8 +106,8 @@ class PauliInteractionGate(eigen_gate.EigenGate,
         yield right_gate0(q0)
         yield right_gate1(q1)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         labels = cast(Dict[pauli_gates.Pauli, np.ndarray], {
             pauli_gates.X: 'X',
             pauli_gates.Y: 'Y',

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -132,7 +132,7 @@ class PauliString(raw_types.Operation):
     @staticmethod
     @deprecated(deadline="v0.7.0",
                 fix="call cirq.PauliString(pauli(qubit)) instead")
-    def from_single(qubit: raw_types.Qid,
+    def from_single(qubit: 'cirq.Qid',
                     pauli: pauli_gates.Pauli) -> 'PauliString':
         """Creates a PauliString with a single qubit."""
         return PauliString(qubit_pauli_map={qubit: pauli})
@@ -171,20 +171,20 @@ class PauliString(raw_types.Operation):
     def equal_up_to_coefficient(self, other: 'PauliString') -> bool:
         return self._qubit_pauli_map == other._qubit_pauli_map
 
-    def __getitem__(self, key: raw_types.Qid) -> pauli_gates.Pauli:
+    def __getitem__(self, key: 'cirq.Qid') -> pauli_gates.Pauli:
         return self._qubit_pauli_map[key]
 
     # pylint: disable=function-redefined
     @overload
-    def get(self, key: raw_types.Qid) -> pauli_gates.Pauli:
+    def get(self, key: 'cirq.Qid') -> pauli_gates.Pauli:
         pass
 
     @overload
-    def get(self, key: raw_types.Qid,
+    def get(self, key: 'cirq.Qid',
             default: TDefault) -> Union[pauli_gates.Pauli, TDefault]:
         pass
 
-    def get(self, key: raw_types.Qid, default=None):
+    def get(self, key: 'cirq.Qid', default=None):
         return self._qubit_pauli_map.get(key, default)
     # pylint: enable=function-redefined
 
@@ -245,7 +245,7 @@ class PauliString(raw_types.Operation):
     def __rsub__(self, other):
         return -self.__sub__(other)
 
-    def __contains__(self, key: raw_types.Qid) -> bool:
+    def __contains__(self, key: 'cirq.Qid') -> bool:
         return key in self._qubit_pauli_map
 
     def _decompose_(self):
@@ -264,7 +264,7 @@ class PauliString(raw_types.Operation):
     def qubits(self) -> Tuple[raw_types.Qid, ...]:
         return tuple(sorted(self.keys()))
 
-    def with_qubits(self, *new_qubits: raw_types.Qid) -> 'PauliString':
+    def with_qubits(self, *new_qubits: 'cirq.Qid') -> 'PauliString':
         return PauliString(qubit_pauli_map=dict(
             zip(new_qubits, (self[q] for q in self.qubits))),
                            coefficient=self._coefficient)
@@ -791,7 +791,7 @@ class PauliString(raw_types.Operation):
 
     @staticmethod
     def _pass_operation_over(pauli_map: Dict[raw_types.Qid, pauli_gates.Pauli],
-                             op: raw_types.Operation,
+                             op: 'cirq.Operation',
                              after_to_before: bool = False) -> bool:
         if isinstance(op, gate_operation.GateOperation):
             gate = op.gate
@@ -811,7 +811,7 @@ class PauliString(raw_types.Operation):
     def _pass_single_clifford_gate_over(
             pauli_map: Dict[raw_types.Qid, pauli_gates.Pauli],
             gate: clifford_gate.SingleQubitCliffordGate,
-            qubit: raw_types.Qid,
+            qubit: 'cirq.Qid',
             after_to_before: bool = False) -> bool:
         if qubit not in pauli_map:
             return False
@@ -825,11 +825,11 @@ class PauliString(raw_types.Operation):
     def _pass_pauli_interaction_gate_over(
             pauli_map: Dict[raw_types.Qid, pauli_gates.Pauli],
             gate: pauli_interaction_gate.PauliInteractionGate,
-            qubit0: raw_types.Qid,
-            qubit1: raw_types.Qid,
+            qubit0: 'cirq.Qid',
+            qubit1: 'cirq.Qid',
             after_to_before: bool = False) -> bool:
 
-        def merge_and_kickback(qubit: raw_types.Qid,
+        def merge_and_kickback(qubit: 'cirq.Qid',
                                pauli_left: Optional[pauli_gates.Pauli],
                                pauli_right: Optional[pauli_gates.Pauli],
                                inv: bool) -> int:
@@ -868,7 +868,7 @@ class PauliString(raw_types.Operation):
 
 
 def _validate_qubit_mapping(qubit_map: Mapping[raw_types.Qid, int],
-                            pauli_qubits: Tuple[raw_types.Qid, ...],
+                            pauli_qubits: Tuple['cirq.Qid', ...],
                             num_state_qubits: int) -> None:
     """Validates that a qubit map is a valid mapping.
 
@@ -908,12 +908,12 @@ class SingleQubitPauliStringGateOperation(  # type: ignore
     GateOperation(X, [q]).
     """
 
-    def __init__(self, pauli: pauli_gates.Pauli, qubit: raw_types.Qid):
+    def __init__(self, pauli: pauli_gates.Pauli, qubit: 'cirq.Qid'):
         PauliString.__init__(self, {qubit: pauli})
         gate_operation.GateOperation.__init__(self, cast(raw_types.Gate, pauli),
                                               [qubit])
 
-    def with_qubits(self, *new_qubits: raw_types.Qid
+    def with_qubits(self, *new_qubits: 'cirq.Qid'
                    ) -> 'SingleQubitPauliStringGateOperation':
         if len(new_qubits) != 1:
             raise ValueError("len(new_qubits) != 1")
@@ -952,7 +952,7 @@ class SingleQubitPauliStringGateOperation(  # type: ignore
 
     @classmethod
     def _from_json_dict_(  # type: ignore
-            cls, pauli: pauli_gates.Pauli, qubit: raw_types.Qid, **kwargs):
+            cls, pauli: pauli_gates.Pauli, qubit: 'cirq.Qid', **kwargs):
         # Note, this method is required or else superclasses' deserialization
         # would be used
         return cls(pauli=pauli, qubit=qubit)

--- a/cirq/ops/pauli_string_phasor.py
+++ b/cirq/ops/pauli_string_phasor.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Iterable, Union
+from typing import Dict, Iterable, Union, TYPE_CHECKING
 
 import sympy
 
@@ -20,6 +20,9 @@ from cirq import value, protocols
 from cirq._compat import proper_repr
 from cirq.ops import (raw_types, common_gates, pauli_string as ps, pauli_gates,
                       op_tree, pauli_string_raw_types)
+
+if TYPE_CHECKING:
+    import cirq
 
 
 @value.value_equality(approximate=True)
@@ -105,7 +108,7 @@ class PauliStringPhasor(pauli_string_raw_types.PauliStringGateOperation):
                                  exponent_pos=pp,
                                  exponent_neg=pn)
 
-    def _decompose_(self) -> op_tree.OP_TREE:
+    def _decompose_(self) -> 'cirq.OP_TREE':
         if len(self.pauli_string) <= 0:
             return
         qubits = self.qubits
@@ -125,8 +128,8 @@ class PauliStringPhasor(pauli_string_raw_types.PauliStringGateOperation):
         yield protocols.inverse(xor_decomp)
         yield protocols.inverse(to_z_ops)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return self._pauli_string_diagram_info(args,
                                                exponent=self.exponent_relative)
 
@@ -175,7 +178,7 @@ class PauliStringPhasor(pauli_string_raw_types.PauliStringGateOperation):
 
 
 def xor_nonlocal_decompose(qubits: Iterable[raw_types.Qid],
-                           onto_qubit: raw_types.Qid
+                           onto_qubit: 'cirq.Qid'
                           ) -> Iterable[raw_types.Operation]:
     """Decomposition ignores connectivity."""
     for qubit in qubits:

--- a/cirq/ops/pauli_string_raw_types.py
+++ b/cirq/ops/pauli_string_raw_types.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Sequence, Tuple, TypeVar
+from typing import Any, Dict, Sequence, Tuple, TypeVar, TYPE_CHECKING
 
 import abc
 
 from cirq import protocols
 from cirq.ops import pauli_string as ps, raw_types
+
+if TYPE_CHECKING:
+    import cirq
 
 TSelf_PauliStringGateOperation = TypeVar('TSelf_PauliStringGateOperation',
                                          bound='PauliStringGateOperation')
@@ -33,8 +36,7 @@ class PauliStringGateOperation(raw_types.Operation, metaclass=abc.ABCMeta):
             raise ValueError('Incorrect number of qubits for gate')
 
     def with_qubits(self: TSelf_PauliStringGateOperation,
-                    *new_qubits: raw_types.Qid
-                   ) -> TSelf_PauliStringGateOperation:
+                    *new_qubits: 'cirq.Qid') -> TSelf_PauliStringGateOperation:
         self.validate_args(new_qubits)
         return self.map_qubits(dict(zip(self.pauli_string.qubits, new_qubits)))
 
@@ -56,7 +58,7 @@ class PauliStringGateOperation(raw_types.Operation, metaclass=abc.ABCMeta):
             self,
             args: 'protocols.CircuitDiagramInfoArgs',
             exponent: Any = 1,
-    ) -> 'protocols.CircuitDiagramInfo':
+    ) -> 'cirq.CircuitDiagramInfo':
         qubits = self.qubits if args.known_qubits is None else args.known_qubits
         syms = tuple(
             '[{}]'.format(self.pauli_string[qubit]) for qubit in qubits)

--- a/cirq/ops/phased_iswap_gate.py
+++ b/cirq/ops/phased_iswap_gate.py
@@ -21,7 +21,7 @@ import sympy
 import cirq
 from cirq import linalg, protocols, value
 from cirq._compat import deprecated, proper_repr
-from cirq.ops import eigen_gate, op_tree, gate_features, raw_types, swap_gates
+from cirq.ops import eigen_gate, gate_features, swap_gates
 
 
 @value.value_equality(manual_cls=True)
@@ -125,7 +125,7 @@ class PhasedISwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
                                       out=args.available_buffer)
         return args.available_buffer
 
-    def _decompose_(self, qubits: Sequence[raw_types.Qid]) -> op_tree.OP_TREE:
+    def _decompose_(self, qubits: Sequence['cirq.Qid']) -> 'cirq.OP_TREE':
         if len(qubits) != 2:
             raise ValueError(f'Expected two qubits, got {len(qubits)}')
         a, b = qubits

--- a/cirq/ops/phased_x_gate.py
+++ b/cirq/ops/phased_x_gate.py
@@ -22,7 +22,7 @@ import sympy
 import cirq
 from cirq import value, protocols
 from cirq._compat import proper_repr
-from cirq.ops import gate_features, raw_types, op_tree, common_gates
+from cirq.ops import gate_features, common_gates
 from cirq.type_workarounds import NotImplementedType
 
 
@@ -46,8 +46,8 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         self._exponent = exponent
         self._global_shift = global_shift
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if cirq.is_parameterized(self):
             return None
 
@@ -69,8 +69,7 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
             'u3({0:half_turns}, {1:half_turns}, {2:half_turns}) {3};\n',
             -e, p + 0.5, -p - 0.5, qubits[0])
 
-    def _decompose_(self, qubits: Sequence[raw_types.Qid]
-                          ) -> op_tree.OP_TREE:
+    def _decompose_(self, qubits: Sequence['cirq.Qid']) -> 'cirq.OP_TREE':
         assert len(qubits) == 1
         q = qubits[0]
         z = cirq.Z(q)**self._phase_exponent

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -20,7 +20,7 @@ This module creates Gate instances for the following gates:
 Each of these are implemented as EigenGates, which means that they can be
 raised to a power (i.e. cirq.ISWAP**0.5). See the definition in EigenGate.
 """
-from typing import Optional, Tuple
+from typing import Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 import sympy
@@ -28,7 +28,10 @@ import sympy
 from cirq import protocols, value
 from cirq._compat import deprecated, proper_repr
 from cirq._doc import document
-from cirq.ops import common_gates, gate_features, eigen_gate, raw_types
+from cirq.ops import common_gates, gate_features, eigen_gate
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class SwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate,
@@ -107,8 +110,8 @@ class SwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate,
             'ZZ': global_phase * c,
         })
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         if not args.use_unicode_characters:
             return protocols.CircuitDiagramInfo(
                 wire_symbols=('swap', 'swap'),
@@ -116,8 +119,8 @@ class SwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate,
         return protocols.CircuitDiagramInfo(
             wire_symbols=('×', '×'), exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if self._exponent != 1:
             return None  # Don't have an equivalent gate in QASM
         args.validate_version('2.0')
@@ -227,8 +230,8 @@ class ISwapPowGate(eigen_gate.EigenGate,
             'ZZ': global_phase * s * s,
         })
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             wire_symbols=('iSwap', 'iSwap'),
             exponent=self._diagram_exponent(args))

--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -27,9 +27,7 @@ from cirq.ops import (
     controlled_gate,
     eigen_gate,
     gate_features,
-    op_tree,
     pauli_gates,
-    raw_types,
     swap_gates,
 )
 
@@ -123,14 +121,14 @@ class CCZPowGate(eigen_gate.EigenGate,
             args.target_tensor *= p
         return args.target_tensor
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             ('@', '@', '@'),
             exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if self._exponent != 1:
             return None
 
@@ -205,8 +203,8 @@ class ThreeQubitDiagonalGate(gate_features.ThreeQubitGate):
             for angle in self._diag_angles_radians
         ])
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         rounded_angles = np.array(self._diag_angles_radians)
         if args.precision is not None:
             rounded_angles = rounded_angles.round(args.precision)
@@ -368,14 +366,14 @@ class CCXPowGate(eigen_gate.EigenGate,
         yield CCZ(c1, c2, t)**self._exponent
         yield common_gates.H(t)
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         return protocols.CircuitDiagramInfo(
             ('@', '@', 'X'),
             exponent=self._diagram_exponent(args))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         if self._exponent != 1:
             return None
 
@@ -436,11 +434,9 @@ class CSwapGate(gate_features.ThreeQubitGate,
 
         return self._decompose_outside_control(c, t1, t2)
 
-    def _decompose_inside_control(self,
-                                  target1: raw_types.Qid,
-                                  control: raw_types.Qid,
-                                  target2: raw_types.Qid
-                                  ) -> op_tree.OP_TREE:
+    def _decompose_inside_control(self, target1: 'cirq.Qid',
+                                  control: 'cirq.Qid',
+                                  target2: 'cirq.Qid') -> 'cirq.OP_TREE':
         """A decomposition assuming the control separates the targets.
 
         target1: ─@─X───────T──────@────────@─────────X───@─────X^-0.5─
@@ -482,11 +478,9 @@ class CSwapGate(gate_features.ThreeQubitGate,
                                        args.available_buffer, args.axes),
             default=NotImplemented)
 
-    def _decompose_outside_control(self,
-                                   control: raw_types.Qid,
-                                   near_target: raw_types.Qid,
-                                   far_target: raw_types.Qid
-                                   ) -> op_tree.OP_TREE:
+    def _decompose_outside_control(self, control: 'cirq.Qid',
+                                   near_target: 'cirq.Qid',
+                                   far_target: 'cirq.Qid') -> 'cirq.OP_TREE':
         """A decomposition assuming one of the targets is in the middle.
 
         control: ───T──────@────────@───@────────────@────────────────
@@ -524,14 +518,14 @@ class CSwapGate(gate_features.ThreeQubitGate,
                                  np.array([[0, 1], [1, 0]]),
                                  np.diag([1]))
 
-    def _circuit_diagram_info_(self, args: 'protocols.CircuitDiagramInfoArgs'
-                              ) -> 'protocols.CircuitDiagramInfo':
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         if not args.use_unicode_characters:
             return protocols.CircuitDiagramInfo(('@', 'swap', 'swap'))
         return protocols.CircuitDiagramInfo(('@', '×', '×'))
 
-    def _qasm_(self, args: 'protocols.QasmArgs',
-               qubits: Tuple[raw_types.Qid, ...]) -> Optional[str]:
+    def _qasm_(self, args: 'cirq.QasmArgs',
+               qubits: Tuple['cirq.Qid', ...]) -> Optional[str]:
         args.validate_version('2.0')
         return args.format('cswap {0},{1},{2};\n',
                            qubits[0], qubits[1], qubits[2])

--- a/cirq/optimizers/eject_phased_paulis.py
+++ b/cirq/optimizers/eject_phased_paulis.py
@@ -15,28 +15,25 @@
 """Pushes 180 degree rotations around axes in the XY plane later in the circuit.
 """
 
-from typing import Optional, cast, TYPE_CHECKING, Iterable, Tuple
+from typing import Optional, cast, TYPE_CHECKING, Iterable, Tuple, Dict, List
 import sympy
 
 from cirq import circuits, ops, value, protocols
 from cirq.optimizers import decompositions
 
 if TYPE_CHECKING:
-    from typing import Dict, List
-
-
-
+    import cirq
 
 
 class _OptimizerState:
     def __init__(self):
         # The phases of the W gates currently being pushed along each qubit.
-        self.held_w_phases = {}  # type: Dict[ops.Qid, value.TParamVal]
+        self.held_w_phases: Dict[ops.Qid, value.TParamVal] = {}
 
         # Accumulated commands to batch-apply to the circuit later.
-        self.deletions = []  # type: List[Tuple[int, ops.Operation]]
-        self.inline_intos = []  # type: List[Tuple[int, ops.Operation]]
-        self.insertions = []  # type: List[Tuple[int, ops.Operation]]
+        self.deletions: List[Tuple[int, ops.Operation]] = []
+        self.inline_intos: List[Tuple[int, ops.Operation]] = []
+        self.insertions: List[Tuple[int, ops.Operation]] = []
 
 
 class EjectPhasedPaulis():
@@ -231,9 +228,8 @@ def _potential_cross_partial_w(moment_index: int,
     state.inline_intos.append((moment_index, new_op))
 
 
-def _single_cross_over_cz(moment_index: int,
-                          op: ops.Operation,
-                          qubit_with_w: ops.Qid,
+def _single_cross_over_cz(moment_index: int, op: ops.Operation,
+                          qubit_with_w: 'cirq.Qid',
                           state: _OptimizerState) -> None:
     """Crosses exactly one W flip over a partial CZ.
 

--- a/cirq/optimizers/merge_interactions.py
+++ b/cirq/optimizers/merge_interactions.py
@@ -14,12 +14,16 @@
 
 """An optimization pass that combines adjacent single-qubit rotations."""
 
-from typing import Callable, List, Optional, Sequence, Tuple, cast
+from typing import Callable, List, Optional, Sequence, Tuple, cast, \
+    TYPE_CHECKING
 
 import numpy as np
 
 from cirq import circuits, ops, protocols
 from cirq.optimizers import two_qubit_decompositions
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class MergeInteractions(circuits.PointOptimizer):
@@ -88,7 +92,7 @@ class MergeInteractions(circuits.PointOptimizer):
             new_operations=new_operations)
 
     def _op_to_matrix(self, op: ops.Operation,
-                      qubits: Tuple[ops.Qid, ...]) -> Optional[np.ndarray]:
+                      qubits: Tuple['cirq.Qid', ...]) -> Optional[np.ndarray]:
         """Determines the effect of an operation on the given qubits.
 
         If the operation is a 1-qubit operation on one of the given qubits,
@@ -126,10 +130,8 @@ class MergeInteractions(circuits.PointOptimizer):
         return None
 
     def _scan_two_qubit_ops_into_matrix(
-            self,
-            circuit: circuits.Circuit,
-            index: Optional[int],
-            qubits: Tuple[ops.Qid, ...]
+            self, circuit: circuits.Circuit, index: Optional[int],
+            qubits: Tuple['cirq.Qid', ...]
     ) -> Tuple[List[ops.Operation], List[int], np.ndarray]:
         """Accumulates operations affecting the given pair of qubits.
 

--- a/cirq/optimizers/merge_single_qubit_gates.py
+++ b/cirq/optimizers/merge_single_qubit_gates.py
@@ -14,12 +14,15 @@
 
 """An optimization pass that combines adjacent single-qubit rotations."""
 
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, TYPE_CHECKING
 
 import numpy as np
 
 from cirq import ops, linalg, protocols, circuits
 from cirq.optimizers import decompositions
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class MergeSingleQubitGates(circuits.PointOptimizer):
@@ -112,7 +115,7 @@ def merge_single_qubit_gates_into_phased_x_z(
             negligible gates to be dropped, smaller values increase accuracy.
     """
 
-    def synth(qubit: ops.Qid, matrix: np.ndarray) -> List[ops.Operation]:
+    def synth(qubit: 'cirq.Qid', matrix: np.ndarray) -> List[ops.Operation]:
         out_gates = decompositions.single_qubit_matrix_to_phased_x_z(
             matrix, atol)
         return [gate(qubit) for gate in out_gates]

--- a/cirq/optimizers/two_qubit_decompositions.py
+++ b/cirq/optimizers/two_qubit_decompositions.py
@@ -14,7 +14,7 @@
 
 """Utility methods related to optimizing quantum circuits."""
 
-from typing import Iterable, List, Tuple, Optional, cast
+from typing import Iterable, List, Tuple, Optional, cast, TYPE_CHECKING
 
 import numpy as np
 
@@ -26,14 +26,18 @@ from cirq.optimizers import (
     merge_single_qubit_gates,
 )
 
+if TYPE_CHECKING:
+    import cirq
 
-def two_qubit_matrix_to_operations(q0: ops.Qid,
-                                   q1: ops.Qid,
-                                   mat: np.ndarray,
-                                   allow_partial_czs: bool,
-                                   atol: float = 1e-8,
-                                   clean_operations: bool = True,
-                                   ) -> List[ops.Operation]:
+
+def two_qubit_matrix_to_operations(
+        q0: 'cirq.Qid',
+        q1: 'cirq.Qid',
+        mat: np.ndarray,
+        allow_partial_czs: bool,
+        atol: float = 1e-8,
+        clean_operations: bool = True,
+) -> List[ops.Operation]:
     """Decomposes a two-qubit operation into Z/XY/CZ gates.
 
     Args:
@@ -57,9 +61,7 @@ def two_qubit_matrix_to_operations(q0: ops.Qid,
     return operations
 
 
-def _xx_interaction_via_full_czs(q0: ops.Qid,
-                                 q1: ops.Qid,
-                                 x: float):
+def _xx_interaction_via_full_czs(q0: 'cirq.Qid', q1: 'cirq.Qid', x: float):
     a = x * -2 / np.pi
     yield ops.H(q1)
     yield ops.CZ(q0, q1)
@@ -68,9 +70,7 @@ def _xx_interaction_via_full_czs(q0: ops.Qid,
     yield ops.H(q1)
 
 
-def _xx_yy_interaction_via_full_czs(q0: ops.Qid,
-                                    q1: ops.Qid,
-                                    x: float,
+def _xx_yy_interaction_via_full_czs(q0: 'cirq.Qid', q1: 'cirq.Qid', x: float,
                                     y: float):
     a = x * -2 / np.pi
     b = y * -2 / np.pi
@@ -86,11 +86,8 @@ def _xx_yy_interaction_via_full_czs(q0: ops.Qid,
     yield ops.X(q0)**-0.5
 
 
-def _xx_yy_zz_interaction_via_full_czs(q0: ops.Qid,
-                                       q1: ops.Qid,
-                                       x: float,
-                                       y: float,
-                                       z: float):
+def _xx_yy_zz_interaction_via_full_czs(q0: 'cirq.Qid', q1: 'cirq.Qid', x: float,
+                                       y: float, z: float):
     a = x * -2 / np.pi + 0.5
     b = y * -2 / np.pi + 0.5
     c = z * -2 / np.pi + 0.5
@@ -120,12 +117,11 @@ def _cleanup_operations(operations: List[ops.Operation]):
     return list(circuit.all_operations())
 
 
-def _kak_decomposition_to_operations(q0: ops.Qid,
-                                     q1: ops.Qid,
+def _kak_decomposition_to_operations(q0: 'cirq.Qid',
+                                     q1: 'cirq.Qid',
                                      kak: linalg.KakDecomposition,
                                      allow_partial_czs: bool,
-                                     atol: float = 1e-8
-                                     ) -> List[ops.Operation]:
+                                     atol: float = 1e-8) -> List[ops.Operation]:
     """Assumes that the decomposition is canonical."""
     b0, b1 = kak.single_qubit_operations_before
     pre = [_do_single_on(b0, q0, atol=atol), _do_single_on(b1, q1, atol=atol)]
@@ -153,8 +149,8 @@ def _is_trivial_angle(rad: float, atol: float) -> bool:
     return abs(rad) < atol or abs(abs(rad) - np.pi / 4) < atol
 
 
-def _parity_interaction(q0: ops.Qid,
-                        q1: ops.Qid,
+def _parity_interaction(q0: 'cirq.Qid',
+                        q1: 'cirq.Qid',
                         rads: float,
                         atol: float,
                         gate: Optional[ops.Gate] = None):
@@ -180,13 +176,13 @@ def _parity_interaction(q0: ops.Qid,
         yield g.on(q0), g.on(q1)
 
 
-def _do_single_on(u: np.ndarray, q: ops.Qid, atol: float=1e-8):
+def _do_single_on(u: np.ndarray, q: 'cirq.Qid', atol: float = 1e-8):
     for gate in decompositions.single_qubit_matrix_to_gates(u, atol):
         yield gate(q)
 
 
-def _non_local_part(q0: ops.Qid,
-                    q1: ops.Qid,
+def _non_local_part(q0: 'cirq.Qid',
+                    q1: 'cirq.Qid',
                     interaction_coefficients: Tuple[float, float, float],
                     allow_partial_czs: bool,
                     atol: float = 1e-8):

--- a/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq/sim/clifford/clifford_simulator.py
@@ -35,7 +35,6 @@ import numpy as np
 import cirq
 from cirq.sim import simulator
 from cirq.sim.clifford import clifford_tableau, stabilizer_state_ch_form
-from cirq.ops import raw_types
 from cirq.ops.dense_pauli_string import DensePauliString
 from cirq import circuits, study, ops, protocols, value
 
@@ -266,7 +265,7 @@ class CliffordState():
     def wave_function(self):
         return self.ch_form.wave_function()
 
-    def apply_unitary(self, op: raw_types.Operation):
+    def apply_unitary(self, op: 'cirq.Operation'):
         if op.gate == cirq.CNOT:
             self.tableau._CNOT(self.qubit_map[op.qubits[0]],
                                self.qubit_map[op.qubits[1]])

--- a/cirq/sim/wave_function.py
+++ b/cirq/sim/wave_function.py
@@ -155,7 +155,7 @@ class StateVectorMixin():
             [self.qubit_map[q] for q in qubits] if qubits is not None else None,
             qid_shape=self._qid_shape)
 
-    def bloch_vector_of(self, qubit: ops.Qid) -> np.ndarray:
+    def bloch_vector_of(self, qubit: 'cirq.Qid') -> np.ndarray:
         """Returns the bloch vector of a qubit in the state.
 
         Calculates the bloch vector of the given qubit

--- a/cirq/testing/sample_circuits.py
+++ b/cirq/testing/sample_circuits.py
@@ -11,14 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import TYPE_CHECKING
 
 from cirq import ops, circuits, devices
 
+if TYPE_CHECKING:
+    import cirq
+
 
 def nonoptimal_toffoli_circuit(
-        q0: ops.Qid,
-        q1: ops.Qid,
-        q2: ops.Qid,
+        q0: 'cirq.Qid',
+        q1: 'cirq.Qid',
+        q2: 'cirq.Qid',
         device: devices.Device = devices.UNCONSTRAINED_DEVICE
 ) -> circuits.Circuit:
     return circuits.Circuit(ops.Y(q2)**0.5,


### PR DESCRIPTION
- Replace stuff like raw_types.Qid with 'cirq.Qid'

This improves the documentation and IDE autocompletion, by making it refer to the user-visible type instead of internal variants.