### PR TITLE
Fix docs build

### DIFF
--- a/cirq/google/gate_sets.py
+++ b/cirq/google/gate_sets.py
@@ -109,6 +109,9 @@ NAMED_GATESETS = {
     'sycamore': SYC_GATESET,
     'fsim': FSIM_GATESET,
 }
+document(NAMED_GATESETS,
+         """Gate sets that can be used with the Google engine.""")
+
 
 GOOGLE_GATESETS = [
     SYC_GATESET,

--- a/cirq/google/gate_sets.py
+++ b/cirq/google/gate_sets.py
@@ -109,9 +109,6 @@ NAMED_GATESETS = {
     'sycamore': SYC_GATESET,
     'fsim': FSIM_GATESET,
 }
-document(NAMED_GATESETS,
-         """Gate sets that can be used with the Google engine.""")
-
 
 GOOGLE_GATESETS = [
     SYC_GATESET,

--- a/dev_tools/build-docs.sh
+++ b/dev_tools/build-docs.sh
@@ -44,7 +44,7 @@ rm -rf "${docs_conf_dir}/generated"
 rm -rf "${out_dir}"
 
 # Regenerate docs.
-sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W
+sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W --keep-going -j auto
 
 # Cleanup newly generated temporary files.
 rm -rf "${docs_conf_dir}/generated"

--- a/dev_tools/build-docs.sh
+++ b/dev_tools/build-docs.sh
@@ -44,7 +44,7 @@ rm -rf "${docs_conf_dir}/generated"
 rm -rf "${out_dir}"
 
 # Regenerate docs.
-sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W --keep-going -j auto
+sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W --keep-going
 
 # Cleanup newly generated temporary files.
 rm -rf "${docs_conf_dir}/generated"

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -20,7 +20,7 @@ qiskit~=0.13.0
 # For generating documentation.
 pypandoc
 recommonmark >= 0.4.0
-Sphinx
+Sphinx~=3.1.0
 sphinx_rtd_theme
 sphinx-markdown-tables
 


### PR DESCRIPTION
Fixes #3200.

As we will deprecate Sphinx soon anyway, and I wanted to have this situation resolved asap, I decided to pin to 3.1.* version of sphinx instead of fighting the new warnings from 3.2.0. 