### PR TITLE
Make GridInteractionLayer a JSON serializable dataclass

### DIFF
--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -14,7 +14,7 @@
 """Code for generating random quantum circuits."""
 
 from typing import (Callable, Container, Dict, Iterable, List, Sequence,
-                    TYPE_CHECKING, Tuple)
+                    TYPE_CHECKING, Tuple, Union)
 
 import dataclasses
 
@@ -22,7 +22,6 @@ from cirq import circuits, devices, google, ops, protocols, value
 from cirq._doc import document
 
 if TYPE_CHECKING:
-    from typing import Union
     import numpy as np
     import cirq
 

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -99,8 +99,8 @@ class GridInteractionLayer(
         return pos == (0, 0) or pos == (1, self.stagger)
 
     def _json_dict_(self):
-        return protocols.obj_to_dict_helper(self,
-                                            ['col_offset', 'vertical, stagger'])
+        return protocols.obj_to_dict_helper(
+            self, ['col_offset', 'vertical', 'stagger'])
 
     def __repr__(self):
         return ('cirq.experiments.GridInteractionLayer('

--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -206,9 +206,9 @@ def random_rotations_between_grid_interaction_layers_circuit(
     circuit = circuits.Circuit()
     previous_single_qubit_layer = {}  # type: Dict[cirq.GridQubit, cirq.Gate]
     if len(set(single_qubit_gates)) == 1:
-        single_qubit_layer_factory = _FixedSingleQubitLayerFactory(
-            {q: single_qubit_gates[0] for q in qubits}) \
-    # type: Union[_FixedSingleQubitLayerFactory, _RandomSingleQubitLayerFactory]
+        single_qubit_layer_factory = _FixedSingleQubitLayerFactory({
+            q: single_qubit_gates[0] for q in qubits
+        })  # type: _SingleQubitLayerFactory
 
     else:
         single_qubit_layer_factory = _RandomSingleQubitLayerFactory(
@@ -288,6 +288,10 @@ class _FixedSingleQubitLayerFactory:
             previous_single_qubit_layer: Dict['cirq.GridQubit', 'cirq.Gate']
     ) -> Dict['cirq.GridQubit', 'cirq.Gate']:
         return self.fixed_single_qubit_layer
+
+
+_SingleQubitLayerFactory = Union[_FixedSingleQubitLayerFactory,
+                                 _RandomSingleQubitLayerFactory]
 
 
 def _two_qubit_layer(

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -90,6 +90,12 @@ def test_random_rotations_between_grid_interaction_layers(
         pattern)
 
 
+def test_grid_interaction_layer_repr():
+    layer = GridInteractionLayer(col_offset=0, vertical=True, stagger=False)
+    assert repr(layer) == ('cirq.experiments.GridInteractionLayer('
+                           'col_offset=0, vertical=True, stagger=False)')
+
+
 def _validate_single_qubit_layers(qubits: Set[cirq.GridQubit],
                                   moments: Sequence[cirq.Moment],
                                   non_repeating_layers: bool = True) -> None:

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -54,7 +54,8 @@ class _ResolverCache:
         if self._crd is None:
             import cirq
             from cirq.devices.noise_model import _NoNoiseModel
-            from cirq.experiments import CrossEntropyResult
+            from cirq.experiments import (CrossEntropyResult,
+                                          GridInteractionLayer)
             from cirq.google.devices.known_devices import (
                 _NamedConstantXmonDevice)
 
@@ -95,6 +96,7 @@ class _ResolverCache:
                 'GeneralizedAmplitudeDampingChannel':
                 cirq.GeneralizedAmplitudeDampingChannel,
                 'GlobalPhaseOperation': cirq.GlobalPhaseOperation,
+                'GridInteractionLayer': GridInteractionLayer,
                 'GridQubit': cirq.GridQubit,
                 'HPowGate': cirq.HPowGate,
                 'ISwapPowGate': cirq.ISwapPowGate,

--- a/cirq/protocols/json_test_data/GridInteractionLayer.json
+++ b/cirq/protocols/json_test_data/GridInteractionLayer.json
@@ -1,0 +1,6 @@
+{
+  "cirq_type": "GridInteractionLayer",
+  "col_offset": 0,
+  "vertical": false,
+  "stagger": false
+}

--- a/cirq/protocols/json_test_data/GridInteractionLayer.repr
+++ b/cirq/protocols/json_test_data/GridInteractionLayer.repr
@@ -1,0 +1,1 @@
+cirq.experiments.GridInteractionLayer(col_offset=0, vertical=False, stagger=False)


### PR DESCRIPTION
I refrained from using `json_serializable_dataclass` because it caused mypy errors in the definition of the grid patterns (see #2769), and fixing those errors would have made the code much less readable because the grid patterns have comments I want to preserve.