### PR TITLE
Fix slow tests

### DIFF
--- a/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq/contrib/acquaintance/executor_test.py
@@ -149,16 +149,14 @@ def random_diagonal_gates(num_qubits: int,
              combinations(cirq.LineQubit.range(num_qubits), acquaintance_size)}
 
 
-@pytest.mark.parametrize('num_qubits, acquaintance_size, gates',
+@pytest.mark.parametrize(
+    'num_qubits, acquaintance_size, gates',
     [(num_qubits, acquaintance_size,
       random_diagonal_gates(num_qubits, acquaintance_size))
-      for acquaintance_size, num_qubits in
-      ([(2, n) for n in range(2, 9)] +
-       [(3, n) for n in range(3, 9)] +
-       [(4, n) for n in (4, 7)] +
-       [(5, n) for n in (5, 6)])
-      for _ in range(2)
-      ])
+     for acquaintance_size, num_qubits in ([(2, n) for n in range(2, 9)] +
+                                           [(3, n) for n in range(3, 8)] +
+                                           [(4, 4), (4, 6), (5, 5)])
+     for _ in range(2)])
 def test_executor_random(num_qubits: int,
                          acquaintance_size: int,
                          gates: Dict[Tuple[cirq.Qid, ...], cirq.Gate]):

--- a/cirq/contrib/acquaintance/inspection_utils_test.py
+++ b/cirq/contrib/acquaintance/inspection_utils_test.py
@@ -21,7 +21,7 @@ import cirq.contrib.acquaintance as cca
 
 
 @pytest.mark.parametrize('n_qubits, acquaintance_size',
-    product(range(2, 7), range(2, 5)))
+                         product(range(2, 6), range(2, 5)))
 def test_get_logical_acquaintance_opportunities(n_qubits, acquaintance_size):
     qubits = cirq.LineQubit.range(n_qubits)
     acquaintance_strategy = cca.complete_acquaintance_strategy(

--- a/cirq/contrib/acquaintance/strategies/cubic_test.py
+++ b/cirq/contrib/acquaintance/strategies/cubic_test.py
@@ -28,7 +28,7 @@ def test_skip_and_wrap_around():
     assert ccasc.skip_and_wrap_around('abcdef') == tuple('afbecd')
 
 
-@pytest.mark.parametrize('n_qubits', range(3, 10))
+@pytest.mark.parametrize('n_qubits', range(3, 9))
 def test_cubic_acquaintance_strategy(n_qubits):
     qubits = tuple(cirq.LineQubit.range(n_qubits))
     strategy = cca.cubic_acquaintance_strategy(qubits)

--- a/cirq/contrib/quantum_volume/quantum_volume_test.py
+++ b/cirq/contrib/quantum_volume/quantum_volume_test.py
@@ -316,8 +316,8 @@ def test_calculate_quantum_volume_loop_with_readout_correction():
     # Keep test from taking a long time by lowering circuits and routing
     # attempts.
     cirq.contrib.quantum_volume.calculate_quantum_volume(
-        num_qubits=5,
-        depth=5,
+        num_qubits=4,
+        depth=4,
         num_circuits=1,
         routing_attempts=2,
         random_state=1,

--- a/cirq/contrib/routing/router_test.py
+++ b/cirq/contrib/routing/router_test.py
@@ -28,7 +28,7 @@ def random_seed():
 
 
 @pytest.mark.parametrize('n_moments,algo,circuit_seed,routing_seed',
-                         [(30, algo, random_seed(), random_seed())
+                         [(20, algo, random_seed(), random_seed())
                           for algo in ccr.ROUTERS
                           for _ in range(5)] +
                          [(0, 'greedy', random_seed(), random_seed())] +
@@ -55,7 +55,7 @@ def test_route_circuit(n_moments, algo, circuit_seed, routing_seed):
     'algo,seed',
     [(algo, random_seed()) for algo in ccr.ROUTERS for _ in range(3)])
 def test_route_circuit_reproducible_with_seed(algo, seed):
-    circuit = cirq.testing.random_circuit(10, 30, 0.5, random_state=seed)
+    circuit = cirq.testing.random_circuit(8, 20, 0.5, random_state=seed)
     device_graph = ccr.get_grid_device_graph(4, 3)
     wrappers = (lambda s: s, np.random.RandomState)
 

--- a/cirq/experiments/cross_entropy_benchmarking_test.py
+++ b/cirq/experiments/cross_entropy_benchmarking_test.py
@@ -45,13 +45,13 @@ def test_cross_entropy_benchmarking():
                                            qubits,
                                            num_circuits=3,
                                            repetitions=1000,
-                                           cycles=range(4, 30, 5))
+                                           cycles=range(4, 20, 5))
     results_1 = cross_entropy_benchmarking(
         simulator,
         qubits,
         num_circuits=3,
         repetitions=1000,
-        cycles=range(4, 30, 5),
+        cycles=[4, 8, 12],
         scrambling_gates_per_cycle=single_qubit_rots)
     results_2 = cross_entropy_benchmarking(
         simulator,
@@ -59,7 +59,7 @@ def test_cross_entropy_benchmarking():
         benchmark_ops=interleaved_ops,
         num_circuits=3,
         repetitions=1000,
-        cycles=range(4, 30, 5),
+        cycles=[4, 8, 12],
         scrambling_gates_per_cycle=single_qubit_rots)
     results_3 = cross_entropy_benchmarking(
         simulator,
@@ -67,7 +67,7 @@ def test_cross_entropy_benchmarking():
         benchmark_ops=interleaved_ops,
         num_circuits=3,
         repetitions=1000,
-        cycles=20,
+        cycles=15,
         scrambling_gates_per_cycle=single_qubit_rots)
     fidelities_0 = [datum.xeb_fidelity for datum in results_0.data]
     fidelities_1 = [datum.xeb_fidelity for datum in results_1.data]

--- a/cirq/experiments/n_qubit_tomography_test.py
+++ b/cirq/experiments/n_qubit_tomography_test.py
@@ -29,12 +29,12 @@ def test_state_tomography_diagonal():
         res = cirq.experiments.state_tomography(cirq.Simulator(),
                                                 qubits,
                                                 circuit,
-                                                repetitions=10000,
+                                                repetitions=1000,
                                                 prerotations=[(0, 0), (0, 0.5),
                                                               (0.5, 0.5)])
         should_be = np.zeros((2**n, 2**n))
         should_be[state, state] = 1
-        assert np.allclose(res.data, should_be, atol=2e-2)
+        assert np.allclose(res.data, should_be, atol=0.05)
 
 
 def test_state_tomography_ghz_state():
@@ -48,13 +48,13 @@ def test_state_tomography_ghz_state():
          cirq.LineQubit(1),
          cirq.LineQubit(2)],
         circuit,
-        repetitions=10000)
+        repetitions=1000)
     should_be = np.zeros((8, 8))
     should_be[0, 0] = .5
     should_be[7, 7] = .5
     should_be[0, 7] = .5
     should_be[7, 0] = .5
-    assert np.allclose(res.data, should_be, atol=1e-2)
+    assert np.allclose(res.data, should_be, atol=0.05)
 
 
 def test_make_experiment_no_rots():

--- a/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq/experiments/qubit_characterizations_test.py
@@ -60,11 +60,12 @@ def test_two_qubit_randomized_benchmarking():
     simulator = sim.Simulator()
     q_0 = GridQubit(0, 0)
     q_1 = GridQubit(0, 1)
-    num_cfds = range(5, 20, 5)
+    num_cfds = [5, 10]
     results = two_qubit_randomized_benchmarking(simulator,
                                                 q_0,
                                                 q_1,
                                                 num_clifford_range=num_cfds,
+                                                num_circuits=10,
                                                 repetitions=100)
     g_pops = np.asarray(results.data)[:, 1]
     assert np.isclose(np.mean(g_pops), 1.0)

--- a/cirq/google/optimizers/convert_to_sqrt_iswap_test.py
+++ b/cirq/google/optimizers/convert_to_sqrt_iswap_test.py
@@ -74,7 +74,7 @@ def test_two_qubit_gates_with_symbols(gate: cirq.Gate, expected_length: int):
     assert len(converted_circuit) <= expected_length
 
     # Check if unitaries are the same
-    for val in np.linspace(0, 2 * np.pi, 20):
+    for val in np.linspace(0, 2 * np.pi, 12):
         assert _unitaries_allclose(
             cirq.resolve_parameters(original_circuit, {'t': val}),
             cirq.resolve_parameters(converted_circuit, {'t': val}))

--- a/cirq/google/optimizers/optimize_for_sycamore_test.py
+++ b/cirq/google/optimizers/optimize_for_sycamore_test.py
@@ -59,10 +59,11 @@ def test_tabulation():
                                                     atol=1e-5)
     assert len(circuit2) == 14
 
-    # sorry for the weak tolerances...
+    # Note this is run on every commit, so it needs to be relatively quick.
+    # This requires us to use relatively loose tolerances
     circuit3 = cg.optimized_for_sycamore(circuit,
                                          optimizer_type='sycamore',
-                                         tabulation_resolution=0.01)
+                                         tabulation_resolution=0.1)
     cirq.testing.assert_allclose_up_to_global_phase(u,
                                                     cirq.unitary(circuit3),
                                                     rtol=1e-1,

--- a/cirq/google/optimizers/optimize_for_xmon_test.py
+++ b/cirq/google/optimizers/optimize_for_xmon_test.py
@@ -26,7 +26,7 @@ from cirq.testing import (
     (4, 3),
     (4, 4),
     (5, 4),
-    (22, 4),
+    (7, 4),
 ])
 def test_swap_field(n: int, d: int):
     before = cirq.Circuit(

--- a/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq/ops/pauli_interaction_gate_test.py
@@ -47,13 +47,28 @@ def test_eq_ne_and_hash():
             _paulis, _bools,
             _paulis, _bools,
             (0.125, -0.25, 1)):
-        def gate_gen(offset):
-            return cirq.PauliInteractionGate(
-                pauli0, invert0,
-                pauli1, invert1,
-                exponent=e + offset)
-        eq.add_equality_group(gate_gen(0), gate_gen(0), gate_gen(2),
-                              gate_gen(-4), gate_gen(-2))
+        eq.add_equality_group(
+            cirq.PauliInteractionGate(pauli0,
+                                      invert0,
+                                      pauli1,
+                                      invert1,
+                                      exponent=e))
+
+
+def test_exponent_shifts_are_equal():
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(
+        cirq.PauliInteractionGate(cirq.X, False, cirq.X, False, exponent=e)
+        for e in [0.1, 0.1, 2.1, -1.9, 4.1])
+    eq.add_equality_group(
+        cirq.PauliInteractionGate(cirq.X, True, cirq.X, False, exponent=e)
+        for e in [0.1, 0.1, 2.1, -1.9, 4.1])
+    eq.add_equality_group(
+        cirq.PauliInteractionGate(cirq.Y, False, cirq.Z, False, exponent=e)
+        for e in [0.1, 0.1, 2.1, -1.9, 4.1])
+    eq.add_equality_group(
+        cirq.PauliInteractionGate(cirq.Z, False, cirq.Y, True, exponent=e)
+        for e in [0.1, 0.1, 2.1, -1.9, 4.1])
 
 
 @pytest.mark.parametrize('gate',

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -47,7 +47,6 @@ def _small_sample_qubit_pauli_maps():
     Only tests 10 combinations of Paulis to speed up testing.
     """
     qubits = _make_qubits(3)
-    paulis_or_none = (None, cirq.X, cirq.Y, cirq.Z)
     yield {}
     yield {qubits[0]: cirq.X}
     yield {qubits[1]: cirq.X}

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -28,11 +28,37 @@ def _make_qubits(n):
 
 
 def _sample_qubit_pauli_maps():
+    """ All combinations of having a Pauli or nothing on 3 qubits.
+    Yields 64 qubit pauli maps
+    """
     qubits = _make_qubits(3)
     paulis_or_none = (None, cirq.X, cirq.Y, cirq.Z)
     for paulis in itertools.product(paulis_or_none, repeat=len(qubits)):
-        yield {qubit: pauli for qubit, pauli in zip(qubits, paulis)
-                            if pauli is not None}
+        yield {
+            qubit: pauli
+            for qubit, pauli in zip(qubits, paulis)
+            if pauli is not None
+        }
+
+
+def _small_sample_qubit_pauli_maps():
+    """ A few representative samples of qubit maps.
+
+    Only tests 10 combinations of Paulis to speed up testing.
+    """
+    qubits = _make_qubits(3)
+    paulis_or_none = (None, cirq.X, cirq.Y, cirq.Z)
+    yield {}
+    yield {qubits[0]: cirq.X}
+    yield {qubits[1]: cirq.X}
+    yield {qubits[2]: cirq.X}
+    yield {qubits[1]: cirq.Z}
+
+    yield {qubits[0]: cirq.Y, qubits[1]: cirq.Z}
+    yield {qubits[1]: cirq.Z, qubits[2]: cirq.X}
+    yield {qubits[0]: cirq.X, qubits[1]: cirq.X, qubits[2]: cirq.X}
+    yield {qubits[0]: cirq.X, qubits[1]: cirq.Y, qubits[2]: cirq.Z}
+    yield {qubits[0]: cirq.Z, qubits[1]: cirq.X, qubits[2]: cirq.Y}
 
 
 def test_eq_ne_hash():
@@ -253,37 +279,26 @@ def test_contains(qubit_pauli_map):
 
 
 @pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_keys(qubit_pauli_map):
+def test_basic_functionality(qubit_pauli_map):
     pauli_string = cirq.PauliString(qubit_pauli_map)
-    assert (len(qubit_pauli_map.keys()) == len(pauli_string.keys())
-            == len(pauli_string.qubits))
-    assert (set(qubit_pauli_map.keys()) == set(pauli_string.keys())
-            == set(pauli_string.qubits))
-
-
-@pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_items(qubit_pauli_map):
-    pauli_string = cirq.PauliString(qubit_pauli_map)
+    # Test items
     assert len(qubit_pauli_map.items()) == len(pauli_string.items())
     assert set(qubit_pauli_map.items()) == set(pauli_string.items())
 
-
-@pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_values(qubit_pauli_map):
-    pauli_string = cirq.PauliString(qubit_pauli_map)
+    # Test values
     assert len(qubit_pauli_map.values()) == len(pauli_string.values())
     assert set(qubit_pauli_map.values()) == set(pauli_string.values())
 
-
-@pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_len(qubit_pauli_map):
-    pauli_string = cirq.PauliString(qubit_pauli_map)
+    # Test length
     assert len(qubit_pauli_map) == len(pauli_string)
 
+    # Test keys
+    assert (len(qubit_pauli_map.keys()) == len(pauli_string.keys()) == len(
+        pauli_string.qubits))
+    assert (set(qubit_pauli_map.keys()) == set(pauli_string.keys()) == set(
+        pauli_string.qubits))
 
-@pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_iter(qubit_pauli_map):
-    pauli_string = cirq.PauliString(qubit_pauli_map)
+    # Test iteration
     assert len(tuple(qubit_pauli_map)) == len(tuple(pauli_string))
     assert set(tuple(qubit_pauli_map)) == set(tuple(pauli_string))
 
@@ -674,7 +689,7 @@ def test_with_qubits():
     assert new_pauli_string.coefficient == -1
 
 
-@pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
+@pytest.mark.parametrize('qubit_pauli_map', _small_sample_qubit_pauli_maps())
 def test_consistency(qubit_pauli_map):
     pauli_string = cirq.PauliString(qubit_pauli_map)
     cirq.testing.assert_implements_consistent_protocols(pauli_string)
@@ -1235,7 +1250,7 @@ def test_pauli_string_expectation_from_density_matrix_pure_state_with_coef():
 
 
 def test_pauli_string_expectation_from_wavefunction_mixed_state_linearity():
-    n_qubits = 10
+    n_qubits = 6
 
     wavefunction1 = cirq.testing.random_superposition(2**n_qubits)
     wavefunction2 = cirq.testing.random_superposition(2**n_qubits)
@@ -1409,7 +1424,7 @@ def test_conjugated_by_common_two_qubit_gates():
             return [cirq.Y(qubits[0])**-0.5, cirq.CNOT(*qubits)]
 
     a, b, c, d = cirq.LineQubit.range(4)
-    base_two_qubit_gates = [
+    two_qubit_gates = [
         cirq.CNOT,
         cirq.CZ,
         cirq.ISWAP,
@@ -1418,19 +1433,21 @@ def test_conjugated_by_common_two_qubit_gates():
         cirq.XX**0.5,
         cirq.YY**0.5,
         cirq.ZZ**0.5,
+        cirq.XX,
+        cirq.YY,
+        cirq.ZZ,
         cirq.XX**-0.5,
         cirq.YY**-0.5,
         cirq.ZZ**-0.5,
     ]
-    two_qubit_gates = [g**i for i in range(4) for g in base_two_qubit_gates]
     two_qubit_gates.extend([
         OrderSensitiveGate(),
     ])
     for p1 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
         for p2 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
+            pd = cirq.DensePauliString([p1, p2])
+            p = pd.sparse()
             for g in two_qubit_gates:
-                pd = cirq.DensePauliString([p1, p2])
-                p = pd.sparse()
                 assert p.conjugated_by(g.on(c, d)) == p
 
                 actual = cirq.unitary(p.conjugated_by(g.on(a, b)).dense([a, b]))

--- a/cirq/ops/phased_iswap_gate_test.py
+++ b/cirq/ops/phased_iswap_gate_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
-
 import numpy as np
 import pytest
 import scipy

--- a/cirq/ops/phased_iswap_gate_test.py
+++ b/cirq/ops/phased_iswap_gate_test.py
@@ -97,11 +97,23 @@ def test_decompose_invalid_qubits():
         cirq.protocols.decompose_once_with_qubits(cirq.PhasedISwapPowGate(), qs)
 
 
-@pytest.mark.parametrize('phase_exponent, exponent',
-                         itertools.product(
-                             (-0.3, 0, 0.1, 0.5, 1, 2, sympy.Symbol('p')),
-                             (-0.1, 0, 0.1, 1, sympy.Symbol('t')),
-                         ))
+@pytest.mark.parametrize('phase_exponent, exponent', [
+    (0, 0),
+    (0, 0.1),
+    (0, 0.5),
+    (0, -1),
+    (-0.3, 0),
+    (0.1, 0.1),
+    (0.1, 0.5),
+    (0.5, 0.5),
+    (-0.1, 0.1),
+    (-0.5, 1),
+    (0.3, 2),
+    (0.4, -2),
+    (0.1, sympy.Symbol('p')),
+    (sympy.Symbol('t'), 0.5),
+    (sympy.Symbol('t'), sympy.Symbol('p')),
+])
 def test_phased_iswap_has_consistent_protocols(phase_exponent, exponent):
     cirq.testing.assert_implements_consistent_protocols(
         cirq.PhasedISwapPowGate(phase_exponent=phase_exponent,

--- a/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq/sim/clifford/clifford_simulator.py
@@ -84,7 +84,6 @@ class CliffordSimulator(simulator.SimulatesSamples,
                     list)  # type: Dict[str, List[np.ndarray]]
 
                 for op in moment:
-                    print(type(op))
                     if protocols.has_unitary(op):
                         state.apply_unitary(op)
                     elif protocols.is_measurement(op):

--- a/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq/sim/clifford/clifford_simulator_test.py
@@ -330,9 +330,9 @@ def test_clifford_circuit():
 def test_clifford_circuit_2(qubits):
     circuit = cirq.Circuit()
 
-    np.random.seed(1)
+    np.random.seed(2)
 
-    for _ in range(100):
+    for _ in range(50):
         x = np.random.randint(7)
 
         if x == 0:

--- a/cirq/testing/consistent_protocols.py
+++ b/cirq/testing/consistent_protocols.py
@@ -35,14 +35,13 @@ from cirq.testing.equivalent_repr_eval import assert_equivalent_repr
 def assert_implements_consistent_protocols(
         val: Any,
         *,
-        exponents: Sequence[Any] = (
-            0, 1, -1, 0.5, 0.25, -0.5, 0.1, sympy.Symbol('s')),
+        exponents: Sequence[Any] = (0, 1, -1, 0.25, -0.5, 0.1,
+                                    sympy.Symbol('s')),
         qubit_count: Optional[int] = None,
-        ignoring_global_phase: bool=False,
+        ignoring_global_phase: bool = False,
         setup_code: str = 'import cirq\nimport numpy as np\nimport sympy',
         global_vals: Optional[Dict[str, Any]] = None,
-        local_vals: Optional[Dict[str, Any]] = None
-        ) -> None:
+        local_vals: Optional[Dict[str, Any]] = None) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
     global_vals = global_vals or {}
     local_vals = local_vals or {}

--- a/cirq/testing/random_circuit_test.py
+++ b/cirq/testing/random_circuit_test.py
@@ -74,8 +74,8 @@ def test_random_circuit(n_qubits: Union[int, Sequence[cirq.Qid]],
 def test_random_circuit_reproducible_with_seed(seed):
     wrappers = (lambda s: s, np.random.RandomState)
     circuits = [
-        random_circuit(qubits=20,
-                       n_moments=20,
+        random_circuit(qubits=10,
+                       n_moments=10,
                        op_density=0.7,
                        random_state=wrapper(seed))
         for wrapper in wrappers

--- a/examples/advanced/quantum_volume.py
+++ b/examples/advanced/quantum_volume.py
@@ -25,7 +25,8 @@ from cirq.contrib.quantum_volume import calculate_quantum_volume
 import cirq
 
 
-def main(*, num_qubits: int, depth: int, num_circuits: int, seed: int):
+def main(*, num_qubits: int, depth: int, num_circuits: int, seed: int,
+         routes: int):
     """Run the quantum volume algorithm with a preset configuration.
 
     See the calculate_quantum_volume documentation for more details.
@@ -49,6 +50,7 @@ def main(*, num_qubits: int, depth: int, num_circuits: int, seed: int):
                              random_state=seed,
                              device_or_qubits=device,
                              samplers=[cirq.Simulator(), noisy],
+                             routing_attempts=routes,
                              compiler=compiler)
 
 
@@ -63,6 +65,10 @@ def parse_arguments(args):
                         default=4,
                         type=int,
                         help='SU(4) circuit depth.')
+    parser.add_argument('--routes',
+                        default=30,
+                        type=int,
+                        help='Number of different qubit routes to try')
     parser.add_argument('--seed',
                         default=None,
                         type=int,

--- a/examples/advanced/quantum_volume_test.py
+++ b/examples/advanced/quantum_volume_test.py
@@ -9,7 +9,7 @@ import cirq
 def test_main_loop():
     """Test that the main loop is able to run without erring."""
     # Keep test from taking a long time by lowering repetitions.
-    args = '--num_qubits 5 --depth 5 --num_circuits 1'.split()
+    args = '--num_qubits 5 --depth 5 --num_circuits 1  --routes 3'.split()
     quantum_volume.main(**quantum_volume.parse_arguments(args))
 
 def test_parse_args():
@@ -21,4 +21,5 @@ def test_parse_args():
         'depth': 5,
         'num_circuits': 200,
         'seed': 1234,
+        'routes': 30,
     }

--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -97,7 +97,9 @@ def test_example_runs_hhl():
 
 
 def test_example_runs_qubit_characterizations():
-    examples.qubit_characterizations_example.main()
+    examples.qubit_characterizations_example.main(minimum_cliffords=2,
+                                                  maximum_cliffords=6,
+                                                  cliffords_step=2)
 
 
 def test_example_swap_networks():
@@ -199,7 +201,7 @@ def test_example_shor_naive_order_finder(x, n):
     assert_order(r, x, n)
 
 
-@pytest.mark.parametrize('x, n', ((2, 3), (5, 6), (2, 7), (6, 7), (5, 8)))
+@pytest.mark.parametrize('x, n', ((2, 3), (5, 6), (2, 7), (6, 7)))
 def test_example_shor_quantum_order_finder(x, n):
     r = None
     for _ in range(15):

--- a/examples/qubit_characterizations_example.py
+++ b/examples/qubit_characterizations_example.py
@@ -2,7 +2,26 @@ import numpy as np
 import cirq
 
 
-def main():
+def main(minimum_cliffords=5, maximum_cliffords=20, cliffords_step=5):
+    """
+    Examples of how to run various qubit characterizations.  This example
+    shows various methods on how to characterize a qubit, including a Rabi
+    oscillation experiments, Clifford-based randomized benchmarking, and
+    state tomography.
+
+    The number of cliffords to use in a randomized benchmarking experiment
+    can be varied.  For instance, setting minimum_cliffords=10,
+    maximum_cliffords=30 and cliffords_step=5 will test depths of 10, 15, 20,
+    and 25 (the maximum of the range is exclusive).
+
+    Args:
+        minimum_cliffords: the number of Clifford gates to start with in a
+          randomized benchmarking study
+        maximum_cliffords: the number of Clifford gates to scale up to in a
+          randomized benchmarking study.  This is used as an exclusive limit.
+        cliffords_step: the increment to step with from the minimum to maximum
+          number of Clifford gates.
+    """
     # The device to run the experiment.
     simulator = cirq.Simulator()
 
@@ -14,16 +33,16 @@ def main():
     rabi_results = cirq.experiments.rabi_oscillations(simulator, q_0, 4 * np.pi)
     rabi_results.plot()
 
-    num_cfds = range(5, 20, 5)
+    clifford_range = range(minimum_cliffords, maximum_cliffords, cliffords_step)
 
     # Clifford-based randomized benchmarking of single-qubit gates on q_0.
     rb_result_1q = cirq.experiments.single_qubit_randomized_benchmarking(
-        simulator, q_0, num_clifford_range=num_cfds, repetitions=100)
+        simulator, q_0, num_clifford_range=clifford_range, repetitions=100)
     rb_result_1q.plot()
 
     # Clifford-based randomized benchmarking of two-qubit gates on q_0 and q_1.
     rb_result_2q = cirq.experiments.two_qubit_randomized_benchmarking(
-        simulator, q_0, q_1, num_clifford_range=num_cfds, repetitions=100)
+        simulator, q_0, q_1, num_clifford_range=clifford_range, repetitions=100)
     rb_result_2q.plot()
 
     # State-tomography of q_0 after application of an X/2 rotation.


### PR DESCRIPTION
- Amend a bunch of the tests to use simpler values so as to speed
up testing.
- Combine a few places where itertools.product results in a huge
number of tests.
- On my machine, these changes speed up "pytest ." from 2m33s to 1m55s.
- Also added additional parameters to vary the number of gates for qubit characterization and added appropriate docstring

Fixes #1339 