### PR TITLE
Make pytest-changed-files include api tests when an __init__ file is changed

### DIFF
--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -61,11 +61,16 @@ changed=$(git diff --name-only ${rev} -- \
     | sort \
     | uniq \
 )
-num_changed=$(echo -e "${changed}" | wc -w)
+if git diff --name-only "${rev}" -- | grep "__init__\.py$" > /dev/null; then
+  # Include global API tests when an __init__ file is touched.
+  changed+=('docs/docs_coverage_test.py')
+  changed+=('cirq/protocols/json_test.py')
+fi
+num_changed=$(echo -e "${changed[@]}" | wc -w)
 
 # Run it.
-echo "Found ${num_changed} differing files with associated tests." >&2
-if [ -z "${changed}" ]; then
+echo "Found ${num_changed} test files associated with changes." >&2
+if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
-pytest ${rest} ${changed}
+pytest ${rest} ${changed[@]}

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -73,4 +73,4 @@ echo "Found ${num_changed} test files associated with changes." >&2
 if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
-pytest ${rest} ${changed[@]}
+pytest ${rest} ${changed}

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -73,4 +73,4 @@ echo "Found ${num_changed} test files associated with changes." >&2
 if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
-pytest ${rest} ${changed}
+pytest ${rest} "${changed[@]}"

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -74,6 +74,11 @@ changed_python_tests=$(git diff --name-only "${rev}" -- \
     | sort \
     | uniq \
 )
+if git diff --name-only "${rev}" -- | grep "__init__\.py$" > /dev/null; then
+  # Include global API tests when an __init__ file is touched.
+  changed_python_tests+=('docs/docs_coverage_test.py')
+  changed_python_tests+=('cirq/protocols/json_test.py')
+fi
 if [ "${#changed_python_tests[@]}" -eq 0 ]; then
     echo -e "\033[33mNo changed files with associated python tests.\033[0m" >&2
     exit 0

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -89,7 +89,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'HEAD~1'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -101,7 +101,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert result.out == 'INTERCEPTED pytest file_test.py\n'
     assert result.err.split() == (
         "Comparing against revision 'HEAD~1'.\n"
-        "Found 1 differing files with associated tests.\n").split()
+        "Found 1 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -113,7 +113,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert result.out == 'INTERCEPTED pytest file_test.py\n'
     assert result.err.split() == (
         "Comparing against revision 'HEAD~1'.\n"
-        "Found 1 differing files with associated tests.\n").split()
+        "Found 1 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -126,7 +126,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert result.out == 'INTERCEPTED pytest file_test.py\n'
     assert result.err.split() == (
         "Comparing against revision 'HEAD'.\n"
-        "Found 1 differing files with associated tests.\n").split()
+        "Found 1 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -139,7 +139,21 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert result.out == 'INTERCEPTED pytest file_test.py\n'
     assert result.err.split() == (
         "Comparing against revision 'HEAD'.\n"
-        "Found 1 differing files with associated tests.\n").split()
+        "Found 1 test files associated with changes.\n").split()
+
+    result = run(script_file='check/pytest-changed-files',
+                 tmpdir_factory=tmpdir_factory,
+                 arg='HEAD',
+                 setup='touch __init__.py\n'
+                 'git add -A\n'
+                 'git commit -m test --quiet --no-gpg-sign\n'
+                 'echo x > __init__.py\n')
+    assert result.exit_code == 0
+    assert result.out == ('INTERCEPTED pytest docs/docs_coverage_test.py '
+                          'cirq/protocols/json_test.py\n')
+    assert result.err.split() == (
+        "Comparing against revision 'HEAD'.\n"
+        "Found 2 test files associated with changes.\n").split()
 
 
 @only_on_posix
@@ -152,7 +166,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'HEAD'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -167,7 +181,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'master'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -176,7 +190,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'origin/master'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -185,7 +199,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'upstream/master'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -194,7 +208,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'upstream/master'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -227,7 +241,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
        "Comparing against revision 'HEAD'.\n"
-       "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',
                  tmpdir_factory=tmpdir_factory,
@@ -238,7 +252,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'master'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
     # Works on remotes.
     result = run(script_file='check/pytest-changed-files',
@@ -254,7 +268,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.out == ''
     assert result.err.split() == (
         "Comparing against revision 'origin/master'.\n"
-        "Found 0 differing files with associated tests.\n").split()
+        "Found 0 test files associated with changes.\n").split()
 
 
 @only_on_posix

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -240,7 +240,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == ''
     assert result.err.split() == (
-       "Comparing against revision 'HEAD'.\n"
+        "Comparing against revision 'HEAD'.\n"
         "Found 0 test files associated with changes.\n").split()
 
     result = run(script_file='check/pytest-changed-files',


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/2506