### PR TITLE
Minimum required version of quimb.

### DIFF
--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -4,7 +4,7 @@ ply>=3.4
 pylatex~=1.3.0
 
 # quimb
-quimb>=1.3.0
+quimb
 opt_einsum
 autoray
 

--- a/cirq/contrib/contrib-requirements.txt
+++ b/cirq/contrib/contrib-requirements.txt
@@ -4,7 +4,7 @@ ply>=3.4
 pylatex~=1.3.0
 
 # quimb
-quimb
+quimb>=1.3.0
 opt_einsum
 autoray
 

--- a/cirq/contrib/quimb/state_vector.py
+++ b/cirq/contrib/quimb/state_vector.py
@@ -151,6 +151,7 @@ def tensor_expectation_value(circuit: cirq.Circuit,
     ]
     tn = qtn.TensorNetwork(tensors + end_bras)
     if QUIMB_VERSION < (1, 3):
+        # coverage: ignore
         warnings.warn('Please use quimb>=1.3 for optimal performance in '
                       '`tensor_expectation_value`. '
                       'See https://github.com/quantumlib/Cirq/issues/3263')

--- a/cirq/contrib/quimb/state_vector.py
+++ b/cirq/contrib/quimb/state_vector.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Sequence, Union, List, Tuple, Dict, Optional
 
 import numpy as np
@@ -5,6 +6,8 @@ import quimb
 import quimb.tensor as qtn
 
 import cirq
+
+QUIMB_VERSION = tuple(int(x) for x in quimb.__version__.split('.'))
 
 
 def circuit_to_tensors(circuit: cirq.Circuit,
@@ -147,7 +150,12 @@ def tensor_expectation_value(circuit: cirq.Circuit,
                    tags={'Q0', 'bra0'}) for q in qubits
     ]
     tn = qtn.TensorNetwork(tensors + end_bras)
-    tn.rank_simplify(inplace=True)
+    if QUIMB_VERSION < (1, 3):
+        warnings.warn('Please use quimb>=1.3 for optimal performance in '
+                      '`tensor_expectation_value`. '
+                      'See https://github.com/quantumlib/Cirq/issues/3263')
+    else:
+        tn.rank_simplify(inplace=True)
     path_info = tn.contract(get='path-info')
     ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
     if ram_gb > max_ram_gb:


### PR DESCRIPTION
Alternatively, you can comment out `state_vector.py` line 150.

Fixes gh-3263