### PR TITLE
Refactor to_resolvers to use to_sweeps

### DIFF
--- a/cirq/sim/simulator_test.py
+++ b/cirq/sim/simulator_test.py
@@ -31,6 +31,7 @@ def test_run_simulator_run():
     circuit = mock.Mock(cirq.Circuit)
     circuit.__iter__ = mock.Mock(return_value=iter([]))
     param_resolver = mock.Mock(cirq.ParamResolver)
+    param_resolver.param_dict = {}
     expected_result = cirq.TrialResult.from_single_parameter_set(
         measurements=expected_measurements, params=param_resolver)
     assert expected_result == simulator.run(program=circuit,
@@ -52,6 +53,8 @@ def test_run_simulator_sweeps():
     circuit.__iter__ = mock.Mock(return_value=iter([]))
     param_resolvers = [mock.Mock(cirq.ParamResolver),
                        mock.Mock(cirq.ParamResolver)]
+    for resolver in param_resolvers:
+        resolver.param_dict = {}
     expected_results = [
         cirq.TrialResult.from_single_parameter_set(
             measurements=expected_measurements, params=param_resolvers[0]),
@@ -86,6 +89,7 @@ def test_intermediate_simulator():
     simulator._simulator_iterator.side_effect = steps
     circuit = mock.Mock(cirq.Circuit)
     param_resolver = mock.Mock(cirq.ParamResolver)
+    param_resolver.param_dict = {}
     qubit_order = mock.Mock(cirq.QubitOrder)
     result = simulator.simulate(program=circuit,
                                 param_resolver=param_resolver,
@@ -116,6 +120,8 @@ def test_intermediate_sweeps():
     circuit = mock.Mock(cirq.Circuit)
     param_resolvers = [mock.Mock(cirq.ParamResolver),
                        mock.Mock(cirq.ParamResolver)]
+    for resolver in param_resolvers:
+        resolver.param_dict = {}
     qubit_order = mock.Mock(cirq.QubitOrder)
     results = simulator.simulate_sweep(program=circuit,
                                        params=param_resolvers,

--- a/cirq/study/sweepable.py
+++ b/cirq/study/sweepable.py
@@ -35,20 +35,8 @@ document(
 
 def to_resolvers(sweepable: Sweepable) -> Iterator[ParamResolver]:
     """Convert a Sweepable to a list of ParamResolvers."""
-    if sweepable is None:
-        yield ParamResolver({})
-    elif isinstance(sweepable, ParamResolver):
-        yield sweepable
-    elif isinstance(sweepable, Sweep):
-        yield from sweepable
-    elif isinstance(sweepable, dict):
-        yield ParamResolver(cast(Dict, sweepable))
-    elif isinstance(sweepable, Iterable) and not isinstance(sweepable, str):
-        for item in cast(Iterable, sweepable):
-            yield from to_resolvers(item)
-    else:
-        raise TypeError(f'Unrecognized sweepable type: {type(sweepable)}.\n'
-                        f'sweepable: {sweepable}')
+    for sweep in to_sweeps(sweepable):
+        yield from sweep
 
 
 def to_sweeps(sweepable: Sweepable) -> List[Sweep]:


### PR DESCRIPTION
This seems logical. Note, however, that since `to_sweeps` currently contains deprecated code, this introduces deprecated behavior into `to_resolvers`. To avoid that we could wait for the next release before merging this.