### PR TITLE
fix pytest changed files script for mac

### DIFF
--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -61,7 +61,7 @@ fi
 cov_changed_python_file_dirs=$(git diff --name-only "${rev}" -- \
     | grep "\.py$" \
     | grep -v "_pb2\.py$" \
-    | xargs dirname \
+    | xargs -I {} dirname {} \
     | perl -ne 'chomp(); if (-e $_) {print "--cov=$_\n"}' \
     | sort \
     | uniq \


### PR DESCRIPTION
Fixes an error on Mac, as soon more than 1 file changes: 

```
Comparing against revision 'upstream/master'.
usage: dirname path
```
