### PR TITLE
Shortening titles of tutorials

### DIFF
--- a/docs/studies/Quantum_Walk.ipynb
+++ b/docs/studies/Quantum_Walk.ipynb
@@ -33,7 +33,7 @@
         "colab_type": "text"
       },
       "source": [
-        "# Quantum Walks With Cirq - Tutorial"
+        "# Quantum Walks"
       ]
     },
     {

--- a/docs/studies/variational_algorithm.ipynb
+++ b/docs/studies/variational_algorithm.ipynb
@@ -38,7 +38,7 @@
         "colab_type": "text"
       },
       "source": [
-        "# Creating a Quantum Variational Algorithm\n",
+        "# Quantum Variational Algorithm\n",
         "\n",
         "In this tutorial, we will create a [quantum variational algorithm](https://arxiv.org/abs/1304.3061) using cirq and show how it can optimize a simple Ising model.\n",
         "\n",


### PR DESCRIPTION
- The top-level title e.g. "# Title" is what shows on the
table of contents in read the docs.
- Shortened two of the titles to make them show up better.