### PR TITLE
Add pow function to arg_func_lang

### DIFF
--- a/cirq/google/arg_func_langs.py
+++ b/cirq/google/arg_func_langs.py
@@ -31,11 +31,12 @@ from cirq.google.api import v2
 SUPPORTED_FUNCTIONS_FOR_LANGUAGE: Dict[Optional[str], FrozenSet[str]] = {
     '': frozenset(),
     'linear': frozenset({'add', 'mul'}),
+    'poly': frozenset({'add', 'mul', 'pow'}),
     # None means any. Is used when inferring the language during serialization.
-    None: frozenset({'add', 'mul'}),
+    None: frozenset({'add', 'mul', 'pow'}),
 }
 
-SUPPORTED_SYMPY_OPS = (sympy.Symbol, sympy.Add, sympy.Mul)
+SUPPORTED_SYMPY_OPS = (sympy.Symbol, sympy.Add, sympy.Mul, sympy.Pow)
 
 # Argument types for gates.
 ARG_LIKE = Union[int, float, List[bool], str, sympy.Symbol, sympy.Add, sympy.
@@ -47,6 +48,7 @@ ARG_LIKE = Union[int, float, List[bool], str, sympy.Symbol, sympy.Add, sympy.
 LANGUAGE_ORDER = [
     '',
     'linear',
+    'poly',
 ]
 
 
@@ -83,6 +85,10 @@ def _function_languages_from_arg(arg_proto: v2.program_pb2.Arg
     if which == 'func':
         if arg_proto.func.type in ['add', 'mul']:
             yield 'linear'
+            for a in arg_proto.func.args:
+                yield from _function_languages_from_arg(a)
+        if arg_proto.func.type in ['pow']:
+            yield 'poly'
             for a in arg_proto.func.args:
                 yield from _function_languages_from_arg(a)
 
@@ -140,6 +146,12 @@ def _arg_to_proto(value: ARG_LIKE,
                           out=msg.func.args.add())
     elif isinstance(value, sympy.Mul):
         msg.func.type = check_support('mul')
+        for arg in value.args:
+            _arg_to_proto(arg,
+                          arg_function_language=arg_function_language,
+                          out=msg.func.args.add())
+    elif isinstance(value, sympy.Pow):
+        msg.func.type = check_support('pow')
         for arg in value.args:
             _arg_to_proto(arg,
                           arg_function_language=arg_function_language,
@@ -218,6 +230,14 @@ def _arg_from_proto(
                 _arg_from_proto(a,
                                 arg_function_language=arg_function_language,
                                 required_arg_name='A multiplication argument')
+                for a in func.args
+            ])
+
+        if func.type == 'pow':
+            return sympy.Pow(*[
+                _arg_from_proto(a,
+                                arg_function_language=arg_function_language,
+                                required_arg_name='A power argument')
                 for a in func.args
             ])
 

--- a/cirq/google/arg_func_langs.py
+++ b/cirq/google/arg_func_langs.py
@@ -31,7 +31,7 @@ from cirq.google.api import v2
 SUPPORTED_FUNCTIONS_FOR_LANGUAGE: Dict[Optional[str], FrozenSet[str]] = {
     '': frozenset(),
     'linear': frozenset({'add', 'mul'}),
-    'poly': frozenset({'add', 'mul', 'pow'}),
+    'exp': frozenset({'add', 'mul', 'pow'}),
     # None means any. Is used when inferring the language during serialization.
     None: frozenset({'add', 'mul', 'pow'}),
 }
@@ -48,7 +48,7 @@ ARG_LIKE = Union[int, float, List[bool], str, sympy.Symbol, sympy.Add, sympy.
 LANGUAGE_ORDER = [
     '',
     'linear',
-    'poly',
+    'exp',
 ]
 
 
@@ -88,7 +88,7 @@ def _function_languages_from_arg(arg_proto: v2.program_pb2.Arg
             for a in arg_proto.func.args:
                 yield from _function_languages_from_arg(a)
         if arg_proto.func.type in ['pow']:
-            yield 'poly'
+            yield 'exp'
             for a in arg_proto.func.args:
                 yield from _function_languages_from_arg(a)
 

--- a/cirq/google/arg_func_langs_test.py
+++ b/cirq/google/arg_func_langs_test.py
@@ -74,7 +74,7 @@ from cirq.google.api import v2
             }]
         }
     }),
-    ('poly', sympy.Symbol('x')**sympy.Symbol('y'), {
+    ('exp', sympy.Symbol('x')**sympy.Symbol('y'), {
         'func': {
             'type': 'pow',
             'args': [{
@@ -181,6 +181,6 @@ def test_infer_language():
     packed = cirq.google.XMON.serialize(c_empty)
     assert packed.language.arg_function_language == ''
 
-    c_poly = cirq.Circuit(cirq.X(q)**(b**a))
-    packed = cirq.google.XMON.serialize(c_poly)
-    assert packed.language.arg_function_language == 'poly'
+    c_exp = cirq.Circuit(cirq.X(q)**(b**a))
+    packed = cirq.google.XMON.serialize(c_exp)
+    assert packed.language.arg_function_language == 'exp'

--- a/cirq/google/arg_func_langs_test.py
+++ b/cirq/google/arg_func_langs_test.py
@@ -74,6 +74,16 @@ from cirq.google.api import v2
             }]
         }
     }),
+    ('poly', sympy.Symbol('x')**sympy.Symbol('y'), {
+        'func': {
+            'type': 'pow',
+            'args': [{
+                'symbol': 'x'
+            }, {
+                'symbol': 'y'
+            }]
+        }
+    }),
 ])
 def test_correspondence(min_lang: str, value: ARG_LIKE,
                         proto: v2.program_pb2.Arg):
@@ -170,3 +180,7 @@ def test_infer_language():
     c_empty = cirq.Circuit(cirq.X(q)**b)
     packed = cirq.google.XMON.serialize(c_empty)
     assert packed.language.arg_function_language == ''
+
+    c_poly = cirq.Circuit(cirq.X(q)**(b**a))
+    packed = cirq.google.XMON.serialize(c_poly)
+    assert packed.language.arg_function_language == 'poly'


### PR DESCRIPTION
- Add exponentiation to symbol serialization support.
This will make a new Arg func type called 'poly' that supports
exponents (polynomials).

Fixes #3078