### PR TITLE
Decompose cphase to two fSim gates

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -272,7 +272,9 @@ from cirq.ops import (
 )
 
 from cirq.optimizers import (
+    compute_cphase_exponents_for_fsim_decomposition,
     ConvertToCzAndSingleGates,
+    decompose_cphase_into_two_fsim,
     decompose_multi_controlled_x,
     decompose_multi_controlled_rotation,
     decompose_two_qubit_interaction_into_four_fsim_gates_via_b,

--- a/cirq/optimizers/__init__.py
+++ b/cirq/optimizers/__init__.py
@@ -14,6 +14,11 @@
 
 """Circuit transformation utilities."""
 
+from cirq.optimizers.cphase_to_fsim import (
+    compute_cphase_exponents_for_fsim_decomposition,
+    decompose_cphase_into_two_fsim,
+)
+
 from cirq.optimizers.controlled_gate_decomposition import (
     decompose_multi_controlled_x, decompose_multi_controlled_rotation)
 

--- a/cirq/optimizers/cphase_to_fsim.py
+++ b/cirq/optimizers/cphase_to_fsim.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
 
-from cirq import ops, circuits, devices, protocols
+from cirq import circuits, devices, ops, protocols
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq/optimizers/cphase_to_fsim.py
+++ b/cirq/optimizers/cphase_to_fsim.py
@@ -1,0 +1,224 @@
+from typing import Optional, Sequence, Tuple, TYPE_CHECKING
+
+import numpy as np
+
+from cirq import ops, circuits, devices, protocols
+from cirq.optimizers.merge_single_qubit_gates import MergeSingleQubitGates
+from cirq.optimizers.drop_empty_moments import DropEmptyMoments
+
+if TYPE_CHECKING:
+    import cirq
+
+
+def _asinsin(x: float) -> float:
+    """Computes arcsin(sin(x)) for any x. Return value in [-π/2, π/2]."""
+    k = round(x / np.pi)
+    if k % 2 == 0:
+        return x - k * np.pi
+    return k * np.pi - x
+
+
+def compute_cphase_exponents_for_fsim_decomposition(
+        fsim_gate: 'cirq.FSimGate') -> Sequence[Tuple[float, float]]:
+    """Returns intervals of CZPowGate exponents valid for FSim decomposition.
+
+    Ideal intervals associated with the constraints are closed, but due to
+    numerical error the caller should not assume the endpoints themselves
+    are valid for the decomposition. See `decompose_cphase_into_two_fsim`
+    for details on how FSimGate parameters constrain the phase angle of
+    CZPowGate.
+
+    Args:
+        fsim_gate: FSimGate into which CZPowGate would be decomposed.
+
+    Returns:
+        Sequence of 2-tuples each consisting of the minimum and maximum
+        value of the exponent for which CZPowGate can be decomposed into
+        two FSimGates. The intervals are cropped to [0, 2]. The function
+        returns zero, one or two intervals.
+    """
+
+    def filter_out_empty_intervals(intervals: Sequence[Tuple[float, float]]
+                                  ) -> Sequence[Tuple[float, float]]:
+        return tuple((a, b) for a, b in intervals if a < b)
+
+    # Each of the two FSimGate parameters sets a bound on phase angle.
+    bound1 = abs(_asinsin(fsim_gate.theta))
+    bound2 = abs(_asinsin(fsim_gate.phi / 2))
+
+    # First potential interval corresponds to the left side of sine's "hump".
+    min_exponent_1 = 4 * min(bound1, bound2) / np.pi
+    max_exponent_1 = 4 * max(bound1, bound2) / np.pi
+    assert min_exponent_1 <= max_exponent_1
+
+    # Second potential interval corresponds to the right side of sine's "hump".
+    min_exponent_2 = 2 - max_exponent_1
+    max_exponent_2 = 2 - min_exponent_1
+    assert min_exponent_2 <= max_exponent_2
+
+    # Intervals are disjoint. Return both.
+    if max_exponent_1 < min_exponent_2:
+        return filter_out_empty_intervals([(min_exponent_1, max_exponent_1),
+                                           (min_exponent_2, max_exponent_2)])
+    if max_exponent_2 < min_exponent_1:
+        return filter_out_empty_intervals([(min_exponent_2, max_exponent_2),
+                                           (min_exponent_1, max_exponent_1)])
+
+    # Intervals overlap. Merge.
+    min_exponent = min(min_exponent_1, min_exponent_2)
+    max_exponent = max(max_exponent_1, max_exponent_2)
+    return filter_out_empty_intervals([(min_exponent, max_exponent)])
+
+
+def decompose_cphase_into_two_fsim(
+        cphase_gate: 'cirq.CZPowGate',
+        *,
+        fsim_gate: 'cirq.FSimGate',
+        qubits: Optional[Sequence['cirq.Qid']] = None,
+        atol: float = 1e-8) -> 'cirq.Circuit':
+    """Decomposes CZPowGate into two FSimGates.
+
+    This function implements the decomposition described in section VII F I
+    of https://arxiv.org/abs/1910.11333.
+
+    The decomposition results in exactly two FSimGates and a few single-qubit
+    rotations. It is feasible if and only if one of the following conditions
+    is met:
+
+        |sin(θ)| <= |sin(δ/4)| <= |sin(φ/2)|
+        |sin(φ/2)| <= |sin(δ/4)| <= |sin(θ)|
+
+    where:
+
+         θ = fsim_gate.theta,
+         φ = fsim_gate.phi,
+         δ = -π * cphase_gate.exponent.
+
+    Note that the gate parametrizations are non-injective. For the
+    decomposition to be feasible it is sufficient that one of the
+    parameter values which correspond to the provided gate satisfies
+    the constraints. This function will find and use the appropriate
+    value whenever it exists.
+
+    The constraints above imply that certain FSimGates are not suitable
+    for use in this decomposition regardless of the target CZPowGate. We
+    reject such gates based on how close |sin(θ)| is to |sin(φ/2)|, see
+    atol argument below.
+
+    This implementation accounts for the global phase.
+
+    Args:
+        cphase_gate: The CZPowGate to synthesize.
+        fsim_gate: The only two qubit gate that is permitted to appear in the
+            output.
+        qubits: The qubits to apply the resulting operations to. If not set,
+            defaults `cirq.LineQubit.range(2)`.
+        atol: Tolerance used to determine whether fsim_gate is valid. The gate
+            is invalid if the squares of the sines of the theta angle and half
+            the phi angle are too close.
+
+    Returns:
+        Circuit equivalent to cphase_gate and consisting solely of two copies
+        of fsim_gate and a few single-qubit rotations.
+
+    Raises:
+        ValueError under any of the following circumstances:
+         * cphase_gate or fsim_gate is parametrized,
+         * cphase_gate and fsim_gate do not satisfy the conditions above,
+         * fsim_gate has invalid angles (see atol argument above),
+         * incorrect number of qubits are provided.
+    """
+    if protocols.is_parameterized(cphase_gate):
+        raise ValueError('Cannot decompose a parametrized gate.')
+    if protocols.is_parameterized(fsim_gate):
+        raise ValueError('Cannot decompose into a parametrized gate.')
+    if qubits is None:
+        qubits = devices.LineQubit.range(2)
+    if len(qubits) != 2:
+        raise ValueError(f'Expected a pair of qubits, but got {qubits!r}.')
+    q0, q1 = qubits
+
+    theta = fsim_gate.theta
+    phi = fsim_gate.phi
+
+    sin_half_phi = np.sin(phi / 2)
+    cos_half_phi = np.cos(phi / 2)
+    sin_theta = np.sin(theta)
+    cos_theta = np.cos(theta)
+
+    #
+    # Step 1: find alpha
+    #
+    denominator = (sin_theta - sin_half_phi) * (sin_theta + sin_half_phi)
+    if abs(denominator) < atol:
+        raise ValueError(
+            f'{fsim_gate} cannot be used to decompose CZPowGate because '
+            'sin(theta)**2 is too close to sin(phi/2)**2 '
+            f'(difference is {denominator}).')
+
+    # Parametrization of CZPowGate by a real angle is a non-injective function
+    # with the preimage of cphase_gate infinite. However, it is sufficient to
+    # check just two of the angles against the constraints of the decomposition.
+    canonical_delta = -np.pi * (cphase_gate.exponent % 2)
+    for delta in (canonical_delta, canonical_delta + 2 * np.pi):
+        sin_quarter_delta = np.sin(delta / 4)
+        numerator = (sin_quarter_delta - sin_half_phi) * (sin_quarter_delta +
+                                                          sin_half_phi)
+        sin_alpha_squared = numerator / denominator
+        if 0 <= sin_alpha_squared <= 1:
+            break
+    else:
+        rs = compute_cphase_exponents_for_fsim_decomposition(fsim_gate)
+        raise ValueError(
+            f'{cphase_gate} cannot be decomposed into two {fsim_gate}. '
+            f'Valid intervals for canonical exponent of CZPowGate: {rs}.')
+    assert 0 <= sin_alpha_squared <= 1
+    alpha = np.arcsin(np.sqrt(sin_alpha_squared))
+
+    #
+    # Step 2: find xi and eta
+    #
+    tan_alpha = np.tan(alpha)
+    xi = np.arctan2(tan_alpha * cos_theta, cos_half_phi)
+    eta = np.arctan2(tan_alpha * sin_theta, sin_half_phi)
+    if delta < 0:
+        eta += np.pi
+
+    #
+    # Step 3: synthesize output circuit
+    #
+    circuit = circuits.Circuit(
+        # Local X rotations to convert Γ1⊗I − iZ⊗Γ2 into exp(-i Z⊗Z δ/4)
+        ops.rx(xi).on(q0),
+        ops.rx(eta).on(q1),
+
+        # Y(θ, φ) := exp(-i X⊗X θ/2) exp(-i Y⊗Y θ/2) exp(-i Z⊗Z φ/4)
+        fsim_gate.on(q0, q1),
+        ops.rz(phi / 2).on(q0),
+        ops.rz(phi / 2).on(q1),
+        ops.GlobalPhaseOperation(np.exp(1j * phi / 4)),
+
+        # exp(i X1 α)
+        ops.rx(-2 * alpha).on(q0),
+
+        # Y(-θ, φ) := exp(i X⊗X θ/2) exp(i Y⊗Y θ/2) exp(-i Z⊗Z φ/4)
+        ops.Z(q0),
+        fsim_gate.on(q0, q1),
+        ops.rz(phi / 2).on(q0),
+        ops.rz(phi / 2).on(q1),
+        ops.GlobalPhaseOperation(np.exp(1j * phi / 4)),
+        ops.Z(q0),
+
+        # Local X rotations to convert Γ1⊗I − iZ⊗Γ2 into exp(-i Z⊗Z δ/4)
+        ops.rx(-eta).on(q1),
+        ops.rx(xi).on(q0),
+
+        # Local Z rotations to convert exp(-i Z⊗Z δ/4) into desired CPhase.
+        ops.rz(-delta / 2).on(q0),
+        ops.rz(-delta / 2).on(q1),
+        ops.GlobalPhaseOperation(np.exp(-1j * delta / 4)),
+    )
+
+    MergeSingleQubitGates().optimize_circuit(circuit)
+    DropEmptyMoments().optimize_circuit(circuit)
+    return circuit

--- a/cirq/optimizers/cphase_to_fsim.py
+++ b/cirq/optimizers/cphase_to_fsim.py
@@ -3,8 +3,6 @@ from typing import Optional, Sequence, Tuple, TYPE_CHECKING
 import numpy as np
 
 from cirq import ops, circuits, devices, protocols
-from cirq.optimizers.merge_single_qubit_gates import MergeSingleQubitGates
-from cirq.optimizers.drop_empty_moments import DropEmptyMoments
 
 if TYPE_CHECKING:
     import cirq
@@ -187,7 +185,7 @@ def decompose_cphase_into_two_fsim(
     #
     # Step 3: synthesize output circuit
     #
-    circuit = circuits.Circuit(
+    return circuits.Circuit(
         # Local X rotations to convert Γ1⊗I − iZ⊗Γ2 into exp(-i Z⊗Z δ/4)
         ops.rx(xi).on(q0),
         ops.rx(eta).on(q1),
@@ -218,7 +216,3 @@ def decompose_cphase_into_two_fsim(
         ops.rz(-delta / 2).on(q1),
         ops.GlobalPhaseOperation(np.exp(-1j * delta / 4)),
     )
-
-    MergeSingleQubitGates().optimize_circuit(circuit)
-    DropEmptyMoments().optimize_circuit(circuit)
-    return circuit

--- a/cirq/optimizers/cphase_to_fsim.py
+++ b/cirq/optimizers/cphase_to_fsim.py
@@ -166,10 +166,10 @@ def decompose_cphase_into_two_fsim(
         if 0 <= sin_alpha_squared <= 1:
             break
     else:
-        rs = compute_cphase_exponents_for_fsim_decomposition(fsim_gate)
+        intervals = compute_cphase_exponents_for_fsim_decomposition(fsim_gate)
         raise ValueError(
-            f'{cphase_gate} cannot be decomposed into two {fsim_gate}. '
-            f'Valid intervals for canonical exponent of CZPowGate: {rs}.')
+            f'{cphase_gate} cannot be decomposed into two {fsim_gate}. Valid '
+            f'intervals for canonical exponent of CZPowGate: {intervals}.')
     assert 0 <= sin_alpha_squared <= 1
     alpha = np.arcsin(np.sqrt(sin_alpha_squared))
 

--- a/cirq/optimizers/cphase_to_fsim_test.py
+++ b/cirq/optimizers/cphase_to_fsim_test.py
@@ -1,0 +1,137 @@
+from typing import List, Sequence, Tuple
+
+import itertools
+import numpy as np
+import pytest
+import sympy
+
+import cirq
+
+
+def test_parameterized_gates():
+    t = sympy.Symbol('t')
+    with pytest.raises(ValueError):
+        cphase_gate = cirq.CZPowGate(exponent=t)
+        fsim_gate = cirq.google.SYC
+        cirq.decompose_cphase_into_two_fsim(cphase_gate, fsim_gate=fsim_gate)
+
+    with pytest.raises(ValueError):
+        cphase_gate = cirq.CZ
+        fsim_gate = cirq.FSimGate(theta=t, phi=np.pi / 2)
+        cirq.decompose_cphase_into_two_fsim(cphase_gate, fsim_gate=fsim_gate)
+
+    with pytest.raises(ValueError):
+        cphase_gate = cirq.CZ
+        fsim_gate = cirq.FSimGate(theta=np.pi / 2, phi=t)
+        cirq.decompose_cphase_into_two_fsim(cphase_gate, fsim_gate=fsim_gate)
+
+
+def test_invalid_qubits():
+    with pytest.raises(ValueError):
+        cirq.decompose_cphase_into_two_fsim(cphase_gate=cirq.CZ,
+                                            fsim_gate=cirq.google.SYC,
+                                            qubits=cirq.LineQubit.range(3))
+
+
+def test_circuit_structure():
+    circuit = cirq.decompose_cphase_into_two_fsim(cirq.CZ,
+                                                  fsim_gate=cirq.google.SYC)
+    assert len(circuit) == 5
+
+    # First moment consists of 0- and 1-qubit operations.
+    assert set(len(op.qubits) for op in circuit[0].operations) == {0, 1}
+
+    # Second moment consists of a single Sycamore gate.
+    assert len(circuit[1]) == 1
+    assert isinstance(circuit[1].operations[0].gate, cirq.google.SycamoreGate)
+
+    # Third moment consists of 1-qubit operations only.
+    assert set(len(op.qubits) for op in circuit[2].operations) == {1}
+
+    # Fourth moment consists of a single Sycamore gate.
+    assert len(circuit[3]) == 1
+    assert isinstance(circuit[3].operations[0].gate, cirq.google.SycamoreGate)
+
+    # Fifth moment consists of 1-qubit operations only.
+    assert set(len(op.qubits) for op in circuit[4].operations) == {1}
+
+
+def assert_decomposition_valid(cphase_gate, fsim_gate):
+    u_expected = cirq.unitary(cphase_gate)
+    circuit = cirq.decompose_cphase_into_two_fsim(cphase_gate,
+                                                  fsim_gate=fsim_gate)
+    u_actual = cirq.unitary(circuit)
+    assert np.allclose(u_actual, u_expected)
+
+
+@pytest.mark.parametrize(
+    'exponent', (-5.5, -3, -1.5, -1, -0.65, -0.2, 0, 0.1, 0.75, 1, 1.5, 2, 5.5))
+def test_decomposition_to_sycamore_gate(exponent):
+    cphase_gate = cirq.CZPowGate(exponent=exponent)
+    assert_decomposition_valid(cphase_gate, cirq.google.SYC)
+
+
+@pytest.mark.parametrize(
+    'theta, phi',
+    itertools.product(
+        (-2.4 * np.pi, -np.pi / 11, np.pi / 9, np.pi / 2, 1.4 * np.pi),
+        (-1.4 * np.pi, -np.pi / 9, np.pi / 11, np.pi / 2, 2.4 * np.pi)))
+def test_valid_cphase_exponents(theta, phi):
+    fsim_gate = cirq.FSimGate(theta=theta, phi=phi)
+    valid_exponent_intervals = (
+        cirq.compute_cphase_exponents_for_fsim_decomposition(fsim_gate))
+    assert valid_exponent_intervals
+
+    for min_exponent, max_exponent in valid_exponent_intervals:
+        margin = 1e-8
+        min_exponent += margin
+        max_exponent -= margin
+        assert min_exponent < max_exponent
+        for exponent in np.linspace(min_exponent, max_exponent, 3):
+            for d in (-2, 0, 4):
+                cphase_gate = cirq.CZPowGate(exponent=exponent + d)
+                assert_decomposition_valid(cphase_gate, fsim_gate=fsim_gate)
+                cphase_gate = cirq.CZPowGate(exponent=-exponent + d)
+                assert_decomposition_valid(cphase_gate, fsim_gate=fsim_gate)
+
+
+def complement_intervals(intervals: Sequence[Tuple[float, float]]
+                        ) -> Sequence[Tuple[float, float]]:
+    """Computes complement of union of intervals in [0, 2]."""
+    complements: List[Tuple[float, float]] = []
+    a = 0.0
+    for b, c in intervals:
+        complements.append((a, b))
+        a = c
+    complements.append((a, 2.0))
+    return tuple((a, b) for a, b in complements if a < b)
+
+
+@pytest.mark.parametrize('theta, phi',
+                         itertools.product(
+                             (-2.3 * np.pi, -np.pi / 7, np.pi / 5, 1.8 * np.pi),
+                             (-1.7 * np.pi, -np.pi / 5, np.pi / 7, 2.5 * np.pi))
+                        )
+def test_invalid_cphase_exponents(theta, phi):
+    fsim_gate = cirq.FSimGate(theta=theta, phi=phi)
+    valid_exponent_intervals = (
+        cirq.compute_cphase_exponents_for_fsim_decomposition(fsim_gate))
+    invalid_exponent_intervals = complement_intervals(valid_exponent_intervals)
+    assert invalid_exponent_intervals
+
+    for min_exponent, max_exponent in invalid_exponent_intervals:
+        margin = 1e-8
+        min_exponent += margin
+        max_exponent -= margin
+        assert min_exponent < max_exponent
+        for exponent in np.linspace(min_exponent, max_exponent, 3):
+            with pytest.raises(ValueError):
+                cphase_gate = cirq.CZPowGate(exponent=exponent)
+                assert_decomposition_valid(cphase_gate, fsim_gate=fsim_gate)
+
+
+@pytest.mark.parametrize('bad_fsim_gate', (cirq.FSimGate(
+    theta=0, phi=0), cirq.FSimGate(theta=np.pi / 4, phi=np.pi / 2)))
+def test_invalid_fsim_gate(bad_fsim_gate):
+    with pytest.raises(ValueError):
+        cirq.decompose_cphase_into_two_fsim(cirq.CZ, fsim_gate=bad_fsim_gate)

--- a/cirq/optimizers/cphase_to_fsim_test.py
+++ b/cirq/optimizers/cphase_to_fsim_test.py
@@ -34,23 +34,21 @@ def test_invalid_qubits():
 
 
 def test_circuit_structure():
-    circuit = cirq.decompose_cphase_into_two_fsim(cirq.CZ,
-                                                  fsim_gate=cirq.google.SYC)
+    ops = cirq.decompose_cphase_into_two_fsim(cirq.CZ,
+                                              fsim_gate=cirq.google.SYC)
     num_interaction_moments = 0
-    for moment in circuit:
-        for op in moment.operations:
-            assert len(op.qubits) in (0, 1, 2)
-            if len(op.qubits) == 2:
-                num_interaction_moments += 1
-                assert isinstance(op.gate, cirq.google.SycamoreGate)
+    for op in ops:
+        assert len(op.qubits) in (0, 1, 2)
+        if len(op.qubits) == 2:
+            num_interaction_moments += 1
+            assert isinstance(op.gate, cirq.google.SycamoreGate)
     assert num_interaction_moments == 2
 
 
 def assert_decomposition_valid(cphase_gate, fsim_gate):
     u_expected = cirq.unitary(cphase_gate)
-    circuit = cirq.decompose_cphase_into_two_fsim(cphase_gate,
-                                                  fsim_gate=fsim_gate)
-    u_actual = cirq.unitary(circuit)
+    ops = cirq.decompose_cphase_into_two_fsim(cphase_gate, fsim_gate=fsim_gate)
+    u_actual = cirq.unitary(cirq.Circuit(ops))
     assert np.allclose(u_actual, u_expected)
 
 

--- a/cirq/optimizers/cphase_to_fsim_test.py
+++ b/cirq/optimizers/cphase_to_fsim_test.py
@@ -36,24 +36,14 @@ def test_invalid_qubits():
 def test_circuit_structure():
     circuit = cirq.decompose_cphase_into_two_fsim(cirq.CZ,
                                                   fsim_gate=cirq.google.SYC)
-    assert len(circuit) == 5
-
-    # First moment consists of 0- and 1-qubit operations.
-    assert set(len(op.qubits) for op in circuit[0].operations) == {0, 1}
-
-    # Second moment consists of a single Sycamore gate.
-    assert len(circuit[1]) == 1
-    assert isinstance(circuit[1].operations[0].gate, cirq.google.SycamoreGate)
-
-    # Third moment consists of 1-qubit operations only.
-    assert set(len(op.qubits) for op in circuit[2].operations) == {1}
-
-    # Fourth moment consists of a single Sycamore gate.
-    assert len(circuit[3]) == 1
-    assert isinstance(circuit[3].operations[0].gate, cirq.google.SycamoreGate)
-
-    # Fifth moment consists of 1-qubit operations only.
-    assert set(len(op.qubits) for op in circuit[4].operations) == {1}
+    num_interaction_moments = 0
+    for moment in circuit:
+        for op in moment.operations:
+            assert len(op.qubits) in (0, 1, 2)
+            if len(op.qubits) == 2:
+                num_interaction_moments += 1
+                assert isinstance(op.gate, cirq.google.SycamoreGate)
+    assert num_interaction_moments == 2
 
 
 def assert_decomposition_valid(cphase_gate, fsim_gate):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -314,7 +314,9 @@ the magic methods that can be implemented.
     cirq.approx_eq
     cirq.channel
     cirq.circuit_diagram_info
+    cirq.compute_cphase_exponents_for_fsim_decomposition
     cirq.decompose
+    cirq.decompose_cphase_into_two_fsim
     cirq.decompose_once
     cirq.decompose_once_with_qubits
     cirq.equal_up_to_global_phase


### PR DESCRIPTION
This implements the decomposition described in section VII F I of the [supplement](https://arxiv.org/abs/1910.11333) to the quantum supremacy paper.