### PR TITLE
Add json_test_data to cirq package

### DIFF
--- a/cirq/protocols/json_test_data/__init__.py
+++ b/cirq/protocols/json_test_data/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/cirq/protocols/json_test_data/__init__.py
+++ b/cirq/protocols/json_test_data/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/setup.py
+++ b/setup.py
@@ -73,4 +73,5 @@ setup(name=name,
           'cirq': ['py.typed'],
           'cirq.google.api.v1': ['*.proto', '*.pyi'],
           'cirq.google.api.v2': ['*.proto', '*.pyi'],
+          'cirq.protocols.json_test_data': ['*'],
       })


### PR DESCRIPTION
- json_test_data is *.json and *.repr files (not *.py) so will not be
  automatically included in the package
- Add these as package_files in setup.py
- Also, add a blank __init__.py file to add cirq.protocols.json_test_data as a package so it gets picked up.