### PR TITLE
upgrade to pylint 2.6

### DIFF
--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -54,7 +54,7 @@ else
 fi
 
 changed=$(git diff --name-only ${rev} -- \
-    | grep -E "^(cirq|dev_tools|examples).*"
+    | grep -E "^(cirq|dev_tools|examples).*.py$"
 )
 
 num_changed=$(echo -e "${changed[@]}" | wc -w)

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -31,9 +31,8 @@ import string
 from typing import (Dict, Iterable, List, Optional, Sequence, Set, TypeVar,
                     Union, TYPE_CHECKING)
 
-from cirq.google.engine.client import quantum
 from google.protobuf import any_pb2
-
+from cirq.google.engine.client import quantum
 from cirq import circuits, study, value
 from cirq.google import serializable_gate_set as sgs
 from cirq.google.api import v2

--- a/cirq/sim/clifford/stabilizer_sampler_test.py
+++ b/cirq/sim/clifford/stabilizer_sampler_test.py
@@ -1,6 +1,20 @@
-import cirq
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import numpy as np
+
+import cirq
 
 
 def test_produces_samples():

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -573,14 +573,14 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
                  tmpdir_factory=tmpdir_factory,
                  arg='HEAD~1',
                  setup='mkdir cirq dev_tools examples ignore\n'
-                 'touch cirq/file.py dev_tools/file.py examples/file.y\n'
+                 'touch cirq/file.py dev_tools/file.py examples/file.py\n'
                  'touch ignore/ignore.py\n'
                  'git add -A\n'
                  'git commit -m test --quiet --no-gpg-sign\n')
     print(result)
     assert result.exit_code == 0
     assert result.out == intercepted_prefix + ('cirq/file.py dev_tools/file.py '
-                                               'examples/file.y\n')
+                                               'examples/file.py\n')
     assert result.err.split() == (
         "Comparing against revision 'HEAD~1'.\n"
         "Found 3 lintable files associated with changes.\n").split()

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -1,4 +1,4 @@
-[config]
+[MASTER]
 max-line-length=80
 disable=all
 ignore-patterns=.*_pb2\.py,quantum_engine_service_client.py,engine_pb2_grpc.py
@@ -39,7 +39,8 @@ enable=
     syntax-error,
     too-many-function-args,
     trailing-whitespace,
-    undefined-variable,
+    # Disabling until https://github.com/PyCQA/pylint/issues/3791 is fixed
+    # undefined-variable,
     unexpected-keyword-arg,
     unhashable-dict-key,
     unnecessary-pass,
@@ -56,3 +57,10 @@ enable=
 
 # Ignore long lines containing urls or pylint directives.
 ignore-long-lines=^(.*#\w*pylint: disable.*|\s*(# )?<?https?://\S+>?)$
+
+[TYPECHECK]
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=numpy.*

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -1,6 +1,6 @@
 # For testing and analyzing code.
 mypy~=0.782.0
-pylint~=2.3.0
+pylint~=2.6.0
 pytest~=5.4.1
 pytest-asyncio~=0.12.0
 pytest-cov~=2.5.0


### PR DESCRIPTION
Upgrades pylint to 2.6.*

Also: 
* I noticed that the pylintrc file was not properly setup - there was no `[MASTER]` section. 
* `check/pylint-changed-files` passed to pylint not only python files but requirements.txt and pylintrc for example - now it is filtering to .py files only 
* there was a missing licenese header in a recently added file

Fixes #1986.