### PR TITLE
docstrings for type aliases in devsite API docs

### DIFF
--- a/cirq/_doc.py
+++ b/cirq/_doc.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Workaround for associating docstrings with public constants."""
+import sys
+
 from typing import Any, Dict, NamedTuple, Optional
 
 DocProperties = NamedTuple(
@@ -44,4 +46,20 @@ def document(value: Any, doc_string: Optional[str] = None):
     """
     docs = DocProperties(doc_string=doc_string)
     RECORDED_CONST_DOCS[id(value)] = docs
+
+    ## this is how the devsite API generator picks up
+    ## docstrings for type aliases
+    if sys.version_info >= (3, 7):
+        try:
+            value.__doc__ = doc_string
+        except AttributeError:
+            # we have a couple (~ 7) global constants of type list, tuple, dict,
+            # that fail here as their __doc__ attribute is read-only.
+            # For the time being these are not going to be part of the generated
+            # API docs. See b/166663013 for more info.
+
+            # to list them, uncomment these lines and run `import cirq`:
+            # print(f"WARNING: {e}")
+            # print(traceback.format_stack(limit=2)[0])
+            pass
     return value

--- a/cirq/_doc.py
+++ b/cirq/_doc.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Workaround for associating docstrings with public constants."""
-import sys
 
 from typing import Any, Dict, NamedTuple, Optional
 
@@ -49,17 +48,17 @@ def document(value: Any, doc_string: Optional[str] = None):
 
     ## this is how the devsite API generator picks up
     ## docstrings for type aliases
-    if sys.version_info >= (3, 7):
-        try:
-            value.__doc__ = doc_string
-        except AttributeError:
-            # we have a couple (~ 7) global constants of type list, tuple, dict,
-            # that fail here as their __doc__ attribute is read-only.
-            # For the time being these are not going to be part of the generated
-            # API docs. See b/166663013 for more info.
+    try:
+        value.__doc__ = doc_string
+    except AttributeError:
+        # we have a couple (~ 7) global constants of type list, tuple, dict,
+        # that fail here as their __doc__ attribute is read-only.
+        # For the time being these are not going to be part of the generated
+        # API docs. See https://github.com/quantumlib/Cirq/issues/3276 for
+        # more info.
 
-            # to list them, uncomment these lines and run `import cirq`:
-            # print(f"WARNING: {e}")
-            # print(traceback.format_stack(limit=2)[0])
-            pass
+        # to list them, uncomment these lines and run `import cirq`:
+        # print(f"WARNING: {e}")
+        # print(traceback.format_stack(limit=2)[0])
+        pass
     return value

--- a/cirq/google/gate_sets.py
+++ b/cirq/google/gate_sets.py
@@ -111,7 +111,7 @@ NAMED_GATESETS = {
 }
 
 document(NAMED_GATESETS,
-         """"A convenience mapping from gateset names to gatesets""")
+         """A convenience mapping from gateset names to gatesets""")
 
 GOOGLE_GATESETS = [
     SYC_GATESET,


### PR DESCRIPTION
The devsite API docs generation script doesn't pick up docstrings for our type aliases currently. This fixes it. 
Inspired by https://github.com/tensorflow/tensorflow/blob/40a314cab8d6c7afbc62456433a033c1cab8d74f/tensorflow/python/types/doc_typealias.py#L24:5