### PR TITLE
Fix typo in custom gates guide

### DIFF
--- a/docs/custom_gates.ipynb
+++ b/docs/custom_gates.ipynb
@@ -460,7 +460,7 @@
    "source": [
     "The `_decompose_` method yields the operations which implement the custom gate. (One can also return a list of operations instead of a generator.)\n",
     "\n",
-    "When we use this gate in a circuit, the individual gates in the decomposition do not appear in the circuit. Instead, the `_circuit_diagram__info_` appears in the circuit. As mentioned, this can be useful for interpreting circuits at a higher level than individual (primitive) gates."
+    "When we use this gate in a circuit, the individual gates in the decomposition do not appear in the circuit. Instead, the `_circuit_diagram_info_` appears in the circuit. As mentioned, this can be useful for interpreting circuits at a higher level than individual (primitive) gates."
    ]
   },
   {


### PR DESCRIPTION
@balopat I found a small typo when checking that the matrix equations rendered correctly (which they indeed do now).