### PR TITLE
Unpin networkx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 dataclasses; python_version < '3.7'
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
 matplotlib~=3.0
-networkx==2.3
+networkx~=2.4
 numpy~=1.16
 pandas
 protobuf==3.8.0


### PR DESCRIPTION
Our tests now pass with networkx 2.4 (context for the original pin: #2368).