### PR TITLE
Fix error message from cirq.final_wavefunction to cirq.final_density_matrix #2778

### DIFF
--- a/cirq/sim/mux.py
+++ b/cirq/sim/mux.py
@@ -149,7 +149,7 @@ def final_wavefunction(
         raise ValueError(
             "Program doesn't have a single well defined final wavefunction "
             "because it is not unitary. "
-            "Maybe you wanted cirq.final_density_matrix?\n"
+            "Maybe you wanted `cirq.final_density_matrix`?\n"
             "\n"
             "Program: {!r}".format(circuit_like))
 

--- a/cirq/sim/mux.py
+++ b/cirq/sim/mux.py
@@ -149,7 +149,7 @@ def final_wavefunction(
         raise ValueError(
             "Program doesn't have a single well defined final wavefunction "
             "because it is not unitary. "
-            "Maybe you wanted `cirq.sample_wavefunction`?\n"
+            "Maybe you wanted cirq.final_density_matrix?\n"
             "\n"
             "Program: {!r}".format(circuit_like))
 


### PR DESCRIPTION
Error message changes for  cirq/sim/mux.py

From:-
"Maybe you wanted `cirq.final_wavefunction`
To:-
"Maybe you wanted `cirq.final_density_matrix`? "

Fixes: https://github.com/quantumlib/Cirq/issues/2778