### PR TITLE
Speed up GridQubit __eq__

### DIFF
--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -45,7 +45,7 @@ class GridQubit(ops.Qid):
         if not isinstance(other, GridQubit):
             return NotImplemented
         return self._row == other._row and self._col == other._col
-    
+
     def __hash__(self):
         return hash((self.__class__, self._row, self._col))
 

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -40,7 +40,12 @@ class GridQubit(ops.Qid):
     def __init__(self, row: int, col: int):
         self._row = row
         self._col = col
-
+    
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, GridQubit):
+            return NotImplemented
+        return self._row == other._row and self._col == other._col
+        
     def __hash__(self):
         return hash((self.__class__, self._row, self._col))
 

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -40,12 +40,12 @@ class GridQubit(ops.Qid):
     def __init__(self, row: int, col: int):
         self._row = row
         self._col = col
-    
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, GridQubit):
             return NotImplemented
         return self._row == other._row and self._col == other._col
-        
+    
     def __hash__(self):
         return hash((self.__class__, self._row, self._col))
 


### PR DESCRIPTION
Similar to the PR speeding hashes, directly defining eq is about 5 times faster. 

One wrinkle is the `__eq__` for Qid doesn't actually check that the two things have the same type, only that they have the same name and repr. We can preserve that behavior if we think it's important for some reason.