### PR TITLE
Accept FSim(pi/2, pi/6) in ConvertToSycamoreGates

### DIFF
--- a/cirq/google/optimizers/convert_to_sycamore_gates.py
+++ b/cirq/google/optimizers/convert_to_sycamore_gates.py
@@ -75,10 +75,20 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
         Returns:
             True if the operation is native to the gmon, false otherwise.
         """
-        return (isinstance(op, ops.GateOperation) and isinstance(
-            cast(ops.GateOperation, op).gate,
-            (SycamoreGate, ops.MeasurementGate, ops.PhasedXPowGate,
-             ops.XPowGate, ops.YPowGate, ops.ZPowGate)))
+        gate = op.gate
+
+        if isinstance(
+                gate,
+            (SycamoreGate, ops.MeasurementGate, ops.PhasedXZGate,
+             ops.PhasedXPowGate, ops.XPowGate, ops.YPowGate, ops.ZPowGate)):
+            return True
+
+        if (isinstance(gate, ops.FSimGate) and
+                math.isclose(gate.theta, np.pi / 2) and
+                math.isclose(gate.phi, np.pi / 6)):
+            return True
+
+        return False
 
     def _convert_one(self, op: ops.Operation) -> ops.OP_TREE:
         """

--- a/cirq/google/optimizers/convert_to_sycamore_gates_test.py
+++ b/cirq/google/optimizers/convert_to_sycamore_gates_test.py
@@ -38,6 +38,16 @@ def test_convert_to_sycamore_gates_swap_zz():
         circuit1, compiled_circuit1, atol=1e-7)
 
 
+def test_convert_to_sycamore_gates_fsim():
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6)(q0, q1))
+    compiled_circuit = circuit.copy()
+    cgoc.ConvertToSycamoreGates()(compiled_circuit)
+
+    cirq.testing.assert_same_circuits(circuit, compiled_circuit)
+
+
 def test_single_qubit_gate():
     q = cirq.LineQubit(0)
     mat = cirq.testing.random_unitary(2)

--- a/cirq/google/optimizers/convert_to_sycamore_gates_test.py
+++ b/cirq/google/optimizers/convert_to_sycamore_gates_test.py
@@ -62,6 +62,19 @@ def test_single_qubit_gate():
         circuit, converted_circuit, atol=1e-8)
 
 
+def test_single_qubit_gate_phased_xz():
+    q = cirq.LineQubit(0)
+    gate = cirq.PhasedXZGate(axis_phase_exponent=0.2,
+                             x_exponent=0.3,
+                             z_exponent=0.4)
+    circuit = cirq.Circuit(gate(q))
+    converted_circuit = circuit.copy()
+    cgoc.ConvertToSycamoreGates().optimize_circuit(converted_circuit)
+    ops = list(converted_circuit.all_operations())
+    assert len(ops) == 1
+    assert ops[0].gate == gate
+
+
 def test_unsupported_gate():
 
     class UnknownGate(cirq.TwoQubitGate):


### PR DESCRIPTION
Currently the optimizer accepts the `SycamoreGate` specifically, but fails on an equivalent `FSimGate`. This adds support for fsim gates with sycamore parameters (theta = pi/2, phi = ph/6).

Also adds support for PhasedXZGate as a native gate that will be passed through when optimizing for sycamore.