### PR TITLE
Fix copyright notes: Google LLC -> The Cirq Developers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,4 @@
 # This does not necessarily list everyone who has contributed code, since in
 # some cases, their employer may be the copyright holder.  To see the full list
 # of contributors, see the revision history in source control.
-Google LLC
+The Cirq Developers

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,4 @@
 # This does not necessarily list everyone who has contributed code, since in
 # some cases, their employer may be the copyright holder.  To see the full list
 # of contributors, see the revision history in source control.
-The Cirq Developers
+Google LLC

--- a/cirq/contrib/quirk/export_to_quirk_test.py
+++ b/cirq/contrib/quirk/export_to_quirk_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum.py
+++ b/cirq/google/engine/client/quantum.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/__init__.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/gapic/enums.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/gapic/enums.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/gapic/quantum_engine_service_client.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/gapic/quantum_engine_service_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/proto/engine.proto
+++ b/cirq/google/engine/client/quantum_v1alpha1/proto/engine.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020 The Cirq Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/proto/quantum.proto
+++ b/cirq/google/engine/client/quantum_v1alpha1/proto/quantum.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2020 The Cirq Developers
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cirq/google/engine/client/quantum_v1alpha1/types/__init__.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/types/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/__init__.py
+++ b/cirq/google/line/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/__init__.py
+++ b/cirq/google/line/placement/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/anneal.py
+++ b/cirq/google/line/placement/anneal.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/anneal_test.py
+++ b/cirq/google/line/placement/anneal_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/chip.py
+++ b/cirq/google/line/placement/chip.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/chip_test.py
+++ b/cirq/google/line/placement/chip_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/greedy.py
+++ b/cirq/google/line/placement/greedy.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/greedy_test.py
+++ b/cirq/google/line/placement/greedy_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/optimization.py
+++ b/cirq/google/line/placement/optimization.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq/google/line/placement/optimization_test.py
+++ b/cirq/google/line/placement/optimization_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dev_tools/check.py
+++ b/dev_tools/check.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dev_tools/check_incremental_coverage_annotations.py
+++ b/dev_tools/check_incremental_coverage_annotations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dev_tools/docs/run_doctest.py
+++ b/dev_tools/docs/run_doctest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2019 Google LLC
+# Copyright 2019 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2018 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -1,5 +1,5 @@
 # 
-# Copyright 2020 Google LLC
+# Copyright 2020 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/_index.yaml
+++ b/docs/_index.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC. All Rights Reserved.
+# Copyright 2020 The Cirq Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
As we have the AUTHORS file we should use "The Cirq Developers" type copyright notice. 