### PR TITLE
Add SerializableGateSet.is_supported

### DIFF
--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -83,6 +83,12 @@ def test_supported_gate_types():
     assert MY_GATE_SET.supported_gate_types() == (cirq.XPowGate,)
 
 
+def test_is_supported():
+    q0, q1 = cirq.GridQubit.rect(1, 2)
+    assert MY_GATE_SET.is_supported(cirq.Circuit(cirq.X(q0), cirq.X(q1)))
+    assert not MY_GATE_SET.is_supported(cirq.Circuit(cirq.X(q0), cirq.Z(q1)))
+
+
 def test_is_supported_operation():
     q = cirq.GridQubit(1, 1)
     assert MY_GATE_SET.is_supported_operation(cirq.XPowGate()(q))


### PR DESCRIPTION
This method checks if a given object containing operations (a circuit, moment, or other arbitrary op tree) is supported by a gateset. Note that this does not address separating the notions of belonging to a gateset from serializability, but at it provides a way to check if a circuit is supported without actually serializing, which can be expensive.