### PR TITLE
Replace `Study` with `sweep` in docs

### DIFF
--- a/docs/simulation.ipynb
+++ b/docs/simulation.ipynb
@@ -535,12 +535,10 @@
     "Here we see that the ``Symbol`` is used in two gates, and then the resolver provides this value at run time.\n",
     "\n",
     "Parameterized values are most useful in defining what we call a\n",
-    "``sweep``.  A ``sweep`` is a collection of trials, where each\n",
-    "trial is a run with a particular set of configurations and which\n",
-    "may be run repeatedly.  \n",
+    "``sweep``.  A ``sweep`` is a sequence of trials, where each\n",
+    "trial is a run with a particular set of parameter values.\n",
     "\n",
-    "Running a `sweep` returns a\n",
-    "``Result`` per set of fixed parameter values and repetitions.  \n",
+    "Running a ``sweep`` returns a ``Result`` for each set of fixed parameter values and repetitions.  \n",
     "\n",
     "For instance:"
    ]
@@ -583,9 +581,9 @@
     "id": "5ca5f417ca71"
    },
    "source": [
-    "Above we see that different repetitions for the case that the\n",
-    "qubit has been rotated into a superposition over computational\n",
-    "basis states yield different measurement results per run."
+    "Above we see that assigning different values to gate parameters yields\n",
+    "different results for each trial in the sweep, and that each trial is repeated\n",
+    "``repetitions`` times."
    ]
   },
   {

--- a/docs/simulation.ipynb
+++ b/docs/simulation.ipynb
@@ -535,14 +535,12 @@
     "Here we see that the ``Symbol`` is used in two gates, and then the resolver provides this value at run time.\n",
     "\n",
     "Parameterized values are most useful in defining what we call a\n",
-    "``Study``.  A ``Study`` is a collection of trials, where each\n",
+    "``sweep``.  A ``sweep`` is a collection of trials, where each\n",
     "trial is a run with a particular set of configurations and which\n",
     "may be run repeatedly.  \n",
     "\n",
-    "Running a `Study` returns one\n",
-    "``TrialContext`` and ``Result`` per set of fixed parameter\n",
-    "values and repetitions (which are reported as the ``repetition_id``\n",
-    "in the ``TrialContext`` object).  \n",
+    "Running a `sweep` returns a\n",
+    "``Result`` per set of fixed parameter values and repetitions.  \n",
     "\n",
     "For instance:"
    ]
@@ -587,11 +585,7 @@
    "source": [
     "Above we see that different repetitions for the case that the\n",
     "qubit has been rotated into a superposition over computational\n",
-    "basis states yield different measurement results per run.\n",
-    "\n",
-    "Also note that we now see the use of the ``TrialContext`` returned\n",
-    "as the first tuple from ``run``: it contains the ``param_dict``\n",
-    "describing what values were actually used in resolving the ``Symbol`` objects."
+    "basis states yield different measurement results per run."
    ]
   },
   {


### PR DESCRIPTION
From what I can tell, the nearest equivalent to the old concept of "Study" is a sweep. Strangely, the example code seems to be up-to-date for this.