### PR TITLE
fixing broken deprecation namings

### DIFF
--- a/cirq/_compat_test.py
+++ b/cirq/_compat_test.py
@@ -76,11 +76,27 @@ def f(a, b):
     return a + b
 
 
-def test_deprecated():
+def test_deprecated_with_name():
     with cirq.testing.assert_logs('test_func was used',
                                   'will be removed in cirq vNever',
                                   'Roll some dice.'):
         assert f(1, 2) == 3
+
+
+def new_func(a, b):
+    return a + b
+
+
+@deprecated(deadline='vNever', fix='Roll some dice.')
+def resolved_name(*args, **kwargs):
+    return new_func(*args, **kwargs)
+
+
+def test_deprecated_with_name_resolution():
+    with cirq.testing.assert_logs('resolved_name was used',
+                                  'will be removed in cirq vNever',
+                                  'Roll some dice.'):
+        assert resolved_name(1, 2) == 3
 
 
 def test_deprecated_parameter():

--- a/cirq/_compat_test.py
+++ b/cirq/_compat_test.py
@@ -71,32 +71,31 @@ def test_proper_eq():
     assert not proper_eq(pd.Index([1, 2, 3]), pd.Index([1, 4, 3]))
 
 
-@deprecated(deadline='vNever', fix='Roll some dice.', name='test_func')
-def f(a, b):
-    return a + b
-
-
 def test_deprecated_with_name():
+
+    @deprecated(deadline='vNever', fix='Roll some dice.', name='test_func')
+    def f(a, b):
+        return a + b
+
     with cirq.testing.assert_logs('test_func was used',
                                   'will be removed in cirq vNever',
                                   'Roll some dice.'):
         assert f(1, 2) == 3
 
 
-def new_func(a, b):
-    return a + b
+def test_deprecated():
 
+    def new_func(a, b):
+        return a + b
 
-@deprecated(deadline='vNever', fix='Roll some dice.')
-def resolved_name(*args, **kwargs):
-    return new_func(*args, **kwargs)
+    @deprecated(deadline='vNever', fix='Roll some dice.')
+    def old_func(*args, **kwargs):
+        return new_func(*args, **kwargs)
 
-
-def test_deprecated_with_name_resolution():
-    with cirq.testing.assert_logs('resolved_name was used',
+    with cirq.testing.assert_logs('old_func was used',
                                   'will be removed in cirq vNever',
                                   'Roll some dice.'):
-        assert resolved_name(1, 2) == 3
+        assert old_func(1, 2) == 3
 
 
 def test_deprecated_parameter():

--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -388,10 +388,10 @@ def partial_trace_of_state_vector_as_mixture(
                   if not protocols.approx_eq(p[0], 0.0)])
 
 
-wavefunction_partial_trace_as_mixture = deprecated(
-    deadline='v0.10.0',
-    fix='Use `cirq.partial_trace_of_state_vector_as_mixture` instead.')(
-        partial_trace_of_state_vector_as_mixture)
+@deprecated(deadline='v0.10.0',
+            fix='Use `cirq.partial_trace_of_state_vector_as_mixture` instead.')
+def wavefunction_partial_trace_as_mixture(*args, **kwargs):
+    return partial_trace_of_state_vector_as_mixture(*args, **kwargs)
 
 
 @deprecated_parameter(deadline='v0.10.0',
@@ -501,6 +501,6 @@ def sub_state_vector(state_vector: np.ndarray,
         "indices {}".format(keep_indices))
 
 
-subwavefunction = deprecated(
-    deadline='v0.10.0',
-    fix='Use `cirq.sub_state_vector` instead.')(sub_state_vector)
+@deprecated(deadline='v0.10.0', fix='Use `cirq.sub_state_vector` instead.')
+def subwavefunction(*args, **kwargs):
+    return sub_state_vector(*args, **kwargs)

--- a/cirq/ops/fourier_transform.py
+++ b/cirq/ops/fourier_transform.py
@@ -199,4 +199,6 @@ def qft(*qubits: 'cirq.Qid',
     return result
 
 
-QFT = deprecated(deadline='v0.10.0', fix='Use cirq.qft instead.')(qft)
+@deprecated(deadline='v0.10.0', fix='Use cirq.qft instead.')
+def QFT(*args, **kwargs):
+    return qft(*args, **kwargs)

--- a/cirq/sim/density_matrix_utils.py
+++ b/cirq/sim/density_matrix_utils.py
@@ -23,12 +23,15 @@ from cirq._compat import deprecated
 if TYPE_CHECKING:
     import cirq
 
-to_valid_density_matrix = deprecated(
-    deadline='v0.9', fix='Use cirq.to_valid_density_matrix instead.')(
-        qis.to_valid_density_matrix)
-von_neumann_entropy = deprecated(deadline='v0.9',
-                                 fix='Use cirq.von_neumann_entropy instead.')(
-                                     qis.von_neumann_entropy)
+
+@deprecated(deadline='v0.9', fix='Use cirq.to_valid_density_matrix instead.')
+def to_valid_density_matrix(*args, **kwargs):
+    return qis.to_valid_density_matrix(*args, **kwargs)
+
+
+@deprecated(deadline='v0.9', fix='Use cirq.von_neumann_entropy instead.')
+def von_neumann_entropy(*args, **kwargs):
+    return qis.von_neumann_entropy(*args, **kwargs)
 
 
 def sample_density_matrix(

--- a/cirq/sim/mux.py
+++ b/cirq/sim/mux.py
@@ -161,9 +161,12 @@ def final_state_vector(
     return cast(sparse_simulator.SparseSimulatorStep, result).state_vector()
 
 
-final_wavefunction = deprecated(
+@deprecated(
     deadline='v0.10.0',
-    fix='Use `cirq.final_state_vector` instead.')(final_state_vector)
+    fix='Use `cirq.final_state_vector` instead.',
+)
+def final_wavefunction(*args, **kwargs):
+    return final_state_vector(*args, **kwargs)
 
 
 def sample_sweep(program: 'cirq.Circuit',

--- a/cirq/sim/state_vector.py
+++ b/cirq/sim/state_vector.py
@@ -25,21 +25,35 @@ from cirq._compat import deprecated, deprecated_parameter
 if TYPE_CHECKING:
     import cirq
 
-bloch_vector_from_state_vector = deprecated(
-    deadline='v0.9', fix='Use cirq.bloch_vector_from_state_vector instead.')(
-        qis.bloch_vector_from_state_vector)
-density_matrix_from_state_vector = deprecated(
-    deadline='v0.9', fix='Use cirq.density_matrix_from_state_vector instead.')(
-        qis.density_matrix_from_state_vector)
-dirac_notation = deprecated(deadline='v0.9',
-                            fix='Use cirq.dirac_notation instead.')(
-                                qis.dirac_notation)
-to_valid_state_vector = deprecated(
-    deadline='v0.9',
-    fix='Use cirq.to_valid_state_vector instead.')(qis.to_valid_state_vector)
-validate_normalized_state = deprecated(
-    deadline='v0.10', fix='Use cirq.validate_normalized_state_vector instead.')(
-        qis.validate_normalized_state_vector)
+
+@deprecated(deadline='v0.9',
+            fix='Use cirq.bloch_vector_from_state_vector instead.')
+def bloch_vector_from_state_vector(*args, **kwargs):
+    return qis.bloch_vector_from_state_vector(*args, **kwargs)
+
+
+@deprecated(deadline='v0.9',
+            fix='Use cirq.density_matrix_from_state_vector instead.')
+def density_matrix_from_state_vector(*args, **kwargs):
+    return qis.density_matrix_from_state_vector(*args, **kwargs)
+
+
+@deprecated(deadline='v0.9', fix='Use cirq.dirac_notation instead.')
+def dirac_notation(*args, **kwargs):
+    return qis.dirac_notation(*args, **kwargs)
+
+
+@deprecated(deadline='v0.9', fix='Use cirq.to_valid_state_vector instead.')
+def to_valid_state_vector(*args, **kwargs):
+    return qis.to_valid_state_vector(*args, **kwargs)
+
+
+@deprecated(deadline='v0.10',
+            fix='Use cirq.validate_normalized_state_vector instead.')
+def validate_normalized_state(*args, **kwargs):
+    return qis.validate_normalized_state_vector(*args, **kwargs)
+
+
 STATE_VECTOR_LIKE = qis.STATE_VECTOR_LIKE
 
 


### PR DESCRIPTION
Fixes #3170. 

The deprecated decorator should not be used in a way it was directly used. 
The pattern was: 

```
old_function = deprecated(
    deadline='v0.9', fix='Use cirq.new_func instead.')(
        cirq.new_func)
```

The main problem is that we pass in the _new_ function into the deprecated decorator...now it does return a new function instance that is a decorated one and hence the old function gets a good wrapper around it. However, the name calculation in case `name` arg is not defined cannot determine what the name of `old_function` is. 

There are two ways to fix this AFAICT (unless I'm missing some python magic that can tell what the name of the variable is that is calling the current function - which I found to be not possible): 
1.) set `name` and duplicate the variable (function) name 
```
old_function = deprecated(
    deadline='v0.9', fix='Use cirq.new_func instead.', name = 'old_function')(
        cirq.new_func)
```
2.) use the decorator on a proper def
```
@deprecated(
    deadline='v0.9', fix='Use cirq.new_func instead.', name = 'old_function')
def old_function(*args,**kwargs):
     return cirq.new_func(*args,**kwargs)
```

I chose 2 in my solution, a bit more verbose but there is no duplication at least.
