### PR TITLE
Add Conversion optimizers to cirq.google __init__

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -70,6 +70,8 @@ from cirq.google.ops.sycamore_gate import (
 
 from cirq.google.optimizers import (
     ConvertToXmonGates,
+    ConvertToSqrtIswapGates,
+    ConvertToSycamoreGates,
     optimized_for_xmon,
 )
 

--- a/cirq/google/optimizers/__init__.py
+++ b/cirq/google/optimizers/__init__.py
@@ -15,6 +15,12 @@
 Package for optimizers and gate compilers related to Google-specific devices.
 """
 
+from cirq.google.optimizers.convert_to_sycamore_gates import (
+    ConvertToSycamoreGates,)
+
+from cirq.google.optimizers.convert_to_sqrt_iswap import (
+    ConvertToSqrtIswapGates,)
+
 from cirq.google.optimizers.convert_to_xmon_gates import (
     ConvertToXmonGates,)
 

--- a/cirq/google/optimizers/convert_to_sycamore_gates.py
+++ b/cirq/google/optimizers/convert_to_sycamore_gates.py
@@ -17,7 +17,7 @@ import math
 import numpy as np
 import scipy.linalg
 from cirq import circuits, google, linalg, ops, optimizers, protocols
-from cirq.google import SycamoreGate
+from cirq.google.ops import SycamoreGate
 
 UNITARY_ZZ = np.kron(protocols.unitary(ops.Z), protocols.unitary(ops.Z))
 PAULI_OPS = [

--- a/cirq/protocols/json_test.py
+++ b/cirq/protocols/json_test.py
@@ -136,6 +136,8 @@ SHOULDNT_BE_SERIALIZED = [
     'ConvertToCzAndSingleGates',
     'ConvertToIonGates',
     'ConvertToNeutralAtomGates',
+    'ConvertToSqrtIswapGates',
+    'ConvertToSycamoreGates',
     'ConvertToXmonGates',
     'DropEmptyMoments',
     'DropNegligible',

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -481,6 +481,8 @@ Functionality specific to quantum hardware and services from Google.
     cirq.google.AnnealSequenceSearchStrategy
     cirq.google.Bristlecone
     cirq.google.Calibration
+    cirq.google.ConvertToSqrtIswapGates
+    cirq.google.ConvertToSycamoreGates
     cirq.google.ConvertToXmonGates
     cirq.google.DeserializingArg
     cirq.google.Engine


### PR DESCRIPTION
Adding these to __init__ will make this similar to ConvertToXmonGates and also allow an easier transition from cirq-internal.