### PR TITLE
CircuitOperations

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -67,6 +67,7 @@ from cirq.circuits import (
     Circuit,
     CircuitDag,
     CircuitGate,
+    CircuitOperation,
     FrozenCircuit,
     InsertStrategy,
     PointOptimizationSummary,

--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -66,6 +66,7 @@ from cirq._version import (
 from cirq.circuits import (
     Circuit,
     CircuitDag,
+    CircuitGate,
     FrozenCircuit,
     InsertStrategy,
     PointOptimizationSummary,

--- a/cirq/circuits/__init__.py
+++ b/cirq/circuits/__init__.py
@@ -31,6 +31,8 @@ from cirq.circuits.circuit_dag import (
     CircuitDag,
     Unique,
 )
+from cirq.circuits.circuit_gate import (
+    CircuitGate,)
 from cirq.circuits.frozen_circuit import (
     FrozenCircuit,)
 from cirq.circuits.insert_strategy import (

--- a/cirq/circuits/__init__.py
+++ b/cirq/circuits/__init__.py
@@ -32,7 +32,9 @@ from cirq.circuits.circuit_dag import (
     Unique,
 )
 from cirq.circuits.circuit_gate import (
-    CircuitGate,)
+    CircuitGate,
+    CircuitOperation,
+)
 from cirq.circuits.frozen_circuit import (
     FrozenCircuit,)
 from cirq.circuits.insert_strategy import (

--- a/cirq/circuits/circuit_gate.py
+++ b/cirq/circuits/circuit_gate.py
@@ -139,7 +139,7 @@ class CircuitGate(ops.Gate):
         # TODO: support out-of-line subcircuit definition in string format.
         if self.name is None:
             # In the absence of a name, use a unique ID.
-            header = f'CircuitGate_{hash(self) % int(1e7):06d}:'
+            header = f'CircuitGate_{hash(self) % int(1e6):06d}:'
         else:
             header = f'{self.name}:'
         msg_lines = str(self.circuit).split('\n')
@@ -288,8 +288,8 @@ class CircuitOperation(ops.GateOperation):
         new_op._gate = new_gate
         return new_op
 
-    def with_measurement_key_mapping(
-            self, key_map: Dict[str, str]) -> 'CircuitOperation':
+    def with_measurement_key_mapping(self, key_map: Dict[str, str]
+                                    ) -> 'CircuitOperation':
         """Returns a copy of this operation with an updated key mapping.
 
         Parameter values and repetitions are preserved. The provided key_map
@@ -309,12 +309,12 @@ class CircuitOperation(ops.GateOperation):
         })
         return new_op
 
-    def _with_measurement_key_mapping_(
-            self, key_map: Dict[str, str]) -> 'CircuitOperation':
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]
+                                      ) -> 'CircuitOperation':
         return self.with_measurement_key_mapping(key_map)
 
-    def with_params(
-            self, param_values: Dict[sympy.Symbol, Any]) -> 'CircuitOperation':
+    def with_params(self, param_values: Dict[sympy.Symbol, Any]
+                   ) -> 'CircuitOperation':
         """Returns a copy of this operation with an updated key mapping.
 
         Key mappings and repetitions are preserved. The provided param_values

--- a/cirq/circuits/circuit_gate.py
+++ b/cirq/circuits/circuit_gate.py
@@ -18,9 +18,13 @@ of a larger circuit, a CircuitGate will execute all component gates in order,
 including any nested CircuitGates.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
+from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple,
+                    Union)
 
-from cirq import circuits, devices, ops, protocols
+import numpy as np
+import sympy
+
+from cirq import circuits, devices, linalg, ops, protocols
 from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.type_workarounds import NotImplementedType
 
@@ -59,10 +63,16 @@ class CircuitGate(ops.Gate):
                                                strategy=strategy,
                                                device=device)
         self._name = name
-        if exp_modulus is not None and protocols.is_measurement(self._circuit):
-            raise ValueError(
-                'CircuitGates with measurement cannot have exp_modulus.')
         self._exp_modulus = exp_modulus
+        if exp_modulus is not None:
+            if protocols.is_measurement(self.circuit):
+                raise ValueError(
+                    'CircuitGates with measurement cannot have exp_modulus.')
+            if not linalg.allclose_up_to_global_phase(
+                    protocols.unitary(self.circuit * exp_modulus),
+                    np.eye(2 ** protocols.num_qubits(self.circuit))):
+                raise ValueError('Raising the gate contents to exp_modulus '
+                                 'must produce the identity.')
 
     @property
     def circuit(self) -> 'cirq.FrozenCircuit':
@@ -182,9 +192,138 @@ class CircuitOperation(ops.GateOperation):
 
     This class captures modifications to the contained circuit, such as tags
     and loops, to support more condensed serialization.
-    """
 
-    # TODO: Fully implement this class.
+    Similar to GateOperation, this type is immutable.
+    """
 
     def __init__(self, gate: 'CircuitGate', qubits: Sequence['cirq.Qid']):
         super().__init__(gate, qubits)
+        self._gate: 'CircuitGate'
+        self._measurement_key_map: Dict[str, str] = {}
+        self._param_values: Dict[sympy.Symbol, Any] = {}
+        self._repetitions: int = 1
+
+    @property
+    def gate(self) -> 'CircuitGate':
+        return self._gate
+
+    @property
+    def circuit(self):
+        return self.gate.circuit
+
+    @property
+    def measurement_key_map(self):
+        return self._measurement_key_map
+
+    @property
+    def param_values(self):
+        return self._param_values
+
+    @property
+    def repetitions(self):
+        return self._repetitions
+
+    def __repr__(self):
+        base_repr = super().__repr__()
+        if self._measurement_key_map:
+            base_repr += (
+                f'.with_measurement_key_mapping({self._measurement_key_map})')
+        if self._param_values:
+            base_repr += f'.with_params({self._param_values})'
+        if self._repetitions:
+            base_repr += f'.repeat({self._repetitions})'
+        return base_repr
+
+    def base_operation(self):
+        return CircuitOperation(self._gate, self._qubits)
+
+    def copy(self):
+        new_op = self.base_operation()
+        new_op._measurement_key_map = self._measurement_key_map
+        new_op._param_values = self._param_values
+        new_op._repetitions = self._repetitions
+        return new_op
+
+    def with_gate(self, new_gate: 'cirq.Gate'):
+        if not isinstance(new_gate, CircuitGate):
+            raise TypeError('CircuitOperations may only contain CircuitGates.')
+        if protocols.is_measurement(new_gate) and self._repetitions != 1:
+            raise NotImplementedError(
+                'Measurements cannot be added to looped circuits.')
+        new_op = self.copy()
+        new_op._gate = new_gate
+        return new_op
+
+    def with_measurement_key_mapping(self, key_map: Dict[str, str]):
+        new_op = self.copy()
+        new_op._measurement_key_map = {
+            k: (key_map[v] if v in key_map else v)
+            for k, v in self._measurement_key_map.items()
+        }
+        new_op._measurement_key_map.update({
+            key: val
+            for key, val in key_map.items()
+            if key not in self._measurement_key_map.values()
+        })
+        return new_op
+
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        return self.with_measurement_key_mapping(key_map)
+
+    def with_params(self, param_values: Dict[sympy.Symbol, Any]):
+        new_op = self.copy()
+        new_op._param_values = {
+            key: (val if not protocols.is_parameterized(val) else
+                  protocols.resolve_parameters(val, param_values))
+            for key, val in self._param_values.items()
+        }
+        new_op._param_values.update({
+            key: val
+            for key, val in param_values.items()
+            if key not in self._param_values.values()
+        })
+        return new_op
+
+    def repeat(self, repetitions: int):
+        if protocols.is_measurement(self.circuit):
+            raise NotImplementedError(
+                'Loops over measurements are not supported.')
+        new_op = self.copy()
+        new_op._repetitions *= repetitions
+        if self.gate.exp_modulus is not None:
+            # Map repetitions to [-exp_modulus / 2, exp_modulus / 2)
+            new_op._repetitions %= self.gate.exp_modulus
+            if new_op._repetitions >= self.gate.exp_modulus / 2:
+                new_op._repetitions -= self.gate.exp_modulus
+        return new_op
+
+    def __pow__(self, power: int):
+        if not isinstance(power, int):
+            return NotImplemented
+        return self.repeat(power)
+
+    def _measurement_keys_(self):
+        base_keys = protocols.measurement_keys(self.gate)
+        return set(self._measurement_key_map[key] if key in
+                   self._measurement_key_map else key for key in base_keys)
+
+    def _decompose_(self) -> 'cirq.OP_TREE':
+        result = self.circuit.unfreeze()
+        if (self.qubits is not None and
+                self.qubits != self.gate.ordered_qubits()):
+            qmap = {
+                old: new
+                for old, new in zip(self.gate.ordered_qubits(), self.qubits)
+            }
+            result = result.transform_qubits(lambda q: qmap[q])
+
+        if self._repetitions < 0:
+            result = result**-1
+
+        if self._measurement_key_map:
+            result = protocols.with_measurement_key_mapping(
+                result, self._measurement_key_map)
+        if self._param_values:
+            result = protocols.resolve_parameters(result, self._param_values)
+
+        return list(result.all_operations()) * abs(self._repetitions)

--- a/cirq/circuits/circuit_gate.py
+++ b/cirq/circuits/circuit_gate.py
@@ -155,7 +155,7 @@ class CircuitGate(ops.Gate):
             qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
     ) -> Sequence['cirq.Qid']:
         """Returns the qubits in the contained circuit.
-        
+
         Args:
             qubit_order: The order in which to return the circuit's qubits.
         """

--- a/cirq/circuits/circuit_gate.py
+++ b/cirq/circuits/circuit_gate.py
@@ -355,8 +355,6 @@ class CircuitOperation(ops.GateOperation):
         return new_op
 
     def __pow__(self, power: int) -> 'CircuitOperation':
-        if not isinstance(power, int):
-            return NotImplemented
         return self.repeat(power)
 
     def _measurement_keys_(self) -> AbstractSet[str]:

--- a/cirq/circuits/circuit_gate.py
+++ b/cirq/circuits/circuit_gate.py
@@ -1,0 +1,176 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A structure for encapsulating entire circuits in a gate.
+
+A CircuitGate is a Gate object that wraps a FrozenCircuit. When applied as part
+of a larger circuit, a CircuitGate will execute all component gates in order,
+including any nested CircuitGates.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
+
+from cirq import circuits, devices, ops, protocols
+from cirq.circuits.insert_strategy import InsertStrategy
+from cirq.type_workarounds import NotImplementedType
+
+if TYPE_CHECKING:
+    import cirq
+
+
+class CircuitGate(ops.Gate):
+    """A single gate that encapsulates a Circuit."""
+
+    def __init__(self,
+                 *contents: 'cirq.OP_TREE',
+                 strategy: 'cirq.InsertStrategy' = InsertStrategy.EARLIEST,
+                 device: 'cirq.Device' = devices.UNCONSTRAINED_DEVICE,
+                 name: Optional[str] = None,
+                 exp_modulus: Optional[int] = None) -> None:
+        """Constructs a gate that wraps a circuit.
+
+        Args:
+            contents: The initial list of moments and operations defining the
+                circuit. This accepts the same set of objects as the Circuit
+                constructor.
+            strategy: When initializing the circuit with operations and moments
+                from `contents`, this determines how the operations are packed
+                together.
+            device: Hardware that the circuit should be able to run on.
+            name: (Optional) A name for this gate. This will appear alongside
+                the gate's hash in its serialized form.
+            exp_modulus: (Optional) The root of identity that this gate
+                represents. When an operation using this gate is looped over,
+                it will consult this value to minimize the total operations
+                performed. CircuitGates containing measurements cannot have
+                an exp_modulus value.
+        """
+        self._circuit = circuits.FrozenCircuit(contents,
+                                               strategy=strategy,
+                                               device=device)
+        self._name = name
+        if exp_modulus is not None and protocols.is_measurement(self._circuit):
+            raise ValueError(
+                'CircuitGates with measurement cannot have exp_modulus.')
+        self._exp_modulus = exp_modulus
+
+    @property
+    def circuit(self):
+        return self._circuit
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def exp_modulus(self):
+        return self._exp_modulus
+
+    def _num_qubits_(self):
+        return protocols.num_qubits(self.circuit)
+
+    def _qid_shape_(self):
+        return protocols.qid_shape(self.circuit)
+
+    def on(self, *qubits: 'cirq.Qid') -> 'CircuitOperation':
+        return CircuitOperation(self, qubits)
+
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
+        new_gate = CircuitGate()
+        new_gate._circuit = protocols.with_measurement_key_mapping(
+            self.circuit, key_map)
+        new_gate._name = self.name
+        new_gate._exp_modulus = self.exp_modulus
+        return new_gate
+
+    def __eq__(self, other):
+        if type(other) != type(self):
+            return False
+        return (self.circuit == other.circuit and self.name == other.name and
+                self.exp_modulus == other.exp_modulus)
+
+    def __hash__(self):
+        return hash((self.circuit, self.name, self.exp_modulus))
+
+    def __pow__(self, power):
+        try:
+            return CircuitGate(self.circuit**power, device=self.circuit.device)
+        except:
+            return NotImplemented
+
+    def __repr__(self):
+        base_repr = repr(self.circuit)
+        if self.name is not None:
+            base_repr += f', name={self.name}'
+        if self.exp_modulus is not None:
+            base_repr += f', exp_modulus={self.exp_modulus}'
+        return f'cirq.CircuitGate({base_repr})'
+
+    def __str__(self):
+        header = 'CircuitGate:' if self.name is None else f'{self.name}:'
+        msg_lines = str(self.circuit).split('\n')
+        msg_width = max([len(header) - 4] + [len(line) for line in msg_lines])
+        full_msg = '\n'.join([
+            '[ {line:<{width}} ]'.format(line=line, width=msg_width)
+            for line in msg_lines
+        ])
+        return header + '\n' + full_msg
+
+    def _commutes_(self, other: Any,
+                   atol: float) -> Union[None, NotImplementedType, bool]:
+        return protocols.commutes(self.circuit, other, atol=atol)
+
+    def _has_unitary_(self):
+        return protocols.has_unitary(self.circuit)
+
+    def _decompose_(self, qubits=None):
+        applied_circuit = self.circuit.unfreeze()
+        if qubits is not None and qubits != self.ordered_qubits():
+            qmap = {old: new for old, new in zip(self.ordered_qubits(), qubits)}
+            applied_circuit = applied_circuit.transform_qubits(lambda q: qmap[q]
+                                                              )
+        return protocols.decompose(applied_circuit)
+
+    def ordered_qubits(
+            self,
+            qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+    ):
+        return ops.QubitOrder.as_qubit_order(qubit_order).order_for(
+            self.circuit.all_qubits())
+
+    def _json_dict_(self):
+        return protocols.obj_to_dict_helper(self,
+                                            ['circuit', 'name', 'exp_modulus'])
+
+    @classmethod
+    def _from_json_dict_(cls, circuit, name, exp_modulus, **kwargs):
+        return cls(circuit,
+                   strategy=InsertStrategy.EARLIEST,
+                   device=circuit.device,
+                   name=name,
+                   exp_modulus=exp_modulus)
+
+
+class CircuitOperation(ops.GateOperation):
+    """An operation that encapsulates a circuit.
+
+    This class captures modifications to the contained circuit, such as tags
+    and loops, to support more condensed serialization.
+    """
+
+    # TODO: Fully implement this class.
+
+    def __init__(self, gate: 'CircuitGate', qubits: Sequence['cirq.Qid']):
+        if not isinstance(gate, CircuitGate):
+            raise TypeError('CircuitOperations must contain CircuitGates.')
+        super().__init__(gate, qubits)

--- a/cirq/circuits/circuit_gate.py
+++ b/cirq/circuits/circuit_gate.py
@@ -120,7 +120,7 @@ class CircuitGate(ops.Gate):
     def __repr__(self) -> str:
         base_repr = repr(self.circuit)
         if self.name is not None:
-            base_repr += f', name={self.name}'
+            base_repr += f""", name='{self.name}'"""
         if self.exp_modulus is not None:
             base_repr += f', exp_modulus={self.exp_modulus}'
         return f'cirq.CircuitGate({base_repr})'
@@ -137,6 +137,7 @@ class CircuitGate(ops.Gate):
 
     def _commutes_(self, other: Any,
                    atol: float) -> Union[None, NotImplementedType, bool]:
+        # Until Circuit supports _commutes_, this will return NotImplemented.
         return protocols.commutes(self.circuit, other, atol=atol)
 
     def _has_unitary_(self) -> bool:
@@ -186,6 +187,4 @@ class CircuitOperation(ops.GateOperation):
     # TODO: Fully implement this class.
 
     def __init__(self, gate: 'CircuitGate', qubits: Sequence['cirq.Qid']):
-        if not isinstance(gate, CircuitGate):
-            raise TypeError('CircuitOperations must contain CircuitGates.')
         super().__init__(gate, qubits)

--- a/cirq/circuits/circuit_gate_test.py
+++ b/cirq/circuits/circuit_gate_test.py
@@ -1,0 +1,423 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pytest
+import numpy as np
+
+import cirq
+
+
+def test_circuit_gate():
+    a, b, c = cirq.LineQubit.range(3)
+
+    g = cirq.CircuitGate(cirq.CZ(a, b))
+    assert cirq.num_qubits(g) == 2
+
+    _ = g.on(a, c)
+    with pytest.raises(ValueError, match='Wrong number'):
+        _ = g.on(a, c, b)
+
+    _ = g(a, c)
+    with pytest.raises(ValueError, match='Wrong number'):
+        _ = g(a)
+    with pytest.raises(ValueError, match='Wrong number'):
+        _ = g(c, b, a)
+    with pytest.raises(ValueError, match='Wrong shape'):
+        _ = g(a, b.with_dimension(3))
+
+    assert g.controlled(0) is g
+
+    gn = cirq.CircuitGate(cirq.CZ(a, b), name='named_gate')
+    assert g.circuit == gn.circuit
+    assert g != gn
+
+    gn = cirq.CircuitGate(cirq.CZ(a, b), exp_modulus=2)
+    assert g.circuit == gn.circuit
+    assert g != gn
+
+
+def test_circuit_op():
+    a, b, c = cirq.LineQubit.range(3)
+    g = cirq.CircuitGate(cirq.X(a))
+    op = g(a)
+    assert op.controlled_by() is op
+    controlled_op = op.controlled_by(b, c)
+    assert controlled_op.sub_operation == op
+    assert controlled_op.controls == (b, c)
+
+
+def test_circuit_op_validate():
+    cg = cirq.CircuitGate(cirq.X(cirq.NamedQubit('placeholder')))
+    op = cg.on(cirq.LineQid(0, 2))
+    cg2 = cirq.CircuitGate(cirq.CNOT(*cirq.LineQubit.range(2)))
+    op2 = cg2.on(*cirq.LineQid.range(2, dimension=2))
+    op.validate_args([cirq.LineQid(1, 2)])  # Valid
+    op2.validate_args(cirq.LineQid.range(1, 3, dimension=2))  # Valid
+    with pytest.raises(ValueError, match='Wrong shape'):
+        op.validate_args([cirq.LineQid(1, 9)])
+    with pytest.raises(ValueError, match='Wrong number'):
+        op.validate_args([cirq.LineQid(1, 2), cirq.LineQid(2, 2)])
+    with pytest.raises(ValueError, match='Duplicate'):
+        op2.validate_args([cirq.LineQid(1, 2), cirq.LineQid(1, 2)])
+
+
+def test_default_validation_and_inverse():
+    a, b = cirq.LineQubit.range(2)
+    cg = cirq.CircuitGate(cirq.Z(a), cirq.S(b), cirq.X(a))
+
+    i = cg**-1
+    assert i**-1 == cg
+    assert cg**-1 == i
+    assert cirq.Circuit(cirq.decompose(i)) == cirq.Circuit(
+        cirq.X(a),
+        cirq.S(b)**-1, cirq.Z(a))
+    cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(i),
+                                                    cirq.unitary(cg).conj().T,
+                                                    atol=1e-8)
+
+    cirq.testing.assert_implements_consistent_protocols(
+        i, local_vals={'CircuitGate': cirq.CircuitGate})
+
+
+def test_default_inverse():
+    qubits = cirq.LineQubit.range(3)
+    cg = cirq.CircuitGate(cirq.X(q) for q in qubits)
+
+    assert cirq.inverse(cg, None) is not None
+    cirq.testing.assert_has_consistent_qid_shape(cirq.inverse(cg))
+    cirq.testing.assert_has_consistent_qid_shape(
+        cirq.inverse(cg.on(*cirq.LineQubit.range(3))))
+
+
+def test_no_inverse_if_not_unitary():
+    cg = cirq.CircuitGate(cirq.amplitude_damp(0.5).on(cirq.LineQubit(0)))
+    assert cirq.inverse(cg, None) is None
+
+
+def test_default_qudit_inverse():
+    q = cirq.LineQid.for_qid_shape((1, 2, 3))
+    cg = cirq.CircuitGate(
+        cirq.IdentityGate(qid_shape=(1,)).on(q[0]),
+        (cirq.X**0.1).on(q[1]),
+        cirq.IdentityGate(qid_shape=(3,)).on(q[2]),
+    )
+
+    assert cirq.qid_shape(cg) == (1, 2, 3)
+    assert cirq.qid_shape(cirq.inverse(cg, None)) == (1, 2, 3)
+    cirq.testing.assert_has_consistent_qid_shape(cirq.inverse(cg))
+
+
+def test_circuit_gate_shape():
+    shape_gate = cirq.CircuitGate(
+        cirq.IdentityGate(qid_shape=(q.dimension,)).on(q)
+        for q in cirq.LineQid.for_qid_shape((1, 2, 3, 4)))
+    assert cirq.qid_shape(shape_gate) == (1, 2, 3, 4)
+    assert cirq.num_qubits(shape_gate) == 4
+    assert shape_gate.num_qubits() == 4
+
+    qubit_gate = cirq.CircuitGate(cirq.I(q) for q in cirq.LineQubit.range(3))
+    assert cirq.qid_shape(qubit_gate) == (2, 2, 2)
+    assert cirq.num_qubits(qubit_gate) == 3
+    assert qubit_gate.num_qubits() == 3
+
+
+def test_circuit_gate_json_dict():
+    cg = cirq.CircuitGate(cirq.X(cirq.LineQubit(0)))
+    assert cg._json_dict_() == {
+        'cirq_type': 'CircuitGate',
+        'circuit': cg.circuit,
+        'name': cg.name,
+        'exp_modulus': cg.exp_modulus,
+    }
+
+
+def test_string_format():
+    x, y, z = cirq.LineQubit.range(3)
+
+    cg = cirq.CircuitGate(cirq.X(x), cirq.H(y), cirq.CX(y, z),
+                          cirq.measure(x, y, z, key='m'))
+
+    assert str(cg) == """\
+CircuitGate:
+[ 0: ───X───────M('m')─── ]
+[               │         ]
+[ 1: ───H───@───M──────── ]
+[           │   │         ]
+[ 2: ───────X───M──────── ]"""
+
+
+# Test CircuitGates in Circuits.
+
+
+def test_circuit_gate_and_gate():
+    # A circuit gate and gate in parallel.
+    q = cirq.LineQubit.range(3)
+    ops_circuit = cirq.Circuit(
+        cirq.CircuitGate(
+            cirq.X(q[0]),
+            cirq.H(q[2]),
+            cirq.CZ(q[0], q[2]),
+        ).on(q[0], q[2]),
+        cirq.X(q[1]),
+    )
+    flat_circuit = cirq.Circuit(
+        cirq.X(q[0]),
+        cirq.H(q[2]),
+        cirq.CZ(q[0], q[2]),
+        cirq.X(q[1]),
+    )
+
+    assert np.allclose(ops_circuit.unitary(), flat_circuit.unitary())
+
+
+def test_parallel_circuit_gates():
+    # Two circuit gates in parallel.
+    q = cirq.LineQubit.range(3)
+    ops_circuit = cirq.Circuit(
+        cirq.CircuitGate(
+            cirq.X(q[0]),
+            cirq.H(q[2]),
+            cirq.CZ(q[0], q[2]),
+        ).on(q[0], q[2]),
+        cirq.CircuitGate(
+            cirq.X(q[1]),
+            cirq.H(q[1]),
+        ).on(q[1]),
+    )
+    flat_circuit = cirq.Circuit(
+        cirq.X(q[0]),
+        cirq.H(q[2]),
+        cirq.CZ(q[0], q[2]),
+        cirq.X(q[1]),
+        cirq.H(q[1]),
+    )
+
+    assert np.allclose(ops_circuit.unitary(), flat_circuit.unitary())
+
+
+def test_nested_circuit_gates():
+    # A circuit gate inside another circuit gate.
+    q = cirq.LineQubit.range(3)
+    ops_circuit = cirq.Circuit(
+        cirq.CircuitGate(
+            cirq.CircuitGate(cirq.X(q[0]), cirq.H(q[0])).on(q[0]),
+            cirq.H(q[2]),
+            cirq.CZ(q[0], q[2]),
+        ).on(q[0], q[2]),
+        cirq.CircuitGate(cirq.X(q[1]), cirq.H(q[1])).on(q[1]),
+    )
+    flat_circuit = cirq.Circuit(
+        cirq.X(q[0]),
+        cirq.H(q[0]),
+        cirq.H(q[2]),
+        cirq.CZ(q[0], q[2]),
+        cirq.X(q[1]),
+        cirq.H(q[1]),
+    )
+
+    assert np.allclose(ops_circuit.unitary(), flat_circuit.unitary())
+
+
+def test_circuit_gate_with_qubits():
+    # Reassigning qubits of a circuit gate using on().
+    q = cirq.LineQubit.range(3)
+    ops_circuit = cirq.Circuit(
+        cirq.CircuitGate(
+            cirq.X(q[0]),
+            cirq.H(q[1]),
+            cirq.CZ(q[0], q[1]),
+        ).on(q[0], q[2]),
+        cirq.X(q[1]),
+    )
+    flat_circuit = cirq.Circuit(
+        cirq.X(q[0]),
+        cirq.H(q[2]),
+        cirq.CZ(q[0], q[2]),
+        cirq.X(q[1]),
+    )
+
+    assert np.allclose(ops_circuit.unitary(), flat_circuit.unitary())
+
+
+def test_circuit_gate_gate_collision():
+    # A circuit gate and a gate on the same qubit(s) at the same time
+    # should produce an error.
+    q = cirq.LineQubit.range(3)
+    with pytest.raises(ValueError):
+        cirq.Circuit(
+            cirq.Moment(
+                cirq.CircuitGate(
+                    cirq.X(q[0]),
+                    cirq.H(q[1]),
+                    cirq.CZ(q[0], q[1]),
+                ).on(q[0], q[1]),
+                cirq.X(q[1]),
+            ),)
+
+
+def test_multi_circuit_gate_collision():
+    # Two circuit gates on the same qubit(s) at the same time should
+    # produce an error.
+    q = cirq.LineQubit.range(3)
+    with pytest.raises(ValueError):
+        cirq.Circuit(
+            cirq.Moment(
+                cirq.CircuitGate(
+                    cirq.X(q[0]),
+                    cirq.H(q[1]),
+                    cirq.CZ(q[0], q[1]),
+                ).on(q[0], q[1]),
+                cirq.CircuitGate(
+                    cirq.X(q[2]),
+                    cirq.H(q[1]),
+                    cirq.CZ(q[2], q[1]),
+                ).on(q[1], q[2]),
+            ),)
+
+
+def test_no_exp_modulus_for_measurement():
+    with pytest.raises(ValueError):
+        _ = cirq.CircuitGate(cirq.measure(cirq.LineQubit(0)), exp_modulus=2)
+
+
+def test_terminal_matches():
+    a, b = cirq.LineQubit.range(2)
+    cg = cirq.CircuitGate(
+        cirq.H(a),
+        cirq.measure(b, key='m1'),
+    )
+
+    c = cirq.Circuit(cirq.X(a), cg.on(a, b))
+    assert c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cirq.X(b), cg.on(a, b))
+    assert c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cirq.measure(a), cg.on(a, b))
+    assert not c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cirq.measure(b), cg.on(a, b))
+    assert not c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cg.on(a, b), cirq.X(a))
+    assert c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cg.on(a, b), cirq.X(b))
+    assert not c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cg.on(a, b), cirq.measure(a))
+    assert c.are_all_measurements_terminal()
+
+    c = cirq.Circuit(cg.on(a, b), cirq.measure(b))
+    assert not c.are_all_measurements_terminal()
+
+
+def test_nonterminal_in_circuit_gate():
+    a, b = cirq.LineQubit.range(2)
+    cg = cirq.CircuitGate(
+        cirq.H(a),
+        cirq.measure(b, key='m1'),
+        cirq.X(b),
+    )
+
+    c = cirq.Circuit(cirq.X(a), cg.on(a, b))
+    assert not c.are_all_measurements_terminal()
+
+
+# Demonstrate applications.
+
+
+def test_simulate_circuit_gate():
+    q = cirq.LineQubit.range(4)
+    ops_circuit = cirq.Circuit(
+        cirq.Moment(
+            cirq.X(q[3]),
+            cirq.CircuitGate(
+                cirq.H(q[0]),
+                cirq.CX(q[0], q[2]),
+            ).on(q[0], q[2]),
+            cirq.X(q[1]),
+        ),)
+    flat_circuit = cirq.Circuit(
+        cirq.H(q[0]),
+        cirq.CX(q[0], q[2]),
+        cirq.X(q[1]),
+        cirq.X(q[3]),
+    )
+
+    simulator = cirq.Simulator()
+    ops_result = simulator.simulate(ops_circuit)
+    flat_result = simulator.simulate(flat_circuit)
+    assert cirq.equal_up_to_global_phase(ops_result.state_vector(),
+                                         flat_result.state_vector())
+
+
+def test_point_optimizer():
+
+    class Opty(cirq.PointOptimizer):
+
+        def optimization_at(self, circuit: 'cirq.Circuit', index: int,
+                            op: 'cirq.Operation'
+                           ) -> Optional[cirq.PointOptimizationSummary]:
+            if isinstance(op.gate, cirq.CircuitGate):
+                base_circuit = op.gate.circuit.unfreeze()
+                Opty().optimize_circuit(base_circuit)
+                return cirq.PointOptimizationSummary(
+                    clear_span=1,
+                    clear_qubits=op.qubits,
+                    new_operations=cirq.CircuitGate(base_circuit).on(
+                        *op.qubits))
+            if isinstance(op.gate, cirq.CZPowGate):
+                return cirq.PointOptimizationSummary(
+                    clear_span=1,
+                    clear_qubits=op.qubits,
+                    new_operations=cirq.CircuitGate(
+                        cirq.CZ(*op.qubits), cirq.X.on_each(*op.qubits),
+                        cirq.X.on_each(*op.qubits),
+                        cirq.CZ(*op.qubits)).on(*op.qubits))
+            return None
+
+    cg_qubits = [cirq.GridQubit(5, 2), cirq.GridQubit(5, 3)]
+    circuit = cirq.Circuit(
+        cirq.CZ(*cg_qubits),
+        cirq.X(cirq.GridQubit(6, 2)),
+    )
+
+    Opty().optimize_circuit(circuit)
+    assert circuit == cirq.Circuit(
+        cirq.CircuitGate(
+            cirq.CZ(*cg_qubits),
+            cirq.X.on_each(*cg_qubits),
+            cirq.X.on_each(*cg_qubits),
+            cirq.CZ(*cg_qubits),
+        ).on(*cg_qubits),
+        cirq.X(cirq.GridQubit(6, 2)),
+    )
+
+    Opty().optimize_circuit(circuit)
+    assert circuit == cirq.Circuit(
+        cirq.CircuitGate(
+            cirq.CircuitGate(cirq.CZ(*cg_qubits), cirq.X.on_each(*cg_qubits),
+                             cirq.X.on_each(*cg_qubits),
+                             cirq.CZ(*cg_qubits)).on(*cg_qubits),
+            cirq.X.on_each(*cg_qubits),
+            cirq.X.on_each(*cg_qubits),
+            cirq.CircuitGate(cirq.CZ(*cg_qubits), cirq.X.on_each(*cg_qubits),
+                             cirq.X.on_each(*cg_qubits),
+                             cirq.CZ(*cg_qubits)).on(*cg_qubits),
+        ).on(*cg_qubits),
+        cirq.X(cirq.GridQubit(6, 2)),
+    )

--- a/cirq/circuits/circuit_gate_test.py
+++ b/cirq/circuits/circuit_gate_test.py
@@ -172,14 +172,14 @@ def test_string_format():
 
     cg0 = cirq.CircuitGate()
     assert str(cg0) == f"""\
-CircuitGate_{hash(cg0) % int(1e7):06d}:
-[                  ]"""
+CircuitGate_{hash(cg0) % int(1e6):06d}:
+[                 ]"""
 
     cg1 = cirq.CircuitGate(cirq.X(x), cirq.H(y), cirq.CX(y, z),
                            cirq.measure(x, y, z, key='m'))
 
     assert str(cg1) == f"""\
-CircuitGate_{hash(cg1) % int(1e7):06d}:
+CircuitGate_{hash(cg1) % int(1e6):06d}:
 [ 0: ───X───────M('m')─── ]
 [               │         ]
 [ 1: ───H───@───M──────── ]
@@ -239,7 +239,7 @@ cirq.CircuitGate(cirq.FrozenCircuit([
     )
 
     assert str(cg3) == f"""\
-CircuitGate_{hash(cg3) % int(1e7):06d}:
+CircuitGate_{hash(cg3) % int(1e6):06d}:
 [ 0: ───X^b───M─── ]"""
 
     op3 = cg3.on(y).with_measurement_key_mapping({

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -98,6 +98,7 @@ class _ResolverCache:
                 'CrossEntropyResultDict': CrossEntropyResultDict,
                 'Circuit': cirq.Circuit,
                 'CircuitGate': cirq.CircuitGate,
+                'CircuitOperation': cirq.CircuitOperation,
                 'CliffordState': cirq.CliffordState,
                 'CliffordTableau': cirq.CliffordTableau,
                 'DepolarizingChannel': cirq.DepolarizingChannel,

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -97,6 +97,7 @@ class _ResolverCache:
                 'CrossEntropyResult': CrossEntropyResult,
                 'CrossEntropyResultDict': CrossEntropyResultDict,
                 'Circuit': cirq.Circuit,
+                'CircuitGate': cirq.CircuitGate,
                 'CliffordState': cirq.CliffordState,
                 'CliffordTableau': cirq.CliffordTableau,
                 'DepolarizingChannel': cirq.DepolarizingChannel,

--- a/cirq/protocols/json_test_data/CircuitGate.json
+++ b/cirq/protocols/json_test_data/CircuitGate.json
@@ -1,0 +1,247 @@
+[
+  {
+    "cirq_type": "CircuitGate",
+    "circuit": {
+      "cirq_type": "FrozenCircuit",
+      "moments": [
+        {
+          "cirq_type": "Moment",
+          "operations": [
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "HPowGate",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 0
+                }
+              ]
+            },
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "HPowGate",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 1
+                }
+              ]
+            },
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "HPowGate",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 2
+                }
+              ]
+            },
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "HPowGate",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 3
+                }
+              ]
+            },
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "HPowGate",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 4
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "cirq_type": "Moment",
+          "operations": [
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "MeasurementGate",
+                "num_qubits": 5,
+                "key": "0,1,2,3,4",
+                "invert_mask": []
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 0
+                },
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 1
+                },
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 2
+                },
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 3
+                },
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 4
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "device": {
+        "cirq_type": "_UnconstrainedDevice"
+      }
+    },
+    "name": null,
+    "exp_modulus": null
+  },
+  {
+    "cirq_type": "CircuitGate",
+    "circuit": {
+      "cirq_type": "FrozenCircuit",
+      "moments": [
+        {
+          "cirq_type": "Moment",
+          "operations": [
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "ZPowGate",
+                "exponent": 0.5,
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 0
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "device": {
+        "cirq_type": "_UnconstrainedDevice"
+      }
+    },
+    "name": null,
+    "exp_modulus": 4
+  },
+  {
+    "cirq_type": "CircuitGate",
+    "circuit": {
+      "cirq_type": "FrozenCircuit",
+      "moments": [
+        {
+          "cirq_type": "Moment",
+          "operations": [
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "XPowGate",
+                "exponent": {
+                  "cirq_type": "sympy.Symbol",
+                  "name": "theta"
+                },
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "LineQubit",
+                  "x": 0
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "device": {
+        "cirq_type": "_UnconstrainedDevice"
+      }
+    },
+    "name": "xpow",
+    "exp_modulus": null
+  },
+  {
+    "cirq_type": "CircuitGate",
+    "circuit": {
+      "cirq_type": "FrozenCircuit",
+      "moments": [
+        {
+          "cirq_type": "Moment",
+          "operations": [
+            {
+              "cirq_type": "SingleQubitPauliStringGateOperation",
+              "pauli": {
+                "cirq_type": "_PauliX",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubit": {
+                "cirq_type": "LineQubit",
+                "x": 0
+              }
+            },
+            {
+              "cirq_type": "SingleQubitPauliStringGateOperation",
+              "pauli": {
+                "cirq_type": "_PauliX",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubit": {
+                "cirq_type": "LineQubit",
+                "x": 1
+              }
+            },
+            {
+              "cirq_type": "SingleQubitPauliStringGateOperation",
+              "pauli": {
+                "cirq_type": "_PauliX",
+                "exponent": 1.0,
+                "global_shift": 0.0
+              },
+              "qubit": {
+                "cirq_type": "LineQubit",
+                "x": 2
+              }
+            }
+          ]
+        }
+      ],
+      "device": {
+        "cirq_type": "_UnconstrainedDevice"
+      }
+    },
+    "name": "flip_three",
+    "exp_modulus": 2
+  }
+]

--- a/cirq/protocols/json_test_data/CircuitGate.repr
+++ b/cirq/protocols/json_test_data/CircuitGate.repr
@@ -1,0 +1,34 @@
+[cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            cirq.H(cirq.LineQubit(0)),
+            cirq.H(cirq.LineQubit(1)),
+            cirq.H(cirq.LineQubit(2)),
+            cirq.H(cirq.LineQubit(3)),
+            cirq.H(cirq.LineQubit(4)),
+        ),
+        cirq.Moment(
+            cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
+        ),
+    ])
+), cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            cirq.S(cirq.LineQubit(0)),
+        ),
+    ]), exp_modulus=4
+), cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
+        ),
+    ]), name='xpow' 
+), cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            cirq.X(cirq.LineQubit(0)),
+            cirq.X(cirq.LineQubit(1)),
+            cirq.X(cirq.LineQubit(2)),
+        ),
+    ]), name='flip_three', exp_modulus=2
+)]

--- a/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq/protocols/json_test_data/CircuitOperation.json
@@ -1,0 +1,307 @@
+[
+    {
+      "cirq_type": "CircuitOperation",
+      "gate": {
+        "cirq_type": "CircuitGate",
+        "circuit": {
+          "cirq_type": "FrozenCircuit",
+          "moments": [
+            {
+              "cirq_type": "Moment",
+              "operations": [
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "HPowGate",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 0
+                    }
+                  ]
+                },
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "HPowGate",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 1
+                    }
+                  ]
+                },
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "HPowGate",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 2
+                    }
+                  ]
+                },
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "HPowGate",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 3
+                    }
+                  ]
+                },
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "HPowGate",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 4
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "cirq_type": "Moment",
+              "operations": [
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "MeasurementGate",
+                    "num_qubits": 5,
+                    "key": "0,1,2,3,4",
+                    "invert_mask": []
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 0
+                    },
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 1
+                    },
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 2
+                    },
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 3
+                    },
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 4
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "device": {
+            "cirq_type": "_UnconstrainedDevice"
+          }
+        },
+        "name": null,
+        "exp_modulus": null
+      },
+      "qubits": [
+        {
+          "cirq_type": "LineQubit",
+          "x": 0
+        },
+        {
+          "cirq_type": "LineQubit",
+          "x": 1
+        },
+        {
+          "cirq_type": "LineQubit",
+          "x": 2
+        },
+        {
+          "cirq_type": "LineQubit",
+          "x": 3
+        },
+        {
+          "cirq_type": "LineQubit",
+          "x": 4
+        }
+      ]
+    },
+    {
+      "cirq_type": "CircuitOperation",
+      "gate": {
+        "cirq_type": "CircuitGate",
+        "circuit": {
+          "cirq_type": "FrozenCircuit",
+          "moments": [
+            {
+              "cirq_type": "Moment",
+              "operations": [
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "ZPowGate",
+                    "exponent": 0.5,
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "device": {
+            "cirq_type": "_UnconstrainedDevice"
+          }
+        },
+        "name": null,
+        "exp_modulus": 4
+      },
+      "qubits": [
+        {
+          "cirq_type": "LineQubit",
+          "x": 0
+        }
+      ]
+    },
+    {
+      "cirq_type": "CircuitOperation",
+      "gate": {
+        "cirq_type": "CircuitGate",
+        "circuit": {
+          "cirq_type": "FrozenCircuit",
+          "moments": [
+            {
+              "cirq_type": "Moment",
+              "operations": [
+                {
+                  "cirq_type": "GateOperation",
+                  "gate": {
+                    "cirq_type": "XPowGate",
+                    "exponent": {
+                      "cirq_type": "sympy.Symbol",
+                      "name": "theta"
+                    },
+                    "global_shift": 0.0
+                  },
+                  "qubits": [
+                    {
+                      "cirq_type": "LineQubit",
+                      "x": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "device": {
+            "cirq_type": "_UnconstrainedDevice"
+          }
+        },
+        "name": "xpow",
+        "exp_modulus": null
+      },
+      "qubits": [
+        {
+          "cirq_type": "LineQubit",
+          "x": 0
+        }
+      ]
+    },
+    {
+      "cirq_type": "CircuitOperation",
+      "gate": {
+        "cirq_type": "CircuitGate",
+        "circuit": {
+          "cirq_type": "FrozenCircuit",
+          "moments": [
+            {
+              "cirq_type": "Moment",
+              "operations": [
+                {
+                  "cirq_type": "SingleQubitPauliStringGateOperation",
+                  "pauli": {
+                    "cirq_type": "_PauliX",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubit": {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                },
+                {
+                  "cirq_type": "SingleQubitPauliStringGateOperation",
+                  "pauli": {
+                    "cirq_type": "_PauliX",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubit": {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  }
+                },
+                {
+                  "cirq_type": "SingleQubitPauliStringGateOperation",
+                  "pauli": {
+                    "cirq_type": "_PauliX",
+                    "exponent": 1.0,
+                    "global_shift": 0.0
+                  },
+                  "qubit": {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                }
+              ]
+            }
+          ],
+          "device": {
+            "cirq_type": "_UnconstrainedDevice"
+          }
+        },
+        "name": "flip_three",
+        "exp_modulus": 2
+      },
+      "qubits": [
+        {
+          "cirq_type": "LineQubit",
+          "x": 0
+        },
+        {
+          "cirq_type": "LineQubit",
+          "x": 1
+        },
+        {
+          "cirq_type": "LineQubit",
+          "x": 2
+        }
+      ]
+    }
+  ]

--- a/cirq/protocols/json_test_data/CircuitOperation.repr
+++ b/cirq/protocols/json_test_data/CircuitOperation.repr
@@ -1,0 +1,38 @@
+[cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            cirq.H(cirq.LineQubit(0)),
+            cirq.H(cirq.LineQubit(1)),
+            cirq.H(cirq.LineQubit(2)),
+            cirq.H(cirq.LineQubit(3)),
+            cirq.H(cirq.LineQubit(4)),
+        ),
+        cirq.Moment(
+            cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
+        ),
+    ])
+).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4))
+.with_measurement_key_mapping({'0,1,2,3,4': 'mixed_state'}),
+cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            cirq.S(cirq.LineQubit(0)),
+        ),
+    ]), exp_modulus=4
+).on(cirq.LineQubit(0)).repeat(-2),
+cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
+        ),
+    ]), name='xpow' 
+).on(cirq.LineQubit(0)).with_params({'theta': 1.5}),
+cirq.CircuitGate(
+    cirq.FrozenCircuit([
+        cirq.Moment(
+            cirq.X(cirq.LineQubit(0)),
+            cirq.X(cirq.LineQubit(1)),
+            cirq.X(cirq.LineQubit(2)),
+        ),
+    ]), name='flip_three', exp_modulus=2
+).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2))]

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -192,6 +192,7 @@ Circuits, Operations, and Moments.
     cirq.Circuit
     cirq.CircuitDag
     cirq.CircuitGate
+    cirq.CircuitOperation
     cirq.FrozenCircuit
     cirq.GateOperation
     cirq.InsertStrategy

--- a/rtd_docs/api.rst
+++ b/rtd_docs/api.rst
@@ -191,6 +191,7 @@ Circuits, Operations, and Moments.
     cirq.transform_op_tree
     cirq.Circuit
     cirq.CircuitDag
+    cirq.CircuitGate
     cirq.FrozenCircuit
     cirq.GateOperation
     cirq.InsertStrategy


### PR DESCRIPTION
Sequel to #3509. Part of #3235.

This PR adds an initial version of the "CircuitOperation" type, which wraps a CircuitGate for use in Circuits or other CircuitGates. CircuitOperations can specify measurement keys, parameter values, and repetitions for their component CircuitGate.

Notable features that are absent in this version:
- Measurement in loops. The current measurement format (a 1:1 dict of keys to results) does not play well with repeating the same measurement multiple times, or with attempting to rename that measurement based on loop index.
- Condensed serialization. This feature requires changes outside the CircuitGate itself to allow for references inside the serialization structure.
- Condensed circuit diagrams. Similar to serialization, this requires changes to the diagram behavior for printing CircuitOperations separate from the rest of the circuit.