### PR TITLE
Use warnings.warn for deprecation warnings

### DIFF
--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -14,7 +14,7 @@
 
 """Workarounds for compatibility issues between versions and libraries."""
 import functools
-import logging
+import warnings
 from typing import Any, Callable, Optional, Dict, Tuple
 
 import numpy as np
@@ -81,15 +81,15 @@ def proper_eq(a: Any, b: Any) -> bool:
     return a == b
 
 
-def deprecated(*, deadline: str, fix: str, func_name: Optional[str] = None
-              ) -> Callable[[Callable], Callable]:
+def deprecated(*, deadline: str, fix: str,
+               name: Optional[str] = None) -> Callable[[Callable], Callable]:
     """Marks a function as deprecated.
 
     Args:
         deadline: The version where the function will be deleted (e.g. "v0.7").
         fix: A complete sentence describing what the user should be using
             instead of this particular function (e.g. "Use cos instead.")
-        func_name: How to refer to the function.
+        name: How to refer to the function.
             Defaults to `func.__qualname__`.
 
     Returns:
@@ -97,20 +97,16 @@ def deprecated(*, deadline: str, fix: str, func_name: Optional[str] = None
     """
 
     def decorator(func: Callable) -> Callable:
-        used = False
 
         @functools.wraps(func)
         def decorated_func(*args, **kwargs) -> Any:
-            nonlocal used
-            if not used:
-                used = True
-                qualname = (func.__qualname__
-                            if func_name is None else func_name)
-                logging.warning(
-                    'DEPRECATION\n'
-                    'The function %s was used but is deprecated.\n'
-                    'It will be removed in cirq %s.\n'
-                    '%s\n', qualname, deadline, fix)
+            qualname = (func.__qualname__ if name is None else name)
+            warnings.warn(
+                f'{qualname} was used but is deprecated.\n'
+                f'It will be removed in cirq {deadline}.\n'
+                f'{fix}\n',
+                DeprecationWarning,
+                stacklevel=2)
 
             return func(*args, **kwargs)
 
@@ -162,24 +158,22 @@ def deprecated_parameter(
     """
 
     def decorator(func: Callable) -> Callable:
-        used = False
 
         @functools.wraps(func)
         def decorated_func(*args, **kwargs) -> Any:
-            nonlocal used
             if match(args, kwargs):
                 if rewrite is not None:
                     args, kwargs = rewrite(args, kwargs)
 
-                if not used:
-                    used = True
-                    qualname = (func.__qualname__
-                                if func_name is None else func_name)
-                    logging.warning(
-                        'DEPRECATION\n'
-                        f'The %s parameter of %s was used but is deprecated.\n'
-                        'It will be removed in cirq %s.\n'
-                        '%s\n', parameter_desc, qualname, deadline, fix)
+                qualname = (func.__qualname__
+                            if func_name is None else func_name)
+                warnings.warn(
+                    f'The {parameter_desc} parameter of {qualname} was '
+                    f'used but is deprecated.\n'
+                    f'It will be removed in cirq {deadline}.\n'
+                    f'{fix}\n',
+                    DeprecationWarning,
+                    stacklevel=2)
 
             return func(*args, **kwargs)
 

--- a/cirq/_compat_test.py
+++ b/cirq/_compat_test.py
@@ -75,24 +75,19 @@ def test_proper_eq():
     assert not proper_eq(pd.Index([1, 2, 3]), pd.Index([1, 4, 3]))
 
 
+@deprecated(deadline='vNever', fix='Roll some dice.', name='test_func')
+def f(a, b):
+    return a + b
+
+
 def test_deprecated():
 
-    @deprecated(deadline='vNever', fix='Roll some dice.', func_name='test_func')
-    def f(a, b):
-        return a + b
-
-    # Warns on first use.
     with capture_logging() as log:
         assert f(1, 2) == 3
     assert len(log) == 1
-    assert 'function test_func was used' in log[0].getMessage()
+    assert 'test_func was used' in log[0].getMessage()
     assert 'will be removed in cirq vNever' in log[0].getMessage()
     assert 'Roll some dice.' in log[0].getMessage()
-
-    # Only warns once.
-    with capture_logging() as log:
-        assert f(1, 2) == 3
-    assert len(log) == 0
 
 
 def test_deprecated_parameter():
@@ -115,7 +110,6 @@ def test_deprecated_parameter():
         assert f(new_count=1) == 1
     assert len(log) == 0
 
-    # Warns on first use.
     with capture_logging() as log:
         # pylint: disable=unexpected-keyword-arg
         # pylint: disable=no-value-for-parameter
@@ -127,15 +121,6 @@ def test_deprecated_parameter():
     assert 'will be removed in cirq vAlready' in log[0].getMessage()
     assert 'Double it yourself.' in log[0].getMessage()
 
-    # Only warns once.
-    with capture_logging() as log:
-        # pylint: disable=unexpected-keyword-arg
-        # pylint: disable=no-value-for-parameter
-        assert f(double_count=1) == 2
-        # pylint: enable=no-value-for-parameter
-        # pylint: enable=unexpected-keyword-arg
-    assert len(log) == 0
-
 
 def capture_logging() -> ContextManager[List[logging.LogRecord]]:
     records = []
@@ -146,10 +131,12 @@ def capture_logging() -> ContextManager[List[logging.LogRecord]]:
             records.append(record)
 
         def __enter__(self):
+            logging.captureWarnings(True)
             logging.getLogger().addHandler(self)
             return records
 
         def __exit__(self, exc_type, exc_val, exc_tb):
             logging.getLogger().removeHandler(self)
+            logging.captureWarnings(False)
 
     return Handler()

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1501,12 +1501,12 @@ class Circuit:
         return result.reshape((state_len,))
 
     to_unitary_matrix = deprecated(
-        func_name='Circuit.to_unitary_matrix',
+        name='Circuit.to_unitary_matrix',
         deadline='v0.7.0',
         fix='Use `Circuit.unitary()` instead.')(unitary)
 
     apply_unitary_effect_to_state = deprecated(
-        func_name='Circuit.apply_unitary_effect_to_state',
+        name='Circuit.apply_unitary_effect_to_state',
         deadline='v0.7.0',
         fix="Use `cirq.final_wavefunction(circuit)` or "
         "`Circuit.final_wavefunction()` instead")(final_wavefunction)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1594,24 +1594,21 @@ def test_deprecated_from_ops():
     assert 'Circuit.from_ops' in log[0].getMessage()
     assert 'deprecated' in log[0].getMessage()
 
-    with capture_logging() as log:
-        _ = cirq.Circuit.from_ops()
-    assert len(log) == 0
-
-    actual = cirq.Circuit.from_ops(
-        cirq.X(a),
-        [cirq.Y(a), cirq.Z(b)],
-        cirq.CZ(a, b),
-        cirq.X(a),
-        [cirq.Z(b), cirq.Y(a)],
-    )
-    assert actual == cirq.Circuit([
-        cirq.Moment([cirq.X(a), cirq.Z(b)]),
-        cirq.Moment([cirq.Y(a)]),
-        cirq.Moment([cirq.CZ(a, b)]),
-        cirq.Moment([cirq.X(a), cirq.Z(b)]),
-        cirq.Moment([cirq.Y(a)]),
-    ])
+    with capture_logging():
+        actual = cirq.Circuit.from_ops(
+            cirq.X(a),
+            [cirq.Y(a), cirq.Z(b)],
+            cirq.CZ(a, b),
+            cirq.X(a),
+            [cirq.Z(b), cirq.Y(a)],
+        )
+        assert actual == cirq.Circuit([
+            cirq.Moment([cirq.X(a), cirq.Z(b)]),
+            cirq.Moment([cirq.Y(a)]),
+            cirq.Moment([cirq.CZ(a, b)]),
+            cirq.Moment([cirq.X(a), cirq.Z(b)]),
+            cirq.Moment([cirq.Y(a)]),
+        ])
 
 
 def test_to_text_diagram_teleportation_to_diagram():

--- a/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq/contrib/quantum_volume/quantum_volume.py
@@ -182,8 +182,9 @@ def process_results(mapping: Dict[cirq.Qid, cirq.Qid],
     for final_qubit, original_qubit in mapping.items():
         if original_qubit in parity_mapping:
             final_parity_qubit = inverse_mapping[parity_mapping[original_qubit]]
-            mismatches = np.nonzero(np.atleast_1d(
-                data[str(final_qubit)] == data[str(final_parity_qubit)]))
+            mismatches = np.nonzero(
+                np.atleast_1d(
+                    data[str(final_qubit)] == data[str(final_parity_qubit)]))
             bad_measurements.update(*mismatches)
 
     # Remove the parity qubits from the measurements.

--- a/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq/contrib/quantum_volume/quantum_volume.py
@@ -51,7 +51,7 @@ def generate_model_circuit(num_qubits: int,
             # Convert the decomposed unitary to Cirq operations and add them to
             # the circuit.
             circuit.append(
-                cirq.TwoQubitMatrixGate(special_unitary).on(
+                cirq.MatrixGate(special_unitary).on(
                     qubits[permuted_indices[0]], qubits[permuted_indices[1]]))
 
     # Don't measure all of the qubits at the end of the circuit because we will
@@ -182,8 +182,8 @@ def process_results(mapping: Dict[cirq.Qid, cirq.Qid],
     for final_qubit, original_qubit in mapping.items():
         if original_qubit in parity_mapping:
             final_parity_qubit = inverse_mapping[parity_mapping[original_qubit]]
-            mismatches = np.nonzero(
-                data[str(final_qubit)] == data[str(final_parity_qubit)])
+            mismatches = np.nonzero(np.atleast_1d(
+                data[str(final_qubit)] == data[str(final_parity_qubit)]))
             bad_measurements.update(*mismatches)
 
     # Remove the parity qubits from the measurements.

--- a/cirq/ops/identity.py
+++ b/cirq/ops/identity.py
@@ -176,7 +176,7 @@ class IdentityOperation(raw_types.Operation):
 
     @deprecated(deadline='v0.8',
                 fix='Use cirq.IdentityGate or cirq.identity_each instead.',
-                func_name='IdentityOperation.__new__')
+                name='IdentityOperation')
     def __new__(cls, qubits: Sequence['cirq.Qid']):
         return IdentityGate(qid_shape=protocols.qid_shape(qubits)).on(*qubits)
 

--- a/cirq/ops/matrix_gates.py
+++ b/cirq/ops/matrix_gates.py
@@ -148,7 +148,7 @@ class SingleQubitMatrixGate(MatrixGate, gate_features.SingleQubitGate):
 
     @deprecated(deadline='v0.8',
                 fix='Use `cirq.MatrixGate` instead.',
-                func_name='cirq.SingleQubitMatrixGate')
+                name='cirq.SingleQubitMatrixGate')
     def __init__(self, matrix: np.ndarray) -> None:
         """
         Initializes the single qubit matrix gate.
@@ -183,7 +183,7 @@ class TwoQubitMatrixGate(MatrixGate, gate_features.TwoQubitGate):
 
     @deprecated(deadline='v0.8',
                 fix='Use `cirq.MatrixGate` instead.',
-                func_name='cirq.TwoQubitMatrixGate')
+                name='cirq.TwoQubitMatrixGate')
     def __init__(self, matrix: np.ndarray) -> None:
         """
         Initializes the 2-qubit matrix gate.

--- a/cirq/ops/matrix_gates_test.py
+++ b/cirq/ops/matrix_gates_test.py
@@ -68,8 +68,7 @@ def test_single_qubit_init():
 def test_single_qubit_eq():
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cirq.MatrixGate(np.eye(2)))
-    eq.make_equality_group(
-        lambda: cirq.MatrixGate(np.array([[0, 1], [1, 0]])))
+    eq.make_equality_group(lambda: cirq.MatrixGate(np.array([[0, 1], [1, 0]])))
     x2 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
     eq.make_equality_group(lambda: cirq.MatrixGate(x2))
     eq.add_equality_group(cirq.MatrixGate(PLUS_ONE, qid_shape=(3,)))
@@ -77,8 +76,7 @@ def test_single_qubit_eq():
 
 def test_single_qubit_trace_distance_bound():
     x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
-    x2 = cirq.MatrixGate(
-        np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
+    x2 = cirq.MatrixGate(np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
     assert cirq.trace_distance_bound(x) >= 1
     assert cirq.trace_distance_bound(x2) >= 0.5
 
@@ -86,8 +84,7 @@ def test_single_qubit_trace_distance_bound():
 def test_single_qubit_approx_eq():
     x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
     i = cirq.MatrixGate(np.array([[1, 0], [0, 1]]))
-    i_ish = cirq.MatrixGate(
-        np.array([[1, 0.000000000000001], [0, 1]]))
+    i_ish = cirq.MatrixGate(np.array([[1, 0.000000000000001], [0, 1]]))
     assert cirq.approx_eq(i, i_ish, atol=1e-9)
     assert cirq.approx_eq(i, i, atol=1e-9)
     assert not cirq.approx_eq(i, x, atol=1e-9)
@@ -97,8 +94,7 @@ def test_single_qubit_approx_eq():
 def test_single_qubit_extrapolate():
     i = cirq.MatrixGate(np.eye(2))
     x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
-    x2 = cirq.MatrixGate(
-        np.array([[1, 1j], [1j, 1]]) * (1 - 1j) / 2)
+    x2 = cirq.MatrixGate(np.array([[1, 1j], [1j, 1]]) * (1 - 1j) / 2)
     assert cirq.has_unitary(x2)
     x2i = cirq.MatrixGate(np.conj(cirq.unitary(x2).T))
 
@@ -110,8 +106,7 @@ def test_single_qubit_extrapolate():
     assert cirq.approx_eq(x**-1, x, atol=1e-9)
 
     z2 = cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))
-    z4 = cirq.MatrixGate(
-        np.array([[1, 0], [0, (1 + 1j) * np.sqrt(0.5)]]))
+    z4 = cirq.MatrixGate(np.array([[1, 0], [0, (1 + 1j) * np.sqrt(0.5)]]))
     assert cirq.approx_eq(z2**0.5, z4, atol=1e-9)
     with pytest.raises(TypeError):
         _ = x**sympy.Symbol('a')
@@ -137,11 +132,7 @@ def test_two_qubit_approx_eq():
 
     assert cirq.approx_eq(f, cirq.MatrixGate(QFT2), atol=1e-9)
 
-    assert not cirq.approx_eq(
-        f,
-        cirq.MatrixGate(QFT2 + perturb),
-        atol=1e-9
-    )
+    assert not cirq.approx_eq(f, cirq.MatrixGate(QFT2 + perturb), atol=1e-9)
     assert cirq.approx_eq(f, cirq.MatrixGate(QFT2 + perturb), atol=1e-7)
 
     assert not cirq.approx_eq(f, cirq.MatrixGate(HH), atol=1e-9)

--- a/cirq/ops/matrix_gates_test.py
+++ b/cirq/ops/matrix_gates_test.py
@@ -18,6 +18,7 @@ import pytest
 import sympy
 
 import cirq
+from cirq._compat_test import capture_logging
 
 H = np.array([[1, 1], [1, -1]]) * np.sqrt(0.5)
 HH = cirq.kron(H, H)
@@ -28,50 +29,64 @@ QFT2 = np.array([[1, 1, 1, 1],
 PLUS_ONE = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
 
 
+def test_deprecated():
+    with capture_logging() as log:
+        _ = cirq.SingleQubitMatrixGate(np.eye(2))
+    assert len(log) == 1
+    assert "cirq.SingleQubitMatrixGate" in log[0].getMessage()
+    assert "deprecated" in log[0].getMessage()
+
+    with capture_logging() as log:
+        _ = cirq.TwoQubitMatrixGate(np.eye(4))
+    assert len(log) == 1
+    assert "cirq.TwoQubitMatrixGate" in log[0].getMessage()
+    assert "deprecated" in log[0].getMessage()
+
+
 def test_single_qubit_init():
     m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
-    x2 = cirq.SingleQubitMatrixGate(m)
+    x2 = cirq.MatrixGate(m)
     assert cirq.has_unitary(x2)
     assert np.alltrue(cirq.unitary(x2) == m)
     assert cirq.qid_shape(x2) == (2,)
 
-    x2 = cirq.SingleQubitMatrixGate(PLUS_ONE)
+    x2 = cirq.MatrixGate(PLUS_ONE, qid_shape=(3,))
     assert cirq.has_unitary(x2)
     assert np.alltrue(cirq.unitary(x2) == PLUS_ONE)
     assert cirq.qid_shape(x2) == (3,)
 
     with pytest.raises(ValueError, match='Not a .*unitary matrix'):
-        cirq.SingleQubitMatrixGate(np.zeros((2, 2)))
+        cirq.MatrixGate(np.zeros((2, 2)))
     with pytest.raises(ValueError, match='must be a square 2d numpy array'):
-        cirq.SingleQubitMatrixGate(cirq.eye_tensor((2, 2), dtype=float))
+        cirq.MatrixGate(cirq.eye_tensor((2, 2), dtype=float))
     with pytest.raises(ValueError, match='must be a square 2d numpy array'):
-        cirq.SingleQubitMatrixGate(np.ones((3, 4)))
+        cirq.MatrixGate(np.ones((3, 4)))
     with pytest.raises(ValueError, match='must be a square 2d numpy array'):
-        cirq.SingleQubitMatrixGate(np.ones((2, 2, 2)))
+        cirq.MatrixGate(np.ones((2, 2, 2)))
 
 
 def test_single_qubit_eq():
     eq = cirq.testing.EqualsTester()
-    eq.make_equality_group(lambda: cirq.SingleQubitMatrixGate(np.eye(2)))
+    eq.make_equality_group(lambda: cirq.MatrixGate(np.eye(2)))
     eq.make_equality_group(
-        lambda: cirq.SingleQubitMatrixGate(np.array([[0, 1], [1, 0]])))
+        lambda: cirq.MatrixGate(np.array([[0, 1], [1, 0]])))
     x2 = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
-    eq.make_equality_group(lambda: cirq.SingleQubitMatrixGate(x2))
-    eq.add_equality_group(cirq.SingleQubitMatrixGate(PLUS_ONE))
+    eq.make_equality_group(lambda: cirq.MatrixGate(x2))
+    eq.add_equality_group(cirq.MatrixGate(PLUS_ONE, qid_shape=(3,)))
 
 
 def test_single_qubit_trace_distance_bound():
-    x = cirq.SingleQubitMatrixGate(np.array([[0, 1], [1, 0]]))
-    x2 = cirq.SingleQubitMatrixGate(
+    x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
+    x2 = cirq.MatrixGate(
         np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
     assert cirq.trace_distance_bound(x) >= 1
     assert cirq.trace_distance_bound(x2) >= 0.5
 
 
 def test_single_qubit_approx_eq():
-    x = cirq.SingleQubitMatrixGate(np.array([[0, 1], [1, 0]]))
-    i = cirq.SingleQubitMatrixGate(np.array([[1, 0], [0, 1]]))
-    i_ish = cirq.SingleQubitMatrixGate(
+    x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
+    i = cirq.MatrixGate(np.array([[1, 0], [0, 1]]))
+    i_ish = cirq.MatrixGate(
         np.array([[1, 0.000000000000001], [0, 1]]))
     assert cirq.approx_eq(i, i_ish, atol=1e-9)
     assert cirq.approx_eq(i, i, atol=1e-9)
@@ -80,12 +95,12 @@ def test_single_qubit_approx_eq():
 
 
 def test_single_qubit_extrapolate():
-    i = cirq.SingleQubitMatrixGate(np.eye(2))
-    x = cirq.SingleQubitMatrixGate(np.array([[0, 1], [1, 0]]))
-    x2 = cirq.SingleQubitMatrixGate(
+    i = cirq.MatrixGate(np.eye(2))
+    x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
+    x2 = cirq.MatrixGate(
         np.array([[1, 1j], [1j, 1]]) * (1 - 1j) / 2)
     assert cirq.has_unitary(x2)
-    x2i = cirq.SingleQubitMatrixGate(np.conj(cirq.unitary(x2).T))
+    x2i = cirq.MatrixGate(np.conj(cirq.unitary(x2).T))
 
     assert cirq.approx_eq(x**0, i, atol=1e-9)
     assert cirq.approx_eq(x2**0, i, atol=1e-9)
@@ -94,8 +109,8 @@ def test_single_qubit_extrapolate():
     assert cirq.approx_eq(x2**3, x2i, atol=1e-9)
     assert cirq.approx_eq(x**-1, x, atol=1e-9)
 
-    z2 = cirq.SingleQubitMatrixGate(np.array([[1, 0], [0, 1j]]))
-    z4 = cirq.SingleQubitMatrixGate(
+    z2 = cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))
+    z4 = cirq.MatrixGate(
         np.array([[1, 0], [0, (1 + 1j) * np.sqrt(0.5)]]))
     assert cirq.approx_eq(z2**0.5, z4, atol=1e-9)
     with pytest.raises(TypeError):
@@ -103,39 +118,39 @@ def test_single_qubit_extrapolate():
 
 
 def test_two_qubit_init():
-    x2 = cirq.TwoQubitMatrixGate(QFT2)
+    x2 = cirq.MatrixGate(QFT2)
     assert cirq.has_unitary(x2)
     assert np.alltrue(cirq.unitary(x2) == QFT2)
 
 
 def test_two_qubit_eq():
     eq = cirq.testing.EqualsTester()
-    eq.make_equality_group(lambda: cirq.TwoQubitMatrixGate(np.eye(4)))
-    eq.make_equality_group(lambda: cirq.TwoQubitMatrixGate(QFT2))
-    eq.make_equality_group(lambda: cirq.TwoQubitMatrixGate(HH))
+    eq.make_equality_group(lambda: cirq.MatrixGate(np.eye(4)))
+    eq.make_equality_group(lambda: cirq.MatrixGate(QFT2))
+    eq.make_equality_group(lambda: cirq.MatrixGate(HH))
 
 
 def test_two_qubit_approx_eq():
-    f = cirq.TwoQubitMatrixGate(QFT2)
+    f = cirq.MatrixGate(QFT2)
     perturb = np.zeros(shape=QFT2.shape, dtype=np.float64)
     perturb[1, 2] = 1e-8
 
-    assert cirq.approx_eq(f, cirq.TwoQubitMatrixGate(QFT2), atol=1e-9)
+    assert cirq.approx_eq(f, cirq.MatrixGate(QFT2), atol=1e-9)
 
     assert not cirq.approx_eq(
         f,
-        cirq.TwoQubitMatrixGate(QFT2 + perturb),
+        cirq.MatrixGate(QFT2 + perturb),
         atol=1e-9
     )
-    assert cirq.approx_eq(f, cirq.TwoQubitMatrixGate(QFT2 + perturb), atol=1e-7)
+    assert cirq.approx_eq(f, cirq.MatrixGate(QFT2 + perturb), atol=1e-7)
 
-    assert not cirq.approx_eq(f, cirq.TwoQubitMatrixGate(HH), atol=1e-9)
+    assert not cirq.approx_eq(f, cirq.MatrixGate(HH), atol=1e-9)
 
 
 def test_two_qubit_extrapolate():
-    cz2 = cirq.TwoQubitMatrixGate(np.diag([1, 1, 1, 1j]))
-    cz4 = cirq.TwoQubitMatrixGate(np.diag([1, 1, 1, (1 + 1j) * np.sqrt(0.5)]))
-    i = cirq.TwoQubitMatrixGate(np.eye(4))
+    cz2 = cirq.MatrixGate(np.diag([1, 1, 1, 1j]))
+    cz4 = cirq.MatrixGate(np.diag([1, 1, 1, (1 + 1j) * np.sqrt(0.5)]))
+    i = cirq.MatrixGate(np.eye(4))
 
     assert cirq.approx_eq(cz2**0, i, atol=1e-9)
     assert cirq.approx_eq(cz4**0, i, atol=1e-9)
@@ -148,7 +163,7 @@ def test_single_qubit_diagram():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
-    c = cirq.Circuit(cirq.SingleQubitMatrixGate(m).on(a), cirq.CZ(a, b))
+    c = cirq.Circuit(cirq.MatrixGate(m).on(a), cirq.CZ(a, b))
 
     assert re.match(r"""
       ┌[          ]+┐
@@ -177,8 +192,8 @@ def test_two_qubit_diagram():
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
     c = cirq.Circuit(
-        cirq.TwoQubitMatrixGate(cirq.unitary(cirq.CZ)).on(a, b),
-        cirq.TwoQubitMatrixGate(cirq.unitary(cirq.CZ)).on(c, a))
+        cirq.MatrixGate(cirq.unitary(cirq.CZ)).on(a, b),
+        cirq.MatrixGate(cirq.unitary(cirq.CZ)).on(c, a))
     assert re.match(r"""
       ┌[          ]+┐
       │[0-9\.+\-j ]+│
@@ -218,31 +233,31 @@ a[          ]+  b  c
 
 
 def test_str_executes():
-    assert '1' in str(cirq.SingleQubitMatrixGate(np.eye(2)))
-    assert '0' in str(cirq.TwoQubitMatrixGate(np.eye(4)))
+    assert '1' in str(cirq.MatrixGate(np.eye(2)))
+    assert '0' in str(cirq.MatrixGate(np.eye(4)))
 
 
 def test_one_qubit_consistent():
     u = cirq.testing.random_unitary(2)
-    g = cirq.SingleQubitMatrixGate(u)
+    g = cirq.MatrixGate(u)
     cirq.testing.assert_implements_consistent_protocols(g)
 
 
 def test_two_qubit_consistent():
     u = cirq.testing.random_unitary(4)
-    g = cirq.TwoQubitMatrixGate(u)
+    g = cirq.MatrixGate(u)
     cirq.testing.assert_implements_consistent_protocols(g)
 
 
 def test_two_qubit_matrix_gate():
     u = cirq.testing.random_unitary(4)
-    g = cirq.TwoQubitMatrixGate(u)
+    g = cirq.MatrixGate(u)
     cirq.testing.assert_equivalent_repr(g)
 
 
 def test_single_qubit_matrix_gate():
     u = cirq.testing.random_unitary(2)
-    g = cirq.SingleQubitMatrixGate(u)
+    g = cirq.MatrixGate(u)
     cirq.testing.assert_equivalent_repr(g)
 
 

--- a/cirq/protocols/trace_distance_bound_test.py
+++ b/cirq/protocols/trace_distance_bound_test.py
@@ -36,9 +36,9 @@ def test_trace_distance_bound():
         def _trace_distance_bound_(self) -> float:
             return self.bound
 
-    x = cirq.SingleQubitMatrixGate(cirq.unitary(cirq.X))
-    cx = cirq.TwoQubitMatrixGate(cirq.unitary(cirq.CX))
-    cxh = cirq.TwoQubitMatrixGate(cirq.unitary(cirq.CX**0.5))
+    x = cirq.MatrixGate(cirq.unitary(cirq.X))
+    cx = cirq.MatrixGate(cirq.unitary(cirq.CX))
+    cxh = cirq.MatrixGate(cirq.unitary(cirq.CX**0.5))
 
     assert np.isclose(cirq.trace_distance_bound(x),
                       cirq.trace_distance_bound(cirq.X))

--- a/cirq/value/duration.py
+++ b/cirq/value/duration.py
@@ -86,7 +86,7 @@ class Duration:
     @classmethod
     @deprecated(deadline='v0.7',
                 fix='Use `cirq.Duration(...)` instead.',
-                func_name='cirq.Duration.create')
+                name='cirq.Duration.create')
     def create(cls, duration: DURATION_LIKE) -> 'Duration':
         """Creates a Duration from datetime.timedelta if necessary"""
         return Duration(duration)


### PR DESCRIPTION
- @mpharrigan was right, this is way better
- warnings now show up when running pytest even when tests succeed
- warning text will now include the offending line, and will show only once for each offending line
- Fix deprecated usage of SingleQubit/TwoQubitMatrixGate
- Fix deprecated usage case of np.nonzero