### PR TITLE
Bump pytest-asyncio version to remove warning

### DIFF
--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -2,7 +2,7 @@
 mypy~=0.701.0
 pylint~=2.3.0
 pytest~=5.4.1
-pytest-asyncio~=0.10.0
+pytest-asyncio~=0.12.0
 pytest-cov~=2.5.0
 pytest-benchmark~=3.2.0
 yapf~=0.27.0


### PR DESCRIPTION
Removes warning that appears in coverage tests.