### PR TITLE
ignore q in gridqubit ids

### DIFF
--- a/cirq/google/api/v2/program.py
+++ b/cirq/google/api/v2/program.py
@@ -19,6 +19,8 @@ from cirq import devices, ops
 if TYPE_CHECKING:
     import cirq
 
+GRID_QUBIT_ID_PATTERN = r'^q?(-?\d+)_(-?\d+)$'
+
 
 def qubit_to_proto_id(q: 'cirq.Qid') -> str:
     """Return a proto id for a `cirq.Qid`.
@@ -94,7 +96,7 @@ def grid_qubit_from_proto_id(proto_id: str) -> 'cirq.GridQubit':
         ValueError: If the string not of the correct format.
     """
 
-    match = re.match(r'^q?(-?\d+)_(-?\d+)$', proto_id)
+    match = re.match(GRID_QUBIT_ID_PATTERN, proto_id)
     if match is None:
         raise ValueError(
             'GridQubit proto id must be of the form <int>_<int> but was {}'.

--- a/cirq/google/api/v2/program.py
+++ b/cirq/google/api/v2/program.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 from typing import TYPE_CHECKING
 
 from cirq import devices, ops
@@ -93,13 +93,14 @@ def grid_qubit_from_proto_id(proto_id: str) -> 'cirq.GridQubit':
     Raises:
         ValueError: If the string not of the correct format.
     """
-    parts = proto_id.replace("q","").split('_')
-    if len(parts) != 2:
+
+    match = re.match(r'^q?(-?\d+)_(-?\d+)$', proto_id)
+    if match is None:
         raise ValueError(
             'GridQubit proto id must be of the form <int>_<int> but was {}'.
             format(proto_id))
     try:
-        row, col = parts
+        row, col = match.groups()
         return devices.GridQubit(row=int(row), col=int(col))
     except ValueError:
         raise ValueError(

--- a/cirq/google/api/v2/program.py
+++ b/cirq/google/api/v2/program.py
@@ -93,7 +93,7 @@ def grid_qubit_from_proto_id(proto_id: str) -> 'cirq.GridQubit':
     Raises:
         ValueError: If the string not of the correct format.
     """
-    parts = proto_id.split('_')
+    parts = proto_id.replace("q","").split('_')
     if len(parts) != 2:
         raise ValueError(
             'GridQubit proto id must be of the form <int>_<int> but was {}'.

--- a/cirq/google/api/v2/program_test.py
+++ b/cirq/google/api/v2/program_test.py
@@ -51,16 +51,20 @@ def test_grid_qubit_from_proto_id():
     assert v2.grid_qubit_from_proto_id('10_2') == cirq.GridQubit(10, 2)
     assert v2.grid_qubit_from_proto_id('-1_2') == cirq.GridQubit(-1, 2)
     assert v2.grid_qubit_from_proto_id('q-1_2') == cirq.GridQubit(-1, 2)
-    assert v2.grid_qubit_from_proto_id('q-1_2') == cirq.GridQubit(-1, 2)
     assert v2.grid_qubit_from_proto_id('q1_2') == cirq.GridQubit(1, 2)
-    assert v2.grid_qubit_from_proto_id('q1_q2') == cirq.GridQubit(1, 2)
-    assert v2.grid_qubit_from_proto_id('q-1_q2') == cirq.GridQubit(-1, 2)
+
 
 def test_grid_qubit_from_proto_id_invalid():
     with pytest.raises(ValueError, match='3_3_3'):
         _ = v2.grid_qubit_from_proto_id('3_3_3')
     with pytest.raises(ValueError, match='a_2'):
         _ = v2.grid_qubit_from_proto_id('a_2')
+    with pytest.raises(ValueError, match='q1_q2'):
+        v2.grid_qubit_from_proto_id('q1_q2')
+    with pytest.raises(ValueError, match='q-1_q2'):
+        v2.grid_qubit_from_proto_id('q-1_q2')
+    with pytest.raises(ValueError, match='-1_q2'):
+        v2.grid_qubit_from_proto_id('-1_q2')
 
 
 def test_line_qubit_from_proto_id():

--- a/cirq/google/api/v2/program_test.py
+++ b/cirq/google/api/v2/program_test.py
@@ -50,7 +50,11 @@ def test_grid_qubit_from_proto_id():
     assert v2.grid_qubit_from_proto_id('1_2') == cirq.GridQubit(1, 2)
     assert v2.grid_qubit_from_proto_id('10_2') == cirq.GridQubit(10, 2)
     assert v2.grid_qubit_from_proto_id('-1_2') == cirq.GridQubit(-1, 2)
-
+    assert v2.grid_qubit_from_proto_id('q-1_2') == cirq.GridQubit(-1, 2)
+    assert v2.grid_qubit_from_proto_id('q-1_2') == cirq.GridQubit(-1, 2)
+    assert v2.grid_qubit_from_proto_id('q1_2') == cirq.GridQubit(1, 2)
+    assert v2.grid_qubit_from_proto_id('q1_q2') == cirq.GridQubit(1, 2)
+    assert v2.grid_qubit_from_proto_id('q-1_q2') == cirq.GridQubit(-1, 2)
 
 def test_grid_qubit_from_proto_id_invalid():
     with pytest.raises(ValueError, match='3_3_3'):


### PR DESCRIPTION
Extending the protocol to cater for some older pieces of the infrastructure that mark gridqubits with `q1_2` instead of `1_2`. 

Fixes #3219.