### PR TITLE
Remove XMON as engine default

### DIFF
--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -32,7 +32,6 @@ from typing import Dict, List, Optional, Sequence, TypeVar, Union, TYPE_CHECKING
 from google.protobuf import any_pb2
 
 from cirq import circuits, study, value
-from cirq.google import gate_sets
 from cirq.google import serializable_gate_set as sgs
 from cirq.google.api import v1, v2
 from cirq.google.engine import (engine_client, engine_program, engine_job,
@@ -208,7 +207,8 @@ class Engine:
         Returns:
             A single TrialResult for this run.
         """
-        gate_set = gate_set or gate_sets.XMON
+        if not gate_set:
+            raise ValueError('No gate set provided')
         return list(
             self.run_sweep(program=program,
                            program_id=program_id,
@@ -269,7 +269,8 @@ class Engine:
             An EngineJob. If this is iterated over it returns a list of
             TrialResults, one for each parameter sweep.
         """
-        gate_set = gate_set or gate_sets.XMON
+        if not gate_set:
+            raise ValueError('No gate set provided')
         engine_program = self.create_program(program, program_id, gate_set,
                                              program_description,
                                              program_labels)
@@ -374,7 +375,8 @@ class Engine:
         Returns:
             A EngineProgram for the newly created program.
         """
-        gate_set = gate_set or gate_sets.XMON
+        if not gate_set:
+            raise ValueError('No gate set provided')
 
         if not program_id:
             program_id = _make_random_id('prog-')
@@ -436,12 +438,8 @@ class Engine:
                                             new_program,
                                             batch_mode=True)
 
-    def _serialize_program(self,
-                           program: 'cirq.Circuit',
-                           gate_set: Optional[sgs.SerializableGateSet] = None
-                          ) -> any_pb2.Any:
-        gate_set = gate_set or gate_sets.XMON
-
+    def _serialize_program(self, program: 'cirq.Circuit',
+                           gate_set: sgs.SerializableGateSet) -> any_pb2.Any:
         if not isinstance(program, circuits.Circuit):
             raise TypeError(f'Unrecognized program type: {type(program)}')
         program.device.validate_circuit(program)


### PR DESCRIPTION
- Engine now raises ValueError if you don't specify gate_set.
- While technically backwards incompatible, I don't think anyone
will have working code that doesn't specify a gate_set here.

Solves #2957 