### PR TITLE
Escape special characters in Jupyter circuit diagram

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -27,6 +27,8 @@ from typing import (Any, Callable, cast, Dict, FrozenSet, Iterable, Iterator,
                     List, Optional, overload, Sequence, Set, Tuple, Type,
                     TYPE_CHECKING, TypeVar, Union)
 
+import html
+
 import re
 import numpy as np
 
@@ -375,7 +377,7 @@ class Circuit:
     def _repr_html_(self) -> str:
         """Print ASCII diagram in Jupyter notebook without wrapping lines."""
         return ('<pre style="overflow: auto; white-space: pre;">'
-                + self.to_text_diagram()
+                + html.escape(self.to_text_diagram())
                 + '</pre>')
 
     def _first_moment_operating_on(self, qubits: Iterable['cirq.Qid'],

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -28,7 +28,6 @@ from typing import (Any, Callable, cast, Dict, FrozenSet, Iterable, Iterator,
                     TYPE_CHECKING, TypeVar, Union)
 
 import html
-
 import re
 import numpy as np
 

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -376,9 +376,8 @@ class Circuit:
 
     def _repr_html_(self) -> str:
         """Print ASCII diagram in Jupyter notebook without wrapping lines."""
-        return ('<pre style="overflow: auto; white-space: pre;">'
-                + html.escape(self.to_text_diagram())
-                + '</pre>')
+        return ('<pre style="overflow: auto; white-space: pre;">' +
+                html.escape(self.to_text_diagram()) + '</pre>')
 
     def _first_moment_operating_on(self, qubits: Iterable['cirq.Qid'],
                                    indices: Iterable[int]) -> Optional[int]:

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3848,15 +3848,16 @@ def test_repr_html_escaping():
 """.strip()
 
     escaped_diagram = ('<pre style="overflow: auto; '
-    'white-space: pre;">0: ─────&lt; &#x27; F &#x27; '
-    '&gt; ────────────────&lt; &#x27; F &#x27; &gt; ──'
-    '─\n        │                         │\n1: ─────'
-    '&lt; &#x27; F &#x27; &gt; ───&lt; &#x27; F &#x27;'
-    ' &gt; ───┼────────────\n                     │    '
-    '        │\n|c&gt;: ────────────────&lt; &#x27;'
-    ' F &#x27; &gt; ───&lt; &#x27; F &#x27; &gt; ───</pre>')
-    cleaned_escaped_diagram = escaped_diagram.replace(('<pre style="overflow:'
-    ' auto; white-space: pre;">'), '')
+                       'white-space: pre;">0: ─────&lt; &#x27; F &#x27; '
+                       '&gt; ────────────────&lt; &#x27; F &#x27; &gt; ──'
+                       '─\n        │                         │\n1: ─────'
+                       '&lt; &#x27; F &#x27; &gt; ───&lt; &#x27; F &#x27;'
+                       ' &gt; ───┼────────────\n                     │   '
+                       '         │\n|c&gt;: ────────────────&lt; &#x27;'
+                       ' F &#x27; &gt; ───&lt; &#x27; F &#x27; &gt; ───</pre>')
+    cleaned_escaped_diagram = escaped_diagram.replace(
+        ('<pre style="overflow:'
+         ' auto; white-space: pre;">'), '')
     cleaned_escaped_diagram = cleaned_escaped_diagram.replace('</pre>', '')
 
     cirq.testing.assert_has_diagram(circuit, original_diagram)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3824,13 +3824,11 @@ def test_repr_html_escaping():
     class TestGate(cirq.Gate):
 
         def num_qubits(self):
-            self.n_qubits = 2
-            return self.n_qubits
+            return 2
 
         def _circuit_diagram_info_(self, args):
-            self.label = "< ' F ' >"
-            return cirq.CircuitDiagramInfo(wire_symbols=[self.label] *
-                                           self.n_qubits)
+            return cirq.CircuitDiagramInfo(wire_symbols=["< ' F ' >",
+                                                     "< ' F ' >"])
 
     F2 = TestGate()
     a = cirq.LineQubit(1)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3832,7 +3832,7 @@ def test_repr_html_escaping():
 
         def _circuit_diagram_info_(self, args):
             return cirq.CircuitDiagramInfo(wire_symbols=[self.label] *
-                                            self.n_qubits)
+                                           self.n_qubits)
 
     F2 = TestGate(2, "< ' F ' > ")
     a, b = cirq.LineQubit.range(2)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3827,8 +3827,8 @@ def test_repr_html_escaping():
             return 2
 
         def _circuit_diagram_info_(self, args):
-            return cirq.CircuitDiagramInfo(wire_symbols=["< ' F ' >",
-                                                     "< ' F ' >"])
+            return cirq.CircuitDiagramInfo(
+                wire_symbols=["< ' F ' >", "< ' F ' >"])
 
     F2 = TestGate()
     a = cirq.LineQubit(1)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3832,7 +3832,7 @@ def test_repr_html_escaping():
 
         def _circuit_diagram_info_(self, args):
             return cirq.CircuitDiagramInfo(wire_symbols=[self.label] *
-                                        self.n_qubits)
+                                            self.n_qubits)
 
     F2 = TestGate(2, "< ' F ' > ")
     a, b = cirq.LineQubit.range(2)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -17,6 +17,7 @@ from typing import Tuple
 from collections import defaultdict
 from random import randint, random, sample, randrange
 import os
+import html
 import numpy as np
 import pytest
 import sympy
@@ -3817,3 +3818,47 @@ def test_zip():
             cirq.Circuit(cirq.X(a), cirq.CNOT(a, b)),
             cirq.Circuit(cirq.X(b), cirq.Z(b)),
         )
+
+def test_repr_html_escaping():
+
+    class TestGate(cirq.Gate):
+
+        def __init__(self, n_qubits, label):
+            self.n_qubits = n_qubits
+            self.label = label
+
+        def num_qubits(self):
+            return self.n_qubits
+
+        def _circuit_diagram_info_(self, args):
+            return cirq.CircuitDiagramInfo(wire_symbols=[self.label] *
+                                        self.n_qubits)
+
+    F2 = TestGate(2, "< ' F ' > ")
+    a, b = cirq.LineQubit.range(2)
+    c = cirq.NamedQubit("|c>")
+
+    circuit = cirq.Circuit([F2(a, b), F2(b, c), F2(a, c)])
+    original_diagram = """
+0: ─────< ' F ' > ────────────────< ' F ' > ───
+        │                         │
+1: ─────< ' F ' > ───< ' F ' > ───┼────────────
+                     │            │
+|c>: ────────────────< ' F ' > ───< ' F ' > ───
+""".strip()
+
+    escaped_diagram = ('<pre style="overflow: auto; '
+    'white-space: pre;">0: ─────&lt; &#x27; F &#x27; '
+    '&gt; ────────────────&lt; &#x27; F &#x27; &gt; ──'
+    '─\n        │                         │\n1: ─────'
+    '&lt; &#x27; F &#x27; &gt; ───&lt; &#x27; F &#x27;'
+    ' &gt; ───┼────────────\n                     │    '
+    '        │\n|c&gt;: ────────────────&lt; &#x27;'
+    ' F &#x27; &gt; ───&lt; &#x27; F &#x27; &gt; ───</pre>')
+    cleaned_escaped_diagram = escaped_diagram.replace(('<pre style="overflow:'
+    ' auto; white-space: pre;">'), '')
+    cleaned_escaped_diagram = cleaned_escaped_diagram.replace('</pre>', '')
+
+    cirq.testing.assert_has_diagram(circuit, original_diagram)
+    assert circuit._repr_html_() == escaped_diagram
+    assert cleaned_escaped_diagram == html.escape(original_diagram.strip())

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3819,6 +3819,7 @@ def test_zip():
             cirq.Circuit(cirq.X(b), cirq.Z(b)),
         )
 
+
 def test_repr_html_escaping():
 
     class TestGate(cirq.Gate):

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3823,22 +3823,20 @@ def test_repr_html_escaping():
 
     class TestGate(cirq.Gate):
 
-        def __init__(self, n_qubits, label):
-            self.n_qubits = n_qubits
-            self.label = label
-
         def num_qubits(self):
+            self.n_qubits = 2
             return self.n_qubits
 
         def _circuit_diagram_info_(self, args):
+            self.label = "< ' F ' >"
             return cirq.CircuitDiagramInfo(wire_symbols=[self.label] *
-                                           self.n_qubits)
+                                          self.n_qubits)
 
-    F2 = TestGate(2, "< ' F ' > ")
-    a, b = cirq.LineQubit.range(2)
+    F2 = TestGate()
+    a = cirq.LineQubit(1)
     c = cirq.NamedQubit("|c>")
 
-    circuit = cirq.Circuit([F2(a, b), F2(b, c), F2(a, c)])
+    circuit = cirq.Circuit([F2(a, c)])
 
     # Escaping Special Characters in Gate names.
     assert '&lt; &#x27; F &#x27; &gt;' in circuit._repr_html_()

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3830,7 +3830,7 @@ def test_repr_html_escaping():
         def _circuit_diagram_info_(self, args):
             self.label = "< ' F ' >"
             return cirq.CircuitDiagramInfo(wire_symbols=[self.label] *
-                                          self.n_qubits)
+                                           self.n_qubits)
 
     F2 = TestGate()
     a = cirq.LineQubit(1)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -17,7 +17,6 @@ from typing import Tuple
 from collections import defaultdict
 from random import randint, random, sample, randrange
 import os
-import html
 import numpy as np
 import pytest
 import sympy
@@ -3840,27 +3839,9 @@ def test_repr_html_escaping():
     c = cirq.NamedQubit("|c>")
 
     circuit = cirq.Circuit([F2(a, b), F2(b, c), F2(a, c)])
-    original_diagram = """
-0: ─────< ' F ' > ────────────────< ' F ' > ───
-        │                         │
-1: ─────< ' F ' > ───< ' F ' > ───┼────────────
-                     │            │
-|c>: ────────────────< ' F ' > ───< ' F ' > ───
-""".strip()
 
-    escaped_diagram = ('<pre style="overflow: auto; '
-                       'white-space: pre;">0: ─────&lt; &#x27; F &#x27; '
-                       '&gt; ────────────────&lt; &#x27; F &#x27; &gt; ──'
-                       '─\n        │                         │\n1: ─────'
-                       '&lt; &#x27; F &#x27; &gt; ───&lt; &#x27; F &#x27;'
-                       ' &gt; ───┼────────────\n                     │   '
-                       '         │\n|c&gt;: ────────────────&lt; &#x27;'
-                       ' F &#x27; &gt; ───&lt; &#x27; F &#x27; &gt; ───</pre>')
-    cleaned_escaped_diagram = escaped_diagram.replace(
-        ('<pre style="overflow:'
-         ' auto; white-space: pre;">'), '')
-    cleaned_escaped_diagram = cleaned_escaped_diagram.replace('</pre>', '')
+    # Escaping Special Characters in Gate names.
+    assert '&lt; &#x27; F &#x27; &gt;' in circuit._repr_html_()
 
-    cirq.testing.assert_has_diagram(circuit, original_diagram)
-    assert circuit._repr_html_() == escaped_diagram
-    assert cleaned_escaped_diagram == html.escape(original_diagram.strip())
+    # Escaping Special Characters in Qubit names.
+    assert '|c&gt;' in circuit._repr_html_()


### PR DESCRIPTION
This PR fixes #3196 by using the ```html``` module for escaping characters when the circuit diagram is produced. The escaping allows easy and correct rendering of the diagram when it is used as a cell output of a Jupyter Notebook instead of using ```print(circuit)```.
Previsouly, the special characters like ```< >``` were not being rendered after the circuit was flattened as they were being interpreted as part of HTML tags. Using ```html.escape( )``` in ```circuit._repr_html(self)``` prevents that from happening.