### PR TITLE
Change Operation.with_qubits return type to match self type

### DIFF
--- a/cirq/ops/arithmetic_operation.py
+++ b/cirq/ops/arithmetic_operation.py
@@ -15,7 +15,7 @@
 
 import abc
 import itertools
-from typing import Union, Iterable, List, Sequence, cast, TYPE_CHECKING
+from typing import Union, Iterable, List, Sequence, cast, TypeVar, TYPE_CHECKING
 
 import numpy as np
 
@@ -23,6 +23,9 @@ from cirq.ops.raw_types import Operation
 
 if TYPE_CHECKING:
     import cirq
+
+
+TSelf = TypeVar('TSelf', bound='ArithmeticOperation')
 
 
 class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
@@ -100,8 +103,9 @@ class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def with_registers(self, *new_registers: Union[int, Sequence['cirq.Qid']]
-                      ) -> 'cirq.ArithmeticOperation':
+    def with_registers(self: TSelf,
+                       *new_registers: Union[int, Sequence['cirq.Qid']]
+                      ) -> TSelf:
         """Returns the same operation targeting different registers.
 
         Args:
@@ -165,7 +169,7 @@ class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
         return tuple(qubit for register in self.registers()
                      if not isinstance(register, int) for qubit in register)
 
-    def with_qubits(self, *new_qubits: 'cirq.Qid') -> 'cirq.Operation':
+    def with_qubits(self: TSelf, *new_qubits: 'cirq.Qid') -> TSelf:
         new_registers: List[Union[int, Sequence['cirq.Qid']]] = []
         qs = iter(new_qubits)
         for register in self.registers():

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -15,8 +15,8 @@
 """Basic types defining qubits, gates, and operations."""
 
 import re
-from typing import (Any, Dict, FrozenSet, Iterable, List, Optional, Sequence,
-                    Tuple, TypeVar, Union, TYPE_CHECKING)
+from typing import (Any, cast, Dict, FrozenSet, Iterable, List, Optional,
+                    Sequence, Tuple, TypeVar, TYPE_CHECKING, Union)
 
 import numpy as np
 
@@ -26,6 +26,9 @@ from cirq.type_workarounds import NotImplementedType
 
 if TYPE_CHECKING:
     import cirq
+
+
+TSelf = TypeVar('TSelf', bound='GateOperation')
 
 
 @value.value_equality(approximate=True)
@@ -52,8 +55,8 @@ class GateOperation(raw_types.Operation):
         """The qubits targeted by the operation."""
         return self._qubits
 
-    def with_qubits(self, *new_qubits: 'cirq.Qid') -> 'cirq.Operation':
-        return self.gate.on(*new_qubits)
+    def with_qubits(self: TSelf, *new_qubits: 'cirq.Qid') -> TSelf:
+        return cast(TSelf, self.gate.on(*new_qubits))
 
     def with_gate(self, new_gate: 'cirq.Gate') -> 'cirq.Operation':
         if self.gate is new_gate:

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -15,7 +15,7 @@
 """Basic types defining qubits, gates, and operations."""
 
 from typing import (Any, Callable, Collection, Dict, Hashable, Optional,
-                    Sequence, Tuple, TYPE_CHECKING, Union)
+                    Sequence, Tuple, TypeVar, TYPE_CHECKING, Union)
 
 import abc
 import functools
@@ -366,6 +366,9 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         return protocols.obj_to_dict_helper(self, attribute_names=[])
 
 
+TSelf = TypeVar('TSelf', bound='Operation')
+
+
 class Operation(metaclass=abc.ABCMeta):
     """An effect applied to a collection of qubits.
 
@@ -393,7 +396,7 @@ class Operation(metaclass=abc.ABCMeta):
         return protocols.qid_shape(self.qubits)
 
     @abc.abstractmethod
-    def with_qubits(self, *new_qubits: 'cirq.Qid') -> 'cirq.Operation':
+    def with_qubits(self: TSelf, *new_qubits: 'cirq.Qid') -> TSelf:
         """Returns the same operation, but applied to different qubits.
 
         Args:
@@ -432,8 +435,8 @@ class Operation(metaclass=abc.ABCMeta):
         """
         return TaggedOperation(self, *new_tags)
 
-    def transform_qubits(self, func: Callable[['cirq.Qid'], 'cirq.Qid']
-                        ) -> 'Operation':
+    def transform_qubits(self: TSelf,
+                         func: Callable[['cirq.Qid'], 'cirq.Qid']) -> TSelf:
         """Returns the same operation, but with different qubits.
 
         Args:

--- a/examples/shor.py
+++ b/examples/shor.py
@@ -140,7 +140,7 @@ class ModularExp(cirq.ArithmeticOperation):
     def with_registers(
             self,
             *new_registers: Union[int, Sequence['cirq.Qid']],
-    ) -> cirq.ArithmeticOperation:
+    ) -> 'ModularExp':
         if len(new_registers) != 4:
             raise ValueError(f'Expected 4 registers (target, exponent, base, '
                              f'modulus), but got {len(new_registers)}')


### PR DESCRIPTION
Also change the return type of `transform_qubits` in the same way. AFAICT this should always be correct, but it's sometimes tricky to convince mypy of this (have to cast in `GateOperation.with_qubits`, for example).