### PR TITLE
fix educators links in book.yaml

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -149,17 +149,17 @@ upper_tabs:
       ####  EDUCATORS WORKSHOP ####
       - heading: "Educators workshop"
       - title: "Cirq intro workshop"
-      - path: /cirq/tutorials/educators/intro
+        path: /cirq/tutorials/educators/intro
       - title: "Textbook algorithms in Cirq"
-      - path: /cirq/tutorials/educators/textbook_algorithms
+        path: /cirq/tutorials/educators/textbook_algorithms
       - title: "Quantum chemistry with OpenFermion"
-      - path: /cirq/tutorials/educators/chemistry
+        path: /cirq/tutorials/educators/chemistry
       - title: "QAOA: Ising model"
-      - path: /cirq/tutorials/educators/qaoa_ising
+        path: /cirq/tutorials/educators/qaoa_ising
       - title: "Neutral atom device"
-      - path: /cirq/tutorials/educators/neutral_atom
+        path: /cirq/tutorials/educators/neutral_atom
       - title: "Ion device"
-      - path: /cirq/tutorials/educators/ion_device
+        path: /cirq/tutorials/educators/ion_device
 
 
     - name: "Experiments"


### PR DESCRIPTION
Fix educators links in book.yaml. 

This breaks devsite staging currently.