### PR TITLE
Fix np.pad issue in numpy 1.16

### DIFF
--- a/cirq/experiments/grid_parallel_two_qubit_xeb.py
+++ b/cirq/experiments/grid_parallel_two_qubit_xeb.py
@@ -492,7 +492,8 @@ def _get_xeb_result(qubit_pair: GridQubitPair, circuits: List['cirq.Circuit'],
             _, counts = np.unique(measurements, return_counts=True)
             empirical_probs = counts / len(measurements)
             empirical_probs = np.pad(empirical_probs,
-                                     (0, 4 - len(empirical_probs)))
+                                     (0, 4 - len(empirical_probs)),
+                                     mode='constant')
             all_and_observed_probabilities[depth].append(
                 (probabilities, probabilities[measurements]))
             empirical_probabilities[depth].append(empirical_probs)


### PR DESCRIPTION
Cirq minimum requirement for numpy is 1.16.

In 1.16, the mode parameter for np.pad is required.
(It was changed to optional in numpy 1.17).

Add this parameter in with the default value to support numpy 1.16.