### PR TITLE
Change initial backoff in engine client.

### DIFF
--- a/cirq/google/engine/engine_client.py
+++ b/cirq/google/engine/engine_client.py
@@ -44,7 +44,6 @@ class EngineClient:
     served by using the Engine, EngineProgram, EngineJob, EngineProcessor, and
     Calibration objects instead of using this directly.
     """
-
     def __init__(
             self,
             service_args: Optional[Dict] = None,
@@ -160,7 +159,6 @@ class EngineClient:
                 if err.code.value not in RETRYABLE_ERROR_CODES:
                     raise EngineException(message) from err
 
-            current_delay *= 2
             if current_delay > self.max_retry_delay_seconds:
                 raise TimeoutError(
                     'Reached max retry attempts for error: {}'.format(message))
@@ -171,6 +169,7 @@ class EngineClient:
                       'seconds before retrying.',
                       file=sys.stderr)
             time.sleep(current_delay)
+            current_delay *= 2
 
     def create_program(
             self,

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -106,8 +106,7 @@ def test_list_program(client_constructor):
 
     client = EngineClient()
     assert client.list_programs(project_id='proj') == results
-    assert grpc_client.list_quantum_programs.call_args[0] == (
-        'projects/proj', )
+    assert grpc_client.list_quantum_programs.call_args[0] == ('projects/proj',)
     assert grpc_client.list_quantum_programs.call_args[1] == {
         'filter_': '',
     }
@@ -188,8 +187,7 @@ def test_set_program_description(client_constructor):
     grpc_client.update_quantum_program.return_value = result
 
     client = EngineClient()
-    assert client.set_program_description('proj', 'prog',
-                                          'A program') == result
+    assert client.set_program_description('proj', 'prog', 'A program') == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumProgram(name='projects/proj/programs/prog',
@@ -429,8 +427,7 @@ def test_create_job(client_constructor):
                     processor_names=['projects/proj/processors/processor0'])),
         ), False)
 
-    with pytest.raises(ValueError,
-                       match='priority must be between 0 and 1000'):
+    with pytest.raises(ValueError, match='priority must be between 0 and 1000'):
         client.create_job('proj',
                           'prog',
                           job_id=None,
@@ -464,8 +461,7 @@ def test_set_job_description(client_constructor):
     grpc_client.update_quantum_job.return_value = result
 
     client = EngineClient()
-    assert client.set_job_description('proj', 'prog', 'job0',
-                                      'A job') == result
+    assert client.set_job_description('proj', 'prog', 'job0', 'A job') == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
         qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
@@ -608,7 +604,7 @@ def test_delete_job(client_constructor):
     client = EngineClient()
     assert not client.delete_job('proj', 'prog', 'job0')
     assert grpc_client.delete_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0', )
+        'projects/proj/programs/prog/jobs/job0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -618,7 +614,7 @@ def test_cancel_job(client_constructor):
     client = EngineClient()
     assert not client.cancel_job('proj', 'prog', 'job0')
     assert grpc_client.cancel_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0', )
+        'projects/proj/programs/prog/jobs/job0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -632,7 +628,7 @@ def test_job_results(client_constructor):
     client = EngineClient()
     assert client.get_job_results('proj', 'prog', 'job0') == result
     assert grpc_client.get_quantum_result.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0', )
+        'projects/proj/programs/prog/jobs/job0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -648,14 +644,14 @@ def test_list_jobs(client_constructor):
     client = EngineClient()
     assert client.list_jobs(project_id='proj', program_id='prog1') == results
     assert grpc_client.list_quantum_jobs.call_args[0] == (
-        'projects/proj/programs/prog1', )
+        'projects/proj/programs/prog1',)
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': '',
     }
 
     assert client.list_jobs(project_id='proj') == results
     assert grpc_client.list_quantum_jobs.call_args[0] == (
-        'projects/proj/programs/-', )
+        'projects/proj/programs/-',)
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': '',
     }
@@ -756,7 +752,7 @@ def test_list_processors(client_constructor):
     client = EngineClient()
     assert client.list_processors('proj') == results
     assert grpc_client.list_quantum_processors.call_args[0] == (
-        'projects/proj', )
+        'projects/proj',)
     assert grpc_client.list_quantum_processors.call_args[1] == {
         'filter_': '',
     }
@@ -766,14 +762,13 @@ def test_list_processors(client_constructor):
 def test_get_processor(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    result = qtypes.QuantumProcessor(
-        name='projects/proj/processors/processor0')
+    result = qtypes.QuantumProcessor(name='projects/proj/processors/processor0')
     grpc_client.get_quantum_processor.return_value = result
 
     client = EngineClient()
     assert client.get_processor('proj', 'processor0') == result
     assert grpc_client.get_quantum_processor.call_args[0] == (
-        'projects/proj/processors/processor0', )
+        'projects/proj/processors/processor0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -791,7 +786,7 @@ def test_list_calibrations(client_constructor):
     client = EngineClient()
     assert client.list_calibrations('proj', 'processor0') == results
     assert grpc_client.list_quantum_calibrations.call_args[0] == (
-        'projects/proj/processors/processor0', )
+        'projects/proj/processors/processor0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -805,7 +800,7 @@ def test_get_calibration(client_constructor):
     client = EngineClient()
     assert client.get_calibration('proj', 'processor0', 123456) == result
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/123456', )
+        'projects/proj/processors/processor0/calibrations/123456',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -819,7 +814,7 @@ def test_get_current_calibration(client_constructor):
     client = EngineClient()
     assert client.get_current_calibration('proj', 'processor0') == result
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/current', )
+        'projects/proj/processors/processor0/calibrations/current',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -832,7 +827,7 @@ def test_get_current_calibration_does_not_exist(client_constructor):
     client = EngineClient()
     assert client.get_current_calibration('proj', 'processor0') is None
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/current', )
+        'projects/proj/processors/processor0/calibrations/current',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -886,8 +881,8 @@ def test_api_retry_times(client_constructor, mock_time):
     assert grpc_client.get_quantum_program.call_count == 3
 
     assert len(mock_time.call_args_list) == 2
-    assert all(x.args == y
-               for x, y in zip(mock_time.call_args_list, [(0.1, ), (0.2, )]))
+    assert all(
+        x.args == y for x, y in zip(mock_time.call_args_list, [(0.1,), (0.2,)]))
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -860,11 +860,27 @@ def test_api_retry_5xx_errors(client_constructor):
     grpc_client.get_quantum_program.side_effect = exceptions.ServiceUnavailable(
         'internal error')
 
-    client = EngineClient(max_retry_delay_seconds=1)
+    client = EngineClient(max_retry_delay_seconds=0.3)
     with pytest.raises(TimeoutError,
                        match='Reached max retry attempts.*internal error'):
         client.get_program('proj', 'prog', False)
-    assert grpc_client.get_quantum_program.call_count > 1
+    assert grpc_client.get_quantum_program.call_count == 3
+
+
+@mock.patch('time.sleep', return_value=None)
+@mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
+def test_api_retry_times(client_constructor, mock_time):
+    grpc_client = setup_mock_(client_constructor)
+    grpc_client.get_quantum_program.side_effect = exceptions.ServiceUnavailable(
+        'internal error')
+
+    client = EngineClient(max_retry_delay_seconds=0.3)
+    with pytest.raises(TimeoutError,
+                       match='Reached max retry attempts.*internal error'):
+        client.get_program('proj', 'prog', False)
+    assert grpc_client.get_quantum_program.call_count == 3
+
+    assert [a.args for a in mock_time.call_args_list] == [(0.1,), (0.2,)]
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -106,7 +106,8 @@ def test_list_program(client_constructor):
 
     client = EngineClient()
     assert client.list_programs(project_id='proj') == results
-    assert grpc_client.list_quantum_programs.call_args[0] == ('projects/proj',)
+    assert grpc_client.list_quantum_programs.call_args[0] == (
+        'projects/proj', )
     assert grpc_client.list_quantum_programs.call_args[1] == {
         'filter_': '',
     }
@@ -187,7 +188,8 @@ def test_set_program_description(client_constructor):
     grpc_client.update_quantum_program.return_value = result
 
     client = EngineClient()
-    assert client.set_program_description('proj', 'prog', 'A program') == result
+    assert client.set_program_description('proj', 'prog',
+                                          'A program') == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumProgram(name='projects/proj/programs/prog',
@@ -427,7 +429,8 @@ def test_create_job(client_constructor):
                     processor_names=['projects/proj/processors/processor0'])),
         ), False)
 
-    with pytest.raises(ValueError, match='priority must be between 0 and 1000'):
+    with pytest.raises(ValueError,
+                       match='priority must be between 0 and 1000'):
         client.create_job('proj',
                           'prog',
                           job_id=None,
@@ -461,7 +464,8 @@ def test_set_job_description(client_constructor):
     grpc_client.update_quantum_job.return_value = result
 
     client = EngineClient()
-    assert client.set_job_description('proj', 'prog', 'job0', 'A job') == result
+    assert client.set_job_description('proj', 'prog', 'job0',
+                                      'A job') == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
         qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
@@ -604,7 +608,7 @@ def test_delete_job(client_constructor):
     client = EngineClient()
     assert not client.delete_job('proj', 'prog', 'job0')
     assert grpc_client.delete_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0',)
+        'projects/proj/programs/prog/jobs/job0', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -614,7 +618,7 @@ def test_cancel_job(client_constructor):
     client = EngineClient()
     assert not client.cancel_job('proj', 'prog', 'job0')
     assert grpc_client.cancel_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0',)
+        'projects/proj/programs/prog/jobs/job0', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -628,7 +632,7 @@ def test_job_results(client_constructor):
     client = EngineClient()
     assert client.get_job_results('proj', 'prog', 'job0') == result
     assert grpc_client.get_quantum_result.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0',)
+        'projects/proj/programs/prog/jobs/job0', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -644,14 +648,14 @@ def test_list_jobs(client_constructor):
     client = EngineClient()
     assert client.list_jobs(project_id='proj', program_id='prog1') == results
     assert grpc_client.list_quantum_jobs.call_args[0] == (
-        'projects/proj/programs/prog1',)
+        'projects/proj/programs/prog1', )
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': '',
     }
 
     assert client.list_jobs(project_id='proj') == results
     assert grpc_client.list_quantum_jobs.call_args[0] == (
-        'projects/proj/programs/-',)
+        'projects/proj/programs/-', )
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': '',
     }
@@ -752,7 +756,7 @@ def test_list_processors(client_constructor):
     client = EngineClient()
     assert client.list_processors('proj') == results
     assert grpc_client.list_quantum_processors.call_args[0] == (
-        'projects/proj',)
+        'projects/proj', )
     assert grpc_client.list_quantum_processors.call_args[1] == {
         'filter_': '',
     }
@@ -762,13 +766,14 @@ def test_list_processors(client_constructor):
 def test_get_processor(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    result = qtypes.QuantumProcessor(name='projects/proj/processors/processor0')
+    result = qtypes.QuantumProcessor(
+        name='projects/proj/processors/processor0')
     grpc_client.get_quantum_processor.return_value = result
 
     client = EngineClient()
     assert client.get_processor('proj', 'processor0') == result
     assert grpc_client.get_quantum_processor.call_args[0] == (
-        'projects/proj/processors/processor0',)
+        'projects/proj/processors/processor0', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -786,7 +791,7 @@ def test_list_calibrations(client_constructor):
     client = EngineClient()
     assert client.list_calibrations('proj', 'processor0') == results
     assert grpc_client.list_quantum_calibrations.call_args[0] == (
-        'projects/proj/processors/processor0',)
+        'projects/proj/processors/processor0', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -800,7 +805,7 @@ def test_get_calibration(client_constructor):
     client = EngineClient()
     assert client.get_calibration('proj', 'processor0', 123456) == result
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/123456',)
+        'projects/proj/processors/processor0/calibrations/123456', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -814,7 +819,7 @@ def test_get_current_calibration(client_constructor):
     client = EngineClient()
     assert client.get_current_calibration('proj', 'processor0') == result
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/current',)
+        'projects/proj/processors/processor0/calibrations/current', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -827,7 +832,7 @@ def test_get_current_calibration_does_not_exist(client_constructor):
     client = EngineClient()
     assert client.get_current_calibration('proj', 'processor0') is None
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/current',)
+        'projects/proj/processors/processor0/calibrations/current', )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -880,7 +885,9 @@ def test_api_retry_times(client_constructor, mock_time):
         client.get_program('proj', 'prog', False)
     assert grpc_client.get_quantum_program.call_count == 3
 
-    assert [a.args for a in mock_time.call_args_list] == [(0.1,), (0.2,)]
+    assert len(mock_time.call_args_list) == 2
+    assert all(x.args == y
+               for x, y in zip(mock_time.call_args_list, [(0.1, ), (0.2, )]))
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)

--- a/cirq/google/engine/engine_client_test.py
+++ b/cirq/google/engine/engine_client_test.py
@@ -882,7 +882,7 @@ def test_api_retry_times(client_constructor, mock_time):
 
     assert len(mock_time.call_args_list) == 2
     assert all(
-        x.args == y for x, y in zip(mock_time.call_args_list, [(0.1,), (0.2,)]))
+        x == y for (x, _), y in zip(mock_time.call_args_list, [(0.1,), (0.2,)]))
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)


### PR DESCRIPTION
Code says initial backoff is 0.1 seconds, but code multiplied this by 2 before sleeping
- Made it match the comment.  
- Added a test.
- Decreased time in nearby test to speed overall tests, tests that two sleeps are called not four now.