### PR TITLE
Fix a bug in validating computational basis limits

### DIFF
--- a/cirq/qis/states.py
+++ b/cirq/qis/states.py
@@ -383,7 +383,7 @@ def _computational_basis_state_to_state_tensor(*, state_rep: int,
                                                dtype: Type[np.number]
                                               ) -> np.ndarray:
     n = np.prod(qid_shape, dtype=int)
-    if not 0 <= state_rep <= n:
+    if not 0 <= state_rep < n:
         raise ValueError(f'Computational basis state is out of range.\n'
                          f'\n'
                          f'state={state_rep!r}\n'

--- a/cirq/qis/states_test.py
+++ b/cirq/qis/states_test.py
@@ -253,6 +253,9 @@ def test_dirac_notation_precision():
 
 
 def test_to_valid_state_vector():
+    with pytest.raises(ValueError,
+                       match='Computational basis state is out of range'):
+        cirq.to_valid_state_vector(2, 1)
     np.testing.assert_almost_equal(
         cirq.to_valid_state_vector(
             np.array([1.0, 0.0, 0.0, 0.0], dtype=np.complex64), 2),


### PR DESCRIPTION
Could potentially cause out of bounds access for `one_hot`