### PR TITLE
Fix some documentation for engine

### DIFF
--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -75,7 +75,8 @@ class EngineContext:
         """Context and client for using Quantum Engine.
 
         Args:
-            proto_version: The version of cirq protos to use.
+            proto_version: The version of cirq protos to use. If None, then
+                ProtoVersion.V2 will be used.
             service_args: A dictionary of arguments that can be used to
                 configure options on the underlying client.
             verbose: Suppresses stderr messages when set to False. Default is
@@ -133,7 +134,8 @@ class Engine:
                 resources created will be owned by the project. See
                 https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
             context: Engine configuration and context to use.
-            proto_version: The version of cirq protos to use.
+            proto_version: The version of cirq protos to use. If None, then
+                ProtoVersion.V2 will be used.
             service_args: A dictionary of arguments that can be used to
                 configure options on the underlying client.
             verbose: Suppresses stderr messages when set to False. Default is

--- a/docs/google/calibration.md
+++ b/docs/google/calibration.md
@@ -20,7 +20,7 @@ import cirq.google as cg
 
 # Create an Engine object to use.
 # Replace YOUR_PROJECT_ID with the id from your cloud project.
-engine = cg.Engine(project_id=YOUR_PROJECT_ID, proto_version=cg.ProtoVersion.V2)
+engine = cg.Engine(project_id=YOUR_PROJECT_ID)
 processor = engine.get_processor(processor_id=PROCESSOR_ID)
 
 # Get the latest calibration metrics.

--- a/docs/google/engine.md
+++ b/docs/google/engine.md
@@ -56,7 +56,7 @@ circuit = cirq.Circuit(
 
 # Create an Engine object to use.
 # Replace YOUR_PROJECT_ID with the id from your cloud project.
-engine = cg.Engine(project_id=YOUR_PROJECT_ID, proto_version=cg.ProtoVersion.V2)
+engine = cg.Engine(project_id=YOUR_PROJECT_ID)
 
 # Create a sampler from the engine
 sampler = engine.sampler(processor_id='PROCESSOR_ID', gate_set=cg.SYC_GATESET)
@@ -94,9 +94,11 @@ device specifications.
 ## Calibration Metrics
 
 Metrics from the current status of the device can be retrieved using the\
-`get_latest_calibration` method of the `Engine` object.  This will return a
-Python dictionary where each key is the metric name.  The value of the
-dictionary will be the value of the metric, which can also be a dictionary.
+`get_current_calibration` method of an `EngineProcessor` object.  
+`EngineProcessor` objects can be retrieved from `Engine` using `get_processor`.
+This will return a Python dictionary where each key is the metric name.  The 
+value of the dictionary will be the value of the metric, which can also be 
+a dictionary.
 
 For example, the key may refer to a two-qubit gate error, and the value may
 be a dictionary from 2-tuples of `cirq.GridQubits` to an error rate represented

--- a/docs/google/specification.md
+++ b/docs/google/specification.md
@@ -40,8 +40,7 @@ device is shown below:
 import cirq
 
 # Create an Engine object to use.
-engine = cirq.google.Engine(project_id='your_project_id',
-                            proto_version=cirq.google.ProtoVersion.V2)
+engine = cirq.google.Engine(project_id='your_project_id')
 
 # Replace the processor id to get the device specification with that id.
 spec = engine.get_processor('processor_id').get_device_specification()
@@ -52,7 +51,7 @@ for gateset in spec.valid_gate_sets:
     print('-------')
     # Prints each gate valid in the set with its duration
     for gate in gateset.valid_gates:
-      print('%s %d' % (gate.id, gate.gate_duration_picos))
+        print('%s %d' % (gate.id, gate.gate_duration_picos))
 ```
 
 Note that, by convention, measurement gate duration includes both the duration


### PR DESCRIPTION
* Clarified that not specifying the proto version gives you version 2
* Removed protoversion defaults from example code
* Fixed remaining use of `get_latest_calibration` in docs, which no longer exists.