### PR TITLE
Fix all latex expressions without enclosing $ signs

### DIFF
--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -429,45 +429,62 @@ def two_qubit_state_tomography(sampler: work.Sampler,
     To measure the density matrix of the output state of a two-qubit circuit,
     different combinations of I, X/2 and Y/2 operations are applied to the
     two qubits before measurements in the z-basis to determine the state
-    probabilities P_00, P_01, P_10.
+    probabilities $P_{00}, P_{01}, P_{10}.$
 
     The density matrix rho is decomposed into an operator-sum representation
-    \sum_{i, j} c_ij * sigma_i \bigotimes sigma_j, where i, j = 0, 1, 2,
-    3 and sigma_0 = I, sigma_1 = sigma_x, sigma_2 = sigma_y, sigma_3 =
-    sigma_z are the single-qubit Identity and Pauli matrices.
+    $\sum_{i, j} c_{ij} * \sigma_i \bigotimes \sigma_j$, where $i, j = 0, 1, 2,
+    3$ and $\sigma_0 = I, \sigma_1 = \sigma_x, \sigma_2 = \sigma_y, \sigma_3 =
+    \sigma_z$ are the single-qubit Identity and Pauli matrices.
 
     Based on the measured probabilities probs and the transformations of the
     measurement operator by different basis rotations, one can build an
     overdetermined set of linear equations.
 
-    As an example, if the identity operation (I) is applied to both qubits,
-    the measurement operators are (I +/- sigma_z) \bigotimes (I +/- sigma_z).
-    The state probabilities P_00, P_01, P_10 thus obtained contribute to the
-    following linear equations (setting c_00 = 1):
+    As an example, if the identity operation (I) is applied to both qubits, the
+    measurement operators are $(I +/- \sigma_z) \bigotimes (I +/- \sigma_z)$.
+    The state probabilities $P_{00}, P_{01}, P_{10}$ thus obtained contribute
+    to the following linear equations (setting $c_{00} = 1$):
 
-    c_03 + c_30 + c_33 = 4*P_00 - 1
-    -c_03 + c_30 - c_33 = 4*P_01 - 1
-    c_03 - c_30 - c_33 = 4*P_10 - 1
+        $$
+        c_{03} + c_{30} + c_{33} = 4*P_{00} - 1
+        $$
+
+        $$
+        -c_{03} + c_{30} - c_{33} = 4*P_{01} - 1
+        $$
+
+        $$
+        c_{03} - c_{30} - c_{33} = 4*P_{10} - 1
+        $$
 
     And if a Y/2 rotation is applied to the first qubit and a X/2 rotation
     is applied to the second qubit before measurement, the measurement
-    operators are (I -/+ sigma_x) \bigotimes (I +/- sigma_y). The probabilities
-    obtained instead contribute to the following linear equations:
+    operators are $(I -/+ \sigma_x) \bigotimes (I +/- \sigma_y)$. The
+    probabilities obtained instead contribute to the following linear equations:
 
-    c_02 - c_10 - c_12 = 4*P_00 - 1
-    -c_02 - c_10 + c_12 = 4*P_01 - 1
-    c_02 + c_10 + c_12 = 4*P_10 - 1
+        $$
+        c_{02} - c_{10} - c_{12} = 4*P_{00} - 1
+        $$
+
+        $$
+        -c_{02} - c_{10} + c_{12} = 4*P_{01} - 1
+        $$
+
+        $$
+        c_{02} + c_{10} + c_{12} = 4*P_{10} - 1
+        $$
 
     Note that this set of equations has the same form as the first set under
-    the transformation c_03 <-> c_02, c_30 <-> -c_10 and c_33 <-> -c_12.
+    the transformation $c_{03}$ <-> $c_{02}, c_{30}$ <-> $-c_{10}$ and
+    $c_{33}$ <-> $-c_{12}$.
 
     Since there are 9 possible combinations of rotations (each producing 3
-    independent probabilities) and a total of 15 unknown coefficients c_ij,
+    independent probabilities) and a total of 15 unknown coefficients $c_{ij}$,
     one can cast all the measurement results into a overdetermined set of
     linear equations numpy.dot(mat, c) = probs. Here c is of length 15 and
-    contains all the c_ij's (except c_00 which is set to 1), and mat is a 27
-    by 15 matrix having three non-zero elements in each row that are either
-    1 or -1.
+    contains all the $c_{ij}$'s (except $c_{00}$ which is set to 1), and mat
+    is a 27 by 15 matrix having three non-zero elements in each row that are
+    either 1 or -1.
 
     The least-square solution to the above set of linear equations is then
     used to construct the density matrix rho.

--- a/cirq/google/optimizers/two_qubit_gates/gate_compilation.py
+++ b/cirq/google/optimizers/two_qubit_gates/gate_compilation.py
@@ -19,7 +19,8 @@ _SingleQubitGatePair = Tuple[np.ndarray, np.ndarray]
 
 
 class TwoQubitGateCompilation(NamedTuple):
-    """Represents a compilation of a target 2-qubit with respect to a base gate.
+    r"""Represents a compilation of a target 2-qubit with respect to a base
+    gate.
 
     This object encodes the relationship between 4x4 unitary operators
 
@@ -30,9 +31,10 @@ class TwoQubitGateCompilation(NamedTuple):
     Attributes:
         base_gate: 4x4 unitary denoting U_base above.
         target_gate: 4x4 unitary denoting U_target above.
-        local_unitaries: Sequence of 2-tuples (k_{00},k_{01}),(k_{10},k_{11})...
-            where k_j = k_{j0} ⊗ k_{j1} in the product above. Each k_{j0},
-            k_{j1} is a 2x2 unitary.
+        local_unitaries: Sequence of 2-tuples
+            $(k_{00}, k_{01}), (k_{10}, k_{11}) \ldots$ where
+            $k_j = k_{j0} \otimes k_{j1}$ in the product above.
+            Each $k_{j0}, k_{j1}$ is a 2x2 unitary.
         actual_gate: 4x4 unitary denoting the right hand side above, ideally
             equal to U_target.
         success: Whether actual_gate is expected to be close to U_target.
@@ -68,9 +70,9 @@ class GateTabulation:
         r"""Compute single qubit gates required to compile a desired unitary.
 
         Given a desired unitary U, this computes the sequence of 1-local gates
-        k_j such that the product
+        $k_j$ such that the product
 
-        k_{n-1} A k_{n-2} A ... k_1 A k_0
+        $k_{n-1} A k_{n-2} A ... k_1 A k_0$
 
         is close to U. Here A is the base_gate of the tabulation.
 
@@ -304,11 +306,11 @@ def gate_product_tabulation(
         base_gate: The base gate of the tabulation.
         max_infidelity: Sets the desired density of tabulated product unitaries.
             The typical nearest neighbor Euclidean spacing (of the KAK vectors)
-            will be on the order of \sqrt(max_infidelity). Thus the number of
-            tabulated points will scale as max_infidelity^{-3/2}.
+            will be on the order of $\sqrt{max\_infidelity}$. Thus the number of
+            tabulated points will scale as $max\_infidelity^{-3/2}$.
         sample_scaling: Relative number of random gate products to use in the
             tabulation. The total number of random local unitaries scales as
-            ~ max_infidelity^{-3/2} * sample_scaling. Must be positive.
+            ~ $max\_infidelity^{-3/2} * sample\_scaling$. Must be positive.
         random_state: Random state or random state seed.
         allow_missed_points: If True, the tabulation is allowed to conclude
             even if not all points in the Weyl chamber are expected to be

--- a/cirq/google/optimizers/two_qubit_gates/math_utils.py
+++ b/cirq/google/optimizers/two_qubit_gates/math_utils.py
@@ -138,9 +138,11 @@ def kak_vector_infidelity(k_vec_a: np.ndarray,
 
     This is the quantity
 
-    \min 1 - F_e( exp(i k_a · (XX,YY,ZZ)) kL exp(i k_b · (XX,YY,ZZ)) kR)
+    $$
+    \min 1 - F_e( \exp(i k_a · (XX,YY,ZZ)) kL \exp(i k_b · (XX,YY,ZZ)) kR)
+    $$
 
-    where F_e is the entanglement (process) fidelity and the minimum is taken
+    where $F_e$ is the entanglement (process) fidelity and the minimum is taken
     over all 1-local unitaries kL, kR.
 
     Args:
@@ -252,8 +254,8 @@ def kak_vector_to_unitary(vector: np.ndarray) -> np.ndarray:
 
     Returns:
         unitary: Corresponding 2-qubit unitary, of the form
-           exp( i k_x \sigma_x \sigma_x + i k_y \sigma_y \sigma_y
-                + i k_z \sigma_z \sigma_z).
+           $exp( i k_x \sigma_x \sigma_x + i k_y \sigma_y \sigma_y
+                + i k_z \sigma_z \sigma_z)$.
            matrix or tensor of matrices of shape (..., 4,4).
     """
     vector = np.asarray(vector)

--- a/cirq/linalg/decompositions_test.py
+++ b/cirq/linalg/decompositions_test.py
@@ -626,12 +626,14 @@ def _local_invariants_from_kak(vector: np.ndarray) -> np.ndarray:
 
     Any 2 qubit unitary may be expressed as
 
-    U = k_l A k_r
-    where k_l, k_r are single qubit (local) unitaries and
+    $U = k_l A k_r$
+    where $k_l, k_r$ are single qubit (local) unitaries and
 
-    A = \exp( i * \sum_{j=x,y,z} k_j \sigma_{j,0}\sigma{j,1} )
+    $$
+    A = \exp( i * \sum_{j=x,y,z} k_j \sigma_{(j,0)}\sigma_{(j,1)})
+    $$
 
-    Here (k_x,k_y,k_z) is the KAK vector.
+    Here $(k_x,k_y,k_z)$ is the KAK vector.
 
     Args:
         vector: Shape (...,3) tensor representing different KAK vectors.

--- a/cirq/linalg/transformations.py
+++ b/cirq/linalg/transformations.py
@@ -184,11 +184,12 @@ def targeted_conjugate_about(tensor: np.ndarray,
     conj_indices for second $\cdot$).
 
     More specifically this computes
-        sum tensor_{i_0,...,i_{r-1},j_0,...,j_{r-1}}
-        * target_{k_0,...,k_{r-1},l_0,...,l_{r-1}
-        * tensor_{m_0,...,m_{r-1},n_0,...,n_{r-1}}^*
-    where the sum is over indices where j_s = k_s and s is in `indices`
-    and l_s = m_s and s is in `conj_indices`.
+        $\sum tensor_{i_0,...,i_{r-1},j_0,...,j_{r-1}} *
+        target_{k_0,...,k_{r-1},l_0,...,l_{r-1}} *
+        tensor_{m_0,...,m_{r-1},n_0,...,n_{r-1}}^*$
+
+    where the sum is over indices where $j_s$ = $k_s$ and $s$ is in `indices`
+    and $l_s$ = $m_s$ and s is in `conj_indices`.
 
     Args:
         tensor: The tensor that will be conjugated about the target tensor.

--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -50,7 +50,7 @@ class AsymmetricDepolarizingChannel(gate_features.SingleQubitGate):
             $$
 
         where i varies from 0 to 4**n-1 and Pi represents n-qubit Pauli operator
-        (including identity). The input \rho is the density matrix before the
+        (including identity). The input $\rho$ is the density matrix before the
         depolarization.
 
         Args:
@@ -206,10 +206,12 @@ def asymmetric_depolarize(
 
         This channel evolves a density matrix via
 
-            $ \sum_i p_i Pi \rho Pi $
+            $$
+            \sum_i p_i Pi \rho Pi
+            $$
 
         where i varies from 0 to 4**n-1 and Pi represents n-qubit Pauli operator
-        (including identity). The input \rho is the density matrix before the
+        (including identity). The input $\rho$ is the density matrix before the
         depolarization.
 
         Args:
@@ -252,9 +254,11 @@ class DepolarizingChannel(gate_features.SingleQubitGate):
 
         This channel evolves a density matrix via
 
-        $ \rho \rightarrow (1 - p) \rho + 1 / (4**n - 1) \sum _i P_i X P_i $
+            $$
+            \rho \rightarrow (1 - p) \rho + 1 / (4**n - 1) \sum _i P_i X P_i
+            $$
 
-        where P_i are the $4^n - 1$ Pauli gates (excluding the identity).
+        where $P_i$ are the $4^n - 1$ Pauli gates (excluding the identity).
 
         Args:
             p: The probability that one of the Pauli gates is applied. Each of
@@ -351,9 +355,11 @@ def depolarize(p: float, n_qubits: int = 1) -> DepolarizingChannel:
 
     This channel evolves a density matrix via
 
-    $ \rho \rightarrow (1 - p) \rho + 1 / (4**n - 1) \sum _i P_i X P_i $
+        $$
+        \rho \rightarrow (1 - p) \rho + 1 / (4**n - 1) \sum _i P_i X P_i
+        $$
 
-    where P_i are the $4^n - 1$ Pauli gates (excluding the identity).
+    where $P_i$ are the $4^n - 1$ Pauli gates (excluding the identity).
 
     Args:
         p: The probability that one of the Pauli gates is applied. Each of

--- a/cirq/ops/parity_gates.py
+++ b/cirq/ops/parity_gates.py
@@ -30,20 +30,32 @@ if TYPE_CHECKING:
 class XXPowGate(eigen_gate.EigenGate,
                 gate_features.TwoQubitGate,
                 gate_features.InterchangeableQubitsGate):
-    """The X-parity gate, possibly raised to a power.
+    r"""The X-parity gate, possibly raised to a power.
 
     The XX**t gate implements the following unitary:
 
-        (X⊗X)^t = [c . . s]
-                  [. c s .]
-                  [. s c .]
-                  [s . . c]
+        $$
+        (X \otimes X)^t = \begin{bmatrix}
+                          c & . & . & s \\
+                          . & c & s & . \\
+                          . & s & c & . \\
+                          s & . & . & c
+                          \end{bmatrix}
+        $$
 
     where '.' means '0' and
 
-        c = f cos(πt / 2)
-        s = -i f sin(πt / 2)
-        f = e^{iπt / 2}.
+        $$
+        c = f \cos(\frac{\pi t}{2})
+        $$
+
+        $$
+        s = -i f \sin(\frac{\pi t}{2})
+        $$
+
+        $$
+        f = e^{\frac{i \pi t}{2}}.
+        $$
 
     See also: `cirq.MSGate` (the Mølmer–Sørensen gate), which is implemented via
     this class.
@@ -121,20 +133,32 @@ class XXPowGate(eigen_gate.EigenGate,
 class YYPowGate(eigen_gate.EigenGate,
                 gate_features.TwoQubitGate,
                 gate_features.InterchangeableQubitsGate):
-    """The Y-parity gate, possibly raised to a power.
+    r"""The Y-parity gate, possibly raised to a power.
 
     The YY**t gate implements the following unitary:
 
-        (Y⊗Y)^t = [ c . . -s]
-                  [ . c s  .]
-                  [ . s c  .]
-                  [-s . .  c]
+        $$
+        (Y \otimes Y)^t = \begin{bmatrix}
+                          c & . & . & -s \\
+                          . & c & s & . \\
+                          . & s & c & . \\
+                          -s & . & . & c \\
+                          \end{bmatrix}
+        $$
 
     where '.' means '0' and
 
-        c = f cos(πt / 2)
-        s = -i f sin(πt / 2)
-        f = e^{iπt / 2}.
+        $$
+        c = f \cos(\frac{\pi t}{2})
+        $$
+
+        $$
+        s = -i f \sin(\frac{\pi t}{2})
+        $$
+
+        $$
+        f = e^{\frac{i \pi t}{2}}.
+        $$
     """
 
     def _eigen_components(self):
@@ -214,12 +238,16 @@ class ZZPowGate(eigen_gate.EigenGate,
 
     The ZZ**t gate implements the following unitary:
 
-        (Z⊗Z)^t = [1 . . .]
-                  [. w . .]
-                  [. . w .]
-                  [. . . 1]
+        $$
+        (Z \otimes Z)^t = \begin{bmatrix}
+                          1 & . & . & . \\
+                          . & w & . & . \\
+                          . & . & w & . \\
+                          . & . & . & 1
+                          \end{bmatrix}
+        $$
 
-    where w = e^{iπt} and '.' means '0'.
+    where $w = e^{i \pi t}$ and '.' means '0'.
     """
 
     def _decompose_(self, qubits):

--- a/cirq/protocols/channel.py
+++ b/cirq/protocols/channel.py
@@ -45,14 +45,18 @@ class SupportsChannel(Protocol):
     def _channel_(self) -> Union[Sequence[np.ndarray], NotImplementedType]:
         r"""A list of matrices describing the quantum channel.
 
-        These matrices are the terms in the operator sum representation of
-        a quantum channel. If the returned matrices are {A_0,A_1,..., A_{r-1}},
+        These matrices are the terms in the operator sum representation of a
+        quantum channel. If the returned matrices are ${A_0,A_1,..., A_{r-1}}$,
         then this describes the channel:
+            $$
             \rho \rightarrow \sum_{k=0}^{r-1} A_0 \rho A_0^\dagger
+            $$
         These matrices are required to satisfy the trace preserving condition
+            $$
             \sum_{k=0}^{r-1} A_i^\dagger A_i = I
-        where I is the identity matrix. The matrices A_i are sometimes called
-        Kraus or noise operators.
+            $$
+        where $I$ is the identity matrix. The matrices $A_i$ are sometimes
+        called Kraus or noise operators.
 
         This method is used by the global `cirq.channel` method. If this method
         or the _unitary_ method is not present, or returns NotImplement,
@@ -92,12 +96,16 @@ def channel(val: Any, default: Any = RaiseTypeErrorIfNotProvided
     r"""Returns a list of matrices describing the channel for the given value.
 
     These matrices are the terms in the operator sum representation of
-    a quantum channel. If the returned matrices are {A_0,A_1,..., A_{r-1}},
+    a quantum channel. If the returned matrices are ${A_0,A_1,..., A_{r-1}}$,
     then this describes the channel:
+        $$
         \rho \rightarrow \sum_{k=0}^{r-1} A_0 \rho A_0^\dagger
+        $$
     These matrices are required to satisfy the trace preserving condition
+        $$
         \sum_{k=0}^{r-1} A_i^\dagger A_i = I
-    where I is the identity matrix. The matrices A_i are sometimes called
+        $$
+    where $I$ is the identity matrix. The matrices $A_i$ are sometimes called
     Kraus or noise operators.
 
     Args:

--- a/cirq/protocols/measurement_key_protocol.py
+++ b/cirq/protocols/measurement_key_protocol.py
@@ -39,10 +39,14 @@ class SupportsMeasurementKey(Protocol):
     Note: Measurements, in contrast to general quantum channels, are
     distinguished by the recording of the quantum operation that occurred.
     That is a general quantum channel may enact the evolution
+        $$
         \rho \rightarrow \sum_k A_k \rho A_k^\dagger
+        $$
     where as a measurement enacts the evolution
+        $$
         \rho \rightarrow A_k \rho A_k^\dagger
-    conditional on the measurement outcome being k.
+        $$
+    conditional on the measurement outcome being $k$.
     """
 
     @document

--- a/examples/bcs_mean_field.py
+++ b/examples/bcs_mean_field.py
@@ -10,9 +10,10 @@ represent spin-up (down) basis states.
 
 The Bogoliubov transformation can be readily implemented by
 applying quantum gates on vertical pairs of qubits, which takes the form
-|BCS⟩ = \prod_k (u_k + v_k c^\dag_{k,↑} c^\dag_{−k,↓}|vac⟩ where |vac⟩ is
-the vacuum state and u_k^2 = (1+ ξ_k/(ξ_k^2+Δ_k^2)^{1/2})/2 and v_k^2
-= (1 - ξ_k/(ξ_k^2+Δ_k^2)^{1/2})/2.
+$|BCS⟩ = \prod_k (u_k + v_k) c^\dagger_{k,↑} c^\dagger_{−k,↓}|vac⟩$ where
+$|vac⟩$ is the vacuum state and
+$u_k^2 = \frac{1}{2}(1+ \frac{ξ_k}{\sqrt{ξ_k^2+Δ_k^2}})$ and
+$v_k^2 = \frac{1}{2}(1 - \frac{ξ_k}{\sqrt{ξ_k^2+Δ_k^2}})$
 
 We use the fast fermionic Fourier transformation (FFFT) to implement the basis
 transformation from the momentum picture to the position picture.
@@ -203,9 +204,9 @@ def fswap(p, q):
 
 def bogoliubov_trans(p, q, theta):
     r"""The 2-mode Bogoliubov transformation is mapped to two-qubit operations.
-     We use the identity X S^\dag X S X = Y X S^\dag Y S X = X to transform
-     the Hamiltonian XY+YX to XX+YY type. The time evolution of the XX + YY
-     Hamiltonian can be expressed as a power of the iSWAP gate.
+     We use the identity $X S^\dagger X S X = Y X S^\dagger Y S X = X$ to
+     transform the Hamiltonian XY+YX to XX+YY type. The time evolution of the
+     XX + YY Hamiltonian can be expressed as a power of the iSWAP gate.
 
     Args:
         p: the first qubit


### PR DESCRIPTION
Fix all latex expressions without the enclosing $ signs. Fixes issue #3286

Approach: I searched for all the raw strings in the repository, and went these strings one by one to check for missing latex expressions.

Some comments regarding specific changes to make sure they are correct:

* For file `cirq/linalg/transformations.py`: The changes would look like [this](https://hackmd.io/0UK6Na6mQ1aY2tkcEFSlxg?view).

* For file `examples/bcs_mean_field.py`: The changes would look like [this](https://hackmd.io/ZpqO-TdnQbajFo_TSRBiCA?view). I have changed the command `\dag` to `\dagger` as `\dag` wasn't being rendered properly in HackMd.

* For file `cirq/ops/common_channels.py`: Changed `$ \sum_i p_i Pi \rho Pi $` to  `$\sum_i p_i Pi \rho Pi$`, as the first expression isn't being rendered correctly in HackMd ([link](https://hackmd.io/v8_W6pXjTsqj2KuSXlJK6w?view) to view this). 
