### PR TITLE
Defensively copy density matrices in simulator

### DIFF
--- a/cirq/qis/states.py
+++ b/cirq/qis/states.py
@@ -464,8 +464,7 @@ def to_valid_density_matrix(
         *,  # Force keyword arguments
         qid_shape: Optional[Tuple[int, ...]] = None,
         dtype: Type[np.number] = np.complex64,
-        atol: float = 1e-7,
-        copy: bool = False) -> np.ndarray:
+        atol: float = 1e-7) -> np.ndarray:
     """Verifies the density_matrix_rep is valid and converts it to ndarray form.
 
     This method is used to support passing a matrix, a state vector,
@@ -484,13 +483,11 @@ def to_valid_density_matrix(
             the state for a computational basis state (int), or validated
             against if density_matrix_rep is a numpy array.
         atol: Numerical tolerance for verifying density matrix properties.
-        copy: Whether to return a copy of the density matrix if the rep is
-            provided as a numpy array. If the rep is a state vector or int, the
-            returned object is always new.
 
     Returns:
         A numpy matrix corresponding to the density matrix on the given number
-        of qubits.
+        of qubits. Note that this matrix may share memory with the input
+        `density_matrix_rep`.
 
     Raises:
         ValueError if the density_matrix_rep is not valid.
@@ -516,7 +513,7 @@ def to_valid_density_matrix(
                     density_matrix_rep.dtype, dtype))
         if not np.all(np.linalg.eigvalsh(density_matrix_rep) > -atol):
             raise ValueError('The density matrix is not positive semidefinite.')
-        return density_matrix_rep.copy() if copy else density_matrix_rep
+        return density_matrix_rep
 
     state_vector = to_valid_state_vector(density_matrix_rep,
                                          len(qid_shape),

--- a/cirq/qis/states.py
+++ b/cirq/qis/states.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Utility methods for creating vectors and matrices."""
 
-from typing import (Any, Iterable, List, Optional, Sequence, Union,
-                    TYPE_CHECKING, Tuple, Type, cast)
+from typing import (Any, cast, Iterable, Optional, Sequence, TYPE_CHECKING,
+                    Tuple, Type, Union)
 
 import itertools
 
@@ -464,7 +464,8 @@ def to_valid_density_matrix(
         *,  # Force keyword arguments
         qid_shape: Optional[Tuple[int, ...]] = None,
         dtype: Type[np.number] = np.complex64,
-        atol: float = 1e-7) -> np.ndarray:
+        atol: float = 1e-7,
+        copy: bool = False) -> np.ndarray:
     """Verifies the density_matrix_rep is valid and converts it to ndarray form.
 
     This method is used to support passing a matrix, a state vector,
@@ -483,6 +484,9 @@ def to_valid_density_matrix(
             the state for a computational basis state (int), or validated
             against if density_matrix_rep is a numpy array.
         atol: Numerical tolerance for verifying density matrix properties.
+        copy: Whether to return a copy of the density matrix if the rep is
+            provided as a numpy array. If the rep is a state vector or int, the
+            returned object is always new.
 
     Returns:
         A numpy matrix corresponding to the density matrix on the given number
@@ -512,7 +516,7 @@ def to_valid_density_matrix(
                     density_matrix_rep.dtype, dtype))
         if not np.all(np.linalg.eigvalsh(density_matrix_rep) > -atol):
             raise ValueError('The density matrix is not positive semidefinite.')
-        return density_matrix_rep
+        return density_matrix_rep.copy() if copy else density_matrix_rep
 
     state_vector = to_valid_state_vector(density_matrix_rep,
                                          len(qid_shape),

--- a/cirq/qis/states_test.py
+++ b/cirq/qis/states_test.py
@@ -369,19 +369,6 @@ def test_to_valid_density_matrix_from_density_matrix():
     assert_valid_density_matrix(np.diag([0.2, 0.8, 0, 0]), qid_shape=(4,))
 
 
-def test_to_valid_density_matrix_copy():
-    matrix = np.array([[1, 0], [0, 0]], dtype=np.complex64)
-    valid_matrix = cirq.to_valid_density_matrix(matrix, qid_shape=(2,))
-    assert matrix is valid_matrix
-
-    matrix = np.array([[1, 0], [0, 0]], dtype=np.complex64)
-    valid_matrix = cirq.to_valid_density_matrix(matrix,
-                                                qid_shape=(2,),
-                                                copy=True)
-    assert matrix is not valid_matrix
-    np.testing.assert_equal(matrix, valid_matrix)
-
-
 def test_to_valid_density_matrix_not_square():
     with pytest.raises(ValueError, match='square'):
         cirq.to_valid_density_matrix(np.array([[1, 0]]), num_qubits=1)

--- a/cirq/qis/states_test.py
+++ b/cirq/qis/states_test.py
@@ -369,6 +369,19 @@ def test_to_valid_density_matrix_from_density_matrix():
     assert_valid_density_matrix(np.diag([0.2, 0.8, 0, 0]), qid_shape=(4,))
 
 
+def test_to_valid_density_matrix_copy():
+    matrix = np.array([[1, 0], [0, 0]], dtype=np.complex64)
+    valid_matrix = cirq.to_valid_density_matrix(matrix, qid_shape=(2,))
+    assert matrix is valid_matrix
+
+    matrix = np.array([[1, 0], [0, 0]], dtype=np.complex64)
+    valid_matrix = cirq.to_valid_density_matrix(matrix,
+                                                qid_shape=(2,),
+                                                copy=True)
+    assert matrix is not valid_matrix
+    np.testing.assert_equal(matrix, valid_matrix)
+
+
 def test_to_valid_density_matrix_not_square():
     with pytest.raises(ValueError, match='square'):
         cirq.to_valid_density_matrix(np.array([[1, 0]]), num_qubits=1)

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -256,7 +256,7 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
         initial_matrix = qis.to_valid_density_matrix(initial_state,
                                                      len(qid_shape),
                                                      qid_shape=qid_shape,
-                                                     dtype=self._dtype)
+                                                     dtype=self._dtype).copy()
         measured = collections.defaultdict(
             bool)  # type: Dict[Tuple[cirq.Qid, ...], bool]
         if len(circuit) == 0:
@@ -407,7 +407,7 @@ class DensityMatrixStepResult(simulator.StepResult):
         density_matrix = np.reshape(density_matrix, sim_state_matrix.shape)
         np.copyto(dst=sim_state_matrix, src=density_matrix)
 
-    def density_matrix(self):
+    def density_matrix(self, copy=True):
         """Returns the density matrix at this step in the simulation.
 
         The density matrix that is stored in this result is returned in the
@@ -435,9 +435,16 @@ class DensityMatrixStepResult(simulator.StepResult):
                 |  6  |   1    |   1    |   0    |
                 |  7  |   1    |   1    |   1    |
 
+        Args:
+            copy: If True, then the returned state is a copy of the density
+            matrix. If False, then the density matrix is not copied, potentially
+            saving memory. If one only needs to read derived parameters from the
+            density matrix and store then using False can speed up simulation by
+            eliminating a memory copy.
         """
         size = np.prod(self._qid_shape, dtype=int)
-        return np.reshape(self._density_matrix, (size, size))
+        matrix = self._density_matrix.copy() if copy else self._density_matrix
+        return np.reshape(matrix, (size, size))
 
     def sample(self,
                qubits: List[ops.Qid],
@@ -528,7 +535,7 @@ class DensityMatrixTrialResult(simulator.SimulationTrialResult):
                          final_simulator_state=final_simulator_state)
         size = np.prod(protocols.qid_shape(self), dtype=int)
         self.final_density_matrix = np.reshape(
-            final_simulator_state.density_matrix, (size, size))
+            final_simulator_state.density_matrix, (size, size)).copy()
 
     def _value_equality_values_(self) -> Any:
         measurements = {

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -256,7 +256,8 @@ class DensityMatrixSimulator(simulator.SimulatesSamples,
         initial_matrix = qis.to_valid_density_matrix(initial_state,
                                                      len(qid_shape),
                                                      qid_shape=qid_shape,
-                                                     dtype=self._dtype).copy()
+                                                     dtype=self._dtype,
+                                                     copy=True)
         measured = collections.defaultdict(
             bool)  # type: Dict[Tuple[cirq.Qid, ...], bool]
         if len(circuit) == 0:

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -1124,6 +1124,8 @@ def test_density_matrix_copy():
     for step in sim.simulate_moment_steps(circuit):
         matrices.append(step.density_matrix(copy=True))
     assert all(np.isclose(np.trace(x), 1.0) for x in matrices)
+    for x, y in itertools.combinations(matrices, 2):
+        assert not np.shares_memory(x, y)
 
     # If the density matrix is not copied, then applying second Hadamard
     # causes old state to be modified.
@@ -1134,6 +1136,8 @@ def test_density_matrix_copy():
         traces.append(np.trace(step.density_matrix(copy=False)))
     assert any(not np.isclose(np.trace(x), 1.0) for x in matrices)
     assert all(np.isclose(x, 1.0) for x in traces)
+    assert any(not np.shares_memory(x, y) for x, y in
+               itertools.combinations(matrices, 2))
 
 
 def test_final_density_matrix_is_not_last_object():
@@ -1144,4 +1148,5 @@ def test_final_density_matrix_is_not_last_object():
     circuit = cirq.Circuit(cirq.WaitGate(0)(q))
     result = sim.simulate(circuit, initial_state=initial_state)
     assert result.final_density_matrix is not initial_state
+    assert not np.shares_memory(result.final_density_matrix, initial_state)
     np.testing.assert_equal(result.final_density_matrix, initial_state)

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -1112,3 +1112,36 @@ def test_simulate_noise_with_terminal_measurements():
     result2 = simulator.run(circuit2, repetitions=10)
 
     assert result1 == result2
+
+
+def test_density_matrix_copy():
+    sim = cirq.DensityMatrixSimulator()
+
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.H(q), cirq.H(q))
+
+    matrices = []
+    for step in sim.simulate_moment_steps(circuit):
+        matrices.append(step.density_matrix(copy=True))
+    assert all(np.isclose(np.trace(x), 1.0) for x in matrices)
+
+    # If the density matrix is not copied, then applying second Hadamard
+    # causes old state to be modified.
+    matrices = []
+    traces = []
+    for step in sim.simulate_moment_steps(circuit):
+        matrices.append(step.density_matrix(copy=False))
+        traces.append(np.trace(step.density_matrix(copy=False)))
+    assert any(not np.isclose(np.trace(x), 1.0) for x in matrices)
+    assert all(np.isclose(x, 1.0) for x in traces)
+
+
+def test_final_density_matrix_is_not_last_object():
+    sim = cirq.DensityMatrixSimulator()
+
+    q = cirq.LineQubit(0)
+    initial_state = np.array([[1, 0], [0, 0]], dtype=np.complex64)
+    circuit = cirq.Circuit(cirq.WaitGate(0)(q))
+    result = sim.simulate(circuit, initial_state=initial_state)
+    assert result.final_density_matrix is not initial_state
+    np.testing.assert_equal(result.final_density_matrix, initial_state)

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -1136,8 +1136,8 @@ def test_density_matrix_copy():
         traces.append(np.trace(step.density_matrix(copy=False)))
     assert any(not np.isclose(np.trace(x), 1.0) for x in matrices)
     assert all(np.isclose(x, 1.0) for x in traces)
-    assert any(not np.shares_memory(x, y) for x, y in
-               itertools.combinations(matrices, 2))
+    assert any(not np.shares_memory(x, y)
+               for x, y in itertools.combinations(matrices, 2))
 
 
 def test_final_density_matrix_is_not_last_object():

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -1136,7 +1136,7 @@ def test_density_matrix_copy():
         traces.append(np.trace(step.density_matrix(copy=False)))
     assert any(not np.isclose(np.trace(x), 1.0) for x in matrices)
     assert all(np.isclose(x, 1.0) for x in traces)
-    assert any(not np.shares_memory(x, y)
+    assert all(not np.shares_memory(x, y)
                for x, y in itertools.combinations(matrices, 2))
 
 


### PR DESCRIPTION
This makes it so that by default when you access the density matrix during simulation, it makes a copy of the matrix.  This can be overridden if one wants to get the speed benefits of not copying.