### PR TITLE
Add jupyter-compatible repr for SerializableDevice

### DIFF
--- a/cirq/google/devices/serializable_device.py
+++ b/cirq/google/devices/serializable_device.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Device object for converting from device specification protos"""
 
-from typing import (Callable, cast, Dict, Iterable, Optional, List, Set, Tuple,
-                    Type, TYPE_CHECKING, FrozenSet)
+from typing import (Any, Callable, cast, Dict, Iterable, Optional, List, Set,
+                    Tuple, Type, TYPE_CHECKING, FrozenSet)
 
 from cirq import circuits, devices
 from cirq.google import serializable_gate_set
@@ -234,6 +234,11 @@ class SerializableDevice(devices.Device):
                                   use_unicode_characters=True)
 
         return super().__str__()
+
+    def _repr_pretty_(self, p: Any, cycle: bool) -> None:
+        """Creates ASCII diagram for Jupyter, IPython, etc."""
+        # There should never be a cycle, but just in case use the default repr.
+        p.text(repr(self) if cycle else str(self))
 
     def _find_operation_type(self,
                              op: 'cirq.Operation') -> Optional[_GateDefinition]:

--- a/cirq/google/devices/serializable_device_test.py
+++ b/cirq/google/devices/serializable_device_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import textwrap
 import unittest.mock as mock
 
 import pytest
@@ -22,6 +23,7 @@ import cirq.google as cg
 import cirq.google.api.v2 as v2
 import cirq.google.api.v2.device_pb2 as device_pb2
 import cirq.google.common_serializers as cgc
+import cirq.google.devices.known_devices as cgdk
 
 _JUST_CZ = cg.SerializableGateSet(
     gate_set_name='cz_gate_set',
@@ -50,6 +52,26 @@ _JUST_MEAS = cg.SerializableGateSet(
                               args=[])
     ],
 )
+
+
+def test_str_with_grid_qubits():
+    qubits = cirq.GridQubit.rect(2, 3, left=1, top=1)
+    device_proto = cgdk.create_device_proto_for_qubits(
+        qubits=qubits,
+        pairs=[
+            (qubits[0], qubits[1]),
+            (qubits[0], qubits[3]),
+            (qubits[1], qubits[4]),
+            (qubits[4], qubits[5]),
+        ],
+        gate_sets=[cg.FSIM_GATESET])
+    device = cgdk.SerializableDevice.from_proto(device_proto,
+                                                gate_sets=[cg.FSIM_GATESET])
+    assert str(device) == textwrap.dedent("""\
+        (1, 1)───(1, 2)   (1, 3)
+        │        │
+        │        │
+        (2, 1)   (2, 2)───(2, 3)""")
 
 
 @pytest.mark.parametrize('cycle,func', [(False, str), (True, repr)])

--- a/cirq/google/devices/serializable_device_test.py
+++ b/cirq/google/devices/serializable_device_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import copy
+import unittest.mock as mock
+
 import pytest
 
 import cirq
@@ -48,6 +50,14 @@ _JUST_MEAS = cg.SerializableGateSet(
                               args=[])
     ],
 )
+
+
+@pytest.mark.parametrize('cycle,func', [(False, str), (True, repr)])
+def test_repr_pretty(cycle, func):
+    device = cg.Sycamore
+    printer = mock.Mock()
+    device._repr_pretty_(printer, cycle)
+    printer.text.assert_called_once_with(func(device))
 
 
 def test_gate_definition_equality():


### PR DESCRIPTION
Makes working with SerializableDevice in ipython or jupyter a bit nicer.

Before:
```
In [1]: import cirq                                                                                      

In [2]: cirq.google.Sycamore                                                                             
Out[2]: <cirq.google.devices.serializable_device.SerializableDevice at 0x7fa7e2840b50>
```


After:
```
In [1]: import cirq                                                                                      

In [2]: cirq.google.Sycamore                                                                             
Out[2]: 
                                             (0, 5)───(0, 6)
                                             │        │
                                             │        │
                                    (1, 4)───(1, 5)───(1, 6)───(1, 7)
                                    │        │        │        │
                                    │        │        │        │
                           (2, 3)───(2, 4)───(2, 5)───(2, 6)───(2, 7)───(2, 8)
                           │        │        │        │        │        │
                           │        │        │        │        │        │
                  (3, 2)───(3, 3)───(3, 4)───(3, 5)───(3, 6)───(3, 7)───(3, 8)───(3, 9)
                  │        │        │        │        │        │        │        │
                  │        │        │        │        │        │        │        │
         (4, 1)───(4, 2)───(4, 3)───(4, 4)───(4, 5)───(4, 6)───(4, 7)───(4, 8)───(4, 9)
         │        │        │        │        │        │        │        │
         │        │        │        │        │        │        │        │
(5, 0)───(5, 1)───(5, 2)───(5, 3)───(5, 4)───(5, 5)───(5, 6)───(5, 7)───(5, 8)
         │        │        │        │        │        │        │
         │        │        │        │        │        │        │
         (6, 1)───(6, 2)───(6, 3)───(6, 4)───(6, 5)───(6, 6)───(6, 7)
                  │        │        │        │        │
                  │        │        │        │        │
                  (7, 2)───(7, 3)───(7, 4)───(7, 5)───(7, 6)
                           │        │        │
                           │        │        │
                           (8, 3)───(8, 4)───(8, 5)
                                    │
                                    │
                                    (9, 4)
```
