### PR TITLE
In unitary_eig, check preconditions before performing computing eigenvalues

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -122,6 +122,7 @@ from cirq.linalg import (
     eye_tensor,
     is_diagonal,
     is_hermitian,
+    is_normal,
     is_orthogonal,
     is_special_orthogonal,
     is_special_unitary,

--- a/cirq/linalg/__init__.py
+++ b/cirq/linalg/__init__.py
@@ -66,6 +66,7 @@ from cirq.linalg.predicates import (
     allclose_up_to_global_phase,
     is_diagonal,
     is_hermitian,
+    is_normal,
     is_orthogonal,
     is_special_orthogonal,
     is_special_unitary,

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -125,10 +125,10 @@ def unitary_eig(matrix: np.ndarray,
          eigvals: the eigenvalues of `matrix`
          V: the unitary matrix with the eigenvectors as columns
     """
-    R, V = scipy.linalg.schur(matrix, output="complex")
-    if check_preconditions and not predicates.is_diagonal(R, atol=atol):
-        raise ValueError('Input must correspond to a unitary matrix '
+    if check_preconditions and not predicates.is_normal(matrix, atol=atol):
+        raise ValueError('Input must correspond to a normal matrix '
                          f'.Received input:\n{matrix}')
+    R, V = scipy.linalg.schur(matrix, output="complex")
     return R.diagonal(), V
 
 

--- a/cirq/linalg/predicates.py
+++ b/cirq/linalg/predicates.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Utility methods for checking properties of matrices."""
 from typing import cast, List, Optional, Sequence, Union, Tuple
 
@@ -39,11 +38,8 @@ def is_diagonal(matrix: np.ndarray, *, atol: float = 1e-8) -> bool:
     return tolerance.all_near_zero(matrix, atol=atol)
 
 
-def is_hermitian(
-        matrix: np.ndarray,
-        *,
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> bool:
+def is_hermitian(matrix: np.ndarray, *, rtol: float = 1e-5,
+                 atol: float = 1e-8) -> bool:
     """Determines if a matrix is approximately Hermitian.
 
     A matrix is Hermitian if it's square and equal to its adjoint.
@@ -60,11 +56,8 @@ def is_hermitian(
             np.allclose(matrix, np.conj(matrix.T), rtol=rtol, atol=atol))
 
 
-def is_orthogonal(
-        matrix: np.ndarray,
-        *,
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> bool:
+def is_orthogonal(matrix: np.ndarray, *, rtol: float = 1e-5,
+                  atol: float = 1e-8) -> bool:
     """Determines if a matrix is approximately orthogonal.
 
     A matrix is orthogonal if it's square and real and its transpose is its
@@ -80,16 +73,16 @@ def is_orthogonal(
     """
     return (matrix.shape[0] == matrix.shape[1] and
             np.all(np.imag(matrix) == 0) and
-            np.allclose(matrix.dot(matrix.T), np.eye(matrix.shape[0]),
+            np.allclose(matrix.dot(matrix.T),
+                        np.eye(matrix.shape[0]),
                         rtol=rtol,
                         atol=atol))
 
 
-def is_special_orthogonal(
-        matrix: np.ndarray,
-        *,
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> bool:
+def is_special_orthogonal(matrix: np.ndarray,
+                          *,
+                          rtol: float = 1e-5,
+                          atol: float = 1e-8) -> bool:
     """Determines if a matrix is approximately special orthogonal.
 
     A matrix is special orthogonal if it is square and real and its transpose
@@ -108,11 +101,8 @@ def is_special_orthogonal(
              np.allclose(np.linalg.det(matrix), 1, rtol=rtol, atol=atol)))
 
 
-def is_unitary(
-        matrix: np.ndarray,
-        *,
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> bool:
+def is_unitary(matrix: np.ndarray, *, rtol: float = 1e-5,
+               atol: float = 1e-8) -> bool:
     """Determines if a matrix is approximately unitary.
 
     A matrix is unitary if it's square and its adjoint is its inverse.
@@ -126,16 +116,16 @@ def is_unitary(
         Whether the matrix is unitary within the given tolerance.
     """
     return (matrix.shape[0] == matrix.shape[1] and
-            np.allclose(matrix.dot(np.conj(matrix.T)), np.eye(matrix.shape[0]),
+            np.allclose(matrix.dot(np.conj(matrix.T)),
+                        np.eye(matrix.shape[0]),
                         rtol=rtol,
                         atol=atol))
 
 
-def is_special_unitary(
-        matrix: np.ndarray,
-        *,
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> bool:
+def is_special_unitary(matrix: np.ndarray,
+                       *,
+                       rtol: float = 1e-5,
+                       atol: float = 1e-8) -> bool:
     """Determines if a matrix is approximately unitary with unit determinant.
 
     A matrix is special-unitary if it is square and its adjoint is its inverse
@@ -154,11 +144,8 @@ def is_special_unitary(
              np.allclose(np.linalg.det(matrix), 1, rtol=rtol, atol=atol)))
 
 
-def is_normal(
-        matrix: np.ndarray,
-        *,
-        rtol: float = 1e-5,
-        atol: float = 1e-8) -> bool:
+def is_normal(matrix: np.ndarray, *, rtol: float = 1e-5,
+              atol: float = 1e-8) -> bool:
     """Determines if a matrix is approximately normal.
 
     A matrix is normal if it's square and commutes with its adjoint.
@@ -194,19 +181,16 @@ def matrix_commutes(m1: np.ndarray,
         Whether the two matrices have compatible sizes and a commutator equal
         to zero within tolerance.
   """
-    return (m1.shape[0] == m1.shape[1] and
-            m1.shape == m2.shape and
+    return (m1.shape[0] == m1.shape[1] and m1.shape == m2.shape and
             np.allclose(m1.dot(m2), m2.dot(m1), rtol=rtol, atol=atol))
 
 
-def allclose_up_to_global_phase(
-        a: np.ndarray,
-        b: np.ndarray,
-        *,
-        rtol: float = 1.e-5,
-        atol: float = 1.e-8,
-        equal_nan: bool = False
-) -> bool:
+def allclose_up_to_global_phase(a: np.ndarray,
+                                b: np.ndarray,
+                                *,
+                                rtol: float = 1.e-5,
+                                atol: float = 1.e-8,
+                                equal_nan: bool = False) -> bool:
     """Determines if a ~= b * exp(i t) for some t.
 
     Args:

--- a/cirq/linalg/predicates.py
+++ b/cirq/linalg/predicates.py
@@ -154,6 +154,26 @@ def is_special_unitary(
              np.allclose(np.linalg.det(matrix), 1, rtol=rtol, atol=atol)))
 
 
+def is_normal(
+        matrix: np.ndarray,
+        *,
+        rtol: float = 1e-5,
+        atol: float = 1e-8) -> bool:
+    """Determines if a matrix is approximately normal.
+
+    A matrix is normal if it's square and commutes with its adjoint.
+
+    Args:
+        matrix: The matrix to check.
+        rtol: The per-matrix-entry relative tolerance on equality.
+        atol: The per-matrix-entry absolute tolerance on equality.
+
+    Returns:
+        Whether the matrix is normal within the given tolerance.
+    """
+    return matrix_commutes(matrix, matrix.T.conj(), rtol=rtol, atol=atol)
+
+
 def matrix_commutes(m1: np.ndarray,
                     m2: np.ndarray,
                     *,

--- a/cirq/linalg/predicates_test.py
+++ b/cirq/linalg/predicates_test.py
@@ -81,8 +81,7 @@ def test_is_hermitian():
     assert not cirq.is_hermitian(np.array([[1, 1j], [1j, 1]]))
     assert not cirq.is_hermitian(np.array([[1, 0.1], [-0.1, 1]]))
 
-    assert cirq.is_hermitian(
-        np.array([[1, 1j + 1e-11], [-1j, 1 + 1j * 1e-9]]))
+    assert cirq.is_hermitian(np.array([[1, 1j + 1e-11], [-1j, 1 + 1j * 1e-9]]))
 
 
 def test_is_hermitian_tolerance():
@@ -95,12 +94,12 @@ def test_is_hermitian_tolerance():
     assert not cirq.is_hermitian(np.array([[1, 0.25], [-0.35, 1]]), atol=atol)
 
     # Error isn't accumulated across entries.
-    assert cirq.is_hermitian(
-        np.array([[1, 0.5, 0.5], [0, 1, 0], [0, 0, 1]]), atol=atol)
+    assert cirq.is_hermitian(np.array([[1, 0.5, 0.5], [0, 1, 0], [0, 0, 1]]),
+                             atol=atol)
     assert not cirq.is_hermitian(
         np.array([[1, 0.5, 0.6], [0, 1, 0], [0, 0, 1]]), atol=atol)
-    assert not cirq.is_hermitian(
-        np.array([[1, 0, 0.6], [0, 1, 0], [0, 0, 1]]), atol=atol)
+    assert not cirq.is_hermitian(np.array([[1, 0, 0.6], [0, 1, 0], [0, 0, 1]]),
+                                 atol=atol)
 
 
 def test_is_unitary():
@@ -126,8 +125,7 @@ def test_is_unitary():
     assert not cirq.is_unitary(np.array([[1, -1], [1, 1]]))
     assert cirq.is_unitary(np.array([[1, -1], [1, 1]]) * np.sqrt(0.5))
     assert cirq.is_unitary(np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
-    assert not cirq.is_unitary(
-        np.array([[1, -1j], [1j, 1]]) * np.sqrt(0.5))
+    assert not cirq.is_unitary(np.array([[1, -1j], [1j, 1]]) * np.sqrt(0.5))
 
     assert cirq.is_unitary(
         np.array([[1, 1j + 1e-11], [1j, 1 + 1j * 1e-9]]) * np.sqrt(0.5))
@@ -141,8 +139,8 @@ def test_is_unitary_tolerance():
     assert not cirq.is_unitary(np.array([[1, 0], [-0.6, 1]]), atol=atol)
 
     # Error isn't accumulated across entries.
-    assert cirq.is_unitary(
-        np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1.2]]), atol=atol)
+    assert cirq.is_unitary(np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1.2]]),
+                           atol=atol)
     assert not cirq.is_unitary(
         np.array([[1.2, 0, 0], [0, 1.3, 0], [0, 0, 1.2]]), atol=atol)
 
@@ -169,10 +167,8 @@ def test_is_orthogonal():
     assert not cirq.is_orthogonal(np.array([[1, 1], [1, 1]]))
     assert not cirq.is_orthogonal(np.array([[1, -1], [1, 1]]))
     assert cirq.is_orthogonal(np.array([[1, -1], [1, 1]]) * np.sqrt(0.5))
-    assert not cirq.is_orthogonal(
-        np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
-    assert not cirq.is_orthogonal(
-        np.array([[1, -1j], [1j, 1]]) * np.sqrt(0.5))
+    assert not cirq.is_orthogonal(np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
+    assert not cirq.is_orthogonal(np.array([[1, -1j], [1j, 1]]) * np.sqrt(0.5))
 
     assert cirq.is_orthogonal(np.array([[1, 1e-11], [0, 1 + 1e-11]]))
 
@@ -185,8 +181,8 @@ def test_is_orthogonal_tolerance():
     assert not cirq.is_orthogonal(np.array([[1, 0], [-0.6, 1]]), atol=atol)
 
     # Error isn't accumulated across entries.
-    assert cirq.is_orthogonal(
-        np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1.2]]), atol=atol)
+    assert cirq.is_orthogonal(np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1.2]]),
+                              atol=atol)
     assert not cirq.is_orthogonal(
         np.array([[1.2, 0, 0], [0, 1.3, 0], [0, 0, 1.2]]), atol=atol)
 
@@ -222,22 +218,21 @@ def test_is_special_orthogonal():
     assert not cirq.is_special_orthogonal(
         np.array([[1, -1j], [1j, 1]]) * np.sqrt(0.5))
 
-    assert cirq.is_special_orthogonal(
-        np.array([[1, 1e-11], [0, 1 + 1e-11]]))
+    assert cirq.is_special_orthogonal(np.array([[1, 1e-11], [0, 1 + 1e-11]]))
 
 
 def test_is_special_orthogonal_tolerance():
     atol = 0.5
 
     # Pays attention to specified tolerance.
-    assert cirq.is_special_orthogonal(
-        np.array([[1, 0], [-0.5, 1]]), atol=atol)
-    assert not cirq.is_special_orthogonal(
-        np.array([[1, 0], [-0.6, 1]]), atol=atol)
+    assert cirq.is_special_orthogonal(np.array([[1, 0], [-0.5, 1]]), atol=atol)
+    assert not cirq.is_special_orthogonal(np.array([[1, 0], [-0.6, 1]]),
+                                          atol=atol)
 
     # Error isn't accumulated across entries, except for determinant factors.
-    assert cirq.is_special_orthogonal(
-        np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1 / 1.2]]), atol=atol)
+    assert cirq.is_special_orthogonal(np.array([[1.2, 0, 0], [0, 1.2, 0],
+                                                [0, 0, 1 / 1.2]]),
+                                      atol=atol)
     assert not cirq.is_special_orthogonal(
         np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1.2]]), atol=atol)
     assert not cirq.is_special_orthogonal(
@@ -263,10 +258,8 @@ def test_is_special_unitary():
     assert not cirq.is_special_unitary(np.array([[1, 1], [0, 1]]))
     assert not cirq.is_special_unitary(np.array([[1, 1], [1, 1]]))
     assert not cirq.is_special_unitary(np.array([[1, -1], [1, 1]]))
-    assert cirq.is_special_unitary(
-        np.array([[1, -1], [1, 1]]) * np.sqrt(0.5))
-    assert cirq.is_special_unitary(
-        np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
+    assert cirq.is_special_unitary(np.array([[1, -1], [1, 1]]) * np.sqrt(0.5))
+    assert cirq.is_special_unitary(np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
     assert not cirq.is_special_unitary(
         np.array([[1, -1j], [1j, 1]]) * np.sqrt(0.5))
 
@@ -280,14 +273,16 @@ def test_is_special_unitary_tolerance():
     # Pays attention to specified tolerance.
     assert cirq.is_special_unitary(np.array([[1, 0], [-0.5, 1]]), atol=atol)
     assert not cirq.is_special_unitary(np.array([[1, 0], [-0.6, 1]]), atol=atol)
-    assert cirq.is_special_unitary(
-        np.array([[1, 0], [0, 1]]) * cmath.exp(1j * 0.1), atol=atol)
+    assert cirq.is_special_unitary(np.array([[1, 0], [0, 1]]) *
+                                   cmath.exp(1j * 0.1),
+                                   atol=atol)
     assert not cirq.is_special_unitary(
         np.array([[1, 0], [0, 1]]) * cmath.exp(1j * 0.3), atol=atol)
 
     # Error isn't accumulated across entries, except for determinant factors.
-    assert cirq.is_special_unitary(
-        np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1 / 1.2]]), atol=atol)
+    assert cirq.is_special_unitary(np.array([[1.2, 0, 0], [0, 1.2, 0],
+                                             [0, 0, 1 / 1.2]]),
+                                   atol=atol)
     assert not cirq.is_special_unitary(
         np.array([[1.2, 0, 0], [0, 1.2, 0], [0, 0, 1.2]]), atol=atol)
     assert not cirq.is_special_unitary(
@@ -311,10 +306,10 @@ def test_is_normal_tolerance():
     assert not cirq.is_normal(np.array([[0, 0.6], [0, 0]]), atol=atol)
 
     # Error isn't accumulated across entries.
-    assert cirq.is_normal(
-        np.array([[0, 0.5, 0], [0, 0, 0.5], [0, 0, 0]]), atol=atol)
-    assert not cirq.is_normal(
-        np.array([[0, 0.5, 0], [0, 0, 0.6], [0, 0, 0]]), atol=atol)
+    assert cirq.is_normal(np.array([[0, 0.5, 0], [0, 0, 0.5], [0, 0, 0]]),
+                          atol=atol)
+    assert not cirq.is_normal(np.array([[0, 0.5, 0], [0, 0, 0.6], [0, 0, 0]]),
+                              atol=atol)
 
 
 def test_commutes():
@@ -356,41 +351,28 @@ def test_commutes_tolerance():
 
 
 def test_allclose_up_to_global_phase():
-    assert cirq.allclose_up_to_global_phase(
-        np.array([1]),
-        np.array([1j]))
+    assert cirq.allclose_up_to_global_phase(np.array([1]), np.array([1j]))
 
     assert not cirq.allclose_up_to_global_phase(np.array([[[1]]]), np.array([1
                                                                             ]))
 
-    assert cirq.allclose_up_to_global_phase(
-        np.array([[1]]),
-        np.array([[1]]))
-    assert cirq.allclose_up_to_global_phase(
-        np.array([[1]]),
-        np.array([[-1]]))
+    assert cirq.allclose_up_to_global_phase(np.array([[1]]), np.array([[1]]))
+    assert cirq.allclose_up_to_global_phase(np.array([[1]]), np.array([[-1]]))
 
-    assert cirq.allclose_up_to_global_phase(
-        np.array([[0]]),
-        np.array([[0]]))
+    assert cirq.allclose_up_to_global_phase(np.array([[0]]), np.array([[0]]))
 
-    assert cirq.allclose_up_to_global_phase(
-        np.array([[1, 2]]),
-        np.array([[1j, 2j]]))
+    assert cirq.allclose_up_to_global_phase(np.array([[1, 2]]),
+                                            np.array([[1j, 2j]]))
 
-    assert cirq.allclose_up_to_global_phase(
-        np.array([[1, 2.0000000001]]),
-        np.array([[1j, 2j]]))
+    assert cirq.allclose_up_to_global_phase(np.array([[1, 2.0000000001]]),
+                                            np.array([[1j, 2j]]))
 
-    assert not cirq.allclose_up_to_global_phase(
-        np.array([[1]]),
-        np.array([[1, 0]]))
-    assert not cirq.allclose_up_to_global_phase(
-        np.array([[1]]),
-        np.array([[2]]))
-    assert not cirq.allclose_up_to_global_phase(
-        np.array([[1]]),
-        np.array([[2]]))
+    assert not cirq.allclose_up_to_global_phase(np.array([[1]]),
+                                                np.array([[1, 0]]))
+    assert not cirq.allclose_up_to_global_phase(np.array([[1]]), np.array([[2]
+                                                                          ]))
+    assert not cirq.allclose_up_to_global_phase(np.array([[1]]), np.array([[2]
+                                                                          ]))
 
 
 def test_binary_sub_tensor_slice():

--- a/cirq/linalg/predicates_test.py
+++ b/cirq/linalg/predicates_test.py
@@ -294,6 +294,29 @@ def test_is_special_unitary_tolerance():
         np.array([[1.2, 0, 0], [0, 1.3, 0], [0, 0, 1 / 1.2]]), atol=atol)
 
 
+def test_is_normal():
+    assert cirq.is_normal(np.array([[1]]))
+    assert cirq.is_normal(np.array([[3j]]))
+    assert cirq.is_normal(cirq.testing.random_density_matrix(4))
+    assert cirq.is_normal(cirq.testing.random_unitary(5))
+    assert not cirq.is_normal(np.array([[0, 1], [0, 0]]))
+    assert not cirq.is_normal(np.zeros((1, 0)))
+
+
+def test_is_normal_tolerance():
+    atol = 0.25
+
+    # Pays attention to specified tolerance.
+    assert cirq.is_normal(np.array([[0, 0.5], [0, 0]]), atol=atol)
+    assert not cirq.is_normal(np.array([[0, 0.6], [0, 0]]), atol=atol)
+
+    # Error isn't accumulated across entries.
+    assert cirq.is_normal(
+        np.array([[0, 0.5, 0], [0, 0, 0.5], [0, 0, 0]]), atol=atol)
+    assert not cirq.is_normal(
+        np.array([[0, 0.5, 0], [0, 0, 0.6], [0, 0, 0]]), atol=atol)
+
+
 def test_commutes():
     assert matrix_commutes(np.empty((0, 0)), np.empty((0, 0)))
     assert not matrix_commutes(np.empty((1, 0)), np.empty((0, 1)))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -612,6 +612,7 @@ Algebra and Representation
     cirq.is_diagonal
     cirq.is_hermitian
     cirq.is_negligible_turn
+    cirq.is_normal
     cirq.is_orthogonal
     cirq.is_special_orthogonal
     cirq.is_special_unitary


### PR DESCRIPTION
They are _pre_-conditions after all.

Also defines `cirq.is_normal`.