### PR TITLE
Generalize resolve_parameters to allow resolving to custom datatypes

### DIFF
--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -91,7 +91,7 @@ def resolve_parameters(
 
     # Ensure its a dictionary wrapped in a ParamResolver.
     param_resolver = study.ParamResolver(param_resolver)
-    if isinstance(val, sympy.Basic):
+    if isinstance(val, (str, sympy.Basic)):
         return param_resolver.value_of(val)
     if isinstance(val, (list, tuple)):
         return type(val)(resolve_parameters(e, param_resolver) for e in val)

--- a/cirq/value/type_alias.py
+++ b/cirq/value/type_alias.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import Union, Any
 import sympy
 
 from cirq._doc import document
 """Supply aliases for commonly used types.
 """
 
-TParamVal = Union[float, sympy.Basic]
+TParamVal = Union[float, sympy.Basic, Any]
 document(
     TParamVal,  # type: ignore
     """A value that a parameter resolver may return for a symbol.""")


### PR DESCRIPTION
- Currently iterables are not allowed due to collision with cartesian shorthand
- Fix some recursive resolution bugs

This is a potentially large semantic change, so will discuss at weekly meeting before merging.