### PR TITLE
Fix invalid argument in list_processors.

### DIFF
--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -522,9 +522,9 @@ class EngineClient:
         Returns:
             A list of metadata of each processor.
         """
-        response = self._make_request(lambda: self.grpc_client.
-                                      list_quantum_processors(
-                                          self._project_name(project_id), filter=''))
+        response = self._make_request(
+            lambda: self.grpc_client.list_quantum_processors(
+                self._project_name(project_id), filter_=''))
         return list(response)
 
     def get_processor(self, project_id: str,

--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -524,7 +524,7 @@ class EngineClient:
         """
         response = self._make_request(lambda: self.grpc_client.
                                       list_quantum_processors(
-                                          self._project_name(project_id), ''))
+                                          self._project_name(project_id), filter=''))
         return list(response)
 
     def get_processor(self, project_id: str,

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -561,7 +561,7 @@ def test_list_processors(client_constructor):
     assert grpc_client.list_quantum_processors.call_args[0] == (
         'projects/proj',)
     assert grpc_client.list_quantum_processors.call_args[1] == {
-        'filter': '',
+        'filter_': '',
     }
 
 

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -23,6 +23,7 @@ from cirq.google.engine.client import quantum
 from cirq.google.engine.client.quantum_v1alpha1 import enums as qenums
 from cirq.google.engine.client.quantum_v1alpha1 import types as qtypes
 
+
 def setup_mock_(client_constructor):
     grpc_client = mock.Mock()
     client_constructor.return_value = grpc_client
@@ -557,8 +558,11 @@ def test_list_processors(client_constructor):
 
     client = EngineClient()
     assert client.list_processors('proj') == results
-    assert grpc_client.list_quantum_processors.call_args[0] == ('projects/proj',
-                                                                '')
+    assert grpc_client.list_quantum_processors.call_args[0] == (
+        'projects/proj',)
+    assert grpc_client.list_quantum_processors.call_args[1] == {
+        'filter': '',
+    }
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)


### PR DESCRIPTION
Calling `engine.list_processors` currently fails, as in the grpc client the second argument must be a number. This fixes the issue, but does not fully test for it, as that would require an integration test.