### PR TITLE
Tweak coverage to prepare for switching to black

### DIFF
--- a/cirq/ops/qubit_order_test.py
+++ b/cirq/ops/qubit_order_test.py
@@ -120,3 +120,9 @@ def test_qubit_order_iterator():
     generator = (q for q in cirq.LineQubit.range(5))
     assert cirq.QubitOrder.as_qubit_order(generator).order_for(
         (cirq.LineQubit(3),)) == tuple(cirq.LineQubit.range(5))
+
+
+def test_qubit_order_invalid():
+    with pytest.raises(ValueError,
+                       match="Don't know how to interpret <5> as a Basis."):
+        _ = cirq.QubitOrder.as_qubit_order(5)

--- a/cirq/testing/consistent_pauli_expansion_test.py
+++ b/cirq/testing/consistent_pauli_expansion_test.py
@@ -37,9 +37,6 @@ class GoodGateNoPauliExpansion(cirq.Gate):
     def num_qubits(self) -> int:
         return 4
 
-    def _unitary_(self) -> np.ndarray:
-        return np.eye(2**self.num_qubits())
-
 
 class GoodGateNoUnitary(cirq.SingleQubitGate):
     def _pauli_expansion_(self) -> cirq.LinearDict[str]:

--- a/dev_tools/incremental_coverage_test.py
+++ b/dev_tools/incremental_coverage_test.py
@@ -93,3 +93,11 @@ def test_determine_ignored_lines():
         b = 2 # coverage: definitely
         b = 3 # lint: ignore
     """) == {2, 3, 4, 5, 6, 7, 8}
+
+    assert f("""
+        if TYPE_CHECKING:
+            import cirq
+            import foo
+        def bar(a: 'cirq.Circuit'):
+            pass
+    """) == {2, 3, 4}

--- a/examples/examples_perf_test.py
+++ b/examples/examples_perf_test.py
@@ -11,6 +11,9 @@ import examples.basic_arithmetic
 import examples.quantum_teleportation
 import examples.superdense_coding
 
+# Standard test runs do not include performance benchmarks.
+# coverage: ignore
+
 
 def test_example_runs_bernstein_vazirani_perf(benchmark):
     benchmark(examples.bernstein_vazirani.main, qubit_count=3)


### PR DESCRIPTION
These changes came out of #3516 when trying to switch to using black for formatting.
- Add qubit_order test to cover exception case
- Remove `_unitary_` method on a test class which is not covered by tests
- Ignore coverage check for performance tests which are not run in a standard pytest run
- Modify the coverage script to ignore `if TYPE_CHECKING` blocks which don't run during tests (this resulted in unrelated formatting changes on `incremental_coverage.py` which apparently had never been formatted by yapf)