### PR TITLE
Add dataclass annotation to CrossEntropyResult

### DIFF
--- a/cirq/experiments/cross_entropy_benchmarking.py
+++ b/cirq/experiments/cross_entropy_benchmarking.py
@@ -62,6 +62,7 @@ class CrossEntropyDepolarizingModel:
     covariance: Optional[np.ndarray] = None
 
 
+@dataclasses.dataclass
 @protocols.json_serializable_dataclass(frozen=True)
 class CrossEntropyResult:
     """Results from a cross-entropy benchmarking (XEB) experiment.


### PR DESCRIPTION
Fairly certain this was not meant to be a class level variable. 