### PR TITLE
Loosen tolerance restrictions in Quantum Engine

### DIFF
--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -37,17 +37,25 @@ PHYSICAL_Z = 'physical'
 VIRTUAL_Z = 'virtual_propagates_forward'
 
 
-def _near_mod_n(e, t, n, atol=1e-6):
+# Default tolerance for differences in floating point
+# Note that Google protocol buffers use floats
+# which trigger a conversion from double precision to single precision
+# This results in errors possibly up to 1e-6
+# (23 bits for mantissa in single precision)
+_DEFAULT_ATOL = 1e-6
+
+
+def _near_mod_n(e, t, n, atol=_DEFAULT_ATOL):
     if isinstance(e, sympy.Symbol):
         return False
     return abs((e - t + 1) % n - 1) <= atol
 
 
-def _near_mod_2pi(e, t, atol=1e-6):
+def _near_mod_2pi(e, t, atol=_DEFAULT_ATOL):
     return _near_mod_n(e, t, n=2 * np.pi, atol=atol)
 
 
-def _near_mod_2(e, t, atol=1e-6):
+def _near_mod_2(e, t, atol=_DEFAULT_ATOL):
     return _near_mod_n(e, t, n=2, atol=atol)
 
 

--- a/cirq/google/common_serializers.py
+++ b/cirq/google/common_serializers.py
@@ -37,17 +37,17 @@ PHYSICAL_Z = 'physical'
 VIRTUAL_Z = 'virtual_propagates_forward'
 
 
-def _near_mod_n(e, t, n, atol=1e-8):
+def _near_mod_n(e, t, n, atol=1e-6):
     if isinstance(e, sympy.Symbol):
         return False
     return abs((e - t + 1) % n - 1) <= atol
 
 
-def _near_mod_2pi(e, t, atol=1e-8):
+def _near_mod_2pi(e, t, atol=1e-6):
     return _near_mod_n(e, t, n=2 * np.pi, atol=atol)
 
 
-def _near_mod_2(e, t, atol=1e-8):
+def _near_mod_2(e, t, atol=1e-6):
     return _near_mod_n(e, t, n=2, atol=atol)
 
 

--- a/cirq/google/common_serializers_test.py
+++ b/cirq/google/common_serializers_test.py
@@ -669,6 +669,8 @@ def test_wait_gate():
     (cirq.FSimGate(theta=-7 * np.pi / 4, phi=0), -7 * np.pi / 4, 0),
     (cirq.google.SYC, np.pi / 2, np.pi / 6),
     (cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6), np.pi / 2, np.pi / 6),
+    (cirq.FSimGate(theta=1.5707963705062866, phi=0.5235987901687622),
+     1.5707963705062866, 0.5235987901687622),
 ])
 def test_serialize_deserialize_fsim_gate(gate, theta, phi):
     gate_set = cg.SerializableGateSet('test', cgc.LIMITED_FSIM_SERIALIZERS,


### PR DESCRIPTION
- It looks like serialization and deserialization of
floats can have an error up to around 5e-8, so loosening the
restriction to 1e-6 to be safe, since this is only used to determine
gates close to the desired gates.