### PR TITLE
Test the right order finder

### DIFF
--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -242,7 +242,7 @@ def test_example_shor_find_factor_with_composite_n_and_naive_order_finder(n):
 
 @pytest.mark.parametrize('n', (4, 6, 15, 125))
 def test_example_shor_find_factor_with_composite_n_and_quantum_order_finder(n):
-    d = examples.shor.find_factor(n, examples.shor.naive_order_finder)
+    d = examples.shor.find_factor(n, examples.shor.quantum_order_finder)
     assert 1 < d < n
     assert n % d == 0
 


### PR DESCRIPTION
Just noticed that `test_example_shor_find_factor_with_composite_n_and_quantum_order_finder` actually tests the naive order finder instead of testing the quantum order finder.

Note that the naive order finder is already tested by `test_example_shor_find_factor_with_composite_n_and_naive_order_finder`. Looks like a copy-paste error.