### PR TITLE
Add a few extra links to documentation

### DIFF
--- a/docs/google/calibration.md
+++ b/docs/google/calibration.md
@@ -13,7 +13,12 @@ of the metric.  Note that the value of the metric is also usually a dictionary
 
 ## Retrieving calibration metrics
 
-Calibration metrics can be retrieved using an engine instance or with a job.
+You can view calibration metrics in the Cloud Console by clicking on the
+relevant processor in the
+[processors list](https://console.cloud.google.com/quantum/processors).
+A dropdown menu will let you choose the current characterization or historical
+metrics from a previous run.  Calibration metrics can also be retrieved
+programmatically using an engine instance or with a job.
 
 ```
 import cirq.google as cg

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -33,7 +33,7 @@
         "## How to download iPython notebooks from github\n",
         "\n",
         "You can retrieve ipython notebooks in the cirq repository by\n",
-        "going to the [doc directory](https://github.com/quantumlib/Cirq/tree/master/docs).  Select the file that you would like to download and then click the \"Raw\" button in the upper right part of the window:\n",
+        "going to the [doc directory](https://github.com/quantumlib/Cirq/tree/master/docs).  For instance, this colab template can be found [here](https://github.com/quantumlib/Cirq/blob/master/docs/tutorials/google/colab.ipynb).  Select the file that you would like to download and then click the \"Raw\" button in the upper right part of the window:\n",
         "\n",
         "![Raw button](../../images/colab_github.png)\n",
         "\n",

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -37,7 +37,7 @@
         "\n",
         "![Raw button](../../images/colab_github.png)\n",
         "\n",
-        "This will show the entire file contents.  Right-click and select \"Save as\" to save this file to your computer.  Make sure to save to a file with a \".ipynb\" extension.  (Note: you may need to select \"All files\" from the format dropdown instead of \"text\").\n",
+        "This will show the entire file contents.  Right-click and select \"Save as\" to save this file to your computer.  Make sure to save to a file with a \".ipynb\" extension.  (Note: you may need to select \"All files\" from the format dropdown instead of \"text\").   You can also get to this colab's [raw contenti directly](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/tutorials/google/colab.ipynb)\n",
         "\n",
         "You can also retrieve the entire cirq repository by running the following command in a terminal that has git installed.  `git checkout https://github.com/quantumlib/Cirq.git` \n",
         "\n",

--- a/docs/tutorials/google/reservations.ipynb
+++ b/docs/tutorials/google/reservations.ipynb
@@ -28,7 +28,7 @@
         "\n",
         "This Colab provides canned interactions with Cirq to manage a project's reservations on the Quantum Engine.\n",
         "\n",
-        "For information on how to download a colab from github, see [these instructions](colab.ipynb)"
+        "For information on how to download a colab from github, see [these instructions](colab.ipynb).  You can also [view this file](https://github.com/quantumlib/Cirq/blob/master/docs/tutorials/google/reservations.ipynb) or download the [raw content](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/tutorials/google/reservations.ipynb) of this content from Github."
       ]
     },
     {

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -26,7 +26,7 @@
         "\n",
         "Access is currently restricted to those in an approved group, and you must be in that group before running this tutorial.\n",
         "\n",
-        "You can find more about running this in colaboratory in the [Colab documentation](https://colab.sandbox.google.com/notebooks/welcome.ipynb) or in our cirq-specific guide to [running in colab](colab.ipynb)."
+        "You can find more about running this in colaboratory in the [Colab documentation](https://colab.sandbox.google.com/notebooks/welcome.ipynb) or in our cirq-specific guide to [running in colab](colab.ipynb).  You can download this colab from the [GitHub repository](https://github.com/quantumlib/Cirq/blob/master/docs/tutorials/google/start.ipynb)."
       ]
     },
     {


### PR DESCRIPTION
- Add links to the files in github for colabs that are
primarily meant to be downloaded.
- Add link to GCP console for retrieving calibration
metrics.