### PR TITLE
Tweak formatting to prepare for switching to black

### DIFF
--- a/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq/contrib/qasm_import/_parser_test.py
@@ -67,12 +67,12 @@ def test_comments():
     parser = QasmParser()
 
     parsed_qasm = parser.parse("""
-    //this is the format 
+    //this is the format
     OPENQASM 2.0;
     // this is some other comment
     include "qelib1.inc";
     // and something at the end of the file
-    // multiline 
+    // multiline
     """)
 
     assert parsed_qasm.supportedFormat

--- a/cirq/interop/quirk/url_to_circuit_test.py
+++ b/cirq/interop/quirk/url_to_circuit_test.py
@@ -79,15 +79,15 @@ def test_parse_with_qubits():
 
     assert quirk_url_to_circuit(
         'http://algassert.com/quirk#circuit={"cols":[["H"],["•","X"]]}',
-        qubits=cirq.GridQubit.rect(4, 4)) == cirq.Circuit(
-            cirq.H(a),
-            cirq.X(b).controlled_by(a))
+        qubits=cirq.GridQubit.rect(4, 4),
+    ) == cirq.Circuit(cirq.H(a),
+                      cirq.X(b).controlled_by(a))
 
     assert quirk_url_to_circuit(
         'http://algassert.com/quirk#circuit={"cols":[["H"],["•",1,"X"]]}',
-        qubits=cirq.GridQubit.rect(4, 4)) == cirq.Circuit(
-            cirq.H(a),
-            cirq.X(c).controlled_by(a))
+        qubits=cirq.GridQubit.rect(4, 4),
+    ) == cirq.Circuit(cirq.H(a),
+                      cirq.X(c).controlled_by(a))
 
     with pytest.raises(IndexError, match="qubits specified"):
         _ = quirk_url_to_circuit(
@@ -103,12 +103,13 @@ def test_extra_cell_makers():
                 identifier='iswap',
                 size=2,
                 maker=lambda args: cirq.ISWAP(*args.qubits))
-        ]) == cirq.Circuit(cirq.ISWAP(*cirq.LineQubit.range(2)))
+        ],
+    ) == cirq.Circuit(cirq.ISWAP(*cirq.LineQubit.range(2)))
 
     assert cirq.quirk_url_to_circuit(
         'http://algassert.com/quirk#circuit={"cols":[["iswap"]]}',
-        extra_cell_makers={'iswap': cirq.ISWAP}) == cirq.Circuit(
-            cirq.ISWAP(*cirq.LineQubit.range(2)))
+        extra_cell_makers={'iswap': cirq.ISWAP},
+    ) == cirq.Circuit(cirq.ISWAP(*cirq.LineQubit.range(2)))
 
     assert cirq.quirk_url_to_circuit(
         'http://algassert.com/quirk#circuit={"cols":[["iswap"], ["toffoli"]]}',

--- a/cirq/ops/measurement_gate_test.py
+++ b/cirq/ops/measurement_gate_test.py
@@ -135,8 +135,8 @@ def test_measurement_gate_diagram():
                                     known_qubit_count=3,
                                     use_unicode_characters=True,
                                     precision=None,
-                                    qubit_map=None)) == cirq.CircuitDiagramInfo(
-                                        ("M('')", 'M', 'M'))
+                                    qubit_map=None),
+    ) == cirq.CircuitDiagramInfo(("M('')", 'M', 'M'))
 
     # Shows invert mask.
     assert cirq.circuit_diagram_info(

--- a/cirq/ops/pauli_string_test.py
+++ b/cirq/ops/pauli_string_test.py
@@ -1663,6 +1663,7 @@ def test_deprecated():
         }).expectation_from_state_vector(state=state_vector, qubit_map={a: 0})
 
 
+# pylint: disable=line-too-long
 def test_circuit_diagram_info():
     a, b, c = cirq.LineQubit.range(3)
 
@@ -1676,13 +1677,18 @@ def test_circuit_diagram_info():
             1j * cirq.X(a) * cirq.Y(b),
             -1j * cirq.Y(b),
             1j**0.5 * cirq.X(a) * cirq.Y(b),
-        ), """
+        ),
+        """
 0: ───PauliString(+X)───PauliString(-X)───PauliString(+X)───PauliString(iX)──────────────────────PauliString((0.707+0.707i)*X)───
                                           │                 │                                    │
 1: ───────────────────────────────────────┼─────────────────Y─────────────────PauliString(-iY)───Y───────────────────────────────
                                           │
 2: ───────────────────────────────────────Z──────────────────────────────────────────────────────────────────────────────────────
-        """)
+        """,
+    )
+
+
+# pylint: enable=line-too-long
 
 
 def test_mutable_pauli_string_equality():

--- a/cirq/pasqal/pasqal_device.py
+++ b/cirq/pasqal/pasqal_device.py
@@ -101,11 +101,13 @@ class PasqalDevice(cirq.devices.Device):
                                cirq.ops.YPowGate, cirq.ops.ZPowGate))
 
         if not valid_op:  # To prevent further checking if already passed
-            if (isinstance(
-                    op.gate,
-                (cirq.ops.HPowGate, cirq.ops.CNotPowGate, cirq.ops.CZPowGate,
-                 cirq.ops.CCZPowGate, cirq.ops.CCXPowGate)) and
-                    not cirq.is_parameterized(op)):
+            if (isinstance(op.gate, (
+                    cirq.ops.HPowGate,
+                    cirq.ops.CNotPowGate,
+                    cirq.ops.CZPowGate,
+                    cirq.ops.CCZPowGate,
+                    cirq.ops.CCXPowGate,
+            )) and not cirq.is_parameterized(op)):
                 expo = op.gate.exponent
                 valid_op = np.isclose(expo, np.around(expo, decimals=0))
 

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -884,7 +884,7 @@ def test_density_matrix_trial_result_qid_shape():
                 density_matrix=np.ones((4, 4)) / 4, qubit_map={
                     q0: 0,
                     q1: 1
-                }))) == (2, 2)
+                })),) == (2, 2)
     q0, q1 = cirq.LineQid.for_qid_shape((3, 4))
     assert cirq.qid_shape(
         cirq.DensityMatrixTrialResult(
@@ -894,7 +894,7 @@ def test_density_matrix_trial_result_qid_shape():
                 density_matrix=np.ones((12, 12)) / 12, qubit_map={
                     q0: 0,
                     q1: 1
-                }))) == (3, 4)
+                })),) == (3, 4)
 
 
 def test_density_matrix_trial_result_repr():

--- a/cirq/value/product_state.py
+++ b/cirq/value/product_state.py
@@ -244,7 +244,7 @@ class _ZEigenState(_PauliEigenState):
 KET_PLUS = _XEigenState(eigenvalue=+1)
 document(
     KET_PLUS, """The |+⟩ State
-    
+
     This is the state such that X|+⟩ = +1 |+⟩
 
     Vector:
@@ -255,7 +255,7 @@ document(
 KET_MINUS = _XEigenState(eigenvalue=-1)
 document(
     KET_MINUS, """The |-⟩ State
-    
+
     This is the state such that X|-⟩ = -1 |-⟩
 
     Vector:
@@ -266,7 +266,7 @@ document(
 KET_IMAG = _YEigenState(eigenvalue=+1)
 document(
     KET_IMAG, """The |i⟩ State
-    
+
     This is the state such that Y|i⟩ = +1 |i⟩
 
     Vector:

--- a/dev_tools/incremental_coverage_test.py
+++ b/dev_tools/incremental_coverage_test.py
@@ -26,12 +26,12 @@ def test_determine_ignored_lines():
     """) == {2}
 
     assert f("""
-        a = 0  
+        a = 0
         b = 0  # coverage: ignore
     """) == {3}
 
     assert f("""
-        a = 0  # coverage: ignore  
+        a = 0  # coverage: ignore
         b = 0  # coverage: ignore
     """) == {2, 3}
 
@@ -88,7 +88,7 @@ def test_determine_ignored_lines():
         a = 6#coverage: ignore
         a = 7#coverage: ignore\t
         a = 8#coverage:\tignore\t
-        
+
         b = 1 # no cover
         b = 2 # coverage: definitely
         b = 3 # lint: ignore

--- a/dev_tools/shell_tools_test.py
+++ b/dev_tools/shell_tools_test.py
@@ -90,7 +90,8 @@ def test_run_shell_does_not_deadlock_on_large_outputs():
         r"""print((('e' * 99) + '\n') * 10000, file=sys.stderr)"""
         '"',
         out=None,
-        err=None) == (None, None, 0)
+        err=None,
+    ) == (None, None, 0)
 
 
 @only_on_posix


### PR DESCRIPTION
Switching the formatting to black in #3516 brought up a few issues. Black has an edge case that requires inserting trailing commas in some constructs (https://github.com/psf/black/issues/1629), which I've done here. Also removes trailing whitespace in a few places that pylint complains about when the files are reformatted (those lint errors are latent since we only lint changed files on PRs).