### PR TITLE
Check 2x2 unitary in has_stabilizer_effect

### DIFF
--- a/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -76,5 +76,5 @@ def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
         return None
     unitary = protocols.unitary(val)
     if unitary.shape == (2, 2):
-        return not SingleQubitCliffordGate.from_unitary(unitary) is None
+        return SingleQubitCliffordGate.from_unitary(unitary) is not None
     return None

--- a/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -25,6 +25,9 @@ from cirq import protocols
 def has_stabilizer_effect(val: Any) -> bool:
     """
     Returns whether the input has a stabilizer effect.
+
+    For 1-qubit gates always returns correct result. For other operations relies
+    on the operation to define whether it has stabilizer effect.
     """
     strats = [
         _strat_has_stabilizer_effect_from_has_stabilizer_effect,
@@ -66,7 +69,8 @@ def _strat_has_stabilizer_effect_from_gate(val: Any) -> Optional[bool]:
 def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
     """Attempts to infer whether val has stabilizer effect from its unitary.
 
-    Returns whether unitary of `val` normalizes Pauli group.
+    Returns whether unitary of `val` normalizes the Pauli group. Works only for
+    2x2 unitaries.
     """
     if not protocols.has_unitary(val):
         return None

--- a/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -17,17 +17,19 @@ from typing import (
     Optional,
 )
 
+from cirq.ops.clifford_gate import SingleQubitCliffordGate
+
+from cirq import protocols
+
 
 def has_stabilizer_effect(val: Any) -> bool:
     """
-    Returns whether the input has a stabilizer effect. Currently only limits to
-    Pauli, H, S, CNOT and CZ gates and their Operations. Does not attempt to
-    decompose a gate into supported gates. For e.g. iSWAP or X**0.5 gate will
-    return False.
+    Returns whether the input has a stabilizer effect.
     """
     strats = [
         _strat_has_stabilizer_effect_from_has_stabilizer_effect,
-        _strat_has_stabilizer_effect_from_gate
+        _strat_has_stabilizer_effect_from_gate,
+        _strat_has_stabilizer_effect_from_unitary,
     ]
     for strat in strats:
         result = strat(val)
@@ -58,4 +60,17 @@ def _strat_has_stabilizer_effect_from_gate(val: Any) -> Optional[bool]:
     """
     if hasattr(val, 'gate'):
         return _strat_has_stabilizer_effect_from_has_stabilizer_effect(val.gate)
+    return None
+
+
+def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
+    """Attempts to infer whether val has stabilizer effect from its unitary.
+
+    Returns whether unitary of `val` normalizes Pauli group.
+    """
+    if not protocols.has_unitary(val):
+        return None
+    unitary = protocols.unitary(val)
+    if unitary.shape == (2, 2):
+        return not SingleQubitCliffordGate.from_unitary(unitary) is None
     return None

--- a/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -128,8 +128,11 @@ def test_via_unitary():
     op1 = OpWithUnitary(np.array([[0, 1], [1, 0]]))
     assert cirq.has_stabilizer_effect(op1)
 
-    op2 = OpWithUnitary(np.array([[1, 0], [0, np.sqrt(1j)]]))
-    assert not cirq.has_stabilizer_effect(op2)
+    op2 = OpWithUnitary(np.array([[0, 1j], [1j, 0]]))
+    assert cirq.has_stabilizer_effect(op2)
+
+    op3 = OpWithUnitary(np.array([[1, 0], [0, np.sqrt(1j)]]))
+    assert not cirq.has_stabilizer_effect(op3)
 
 
 def test_via_unitary_not_supported():

--- a/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -124,9 +124,15 @@ def test_via_gate_of_op():
     assert not cirq.has_stabilizer_effect(NoOp3())
 
 
-def test_from_unitary():
+def test_via_unitary():
     op1 = OpWithUnitary(np.array([[0, 1], [1, 0]]))
     assert cirq.has_stabilizer_effect(op1)
 
     op2 = OpWithUnitary(np.array([[1, 0], [0, np.sqrt(1j)]]))
     assert not cirq.has_stabilizer_effect(op2)
+
+
+def test_via_unitary_not_supported():
+    # Unitaries larger than 2x2 are not yet supported.
+    op = OpWithUnitary(cirq.unitary(cirq.CNOT))
+    assert not cirq.has_stabilizer_effect(op)

--- a/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 import cirq
 
 
@@ -90,6 +92,13 @@ class YesOp(EmptyOp):
     def gate(self):
         return Yes()
 
+class OpWithUnitary(EmptyOp):
+    def __init__(self, unitary):
+        self.unitary = unitary
+
+    def _unitary_(self):
+        return self.unitary
+
 
 def test_inconclusive():
     assert not cirq.has_stabilizer_effect(object())
@@ -111,3 +120,10 @@ def test_via_gate_of_op():
     assert not cirq.has_stabilizer_effect(NoOp1())
     assert not cirq.has_stabilizer_effect(NoOp2())
     assert not cirq.has_stabilizer_effect(NoOp3())
+
+def test_from_unitary():
+    op1 = OpWithUnitary(np.array([[0, 1], [1, 0]]))
+    assert cirq.has_stabilizer_effect(op1)
+
+    op2 = OpWithUnitary(np.array([[1, 0], [0, np.sqrt(1j)]]))
+    assert not cirq.has_stabilizer_effect(op2)

--- a/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -92,7 +92,9 @@ class YesOp(EmptyOp):
     def gate(self):
         return Yes()
 
+
 class OpWithUnitary(EmptyOp):
+
     def __init__(self, unitary):
         self.unitary = unitary
 
@@ -120,6 +122,7 @@ def test_via_gate_of_op():
     assert not cirq.has_stabilizer_effect(NoOp1())
     assert not cirq.has_stabilizer_effect(NoOp2())
     assert not cirq.has_stabilizer_effect(NoOp3())
+
 
 def test_from_unitary():
     op1 = OpWithUnitary(np.array([[0, 1], [1, 0]]))


### PR DESCRIPTION
If everything else fails (i.e. op and its gate don't declare has_stabilizer effect), and op has unitary, 2hich is 2x2 unitary, explicilty check if that unitary has stabilizer effect.
After this change `has_stabilizer_effect` returns `True` exactly for those gates which are supported by `CliffordSimulator`.
This is follow-up to PR #2803.