### PR TITLE
Make n-qubit tomography code available under cirq.experiments

### DIFF
--- a/cirq/experiments/__init__.py
+++ b/cirq/experiments/__init__.py
@@ -30,6 +30,12 @@ from cirq.experiments.fidelity_estimation import (
     xeb_fidelity,
 )
 
+from cirq.experiments.n_qubit_tomography import (
+    get_state_tomography_data,
+    state_tomography,
+    StateTomographyExperiment,
+)
+
 from cirq.experiments.single_qubit_readout_calibration import (
     estimate_single_qubit_readout_errors,
     SingleQubitReadoutCalibrationResult,

--- a/cirq/experiments/n_qubit_tomography.py
+++ b/cirq/experiments/n_qubit_tomography.py
@@ -17,13 +17,16 @@ different pre-measurement rotations.
 The code is designed to be modular with regards to data collection
 so that occurs outside of the StateTomographyExperiment class.
 """
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
 import sympy
 
-from cirq import circuits, ops, protocols, study, work
+from cirq import circuits, ops, protocols, study
 from cirq.experiments.qubit_characterizations import TomographyResult
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class StateTomographyExperiment:
@@ -45,7 +48,7 @@ class StateTomographyExperiment:
     """
 
     def __init__(self,
-                 qubits: Sequence[ops.Qid],
+                 qubits: Sequence['cirq.Qid'],
                  prerotations: Optional[Sequence[Tuple[float, float]]] = None):
         """Initializes the rotation protocol and matrix for system.
 
@@ -64,8 +67,8 @@ class StateTomographyExperiment:
 
         phase_exp_vals, exp_vals = zip(*prerotations)
 
-        operations: List[ops.Operation] = []
-        sweeps: List[study.Sweep] = []
+        operations: List['cirq.Operation'] = []
+        sweeps: List['cirq.Sweep'] = []
         for i, qubit in enumerate(qubits):
             phase_exp = sympy.Symbol(f'phase_exp_{i}')
             exp = sympy.Symbol(f'exp_{i}')
@@ -100,7 +103,7 @@ class StateTomographyExperiment:
         mat = np.einsum('jkm,jkn->jkmn', unitaries, unitaries.conj())
         return mat.reshape((num_rots * num_states, num_states * num_states))
 
-    def fit_density_matrix(self, counts: np.ndarray) -> 'TomographyResult':
+    def fit_density_matrix(self, counts: np.ndarray) -> TomographyResult:
         """Solves equation mat * rho = probs.
 
         Args:
@@ -123,12 +126,12 @@ class StateTomographyExperiment:
 
 
 def state_tomography(
-        sampler: work.Sampler,
-        qubits: Sequence[ops.Qid],
-        circuit: circuits.Circuit,
+        sampler: 'cirq.Sampler',
+        qubits: Sequence['cirq.Qid'],
+        circuit: 'cirq.Circuit',
         repetitions: int = 1000,
         prerotations: Sequence[Tuple[float, float]] = None,
-) -> 'TomographyResult':
+) -> TomographyResult:
     """This performs n qubit tomography on a cirq circuit
 
     Follows https://web.physics.ucsb.edu/~martinisgroup/theses/Neeley2010b.pdf
@@ -162,11 +165,11 @@ def state_tomography(
     return exp.fit_density_matrix(probs)
 
 
-def get_state_tomography_data(sampler: work.Sampler,
-                              qubits: Sequence[ops.Qid],
-                              circuit: circuits.Circuit,
-                              rot_circuit: circuits.Circuit,
-                              rot_sweep: study.Sweep,
+def get_state_tomography_data(sampler: 'cirq.Sampler',
+                              qubits: Sequence['cirq.Qid'],
+                              circuit: 'cirq.Circuit',
+                              rot_circuit: 'cirq.Circuit',
+                              rot_sweep: 'cirq.Sweep',
                               repetitions: int = 1000) -> np.ndarray:
     """Gets the data for each rotation string added to the circuit.
 

--- a/cirq/experiments/n_qubit_tomography.py
+++ b/cirq/experiments/n_qubit_tomography.py
@@ -145,11 +145,10 @@ def state_tomography(
         repetitions: Number of times to sample each rotation.
         prerotations: Tuples of (phase_exponent, exponent) parameters for gates
             to apply to the qubits before measurement. The actual rotation
-            applied will be
-                `cirq.PhasedXPowGate(
-                    phase_exponent=phase_exponent, exponent=exponent)`
-            If none, we use [(0, 0), (0, 0.5), (0.5, 0.5)], which corresponds to
-            rotation gates [I, X**0.5, Y**0.5].
+            applied will be `cirq.PhasedXPowGate` with the specified values
+            of phase_exponent and exponent. If None, we use [(0, 0), (0, 0.5),
+            (0.5, 0.5)], which corresponds to rotation gates
+            [I, X**0.5, Y**0.5].
 
     Returns:
         `TomographyResult` which contains the density matrix of the qubits

--- a/cirq/experiments/n_qubit_tomography.py
+++ b/cirq/experiments/n_qubit_tomography.py
@@ -53,11 +53,10 @@ class StateTomographyExperiment:
             qubits: Qubits to do the tomography on.
             prerotations: Tuples of (phase_exponent, exponent) parameters for
                 gates to apply to the qubits before measurement. The actual
-                rotation applied will be
-                    `cirq.PhasedXPowGate(
-                        phase_exponent=phase_exponent, exponent=exponent)`
-                If none, we use [(0, 0), (0, 0.5), (0.5, 0.5)], which
-                corresponds to rotation gates [I, X**0.5, Y**0.5].
+                rotation applied will be `cirq.PhasedXPowGate` with the
+                specified values of phase_exponent and exponent. If None,
+                we use [(0, 0), (0, 0.5), (0.5, 0.5)], which corresponds
+                to rotation gates [I, X**0.5, Y**0.5].
         """
         if prerotations is None:
             prerotations = [(0, 0), (0, 0.5), (0.5, 0.5)]

--- a/cirq/experiments/n_qubit_tomography_test.py
+++ b/cirq/experiments/n_qubit_tomography_test.py
@@ -15,7 +15,6 @@
 import numpy as np
 
 import cirq
-import cirq.experiments.n_qubit_tomography as nqt
 
 
 def test_state_tomography_diagonal():
@@ -27,11 +26,12 @@ def test_state_tomography_diagonal():
             bit = state & (1 << (n - i - 1))
             if bit:
                 circuit.append(cirq.X(q))
-        res = nqt.state_tomography(cirq.Simulator(),
-                                   qubits,
-                                   circuit,
-                                   repetitions=10000,
-                                   prerotations=[(0, 0), (0, 0.5), (0.5, 0.5)])
+        res = cirq.experiments.state_tomography(cirq.Simulator(),
+                                                qubits,
+                                                circuit,
+                                                repetitions=10000,
+                                                prerotations=[(0, 0), (0, 0.5),
+                                                              (0.5, 0.5)])
         should_be = np.zeros((2**n, 2**n))
         should_be[state, state] = 1
         assert np.allclose(res.data, should_be, atol=2e-2)
@@ -42,7 +42,7 @@ def test_state_tomography_ghz_state():
     circuit.append(cirq.H(cirq.LineQubit(0)))
     circuit.append(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
     circuit.append(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(2)))
-    res = nqt.state_tomography(
+    res = cirq.experiments.state_tomography(
         cirq.Simulator(),
         [cirq.LineQubit(0),
          cirq.LineQubit(1),
@@ -58,7 +58,7 @@ def test_state_tomography_ghz_state():
 
 
 def test_make_experiment_no_rots():
-    exp = nqt.StateTomographyExperiment(
+    exp = cirq.experiments.StateTomographyExperiment(
         [cirq.LineQubit(0),
          cirq.LineQubit(1),
          cirq.LineQubit(2)])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -420,9 +420,11 @@ run experiments.
     cirq.log_xeb_fidelity_from_probabilities
     cirq.experiments.build_entangling_layers
     cirq.experiments.cross_entropy_benchmarking
+    cirq.experiments.get_state_tomography_data
     cirq.experiments.rabi_oscillations
     cirq.experiments.single_qubit_randomized_benchmarking
     cirq.experiments.single_qubit_state_tomography
+    cirq.experiments.state_tomography
     cirq.experiments.t1_decay
     cirq.experiments.two_qubit_randomized_benchmarking
     cirq.experiments.two_qubit_state_tomography
@@ -430,6 +432,7 @@ run experiments.
     cirq.experiments.RabiResult
     cirq.experiments.RandomizedBenchMarkResult
     cirq.experiments.SingleQubitReadoutCalibrationResult
+    cirq.experiments.StateTomographyExperiment
     cirq.experiments.T1DecayResult
     cirq.experiments.TomographyResult
 


### PR DESCRIPTION
Also updates tests to access the symbols under cirq instead of cirq.experiments.n_qubit_tomography. This forces n_qubit_tomography to import individual modules (which is also consistent with how we do this elsewhere).