### PR TITLE
Add with_qubits_mapped to SingleQubitReadoutCalibrationResult

### DIFF
--- a/cirq/experiments/single_qubit_readout_calibration.py
+++ b/cirq/experiments/single_qubit_readout_calibration.py
@@ -43,6 +43,29 @@ class SingleQubitReadoutCalibrationResult:
     repetitions: int
     timestamp: float
 
+    def with_qubits_mapped(self, qubit_map: Dict['cirq.Qid', 'cirq.Qid']
+                          ) -> 'SingleQubitReadoutCalibrationResult':
+        """Remap the qubits of this calibration result.
+
+        Args:
+            qubit_map: A dictionary from qubits in the existing result to new
+                qubits.
+
+        Returns: A new calibration result with qubits mapped according to the
+            given qubit map.
+        """
+        mapped_zero_state_errors = {
+            qubit_map[q]: e for q, e in self.zero_state_errors.items()
+        }
+        mapped_one_state_errors = {
+            qubit_map[q]: e for q, e in self.one_state_errors.items()
+        }
+        return SingleQubitReadoutCalibrationResult(
+            zero_state_errors=mapped_zero_state_errors,
+            one_state_errors=mapped_one_state_errors,
+            repetitions=self.repetitions,
+            timestamp=self.timestamp)
+
     def _json_dict_(self):
         return {
             'cirq_type': self.__class__.__name__,

--- a/cirq/experiments/single_qubit_readout_calibration_test.py
+++ b/cirq/experiments/single_qubit_readout_calibration_test.py
@@ -83,6 +83,36 @@ def test_estimate_single_qubit_readout_errors_with_noise():
     assert isinstance(result.timestamp, float)
 
 
+def test_single_qubit_readout_calibration_result_with_qubits_mapped():
+    a, b = cirq.LineQubit.range(2)
+    c, d = cirq.GridQubit.rect(1, 2)
+    qubit_map = {a: c, b: d}
+    result = cirq.experiments.SingleQubitReadoutCalibrationResult(
+        zero_state_errors={
+            a: 0.1,
+            b: 0.2
+        },
+        one_state_errors={
+            a: 0.3,
+            b: 0.4
+        },
+        repetitions=1000,
+        timestamp=0.3)
+    mapped_result = result.with_qubits_mapped(qubit_map)
+    assert (
+        mapped_result == cirq.experiments.SingleQubitReadoutCalibrationResult(
+            zero_state_errors={
+                c: 0.1,
+                d: 0.2
+            },
+            one_state_errors={
+                c: 0.3,
+                d: 0.4
+            },
+            repetitions=1000,
+            timestamp=0.3))
+
+
 def test_single_qubit_readout_calibration_result_repr():
     result = cirq.experiments.SingleQubitReadoutCalibrationResult(
         zero_state_errors={cirq.LineQubit(0): 0.1},


### PR DESCRIPTION
This is used when there is a nontrivial mapping between qubits abstractly defined for a problem and qubits on the device.