### PR TITLE
pygment 2.6.1 to fix readthedocs

### DIFF
--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -24,6 +24,7 @@ qiskit~=0.20.0
 pypandoc
 myst-parser
 Sphinx~=3.2.0
+Pygments==2.6.1
 sphinx_rtd_theme
 sphinx-markdown-tables
 

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -24,7 +24,11 @@ qiskit~=0.20.0
 pypandoc
 myst-parser
 Sphinx~=3.2.0
+
+# have to pin otherwise RTD fails
+# see https://github.com/readthedocs/readthedocs.org/issues/7492
 Pygments==2.6.1
+
 sphinx_rtd_theme
 sphinx-markdown-tables
 


### PR DESCRIPTION
Pinning Pygment==2.6.1 for readthedocs.

See https://github.com/sphinx-doc/sphinx/issues/8198#issuecomment-692525937. 
Fixes #3315.

Test run of this branch on my fork using readthedocs itself succeeds: https://readthedocs.org/projects/balopat-cirq-rtd/builds/11906952/