### PR TITLE
Fix split_into_unitary_then_general not spreading blocks across operation

### DIFF
--- a/cirq/sim/sparse_simulator.py
+++ b/cirq/sim/sparse_simulator.py
@@ -357,7 +357,8 @@ def _split_into_unitary_then_general(circuit: 'cirq.Circuit'
         general_part = []
         for op in moment:
             qs = set(op.qubits)
-            if not protocols.has_unitary(op):
+            if (not protocols.has_unitary(op) or
+                    not qs.isdisjoint(blocked_qubits)):
                 blocked_qubits |= qs
 
             if qs.isdisjoint(blocked_qubits):

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -948,3 +948,18 @@ def test_overlapping_measurements_at_end():
     assert len(counts) == 2
     assert 10 <= counts[0] <= 90
     assert 10 <= counts[1] <= 90
+
+
+def test_separated_measurements():
+    a, b = cirq.LineQubit.range(2)
+    c = cirq.Circuit([
+        cirq.H(a),
+        cirq.H(b),
+        cirq.CZ(a, b),
+        cirq.measure(a, key=''),
+        cirq.CZ(a, b),
+        cirq.H(b),
+        cirq.measure(b, key='zero'),
+    ])
+    sample = cirq.Simulator().sample(c, repetitions=10)
+    np.testing.assert_array_equal(sample['zero'].values, [0]*10)

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -962,4 +962,4 @@ def test_separated_measurements():
         cirq.measure(b, key='zero'),
     ])
     sample = cirq.Simulator().sample(c, repetitions=10)
-    np.testing.assert_array_equal(sample['zero'].values, [0]*10)
+    np.testing.assert_array_equal(sample['zero'].values, [0] * 10)


### PR DESCRIPTION
This was such a dumb mistake for me to make.