### PR TITLE
ContextManager for testing logs

### DIFF
--- a/cirq/linalg/states_test.py
+++ b/cirq/linalg/states_test.py
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 import cirq
-from cirq._compat_test import capture_logging
+import cirq.testing
 
 
 def test_deprecated():
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.eye_tensor', 'deprecated'):
         _ = cirq.linalg.eye_tensor((1,), dtype=float)
-    assert len(log) == 1
-    assert "cirq.eye_tensor" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.one_hot', 'deprecated'):
         _ = cirq.linalg.one_hot(shape=(1,), dtype=float)
-    assert len(log) == 1
-    assert "cirq.one_hot" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -45,7 +45,7 @@ class Moment:
 
     @deprecated_parameter(
         deadline='v0.9',
-        fix="Don't specify a keyword.",
+        fix='Don\'t specify a keyword.',
         match=lambda _, kwargs: 'operations' in kwargs,
         parameter_desc='operations',
         rewrite=lambda args, kwargs: (args + (kwargs['operations'],), {}))

--- a/cirq/ops/moment_test.py
+++ b/cirq/ops/moment_test.py
@@ -15,8 +15,7 @@
 import pytest
 
 import cirq
-from cirq import Moment
-from cirq._compat_test import capture_logging
+import cirq.testing
 
 
 def test_validation():
@@ -25,20 +24,20 @@ def test_validation():
     c = cirq.NamedQubit('c')
     d = cirq.NamedQubit('d')
 
-    _ = Moment([])
-    _ = Moment([cirq.X(a)])
-    _ = Moment([cirq.CZ(a, b)])
-    _ = Moment([cirq.CZ(b, d)])
-    _ = Moment([cirq.CZ(a, b), cirq.CZ(c, d)])
-    _ = Moment([cirq.CZ(a, c), cirq.CZ(b, d)])
-    _ = Moment([cirq.CZ(a, c), cirq.X(b)])
+    _ = cirq.Moment([])
+    _ = cirq.Moment([cirq.X(a)])
+    _ = cirq.Moment([cirq.CZ(a, b)])
+    _ = cirq.Moment([cirq.CZ(b, d)])
+    _ = cirq.Moment([cirq.CZ(a, b), cirq.CZ(c, d)])
+    _ = cirq.Moment([cirq.CZ(a, c), cirq.CZ(b, d)])
+    _ = cirq.Moment([cirq.CZ(a, c), cirq.X(b)])
 
     with pytest.raises(ValueError):
-        _ = Moment([cirq.X(a), cirq.X(a)])
+        _ = cirq.Moment([cirq.X(a), cirq.X(a)])
     with pytest.raises(ValueError):
-        _ = Moment([cirq.CZ(a, c), cirq.X(c)])
+        _ = cirq.Moment([cirq.CZ(a, c), cirq.X(c)])
     with pytest.raises(ValueError):
-        _ = Moment([cirq.CZ(a, c), cirq.CZ(c, d)])
+        _ = cirq.Moment([cirq.CZ(a, c), cirq.CZ(c, d)])
 
 
 def test_equality():
@@ -50,46 +49,45 @@ def test_equality():
     eq = cirq.testing.EqualsTester()
 
     # Default is empty. Iterables get frozen into tuples.
-    eq.add_equality_group(Moment(),
-                          Moment([]), Moment(()))
-    eq.add_equality_group(
-        Moment([cirq.X(d)]), Moment((cirq.X(d),)))
+    eq.add_equality_group(cirq.Moment(), cirq.Moment([]), cirq.Moment(()))
+    eq.add_equality_group(cirq.Moment([cirq.X(d)]), cirq.Moment((cirq.X(d),)))
 
     # Equality depends on gate and qubits.
-    eq.add_equality_group(Moment([cirq.X(a)]))
-    eq.add_equality_group(Moment([cirq.X(b)]))
-    eq.add_equality_group(Moment([cirq.Y(a)]))
+    eq.add_equality_group(cirq.Moment([cirq.X(a)]))
+    eq.add_equality_group(cirq.Moment([cirq.X(b)]))
+    eq.add_equality_group(cirq.Moment([cirq.Y(a)]))
 
     # Equality doesn't depend on order.
-    eq.add_equality_group(Moment([cirq.X(a), cirq.X(b)]),
-                          Moment([cirq.X(a), cirq.X(b)]))
+    eq.add_equality_group(cirq.Moment([cirq.X(a), cirq.X(b)]),
+                          cirq.Moment([cirq.X(a), cirq.X(b)]))
 
     # Two qubit gates.
-    eq.make_equality_group(lambda: Moment([cirq.CZ(c, d)]))
-    eq.make_equality_group(lambda: Moment([cirq.CZ(a, c)]))
-    eq.make_equality_group(lambda: Moment([cirq.CZ(a, b), cirq.CZ(c, d)]))
-    eq.make_equality_group(lambda: Moment([cirq.CZ(a, c), cirq.CZ(b, d)]))
+    eq.make_equality_group(lambda: cirq.Moment([cirq.CZ(c, d)]))
+    eq.make_equality_group(lambda: cirq.Moment([cirq.CZ(a, c)]))
+    eq.make_equality_group(lambda: cirq.Moment([cirq.CZ(a, b), cirq.CZ(c, d)]))
+    eq.make_equality_group(lambda: cirq.Moment([cirq.CZ(a, c), cirq.CZ(b, d)]))
 
 
 def test_approx_eq():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
-    assert not cirq.approx_eq(Moment([cirq.X(a)]), cirq.X(a))
+    assert not cirq.approx_eq(cirq.Moment([cirq.X(a)]), cirq.X(a))
 
     # Default is empty. Iterables get frozen into tuples.
-    assert cirq.approx_eq(Moment(), Moment([]))
-    assert cirq.approx_eq(Moment([]), Moment(()))
+    assert cirq.approx_eq(cirq.Moment(), cirq.Moment([]))
+    assert cirq.approx_eq(cirq.Moment([]), cirq.Moment(()))
 
-    assert cirq.approx_eq(Moment([cirq.X(a)]), Moment([cirq.X(a)]))
-    assert not cirq.approx_eq(Moment([cirq.X(a)]), Moment([cirq.X(b)]))
+    assert cirq.approx_eq(cirq.Moment([cirq.X(a)]), cirq.Moment([cirq.X(a)]))
+    assert not cirq.approx_eq(cirq.Moment([cirq.X(a)]), cirq.Moment([cirq.X(b)
+                                                                    ]))
 
-    assert cirq.approx_eq(Moment([cirq.XPowGate(exponent=0)(a)]),
-                          Moment([cirq.XPowGate(exponent=1e-9)(a)]))
-    assert not cirq.approx_eq(Moment([cirq.XPowGate(exponent=0)(a)]),
-                              Moment([cirq.XPowGate(exponent=1e-7)(a)]))
-    assert cirq.approx_eq(Moment([cirq.XPowGate(exponent=0)(a)]),
-                          Moment([cirq.XPowGate(exponent=1e-7)(a)]),
+    assert cirq.approx_eq(cirq.Moment([cirq.XPowGate(exponent=0)(a)]),
+                          cirq.Moment([cirq.XPowGate(exponent=1e-9)(a)]))
+    assert not cirq.approx_eq(cirq.Moment([cirq.XPowGate(exponent=0)(a)]),
+                              cirq.Moment([cirq.XPowGate(exponent=1e-7)(a)]))
+    assert cirq.approx_eq(cirq.Moment([cirq.XPowGate(exponent=0)(a)]),
+                          cirq.Moment([cirq.XPowGate(exponent=1e-7)(a)]),
                           atol=1e-6)
 
 
@@ -99,47 +97,47 @@ def test_operates_on():
     c = cirq.NamedQubit('c')
 
     # Empty case.
-    assert not Moment().operates_on([])
-    assert not Moment().operates_on([a])
-    assert not Moment().operates_on([b])
-    assert not Moment().operates_on([a, b])
+    assert not cirq.Moment().operates_on([])
+    assert not cirq.Moment().operates_on([a])
+    assert not cirq.Moment().operates_on([b])
+    assert not cirq.Moment().operates_on([a, b])
 
     # One-qubit operation case.
-    assert not Moment([cirq.X(a)]).operates_on([])
-    assert Moment([cirq.X(a)]).operates_on([a])
-    assert not Moment([cirq.X(a)]).operates_on([b])
-    assert Moment([cirq.X(a)]).operates_on([a, b])
+    assert not cirq.Moment([cirq.X(a)]).operates_on([])
+    assert cirq.Moment([cirq.X(a)]).operates_on([a])
+    assert not cirq.Moment([cirq.X(a)]).operates_on([b])
+    assert cirq.Moment([cirq.X(a)]).operates_on([a, b])
 
     # Two-qubit operation case.
-    assert not Moment([cirq.CZ(a, b)]).operates_on([])
-    assert Moment([cirq.CZ(a, b)]).operates_on([a])
-    assert Moment([cirq.CZ(a, b)]).operates_on([b])
-    assert Moment([cirq.CZ(a, b)]).operates_on([a, b])
-    assert not Moment([cirq.CZ(a, b)]).operates_on([c])
-    assert Moment([cirq.CZ(a, b)]).operates_on([a, c])
-    assert Moment([cirq.CZ(a, b)]).operates_on([a, b, c])
+    assert not cirq.Moment([cirq.CZ(a, b)]).operates_on([])
+    assert cirq.Moment([cirq.CZ(a, b)]).operates_on([a])
+    assert cirq.Moment([cirq.CZ(a, b)]).operates_on([b])
+    assert cirq.Moment([cirq.CZ(a, b)]).operates_on([a, b])
+    assert not cirq.Moment([cirq.CZ(a, b)]).operates_on([c])
+    assert cirq.Moment([cirq.CZ(a, b)]).operates_on([a, c])
+    assert cirq.Moment([cirq.CZ(a, b)]).operates_on([a, b, c])
 
     # Multiple operations case.
-    assert not Moment([cirq.X(a), cirq.X(b)]).operates_on([])
-    assert Moment([cirq.X(a), cirq.X(b)]).operates_on([a])
-    assert Moment([cirq.X(a), cirq.X(b)]).operates_on([b])
-    assert Moment([cirq.X(a), cirq.X(b)]).operates_on([a, b])
-    assert not Moment([cirq.X(a), cirq.X(b)]).operates_on([c])
-    assert Moment([cirq.X(a), cirq.X(b)]).operates_on([a, c])
-    assert Moment([cirq.X(a), cirq.X(b)]).operates_on([a, b, c])
+    assert not cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([])
+    assert cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([a])
+    assert cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([b])
+    assert cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([a, b])
+    assert not cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([c])
+    assert cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([a, c])
+    assert cirq.Moment([cirq.X(a), cirq.X(b)]).operates_on([a, b, c])
 
 
 def test_with_operation():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
-    assert Moment().with_operation(cirq.X(a)) == Moment([cirq.X(a)])
+    assert cirq.Moment().with_operation(cirq.X(a)) == cirq.Moment([cirq.X(a)])
 
-    assert (Moment([cirq.X(a)]).with_operation(cirq.X(b)) ==
-            Moment([cirq.X(a), cirq.X(b)]))
+    assert (cirq.Moment([cirq.X(a)]).with_operation(cirq.X(b)) == cirq.Moment(
+        [cirq.X(a), cirq.X(b)]))
 
     with pytest.raises(ValueError):
-        _ = Moment([cirq.X(a)]).with_operation(cirq.X(a))
+        _ = cirq.Moment([cirq.X(a)]).with_operation(cirq.X(a))
 
 
 def test_without_operations_touching():
@@ -148,53 +146,47 @@ def test_without_operations_touching():
     c = cirq.NamedQubit('c')
 
     # Empty case.
-    assert Moment().without_operations_touching([]) == Moment()
-    assert Moment().without_operations_touching([a]) == Moment()
-    assert Moment().without_operations_touching([a, b]) == Moment()
+    assert cirq.Moment().without_operations_touching([]) == cirq.Moment()
+    assert cirq.Moment().without_operations_touching([a]) == cirq.Moment()
+    assert cirq.Moment().without_operations_touching([a, b]) == cirq.Moment()
 
     # One-qubit operation case.
-    assert (Moment([cirq.X(a)]).without_operations_touching([]) ==
-            Moment([cirq.X(a)]))
-    assert (Moment([cirq.X(a)]).without_operations_touching([a]) ==
-            Moment())
-    assert (Moment([cirq.X(a)]).without_operations_touching([b]) ==
-            Moment([cirq.X(a)]))
+    assert (cirq.Moment([cirq.X(a)]).without_operations_touching(
+        []) == cirq.Moment([cirq.X(a)]))
+    assert (cirq.Moment([cirq.X(a)
+                        ]).without_operations_touching([a]) == cirq.Moment())
+    assert (cirq.Moment([cirq.X(a)]).without_operations_touching(
+        [b]) == cirq.Moment([cirq.X(a)]))
 
     # Two-qubit operation case.
-    assert (Moment([cirq.CZ(a, b)]).without_operations_touching([]) ==
-            Moment([cirq.CZ(a, b)]))
-    assert (Moment([cirq.CZ(a, b)]).without_operations_touching([a]) ==
-            Moment())
-    assert (Moment([cirq.CZ(a, b)]).without_operations_touching([b]) ==
-            Moment())
-    assert (Moment([cirq.CZ(a, b)]).without_operations_touching([c]) ==
-            Moment([cirq.CZ(a, b)]))
+    assert (cirq.Moment([cirq.CZ(a, b)]).without_operations_touching(
+        []) == cirq.Moment([cirq.CZ(a, b)]))
+    assert (cirq.Moment([cirq.CZ(a, b)
+                        ]).without_operations_touching([a]) == cirq.Moment())
+    assert (cirq.Moment([cirq.CZ(a, b)
+                        ]).without_operations_touching([b]) == cirq.Moment())
+    assert (cirq.Moment([cirq.CZ(a, b)]).without_operations_touching(
+        [c]) == cirq.Moment([cirq.CZ(a, b)]))
 
     # Multiple operation case.
-    assert (Moment([cirq.CZ(a, b),
-                    cirq.X(c)]).without_operations_touching([]) ==
-            Moment([cirq.CZ(a, b), cirq.X(c)]))
-    assert (Moment([cirq.CZ(a, b),
-                    cirq.X(c)]).without_operations_touching([a]) ==
-            Moment([cirq.X(c)]))
-    assert (Moment([cirq.CZ(a, b),
-                    cirq.X(c)]).without_operations_touching([b]) ==
-            Moment([cirq.X(c)]))
-    assert (Moment([cirq.CZ(a, b),
-                    cirq.X(c)]).without_operations_touching([c]) ==
-            Moment([cirq.CZ(a, b)]))
-    assert (Moment([cirq.CZ(a, b),
-                    cirq.X(c)]).without_operations_touching([a, b]) ==
-            Moment([cirq.X(c)]))
-    assert (Moment([cirq.CZ(a, b),
-                    cirq.X(c)]).without_operations_touching([a, c]) ==
-            Moment())
+    assert (cirq.Moment([cirq.CZ(a, b), cirq.X(c)]).without_operations_touching(
+        []) == cirq.Moment([cirq.CZ(a, b), cirq.X(c)]))
+    assert (cirq.Moment([cirq.CZ(a, b), cirq.X(c)]).without_operations_touching(
+        [a]) == cirq.Moment([cirq.X(c)]))
+    assert (cirq.Moment([cirq.CZ(a, b), cirq.X(c)]).without_operations_touching(
+        [b]) == cirq.Moment([cirq.X(c)]))
+    assert (cirq.Moment([cirq.CZ(a, b), cirq.X(c)]).without_operations_touching(
+        [c]) == cirq.Moment([cirq.CZ(a, b)]))
+    assert (cirq.Moment([cirq.CZ(a, b), cirq.X(c)]).without_operations_touching(
+        [a, b]) == cirq.Moment([cirq.X(c)]))
+    assert (cirq.Moment([cirq.CZ(a, b), cirq.X(c)
+                        ]).without_operations_touching([a, c]) == cirq.Moment())
 
 
 def test_copy():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
-    original = Moment([cirq.CZ(a, b)])
+    original = cirq.Moment([cirq.CZ(a, b)])
     copy = original.__copy__()
     assert original == copy
     assert id(original) != id(copy)
@@ -204,15 +196,15 @@ def test_qubits():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
-    assert Moment([cirq.X(a), cirq.X(b)]).qubits == {a, b}
-    assert Moment([cirq.X(a)]).qubits == {a}
-    assert Moment([cirq.CZ(a, b)]).qubits == {a, b}
+    assert cirq.Moment([cirq.X(a), cirq.X(b)]).qubits == {a, b}
+    assert cirq.Moment([cirq.X(a)]).qubits == {a}
+    assert cirq.Moment([cirq.CZ(a, b)]).qubits == {a, b}
 
 
 def test_container_methods():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
-    m = Moment([cirq.H(a), cirq.H(b)])
+    m = cirq.Moment([cirq.H(a), cirq.H(b)])
     assert list(m) == list(m.operations)
     # __iter__
     assert list(iter(m)) == list(m.operations)
@@ -223,9 +215,9 @@ def test_container_methods():
 
 
 def test_bool():
-    assert not Moment()
+    assert not cirq.Moment()
     a = cirq.NamedQubit('a')
-    assert Moment([cirq.X(a)])
+    assert cirq.Moment([cirq.X(a)])
 
 
 def test_repr():
@@ -240,7 +232,7 @@ def test_repr():
 def test_json_dict():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
-    mom = Moment([cirq.CZ(a, b)])
+    mom = cirq.Moment([cirq.CZ(a, b)])
     assert mom._json_dict_() == {
         'cirq_type': 'Moment',
         'operations': (cirq.CZ(a, b),)
@@ -310,13 +302,10 @@ def test_op_tree():
 
 
 def test_deprecated_operations_parameter():
-    with capture_logging() as log:
-        op = cirq.X(cirq.LineQubit(0))
-        assert not log
+    op = cirq.X(cirq.LineQubit(0))
+    with cirq.testing.assert_logs('Don\'t specify a keyword.'):
         # pylint: disable=unexpected-keyword-arg
         m = cirq.Moment(operations=[op])
-        # pylint: enable=unexpected-keyword-arg
-        assert log
     assert m == cirq.Moment(op)
 
 
@@ -341,12 +330,12 @@ def test_indexes_by_list_of_qubits():
     q = cirq.LineQubit.range(4)
     moment = cirq.Moment([cirq.Z(q[0]), cirq.CNOT(q[1], q[2])])
 
-    assert moment[[q[0]]] == Moment([cirq.Z(q[0])])
-    assert moment[[q[1]]] == Moment([cirq.CNOT(q[1], q[2])])
-    assert moment[[q[2]]] == Moment([cirq.CNOT(q[1], q[2])])
-    assert moment[[q[3]]] == Moment([])
+    assert moment[[q[0]]] == cirq.Moment([cirq.Z(q[0])])
+    assert moment[[q[1]]] == cirq.Moment([cirq.CNOT(q[1], q[2])])
+    assert moment[[q[2]]] == cirq.Moment([cirq.CNOT(q[1], q[2])])
+    assert moment[[q[3]]] == cirq.Moment([])
     assert moment[q[0:2]] == moment
-    assert moment[q[1:3]] == Moment([cirq.CNOT(q[1], q[2])])
-    assert moment[q[2:4]] == Moment([cirq.CNOT(q[1], q[2])])
-    assert moment[[q[0], q[3]]] == Moment([cirq.Z(q[0])])
+    assert moment[q[1:3]] == cirq.Moment([cirq.CNOT(q[1], q[2])])
+    assert moment[q[2:4]] == cirq.Moment([cirq.CNOT(q[1], q[2])])
+    assert moment[[q[0], q[3]]] == cirq.Moment([cirq.Z(q[0])])
     assert moment[q] == moment

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -14,7 +14,7 @@
 
 """Quantum gates that phase with respect to product-of-pauli observables."""
 
-from typing import Any, Optional, Sequence, Tuple, Union, TYPE_CHECKING
+from typing import Optional, Tuple, Union, TYPE_CHECKING
 
 import numpy as np
 

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -1,6 +1,6 @@
 # Copyright 2018 The Cirq Developers
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the "License");l
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #

--- a/cirq/sim/density_matrix_utils_test.py
+++ b/cirq/sim/density_matrix_utils_test.py
@@ -18,21 +18,15 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq._compat_test import capture_logging
+import cirq.testing
 
 
 def test_deprecated():
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.to_valid_density_matrix', 'deprecated'):
         _ = cirq.sim.to_valid_density_matrix(0, 1)
-    assert len(log) == 1
-    assert "cirq.to_valid_density_matrix" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.von_neumann_entropy', 'deprecated'):
         _ = cirq.sim.von_neumann_entropy(np.eye(2) / 2)
-    assert len(log) == 1
-    assert "cirq.von_neumann_entropy" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
 
 def test_sample_density_matrix_big_endian():

--- a/cirq/sim/wave_function_test.py
+++ b/cirq/sim/wave_function_test.py
@@ -19,48 +19,33 @@ import pytest
 import numpy as np
 
 import cirq
-from cirq._compat_test import capture_logging
+import cirq.testing
 
 
 def test_deprecated():
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.bloch_vector_from_state_vector',
+                                  'deprecated'):
         _ = cirq.sim.bloch_vector_from_state_vector(np.array([1, 0]), 0)
-    assert len(log) == 1
-    assert "cirq.bloch_vector_from_state_vector" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.density_matrix_from_state_vector',
+                                  'deprecated'):
         _ = cirq.sim.density_matrix_from_state_vector(np.array([1, 0]))
-    assert len(log) == 1
-    assert "cirq.density_matrix_from_state_vector" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.dirac_notation', 'deprecated'):
         _ = cirq.sim.dirac_notation(np.array([1, 0]))
-    assert len(log) == 1
-    assert "cirq.dirac_notation" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.to_valid_state_vector', 'deprecated'):
         _ = cirq.sim.to_valid_state_vector(0, 1)
-    assert len(log) == 1
-    assert "cirq.to_valid_state_vector" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('irq.validate_normalized_state',
+                                  'deprecated'):
         _ = cirq.sim.validate_normalized_state(np.array([1, 0],
                                                         dtype=np.complex64),
                                                qid_shape=(2,))
-    assert len(log) == 1
-    assert "cirq.validate_normalized_state" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
-    with capture_logging() as log:
+    with cirq.testing.assert_logs('cirq.STATE_VECTOR_LIKE', 'deprecated'):
         # Reason for type: ignore: https://github.com/python/mypy/issues/5354
         _ = cirq.sim.STATE_VECTOR_LIKE  # type: ignore
-    assert len(log) == 1
-    assert "cirq.STATE_VECTOR_LIKE" in log[0].getMessage()
-    assert "deprecated" in log[0].getMessage()
 
 
 def test_state_mixin():

--- a/cirq/testing/__init__.py
+++ b/cirq/testing/__init__.py
@@ -68,6 +68,9 @@ from cirq.testing.lin_alg_utils import (
     random_unitary,
 )
 
+from cirq.testing.logs import (
+    assert_logs,)
+
 from cirq.testing.order_tester import (
     OrderTester,)
 

--- a/cirq/testing/logs.py
+++ b/cirq/testing/logs.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Helpers for testing python logging statements."""
+"""Helper for testing python logging statements."""
 
 import logging
 from typing import ContextManager, List
@@ -25,7 +25,7 @@ def assert_logs(*matches: str,
     """A context manager for testing logging and warning events.
 
     To use this one wraps the code that is to be tested for log events within
-    the context of the ContextManager this method returns:
+    the context of this method's return value:
 
         with assert_logs(count=2, 'first_match', 'second_match') as logs:
             <code that produces python logs>
@@ -43,17 +43,14 @@ def assert_logs(*matches: str,
         level: The level at which to capture the logs. See the python logging
             module for valid levels. By default this captures at the
             `logging.WARNING` level, so this does not capture `logging.INFO`
-            or `logging.DEBUG` logs.
+            or `logging.DEBUG` logs by default.
         capture_warnings: Whether warnings from the python's `warnings` module
             are redirected to the logging system and captured.
 
     Returns:
         A ContextManager that can be entered into which captures the logs
         for code executed within the entered context. This ContextManager
-        checks that the asserts for the logs are true on exit. All of the
-        logs are captured by this ContextManager, in the order the logs
-        appear in the execution, and these can be assigned to a target
-        for future assertion.
+        checks that the asserts for the logs are true on exit.
     """
     records = []
 

--- a/cirq/testing/logs.py
+++ b/cirq/testing/logs.py
@@ -1,0 +1,84 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for testing python logging statements."""
+
+import logging
+from typing import ContextManager, List
+
+
+def assert_logs(*matches: str,
+                count: int = 1,
+                level: int = logging.WARNING,
+                capture_warnings: bool = True
+               ) -> ContextManager[List[logging.LogRecord]]:
+    """A context manager for testing logging and warning events.
+
+    To use this one wraps the code that is to be tested for log events within
+    the context of the ContextManager this method returns:
+
+        with assert_logs(count=2, 'first_match', 'second_match') as logs:
+            <code that produces python logs>
+
+    This captures the logging that occurs in the context of the with statement,
+    asserts that the number of logs is equal to `count`, and then asserts that
+    all of the strings in `matches` appear in the messages of the logs.
+    Further, the captured logs are accessible as `logs` and further testing
+    can be done beyond these simple asserts.
+
+    Args:
+        matches: Each of these is checked to see if they match, as a substring,
+            any of the captures log meassages.
+        count: The expected number of messages in logs. Defaults to 1.
+        level: The level at which to capture the logs. See the python logging
+            module for valid levels. By default this captures at the
+            `logging.WARNING` level, so this does not capture `logging.INFO`
+            or `logging.DEBUG` logs.
+        capture_warnings: Whether warnings from the python's `warnings` module
+            are redirected to the logging system and captured.
+
+    Returns:
+        A ContextManager that can be entered into which captures the logs
+        for code executed within the entered context. This ContextManager
+        checks that the asserts for the logs are true on exit. All of the
+        logs are captured by this ContextManager, in the order the logs
+        appear in the execution, and these can be assigned to a target
+        for future assertion.
+    """
+    records = []
+
+    class Handler(logging.Handler):
+
+        def emit(self, record):
+            records.append(record)
+
+        def __enter__(self):
+            logging.captureWarnings(capture_warnings)
+            logger = logging.getLogger()
+            logger.setLevel(level)
+            logger.addHandler(self)
+            return records
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            logging.getLogger().removeHandler(self)
+            if capture_warnings:
+                logging.captureWarnings(False)
+            assert len(records) == count, (
+                f'Expected {count} log message but got {len(records)}.')
+            msgs = [record.getMessage() for record in records]
+            for match in matches:
+                assert match in ''.join(msgs), (
+                    f'{match} expected to appear in log messages but it was '
+                    f'not found. Logs messages: {msgs}.')
+
+    return Handler()

--- a/cirq/testing/logs_test.py
+++ b/cirq/testing/logs_test.py
@@ -1,0 +1,144 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import warnings
+
+import pytest
+
+import cirq.testing
+
+
+def test_assert_logs_valid_single_logs():
+    with cirq.testing.assert_logs('apple'):
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple', 'orange'):
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs():
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple', 'fruit'):
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple') as logs:
+        logging.error('orange apple fruit')
+    assert len(logs) == 1
+    assert logs[0].getMessage() == 'orange apple fruit'
+    assert logs[0].levelno == logging.ERROR
+
+    with cirq.testing.assert_logs('apple'):
+        warnings.warn('orange apple fruit')
+
+
+def test_assert_logs_invalid_single_logs():
+    match = ('^dog expected to appear in log messages but it was not found. '
+             'Logs messages: \\[\'orange apple fruit\'\\].$')
+    with pytest.raises(AssertionError, match=match):
+        with cirq.testing.assert_logs('dog'):
+            logging.error('orange apple fruit')
+
+    with pytest.raises(AssertionError, match='dog'):
+        with cirq.testing.assert_logs('dog', 'cat'):
+            logging.error('orange apple fruit')
+
+
+def test_assert_logs_valid_multiple_logs():
+    with cirq.testing.assert_logs('apple', count=2):
+        logging.error('orange apple fruit')
+        logging.error('other')
+
+    with cirq.testing.assert_logs('apple', count=2):
+        logging.error('other')
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple', count=2):
+        logging.error('other')
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple', count=2):
+        logging.error('other')
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple', 'other', count=2):
+        logging.error('other')
+        logging.error('orange apple fruit')
+
+    with cirq.testing.assert_logs('apple', count=3):
+        logging.error('orange apple fruit')
+        logging.error('other')
+        logging.warning('other two')
+
+
+def test_assert_logs_invalid_multiple_logs():
+    match = '^Expected 1 log message but got 2.$'
+    with pytest.raises(AssertionError,
+                       match='^Expected 1 log message but got 2.$'):
+        with cirq.testing.assert_logs('dog'):
+            logging.error('orange apple fruit')
+            logging.error('dog')
+
+    with pytest.raises(AssertionError,
+                       match='^Expected 2 log message but got 3.$'):
+        with cirq.testing.assert_logs('dog', count=2):
+            logging.error('orange apple fruit')
+            logging.error('other')
+            logging.error('dog')
+
+    match = ('^dog expected to appear in log messages but it was not found. '
+             'Logs messages: \\[\'orange\', \'other\', \'whatever\'\\].$')
+    with pytest.raises(AssertionError, match=match):
+        with cirq.testing.assert_logs('dog', count=3):
+            logging.error('orange')
+            logging.error('other')
+            logging.error('whatever')
+
+
+def test_assert_logs_log_level():
+    # Default is warning
+    with cirq.testing.assert_logs('apple'):
+        logging.error('orange apple fruit')
+        logging.debug('should not')
+        logging.info('count')
+    with cirq.testing.assert_logs('apple', 'critical', count=2):
+        logging.critical('critical')
+        logging.error('orange apple fruit')
+        logging.debug('should not')
+        logging.info('count')
+    with cirq.testing.assert_logs('apple', level=logging.INFO, count=2):
+        logging.error('orange apple fruit')
+        logging.debug('should not')
+        logging.info('count')
+
+
+def test_assert_logs_warnings():
+    # Capture all warnings in one context, so that test cases that will
+    # display a warning do not do so when the test is run.
+    with warnings.catch_warnings(record=True):
+        with cirq.testing.assert_logs('apple'):
+            warnings.warn('orange apple fruit')
+
+        with cirq.testing.assert_logs('apple', count=2):
+            warnings.warn('orange apple fruit')
+            logging.error('other')
+
+        with cirq.testing.assert_logs('apple', capture_warnings=False):
+            logging.error('orange apple fruit')
+            warnings.warn('warn')
+
+        with pytest.raises(AssertionError,
+                           match='^Expected 1 log message but got 0.$'):
+            with cirq.testing.assert_logs('apple', capture_warnings=False):
+                warnings.warn('orange apple fruit')

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -574,6 +574,7 @@ operation.
     cirq.testing.assert_has_diagram
     cirq.testing.assert_implements_consistent_protocols
     cirq.testing.assert_json_roundtrip_works
+    cirq.testing.assert_logs
     cirq.testing.assert_pauli_expansion_is_consistent_with_unitary
     cirq.testing.assert_phase_by_is_consistent_with_unitary
     cirq.testing.assert_qasm_is_consistent_with_unitary


### PR DESCRIPTION
Adds a helper for testing logs.
```
with cirq.testing.assert_logs('bacon', 'eggs', 'celery', count=2):
    logging.error('bacon and eggs is not available')
    logging.error('only celery is available')
```
This removes capture code from `cirq._compat_test` which was used to test deprecation warnings across our codebase.

Features:

* Ability to set log level.
* Ability to capture or not capture from python's `warnings` module.

PR also cleans up two things encountered while using:

* Use `import cirq` pattern in `moments_test.py`
* Fix unused type annotations in parity_gates.py.