### PR TITLE
Make WaitGate variadic and add wait helper function

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -274,6 +274,7 @@ from cirq.ops import (
     TwoQubitDiagonalGate,
     TwoQubitGate,
     VirtualTag,
+    wait,
     WaitGate,
     X,
     XPowGate,

--- a/cirq/circuits/quil_output_test.py
+++ b/cirq/circuits/quil_output_test.py
@@ -323,7 +323,7 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
         cirq.PhasedXPowGate(phase_exponent=0.111, exponent=0.25).on(q1),
         cirq.PhasedXPowGate(phase_exponent=0.333, exponent=0.5).on(q1),
         cirq.PhasedXPowGate(phase_exponent=0.777, exponent=-0.5).on(q1),
-        cirq.WaitGate(0).on(q0),
+        cirq.wait(q0, nanos=0),
         cirq.measure(q0, key='xX'),
         cirq.measure(q2, key='x_a'),
         cirq.measure(q3, key='X'),

--- a/cirq/experiments/t1_decay_experiment.py
+++ b/cirq/experiments/t1_decay_experiment.py
@@ -67,7 +67,7 @@ def t1_decay(sampler: work.Sampler,
 
     circuit = circuits.Circuit(
         ops.X(qubit),
-        ops.WaitGate(value.Duration(nanos=var)).on(qubit),
+        ops.wait(qubit, nanos=var),
         ops.measure(qubit, key='output'),
     )
 

--- a/cirq/experiments/t2_decay_experiment.py
+++ b/cirq/experiments/t2_decay_experiment.py
@@ -160,7 +160,7 @@ def t2_decay(sampler: work.Sampler,
 
         circuit = circuits.Circuit(
             ops.Y(qubit)**0.5,
-            ops.WaitGate(value.Duration(nanos=delay_var))(qubit),
+            ops.wait(qubit, nanos=delay_var),
         )
     else:
         if experiment_type == ExperimentType.HAHN_ECHO:
@@ -250,15 +250,12 @@ def _cpmg_circuit(qubit: devices.GridQubit, delay_var: sympy.Symbol,
     into the same paramterized circuit.
     """
     circuit = circuits.Circuit(
-        ops.Y(qubit)**0.5,
-        ops.WaitGate(value.Duration(nanos=delay_var))(qubit), ops.X(qubit))
+        ops.Y(qubit)**0.5, ops.wait(qubit, nanos=delay_var), ops.X(qubit))
     for n in range(max_pulses):
         pulse_n_on = sympy.Symbol(f'pulse_{n}')
-        circuit.append(
-            ops.WaitGate(value.Duration(nanos=2 * delay_var *
-                                        pulse_n_on))(qubit))
+        circuit.append(ops.wait(qubit, nanos=2 * delay_var * pulse_n_on))
         circuit.append(ops.X(qubit)**pulse_n_on)
-    circuit.append(ops.WaitGate(value.Duration(nanos=delay_var))(qubit))
+    circuit.append(ops.wait(qubit, nanos=delay_var))
     return circuit
 
 

--- a/cirq/experiments/t2_decay_experiment_test.py
+++ b/cirq/experiments/t2_decay_experiment_test.py
@@ -375,13 +375,11 @@ def test_cpmg_circuit():
     t = sympy.Symbol('t')
     circuit = t2._cpmg_circuit(q, t, 2)
     expected = cirq.Circuit(
-        cirq.Y(q)**0.5,
-        cirq.WaitGate(cirq.Duration(nanos=t))(q), cirq.X(q),
-        cirq.WaitGate(cirq.Duration(nanos=2 * t * sympy.Symbol('pulse_0')))(q),
+        cirq.Y(q)**0.5, cirq.wait(q, nanos=t), cirq.X(q),
+        cirq.wait(q, nanos=2 * t * sympy.Symbol('pulse_0')),
         cirq.X(q)**sympy.Symbol('pulse_0'),
-        cirq.WaitGate(cirq.Duration(nanos=2 * t * sympy.Symbol('pulse_1')))(q),
-        cirq.X(q)**sympy.Symbol('pulse_1'),
-        cirq.WaitGate(cirq.Duration(nanos=t))(q))
+        cirq.wait(q, nanos=2 * t * sympy.Symbol('pulse_1')),
+        cirq.X(q)**sympy.Symbol('pulse_1'), cirq.wait(q, nanos=t))
     assert circuit == expected
 
 

--- a/cirq/google/common_serializers_test.py
+++ b/cirq/google/common_serializers_test.py
@@ -650,7 +650,7 @@ def test_wait_gate():
         }]
     })
     q = cirq.GridQubit(1, 2)
-    op = cirq.WaitGate(cirq.Duration(nanos=20)).on(q)
+    op = cirq.wait(q, nanos=20)
     assert gate_set.serialize_op(op) == proto
     assert gate_set.deserialize_op(proto) == op
 

--- a/cirq/google/devices/known_devices_test.py
+++ b/cirq/google/devices/known_devices_test.py
@@ -499,7 +499,7 @@ def test_proto_with_waitgate():
     wait_device = cg.SerializableDevice.from_proto(proto=wait_proto,
                                                    gate_sets=[wait_gateset])
     q0 = cirq.GridQubit(1, 1)
-    wait_op = cirq.WaitGate(duration=cirq.Duration(nanos=25))(q0)
+    wait_op = cirq.wait(q0, nanos=25)
     wait_device.validate_operation(wait_op)
 
     assert str(wait_proto) == """\
@@ -564,7 +564,7 @@ def test_adding_gates_multiple_times():
     wait_device = cg.SerializableDevice.from_proto(
         proto=wait_proto, gate_sets=[waiting_for_godot])
     q0 = cirq.GridQubit(0, 0)
-    wait_op = cirq.WaitGate(duration=cirq.Duration(nanos=25))(q0)
+    wait_op = cirq.wait(q0, nanos=25)
     wait_device.validate_operation(wait_op)
 
     assert str(wait_proto) == """\

--- a/cirq/google/gate_sets_test.py
+++ b/cirq/google/gate_sets_test.py
@@ -685,7 +685,7 @@ def test_serialize_deserialize_meas(qubits, qubit_ids, key, invert_mask):
 
 
 def test_serialize_deserialize_wait_gate():
-    op = cirq.WaitGate(duration=cirq.Duration(nanos=50.0))(cirq.GridQubit(1, 2))
+    op = cirq.wait(cirq.GridQubit(1, 2), nanos=50.0)
     proto = op_proto({
         'gate': {
             'id': 'wait'

--- a/cirq/ops/__init__.py
+++ b/cirq/ops/__init__.py
@@ -235,4 +235,6 @@ from cirq.ops.two_qubit_diagonal_gate import (
     TwoQubitDiagonalGate,)
 
 from cirq.ops.wait_gate import (
-    WaitGate,)
+    wait,
+    WaitGate,
+)

--- a/cirq/ops/wait_gate.py
+++ b/cirq/ops/wait_gate.py
@@ -43,15 +43,15 @@ class WaitGate(raw_types.Gate):
         self.duration = value.Duration(duration)
         if not protocols.is_parameterized(self.duration) and self.duration < 0:
             raise ValueError('duration < 0')
-        if qid_shape is None and num_qubits is None:
-            # Assume one qubit for backwards compatibility
-            num_qubits = 1
-            qid_shape = (2,)
-        elif qid_shape is None:
-            qid_shape = (2,) * num_qubits
-        elif num_qubits is None:
+        if qid_shape is None:
+            if num_qubits is None:
+                # Assume one qubit for backwards compatibility
+                qid_shape = (2,)
+            else:
+                qid_shape = (2,) * num_qubits
+        if num_qubits is None:
             num_qubits = len(qid_shape)
-        if num_qubits == 0:
+        if not qid_shape:
             raise ValueError('Waiting on an empty set of qubits.')
         if num_qubits != len(qid_shape):
             raise ValueError('len(qid_shape) != num_qubits')

--- a/cirq/ops/wait_gate.py
+++ b/cirq/ops/wait_gate.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import AbstractSet, Any, Dict, Tuple, TYPE_CHECKING
+from typing import AbstractSet, Any, Dict, Optional, Tuple, TYPE_CHECKING, Union
+
+import sympy
 
 from cirq import value, protocols
 from cirq.ops import raw_types
@@ -28,7 +30,10 @@ class WaitGate(raw_types.Gate):
     simulators and noise models may insert more error for longer waits.
     """
 
-    def __init__(self, duration: 'cirq.DURATION_LIKE') -> None:
+    def __init__(self,
+                 duration: 'cirq.DURATION_LIKE',
+                 num_qubits: Optional[int] = None,
+                 qid_shape: Tuple[int, ...] = None) -> None:
         """Initialize a wait gate with the given duration.
 
         Args:
@@ -38,6 +43,19 @@ class WaitGate(raw_types.Gate):
         self.duration = value.Duration(duration)
         if not protocols.is_parameterized(self.duration) and self.duration < 0:
             raise ValueError('duration < 0')
+        if qid_shape is None and num_qubits is None:
+            # Assume one qubit for backwards compatibility
+            num_qubits = 1
+            qid_shape = (2,)
+        elif qid_shape is None:
+            qid_shape = (2,) * num_qubits
+        elif num_qubits is None:
+            num_qubits = len(qid_shape)
+        if num_qubits == 0:
+            raise ValueError('Waiting on an empty set of qubits.')
+        if num_qubits != len(qid_shape):
+            raise ValueError('len(qid_shape) != num_qubits')
+        self._qid_shape = qid_shape
 
     def _is_parameterized_(self) -> bool:
         return protocols.is_parameterized(self.duration)
@@ -49,8 +67,8 @@ class WaitGate(raw_types.Gate):
         return WaitGate(
             protocols.resolve_parameters(self.duration, param_resolver))
 
-    def _num_qubits_(self) -> int:
-        return 1
+    def _qid_shape_(self) -> Tuple[int, ...]:
+        return self._qid_shape
 
     def _has_unitary_(self) -> bool:
         return True
@@ -80,7 +98,22 @@ class WaitGate(raw_types.Gate):
         return f'cirq.WaitGate({repr(self.duration)})'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return protocols.obj_to_dict_helper(self, ['duration'])
+        d = protocols.obj_to_dict_helper(self, ['duration'])
+        if len(self._qid_shape) != 1:
+            d['num_qubits'] = len(self._qid_shape)
+        if any(d != 2 for d in self._qid_shape):
+            d['qid_shape'] = self._qid_shape
+        return d
+
+    @classmethod
+    def _from_json_dict_(cls,
+                         duration,
+                         num_qubits=None,
+                         qid_shape=None,
+                         **kwargs):
+        return cls(duration=duration,
+                   num_qubits=num_qubits,
+                   qid_shape=None if qid_shape is None else tuple(qid_shape))
 
     def _value_equality_values_(self) -> Any:
         return self.duration
@@ -88,3 +121,34 @@ class WaitGate(raw_types.Gate):
     def _quil_(self, qubits: Tuple['cirq.Qid', ...],
                formatter: 'cirq.QuilFormatter'):
         return 'WAIT\n'
+
+
+def wait(*target: 'cirq.Qid',
+         duration: 'cirq.DURATION_LIKE' = None,
+         picos: Union[int, float, sympy.Basic] = 0,
+         nanos: Union[int, float, sympy.Basic] = 0,
+         micros: Union[int, float, sympy.Basic] = 0,
+         millis: Union[int, float, sympy.Basic] = 0) -> raw_types.Operation:
+    """Creates a WaitGate applied to all the given qubits.
+
+    The duration can be specified as a DURATION_LIKE or using keyword args with
+    numbers in the appropriate units. See Duration for details.
+
+    Args:
+        *target: The qubits that should wait.
+        value: Wait duration (see Duration).
+        picos: Picoseconds to wait (see Duration).
+        nanos: Picoseconds to wait (see Duration).
+        micros: Picoseconds to wait (see Duration).
+        millis: Picoseconds to wait (see Duration).
+    """
+    return WaitGate(
+        duration=value.Duration(
+            duration,
+            picos=picos,
+            nanos=nanos,
+            micros=micros,
+            millis=millis,
+        ),
+        qid_shape=protocols.qid_shape(target),
+    ).on(*target)

--- a/cirq/ops/wait_gate_test.py
+++ b/cirq/ops/wait_gate_test.py
@@ -48,7 +48,7 @@ def test_protocols():
     c = cirq.WaitGate(cirq.Duration(millis=2))
     q = cirq.LineQubit(0)
 
-    cirq.testing.assert_implements_consistent_protocols(cirq.WaitGate(0).on(q))
+    cirq.testing.assert_implements_consistent_protocols(cirq.wait(q, nanos=0))
     cirq.testing.assert_implements_consistent_protocols(c.on(q))
     cirq.testing.assert_implements_consistent_protocols(p.on(q))
 
@@ -65,6 +65,24 @@ def test_protocols():
     assert cirq.inverse(p) == p
     assert cirq.decompose(c.on(q)) == []
     assert cirq.decompose(p.on(q)) == []
+
+
+def test_qid_shape():
+    assert cirq.qid_shape(cirq.WaitGate(0, qid_shape=(2, 3))) == (2, 3)
+    assert cirq.qid_shape(cirq.WaitGate(0, num_qubits=3)) == (2, 2, 2)
+    with pytest.raises(ValueError, match='empty set of qubits'):
+        cirq.WaitGate(0, num_qubits=0)
+    with pytest.raises(ValueError, match='num_qubits'):
+        cirq.WaitGate(0, qid_shape=(2, 2), num_qubits=1)
+
+
+def test_json():
+    q0, q1 = cirq.GridQubit.rect(1, 2)
+    qtrit = cirq.GridQid(1, 2, dimension=3)
+    cirq.testing.assert_json_roundtrip_works(cirq.wait(q0, nanos=10))
+    cirq.testing.assert_json_roundtrip_works(cirq.wait(q0, q1, nanos=10))
+    cirq.testing.assert_json_roundtrip_works(cirq.wait(qtrit, nanos=10))
+    cirq.testing.assert_json_roundtrip_works(cirq.wait(qtrit, q1, nanos=10))
 
 
 def test_str():

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -1196,7 +1196,7 @@ def test_final_density_matrix_is_not_last_object():
 
     q = cirq.LineQubit(0)
     initial_state = np.array([[1, 0], [0, 0]], dtype=np.complex64)
-    circuit = cirq.Circuit(cirq.WaitGate(0)(q))
+    circuit = cirq.Circuit(cirq.wait(q))
     result = sim.simulate(circuit, initial_state=initial_state)
     assert result.final_density_matrix is not initial_state
     assert not np.shares_memory(result.final_density_matrix, initial_state)

--- a/cirq/sim/sparse_simulator_test.py
+++ b/cirq/sim/sparse_simulator_test.py
@@ -1002,7 +1002,7 @@ def test_final_state_vector_is_not_last_object():
 
     q = cirq.LineQubit(0)
     initial_state = np.array([1, 0], dtype=np.complex64)
-    circuit = cirq.Circuit(cirq.WaitGate(0)(q))
+    circuit = cirq.Circuit(cirq.wait(q))
     result = sim.simulate(circuit, initial_state=initial_state)
     assert result.state_vector() is not initial_state
     assert not np.shares_memory(result.state_vector(), initial_state)

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -72,6 +72,7 @@ Unitary effects that can be applied to one or more qubits.
     cirq.identity_each
     cirq.qft
     cirq.riswap
+    cirq.wait
     .. autoclass:: cirq.CCNotPowGate
     cirq.CCXPowGate
     cirq.CCZPowGate


### PR DESCRIPTION
In some cases we want a wait gate that applies to multiple qubits, to
creates a "barrier" that other gates cannot be moved past even while
a circuit is being manipulated in other ways. This makes the wait gate
variadic and adds a helper function to create WaitGate instances and
deal with qid_shape, similar to MeasurementGate/measure.