### PR TITLE
fix protobuf serialization test issue

### DIFF
--- a/cirq/google/arg_func_langs_test.py
+++ b/cirq/google/arg_func_langs_test.py
@@ -130,7 +130,7 @@ def test_serialize_sympy_constants():
     assert len(packed['arg_value']) == 1
     # protobuf 3.12+ truncates floats to 4 bytes
     assert np.isclose(packed['arg_value']['float_value'],
-                      np.float32(sympy.pi), atol=1e-8)
+                      np.float32(sympy.pi), atol=1e-7)
 
 
 

--- a/cirq/google/arg_func_langs_test.py
+++ b/cirq/google/arg_func_langs_test.py
@@ -130,8 +130,8 @@ def test_serialize_sympy_constants():
     assert len(packed['arg_value']) == 1
     # protobuf 3.12+ truncates floats to 4 bytes
     assert np.isclose(packed['arg_value']['float_value'],
-                      np.float32(sympy.pi), atol=1e-7)
-
+                      np.float32(sympy.pi),
+                      atol=1e-7)
 
 
 def test_unsupported_function_language():

--- a/cirq/google/arg_func_langs_test.py
+++ b/cirq/google/arg_func_langs_test.py
@@ -126,12 +126,12 @@ def test_serialize_sympy_constants():
                                        including_default_value_fields=True,
                                        preserving_proto_field_name=True,
                                        use_integers_for_enums=True)
+    assert len(packed) == 1
+    assert len(packed['arg_value']) == 1
     # protobuf 3.12+ truncates floats to 4 bytes
-    assert packed == {
-        'arg_value': {
-            'float_value': float(str(np.float32(sympy.pi)))
-        }
-    }
+    assert np.isclose(packed['arg_value']['float_value'],
+                      np.float32(sympy.pi), atol=1e-8)
+
 
 
 def test_unsupported_function_language():


### PR DESCRIPTION
Fix protobuf serialization test issue - as in some environments protobuf might not truncate to 4 bytes the test should cater for approximate equality.