### PR TITLE
Accept empty list of whitelisted_users when updating reservations.

### DIFF
--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -754,6 +754,8 @@ class EngineClient:
             start: the new starting time of the reservation as a datetime object
             end: the new ending time of the reservation as a datetime object
             whitelisted_users: a list of emails that can use the reservation.
+                The empty list, [], will clear the whitelisted_users while None
+                will leave the value unchanged.
         """
         name = self._reservation_name_from_ids(
             project_id, processor_id, reservation_id) if reservation_id else ''

--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -766,7 +766,7 @@ class EngineClient:
         if end:
             reservation.end_time.seconds = int(end.timestamp())
             paths.append('end_time')
-        if whitelisted_users:
+        if whitelisted_users != None:
             reservation.whitelisted_users.extend(whitelisted_users)
             paths.append('whitelisted_users')
 

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -853,8 +853,6 @@ def test_update_reservation_remove_all_users(client_constructor):
     name = 'projects/proj/processors/processor0/reservations/papar-party-44'
     result = qtypes.QuantumReservation(
         name=name,
-        start_time=Timestamp(seconds=1000001000),
-        end_time=Timestamp(seconds=1000002000),
         whitelisted_users=[],
     )
     grpc_client.update_quantum_reservation.return_value = result
@@ -868,12 +866,9 @@ def test_update_reservation_remove_all_users(client_constructor):
     ) == result)
     kwargs = grpc_client.update_quantum_reservation.call_args[1]
     assert kwargs == {
-        'name':
-        name,
-        'quantum_reservation':
-        result,
-        'update_mask':
-        FieldMask(paths=['whitelisted_users'])
+        'name': name,
+        'quantum_reservation': result,
+        'update_mask': FieldMask(paths=['whitelisted_users'])
     }
 
 

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -866,9 +866,12 @@ def test_update_reservation_remove_all_users(client_constructor):
     ) == result)
     kwargs = grpc_client.update_quantum_reservation.call_args[1]
     assert kwargs == {
-        'name': name,
-        'quantum_reservation': result,
-        'update_mask': FieldMask(paths=['whitelisted_users'])
+        'name':
+        name,
+        'quantum_reservation':
+        result,
+        'update_mask':
+        FieldMask(paths=['whitelisted_users'])
     }
 
 

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -848,6 +848,36 @@ def test_update_reservation(client_constructor):
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
+def test_update_reservation_remove_all_users(client_constructor):
+    grpc_client = setup_mock_(client_constructor)
+    name = 'projects/proj/processors/processor0/reservations/papar-party-44'
+    result = qtypes.QuantumReservation(
+        name=name,
+        start_time=Timestamp(seconds=1000001000),
+        end_time=Timestamp(seconds=1000002000),
+        whitelisted_users=[],
+    )
+    grpc_client.update_quantum_reservation.return_value = result
+
+    client = EngineClient()
+    assert (client.update_reservation(
+        'proj',
+        'processor0',
+        'papar-party-44',
+        whitelisted_users=[],
+    ) == result)
+    kwargs = grpc_client.update_quantum_reservation.call_args[1]
+    assert kwargs == {
+        'name':
+        name,
+        'quantum_reservation':
+        result,
+        'update_mask':
+        FieldMask(paths=['whitelisted_users'])
+    }
+
+
+@mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_list_time_slots(client_constructor):
     grpc_client = setup_mock_(client_constructor)
     results = [

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -866,12 +866,9 @@ def test_update_reservation_remove_all_users(client_constructor):
     ) == result)
     kwargs = grpc_client.update_quantum_reservation.call_args[1]
     assert kwargs == {
-        'name':
-        name,
-        'quantum_reservation':
-        result,
-        'update_mask':
-        FieldMask(paths=['whitelisted_users'])
+        'name': name,
+        'quantum_reservation': result,
+        'update_mask': FieldMask(paths=['whitelisted_users'])
     }
 
 


### PR DESCRIPTION
Check that whitelisted_users is actually None to accept updates where input is an empty list (i.e. clearing all users).