### PR TITLE
Only override control when global phase is zero

### DIFF
--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -136,11 +136,16 @@ class XPowGate(eigen_gate.EigenGate,
         a generic qudit) and where the control is satisfied by the qubit being
         ON, as opposed to OFF.
 
+        Note that this only transforms into a CXPowGate (or controlled version
+        of that gate) if the global shift of the XPowGate is 0, otherwise
+        it produces a normal ControlledGate.
+
         (Note that a CXPowGate is, by definition, a controlled-XPowGate.)
         """
         result = super().controlled(num_controls, control_values,
                                     control_qid_shape)
-        if (isinstance(result, controlled_gate.ControlledGate) and
+        if (self._global_shift == 0 and
+                isinstance(result, controlled_gate.ControlledGate) and
                 result.control_values[-1] == (1,) and
                 result.control_qid_shape[-1] == 2):
             return cirq.CXPowGate(exponent=self._exponent,
@@ -454,11 +459,16 @@ class ZPowGate(eigen_gate.EigenGate,
         a generic qudit) and where the control is satisfied by the qubit being
         ON, as opposed to OFF.
 
+        Note that this only transforms into a CZPowGate (or controlled version
+        of that gate) if the global shift of the ZPowGate is 0, otherwise
+        it produces a normal ControlledGate.
+
         (Note that a CZPowGate is, by definition, a controlled-ZPowGate.)
         """
         result = super().controlled(num_controls, control_values,
                                     control_qid_shape)
-        if (isinstance(result, controlled_gate.ControlledGate) and
+        if (self._global_shift == 0 and
+                isinstance(result, controlled_gate.ControlledGate) and
                 result.control_values[-1] == (1,) and
                 result.control_qid_shape[-1] == 2):
             return cirq.CZPowGate(exponent=self._exponent,
@@ -805,11 +815,16 @@ class CZPowGate(eigen_gate.EigenGate,
         a generic qudit) and where the control is satisfied by the qubit being
         ON, as opposed to OFF.
 
+        Note that this only transforms into a CCZPowGate (or controlled version
+        of that gate) if the global shift of the CZPowGate is 0, otherwise
+        it produces a normal ControlledGate.
+
         (Note that a CCZPowGate is, by definition, a controlled-CZPowGate.)
         """
         result = super().controlled(num_controls, control_values,
                                     control_qid_shape)
-        if (isinstance(result, controlled_gate.ControlledGate) and
+        if (self._global_shift == 0 and
+                isinstance(result, controlled_gate.ControlledGate) and
                 result.control_values[-1] == (1,) and
                 result.control_qid_shape[-1] == 2):
             return cirq.CCZPowGate(exponent=self._exponent,
@@ -971,11 +986,16 @@ class CXPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
         a generic qudit) and where the control is satisfied by the qubit being
         ON, as opposed to OFF.
 
+        Note that this only transforms into a CCXPowGate (or controlled version
+        of that gate) if the global shift of the CXPowGate is 0, otherwise
+        it produces a normal ControlledGate.
+
         (Note that a CCXPowGate is, by definition, a controlled-CXPowGate.)
         """
         result = super().controlled(num_controls, control_values,
                                     control_qid_shape)
-        if (isinstance(result, controlled_gate.ControlledGate) and
+        if (self._global_shift == 0 and
+                isinstance(result, controlled_gate.ControlledGate) and
                 result.control_values[-1] == (1,) and
                 result.control_qid_shape[-1] == 2):
             return cirq.CCXPowGate(exponent=self._exponent,

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -134,11 +134,9 @@ class XPowGate(eigen_gate.EigenGate,
         This behavior only occurs when the last control qubit is a default-type
         control qubit. A default-type control qubit is one with shape of 2 (not
         a generic qudit) and where the control is satisfied by the qubit being
-        ON, as opposed to OFF.
-
-        Note that this only transforms into a CXPowGate (or controlled version
-        of that gate) if the global shift of the XPowGate is 0, otherwise
-        it produces a normal ControlledGate.
+        ON, as opposed to OFF. Note also that this only transforms into a
+        CXPowGate (or controlled version of that gate) if the global shift on
+        the XPowGate is 0, otherwise it produces a normal ControlledGate.
 
         (Note that a CXPowGate is, by definition, a controlled-XPowGate.)
         """
@@ -457,11 +455,9 @@ class ZPowGate(eigen_gate.EigenGate,
         This behavior only occurs when the last control qubit is a default-type
         control qubit. A default-type control qubit is one with shape of 2 (not
         a generic qudit) and where the control is satisfied by the qubit being
-        ON, as opposed to OFF.
-
-        Note that this only transforms into a CZPowGate (or controlled version
-        of that gate) if the global shift of the ZPowGate is 0, otherwise
-        it produces a normal ControlledGate.
+        ON, as opposed to OFF. Note also that this only transforms into a
+        CZPowGate (or controlled version of that gate) if the global shift of
+        the ZPowGate is 0, otherwise it produces a normal ControlledGate.
 
         (Note that a CZPowGate is, by definition, a controlled-ZPowGate.)
         """
@@ -813,11 +809,9 @@ class CZPowGate(eigen_gate.EigenGate,
         This behavior only occurs when the last control qubit is a default-type
         control qubit. A default-type control qubit is one with shape of 2 (not
         a generic qudit) and where the control is satisfied by the qubit being
-        ON, as opposed to OFF.
-
-        Note that this only transforms into a CCZPowGate (or controlled version
-        of that gate) if the global shift of the CZPowGate is 0, otherwise
-        it produces a normal ControlledGate.
+        ON, as opposed to OFF. Note also that this only transforms into a
+        CCZPowGate (or controlled version of that gate) if the global shift of
+        the CZPowGate is 0, otherwise it produces a normal ControlledGate.
 
         (Note that a CCZPowGate is, by definition, a controlled-CZPowGate.)
         """
@@ -984,11 +978,9 @@ class CXPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
         This behavior only occurs when the last control qubit is a default-type
         control qubit. A default-type control qubit is one with shape of 2 (not
         a generic qudit) and where the control is satisfied by the qubit being
-        ON, as opposed to OFF.
-
-        Note that this only transforms into a CCXPowGate (or controlled version
-        of that gate) if the global shift of the CXPowGate is 0, otherwise
-        it produces a normal ControlledGate.
+        ON, as opposed to OFF. Note also that this only transforms into a
+        CCXPowGate (or controlled version of that gate) if the global shift of
+        the CXPowGate is 0, otherwise it produces a normal ControlledGate.
 
         (Note that a CCXPowGate is, by definition, a controlled-CXPowGate.)
         """

--- a/cirq/ops/common_gates_test.py
+++ b/cirq/ops/common_gates_test.py
@@ -183,6 +183,35 @@ def test_specialized_control(input_gate, specialized_output):
                 input_gate, num_controls=3, control_qid_shape=(3, 2, 4))
 
 
+@pytest.mark.parametrize(
+    'gate, specialized_type',
+    [(cirq.ZPowGate(global_shift=-0.5, exponent=0.5), cirq.CZPowGate),
+     (cirq.CZPowGate(global_shift=-0.5, exponent=0.5), cirq.CCZPowGate),
+     (cirq.XPowGate(global_shift=-0.5, exponent=0.5), cirq.CXPowGate),
+     (cirq.CXPowGate(global_shift=-0.5, exponent=0.5), cirq.CCXPowGate)])
+def test_no_specialized_control_for_global_shift_non_zero(
+        gate, specialized_type):
+    assert not isinstance(gate.controlled(), specialized_type)
+
+
+@pytest.mark.parametrize(
+    'gate, matrix',
+    [(cirq.ZPowGate(global_shift=-0.5, exponent=1), np.diag([1, 1, -1j, 1j])),
+     (cirq.CZPowGate(global_shift=-0.5,
+                     exponent=1), np.diag([1, 1, 1, 1, -1j, -1j, -1j, 1j])),
+     (cirq.XPowGate(global_shift=-0.5, exponent=1),
+      np.block([[np.eye(2), np.zeros(
+          (2, 2))], [np.zeros(
+              (2, 2)), np.array([[0, -1j], [-1j, 0]])]])),
+     (cirq.CXPowGate(global_shift=-0.5, exponent=1),
+      np.block([[np.diag([1, 1, 1, 1, -1j, -1j]),
+                 np.zeros((6, 2))],
+                [np.zeros(
+                    (2, 6)), np.array([[0, -1j], [-1j, 0]])]]))])
+def test_global_phase_controlled_gate(gate, matrix):
+    np.testing.assert_equal(cirq.unitary(gate.controlled()), matrix)
+
+
 def test_rot_gates_eq():
     eq = cirq.testing.EqualsTester()
     gates = [


### PR DESCRIPTION
Fixes #3111 

Presently the control override on XPowGate results in copying over the global phase shift of the XPowGate to the CXPowGate (similar for other control constuctions).  This is inconsistent with most people's notion of "control" where the identity component has no phase. 

This makes this override occur only when the global phase is zero.