### PR TITLE
Add shortcut for get_engine_calibration

### DIFF
--- a/cirq/google/__init__.py
+++ b/cirq/google/__init__.py
@@ -34,6 +34,7 @@ from cirq.google.engine import (
     ProtoVersion,
     QuantumEngineSampler,
     get_engine,
+    get_engine_calibration,
     get_engine_device,
     get_engine_sampler,
 )

--- a/cirq/google/engine/__init__.py
+++ b/cirq/google/engine/__init__.py
@@ -21,6 +21,7 @@ from cirq.google.engine.calibration import (
 from cirq.google.engine.engine import (
     Engine,
     get_engine,
+    get_engine_calibration,
     get_engine_device,
     ProtoVersion,
 )

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -563,5 +563,26 @@ def get_engine_device(processor_id: str,
                       project_id: Optional[str] = None,
                       gatesets: Iterable[sgs.SerializableGateSet] = ()
                      ) -> 'cirq.Device':
+    """Returns a `Device` object for a given processor.
+
+    This is a short-cut for creating an engine object, getting the
+    processor object, and retrieving the device.  Note that the
+    gateset is required in order to match the serialized specification
+    back into cirq objects.
+    """
     return get_engine(project_id).get_processor(processor_id).get_device(
         gatesets)
+
+
+def get_engine_calibration(
+        processor_id: str,
+        project_id: Optional[str] = None,
+) -> Optional['cirq.google.Calibration']:
+    """Returns calibration metrics for a given processor.
+
+    This is a short-cut for creating an engine object, getting the
+    processor object, and retrieving the current calibration.
+    May return None if no calibration metrics exist for the device.
+    """
+    return get_engine(project_id).get_processor(
+        processor_id).get_current_calibration()

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -501,6 +501,7 @@ Functionality specific to quantum hardware and services from Google.
     cirq.google.SYC_GATESET
     cirq.google.XMON
     cirq.google.get_engine
+    cirq.google.get_engine_calibration
     cirq.google.get_engine_device
     cirq.google.get_engine_sampler
     cirq.google.line_on_device

--- a/rtd_docs/docs_coverage_test.py
+++ b/rtd_docs/docs_coverage_test.py
@@ -74,10 +74,10 @@ def test_public_values_equals_documented_values():
         if not fullname.startswith('cirq.contrib.')
     }
     assert not unlisted, (
-        'Public class/method/value not listed in docs/api.rst:'
+        'Public class/method/value not listed in rtd_docs/api.rst:'
         '\n    ' + '\n    '.join(sorted(unlisted)))
     assert not hidden, (
-        'Private or non-existent class/method/value listed in docs/api.rst:'
+        'Private or non-existent class/method/value listed in rtd_docs/api.rst:'
         '\n    ' + '\n    '.join(sorted(hidden)))
 
 


### PR DESCRIPTION
- This function allows a user to directly retrieve calibration objects
without having to instantiate an Engine object.

Fixes #3150