### PR TITLE
Fix empty gate domain problem in random_circuit

### DIFF
--- a/cirq/testing/__init__.py
+++ b/cirq/testing/__init__.py
@@ -75,7 +75,9 @@ from cirq.testing.order_tester import (
     OrderTester,)
 
 from cirq.testing.random_circuit import (
-    random_circuit,)
+    DEFAULT_GATE_DOMAIN,
+    random_circuit,
+)
 
 from cirq.testing.sample_circuits import (
     nonoptimal_toffoli_circuit,)

--- a/cirq/testing/random_circuit_test.py
+++ b/cirq/testing/random_circuit_test.py
@@ -12,46 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Optional, Dict, Sequence, Union, cast
-from random import randint, random, sample, choice
+import random
 
 import numpy as np
 import pytest
 
 import cirq
-from cirq.testing.random_circuit import random_circuit, DEFAULT_GATE_DOMAIN
+import cirq.testing
 
 
 def test_random_circuit_errors():
-    with pytest.raises(ValueError):
-        random_circuit(randint(1, 10), randint(1, 10), -1)
-    with pytest.raises(ValueError):
-        random_circuit(randint(1, 10), randint(1, 10), 1.)
+    with pytest.raises(ValueError, match='-1'):
+        _ = cirq.testing.random_circuit(qubits=5, n_moments=5, op_density=-1)
 
-    with pytest.raises(ValueError):
-        random_circuit(randint(1, 10), randint(1, 10), random(), gate_domain={})
+    with pytest.raises(ValueError, match='empty'):
+        _ = cirq.testing.random_circuit(qubits=5,
+                                        n_moments=5,
+                                        op_density=0.5,
+                                        gate_domain={})
 
-    with pytest.raises(ValueError):
-        random_circuit(0, randint(1, 10), random())
+    with pytest.raises(ValueError, match='At least one'):
+        _ = cirq.testing.random_circuit(qubits=0, n_moments=5, op_density=0.5)
 
-    with pytest.raises(ValueError):
-        random_circuit((), randint(1, 10), random())
+    with pytest.raises(ValueError, match='At least one'):
+        _ = cirq.testing.random_circuit(qubits=(), n_moments=5, op_density=0.5)
+
+    with pytest.raises(ValueError, match='had no gates'):
+        _ = cirq.testing.random_circuit(qubits=1,
+                                        n_moments=5,
+                                        op_density=0.5,
+                                        gate_domain={cirq.CNOT: 2})
 
 
 @pytest.mark.parametrize(
     'n_qubits,n_moments,op_density,gate_domain,pass_qubits',
-    [(
-        randint(1, 20),
-        randint(1, 10),
-        random(),
-        (
-            None
-            if randint(0, 1)
-            else dict(sample(tuple(DEFAULT_GATE_DOMAIN.items()),
-                             randint(1, len(DEFAULT_GATE_DOMAIN))))
-        ),
-        choice((True, False))
-    ) for _ in range(10)]
-)
+    [(random.randint(1, 20), random.randint(1, 10), random.random(),
+      (None if random.randint(0, 1) else dict(
+          random.sample(
+              tuple(cirq.testing.DEFAULT_GATE_DOMAIN.items()),
+              random.randint(1, len(cirq.testing.DEFAULT_GATE_DOMAIN))))),
+      random.choice((True, False))) for _ in range(10)])
 def test_random_circuit(n_qubits: Union[int, Sequence[cirq.Qid]],
                         n_moments: int,
                         op_density: float,
@@ -59,25 +59,26 @@ def test_random_circuit(n_qubits: Union[int, Sequence[cirq.Qid]],
                         pass_qubits: bool):
     qubit_set = cirq.LineQubit.range(n_qubits)
     qubit_arg = qubit_set if pass_qubits else n_qubits
-    circuit = random_circuit(qubit_arg, n_moments, op_density, gate_domain)
+    circuit = cirq.testing.random_circuit(qubit_arg, n_moments, op_density,
+                                          gate_domain)
     if qubit_arg is qubit_set:
         assert circuit.all_qubits().issubset(qubit_set)
     assert len(circuit) == n_moments
     if gate_domain is None:
-        gate_domain = DEFAULT_GATE_DOMAIN
+        gate_domain = cirq.testing.DEFAULT_GATE_DOMAIN
     assert set(cast(cirq.GateOperation, op).gate
                for op in circuit.all_operations()
                ).issubset(gate_domain)
 
 
-@pytest.mark.parametrize('seed', [randint(0, 2**32) for _ in range(10)])
+@pytest.mark.parametrize('seed', [random.randint(0, 2**32) for _ in range(10)])
 def test_random_circuit_reproducible_with_seed(seed):
     wrappers = (lambda s: s, np.random.RandomState)
     circuits = [
-        random_circuit(qubits=10,
-                       n_moments=10,
-                       op_density=0.7,
-                       random_state=wrapper(seed))
+        cirq.testing.random_circuit(qubits=10,
+                                    n_moments=10,
+                                    op_density=0.7,
+                                    random_state=wrapper(seed))
         for wrapper in wrappers
         for _ in range(2)
     ]
@@ -85,8 +86,19 @@ def test_random_circuit_reproducible_with_seed(seed):
     eq.add_equality_group(*circuits)
 
 
+def test_random_circuit_not_expected_number_of_qubits():
+
+    circuit = cirq.testing.random_circuit(qubits=3,
+                                          n_moments=1,
+                                          op_density=1.0,
+                                          gate_domain={cirq.CNOT: 2})
+    # Despite having an op density of 1, we always only end up acting on
+    # two qubits.
+    assert len(circuit.all_qubits()) == 2
+
+
 def test_random_circuit_reproducible_between_runs():
-    circuit = random_circuit(5, 8, 0.5, random_state=77)
+    circuit = cirq.testing.random_circuit(5, 8, 0.5, random_state=77)
     expected_diagram = """
                   ┌──┐
 0: ────────────────S─────iSwap───────Y───X───

--- a/cirq/testing/random_circuit_test.py
+++ b/cirq/testing/random_circuit_test.py
@@ -22,7 +22,7 @@ import cirq.testing
 
 
 def test_random_circuit_errors():
-    with pytest.raises(ValueError, match='-1'):
+    with pytest.raises(ValueError, match='but was -1'):
         _ = cirq.testing.random_circuit(qubits=5, n_moments=5, op_density=-1)
 
     with pytest.raises(ValueError, match='empty'):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -566,6 +566,7 @@ operation.
     cirq.InterchangeableQubitsGate
     cirq.LinearDict
     cirq.PeriodicValue
+    cirq.testing.DEFAULT_GATE_DOMAIN
     cirq.testing.assert_allclose_up_to_global_phase
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent
     cirq.testing.assert_commutes_magic_method_consistent_with_unitaries


### PR DESCRIPTION
Fixes #3033 

Fixes a bug where an empty gate domain occurs due to there not being any gates that operate on the proper number of qubits and the circuit has fewer number of qubits.

Also cleans up random circuit tests
* Adds `DEFAULT_GATE_DOMAIN` to `cirq.testing`, users might want to use it for the circuits they generate
* Allows for an `op_density` of 1.0.
* Correct an incorrect documentation assertion about what `op_density` means and added a test that demonstrates why that document assertion was incorrect.
* Moved to standard style for importing modules and not methods.