### PR TITLE
Make it easier to implement cirq.Sampler

### DIFF
--- a/cirq/study/sweepable.py
+++ b/cirq/study/sweepable.py
@@ -14,13 +14,15 @@
 
 """Defines which types are Sweepable."""
 
-from typing import Dict, Iterable, Iterator, List, Union, cast
+from typing import Dict, Iterable, Iterator, List, Union, cast, TYPE_CHECKING
 import itertools
 
 from cirq._doc import document
 from cirq.study.resolver import ParamResolver, ParamResolverOrSimilarType
 from cirq.study.sweeps import ListSweep, Points, Sweep, UnitSweep, Zip
 
+if TYPE_CHECKING:
+    import cirq
 
 Sweepable = Union[Dict[str, float], ParamResolver, Sweep, Iterable[
     Union[Dict[str, float], ParamResolver, Sweep]], None]
@@ -81,9 +83,7 @@ def to_sweeps(sweepable: Sweepable) -> List[Sweep]:
                     f'sweepable: {sweepable}')
 
 
-def to_sweep(sweep_or_resolver_list: Union['Sweep', ParamResolverOrSimilarType,
-                                           Iterable[ParamResolverOrSimilarType]]
-            ) -> 'Sweep':
+def to_sweep(sweep_or_resolver_list: 'cirq.Sweepable') -> 'cirq.Sweep':
     """Converts the argument into a ``cirq.Sweep``.
 
     Args:

--- a/cirq/work/sampler_test.py
+++ b/cirq/work/sampler_test.py
@@ -14,6 +14,7 @@
 """Tests for cirq.Sampler."""
 import pytest
 
+import numpy as np
 import pandas as pd
 import sympy
 
@@ -155,3 +156,145 @@ async def test_sampler_async_not_run_inline():
     assert not ran
     assert await a == []
     assert ran
+
+
+def test_sampler_alternate_method_choices():
+
+    def assert_sampler_methods_work(sampler: cirq.Sampler):
+        a, b = cirq.LineQubit.range(2)
+        c2 = cirq.Circuit(
+            cirq.Moment(
+                [cirq.measure(a, key='c'),
+                 cirq.measure(b, key='out_t')]),
+            cirq.Moment([cirq.measure(a, b, key='n')]),
+        )
+        dict_no_t = {'c': 1, 'n': 2, 'out_t': 0}
+        dict_yes_t = {'c': 1, 'n': 2, 'out_t': 1}
+        no_t_trial_result = cirq.TrialResult(params=cirq.ParamResolver(None),
+                                             measurements={
+                                                 'c':
+                                                 np.array([[1], [1], [1]],
+                                                          dtype=np.int64),
+                                                 'out_t':
+                                                 np.array([[0], [0], [0]],
+                                                          dtype=np.int64),
+                                                 'n':
+                                                 np.array(
+                                                     [[1, 0], [1, 0], [1, 0]],
+                                                     dtype=np.int64),
+                                             })
+        yes_t_trial_result = cirq.TrialResult(
+            params=cirq.ParamResolver({'t': 1}),
+            measurements={
+                'c': np.array([[1], [1], [1]], dtype=np.int64),
+                'out_t': np.array([[1], [1], [1]], dtype=np.int64),
+                'n': np.array([[1, 0], [1, 0], [1, 0]], dtype=np.int64),
+            })
+
+        assert sampler.sample_dict(c2) == dict_no_t
+        assert sampler.sample_dict(c2, params={'t': 1}) == dict_yes_t
+
+        assert sampler.sample_dicts(c2, repetitions=0, params={'t': 1}) == []
+        assert sampler.sample_dicts(c2, repetitions=2) == [dict_no_t] * 2
+        assert sampler.sample_dicts(c2, repetitions=3) == [dict_no_t] * 3
+        assert sampler.sample_dicts(c2, repetitions=3,
+                                    params={'t': 1}) == [dict_yes_t] * 3
+
+        assert sampler.run(c2, repetitions=3,
+                           param_resolver={'t': 1}) == yes_t_trial_result
+        assert sampler.run_sweep(c2, repetitions=3, params=[{}, {}, {
+            't': 1
+        }]) == [
+            no_t_trial_result,
+            no_t_trial_result,
+            yes_t_trial_result,
+        ]
+
+        pd.testing.assert_frame_equal(
+            sampler.sample(c2, params=[{
+                't': 0
+            }, {
+                't': 1
+            }], repetitions=2),
+            pd.DataFrame(index=pd.Int64Index([0, 1, 0, 1]),
+                         columns=['t', 'c', 'out_t', 'n'],
+                         data=[
+                             [0, 1, 0, 2],
+                             [0, 1, 0, 2],
+                             [1, 1, 1, 2],
+                             [1, 1, 1, 2],
+                         ]))
+        pd.testing.assert_frame_equal(
+            sampler.sample(c2, params={}, repetitions=3),
+            pd.DataFrame(index=pd.Int64Index([0, 1, 2]),
+                         columns=['c', 'out_t', 'n'],
+                         data=[
+                             [1, 0, 2],
+                             [1, 0, 2],
+                             [1, 0, 2],
+                         ]))
+
+        # Check expected data dependency: n should be the circuit length.
+        c3 = cirq.Circuit(
+            cirq.Moment(
+                [cirq.measure(a, key='c'),
+                 cirq.measure(b, key='out_t')]),
+            cirq.Moment([cirq.measure(a, b, key='n')]),
+            cirq.Moment(),
+        )
+        pd.testing.assert_frame_equal(
+            sampler.sample(c3, params={}, repetitions=3),
+            pd.DataFrame(index=pd.Int64Index([0, 1, 2]),
+                         columns=['c', 'out_t', 'n'],
+                         data=[
+                             [1, 0, 3],
+                             [1, 0, 3],
+                             [1, 0, 3],
+                         ]))
+
+    class AbstractSampler(cirq.Sampler):
+        pass
+
+    with pytest.raises(TypeError, match="abstract class"):
+        _ = AbstractSampler()
+
+    class SamplerViaSampleDict(cirq.Sampler):
+
+        def sample_dict(self, program, *, params=None):
+            t = cirq.ParamResolver(params).param_dict.get('t', 0)
+            return {'c': 1, 'n': len(program), 'out_t': t}
+
+    assert_sampler_methods_work(SamplerViaSampleDict())
+
+    class SamplerViaSampleDicts(cirq.Sampler):
+
+        def sample_dicts(self, program, *, repetitions=1, params=None):
+            t = cirq.ParamResolver(params).param_dict.get('t', 0)
+            return [{'c': 1, 'n': len(program), 'out_t': t}] * repetitions
+
+    assert_sampler_methods_work(SamplerViaSampleDicts())
+
+    class SamplerViaRun(cirq.Sampler):
+
+        def run(self, program, param_resolver=None, repetitions=1):
+            param_resolver = cirq.ParamResolver(param_resolver)
+            t = param_resolver.param_dict.get('t', 0)
+            b = cirq.big_endian_int_to_bits(len(program), bit_count=2)
+            return cirq.TrialResult(params=param_resolver,
+                                    measurements={
+                                        'c': np.array([[1]] * repetitions),
+                                        'out_t': np.array([[t]] * repetitions),
+                                        'n': np.array([b] * repetitions),
+                                    })
+
+    assert_sampler_methods_work(SamplerViaRun())
+
+    class SamplerViaRunSweep(cirq.Sampler):
+
+        def run_sweep(self, program, params=None, repetitions=1):
+            return [
+                SamplerViaRun().run(program, param, repetitions)
+                for param in cirq.to_sweep(params)
+            ]
+
+    assert_sampler_methods_work(SamplerViaRunSweep())

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -2,7 +2,7 @@
 mypy~=0.701.0
 pylint~=2.3.0
 pytest~=5.4.1
-pytest-asyncio~=0.10.0
+pytest-asyncio~=0.12.0
 pytest-cov~=2.5.0
 pytest-benchmark~=3.2.0
 yapf~=0.27.0


### PR DESCRIPTION
- Add `sample_dict` / `sample_dicts` methods to Sampler
- Use `cirq.ABCMetaImplementAnyOneOf` to derive any of run/run_sweep/sample_dict/sample_dicts from any of the others
- Fix deprecation warning from pytest by bumping version of pytest-asyncio
- Fix `cirq.to_sweep` not saying it takes `cirq.Sweepable`

Discussion points:

The implementer still has to deal with boilerplate parameter resolution. Is there some nice way to expose a `params` argument to the user without requiring the implementer to deal with it? I came up with something interesting but possibly confusing:

```
    @value.boilerplate(lambda wrapped_function, self, program, *, params = None:
                       wrapped_function(self, program=protocols.resolve_parameters(program, params)))
    @value.alternative(requires='sample_dicts',
                       implementation=_sample_dict_from_sample_dicts)
    def sample_dict(
            self,
            program: 'cirq.Circuit',
    ) -> Dict[str, Any]:
```