### PR TITLE
Add measurement key remapping protocol.

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -516,6 +516,7 @@ from cirq.protocols import (
     trace_distance_from_angle_list,
     unitary,
     validate_mixture,
+    with_measurement_key_mapping,
 )
 
 from cirq.ion import (

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1392,6 +1392,14 @@ class Circuit(AbstractCircuit):
 
     __hash__ = None  # type: ignore
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        remapped_ops = [
+            protocols.with_measurement_key_mapping(op, key_map)
+            if protocols.is_measurement(op) else op
+            for op in self.all_operations()
+        ]
+        return Circuit(remapped_ops, device=self.device)
+
     def with_device(
             self,
             new_device: 'cirq.Device',

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -815,6 +815,14 @@ class AbstractCircuit(abc.ABC):
     def all_measurement_keys(self) -> AbstractSet[str]:
         return protocols.measurement_keys(self)
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        remapped_ops = [
+            protocols.with_measurement_key_mapping(op, key_map)
+            if protocols.is_measurement(op) else op
+            for op in self.all_operations()
+        ]
+        return type(self)(remapped_ops, device=self.device)
+
     def _qid_shape_(self) -> Tuple[int, ...]:
         return self.qid_shape()
 
@@ -1391,14 +1399,6 @@ class Circuit(AbstractCircuit):
         return cirq.Circuit(inv_moments, device=self._device)
 
     __hash__ = None  # type: ignore
-
-    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        remapped_ops = [
-            protocols.with_measurement_key_mapping(op, key_map)
-            if protocols.is_measurement(op) else op
-            for op in self.all_operations()
-        ]
-        return Circuit(remapped_ops, device=self.device)
 
     def with_device(
             self,

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -815,14 +815,6 @@ class AbstractCircuit(abc.ABC):
     def all_measurement_keys(self) -> AbstractSet[str]:
         return protocols.measurement_keys(self)
 
-    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        remapped_ops = [
-            protocols.with_measurement_key_mapping(op, key_map)
-            if protocols.is_measurement(op) else op
-            for op in self.all_operations()
-        ]
-        return type(self)(remapped_ops, device=self.device)
-
     def _qid_shape_(self) -> Tuple[int, ...]:
         return self.qid_shape()
 
@@ -1399,6 +1391,14 @@ class Circuit(AbstractCircuit):
         return cirq.Circuit(inv_moments, device=self._device)
 
     __hash__ = None  # type: ignore
+
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        remapped_ops = [
+            protocols.with_measurement_key_mapping(op, key_map)
+            if protocols.is_measurement(op) else op
+            for op in self.all_operations()
+        ]
+        return Circuit(remapped_ops, device=self.device)
 
     def with_device(
             self,

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -815,6 +815,12 @@ class AbstractCircuit(abc.ABC):
     def all_measurement_keys(self) -> AbstractSet[str]:
         return protocols.measurement_keys(self)
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        return self._with_sliced_moments([
+            protocols.with_measurement_key_mapping(moment, key_map)
+            for moment in self.moments
+        ])
+
     def _qid_shape_(self) -> Tuple[int, ...]:
         return self.qid_shape()
 
@@ -1391,14 +1397,6 @@ class Circuit(AbstractCircuit):
         return cirq.Circuit(inv_moments, device=self._device)
 
     __hash__ = None  # type: ignore
-
-    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        remapped_ops = [
-            protocols.with_measurement_key_mapping(op, key_map)
-            if protocols.is_measurement(op) else op
-            for op in self.all_operations()
-        ]
-        return Circuit(remapped_ops, device=self.device)
 
     def with_device(
             self,

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3590,6 +3590,24 @@ def test_measurement_key_mapping(circuit_cls):
 
 
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
+def test_measurement_key_mapping_preserves_moments(circuit_cls):
+    a, b = cirq.LineQubit.range(2)
+    c = circuit_cls(
+        cirq.Moment(cirq.X(a)),
+        cirq.Moment(),
+        cirq.Moment(cirq.measure(a, key='m1')),
+        cirq.Moment(cirq.measure(b, key='m2')),
+    )
+
+    key_map = {'m1': 'p1'}
+    remapped_circuit = cirq.with_measurement_key_mapping(c, key_map)
+    assert list(remapped_circuit.moments) == [
+        cirq.with_measurement_key_mapping(moment, key_map)
+        for moment in c.moments
+    ]
+
+
+@pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
 def test_inverse(circuit_cls):
     a, b = cirq.LineQubit.range(2)
     forward = circuit_cls((cirq.X**0.5)(a), (cirq.Y**-0.2)(b), cirq.CZ(a, b))

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3558,6 +3558,38 @@ def test_decompose(circuit_cls):
 
 
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
+def test_measurement_key_mapping(circuit_cls):
+    a, b = cirq.LineQubit.range(2)
+    c = circuit_cls(
+        cirq.X(a),
+        cirq.measure(a, key='m1'),
+        cirq.measure(b, key='m2'),
+    )
+    assert c.all_measurement_keys() == {'m1', 'm2'}
+
+    assert cirq.with_measurement_key_mapping(c, {
+        'm1': 'p1'
+    }).all_measurement_keys() == {'p1', 'm2'}
+
+    assert cirq.with_measurement_key_mapping(c, {
+        'm1': 'p1',
+        'm2': 'p2'
+    }).all_measurement_keys() == {'p1', 'p2'}
+
+    c_swapped = cirq.with_measurement_key_mapping(c, {'m1': 'm2', 'm2': 'm1'})
+    assert c_swapped.all_measurement_keys() == {'m1', 'm2'}
+
+    # Verify that the keys were actually swapped.
+    simulator = cirq.Simulator()
+    assert simulator.run(c).measurements == {'m1': 1, 'm2': 0}
+    assert simulator.run(c_swapped).measurements == {'m1': 0, 'm2': 1}
+
+    assert cirq.with_measurement_key_mapping(c, {
+        'x': 'z',
+    }).all_measurement_keys() == {'m1', 'm2'}
+
+
+@pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
 def test_inverse(circuit_cls):
     a, b = cirq.LineQubit.range(2)
     forward = circuit_cls((cirq.X**0.5)(a), (cirq.Y**-0.2)(b), cirq.CZ(a, b))

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -18,7 +18,7 @@ from typing import (TYPE_CHECKING, AbstractSet, Callable, Dict, FrozenSet,
 
 import numpy as np
 
-from cirq import devices, ops, protocols
+from cirq import devices, ops
 from cirq.circuits import AbstractCircuit, Circuit
 from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.type_workarounds import NotImplementedType

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -147,14 +147,6 @@ class FrozenCircuit(AbstractCircuit):
         new_circuit._moments = tuple(moments)
         return new_circuit
 
-    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        remapped_ops = [
-            protocols.with_measurement_key_mapping(op, key_map)
-            if protocols.is_measurement(op) else op
-            for op in self.all_operations()
-        ]
-        return FrozenCircuit(remapped_ops, device=self.device)
-
     def with_device(
             self,
             new_device: 'cirq.Device',

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 """An immutable version of the Circuit data structure."""
 
-from typing import (TYPE_CHECKING, AbstractSet, Callable, FrozenSet, Iterator,
-                    Optional, Sequence, Tuple, Union)
+from typing import (TYPE_CHECKING, AbstractSet, Callable, Dict, FrozenSet,
+                    Iterator, Optional, Sequence, Tuple, Union)
 
 import numpy as np
 
-from cirq import devices, ops
+from cirq import devices, ops, protocols
 from cirq.circuits import AbstractCircuit, Circuit
 from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.type_workarounds import NotImplementedType
@@ -146,6 +146,14 @@ class FrozenCircuit(AbstractCircuit):
         new_circuit = FrozenCircuit(device=self.device)
         new_circuit._moments = tuple(moments)
         return new_circuit
+
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        remapped_ops = [
+            protocols.with_measurement_key_mapping(op, key_map)
+            if protocols.is_measurement(op) else op
+            for op in self.all_operations()
+        ]
+        return FrozenCircuit(remapped_ops, device=self.device)
 
     def with_device(
             self,

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -147,6 +147,14 @@ class FrozenCircuit(AbstractCircuit):
         new_circuit._moments = tuple(moments)
         return new_circuit
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        remapped_ops = [
+            protocols.with_measurement_key_mapping(op, key_map)
+            if protocols.is_measurement(op) else op
+            for op in self.all_operations()
+        ]
+        return FrozenCircuit(remapped_ops, device=self.device)
+
     def with_device(
             self,
             new_device: 'cirq.Device',

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -63,6 +63,12 @@ class GateOperation(raw_types.Operation):
             return self
         return new_gate.on(*self.qubits)
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        if not protocols.is_measurement(self.gate):
+            return self
+        new_gate = protocols.with_measurement_key_mapping(self.gate, key_map)
+        return new_gate.on(*self.qubits)
+
     def __repr__(self):
         if hasattr(self.gate, '_op_repr_'):
             result = self.gate._op_repr_(self.qubits)

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -33,7 +33,10 @@ TSelf = TypeVar('TSelf', bound='GateOperation')
 
 @value.value_equality(approximate=True)
 class GateOperation(raw_types.Operation):
-    """An application of a gate to a sequence of qubits."""
+    """An application of a gate to a sequence of qubits.
+
+    Objects of this type are immutable.
+    """
 
     def __init__(self, gate: 'cirq.Gate', qubits: Sequence['cirq.Qid']) -> None:
         """
@@ -60,6 +63,7 @@ class GateOperation(raw_types.Operation):
 
     def with_gate(self, new_gate: 'cirq.Gate') -> 'cirq.Operation':
         if self.gate is new_gate:
+            # As GateOperation is immutable, this can return the original.
             return self
         return new_gate.on(*self.qubits)
 
@@ -68,6 +72,7 @@ class GateOperation(raw_types.Operation):
         if new_gate is NotImplemented:
             return NotImplemented
         if new_gate is self.gate:
+            # As GateOperation is immutable, this can return the original.
             return self
         return new_gate.on(*self.qubits)
 

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -64,9 +64,9 @@ class GateOperation(raw_types.Operation):
         return new_gate.on(*self.qubits)
 
     def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        if not protocols.is_measurement(self.gate):
-            return self
         new_gate = protocols.with_measurement_key_mapping(self.gate, key_map)
+        if self.gate is new_gate:
+            return self
         return new_gate.on(*self.qubits)
 
     def __repr__(self):

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -65,7 +65,9 @@ class GateOperation(raw_types.Operation):
 
     def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
         new_gate = protocols.with_measurement_key_mapping(self.gate, key_map)
-        if self.gate is new_gate:
+        if new_gate is NotImplemented:
+            return NotImplemented
+        if new_gate is self.gate:
             return self
         return new_gate.on(*self.qubits)
 

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -372,6 +372,15 @@ def test_with_gate():
     assert g1.with_gate(cirq.Y) == g2
 
 
+def test_with_measurement_key_mapping():
+    a = cirq.LineQubit(0)
+    op = cirq.measure(a, key='m')
+
+    remap_op = cirq.with_measurement_key_mapping(op, {'m': 'k'})
+    assert cirq.measurement_keys(remap_op) == {'k'}
+    assert cirq.with_measurement_key_mapping(op, {'x': 'k'}) is op
+
+
 def test_is_parameterized():
 
     class No1(cirq.Gate):

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -381,6 +381,13 @@ def test_with_measurement_key_mapping():
     assert cirq.with_measurement_key_mapping(op, {'x': 'k'}) is op
 
 
+def test_cannot_remap_non_measurement_gate():
+    a = cirq.LineQubit(0)
+    op = cirq.X(a)
+
+    assert cirq.with_measurement_key_mapping(op, {'m': 'k'}) is NotImplemented
+
+
 def test_is_parameterized():
 
     class No1(cirq.Gate):

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -33,6 +33,17 @@ def test_invalid_gate_operation():
         cirq.GateOperation(three_qubit_gate, single_qubit)
 
 
+def test_immutable():
+    a, b = cirq.LineQubit.range(2)
+    op = cirq.X(a)
+
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        op.gate = cirq.Y
+
+    with pytest.raises(AttributeError, match="can't set attribute"):
+        op.qubits = [b]
+
+
 def test_gate_operation_eq():
     g1 = cirq.SingleQubitGate()
     g2 = cirq.SingleQubitGate()

--- a/cirq/ops/measurement_gate.py
+++ b/cirq/ops/measurement_gate.py
@@ -79,6 +79,11 @@ class MeasurementGate(raw_types.Gate):
                                invert_mask=self.invert_mask,
                                qid_shape=self._qid_shape)
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        if self.key not in key_map:
+            return self
+        return self.with_key(key_map[self.key])
+
     def with_bits_flipped(self, *bit_positions: int) -> 'MeasurementGate':
         """Toggles whether or not the measurement inverts various outputs."""
         old_mask = self.invert_mask or ()

--- a/cirq/ops/measurement_gate_test.py
+++ b/cirq/ops/measurement_gate_test.py
@@ -61,19 +61,26 @@ def test_measurement_full_invert_mask():
         2, 'a', invert_mask=(True,)).full_invert_mask() == (True, False))
 
 
+@pytest.mark.parametrize('use_protocol', [False, True])
 @pytest.mark.parametrize('gate', [
     cirq.MeasurementGate(1, 'a'),
     cirq.MeasurementGate(1, 'a', invert_mask=(True,)),
     cirq.MeasurementGate(1, 'a', qid_shape=(3,)),
     cirq.MeasurementGate(2, 'a', invert_mask=(True, False), qid_shape=(2, 3)),
 ])
-def test_measurement_with_key(gate):
-    gate1 = gate.with_key('b')
+def test_measurement_with_key(use_protocol, gate):
+    if use_protocol:
+        gate1 = cirq.with_measurement_key_mapping(gate, {'a': 'b'})
+    else:
+        gate1 = gate.with_key('b')
     assert gate1.key == 'b'
     assert gate1.num_qubits() == gate.num_qubits()
     assert gate1.invert_mask == gate.invert_mask
     assert cirq.qid_shape(gate1) == cirq.qid_shape(gate)
-    gate2 = gate1.with_key('a')
+    if use_protocol:
+        gate2 = cirq.with_measurement_key_mapping(gate, {'a': 'a'})
+    else:
+        gate2 = gate.with_key('a')
     assert gate2 == gate
 
 

--- a/cirq/ops/moment.py
+++ b/cirq/ops/moment.py
@@ -195,6 +195,11 @@ class Moment:
                 return op
         raise KeyError("Moment doesn't act on given qubit")
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        return Moment(
+            protocols.with_measurement_key_mapping(op, key_map) if protocols.
+            is_measurement(op) else op for op in self.operations)
+
     def __copy__(self):
         return type(self)(self.operations)
 

--- a/cirq/ops/moment_test.py
+++ b/cirq/ops/moment_test.py
@@ -199,6 +199,20 @@ def test_without_operations_touching():
                         ]).without_operations_touching([a, c]) == cirq.Moment())
 
 
+def test_with_measurement_keys():
+    a, b = cirq.LineQubit.range(2)
+    m = cirq.Moment(cirq.measure(a, key='m1'), cirq.measure(b, key='m2'))
+
+    new_moment = cirq.with_measurement_key_mapping(m, {
+        'm1': 'p1',
+        'm2': 'p2',
+        'x': 'z',
+    })
+
+    assert new_moment.operations[0] == cirq.measure(a, key='p1')
+    assert new_moment.operations[1] == cirq.measure(b, key='p2')
+
+
 def test_copy():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -532,6 +532,8 @@ class TaggedOperation(Operation):
     def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
         sub_op = protocols.with_measurement_key_mapping(self.sub_operation,
                                                         key_map)
+        if sub_op is NotImplemented:
+            return NotImplemented
         if sub_op is self.sub_operation:
             return self
         return TaggedOperation(sub_op, *self.tags)

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -534,8 +534,6 @@ class TaggedOperation(Operation):
                                                         key_map)
         if sub_op is NotImplemented:
             return NotImplemented
-        if sub_op is self.sub_operation:
-            return self
         return TaggedOperation(sub_op, *self.tags)
 
     def controlled_by(self,

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -530,11 +530,11 @@ class TaggedOperation(Operation):
                                *self._tags)
 
     def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        if not protocols.is_measurement(self.sub_operation):
+        sub_op = protocols.with_measurement_key_mapping(self.sub_operation,
+                                                        key_map)
+        if sub_op is self.sub_operation:
             return self
-        return TaggedOperation(
-            protocols.with_measurement_key_mapping(self.sub_operation, key_map),
-            *self.tags)
+        return TaggedOperation(sub_op, *self.tags)
 
     def controlled_by(self,
                       *control_qubits: 'cirq.Qid',

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -529,6 +529,13 @@ class TaggedOperation(Operation):
         return TaggedOperation(self.sub_operation.with_qubits(*new_qubits),
                                *self._tags)
 
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        if not protocols.is_measurement(self.sub_operation):
+            return self
+        return TaggedOperation(
+            protocols.with_measurement_key_mapping(self.sub_operation, key_map),
+            *self.tags)
+
     def controlled_by(self,
                       *control_qubits: 'cirq.Qid',
                       control_values: Optional[Sequence[

--- a/cirq/ops/raw_types_test.py
+++ b/cirq/ops/raw_types_test.py
@@ -468,7 +468,7 @@ def test_tagged_measurement():
     remap_op = cirq.with_measurement_key_mapping(op, {'m': 'k'})
     assert remap_op.tags == ('tag',)
     assert cirq.measurement_keys(remap_op) == {'k'}
-    assert cirq.with_measurement_key_mapping(op, {'x': 'k'}) is op
+    assert cirq.with_measurement_key_mapping(op, {'x': 'k'}) == op
 
 
 def test_cannot_remap_non_measurement_gate():

--- a/cirq/ops/raw_types_test.py
+++ b/cirq/ops/raw_types_test.py
@@ -461,6 +461,16 @@ def test_tagged_operation():
     assert op.with_qubits(q2).qubits == (q2,)
 
 
+def test_tagged_measurement():
+    a = cirq.LineQubit(0)
+    op = cirq.measure(a, key='m').with_tags('tag')
+
+    remap_op = cirq.with_measurement_key_mapping(op, {'m': 'k'})
+    assert remap_op.tags == ('tag',)
+    assert cirq.measurement_keys(remap_op) == {'k'}
+    assert cirq.with_measurement_key_mapping(op, {'x': 'k'}) is op
+
+
 def test_circuit_diagram():
 
     class TaggyTag:

--- a/cirq/ops/raw_types_test.py
+++ b/cirq/ops/raw_types_test.py
@@ -471,6 +471,13 @@ def test_tagged_measurement():
     assert cirq.with_measurement_key_mapping(op, {'x': 'k'}) is op
 
 
+def test_cannot_remap_non_measurement_gate():
+    a = cirq.LineQubit(0)
+    op = cirq.X(a).with_tags('tag')
+
+    assert cirq.with_measurement_key_mapping(op, {'m': 'k'}) is NotImplemented
+
+
 def test_circuit_diagram():
 
     class TaggyTag:

--- a/cirq/protocols/__init__.py
+++ b/cirq/protocols/__init__.py
@@ -85,6 +85,7 @@ from cirq.protocols.measurement_key_protocol import (
     is_measurement,
     measurement_key,
     measurement_keys,
+    with_measurement_key_mapping,
     SupportsMeasurementKey,
 )
 from cirq.protocols.mixture_protocol import (

--- a/cirq/protocols/measurement_key_protocol.py
+++ b/cirq/protocols/measurement_key_protocol.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Protocol for object that have measurement keys."""
 
-from typing import AbstractSet, Any, Iterable
+from typing import AbstractSet, Any, Dict, Iterable
 
 from typing_extensions import Protocol
 
@@ -63,6 +63,13 @@ class SupportsMeasurementKey(Protocol):
         When a measurement occurs, either on hardware, or in a simulation,
         these are the key values under which the results of the measurements
         will be stored.
+        """
+
+    @doc_private
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        """Return a copy of this object with the measurement keys remapped.
+
+        This method allows measurement keys to be reassigned at runtime.
         """
 
 
@@ -143,3 +150,8 @@ def is_measurement(val: Any) -> bool:
     a non-empty result for them.
     """
     return bool(measurement_keys(val))
+
+
+def with_measurement_key_mapping(val: Any, key_map: Dict[str, str]):
+    getter = getattr(val, '_with_measurement_key_mapping_', None)
+    return NotImplemented if getter is None else getter(key_map)

--- a/cirq/protocols/measurement_key_protocol.py
+++ b/cirq/protocols/measurement_key_protocol.py
@@ -153,5 +153,10 @@ def is_measurement(val: Any) -> bool:
 
 
 def with_measurement_key_mapping(val: Any, key_map: Dict[str, str]):
+    """Remaps the target's measurement keys according to the provided key_map.
+
+    This method can be used to reassign measurement keys at runtime, or to
+    assign measurement keys from a higher-level object (such as a Circuit).
+    """
     getter = getattr(val, '_with_measurement_key_mapping_', None)
     return NotImplemented if getter is None else getter(key_map)

--- a/cirq/protocols/measurement_key_protocol_test.py
+++ b/cirq/protocols/measurement_key_protocol_test.py
@@ -132,3 +132,44 @@ def test_measurement_keys():
                      cirq.measure(b, key='2'))) == {'a', '2'}
     assert cirq.measurement_keys(MeasurementKeysGate()) == {'a', 'b'}
     assert cirq.measurement_keys(MeasurementKeysGate().on(a)) == {'a', 'b'}
+
+
+def test_measurement_key_mapping():
+
+    class MultiKeyGate:
+
+        def __init__(self, keys):
+            self._keys = set(keys)
+
+        def _measurement_keys_(self):
+            return self._keys
+
+        def _with_measurement_key_mapping_(self, key_map):
+            if not all(key in key_map for key in self._keys):
+                raise ValueError('missing keys')
+            return MultiKeyGate([key_map[key] for key in self._keys])
+
+    assert cirq.measurement_keys(MultiKeyGate([])) == set()
+    assert cirq.measurement_keys(MultiKeyGate(['a'])) == {'a'}
+
+    mkg_ab = MultiKeyGate(['a', 'b'])
+    assert cirq.measurement_keys(mkg_ab) == {'a', 'b'}
+
+    mkg_cd = cirq.with_measurement_key_mapping(mkg_ab, {'a': 'c', 'b': 'd'})
+    assert cirq.measurement_keys(mkg_cd) == {'c', 'd'}
+
+    mkg_ac = cirq.with_measurement_key_mapping(mkg_ab, {'a': 'a', 'b': 'c'})
+    assert cirq.measurement_keys(mkg_ac) == {'a', 'c'}
+
+    mkg_ba = cirq.with_measurement_key_mapping(mkg_ab, {'a': 'b', 'b': 'a'})
+    assert cirq.measurement_keys(mkg_ba) == {'a', 'b'}
+
+    with pytest.raises(ValueError):
+        cirq.with_measurement_key_mapping(mkg_ab, {'a': 'c'})
+
+    mkg_cdx = cirq.with_measurement_key_mapping(mkg_ab, {
+        'a': 'c',
+        'b': 'd',
+        'x': 'y'
+    })
+    assert cirq.measurement_keys(mkg_cdx) == {'c', 'd'}

--- a/cirq/protocols/measurement_key_protocol_test.py
+++ b/cirq/protocols/measurement_key_protocol_test.py
@@ -167,8 +167,8 @@ def test_measurement_key_mapping():
     with pytest.raises(ValueError):
         cirq.with_measurement_key_mapping(mkg_ab, {'a': 'c'})
 
-    with pytest.raises(NotImplementedError):
-        cirq.with_measurement_key_mapping(cirq.X(), {'a': 'c'})
+    assert cirq.with_measurement_key_mapping(cirq.X,
+                                             {'a': 'c'}) is NotImplemented
 
     mkg_cdx = cirq.with_measurement_key_mapping(mkg_ab, {
         'a': 'c',

--- a/cirq/protocols/measurement_key_protocol_test.py
+++ b/cirq/protocols/measurement_key_protocol_test.py
@@ -167,6 +167,9 @@ def test_measurement_key_mapping():
     with pytest.raises(ValueError):
         cirq.with_measurement_key_mapping(mkg_ab, {'a': 'c'})
 
+    with pytest.raises(NotImplementedError):
+        cirq.with_measurement_key_mapping(cirq.X(), {'a': 'c'})
+
     mkg_cdx = cirq.with_measurement_key_mapping(mkg_ab, {
         'a': 'c',
         'b': 'd',

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -364,6 +364,7 @@ the magic methods that can be implemented.
     cirq.trace_distance_bound
     cirq.trace_distance_from_angle_list
     cirq.unitary
+    cirq.with_measurement_key_mapping
     cirq.ApplyChannelArgs
     cirq.ApplyMixtureArgs
     cirq.ApplyUnitaryArgs


### PR DESCRIPTION
Related to #3235. This is necessary for encapsulating FrozenCircuits in Gates; if a FrozenCircuit contains a measurement, any Gate that contains that FrozenCircuit cannot be reused in the same Circuit without remapping its measurement keys.