### PR TITLE
Relax Proto requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib~=3.0
 networkx~=2.4
 numpy~=1.16, < 1.19
 pandas
-protobuf~=3.12.0
+protobuf>=3.12.0
 requests~=2.18
 sortedcontainers~=2.0
 scipy


### PR DESCRIPTION
This locked proto version is ( and will likely continue to be a problem ) for downstream TFQ docs builds. Are people alright with opening this up to `>=` instead of `~=` ?