### PR TITLE
fix readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,7 @@ Cirq is uploaded to Zenodo automatically. Click on this badge [![DOI](https://ze
 
 An equivalent BibTex format reference is below for all the versions:
 
+```
 @software{quantum_ai_team_and_collaborators_2020_4062499,
   author       = {Quantum AI team and collaborators},
   title        = {Cirq},

--- a/README.rst
+++ b/README.rst
@@ -87,17 +87,18 @@ Cirq is uploaded to Zenodo automatically. Click on this badge [![DOI](https://ze
 
 An equivalent BibTex format reference is below for all the versions:
 
-```
-@software{quantum_ai_team_and_collaborators_2020_4062499,
-  author       = {Quantum AI team and collaborators},
-  title        = {Cirq},
-  month        = Oct,
-  year         = 2020,
-  publisher    = {Zenodo},
-  doi          = {10.5281/zenodo.4062499},
-  url          = {https://doi.org/10.5281/zenodo.4062499}
-}
-```
+.. code-block::
+
+    @software{quantum_ai_team_and_collaborators_2020_4062499,
+      author       = {Quantum AI team and collaborators},
+      title        = {Cirq},
+      month        = Oct,
+      year         = 2020,
+      publisher    = {Zenodo},
+      doi          = {10.5281/zenodo.4062499},
+      url          = {https://doi.org/10.5281/zenodo.4062499}
+    }
+
 
 Cirq Contributors Community
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,11 @@ For questions about how to use Cirq post to
 How to cite Cirq
 ----------------
 
-Cirq is uploaded to Zenodo automatically. Click on this badge [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4062499.svg)](https://doi.org/10.5281/zenodo.4062499) to see all the citation formats for all versions.
+Cirq is uploaded to Zenodo automatically. Click on the badge below to see all the citation formats for all versions.
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4062499.svg
+  :target: https://doi.org/10.5281/zenodo.4062499
+  :alt: DOI
 
 An equivalent BibTex format reference is below for all the versions:
 


### PR DESCRIPTION
Our readme is broken and that breaks the cirq-unstable release as well.
It was a copy-paste error - I always forget that the readme is in RST and both the badge and the citation BibTex were in markdown.