### PR TITLE
Document matrices for parity gates

### DIFF
--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -43,7 +43,7 @@ class XXPowGate(eigen_gate.EigenGate,
 
         c = f cos(πt / 2)
         s = -i f sin(πt / 2)
-        f = e^{iπt/2}.
+        f = e^{iπt / 2}.
 
     See also: `cirq.MSGate` (the Mølmer–Sørensen gate), which is implemented via
     this class.
@@ -133,7 +133,7 @@ class YYPowGate(eigen_gate.EigenGate,
 
         c = f cos(πt / 2)
         s = -i f sin(πt / 2)
-        f = e^{iπt/2}.
+        f = e^{iπt / 2}.
     """
 
     def _eigen_components(self):

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -32,15 +32,21 @@ class XXPowGate(eigen_gate.EigenGate,
                 gate_features.InterchangeableQubitsGate):
     """The X-parity gate, possibly raised to a power.
 
-    At exponent=1, this gate implements the following unitary:
+    The XX**t gate implements the following unitary:
 
-        X⊗X = [0 0 0 1]
-              [0 0 1 0]
-              [0 1 0 0]
-              [1 0 0 0]
+        (X⊗X)^t = [c . . s]
+                  [. c s .]
+                  [. s c .]
+                  [s . . c]
+
+    where '.' means '0' and
+
+        c = f cos(πt / 2)
+        s = -i f sin(πt / 2)
+        f = e^{iπt/2}.
 
     See also: `cirq.MSGate` (the Mølmer–Sørensen gate), which is implemented via
-        this class.
+    this class.
     """
 
     def _eigen_components(self):
@@ -114,7 +120,21 @@ class XXPowGate(eigen_gate.EigenGate,
 class YYPowGate(eigen_gate.EigenGate,
                 gate_features.TwoQubitGate,
                 gate_features.InterchangeableQubitsGate):
-    """The Y-parity gate, possibly raised to a power."""
+    """The Y-parity gate, possibly raised to a power.
+
+    The YY**t gate implements the following unitary:
+
+        (Y⊗Y)^t = [ c . . -s]
+                  [ . c s  .]
+                  [ . s c  .]
+                  [-s . .  c]
+
+    where '.' means '0' and
+
+        c = f cos(πt / 2)
+        s = -i f sin(πt / 2)
+        f = e^{iπt/2}.
+    """
 
     def _eigen_components(self):
         return [
@@ -197,7 +217,7 @@ class ZZPowGate(eigen_gate.EigenGate,
                   [. . w .]
                   [. . . 1]
 
-        where w = e^{i \pi t} and '.' means '0'.
+    where w = e^{iπt} and '.' means '0'.
     """
 
     def _decompose_(self, qubits):


### PR DESCRIPTION
Fixes #2806.

This is covered by tests, but I ran these checks to be sure:

```
In [1]: import cirq, numpy as np

In [2]: def mxx(t): 
   ...:     f = np.e**(1j*np.pi*t/2) 
   ...:     c = f * np.cos(np.pi*t/2) 
   ...:     s = -1j * f * np.sin(np.pi*t/2) 
   ...:     return np.array([[c, 0, 0, s], [0, c, s, 0], [0, s, c, 0], [s, 0, 0, c]]) 
   ...:     

In [3]: def myy(t): 
   ...:     f = np.e**(1j*np.pi*t/2) 
   ...:     c = f * np.cos(np.pi*t/2) 
   ...:     s = -1j * f * np.sin(np.pi*t/2) 
   ...:     return np.array([[c, 0, 0, -s], [0, c, s, 0], [0, s, c, 0], [-s, 0, 0, c]]) 
   ...:     

In [4]: np.allclose(cirq.unitary(cirq.XX**0.1), mxx(0.1))
Out[4]: True

In [5]: np.allclose(cirq.unitary(cirq.YY**0.1), myy(0.1))
Out[5]: True
```

NB: Global phase factors complicate documentation. I think we should prefer SU(n) gates (over trying to force one eigenvalue onto the real axis).