### PR TITLE
Adds the stale issue Github Actions workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 name: "Close stale issues"
-description: 'Close issues and pull requests with no recent activity'
+description: 'Close issues with no recent activity'
 
 on:
   schedule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale issues"
+description: 'Close issues and pull requests with no recent activity'
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+    repo-token: ${{ secrets.GITHUB_TOKEN }}
+    stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days'
+    days-before-stale: 30
+    days-before-close: 30
+    close-issue-message: 'Issue closed due to inactivity.'
+    stale-issue-label: 'triage/stale'
+    exempt-issue-labels: 'triage/accepted,triage/discuss,kind/design-issue,kind/health,kind/roadmap-item,kind/task'


### PR DESCRIPTION
Adding stale issue workflow as per http://bit.do/cirq-triage. 
Issues that are exempt from the stale check are the ones that have any of these labels: 

- triage/accepted
- triage/discuss
- kind/design-issue
- kind/health 
- kind/roadmap-item
- kind/task 

PRs are not subject to stale check yet.