### PR TITLE
Add Moment.to_text_diagram

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1940,8 +1940,7 @@ def _draw_moment_in_diagram(
         include_tags: bool = True):
     if get_circuit_diagram_info is None:
         get_circuit_diagram_info = (
-            protocols.CircuitDiagramInfo.
-            _get_operation_circuit_diagram_info_with_fallback)
+            protocols.CircuitDiagramInfo._op_info_with_fallback)
     x0 = out_diagram.width()
 
     non_global_ops = [op for op in moment.operations if op.qubits]

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1974,7 +1974,7 @@ def _draw_moment_in_diagram(
         # Print gate qubit labels.
         symbols = info._wire_symbols_including_formatted_exponent(
             args,
-            preferred_exponent_index=max([i for i in range(len(op.qubits))],
+            preferred_exponent_index=max(range(len(op.qubits)),
                                          key=lambda i: qubit_map[op.qubits[i]]))
         for s, q in zip(symbols, op.qubits):
             out_diagram.write(x, qubit_map[q], s)

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -20,7 +20,6 @@ Moment the Operations must all act on distinct Qubits.
 """
 
 from collections import defaultdict
-from fractions import Fraction
 from itertools import groupby
 import math
 
@@ -29,7 +28,6 @@ from typing import (AbstractSet, Any, Callable, cast, Dict, FrozenSet, Iterable,
                     Type, TYPE_CHECKING, TypeVar, Union)
 
 import html
-import re
 import numpy as np
 
 from cirq import devices, ops, protocols, qis
@@ -1929,85 +1927,6 @@ def _resolve_operations(operations: Iterable['cirq.Operation'],
     return resolved_operations
 
 
-def _get_operation_circuit_diagram_info_with_fallback(
-        op: 'cirq.Operation',
-        args: 'cirq.CircuitDiagramInfoArgs') -> 'cirq.CircuitDiagramInfo':
-    info = protocols.circuit_diagram_info(op, args, None)
-    if info is not None:
-        if len(op.qubits) != len(info.wire_symbols):
-            raise ValueError(
-                'Wanted diagram info from {!r} for {} '
-                'qubits but got {!r}'.format(
-                    op,
-                    len(op.qubits),
-                    info))
-        return info
-
-    # Use the untagged operation's __str__.
-    name = str(op.untagged)
-
-    # Representation usually looks like 'gate(qubit1, qubit2, etc)'.
-    # Try to cut off the qubit part, since that would be redundant information.
-    redundant_tail = '({})'.format(', '.join(str(e) for e in op.qubits))
-    if name.endswith(redundant_tail):
-        name = name[:-len(redundant_tail)]
-
-    # Add tags onto the representation, if they exist
-    if op.tags:
-        name += f'{list(op.tags)}'
-
-    # Include ordering in the qubit labels.
-    symbols = (name,) + tuple('#{}'.format(i + 1)
-                              for i in range(1, len(op.qubits)))
-
-    return protocols.CircuitDiagramInfo(wire_symbols=symbols)
-
-
-def _is_exposed_formula(text: str) -> bool:
-    return re.match('[a-zA-Z_][a-zA-Z0-9_]*$', text) is None
-
-
-def _formatted_exponent(info: 'cirq.CircuitDiagramInfo',
-                        args: 'cirq.CircuitDiagramInfoArgs') -> Optional[str]:
-
-    if protocols.is_parameterized(info.exponent):
-        name = str(info.exponent)
-        return ('({})'.format(name)
-                if _is_exposed_formula(name)
-                else name)
-
-    if info.exponent == 0:
-        return '0'
-
-    # 1 is not shown.
-    if info.exponent == 1:
-        return None
-
-    # Round -1.0 into -1.
-    if info.exponent == -1:
-        return '-1'
-
-    # If it's a float, show the desired precision.
-    if isinstance(info.exponent, float):
-        if args.precision is not None:
-            # funky behavior of fraction, cast to str in constructor helps.
-            approx_frac = Fraction(info.exponent).limit_denominator(16)
-            if approx_frac.denominator not in [2, 4, 5, 10]:
-                if abs(float(approx_frac)
-                       - info.exponent) < 10**-args.precision:
-                    return '({})'.format(approx_frac)
-
-            return args.format_real(info.exponent)
-        return repr(info.exponent)
-
-    # If the exponent is any other object, use its string representation.
-    s = str(info.exponent)
-    if info.auto_exponent_parens and ('+' in s or ' ' in s or '-' in s[1:]):
-        # The string has confusing characters. Put parens around it.
-        return '({})'.format(info.exponent)
-    return s
-
-
 def _draw_moment_in_diagram(
         moment: 'cirq.Moment',
         use_unicode_characters: bool,
@@ -2021,7 +1940,8 @@ def _draw_moment_in_diagram(
         include_tags: bool = True):
     if get_circuit_diagram_info is None:
         get_circuit_diagram_info = (
-                _get_operation_circuit_diagram_info_with_fallback)
+            protocols.CircuitDiagramInfo.
+            _get_operation_circuit_diagram_info_with_fallback)
     x0 = out_diagram.width()
 
     non_global_ops = [op for op in moment.operations if op.qubits]
@@ -2053,22 +1973,13 @@ def _draw_moment_in_diagram(
             out_diagram.vertical_line(x, y1, y2)
 
         # Print gate qubit labels.
-        for s, q in zip(info.wire_symbols, op.qubits):
+        symbols = info._wire_symbols_including_formatted_exponent(
+            args,
+            preferred_exponent_index=max([i for i in range(len(op.qubits))],
+                                         key=lambda i: qubit_map[op.qubits[i]]))
+        for s, q in zip(symbols, op.qubits):
             out_diagram.write(x, qubit_map[q], s)
 
-        exponent = _formatted_exponent(info, args)
-        if exponent is not None:
-            if info.connected:
-                # Add an exponent to the last label only.
-                if info.exponent_qubit_index is not None:
-                    y3 = qubit_map[op.qubits[info.exponent_qubit_index]]
-                else:
-                    y3 = y2
-                out_diagram.write(x, y3, '^' + exponent)
-            else:
-                # Add an exponent to every label
-                for index in indices:
-                    out_diagram.write(x, index, '^' + exponent)
         if x > max_x:
             max_x = x
 

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -72,6 +72,9 @@ class _BaseGridQid(ops.Qid):
     def _with_row_col(self: TSelf, row: int, col: int) -> TSelf:
         """Returns a qid with the same type but a different coordinate."""
 
+    def __complex__(self):
+        return self.col + 1j * self.row
+
     def __add__(self: TSelf, other: Tuple[int, int]) -> 'TSelf':
         if isinstance(other, _BaseGridQid):
             if self.dimension != other.dimension:

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -72,7 +72,7 @@ class _BaseGridQid(ops.Qid):
     def _with_row_col(self: TSelf, row: int, col: int) -> TSelf:
         """Returns a qid with the same type but a different coordinate."""
 
-    def __complex__(self):
+    def __complex__(self) -> complex:
         return self.col + 1j * self.row
 
     def __add__(self: TSelf, other: Tuple[int, int]) -> 'TSelf':

--- a/cirq/devices/grid_qubit_test.py
+++ b/cirq/devices/grid_qubit_test.py
@@ -353,3 +353,8 @@ def test_immutable():
     with pytest.raises(AttributeError, match="can't set attribute"):
         q = cirq.GridQid(1, 2, dimension=3)
         q.dimension = 3
+
+
+def test_complex():
+    assert complex(cirq.GridQubit(row=1, col=2)) == 2 + 1j
+    assert isinstance(complex(cirq.GridQubit(row=1, col=2)), complex)

--- a/cirq/devices/line_qubit.py
+++ b/cirq/devices/line_qubit.py
@@ -99,13 +99,13 @@ class _BaseLineQid(ops.Qid):
     def __neg__(self: TSelf) -> TSelf:
         return self._with_x(-self.x)
 
-    def __complex__(self):
+    def __complex__(self) -> complex:
         return complex(self.x)
 
-    def __float__(self):
+    def __float__(self) -> float:
         return float(self.x)
 
-    def __int__(self):
+    def __int__(self) -> int:
         return int(self.x)
 
 

--- a/cirq/devices/line_qubit.py
+++ b/cirq/devices/line_qubit.py
@@ -99,6 +99,15 @@ class _BaseLineQid(ops.Qid):
     def __neg__(self: TSelf) -> TSelf:
         return self._with_x(-self.x)
 
+    def __complex__(self):
+        return complex(self.x)
+
+    def __float__(self):
+        return float(self.x)
+
+    def __int__(self):
+        return int(self.x)
+
 
 class LineQid(_BaseLineQid):
     """A qid on a 1d lattice with nearest-neighbor connectivity.

--- a/cirq/devices/line_qubit_test.py
+++ b/cirq/devices/line_qubit_test.py
@@ -282,3 +282,12 @@ def test_immutable():
     with pytest.raises(AttributeError, match="can't set attribute"):
         q = cirq.LineQid(5, dimension=4)
         q.x = 6
+
+
+def test_numeric():
+    assert int(cirq.LineQubit(x=5)) == 5
+    assert float(cirq.LineQubit(x=5)) == 5
+    assert complex(cirq.LineQubit(x=5)) == 5 + 0j
+    assert isinstance(int(cirq.LineQubit(x=5)), int)
+    assert isinstance(float(cirq.LineQubit(x=5)), float)
+    assert isinstance(complex(cirq.LineQubit(x=5)), complex)

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -356,10 +356,10 @@ class Moment:
         y_keys = sorted({pt[1] for pt in points}, key=_SortByValFallbackToType)
         x_map = {x_key: x + 2 for x, x_key in enumerate(x_keys)}
         y_map = {y_key: y + 2 for y, y_key in enumerate(y_keys)}
-        qubit_map = {}
+        qubit_positions = {}
         for q in qs:
             a, b = xy_breakdown_func(q)
-            qubit_map[q] = x_map[a], y_map[b]
+            qubit_positions[q] = x_map[a], y_map[b]
 
         from cirq.circuits.text_diagram_drawer import TextDiagramDrawer
         diagram = TextDiagramDrawer()
@@ -392,7 +392,7 @@ class Moment:
                 op, args=args)
             symbols = info._wire_symbols_including_formatted_exponent(args)
             for label, q in zip(symbols, op.qubits):
-                x, y = qubit_map[q]
+                x, y = qubit_positions[q]
                 diagram.write(x, y, label)
             if info.connected:
                 for q1, q2 in zip(op.qubits, op.qubits[1:]):
@@ -400,8 +400,8 @@ class Moment:
                     # This reduces how often lines overlap in the diagram.
                     q1, q2 = sorted([q1, q2])
 
-                    x1, y1 = qubit_map[q1]
-                    x2, y2 = qubit_map[q2]
+                    x1, y1 = qubit_positions[q1]
+                    x2, y2 = qubit_positions[q2]
                     if x1 != x2:
                         diagram.horizontal_line(y1, x1, x2)
                     if y1 != y2:

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -15,8 +15,7 @@
 """A simplified time-slice of operations within a sequenced circuit."""
 
 from typing import (Any, Callable, Dict, FrozenSet, Iterable, Iterator,
-                    overload, Optional, Tuple, TYPE_CHECKING, TypeVar, Union,
-                    Sequence)
+                    overload, Optional, Tuple, TYPE_CHECKING, TypeVar, Union)
 from cirq import protocols
 from cirq._compat import deprecated_parameter
 from cirq.ops import raw_types

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -15,7 +15,8 @@
 """A simplified time-slice of operations within a sequenced circuit."""
 
 from typing import (Any, Callable, Dict, FrozenSet, Iterable, Iterator,
-                    overload, Optional, Tuple, TYPE_CHECKING, TypeVar, Union)
+                    overload, Optional, Tuple, TYPE_CHECKING, TypeVar, Union,
+                    Sequence)
 from cirq import protocols
 from cirq._compat import deprecated_parameter
 from cirq.ops import raw_types
@@ -24,6 +25,15 @@ if TYPE_CHECKING:
     import cirq
 
 TSelf_Moment = TypeVar('TSelf_Moment', bound='Moment')
+
+
+def _default_breakdown(qid: 'cirq.Qid') -> Tuple[Any, Any]:
+    # Attempt to convert into a position on the complex plane.
+    try:
+        plane_pos = complex(qid)  # type: ignore
+        return plane_pos.real, plane_pos.imag
+    except TypeError:
+        return None, qid
 
 
 class Moment:
@@ -244,7 +254,7 @@ class Moment:
         return f'cirq.Moment(\n{indented}\n)'
 
     def __str__(self) -> str:
-        return ' and '.join(str(op) for op in self.operations)
+        return self.to_text_diagram()
 
     def transform_qubits(self: TSelf_Moment,
                          func: Callable[['cirq.Qid'], 'cirq.Qid']
@@ -308,3 +318,108 @@ class Moment:
                 op for op in self.operations
                 if not qubits_to_keep.isdisjoint(frozenset(op.qubits)))
             return Moment(ops_to_keep)
+
+    def to_text_diagram(
+            self: 'cirq.Moment',
+            *,
+            xy_breakdown_func: Callable[['cirq.Qid'],
+                                        Tuple[Any, Any]] = _default_breakdown,
+            extra_qubits: Iterable['cirq.Qid'] = (),
+            use_unicode_characters: bool = True,
+            precision: Optional[int] = None,
+            include_tags: bool = True):
+        """
+        Args:
+            xy_breakdown_func: A function to split qubits/qudits into x and y
+                components. For example, the default breakdown turns
+                `cirq.GridQubit(row, col)` into the tuple `(col, row)` and
+                `cirq.LineQubit(x)` into `(x, 0)`.
+            extra_qubits: Extra qubits/qudits to include in the diagram, even
+                if they don't have any operations applied in the moment.
+            use_unicode_characters: Whether or not the output should use fancy
+                unicode characters or stick to plain ASCII. Unicode characters
+                look nicer, but some environments don't draw them with the same
+                width as ascii characters (which ruins the diagrams).
+            precision: How precise numbers, such as angles, should be. Use None
+                for infinite precision, or an integer for a certain number of
+                digits of precision.
+            include_tags: Whether or not to include operation tags in the
+                diagram.
+
+        Returns:
+            The text diagram rendered into text.
+        """
+
+        # Figure out where to place everything.
+        qs = set(self.qubits) | set(extra_qubits)
+        points = {xy_breakdown_func(q) for q in qs}
+        x_keys = sorted({pt[0] for pt in points}, key=_SortByValFallbackToType)
+        y_keys = sorted({pt[1] for pt in points}, key=_SortByValFallbackToType)
+        x_map = {x_key: x + 2 for x, x_key in enumerate(x_keys)}
+        y_map = {y_key: y + 2 for y, y_key in enumerate(y_keys)}
+        qubit_map = {}
+        for q in qs:
+            a, b = xy_breakdown_func(q)
+            qubit_map[q] = x_map[a], y_map[b]
+
+        from cirq.circuits.text_diagram_drawer import TextDiagramDrawer
+        diagram = TextDiagramDrawer()
+
+        def cleanup_key(key: Any) -> Any:
+            if isinstance(key, float) and key == int(key):
+                return str(int(key))
+            return str(key)
+
+        # Add table headers.
+        for key, x in x_map.items():
+            diagram.write(x, 0, cleanup_key(key))
+        for key, y in y_map.items():
+            diagram.write(0, y, cleanup_key(key))
+        diagram.horizontal_line(1, 0, len(x_map) + 2)
+        diagram.vertical_line(1, 0, len(y_map) + 2)
+        diagram.force_vertical_padding_after(0, 0)
+        diagram.force_vertical_padding_after(1, 0)
+
+        # Add operations.
+        for op in self.operations:
+            args = protocols.CircuitDiagramInfoArgs(
+                known_qubits=op.qubits,
+                known_qubit_count=len(op.qubits),
+                use_unicode_characters=use_unicode_characters,
+                qubit_map=None,
+                precision=precision,
+                include_tags=include_tags)
+            info = protocols.CircuitDiagramInfo._get_operation_circuit_diagram_info_with_fallback(
+                op, args=args)
+            symbols = info._wire_symbols_including_formatted_exponent(args)
+            for label, q in zip(symbols, op.qubits):
+                x, y = qubit_map[q]
+                diagram.write(x, y, label)
+            if info.connected:
+                for q1, q2 in zip(op.qubits, op.qubits[1:]):
+                    # Sort to get a more consistent orientation for diagonals.
+                    # This reduces how often lines overlap in the diagram.
+                    q1, q2 = sorted([q1, q2])
+
+                    x1, y1 = qubit_map[q1]
+                    x2, y2 = qubit_map[q2]
+                    if x1 != x2:
+                        diagram.horizontal_line(y1, x1, x2)
+                    if y1 != y2:
+                        diagram.vertical_line(x2, y1, y2)
+
+        return diagram.render()
+
+
+class _SortByValFallbackToType:
+
+    def __init__(self, value):
+        self.value = value
+
+    def __lt__(self, other):
+        try:
+            return self.value < other.value
+        except TypeError:
+            t1 = type(self.value)
+            t2 = type(other.value)
+            return str(t1) < str(t2)

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -388,7 +388,7 @@ class Moment:
                 qubit_map=None,
                 precision=precision,
                 include_tags=include_tags)
-            info = protocols.CircuitDiagramInfo._get_operation_circuit_diagram_info_with_fallback(
+            info = protocols.CircuitDiagramInfo._op_info_with_fallback(
                 op, args=args)
             symbols = info._wire_symbols_including_formatted_exponent(args)
             for label, q in zip(symbols, op.qubits):

--- a/cirq/ops/raw_types_test.py
+++ b/cirq/ops/raw_types_test.py
@@ -547,9 +547,6 @@ global phase:   π['tag1', 'tag2']""",
     # Two moments with global phase, one with another tagged gate
     c = cirq.Circuit([cirq.X(q).with_tags('x_tag'), tag1])
     c.append(cirq.Moment([cirq.X(q), tag2]))
-    for m in c:
-        print(m)
-        print('----')
     cirq.testing.assert_has_diagram(c,
                                     """\
 a: ─────────────X['x_tag']─────X──────────────

--- a/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq/protocols/circuit_diagram_info_protocol.py
@@ -143,9 +143,9 @@ class CircuitDiagramInfo:
         return s
 
     @staticmethod
-    def _get_operation_circuit_diagram_info_with_fallback(
-            op: 'cirq.Operation',
-            args: 'cirq.CircuitDiagramInfoArgs') -> 'cirq.CircuitDiagramInfo':
+    def _op_info_with_fallback(op: 'cirq.Operation',
+                               args: 'cirq.CircuitDiagramInfoArgs'
+                              ) -> 'cirq.CircuitDiagramInfo':
         info = protocols.circuit_diagram_info(op, args, None)
         if info is not None:
             if len(op.qubits) != len(info.wire_symbols):

--- a/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq/protocols/circuit_diagram_info_protocol.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
+from fractions import Fraction
 from typing import (Any, TYPE_CHECKING, Optional, Union, TypeVar, Dict,
-                    overload, Iterable)
+                    overload, Iterable, List, Sequence)
 
 import numpy as np
 import sympy
@@ -81,6 +82,97 @@ class CircuitDiagramInfo:
             self.auto_exponent_parens,
         )
 
+    def _wire_symbols_including_formatted_exponent(
+            self,
+            args: 'cirq.CircuitDiagramInfoArgs',
+            *,
+            preferred_exponent_index: Optional[int] = None) -> List[str]:
+        result = list(self.wire_symbols)
+        exponent = self._formatted_exponent(args)
+        if exponent is not None:
+            ks: Sequence[int]
+            if self.exponent_qubit_index is not None:
+                ks = (self.exponent_qubit_index,)
+            elif not self.connected:
+                ks = range(len(result))
+            elif preferred_exponent_index is not None:
+                ks = (preferred_exponent_index,)
+            else:
+                ks = (0,)
+            for k in ks:
+                result[k] += '^' + exponent
+        return result
+
+    def _formatted_exponent(self: 'cirq.CircuitDiagramInfo',
+                            args: 'cirq.CircuitDiagramInfoArgs'
+                           ) -> Optional[str]:
+
+        if protocols.is_parameterized(self.exponent):
+            name = str(self.exponent)
+            return ('({})'.format(name) if _is_exposed_formula(name) else name)
+
+        if self.exponent == 0:
+            return '0'
+
+        # 1 is not shown.
+        if self.exponent == 1:
+            return None
+
+        # Round -1.0 into -1.
+        if self.exponent == -1:
+            return '-1'
+
+        # If it's a float, show the desired precision.
+        if isinstance(self.exponent, float):
+            if args.precision is not None:
+                # funky behavior of fraction, cast to str in constructor helps.
+                approx_frac = Fraction(self.exponent).limit_denominator(16)
+                if approx_frac.denominator not in [2, 4, 5, 10]:
+                    if abs(float(approx_frac) -
+                           self.exponent) < 10**-args.precision:
+                        return '({})'.format(approx_frac)
+
+                return args.format_real(self.exponent)
+            return repr(self.exponent)
+
+        # If the exponent is any other object, use its string representation.
+        s = str(self.exponent)
+        if self.auto_exponent_parens and ('+' in s or ' ' in s or '-' in s[1:]):
+            # The string has confusing characters. Put parens around it.
+            return '({})'.format(self.exponent)
+        return s
+
+    @staticmethod
+    def _get_operation_circuit_diagram_info_with_fallback(
+            op: 'cirq.Operation',
+            args: 'cirq.CircuitDiagramInfoArgs') -> 'cirq.CircuitDiagramInfo':
+        info = protocols.circuit_diagram_info(op, args, None)
+        if info is not None:
+            if len(op.qubits) != len(info.wire_symbols):
+                raise ValueError('Wanted diagram info from {!r} for {} '
+                                 'qubits but got {!r}'.format(
+                                     op, len(op.qubits), info))
+            return info
+
+        # Use the untagged operation's __str__.
+        name = str(op.untagged)
+
+        # Representation usually looks like 'gate(qubit1, qubit2, etc)'.
+        # Try to cut off the qubit part, since that would be redundant.
+        redundant_tail = '({})'.format(', '.join(str(e) for e in op.qubits))
+        if name.endswith(redundant_tail):
+            name = name[:-len(redundant_tail)]
+
+        # Add tags onto the representation, if they exist
+        if op.tags:
+            name += f'{list(op.tags)}'
+
+        # Include ordering in the qubit labels.
+        symbols = (name,) + tuple(
+            '#{}'.format(i + 1) for i in range(1, len(op.qubits)))
+
+        return protocols.CircuitDiagramInfo(wire_symbols=symbols)
+
     def __repr__(self) -> str:
         return ('cirq.CircuitDiagramInfo('
                 f'wire_symbols={self.wire_symbols!r}, '
@@ -88,6 +180,10 @@ class CircuitDiagramInfo:
                 f'connected={self.connected!r}, '
                 f'exponent_qubit_index={self.exponent_qubit_index!r}, '
                 f'auto_exponent_parens={self.auto_exponent_parens!r})')
+
+
+def _is_exposed_formula(text: str) -> bool:
+    return re.match('[a-zA-Z_][a-zA-Z0-9_]*$', text) is None
 
 
 @value.value_equality

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 from collections import defaultdict
 import itertools
@@ -217,10 +217,8 @@ def _first_differing_moment_index(circuit1: circuits.Circuit,
     return None  # coverage: ignore
 
 
-def assert_has_diagram(
-        actual: circuits.Circuit,
-        desired: str,
-        **kwargs) -> None:
+def assert_has_diagram(actual: Union[circuits.Circuit, ops.Moment],
+                       desired: str, **kwargs) -> None:
     """Determines if a given circuit has the desired text diagram.
 
     Args:


### PR DESCRIPTION
- Creates a 2d view of the moment
- `Moment.__str__` now produces a text diagram
- Moved several diagram utilities out of circuit and into private methods inside the diagram info protocol file
- Added `__complex__`/`__float__`/`__int__` to GridQubit/LineQubit as appropriate

This was motivated by being confused by a large circuit on a grid, and wanting to see some of the 2d structure more directly.

Example diagram:

```
import cirq
a, b, c, d = cirq.GridQubit.rect(2, 2)
print(cirq.Moment(cirq.S(c), cirq.ISWAP(a, d))
```

```
  ╷ 0     1
╶─┼─────────────
0 │ iSwap─┐
  │       │
1 │ S     iSwap
  │
```