### PR TITLE
cleanup engine docstrings

### DIFF
--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -191,7 +191,7 @@ class EngineClient:
                     return_code: bool) -> qtypes.QuantumProgram:
         """Returns a previously created quantum program.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             return_code: If True returns the serialized program code.
@@ -203,7 +203,7 @@ class EngineClient:
                                 description: str) -> qtypes.QuantumProgram:
         """Sets the description for a previously created quantum program.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             description: The new program description.
@@ -238,7 +238,7 @@ class EngineClient:
         """Sets (overwriting) the labels for a previously created quantum
         program.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             labels: The entire set of new program labels.
@@ -254,7 +254,7 @@ class EngineClient:
                            labels: Dict[str, str]) -> qtypes.QuantumProgram:
         """Adds new labels to a previously created quantum program.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             labels: New labels to add to the existing program labels.
@@ -277,7 +277,7 @@ class EngineClient:
         """Removes labels with given keys from the labels of a previously
         created quantum program.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             label_keys: Label keys to remove from the existing program labels.
@@ -302,7 +302,7 @@ class EngineClient:
                        delete_jobs: bool = False) -> None:
         """Deletes a previously created quantum program.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             delete_jobs: If True will delete all the program's jobs, other this
@@ -368,7 +368,7 @@ class EngineClient:
                 return_run_context: bool) -> qtypes.QuantumJob:
         """Returns a previously created job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -381,7 +381,7 @@ class EngineClient:
                             description: str) -> qtypes.QuantumJob:
         """Sets the description for a previously created quantum job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -413,7 +413,7 @@ class EngineClient:
                        labels: Dict[str, str]) -> qtypes.QuantumJob:
         """Sets (overwriting) the labels for a previously created quantum job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -430,7 +430,7 @@ class EngineClient:
                        labels: Dict[str, str]) -> qtypes.QuantumJob:
         """Adds new labels to a previously created quantum job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -454,7 +454,7 @@ class EngineClient:
         """Removes labels with given keys from the labels of a previously
         created quantum job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -477,7 +477,7 @@ class EngineClient:
     def delete_job(self, project_id: str, program_id: str, job_id: str) -> None:
         """Deletes a previously created quantum job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -488,7 +488,7 @@ class EngineClient:
     def cancel_job(self, project_id: str, program_id: str, job_id: str) -> None:
         """Cancels the given job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -500,7 +500,7 @@ class EngineClient:
                         job_id: str) -> qtypes.QuantumResult:
         """Returns the results of a completed job.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
@@ -516,7 +516,7 @@ class EngineClient:
         current Engine project. The names of these processors are used to
         identify devices when scheduling jobs and gathering calibration metrics.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
 
         Returns:
@@ -531,7 +531,7 @@ class EngineClient:
                       processor_id: str) -> qtypes.QuantumProcessor:
         """Returns a quantum processor.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
 
@@ -549,16 +549,13 @@ class EngineClient:
                          ) -> List[qtypes.QuantumCalibration]:
         """Returns a list of quantum calibrations.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             filter: Filter string current only supports 'timestamp' with values
-              of epoch time in seconds or short string 'yyyy-MM-dd' or long
-              string 'yyyy-MM-dd HH:mm:ss.SSS' both in UTC. For example:
+            of epoch time in seconds or short string 'yyyy-MM-dd'. For example:
                 'timestamp > 1577960125 AND timestamp <= 1578241810'
                 'timestamp > 2020-01-02 AND timestamp <= 2020-01-05'
-                'timestamp > "2020-01-02 10:15:25.000" AND timestamp <=
-                  "2020-01-05 16:30:10.456"'
 
         Returns:
             A list of calibrations.
@@ -574,7 +571,7 @@ class EngineClient:
                        ) -> qtypes.QuantumCalibration:
         """Returns a quantum calibration.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             calibration_timestamp_seconds: The timestamp of the calibration in
@@ -593,7 +590,7 @@ class EngineClient:
         """Returns the current quantum calibration for a processor if it has
         one.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
 
@@ -618,7 +615,7 @@ class EngineClient:
                            whitelisted_users: Optional[List[str]] = None):
         """Creates a quantum reservation and returns the created object.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             reservation_id: Unique ID of the reservation in the parent project,
@@ -654,7 +651,7 @@ class EngineClient:
         has already ended or is beyond the processor's freeze window, then the
         call will return an error.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             reservation_id: Unique ID of the reservation in the parent project,
@@ -675,7 +672,7 @@ class EngineClient:
         If the reservation has already ended or is within the processor's
         freeze window, then the call will return a `FAILED_PRECONDITION` error.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             reservation_id: Unique ID of the reservation in the parent project,
@@ -689,7 +686,7 @@ class EngineClient:
                         reservation_id: str):
         """ Gets a quantum reservation from the engine.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             reservation_id: Unique ID of the reservation in the parent project,
@@ -713,7 +710,7 @@ class EngineClient:
 
         Only reservations owned by this project will be returned.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             filter: A string for filtering quantum reservations.
@@ -721,8 +718,8 @@ class EngineClient:
                 Examples:
                     `start_time >= 1584385200`: Reservation began on or after
                         the epoch time Mar 16th, 7pm GMT.
-                    `end_time >= "2017-01-02 15:21:15.142"`: Reservation ends on
-                        or after Jan 2nd 2017 15:21:15.142
+                    `end_time >= 1483370475`: Reservation ends on
+                        or after Jan 2nd 2017 15:21:15
 
         Returns:
             A list of QuantumReservation objects.
@@ -747,7 +744,7 @@ class EngineClient:
         and list of whitelisted users.  If any field is not filled, it will
         not be updated.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             reservation_id: Unique ID of the reservation in the parent project,
@@ -784,7 +781,7 @@ class EngineClient:
                         filter_str: str = '') -> List[qtypes.QuantumTimeSlot]:
         """Returns a list of quantum time slots on a processor.
 
-        Params:
+        Args:
             project_id: A project_id of the parent Google Cloud Project.
             processor_id: The processor unique identifier.
             filter:  A string expression for filtering the quantum


### PR DESCRIPTION
Cleanup of method docstrings in the Engine API. 

* some places we had Params instead of Args
* some places we had filter strings for timestamps referring to the long string format which is actually not supported, only epoch timestamps