### PR TITLE
Respect virtual moments with noisy_ops.

### DIFF
--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -106,7 +106,8 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
         for moment in moments:
             if self.is_virtual_moment(moment):
                 result.append(moment)
-            result.append([self.noisy_operation(op) for op in moment])
+            else:
+                result.append([self.noisy_operation(op) for op in moment])
         return result
 
     @value.alternative(requires='noisy_moment',

--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -104,6 +104,7 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
                                      ) -> Sequence['cirq.OP_TREE']:
         result: List['cirq.OP_TREE'] = []
         for moment in moments:
+            # Virtual moments have no duration and should not create noise.
             if self.is_virtual_moment(moment):
                 result.append(moment)
             else:
@@ -136,6 +137,7 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
     def _noisy_moment_impl_operation(self, moment: 'cirq.Moment',
                                      system_qubits: Sequence['cirq.Qid']
                                     ) -> 'cirq.OP_TREE':
+        # Virtual moments have no duration and should not create noise.
         if self.is_virtual_moment(moment):
             return moment
         return [self.noisy_operation(op) for op in moment]

--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Sequence, TYPE_CHECKING, Union
+from typing import List, Sequence, TYPE_CHECKING, Union
 
 from cirq import ops, protocols, value
 from cirq._doc import document
@@ -102,7 +102,7 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
     def _noisy_moments_impl_operation(self, moments: 'Iterable[cirq.Moment]',
                                       system_qubits: Sequence['cirq.Qid']
                                      ) -> Sequence['cirq.OP_TREE']:
-        result = []
+        result: List['cirq.OP_TREE'] = []
         for moment in moments:
             if self.is_virtual_moment(moment):
                 result.append(moment)

--- a/cirq/devices/noise_model.py
+++ b/cirq/devices/noise_model.py
@@ -104,6 +104,8 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
                                      ) -> Sequence['cirq.OP_TREE']:
         result = []
         for moment in moments:
+            if self.is_virtual_moment(moment):
+                result.append(moment)
             result.append([self.noisy_operation(op) for op in moment])
         return result
 
@@ -133,6 +135,8 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
     def _noisy_moment_impl_operation(self, moment: 'cirq.Moment',
                                      system_qubits: Sequence['cirq.Qid']
                                     ) -> 'cirq.OP_TREE':
+        if self.is_virtual_moment(moment):
+            return moment
         return [self.noisy_operation(op) for op in moment]
 
     @value.alternative(requires='noisy_moments',

--- a/cirq/devices/noise_model_test.py
+++ b/cirq/devices/noise_model_test.py
@@ -98,6 +98,21 @@ def test_infers_other_methods():
         c.noisy_moments([cirq.Moment(), cirq.Moment([cirq.H(q)])], [q]),
         [[], cirq.Z(q).with_tags(ops.VirtualTag())])
 
+    # Demonstrate that noisy_operation respects virtual moments.
+    q2 = cirq.LineQubit(1)
+    half_virtual_moment = cirq.Moment(
+        [cirq.H(q), cirq.X(q2).with_tags(ops.VirtualTag())])
+    full_virtual_moment = cirq.Moment([
+        cirq.H(q).with_tags(ops.VirtualTag()),
+        cirq.X(q2).with_tags(ops.VirtualTag())
+    ])
+    _assert_equivalent_op_tree(c.noisy_moment(half_virtual_moment, [q, q2]), [
+        cirq.Z(q).with_tags(ops.VirtualTag()),
+        cirq.Z(q2).with_tags(ops.VirtualTag())
+    ])
+    _assert_equivalent_op_tree(c.noisy_moment(full_virtual_moment, [q, q2]),
+                               full_virtual_moment)
+
 
 def test_no_noise():
     q = cirq.LineQubit(0)

--- a/cirq/devices/noise_model_test.py
+++ b/cirq/devices/noise_model_test.py
@@ -114,10 +114,9 @@ def test_infers_other_methods():
                                full_virtual_moment)
     _assert_equivalent_op_tree(
         c.noisy_moments([half_virtual_moment, full_virtual_moment], [q, q2]), [
-        cirq.Z(q).with_tags(ops.VirtualTag()),
-        cirq.Z(q2).with_tags(ops.VirtualTag()),
-        full_virtual_moment
-    ])
+            cirq.Z(q).with_tags(ops.VirtualTag()),
+            cirq.Z(q2).with_tags(ops.VirtualTag()), full_virtual_moment
+        ])
 
 
 def test_no_noise():

--- a/cirq/devices/noise_model_test.py
+++ b/cirq/devices/noise_model_test.py
@@ -112,6 +112,12 @@ def test_infers_other_methods():
     ])
     _assert_equivalent_op_tree(c.noisy_moment(full_virtual_moment, [q, q2]),
                                full_virtual_moment)
+    _assert_equivalent_op_tree(
+        c.noisy_moments([half_virtual_moment, full_virtual_moment], [q, q2]), [
+        cirq.Z(q).with_tags(ops.VirtualTag()),
+        cirq.Z(q2).with_tags(ops.VirtualTag()),
+        full_virtual_moment
+    ])
 
 
 def test_no_noise():


### PR DESCRIPTION
Previously, noise models defined with `noisy_operations` would ignore virtual moments, potentially leading to some unusual behavior. This is now enforced in the base NoiseModel.

My concerns: is this the correct place to put this? This makes `noisy_operations` default to respecting virtual moments, but neither of the other methods (`noisy_moment[s]`) have such a default.