### PR TITLE
Add a limited FSIM gateset

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -43,6 +43,7 @@ from cirq.google.engine import (
 
 from cirq.google.gate_sets import (
     XMON,
+    FSIM_GATESET,
     SQRT_ISWAP_GATESET,
     SYC_GATESET,
 )

--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -418,6 +418,68 @@ SQRT_ISWAP_DESERIALIZERS = [
         args=[]),
 ]
 
+
+#
+# FSim serializer
+# Only allows sqrt_iswap, its inverse, identity, and sycamore
+#
+def _can_serialize_limited_fsim(theta: float, phi: float):
+    # Identity
+    if _near_mod_2pi(theta, 0) and _near_mod_2pi(phi, 0):
+        return True
+    # sqrt ISWAP and inverse sqrt ISWAP
+    if _near_mod_2pi(abs(theta), np.pi / 4) and _near_mod_2pi(phi, 0):
+        return True
+    # Sycamore
+    if _near_mod_2pi(theta, np.pi / 2) and _near_mod_2pi(phi, np.pi / 6):
+        return True
+    return False
+
+
+LIMITED_FSIM_SERIALIZERS = [
+    op_serializer.GateOpSerializer(
+        gate_type=ops.FSimGate,
+        serialized_gate_id='fsim',
+        args=[
+            op_serializer.SerializingArg(serialized_name='theta',
+                                         serialized_type=float,
+                                         op_getter='theta'),
+            op_serializer.SerializingArg(serialized_name='phi',
+                                         serialized_type=float,
+                                         op_getter='phi')
+        ],
+        can_serialize_predicate=(lambda op: _can_serialize_limited_fsim(
+            cast(ops.FSimGate, op.gate).theta,
+            cast(ops.FSimGate, op.gate).phi))),
+    op_serializer.GateOpSerializer(
+        gate_type=ops.ISwapPowGate,
+        serialized_gate_id='fsim',
+        args=[
+            op_serializer.SerializingArg(
+                serialized_name='theta',
+                serialized_type=float,
+                op_getter=(lambda op: cast(ops.ISwapPowGate, op.gate).exponent *
+                           np.pi / 2)),
+            op_serializer.SerializingArg(serialized_name='phi',
+                                         serialized_type=float,
+                                         op_getter=lambda e: 0)
+        ],
+        can_serialize_predicate=(lambda op: _near_mod_n(
+            abs(cast(ops.ISwapPowGate, op.gate).exponent), 0.5, 4
+        ) or _near_mod_n(cast(ops.ISwapPowGate, op.gate).exponent, 0, 4))),
+]
+
+LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(
+    serialized_gate_id='fsim',
+    gate_constructor=ops.FSimGate,
+    args=[
+        op_deserializer.DeserializingArg(serialized_name='theta',
+                                         constructor_arg_name='theta'),
+        op_deserializer.DeserializingArg(serialized_name='phi',
+                                         constructor_arg_name='phi'),
+    ])
+
+
 #
 # WaitGate serializer and deserializer
 #

--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -458,8 +458,9 @@ LIMITED_FSIM_SERIALIZERS = [
             op_serializer.SerializingArg(
                 serialized_name='theta',
                 serialized_type=float,
+                # Note that ISWAP ** 0.5 is Fsim(-pi/4,0)
                 op_getter=(lambda op: cast(ops.ISwapPowGate, op.gate).exponent *
-                           np.pi / 2)),
+                           -np.pi / 2)),
             op_serializer.SerializingArg(serialized_name='phi',
                                          serialized_type=float,
                                          op_getter=lambda e: 0)

--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -427,11 +427,27 @@ def _can_serialize_limited_fsim(theta: float, phi: float):
     # Identity
     if _near_mod_2pi(theta, 0) and _near_mod_2pi(phi, 0):
         return True
-    # sqrt ISWAP and inverse sqrt ISWAP
-    if _near_mod_2pi(abs(theta), np.pi / 4) and _near_mod_2pi(phi, 0):
+    # sqrt ISWAP
+    if _near_mod_2pi(theta, -np.pi / 4) and _near_mod_2pi(phi, 0):
+        return True
+    # inverse sqrt ISWAP
+    if _near_mod_2pi(theta, np.pi / 4) and _near_mod_2pi(phi, 0):
         return True
     # Sycamore
     if _near_mod_2pi(theta, np.pi / 2) and _near_mod_2pi(phi, np.pi / 6):
+        return True
+    return False
+
+
+def _can_serialize_limited_iswap(exponent: float):
+    # Sqrt ISWAP
+    if _near_mod_n(exponent, 0.5, 4):
+        return True
+    # Inverse Sqrt ISWAP
+    if _near_mod_n(exponent, -0.5, 4):
+        return True
+    # Identity
+    if _near_mod_n(exponent, 0.0, 4):
         return True
     return False
 
@@ -465,9 +481,8 @@ LIMITED_FSIM_SERIALIZERS = [
                                          serialized_type=float,
                                          op_getter=lambda e: 0)
         ],
-        can_serialize_predicate=(lambda op: _near_mod_n(
-            abs(cast(ops.ISwapPowGate, op.gate).exponent), 0.5, 4
-        ) or _near_mod_n(cast(ops.ISwapPowGate, op.gate).exponent, 0, 4))),
+        can_serialize_predicate=(lambda op: _can_serialize_limited_iswap(
+            cast(ops.ISwapPowGate, op.gate).exponent))),
 ]
 
 LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(

--- a/cirq/google/common_serializers_test.py
+++ b/cirq/google/common_serializers_test.py
@@ -610,7 +610,8 @@ def test_wait_gate():
 
 
 @pytest.mark.parametrize(('gate', 'theta', 'phi'), [
-    (cirq.ISWAP**0.5, np.pi / 4, 0),
+    (cirq.ISWAP**0.5, -np.pi / 4, 0),
+    (cirq.ISWAP**-0.5, np.pi / 4, 0),
     (cirq.ISWAP**0.0, 0, 0),
     (cirq.FSimGate(theta=0, phi=0), 0, 0),
     (cirq.FSimGate(theta=np.pi / 4, phi=0), np.pi / 4, 0),

--- a/cirq/google/common_serializers_test.py
+++ b/cirq/google/common_serializers_test.py
@@ -615,7 +615,9 @@ def test_wait_gate():
     (cirq.ISWAP**0.0, 0, 0),
     (cirq.FSimGate(theta=0, phi=0), 0, 0),
     (cirq.FSimGate(theta=np.pi / 4, phi=0), np.pi / 4, 0),
+    (cirq.FSimGate(theta=7 * np.pi / 4, phi=0), 7 * np.pi / 4, 0),
     (cirq.FSimGate(theta=-np.pi / 4, phi=0), -np.pi / 4, 0),
+    (cirq.FSimGate(theta=-7 * np.pi / 4, phi=0), -7 * np.pi / 4, 0),
     (cirq.google.SYC, np.pi / 2, np.pi / 6),
     (cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6), np.pi / 2, np.pi / 6),
 ])

--- a/cirq/google/common_serializers_test.py
+++ b/cirq/google/common_serializers_test.py
@@ -607,3 +607,63 @@ def test_wait_gate():
     op = cirq.WaitGate(cirq.Duration(nanos=20)).on(q)
     assert gate_set.serialize_op(op) == proto
     assert gate_set.deserialize_op(proto) == op
+
+
+@pytest.mark.parametrize(('gate', 'theta', 'phi'), [
+    (cirq.ISWAP**0.5, np.pi / 4, 0),
+    (cirq.ISWAP**0.0, 0, 0),
+    (cirq.FSimGate(theta=0, phi=0), 0, 0),
+    (cirq.FSimGate(theta=np.pi / 4, phi=0), np.pi / 4, 0),
+    (cirq.FSimGate(theta=-np.pi / 4, phi=0), -np.pi / 4, 0),
+    (cirq.google.SYC, np.pi / 2, np.pi / 6),
+    (cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6), np.pi / 2, np.pi / 6),
+])
+def test_serialize_deserialize_fsim_gate(gate, theta, phi):
+    gate_set = cg.SerializableGateSet('test', cgc.LIMITED_FSIM_SERIALIZERS,
+                                      [cgc.LIMITED_FSIM_DESERIALIZER])
+    proto = op_proto({
+        'gate': {
+            'id': 'fsim'
+        },
+        'args': {
+            'theta': {
+                'arg_value': {
+                    'float_value': theta
+                }
+            },
+            'phi': {
+                'arg_value': {
+                    'float_value': phi
+                }
+            }
+        },
+        'qubits': [{
+            'id': '5_4'
+        }, {
+            'id': '5_5'
+        }]
+    })
+    q1 = cirq.GridQubit(5, 4)
+    q2 = cirq.GridQubit(5, 5)
+    op = cirq.FSimGate(theta=theta, phi=phi)
+    assert gate_set.serialize_op(gate(q1, q2)) == proto
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(gate_set.deserialize_op(proto)),
+        cirq.unitary(op),
+        atol=1e-7,
+    )
+
+
+@pytest.mark.parametrize('gate', [
+    cirq.ISWAP**0.25,
+    cirq.ISWAP,
+    cirq.FSimGate(theta=0.1, phi=0),
+    cirq.FSimGate(theta=0, phi=0.1),
+])
+def test_fsim_gate_not_allowed(gate):
+    q1 = cirq.GridQubit(5, 4)
+    q2 = cirq.GridQubit(5, 5)
+    gate_set = cg.SerializableGateSet('test', cgc.LIMITED_FSIM_SERIALIZERS,
+                                      [cgc.LIMITED_FSIM_DESERIALIZER])
+    with pytest.raises(ValueError):
+        gate_set.serialize_op(gate(q1, q2))

--- a/cirq/google/gate_sets.py
+++ b/cirq/google/gate_sets.py
@@ -27,6 +27,8 @@ from cirq.google.common_serializers import (
     SYC_DESERIALIZER,
     SQRT_ISWAP_SERIALIZERS,
     SQRT_ISWAP_DESERIALIZERS,
+    LIMITED_FSIM_SERIALIZERS,
+    LIMITED_FSIM_DESERIALIZER,
     WAIT_GATE_SERIALIZER,
     WAIT_GATE_DESERIALIZER,
 )
@@ -49,7 +51,7 @@ SYC_GATESET = serializable_gate_set.SerializableGateSet(
     ],
 )
 document(SYC_GATESET,
-         """Gate set with fsim(pi/4, pi/6) as the core 2 qubit interaction.""")
+         """Gate set with fsim(pi/2, pi/6) as the core 2 qubit interaction.""")
 
 SQRT_ISWAP_GATESET = serializable_gate_set.SerializableGateSet(
     gate_set_name='sqrt_iswap',
@@ -68,6 +70,23 @@ SQRT_ISWAP_GATESET = serializable_gate_set.SerializableGateSet(
 document(SQRT_ISWAP_GATESET,
          """Gate set with sqrt(iswap) as the core 2 qubit interaction.""")
 
+
+FSIM_GATESET = serializable_gate_set.SerializableGateSet(
+    gate_set_name='fsim',
+    serializers=[
+        *LIMITED_FSIM_SERIALIZERS,
+        *SINGLE_QUBIT_SERIALIZERS,
+        MEASUREMENT_SERIALIZER,
+        WAIT_GATE_SERIALIZER,
+    ],
+    deserializers=[
+        LIMITED_FSIM_DESERIALIZER,
+        *SINGLE_QUBIT_DESERIALIZERS,
+        MEASUREMENT_DESERIALIZER,
+        WAIT_GATE_DESERIALIZER,
+    ])
+document(SQRT_ISWAP_GATESET,
+         """Gate set that combines sqrt(iswap) and syc as one fsim id.""")
 
 # The xmon gate set.
 XMON = serializable_gate_set.SerializableGateSet(

--- a/cirq/google/gate_sets.py
+++ b/cirq/google/gate_sets.py
@@ -85,7 +85,7 @@ FSIM_GATESET = serializable_gate_set.SerializableGateSet(
         MEASUREMENT_DESERIALIZER,
         WAIT_GATE_DESERIALIZER,
     ])
-document(SQRT_ISWAP_GATESET,
+document(FSIM_GATESET,
          """Gate set that combines sqrt(iswap) and syc as one fsim id.""")
 
 # The xmon gate set.

--- a/cirq/protocols/json_serialization_test.py
+++ b/cirq/protocols/json_serialization_test.py
@@ -276,6 +276,7 @@ NOT_YET_SERIALIZABLE = [
     'DensityMatrixStepResult',
     'DensityMatrixTrialResult',
     'ExpressionMap',
+    'FSIM_GATESET',
     'Heatmap',
     'InsertStrategy',
     'IonDevice',

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -476,6 +476,7 @@ Functionality specific to quantum hardware and services from Google.
 .. autosummary::
     :toctree: generated/
 
+    cirq.google.FSIM_GATESET
     cirq.google.SQRT_ISWAP_GATESET
     cirq.google.SYC
     cirq.google.SYC_GATESET


### PR DESCRIPTION
- This will be equivalent to combining the sqrt iswap and syc gatesets.
- Combining these two gatesets will have the following advantages:
--  This can allow for parameterization of the ISWAP**0 gate
--  That allows circuits to drop out iSwaps and batch efficiently
--  Also allows for expansion if other FSim variants become available