### PR TITLE
Disable cirq v1 api docs

### DIFF
--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -54,7 +54,8 @@ def main(unused_argv):
             "cirq.google.engine.client.quantum.QuantumEngineServiceClient":
             ["enums"],
             "cirq.google.engine.client.quantum_v1alpha1.QuantumEngineServiceClient":
-            ["enums"]
+            ["enums"],
+            "cirq.google.api": ["v1"]
         })
 
     doc_generator.build(output_dir=FLAGS.output_dir)


### PR DESCRIPTION
The v1 api is deprecated and no one should be using it.