### PR TITLE
requirements: remove sympy pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ protobuf==3.8.0
 requests~=2.18
 sortedcontainers~=2.0
 scipy
-sympy==1.4  # Can't use 1.5 until https://github.com/sympy/sympy/issues/18056 is fixed
+sympy
 typing_extensions


### PR DESCRIPTION
Sympy v1.5.1 is now available, fixes https://github.com/sympy/sympy/issues/18056.

See https://github.com/sympy/sympy/releases/tag/sympy-1.5.1 & changelog: https://github.com/sympy/sympy/wiki/Release-Notes-for-1.5.1

Ref: #2648 #2655 