### PR TITLE
Check 2x2 unitary in has_stabilizer_effect

### DIFF
--- a/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 import cirq
 
 
@@ -91,6 +93,15 @@ class YesOp(EmptyOp):
         return Yes()
 
 
+class OpWithUnitary(EmptyOp):
+
+    def __init__(self, unitary):
+        self.unitary = unitary
+
+    def _unitary_(self):
+        return self.unitary
+
+
 def test_inconclusive():
     assert not cirq.has_stabilizer_effect(object())
     assert not cirq.has_stabilizer_effect('boo')
@@ -111,3 +122,21 @@ def test_via_gate_of_op():
     assert not cirq.has_stabilizer_effect(NoOp1())
     assert not cirq.has_stabilizer_effect(NoOp2())
     assert not cirq.has_stabilizer_effect(NoOp3())
+
+
+def test_via_unitary():
+    op1 = OpWithUnitary(np.array([[0, 1], [1, 0]]))
+    assert cirq.has_stabilizer_effect(op1)
+
+    op2 = OpWithUnitary(np.array([[0, 1j], [1j, 0]]))
+    assert cirq.has_stabilizer_effect(op2)
+
+    op3 = OpWithUnitary(np.array([[1, 0], [0, np.sqrt(1j)]]))
+    assert not cirq.has_stabilizer_effect(op3)
+
+
+def test_via_unitary_not_supported():
+    # Unitaries larger than 2x2 are not yet supported.
+    op = OpWithUnitary(cirq.unitary(cirq.CNOT))
+    assert not cirq.has_stabilizer_effect(op)
+    assert not cirq.has_stabilizer_effect(op)


### PR DESCRIPTION
If everything else fails (i.e. op and its gate don't declare has_stabilizer effect), and op has unitary, 2hich is 2x2 unitary, explicilty check if that unitary has stabilizer effect.
After this change has_stabilizer_effect returns True exactly for those gates which are supported by CliffordSimulator.
This is follow-up to PR #2803.

This is copy of PR #2885 which ended up in urepairable state because of CLA.