### PR TITLE
Fix typo in SerializableDevice print out

### DIFF
--- a/cirq/google/devices/serializable_device.py
+++ b/cirq/google/devices/serializable_device.py
@@ -205,8 +205,13 @@ class SerializableDevice(devices.Device):
             diagram = circuits.TextDiagramDrawer()
 
             qubits = cast(List['cirq.GridQubit'], self.qubits)
+
+            # Don't print out extras newlines if the row/col doesn't start at 0
+            min_col = min(q.col for q in qubits)
+            min_row = min(q.row for q in qubits)
+
             for q in qubits:
-                diagram.write(q.col, q.row, str(q))
+                diagram.write(q.col - min_col, q.row - min_row, str(q))
 
             # Find pairs that are connected by two-qubit gates.
             Pair = Tuple['cirq.GridQubit', 'cirq.GridQubit']
@@ -220,8 +225,9 @@ class SerializableDevice(devices.Device):
             # Draw lines between connected pairs. Limit to horizontal/vertical
             # lines since that is all the diagram drawer can handle.
             for q1, q2 in sorted(pairs):
-                if q1.row == q2.row or q1.col == q2.row:
-                    diagram.grid_line(q1.col, q1.row, q2.col, q2.row)
+                if q1.row == q2.row or q1.col == q2.col:
+                    diagram.grid_line(q1.col - min_col, q1.row - min_row,
+                                      q2.col - min_col, q2.row - min_row)
 
             return diagram.render(horizontal_spacing=3,
                                   vertical_spacing=2,

--- a/cirq/google/devices/serializable_device_test.py
+++ b/cirq/google/devices/serializable_device_test.py
@@ -405,3 +405,26 @@ def test_serializable_device_str_named_qubits():
                 cirq.NamedQubit('b')],
         gate_definitions={})
     assert device.__class__.__name__ in str(device)
+
+
+def test_sycamore23_str():
+    assert str(cg.Sycamore23) == """\
+                  (3, 2)
+                  │
+                  │
+         (4, 1)───(4, 2)───(4, 3)
+         │        │        │
+         │        │        │
+(5, 0)───(5, 1)───(5, 2)───(5, 3)───(5, 4)
+         │        │        │        │
+         │        │        │        │
+         (6, 1)───(6, 2)───(6, 3)───(6, 4)───(6, 5)
+                  │        │        │        │
+                  │        │        │        │
+                  (7, 2)───(7, 3)───(7, 4)───(7, 5)───(7, 6)
+                           │        │        │
+                           │        │        │
+                           (8, 3)───(8, 4)───(8, 5)
+                                    │
+                                    │
+                                    (9, 4)"""


### PR DESCRIPTION
- Fix row/col typo
- Also, modify it so that there's not a bunch of extra new lines
if the grid doesn't start at (0,0) [e.g. Sycamore23]