### PR TITLE
Fix freezegun related issues

### DIFF
--- a/cirq/google/engine/engine_processor_test.py
+++ b/cirq/google/engine/engine_processor_test.py
@@ -551,16 +551,16 @@ def test_get_schedule_filter_by_time_slot(list_time_slots):
         'time_slot_type = MAINTENANCE')
 
 
-@freezegun.freeze_time(datetime.datetime.utcfromtimestamp(100_000))
+@freezegun.freeze_time()
 @mock.patch('cirq.google.engine.engine_client.EngineClient.list_time_slots')
 def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
 
+    now = int(datetime.datetime.now().timestamp())
     processor.get_schedule()
     list_time_slots.assert_called_with(
-        'proj', 'p0',
-        f'start_time < {100_000 + 60*60*24*14} AND end_time > {100_000}')
+        'proj', 'p0', f'start_time < {now + 60*60*24*14} AND end_time > {now}')
 
     with pytest.raises(ValueError, match='from_time of type'):
         processor.get_schedule(from_time=object())
@@ -572,38 +572,39 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.assert_called_with('proj', 'p0', '')
 
     processor.get_schedule(from_time=datetime.timedelta(0), to_time=None)
-    list_time_slots.assert_called_with('proj', 'p0', f'end_time > {100_000}')
+    list_time_slots.assert_called_with('proj', 'p0', f'end_time > {now}')
 
     processor.get_schedule(from_time=datetime.timedelta(seconds=200),
                            to_time=None)
-    list_time_slots.assert_called_with('proj', 'p0', f'end_time > {100_200}')
+    list_time_slots.assert_called_with('proj', 'p0', f'end_time > {now + 200}')
 
-    processor.get_schedule(from_time=datetime.datetime.utcfromtimestamp(52),
-                           to_time=None)
-    list_time_slots.assert_called_with('proj', 'p0', f'end_time > {52}')
+    test_timestamp = datetime.datetime.utcfromtimestamp(52)
+    utc_ts = int(test_timestamp.timestamp())
+    processor.get_schedule(from_time=test_timestamp, to_time=None)
+    list_time_slots.assert_called_with('proj', 'p0', f'end_time > {utc_ts}')
 
     processor.get_schedule(from_time=None, to_time=datetime.timedelta(0))
-    list_time_slots.assert_called_with('proj', 'p0', f'start_time < {100_000}')
+    list_time_slots.assert_called_with('proj', 'p0', f'start_time < {now}')
 
     processor.get_schedule(from_time=None,
                            to_time=datetime.timedelta(seconds=200))
-    list_time_slots.assert_called_with('proj', 'p0', f'start_time < {100_200}')
+    list_time_slots.assert_called_with('proj', 'p0',
+                                       f'start_time < {now + 200}')
 
-    processor.get_schedule(from_time=None,
-                           to_time=datetime.datetime.utcfromtimestamp(52))
-    list_time_slots.assert_called_with('proj', 'p0', f'start_time < {52}')
+    processor.get_schedule(from_time=None, to_time=test_timestamp)
+    list_time_slots.assert_called_with('proj', 'p0', f'start_time < {utc_ts}')
 
 
-@freezegun.freeze_time(datetime.datetime.utcfromtimestamp(100_000))
+@freezegun.freeze_time()
 @mock.patch('cirq.google.engine.engine_client.EngineClient.list_reservations')
 def test_list_reservations_time_filter_behavior(list_reservations):
     list_reservations.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
 
+    now = int(datetime.datetime.now().timestamp())
     processor.list_reservations()
     list_reservations.assert_called_with(
-        'proj', 'p0',
-        f'start_time < {100_000 + 60*60*24*14} AND end_time > {100_000}')
+        'proj', 'p0', f'start_time < {now + 60*60*24*14} AND end_time > {now}')
 
     with pytest.raises(ValueError, match='from_time of type'):
         processor.list_reservations(from_time=object())
@@ -615,28 +616,28 @@ def test_list_reservations_time_filter_behavior(list_reservations):
     list_reservations.assert_called_with('proj', 'p0', '')
 
     processor.list_reservations(from_time=datetime.timedelta(0), to_time=None)
-    list_reservations.assert_called_with('proj', 'p0', f'end_time > {100_000}')
+    list_reservations.assert_called_with('proj', 'p0', f'end_time > {now}')
 
     processor.list_reservations(from_time=datetime.timedelta(seconds=200),
                                 to_time=None)
-    list_reservations.assert_called_with('proj', 'p0', f'end_time > {100_200}')
+    list_reservations.assert_called_with('proj', 'p0',
+                                         f'end_time > {now + 200}')
 
-    processor.list_reservations(
-        from_time=datetime.datetime.utcfromtimestamp(52), to_time=None)
-    list_reservations.assert_called_with('proj', 'p0', f'end_time > {52}')
+    test_timestamp = datetime.datetime.utcfromtimestamp(52)
+    utc_ts = int(test_timestamp.timestamp())
+    processor.list_reservations(from_time=test_timestamp, to_time=None)
+    list_reservations.assert_called_with('proj', 'p0', f'end_time > {utc_ts}')
 
     processor.list_reservations(from_time=None, to_time=datetime.timedelta(0))
-    list_reservations.assert_called_with('proj', 'p0',
-                                         f'start_time < {100_000}')
+    list_reservations.assert_called_with('proj', 'p0', f'start_time < {now}')
 
     processor.list_reservations(from_time=None,
                                 to_time=datetime.timedelta(seconds=200))
     list_reservations.assert_called_with('proj', 'p0',
-                                         f'start_time < {100_200}')
+                                         f'start_time < {now + 200}')
 
-    processor.list_reservations(from_time=None,
-                                to_time=datetime.datetime.utcfromtimestamp(52))
-    list_reservations.assert_called_with('proj', 'p0', f'start_time < {52}')
+    processor.list_reservations(from_time=None, to_time=test_timestamp)
+    list_reservations.assert_called_with('proj', 'p0', f'start_time < {utc_ts}')
 
 
 def test_str():


### PR DESCRIPTION
- Freezegun assumes that naive timestamps are UTC and changes
timestamps under the hood.  For example,
   datetime.datetime.fromtimestamp(52).timestamp() may not equal 52.0

We may want to get rid of freezegun since it is starting to be more
trouble than it is worth, but that's a problem for another day.