### PR TITLE
Adjust docs for Getting started guide

### DIFF
--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -35,7 +35,7 @@
         "You can retrieve ipython notebooks in the cirq repository by\n",
         "going to the [doc directory](https://github.com/quantumlib/Cirq/tree/master/docs).  For instance, this colab template can be found [here](https://github.com/quantumlib/Cirq/blob/master/docs/tutorials/google/colab.ipynb).  Select the file that you would like to download and then click the \"Raw\" button in the upper right part of the window:\n",
         "\n",
-        "![Raw button](https://cirq.readthedocs.io/en/latest/_images/colab_github.png)\n",
+        "![Raw button](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/colab_github.png)\n",
         "\n",
         "This will show the entire file contents.  Right-click and select \"Save as\" to save this file to your computer.  Make sure to save to a file with a \".ipynb\" extension.  (Note: you may need to select \"All files\" from the format dropdown instead of \"text\").   You can also get to this colab's [raw contenti directly](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/tutorials/google/colab.ipynb)\n",
         "\n",
@@ -45,7 +45,7 @@
         "\n",
         "You can open a new colab from your Google Drive window or by visiting the [colab site](https://colab.research.google.com/notebooks/intro.ipynb).  From the colaboratory site, you can use the menu to upload an ipython notebook:\n",
         "\n",
-        "![Upload menu](https://cirq.readthedocs.io/en/latest/_images/colab_upload.png)\n",
+        "![Upload menu](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/colab_upload.png)\n",
         "\n",
         "This will upload the ipynb file that you downloaded before.  You can now run all the commands, modify it to suit your goals, and share it with others.\n",
         "\n",
@@ -74,7 +74,7 @@
         "\n",
         "2. Then run the cell below (and go through the auth flow for access to the project id you entered).\n",
         "\n",
-        "![Quantum Engine console](https://cirq.readthedocs.io/en/latest/_images/run-code-block.png)"
+        "![Quantum Engine console](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/run-code-block.png)"
       ]
     },
     {

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -35,7 +35,7 @@
         "You can retrieve ipython notebooks in the cirq repository by\n",
         "going to the [doc directory](https://github.com/quantumlib/Cirq/tree/master/docs).  For instance, this colab template can be found [here](https://github.com/quantumlib/Cirq/blob/master/docs/tutorials/google/colab.ipynb).  Select the file that you would like to download and then click the \"Raw\" button in the upper right part of the window:\n",
         "\n",
-        "![Raw button](../../images/colab_github.png)\n",
+        "![Raw button](https://cirq.readthedocs.io/en/latest/_images/colab_github.png)\n",
         "\n",
         "This will show the entire file contents.  Right-click and select \"Save as\" to save this file to your computer.  Make sure to save to a file with a \".ipynb\" extension.  (Note: you may need to select \"All files\" from the format dropdown instead of \"text\").   You can also get to this colab's [raw contenti directly](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/tutorials/google/colab.ipynb)\n",
         "\n",
@@ -45,7 +45,7 @@
         "\n",
         "You can open a new colab from your Google Drive window or by visiting the [colab site](https://colab.research.google.com/notebooks/intro.ipynb).  From the colaboratory site, you can use the menu to upload an ipython notebook:\n",
         "\n",
-        "![Upload menu](../../images/colab_upload.png)\n",
+        "![Upload menu](https://cirq.readthedocs.io/en/latest/_images/colab_upload.png)\n",
         "\n",
         "This will upload the ipynb file that you downloaded before.  You can now run all the commands, modify it to suit your goals, and share it with others.\n",
         "\n",
@@ -74,7 +74,7 @@
         "\n",
         "2. Then run the cell below (and go through the auth flow for access to the project id you entered).\n",
         "\n",
-        "![Quantum Engine console](../../images/run-code-block.png)"
+        "![Quantum Engine console](https://cirq.readthedocs.io/en/latest/_images/run-code-block.png)"
       ]
     },
     {

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -38,21 +38,21 @@
       "source": [
         "## Before you begin\n",
         "\n",
-        "First, follow this link to [**enable the Quantum Engine API**](https://console.cloud.google.com/apis/library/quantum.googleapis.com?returnUrl=quantum) in a Google Cloud Platform project. You may be prompted to:\n",
-        " * Log in and agree to [Terms of Service](https://cloud.google.com/terms/)\n",
-        " * **Create or select a project**: Google Cloud Platform uses projects to organize resources & control access.  All of your quantum programs and results will live under a project which you specify when creating and running these programs using Quantum Engine.  You should create a project for use in this colab. [Learn more about creating a project](https://cloud.google.com/docs/overview/)\n",
+        "*  First, decide which project you will use the Quantum Computing Services from.  All of your quantum programs and results will live under a project which you specify when creating and running these programs using Quantum Engine.  You can use an existing project or create a new project.  [Learn more about creating a project](https://cloud.google.com/docs/overview/)\n",
+        "*  Log in and agree to [Terms of Service](https://cloud.google.com/terms/)\n",
+        "*  Follow this link to [**enable the Quantum Engine API**](https://console.cloud.google.com/apis/library/quantum.googleapis.com?returnUrl=quantum) in your Google Cloud Platform project.\n",
         "\n",
         "After the API is enabled, you should be redirected to the [Quantum Engine console](https://console.cloud.google.com/quantum) and it should look like the following screenshot.\n",
         "\n",
-        "![Quantum Engine landing](../../images/console-landing.png)\n",
+        "![Quantum Engine landing](https://cirq.readthedocs.io/en/latest/_images/console-landing.png)\n",
         "\n",
         "**Enter your project id into the input text box below**. To find your project id, click on the project menu in the blue bar at the top of the console. This will open a menu that displays your project name (e.g. \"My project\") and unique **project id** (e.g. my-project-1234). Enter the **project id** into the input below. ([Help on finding your project id](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects))\n",
         "\n",
-        "![Find project id](../../images/console-project-id.png)\n",
+        "![Find project id](https://cirq.readthedocs.io/en/latest/_images/console-project-id.png)\n",
         "\n",
-        "**Run the code in the next block (the one with the text box)**, which will prompt you to authenticate Google Cloud SDK to use your project.  You can run the code by either clicking the play button (pointed by arrow below) or by selecting the block and pressing CTRL-ENTER.  After running the block you will see a link which you should click.  This will open a new browser window.  Follow the authentication flow for this window.  After you authenticate and allow access to your project, you will be given a string which you should enter into the text box that appears in the run area (and then press return).  If you see \"Authentication complete\" you have done this step successfully.\n",
+        "**Run the code in the next block (the one with the text box)**, which will prompt you to authenticate Google Cloud SDK to use your project.  You can run the code by either clicking the play button (pointed by arrow below) or by selecting the block and pressing CTRL-ENTER.  After running the block you will see a link which you should click.  This will open a new browser window.  Follow the authentication flow for this window.  After you authenticate and allow access to your project, you will be given a string which you should enter into the text box that appears in the run area (and then press return).  If you see \"Authentication complete\" you have done this step successfully. If this fails, make sure that you have cut and paste the string correctly (e.g. the clipboard button seems to not work for some browser/OS combinations). \n",
         "\n",
-        "![Run code block below](../../images/run-code-block.png)"
+        "![Run code block below](https://cirq.readthedocs.io/en/latest/_images/run-code-block.png)"
       ]
     },
     {
@@ -553,7 +553,8 @@
       "source": [
         "## Next steps\n",
         "* Use [this template colab](colab.ipynb) as a base for your own explorations.\n",
-        "* Explore [best practices](../../google/best_practices.md) for getting circuits to run on hardware."
+        "* Explore [best practices](../../google/best_practices.md) for getting circuits to run on hardware.",
+        "* Use the [reservation colab](reservations.ipynb) for getting circuits to run on hardware."
       ]
     }
   ]

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -44,15 +44,15 @@
         "\n",
         "After the API is enabled, you should be redirected to the [Quantum Engine console](https://console.cloud.google.com/quantum) and it should look like the following screenshot.\n",
         "\n",
-        "![Quantum Engine landing](https://cirq.readthedocs.io/en/latest/_images/console-landing.png)\n",
+        "![Quantum Engine landing](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/console-landing.png)\n",
         "\n",
         "**Enter your project id into the input text box below**. To find your project id, click on the project menu in the blue bar at the top of the console. This will open a menu that displays your project name (e.g. \"My project\") and unique **project id** (e.g. my-project-1234). Enter the **project id** into the input below. ([Help on finding your project id](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects))\n",
         "\n",
-        "![Find project id](https://cirq.readthedocs.io/en/latest/_images/console-project-id.png)\n",
+        "![Find project id](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/console-project-id.png)\n",
         "\n",
         "**Run the code in the next block (the one with the text box)**, which will prompt you to authenticate Google Cloud SDK to use your project.  You can run the code by either clicking the play button (pointed by arrow below) or by selecting the block and pressing CTRL-ENTER.  After running the block you will see a link which you should click.  This will open a new browser window.  Follow the authentication flow for this window.  After you authenticate and allow access to your project, you will be given a string which you should enter into the text box that appears in the run area (and then press return).  If you see \"Authentication complete\" you have done this step successfully. If this fails, make sure that you have cut and paste the string correctly (e.g. the clipboard button seems to not work for some browser/OS combinations). \n",
         "\n",
-        "![Run code block below](https://cirq.readthedocs.io/en/latest/_images/run-code-block.png)"
+        "![Run code block below](https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/run-code-block.png)"
       ]
     },
     {


### PR DESCRIPTION
- Minor issues found through walk-through
- Google colabs are meant to be downloaded,
   so image links need to be absolute
- Rearrange text so that project creation/selection
   happens before trying to enable the API
- Add link to reservation colab on getting started guide.