### PR TITLE
Enforce copying in with_gate

### DIFF
--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -59,8 +59,6 @@ class GateOperation(raw_types.Operation):
         return cast(TSelf, self.gate.on(*new_qubits))
 
     def with_gate(self, new_gate: 'cirq.Gate') -> 'cirq.Operation':
-        if self.gate is new_gate:
-            return self
         return new_gate.on(*self.qubits)
 
     def __repr__(self):

--- a/cirq/ops/gate_operation_test.py
+++ b/cirq/ops/gate_operation_test.py
@@ -368,7 +368,8 @@ def test_mul():
 def test_with_gate():
     g1 = cirq.GateOperation(cirq.X, cirq.LineQubit.range(1))
     g2 = cirq.GateOperation(cirq.Y, cirq.LineQubit.range(1))
-    assert g1.with_gate(cirq.X) is g1
+    assert g1.with_gate(cirq.X) is not g1
+    assert g1.with_gate(cirq.X) == g1
     assert g1.with_gate(cirq.Y) == g2
 
 


### PR DESCRIPTION
See also: PR #3495. This is a breaking change.

`with`-functions are generally expected to return a copy of the object, even if the copy is identical. Returning the original invites the possibility of mutation errors.