### PR TITLE
Add timeout to engine object

### DIFF
--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -124,6 +124,7 @@ class Engine:
             service_args: Optional[Dict] = None,
             verbose: Optional[bool] = None,
             context: Optional[EngineContext] = None,
+            timeout: Optional[int] = None,
     ) -> None:
         """Supports creating and running programs against the Quantum Engine.
 
@@ -138,6 +139,8 @@ class Engine:
                 configure options on the underlying client.
             verbose: Suppresses stderr messages when set to False. Default is
                 true.
+            timeout: Timeout for polling for results, in seconds.  Default is
+                to never timeout
         """
         if context and (proto_version or service_args or verbose):
             raise ValueError(
@@ -150,6 +153,7 @@ class Engine:
                                     service_args=service_args,
                                     verbose=verbose)
         self.context = context
+        self.timeout = timeout
 
     def run(
             self,
@@ -303,8 +307,11 @@ class Engine:
             description=description,
             labels=labels)
 
-        return engine_program.EngineProgram(self.project_id, new_program_id,
-                                            self.context, new_program)
+        return engine_program.EngineProgram(self.project_id,
+                                            new_program_id,
+                                            self.context,
+                                            new_program,
+                                            timeout=self.timeout)
 
     def _serialize_program(
             self,

--- a/cirq/google/engine/engine_job.py
+++ b/cirq/google/engine/engine_job.py
@@ -53,8 +53,7 @@ class EngineJob:
                  program_id: str,
                  job_id: str,
                  context: 'engine_base.EngineContext',
-                 _job: Optional[quantum.types.QuantumJob] = None,
-                 timeout: Optional[int] = None) -> None:
+                 _job: Optional[quantum.types.QuantumJob] = None) -> None:
         """A job submitted to the engine.
 
         Args:
@@ -63,7 +62,6 @@ class EngineJob:
             job_id: Unique ID of the job within the parent program.
             context: Engine configuration and context to use.
             _job: The optional current job state.
-            timeout: Seconds to wait for results before time out
         """
         self.project_id = project_id
         self.program_id = program_id
@@ -71,7 +69,6 @@ class EngineJob:
         self.context = context
         self._job = _job
         self._results: Optional[List[study.TrialResult]] = None
-        self.timeout = timeout
 
     def engine(self) -> 'engine_base.Engine':
         """Returns the parent Engine object."""
@@ -266,8 +263,9 @@ class EngineJob:
         if not self._results:
             job = self._refresh_job()
             total_seconds_waited = 0.0
+            timeout = self.context.timeout
             while True:
-                if self.timeout and total_seconds_waited >= self.timeout:
+                if timeout and total_seconds_waited >= timeout:
                     break
                 if job.execution_status.state in TERMINAL_STATES:
                     break

--- a/cirq/google/engine/engine_job_test.py
+++ b/cirq/google/engine/engine_job_test.py
@@ -374,7 +374,7 @@ def test_timeout(patched_time_sleep, get_job):
     qjob = qtypes.QuantumJob(execution_status=qtypes.ExecutionStatus(
         state=qtypes.ExecutionStatus.State.RUNNING))
     get_job.return_value = qjob
-    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), timeout=500)
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(timeout=500))
     with pytest.raises(RuntimeError, match='Timed out'):
         job.results()
 

--- a/cirq/google/engine/engine_job_test.py
+++ b/cirq/google/engine/engine_job_test.py
@@ -374,7 +374,7 @@ def test_timeout(patched_time_sleep, get_job):
     qjob = qtypes.QuantumJob(execution_status=qtypes.ExecutionStatus(
         state=qtypes.ExecutionStatus.State.RUNNING))
     get_job.return_value = qjob
-    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), timeout=500)
     with pytest.raises(RuntimeError, match='Timed out'):
         job.results()
 

--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -40,7 +40,8 @@ class EngineProgram:
                  project_id: str,
                  program_id: str,
                  context: 'engine_base.EngineContext',
-                 _program: Optional[qtypes.QuantumProgram] = None) -> None:
+                 _program: Optional[qtypes.QuantumProgram] = None,
+                 timeout: Optional[int] = None) -> None:
         """A job submitted to the engine.
 
         Args:
@@ -48,11 +49,13 @@ class EngineProgram:
             program_id: Unique ID of the program within the parent project.
             context: Engine configuration and context to use.
             _program: The optional current program state.
+            timeout: Seconds to wait for job results before timeout
         """
         self.project_id = project_id
         self.program_id = program_id
         self.context = context
         self._program = _program
+        self.timeout = timeout
 
     def run_sweep(
             self,
@@ -99,8 +102,12 @@ class EngineProgram:
             run_context=run_context,
             description=description,
             labels=labels)
-        return engine_job.EngineJob(self.project_id, self.program_id,
-                                    created_job_id, self.context, job)
+        return engine_job.EngineJob(self.project_id,
+                                    self.program_id,
+                                    created_job_id,
+                                    self.context,
+                                    job,
+                                    timeout=self.timeout)
 
     def run(
             self,

--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -40,8 +40,7 @@ class EngineProgram:
                  project_id: str,
                  program_id: str,
                  context: 'engine_base.EngineContext',
-                 _program: Optional[qtypes.QuantumProgram] = None,
-                 timeout: Optional[int] = None) -> None:
+                 _program: Optional[qtypes.QuantumProgram] = None) -> None:
         """A job submitted to the engine.
 
         Args:
@@ -49,13 +48,11 @@ class EngineProgram:
             program_id: Unique ID of the program within the parent project.
             context: Engine configuration and context to use.
             _program: The optional current program state.
-            timeout: Seconds to wait for job results before timeout
         """
         self.project_id = project_id
         self.program_id = program_id
         self.context = context
         self._program = _program
-        self.timeout = timeout
 
     def run_sweep(
             self,
@@ -102,12 +99,8 @@ class EngineProgram:
             run_context=run_context,
             description=description,
             labels=labels)
-        return engine_job.EngineJob(self.project_id,
-                                    self.program_id,
-                                    created_job_id,
-                                    self.context,
-                                    job,
-                                    timeout=self.timeout)
+        return engine_job.EngineJob(self.project_id, self.program_id,
+                                    created_job_id, self.context, job)
 
     def run(
             self,

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -338,7 +338,7 @@ def test_run_circuit_timeout(patched_time_sleep, client):
             'state': 'RUNNING',
         })
 
-    engine = cg.Engine(project_id='project-id')
+    engine = cg.Engine(project_id='project-id', timeout=600)
     with pytest.raises(RuntimeError, match='Timed out'):
         engine.run(program=_CIRCUIT)
 


### PR DESCRIPTION
- Adds timeout to Engine object and makes it configurable
- This plumbs the timeout down to results object so that the
amount of polling is configurable.

Solves #2817 