### PR TITLE
adding rstcheck for rst files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           pip install -r requirements.txt
           python -m pip install -r cirq/contrib/contrib-requirements.txt
           pip install -r dev_tools/conf/pip-list-dev-tools.txt
+      - name: RST check
+        run: find . -type f -name "*.rst" | xargs rstcheck --report warning --ignore-directives autoclass,automodule
       - name: Doc check
         run: check/doctest -q
   pytest:

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ A simple example to get you up and running:
 
 Example output:
 
-.. code-block:: bash
+.. code-block::
 
   Circuit:
   (0, 0): ───X^0.5───M('m')───

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -30,4 +30,4 @@ ipython
 ipykernel
 
 # For verifying rst
-rstcheck
+rstcheck~=3.3.1

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -23,7 +23,11 @@ recommonmark >= 0.4.0
 Sphinx
 sphinx_rtd_theme
 sphinx-markdown-tables
+
 # For generating notebooks in documentation
 nbsphinx
 ipython
 ipykernel
+
+# For verifying rst
+rstcheck


### PR DESCRIPTION
Adds rstcheck to the doc tests CI step.

This is to avoid accidentally breaking pypi publishing with syntactically incorrect. See https://github.com/quantumlib/Cirq/issues/3175 for when this happened. 