### PR TITLE
adding 3.7 to the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,14 @@ jobs:
         run: check/doctest -q
   pytest:
     name: Pytest Ubuntu
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7' ]
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -158,12 +160,14 @@ jobs:
         run: check/pytest-and-incremental-coverage --actually-quiet
   windows:
     name: Pytest Windows
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7' ]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -174,12 +178,14 @@ jobs:
         shell: bash
   macos:
     name: Pytest MacOS
+    strategy:
+      matrix:
+        python-version: [ '3.6', '3.7' ]
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
           architecture: 'x64'
       - name: Install requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
+          python-version: ${{ matrix.python-version }}
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -168,6 +169,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
+          python-version: ${{ matrix.python-version }}
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -186,6 +188,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
+          python-version: ${{ matrix.python-version }}
           architecture: 'x64'
       - name: Install requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Misc
         run: check/misc
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install yapf
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep yapf | xargs pip install
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install mypy
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep mypy | xargs pip install
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install changed files test dependencies
         run: dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install pylint
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep "pylint" | grep -v "#" | xargs pip install
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -150,7 +150,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.6'
+          python-version: '3.7'
           architecture: 'x64'
       - name: Install requirements
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-dataclasses; python_version < '3.7'
+dataclasses; python_version < '3.8'
 freezegun~=0.3.15
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
 matplotlib~=3.0


### PR DESCRIPTION
To cover all python runtimes that we support, adding coverage for 3.7 besides 3.6.
With #3194 we can add 3.8 as well, and soon 3.9 hopefully to the mix. 
If we agree on #3347, then we can drop 3.6 as well.