### PR TITLE
Actually test zip sweep with duplicate keys

### DIFF
--- a/cirq/study/sweeps_test.py
+++ b/cirq/study/sweeps_test.py
@@ -23,7 +23,7 @@ def test_product_duplicate_keys():
 
 def test_zip_duplicate_keys():
     with pytest.raises(ValueError):
-        _ = cirq.Linspace('a', 0, 9, 10) * cirq.Linspace('a', 0, 10, 11)
+        _ = cirq.Linspace('a', 0, 9, 10) + cirq.Linspace('a', 0, 10, 11)
 
 
 def test_linspace():


### PR DESCRIPTION
At present, `test_zip_duplicate_keys` just repeats `test_product_duplicate_keys`.