### PR TITLE
[SVG Circuits] Give up gracefully on gates with big labels

### DIFF
--- a/cirq/contrib/svg/svg.py
+++ b/cirq/contrib/svg/svg.py
@@ -9,6 +9,8 @@ QBLUE = '#1967d2'
 
 
 def _get_text_width(t: str) -> float:
+    if '\n' in t:
+        return _get_text_width('?')
     tp = matplotlib.textpath.TextPath((0, 0), t, size=14, prop='Arial')
     bb = tp.get_extents()
     return bb.width + 10
@@ -205,6 +207,10 @@ def tdd_to_svg(
             continue
         if v.text == '×':
             t += _text(x, y + 3, '×', fontsize=40)
+            continue
+        if '\n' in v.text:
+            t += _rect(boxx, boxy, boxwidth, boxheight)
+            t += _text(x, y, '?', fontsize=18)
             continue
 
         t += _rect(boxx, boxy, boxwidth, boxheight)

--- a/cirq/contrib/svg/svg_test.py
+++ b/cirq/contrib/svg/svg_test.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 
 import cirq
 from cirq.contrib.svg import circuit_to_svg
@@ -9,9 +10,14 @@ def test_svg():
 
     svg_text = circuit_to_svg(
         cirq.Circuit(
-            cirq.CNOT(a, b), cirq.CZ(b, c), cirq.SWAP(a, c),
+            cirq.CNOT(a, b),
+            cirq.CZ(b, c),
+            cirq.SWAP(a, c),
             cirq.PhasedXPowGate(exponent=0.123, phase_exponent=0.456).on(c),
-            cirq.Z(a), cirq.measure(a, b, c, key='z')))
+            cirq.Z(a),
+            cirq.measure(a, b, c, key='z'),
+            cirq.MatrixGate(np.eye(2)).on(a),
+        ))
     assert '<svg' in svg_text
     assert '</svg>' in svg_text
 


### PR DESCRIPTION
`MatrixGate` tries to print its whole matrix which is just huge. This PR hacks in a check that uses `?` for any gate whose label includes a newline. I will quickly remind reviewers that this functionality is in contrib, xref #2313 if anyone wants to "productionize" this functionality. 