### PR TITLE
Restore deprecated noise models.

### DIFF
--- a/cirq/contrib/noise_models/__init__.py
+++ b/cirq/contrib/noise_models/__init__.py
@@ -16,4 +16,6 @@ from cirq.contrib.noise_models.noise_models import (
     DepolarizingNoiseModel,
     ReadoutNoiseModel,
     DampedReadoutNoiseModel,
+    DepolarizingWithReadoutNoiseModel,
+    DepolarizingWithDampedReadoutNoiseModel,
 )

--- a/cirq/contrib/noise_models/noise_models.py
+++ b/cirq/contrib/noise_models/noise_models.py
@@ -16,8 +16,6 @@ from typing import Dict, Sequence, TYPE_CHECKING
 
 from cirq import devices, value, ops, protocols
 
-from cirq._compat import deprecated
-from cirq.circuits import Circuit
 from cirq.google import engine
 
 if TYPE_CHECKING:
@@ -145,9 +143,6 @@ class DepolarizingWithReadoutNoiseModel(devices.NoiseModel):
     also contain gates.
     """
 
-    @deprecated(
-        deadline='v0.9',
-        fix='Compose small models instead of constructing aggregate models.')
     def __init__(self, depol_prob: float, bitflip_prob: float):
         """A depolarizing noise model with readout error.
         Args:
@@ -181,9 +176,6 @@ class DepolarizingWithDampedReadoutNoiseModel(devices.NoiseModel):
     also contain gates.
     """
 
-    @deprecated(
-        deadline='v0.9',
-        fix='Compose small models instead of constructing aggregate models.')
     def __init__(
             self,
             depol_prob: float,

--- a/cirq/contrib/noise_models/noise_models_test.py
+++ b/cirq/contrib/noise_models/noise_models_test.py
@@ -191,8 +191,8 @@ def test_decay_noise_after_moment():
     _assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
 
 
-# Test the deprecated aggregate noise models.
-def test_deprecated_readout_noise_after_moment():
+# Test the aggregate noise models.
+def test_aggregate_readout_noise_after_moment():
     program = cirq.Circuit()
     qubits = cirq.LineQubit.range(3)
     program.append([
@@ -235,7 +235,7 @@ def test_deprecated_readout_noise_after_moment():
     _assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
 
 
-def test_decay_noise_after_moment():
+def test_aggregate_decay_noise_after_moment():
     program = cirq.Circuit()
     qubits = cirq.LineQubit.range(3)
     program.append([

--- a/cirq/contrib/noise_models/noise_models_test.py
+++ b/cirq/contrib/noise_models/noise_models_test.py
@@ -191,6 +191,96 @@ def test_decay_noise_after_moment():
     _assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
 
 
+# Test the deprecated aggregate noise models.
+def test_deprecated_readout_noise_after_moment():
+    program = cirq.Circuit()
+    qubits = cirq.LineQubit.range(3)
+    program.append([
+        cirq.H(qubits[0]),
+        cirq.CNOT(qubits[0], qubits[1]),
+        cirq.CNOT(qubits[1], qubits[2])
+    ])
+    program.append([
+        cirq.measure(qubits[0], key='q0'),
+        cirq.measure(qubits[1], key='q1'),
+        cirq.measure(qubits[2], key='q2')
+    ],
+                   strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+
+    # Use noise model to generate circuit
+    noise_model = ccn.DepolarizingWithReadoutNoiseModel(depol_prob=0.01,
+                                                        bitflip_prob=0.05)
+    noisy_circuit = cirq.Circuit(noise_model.noisy_moments(program, qubits))
+
+    # Insert channels explicitly
+    true_noisy_program = cirq.Circuit()
+    true_noisy_program.append([cirq.H(qubits[0])])
+    true_noisy_program.append(
+        [cirq.DepolarizingChannel(0.01).on(q) for q in qubits],
+        strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+    true_noisy_program.append([cirq.CNOT(qubits[0], qubits[1])])
+    true_noisy_program.append(
+        [cirq.DepolarizingChannel(0.01).on(q) for q in qubits],
+        strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+    true_noisy_program.append([cirq.CNOT(qubits[1], qubits[2])])
+    true_noisy_program.append(
+        [cirq.DepolarizingChannel(0.01).on(q) for q in qubits],
+        strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+    true_noisy_program.append([cirq.BitFlipChannel(0.05).on(q) for q in qubits])
+    true_noisy_program.append([
+        cirq.measure(qubits[0], key='q0'),
+        cirq.measure(qubits[1], key='q1'),
+        cirq.measure(qubits[2], key='q2')
+    ])
+    _assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
+
+
+def test_decay_noise_after_moment():
+    program = cirq.Circuit()
+    qubits = cirq.LineQubit.range(3)
+    program.append([
+        cirq.H(qubits[0]),
+        cirq.CNOT(qubits[0], qubits[1]),
+        cirq.CNOT(qubits[1], qubits[2])
+    ])
+    program.append([
+        cirq.measure(qubits[0], key='q0'),
+        cirq.measure(qubits[1], key='q1'),
+        cirq.measure(qubits[2], key='q2')
+    ],
+                   strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+
+    # Use noise model to generate circuit
+    noise_model = ccn.DepolarizingWithDampedReadoutNoiseModel(depol_prob=0.01,
+                                                              decay_prob=0.02,
+                                                              bitflip_prob=0.05)
+    noisy_circuit = cirq.Circuit(noise_model.noisy_moments(program, qubits))
+
+    # Insert channels explicitly
+    true_noisy_program = cirq.Circuit()
+    true_noisy_program.append([cirq.H(qubits[0])])
+    true_noisy_program.append(
+        [cirq.DepolarizingChannel(0.01).on(q) for q in qubits],
+        strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+    true_noisy_program.append([cirq.CNOT(qubits[0], qubits[1])])
+    true_noisy_program.append(
+        [cirq.DepolarizingChannel(0.01).on(q) for q in qubits],
+        strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+    true_noisy_program.append([cirq.CNOT(qubits[1], qubits[2])])
+    true_noisy_program.append(
+        [cirq.DepolarizingChannel(0.01).on(q) for q in qubits],
+        strategy=cirq.InsertStrategy.NEW_THEN_INLINE)
+    true_noisy_program.append(
+        [cirq.AmplitudeDampingChannel(0.02).on(q) for q in qubits])
+    true_noisy_program.append([cirq.BitFlipChannel(0.05).on(q) for q in qubits])
+    true_noisy_program.append([
+        cirq.measure(qubits[0], key='q0'),
+        cirq.measure(qubits[1], key='q1'),
+        cirq.measure(qubits[2], key='q2')
+    ])
+    _assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
+
+
 # Fake calibration data object.
 _CALIBRATION_DATA = Merge(
     """


### PR DESCRIPTION
As noted in #2826, it won't be possible to use single-noise-type models to implement these aggregate models until the noise model composition story is solidified. For now, I've restored the models removed in #2734 (and associated tests) and marked them as deprecated.