### PR TITLE
Add tags and untagged properties on cirq.Operation

### DIFF
--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -128,9 +128,8 @@ SINGLE_QUBIT_SERIALIZERS = [
             op_serializer.SerializingArg(
                 serialized_name='type',
                 serialized_type=str,
-                op_getter=lambda op: PHYSICAL_Z if isinstance(
-                    op, ops.TaggedOperation) and PhysicalZTag() in op.tags else
-                VIRTUAL_Z,
+                op_getter=lambda op: PHYSICAL_Z
+                if PhysicalZTag() in op.tags else VIRTUAL_Z,
             ),
         ],
     ),

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -393,6 +393,16 @@ class Operation(metaclass=abc.ABCMeta):
                 `qubits` property.
         """
 
+    @property
+    def tags(self) -> Tuple[Hashable, ...]:
+        """Returns a tuple of the operation's tags."""
+        return ()
+
+    @property
+    def untagged(self) -> 'cirq.Operation':
+        """Returns the underlying operation without any tags."""
+        return self
+
     def with_tags(self, *new_tags: Hashable) -> 'cirq.TaggedOperation':
         """Creates a new TaggedOperation, with this op and the specified tags.
 
@@ -508,6 +518,11 @@ class TaggedOperation(Operation):
     def tags(self) -> Tuple[Hashable, ...]:
         """Returns a tuple of the operation's tags."""
         return self._tags
+
+    @property
+    def untagged(self) -> 'cirq.Operation':
+        """Returns the underlying operation without any tags."""
+        return self.sub_operation
 
     def with_tags(self, *new_tags: Hashable) -> 'cirq.TaggedOperation':
         """Creates a new TaggedOperation with combined tags.


### PR DESCRIPTION
These allow handling tagged operations without isinstance checks:

- `tags` allows getting tags on any operation.
- `untagged` allows getting the underlying op with no tags.