### PR TITLE
Observable Measurement

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -532,6 +532,11 @@ from cirq.work import (
     PauliSumCollector,
     Sampler,
     Collector,
+    InitObsSetting,
+    BitstringAccumulator,
+    MeasurementSpec,
+    group_settings_greedy,
+    observables_to_settings,
     ZerosSampler,
 )
 

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -134,6 +134,10 @@ class PauliString(raw_types.Operation, Generic[TKey]):
             self._qubit_pauli_map = m._qubit_pauli_map
             self._coefficient = m._coefficient
 
+    def copy(self):
+        return PauliString(qubit_pauli_map=self._qubit_pauli_map.copy(),
+                           coefficient=self.coefficient)
+
     @property
     def coefficient(self) -> complex:
         return self._coefficient
@@ -356,6 +360,8 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         factors = []
         if self._coefficient == -1:
             prefix = '-'
+        elif self._coefficient == 1 and len(ordered_qubits) == 1:
+            factors.append('1')
         elif self._coefficient != 1:
             factors.append(repr(self._coefficient))
 

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -80,6 +80,7 @@ class _ResolverCache:
                 'AsymmetricDepolarizingChannel':
                 cirq.AsymmetricDepolarizingChannel,
                 'BitFlipChannel': cirq.BitFlipChannel,
+                'BitstringAccumulator': cirq.BitstringAccumulator,
                 'ProductState': cirq.ProductState,
                 'CCNotPowGate': cirq.CCNotPowGate,
                 'CCXPowGate': cirq.CCXPowGate,
@@ -115,11 +116,13 @@ class _ResolverCache:
                 'ISwapPowGate': cirq.ISwapPowGate,
                 'IdentityGate': cirq.IdentityGate,
                 'IdentityOperation': _identity_operation_from_dict,
+                'InitObsSetting': cirq.InitObsSetting,
                 'LinearDict': cirq.LinearDict,
                 'LineQubit': cirq.LineQubit,
                 'LineQid': cirq.LineQid,
                 'MatrixGate': cirq.MatrixGate,
                 'MeasurementGate': cirq.MeasurementGate,
+                'MeasurementSpec': cirq.MeasurementSpec,
                 'Moment': cirq.Moment,
                 '_XEigenState':
                 cirq.value.product_state._XEigenState,  # type: ignore

--- a/cirq/work/__init__.py
+++ b/cirq/work/__init__.py
@@ -3,7 +3,20 @@ from cirq.work.collector import (
     Collector,
 )
 from cirq.work.pauli_sum_collector import (
-    PauliSumCollector,)
+    PauliSumCollector,
+)
+from cirq.work.observable_settings import (
+    InitObsSetting,
+    MeasurementSpec,
+    observables_to_settings,
+)
+from cirq.work.observable_measurement_data import (
+    BitstringAccumulator,
+    ObservableMeasuredResult,
+)
+from cirq.work.observable_grouping import (
+    group_settings_greedy
+)
 from cirq.work.sampler import (
     Sampler,)
 from cirq.work.zeros_sampler import (

--- a/cirq/work/observable_grouping.py
+++ b/cirq/work/observable_grouping.py
@@ -1,0 +1,94 @@
+# This file contains code modified from PyQuil.
+# https://github.com/rigetti/pyquil
+# The original code's license is:
+#
+# Copyright 2016-2019 Rigetti Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications are covered under:
+#
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, Dict, List, TYPE_CHECKING
+
+from cirq.work.observable_settings import InitObsSetting, _max_weight_state, _max_weight_observable
+
+if TYPE_CHECKING:
+    pass
+
+
+def group_settings_greedy(settings: Iterable[InitObsSetting]) \
+        -> Dict[InitObsSetting, List[InitObsSetting]]:
+    """
+    Group a list of settings which can be simultaneously measured via
+    a greedy algorithm.
+
+    We construct a dictionary keyed by `max_setting` (see docstrings
+    for `_max_weight_state` and `_max_weight_observable`) where the value
+    is a list of settings compatible with `max_setting`. For each new setting,
+    we try to find an existing group to add it and update `max_setting` for
+    that group if necessary. Otherwise, we make a new group.
+
+    In practice, this greedy algorithm performs comparably to something
+    more complicated by solving the clique cover problem on a graph
+    of simultaneously-measurable settings.
+
+    Args:
+        settings: The settings to group.
+
+    Returns:
+        A dictionary keyed by `max_setting` which need not exist in the
+        input list of settings. Each dictionary value is a list of
+        settings compatible with `max_setting`.
+    """
+    grouped_settings = {}  # type: Dict[InitObsSetting, List[InitObsSetting]]
+    for setting in settings:
+        for max_setting, simul_settings in grouped_settings.items():
+            trial_grouped_settings = simul_settings + [setting]
+            new_max_weight_state = _max_weight_state(
+                stg.init_state for stg in trial_grouped_settings)
+            new_max_weight_obs = _max_weight_observable(
+                stg.observable for stg in trial_grouped_settings)
+            # max_weight_xxx returns None if the set of xxx's aren't compatible,
+            # so the following conditional is True if setting can
+            # be inserted into the current group.
+            if (new_max_weight_state is not None
+                    and new_max_weight_obs is not None):
+                del grouped_settings[max_setting]
+                new_max_setting = InitObsSetting(new_max_weight_state,
+                                                 new_max_weight_obs)
+                grouped_settings[new_max_setting] = trial_grouped_settings
+                break
+
+        else:
+            # made it through entire dict without finding an existing group
+            # Pass through _max_weight_observable to strip coefficients
+            new_max_weight_obs = _max_weight_observable([setting.observable])
+            new_max_setting = InitObsSetting(
+                setting.init_state, new_max_weight_obs)
+            grouped_settings[new_max_setting] = [setting]
+
+    return grouped_settings

--- a/cirq/work/observable_grouping_test.py
+++ b/cirq/work/observable_grouping_test.py
@@ -1,0 +1,57 @@
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+
+
+def test_group_settings_greedy():
+    qubits = cirq.LineQubit.range(4)
+    q0, q1, q2, q3 = qubits
+    terms = [
+        0.1711977489805745 * cirq.Z(q0),
+        0.17119774898057447 * cirq.Z(q1),
+        -0.2227859302428765 * cirq.Z(q2),
+        -0.22278593024287646 * cirq.Z(q3),
+        0.16862219157249939 * cirq.Z(q0) * cirq.Z(q1),
+        0.04532220205777764 * cirq.Y(q0) * cirq.X(q1) * cirq.X(q2) * cirq.Y(q3),
+        -0.0453222020577776 * cirq.Y(q0) * cirq.Y(q1) * cirq.X(q2) * cirq.X(q3),
+        -0.0453222020577776 * cirq.X(q0) * cirq.X(q1) * cirq.Y(q2) * cirq.Y(q3),
+        0.04532220205777764 * cirq.X(q0) * cirq.Y(q1) * cirq.Y(q2) * cirq.X(q3),
+        0.12054482203290037 * cirq.Z(q0) * cirq.Z(q2),
+        0.16586702409067802 * cirq.Z(q0) * cirq.Z(q3),
+        0.16586702409067802 * cirq.Z(q1) * cirq.Z(q2),
+        0.12054482203290037 * cirq.Z(q1) * cirq.Z(q3),
+        0.1743484418396392 * cirq.Z(q2) * cirq.Z(q3)
+    ]
+    settings = cirq.observables_to_settings(terms, qubits)
+    grouped_settings = cirq.group_settings_greedy(settings)
+    assert len(grouped_settings) == 5
+
+    group_max_obs_should_be = [
+        cirq.Y(q0) * cirq.X(q1) * cirq.X(q2) * cirq.Y(q3),
+        cirq.Y(q0) * cirq.Y(q1) * cirq.X(q2) * cirq.X(q3),
+        cirq.X(q0) * cirq.X(q1) * cirq.Y(q2) * cirq.Y(q3),
+        cirq.X(q0) * cirq.Y(q1) * cirq.Y(q2) * cirq.X(q3),
+        cirq.Z(q0) * cirq.Z(q1) * cirq.Z(q2) * cirq.Z(q3)
+    ]
+    group_max_settings_should_be = cirq.observables_to_settings(
+        group_max_obs_should_be, qubits)
+
+    assert list(grouped_settings.keys()) == list(group_max_settings_should_be)
+    groups = list(grouped_settings.values())
+    assert len(groups[0]) == 1
+    assert len(groups[1]) == 1
+    assert len(groups[2]) == 1
+    assert len(groups[3]) == 1
+    assert len(groups[4]) == len(terms) - 4

--- a/cirq/work/observable_measurement.py
+++ b/cirq/work/observable_measurement.py
@@ -1,0 +1,708 @@
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import dataclasses
+import itertools
+import os
+import tempfile
+import warnings
+from typing import Optional, Union, Iterable, Dict, List, Tuple, \
+    TYPE_CHECKING, Set, Sequence
+
+import numpy as np
+import pandas as pd
+import sympy
+
+from cirq import circuits, study, ops, value, protocols
+from cirq.work.observable_grouping import group_settings_greedy
+from cirq.work.observable_measurement_data import BitstringAccumulator
+from cirq.work.observable_settings import InitObsSetting, observables_to_settings, zeros_state, \
+    MeasurementSpec
+
+if TYPE_CHECKING:
+    import cirq
+
+
+def _with_parameterized_layers(circuit: 'cirq.Circuit',
+                               qubits: Sequence['cirq.Qid'],
+                               no_initialization: bool,
+                               ) -> 'cirq.Circuit':
+    """Return a copy of the input circuit with a parameterized single-qubit
+    rotations.
+
+    These rotations flank the circuit: the initial two layers of X and Y gates
+    are given parameter names "{qubit}-Xi" and "{qubit}-Yi" and are used
+    to set up the initial state. If `no_initialization` is set to True,
+    these two layers of gates are omitted.
+
+    The final two layers of X and Y gates are given parameter names
+    "{qubit}-Xf" and "{qubit}-Yf" and are use to change the frame of the
+    qubit before measurement, effectively measuring in bases other than Z.
+    """
+    x_beg_mom = ops.Moment([
+        ops.X(q) ** sympy.Symbol(f'{q}-Xi')
+        for q in qubits
+    ])
+    y_beg_mom = ops.Moment([
+        ops.Y(q) ** sympy.Symbol(f'{q}-Yi')
+        for q in qubits
+    ])
+    x_end_mom = ops.Moment([
+        ops.X(q) ** sympy.Symbol(f'{q}-Xf')
+        for q in qubits
+    ])
+    y_end_mom = ops.Moment([
+        ops.Y(q) ** sympy.Symbol(f'{q}-Yf')
+        for q in qubits
+    ])
+    meas_mom = ops.Moment([ops.measure(*qubits, key='z')])
+    if no_initialization:
+        total_circuit = circuit.copy()
+    else:
+        total_circuit = circuits.Circuit([x_beg_mom, y_beg_mom])
+        total_circuit += circuit.copy()
+    total_circuit.append([x_end_mom, y_end_mom, meas_mom])
+    return total_circuit
+
+
+class StoppingCriteria(abc.ABC):
+    """An abstract object that queries a BitstringAccumulator to figure out
+    whether that `meas_spec` is complete."""
+
+    @abc.abstractmethod
+    def more_repetitions(self, accumulator) -> int:
+        """Return the number of additional repetitions to take.
+
+        StoppingCriteria should be respectful and have some notion of a
+        maximum number of repetitions per chunk.
+        """
+
+
+@dataclasses.dataclass(frozen=True)
+class VarianceStoppingCriteria(StoppingCriteria):
+    """Stop sampling when average variance per term drops
+    below a variance bound."""
+    variance_bound: float
+    repetitions_per_chunk: int = 10_000
+
+    def more_repetitions(self, accumulator: BitstringAccumulator):
+        if len(accumulator.bitstrings) == 0:
+            return self.repetitions_per_chunk
+
+        cov = accumulator.covariance()
+        o = np.ones(cov.shape[0])
+        sum_variance = o @ cov @ o.T
+        var_of_the_e = sum_variance / len(accumulator.bitstrings)
+        vpt = var_of_the_e / len(o)
+
+        done = vpt <= self.variance_bound
+        if done:
+            return 0
+        return self.repetitions_per_chunk
+
+
+@dataclasses.dataclass(frozen=True)
+class RepetitionsStoppingCriteria(StoppingCriteria):
+    """Stop sampling when the number of repetitions has been reached."""
+    total_repetitions: int
+    repetitions_per_chunk: int = 10_000
+
+    def more_repetitions(self, accumulator: BitstringAccumulator):
+        done = accumulator.n_repetitions
+        todo = self.total_repetitions - done
+        if todo <= 0:
+            return 0
+
+        to_do_next = min(self.repetitions_per_chunk, todo)
+        return to_do_next
+
+
+_PAULI_TO_PARAM_VAL = {
+    (ops.X, False): (0, -1 / 2),
+    (ops.X, True): (0, +1 / 2),
+    (ops.Y, False): (1 / 2, 0),
+    (ops.Y, True): (-1 / 2, 0),
+    (ops.Z, False): (0, 0),
+    (ops.Z, True): (1, 0),
+}
+
+_STATE_TO_PARAM_VAL = {
+    value.KET_PLUS: (0, +1 / 2),
+    value.KET_MINUS: (0, -1 / 2),
+    value.KET_IMAG: (-1 / 2, 0),
+    value.KET_MINUS_IMAG: (+1 / 2, 0),
+    value.KET_ZERO: (0, 0),
+    value.KET_ONE: (1, 0),
+}
+
+
+def _get_params_for_setting(setting: InitObsSetting,
+                            flips: Iterable[bool],
+                            qubits: Sequence['cirq.Qid'],
+                            no_initialization: bool,
+                            ) -> 'cirq.ParamDictType':
+    """Return the parameter dictionary for the given setting.
+
+    This must be used in conjunction with a circuit generated by
+    `_with_parameterized_layers`. `flips` (used for readout symmetrization)
+    should be of the same length as `qubits` and will modify the parameters
+    to also include a bit flip (`X`). Code responsible for running the
+    circuit should make sure to flip bits back prior to analysis.
+    """
+    params = {}
+    for qubit, flip in itertools.zip_longest(qubits, flips):
+        if qubit is None or flip is None:
+            raise ValueError("`qubits` and `flips` must be equal length")
+        # When getting the one-qubit state / observable for this qubit,
+        # you may be wondering what if there's no observable specified
+        # for that qubit. We mandate that by the time you get to this stage,
+        # each _max_setting has
+        # weight(in_state) == weight(out_operator) == len(qubits)
+        # See _pad_setting
+        pauli = setting.observable[qubit]
+        xf_param, yf_param = _PAULI_TO_PARAM_VAL[pauli, flip]
+        params[f'{qubit}-Xf'] = xf_param
+        params[f'{qubit}-Yf'] = yf_param
+
+        if not no_initialization:
+            state = setting.init_state[qubit]
+            xi_param, yi_param = _STATE_TO_PARAM_VAL[state]
+            params[f'{qubit}-Xi'] = xi_param
+            params[f'{qubit}-Yi'] = yi_param
+
+    return params
+
+
+def _aggregate_n_repetitions(next_chunk_repetitions: Set[int]):
+    """In theory, each stopping criteria can request a different number
+    of repetitions for the next chunk. For batching efficiency, we take the
+    max and issue a warning in this case."""
+    if len(next_chunk_repetitions) == 1:
+        return list(next_chunk_repetitions)[0]
+
+    reps = max(next_chunk_repetitions)
+    warnings.warn("Your stopping criteria recommended a various numbers of "
+                  "repetitions to perform next. So we can submit as a single "
+                  "sweep, we will be taking the maximum of {}".format(reps))
+    return reps
+
+
+def _check_meas_specs_still_todo(
+        meas_specs: List[MeasurementSpec],
+        accumulators: Dict[MeasurementSpec, BitstringAccumulator],
+        stopping_criteria: StoppingCriteria):
+    """Filter `meas_specs` in case some are done.
+
+    In the sampling loop in `measure_grouped_settings`, we submit
+    each `meas_spec` in chunks. This function contains the logic for
+    removing `meas_spec`s from the loop if they are done.
+    """
+    still_todo = []
+    repetitions = set()
+    for meas_spec in meas_specs:
+        accumulator = accumulators[meas_spec]
+        more_repetitions = stopping_criteria.more_repetitions(accumulator)
+
+        if more_repetitions < 0:
+            raise ValueError("Stopping criteria's `more_repetitions` "
+                             "should return 0 or a positive number")
+        if more_repetitions == 0:
+            continue
+
+        repetitions.add(more_repetitions)
+        still_todo.append(meas_spec)
+
+    if len(still_todo) == 0:
+        repetitions = 0
+        return still_todo, repetitions
+
+    repetitions = _aggregate_n_repetitions(repetitions)
+    total_repetitions = len(still_todo) * repetitions
+    if total_repetitions > 3_000_000:
+        old_repetitions = repetitions
+        repetitions = 3_000_000 // len(still_todo)
+
+        if repetitions < 10:
+            raise ValueError("Too many parameter settings. Split it up.")
+
+        warnings.warn(
+            "You've requested a lot of parameters. We're throttling the "
+            "number of shots per call to run_sweep (per parameter value) "
+            "from {} to {}".format(old_repetitions, repetitions))
+
+    return still_todo, repetitions
+
+
+def _pad_setting(max_setting: InitObsSetting,
+                 qubits: List['cirq.Qid'],
+                 pad_init_state_with=value.KET_ZERO,
+                 pad_obs_with=ops.Z) -> InitObsSetting:
+    """Pad max_setting's init_state and observable with `pad_xx_with` ops
+    (default |0>, Z) so each max_setting has the same qubits. We need this
+    to be the case so we can fill in all the parameters.
+    """
+    obs = max_setting.observable
+    assert obs.coefficient == 1, "Only max_setting's should be padded."
+    new_obs = obs.copy()
+    for qubit in qubits:
+        if not qubit in new_obs:
+            new_obs *= pad_obs_with(qubit)
+
+    init_state = max_setting.init_state
+    init_state_original_qubits = init_state.qubits
+    for qubit in qubits:
+        if not qubit in init_state_original_qubits:
+            init_state *= pad_init_state_with(qubit)
+
+    return InitObsSetting(init_state=init_state,
+                          observable=new_obs)
+
+
+def _trick_into_sweep(param_tuples):
+    """Turn param tuples into a sweep.
+
+    TODO: this may no longer be necessary.
+    """
+    trick_into_sweep = [dict(pt) for pt in param_tuples]
+    trick_into_sweep = study.to_sweep(trick_into_sweep)
+    return trick_into_sweep
+
+
+@dataclasses.dataclass(frozen=True)
+class _FlippyMeasSpec:
+    """Internally, each MeasurementSpec class is split into two
+    _FlippyMeasSpecs to support readout symmetrization.
+
+    Bitstring results are combined, so this should be opaque to the user.
+    """
+    meas_spec: MeasurementSpec
+    flips: np.ndarray
+    qubits: Sequence['cirq.Qid']
+
+    def param_tuples(self, no_initialization=False):
+        yield from _get_params_for_setting(self.meas_spec.max_setting, flips=self.flips,
+                                           qubits=self.qubits,
+                                           no_initialization=no_initialization).items()
+        yield from self.meas_spec.circuit_params.items()
+
+
+def _subdivide_meas_specs(meas_specs: Iterable[MeasurementSpec],
+                          repetitions: int,
+                          qubits: Sequence['cirq.Qid'],
+                          readout_symmetrization: bool) \
+        -> Tuple[List[_FlippyMeasSpec], int]:
+    """Split measurement specs into sub-jobs for readout symmetrization
+
+    In readout symmetrization, we first run the "normal" circuit followed
+    by running the circuit with flipped measurement.
+    One MeasurementSpec is split into two _FlippyMeasSpecs. These are run
+    separately but accumulated according to their shared MeasurementSpec.
+    """
+    n_qubits = len(qubits)
+    flippy_mspecs = []
+    for meas_spec in meas_specs:
+        all_normal = np.zeros(n_qubits, dtype=bool)
+        flippy_mspecs.append(_FlippyMeasSpec(
+            meas_spec=meas_spec,
+            flips=all_normal,
+            qubits=qubits,
+        ))
+
+        if readout_symmetrization:
+            all_flipped = np.ones(n_qubits, dtype=bool)
+            flippy_mspecs.append(_FlippyMeasSpec(
+                meas_spec=meas_spec,
+                flips=all_flipped,
+                qubits=qubits,
+            ))
+
+    if readout_symmetrization:
+        repetitions //= 2
+
+    return flippy_mspecs, repetitions
+
+
+def _get_qubits(max_settings: Iterable[InitObsSetting]):
+    """Helper function to find all the qubits in a suite of settings used
+    in `measure_grouped_settings`.
+
+    Qubits are returned in sorted order.
+    """
+    qubits = set()
+    for max_setting in max_settings:
+        max_in_st = max_setting.init_state
+        qubits |= set(max_in_st.qubits)
+    return sorted(qubits)
+
+
+def _is_all_zeros_init(init_state: value.ProductState):
+    """Helper function to determine whether we need the initial layer of
+    rotations used in `measure_grouped_settings`.
+    """
+    for q, st in init_state:
+        if st != value.KET_ZERO:
+            return False
+
+    return True
+
+
+def _parse_checkpoint_options(
+        checkpoint: bool,
+        checkpoint_fn: Optional[str],
+        checkpoint_other_fn: Optional[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    """The user can specify these three arguments. This function
+    contains the validation and defaults logic.
+    """
+    if not checkpoint:
+        if checkpoint_fn is not None or checkpoint_other_fn is not None:
+            raise ValueError("Checkpoint filenames were provided "
+                             "but `checkpoint` was set to False.")
+        return None, None
+
+    if checkpoint_fn is None:
+        checkpoint_dir = tempfile.mkdtemp()
+        chk_basename = 'observables'
+        checkpoint_fn = f'{checkpoint_dir}/{chk_basename}.json'
+
+    if checkpoint_other_fn is None:
+        checkpoint_dir = os.path.dirname(checkpoint_fn)
+        chk_basename = os.path.basename(checkpoint_fn)
+        chk_basename, _, ext = chk_basename.rpartition('.')
+        if ext != 'json':
+            raise ValueError("Please use a `.json` filename or fully "
+                             "specify checkpoint_fn and checkpoint_other_fn")
+        checkpoint_other_fn = f'{checkpoint_dir}/{chk_basename}.prev.json'
+
+    print(f"We will save checkpoint files to {checkpoint_fn}")
+    return checkpoint_fn, checkpoint_other_fn
+
+
+def measure_grouped_settings(
+        circuit: circuits.Circuit,
+        grouped_settings: Dict[InitObsSetting, List[InitObsSetting]],
+        sampler: 'cirq.Sampler',
+        stopping_criteria: StoppingCriteria,
+        *,
+        readout_symmetrization: bool = False,
+        circuit_sweep: 'cirq.Sweepable' = None,
+        readout_calibrations: Optional[BitstringAccumulator] = None,
+        checkpoint: bool = False,
+        checkpoint_fn: Optional[str] = None,
+        checkpoint_other_fn: Optional[str] = None,
+
+) -> List[BitstringAccumulator]:
+    """Measure a suite of grouped InitObsSetting settings.
+
+    This is a low-level API for accessing the observable measurement
+    framework. See also `measure_observables` and `measure_observables_df`.
+
+    Args:
+        circuit: The circuit. This can contain parameters, in which case
+            you should also specify `circuit_sweep`.
+        grouped_settings: A series of setting groups expressed as a dictionary.
+            The key is the max-weight setting used for preparing single-qubit
+            basis-change rotations. The value is a list of settings
+            compatible with the maximal setting you desire to measure.
+            Automated routing algorithms like `group_settings_greedy` can
+            be used to construct this input.
+        sampler: A sampler.
+        stopping_criteria: A StoppingCriteria object that can report
+            whether enough samples have been sampled.
+        readout_symmetrization: If set to True, each `meas_spec` will be
+            split into two runs: one normal and one where a bit flip is
+            incorporated prior to measurement. In the latter case, the
+            measured bit will be flipped back classically and accumulated
+            together. This causes readout error to appear symmetric,
+            p(0|0) = p(1|1).
+        circuit_sweep: Additional parameter sweeps for parameters contained
+            in `circuit`. The total sweep is the product of the circuit sweep
+            with parameter settings for the single-qubit basis-change rotations.
+        readout_calibrations: The result of `calibrate_readout_error`.
+        checkpoint: If set to True, save cumulative raw results at the end
+            of each iteration of the sampling loop.
+        checkpoint_fn: The filename for the checkpoint file. If `checkpoint`
+            is set to True and this is not specified, a file in a temporary
+            directory will be used.
+        checkpoint_other_fn: The filename for another checkpoint file, which
+            contains the previous checkpoint. If `checkpoint`
+            is set to True and this is not specified, a file in a temporary
+            directory will be used. If `checkpoint` is set to True and
+            `checkpoint_fn` is specified but this argument is *not* specified,
+            "{checkpoint_fn}.prev.json" will be used.
+    """
+
+    checkpoint_fn, checkpoint_other_fn = _parse_checkpoint_options(
+        checkpoint=checkpoint, checkpoint_fn=checkpoint_fn,
+        checkpoint_other_fn=checkpoint_other_fn)
+    qubits = _get_qubits(grouped_settings.keys())
+    qubit_to_index = {q: i for i, q in enumerate(qubits)}
+
+    no_initialization = True
+    for max_setting in grouped_settings.keys():
+        if not _is_all_zeros_init(max_setting.init_state):
+            no_initialization = False
+            break
+
+    measurement_param_circuit = _with_parameterized_layers(circuit, qubits, no_initialization)
+    grouped_settings = {_pad_setting(max_setting, qubits): settings
+                        for max_setting, settings in grouped_settings.items()}
+
+    if circuit_sweep is None:
+        circuit_sweep = study.UnitSweep
+
+    # meas_spec provides a key for accumulators.
+    # meas_specs_todo is a mutable list. We will pop things from it as various
+    # specs are measured to the satisfaction of the stopping criteria
+    accumulators = {}
+    meas_specs_todo = []
+    for max_setting, circuit_params in itertools.product(grouped_settings.keys(),
+                                                         circuit_sweep.param_tuples()):
+        # The type annotation for Param is just `Iterable`.
+        # We make sure that it's truly a tuple.
+        circuit_params = dict(circuit_params)
+
+        meas_spec = MeasurementSpec(
+            max_setting=max_setting,
+            circuit_params=circuit_params)
+        accumulator = BitstringAccumulator(
+            meas_spec=meas_spec,
+            simul_settings=grouped_settings[max_setting],
+            qubit_to_index=qubit_to_index,
+            readout_calibration=readout_calibrations)
+        accumulators[meas_spec] = accumulator
+        meas_specs_todo += [meas_spec]
+
+    while True:
+        meas_specs_todo, repetitions = _check_meas_specs_still_todo(
+            meas_specs=meas_specs_todo,
+            accumulators=accumulators,
+            stopping_criteria=stopping_criteria)
+        if len(meas_specs_todo) == 0:
+            break
+
+        flippy_meas_specs, repetitions = _subdivide_meas_specs(
+            meas_specs=meas_specs_todo,
+            repetitions=repetitions,
+            qubits=qubits,
+            readout_symmetrization=readout_symmetrization)
+
+        resolved_params = [flippy_ms.param_tuples(no_initialization=no_initialization)
+                           for flippy_ms in flippy_meas_specs]
+        resolved_params = _trick_into_sweep(resolved_params)
+        total_samples = repetitions * len(resolved_params)
+        print("Total samples", total_samples)
+
+        results = sampler.run_sweep(
+            program=measurement_param_circuit,
+            params=resolved_params,
+            repetitions=repetitions)
+
+        assert len(results) == len(flippy_meas_specs)
+        for flippy_ms, result in zip(flippy_meas_specs, results):
+            accumulator = accumulators[flippy_ms.meas_spec]
+            bitstrings = np.logical_xor(flippy_ms.flips, result.measurements['z'])
+            accumulator.consume_results(bitstrings)
+
+        if checkpoint:
+            if os.path.exists(checkpoint_fn):
+                os.rename(checkpoint_fn, checkpoint_other_fn)
+            protocols.to_json(list(accumulators.values()), checkpoint_fn)
+
+    return list(accumulators.values())
+
+
+_GROUPING_FUNCS = {
+    'greedy': group_settings_greedy,
+}
+
+_STOPPING_CRITS = {
+    'repetitions': RepetitionsStoppingCriteria,
+    'variance': VarianceStoppingCriteria,
+}
+
+
+def _parse_stopping_criteria(stopping_criteria: Union[str, StoppingCriteria],
+                             stopping_criteria_val: Optional[float] = None) -> StoppingCriteria:
+    """Logic for turning a named stopping_criteria and value to one of the
+    built-in stopping criteria in support of an easy high-level API,
+    see `measure_observables`.
+    """
+    if isinstance(stopping_criteria, str):
+        stopping_criteria_cls = _STOPPING_CRITS[stopping_criteria]
+        stopping_criteria = stopping_criteria_cls(stopping_criteria_val)
+    return stopping_criteria
+
+
+def measure_observables(
+        circuit: circuits.Circuit,
+        observables: Iterable[ops.PauliString],
+        sampler: Union['cirq.Simulator', 'cirq.Sampler'],
+        stopping_criteria: Union[str, StoppingCriteria],
+        stopping_criteria_val: Optional[float] = None,
+        *,
+        readout_symmetrization=True,
+        circuit_sweep: 'cirq.Sweepable' = None,
+        grouper=group_settings_greedy,
+        readout_calibrations: Optional[BitstringAccumulator] = None,
+        checkpoint: bool = False,
+        checkpoint_fn: Optional[str] = None,
+        checkpoint_other_fn: Optional[str] = None,
+):
+    """Measure a suite of PauliSum observables.
+
+    If you need more control over the process, please see
+    `measure_grouped_settings` for a lower-level API.
+    If you would like your results returned as a pandas DataFrame,
+    please see `measure_observables_df`.
+
+    Args:
+        circuit: The circuit. This can contain parameters, in which case
+            you should also specify `circuit_sweep`.
+        observables: A collection of PauliString observables to measure.
+            These will be grouped into simultaneously-measurable groups,
+            see `grouper` argument.
+        sampler: A sampler.
+        stopping_criteria: Either a StoppingCriteria object or one of
+            'variance', 'repetitions'. In the latter case, you must
+            also specify `stopping_criteria_val`.
+        stopping_criteria_val: The value used for named stopping criteria.
+            If you specified 'repetitions', this is the number of repetitions.
+            If you specified 'variance', this is the variance.
+        readout_symmetrization: If set to True, each run will be
+            split into two: one normal and one where a bit flip is
+            incorporated prior to measurement. In the latter case, the
+            measured bit will be flipped back classically and accumulated
+            together. This causes readout error to appear symmetric,
+            p(0|0) = p(1|1).
+        circuit_sweep: Additional parameter sweeps for parameters contained
+            in `circuit`. The total sweep is the product of the circuit sweep
+            with parameter settings for the single-qubit basis-change rotations.
+        grouper: Either "greedy" or a function that groups lists of
+            `InitObsSetting`. See the documentation for the `grouped_settings`
+            argument of `measure_grouped_settings` for full details.
+        readout_calibrations: The result of `calibrate_readout_error`.
+        checkpoint: If set to True, save cumulative raw results at the end
+            of each iteration of the sampling loop.
+        checkpoint_fn: The filename for the checkpoint file. If `checkpoint`
+            is set to True and this is not specified, a file in a temporary
+            directory will be used.
+        checkpoint_other_fn: The filename for another checkpoint file, which
+            contains the previous checkpoint. If `checkpoint`
+            is set to True and this is not specified, a file in a temporary
+            directory will be used. If `checkpoint` is set to True and
+            `checkpoint_fn` is specified but this argument is *not* specified,
+            "{checkpoint_fn}.prev.json" will be used.
+    """
+    qubits = set()
+    for obs in observables:
+        qubits |= set(obs.qubits)
+    qubits |= circuit.all_qubits()
+    qubits = sorted(qubits)
+    settings = list(observables_to_settings(observables, qubits))
+
+    if isinstance(grouper, str):
+        try:
+            grouper = _GROUPING_FUNCS[grouper.lower()]
+        except KeyError:
+            raise ValueError("Unknown grouping function {}".format(grouper))
+    grouped_settings = grouper(settings)
+
+    stopping_criteria = _parse_stopping_criteria(
+        stopping_criteria, stopping_criteria_val)
+
+    return measure_grouped_settings(
+        circuit=circuit,
+        grouped_settings=grouped_settings,
+        sampler=sampler,
+        stopping_criteria=stopping_criteria,
+        circuit_sweep=circuit_sweep,
+        readout_symmetrization=readout_symmetrization,
+        readout_calibrations=readout_calibrations,
+        checkpoint=checkpoint,
+        checkpoint_fn=checkpoint_fn,
+        checkpoint_other_fn=checkpoint_other_fn,
+    )
+
+
+def measure_observables_df(
+        circuit: circuits.Circuit,
+        observables: Iterable[ops.PauliString],
+        sampler: Union['cirq.Simulator', 'cirq.Sampler'],
+        stopping_criteria: Union[str, StoppingCriteria],
+        stopping_criteria_val: Optional[float] = None,
+        params: 'cirq.Sweepable' = None,
+        grouper=group_settings_greedy,
+        symmetrize_readout=True,
+        readout_calibrations: Optional[BitstringAccumulator] = None,
+):
+    """Measure observables and return resulting data as a dataframe."""
+    accumulators = measure_observables(
+        circuit=circuit, observables=observables, sampler=sampler,
+        stopping_criteria=stopping_criteria, stopping_criteria_val=stopping_criteria_val,
+        circuit_sweep=params, grouper=grouper, readout_symmetrization=symmetrize_readout,
+        readout_calibrations=readout_calibrations, checkpoint=True,
+    )
+
+    df = pd.DataFrame(list(itertools.chain.from_iterable(
+        acc.records for acc in accumulators)))
+    return df
+
+
+def calibrate_readout_error(
+        qubits: Iterable[ops.Qid],
+        sampler: Union['cirq.Simulator', 'cirq.Sampler'],
+        stopping_criteria: Union[str, StoppingCriteria],
+        stopping_criteria_val: Optional[float] = None,
+):
+    stopping_criteria = _parse_stopping_criteria(
+        stopping_criteria, stopping_criteria_val)
+
+    # We know there won't be any fancy sweeps or observables so we can
+    # get away with more repetitions per job
+    stopping_criteria = dataclasses.replace(stopping_criteria,
+                                            repetitions_per_chunk=100_000)
+
+    # Simultaneous readout characterization:
+    # We can measure all qubits simultaneously (i.e. _max_setting is ZZZ..ZZ
+    # for all qubits). We will extract individual qubit quantities, so there
+    # are `n_qubits` TomographySettings, each responsible for one <Z>.
+    #
+    # Readout symmetrization means we just need to measure the "identity"
+    # circuit. In reality, this corresponds to measuring I for half the time
+    # and X for the other half.
+    init_state = zeros_state(qubits)
+    max_setting = InitObsSetting(
+        init_state=init_state,
+        observable=ops.PauliString({q: ops.Z for q in qubits})
+    )
+    grouped_settings = {max_setting: [
+        InitObsSetting(init_state=init_state,
+                       observable=ops.PauliString({q: ops.Z}))
+        for q in qubits
+    ]}
+
+    result = measure_grouped_settings(
+        circuit=circuits.Circuit(),
+        grouped_settings=grouped_settings,
+        sampler=sampler,
+        stopping_criteria=stopping_criteria,
+        circuit_sweep=study.UnitSweep,
+        readout_symmetrization=True,
+    )
+    result = list(result)
+    assert len(result) == 1
+    result = result[0]
+    return result

--- a/cirq/work/observable_measurement_data.py
+++ b/cirq/work/observable_measurement_data.py
@@ -1,0 +1,410 @@
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import datetime
+import itertools
+from typing import Dict, List, Tuple, \
+    TYPE_CHECKING
+
+import numpy as np
+
+from cirq import protocols
+from cirq.work.observable_settings import InitObsSetting, _max_weight_observable, _max_weight_state, \
+    MeasurementSpec
+
+if TYPE_CHECKING:
+    import cirq
+
+
+def _get_real_coef(observable: 'cirq.PauliString'):
+    """Assert that a PauliString has a real coefficient and return it."""
+    coef = observable.coefficient
+    if not np.isclose(coef.imag, 0):
+        raise ValueError(f"{observable} has a complex coefficient.")
+    return coef.real
+
+
+def _obs_vals_from_measurements(bitstrings: np.ndarray,
+                                qubit_to_index: Dict['cirq.Qid', int],
+                                observable: 'cirq.PauliString'):
+    """Multiply together bitstrings to get observed values of operators."""
+    idxs = [qubit_to_index[q] for q in observable.keys()]
+    # Make sure any unit8's coming in get a sign. eigenvalues will be +- 1.
+    # Select the columns we need for this observable
+    selected_bitstrings = np.asarray(bitstrings[:, idxs], dtype=np.int8)
+    # Transform bits to eigenvalues; ie (+1, -1)
+    selected_obsstrings = 1 - 2 * selected_bitstrings
+    coeff = _get_real_coef(observable)
+    obs_vals = coeff * np.prod(selected_obsstrings, axis=1)
+    return obs_vals
+
+
+def _stats_from_measurements(bitstrings: np.ndarray,
+                             qubit_to_index: Dict['cirq.Qid', int],
+                             observable: 'cirq.PauliString',
+                             ) -> Tuple[float, float]:
+    """Return the mean and variance for the given observable according to
+    the measurements in `bitstrings`."""
+    obs_vals = _obs_vals_from_measurements(
+        bitstrings, qubit_to_index, observable)
+    obs_mean = np.mean(obs_vals)
+
+    # Terminology: This isn't technically the variance. It's the
+    # standard error of the mean, but squared.
+    obs_err = np.var(obs_vals) / len(obs_vals)
+    return obs_mean.item(), obs_err.item()
+
+
+@protocols.json_serializable_dataclass(frozen=True)
+class ObservableMeasuredResult:
+    """The result of an observable measurement.
+
+    Please see `cirq.flatten_grouped_results` or
+    `BitstringAccumulator.results` for information on how to get these
+    from `measure_observables` return values.
+
+    This is a flattened form of the contents of a `BitstringAccumulator`
+    which may group many simultaneously-observable settings into one object.
+    As such, `BitstringAccumulator` has more advanced support for covariances
+    between simultaneously-measured observables which is dropped when you
+    flatten into these objects.
+    """
+    setting: InitObsSetting
+    mean: float
+    variance: float
+    repetitions: int
+    circuit_params: Dict[str, float]
+
+    @property
+    def init_state(self):
+        return self.setting.init_state
+
+    @property
+    def observable(self):
+        return self.setting.observable
+
+    @property
+    def stddev(self):
+        return np.sqrt(self.variance)
+
+
+class BitstringAccumulator:
+    """A mutable container of bitstrings and associated metadata populated
+    during a `measure_observables` run.
+
+    This object contains all raw results and can be serialized via JSON to
+    keep a record of your experiment results. There are also various
+    utility methods that can be used to chain a series of BitstringAccumulator
+    results into a form more suitable for analysis like a pandas DataFrame.
+
+    By default, this will be initialized empty. This should only be mutated
+    by calling `consume_results`. Do not mutate values directly.
+
+    Args:
+        meas_spec: The specification with the particular run used to
+            gather these bitstrings. There should be a 1-to-1 correspondence
+            between bitstring accumulators and circuits run on a quantum
+            sampler.
+        simul_settings: The list of settings consistent with this
+            measurement spec, usually the result of grouping a list
+            of requested settings. This list need not be exhausted:
+            any setting consistent with the `meas_spec` can be queried
+            with methods that take a setting as argument (e.g. `mean`,
+            `variance`) whether or not they are provided up-front in
+            `simul_settings`. Those methods that do *not* take a setting
+            as an argument (e.g. `means`, `variances`) will report all values
+            for the settings in `simul_settings`.
+        qubit_to_index: A mapping from qubits to contiguous indices starting
+            from zero. This allows us to store bitstrings as a 2d numpy array.
+        chunksizes: This class accumulates bitstrings from potentially several
+            "chunked" processor runs. Each chunk has a certain number of
+            repetitions, recorded in this array. This theoretically
+            allows you to re-split up the bitstring array should the need
+            arise. The total number of repetitions is the sum of this 1d array.
+        timestamps: We record a timestamp for each request/chunk. This
+            1d array will have the same length as `chunksizes`.
+        readout_calibration:
+            The result of `calibrate_readout_error`. When requesting
+            means and variances, if this is not None, we will use the
+            calibrated value to correct the requested quantity.
+    """
+
+    def __init__(self,
+                 meas_spec: MeasurementSpec,
+                 simul_settings: List[InitObsSetting],
+                 qubit_to_index: Dict['cirq.Qid', int],
+                 bitstrings: np.ndarray = None,
+                 chunksizes: np.ndarray = None,
+                 timestamps: np.ndarray = None,
+                 readout_calibration: 'BitstringAccumulator' = None,
+                 ):
+        self._meas_spec = meas_spec
+        self._simul_settings = simul_settings
+        self._qubit_to_index = qubit_to_index
+        self._readout_calibration = readout_calibration
+
+        if bitstrings is None:
+            n_bits = len(qubit_to_index)
+            self.bitstrings = np.zeros((0, n_bits), dtype=np.uint8)
+        else:
+            self.bitstrings = np.asarray(bitstrings, dtype=np.uint8)
+
+        if chunksizes is None:
+            self.chunksizes = np.zeros((0,), dtype=np.int)
+        else:
+            self.chunksizes = np.asarray(chunksizes, dtype=np.int)
+
+        if timestamps is None:
+            self.timestamps = np.zeros((0,), dtype='datetime64[us]')
+        else:
+            self.timestamps = np.asarray(timestamps, dtype='datetime64[us]')
+
+        if len(self.chunksizes) != len(self.timestamps):
+            raise ValueError(
+                "Invalid BitstringAccumulator state. "
+                "`chunksizes` and `timestamps` must have the same length.")
+
+        if np.sum(self.chunksizes) != len(self.bitstrings):
+            raise ValueError(
+                "Invalid BitstringAccumulator state. "
+                "`chunksizes` must sum to the number of bitstrings.")
+
+    @property
+    def meas_spec(self):
+        return self._meas_spec
+
+    @property
+    def max_setting(self):
+        return self.meas_spec.max_setting
+
+    @property
+    def circuit_params(self):
+        return self.meas_spec.circuit_params
+
+    @property
+    def simul_settings(self):
+        return self._simul_settings
+
+    @property
+    def qubit_to_index(self):
+        return self._qubit_to_index
+
+    def consume_results(self, bitstrings):
+        """Add bitstrings sampled according to `meas_spec`.
+
+        We don't validate that bitstrings were sampled correctly according
+        to `meas_spec` (how could we?) so please be careful. Consider
+        using `measure_observables` rather than calling this method yourself.
+        """
+        self.bitstrings = np.append(
+            self.bitstrings, bitstrings, axis=0)
+        self.chunksizes = np.append(
+            self.chunksizes, [len(bitstrings)], axis=0)
+        self.timestamps = np.append(
+            self.timestamps, [np.datetime64(datetime.datetime.now())])
+
+    @property
+    def n_repetitions(self):
+        return len(self.bitstrings)
+
+    @property
+    def results(self):
+        """Yield individual setting results as `ObservableMeasuredResult`
+        objects."""
+        for setting in self._simul_settings:
+            yield ObservableMeasuredResult(
+                setting=setting,
+                mean=self.mean(setting),
+                variance=self.variance(setting),
+                repetitions=len(self.bitstrings),
+                circuit_params=self._meas_spec.circuit_params
+            )
+
+    @property
+    def records(self):
+        """Yield individual setting results as dictionary records.
+
+        This is suitable for passing to pd.DataFrame constructor, perhaps
+        after chaining these results with those from other BitstringAccumulators.
+        """
+        for result in self.results:
+            record = dataclasses.asdict(result)
+            del record['circuit_params']
+            record.update(**self._meas_spec.circuit_params)
+            yield record
+
+    def _json_dict_(self):
+        from cirq.study.trial_result import _pack_digits
+        def ndarray_to_hex_str(a):
+            return _pack_digits(a, pack_bits='never')[0]
+
+        return {
+            'cirq_type': self.__class__.__name__,
+            'meas_spec': self.meas_spec,
+            'simul_settings': self.simul_settings,
+            'qubit_to_index': list(self.qubit_to_index.items()),
+            'bitstrings': ndarray_to_hex_str(self.bitstrings),
+            'chunksizes': ndarray_to_hex_str(self.chunksizes),
+            'timestamps': ndarray_to_hex_str(self.timestamps),
+        }
+
+    @classmethod
+    def _from_json_dict_(cls, *, meas_spec, simul_settings,
+                         qubit_to_index, bitstrings, chunksizes,
+                         timestamps, **kwargs):
+        from cirq.study.trial_result import _unpack_digits
+        def hex_str_to_ndarray(hexstr):
+            # When binary=False, the other arguments are not needed.
+            return _unpack_digits(hexstr, binary=False, dtype=None, shape=None)
+
+        return cls(meas_spec=meas_spec,
+                   simul_settings=simul_settings,
+                   qubit_to_index=dict(qubit_to_index),
+                   bitstrings=hex_str_to_ndarray(bitstrings),
+                   chunksizes=hex_str_to_ndarray(chunksizes),
+                   timestamps=hex_str_to_ndarray(timestamps))
+
+    def __eq__(self, other):
+        if not isinstance(other, BitstringAccumulator):
+            return False
+
+        if (self.max_setting != other.max_setting
+                or self.simul_settings != other.simul_settings
+                or self.circuit_params != other.circuit_params
+                or self.qubit_to_index != other.qubit_to_index):
+            return False
+
+        if not np.array_equal(self.bitstrings, other.bitstrings):
+            return False
+
+        if not np.array_equal(self.chunksizes, other.chunksizes):
+            return False
+
+        if not np.array_equal(self.timestamps, other.timestamps):
+            return False
+
+        return True
+
+    def summary(self, setting: InitObsSetting):
+        return f'{setting}: {self.mean(setting)} +- {self.stddev(setting)}'
+
+    def __repr__(self):
+        return repr(list(self.records))
+
+    def __str__(self):
+        s = f'Accumulator {self.max_setting}; {self.n_repetitions} repetitions\n'
+        s += '\n'.join('  ' + self.summary(setting) for setting in self._simul_settings)
+        return s
+
+    def covariance(self) -> np.ndarray:
+        """Compute the covariance matrix for all settings.
+        """
+        if len(self.bitstrings) == 0:
+            raise ValueError("No measurements")
+
+        all_obs_vals = np.array([
+            _obs_vals_from_measurements(bitstrings=self.bitstrings,
+                                        qubit_to_index=self._qubit_to_index,
+                                        observable=setting.observable)
+            for setting in self._simul_settings
+        ])
+
+        # https://github.com/numpy/numpy/issues/11502
+        if all_obs_vals.shape[0] == 1:
+            cov = np.array([[np.var(all_obs_vals[0])]])
+            return cov
+
+        cov = np.cov(all_obs_vals, ddof=1)
+        return cov
+
+    def _validate_setting(self, setting: InitObsSetting, what: str):
+        mws = _max_weight_state(
+            [self.max_setting.init_state, setting.init_state])
+        mwo = _max_weight_observable(
+            [self.max_setting.observable, setting.observable])
+        if mws is None or mwo is None:
+            raise ValueError(
+                f"You requested the {what} for a setting that is not compatible "
+                f"with this BitstringAccumulator's meas_spec.")
+
+    def variance(self, setting: InitObsSetting):
+        if len(self.bitstrings) == 0:
+            raise ValueError("No measurements")
+        self._validate_setting(setting, what='variance')
+
+        # TODO: include contribution from covariance?
+        mean, var = _stats_from_measurements(
+            bitstrings=self.bitstrings,
+            qubit_to_index=self._qubit_to_index,
+            observable=setting.observable,
+        )
+
+        if self._readout_calibration is not None:
+            a = mean
+            if np.isclose(a, 0):
+                return np.inf
+            var_a = var
+            b = self._readout_calibration.mean(setting)
+            if np.isclose(b, 0):
+                return np.inf
+            var_b = self._readout_calibration.variance(setting)
+            f = a / b
+
+            # assume cov(a,b) = 0, otherwise there would be another term.
+            var = f ** 2 * (var_a / (a ** 2) + var_b / (b ** 2))
+
+        return var
+
+    def stddev(self, setting: InitObsSetting):
+        return np.sqrt(self.variance(setting))
+
+    def means(self) -> np.ndarray:
+        return np.asarray(
+            [self.mean(setting) for setting in self.simul_settings])
+
+    def mean(self, setting: InitObsSetting):
+        if len(self.bitstrings) == 0:
+            raise ValueError("No measurements")
+        self._validate_setting(setting, what='mean')
+
+        mean, var = _stats_from_measurements(
+            bitstrings=self.bitstrings,
+            qubit_to_index=self._qubit_to_index,
+            observable=setting.observable,
+        )
+
+        if self._readout_calibration is not None:
+            return mean / self._readout_calibration.mean(setting)
+
+        return mean
+
+
+def flatten_grouped_results(grouped_results: List[BitstringAccumulator]) \
+        -> List[ObservableMeasuredResult]:
+    """Flatten results from a collection of BitstringAccumulators into a list
+    of ObservableMeasuredResult.
+
+    Raw results are contained in BitstringAccumulator which contains
+    structure related to how the observables were measured (i.e. their
+    grouping). This can be important for taking covariances into account.
+    This function removes that structure, giving a flat list of results
+    which may be easier to work with.
+
+    Args:
+        grouped_results: A list of BitstringAccumulators, probably returned
+            from `measure_observables` or `measure_grouped_settings`.
+    """
+    return list(itertools.chain.from_iterable(
+        acc.results for acc in grouped_results))

--- a/cirq/work/observable_measurement_data_test.py
+++ b/cirq/work/observable_measurement_data_test.py
@@ -1,0 +1,43 @@
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+import cirq
+from cirq.work.observable_measurement_data import _get_real_coef, _obs_vals_from_measurements
+
+
+def test_get_real_coef():
+    q0 = cirq.LineQubit(0)
+    assert _get_real_coef(cirq.Z(q0) * 2) == 2
+    assert _get_real_coef(cirq.Z(q0) * complex(2.0)) == 2
+    with pytest.raises(ValueError):
+        _get_real_coef(cirq.Z(q0) * 2.j)
+
+
+def test_obs_vals_from_measurements():
+    bitstrings = np.array([
+        [0, 0],
+        [0, 1],
+        [1, 0],
+        [1, 1],
+    ])
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    qubit_to_index = {a: 0, b: 1}
+    obs = cirq.Z(a) * cirq.Z(b) * 10
+    vals = _obs_vals_from_measurements(bitstrings, qubit_to_index, obs)
+    should_be = [10, -10, -10, 10]
+    np.testing.assert_equal(vals, should_be)

--- a/cirq/work/observable_measurement_test.py
+++ b/cirq/work/observable_measurement_test.py
@@ -1,0 +1,81 @@
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import cirq
+from cirq.work.observable_measurement import measure_observables_df, \
+    _with_parameterized_layers
+
+
+def test_with_parameterized_layers():
+    qs = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit([
+        cirq.H.on_each(*qs),
+        cirq.CZ(qs[0], qs[1]),
+        cirq.CZ(qs[1], qs[2]),
+    ])
+    circuit2 = _with_parameterized_layers(circuit, qubits=qs,
+                                          no_initialization=True)
+    assert circuit != circuit2
+    assert len(circuit2) == 3 + 3  # 3 original, then X, Y, measure layer
+
+    circuit3 = _with_parameterized_layers(circuit, qubits=qs,
+                                          no_initialization=False)
+    assert circuit != circuit3
+    assert circuit2 != circuit3
+    assert len(circuit3) == 2 + 3 + 3
+
+
+def test_Z():
+    q = cirq.NamedQubit('q')
+    circuit = cirq.Circuit([
+        cirq.X(q) ** 0.2
+    ])
+    observable = 1 * cirq.Z(q)
+    df = measure_observables_df(circuit, [observable], cirq.Simulator(seed=52),
+                                stopping_criteria='variance',
+                                stopping_criteria_val=1e-3 ** 2)
+    mean = df.loc[0]['mean']
+    np.testing.assert_allclose(0.8, mean, atol=1e-2)
+
+
+def test_X():
+    q = cirq.NamedQubit('q')
+    circuit = cirq.Circuit([
+        cirq.Y(q) ** 0.5,
+        cirq.Z(q) ** 0.2,
+
+    ])
+    observable = cirq.X(q)
+    df = measure_observables_df(circuit, [observable], cirq.Simulator(seed=52),
+                                stopping_criteria='variance',
+                                stopping_criteria_val=1e-3 ** 2)
+    mean = df.loc[0]['mean']
+    np.testing.assert_allclose(0.8, mean, atol=1e-2)
+
+
+def test_Y():
+    q = cirq.NamedQubit('q')
+    circuit = cirq.Circuit([
+        cirq.X(q) ** -0.5,
+        cirq.Z(q) ** 0.2,
+
+    ])
+    observable = cirq.Y(q)
+    df = measure_observables_df(circuit, [observable], cirq.Simulator(seed=52),
+                                stopping_criteria='variance',
+                                stopping_criteria_val=1e-3 ** 2)
+    mean = df.loc[0]['mean']
+    np.testing.assert_allclose(0.8, mean, atol=1e-2)

--- a/cirq/work/observable_settings.py
+++ b/cirq/work/observable_settings.py
@@ -1,0 +1,188 @@
+# This file contains code modified from PyQuil.
+# https://github.com/rigetti/pyquil
+# The original code's license is:
+#
+# Copyright 2016-2019 Rigetti Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modifications are covered under:
+#
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+from typing import Union, Iterable, Dict, TYPE_CHECKING, Tuple
+
+from cirq import ops, value, protocols
+
+if TYPE_CHECKING:
+    import cirq
+    from cirq.value.product_state import _NamedOneQubitState
+
+
+@dataclasses.dataclass(frozen=True)
+class InitObsSetting:
+    """A pair of initial state and observable.
+
+    Usually, given a circuit you want to iterate through many
+    InitObsSettings to vary the initial state preparation and output
+    observable.
+    """
+    init_state: value.ProductState
+    observable: ops.PauliString
+
+    def __post_init__(self):
+        # Special validation for this dataclass.
+        init_qs = self.init_state.qubits
+        obs_qs = self.observable.qubits
+        if set(obs_qs) > set(init_qs):
+            raise ValueError(
+                "`observable`'s qubits should be a subset of those "
+                "found in `init_state`. "
+                "observable qubits: {}. init_state qubits: {}"
+                    .format(obs_qs, init_qs))
+
+    def __str__(self):
+        return f'{self.init_state} → {self.observable}'
+
+    def __repr__(self):
+        return f'cirq.InitObsSetting(' \
+               f'init_state={self.init_state!r}, ' \
+               f'observable={self.observable!r})'
+
+    def _json_dict_(self):
+        # Trying to use cirq.json_serializable_dataclass
+        # results in import loops.
+        return protocols.obj_to_dict_helper(self, ['init_state', 'observable'])
+
+
+def _max_weight_observable(observables: Iterable[ops.PauliString]) \
+        -> Union[None, ops.PauliString]:
+    """Create a new observable that is compatible with all input observables
+    and has the maximum non-identity elements.
+
+    The returned PauliString is constructed by taking the non-identity
+    single-qubit Pauli at each qubit position.
+
+    This function will return `None` if the input observables do not share a
+    tensor product basis.
+
+    For example, the _max_weight_observable of ["XI", "IZ"] is "XZ". Asking for
+    the max weight observable of something like ["XI", "ZI"] will return None.
+
+    The returned value need not actually be present in the input observables.
+    Coefficients from input observables will be dropped.
+    """
+    qubit_pauli_map = dict()  # type: Dict[ops.Qid, ops.Pauli]
+    for observable in observables:
+        for qubit, pauli in observable.items():
+            if qubit in qubit_pauli_map:
+                if qubit_pauli_map[qubit] != pauli:
+                    return None
+            else:
+                qubit_pauli_map[qubit] = pauli
+    return ops.PauliString(qubit_pauli_map)
+
+
+def _max_weight_state(states: Iterable[value.ProductState]) \
+        -> Union[None, value.ProductState]:
+    """Create a new state that is compatible with all input states
+    and has the maximum weight.
+
+    The returned TensorProductState is constructed by taking the
+    single-qubit state at each qubit position.
+
+    This function will return `None` if the input states are not compatible
+
+    For example, the max_weight_state of [+X(0), -Z(1)] is
+    "+X(0) * -Z(1)". Asking for the max weight state of something like
+    [+X(0), +Z(0)] will return None.
+    """
+    qubit_state_map = dict()  # type: Dict[ops.Qid, _NamedOneQubitState]
+    for state in states:
+        for qubit, named_state in state:
+            if qubit in qubit_state_map:
+                if qubit_state_map[qubit] != named_state:
+                    return None
+            else:
+                qubit_state_map[qubit] = named_state
+    return value.ProductState(qubit_state_map)
+
+
+def zeros_state(qubits: Iterable['cirq.Qid']):
+    """Return the ProductState that is |00..00> on all qubits."""
+    return value.ProductState({q: value.KET_ZERO for q in qubits})
+
+
+def observables_to_settings(
+        observables: Iterable['cirq.PauliString'],
+        qubits: Iterable['cirq.Qid']) -> Iterable[InitObsSetting]:
+    """Transform an observable to an InitObsSetting initialized in the
+    all-zeros state.
+    """
+    for observable in observables:
+        yield InitObsSetting(
+            init_state=zeros_state(qubits),
+            observable=observable)
+
+
+def _fix_precision(val: float, precision) -> int:
+    """Convert floating point numbers to (implicitly) fixed point integers.
+
+    Circuit parameters can be floats but we also need to use them as
+    dictionary keys. We secretly use these fixed-precision integers.
+    """
+    return int(val * precision)
+
+
+def _hashable_param(param_tuples: Iterable[Tuple[str, float]], precision=1e7):
+    """Hash circuit parameters using fixed precision.
+
+    Circuit parameters can be floats but we also need to use them as
+    dictionary keys. We secretly use these fixed-precision integers.
+    """
+    return frozenset((k, _fix_precision(v, precision))
+                     for k, v in param_tuples)
+
+
+@protocols.json_serializable_dataclass(frozen=True)
+class MeasurementSpec:
+    """An encapsulation of all the specifications for one run of a
+    quantum processor.
+
+    This includes the maximal input-output setting (which may result in many
+    observables being measured if they are consistent with `max_setting`) and
+    a set of circuit parameters if the circuit is parameterized.
+    """
+    max_setting: InitObsSetting
+    circuit_params: Dict[str, float]
+
+    def __hash__(self):
+        return hash((self.max_setting,
+                     _hashable_param(self.circuit_params.items())))
+
+    def __repr__(self):
+        return f'cirq.MeasurementSpec(max_setting={self.max_setting!r}, ' \
+               f'circuit_params={self.circuit_params!r})'

--- a/cirq/work/observable_settings_test.py
+++ b/cirq/work/observable_settings_test.py
@@ -1,0 +1,104 @@
+# Copyright 2020 The Cirq developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import cirq
+from cirq.work.observable_settings import _max_weight_state, _max_weight_observable, _hashable_param
+
+
+def test_init_obs_setting():
+    q0, q1 = cirq.LineQubit.range(2)
+    setting = cirq.InitObsSetting(
+        init_state=cirq.KET_ZERO(q0) * cirq.KET_ZERO(q1),
+        observable=cirq.X(q0) * cirq.Y(q1)
+    )
+    assert str(setting) == '+Z(0) * +Z(1) → X(0)*Y(1)'
+    assert eval(repr(setting)) == setting
+
+    with pytest.raises(ValueError):
+        setting = cirq.InitObsSetting(
+            init_state=cirq.KET_ZERO(q0),
+            observable=cirq.X(q0) * cirq.Y(q1)
+        )
+
+
+def test_max_weight_observable():
+    q0, q1 = cirq.LineQubit.range(2)
+    observables = [
+        cirq.X(q0),
+        cirq.X(q1)
+    ]
+    assert _max_weight_observable(observables) == cirq.X(q0) * cirq.X(q1)
+
+    observables = [
+        cirq.X(q0),
+        cirq.X(q1),
+        cirq.Z(q1)
+    ]
+    assert _max_weight_observable(observables) is None
+
+
+def test_max_weight_state():
+    q0, q1 = cirq.LineQubit.range(2)
+    states = [
+        cirq.KET_PLUS(q0),
+        cirq.KET_PLUS(q1),
+    ]
+    assert _max_weight_state(states) == cirq.KET_PLUS(q0) * cirq.KET_PLUS(q1)
+
+    states = [
+        cirq.KET_PLUS(q0),
+        cirq.KET_PLUS(q1),
+        cirq.KET_MINUS(q1)
+    ]
+    assert _max_weight_state(states) is None
+
+
+def test_observable_to_setting():
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    observables = [
+        cirq.X(q0) * cirq.Y(q1),
+        cirq.Z(q2) * 1,
+    ]
+
+    zero_state = cirq.KET_ZERO(q0) * cirq.KET_ZERO(q1) * cirq.KET_ZERO(q2)
+    settings_should_be = [
+        cirq.InitObsSetting(zero_state, observables[0]),
+        cirq.InitObsSetting(zero_state, observables[1]),
+
+    ]
+    assert list(cirq.observables_to_settings(
+        observables, qubits=[q0, q1, q2])) == settings_should_be
+
+
+def test_param_hash():
+    params1 = [
+        ('beta', 1.23),
+        ('gamma', 4.56),
+    ]
+    params2 = [
+        ('beta', 1.23),
+        ('gamma', 4.56),
+    ]
+    params3 = [
+        ('beta', 1.24),
+        ('gamma', 4.57),
+    ]
+    assert _hashable_param(params1) == _hashable_param(params1)
+    assert hash(_hashable_param(params1)) == hash(_hashable_param(params1))
+    assert _hashable_param(params1) == _hashable_param(params2)
+    assert hash(_hashable_param(params1)) == hash(_hashable_param(params2))
+    assert _hashable_param(params1) != _hashable_param(params3)
+    assert hash(_hashable_param(params1)) != _hashable_param(params3)

--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -28,6 +28,9 @@ import examples.shor
 import examples.simon_algorithm
 import examples.superdense_coding
 import examples.swap_networks
+import examples.measure_observables_readout
+import examples.measure_observables_vqe
+import examples.measure_observables_tomography
 from examples.shors_code import OneQubitShorsCode
 
 
@@ -272,6 +275,18 @@ def test_example_runs_shor_valid(n):
 def test_example_runs_shor_invalid(n):
     with pytest.raises(ValueError):
         examples.shor.main(n=n)
+
+def test_example_measure_observables_readout(monkeypatch):
+    monkeypatch.delenv('GOOGLE_CLOUD_PROJECT')
+    examples.measure_observables_readout.main(cache=False)
+
+def test_example_measure_observables_vqe(monkeypatch):
+    monkeypatch.delenv('GOOGLE_CLOUD_PROJECT')
+    examples.measure_observables_vqe.main(cache=False, quick=True)
+
+def test_example_measure_observables_tomography(monkeypatch):
+    monkeypatch.delenv('GOOGLE_CLOUD_PROJECT')
+    examples.measure_observables_tomography.main()
 
 
 def test_example_qec_single_qubit():

--- a/examples/measure_observables_readout.py
+++ b/examples/measure_observables_readout.py
@@ -1,0 +1,177 @@
+import cirq
+import sympy
+import pandas as pd
+from matplotlib import pyplot as plt
+import os
+import numpy as np
+import cirq.google as cg
+
+from cirq.work.observable_measurement import measure_observables_df, calibrate_readout_error
+import cirq.contrib.noise_models as ccn
+
+TRY_TO_USE_QUANTUM_ENGINE = True
+OVERWRITE_CACHED_RESULTS = False
+
+
+def get_sampler():
+    if TRY_TO_USE_QUANTUM_ENGINE and 'GOOGLE_CLOUD_PROJECT' in os.environ:
+        # coverage: ignore
+        print("Using quantum engine")
+        return cg.get_engine_sampler('rainbow', 'sqrt_iswap')
+
+    print("Using noisy simulator")
+    return cirq.DensityMatrixSimulator(noise=ccn.DepolarizingWithDampedReadoutNoiseModel(
+        depol_prob=0.005, bitflip_prob=0.03, decay_prob=0.08))
+
+
+def ansatz():
+    a = sympy.Symbol('a')
+    q = cirq.GridQubit(6, 5)
+    qubits = [q]
+    observables = [cirq.Z(q) * 1]
+    circuit = cirq.Circuit([
+        cirq.XPowGate(exponent=a).on(q)
+    ])
+    sweep = cirq.Linspace(a, 0.5, 2.5, 20)
+    return circuit, observables, sweep, qubits
+
+
+def simulate():
+    circuit, observables, sweep, qubits = ansatz()
+    simulator = cirq.Simulator()
+    records = []
+
+    print("Simulating observables ...")
+    sim_results = simulator.simulate_sweep(circuit, sweep)
+    for sim_result in sim_results:
+        for term in observables:
+            termval = term.expectation_from_wavefunction(
+                sim_result.final_state,
+                sim_result.qubit_map,
+                check_preconditions=False)
+            assert np.isclose(termval.imag, 0, atol=1e-4), termval.imag
+            termval = termval.real
+
+            records.append({
+                'a': sim_result.params.value_of('a'),
+                'mean': termval,
+                'variance': 0,
+            })
+
+    results_df = pd.DataFrame(records)
+    pd.to_pickle(results_df, 'measure-observables-readout-simulate.pickl')
+
+
+def collect_data1():
+    print("\nCollecting uncorrected data ...")
+    circuit, observables, sweep, qubits = ansatz()
+    results_df = measure_observables_df(
+        circuit=circuit,
+        observables=observables,
+        sampler=get_sampler(),
+        params=sweep,
+        stopping_criteria='variance',
+        stopping_criteria_val=1e-4,
+        symmetrize_readout=False,
+    )
+    pd.to_pickle(results_df, 'measure-observables-readout-sample1.pickl')
+
+
+def collect_data2():
+    print("\nCollecting symmetrized data ...")
+    circuit, observables, sweep, qubits = ansatz()
+    results_df = measure_observables_df(
+        circuit=circuit,
+        observables=observables,
+        sampler=get_sampler(),
+        params=sweep,
+        stopping_criteria='variance',
+        stopping_criteria_val=1e-4,
+        symmetrize_readout=True,
+    )
+    pd.to_pickle(results_df, 'measure-observables-readout-sample2.pickl')
+
+
+def collect_data3():
+    print("\nCalibrating readout error ...")
+    circuit, observables, sweep, qubits = ansatz()
+    readout_calibration = calibrate_readout_error(qubits=qubits,
+                                                  sampler=get_sampler(),
+                                                  stopping_criteria='variance',
+                                                  stopping_criteria_val=1e-6)
+
+    print("\nCollecting and correcting ...")
+    results_df = measure_observables_df(
+        circuit=circuit,
+        observables=observables,
+        sampler=get_sampler(),
+        params=sweep,
+        stopping_criteria='variance',
+        stopping_criteria_val=1e-4,
+        symmetrize_readout=True,
+        readout_calibrations=readout_calibration
+    )
+    pd.to_pickle(results_df, 'measure-observables-readout-sample3.pickl')
+
+
+def plot():
+    simul_df = pd.read_pickle('measure-observables-readout-simulate.pickl')
+    sample_df1 = pd.read_pickle('measure-observables-readout-sample1.pickl')
+    sample_df2 = pd.read_pickle('measure-observables-readout-sample2.pickl')
+    sample_df3 = pd.read_pickle('measure-observables-readout-sample3.pickl')
+
+    fig, (axl, axr) = plt.subplots(1, 2, figsize=(10, 5))
+
+    axl.axhline(0, color='grey')
+    axl.plot(simul_df['a'], simul_df['mean'], '-', label='Noiseless')
+    axl.plot(sample_df1['a'], sample_df1['mean'], '.-', label='Noisy')
+    axl.plot(sample_df2['a'], sample_df2['mean'], '.-', label='Symmetrized')
+    axl.plot(sample_df3['a'], sample_df3['mean'], '.-', label='Corrected')
+    axl.legend(loc='best')
+
+    simul_df = simul_df.set_index('a')
+    sample_df1 = sample_df1.set_index('a')
+    sample_df2 = sample_df2.set_index('a')
+    sample_df3 = sample_df3.set_index('a')
+
+    axr.axhline(0, color='grey')
+    axr.plot([0.5], [0])  # advance the color cycle
+    axr.errorbar(x=simul_df.index,
+                 y=sample_df1['mean'] - simul_df['mean'],
+                 yerr=sample_df1['variance'] ** 0.5,
+                 capsize=5,
+                 label='delta Noisy')
+    axr.errorbar(x=simul_df.index,
+                 y=sample_df2['mean'] - simul_df['mean'],
+                 yerr=sample_df2['variance'] ** 0.5,
+                 capsize=5,
+                 label='delta Symm')
+    axr.errorbar(x=simul_df.index,
+                 y=sample_df3['mean'] - simul_df['mean'],
+                 yerr=sample_df3['variance'] ** 0.5,
+                 capsize=5,
+                 label='delta corr')
+    axr.legend(loc='best')
+
+    axl.set_xlabel('a', fontsize=16)
+    axr.set_xlabel('a', fontsize=16)
+    axl.set_ylabel(r'$\langle Z \rangle$', fontsize=16)
+    fig.tight_layout()
+    fig.savefig('measure-observables-readout.png', dpi=200)
+
+
+def main(cache=True):
+    if not os.path.exists('measure-observables-readout-simulate.pickl') or not cache:
+        simulate()
+    if not os.path.exists('measure-observables-readout-sample1.pickl') or not cache:
+        collect_data1()
+    if not os.path.exists('measure-observables-readout-sample2.pickl') or not cache:
+        collect_data2()
+    if not os.path.exists('measure-observables-readout-sample3.pickl') or not cache:
+        collect_data3()
+
+    plot()
+
+
+if __name__ == '__main__':
+    main(cache=not OVERWRITE_CACHED_RESULTS)

--- a/examples/measure_observables_tomography.py
+++ b/examples/measure_observables_tomography.py
@@ -1,0 +1,213 @@
+from typing import Sequence, List
+import itertools
+import numpy as np
+
+import cirq.contrib.noise_models as ccn
+import cirq
+from cirq.work.observable_measurement import group_settings_greedy, \
+    measure_grouped_settings, VarianceStoppingCriteria, flatten_grouped_results, \
+    ObservableMeasuredResult
+import cirq.google as cg
+import os
+
+import scipy.linalg
+
+TRY_TO_USE_QUANTUM_ENGINE = True
+
+
+def get_sampler():
+    if TRY_TO_USE_QUANTUM_ENGINE and 'GOOGLE_CLOUD_PROJECT' in os.environ:
+        # coverage: ignore
+        print("Using quantum engine")
+        return cg.get_engine_sampler('rainbow', 'sqrt_iswap')
+
+    print("Using noisy simulator")
+    return cirq.DensityMatrixSimulator(noise=ccn.DepolarizingWithDampedReadoutNoiseModel(
+        depol_prob=0.005, bitflip_prob=0.03, decay_prob=0.08))
+
+
+def process_tomo_settings(qubits: Sequence[cirq.Qid]):
+    """Iterate over [+-XYZ] x [XYZ] initializations and measurements.
+
+    This creates a tomographically (over-)complete set of measurements for
+    quantum process tomography.
+    """
+    for states in itertools.product(cirq.PAULI_STATES, repeat=len(qubits)):
+        init_state = cirq.ProductState({q: st for q, st in zip(qubits, states)})
+
+        for paulis in itertools.product([None, cirq.X, cirq.Y, cirq.Z], repeat=len(qubits)):
+            observable = cirq.PauliString(
+                {q: op for q, op in zip(qubits, paulis) if op is not None})
+
+            yield cirq.InitObsSetting(
+                init_state=init_state,
+                observable=observable,
+            )
+
+
+def vec(matrix: np.ndarray) -> np.ndarray:
+    """Column stack"""
+    return matrix.T.reshape((-1, 1))
+
+
+def unvec(vector: np.ndarray) -> np.ndarray:
+    """Opposite of `vec`."""
+    assert vector.ndim == 1, vector.shape
+    dim = np.sqrt(len(vector))
+    assert int(dim) == dim, dim
+    dim = int(dim)
+    matrix = vector.reshape(dim, dim)
+    return matrix
+
+
+def linear_inv_process_estimate(results: List[ObservableMeasuredResult],
+                                qubits: List[cirq.Qid]) -> np.ndarray:
+    """
+    Estimate a quantum process using linear inversion.
+
+    This is the simplest process tomography post processing and will
+    likely give bad results for real data. Returns the choi matrix
+    representation of the process.
+    """
+    measurement_matrix = np.asarray([
+        vec(np.kron(
+            result.init_state.projector(qubit_order=qubits),
+            result.observable.dense(qubits=qubits)._unitary_().T,
+        )).conj().T.squeeze()
+        for result in results
+    ])
+    expectations = np.array([result.mean for result in results])
+    rho = scipy.linalg.pinv(measurement_matrix) @ expectations
+    return unvec(rho)
+
+
+def get_circuit():
+    """A process to tomographize"""
+    qubits = [cirq.GridQubit(6, 5)]
+    circuit = cirq.Circuit(cirq.YPowGate(exponent=0.5).on(qubits[0]))
+
+    # # Uncomment to try random unitaries:
+    # special_unitary = cirq.testing.random_special_unitary(2, random_state=52)
+    # circuit = cirq.Circuit(cirq.MatrixGate(special_unitary).on(qubits[0]))
+    # circuit = cg.optimized_for_sycamore(circuit)
+    return circuit, qubits
+
+
+def simulate():
+    """Validate the inversion routine by simulating exact observable values."""
+    circuit, qubits = get_circuit()
+    settings = list(process_tomo_settings(qubits))
+
+    print("Circuit:")
+    print(circuit)
+
+    results = []
+    for setting in settings:
+        psi = cirq.final_wavefunction(circuit, initial_state=setting.init_state)
+        o = setting.observable.expectation_from_wavefunction(
+            psi, qubit_map={qubits[0]: 0}, check_preconditions=False)
+        assert np.isclose(o.imag, 0, atol=1e-5)
+        o = o.real
+        results.append(ObservableMeasuredResult(
+            setting=setting,
+            mean=o,
+            variance=0,
+            repetitions=float('inf'),
+            circuit_params=dict(),
+        ))
+
+    print('\nFlattened Results:')
+    for result in results:
+        print(f'{str(result.setting):23s}{result.mean:+1.4f}')
+
+    print("\nInverting results...")
+    chi_est = linear_inv_process_estimate(results, qubits)
+    chi_est = np.real_if_close(chi_est)
+    print(np.round(chi_est, 3))
+
+    print('-' * 30)
+    u_true = vec(cirq.unitary(circuit))
+    chi_true = u_true @ u_true.conj().T
+    chi_true = np.real_if_close(chi_true)
+    print(np.round(chi_true, 3))
+
+    print("Frobenius norm:", np.linalg.norm(chi_true - chi_est))
+    np.testing.assert_allclose(chi_est, chi_true, atol=1e-5)
+
+
+def collect_data():
+    circuit, qubits = get_circuit()
+    settings = list(process_tomo_settings(qubits))
+
+    print("Circuit:")
+    print(circuit)
+    print("\nSettings:")
+    for setting in settings:
+        print(setting)
+    print(f'N = {len(settings)}')
+
+    grouped_settings = group_settings_greedy(settings)
+    print("\nGrouped Settings:")
+    for max_setting, simul_settings in grouped_settings.items():
+        print(str(max_setting) + ':', '[' + ', '.join(str(s) for s in simul_settings) + ']')
+    print(f'N = {len(grouped_settings)}')
+
+    grouped_results = measure_grouped_settings(
+        circuit=circuit,
+        grouped_settings=grouped_settings,
+        sampler=get_sampler(),
+        stopping_criteria=VarianceStoppingCriteria(1e-5),
+        checkpoint=True,
+        checkpoint_fn='./tomo.json'
+    )
+
+    print('\nGrouped Results:')
+    for result in grouped_results:
+        print(str(result.max_setting))
+        print('-' * 30)
+        for setting in result.simul_settings:
+            print(
+                f'  {str(setting):23s}{result.mean(setting):+1.4f} +- {result.stddev(setting):1.4f}')
+        print()
+
+    print('\nFlattened Results:')
+    results = flatten_grouped_results(grouped_results)
+    for result in results:
+        print(f'{str(result.setting):23s}{result.mean:+1.4f} +- {result.stddev:1.4}')
+
+    print("\nInverting results...")
+    chi_est = linear_inv_process_estimate(results, qubits)
+    chi_est = np.real_if_close(chi_est)
+    print(np.round(chi_est, 3))
+
+    print('-' * 30)
+    u_true = vec(cirq.unitary(circuit))
+    chi_true = u_true @ u_true.conj().T
+    chi_true = np.real_if_close(chi_true)
+    print(np.round(chi_true, 3))
+
+    print("Frobenius norm:", np.linalg.norm(chi_true - chi_est))
+
+
+def recover():
+    """If data collection dies, the use of checkpoint files allows
+    you to recover your work. You can also use the final checkpoint file
+    as a rough-and-ready final copy of the data for further analysis.
+    """
+    grouped_results = cirq.read_json('./tomo.json')
+    qubits = grouped_results[0].qubit_to_index.keys()
+    results = flatten_grouped_results(grouped_results)
+
+    chi_est = linear_inv_process_estimate(results, qubits)
+    chi_est = np.real_if_close(chi_est)
+    print(np.round(chi_est, 3))
+
+
+def main():
+    simulate()
+    collect_data()
+    recover()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/measure_observables_vqe.py
+++ b/examples/measure_observables_vqe.py
@@ -1,0 +1,191 @@
+from pprint import pprint
+
+import scipy.interpolate
+
+import cirq.contrib.noise_models as ccn
+
+import cirq
+import sympy
+import pandas as pd
+from matplotlib import pyplot as plt
+import os
+import numpy as np
+import cirq.google as cg
+
+from cirq.work.observable_measurement import measure_observables_df
+
+TRY_TO_USE_QUANTUM_ENGINE = True
+OVERWRITE_CACHED_RESULTS = False
+
+
+def get_sampler():
+    if TRY_TO_USE_QUANTUM_ENGINE and 'GOOGLE_CLOUD_PROJECT' in os.environ:
+        # coverage: ignore
+        print("Using quantum engine")
+        return cg.get_engine_sampler('rainbow', 'sqrt_iswap')
+
+    print("Using noisy simulator")
+    return cirq.DensityMatrixSimulator(noise=ccn.DepolarizingWithDampedReadoutNoiseModel(
+        depol_prob=0.005, bitflip_prob=0.03, decay_prob=0.08))
+
+
+def hydrogen_jw_hamiltonian():
+    # Generated from openfermion
+    q0, q1, q2, q3 = cirq.GridQubit.rect(1, 4, 5, 1)
+    terms = [
+        (0.1711977489805745 + 0j) * cirq.Z(q0),
+        (0.17119774898057447 + 0j) * cirq.Z(q1),
+        (-0.2227859302428765 + 0j) * cirq.Z(q2),
+        (-0.22278593024287646 + 0j) * cirq.Z(q3),
+        (0.16862219157249939 + 0j) * cirq.Z(q0) * cirq.Z(q1),
+        (0.04532220205777764 + 0j) * cirq.Y(q0) * cirq.X(q1) * cirq.X(q2) * cirq.Y(q3),
+        (-0.04532220205777764 + 0j) * cirq.Y(q0) * cirq.Y(q1) * cirq.X(q2) * cirq.X(q3),
+        (-0.04532220205777764 + 0j) * cirq.X(q0) * cirq.X(q1) * cirq.Y(q2) * cirq.Y(q3),
+        (0.04532220205777764 + 0j) * cirq.X(q0) * cirq.Y(q1) * cirq.Y(q2) * cirq.X(q3),
+        (0.12054482203290037 + 0j) * cirq.Z(q0) * cirq.Z(q2),
+        (0.16586702409067802 + 0j) * cirq.Z(q0) * cirq.Z(q3),
+        (0.16586702409067802 + 0j) * cirq.Z(q1) * cirq.Z(q2),
+        (0.12054482203290037 + 0j) * cirq.Z(q1) * cirq.Z(q3),
+        (0.1743484418396392 + 0j) * cirq.Z(q2) * cirq.Z(q3)
+    ]
+    return terms, [q0, q1, q2, q3]
+
+
+def ansatz(quick=False):
+    """Create a mildly interesting circuit with two parameters (arbitrary)."""
+    a = sympy.Symbol('a')
+    b = sympy.Symbol('b')
+    observables, (q0, q1, q2, q3) = hydrogen_jw_hamiltonian()
+    qubits = [q0, q1, q2, q3]
+    circuit = cirq.Circuit([
+        cirq.YPowGate(exponent=0.5).on_each(*qubits),
+        cirq.ISWAP(q0, q1) ** 0.5,
+        cirq.ISWAP(q2, q3) ** 0.5,
+        cirq.XPowGate(exponent=b).on_each(q1, q2),
+        cirq.ISWAP(q1, q2) ** 0.5,
+        cirq.XPowGate(exponent=a).on_each(q0, q3),
+    ])
+
+    res = 2 if quick else 12
+    sweep = cirq.Product(
+        cirq.Linspace(a, 0, 1, res),
+        cirq.Linspace(b, 0, 1, res),
+    )
+    return circuit, observables, sweep, qubits
+
+
+def simulate(quick=False):
+    circuit, observables, sweep, qubits = ansatz(quick=quick)
+    simulator = cirq.Simulator()
+    records = []
+
+    print("Simulating observables ...")
+    sim_results = simulator.simulate_sweep(circuit, sweep)
+    for sim_result in sim_results:
+        for term in observables:
+            termval = term.expectation_from_wavefunction(
+                sim_result.final_state,
+                sim_result.qubit_map,
+                check_preconditions=False)
+            assert np.isclose(termval.imag, 0, atol=1e-4), termval.imag
+            termval = termval.real
+
+            records.append({
+                'a': sim_result.params.value_of('a'),
+                'b': sim_result.params.value_of('b'),
+                'mean': termval,
+                'variance': 0,
+            })
+
+    results_df = pd.DataFrame(records)
+    print(results_df)
+    agg_df = results_df.groupby(['a', 'b']).sum()
+    print(agg_df)
+    agg_df = agg_df.reset_index()
+    pd.to_pickle(agg_df, 'measure-observables-vqe-simulate.pickl')
+
+
+def collect_data(quick=False):
+    circuit, observables, sweep, qubits = ansatz(quick=quick)
+    print("Circuit:")
+    print(circuit)
+    print("\nObservables:")
+    pprint(observables)
+    print("\nSweep:")
+    print(sweep)
+
+    results_df = measure_observables_df(
+        circuit=circuit,
+        observables=observables,
+        sampler=get_sampler(),
+        params=sweep,
+        stopping_criteria='repetitions',
+        stopping_criteria_val=20_000,
+    )
+    print()
+    print(results_df)
+    agg_df = results_df.groupby(['a', 'b']).sum()
+    print(agg_df)
+    agg_df = agg_df.reset_index()
+    pd.to_pickle(agg_df, 'measure-observables-vqe-sample.pickl')
+
+
+def interpolate_for_plot(df, im_res=200):
+    xx, yy = np.meshgrid(np.linspace(0, 1, im_res), np.linspace(0, 1, im_res))
+    zz = scipy.interpolate.griddata(
+        points=df[['a', 'b']].values,
+        values=df['mean'].values,
+        xi=(xx, yy),
+        method='nearest',
+    )
+    return zz
+
+
+def plot():
+    simul_df = pd.read_pickle('measure-observables-vqe-simulate.pickl')
+    sample_df = pd.read_pickle('measure-observables-vqe-sample.pickl')
+
+    from mpl_toolkits.axes_grid1 import ImageGrid
+    fig = plt.figure(figsize=(10, 5))
+    axl, axr = ImageGrid(fig=fig,
+                         rect=111,
+                         nrows_ncols=(1, 2),
+                         cbar_mode='single',
+                         axes_pad=0.15,
+                         cbar_pad=0.15,
+                         )
+
+    axl.set_title('Simulated', fontsize=16)
+    simul_zz = interpolate_for_plot(simul_df)
+    norm = plt.Normalize(simul_zz.min(), simul_zz.max())
+    im = axl.imshow(simul_zz,
+                    extent=(0, 1, 0, 1),
+                    norm=norm,
+                    origin='lower', cmap='PuOr',
+                    interpolation='none')
+    axr.set_title('Sampled', fontsize=16)
+    im = axr.imshow(interpolate_for_plot(sample_df),
+                    extent=(0, 1, 0, 1),
+                    norm=norm,
+                    origin='lower', cmap='PuOr',
+                    interpolation='none')
+
+    axl.set_xlabel('a', fontsize=16)
+    axr.set_xlabel('a', fontsize=16)
+    axl.set_ylabel('b', fontsize=16)
+    axr.cax.colorbar(im)
+    fig.tight_layout(rect=[0, 0, 0.96, 1])
+    fig.savefig('measure-observables-vqe.png', dpi=200)
+
+
+def main(cache=True, quick=False):
+    if not os.path.exists('measure-observables-vqe-simulate.pickl') or not cache:
+        simulate(quick=quick)
+    if not os.path.exists('measure-observables-vqe-sample.pickl') or not cache:
+        collect_data(quick=quick)
+
+    plot()
+
+
+if __name__ == '__main__':
+    main(cache=not OVERWRITE_CACHED_RESULTS, quick=False)


### PR DESCRIPTION
Quantum applications involve measuring PauliStrings after preparing a state according to a Circuit. Some PauliStrings can be measured simultaneously. This PR is for an API that sits atop the sampler API to help with these cases.

We key each run of a sampler interface by MeasurementSpec and the sampled results are contained in a BitstringAccumulator. We implement infrastructure to construct/organize a collection of MeasurementSpecs from a high-level description of a tomographic-like experiment. BitstringAccumulators can be queried for measurement results and hook into a batching and stopping criteria framework to control the execution of jobs.

![observables - data](https://user-images.githubusercontent.com/4967059/74964838-f78d0400-53c8-11ea-8310-fcc09b0e14b4.png)

By structuring your experiment in this way, we can automatically implement some pretty good tricks:
 - Measurement basis change rotations done via sweeps for better batching
 - Chunking of submission if you want more than (max_shots) from quantum engine
 - Checkpointing so you don't loose your work halfway through a job
 - Measuring to a variance tolerance rather than a pre-specified number of repetitions
 - Readout error symmetrization and mitigation

## Examples

Please check out the examples! I tried to make them interesting and informative of how to use this feature.

### Readout correction
![om-ro](https://user-images.githubusercontent.com/4967059/74965251-bd703200-53c9-11ea-9bec-df217c7a0d40.png)

### VQE-ish experiment

![om-vqe](https://user-images.githubusercontent.com/4967059/74965287-d0830200-53c9-11ea-80b5-89d1aca79e27.png)

### Process tomography
```
[[ 0.537+0.j     0.455-0.036j -0.418-0.j     0.416+0.002j]
 [ 0.455+0.036j  0.463-0.j    -0.421+0.j     0.418+0.j   ]
 [-0.418+0.j    -0.421-0.j     0.539+0.j    -0.381-0.037j]
 [ 0.416-0.002j  0.418-0.j    -0.381+0.037j  0.461-0.j   ]]
------------------------------
[[ 0.5  0.5 -0.5  0.5]
 [ 0.5  0.5 -0.5  0.5]
 [-0.5 -0.5  0.5 -0.5]
 [ 0.5  0.5 -0.5  0.5]]
Frobenius norm: 0.3112813656088466
```

As a special treat, some of the above is real data from a real device.

This PR requires #2766 and #2767. I'll rebase once those are in. I'm still working on adding some more tests and/or documentation, but figured this is in a good enough state for people to start looking at it.

### For follow up work

 - complimentary code for *simulating* a batch of observables
 - chunking over parameters (currently chunk over number of repetitions)
