### PR TITLE
List Engine jobs

### DIFF
--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -545,7 +545,9 @@ class Engine:
                 regardless of the label value will be filtered. For example, to
                 query programs that have the shape label and have the color
                 label with value red can be queried using
-                `{'color: red', 'shape:*'}`
+
+                {'color': 'red', 'shape':'*'}
+
             execution_states: retrieve jobs that have an execution state  that
                  is contained in `execution_states`. See
                  `quantum.enums.ExecutionStatus.State` enum for accepted values.

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -28,9 +28,10 @@ import enum
 import os
 import random
 import string
-from typing import (Dict, Iterable, List, Optional, Sequence, TypeVar, Union,
-                    TYPE_CHECKING)
+from typing import (Dict, Iterable, List, Optional, Sequence, Set, TypeVar,
+                    Union, TYPE_CHECKING)
 
+from cirq.google.engine.client import quantum
 from google.protobuf import any_pb2
 
 from cirq import circuits, study, value
@@ -516,6 +517,54 @@ class Engine:
                 _program=p,
                 context=self.context,
             ) for p in response
+        ]
+
+    def list_jobs(self,
+                  created_before: Optional[
+                      Union[datetime.datetime, datetime.date]] = None,
+                  created_after: Optional[
+                      Union[datetime.datetime, datetime.date]] = None,
+                  has_labels: Optional[Dict[str, str]] = None,
+                  execution_states: Optional[Set[
+                      quantum.enums.ExecutionStatus.State]] = None):
+        """Returns the list of jobs in the project.
+
+        All historical jobs can be retrieved using this method and filtering
+        options are available too, to narrow down the search baesd on:
+          * creation time
+          * job labels
+          * execution states
+
+        Args:
+            created_after: retrieve jobs that were created after this date
+                or time.
+            created_before: retrieve jobs that were created after this date
+                or time.
+            has_labels: retrieve jobs that have labels on them specified by
+                this dict. If the value is set to `*`, filters having the label
+                regardless of the label value will be filtered. For example, to
+                query programs that have the shape label and have the color
+                label with value red can be queried using
+                `{'color: red', 'shape:*'}`
+            execution_states: retrieve jobs that have an execution state  that
+                 is contained in `execution_states`. See
+                 `quantum.enums.ExecutionStatus.State` enum for accepted values.
+        """
+        client = self.context.client
+        response = client.list_jobs(self.project_id,
+                                    None,
+                                    created_before=created_before,
+                                    created_after=created_after,
+                                    has_labels=has_labels,
+                                    execution_states=execution_states)
+        return [
+            engine_job.EngineJob(
+                project_id=client._ids_from_job_name(j.name)[0],
+                program_id=client._ids_from_job_name(j.name)[1],
+                job_id=client._ids_from_job_name(j.name)[2],
+                context=self.context,
+                _job=j,
+            ) for j in response
         ]
 
     def list_processors(self) -> List[engine_processor.EngineProcessor]:

--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -236,10 +236,11 @@ class EngineClient:
                 or time.
             has_labels: retrieve programs that have labels on them specified by
                 this dict. If the value is set to `*`, filters having the label
-                regardless of the label value will be filtered. For example, to
-                query programs that have the shape label and have the color
+                egardless of the label value will be filtered. For example, to
+                uery programs that have the shape label and have the color
                 label with value red can be queried using
-                `{'color: red', 'shape:*'}`
+
+                {'color': 'red', 'shape':'*'}
         """
         filters = []
 
@@ -449,10 +450,12 @@ class EngineClient:
                 regardless of the label value will be filtered. For example, to
                 query programs that have the shape label and have the color
                 label with value red can be queried using
-                `{'color: red', 'shape:*'}`
-            execution_states: retrieve jobs that have an execution state  that
-                 is contained in `execution_states`. See
-                 `quantum.enums.ExecutionStatus.State` enum for accepted values.
+
+                {'color': 'red', 'shape':'*'}
+
+            execution_states: retrieve jobs that have an execution state that
+                is contained in `execution_states`. See
+                `quantum.enums.ExecutionStatus.State` enum for accepted values.
         """
         filters = []
 

--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -15,9 +15,8 @@
 import datetime
 import sys
 import time
-from typing import Callable, Dict, List, Optional, Sequence, Set, TypeVar, \
-    Tuple, \
-    Union
+from typing import (Callable, Dict, List, Optional, Sequence, Set, TypeVar,
+                    Tuple, Union)
 import warnings
 
 from google.api_core.exceptions import GoogleAPICallError, NotFound

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -632,6 +632,128 @@ def test_job_results(client_constructor):
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
+def test_list_jobs(client_constructor):
+    grpc_client = setup_mock_(client_constructor)
+
+    results = [
+        qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job1'),
+        qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job2')
+    ]
+    grpc_client.list_quantum_jobs.return_value = results
+
+    client = EngineClient()
+    assert client.list_jobs(project_id='proj', program_id='prog1') == results
+    assert grpc_client.list_quantum_jobs.call_args[0] == (
+        'projects/proj/programs/prog1',)
+    assert grpc_client.list_quantum_jobs.call_args[1] == {
+        'filter_': '',
+    }
+
+
+# yapf: disable
+@pytest.mark.parametrize(
+    'expected_filter, '
+        'created_after, '
+        'created_before, '
+        'labels, '
+        'execution_states, '
+        'priority_interval',
+    [
+        ('',
+            None,
+            None,
+            None,
+            None,
+            None),
+        ('create_time >= 2020-09-01',
+            datetime.date(2020, 9, 1),
+            None,
+            None,
+            None,
+            None),
+        ('create_time >= 1598918400',
+            datetime.datetime(2020, 9, 1, 0, 0, 0,
+                              tzinfo=datetime.timezone.utc),
+            None,
+            None,
+            None,
+            None),
+        ('create_time <= 2020-10-01',
+            None,
+            datetime.date(2020, 10, 1),
+            None,
+            None,
+            None),
+        ('create_time >= 2020-09-01 AND create_time <= 1598918410',
+            datetime.date(2020, 9, 1),
+            datetime.datetime(2020, 9, 1, 0, 0, 10,
+                            tzinfo=datetime.timezone.utc),
+            None,
+            None,
+            None),
+        ('labels.color:red AND labels.shape:*',
+            None,
+            None,
+            {
+            'color': 'red',
+            'shape': '*'
+            },
+            None,
+            None
+        ),
+        ('(execution_status.state = FAILURE OR '
+         'execution_status.state = CANCELLED)',
+            None,
+            None,
+            None,
+            [quantum.enums.ExecutionStatus.State.FAILURE,
+             quantum.enums.ExecutionStatus.State.CANCELLED,],
+            None
+        ),
+        ('scheduling_config.priority >= 10 AND '
+         'scheduling_config.priority <= 20',
+         None,
+         None,
+         None,
+         None,
+         [10, 20]
+         ),
+        ('create_time >= 2020-08-01 AND '
+         'create_time <= 1598918400 AND '
+         'labels.color:red AND labels.shape:* AND '
+         '(execution_status.state = SUCCESS) AND '
+         'scheduling_config.priority >= 0 AND '
+         'scheduling_config.priority <= 10',
+            datetime.date(2020, 8, 1),
+            datetime.datetime(2020, 9, 1, tzinfo=datetime.timezone.utc),
+            {
+            'color': 'red',
+            'shape': '*'
+            },
+            [quantum.enums.ExecutionStatus.State.SUCCESS],
+            [0, 10]
+        ),
+    ])
+# yapf: enable
+@mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
+def test_list_jobs_filters(client_constructor, expected_filter, created_before,
+                           created_after, labels, execution_states,
+                           priority_interval):
+    grpc_client = setup_mock_(client_constructor)
+    client = EngineClient()
+    client.list_jobs(project_id='proj',
+                     program_id='prog',
+                     created_before=created_before,
+                     created_after=created_after,
+                     has_labels=labels,
+                     execution_states=execution_states,
+                     priority_interval=priority_interval)
+    assert grpc_client.list_quantum_jobs.call_args[1] == {
+        'filter_': expected_filter,
+    }
+
+
+@mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_list_processors(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 

--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -285,10 +285,12 @@ class EngineProgram:
                 regardless of the label value will be filtered. For example, to
                 query programs that have the shape label and have the color
                 label with value red can be queried using
-                `{'color: red', 'shape:*'}`
+
+                {'color': 'red', 'shape':'*'}
+
             execution_states: retrieve jobs that have an execution state  that
-                 is contained in `execution_states`. See
-                 `quantum.enums.ExecutionStatus.State` enum for accepted values.
+                is contained in `execution_states`. See
+                `quantum.enums.ExecutionStatus.State` enum for accepted values.
         """
         client = self.context.client
         response = client.list_jobs(self.project_id,

--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -270,8 +270,7 @@ class EngineProgram:
                       Union[datetime.datetime, datetime.date]] = None,
                   has_labels: Optional[Dict[str, str]] = None,
                   execution_states: Optional[Set[
-                      quantum.enums.ExecutionStatus.State]] = None,
-                  priority_interval: Optional[Tuple[int, int]] = None):
+                      quantum.enums.ExecutionStatus.State]] = None):
         """Returns the list of jobs for this program.
 
         Args:
@@ -290,10 +289,6 @@ class EngineProgram:
             execution_states: retrieve jobs that have an execution state  that
                  is contained in `execution_states`. See
                  `quantum.enums.ExecutionStatus.State` enum for accepted values.
-            priority_interval: retrieve jobs that have priority within the given
-                priority interval (inclusive), i.e for [1,3], jobs with priority
-                p will be listed when 1 <= p <= 3. Min priority is 0, max is
-                1000.
         """
         client = self.context.client
         response = client.list_jobs(self.project_id,
@@ -301,8 +296,7 @@ class EngineProgram:
                                     created_before=created_before,
                                     created_after=created_after,
                                     has_labels=has_labels,
-                                    execution_states=execution_states,
-                                    priority_interval=priority_interval)
+                                    execution_states=execution_states)
         return [
             engine_job.EngineJob(
                 project_id=client._ids_from_job_name(j.name)[0],

--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, List, Optional, Sequence, TYPE_CHECKING
+
+import datetime
+from typing import Dict, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, \
+    Union
 
 from cirq import study
+from cirq.google.engine.client import quantum
 from cirq.google.engine.client.quantum import types as qtypes
 from cirq.google import gate_sets
 from cirq.google.api import v2
 from cirq.google.engine import engine_job
 
 if TYPE_CHECKING:
-    import datetime
     import cirq.google.engine.engine as engine_base
     from cirq import Circuit
 
@@ -259,6 +262,56 @@ class EngineProgram:
         """
         return engine_job.EngineJob(self.project_id, self.program_id, job_id,
                                     self.context)
+
+    def list_jobs(self,
+                  created_before: Optional[
+                      Union[datetime.datetime, datetime.date]] = None,
+                  created_after: Optional[
+                      Union[datetime.datetime, datetime.date]] = None,
+                  has_labels: Optional[Dict[str, str]] = None,
+                  execution_states: Optional[Set[
+                      quantum.enums.ExecutionStatus.State]] = None,
+                  priority_interval: Optional[Tuple[int, int]] = None):
+        """Returns the list of jobs for this program.
+
+        Args:
+            project_id: A project_id of the parent Google Cloud Project.
+            program_id: Unique ID of the program within the parent project.
+            created_after: retrieve jobs that were created after this date
+                or time.
+            created_before: retrieve jobs that were created after this date
+                or time.
+            has_labels: retrieve jobs that have labels on them specified by
+                this dict. If the value is set to `*`, filters having the label
+                regardless of the label value will be filtered. For example, to
+                query programs that have the shape label and have the color
+                label with value red can be queried using
+                `{'color: red', 'shape:*'}`
+            execution_states: retrieve jobs that have an execution state  that
+                 is contained in `execution_states`. See
+                 `quantum.enums.ExecutionStatus.State` enum for accepted values.
+            priority_interval: retrieve jobs that have priority within the given
+                priority interval (inclusive), i.e for [1,3], jobs with priority
+                p will be listed when 1 <= p <= 3. Min priority is 0, max is
+                1000.
+        """
+        client = self.context.client
+        response = client.list_jobs(self.project_id,
+                                    self.program_id,
+                                    created_before=created_before,
+                                    created_after=created_after,
+                                    has_labels=has_labels,
+                                    execution_states=execution_states,
+                                    priority_interval=priority_interval)
+        return [
+            engine_job.EngineJob(
+                project_id=client._ids_from_job_name(j.name)[0],
+                program_id=client._ids_from_job_name(j.name)[1],
+                job_id=client._ids_from_job_name(j.name)[2],
+                context=self.context,
+                _job=j,
+            ) for j in response
+        ]
 
     def _inner_program(self) -> qtypes.QuantumProgram:
         if not self._program:

--- a/cirq/google/engine/engine_program_test.py
+++ b/cirq/google/engine/engine_program_test.py
@@ -151,8 +151,27 @@ def test_run_delegation(create_job, get_results):
             'q': np.array([[False], [True], [True], [False]], dtype=np.bool)
         })
 
-# @mock.patch('cirq.google.engine.engine_client.EngineClient.list_jobs')
-# def test_list_jobs(list_jobs):
+
+@mock.patch('cirq.google.engine.engine_client.EngineClient.list_jobs')
+def test_list_jobs(list_jobs):
+    job1 = qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job1')
+    job2 = qtypes.QuantumJob(name='projects/otherproj/programs/prog1/jobs/job2')
+    list_jobs.return_value = [job1, job2]
+
+    ctx = EngineContext()
+    result = cg.EngineProgram(project_id='proj',
+                              program_id='prog1',
+                              context=ctx).list_jobs()
+    list_jobs.assert_called_once_with('proj',
+                                      'prog1',
+                                      created_after=None,
+                                      created_before=None,
+                                      has_labels=None,
+                                      execution_states=None,
+                                      priority_interval=None)
+    assert [(j.program_id, j.project_id, j.job_id, j.context, j._job)
+            for j in result] == [('prog1', 'proj', 'job1', ctx, job1),
+                                 ('prog1', 'otherproj', 'job2', ctx, job2)]
 
 
 def test_engine():

--- a/cirq/google/engine/engine_program_test.py
+++ b/cirq/google/engine/engine_program_test.py
@@ -167,8 +167,7 @@ def test_list_jobs(list_jobs):
                                       created_after=None,
                                       created_before=None,
                                       has_labels=None,
-                                      execution_states=None,
-                                      priority_interval=None)
+                                      execution_states=None)
     assert [(j.program_id, j.project_id, j.job_id, j.context, j._job)
             for j in result] == [('prog1', 'proj', 'job1', ctx, job1),
                                  ('prog1', 'otherproj', 'job2', ctx, job2)]

--- a/cirq/google/engine/engine_program_test.py
+++ b/cirq/google/engine/engine_program_test.py
@@ -151,6 +151,9 @@ def test_run_delegation(create_job, get_results):
             'q': np.array([[False], [True], [True], [False]], dtype=np.bool)
         })
 
+# @mock.patch('cirq.google.engine.engine_client.EngineClient.list_jobs')
+# def test_list_jobs(list_jobs):
+
 
 def test_engine():
     program = cg.EngineProgram('a', 'b', EngineContext())

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -688,6 +688,25 @@ def test_create_program(client):
     assert result.program_id == 'prog'
 
 
+@mock.patch('cirq.google.engine.engine_client.EngineClient.list_jobs')
+def test_list_jobs(list_jobs):
+    job1 = qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job1')
+    job2 = qtypes.QuantumJob(name='projects/proj/programs/prog2/jobs/job2')
+    list_jobs.return_value = [job1, job2]
+
+    ctx = EngineContext()
+    result = cg.Engine(project_id='proj', context=ctx).list_jobs()
+    list_jobs.assert_called_once_with('proj',
+                                      None,
+                                      created_after=None,
+                                      created_before=None,
+                                      has_labels=None,
+                                      execution_states=None)
+    assert [(j.project_id, j.program_id, j.job_id, j.context, j._job)
+            for j in result] == [('proj', 'prog1', 'job1', ctx, job1),
+                                 ('proj', 'prog2', 'job2', ctx, job2)]
+
+
 @mock.patch('cirq.google.engine.engine_client.EngineClient.list_processors')
 def test_list_processors(list_processors):
     processor1 = qtypes.QuantumProcessor(


### PR DESCRIPTION
Adds Engine.list_jobs() and EngineProgram.list_jobs(). 

Adds Engine.list_jobs(), EngineProgram.list_jobs() (which call the newly added EngineClient.list_jobs()) with filtering capabilities: 
 * created_after, created_before, has_labels
 * execution states to filter for a set of states

Related #3302. Next PR will be to update the docs and that will close it.