### PR TITLE
Speed up single qubit gate layer generation for random quantum circuit

### DIFF
--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -20,6 +20,7 @@ from cirq import circuits, devices, google, ops, value
 from cirq._doc import document
 
 if TYPE_CHECKING:
+    from typing import Union
     import numpy as np
     import cirq
 
@@ -199,7 +200,9 @@ def random_rotations_between_grid_interaction_layers_circuit(
     previous_single_qubit_layer = {}  # type: Dict[cirq.GridQubit, cirq.Gate]
     if len(set(single_qubit_gates)) == 1:
         single_qubit_layer_factory = _FixedSingleQubitLayerFactory(
-            {q: single_qubit_gates[0] for q in qubits})
+            {q: single_qubit_gates[0] for q in qubits}) \
+    # type: Union[_FixedSingleQubitLayerFactory, _RandomSingleQubitLayerFactory]
+
     else:
         single_qubit_layer_factory = _RandomSingleQubitLayerFactory(
             qubits, single_qubit_gates, prng)

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -185,8 +185,7 @@ def random_rotations_between_grid_interaction_layers_circuit(
             `two_qubit_op_factory(a, b, prng)`, where `a` and `b` are the qubits
             to operate on and `prng` is the pseudorandom number generator.
         pattern: The pattern of grid interaction layers to use.
-        single_qubit_gates: The single-qubit gates to use. This list should
-            not contain any repeated gates.
+        single_qubit_gates: The single-qubit gates to use.
         add_final_single_qubit_layer: Whether to include a final layer of
             single-qubit gates after the last cycle.
         seed: A seed or random state to use for the pseudorandom number

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -185,7 +185,8 @@ def random_rotations_between_grid_interaction_layers_circuit(
             `two_qubit_op_factory(a, b, prng)`, where `a` and `b` are the qubits
             to operate on and `prng` is the pseudorandom number generator.
         pattern: The pattern of grid interaction layers to use.
-        single_qubit_gates: The single-qubit gates to use.
+        single_qubit_gates: The single-qubit gates to use. This list should
+            not contain any repeated gates.
         add_final_single_qubit_layer: Whether to include a final layer of
             single-qubit gates after the last cycle.
         seed: A seed or random state to use for the pseudorandom number

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -14,7 +14,7 @@
 """Code for generating random quantum circuits."""
 
 from typing import (Callable, Container, Dict, Iterable, List, Optional,
-                    Sequence, TYPE_CHECKING, Tuple)
+                    Sequence, TYPE_CHECKING, Tuple, cast)
 
 from cirq import circuits, devices, google, ops, value
 from cirq._doc import document
@@ -198,7 +198,9 @@ def random_rotations_between_grid_interaction_layers_circuit(
     circuit = circuits.Circuit()
     previous_single_qubit_layer = {}  # type: Dict[cirq.GridQubit, cirq.Gate]
     if len(set(single_qubit_gates)) == 1:
-        fixed_single_qubit_layer = {q: single_qubit_gates[0] for q in qubits}
+        fixed_single_qubit_layer = {q: single_qubit_gates[0] for q in qubits} \
+                # type: Optional[Dict[cirq.GridQubit, cirq.Gate]]
+
         single_qubit_layer_factory = _fixed_single_qubit_layer
     else:
         fixed_single_qubit_layer = None
@@ -268,7 +270,7 @@ def _fixed_single_qubit_layer(
         prng: 'np.random.RandomState',
         fixed_single_qubit_layer: Optional[Dict['cirq.GridQubit', 'cirq.Gate']]
 ) -> Dict['cirq.GridQubit', 'cirq.Gate']:
-    return fixed_single_qubit_layer
+    return cast(Dict['cirq.GridQubit', 'cirq.Gate'], fixed_single_qubit_layer)
 
 
 def _two_qubit_layer(

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -237,12 +237,16 @@ def _single_qubit_layer(
         previous_single_qubit_layer: Dict['cirq.GridQubit', 'cirq.Gate'],
         prng: 'np.random.RandomState',
 ) -> Dict['cirq.GridQubit', 'cirq.Gate']:
+    if len(single_qubit_gates) == 1:
+        return {q: single_qubit_gates[0] for q in qubits}
 
     def random_gate(qubit: 'cirq.GridQubit',
                     prng: 'np.random.RandomState') -> 'cirq.Gate':
         excluded_gate = previous_single_qubit_layer.get(qubit, None)
-        allowed_gates = [g for g in single_qubit_gates if g != excluded_gate]
-        return allowed_gates[prng.randint(0, len(allowed_gates))]
+        g = single_qubit_gates[prng.randint(0, len(single_qubit_gates))]
+        while g == excluded_gate:
+            g = single_qubit_gates[prng.randint(0, len(single_qubit_gates))]
+        return g
 
     return {q: random_gate(q, prng) for q in qubits}
 

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -173,6 +173,10 @@ def random_rotations_between_grid_interaction_layers_circuit(
     appended, subject to the same constraint regarding consecutive cycles
     described above.
 
+    If only one choice of single-qubit gate is given, then the constraint
+    that excludes repeating single-qubit gates in consecutive cycles is not
+    enforced.
+
     Args:
         qubits: The qubits to use.
         depth: The number of cycles.

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -12,83 +12,77 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional, Sequence, Set, Tuple, cast
+from typing import Callable, Iterable, List, Sequence, Set, Tuple, cast
+
+import numpy as np
+import pytest
 
 import cirq
 from cirq.experiments import (
+    GridInteractionLayer,
     random_rotations_between_grid_interaction_layers_circuit)
 
 
-def test_random_rotations_between_grid_interaction_layers():
-    # Staggered pattern
-    qubits = set(cirq.GridQubit.rect(4, 3))
-    depth = 20
-    pattern = cirq.experiments.GRID_STAGGERED_PATTERN
-    circuit = random_rotations_between_grid_interaction_layers_circuit(
-        qubits, depth, seed=1234)
+def _syc_with_adjacent_z_rotations(a: cirq.GridQubit, b: cirq.GridQubit,
+                                   prng: np.random.RandomState):
+    z_exponents = [prng.uniform(0, 1) for _ in range(4)]
+    yield cirq.Z(a)**z_exponents[0]
+    yield cirq.Z(b)**z_exponents[1]
+    yield cirq.google.SYC(a, b)
+    yield cirq.Z(a)**z_exponents[2]
+    yield cirq.Z(b)**z_exponents[3]
 
-    assert len(circuit) == 2 * depth + 1
-    _validate_single_qubit_layers(qubits, circuit[::2])
-    _validate_two_qubit_layers(qubits, circuit[1::2], pattern)
 
-    # Aligned pattern
-    qubits = set(cirq.GridQubit.rect(4, 5))
-    depth = 21
-    pattern = cirq.experiments.GRID_ALIGNED_PATTERN
-    circuit = random_rotations_between_grid_interaction_layers_circuit(
-        qubits, depth, pattern=pattern, seed=1234)
-
-    assert len(circuit) == 2 * depth + 1
-    _validate_single_qubit_layers(qubits, circuit[::2])
-    _validate_two_qubit_layers(qubits, circuit[1::2], pattern)
-
-    # Staggered pattern with two qubit operation factory
-    qubits = set(cirq.GridQubit.rect(5, 4))
-    depth = 22
-    pattern = cirq.experiments.GRID_STAGGERED_PATTERN
-
-    def two_qubit_op_factory(a, b, prng):
-        z_exponents = [prng.uniform(0, 1) for _ in range(4)]
-        yield cirq.Z(a)**z_exponents[0]
-        yield cirq.Z(b)**z_exponents[1]
-        yield cirq.google.SYC(a, b)
-        yield cirq.Z(a)**z_exponents[2]
-        yield cirq.Z(b)**z_exponents[3]
-
-    circuit = random_rotations_between_grid_interaction_layers_circuit(
-        qubits, depth, two_qubit_op_factory=two_qubit_op_factory, seed=1234)
-
-    assert len(circuit) == 4 * depth + 1
-    _validate_single_qubit_layers(qubits, circuit[::4])
-    _validate_two_qubit_layers(qubits, circuit[2::4], pattern)
-
-    # Aligned pattern omitting final single qubit layer
-    qubits = set(cirq.GridQubit.rect(4, 5))
-    depth = 23
-    pattern = cirq.experiments.GRID_ALIGNED_PATTERN
+@pytest.mark.parametrize(
+    'qubits, depth, two_qubit_op_factory, pattern, '
+    'single_qubit_gates, add_final_single_qubit_layer, '
+    'seed, expected_circuit_length, single_qubit_layers_slice, '
+    'two_qubit_layers_slice', (
+        (cirq.GridQubit.rect(4, 3), 20, lambda a, b, _: cirq.google.SYC(a, b),
+         cirq.experiments.GRID_STAGGERED_PATTERN,
+         (cirq.X**0.5, cirq.Y**0.5, cirq.Z**
+          0.5), True, 1234, 41, slice(None, None, 2), slice(1, None, 2)),
+        (cirq.GridQubit.rect(4, 5), 21, lambda a, b, _: cirq.google.SYC(a, b),
+         cirq.experiments.GRID_ALIGNED_PATTERN,
+         (cirq.X**0.5, cirq.Y**0.5, cirq.Z**
+          0.5), True, 1234, 43, slice(None, None, 2), slice(1, None, 2)),
+        (cirq.GridQubit.rect(5, 4), 22, _syc_with_adjacent_z_rotations,
+         cirq.experiments.GRID_STAGGERED_PATTERN,
+         (cirq.X**0.5, cirq.Y**0.5, cirq.Z**
+          0.5), True, 1234, 89, slice(None, None, 4), slice(2, None, 4)),
+        (cirq.GridQubit.rect(5, 5), 23, lambda a, b, _: cirq.google.SYC(a, b),
+         cirq.experiments.GRID_ALIGNED_PATTERN,
+         (cirq.X**0.5, cirq.Y**0.5, cirq.Z**
+          0.5), False, 1234, 46, slice(None, None, 2), slice(1, None, 2)),
+        (cirq.GridQubit.rect(5, 5), 24, lambda a, b, _: cirq.google.SYC(a, b),
+         cirq.experiments.GRID_ALIGNED_PATTERN, (cirq.X**0.5, cirq.X**0.5),
+         True, 1234, 49, slice(None, None, 2), slice(1, None, 2)),
+    ))
+def test_random_rotations_between_grid_interaction_layers(
+        qubits: Iterable[cirq.GridQubit], depth: int,
+        two_qubit_op_factory: Callable[
+            [cirq.GridQubit, cirq.GridQubit, np.random.RandomState], cirq.
+            OP_TREE], pattern: Sequence[GridInteractionLayer],
+        single_qubit_gates: Sequence[cirq.Gate],
+        add_final_single_qubit_layer: bool, seed: cirq.value.RANDOM_STATE_LIKE,
+        expected_circuit_length: int, single_qubit_layers_slice: slice,
+        two_qubit_layers_slice: slice):
+    qubits = set(qubits)
     circuit = random_rotations_between_grid_interaction_layers_circuit(
         qubits,
         depth,
+        two_qubit_op_factory=two_qubit_op_factory,
         pattern=pattern,
-        add_final_single_qubit_layer=False,
-        seed=1234)
+        single_qubit_gates=single_qubit_gates,
+        add_final_single_qubit_layer=add_final_single_qubit_layer,
+        seed=seed)
 
-    assert len(circuit) == 2 * depth
-    _validate_single_qubit_layers(qubits, circuit[::2])
-    _validate_two_qubit_layers(qubits, circuit[1::2], pattern)
-
-    # Staggered pattern with only one kind of single-qubit gate
-    qubits = set(cirq.GridQubit.rect(4, 3))
-    depth = 20
-    pattern = cirq.experiments.GRID_STAGGERED_PATTERN
-    circuit = random_rotations_between_grid_interaction_layers_circuit(
-        qubits, depth, single_qubit_gates=[cirq.X**0.5, cirq.X**0.5], seed=1234)
-
-    assert len(circuit) == 2 * depth + 1
-    _validate_single_qubit_layers(qubits,
-                                  circuit[::2],
-                                  non_repeating_layers=False)
-    _validate_two_qubit_layers(qubits, circuit[1::2], pattern)
+    assert len(circuit) == expected_circuit_length
+    _validate_single_qubit_layers(
+        qubits,
+        circuit[single_qubit_layers_slice],
+        non_repeating_layers=len(set(single_qubit_gates)) > 1)
+    _validate_two_qubit_layers(qubits, circuit[two_qubit_layers_slice], pattern)
 
 
 def _validate_single_qubit_layers(qubits: Set[cirq.GridQubit],

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -96,7 +96,6 @@ def _validate_single_qubit_layers(qubits: Set[cirq.GridQubit],
                                   non_repeating_layers: bool = True) -> None:
     previous_single_qubit_gates = {q: None for q in qubits} \
             # type: Dict[cirq.GridQubit, Optional[cirq.Gate]]
-
     for moment in moments:
         # All qubits are acted upon
         assert moment.qubits == qubits

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Iterable, List, Sequence, Set, Tuple, cast
+from typing import (Callable, Iterable, List, Sequence, Set, TYPE_CHECKING,
+                    Tuple, cast)
 
 import numpy as np
 import pytest
@@ -21,6 +22,9 @@ import cirq
 from cirq.experiments import (
     GridInteractionLayer,
     random_rotations_between_grid_interaction_layers_circuit)
+
+if TYPE_CHECKING:
+    from typing import Dict, Optional
 
 
 def _syc_with_adjacent_z_rotations(a: cirq.GridQubit, b: cirq.GridQubit,
@@ -80,9 +84,11 @@ def test_random_rotations_between_grid_interaction_layers(
     assert len(circuit) == expected_circuit_length
     _validate_single_qubit_layers(
         qubits,
-        circuit[single_qubit_layers_slice],
+        cast(Sequence[cirq.Moment], circuit[single_qubit_layers_slice]),
         non_repeating_layers=len(set(single_qubit_gates)) > 1)
-    _validate_two_qubit_layers(qubits, circuit[two_qubit_layers_slice], pattern)
+    _validate_two_qubit_layers(
+        qubits, cast(Sequence[cirq.Moment], circuit[two_qubit_layers_slice]),
+        pattern)
 
 
 def _validate_single_qubit_layers(qubits: Set[cirq.GridQubit],

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -26,6 +26,8 @@ from cirq.experiments import (
 if TYPE_CHECKING:
     from typing import Dict, Optional
 
+SINGLE_QUBIT_LAYER = Dict[cirq.GridQubit, Optional[cirq.Gate]]
+
 
 def _syc_with_adjacent_z_rotations(a: cirq.GridQubit, b: cirq.GridQubit,
                                    prng: np.random.RandomState):
@@ -94,8 +96,8 @@ def test_random_rotations_between_grid_interaction_layers(
 def _validate_single_qubit_layers(qubits: Set[cirq.GridQubit],
                                   moments: Sequence[cirq.Moment],
                                   non_repeating_layers: bool = True) -> None:
-    previous_single_qubit_gates = {q: None for q in qubits} \
-            # type: Dict[cirq.GridQubit, Optional[cirq.Gate]]
+    previous_single_qubit_gates = {q: None for q in qubits
+                                  }  # type: SINGLE_QUBIT_LAYER
 
     for moment in moments:
         # All qubits are acted upon

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (Callable, Iterable, List, Sequence, Set, TYPE_CHECKING,
+from typing import (Callable, Dict, Iterable, List, Optional, Sequence, Set,
                     Tuple, cast)
 
 import numpy as np
@@ -22,9 +22,6 @@ import cirq
 from cirq.experiments import (
     GridInteractionLayer,
     random_rotations_between_grid_interaction_layers_circuit)
-
-if TYPE_CHECKING:
-    from typing import Dict, Optional
 
 SINGLE_QUBIT_LAYER = Dict[cirq.GridQubit, Optional[cirq.Gate]]
 

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -96,6 +96,7 @@ def _validate_single_qubit_layers(qubits: Set[cirq.GridQubit],
                                   non_repeating_layers: bool = True) -> None:
     previous_single_qubit_gates = {q: None for q in qubits} \
             # type: Dict[cirq.GridQubit, Optional[cirq.Gate]]
+
     for moment in moments:
         # All qubits are acted upon
         assert moment.qubits == qubits

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -82,7 +82,7 @@ def test_random_rotations_between_grid_interaction_layers():
     depth = 20
     pattern = cirq.experiments.GRID_STAGGERED_PATTERN
     circuit = random_rotations_between_grid_interaction_layers_circuit(
-        qubits, depth, single_qubit_gates=[cirq.X**0.5], seed=1234)
+        qubits, depth, single_qubit_gates=[cirq.X**0.5, cirq.X**0.5], seed=1234)
 
     assert len(circuit) == 2 * depth + 1
     _validate_single_qubit_layers(qubits,


### PR DESCRIPTION
This method is much faster when the set of single qubit gates is large since it avoids generating a new list of gates to choose from. For instance, I was using a set of 64 gates and got around a 15x speedup.

I also modified the code to handle the case of when only one choice of single-qubit gate is given. In that case, the condition of no repeating single-qubit gates is simply not enforced.