### PR TITLE
strip license info for RTD pages

### DIFF
--- a/rtd_docs/conf.py
+++ b/rtd_docs/conf.py
@@ -133,7 +133,12 @@ def autodoc_process(app, what: str, name: str, obj: Any, options,
 
 def source_read(app, docname, source):
     source[0] = re.sub(r'"##### (Copyright 20\d\d The Cirq Developers)"',
-                       r'"**\1**"', source[0])
+                       r'""', source[0])
+    license_pattern = r'(\{\s*?"cell_type": "code".*?"#@title.*License.".*?\},)'
+    if re.search(license_pattern, source[0], flags=re.S):
+        source[0] = re.sub(license_pattern,
+                           r'', source[0], flags=re.S)
+
     source[0] = re.sub(r'"<table.*tfo-notebook-buttons.*"</table>"',
                        r'""',
                        source[0],

--- a/rtd_docs/conf.py
+++ b/rtd_docs/conf.py
@@ -134,9 +134,11 @@ def autodoc_process(app, what: str, name: str, obj: Any, options,
 def source_read(app, docname, source):
     source[0] = re.sub(r'"##### (Copyright 20\d\d The Cirq Developers)"', r'""',
                        source[0])
-    license_pattern = r'(\{\s*?"cell_type": "code".*?"#@title.*License.".*?\},)'
-    if re.search(license_pattern, source[0], flags=re.S):
-        source[0] = re.sub(license_pattern, r'', source[0], flags=re.S)
+    source[0] = re.sub(
+        r'(\{\s*?"cell_type": "code".*?"#@title.*License.".*?\},)',
+        r'',
+        source[0],
+        flags=re.S)
 
     source[0] = re.sub(r'"<table.*tfo-notebook-buttons.*"</table>"',
                        r'""',

--- a/rtd_docs/conf.py
+++ b/rtd_docs/conf.py
@@ -132,12 +132,11 @@ def autodoc_process(app, what: str, name: str, obj: Any, options,
 
 
 def source_read(app, docname, source):
-    source[0] = re.sub(r'"##### (Copyright 20\d\d The Cirq Developers)"',
-                       r'""', source[0])
+    source[0] = re.sub(r'"##### (Copyright 20\d\d The Cirq Developers)"', r'""',
+                       source[0])
     license_pattern = r'(\{\s*?"cell_type": "code".*?"#@title.*License.".*?\},)'
     if re.search(license_pattern, source[0], flags=re.S):
-        source[0] = re.sub(license_pattern,
-                           r'', source[0], flags=re.S)
+        source[0] = re.sub(license_pattern, r'', source[0], flags=re.S)
 
     source[0] = re.sub(r'"<table.*tfo-notebook-buttons.*"</table>"',
                        r'""',


### PR DESCRIPTION
Strips license info for readthedocs generation. 

Fixes #3402. 