### PR TITLE
Fix PhaseDampingChannel's channel

### DIFF
--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -638,15 +638,9 @@ class PhaseDampingChannel(gate_features.SingleQubitGate):
 
             $$
             \begin{aligned}
-            M_0 =& \begin{bmatrix}
-                    1 & 0 \\
-                    0 & \sqrt{1 - \gamma}
-                  \end{bmatrix}
+            M_0 =& \sqrt{1 - \gamma / 2} I
             \\
-            M_1 =& \begin{bmatrix}
-                    0 & 0 \\
-                    0 & \sqrt{\gamma}
-                  \end{bmatrix}
+            M_1 =& \sqrt{\gamma / 2} Z
             \end{aligned}
             $$
 
@@ -658,13 +652,13 @@ class PhaseDampingChannel(gate_features.SingleQubitGate):
         """
         self._gamma = value.validate_probability(gamma, 'gamma')
 
-    def _channel_(self) -> Iterable[np.ndarray]:
-        return (
-            np.array([[1., 0.], [0., np.sqrt(1. - self._gamma)]]),
-            np.array([[0., 0.], [0., np.sqrt(self._gamma)]]),
-        )
+    def _mixture_(self):
+        return [
+            (self._gamma / 2, np.array([[1, 0], [0, -1]])),
+            (1 - self._gamma / 2, np.array([[1, 0], [0, 1]])),
+        ]
 
-    def _has_channel_(self) -> bool:
+    def _has_mixture_(self) -> bool:
         return True
 
     def _value_equality_values_(self):
@@ -706,15 +700,9 @@ def phase_damp(gamma: float) -> PhaseDampingChannel:
 
         $$
         \begin{aligned}
-        M_0 =& \begin{bmatrix}
-                1 & 0  \\
-                0 & \sqrt{1 - \gamma}
-              \end{bmatrix}
-        \\
-        M_1 =& \begin{bmatrix}
-                0 & 0 \\
-                0 & \sqrt{\gamma}
-              \end{bmatrix}
+            M_0 =& \sqrt{1 - \gamma / 2} I
+            \\
+            M_1 =& \sqrt{\gamma / 2} Z
         \end{aligned}
         $$
 

--- a/cirq/ops/common_channels_test.py
+++ b/cirq/ops/common_channels_test.py
@@ -508,6 +508,7 @@ def test_bit_flip_channel_text_diagram():
 def test_phase_damp_equivalent_to_three_matrix_decomposition():
 
     class ThreeTermPhaseDamp(cirq.Gate):
+
         def __init__(self, p):
             self.p = p
 
@@ -522,14 +523,16 @@ def test_phase_damp_equivalent_to_three_matrix_decomposition():
             ]
 
     a, b = cirq.LineQubit.range(2)
-    actual = cirq.final_density_matrix(cirq.Circuit(
-        cirq.H(a),
-        cirq.CNOT(a, b),
-        cirq.phase_damp(0.1).on(a),
-    ))
-    expected = cirq.final_density_matrix(cirq.Circuit(
-        cirq.H(a),
-        cirq.CNOT(a, b),
-        ThreeTermPhaseDamp(0.1).on(a),
-    ))
+    actual = cirq.final_density_matrix(
+        cirq.Circuit(
+            cirq.H(a),
+            cirq.CNOT(a, b),
+            cirq.phase_damp(0.1).on(a),
+        ))
+    expected = cirq.final_density_matrix(
+        cirq.Circuit(
+            cirq.H(a),
+            cirq.CNOT(a, b),
+            ThreeTermPhaseDamp(0.1).on(a),
+        ))
     np.testing.assert_allclose(actual, expected, atol=1e-6)


### PR DESCRIPTION
- I checked for equivalence with the definition from Preskill's notes (http://www.theory.caltech.edu/~preskill/ph219/chap3_15.pdf page 28) and found the existing definition was wrong
- Redefined the channel as a mixture of I and Z
- Added a test checking equivalence with the 3-term definition
- The old channel appears to still be a dephasing channel, but the damping had the wrong dependence on gamma.