### PR TITLE
Upgrade pytest to version 5.4.1

### DIFF
--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -1,7 +1,7 @@
 # For testing and analyzing code.
 mypy~=0.701.0
 pylint~=2.3.0
-pytest~=3.8.0
+pytest~=5.4.1
 pytest-asyncio~=0.10.0
 pytest-cov~=2.5.0
 pytest-benchmark~=3.2.0


### PR DESCRIPTION
We just did this at OpenFermion-Cirq and it's a good idea to keep in sync.