### PR TITLE
Extending types for symbol resolution fast pass-through

### DIFF
--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Resolves ParameterValues to assigned values."""
-
-from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
+import numbers
+from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast, SupportsFloat
 import numpy as np
 import sympy
 from cirq._compat import proper_repr
@@ -64,7 +64,7 @@ class ParamResolver:
                                {} if param_dict is None else param_dict)
 
     def value_of(self,
-                 value: Union['cirq.TParamKey', float]) -> 'cirq.TParamVal':
+                 value: Union['cirq.TParamKey', numbers.Number]) -> 'cirq.TParamVal':
         """Attempt to resolve a parameter to its assigned value.
 
         Floats are returned without modification.  Strings are resolved via
@@ -90,7 +90,7 @@ class ParamResolver:
             The value of the parameter as resolved by this resolver.
         """
         # Input is a float, no resolution needed: return early
-        if isinstance(value, float):
+        if isinstance(value, (float, np.float32)):
             return value
 
         # Handles 2 cases:
@@ -99,7 +99,7 @@ class ParamResolver:
         # In both cases, return it directly.
         if value in self.param_dict:
             param_value = self.param_dict[value]
-            if isinstance(param_value, (float, int)):
+            if isinstance(param_value, (float, np.float32, int)):
                 return param_value
 
         # Input is a string and is not in the dictionary.

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -63,8 +63,8 @@ class ParamResolver:
         self.param_dict = cast(ParamDictType,
                                {} if param_dict is None else param_dict)
 
-    def value_of(self,
-                 value: Union['cirq.TParamKey', numbers.Number]) -> 'cirq.TParamVal':
+    def value_of(self, value: Union['cirq.TParamKey', numbers.Number]
+                ) -> 'cirq.TParamVal':
         """Attempt to resolve a parameter to its assigned value.
 
         Floats are returned without modification.  Strings are resolved via

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -14,7 +14,7 @@
 
 """Resolves ParameterValues to assigned values."""
 import numbers
-from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast, SupportsFloat
+from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
 import numpy as np
 import sympy
 from cirq._compat import proper_repr

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -19,7 +19,6 @@ import numpy as np
 import sympy
 from cirq._compat import proper_repr
 from cirq._doc import document
-import fractions
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Resolves ParameterValues to assigned values."""
-import numbers
+
 from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
 import numpy as np
 import sympy
@@ -63,8 +63,8 @@ class ParamResolver:
         self.param_dict = cast(ParamDictType,
                                {} if param_dict is None else param_dict)
 
-    def value_of(self, value: Union['cirq.TParamKey', numbers.Number]
-                ) -> 'cirq.TParamVal':
+    def value_of(self,
+                 value: Union['cirq.TParamKey', float]) -> 'cirq.TParamVal':
         """Attempt to resolve a parameter to its assigned value.
 
         Floats are returned without modification.  Strings are resolved via
@@ -113,7 +113,7 @@ class ParamResolver:
         # in the dictionary ({'a': 1.0}).  Return it.
         if (isinstance(value, sympy.Symbol) and value.name in self.param_dict):
             param_value = self.param_dict[value.name]
-            if isinstance(param_value, (float, int)):
+            if isinstance(param_value, (float, np.float32, int)):
                 return param_value
 
         # The following resolves common sympy expressions

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 """Resolves ParameterValues to assigned values."""
-
+import numbers
 from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
 import numpy as np
 import sympy
 from cirq._compat import proper_repr
 from cirq._doc import document
+import fractions
 
 if TYPE_CHECKING:
     import cirq
@@ -89,9 +90,23 @@ class ParamResolver:
         Returns:
             The value of the parameter as resolved by this resolver.
         """
-        # Input is a float, no resolution needed: return early
-        if isinstance(value, (float, np.float32)):
-            return value
+
+        def pass_through(val) -> Optional[Any]:
+            if isinstance(val,
+                          numbers.Number) and not isinstance(val, sympy.Basic):
+                return val
+            if isinstance(val, sympy.core.numbers.IntegerConstant):
+                return val.p
+            if isinstance(val, sympy.core.numbers.RationalConstant):
+                return val.p / val.q
+            if val == sympy.pi:
+                return np.pi
+            return None
+
+        # Input is a pass through type, no resolution needed: return early
+        v = pass_through(value)
+        if v is not None:
+            return v
 
         # Handles 2 cases:
         # Input is a string and maps to a number in the dictionary
@@ -99,8 +114,9 @@ class ParamResolver:
         # In both cases, return it directly.
         if value in self.param_dict:
             param_value = self.param_dict[value]
-            if isinstance(param_value, (float, np.float32, int)):
-                return param_value
+            v = pass_through(param_value)
+            if v is not None:
+                return v
 
         # Input is a string and is not in the dictionary.
         # Treat it as a symbol instead.
@@ -111,10 +127,11 @@ class ParamResolver:
 
         # Input is a symbol (sympy.Symbol('a')) and its string maps to a number
         # in the dictionary ({'a': 1.0}).  Return it.
-        if (isinstance(value, sympy.Symbol) and value.name in self.param_dict):
+        if isinstance(value, sympy.Symbol) and value.name in self.param_dict:
             param_value = self.param_dict[value.name]
-            if isinstance(param_value, (float, np.float32, int)):
-                return param_value
+            v = pass_through(param_value)
+            if v is not None:
+                return v
 
         # The following resolves common sympy expressions
         # If sympy did its job and wasn't slower than molasses,
@@ -132,10 +149,7 @@ class ParamResolver:
         if isinstance(value, sympy.Pow) and len(value.args) == 2:
             return np.power(self.value_of(value.args[0]),
                             self.value_of(value.args[1]))
-        if value == sympy.pi:
-            return np.pi
-        if value == sympy.S.NegativeOne:
-            return -1
+
 
         # Input is either a sympy formula or the dictionary maps to a
         # formula.  Use sympy to resolve the value.

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -90,20 +90,8 @@ class ParamResolver:
             The value of the parameter as resolved by this resolver.
         """
 
-        def pass_through(val) -> Optional[Any]:
-            if isinstance(val,
-                          numbers.Number) and not isinstance(val, sympy.Basic):
-                return val
-            if isinstance(val, sympy.core.numbers.IntegerConstant):
-                return val.p
-            if isinstance(val, sympy.core.numbers.RationalConstant):
-                return val.p / val.q
-            if val == sympy.pi:
-                return np.pi
-            return None
-
         # Input is a pass through type, no resolution needed: return early
-        v = pass_through(value)
+        v = _sympy_pass_through(value)
         if v is not None:
             return v
 
@@ -113,7 +101,7 @@ class ParamResolver:
         # In both cases, return it directly.
         if value in self.param_dict:
             param_value = self.param_dict[value]
-            v = pass_through(param_value)
+            v = _sympy_pass_through(param_value)
             if v is not None:
                 return v
 
@@ -128,7 +116,7 @@ class ParamResolver:
         # in the dictionary ({'a': 1.0}).  Return it.
         if isinstance(value, sympy.Symbol) and value.name in self.param_dict:
             param_value = self.param_dict[value.name]
-            v = pass_through(param_value)
+            v = _sympy_pass_through(param_value)
             if v is not None:
                 return v
 
@@ -148,7 +136,6 @@ class ParamResolver:
         if isinstance(value, sympy.Pow) and len(value.args) == 2:
             return np.power(self.value_of(value.args[0]),
                             self.value_of(value.args[1]))
-
 
         # Input is either a sympy formula or the dictionary maps to a
         # formula.  Use sympy to resolve the value.
@@ -206,3 +193,16 @@ class ParamResolver:
     @classmethod
     def _from_json_dict_(cls, param_dict, **kwargs):
         return cls(dict(param_dict))
+
+
+def _sympy_pass_through(val: Any) -> Optional[Any]:
+    if isinstance(val,
+                  numbers.Number) and not isinstance(val, sympy.Basic):
+        return val
+    if isinstance(val, sympy.core.numbers.IntegerConstant):
+        return val.p
+    if isinstance(val, sympy.core.numbers.RationalConstant):
+        return val.p / val.q
+    if val == sympy.pi:
+        return np.pi
+    return None

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -196,8 +196,7 @@ class ParamResolver:
 
 
 def _sympy_pass_through(val: Any) -> Optional[Any]:
-    if isinstance(val,
-                  numbers.Number) and not isinstance(val, sympy.Basic):
+    if isinstance(val, numbers.Number) and not isinstance(val, sympy.Basic):
         return val
     if isinstance(val, sympy.core.numbers.IntegerConstant):
         return val.p

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -49,7 +49,6 @@ def test_value_of():
     assert isinstance(r.value_of(np.float32(32)), np.float32)
 
 
-
 def test_param_dict():
     r = cirq.ParamResolver({'a': 0.5, 'b': 0.1})
     r2 = cirq.ParamResolver(r)

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -36,10 +36,18 @@ def test_value_of():
     assert r.value_of(sympy.Symbol('b') / 0.1 - sympy.Symbol('a')) == 0.5
 
     assert r.value_of(sympy.pi) == np.pi
+    assert isinstance(r.value_of(sympy.pi), float)
+
     assert r.value_of(2 * sympy.pi) == 2 * np.pi
     assert r.value_of(4**sympy.Symbol('a') + sympy.Symbol('b') * 10) == 3
     assert r.value_of('c') == 1 + 1j
     assert r.value_of(sympy.I * sympy.pi) == np.pi * 1j
+
+    assert isinstance(r.value_of(sympy.S.NegativeOne), int)
+
+    assert r.value_of(np.float32(32)) == 32
+    assert isinstance(r.value_of(np.float32(32)), np.float32)
+
 
 
 def test_param_dict():

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -53,8 +53,23 @@ def test_value_of_substituted_types(val, resolved):
 
 
 def _assert_consistent_resolution(v, resolved, subs_called=False):
+    """Asserts that parameter resolution works consistently.
 
+    The ParamResolver.value_of method can resolve any Sympy expression - subclasses of sympy.Basic. In the generic case,
+    it calls `sympy.Basic.subs` to substitute symbols with values specified in a dict, which is known to be very slow.
+    Instead value_of defines a pass-through shortcut for known numeric types.
+    For a given value `v` it is asserted that value_of resolves it to `resolved`, with the exact type of `resolved`.
+    `subs_called` indicates whether it is expected to have `subs` called or not during the resolution.
+
+    Args:
+        v: the value to resolve
+        resolved: the expected resolution result
+        subs_called: if True, it is expected that the slow subs method is called
+    Raises:
+        AssertionError in case resolution assertion fail.
+    """
     class SubsAwareSymbol(sympy.Symbol):
+        """A Symbol that registers a call to its `subs` method."""
 
         def __init__(self, sym: str):
             self.called = False

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -70,21 +70,22 @@ def _assert_consistent_resolution(v, resolved, subs_called=False):
     s = SubsAwareSymbol('a')
     assert r.value_of(
         s) == resolved, f"expected {resolved}, got {r.value_of(s)}"
-    assert subs_called == s.called, f"For pass-through type {type(v)} sympy.subs shouldn't have been called."
-    assert isinstance(
-        r.value_of(s),
-        type(resolved)), f"expected {type(resolved)} got {type(r.value_of(s))}"
+    assert (
+        subs_called == s.called,
+        f"For pass-through type {type(v)} sympy.subs shouldn't have been called."
+    )
+    assert (isinstance(r.value_of(s), type(resolved)),
+            f"expected {type(resolved)} got {type(r.value_of(s))}")
     # string based resolution
-    assert r.value_of(
-        'a') == resolved, f"expected {resolved}, got {r.value_of('a')}"
-    assert isinstance(r.value_of('a'), type(
-        resolved)), f"expected {type(resolved)} got {type(r.value_of('a'))}"
+    assert (r.value_of('a') == resolved,
+            f"expected {resolved}, got {r.value_of('a')}")
+    assert (isinstance(r.value_of('a'), type(resolved)),
+            f"expected {type(resolved)} got {type(r.value_of('a'))}")
     # value based resolution
-    assert r.value_of(
-        v) == resolved, f"expected {resolved}, got {r.value_of(v)}"
-    assert isinstance(
-        r.value_of(v),
-        type(resolved)), f"expected {type(resolved)} got {type(r.value_of(v))}"
+    assert (r.value_of(v) == resolved,
+            f"expected {resolved}, got {r.value_of(v)}")
+    assert (isinstance(r.value_of(v), type(resolved)),
+            f"expected {type(resolved)} got {type(r.value_of(v))}")
 
 
 def test_value_of_strings():

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -68,6 +68,7 @@ def _assert_consistent_resolution(v, resolved, subs_called=False):
     Raises:
         AssertionError in case resolution assertion fail.
     """
+
     class SubsAwareSymbol(sympy.Symbol):
         """A Symbol that registers a call to its `subs` method."""
 

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -23,7 +23,12 @@ import cirq
 def test_value_of():
     assert not bool(cirq.ParamResolver())
 
-    r = cirq.ParamResolver({'a': 0.5, 'b': 0.1, 'c': 1 + 1j})
+    r = cirq.ParamResolver({
+        'a': 0.5,
+        'b': 0.1,
+        'c': 1 + 1j,
+        'd': np.float32(3.2)
+    })
     assert bool(r)
 
     assert r.value_of('x') == sympy.Symbol('x')
@@ -47,6 +52,10 @@ def test_value_of():
 
     assert r.value_of(np.float32(32)) == 32
     assert isinstance(r.value_of(np.float32(32)), np.float32)
+
+    assert r.value_of('d') == np.float32(3.2)
+    assert isinstance(r.value_of('d'), np.float32)
+    assert isinstance(r.value_of(sympy.Symbol('d')), np.float32)
 
 
 def test_param_dict():

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -55,11 +55,13 @@ def test_value_of_substituted_types(val, resolved):
 def _assert_consistent_resolution(v, resolved, subs_called=False):
     """Asserts that parameter resolution works consistently.
 
-    The ParamResolver.value_of method can resolve any Sympy expression - subclasses of sympy.Basic. In the generic case,
-    it calls `sympy.Basic.subs` to substitute symbols with values specified in a dict, which is known to be very slow.
-    Instead value_of defines a pass-through shortcut for known numeric types.
-    For a given value `v` it is asserted that value_of resolves it to `resolved`, with the exact type of `resolved`.
-    `subs_called` indicates whether it is expected to have `subs` called or not during the resolution.
+    The ParamResolver.value_of method can resolve any Sympy expression -
+    subclasses of sympy.Basic. In the generic case, it calls `sympy.Basic.subs`
+    to substitute symbols with values specified in a dict, which is known to be
+    very slow. Instead value_of defines a pass-through shortcut for known
+    numeric types. For a given value `v` it is asserted that value_of resolves
+    it to `resolved`, with the exact type of `resolved`.`subs_called` indicates
+    whether it is expected to have `subs` called or not during the resolution.
 
     Args:
         v: the value to resolve

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -67,21 +67,25 @@ def _assert_consistent_resolution(v, resolved, subs_called=False):
             return self.symbol.subs(*args, **kwargs)
 
     r = cirq.ParamResolver({'a': v})
+
+    # symbol based resolution
     s = SubsAwareSymbol('a')
-    assert r.value_of(
-        s) == resolved, f"expected {resolved}, got {r.value_of(s)}"
+    assert r.value_of(s) == resolved, (f"expected {resolved}, "
+                                       f"got {r.value_of(s)}")
     assert subs_called == s.called, (
         f"For pass-through type "
         f"{type(v)} sympy.subs shouldn't have been called.")
     assert isinstance(r.value_of(s),
                       type(resolved)), (f"expected {type(resolved)} "
                                         f"got {type(r.value_of(s))}")
-    # string based resolution
+
+    # string based resolution (which in turn uses symbol based resolution)
     assert r.value_of('a') == resolved, (f"expected {resolved}, "
                                          f"got {r.value_of('a')}")
     assert isinstance(r.value_of('a'),
                       type(resolved)), (f"expected {type(resolved)} "
                                         f"got {type(r.value_of('a'))}")
+
     # value based resolution
     assert r.value_of(v) == resolved, (f"expected {resolved}, "
                                        f"got {r.value_of(v)}")

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -70,22 +70,24 @@ def _assert_consistent_resolution(v, resolved, subs_called=False):
     s = SubsAwareSymbol('a')
     assert r.value_of(
         s) == resolved, f"expected {resolved}, got {r.value_of(s)}"
-    assert (
-        subs_called == s.called,
-        f"For pass-through type {type(v)} sympy.subs shouldn't have been called."
-    )
-    assert (isinstance(r.value_of(s), type(resolved)),
-            f"expected {type(resolved)} got {type(r.value_of(s))}")
+    assert subs_called == s.called, (
+        f"For pass-through type "
+        f"{type(v)} sympy.subs shouldn't have been called.")
+    assert isinstance(r.value_of(s),
+                      type(resolved)), (f"expected {type(resolved)} "
+                                        f"got {type(r.value_of(s))}")
     # string based resolution
-    assert (r.value_of('a') == resolved,
-            f"expected {resolved}, got {r.value_of('a')}")
-    assert (isinstance(r.value_of('a'), type(resolved)),
-            f"expected {type(resolved)} got {type(r.value_of('a'))}")
+    assert r.value_of('a') == resolved, (f"expected {resolved}, "
+                                         f"got {r.value_of('a')}")
+    assert isinstance(r.value_of('a'),
+                      type(resolved)), (f"expected {type(resolved)} "
+                                        f"got {type(r.value_of('a'))}")
     # value based resolution
-    assert (r.value_of(v) == resolved,
-            f"expected {resolved}, got {r.value_of(v)}")
-    assert (isinstance(r.value_of(v), type(resolved)),
-            f"expected {type(resolved)} got {type(r.value_of(v))}")
+    assert r.value_of(v) == resolved, (f"expected {resolved}, "
+                                       f"got {r.value_of(v)}")
+    assert isinstance(r.value_of(v),
+                      type(resolved)), (f"expected {type(resolved)} "
+                                        f"got {type(r.value_of(v))}")
 
 
 def test_value_of_strings():

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -13,49 +13,95 @@
 # limitations under the License.
 
 """Tests for parameter resolvers."""
+import fractions
 
 import numpy as np
+import pytest
 import sympy
 
 import cirq
 
 
-def test_value_of():
+@pytest.mark.parametrize('val', [
+    3.2,
+    np.float32(3.2),
+    int(1),
+    np.int(3),
+    np.int32(45),
+    np.float64(6.3),
+    np.int32(2),
+    np.complex64(1j),
+    np.complex128(2j),
+    np.complex(1j),
+    fractions.Fraction(3, 2),
+])
+def test_value_of_pass_through_types(val):
+    _assert_consistent_resolution(val, val)
+
+
+@pytest.mark.parametrize('val,resolved', [(sympy.pi, np.pi),
+                                          (sympy.S.NegativeOne, -1),
+                                          (sympy.S.Half, 0.5),
+                                          (sympy.S.One, 1)])
+def test_value_of_transformed_types(val, resolved):
+    _assert_consistent_resolution(val, resolved)
+
+
+@pytest.mark.parametrize('val,resolved', [(sympy.I, 1j)])
+def test_value_of_substituted_types(val, resolved):
+    _assert_consistent_resolution(val, resolved, True)
+
+
+def _assert_consistent_resolution(v, resolved, subs_called=False):
+
+    class SubsAwareSymbol(sympy.Symbol):
+
+        def __init__(self, sym: str):
+            self.called = False
+            self.symbol = sympy.Symbol(sym)
+
+        # note: super().subs() doesn't resolve based on the param_dict properly
+        # for some reason, that's why a delegate (self.symbol) is used instead
+        def subs(self, *args, **kwargs):
+            self.called = True
+            return self.symbol.subs(*args, **kwargs)
+
+    r = cirq.ParamResolver({'a': v})
+    s = SubsAwareSymbol('a')
+    assert r.value_of(
+        s) == resolved, f"expected {resolved}, got {r.value_of(s)}"
+    assert subs_called == s.called, f"For pass-through type {type(v)} sympy.subs shouldn't have been called."
+    assert isinstance(
+        r.value_of(s),
+        type(resolved)), f"expected {type(resolved)} got {type(r.value_of(s))}"
+    # string based resolution
+    assert r.value_of(
+        'a') == resolved, f"expected {resolved}, got {r.value_of('a')}"
+    assert isinstance(r.value_of('a'), type(
+        resolved)), f"expected {type(resolved)} got {type(r.value_of('a'))}"
+    # value based resolution
+    assert r.value_of(
+        v) == resolved, f"expected {resolved}, got {r.value_of(v)}"
+    assert isinstance(
+        r.value_of(v),
+        type(resolved)), f"expected {type(resolved)} got {type(r.value_of(v))}"
+
+
+def test_value_of_strings():
+    assert cirq.ParamResolver().value_of('x') == sympy.Symbol('x')
+
+
+def test_value_of_calculations():
     assert not bool(cirq.ParamResolver())
 
-    r = cirq.ParamResolver({
-        'a': 0.5,
-        'b': 0.1,
-        'c': 1 + 1j,
-        'd': np.float32(3.2)
-    })
+    r = cirq.ParamResolver({'a': 0.5, 'b': 0.1, 'c': 1 + 1j})
     assert bool(r)
-
-    assert r.value_of('x') == sympy.Symbol('x')
-    assert r.value_of('a') == 0.5
-    assert r.value_of(sympy.Symbol('a')) == 0.5
-    assert r.value_of(0.5) == 0.5
-    assert r.value_of(sympy.Symbol('b')) == 0.1
-    assert r.value_of(0.3) == 0.3
-    assert r.value_of(sympy.Symbol('a') * 3) == 1.5
-    assert r.value_of(sympy.Symbol('b') / 0.1 - sympy.Symbol('a')) == 0.5
-
-    assert r.value_of(sympy.pi) == np.pi
-    assert isinstance(r.value_of(sympy.pi), float)
 
     assert r.value_of(2 * sympy.pi) == 2 * np.pi
     assert r.value_of(4**sympy.Symbol('a') + sympy.Symbol('b') * 10) == 3
-    assert r.value_of('c') == 1 + 1j
     assert r.value_of(sympy.I * sympy.pi) == np.pi * 1j
-
-    assert isinstance(r.value_of(sympy.S.NegativeOne), int)
-
-    assert r.value_of(np.float32(32)) == 32
-    assert isinstance(r.value_of(np.float32(32)), np.float32)
-
-    assert r.value_of('d') == np.float32(3.2)
-    assert isinstance(r.value_of('d'), np.float32)
-    assert isinstance(r.value_of(sympy.Symbol('d')), np.float32)
+    assert r.value_of(sympy.Symbol('a') * 3) == 1.5
+    assert r.value_of(sympy.Symbol('b') / 0.1 - sympy.Symbol('a')) == 0.5
 
 
 def test_param_dict():

--- a/docs/google/engine.md
+++ b/docs/google/engine.md
@@ -234,7 +234,7 @@ Currently, getting the program and job ids can only be done through the
 You can then use `get_program` and `get_job` to retrieve the results.
 See below for an example:
 
-```
+```python
 # Initialize the engine object
 engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
 
@@ -273,4 +273,52 @@ historical_results = historical_job.results()
 ```
 
 If you did not save the ids, you can still find them from your
-job using the [Cloud Console](https://console.cloud.google.com/quantum/jobs).
+job using the [Cloud Console](https://console.cloud.google.com/quantum/jobs) or
+by using our list methods. 
+
+
+### Listing jobs 
+
+To list the executions of your circuit, i.e. the jobs, you can use `cirq.google.Engine.list_jobs()`. 
+You can search in all the jobs within your project using filtering criteria on creation time, execution state and labels.  
+
+```python
+from cirq.google.engine.client.quantum import enums
+
+# Initialize the engine object
+engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
+
+# List all the jobs on the project since 2020/09/20 that succeeded:
+jobs = engine.list_jobs(created_after=datetime.date(2020,9,20),
+                        execution_states=[enums.ExecutionStatus.State.SUCCESS])
+for j in jobs:
+   print(j.job_id, j.status(), j.create_time())
+``` 
+
+### Listing programs
+
+To list the different instances of your circuits uploaded, i.e. the programs, you can use `cirq.google.Engine.list_programs()`.
+Similar to jobs, filtering makes it possible to list programs by creation time and labels.
+With an existing `cirq.google.EngineProgram` object, you can list any jobs that were run using that program. 
+
+```python
+from cirq.google.engine.client.quantum import enums
+
+# Initialize the engine object
+engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
+
+# List all the programs on the project since 2020/09/20 that have 
+# the "variational" label with any value and the "experiment" label 
+# with value "vqe001":
+programs = engine.list_programs(
+                created_after=datetime.date(2020,9,20),
+                has_labels={"variational":"*", "experiment":"vqe001"}
+           )
+for p in programs:
+   print(p.program_id, p.create_time())
+   # the same filtering parametrization is available as in engine.list_jobs()
+   # for example here we list the jobs under the programs that failed
+   for j in p.list_jobs(execution_states=[enums.ExecutionStatus.State.FAILURE]):
+     print(j.job_id, j.status())
+``` 
+


### PR DESCRIPTION
Extends ParamResolver's logic to circumvent sympy's slowness to members of numbers.Number. 
It also generalizes sympy constants instead of only handling pi and NegativeOne.

Fixes #3359.