### PR TITLE
Add Moment.__sub__ and generalize Moment.__add__

### DIFF
--- a/cirq/contrib/qcircuit/qcircuit_diagram_info.py
+++ b/cirq/contrib/qcircuit/qcircuit_diagram_info.py
@@ -96,9 +96,8 @@ def multigate_qcircuit_diagram_info(
     assert args.known_qubits is not None
     symbols = tuple(box if (args.qubit_map[q] == min_index) else
                     ghost for q in args.known_qubits)
-    return protocols.CircuitDiagramInfo(symbols,
-                                        exponent=info.exponent,
-                                        connected=False)
+    return protocols.CircuitDiagramInfo(
+        symbols, exponent=1 if info is None else info.exponent, connected=False)
 
 
 def fallback_qcircuit_diagram_info(

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -25,10 +25,10 @@ from cirq import ops, protocols
 if TYPE_CHECKING:
     import cirq
 
-TSelf = TypeVar('TSelf', bound='_BaseGridQid')
+TSelf = TypeVar('TSelf', bound='_BaseGridQid')  # type: ignore
 
 
-@functools.total_ordering
+@functools.total_ordering  # type: ignore
 class _BaseGridQid(ops.Qid):
     """The Base class for `GridQid` and `GridQubit`."""
 

--- a/cirq/devices/line_qubit.py
+++ b/cirq/devices/line_qubit.py
@@ -23,10 +23,10 @@ from cirq import ops, protocols
 if TYPE_CHECKING:
     import cirq
 
-TSelf = TypeVar('TSelf', bound='_BaseLineQid')
+TSelf = TypeVar('TSelf', bound='_BaseLineQid')  # type: ignore
 
 
-@functools.total_ordering
+@functools.total_ordering  # type: ignore
 class _BaseLineQid(ops.Qid):
     """The base class for `LineQid` and `LineQubit`."""
 

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -229,6 +229,9 @@ class Moment:
         return Moment(operations)
 
     def __add__(self, other: 'cirq.OP_TREE') -> 'cirq.Moment':
+        from cirq.circuits import circuit
+        if isinstance(other, circuit.Circuit):
+            return NotImplemented  # Delegate to Circuit.__radd__.
         return Moment([self.operations, other])
 
     def __sub__(self, other: 'cirq.OP_TREE') -> 'cirq.Moment':

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -228,13 +228,23 @@ class Moment:
     def _from_json_dict_(cls, operations, **kwargs):
         return Moment(operations)
 
-    def __add__(self,
-                other: Union['cirq.Operation', 'cirq.Moment']) -> 'cirq.Moment':
-        if isinstance(other, raw_types.Operation):
-            return self.with_operation(other)
-        if isinstance(other, Moment):
-            return Moment(self.operations + other.operations)
-        return NotImplemented
+    def __add__(self, other: 'cirq.OP_TREE') -> 'cirq.Moment':
+        return Moment([self.operations, other])
+
+    def __sub__(self, other: 'cirq.OP_TREE') -> 'cirq.Moment':
+        from cirq.ops import op_tree
+        must_remove = set(op_tree.flatten_to_ops(other))
+        new_ops = []
+        for op in self.operations:
+            if op in must_remove:
+                must_remove.remove(op)
+            else:
+                new_ops.append(op)
+        if must_remove:
+            raise ValueError(f"Subtracted missing operations from a moment.\n"
+                             f"Missing operations: {must_remove!r}\n"
+                             f"Moment: {self!r}")
+        return Moment(new_ops)
 
     # pylint: disable=function-redefined
     @overload

--- a/cirq/ops/moment_test.py
+++ b/cirq/ops/moment_test.py
@@ -278,6 +278,28 @@ def test_add():
     with pytest.raises(ValueError, match='Overlap'):
         _ = m1 + m2
 
+    assert m1 + [[[[cirq.Y(b)]]]] == cirq.Moment(cirq.X(a), cirq.Y(b))
+    assert m1 + [] == m1
+
+
+def test_sub():
+    a, b, c = cirq.LineQubit.range(3)
+    m = cirq.Moment(cirq.X(a), cirq.Y(b))
+    assert m - [] == m
+    assert m - cirq.X(a) == cirq.Moment(cirq.Y(b))
+    assert m - [[[[cirq.X(a)]], []]] == cirq.Moment(cirq.Y(b))
+    assert m - [cirq.X(a), cirq.Y(b)] == cirq.Moment()
+    assert m - [cirq.Y(b)] == cirq.Moment(cirq.X(a))
+
+    with pytest.raises(ValueError, match="missing operations"):
+        _ = m - cirq.X(b)
+    with pytest.raises(ValueError, match="missing operations"):
+        _ = m - [cirq.X(a), cirq.Z(c)]
+
+    # Preserves relative order.
+    m2 = cirq.Moment(cirq.X(a), cirq.Y(b), cirq.Z(c))
+    assert m2 - cirq.Y(b) == cirq.Moment(cirq.X(a), cirq.Z(c))
+
 
 def test_op_tree():
     eq = cirq.testing.EqualsTester()

--- a/cirq/protocols/channel.py
+++ b/cirq/protocols/channel.py
@@ -85,9 +85,8 @@ class SupportsChannel(Protocol):
         """
 
 
-def channel(val: Any,
-            default: Any = RaiseTypeErrorIfNotProvided
-            ) -> Union[Tuple[np.ndarray], Sequence[TDefault]]:
+def channel(val: Any, default: Any = RaiseTypeErrorIfNotProvided
+           ) -> Union[Tuple[np.ndarray, ...], TDefault]:
     r"""Returns a list of matrices describing the channel for the given value.
 
     These matrices are the terms in the operator sum representation of

--- a/cirq/sim/act_on_state_vector_args.py
+++ b/cirq/sim/act_on_state_vector_args.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 """Objects and methods for acting efficiently on a state vector."""
 
-from typing import Any, Iterable, Sequence, Tuple, TYPE_CHECKING, Union, Dict, \
-    Optional
+from typing import Any, Iterable, Sequence, Tuple, TYPE_CHECKING, Union, Dict
 
 import numpy as np
 

--- a/cirq/sim/act_on_state_vector_args.py
+++ b/cirq/sim/act_on_state_vector_args.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Objects and methods for acting efficiently on a state vector."""
 
-from typing import Any, Iterable, Sequence, Tuple, TYPE_CHECKING, Union, Dict
+from typing import Any, Iterable, Sequence, Tuple, TYPE_CHECKING, Union, Dict, \
+    Optional
 
 import numpy as np
 

--- a/cirq/study/trial_result.py
+++ b/cirq/study/trial_result.py
@@ -15,7 +15,7 @@
 """Defines trial results."""
 
 from typing import (Any, Callable, Dict, Iterable, Optional, Sequence,
-                    TYPE_CHECKING, Tuple, TypeVar, Union)
+                    TYPE_CHECKING, Tuple, TypeVar, Union, cast)
 
 import collections
 import io
@@ -147,7 +147,8 @@ class TrialResult:
             self,
             *,  # Forces keyword args.
             keys: Iterable[TMeasurementKey],
-            fold_func: Callable[[Tuple], T] = _tuple_of_big_endian_int
+            fold_func: Callable[[Tuple], T] = cast(Callable[[Tuple], T],
+                                                   _tuple_of_big_endian_int)
     ) -> collections.Counter:
         """Counts the number of times combined measurement results occurred.
 
@@ -208,7 +209,8 @@ class TrialResult:
             self,
             *,  # Forces keyword args.
             key: TMeasurementKey,
-            fold_func: Callable[[Tuple], T] = value.big_endian_bits_to_int
+            fold_func: Callable[[Tuple], T] = cast(Callable[[Tuple], T],
+                                                   value.big_endian_bits_to_int)
     ) -> collections.Counter:
         """Counts the number of times a measurement result occurred.
 

--- a/cirq/value/__init__.py
+++ b/cirq/value/__init__.py
@@ -57,5 +57,5 @@ from cirq.value.timestamp import (
 from cirq.value.type_alias import (
     TParamVal,)
 
-from cirq.value.value_equality import (
+from cirq.value.value_equality_attr import (
     value_equality,)

--- a/cirq/value/linear_dict.py
+++ b/cirq/value/linear_dict.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 """Linear combination represented as mapping of things to coefficients."""
-
+import numbers
 from typing import (Any, Callable, Dict, ItemsView, Iterable, Iterator,
                     KeysView, Mapping, MutableMapping, overload, Tuple, TypeVar,
                     Union, ValuesView, Generic, Optional)
 
-Scalar = Union[complex, float]
+Scalar = Union[complex, float, numbers.Complex]
 TVector = TypeVar('TVector')
 
 TDefault = TypeVar('TDefault')

--- a/cirq/value/value_equality_attr.py
+++ b/cirq/value/value_equality_attr.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Defines `@cirq.value_equality`, for easy __eq__/__hash__ methods."""
 
 from typing import Union, Callable, overload, Any
@@ -89,8 +88,8 @@ def _value_equality_ne(self: _SupportsValueEquality,
 
 
 def _value_equality_hash(self: _SupportsValueEquality) -> int:
-    return hash((self._value_equality_values_cls_(),
-                 self._value_equality_values_()))
+    return hash(
+        (self._value_equality_values_cls_(), self._value_equality_values_()))
 
 
 def _value_equality_approx_eq(self: _SupportsValueEquality,
@@ -220,4 +219,6 @@ def value_equality(cls: type = None,
         setattr(cls, '_approx_eq_', _value_equality_approx_eq)
 
     return cls
+
+
 # pylint: enable=function-redefined

--- a/cirq/value/value_equality_attr_test.py
+++ b/cirq/value/value_equality_attr_test.py
@@ -18,6 +18,7 @@ import cirq
 
 @cirq.value_equality
 class BasicC:
+
     def __init__(self, x):
         self.x = x
 
@@ -27,6 +28,7 @@ class BasicC:
 
 @cirq.value_equality
 class BasicD:
+
     def __init__(self, x):
         self.x = x
 
@@ -81,6 +83,7 @@ def test_value_equality_manual():
 
 @cirq.value_equality(unhashable=True)
 class UnhashableC:
+
     def __init__(self, x):
         self.x = x
 
@@ -90,6 +93,7 @@ class UnhashableC:
 
 @cirq.value_equality(unhashable=True)
 class UnhashableD:
+
     def __init__(self, x):
         self.x = x
 
@@ -112,9 +116,7 @@ def test_value_equality_unhashable():
 
     # Equality works as expected.
     eq = cirq.testing.EqualsTester()
-    eq.add_equality_group(UnhashableC(1),
-                          UnhashableC(1),
-                          UnhashableCa(1),
+    eq.add_equality_group(UnhashableC(1), UnhashableC(1), UnhashableCa(1),
                           UnhashableCb(1))
     eq.add_equality_group(UnhashableC(2))
     eq.add_equality_group(UnhashableD(1))
@@ -122,6 +124,7 @@ def test_value_equality_unhashable():
 
 @cirq.value_equality(distinct_child_types=True)
 class DistinctC:
+
     def __init__(self, x):
         self.x = x
 
@@ -131,6 +134,7 @@ class DistinctC:
 
 @cirq.value_equality(distinct_child_types=True)
 class DistinctD:
+
     def __init__(self, x):
         self.x = x
 
@@ -164,6 +168,7 @@ def test_value_equality_distinct_child_types():
 
 @cirq.value_equality(approximate=True)
 class ApproxE:
+
     def __init__(self, x):
         self.x = x
 
@@ -179,6 +184,7 @@ def test_value_equality_approximate():
 
 @cirq.value_equality(approximate=True)
 class PeriodicF:
+
     def __init__(self, x, n):
         self.x = x
         self.n = n
@@ -210,6 +216,7 @@ class ApproxEb(ApproxE):
 
 @cirq.value_equality(distinct_child_types=True, approximate=True)
 class ApproxG:
+
     def __init__(self, x):
         self.x = x
 
@@ -235,6 +242,7 @@ def test_value_equality_approximate_typing():
 
 def test_value_equality_forgot_method():
     with pytest.raises(TypeError, match='_value_equality_values_'):
+
         @cirq.value_equality
         class _:
             pass

--- a/dev_tools/auto_merge.py
+++ b/dev_tools/auto_merge.py
@@ -56,7 +56,7 @@ class PullRequestDetails:
 
         if response.status_code != 200:
             raise RuntimeError(
-                'Pull check failed. Code: {}. Content: {}.'.format(
+                'Pull check failed. Code: {}. Content: {!r}.'.format(
                     response.status_code, response.content))
 
         payload = json.JSONDecoder().decode(response.content.decode())
@@ -139,7 +139,7 @@ def check_collaborator_has_write(repo: GithubRepository, username: str
 
     if response.status_code != 200:
         raise RuntimeError(
-            'Collaborator check failed. Code: {}. Content: {}.'.format(
+            'Collaborator check failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     payload = json.JSONDecoder().decode(response.content.decode())
@@ -166,7 +166,7 @@ def check_auto_merge_labeler(repo: GithubRepository, pull_id: int
 
     if response.status_code != 200:
         raise RuntimeError(
-            'Event check failed. Code: {}. Content: {}.'.format(
+            'Event check failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     payload = json.JSONDecoder().decode(response.content.decode())
@@ -196,8 +196,9 @@ def add_comment(repo: GithubRepository, pull_id: int, text: str) -> None:
     response = requests.post(url, json=data)
 
     if response.status_code != 201:
-        raise RuntimeError('Add comment failed. Code: {}. Content: {}.'.format(
-            response.status_code, response.content))
+        raise RuntimeError(
+            'Add comment failed. Code: {}. Content: {!r}.'.format(
+                response.status_code, response.content))
 
 
 def edit_comment(repo: GithubRepository, text: str, comment_id: int) -> None:
@@ -216,8 +217,9 @@ def edit_comment(repo: GithubRepository, text: str, comment_id: int) -> None:
     response = requests.patch(url, json=data)
 
     if response.status_code != 200:
-        raise RuntimeError('Edit comment failed. Code: {}. Content: {}.'.format(
-            response.status_code, response.content))
+        raise RuntimeError(
+            'Edit comment failed. Code: {}. Content: {!r}.'.format(
+                response.status_code, response.content))
 
 
 def get_branch_details(repo: GithubRepository, branch: str) -> Any:
@@ -234,7 +236,7 @@ def get_branch_details(repo: GithubRepository, branch: str) -> Any:
 
     if response.status_code != 200:
         raise RuntimeError(
-            'Failed to get branch details. Code: {}. Content: {}.'.format(
+            'Failed to get branch details. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     return json.JSONDecoder().decode(response.content.decode())
@@ -255,7 +257,7 @@ def get_pr_statuses(pr: PullRequestDetails) -> List[Dict[str, Any]]:
 
     if response.status_code != 200:
         raise RuntimeError(
-            'Get statuses failed. Code: {}. Content: {}.'.format(
+            'Get statuses failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     return json.JSONDecoder().decode(response.content.decode())
@@ -275,9 +277,8 @@ def get_pr_check_status(pr: PullRequestDetails) -> Any:
     response = requests.get(url)
 
     if response.status_code != 200:
-        raise RuntimeError(
-            'Get status failed. Code: {}. Content: {}.'.format(
-                response.status_code, response.content))
+        raise RuntimeError('Get status failed. Code: {}. Content: {!r}.'.format(
+            response.status_code, response.content))
 
     return json.JSONDecoder().decode(response.content.decode())
 
@@ -334,9 +335,8 @@ def get_pr_review_status(pr: PullRequestDetails, per_page: int = 100) -> Any:
     response = requests.get(url)
 
     if response.status_code != 200:
-        raise RuntimeError(
-            'Get review failed. Code: {}. Content: {}.'.format(
-                response.status_code, response.content))
+        raise RuntimeError('Get review failed. Code: {}. Content: {!r}.'.format(
+            response.status_code, response.content))
 
     return json.JSONDecoder().decode(response.content.decode())
 
@@ -357,7 +357,7 @@ def get_pr_checks(pr: PullRequestDetails) -> Dict[str, Any]:
 
     if response.status_code != 200:
         raise RuntimeError(
-            'Get check-runs failed. Code: {}. Content: {}.'.format(
+            'Get check-runs failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     return json.JSONDecoder().decode(response.content.decode())
@@ -409,9 +409,8 @@ def get_repo_ref(repo: GithubRepository, ref: str) -> Dict[str, Any]:
                                      repo.access_token))
     response = requests.get(url)
     if response.status_code != 200:
-        raise RuntimeError(
-            'Refs get failed. Code: {}. Content: {}.'.format(
-                response.status_code, response.content))
+        raise RuntimeError('Refs get failed. Code: {}. Content: {!r}.'.format(
+            response.status_code, response.content))
     payload = json.JSONDecoder().decode(response.content.decode())
     return payload
 
@@ -435,7 +434,7 @@ def list_pr_comments(repo: GithubRepository, pull_id: int
     response = requests.get(url)
     if response.status_code != 200:
         raise RuntimeError(
-            'Comments get failed. Code: {}. Content: {}.'.format(
+            'Comments get failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
     payload = json.JSONDecoder().decode(response.content.decode())
     return payload
@@ -454,7 +453,7 @@ def delete_comment(repo: GithubRepository, comment_id: int) -> None:
     response = requests.delete(url)
     if response.status_code != 204:
         raise RuntimeError(
-            'Comment delete failed. Code: {}. Content: {}.'.format(
+            'Comment delete failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
 
@@ -509,7 +508,7 @@ def attempt_sync_with_master(pr: PullRequestDetails
     data = {
         'base': pr.branch_name,
         'head': master_sha,
-        'commit_message': 'Update branch (automerge)'.format(pr.branch_name)
+        'commit_message': 'Update branch (automerge)'
     }
     response = requests.post(url, json=data)
 
@@ -534,8 +533,8 @@ def attempt_sync_with_master(pr: PullRequestDetails
             "'Update Branch' for me before trying again.")
 
     raise RuntimeError('Sync with master failed for unknown reason. '
-                       'Code: {}. Content: {}.'.format(response.status_code,
-                                                       response.content))
+                       'Code: {}. Content: {!r}.'.format(
+                           response.status_code, response.content))
 
 
 def attempt_squash_merge(pr: PullRequestDetails
@@ -572,7 +571,7 @@ def attempt_squash_merge(pr: PullRequestDetails
         # Need to sync.
         return False
 
-    raise RuntimeError('Merge failed. Code: {}. Content: {}.'.format(
+    raise RuntimeError('Merge failed. Code: {}. Content: {!r}.'.format(
         response.status_code, response.content))
 
 
@@ -608,7 +607,7 @@ def auto_delete_pr_branch(pr: PullRequestDetails) -> bool:
         log('Deleted branch {!r}.'.format(pr.branch_name))
         return True
 
-    log('Delete failed. Code: {}. Content: {}.'.format(
+    log('Delete failed. Code: {}. Content: {!r}.'.format(
         response.status_code, response.content))
     return False
 
@@ -636,9 +635,8 @@ def add_labels_to_pr(repo: GithubRepository,
     response = requests.post(url, json=list(labels))
 
     if response.status_code != 200:
-        raise RuntimeError(
-            'Add labels failed. Code: {}. Content: {}.'.format(
-                response.status_code, response.content))
+        raise RuntimeError('Add labels failed. Code: {}. Content: {!r}.'.format(
+            response.status_code, response.content))
 
 
 def remove_label_from_pr(repo: GithubRepository,
@@ -665,9 +663,8 @@ def remove_label_from_pr(repo: GithubRepository,
         # Removed the label.
         return True
 
-    raise RuntimeError(
-        'Label remove failed. Code: {}. Content: {}.'.format(
-            response.status_code, response.content))
+    raise RuntimeError('Label remove failed. Code: {}. Content: {!r}.'.format(
+        response.status_code, response.content))
 
 
 def list_open_pull_requests(repo: GithubRepository,
@@ -683,9 +680,8 @@ def list_open_pull_requests(repo: GithubRepository,
     response = requests.get(url, json=data)
 
     if response.status_code != 200:
-        raise RuntimeError(
-            'List pulls failed. Code: {}. Content: {}.'.format(
-                response.status_code, response.content))
+        raise RuntimeError('List pulls failed. Code: {}. Content: {!r}.'.format(
+            response.status_code, response.content))
 
     pulls = json.JSONDecoder().decode(response.content.decode())
     results = [PullRequestDetails(pull, repo) for pull in pulls]

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -1,5 +1,5 @@
 # For testing and analyzing code.
-mypy~=0.701.0
+mypy~=0.782.0
 pylint~=2.3.0
 pytest~=5.4.1
 pytest-asyncio~=0.12.0

--- a/dev_tools/prepared_env.py
+++ b/dev_tools/prepared_env.py
@@ -114,7 +114,7 @@ class PreparedEnv:
         response = requests.post(url, json=payload)
 
         if response.status_code != 201:
-            raise IOError('Request failed. Code: {}. Content: {}.'.format(
+            raise IOError('Request failed. Code: {}. Content: {!r}.'.format(
                 response.status_code, response.content))
 
     def get_changed_files(self) -> List[str]:


### PR DESCRIPTION
- `Moment.__add__` now accepts any `OP_TREE`
- `Moment.__sub__` takes an `OP_TREE` and returns a moment with those operations removed
- If there is an operation-to-remove that was not present, an error is raised
- Also bump mypy version to fix an incompatibility with python 3.8 and fix new warnings
    - Add explicit !r to format statements touching bytes
    - Rename `value_equality.py` to avoid name collision with the decorator it defines
    - Ignore false positives related to abstract base type bounds