### PR TITLE
Fix links in github view

### DIFF
--- a/docs/dev/gates.md
+++ b/docs/dev/gates.md
@@ -30,7 +30,7 @@ effect as the unitary produced by `_unitary_` or the transformation applied by
 
 If the gate is exposed by `cirq/__init__.py` or another public module, other
 tests will notice it and verify that it is serializable.
-See the [serialization guidelines](/dev/serialization.md).
+See the [serialization guidelines](serialization.md).
 
 There are several other informal constraints:
 

--- a/docs/gates.ipynb
+++ b/docs/gates.ipynb
@@ -126,7 +126,7 @@
         "This would create the operations needed to comprise the circuit from the above\n",
         "diagram.  The next step would be composing these operations into moments and\n",
         "circuits.  For more on those types, see the documentation on\n",
-        "[Circuits](circuits.md)."
+        "[Circuits](circuits.ipynb)."
       ]
     },
     {
@@ -150,7 +150,7 @@
         "unitaries and associated probabilities of a mixture can be accessed by\n",
         "`cirq.mixture(gate)`. The Kraus operator representation of a channel can be\n",
         "accessed by `cirq.channel(gate)`. Non-unitary gates are often used in the\n",
-        "simulation of noise. See [noise documentation](noise.md) for more details.\n",
+        "simulation of noise. See [noise documentation](noise.ipynb) for more details.\n",
         "\n",
         "Many arithmetic operators will work in the expected way when applied to\n",
         "gates.  For instance, ``cirq.X**0.5`` represents a square root of X gate.\n",
@@ -361,7 +361,7 @@
         "operation operates on and what dimension each qudit must be.  If only the\n",
         "`_num_qubits_` method is implemented, the object is assumed to operate only on\n",
         "qubits. Callers can query the qid shape of the object by calling\n",
-        "`cirq.qid_shape` on it. See [qudit documentation](qudits.md) for more\n",
+        "`cirq.qid_shape` on it. See [qudit documentation](qudits.ipynb) for more\n",
         "information.\n",
         "\n",
         "#### `cirq.unitary` and `def _unitary_`\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -158,7 +158,7 @@
         "\n",
         "For instance, `cirq.H` is the quantum [Hadamard](https://en.wikipedia.org/wiki/Quantum_logic_gate#Hadamard_(H)_gate) and is a `Gate` object.  `cirq.H(cirq.LineQubit(1))` is an `Operation` object and is the Hadamard gate applied to a specific qubit (line qubit number 1).\n",
         "\n",
-        "Many textbook gates are included within cirq.  `cirq.X`, `cirq.Y`, and `cirq.Z` refer to the single-qubit Pauli gates.  `cirq.CZ`, `cirq.CNOT`, `cirq.SWAP` are a few of the common two-qubit gates.  `cirq.measure` is a macro to apply a `MeasurementGate` to a set of qubits.  You can find more, as well as instructions on how to creats your own custom gates, on the [Gates documentation](gates.md) page.\n",
+        "Many textbook gates are included within cirq.  `cirq.X`, `cirq.Y`, and `cirq.Z` refer to the single-qubit Pauli gates.  `cirq.CZ`, `cirq.CNOT`, `cirq.SWAP` are a few of the common two-qubit gates.  `cirq.measure` is a macro to apply a `MeasurementGate` to a set of qubits.  You can find more, as well as instructions on how to creats your own custom gates, on the [Gates documentation](gates.ipynb) page.\n",
         "\n",
         "Many arithmetic operations can also be applied to gates.  Here are some examples:"
       ]
@@ -277,7 +277,7 @@
         "colab_type": "text"
       },
       "source": [
-        "Sometimes, you may not want cirq to automatically shift operations all the way to the left.  To construct a circuit without doing this, you can create the circuit moment-by-moment or use a different `InsertStrategy`, explained more in the [Circuit documentation](circuits.md)."
+        "Sometimes, you may not want cirq to automatically shift operations all the way to the left.  To construct a circuit without doing this, you can create the circuit moment-by-moment or use a different `InsertStrategy`, explained more in the [Circuit documentation](circuits.ipynb)."
       ]
     },
     {
@@ -783,9 +783,9 @@
         "\n",
         "There is much more to learn and try out for those who are interested:\n",
         "\n",
-        "* Learn about the variety of [Gates](gates.md) available in cirq and more about the different ways to construct [Circuits](circuits.md)\n",
-        "* Learn more about [Simulations](simulation.md) and how it works.\n",
-        "* Learn about [Noise](noise.md) and how to utilize multi-level systems using [Qudits](qudits.md)\n",
+        "* Learn about the variety of [Gates](gates.ipynb) available in cirq and more about the different ways to construct [Circuits](circuits.ipynb)\n",
+        "* Learn more about [Simulations](simulation.ipynb) and how it works.\n",
+        "* Learn about [Noise](noise.ipynb) and how to utilize multi-level systems using [Qudits](qudits.ipynb)\n",
         "* Dive into some [Examples](examples.md) and some case studies of how to use cirq.\n",
         "\n",
         "Also, join our [cirq-announce mailing list](https://groups.google.com/forum/#!forum/cirq-announce) to hear about changes and releases or go to the [cirq github](https://github.com/quantumlib/Cirq/) to file issues."


### PR DESCRIPTION
- Change .md links to .ipynb links.
- From local building the docs, this _should_ work in readthedocs as well.

Closes: https://github.com/quantumlib/Cirq/issues/2887