### PR TITLE
Add symbol capability to LIMITED_FSIM gate set

### DIFF
--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -424,22 +424,32 @@ SQRT_ISWAP_DESERIALIZERS = [
 # Only allows sqrt_iswap, its inverse, identity, and sycamore
 #
 def _can_serialize_limited_fsim(theta: float, phi: float):
-    # Identity
-    if _near_mod_2pi(theta, 0) and _near_mod_2pi(phi, 0):
-        return True
-    # sqrt ISWAP
-    if _near_mod_2pi(theta, -np.pi / 4) and _near_mod_2pi(phi, 0):
-        return True
-    # inverse sqrt ISWAP
-    if _near_mod_2pi(theta, np.pi / 4) and _near_mod_2pi(phi, 0):
-        return True
+    # Symbols for LIMITED_FSIM are allowed, but may fail server-side
+    # if an incorrect run context is specified
+    if _near_mod_2pi(phi, 0) or isinstance(phi, sympy.Symbol):
+        if isinstance(theta, sympy.Symbol):
+            return True
+        # Identity
+        if _near_mod_2pi(theta, 0):
+            return True
+        # sqrt ISWAP
+        if _near_mod_2pi(theta, -np.pi / 4):
+            return True
+        # inverse sqrt ISWAP
+        if _near_mod_2pi(theta, np.pi / 4):
+            return True
     # Sycamore
-    if _near_mod_2pi(theta, np.pi / 2) and _near_mod_2pi(phi, np.pi / 6):
+    if ((_near_mod_2pi(theta, np.pi / 2) or isinstance(theta, sympy.Symbol)) and
+        (_near_mod_2pi(phi, np.pi / 6)) or isinstance(phi, sympy.Symbol)):
         return True
     return False
 
 
 def _can_serialize_limited_iswap(exponent: float):
+    # Symbols for LIMITED_FSIM are allowed, but may fail server-side
+    # if an incorrect run context is specified
+    if isinstance(exponent, sympy.Symbol):
+        return True
     # Sqrt ISWAP
     if _near_mod_n(exponent, 0.5, 4):
         return True

--- a/cirq/google/common_serializers_test.py
+++ b/cirq/google/common_serializers_test.py
@@ -14,6 +14,7 @@
 
 from typing import Dict
 import pytest
+import math
 import numpy as np
 import sympy
 
@@ -657,11 +658,64 @@ def test_serialize_deserialize_fsim_gate(gate, theta, phi):
     )
 
 
+@pytest.mark.parametrize(('gate', 'theta', 'phi'), [
+    (cirq.FSimGate(theta=sympy.Symbol('t'), phi=0), {
+        'symbol': 't'
+    }, {
+        'arg_value': {
+            'float_value': 0.0
+        }
+    }),
+    (cirq.FSimGate(theta=sympy.Symbol('t'), phi=sympy.Symbol('p')), {
+        'symbol': 't'
+    }, {
+        'symbol': 'p'
+    }),
+])
+def test_serialize_deserialize_fsim_gate_symbols(gate, theta, phi):
+    gate_set = cg.SerializableGateSet('test', cgc.LIMITED_FSIM_SERIALIZERS,
+                                      [cgc.LIMITED_FSIM_DESERIALIZER])
+    q1 = cirq.GridQubit(5, 4)
+    q2 = cirq.GridQubit(5, 5)
+    expected = op_proto({
+        'gate': {
+            'id': 'fsim'
+        },
+        'args': {
+            'theta': theta,
+            'phi': phi
+        },
+        'qubits': [{
+            'id': '5_4'
+        }, {
+            'id': '5_5'
+        }]
+    })
+    proto = gate_set.serialize_op(gate(q1, q2), arg_function_language='linear')
+    actual = gate_set.deserialize_op(proto, arg_function_language='linear')
+    assert proto == expected
+    assert actual == gate(q1, q2)
+
+
+def test_serialize_deserialize_iswap_symbols():
+    gate_set = cg.SerializableGateSet('test', cgc.LIMITED_FSIM_SERIALIZERS,
+                                      [cgc.LIMITED_FSIM_DESERIALIZER])
+    q1 = cirq.GridQubit(5, 4)
+    q2 = cirq.GridQubit(5, 5)
+    op = cirq.ISWAP(q1, q2)**sympy.Symbol('t')
+    proto = gate_set.serialize_op(op, arg_function_language='linear')
+    actual = gate_set.deserialize_op(proto, arg_function_language='linear')
+    assert isinstance(actual.gate, cirq.FSimGate)
+    assert math.isclose(actual.gate.phi, 0)
+    assert math.isclose(actual.gate.theta.subs('t', 2), -np.pi, abs_tol=1e-5)
+
+
 @pytest.mark.parametrize('gate', [
     cirq.ISWAP**0.25,
     cirq.ISWAP,
     cirq.FSimGate(theta=0.1, phi=0),
     cirq.FSimGate(theta=0, phi=0.1),
+    cirq.FSimGate(theta=sympy.Symbol('t'), phi=0.1),
 ])
 def test_fsim_gate_not_allowed(gate):
     q1 = cirq.GridQubit(5, 4)


### PR DESCRIPTION
Allow symbols in FSimGate and ISWAP when using LIMITED_FSIM. 

This will allow sweeps that can enable/disable ISWAP gates, at the cost of allowing potentially invalid gates.