### PR TITLE
Reduce numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ freezegun~=0.3.15
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
 matplotlib~=3.0
 networkx~=2.4
-numpy~=1.16
+numpy~=1.16, < 1.19
 pandas
 protobuf~=3.11.0
 requests~=2.18


### PR DESCRIPTION
The numpy 1.19 release broke our tests.  Putting this in while we fix the tests.

#3105 and #3103 for the currently known broken tests.