### PR TITLE
Unit test for Clifford check skipping multi-qubit unitaries

### DIFF
--- a/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq/sim/clifford/clifford_simulator_test.py
@@ -429,6 +429,27 @@ def test_sample_seed():
 
 
 def test_is_supported_operation():
+
+    class MultiQubitOp(cirq.Operation):
+        """Multi-qubit operation with unitary.
+
+        Used to verify that `is_supported_operation` does not attempt to
+        allocate the unitary for multi-qubit operations.
+        """
+
+        @property
+        def qubits(self):
+            return cirq.LineQubit.range(100)
+
+        def with_qubits(self, *new_qubits):
+            raise NotImplementedError()
+
+        def _has_unitary_(self):
+            return True
+
+        def _unitary_(self):
+            assert False
+
     q1, q2 = cirq.LineQubit.range(2)
     assert cirq.CliffordSimulator.is_supported_operation(cirq.X(q1))
     assert cirq.CliffordSimulator.is_supported_operation(cirq.H(q1))
@@ -438,6 +459,7 @@ def test_is_supported_operation():
         cirq.GlobalPhaseOperation(1j))
 
     assert not cirq.CliffordSimulator.is_supported_operation(cirq.T(q1))
+    assert not cirq.CliffordSimulator.is_supported_operation(MultiQubitOp())
 
 
 def test_simulate_pauli_string():


### PR DESCRIPTION
Unit test to prevent reoccurrence of #3164. Goes along with #3165.