### PR TITLE
Turn off --actually-quiet for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
       - python -m pip install -r requirements.txt
       - python -m pip install -r cirq/contrib/contrib-requirements.txt
       - python -m pip install -r dev_tools/conf/pip-list-dev-tools.txt
-    script: check/pytest --benchmark-skip --actually-quiet
+    script: check/pytest --benchmark-skip
   - stage: test
     os: linux
     env: NAME=pytest-and-incremental-coverage


### PR DESCRIPTION
This was already not working due to https://github.com/quantumlib/Cirq/issues/1826 and now it's causing our Windows builds to fail. See: https://github.com/quantumlib/Cirq/pull/2706