### PR TITLE
codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @quantumlib/cirq-maintainers @vtomole @cduck

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @quantumlib/cirq-maintainers @vtomole @cduck
+
+**/google/**/*.* @wcourtney @quantumlib/cirq-maintainers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r dev_tools/conf/pip-list-dev-tools.txt
+          pip install codeowners # linux only package
       - name: Pytest check
         run: check/pytest --ignore=cirq/contrib --benchmark-skip --actually-quiet
   build_docs:

--- a/dev_tools/codeowners_test.py
+++ b/dev_tools/codeowners_test.py
@@ -15,8 +15,13 @@
 import pytest
 from codeowners import CodeOwners
 
-CIRQ_MAINTAINERS = {('TEAM', "@quantumlib/cirq-maintainers"),
-                    ('USERNAME', "@vtomole"), ('USERNAME', "@cduck")}
+CIRQ_MAINTAINERS = ('TEAM', "@quantumlib/cirq-maintainers")
+
+BASE_MAINTAINERS = {
+    CIRQ_MAINTAINERS, ('USERNAME', "@vtomole"), ('USERNAME', "@cduck")
+}
+
+GOOGLE_MAINTAINERS = {CIRQ_MAINTAINERS, ('USERNAME', "@wcourtney")}
 
 
 def _parse_owners():
@@ -28,9 +33,15 @@ def _parse_owners():
 owners = _parse_owners()
 
 
-@pytest.mark.parametrize("pattern,expected",
-                         [("any_file", CIRQ_MAINTAINERS),
-                          ("in/any/dir/any_file.py", CIRQ_MAINTAINERS),
-                          ("cirq/contrib/bla.py", CIRQ_MAINTAINERS)])
+@pytest.mark.parametrize("pattern,expected", [
+    ("any_file", BASE_MAINTAINERS),
+    ("in/any/dir/any_file.py", BASE_MAINTAINERS),
+    ("cirq/contrib/bla.py", BASE_MAINTAINERS),
+    ("cirq/google/test.py", GOOGLE_MAINTAINERS),
+    ("cirq/google/in/any/dir/test.py", GOOGLE_MAINTAINERS),
+    ("platforms/google/protos_as_well.proto", GOOGLE_MAINTAINERS),
+    ("docs/google/notebook.ipynb", GOOGLE_MAINTAINERS),
+    ("docs/tutorials/google/bla.md", GOOGLE_MAINTAINERS),
+])
 def test_codeowners(pattern, expected):
     assert set(owners.of(pattern)) == expected

--- a/dev_tools/codeowners_test.py
+++ b/dev_tools/codeowners_test.py
@@ -33,6 +33,14 @@ def _parse_owners():
 owners = _parse_owners()
 
 
+def only_on_linux(func):
+    import sys
+    if sys.platform != 'linux':
+        return None
+    return func
+
+
+@only_on_linux
 @pytest.mark.parametrize("pattern,expected", [
     ("any_file", BASE_MAINTAINERS),
     ("in/any/dir/any_file.py", BASE_MAINTAINERS),

--- a/dev_tools/codeowners_test.py
+++ b/dev_tools/codeowners_test.py
@@ -40,6 +40,9 @@ def only_on_linux(func):
     return func
 
 
+# for some reason the codeowners library does not publish all the wheels
+# for Mac and Windows. Eventually we could write our own codeowners parser,
+# but for now it is good enough.
 @only_on_linux
 @pytest.mark.parametrize("pattern,expected", [
     ("any_file", BASE_MAINTAINERS),

--- a/dev_tools/codeowners_test.py
+++ b/dev_tools/codeowners_test.py
@@ -1,0 +1,36 @@
+# Copyright 2020 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from codeowners import CodeOwners
+
+CIRQ_MAINTAINERS = {('TEAM', "@quantumlib/cirq-maintainers"),
+                    ('USERNAME', "@vtomole"), ('USERNAME', "@cduck")}
+
+
+def _parse_owners():
+    with open(".github/CODEOWNERS") as f:
+        contents = f.read()
+        return CodeOwners(contents)
+
+
+owners = _parse_owners()
+
+
+@pytest.mark.parametrize("pattern,expected",
+                         [("any_file", CIRQ_MAINTAINERS),
+                          ("in/any/dir/any_file.py", CIRQ_MAINTAINERS),
+                          ("cirq/contrib/bla.py", CIRQ_MAINTAINERS)])
+def test_codeowners(pattern, expected):
+    assert set(owners.of(pattern)) == expected

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -5,7 +5,7 @@ follow_imports = silent
 ignore_missing_imports = true
 
 # 3rd-party libs for which we don't have stubs
-[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,numpy.*,oauth2client.*,pandas.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.oauth2.*,google.protobuf.text_format.*,quimb.*,pyquil.*,google.cloud.*,filelock.*]
+[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,numpy.*,oauth2client.*,pandas.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.oauth2.*,google.protobuf.text_format.*,quimb.*,pyquil.*,google.cloud.*,filelock.*,codeowners.*]
 follow_imports = silent
 ignore_missing_imports = true
 

--- a/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
+++ b/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -26,6 +26,7 @@ pip install -r requirements.txt
 # Install pytest related dev requirements.
 cat dev_tools/conf/pip-list-dev-tools.txt | grep pytest | xargs pip install
 cat dev_tools/conf/pip-list-dev-tools.txt | grep filelock | xargs pip install
+cat dev_tools/conf/pip-list-dev-tools.txt | grep codeowners | xargs pip install
 
 # Install contrib requirements only if needed.
 changed=$(git diff --name-only origin/master | grep "cirq/contrib" || true)

--- a/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
+++ b/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 # Install pytest related dev requirements.
 cat dev_tools/conf/pip-list-dev-tools.txt | grep pytest | xargs pip install
 cat dev_tools/conf/pip-list-dev-tools.txt | grep filelock | xargs pip install
-cat dev_tools/conf/pip-list-dev-tools.txt | grep codeowners | xargs pip install
+pip install codeowners # linux only package
 
 # Install contrib requirements only if needed.
 changed=$(git diff --name-only origin/master | grep "cirq/contrib" || true)

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -39,8 +39,5 @@ ipykernel
 # For verifying rst
 rstcheck~=3.3.1
 
-# for verifying github's code owners file
-codeowners
-
 # For testing time specific logic
 freezegun~=0.3.15

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -39,7 +39,7 @@ ipykernel
 # For verifying rst
 rstcheck~=3.3.1
 
-# for verifying codeowners
+# for verifying github's code owners file
 codeowners
 
 # For testing time specific logic

--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -39,5 +39,8 @@ ipykernel
 # For verifying rst
 rstcheck~=3.3.1
 
+# for verifying codeowners
+codeowners
+
 # For testing time specific logic
 freezegun~=0.3.15


### PR DESCRIPTION
Adds CODEOWNERS file. 

This will enable the following behavior: 

- @cirq-maintainers, @cduck and @vtomole  are the default codeowners for the content of the repo. This has been decided based on levels of contributions in the last 6 months on Cirq Cynque, PR approvals and issue conversations. 
- @wcourtney is added as an owner to the google related code and docs
- Owners are going to be pinged on every PR
- I will turn on "owner approval required" - which means that no one can merge a PR unless an owner has approved the given PR. 

Eventually this will enable the definition of codeowners for vendors, e.g. AQT, IonQ, Pasqal and experimental modules - so that these modules can move faster without the overhead of waiting on Cirq maintainer approval

@cduck, @vtomole, let me know if you want to opt out of this role. 
See more at: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners