### PR TITLE
Add initial support for converting Quil programs into Cirq circuits

### DIFF
--- a/cirq/circuits/quil_output.py
+++ b/cirq/circuits/quil_output.py
@@ -39,9 +39,9 @@ class QuilOneQubitGate(ops.SingleQubitGate):
 
     def _quil_(self, qubits: Tuple['cirq.Qid', ...],
                formatter: 'cirq.QuilFormatter') -> str:
-        return (f'DEFGATE USERGATE:\n\t'
+        return (f'DEFGATE USERGATE:\n    '
                 f'{to_quil_complex_format(self.matrix[0, 0])}, '
-                f'{to_quil_complex_format(self.matrix[0, 1])}\n\t'
+                f'{to_quil_complex_format(self.matrix[0, 1])}\n    '
                 f'{to_quil_complex_format(self.matrix[1, 0])}, '
                 f'{to_quil_complex_format(self.matrix[1, 1])}\n'
                 f'{formatter.format("USERGATE {0}", qubits[0])}\n')
@@ -73,19 +73,19 @@ class QuilTwoQubitGate(ops.TwoQubitGate):
     def _quil_(self, qubits: Tuple['cirq.Qid', ...],
                formatter: 'cirq.QuilFormatter') -> str:
         return (
-            f'DEFGATE USERGATE:\n\t'
+            f'DEFGATE USERGATE:\n    '
             f'{to_quil_complex_format(self.matrix[0, 0])}, '
             f'{to_quil_complex_format(self.matrix[0, 1])}, '
             f'{to_quil_complex_format(self.matrix[0, 2])}, '
-            f'{to_quil_complex_format(self.matrix[0, 3])}\n\t'
+            f'{to_quil_complex_format(self.matrix[0, 3])}\n    '
             f'{to_quil_complex_format(self.matrix[1, 0])}, '
             f'{to_quil_complex_format(self.matrix[1, 1])}, '
             f'{to_quil_complex_format(self.matrix[1, 2])}, '
-            f'{to_quil_complex_format(self.matrix[1, 3])}\n\t'
+            f'{to_quil_complex_format(self.matrix[1, 3])}\n    '
             f'{to_quil_complex_format(self.matrix[2, 0])}, '
             f'{to_quil_complex_format(self.matrix[2, 1])}, '
             f'{to_quil_complex_format(self.matrix[2, 2])}, '
-            f'{to_quil_complex_format(self.matrix[2, 3])}\n\t'
+            f'{to_quil_complex_format(self.matrix[2, 3])}\n    '
             f'{to_quil_complex_format(self.matrix[3, 0])}, '
             f'{to_quil_complex_format(self.matrix[3, 1])}, '
             f'{to_quil_complex_format(self.matrix[3, 2])}, '

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -119,8 +119,8 @@ def test_quil_one_qubit_gate_output():
     assert str(output) == """# Created using Cirq.
 
 DEFGATE USERGATE1:
-\t1.0+0.0i, 0.0+0.0i
-\t0.0+0.0i, 1.0+0.0i
+    1.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 1.0+0.0i
 USERGATE1 0
 """
 
@@ -136,12 +136,12 @@ def test_two_quil_one_qubit_gate_output():
     assert str(output) == """# Created using Cirq.
 
 DEFGATE USERGATE1:
-\t1.0+0.0i, 0.0+0.0i
-\t0.0+0.0i, 1.0+0.0i
+    1.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 1.0+0.0i
 USERGATE1 0
 DEFGATE USERGATE2:
-\t2.0+0.0i, 0.0+0.0i
-\t0.0+0.0i, 3.0+0.0i
+    2.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 3.0+0.0i
 USERGATE2 0
 """
 
@@ -157,10 +157,10 @@ def test_quil_two_qubit_gate_output():
     assert str(output) == """# Created using Cirq.
 
 DEFGATE USERGATE1:
-\t1.0+0.0i, 0.0+0.0i, 0.0+0.0i, 0.0+0.0i
-\t0.0+0.0i, 1.0+0.0i, 0.0+0.0i, 0.0+0.0i
-\t0.0+0.0i, 0.0+0.0i, 1.0+0.0i, 0.0+0.0i
-\t0.0+0.0i, 0.0+0.0i, 0.0+0.0i, 1.0+0.0i
+    1.0+0.0i, 0.0+0.0i, 0.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 1.0+0.0i, 0.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 0.0+0.0i, 1.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 0.0+0.0i, 0.0+0.0i, 1.0+0.0i
 USERGATE1 0 1
 """
 
@@ -425,3 +425,17 @@ def test_two_qubit_diagonal_gate_quil_output():
     output = cirq.QuilOutput(operations, (q0, q1))
     program = pyquil.Program(str(output))
     assert f"\n{program.out()}" == QUIL_DIAGONAL_DEFGATE_PROGRAM
+
+
+def test_parseable_defgate_output():
+    pyquil = pytest.importorskip("pyquil")
+    q0, q1 = _make_qubits(2)
+    operations = [
+        QuilOneQubitGate(np.array([[1, 0], [0, 1]])).on(q0),
+        QuilTwoQubitGate(
+            np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0],
+                      [0, 0, 0, 1]])).on(q0, q1)
+    ]
+    output = cirq.QuilOutput(operations, (q0, q1))
+    # Just checks that we can create a pyQuil Program without crashing.
+    pyquil.Program(str(output))

--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -7,3 +7,6 @@ pylatex~=1.3.0
 quimb
 opt_einsum
 autoray
+
+# quil import
+pyquil~=2.21.0

--- a/cirq/contrib/quil_import/__init__.py
+++ b/cirq/contrib/quil_import/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cirq.contrib.quil_import.quil import circuit_from_quil

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -1,0 +1,275 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Dict, Union
+
+import numpy as np
+from pyquil.parser import parse
+from pyquil.quilbase import (
+    Declare,
+    DefGate,
+    Gate as PyQuilGate,
+    Measurement as PyQuilMeasurement,
+    Pragma,
+    Reset,
+    ResetQubit,
+)
+
+from cirq import Circuit, LineQubit
+from cirq.ops import (
+    CCNOT,
+    CNOT,
+    CSWAP,
+    CZ,
+    CZPowGate,
+    Gate,
+    H,
+    I,
+    ISWAP,
+    ISwapPowGate,
+    MatrixGate,
+    MeasurementGate,
+    S,
+    SWAP,
+    T,
+    X,
+    Y,
+    Z,
+    ZPowGate,
+    rx,
+    ry,
+    rz,
+)
+
+
+class UndefinedQuilGate(Exception):
+    pass
+
+
+class UnsupportedQuilInstruction(Exception):
+    pass
+
+
+#
+# Functions for converting supported parameterized Quil gates.
+#
+
+
+def cphase(param: float) -> CZPowGate:
+    """Returns a controlled-phase gate as a Cirq CZPowGate with exponent
+    determined by the input param. The angle parameter of pyQuil's CPHASE
+    gate and the exponent of Cirq's CZPowGate differ by a factor of pi.
+
+    Args:
+        param: Gate parameter (in radians).
+
+    Returns:
+        A CZPowGate equivalent to a CPHASE gate of given angle.
+    """
+    return CZPowGate(exponent=param / np.pi)
+
+
+def cphase00(phi: float) -> MatrixGate:
+    """Returns a Cirq MatrixGate for pyQuil's CPHASE00 gate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a CPHASE00 gate of given angle.
+    """
+    cphase00_matrix = np.array(
+        [[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+        dtype=complex)
+    return MatrixGate(cphase00_matrix)
+
+
+def cphase01(phi: float) -> MatrixGate:
+    """Returns a Cirq MatrixGate for pyQuil's CPHASE01 gate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a CPHASE01 gate of given angle.
+    """
+    cphase01_matrix = np.array(
+        [[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+        dtype=complex)
+    return MatrixGate(cphase01_matrix)
+
+
+def cphase10(phi: float) -> MatrixGate:
+    """Returns a Cirq MatrixGate for pyQuil's CPHASE10 gate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a CPHASE10 gate of given angle.
+    """
+    cphase10_matrix = np.array(
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]],
+        dtype=complex)
+    return MatrixGate(cphase10_matrix)
+
+
+def phase(param: float) -> ZPowGate:
+    """Returns a single-qubit phase gate as a Cirq ZPowGate with exponent
+    determined by the input param. The angle parameter of pyQuil's PHASE
+    gate and the exponent of Cirq's ZPowGate differ by a factor of pi.
+
+    Args:
+        param: Gate parameter (in radians).
+
+    Returns:
+        A ZPowGate equivalent to a PHASE gate of given angle.
+    """
+    return ZPowGate(exponent=param / np.pi)
+
+
+def pswap(phi: float) -> MatrixGate:
+    """Returns a Cirq MatrixGate for pyQuil's PSWAP gate.
+
+    Args:
+        phi: Gate parameter (in radians).
+
+    Returns:
+        A MatrixGate equivalent to a PSWAP gate of given angle.
+    """
+    pswap_matrix = np.array([
+        [1, 0, 0, 0],
+        [0, 0, np.exp(1j * phi), 0],
+        [0, np.exp(1j * phi), 0, 0],
+        [0, 0, 0, 1],
+    ],
+                            dtype=complex)
+    return MatrixGate(pswap_matrix)
+
+
+def xy(param: float) -> ISwapPowGate:
+    """Returns an ISWAP-family gate as a Cirq ISwapPowGate with exponent
+    determined by the input param. The angle parameter of pyQuil's XY gate
+    and the exponent of Cirq's ISwapPowGate differ by a factor of pi.
+
+    Args:
+        param: Gate parameter (in radians).
+
+    Returns:
+        An ISwapPowGate equivalent to an XY gate of given angle.
+    """
+    return ISwapPowGate(exponent=param / np.pi)
+
+
+PRAGMA_ERROR = """
+Please remove PRAGMAs from your Quil program.
+If you would like to add noise, do so after conversion.
+"""
+
+RESET_ERROR = """
+Please remove RESETs from your Quil program.
+RESET directives have special meaning on QCS, to enable active reset.
+"""
+
+# Parameterized gates map to functions that produce Gate constructors.
+SUPPORTED_GATES: Dict[str, Union[Gate, Callable[..., Gate]]] = {
+    "CCNOT": CCNOT,
+    "CNOT": CNOT,
+    "CSWAP": CSWAP,
+    "CPHASE": cphase,
+    "CPHASE00": cphase00,
+    "CPHASE01": cphase01,
+    "CPHASE10": cphase10,
+    "CZ": CZ,
+    "PHASE": phase,
+    "H": H,
+    "I": I,
+    "ISWAP": ISWAP,
+    "PSWAP": pswap,
+    "RX": rx,
+    "RY": ry,
+    "RZ": rz,
+    "S": S,
+    "SWAP": SWAP,
+    "T": T,
+    "X": X,
+    "Y": Y,
+    "Z": Z,
+    "XY": xy,
+}
+
+
+def circuit_from_quil(quil: str) -> Circuit:
+    """Convert a Quil program to a Cirq Circuit.
+
+    Args:
+        quil: The Quil program to convert.
+
+    Returns:
+        A Cirq Circuit generated from the Quil program.
+
+    References:
+        https://github.com/rigetti/pyquil
+    """
+    circuit = Circuit()
+    defined_gates = SUPPORTED_GATES.copy()
+    instructions = parse(quil)
+
+    for inst in instructions:
+        # Add DEFGATE-defined gates to defgates dict using MatrixGate.
+        if isinstance(inst, DefGate):
+            if inst.parameters:
+                raise UnsupportedQuilInstruction(
+                    "Parameterized DEFGATEs are currently unsupported.")
+            defined_gates[inst.name] = MatrixGate(inst.matrix)
+
+        # Pass when encountering a DECLARE.
+        elif isinstance(inst, Declare):
+            pass
+
+        # Convert pyQuil gates to Cirq operations.
+        elif isinstance(inst, PyQuilGate):
+            quil_gate_name = inst.name
+            quil_gate_params = inst.params
+            line_qubits = list(LineQubit(q.index) for q in inst.qubits)
+            if quil_gate_name not in defined_gates:
+                raise UndefinedQuilGate(
+                    f"Quil gate {quil_gate_name} not supported in Cirq.")
+            cirq_gate_fn = defined_gates[quil_gate_name]
+            if quil_gate_params:
+                circuit += cirq_gate_fn(*quil_gate_params)(*line_qubits)
+            else:
+                circuit += cirq_gate_fn(*line_qubits)
+
+        # Convert pyQuil MEASURE operations to Cirq MeasurementGate objects.
+        elif isinstance(inst, PyQuilMeasurement):
+            line_qubit = LineQubit(inst.qubit.index)
+            quil_memory_reference = inst.classical_reg.out()
+            circuit += MeasurementGate(1, key=quil_memory_reference)(line_qubit)
+
+        # Raise a targeted error when encountering a PRAGMA.
+        elif isinstance(inst, Pragma):
+            raise UnsupportedQuilInstruction(PRAGMA_ERROR)
+
+        # Raise a targeted error when encountering a RESET.
+        elif isinstance(inst, (Reset, ResetQubit)):
+            raise UnsupportedQuilInstruction(RESET_ERROR)
+
+        # Raise a general error when encountering an unconsidered type.
+        else:
+            raise UnsupportedQuilInstruction(
+                f"Quil instruction {inst} of type {type(inst)}"
+                " not currently supported in Cirq.")
+
+    return circuit

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -43,6 +43,7 @@ from cirq.ops import (
     S,
     SWAP,
     T,
+    TwoQubitDiagonalGate,
     X,
     Y,
     Z,
@@ -80,49 +81,52 @@ def cphase(param: float) -> CZPowGate:
     return CZPowGate(exponent=param / np.pi)
 
 
-def cphase00(phi: float) -> MatrixGate:
-    """Returns a Cirq MatrixGate for pyQuil's CPHASE00 gate.
+def cphase00(phi: float) -> TwoQubitDiagonalGate:
+    """Returns a Cirq TwoQubitDiagonalGate for pyQuil's CPHASE00 gate.
+
+    In pyQuil, CPHASE00(phi) = diag([exp(1j * phi), 1, 1, 1]), and in Cirq,
+    a TwoQubitDiagonalGate is specified by its diagonal in radians, which
+    would be [phi, 0, 0, 0].
 
     Args:
         phi: Gate parameter (in radians).
 
     Returns:
-        A MatrixGate equivalent to a CPHASE00 gate of given angle.
+        A TwoQubitDiagonalGate equivalent to a CPHASE00 gate of given angle.
     """
-    cphase00_matrix = np.array(
-        [[np.exp(1j * phi), 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
-        dtype=complex)
-    return MatrixGate(cphase00_matrix)
+    return TwoQubitDiagonalGate([phi, 0, 0, 0])
 
 
-def cphase01(phi: float) -> MatrixGate:
-    """Returns a Cirq MatrixGate for pyQuil's CPHASE01 gate.
+def cphase01(phi: float) -> TwoQubitDiagonalGate:
+    """Returns a Cirq TwoQubitDiagonalGate for pyQuil's CPHASE01 gate.
+
+    In pyQuil, CPHASE01(phi) = diag(1, [exp(1j * phi), 1, 1]), and in Cirq,
+    a TwoQubitDiagonalGate is specified by its diagonal in radians, which
+    would be [0, phi, 0, 0].
 
     Args:
         phi: Gate parameter (in radians).
 
     Returns:
-        A MatrixGate equivalent to a CPHASE01 gate of given angle.
+        A TwoQubitDiagonalGate equivalent to a CPHASE01 gate of given angle.
     """
-    cphase01_matrix = np.array(
-        [[1, 0, 0, 0], [0, np.exp(1j * phi), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
-        dtype=complex)
-    return MatrixGate(cphase01_matrix)
+    return TwoQubitDiagonalGate([0, phi, 0, 0])
 
 
-def cphase10(phi: float) -> MatrixGate:
-    """Returns a Cirq MatrixGate for pyQuil's CPHASE10 gate.
+def cphase10(phi: float) -> TwoQubitDiagonalGate:
+    """Returns a Cirq TwoQubitDiagonalGate for pyQuil's CPHASE10 gate.
+
+    In pyQuil, CPHASE10(phi) = diag(1, 1, [exp(1j * phi), 1]), and in Cirq,
+    a TwoQubitDiagonalGate is specified by its diagonal in radians, which
+    would be [0, 0, phi, 0].
 
     Args:
         phi: Gate parameter (in radians).
 
     Returns:
-        A MatrixGate equivalent to a CPHASE10 gate of given angle.
+        A TwoQubitDiagonalGate equivalent to a CPHASE10 gate of given angle.
     """
-    cphase10_matrix = np.array(
-        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(1j * phi), 0], [0, 0, 0, 1]],
-        dtype=complex)
-    return MatrixGate(cphase10_matrix)
+    return TwoQubitDiagonalGate([0, 0, phi, 0])
 
 
 def phase(param: float) -> ZPowGate:

--- a/cirq/contrib/quil_import/quil_test.py
+++ b/cirq/contrib/quil_import/quil_test.py
@@ -1,0 +1,188 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from pyquil import Program
+from pyquil.simulation.tools import program_unitary
+
+from cirq import Circuit, LineQubit
+from cirq.contrib.quil_import.quil import (
+    UndefinedQuilGate,
+    UnsupportedQuilInstruction,
+    circuit_from_quil,
+    cphase,
+    cphase00,
+    cphase01,
+    cphase10,
+    pswap,
+    xy,
+)
+from cirq.ops import (
+    CCNOT,
+    CNOT,
+    CSWAP,
+    CZ,
+    H,
+    I,
+    ISWAP,
+    MeasurementGate,
+    S,
+    SWAP,
+    T,
+    X,
+    Y,
+    Z,
+    rx,
+    ry,
+    rz,
+)
+
+QUIL_PROGRAM = """
+DECLARE ro BIT[3]
+I 0
+I 1
+I 2
+X 0
+Y 1
+Z 2
+H 0
+S 1
+T 2
+PHASE(pi/8) 0
+PHASE(pi/8) 1
+PHASE(pi/8) 2
+RX(pi/2) 0
+RY(pi/2) 1
+RZ(pi/2) 2
+CZ 0 1
+CNOT 1 2
+CPHASE(pi/2) 0 1
+CPHASE00(pi/2) 1 2
+CPHASE01(pi/2) 0 1
+CPHASE10(pi/2) 1 2
+ISWAP 0 1
+PSWAP(pi/2) 1 2
+SWAP 0 1
+XY(pi/2) 1 2
+CCNOT 0 1 2
+CSWAP 0 1 2
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+MEASURE 2 ro[2]
+"""
+
+
+def test_circuit_from_quil():
+    q0, q1, q2 = LineQubit.range(3)
+    cirq_circuit = Circuit([
+        I(q0),
+        I(q1),
+        I(q2),
+        X(q0),
+        Y(q1),
+        Z(q2),
+        H(q0),
+        S(q1),
+        T(q2),
+        Z(q0)**(1 / 8),
+        Z(q1)**(1 / 8),
+        Z(q2)**(1 / 8),
+        rx(np.pi / 2)(q0),
+        ry(np.pi / 2)(q1),
+        rz(np.pi / 2)(q2),
+        CZ(q0, q1),
+        CNOT(q1, q2),
+        cphase(np.pi / 2)(q0, q1),
+        cphase00(np.pi / 2)(q1, q2),
+        cphase01(np.pi / 2)(q0, q1),
+        cphase10(np.pi / 2)(q1, q2),
+        ISWAP(q0, q1),
+        pswap(np.pi / 2)(q1, q2),
+        SWAP(q0, q1),
+        xy(np.pi / 2)(q1, q2),
+        CCNOT(q0, q1, q2),
+        CSWAP(q0, q1, q2),
+        MeasurementGate(1, key="ro[0]")(q0),
+        MeasurementGate(1, key="ro[1]")(q1),
+        MeasurementGate(1, key="ro[2]")(q2),
+    ])
+    # build the same Circuit, using Quil
+    quil_circuit = circuit_from_quil(QUIL_PROGRAM)
+    # test Circuit equivalence
+    assert cirq_circuit == quil_circuit
+
+    pyquil_circuit = Program(QUIL_PROGRAM)
+    # drop declare and measures, get Program unitary
+    pyquil_unitary = program_unitary(pyquil_circuit[1:-3], n_qubits=3)
+    # fix qubit order convention
+    cirq_circuit_swapped = Circuit(SWAP(q0, q2), cirq_circuit[:-1],
+                                   SWAP(q0, q2))
+    # get Circuit unitary
+    cirq_unitary = cirq_circuit_swapped.unitary()
+    # test unitary equivalence
+    assert np.isclose(pyquil_unitary, cirq_unitary).all()
+
+
+QUIL_PROGRAM_WITH_DEFGATE = """
+DEFGATE MYZ:
+    1,0
+    0,-1
+
+X 0
+MYZ 0
+"""
+
+
+def test_quil_with_defgate():
+    q0 = LineQubit(0)
+    cirq_circuit = Circuit([X(q0), Z(q0)])
+    quil_circuit = circuit_from_quil(QUIL_PROGRAM_WITH_DEFGATE)
+    assert np.isclose(quil_circuit.unitary(), cirq_circuit.unitary()).all()
+
+
+QUIL_PROGRAM_WITH_PARAMETERIZED_DEFGATE = """
+DEFGATE MYPHASE(%phi):
+    1,0
+    0,EXP(i*%phi)
+
+X 0
+MYPHASE 0
+"""
+
+
+def test_unsupported_quil_instruction():
+    with pytest.raises(UnsupportedQuilInstruction):
+        circuit_from_quil("NOP")
+
+    with pytest.raises(UnsupportedQuilInstruction):
+        circuit_from_quil("PRAGMA ADD-KRAUS X 0 \"(0.0 1.0 1.0 0.0)\"")
+
+    with pytest.raises(UnsupportedQuilInstruction):
+        circuit_from_quil("RESET")
+
+    with pytest.raises(UnsupportedQuilInstruction):
+        circuit_from_quil(QUIL_PROGRAM_WITH_PARAMETERIZED_DEFGATE)
+
+
+def test_undefined_quil_gate():
+    """There are no such things as FREDKIN & TOFFOLI in Quil. The standard
+    names for those gates in Quil are CSWAP and CCNOT. Of course, they can
+    be defined via DEFGATE / DEFCIRCUIT."""
+    with pytest.raises(UndefinedQuilGate):
+        circuit_from_quil("FREDKIN 0 1 2")
+
+    with pytest.raises(UndefinedQuilGate):
+        circuit_from_quil("TOFFOLI 0 1 2")

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -259,7 +259,7 @@ class ISwapPowGate(eigen_gate.EigenGate,
                 f'global_shift={self._global_shift!r})')
 
     def _quil_(self, qubits: Tuple['cirq.Qid', ...],
-               formatter: 'cirq.QuilFormatter') -> Optional[str]:
+               formatter: 'cirq.QuilFormatter') -> str:
         if self._exponent == 1:
             return formatter.format('ISWAP {0} {1}\n', qubits[0], qubits[1])
         return formatter.format('XY({0}) {1} {2}\n', self._exponent * np.pi,

--- a/cirq/ops/two_qubit_diagonal_gate.py
+++ b/cirq/ops/two_qubit_diagonal_gate.py
@@ -17,7 +17,7 @@ The gate is used to create a 4x4 matrix with the diagonal elements
 passed as a list.
 """
 
-from typing import Any, Tuple, List, TYPE_CHECKING
+from typing import Any, Tuple, List, Optional, TYPE_CHECKING
 import numpy as np
 import sympy
 
@@ -102,3 +102,24 @@ class TwoQubitDiagonalGate(gate_features.TwoQubitGate):
     def __repr__(self) -> str:
         return 'cirq.TwoQubitDiagonalGate([{}])'.format(','.join(
             proper_repr(angle) for angle in self._diag_angles_radians))
+
+    def _quil_(self, qubits: Tuple['cirq.Qid', ...],
+               formatter: 'cirq.QuilFormatter') -> Optional[str]:
+        if np.count_nonzero(self._diag_angles_radians) == 1:
+            if self._diag_angles_radians[0] != 0:
+                return formatter.format('CPHASE00({0}) {1} {2}\n',
+                                        self._diag_angles_radians[0], qubits[0],
+                                        qubits[1])
+            elif self._diag_angles_radians[1] != 0:
+                return formatter.format('CPHASE01({0}) {1} {2}\n',
+                                        self._diag_angles_radians[1], qubits[0],
+                                        qubits[1])
+            elif self._diag_angles_radians[2] != 0:
+                return formatter.format('CPHASE10({0}) {1} {2}\n',
+                                        self._diag_angles_radians[2], qubits[0],
+                                        qubits[1])
+            elif self._diag_angles_radians[3] != 0:
+                return formatter.format('CPHASE({0}) {1} {2}\n',
+                                        self._diag_angles_radians[3], qubits[0],
+                                        qubits[1])
+        return

--- a/cirq/ops/two_qubit_diagonal_gate.py
+++ b/cirq/ops/two_qubit_diagonal_gate.py
@@ -122,4 +122,4 @@ class TwoQubitDiagonalGate(gate_features.TwoQubitGate):
                 return formatter.format('CPHASE({0}) {1} {2}\n',
                                         self._diag_angles_radians[3], qubits[0],
                                         qubits[1])
-        return
+        return None

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -5,7 +5,7 @@ follow_imports = silent
 ignore_missing_imports = true
 
 # 3rd-party libs for which we don't have stubs
-[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,numpy.*,oauth2client.*,pandas.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.oauth2.*,google.protobuf.text_format.*,quimb.*]
+[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,numpy.*,oauth2client.*,pandas.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.oauth2.*,google.protobuf.text_format.*,quimb.*,pyquil.*]
 follow_imports = silent
 ignore_missing_imports = true
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -549,6 +549,7 @@ contrib may change without notice.
     cirq.contrib.acquaintance
     cirq.contrib.paulistring
     cirq.contrib.qcircuit
+    cirq.contrib.quil_import
     cirq.contrib.quirk
 
 


### PR DESCRIPTION
This PR adds Quil import support in a way analogous to the existing QASM import functionality, by leveraging the Quil parser that already exists in pyQuil.

By using `circuit_from_quil` from the `cirq.contrib.quil_import` module, all Quil standard gates, measurements, and simple (non-parameterized) DEFGATEs can be converted to Cirq operations (see below).

Additionally adds Quil output for special cases of `TwoQubitDiagonalGate`, and fixes a bug in the way DEFGATE blocks were being generated by the Quil outputter.

```python
In [1]: from cirq.contrib.quil_import import circuit_from_quil

In [2]: circuit_from_quil("""
   ...: DECLARE ro BIT[3]
   ...: I 0
   ...: I 1
   ...: I 2
   ...: X 0
   ...: Y 1
   ...: Z 2
   ...: H 0
   ...: S 1
   ...: T 2
   ...: PHASE(pi/8) 0
   ...: PHASE(pi/8) 1
   ...: PHASE(pi/8) 2
   ...: RX(pi/2) 0
   ...: RY(pi/2) 1
   ...: RZ(pi/2) 2
   ...: CZ 0 1
   ...: CNOT 1 2
   ...: CPHASE(pi/2) 0 1
   ...: SWAP 1 2
   ...: ISWAP 0 1
   ...: XY(pi/2) 1 2
   ...: CCNOT 0 1 2
   ...: CSWAP 0 1 2
   ...: MEASURE 0 ro[0]
   ...: MEASURE 1 ro[1]
   ...: MEASURE 2 ro[2]
   ...: """)
Out[2]:
0: ───I───X───H───Z^(1/8)───Rx(0.5π)───@───────@───────────iSwap───────────────@───@───M('ro[0]')───
                                       │       │           │                   │   │
1: ───I───Y───S───Z^(1/8)───Ry(0.5π)───@───@───@^0.5───×───iSwap───iSwap───────@───×───M('ro[1]')───
                                           │           │           │           │   │
2: ───I───Z───T───Z^(1/8)───Rz(0.5π)───────X───────────×───────────iSwap^0.5───X───×───M('ro[2]')───

In [3]: circuit_from_quil("""
   ...: DEFGATE MYZ:
   ...:     1,0
   ...:     0,-1
   ...:
   ...: MYZ 0
   ...: """)
Out[3]:
      ┌     ┐
0: ───│ 1  0│───
      │ 0 -1│
      └     ┘
```

Related to #1742, #2386, #2983