### PR TITLE
Fix NumPy 0.19 related issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
 
 # Configure UTF-8 encoding.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8 
 
 # Make python3 default
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
 
 # Configure UTF-8 encoding.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Make python3 default
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python

--- a/cirq/ion/convert_to_ion_gates_test.py
+++ b/cirq/ion/convert_to_ion_gates_test.py
@@ -54,16 +54,16 @@ def test_convert_to_ion_gates():
 
     rx = cirq.ion.ConvertToIonGates().convert_one(OtherX().on(q0))
     rop = cirq.ion.ConvertToIonGates().convert_one(op)
-    assert rx == [
-        cirq.PhasedXPowGate(phase_exponent=1).on(cirq.GridQubit(0, 0))
-    ]
-    assert rop == [
+    assert cirq.approx_eq(rx, [
+        cirq.PhasedXPowGate(phase_exponent=1.0).on(cirq.GridQubit(0, 0))
+    ])
+    assert cirq.approx_eq(rop, [
         cirq.ry(np.pi / 2).on(op.qubits[0]),
         cirq.ms(np.pi / 4).on(op.qubits[0], op.qubits[1]),
         cirq.rx(-1 * np.pi / 2).on(op.qubits[0]),
         cirq.rx(-1 * np.pi / 2).on(op.qubits[1]),
         cirq.ry(-1 * np.pi / 2).on(op.qubits[0])
-    ]
+    ])
 
     rcnot = cirq.ion.ConvertToIonGates().convert_one(OtherCNOT().on(q0, q1))
     assert cirq.approx_eq([op for op in rcnot if len(op.qubits) > 1],

--- a/cirq/ion/convert_to_ion_gates_test.py
+++ b/cirq/ion/convert_to_ion_gates_test.py
@@ -54,9 +54,8 @@ def test_convert_to_ion_gates():
 
     rx = cirq.ion.ConvertToIonGates().convert_one(OtherX().on(q0))
     rop = cirq.ion.ConvertToIonGates().convert_one(op)
-    assert cirq.approx_eq(rx, [
-        cirq.PhasedXPowGate(phase_exponent=1.0).on(cirq.GridQubit(0, 0))
-    ])
+    assert cirq.approx_eq(
+        rx, [cirq.PhasedXPowGate(phase_exponent=1.0).on(cirq.GridQubit(0, 0))])
     assert cirq.approx_eq(rop, [
         cirq.ry(np.pi / 2).on(op.qubits[0]),
         cirq.ms(np.pi / 4).on(op.qubits[0], op.qubits[1]),

--- a/cirq/optimizers/decompositions.py
+++ b/cirq/optimizers/decompositions.py
@@ -139,7 +139,7 @@ def single_qubit_op_to_framed_phase_form(
         When M is controlled, the control must be rotated around the Z axis to
         apply g.
     """
-    vals, vecs = np.linalg.eig(mat)
+    vals, vecs = linalg.unitary_eig(mat)
     u = np.conj(vecs).T
     r = vals[1] / vals[0]
     g = vals[0]

--- a/cirq/optimizers/decompositions_test.py
+++ b/cirq/optimizers/decompositions_test.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import random
-import sys
 from typing import Sequence
 
 import numpy as np
@@ -174,10 +172,12 @@ def test_single_qubit_matrix_to_gates_tolerance_half_turn_phasing():
         phased_nearly_x, tolerance=0.0001)
     assert len(kept) == 3
 
+
 def _random_unitary_with_close_eigenvalues():
     U = cirq.testing.random_unitary(2)
     d = np.diag(np.exp([-0.2312j, -0.2312j]))
     return U @ d @ U.conj().T
+
 
 @pytest.mark.parametrize('mat', [
     np.eye(2),
@@ -188,8 +188,7 @@ def _random_unitary_with_close_eigenvalues():
     cirq.unitary(cirq.Z),
     cirq.unitary(cirq.Z**0.5),
     _random_unitary_with_close_eigenvalues(),
-] + [cirq.testing.random_unitary(2)
-     for _ in range(10)])
+] + [cirq.testing.random_unitary(2) for _ in range(10)])
 def test_single_qubit_op_to_framed_phase_form_equivalent_on_known_and_random(
         mat):
     u, t, g = cirq.single_qubit_op_to_framed_phase_form(mat)

--- a/cirq/optimizers/decompositions_test.py
+++ b/cirq/optimizers/decompositions_test.py
@@ -174,18 +174,10 @@ def test_single_qubit_matrix_to_gates_tolerance_half_turn_phasing():
         phased_nearly_x, tolerance=0.0001)
     assert len(kept) == 3
 
-
-@pytest.mark.xfail(sys.platform == 'win32',
-                   reason='https://github.com/quantumlib/Cirq/issues/2468')
-def test_single_qubit_op_to_framed_phase_form_output_on_example_case():
-    u, t, g = cirq.single_qubit_op_to_framed_phase_form(
-        cirq.unitary(cirq.Y**0.25))
-    cirq.testing.assert_allclose_up_to_global_phase(u,
-                                                    cirq.unitary(cirq.X**0.5),
-                                                    atol=1e-7)
-    assert abs(t - (1 + 1j) * math.sqrt(0.5)) < 0.00001
-    assert abs(g - 1) < 0.00001
-
+def _random_unitary_with_close_eigenvalues():
+    U = cirq.testing.random_unitary(2)
+    d = np.diag(np.exp([-0.2312j, -0.2312j]))
+    return U @ d @ U.conj().T
 
 @pytest.mark.parametrize('mat', [
     np.eye(2),
@@ -195,6 +187,7 @@ def test_single_qubit_op_to_framed_phase_form_output_on_example_case():
     cirq.unitary(cirq.Y),
     cirq.unitary(cirq.Z),
     cirq.unitary(cirq.Z**0.5),
+    _random_unitary_with_close_eigenvalues(),
 ] + [cirq.testing.random_unitary(2)
      for _ in range(10)])
 def test_single_qubit_op_to_framed_phase_form_equivalent_on_known_and_random(
@@ -202,7 +195,6 @@ def test_single_qubit_op_to_framed_phase_form_equivalent_on_known_and_random(
     u, t, g = cirq.single_qubit_op_to_framed_phase_form(mat)
     z = np.diag([g, g * t])
     assert np.allclose(mat, np.conj(u.T).dot(z).dot(u))
-
 
 def test_single_qubit_matrix_to_phased_x_z_known():
     actual = cirq.single_qubit_matrix_to_phased_x_z(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ freezegun~=0.3.15
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
 matplotlib~=3.0
 networkx~=2.4
-numpy~=1.16, < 1.19
+numpy~=1.16
 pandas
 protobuf~=3.12.0
 requests~=2.18


### PR DESCRIPTION
Remove the upper bound on numpy and fixes the broken tests.

Fixes #3103.
- it [turns out](https://github.com/quantumlib/Cirq/issues/3103#issuecomment-698562537) that the decomposition test needed to be removed
- also switching to use cirq.linalg.unitary_eig that works better for cases when the unitary has close eigenvalues (added extra test for it) and it is faster

Fixes #3105.
- though I cannot reproduce the issue, I added approx_eq in the ion gate conversion tests to be on the safe side

Fixes #3210. 
- finally these two above were the blockers for removing the upper bound of numpy 0.19 which is now removed.


