### PR TITLE
Remove pip upgrade on Windows check in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     before_install:
       - choco install python --version 3.6.3
       - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
-      - python -m pip install --upgrade pip wheel
+      - python -m pip install --upgrade wheel
     install:
       - python -m pip --version
       - python -m pip install -v mkl

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ matrix:
     os: windows
     env: NAME=pytest (Windows)
     language: sh
-    python: '3.7.3'
+    python: '3.6.3'
     before_install:
-      - choco install python --version 3.7.3
-      - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+      - choco install python --version 3.6.3
+      - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
       - python -m pip install --upgrade pip wheel
     install:
       - python -m pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
       - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
       - python -m pip install --upgrade pip wheel
     install:
-      - python -m pip install mkl
+      - python -m pip install -v mkl
       - python -m pip install -r requirements.txt
       - python -m pip install -r cirq/contrib/contrib-requirements.txt
       - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
       - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
       - python -m pip install --upgrade pip wheel
     install:
+      - python -m pip --version
       - python -m pip install -v mkl
       - python -m pip install -r requirements.txt
       - python -m pip install -r cirq/contrib/contrib-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
       - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
       - python -m pip install --upgrade pip wheel
     install:
+      - python -m pip install mkl
       - python -m pip install -r requirements.txt
       - python -m pip install -r cirq/contrib/contrib-requirements.txt
       - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,12 @@ matrix:
     os: windows
     env: NAME=pytest (Windows)
     language: sh
-    python: '3.6.3'
+    python: '3.7.3'
     before_install:
-      - choco install python --version 3.6.3
-      - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
+      - choco install python --version 3.7.3
+      - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
       - python -m pip install --upgrade wheel
     install:
-      - python -m pip --version
-      - python -m pip install -v mkl
       - python -m pip install -r requirements.txt
       - python -m pip install -r cirq/contrib/contrib-requirements.txt
       - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -15,7 +15,7 @@ mypy-protobuf==1.10
 twine
 
 # For verifying behavior of qasm output.
-qiskit~=0.13.0
+qiskit~=0.14.0
 
 # For generating documentation.
 pypandoc

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -15,7 +15,7 @@ mypy-protobuf==1.10
 twine
 
 # For verifying behavior of qasm output.
-qiskit~=0.14.0
+qiskit~=0.13.0
 
 # For generating documentation.
 pypandoc


### PR DESCRIPTION
The latest release of pip (https://pypi.org/project/pip/20.0.1/) breaks the installation of our qiskit dependency. This commit pins our Windows pip version until https://github.com/pypa/pip/issues/7626 is fixed.

Fixes: https://github.com/quantumlib/Cirq/issues/2692