### PR TITLE
Fix an equation which does not display correctly in nbsphinx.

### DIFF
--- a/docs/tutorials/variational_algorithm.ipynb
+++ b/docs/tutorials/variational_algorithm.ipynb
@@ -260,7 +260,7 @@
       "source": [
         "Another important concept here is that the rotation gate is specified in *half turns* ($ht$). For a rotation about `X`, the gate is:\n",
         "\n",
-        "$ \\cos(ht * \\pi) I + i \\sin(ht * \\pi) X$\n",
+        "$\\cos(ht * \\pi) I + i \\sin(ht * \\pi) X$\n",
         "\n",
         "There is a lot of freedom defining a variational ansatz. Here we will do a variation on a [QAOA strategy](https://arxiv.org/abs/1411.4028) and define an ansatz related to the problem we are trying to solve.\n",
         "\n",


### PR DESCRIPTION
The extra space causes the equation not to be displayed properly in readthedocs:

<img width="743" alt="Screenshot 2020-05-15 at 14 33 34" src="https://user-images.githubusercontent.com/9248532/82051155-a768c980-96b9-11ea-8c12-f40094ef0e24.png">

The equation displays correctly when viewed in a Jupyter notebook:

<img width="794" alt="Screenshot 2020-05-15 at 14 34 45" src="https://user-images.githubusercontent.com/9248532/82051185-b3ed2200-96b9-11ea-98e2-b442fa93b562.png">

