### PR TITLE
Generalize types for basic qubit experiments

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -64,6 +64,7 @@ from cirq._version import (
 # Flattened sub-modules.
 
 from cirq.circuits import (
+    AbstractCircuit,
     Circuit,
     CircuitDag,
     FrozenCircuit,

--- a/cirq/experiments/t1_decay_experiment.py
+++ b/cirq/experiments/t1_decay_experiment.py
@@ -18,16 +18,16 @@ import pandas as pd
 import sympy
 from matplotlib import pyplot as plt
 
-from cirq import circuits, devices, ops, study, value, work
+from cirq import circuits, ops, study, value
 from cirq._compat import proper_repr
 
 if TYPE_CHECKING:
     import cirq
 
 
-def t1_decay(sampler: work.Sampler,
+def t1_decay(sampler: 'cirq.Sampler',
              *,
-             qubit: devices.GridQubit,
+             qubit: 'cirq.Qid',
              num_points: int,
              max_delay: 'cirq.DURATION_LIKE',
              min_delay: 'cirq.DURATION_LIKE' = None,

--- a/cirq/experiments/t2_decay_experiment.py
+++ b/cirq/experiments/t2_decay_experiment.py
@@ -19,7 +19,7 @@ import pandas as pd
 import sympy
 from matplotlib import pyplot as plt
 
-from cirq import circuits, devices, ops, study, value, work
+from cirq import circuits, ops, study, value
 from cirq._compat import proper_repr
 
 if TYPE_CHECKING:
@@ -35,9 +35,9 @@ class ExperimentType(enum.Enum):
 _T2_COLUMNS = ['delay_ns', 0, 1]
 
 
-def t2_decay(sampler: work.Sampler,
+def t2_decay(sampler: 'cirq.Sampler',
              *,
-             qubit: devices.GridQubit,
+             qubit: 'cirq.Qid',
              experiment_type: 'ExperimentType' = ExperimentType.RAMSEY,
              num_points: int,
              max_delay: 'cirq.DURATION_LIKE',
@@ -235,7 +235,7 @@ def _create_tabulation(measurements: pd.DataFrame) -> pd.DataFrame:
     return tabulation
 
 
-def _cpmg_circuit(qubit: devices.GridQubit, delay_var: sympy.Symbol,
+def _cpmg_circuit(qubit: 'cirq.Qid', delay_var: sympy.Symbol,
                   max_pulses: int) -> 'cirq.Circuit':
     """Creates a CPMG circuit for a given qubit.
 

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -189,6 +189,7 @@ Circuits, Operations, and Moments.
     cirq.flatten_op_tree
     cirq.freeze_op_tree
     cirq.transform_op_tree
+    cirq.AbstractCircuit
     cirq.Circuit
     cirq.CircuitDag
     cirq.FrozenCircuit


### PR DESCRIPTION
These should accept any cirq.Qid, not just cirq.GridQubit. Similarly, for tomography experiments we can take AbstractCircuit instead of Circuit. I've also updated type definitions to use the preferred convention of `'cirq.Foo'` for types that are exported on the main `cirq` namespace.