### PR TITLE
Add methods for converting dict to product or zip sweep and deprecate implicit cartesian product

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -372,6 +372,8 @@ from cirq.sim import (
 )
 
 from cirq.study import (
+    dict_to_product_sweep,
+    dict_to_zip_sweep,
     ExpressionMap,
     flatten,
     flatten_with_params,

--- a/cirq/study/__init__.py
+++ b/cirq/study/__init__.py
@@ -42,6 +42,8 @@ from cirq.study.sweeps import (
     Sweep,
     UnitSweep,
     Zip,
+    dict_to_product_sweep,
+    dict_to_zip_sweep,
 )
 
 from cirq.study.trial_result import (

--- a/cirq/study/sweepable_test.py
+++ b/cirq/study/sweepable_test.py
@@ -83,15 +83,16 @@ def test_to_sweeps_iterable_sweeps():
 
 
 def test_to_sweeps_dictionary_of_list():
-    assert cirq.study.to_sweeps({'t': [0, 2, 3]}) == \
-        cirq.study.to_sweeps([{'t': 0}, {'t': 2}, {'t': 3}])
-    assert cirq.study.to_sweeps({'t': [0, 1], 's': [2, 3], 'r': 4}) == \
-        cirq.study.to_sweeps([
-            {'t': 0, 's': 2, 'r': 4},
-            {'t': 0, 's': 3, 'r': 4},
-            {'t': 1, 's': 2, 'r': 4},
-            {'t': 1, 's': 3, 'r': 4},
-        ])
+    with pytest.warns(DeprecationWarning, match='dict_to_product_sweep'):
+        assert cirq.study.to_sweeps({'t': [0, 2, 3]}) == \
+            cirq.study.to_sweeps([{'t': 0}, {'t': 2}, {'t': 3}])
+        assert cirq.study.to_sweeps({'t': [0, 1], 's': [2, 3], 'r': 4}) == \
+            cirq.study.to_sweeps([
+                {'t': 0, 's': 2, 'r': 4},
+                {'t': 0, 's': 3, 'r': 4},
+                {'t': 1, 's': 2, 'r': 4},
+                {'t': 1, 's': 3, 'r': 4},
+            ])
 
 
 def test_to_sweeps_invalid():

--- a/cirq/study/sweeps.py
+++ b/cirq/study/sweeps.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     import cirq
 
 Params = Iterable[Tuple['cirq.TParamKey', 'cirq.TParamVal']]
+ProductOrZipSweepLike = Dict[
+    'cirq.TParamKey', Union['cirq.TParamVal', Sequence['cirq.TParamVal']]]
 
 
 def _check_duplicate_keys(sweeps):
@@ -437,10 +439,7 @@ def _params_without_symbols(resolver: resolver.ParamResolver) -> Params:
         yield cast(str, sym), cast(float, val)
 
 
-def dict_to_product_sweep(
-        factor_dict: Dict['cirq.TParamKey',
-                          Union['cirq.TParamVal', Sequence['cirq.TParamVal']]]
-) -> Product:
+def dict_to_product_sweep(factor_dict: ProductOrZipSweepLike) -> Product:
     """Cartesian product of sweeps from a dictionary.
 
     Each entry in the dictionary specifies a sweep as a mapping from the
@@ -457,10 +456,7 @@ def dict_to_product_sweep(
                      for k, v in factor_dict.items()))
 
 
-def dict_to_zip_sweep(
-        factor_dict: Dict['cirq.TParamKey',
-                          Union['cirq.TParamVal', Sequence['cirq.TParamVal']]]
-) -> Zip:
+def dict_to_zip_sweep(factor_dict: ProductOrZipSweepLike) -> Zip:
     """Zip product of sweeps from a dictionary.
 
     Each entry in the dictionary specifies a sweep as a mapping from the

--- a/cirq/study/sweeps.py
+++ b/cirq/study/sweeps.py
@@ -94,7 +94,7 @@ class Sweep(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def keys(self) -> List[str]:
+    def keys(self) -> List['cirq.TParamKey']:
         """The keys for the all of the sympy.Symbols that are resolved."""
 
     @abc.abstractmethod
@@ -175,7 +175,7 @@ class _Unit(Sweep):
         return True
 
     @property
-    def keys(self) -> List[str]:
+    def keys(self) -> List['cirq.TParamKey']:
         return []
 
     def __len__(self) -> int:
@@ -212,7 +212,7 @@ class Product(Sweep):
         return hash(tuple(self.factors))
 
     @property
-    def keys(self) -> List[str]:
+    def keys(self) -> List['cirq.TParamKey']:
         return sum((factor.keys for factor in self.factors), [])
 
     def __len__(self) -> int:
@@ -276,7 +276,7 @@ class Zip(Sweep):
         return hash(tuple(self.sweeps))
 
     @property
-    def keys(self) -> List[str]:
+    def keys(self) -> List['cirq.TParamKey']:
         return sum((sweep.keys for sweep in self.sweeps), [])
 
     def __len__(self) -> int:
@@ -303,7 +303,7 @@ class Zip(Sweep):
 class SingleSweep(Sweep):
     """A simple sweep over one parameter with values from an iterator."""
 
-    def __init__(self, key: Union[str, sympy.Symbol]) -> None:
+    def __init__(self, key: 'cirq.TParamKey') -> None:
         if isinstance(key, sympy.Symbol):
             key = str(key)
         self.key = key
@@ -321,7 +321,7 @@ class SingleSweep(Sweep):
         pass
 
     @property
-    def keys(self) -> List[str]:
+    def keys(self) -> List['cirq.TParamKey']:
         return [self.key]
 
     def param_tuples(self) -> Iterator[Params]:
@@ -337,8 +337,8 @@ class Points(SingleSweep):
     """A simple sweep with explicitly supplied values."""
 
     def __init__(
-        self, key: Union[str, sympy.Symbol],
-        points: Sequence[float]) -> None:
+        self, key: 'cirq.TParamKey',
+        points: Sequence['cirq.TParamVal']) -> None:
         super(Points, self).__init__(key)
         self.points = points
 
@@ -359,7 +359,7 @@ class Linspace(SingleSweep):
     """A simple sweep over linearly-spaced values."""
 
     def __init__(
-        self, key: Union[str, sympy.Symbol],
+        self, key: 'cirq.TParamKey',
         start: float,
         stop: float,
         length: int) -> None:
@@ -418,7 +418,7 @@ class ListSweep(Sweep):
         return not self == other
 
     @property
-    def keys(self) -> List[str]:
+    def keys(self) -> List['cirq.TParamKey']:
         if not self.resolver_list:
             return []
         return list(map(str, self.resolver_list[0].param_dict))

--- a/cirq/study/sweeps.py
+++ b/cirq/study/sweeps.py
@@ -336,9 +336,8 @@ class SingleSweep(Sweep):
 class Points(SingleSweep):
     """A simple sweep with explicitly supplied values."""
 
-    def __init__(
-        self, key: 'cirq.TParamKey',
-        points: Sequence['cirq.TParamVal']) -> None:
+    def __init__(self, key: 'cirq.TParamKey',
+                 points: Sequence['cirq.TParamVal']) -> None:
         super(Points, self).__init__(key)
         self.points = points
 
@@ -358,11 +357,8 @@ class Points(SingleSweep):
 class Linspace(SingleSweep):
     """A simple sweep over linearly-spaced values."""
 
-    def __init__(
-        self, key: 'cirq.TParamKey',
-        start: float,
-        stop: float,
-        length: int) -> None:
+    def __init__(self, key: 'cirq.TParamKey', start: float, stop: float,
+                 length: int) -> None:
         """Creates a linear-spaced sweep for a given key.
 
         For the given args, assigns to the list of values
@@ -439,3 +435,43 @@ def _params_without_symbols(resolver: resolver.ParamResolver) -> Params:
         if isinstance(sym, sympy.Symbol):
             sym = sym.name
         yield cast(str, sym), cast(float, val)
+
+
+def dict_to_product_sweep(
+        factor_dict: Dict['cirq.TParamKey',
+                          Union['cirq.TParamVal', Sequence['cirq.TParamVal']]]
+) -> Product:
+    """Cartesian product of sweeps from a dictionary.
+
+    Each entry in the dictionary specifies a sweep as a mapping from the
+    parameter to a value or sequence of values. The Cartesian product of these
+    sweeps is returned.
+
+    Args:
+        factor_dict: The dictionary containing the sweeps.
+
+    Returns:
+        Cartesian product of the sweeps.
+    """
+    return Product(*(Points(k, v if isinstance(v, Sequence) else [v])
+                     for k, v in factor_dict.items()))
+
+
+def dict_to_zip_sweep(
+        factor_dict: Dict['cirq.TParamKey',
+                          Union['cirq.TParamVal', Sequence['cirq.TParamVal']]]
+) -> Zip:
+    """Zip product of sweeps from a dictionary.
+
+    Each entry in the dictionary specifies a sweep as a mapping from the
+    parameter to a value or sequence of values. The zip product of these
+    sweeps is returned.
+
+    Args:
+        factor_dict: The dictionary containing the sweeps.
+
+    Returns:
+        Zip product of the sweeps.
+    """
+    return Zip(*(Points(k, v if isinstance(v, Sequence) else [v])
+                 for k, v in factor_dict.items()))

--- a/cirq/study/sweeps_test.py
+++ b/cirq/study/sweeps_test.py
@@ -280,3 +280,27 @@ def test_list_sweep_str():
 {'a': 2.0, 'b': 2.0}
 {'a': 3.0, 'b': 1.0}
 {'a': 3.0, 'b': 2.0}'''
+
+
+def test_dict_to_product_sweep():
+    assert cirq.dict_to_product_sweep({'t': [0, 2, 3]}) == (cirq.Product(
+        cirq.Points('t', [0, 2, 3])))
+
+    assert cirq.dict_to_product_sweep({
+        't': [0, 1],
+        's': [2, 3],
+        'r': 4
+    }) == (cirq.Product(cirq.Points('t', [0, 1]), cirq.Points('s', [2, 3]),
+                        cirq.Points('r', [4])))
+
+
+def test_dict_to_zip_sweep():
+    assert cirq.dict_to_zip_sweep({'t': [0, 2, 3]
+                                  }) == (cirq.Zip(cirq.Points('t', [0, 2, 3])))
+
+    assert cirq.dict_to_zip_sweep({
+        't': [0, 1],
+        's': [2, 3],
+        'r': 4
+    }) == (cirq.Zip(cirq.Points('t', [0, 1]), cirq.Points('s', [2, 3]),
+                    cirq.Points('r', [4])))

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -226,6 +226,8 @@ results.
     cirq.big_endian_digits_to_int
     cirq.big_endian_int_to_bits
     cirq.big_endian_int_to_digits
+    cirq.dict_to_product_sweep
+    cirq.dict_to_zip_sweep
     cirq.final_density_matrix
     cirq.final_state_vector
     cirq.flatten


### PR DESCRIPTION
Fixes #2698 .
Fixes #3018 .