### PR TITLE
Add JsonResolver mypy type for custom json resolvers

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -442,6 +442,7 @@ from cirq.protocols import (
     inverse,
     is_measurement,
     is_parameterized,
+    JsonResolver,
     json_serializable_dataclass,
     measurement_key,
     measurement_keys,

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -74,6 +74,7 @@ from cirq.protocols.inverse_protocol import (
     inverse,)
 from cirq.protocols.json_serialization import (
     DEFAULT_RESOLVERS,
+    JsonResolver,
     json_serializable_dataclass,
     to_json,
     read_json,

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -16,18 +16,18 @@ import json
 import numbers
 import pathlib
 from typing import (
-    Union,
     Any,
-    Dict,
-    Optional,
-    List,
-    Callable,
-    Type,
     cast,
-    TYPE_CHECKING,
-    Iterable,
-    overload,
+    Dict,
     IO,
+    Iterable,
+    List,
+    Optional,
+    overload,
+    Sequence,
+    Type,
+    TYPE_CHECKING,
+    Union,
 )
 
 import numpy as np
@@ -184,14 +184,21 @@ class _ResolverCache:
 RESOLVER_CACHE = _ResolverCache()
 
 
-def _cirq_class_resolver(cirq_type: str) -> Union[None, Type]:
+class JsonResolver(Protocol):
+    """Protocol for json resolver functions passed to read_json."""
+
+    def __call__(self, cirq_type: str) -> Optional[Type]:
+        ...
+
+
+def _cirq_class_resolver(cirq_type: str) -> Optional[Type]:
     return RESOLVER_CACHE.cirq_class_resolver_dictionary.get(cirq_type, None)
 
 
-DEFAULT_RESOLVERS = [
+DEFAULT_RESOLVERS: List[JsonResolver] = [
     _cirq_class_resolver,
 ]
-"""A default list of 'resolver' functions for use in read_json.
+"""A default list of 'JsonResolver' functions for use in read_json.
 
 For more information about cirq_type resolution during deserialization
 please read the docstring for `cirq.read_json`.
@@ -400,7 +407,7 @@ class CirqEncoder(json.JSONEncoder):
         return super().default(o)  # coverage: ignore
 
 
-def _cirq_object_hook(d, resolvers: List[Callable[[str], Union[None, Type]]]):
+def _cirq_object_hook(d, resolvers: Sequence[JsonResolver]):
     if 'cirq_type' not in d:
         return d
 
@@ -478,7 +485,7 @@ def read_json(
         file_or_fn: Union[None, IO, pathlib.Path, str] = None,
         *,
         json_text: Optional[str] = None,
-        resolvers: Optional[List[Callable[[str], Union[None, Type]]]] = None):
+        resolvers: Optional[Sequence[JsonResolver]] = None):
     """Read a JSON file that optionally contains cirq objects.
 
     Args:
@@ -501,11 +508,7 @@ def read_json(
         raise ValueError('Must specify ONE of "file_or_fn" or "json".')
 
     if resolvers is None:
-        # This cast is required because mypy does not accept
-        # assigning an expression of type T to a variable of type
-        # Optional[T]. This cast may hide actual bugs, so be careful.
-        resolvers = cast(Optional[List[Callable[[str], Union[None, Type]]]],
-                         DEFAULT_RESOLVERS)
+        resolvers = DEFAULT_RESOLVERS
 
     def obj_hook(x):
         return _cirq_object_hook(x, resolvers)

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -481,11 +481,10 @@ def to_json(obj: Any,
 # pylint: enable=function-redefined
 
 
-def read_json(
-        file_or_fn: Union[None, IO, pathlib.Path, str] = None,
-        *,
-        json_text: Optional[str] = None,
-        resolvers: Optional[Sequence[JsonResolver]] = None):
+def read_json(file_or_fn: Union[None, IO, pathlib.Path, str] = None,
+              *,
+              json_text: Optional[str] = None,
+              resolvers: Optional[Sequence[JsonResolver]] = None):
     """Read a JSON file that optionally contains cirq objects.
 
     Args:

--- a/cirq/protocols/json_serialization_test.py
+++ b/cirq/protocols/json_serialization_test.py
@@ -177,6 +177,7 @@ SHOULDNT_BE_SERIALIZED = [
     # mypy types:
     'CIRCUIT_LIKE',
     'DURATION_LIKE',
+    'JsonResolver',
     'NOISE_MODEL_LIKE',
     'OP_TREE',
     'PAULI_GATE_LIKE',

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -46,6 +46,8 @@ IGNORED_LINE_PATTERNS = [
     r'plt\.show\(\)',
     r'fig(ure)?\.show\(\)',
     r'=\s*plt.subplots?\(',
+    # Body of mypy Protocol methods.
+    r'\.\.\.',
 ]
 EXPLICIT_OPT_OUT_COMMENT = '#coverage:ignore'
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -571,6 +571,7 @@ operation.
     cirq.ABCMetaImplementAnyOneOf
     cirq.ArithmeticOperation
     cirq.InterchangeableQubitsGate
+    cirq.JsonResolver
     cirq.LinearDict
     cirq.PeriodicValue
     cirq.testing.DEFAULT_GATE_DOMAIN


### PR DESCRIPTION
This is easier to use than `Callable[[str], Union[None, Type]]` and can be used by clients who want to write, and typecheck, their own custom resolvers.