### PR TITLE
Intermediate examples had the wrong header

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -45,7 +45,7 @@ qubit to another.
 Transmit 2 classical bits using one quantum bit.
 
 
-# Intermediate Textbook Algorithms
+## Intermediate Textbook Algorithms
 
 *    [Grover Algorithm](https://github.com/quantumlib/Cirq/blob/master/examples/grover.py)
 Textbook algorithm for finding a single element hidden within a oracle function.


### PR DESCRIPTION
- This throws off the readthedocs header.