### PR TITLE
ParamResolver composition.

### DIFF
--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -20,6 +20,7 @@ import sympy
 from sympy.core import numbers as sympy_numbers
 from cirq._compat import proper_repr
 from cirq._doc import document
+from cirq import protocols
 
 if TYPE_CHECKING:
     import cirq
@@ -180,6 +181,13 @@ class ParamResolver:
         else:
             self._deep_eval_map[value] = self.value_of(v, recursive)
         return self._deep_eval_map[value]
+
+    def _resolve_parameters_(self, param_resolver: 'ParamResolver'
+                            ) -> 'ParamResolver':
+        return ParamResolver({
+            k: protocols.resolve_parameters(v, param_resolver)
+            for k, v in self.param_dict.items()
+        })
 
     def __iter__(self) -> Iterator[Union[str, sympy.Symbol]]:
         return iter(self.param_dict)

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -20,7 +20,6 @@ import sympy
 from sympy.core import numbers as sympy_numbers
 from cirq._compat import proper_repr
 from cirq._doc import document
-from cirq import protocols
 
 if TYPE_CHECKING:
     import cirq
@@ -186,14 +185,12 @@ class ParamResolver:
         """Returns a resolver with all keys mapped to their final output."""
         return ParamResolver()._resolve_parameters_(self, recursive=True)
 
-    def _resolve_parameters_(self, param_resolver: 'ParamResolver',
-                             recursive: bool) -> 'ParamResolver':
+    def _resolve_parameters_(
+        self, param_resolver: 'ParamResolver', recursive: bool
+    ) -> 'ParamResolver':
         new_dict = {k: k for k in param_resolver}
         new_dict.update({k: self.value_of(k, recursive) for k in self})
-        new_dict.update({
-            k: param_resolver.value_of(v, recursive)
-            for k, v in new_dict.items()
-        })
+        new_dict.update({k: param_resolver.value_of(v, recursive) for k, v in new_dict.items()})
         if recursive and self.param_dict:
             return ParamResolver(new_dict).flatten()
         return ParamResolver(new_dict)

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -181,8 +181,8 @@ class ParamResolver:
             self._deep_eval_map[value] = self.value_of(v, recursive)
         return self._deep_eval_map[value]
 
-    def flatten(self) -> 'ParamResolver':
-        """Returns a resolver with all keys mapped to their final output."""
+    def resolved_to_single_step(self) -> 'ParamResolver':
+        """Returns a copy of this resolver with all keys mapped to their final output."""
         return ParamResolver()._resolve_parameters_(self, recursive=True)
 
     def _resolve_parameters_(
@@ -192,7 +192,7 @@ class ParamResolver:
         new_dict.update({k: self.value_of(k, recursive) for k in self})
         new_dict.update({k: param_resolver.value_of(v, recursive) for k, v in new_dict.items()})
         if recursive and self.param_dict:
-            return ParamResolver(new_dict).flatten()
+            return ParamResolver(new_dict).resolved_to_single_step()
         return ParamResolver(new_dict)
 
     def __iter__(self) -> Iterator[Union[str, sympy.Symbol]]:

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -181,10 +181,6 @@ class ParamResolver:
             self._deep_eval_map[value] = self.value_of(v, recursive)
         return self._deep_eval_map[value]
 
-    def resolved_to_single_step(self) -> 'ParamResolver':
-        """Returns a copy of this resolver with all keys mapped to their final output."""
-        return ParamResolver()._resolve_parameters_(self, recursive=True)
-
     def _resolve_parameters_(
         self, param_resolver: 'ParamResolver', recursive: bool
     ) -> 'ParamResolver':
@@ -192,7 +188,9 @@ class ParamResolver:
         new_dict.update({k: self.value_of(k, recursive) for k in self})
         new_dict.update({k: param_resolver.value_of(v, recursive) for k, v in new_dict.items()})
         if recursive and self.param_dict:
-            return ParamResolver(new_dict).resolved_to_single_step()
+            new_resolver = ParamResolver(new_dict)
+            # Resolve down to single-step mappings.
+            return ParamResolver()._resolve_parameters_(new_resolver, recursive=True)
         return ParamResolver(new_dict)
 
     def __iter__(self) -> Iterator[Union[str, sympy.Symbol]]:

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -230,6 +230,32 @@ def test_resolve_unknown_type():
     assert r.value_of(cirq.X) == cirq.X
 
 
+def test_compose():
+    """
+    Calling cirq.resolve_paramters on a ParamResolver composes that resolver
+    with the provided resolver.
+    """
+    a = sympy.Symbol('a')
+    b = sympy.Symbol('b')
+    c = sympy.Symbol('c')
+    d = sympy.Symbol('d')
+    r1 = cirq.ParamResolver({a: b})
+    r2 = cirq.ParamResolver({b: c + d})
+    r3 = cirq.ParamResolver({c: 12})
+
+    r12 = cirq.resolve_parameters(r1, r2)
+    assert r12.value_of('a') == c + d
+
+    r23 = cirq.resolve_parameters(r2, r3)
+    assert r23.value_of('b') == 12 + d
+
+    r123 = cirq.resolve_parameters(r12, r3)
+    assert r123.value_of('a') == 12 + d
+
+    r13 = cirq.resolve_parameters(r1, r3)
+    assert r13.value_of('a') == b
+
+
 def test_equals():
     et = cirq.testing.EqualsTester()
     et.add_equality_group(

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -172,13 +172,15 @@ def test_recursive_evaluation():
     c = sympy.Symbol('c')
     d = sympy.Symbol('d')
     e = sympy.Symbol('e')
-    r = cirq.ParamResolver({
-        a: a,
-        b: e + 2,
-        c: b + d,
-        d: a + 3,
-        e: 0,
-    })
+    r = cirq.ParamResolver(
+        {
+            a: a,
+            b: e + 2,
+            c: b + d,
+            d: a + 3,
+            e: 0,
+        }
+    )
 
     # sympy.Basic.subs evaluates in alphabetical order.
     assert c.subs(r.param_dict) == b + a + 3
@@ -254,28 +256,29 @@ def test_compose():
     assert r13.value_of('a') == b
 
 
-@pytest.mark.parametrize('p1, p2, p3', [
-    ({'a': 1}, {}, {}),
-    ({}, {'a': 1}, {}),
-    ({}, {}, {'a': 1}),
-    ({'a': 'b'}, {}, {'b': 'c'}),
-    ({'a': 'b'}, {'c': 'd'}, {'b': 'c'}),
-    ({'a': 'b'}, {'c': 'a'}, {'b': 'd'}),
-    ({'a': 'b'}, {'c': 'd', 'd': 1}, {'d': 2}),
-    ({'a': 'b'}, {'c': 'd', 'd': 'a'}, {'b': 2}),
-])
+@pytest.mark.parametrize(
+    'p1, p2, p3',
+    [
+        ({'a': 1}, {}, {}),
+        ({}, {'a': 1}, {}),
+        ({}, {}, {'a': 1}),
+        ({'a': 'b'}, {}, {'b': 'c'}),
+        ({'a': 'b'}, {'c': 'd'}, {'b': 'c'}),
+        ({'a': 'b'}, {'c': 'a'}, {'b': 'd'}),
+        ({'a': 'b'}, {'c': 'd', 'd': 1}, {'d': 2}),
+        ({'a': 'b'}, {'c': 'd', 'd': 'a'}, {'b': 2}),
+    ],
+)
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
 def test_compose_associative(p1, p2, p3, resolve_fn):
     r1, r2, r3 = [
-        cirq.ParamResolver({
-            sympy.Symbol(k): (sympy.Symbol(v) if isinstance(v, str) else v)
-            for k, v in pd.items()
-        })
+        cirq.ParamResolver(
+            {sympy.Symbol(k): (sympy.Symbol(v) if isinstance(v, str) else v) for k, v in pd.items()}
+        )
         for pd in [p1, p2, p3]
     ]
     assert sympy.Eq(
-        resolve_fn(r1, resolve_fn(r2, r3)).param_dict,
-        resolve_fn(resolve_fn(r1, r2), r3).param_dict
+        resolve_fn(r1, resolve_fn(r2, r3)).param_dict, resolve_fn(resolve_fn(r1, r2), r3).param_dict
     )
 
 


### PR DESCRIPTION
This is convenient to have for subcircuits (#3235), since nested circuits must be able to resolve their parameters based on the parent's parameter mapping.