### PR TITLE
Fix quimb version checking

### DIFF
--- a/cirq/contrib/quimb/state_vector.py
+++ b/cirq/contrib/quimb/state_vector.py
@@ -7,7 +7,16 @@ import quimb.tensor as qtn
 
 import cirq
 
-QUIMB_VERSION = tuple(int(x) for x in quimb.__version__.split('.'))
+
+def _get_quimb_version():
+    version = quimb.__version__
+    try:
+        return tuple(int(x) for x in version.split('.')), version
+    except:
+        return (0, 0), version
+
+
+QUIMB_VERSION = _get_quimb_version()
 
 
 def circuit_to_tensors(circuit: cirq.Circuit,
@@ -150,9 +159,10 @@ def tensor_expectation_value(circuit: cirq.Circuit,
                    tags={'Q0', 'bra0'}) for q in qubits
     ]
     tn = qtn.TensorNetwork(tensors + end_bras)
-    if QUIMB_VERSION < (1, 3):
+    if QUIMB_VERSION[0] < (1, 3):
         # coverage: ignore
-        warnings.warn('Please use quimb>=1.3 for optimal performance in '
+        warnings.warn(f'quimb version {QUIMB_VERSION[1]} detected. Please use '
+                      f'quimb>=1.3 for optimal performance in '
                       '`tensor_expectation_value`. '
                       'See https://github.com/quantumlib/Cirq/issues/3263')
     else:

--- a/cirq/contrib/quimb/state_vector.py
+++ b/cirq/contrib/quimb/state_vector.py
@@ -8,6 +8,7 @@ import quimb.tensor as qtn
 import cirq
 
 
+# coverage: ignore
 def _get_quimb_version():
     version = quimb.__version__
     try:

--- a/cirq/contrib/quimb/state_vector.py
+++ b/cirq/contrib/quimb/state_vector.py
@@ -10,6 +10,10 @@ import cirq
 
 # coverage: ignore
 def _get_quimb_version():
+    """Returns the quimb version and parsed (major,minor) numbers if possible.
+    Returns:
+        a tuple of ((major, minor), version string)
+    """
     version = quimb.__version__
     try:
         return tuple(int(x) for x in version.split('.')), version

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -17,6 +17,7 @@ import numbers
 from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
 import numpy as np
 import sympy
+from sympy.core import numbers as sympy_numbers
 from cirq._compat import proper_repr
 from cirq._doc import document
 
@@ -198,9 +199,9 @@ class ParamResolver:
 def _sympy_pass_through(val: Any) -> Optional[Any]:
     if isinstance(val, numbers.Number) and not isinstance(val, sympy.Basic):
         return val
-    if isinstance(val, sympy.core.numbers.IntegerConstant):
+    if isinstance(val, sympy_numbers.IntegerConstant):
         return val.p
-    if isinstance(val, sympy.core.numbers.RationalConstant):
+    if isinstance(val, sympy_numbers.RationalConstant):
         return val.p / val.q
     if val == sympy.pi:
         return np.pi


### PR DESCRIPTION
Making quimb version check more robust.

In some systems the version might not be parseable as (int,int), e.g `0+unknown`. 
This PR fixes these scenarios.

Fixes #3263. 