### PR TITLE
Add .gitattributes file to hide proto generated code in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Mark generated protobuf files to be collapsed by default in PRs
+# See: https://github.com/github/linguist/#generated-code
+*_pb2.py         linguist-generated=true
+*_pb2.pyi        linguist-generated=true
+


### PR DESCRIPTION
This will cause generated code to be folded by default when viewing
diffs in PRs that touch protobuf definitions. We have automated checks
to ensure that the generated code is updated, so there's typically no
need to look at it.