### PR TITLE
Add possible implementation of aligning Z, 1-qubit, and 2-qubit gates optimizer

### DIFF
--- a/cirq/google/optimizers/align_interactions.py
+++ b/cirq/google/optimizers/align_interactions.py
@@ -1,0 +1,282 @@
+import random
+from enum import Enum
+from typing import List, Set
+
+import cirq
+from cirq import circuits, ops, InsertStrategy
+
+from cirq.google.line.placement import optimization
+
+
+class AlignInteractions():
+    """Aligns two-qubit gates, single-qubit gates, and Z-gates into their own
+    moments. Note that this optimizer does not guarantee that the resulting
+    circuit will be faster - in fact, it may result in a circuit with more
+    moments than the original. Instead, it attempts to split Z operations, non-Z
+    operations, and 2-qubit operations into their own homogeneous moments, with
+    the restriction that single qubit gates cannot move past 2 qubit gates.
+
+    This function's algorithm is non-trivial because it boils down to the
+    following Constraint Satisfiability Problem: given a set of operations which
+    each have ranges where they can be applied, how can they be reorganized in
+    such a way as to minimize the number of heterogeneous and total moments? See
+    the tests for some cases that quickly become tricky without using a full CSP
+    solver.
+
+    Because of the intractable complexity of brute-forcing CSPs, we instead use
+    Simulated Annealing to search for an optimized circuit. An adjacent circuit
+    is defined as one where a single operation is moved to a brand new moment or
+    swapped with an existing operation in another moment.
+
+    Args:
+        num_repetitions: The number of repetitions per temperature in the
+        Simulated Annealing algorithm. The lower this number is, the quicker the
+        algorithm will run, but the greater chance that it ends up with a
+        non-optimal or partially heterogeneous circuit. Usually, the default is
+        fine.
+        random_state: A seed for random number generation.
+       """
+
+    num_repetitions: int
+    random_state: cirq.value.RANDOM_STATE_LIKE
+    max_num_moments: int  # The largest the circuit is allowed to grow to.
+
+    def __init__(self,
+                 *,
+                 num_repetitions=10,
+                 random_state: cirq.value.RANDOM_STATE_LIKE = None) -> None:
+        self.random_state = cirq.value.parse_random_state(random_state)
+        self.num_repetitions = num_repetitions
+
+    def optimize_circuit(self, circuit: circuits.Circuit) -> None:
+        """Optimize the circuit inline according to the algorithm specified in
+        the class comment.
+
+        This algorithm is currently slow - it takes about 5 seconds to run on an
+        8x8 circuit. It could easily be optimized in the following ways:
+
+          - Currently, circuits are used as the model during the simulated
+            annealing, which causes a lot of wasted effort around copying
+            circuits and moving operations around. Converting the initial
+            circuit to a simpler Data Structure before optimizing and then back
+            after would save a lot of time.
+          - We can detect when we are at a local maximum by checking if any
+            operations can be moved to a location that decreases our score. This
+            could be implemented into our search and could potentially be used
+            to end the search early.
+
+        Args:
+            circuit: The circuit to optimize, which will be mutated.
+        """
+        self.max_num_moments = len(circuit) * 3
+        solution = optimization.anneal_minimize(
+            initial=circuit.copy(),
+            cost_func=self.cost_func,
+            move_func=self.move_func,
+            random_sample=self.random_state.random_sample,
+            repeat=self.num_repetitions)
+
+        del circuit[:]
+        for moment in solution:
+            circuit.append(moment)
+
+    def trace_func(self, current: cirq.Circuit, temp: float, cost: float,
+                   accept: float, decision: bool):
+        """A trace function that can be supplied to the annealing function that
+        prints debug information."""
+        print(f"current: {len(current)}, temp: {temp}, cost: {cost}, "
+              f"accept: {accept}, decision: {decision}")
+        if decision:
+            print(current)
+
+    def cost_func(self, current: cirq.Circuit) -> float:
+        """Scores the given circuit. It penalizes heterogeneous moments
+        as well as the total number of moments, although the former incurs a
+        much greater penalty than the latter. This is to allow the annealing
+        algorithm to create new moments if necessary."""
+        num_heterogeneous = 0
+        for moment in current:
+            kinds = set([operation_kind(op) for op in moment])
+            if len(kinds) > 1:
+                # 3-type moments get doubly penalized
+                num_heterogeneous += len(kinds) - 1
+        num_total = len(current)
+        return num_heterogeneous + num_total / 100.0
+
+    def move_func(self, current: cirq.Circuit) -> cirq.Circuit:
+        """Returns a new circuit that is a neighbor of the given circuit.
+
+        Two circuits are adjacent if one can be constructed from the other
+        either by swapping two operations or by moving a single operation to a
+        new moment.
+
+        Args:
+            current: The circuit to find a neighbor of. Will not be mutated.
+
+        Returns: A neighbor of the given circuit.
+        """
+        # Pick a random qubit in the circuit and a random moment that operates
+        # on it.
+        rand_qubit = random.sample(current.all_qubits(), 1)[0]
+        indices_for_qubit = []
+        for moment_idx, moment in enumerate(current):
+            if moment.operates_on_single_qubit(rand_qubit):
+                indices_for_qubit.append(moment_idx)
+        rand_moment_idx = random.sample(indices_for_qubit, 1)[0]
+        rand_op = current.operation_at(rand_qubit, rand_moment_idx)
+
+        # Move this operation, as long as it doesn't cross any 2-qubit gate
+        # boundaries.
+        return self.move_operation(current, rand_moment_idx, rand_op)
+
+    def move_operation(self, current: cirq.Circuit, moment_idx: int,
+                       op: cirq.Operation) -> cirq.Circuit:
+        """Returns a new circuit that is constructed from copying the given
+        circuit and moving the given operation to a valid location. This
+        location is randomly chosen from any moments that would not cause this
+        operation to jump past a two-qubit gate.  Note that this may require
+        swapping the operation with another one.
+
+        Args:
+            current: The circuit to move the operation in. Not mutated.
+            moment_idx: The moment index of the given operation.
+            op: The operation to move.
+
+        Returns: A new circuit with the given operation moved to a new moment.
+        """
+        # Get all the possible places to move the operation.
+        valid_locations = get_possible_move_locations(current, moment_idx, op)
+
+        # If we can't move the operation at all and the circuit is already too
+        # large, just return the original circuit.
+        if len(current) >= self.max_num_moments and len(valid_locations) == 0:
+            return current
+
+        # Remove the operation.
+        copy = current.copy()
+        copy.batch_remove([(moment_idx, op)])
+
+        # With a certain probability OR if this operation can't be moved, insert
+        # it at a new moment. Don't do this if the circuit has already reached
+        # its max size.
+        if len(current) < self.max_num_moments and (random.randint(0, 10) < 3 or
+                                                    len(valid_locations) == 0):
+            valid_locations.add(moment_idx)
+            new_moment_idx = random.sample(valid_locations, 1)[0]
+            copy.insert(new_moment_idx,
+                        cirq.Moment([op]),
+                        strategy=InsertStrategy.NEW)
+            return copy
+
+        # Otherwise, move/swap the operation to a random valid location.
+        new_moment_idx = random.sample(valid_locations, 1)[0]
+
+        # If there is an operation at this location, swap it.
+        for qubit in op.qubits:
+            if copy[new_moment_idx].operates_on([qubit]):
+                old_op = copy.operation_at(qubit, new_moment_idx)
+                # Get rid of the old operation.
+                copy[new_moment_idx] = copy[
+                    new_moment_idx].without_operations_touching([qubit])
+                # Put it in the place of the operation we are going to move.
+                copy[moment_idx] = copy[moment_idx].with_operation(old_op)
+
+        # Finally, put the operation in its new home.
+        copy[new_moment_idx] = copy[new_moment_idx].with_operation(op)
+        # Delete the operation's old moment if it is now empty.
+        if len(copy[moment_idx]) == 0:
+            del copy[moment_idx]
+
+        return copy
+
+
+def get_possible_move_locations(current: cirq.Circuit, moment_idx: int,
+                                op: cirq.Operation) -> Set[int]:
+    """Returns all the possible moment indices that the given operation could be
+     moved to within the given circuit.
+
+     Args:
+        current: The circuit to check for possible move locations.
+        moment_idx: The moment index of the given operation.
+        op: The operation to move.
+
+     Returns: A set of moment indices where the given operation could be moved
+        to within the given circuit.
+    """
+    # Find all the valid locations for each qubit of the operation.
+    all_valid_locations: List[Set[int]] = []
+    for qubit in op.qubits:
+        qubit_valid_locations: Set[int] = set()
+
+        # Go from the current moment to the end of the circuit, or until a
+        # 2-qubit gate is found.
+        idx = moment_idx + 1
+        while idx < len(current):
+            new_op = current.operation_at(qubit, idx)
+            if new_op is not None and (len(new_op.qubits) > 1 or
+                                       len(new_op.qubits) != len(op.qubits)):
+                break
+            if moment_homogeneous_for_op(current[idx], op):
+                qubit_valid_locations.add(idx)
+            idx += 1
+
+        # Go from the current moment to the beginning of the circuit, or until a
+        # 2-qubit gate is found.
+        idx = moment_idx - 1
+        while idx >= 0:
+            new_op = current.operation_at(qubit, idx)
+            if new_op is not None and (len(new_op.qubits) > 1 or
+                                       len(new_op.qubits) != len(op.qubits)):
+                break
+            if moment_homogeneous_for_op(current[idx], op):
+                qubit_valid_locations.add(idx)
+            idx -= 1
+        all_valid_locations.append(qubit_valid_locations)
+
+    # Take the intersection of the possible moments for each qubit of the
+    # operation.
+    return set.intersection(*all_valid_locations)
+
+
+def moment_homogeneous_for_op(moment: cirq.Moment, op: cirq.Operation) -> bool:
+    """Returns true iff all of the operations in the given moment have the same
+    type as the given operation."""
+    for moment_op in moment:
+        if operation_kind(moment_op) != operation_kind(op):
+            return False
+    return True
+
+
+def create_new_moment(current: cirq.Circuit, moment_idx: int,
+                      op: cirq.Operation) -> cirq.Circuit:
+    """Returns a copy of the given circuit with a new moment added containing
+    the given operation, and deletes this operation from its original location.
+
+    Args:
+        current: The circuit to add the new moment to. Not mutated.
+        moment_idx: The moment of the given operation.
+        op: The operation to move.
+
+    Returns: The new circuit with a new moment containing the moved operation.
+    """
+    copy = current.copy()
+    copy.insert(moment_idx, cirq.Moment([op]), strategy=InsertStrategy.NEW)
+    copy.batch_remove([(moment_idx + 1, op)])
+    return copy
+
+
+class OperationKind(Enum):
+    """The different kinds of operations that we want to separate out."""
+    Z = 1
+    SINGLE_QUBIT = 2
+    TWO_QUBIT = 3
+
+
+def operation_kind(op: ops.Operation) -> OperationKind:
+    """Returns the kind of operation for use in sorting it into the correct
+    moment."""
+    if len(op.qubits) > 1:
+        return OperationKind.TWO_QUBIT
+    if isinstance(op.gate, ops.ZPowGate):
+        return OperationKind.Z
+    return OperationKind.SINGLE_QUBIT

--- a/cirq/google/optimizers/align_interactions.py
+++ b/cirq/google/optimizers/align_interactions.py
@@ -1,3 +1,17 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import random
 from enum import Enum
 from typing import List, Set

--- a/cirq/google/optimizers/align_interactions.py
+++ b/cirq/google/optimizers/align_interactions.py
@@ -81,15 +81,6 @@ class AlignInteractions():
         for moment in solution:
             circuit.append(moment)
 
-    def trace_func(self, current: cirq.Circuit, temp: float, cost: float,
-                   accept: float, decision: bool):
-        """A trace function that can be supplied to the annealing function that
-        prints debug information."""
-        print(f"current: {len(current)}, temp: {temp}, cost: {cost}, "
-              f"accept: {accept}, decision: {decision}")
-        if decision:
-            print(current)
-
     def cost_func(self, current: cirq.Circuit) -> float:
         """Scores the given circuit. It penalizes heterogeneous moments
         as well as the total number of moments, although the former incurs a
@@ -127,6 +118,7 @@ class AlignInteractions():
         rand_op = current.operation_at(rand_qubit, rand_moment_idx)
         if rand_op is None:
             # This should never happen, and is here to appease mypy.
+            # coverage: ignore
             raise RuntimeError('Error when finding  random operation')
 
         # Move this operation, as long as it doesn't cross any 2-qubit gate
@@ -181,6 +173,7 @@ class AlignInteractions():
                 old_op = copy.operation_at(qubit, new_moment_idx)
                 if old_op is None:
                     # Should never happen - here to appease mypy.
+                    # coverage: ignore
                     continue
                 # Get rid of the old operation.
                 copy[new_moment_idx] = copy[
@@ -252,24 +245,6 @@ def moment_homogeneous_for_op(moment: cirq.Moment, op: cirq.Operation) -> bool:
         if operation_kind(moment_op) != operation_kind(op):
             return False
     return True
-
-
-def create_new_moment(current: cirq.Circuit, moment_idx: int,
-                      op: cirq.Operation) -> cirq.Circuit:
-    """Returns a copy of the given circuit with a new moment added containing
-    the given operation, and deletes this operation from its original location.
-
-    Args:
-        current: The circuit to add the new moment to. Not mutated.
-        moment_idx: The moment of the given operation.
-        op: The operation to move.
-
-    Returns: The new circuit with a new moment containing the moved operation.
-    """
-    copy = current.copy()
-    copy.insert(moment_idx, cirq.Moment([op]), strategy=InsertStrategy.NEW)
-    copy.batch_remove([(moment_idx + 1, op)])
-    return copy
 
 
 class OperationKind(Enum):

--- a/cirq/google/optimizers/align_interactions.py
+++ b/cirq/google/optimizers/align_interactions.py
@@ -1,6 +1,7 @@
 import random
 from enum import Enum
 from typing import List, Set
+import numpy as np
 
 import cirq
 from cirq import circuits, ops, InsertStrategy
@@ -38,7 +39,7 @@ class AlignInteractions():
        """
 
     num_repetitions: int
-    random_state: cirq.value.RANDOM_STATE_LIKE
+    random_state: np.random.RandomState
     max_num_moments: int  # The largest the circuit is allowed to grow to.
 
     def __init__(self,
@@ -124,6 +125,9 @@ class AlignInteractions():
                 indices_for_qubit.append(moment_idx)
         rand_moment_idx = random.sample(indices_for_qubit, 1)[0]
         rand_op = current.operation_at(rand_qubit, rand_moment_idx)
+        if rand_op is None:
+            # This should never happen, and is here to appease mypy.
+            raise RuntimeError('Error when finding  random operation')
 
         # Move this operation, as long as it doesn't cross any 2-qubit gate
         # boundaries.
@@ -175,6 +179,9 @@ class AlignInteractions():
         for qubit in op.qubits:
             if copy[new_moment_idx].operates_on([qubit]):
                 old_op = copy.operation_at(qubit, new_moment_idx)
+                if old_op is None:
+                    # Should never happen - here to appease mypy.
+                    continue
                 # Get rid of the old operation.
                 copy[new_moment_idx] = copy[
                     new_moment_idx].without_operations_touching([qubit])

--- a/cirq/google/optimizers/align_interactions_test.py
+++ b/cirq/google/optimizers/align_interactions_test.py
@@ -202,6 +202,19 @@ def test_two_qubit_gates_pushed_back():
     assert_optimizes(circuit, 3)
 
 
+def test_greedy_merging():
+    """Tests a tricky situation where the algorithm of "Merge single-qubit gates,
+    greedily search for single-qubit then 2-qubit operations" doesn't work."""
+    q1, q2, q3, q4 = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(cirq.Moment([cirq.X(q1)]),
+                           cirq.Moment([cirq.SWAP(q1, q2),
+                                        cirq.SWAP(q3, q4)]),
+                           cirq.Moment([cirq.X(q3)]),
+                           cirq.Moment([cirq.SWAP(q3, q4)]))
+
+    assert_optimizes(circuit, 3)
+
+
 def test_complex_circuit():
     """Tests that a complex circuit is correctly optimized."""
     q1, q2, q3, q4, q5 = cirq.LineQubit.range(5)

--- a/cirq/google/optimizers/align_interactions_test.py
+++ b/cirq/google/optimizers/align_interactions_test.py
@@ -1,0 +1,279 @@
+from typing import Callable, List, Dict
+
+import numpy as np
+import cirq
+import cirq.google.optimizers.align_interactions as cgoai
+
+
+def assert_all_homogeneous(circuit: cirq.Circuit):
+    """Check that the given circuit has only homogeneous moments."""
+    for moment in circuit:
+        kinds = set([cgoai.operation_kind(op) for op in moment])
+        assert len(kinds) <= 1, f"Moment {moment} was not homogeneous, but " \
+        f" had {len(kinds)} different types of operations"
+
+
+def get_qubit_to_operations(circuit: cirq.Circuit
+                           ) -> Dict[cirq.Qid, List[cirq.Operation]]:
+    """Creates a dictionary from qubit to all the operations that operate on
+    that qubit, in order."""
+    qubit_to_operations: Dict[cirq.Qid, List[cirq.Operation]] = {}
+    for qubit in circuit.all_qubits():
+        operations = []
+        moment_idx = 0
+        while True:
+            moment_idx = circuit.next_moment_operating_on([qubit], moment_idx)
+            if moment_idx is not None:
+                operations.append(circuit.operation_at(qubit, moment_idx))
+                moment_idx += 1
+            else:
+                break
+        qubit_to_operations[qubit] = operations
+    return qubit_to_operations
+
+
+def assert_optimizes(circuit: cirq.Circuit, num_moments: int):
+    """Check that the given circuit has no heterogeneous moments and that the
+    unitary matrix for the input circuit is the same (up to global phase and
+    rounding error) as the unitary matrix for the optimized circuit.
+    Additionally, check that the number of X, Z, and two-qubit moments is
+    correct, and that no gates jumped over any two-qubit gates."""
+    # Store a map from the Qubit ID to the order of the operations for that
+    # qubit.
+    before_qubit_to_operations = get_qubit_to_operations(circuit)
+    circuit_before = circuit.copy()
+    u_before = circuit.unitary()
+    # Perform the optimization
+    cgoai.AlignInteractions(
+        random_state=np.random.RandomState(1)).optimize_circuit(circuit)
+    # Get the same information as before now that the circuit is optimized.
+    u_after = circuit.unitary()
+    after_qubit_to_operations = get_qubit_to_operations(circuit)
+
+    # Ensure that the operations did not cross any 2-qubit operation boundaries.
+    for qubit, before_operations in before_qubit_to_operations.items():
+        after_operations = after_qubit_to_operations[qubit]
+        assert len(before_operations) == len(after_operations)
+        for idx, before_op in enumerate(before_operations):
+            assert len(before_op.qubits) == len(after_operations[idx].qubits), \
+            f"Moment order in the following circuit was violated:\n {circuit}"
+
+    # Ignore differences that would be caught by follow-up optimizations.
+    followup_optimizations: List[Callable[[cirq.Circuit], None]] = [
+        cirq.DropEmptyMoments().optimize_circuit
+    ]
+    for post in followup_optimizations:
+        post(circuit)
+
+    assert_all_homogeneous(circuit)
+    cirq.testing.assert_allclose_up_to_global_phase(
+        u_before,
+        u_after,
+        atol=1e-8,
+        err_msg=f"The following circuits do not match. Initial: \n" \
+        f"{circuit_before}\nAfter: \n{circuit}"
+    )
+    assert len(circuit) <= num_moments, \
+    f"Expected the following circuit to have {num_moments} or fewer moments" \
+        f", but had {len(circuit)} moments:\n {circuit}"
+
+
+def assert_optimizes_exact(circuit: cirq.Circuit, expected: cirq.Circuit):
+    """Check that the given circuit optimizes to the given expected circuit, and
+    that the unitary matrix for the input circuit is the same (up to global
+    phase and rounding error) as the unitary matrix of the optimized circuit.
+    """
+    cgoai.AlignInteractions(
+        random_state=np.random.RandomState(1)).optimize_circuit(circuit)
+
+    assert circuit == expected
+
+
+def test_noop():
+    """Tests that nothing happens on circuits that are already homogeneous."""
+    q1, q2, q3, q4 = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(cirq.X(q1), cirq.Y(q2), cirq.X(q3))
+    assert_optimizes_exact(circuit, circuit.copy())
+
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.X(q1), cirq.Y(q2), cirq.X(q3)]),
+        cirq.Moment([cirq.ISWAP(q1, q2), cirq.ISWAP(q3, q4)]),
+        cirq.Moment([cirq.Z(q1), cirq.Z(q2)]))
+    assert_optimizes_exact(circuit, circuit.copy())
+
+
+def test_simple():
+    """Tests that a simple circuit maintains homogeneity."""
+    q1, q2, q3 = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(cirq.Moment([cirq.X(q1),
+                                        cirq.Y(q2),
+                                        cirq.X(q3)]), cirq.Moment([cirq.X(q1)]))
+    assert_optimizes(circuit, 2)
+
+
+def test_move_adjacent_gates():
+    """Tests that we can move gates between adjacent moments."""
+    q1, q2, q3, q4 = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.X(q3), cirq.X(q4)]),
+        cirq.Moment([cirq.X(q1), cirq.X(q2),
+                     cirq.ISWAP(q3, q4)]))
+    # The circuit should have a moment of Xs and SWAPs.
+    assert_optimizes(circuit, 2)
+
+
+def test_eject_z():
+    """Tests that a Z gate is ejected from a moment with other single-qubit
+    gates."""
+    q1, q2 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.Moment([cirq.ISWAP(q1, q2)]),
+                           cirq.Moment([cirq.Z(q1), cirq.X(q2)]),
+                           cirq.Moment([cirq.X(q1)]))
+    # The circuit should have a moment of SWAPs, Xs, and Zs.
+    assert_optimizes(circuit, 3)
+
+
+def test_sparse_circuit():
+    """Tests that a sparse circuit is still optimized correctly."""
+    q1, q2, q3 = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(cirq.Moment([cirq.ISWAP(q1, q2),
+                                        cirq.X(q3)]), cirq.Moment([]),
+                           cirq.Moment([]),
+                           cirq.Moment([cirq.Z(q1),
+                                        cirq.X(q2)]), cirq.Moment([]),
+                           cirq.Moment([]), cirq.Moment([cirq.X(q1)]))
+    # The circuit should have a moment of SWAPs, Xs, and Zs.
+    assert_optimizes(circuit, 3)
+
+
+def test_x_gates_pushed_back():
+    """Tests that x gates are pushed back to the end if necessary."""
+    q1, q2, q3, q4, q5 = cirq.LineQubit.range(5)
+    circuit = cirq.Circuit(cirq.Moment([cirq.ISWAP(q1, q2),
+                                        cirq.X(q5)]),
+                           cirq.Moment([cirq.ISWAP(q3, q4)]),
+                           cirq.Moment([cirq.X(q1), cirq.X(q2)]))
+    # This circuit should have a moment of SWAPs and a moment of Xs.
+    assert_optimizes(circuit, 2)
+
+
+def test_z_gates_pushed_back():
+    """Tests that z gates are pushed back to the end if necessary."""
+    q1, q2, q3, q4, q5 = cirq.LineQubit.range(5)
+    circuit = cirq.Circuit(cirq.Moment([cirq.ISWAP(q1, q2),
+                                        cirq.Z(q5)]),
+                           cirq.Moment([cirq.ISWAP(q3, q4)]),
+                           cirq.Moment([cirq.Z(q1), cirq.Z(q2)]))
+    # This circuit should have a moment of SWAPs and a moment of Zs.
+    assert_optimizes(circuit, 2)
+
+
+def test_two_qubit_gates_pushed_back():
+    """Tests that two qubit gates are pushed back to the end if necessary."""
+    q1, q2, q3, q4, q5 = cirq.LineQubit.range(5)
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.X(q1),
+                     cirq.X(q2),
+                     cirq.ISWAP(q3, q4),
+                     cirq.X(q5)]), cirq.Moment([cirq.X(q1),
+                                                cirq.X(q2)]),
+        cirq.Moment([cirq.ISWAP(q1, q2)]))
+    # This circuit should have the SWAP gate pushed to the end of the circuit,
+    # and start with two X moments.
+    assert_optimizes(circuit, 3)
+
+
+def test_complex_circuit():
+    """Tests that a complex circuit is correctly optimized."""
+    q1, q2, q3, q4, q5 = cirq.LineQubit.range(5)
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.X(q1), cirq.ISWAP(q2, q3),
+                     cirq.Z(q5)]), cirq.Moment([cirq.X(q1),
+                                                cirq.ISWAP(q4, q5)]),
+        cirq.Moment([cirq.ISWAP(q1, q2), cirq.X(q4)]))
+    assert_optimizes(circuit, 5)
+
+
+def test_heterogeneous_circuit():
+    """Tests that a circuit that is very heterogeneous is correctly optimized"""
+    q1, q2, q3, q4, q5, q6 = cirq.LineQubit.range(6)
+    circuit = cirq.Circuit(
+        cirq.Moment(
+            [cirq.X(q1),
+             cirq.X(q2),
+             cirq.ISWAP(q3, q4),
+             cirq.ISWAP(q5, q6)]),
+        cirq.Moment(
+            [cirq.ISWAP(q1, q2),
+             cirq.ISWAP(q3, q4),
+             cirq.X(q5),
+             cirq.X(q6)]),
+        cirq.Moment([
+            cirq.X(q1),
+            cirq.Z(q2),
+            cirq.X(q3),
+            cirq.Z(q4),
+            cirq.X(q5),
+            cirq.Z(q6)
+        ]))
+    # Ideally, this would have 5 moments, but its complicated to get there
+    # and the algorithm doesn't always pick up on it.
+    assert_optimizes(circuit, 6)
+
+
+def test_trapped_single_qubit_circuit():
+    """Tests that a circuit containing single-qubit gates that are trapped
+    between two-qubit gates are correctly separated."""
+    q1, q2, q3, q4 = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.ISWAP(q1, q2), cirq.ISWAP(q3, q4)]),
+        cirq.Moment([cirq.X(q1), cirq.Z(q2),
+                     cirq.X(q3), cirq.Z(q4)]),
+        cirq.Moment([cirq.ISWAP(q1, q2), cirq.ISWAP(q3, q4)]))
+    assert_optimizes(circuit, 4)
+
+
+def test_large_circuit():
+    """Tests that a large circuit is correctly optimized."""
+    q1, q2, q3, q4, q5, q6, q7, q8 = cirq.LineQubit.range(8)
+    circuit = cirq.Circuit(
+        cirq.Moment([
+            cirq.X(q1),
+            cirq.ISWAP(q2, q3),
+            cirq.Z(q5),
+            cirq.Z(q6),
+            cirq.ISWAP(q7, q8)
+        ]),
+        cirq.Moment([
+            cirq.ISWAP(q1, q2),
+            cirq.ISWAP(q3, q8),
+            cirq.ISWAP(q4, q6),
+            cirq.X(q5),
+            cirq.X(q7)
+        ]),
+        cirq.Moment([
+            cirq.X(q1),
+            cirq.X(q2),
+            cirq.Z(q3),
+            cirq.Z(q4),
+            cirq.X(q5),
+            cirq.X(q6)
+        ]), cirq.Moment([cirq.Z(q7)]),
+        cirq.Moment(
+            [cirq.Z(q1),
+             cirq.Z(q2),
+             cirq.Z(q3),
+             cirq.Z(q4),
+             cirq.Z(q5)]),
+        cirq.Moment(
+            [cirq.ISWAP(q1, q4),
+             cirq.ISWAP(q5, q8),
+             cirq.ISWAP(q2, q3)]), cirq.Moment(),
+        cirq.Moment([
+            cirq.X(q1),
+            cirq.ISWAP(q2, q3),
+            cirq.Z(q5),
+            cirq.Z(q6),
+            cirq.ISWAP(q7, q8)
+        ]))
+    assert_optimizes(circuit, 11)

--- a/cirq/google/optimizers/align_interactions_test.py
+++ b/cirq/google/optimizers/align_interactions_test.py
@@ -19,13 +19,17 @@ def get_qubit_to_operations(circuit: cirq.Circuit
     that qubit, in order."""
     qubit_to_operations: Dict[cirq.Qid, List[cirq.Operation]] = {}
     for qubit in circuit.all_qubits():
-        operations = []
+        operations: List[cirq.Operation] = []
         moment_idx = 0
         while True:
-            moment_idx = circuit.next_moment_operating_on([qubit], moment_idx)
-            if moment_idx is not None:
-                operations.append(circuit.operation_at(qubit, moment_idx))
-                moment_idx += 1
+            n = circuit.next_moment_operating_on([qubit], moment_idx)
+            if n is not None:
+                op = circuit.operation_at(qubit, n)
+                if op is None:
+                    # Should never happen, and is here to appease mypy.
+                    raise RuntimeError('Unexpected error gathering operations')
+                operations.append(op)
+                moment_idx = n + 1
             else:
                 break
         qubit_to_operations[qubit] = operations

--- a/cirq/google/optimizers/align_interactions_test.py
+++ b/cirq/google/optimizers/align_interactions_test.py
@@ -203,14 +203,26 @@ def test_two_qubit_gates_pushed_back():
 
 
 def test_greedy_merging():
-    """Tests a tricky situation where the algorithm of "Merge single-qubit gates,
-    greedily search for single-qubit then 2-qubit operations" doesn't work."""
+    """Tests a tricky situation where the algorithm of "Merge single-qubit
+    gates, greedily align single-qubit then 2-qubit operations" doesn't work."""
     q1, q2, q3, q4 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(cirq.Moment([cirq.X(q1)]),
                            cirq.Moment([cirq.SWAP(q1, q2),
                                         cirq.SWAP(q3, q4)]),
                            cirq.Moment([cirq.X(q3)]),
                            cirq.Moment([cirq.SWAP(q3, q4)]))
+
+    assert_optimizes(circuit, 3)
+
+
+def test_greedy_merging_reverse():
+    """Same as the above test, except that the aligning is done in reverse."""
+    q1, q2, q3, q4 = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(cirq.Moment([cirq.SWAP(q1, q2),
+                                        cirq.SWAP(q3, q4)]),
+                           cirq.Moment([cirq.X(q4)]),
+                           cirq.Moment([cirq.SWAP(q3, q4)]),
+                           cirq.Moment([cirq.X(q1)]))
 
     assert_optimizes(circuit, 3)
 

--- a/cirq/google/optimizers/align_interactions_test.py
+++ b/cirq/google/optimizers/align_interactions_test.py
@@ -1,3 +1,17 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Callable, List, Dict
 
 import numpy as np

--- a/cirq/google/optimizers/align_interactions_test.py
+++ b/cirq/google/optimizers/align_interactions_test.py
@@ -27,6 +27,7 @@ def get_qubit_to_operations(circuit: cirq.Circuit
                 op = circuit.operation_at(qubit, n)
                 if op is None:
                     # Should never happen, and is here to appease mypy.
+                    # coverage: ignore
                     raise RuntimeError('Unexpected error gathering operations')
                 operations.append(op)
                 moment_idx = n + 1


### PR DESCRIPTION
This is a bit of a strawman implementation of the optimizer that separates moments into Z ops, other 1-qubit ops, and 2-qubit ops. I tried for a while to find a good straightforward algorithm to do this, but I almost immediately ran into a situation where said algorithm would break down (see test files for examples).

On the other hand, I found that using Simulated Annealing resulted in very good results that only took a few seconds to compute (and this could be sped up drastically). I know that it seems like overkill for what we want, so I thought I'd send a PR so we can discuss it here. Thanks!