### PR TITLE
Update gates.ipynb

### DIFF
--- a/docs/gates.ipynb
+++ b/docs/gates.ipynb
@@ -249,7 +249,7 @@
     "### Two qubit gates\n",
     "\n",
     "**cirq.CZ / cirq.CZPowGate** The controlled-Z gate.  A two qubit gate that\n",
-    "phases the |11⟩ state.  `cirq.CZPowGate(exponent=y)` is equivalent to\n",
+    "phases the |11⟩ state.  `cirq.CZPowGate(exponent=t)` is equivalent to\n",
     "`cirq.CZ**t` and has a matrix representation of ``exp(i pi |11⟩⟨11| t)``.\n",
     "\n",
     "**cirq.CNOT / cirq.CNotPowGate** The controlled-X gate.  This gate swaps the\n",


### PR DESCRIPTION
there'll be `exponent=t` instead of `exponent=y`