### PR TITLE
Fix pytest

### DIFF
--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -73,4 +73,4 @@ echo "Found ${num_changed} test files associated with changes." >&2
 if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
-pytest ${rest} "${changed[@]}"
+pytest ${rest} ${changed[@]}


### PR DESCRIPTION
- check/pytest-changed-files is broken
- The list of fils to test is put in quotes so it is considered to
be one file by pytest rather than a list of files.