### PR TITLE
Add versioned branches to the travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 branches:
   only:
   - master
+  - /^v\d+\.\d+\.\d+-dev$/
 before_install:
 - pip install --upgrade pip setuptools wheel
 stages:


### PR DESCRIPTION
- Currently, only master runs CI tests.
- This change should add version release branches as well.