### PR TITLE
[doc] remove CircuitDag methods from API doc that are inherited from networkx

### DIFF
--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -16,7 +16,6 @@
 
 import os
 import types
-from types import FunctionType
 
 import networkx
 from absl import app
@@ -24,7 +23,6 @@ from absl import flags
 from tensorflow_docs.api_generator import doc_controls
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import public_api
-from tensorflow_docs.api_generator.doc_controls import do_not_doc_inheritable
 
 import cirq
 from cirq import _doc
@@ -83,9 +81,8 @@ def main(unused_argv):
         },
         extra_docs=_doc.RECORDED_CONST_DOCS,
     )
-    doc_controls.decorate_all_class_attributes(do_not_doc_inheritable,
-                                               networkx.DiGraph,
-                                               skip=[])
+    doc_controls.decorate_all_class_attributes(
+        doc_controls.do_not_doc_inheritable, networkx.DiGraph, skip=[])
     doc_generator.build(output_dir=FLAGS.output_dir)
 
 

--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -15,12 +15,16 @@
 """Tool to generate external api_docs for Cirq (Shameless copy from TFQ)."""
 
 import os
+import types
+from types import FunctionType
 
+import networkx
 from absl import app
 from absl import flags
 from tensorflow_docs.api_generator import doc_controls
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import public_api
+from tensorflow_docs.api_generator.doc_controls import do_not_doc_inheritable
 
 import cirq
 from cirq import _doc
@@ -40,8 +44,24 @@ flags.DEFINE_string("site_path", "quark/cirq/api_docs/python",
 FLAGS = flags.FLAGS
 
 
-def main(unused_argv):
+def filter_unwanted_inherited_methods(path, parent, children):
+    """Filter the unwanted inherited methods.
 
+    CircuitDag inherits a lot of methods from `networkx.DiGraph` and `Graph`.
+    This filter removes these, as it creates a lot of noise in the API docs.
+    """
+    if parent.__name__ != "CircuitDag":
+        return children
+
+    filtered_children = []
+    for name, obj in children:
+        if isinstance(obj, types.FunctionType):
+            if obj.__module__.startswith('cirq'):
+                filtered_children.append((name, obj))
+    return filtered_children
+
+
+def main(unused_argv):
     doc_generator = generate_lib.DocGenerator(
         root_title="Cirq",
         py_modules=[("cirq", cirq)],
@@ -49,7 +69,10 @@ def main(unused_argv):
         code_url_prefix=FLAGS.code_url_prefix,
         search_hints=FLAGS.search_hints,
         site_path=FLAGS.site_path,
-        callbacks=[public_api.local_definitions_filter],
+        callbacks=[
+            public_api.local_definitions_filter,
+            filter_unwanted_inherited_methods
+        ],
         private_map={
             # Opt to not build docs for these paths for now since they error.
             "cirq.google.engine.client.quantum.QuantumEngineServiceClient":
@@ -60,7 +83,9 @@ def main(unused_argv):
         },
         extra_docs=_doc.RECORDED_CONST_DOCS,
     )
-
+    doc_controls.decorate_all_class_attributes(do_not_doc_inheritable,
+                                               networkx.DiGraph,
+                                               skip=[])
     doc_generator.build(output_dir=FLAGS.output_dir)
 
 


### PR DESCRIPTION
Removes CircuitDag methods from API doc that are inherited from networkx.