### PR TITLE
[doc] Fix a newline in the Google Getting started tutorial.

### DIFF
--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -606,7 +606,8 @@
    "source": [
     "## Next steps\n",
     "* Use [this template colab](colab.ipynb) as a base for your own explorations.\n",
-    "* Explore [best practices](../../google/best_practices.md) for getting circuits to run on hardware.* Use the [reservation colab](reservations.ipynb) for getting circuits to run on hardware."
+    "* Explore [best practices](../../google/best_practices.md) for getting circuits to run on hardware.\n",
+    "* Use the [reservation colab](reservations.ipynb) for getting circuits to run on hardware."
    ]
   }
  ],


### PR DESCRIPTION
Fixes a newline in the Google Getting started tutorial.