### PR TITLE
Remove cirq v1 programs from namespace

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -14,13 +14,6 @@
 
 from cirq.google import api
 
-from cirq.google.api.v1.programs import (
-    is_native_xmon_gate,
-    is_native_xmon_op,
-    pack_results,
-    unpack_results,
-)
-
 from cirq.google.devices import (
     Bristlecone,
     Foxtail,

--- a/cirq/google/api/v1/programs_test.py
+++ b/cirq/google/api/v1/programs_test.py
@@ -20,7 +20,6 @@ import cirq
 import cirq.google as cg
 import cirq.google.api.v1.programs as programs
 from cirq.google.api.v1 import operations_pb2
-from cirq.google.api.v1.programs import (_parameterized_value_from_proto)
 
 
 def assert_proto_dict_convert(gate: cirq.Gate, proto: operations_pb2.Operation,
@@ -92,7 +91,7 @@ def test_pack_results():
             [1, 0],
         ])),
     ]
-    data = cg.pack_results(measurements)
+    data = programs.pack_results(measurements)
     expected = make_bytes("""
         000 00
         001 01
@@ -108,7 +107,7 @@ def test_pack_results():
 
 
 def test_pack_results_no_measurements():
-    assert cg.pack_results([]) == b''
+    assert programs.pack_results([]) == b''
 
 
 def test_pack_results_incompatible_shapes():
@@ -117,10 +116,10 @@ def test_pack_results_incompatible_shapes():
         return np.zeros(shape, dtype=bool)
 
     with pytest.raises(ValueError):
-        cg.pack_results([('a', bools(10))])
+        programs.pack_results([('a', bools(10))])
 
     with pytest.raises(ValueError):
-        cg.pack_results([('a', bools(7, 3)), ('b', bools(8, 2))])
+        programs.pack_results([('a', bools(7, 3)), ('b', bools(8, 2))])
 
 
 def test_unpack_results():
@@ -134,7 +133,7 @@ def test_unpack_results():
         110 10
     """)
     assert len(data) == 5  # 35 data bits + 5 padding bits
-    results = cg.unpack_results(data, 7, [('a', 3), ('b', 2)])
+    results = programs.unpack_results(data, 7, [('a', 3), ('b', 2)])
     assert 'a' in results
     assert results['a'].shape == (7, 3)
     assert results['a'].dtype == bool
@@ -301,7 +300,7 @@ def test_invalid_to_proto_dict_qubit_number():
 
 
 def test_parameterized_value_from_proto():
-    from_proto = _parameterized_value_from_proto
+    from_proto = programs._parameterized_value_from_proto
 
     m1 = operations_pb2.ParameterizedFloat(raw=5)
     assert from_proto(m1) == 5
@@ -328,23 +327,23 @@ def test_is_supported():
     a = cirq.GridQubit(0, 0)
     b = cirq.GridQubit(0, 1)
     c = cirq.GridQubit(1, 0)
-    assert cg.is_native_xmon_op(cirq.CZ(a, b))
-    assert cg.is_native_xmon_op(cirq.X(a)**0.5)
-    assert cg.is_native_xmon_op(cirq.Y(a)**0.5)
-    assert cg.is_native_xmon_op(cirq.Z(a)**0.5)
-    assert cg.is_native_xmon_op(
+    assert programs.is_native_xmon_op(cirq.CZ(a, b))
+    assert programs.is_native_xmon_op(cirq.X(a)**0.5)
+    assert programs.is_native_xmon_op(cirq.Y(a)**0.5)
+    assert programs.is_native_xmon_op(cirq.Z(a)**0.5)
+    assert programs.is_native_xmon_op(
         cirq.PhasedXPowGate(phase_exponent=0.2).on(a)**0.5)
-    assert cg.is_native_xmon_op(cirq.Z(a)**1)
-    assert not cg.is_native_xmon_op(cirq.CCZ(a, b, c))
-    assert not cg.is_native_xmon_op(cirq.SWAP(a, b))
+    assert programs.is_native_xmon_op(cirq.Z(a)**1)
+    assert not programs.is_native_xmon_op(cirq.CCZ(a, b, c))
+    assert not programs.is_native_xmon_op(cirq.SWAP(a, b))
 
 
 def test_is_native_xmon_gate():
-    assert cg.is_native_xmon_gate(cirq.CZ)
-    assert cg.is_native_xmon_gate(cirq.X**0.5)
-    assert cg.is_native_xmon_gate(cirq.Y**0.5)
-    assert cg.is_native_xmon_gate(cirq.Z**0.5)
-    assert cg.is_native_xmon_gate(cirq.PhasedXPowGate(phase_exponent=0.2)**0.5)
-    assert cg.is_native_xmon_gate(cirq.Z**1)
-    assert not cg.is_native_xmon_gate(cirq.CCZ)
-    assert not cg.is_native_xmon_gate(cirq.SWAP)
+    assert programs.is_native_xmon_gate(cirq.CZ)
+    assert programs.is_native_xmon_gate(cirq.X**0.5)
+    assert programs.is_native_xmon_gate(cirq.Y**0.5)
+    assert programs.is_native_xmon_gate(cirq.Z**0.5)
+    assert programs.is_native_xmon_gate(cirq.PhasedXPowGate(phase_exponent=0.2)**0.5)
+    assert programs.is_native_xmon_gate(cirq.Z**1)
+    assert not programs.is_native_xmon_gate(cirq.CCZ)
+    assert not programs.is_native_xmon_gate(cirq.SWAP)

--- a/cirq/google/api/v1/programs_test.py
+++ b/cirq/google/api/v1/programs_test.py
@@ -343,7 +343,8 @@ def test_is_native_xmon_gate():
     assert programs.is_native_xmon_gate(cirq.X**0.5)
     assert programs.is_native_xmon_gate(cirq.Y**0.5)
     assert programs.is_native_xmon_gate(cirq.Z**0.5)
-    assert programs.is_native_xmon_gate(cirq.PhasedXPowGate(phase_exponent=0.2)**0.5)
+    assert programs.is_native_xmon_gate(
+        cirq.PhasedXPowGate(phase_exponent=0.2)**0.5)
     assert programs.is_native_xmon_gate(cirq.Z**1)
     assert not programs.is_native_xmon_gate(cirq.CCZ)
     assert not programs.is_native_xmon_gate(cirq.SWAP)

--- a/cirq/google/devices/xmon_device.py
+++ b/cirq/google/devices/xmon_device.py
@@ -75,15 +75,21 @@ class XmonDevice(devices.Device):
             return value.Duration()
         raise ValueError('Unsupported gate type: {!r}'.format(operation))
 
+    @classmethod
+    def is_supported_gate(cls, gate: 'cirq.Gate'):
+        """Returns true if the gate is allowed.
+        """
+        return isinstance(
+            gate, (ops.CZPowGate, ops.XPowGate, ops.YPowGate,
+                   ops.PhasedXPowGate, ops.MeasurementGate, ops.ZPowGate))
+
     def validate_gate(self, gate: 'cirq.Gate'):
         """Raises an error if the given gate isn't allowed.
 
         Raises:
             ValueError: Unsupported gate.
         """
-        if not isinstance(
-                gate, (ops.CZPowGate, ops.XPowGate, ops.YPowGate,
-                       ops.PhasedXPowGate, ops.MeasurementGate, ops.ZPowGate)):
+        if not self.is_supported_gate(gate):
             raise ValueError('Unsupported gate type: {!r}'.format(gate))
 
     def validate_operation(self, operation: 'cirq.Operation'):

--- a/cirq/google/optimizers/convert_to_xmon_gates.py
+++ b/cirq/google/optimizers/convert_to_xmon_gates.py
@@ -78,7 +78,7 @@ class ConvertToXmonGates(PointOptimizer):
                       ops.XPowGate, ops.YPowGate, ops.ZPowGate)))
 
     def convert(self, op: 'cirq.Operation') -> List['cirq.Operation']:
-
+        from cirq.google import XMON
         def on_stuck_raise(bad):
             return TypeError("Don't know how to work with {!r}. "
                              "It isn't a native xmon operation, "
@@ -87,7 +87,7 @@ class ConvertToXmonGates(PointOptimizer):
 
         return protocols.decompose(
             op,
-            keep=self._is_native_xmon_op,
+            keep=XMON.is_supported_operation,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=None if self.ignore_failures else on_stuck_raise)
 

--- a/cirq/google/optimizers/convert_to_xmon_gates.py
+++ b/cirq/google/optimizers/convert_to_xmon_gates.py
@@ -79,6 +79,7 @@ class ConvertToXmonGates(PointOptimizer):
 
     def convert(self, op: 'cirq.Operation') -> List['cirq.Operation']:
         from cirq.google import XMON
+
         def on_stuck_raise(bad):
             return TypeError("Don't know how to work with {!r}. "
                              "It isn't a native xmon operation, "

--- a/cirq/google/optimizers/convert_to_xmon_gates.py
+++ b/cirq/google/optimizers/convert_to_xmon_gates.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 from typing import List, TYPE_CHECKING
 
-from cirq import protocols
+from cirq import ops, protocols
 from cirq.circuits.optimization_pass import (
     PointOptimizationSummary,
     PointOptimizer,
 )
-from cirq.google.api.v1 import programs
 from cirq import optimizers
 
 if TYPE_CHECKING:
@@ -65,6 +64,20 @@ class ConvertToXmonGates(PointOptimizer):
 
         return NotImplemented
 
+    def _is_native_xmon_op(self, op: 'cirq.Operation') -> bool:
+        """Check if the gate corresponding to an operation is a native xmon gate.
+
+        Args:
+            op: Input operation.
+
+        Returns:
+            True if the operation is native to the xmon, false otherwise.
+        """
+        return (isinstance(op, ops.GateOperation) and
+                isinstance(op.gate,
+                      (ops.CZPowGate, ops.MeasurementGate, ops.PhasedXPowGate,
+                       ops.XPowGate, ops.YPowGate, ops.ZPowGate)))
+
     def convert(self, op: 'cirq.Operation') -> List['cirq.Operation']:
 
         def on_stuck_raise(bad):
@@ -75,7 +88,7 @@ class ConvertToXmonGates(PointOptimizer):
 
         return protocols.decompose(
             op,
-            keep=programs.is_native_xmon_op,
+            keep=self._is_native_xmon_op,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=None if self.ignore_failures else on_stuck_raise)
 

--- a/cirq/google/optimizers/convert_to_xmon_gates.py
+++ b/cirq/google/optimizers/convert_to_xmon_gates.py
@@ -65,7 +65,7 @@ class ConvertToXmonGates(PointOptimizer):
         return NotImplemented
 
     def _is_native_xmon_op(self, op: 'cirq.Operation') -> bool:
-        """Check if the gate corresponding to an operation is a native xmon gate.
+        """Check if the gate within an operation is a native xmon gate.
 
         Args:
             op: Input operation.
@@ -73,10 +73,9 @@ class ConvertToXmonGates(PointOptimizer):
         Returns:
             True if the operation is native to the xmon, false otherwise.
         """
-        return (isinstance(op, ops.GateOperation) and
-                isinstance(op.gate,
-                      (ops.CZPowGate, ops.MeasurementGate, ops.PhasedXPowGate,
-                       ops.XPowGate, ops.YPowGate, ops.ZPowGate)))
+        return (isinstance(op, ops.GateOperation) and isinstance(
+            op.gate, (ops.CZPowGate, ops.MeasurementGate, ops.PhasedXPowGate,
+                      ops.XPowGate, ops.YPowGate, ops.ZPowGate)))
 
     def convert(self, op: 'cirq.Operation') -> List['cirq.Operation']:
 

--- a/cirq/google/optimizers/convert_to_xmon_gates.py
+++ b/cirq/google/optimizers/convert_to_xmon_gates.py
@@ -73,12 +73,11 @@ class ConvertToXmonGates(PointOptimizer):
         Returns:
             True if the operation is native to the xmon, false otherwise.
         """
-        return (isinstance(op, ops.GateOperation) and isinstance(
-            op.gate, (ops.CZPowGate, ops.MeasurementGate, ops.PhasedXPowGate,
-                      ops.XPowGate, ops.YPowGate, ops.ZPowGate)))
+        from cirq.google.devices import XmonDevice
+        return (isinstance(op, ops.GateOperation) and
+                XmonDevice.is_supported_gate(op.gate))
 
     def convert(self, op: 'cirq.Operation') -> List['cirq.Operation']:
-        from cirq.google import XMON
 
         def on_stuck_raise(bad):
             return TypeError("Don't know how to work with {!r}. "
@@ -88,7 +87,7 @@ class ConvertToXmonGates(PointOptimizer):
 
         return protocols.decompose(
             op,
-            keep=XMON.is_supported_operation,
+            keep=self._is_native_xmon_op,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=None if self.ignore_failures else on_stuck_raise)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -502,13 +502,9 @@ Functionality specific to quantum hardware and services from Google.
     cirq.google.XMON
     cirq.google.get_engine
     cirq.google.get_engine_sampler
-    cirq.google.is_native_xmon_gate
-    cirq.google.is_native_xmon_op
     cirq.google.line_on_device
     cirq.google.optimized_for_sycamore
     cirq.google.optimized_for_xmon
-    cirq.google.pack_results
-    cirq.google.unpack_results
     cirq.google.AnnealSequenceSearchStrategy
     cirq.google.Bristlecone
     cirq.google.Calibration


### PR DESCRIPTION
- Cirq v1 protos are deprecated.
- No one should have been actively using these functions for over a year.