### PR TITLE
Add more missing type annotations

### DIFF
--- a/cirq/interop/quirk/cells/arithmetic_cells.py
+++ b/cirq/interop/quirk/cells/arithmetic_cells.py
@@ -172,10 +172,10 @@ class ArithmeticCell(Cell):
     def gate_count(self) -> int:
         return 1
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return self.identifier, self.target, self.inputs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f'cirq.interop.quirk.cells.arithmetic_cells.ArithmeticCell('
                 f'\n    {self.identifier!r},'
                 f'\n    {self.target!r},'

--- a/cirq/interop/quirk/cells/control_cells.py
+++ b/cirq/interop/quirk/cells/control_cells.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Iterable, TYPE_CHECKING, Union, Iterator
+from typing import Any, Iterable, Iterator, List, Optional, TYPE_CHECKING, Union
 
 from cirq import ops, value
 from cirq.interop.quirk.cells.cell import Cell, CellMaker
@@ -30,10 +30,10 @@ class ControlCell(Cell):
         self.qubit = qubit
         self._basis_change = tuple(basis_change)
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return self.qubit, self._basis_change
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f'cirq.interop.quirk.cells.control_cells.ControlCell('
                 f'\n    {self.qubit!r},'
                 f'\n    {self._basis_change!r})')
@@ -71,10 +71,10 @@ class ParityControlCell(Cell):
         self.qubits = list(qubits)
         self._basis_change = list(basis_change)
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return self.qubits, self._basis_change
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f'cirq.interop.quirk.cells.control_cells.ParityControlCell('
                 f'\n    {self.qubits!r},'
                 f'\n    {self._basis_change!r})')

--- a/cirq/interop/quirk/cells/input_rotation_cells.py
+++ b/cirq/interop/quirk/cells/input_rotation_cells.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Iterator, Optional, Sequence, Union, List
+from typing import (Any, Iterable, Iterator, List, Optional, Sequence, Tuple,
+                    Union)
 
 import numpy as np
 
@@ -33,7 +34,7 @@ class InputRotationCell(Cell):
         self.base_operation = base_operation
         self.exponent_sign = exponent_sign
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return (
             self.identifier,
             self.register,
@@ -41,7 +42,7 @@ class InputRotationCell(Cell):
             self.exponent_sign,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'cirq.interop.quirk.cells.input_rotation_cells.InputRotationCell('
             f'\n    {self.identifier!r},'
@@ -99,7 +100,7 @@ class QuirkInputRotationOperation(ops.Operation):
         self.base_operation = base_operation
         self.exponent_sign = exponent_sign
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return (
             self.identifier,
             self.register,
@@ -108,7 +109,7 @@ class QuirkInputRotationOperation(ops.Operation):
         )
 
     @property
-    def qubits(self):
+    def qubits(self) -> Tuple['cirq.Qid', ...]:
         return tuple(self.base_operation.qubits) + self.register
 
     def with_qubits(self, *new_qubits):
@@ -132,7 +133,7 @@ class QuirkInputRotationOperation(ops.Operation):
             exponent_qubit_index=qubit_index,
             auto_exponent_parens=False)
 
-    def _has_unitary_(self):
+    def _has_unitary_(self) -> bool:
         return True
 
     def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs'):
@@ -157,7 +158,7 @@ class QuirkInputRotationOperation(ops.Operation):
 
         return args.target_tensor
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f'cirq.interop.quirk.QuirkInputRotationOperation('
                 f'identifier={self.identifier!r}, '
                 f'register={self.register!r}, '

--- a/cirq/interop/quirk/cells/qubit_permutation_cells.py
+++ b/cirq/interop/quirk/cells/qubit_permutation_cells.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Iterator, Tuple, Sequence, TYPE_CHECKING
+from typing import Callable, Iterator, Sequence, Tuple, TYPE_CHECKING
 
 from cirq import ops, value
 from cirq.interop.quirk.cells.cell import (
@@ -64,11 +64,12 @@ class QuirkQubitPermutationGate(ops.Gate):
         args.available_buffer[...] = args.target_tensor.transpose(permuted_axes)
         return args.available_buffer
 
-    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'):
+    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> Tuple[str, ...]:
         return tuple(f'{self.name}[{i}>{self.permutation[i]}]'
                      for i in range(len(self.permutation)))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ('cirq.interop.quirk.QuirkQubitPermutationGate('
                 f'identifier={repr(self.identifier)},'
                 f'name={repr(self.name)},'

--- a/cirq/interop/quirk/cells/swap_cell.py
+++ b/cirq/interop/quirk/cells/swap_cell.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Iterable, List, TYPE_CHECKING, Iterator
+from typing import Any, Iterable, Iterator, List, Optional, TYPE_CHECKING
 
 from cirq import ops, value
 from cirq.interop.quirk.cells.cell import Cell, CellMaker
@@ -53,10 +53,10 @@ class SwapCell(Cell):
     def controlled_by(self, qubit: 'cirq.Qid'):
         return SwapCell(self._qubits, self._controls + [qubit])
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return self._qubits, self._controls
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (f'cirq.interop.quirk.cells.swap_cell.SwapCell('
                 f'\n    {self._qubits!r},'
                 f'\n    {self._controls!r})')

--- a/cirq/ion/ion_device.py
+++ b/cirq/ion/ion_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, Iterable, Optional, Set, TYPE_CHECKING, FrozenSet
+from typing import Any, cast, FrozenSet, Iterable, Optional, Set, TYPE_CHECKING
 
 from cirq import circuits, value, devices, ops, protocols
 from cirq.ion import convert_to_ion_gates
@@ -128,7 +128,8 @@ class IonDevice(devices.Device):
         q = devices.LineQubit(position)
         return q if q in self.qubits else None
 
-    def neighbors_of(self, qubit: devices.LineQubit):
+    def neighbors_of(self,
+                     qubit: devices.LineQubit) -> Iterable[devices.LineQubit]:
         """Returns the qubits that the given qubit can interact with."""
         possibles = [
             devices.LineQubit(qubit.x + 1),
@@ -136,16 +137,14 @@ class IonDevice(devices.Device):
         ]
         return [e for e in possibles if e in self.qubits]
 
-    def __repr__(self):
-        return ('IonDevice(measurement_duration={!r}, '
-                'twoq_gates_duration={!r}, '
-                'oneq_gates_duration={!r} '
-                'qubits={!r})').format(self._measurement_duration,
-                                       self._twoq_gates_duration,
-                                       self._oneq_gates_duration,
-                                       sorted(self.qubits))
+    def __repr__(self) -> str:
+        return (
+            f'IonDevice(measurement_duration={self._measurement_duration!r}, '
+            f'twoq_gates_duration={self._twoq_gates_duration!r}, '
+            f'oneq_gates_duration={self._oneq_gates_duration!r} '
+            f'qubits={sorted(self.qubits)!r})')
 
-    def __str__(self):
+    def __str__(self) -> str:
         diagram = circuits.TextDiagramDrawer()
 
         for q in self.qubits:
@@ -158,7 +157,7 @@ class IonDevice(devices.Device):
             vertical_spacing=2,
             use_unicode_characters=True)
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return (self._measurement_duration,
                 self._twoq_gates_duration,
                 self._oneq_gates_duration,

--- a/cirq/pasqal/pasqal_device.py
+++ b/cirq/pasqal/pasqal_device.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import FrozenSet, Iterable
+from typing import Any, Dict, FrozenSet, Iterable
 from numpy import sqrt
 
 import cirq
@@ -182,13 +182,13 @@ class PasqalDevice(cirq.devices.Device):
         return sqrt((p.row - q.row)**2 + (p.col - q.col)**2 +
                     (p.lay - q.lay)**2)
 
-    def __repr__(self):
-        return ('pasqal.PasqalDevice(control_radius={!r}, '
-                'qubits={!r})').format(self.control_radius, sorted(self.qubits))
+    def __repr__(self) -> str:
+        return (f'pasqal.PasqalDevice(control_radius={self.control_radius!r}, '
+                f'qubits={sorted(self.qubits)!r})')
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return (self.control_radius, self.qubits)
 
-    def _json_dict_(self):
+    def _json_dict_(self) -> Dict[str, Any]:
         return cirq.protocols.obj_to_dict_helper(self,
                                                  ['control_radius', 'qubits'])

--- a/cirq/pasqal/pasqal_qubits.py
+++ b/cirq/pasqal/pasqal_qubits.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 from numpy import sqrt, isclose
 
 import cirq
@@ -157,14 +157,13 @@ class ThreeDGridQubit(cirq.ops.Qid):
             for col in range(left, left + cols)
         ]
 
-    def __repr__(self):
-        return 'pasqal.ThreeDGridQubit({}, {}, {})'.format(
-            self.row, self.col, self.lay)
+    def __repr__(self) -> str:
+        return f'pasqal.ThreeDGridQubit({self.row}, {self.col}, {self.lay})'
 
-    def __str__(self):
-        return '({}, {}, {})'.format(self.row, self.col, self.lay)
+    def __str__(self) -> str:
+        return f'({self.row}, {self.col}, {self.lay})'
 
-    def _json_dict_(self):
+    def _json_dict_(self) -> Dict[str, Any]:
         return cirq.protocols.obj_to_dict_helper(self, ['row', 'col', 'lay'])
 
     def __add__(self, other: Tuple[int, int, int]) -> 'ThreeDGridQubit':

--- a/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq/protocols/circuit_diagram_info_protocol.py
@@ -62,7 +62,7 @@ class CircuitDiagramInfo:
         self.exponent_qubit_index = exponent_qubit_index
         self.auto_exponent_parens = auto_exponent_parens
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return (
             self.wire_symbols,
             self.exponent,
@@ -71,17 +71,13 @@ class CircuitDiagramInfo:
             self.auto_exponent_parens,
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ('cirq.CircuitDiagramInfo('
-                'wire_symbols={!r}, '
-                'exponent={!r}, '
-                'connected={!r}, '
-                'exponent_qubit_index={!r}, '
-                'auto_exponent_parens={!r})'.format(self.wire_symbols,
-                                                    self.exponent,
-                                                    self.connected,
-                                                    self.exponent_qubit_index,
-                                                    self.auto_exponent_parens))
+                f'wire_symbols={self.wire_symbols!r}, '
+                f'exponent={self.exponent!r}, '
+                f'connected={self.connected!r}, '
+                f'exponent_qubit_index={self.exponent_qubit_index!r}, '
+                f'auto_exponent_parens={self.auto_exponent_parens!r})')
 
 
 @value.value_equality
@@ -122,25 +118,21 @@ class CircuitDiagramInfoArgs:
         self.qubit_map = qubit_map
         self.include_tags = include_tags
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return (self.known_qubits, self.known_qubit_count,
                 self.use_unicode_characters, self.precision,
                 None if self.qubit_map is None else tuple(
                     sorted(self.qubit_map.items(), key=lambda e: e[0])),
                 self.include_tags)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return ('cirq.CircuitDiagramInfoArgs('
-                'known_qubits={!r}, '
-                'known_qubit_count={!r}, '
-                'use_unicode_characters={!r}, '
-                'precision={!r}, '
-                'qubit_map={!r},'
-                'include_tags={!r})'.format(self.known_qubits,
-                                            self.known_qubit_count,
-                                            self.use_unicode_characters,
-                                            self.precision, self.qubit_map,
-                                            self.include_tags))
+                f'known_qubits={self.known_qubits!r}, '
+                f'known_qubit_count={self.known_qubit_count!r}, '
+                f'use_unicode_characters={self.use_unicode_characters!r}, '
+                f'precision={self.precision!r}, '
+                f'qubit_map={self.qubit_map!r},'
+                f'include_tags={self.include_tags!r})')
 
     def format_real(self, val: Union[sympy.Basic, int, float]) -> str:
         if isinstance(val, sympy.Basic):

--- a/cirq/testing/order_tester.py
+++ b/cirq/testing/order_tester.py
@@ -134,69 +134,72 @@ class OrderTester:
 
 
 class _EqualToEverything:
-    def __eq__(self, other):
+
+    def __eq__(self, other) -> bool:
         return True
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return False
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return False
 
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         return True
 
-    def __gt__(self, other):
+    def __gt__(self, other) -> bool:
         return False
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> bool:
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '_EqualToEverything'
 
 
 class _SmallerThanEverythingElse:
-    def __eq__(self, other):
+
+    def __eq__(self, other) -> bool:
         return isinstance(other, _SmallerThanEverythingElse)
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not isinstance(other, _SmallerThanEverythingElse)
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return not isinstance(other, _SmallerThanEverythingElse)
 
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         return True
 
-    def __gt__(self, other):
+    def __gt__(self, other) -> bool:
         return False
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> bool:
         return isinstance(other, _SmallerThanEverythingElse)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'SmallerThanEverythingElse'
 
 
 class _LargerThanEverythingElse:
-    def __eq__(self, other):
+
+    def __eq__(self, other) -> bool:
         return isinstance(other, _LargerThanEverythingElse)
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         return not isinstance(other, _LargerThanEverythingElse)
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         return False
 
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         return isinstance(other, _LargerThanEverythingElse)
 
-    def __gt__(self, other):
+    def __gt__(self, other) -> bool:
         return not isinstance(other, _LargerThanEverythingElse)
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> bool:
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'LargerThanEverythingElse()'

--- a/cirq/value/duration.py
+++ b/cirq/value/duration.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """A typed time delta that supports picosecond accuracy."""
 
-from typing import Union, Tuple, TYPE_CHECKING, Any, Optional
+from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING, Union
 import datetime
 
 import sympy
@@ -220,7 +220,7 @@ class Duration:
 
         return amount * rest, unit, suffix
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self._picos == 0:
             return 'Duration(0)'
         amount, _, suffix = self._decompose_into_amount_unit_suffix()
@@ -228,11 +228,11 @@ class Duration:
             amount = f'({amount})'
         return f'{amount} {suffix}'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         amount, unit, _ = self._decompose_into_amount_unit_suffix()
         return f'cirq.Duration({unit}={proper_repr(amount)})'
 
-    def _json_dict_(self):
+    def _json_dict_(self) -> Dict[str, Any]:
         return {
             'cirq_type': self.__class__.__name__,
             'picos': self.total_picos()

--- a/cirq/value/linear_dict.py
+++ b/cirq/value/linear_dict.py
@@ -285,7 +285,7 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
         class_name = self.__class__.__name__
         return 'cirq.{}({!r})'.format(class_name, coefficients)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__format__('.3f')
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:

--- a/cirq/value/periodic_value.py
+++ b/cirq/value/periodic_value.py
@@ -78,11 +78,12 @@ class PeriodicValue:
 
         return approx_eq(low, high, atol=atol)
 
-    def __repr__(self):
-        return 'cirq.PeriodicValue({}, {})'.format(proper_repr(self.value),
-                                                   proper_repr(self.period))
+    def __repr__(self) -> str:
+        v = proper_repr(self.value)
+        p = proper_repr(self.period)
+        return f'cirq.PeriodicValue({v}, {p})'
 
-    def _is_parameterized_(self):
+    def _is_parameterized_(self) -> bool:
         # HACK: Avoids circular dependencies.
         from cirq.protocols import is_parameterized
         return any(is_parameterized(val) for val in (self.value, self.period))

--- a/cirq/value/timestamp.py
+++ b/cirq/value/timestamp.py
@@ -100,11 +100,11 @@ class Timestamp:
     def __le__(self, other):
         return not self > other
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((Timestamp, self._picos))
 
-    def __str__(self):
-        return 't={}'.format(self._picos)
+    def __str__(self) -> str:
+        return f't={self._picos}'
 
-    def __repr__(self):
-        return 'cirq.Timestamp(picos={})'.format(repr(self._picos))
+    def __repr__(self) -> str:
+        return f'cirq.Timestamp(picos={self._picos!r})'

--- a/cirq/value/timestamp_test.py
+++ b/cirq/value/timestamp_test.py
@@ -32,6 +32,12 @@ def test_init():
     assert isinstance(Timestamp(nanos=1.0).raw_picos(), float)
 
 
+def test_str():
+    assert str(Timestamp(picos=1000, nanos=1000)) == 't=1001000'
+    assert str(Timestamp(nanos=5.0)) == 't=5000.0'
+    assert str(Timestamp(picos=-100)) == 't=-100'
+
+
 def test_repr():
     a = Timestamp(picos=1000, nanos=1000)
     cirq.testing.assert_equivalent_repr(a)

--- a/cirq/work/collector.py
+++ b/cirq/work/collector.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Any, Iterable, Union, List, TYPE_CHECKING
+from typing import Any, Iterable, List, Optional, TYPE_CHECKING, Union
 import abc
 import asyncio
 
@@ -49,13 +49,12 @@ class CircuitSampleJob:
         self.repetitions = repetitions
         self.tag = tag
 
-    def _value_equality_values_(self):
+    def _value_equality_values_(self) -> Any:
         return self.circuit, self.repetitions, self.tag
 
-    def __repr__(self):
-        return ('cirq.CircuitSampleJob('
-                'tag={!r}, repetitions={!r}, circuit={!r})').format(
-                    self.tag, self.repetitions, self.circuit)
+    def __repr__(self) -> str:
+        return (f'cirq.CircuitSampleJob(tag={self.tag!r}, '
+                f'repetitions={self.repetitions!r}, circuit={self.circuit!r})')
 
 
 CIRCUIT_SAMPLE_JOB_TREE = Union[CircuitSampleJob, Iterable[Any]]


### PR DESCRIPTION
Follow-up to #2906. As before, also replaced calls to `format` with format strings.