### PR TITLE
Merge adjacent string literals

### DIFF
--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -41,9 +41,7 @@ def proper_repr(value: Any) -> str:
         return 'np.array({!r}, dtype=np.{})'.format(value.tolist(), value.dtype)
 
     if isinstance(value, pd.MultiIndex):
-        return (
-            f'pd.MultiIndex.from_tuples({repr(list(value))}, ' f'names={repr(list(value.names))})'
-        )
+        return f'pd.MultiIndex.from_tuples({repr(list(value))}, names={repr(list(value.names))})'
 
     if isinstance(value, pd.Index):
         return (

--- a/cirq/circuits/_bucket_priority_queue_test.py
+++ b/cirq/circuits/_bucket_priority_queue_test.py
@@ -151,9 +151,7 @@ def test_supports_arbitrary_offsets():
 
 def test_repr():
     r = repr(BucketPriorityQueue(entries=[(1, 2), (3, 4)], drop_duplicate_entries=True))
-    assert r.endswith(
-        'BucketPriorityQueue(entries=[(1, 2), (3, 4)], ' 'drop_duplicate_entries=True)'
-    )
+    assert r.endswith('BucketPriorityQueue(entries=[(1, 2), (3, 4)], drop_duplicate_entries=True)')
 
     cirq.testing.assert_equivalent_repr(BucketPriorityQueue())
     cirq.testing.assert_equivalent_repr(BucketPriorityQueue(entries=[(1, 'a')]))

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1713,7 +1713,7 @@ class Circuit(AbstractCircuit):
         with operations already in the moment or even each other.
         """
         if len(operations) != len(insertion_indices):
-            raise ValueError('operations and insertion_indices must have the' 'same length.')
+            raise ValueError('operations and insertion_indices must have the same length.')
         self._moments += [ops.Moment() for _ in range(1 + max(insertion_indices) - len(self))]
         moment_to_ops = defaultdict(list)  # type: Dict[int, List['cirq.Operation']]
         for op_index, moment_index in enumerate(insertion_indices):
@@ -1786,7 +1786,7 @@ class Circuit(AbstractCircuit):
                 result.append(cirq.Moment(c[k] for c in circuits if k < len(c)))
             except ValueError as ex:
                 raise ValueError(
-                    f"Overlapping operations between zipped circuits " f"at moment index {k}.\n{ex}"
+                    f"Overlapping operations between zipped circuits at moment index {k}.\n{ex}"
                 ) from ex
         return result
 

--- a/cirq/circuits/optimization_pass.py
+++ b/cirq/circuits/optimization_pass.py
@@ -161,7 +161,7 @@ class PointOptimizer:
 
                 if not new_qubits.issubset(set(opt.clear_qubits)):
                     raise ValueError(
-                        'New operations in PointOptimizer should not act on new' ' qubits.'
+                        'New operations in PointOptimizer should not act on new qubits.'
                     )
 
                 circuit.insert_at_frontier(flat_new_operations, i, frontier)

--- a/cirq/circuits/qasm_output_test.py
+++ b/cirq/circuits/qasm_output_test.py
@@ -27,7 +27,7 @@ def _make_qubits(n):
 
 def test_u_gate_repr():
     gate = QasmUGate(0.1, 0.2, 0.3)
-    assert repr(gate) == ('cirq.circuits.qasm_output.QasmUGate(' 'theta=0.1, phi=0.2, lmda=0.3)')
+    assert repr(gate) == 'cirq.circuits.qasm_output.QasmUGate(theta=0.1, phi=0.2, lmda=0.3)'
 
 
 def test_u_gate_eq():

--- a/cirq/circuits/quil_output.py
+++ b/cirq/circuits/quil_output.py
@@ -48,7 +48,7 @@ class QuilOneQubitGate(ops.SingleQubitGate):
         )
 
     def __repr__(self) -> str:
-        return f'cirq.circuits.quil_output.QuilOneQubitGate(matrix=\n' f'{self.matrix}\n)'
+        return f'cirq.circuits.quil_output.QuilOneQubitGate(matrix=\n{self.matrix}\n)'
 
     def _value_equality_values_(self):
         return self.matrix
@@ -93,7 +93,7 @@ class QuilTwoQubitGate(ops.TwoQubitGate):
         )
 
     def __repr__(self) -> str:
-        return f'cirq.circuits.quil_output.QuilTwoQubitGate(matrix=\n' f'{self.matrix}\n)'
+        return f'cirq.circuits.quil_output.QuilTwoQubitGate(matrix=\n{self.matrix}\n)'
 
 
 class QuilOutput:

--- a/cirq/contrib/acquaintance/bipartite.py
+++ b/cirq/contrib/acquaintance/bipartite.py
@@ -126,7 +126,7 @@ class BipartiteSwapNetworkGate(PermutationGate):
     def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs') -> Tuple[str, ...]:
         qubit_count = 2 * self.part_size
         if args.known_qubit_count not in (None, qubit_count):
-            raise ValueError('args.known_qubit_count not in ' '(None, 2 * self.part_size)')
+            raise ValueError('args.known_qubit_count not in (None, 2 * self.part_size)')
         partial_permutation = self.permutation()
         permutation = {i: partial_permutation.get(i, i) for i in range(qubit_count)}
 
@@ -152,7 +152,7 @@ class BipartiteSwapNetworkGate(PermutationGate):
         if self.swap_gate != ops.SWAP:
             args += (repr(self.swap_gate),)
         args_str = ', '.join(args)
-        return 'cirq.contrib.acquaintance.bipartite.BipartiteSwapNetworkGate' f'({args_str})'
+        return f'cirq.contrib.acquaintance.bipartite.BipartiteSwapNetworkGate({args_str})'
 
     def __eq__(self, other) -> bool:
         return (

--- a/cirq/contrib/acquaintance/executor.py
+++ b/cirq/contrib/acquaintance/executor.py
@@ -140,7 +140,7 @@ class GreedyExecutionStrategy(ExecutionStrategy):
 
         if len(set(len(indices) for indices in gates)) > 1:
             raise NotImplementedError(
-                'Can only implement greedy strategy if all gates ' 'are of the same arity.'
+                'Can only implement greedy strategy if all gates are of the same arity.'
             )
         self.index_set_to_gates = self.canonicalize_gates(gates)
         self._initial_mapping = initial_mapping.copy()

--- a/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq/contrib/acquaintance/executor_test.py
@@ -94,7 +94,7 @@ class DiagonalGate(cirq.Gate):
             np.absolute(diagonal), np.ones(dimension)
         ):
             raise ValueError(
-                'Diagonal must be an (2**num_qubits)-dimensional ' 'vector with unit-norm entries.'
+                'Diagonal must be an (2**num_qubits)-dimensional vector with unit-norm entries.'
             )
         self._num_qubits = num_qubits
         self.diagonal = diagonal

--- a/cirq/contrib/acquaintance/gates.py
+++ b/cirq/contrib/acquaintance/gates.py
@@ -351,7 +351,7 @@ class SwapNetworkGate(PermutationGate):
         return {i: j for i, j in enumerate(reversed(range(sum(self.part_lens))))}
 
     def __repr__(self) -> str:
-        return 'cirq.contrib.acquaintance.SwapNetworkGate(' '{!r}, {!r})'.format(
+        return 'cirq.contrib.acquaintance.SwapNetworkGate({!r}, {!r})'.format(
             self.part_lens, self.acquaintance_size
         )
 

--- a/cirq/contrib/acquaintance/shift_swap_network.py
+++ b/cirq/contrib/acquaintance/shift_swap_network.py
@@ -128,7 +128,7 @@ class ShiftSwapNetworkGate(PermutationGate):
         if self.swap_gate != ops.SWAP:
             args += (repr(self.swap_gate),)
         args_str = ', '.join(args)
-        return 'cirq.contrib.acquaintance.shift_swap_network.' f'ShiftSwapNetworkGate({args_str})'
+        return f'cirq.contrib.acquaintance.shift_swap_network.ShiftSwapNetworkGate({args_str})'
 
     def __eq__(self, other) -> bool:
         return (

--- a/cirq/contrib/acquaintance/strategies/quartic_paired.py
+++ b/cirq/contrib/acquaintance/strategies/quartic_paired.py
@@ -32,7 +32,7 @@ def qubit_pairs_to_qubit_order(qubit_pairs: Sequence[Sequence['cirq.Qid']]) -> L
     """
 
     if set(len(qubit_pair) for qubit_pair in qubit_pairs) != set((2,)):
-        raise ValueError('set(len(qubit_pair) for qubit_pair in qubit_pairs) != ' 'set((2,))')
+        raise ValueError('set(len(qubit_pair) for qubit_pair in qubit_pairs) != set((2,))')
     n_pairs = len(qubit_pairs)
     qubits = []  # type: List['cirq.Qid']
     for i in range(0, 2 * (n_pairs // 2), 2):

--- a/cirq/contrib/noise_models/noise_models.py
+++ b/cirq/contrib/noise_models/noise_models.py
@@ -31,7 +31,7 @@ def _homogeneous_moment_is_measurements(moment: 'cirq.Moment') -> bool:
     """
     cases = {protocols.is_measurement(gate) for gate in moment}
     if len(cases) == 2:
-        raise ValueError("Moment must be homogeneous: all measurements " "or all operations.")
+        raise ValueError("Moment must be homogeneous: all measurements or all operations.")
     return True in cases
 
 

--- a/cirq/contrib/paulistring/convert_to_clifford_gates.py
+++ b/cirq/contrib/paulistring/convert_to_clifford_gates.py
@@ -94,9 +94,7 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
 
     def _on_stuck_raise(self, op: ops.Operation):
         if len(op.qubits) == 1 and protocols.has_unitary(op):
-            raise ValueError(
-                'Single qubit operation is not in the ' 'Clifford group: {!r}'.format(op)
-            )
+            raise ValueError('Single qubit operation is not in the Clifford group: {!r}'.format(op))
 
         raise TypeError(
             "Don't know how to work with {!r}. "

--- a/cirq/contrib/paulistring/recombine.py
+++ b/cirq/contrib/paulistring/recombine.py
@@ -87,7 +87,7 @@ def move_pauli_strings_into_circuit(
 
             assert (
                 best_index <= last_index
-            ), "Unexpected insertion index order," " {} >= {}, len: {}".format(
+            ), "Unexpected insertion index order, {} >= {}, len: {}".format(
                 best_index, last_index, len(output_ops)
             )
 

--- a/cirq/contrib/qasm_import/_parser.py
+++ b/cirq/contrib/qasm_import/_parser.py
@@ -119,7 +119,7 @@ class QasmGateStatement:
             if isinstance(qubits, ops.Qid):
                 yield final_gate.on(qubits)
             elif len(np.unique(qubits)) < len(qubits):
-                raise QasmException("Overlapping qubits in arguments" " at line {}".format(lineno))
+                raise QasmException("Overlapping qubits in arguments at line {}".format(lineno))
             else:
                 yield final_gate.on(*qubits)
 
@@ -297,10 +297,10 @@ class QasmParser:
         | CREG ID '[' NATURAL_NUMBER ']' ';'"""
         name, length = p[2], p[4]
         if name in self.qregs.keys() or name in self.cregs.keys():
-            raise QasmException("{} is already defined " "at line {}".format(name, p.lineno(2)))
+            raise QasmException("{} is already defined at line {}".format(name, p.lineno(2)))
         if length == 0:
             raise QasmException(
-                "Illegal, zero-length register '{}' " "at line {}".format(name, p.lineno(4))
+                "Illegal, zero-length register '{}' at line {}".format(name, p.lineno(4))
             )
         if p[1] == "qreg":
             self.qregs[name] = length
@@ -410,7 +410,7 @@ class QasmParser:
         reg = p[1]
         if reg not in self.qregs.keys():
             raise QasmException(
-                'Undefined quantum register "{}" ' 'at line {}'.format(reg, p.lineno(1))
+                'Undefined quantum register "{}" at line {}'.format(reg, p.lineno(1))
             )
         qubits = []
         for idx in range(self.qregs[reg]):
@@ -428,7 +428,7 @@ class QasmParser:
         reg = p[1]
         if reg not in self.cregs.keys():
             raise QasmException(
-                'Undefined classical register "{}" ' 'at line {}'.format(reg, p.lineno(1))
+                'Undefined classical register "{}" at line {}'.format(reg, p.lineno(1))
             )
 
         p[0] = [self.make_name(idx, reg) for idx in range(self.cregs[reg])]
@@ -443,7 +443,7 @@ class QasmParser:
         arg_name = self.make_name(idx, reg)
         if reg not in self.qregs.keys():
             raise QasmException(
-                'Undefined quantum register "{}" ' 'at line {}'.format(reg, p.lineno(1))
+                'Undefined quantum register "{}" at line {}'.format(reg, p.lineno(1))
             )
         size = self.qregs[reg]
         if idx >= size:
@@ -463,7 +463,7 @@ class QasmParser:
         arg_name = self.make_name(idx, reg)
         if reg not in self.cregs.keys():
             raise QasmException(
-                'Undefined classical register "{}" ' 'at line {}'.format(reg, p.lineno(1))
+                'Undefined classical register "{}" at line {}'.format(reg, p.lineno(1))
             )
 
         size = self.cregs[reg]

--- a/cirq/contrib/quil_import/quil.py
+++ b/cirq/contrib/quil_import/quil.py
@@ -275,7 +275,7 @@ def circuit_from_quil(quil: str) -> Circuit:
         # Raise a general error when encountering an unconsidered type.
         else:
             raise UnsupportedQuilInstruction(
-                f"Quil instruction {inst} of type {type(inst)}" " not currently supported in Cirq."
+                f"Quil instruction {inst} of type {type(inst)} not currently supported in Cirq."
             )
 
     return circuit

--- a/cirq/contrib/quimb/state_vector.py
+++ b/cirq/contrib/quimb/state_vector.py
@@ -67,7 +67,7 @@ def circuit_to_tensors(
         # no input tensors, return a network representing the unitary
         pass
     else:
-        raise ValueError("Right now, only |0> or `None` " "initial states are supported.")
+        raise ValueError("Right now, only |0> or `None` initial states are supported.")
 
     for moment in circuit.moments:
         for op in moment.operations:
@@ -171,7 +171,7 @@ def tensor_expectation_value(
     ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
     if ram_gb > max_ram_gb:
         raise MemoryError(
-            "We estimate that this contraction " "will take too much RAM! {} GB".format(ram_gb)
+            "We estimate that this contraction will take too much RAM! {} GB".format(ram_gb)
         )
     e_val = tn.contract(inplace=True)
     assert e_val.imag < tol

--- a/cirq/contrib/quirk/export_to_quirk_test.py
+++ b/cirq/contrib/quirk/export_to_quirk_test.py
@@ -40,7 +40,7 @@ def test_x_z_same_col():
     )
     assert_links_to(
         circuit,
-        'http://algassert.com/quirk#circuit=' '%7B%22cols%22%3A%5B%5B%22X%22%2C%22Z%22%5D%5D%7D',
+        'http://algassert.com/quirk#circuit=%7B%22cols%22%3A%5B%5B%22X%22%2C%22Z%22%5D%5D%7D',
     )
 
 

--- a/cirq/contrib/routing/router.py
+++ b/cirq/contrib/routing/router.py
@@ -47,10 +47,10 @@ def route_circuit(
     """
 
     if any(protocols.num_qubits(op) > 2 for op in circuit.all_operations()):
-        raise ValueError('Can only route circuits with operations that act on' ' at most 2 qubits.')
+        raise ValueError('Can only route circuits with operations that act on at most 2 qubits.')
 
     if len(list(circuit.all_qubits())) > device_graph.number_of_nodes():
-        raise ValueError('Number of logical qubits is greater than number' ' of physical qubits.')
+        raise ValueError('Number of logical qubits is greater than number of physical qubits.')
 
     if not (algo_name is None or router is None):
         raise ValueError('At most one of algo_name or router can be specified.')

--- a/cirq/contrib/svg/svg.py
+++ b/cirq/contrib/svg/svg.py
@@ -197,9 +197,7 @@ def tdd_to_svg(
         else:
             # coverage: ignore
             stroke = 'black'
-        t += (
-            f'<line x1="{x1}" x2="{x2}" y1="{y}" y2="{y}" ' f'stroke="{stroke}" stroke-width="1" />'
-        )
+        t += f'<line x1="{x1}" x2="{x2}" y1="{y}" y2="{y}" stroke="{stroke}" stroke-width="1" />'
 
     for xi, yi1, yi2, _ in tdd.vertical_lines:
         yi1 = yi_map[yi1]
@@ -209,7 +207,7 @@ def tdd_to_svg(
 
         xi = cast(int, xi)
         x = col_starts[xi] + col_widths[xi] / 2
-        t += f'<line x1="{x}" x2="{x}" y1="{y1}" y2="{y2}" ' f'stroke="black" stroke-width="3" />'
+        t += f'<line x1="{x}" x2="{x}" y1="{y1}" y2="{y2}" stroke="black" stroke-width="3" />'
 
     for (xi, yi), v in tdd.entries.items():
         xi = cast(int, xi)

--- a/cirq/devices/grid_qubit.py
+++ b/cirq/devices/grid_qubit.py
@@ -249,7 +249,7 @@ class GridQid(_BaseGridQid):
         return [GridQid(*c, dimension=dimension) for c in coords]
 
     def __repr__(self) -> str:
-        return f"cirq.GridQid({self.row}, {self.col}, " f"dimension={self.dimension})"
+        return f"cirq.GridQid({self.row}, {self.col}, dimension={self.dimension})"
 
     def __str__(self) -> str:
         return f"({self.row}, {self.col}) (d={self.dimension})"

--- a/cirq/devices/line_qubit.py
+++ b/cirq/devices/line_qubit.py
@@ -72,7 +72,7 @@ class _BaseLineQid(ops.Qid):
                 )
             return self._with_x(x=self.x + other.x)
         if not isinstance(other, int):
-            raise TypeError(f"Can only add ints and {type(self).__name__}. " f"Instead was {other}")
+            raise TypeError(f"Can only add ints and {type(self).__name__}. Instead was {other}")
         return self._with_x(self.x + other)
 
     def __sub__(self: TSelf, other: int) -> TSelf:
@@ -85,7 +85,7 @@ class _BaseLineQid(ops.Qid):
             return self._with_x(x=self.x - other.x)
         if not isinstance(other, int):
             raise TypeError(
-                f"Can only subtract ints and {type(self).__name__}. " f"Instead was {other}"
+                f"Can only subtract ints and {type(self).__name__}. Instead was {other}"
             )
         return self._with_x(self.x - other)
 

--- a/cirq/experiments/cross_entropy_benchmarking.py
+++ b/cirq/experiments/cross_entropy_benchmarking.py
@@ -205,7 +205,7 @@ class CrossEntropyResult:
         )
 
     def __repr__(self) -> str:
-        args = f'data={[tuple(p) for p in self.data]!r}, ' f'repetitions={self.repetitions!r}'
+        args = f'data={[tuple(p) for p in self.data]!r}, repetitions={self.repetitions!r}'
         if self.purity_data is not None:
             args += f', purity_data={[tuple(p) for p in self.purity_data]!r}'
         return f'cirq.experiments.CrossEntropyResult({args})'
@@ -260,7 +260,7 @@ class CrossEntropyResultDict(Mapping[Tuple['cirq.Qid', ...], CrossEntropyResult]
         return cls(results={tuple(qubits): result for qubits, result in results})
 
     def __repr__(self) -> str:
-        return 'cirq.experiments.CrossEntropyResultDict(' f'results={self.results!r})'
+        return f'cirq.experiments.CrossEntropyResultDict(results={self.results!r})'
 
     def __getitem__(self, key: Tuple['cirq.Qid', ...]) -> CrossEntropyResult:
         return self.results[key]

--- a/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -144,7 +144,7 @@ def test_random_rotations_between_grid_interaction_layers(
 def test_grid_interaction_layer_repr():
     layer = GridInteractionLayer(col_offset=0, vertical=True, stagger=False)
     assert repr(layer) == (
-        'cirq.experiments.GridInteractionLayer(' 'col_offset=0, vertical=True, stagger=False)'
+        'cirq.experiments.GridInteractionLayer(col_offset=0, vertical=True, stagger=False)'
     )
 
 

--- a/cirq/experiments/t2_decay_experiment.py
+++ b/cirq/experiments/t2_decay_experiment.py
@@ -151,7 +151,7 @@ def t2_decay(
             length=num_points,
         )
     if delay_sweep.keys != ['delay_ns']:
-        raise ValueError('delay_sweep must be a SingleSweep ' 'with delay_ns parameter')
+        raise ValueError('delay_sweep must be a SingleSweep with delay_ns parameter')
 
     if experiment_type == ExperimentType.RAMSEY:
         # Ramsey T2* experiment
@@ -182,9 +182,7 @@ def t2_decay(
         # where N sweeps over the values of num_pulses
         #
         if not num_pulses:
-            raise ValueError(
-                'At least one value must be given ' 'for num_pulses in a CPMG experiment'
-            )
+            raise ValueError('At least one value must be given for num_pulses in a CPMG experiment')
         circuit = _cpmg_circuit(qubit, delay_var, max_pulses)
 
     # Add simple state tomography
@@ -421,7 +419,7 @@ class T2DecayResult:
         return ax
 
     def __str__(self):
-        return f'T2DecayResult with data:\n' f'<X>\n{self._x_basis_data}\n<Y>\n{self._y_basis_data}'
+        return f'T2DecayResult with data:\n<X>\n{self._x_basis_data}\n<Y>\n{self._y_basis_data}'
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):

--- a/cirq/google/arg_func_langs.py
+++ b/cirq/google/arg_func_langs.py
@@ -107,7 +107,7 @@ def arg_to_proto(
     """
 
     if arg_function_language not in SUPPORTED_FUNCTIONS_FOR_LANGUAGE:
-        raise ValueError(f'Unrecognized arg_function_language: ' f'{arg_function_language!r}')
+        raise ValueError(f'Unrecognized arg_function_language: {arg_function_language!r}')
     supported = SUPPORTED_FUNCTIONS_FOR_LANGUAGE[arg_function_language]
 
     msg = v2.program_pb2.Arg() if out is None else out
@@ -116,7 +116,7 @@ def arg_to_proto(
         if func_type not in supported:
             lang = repr(arg_function_language) if arg_function_language is not None else '[any]'
             raise ValueError(
-                f'Function type {func_type!r} not supported by ' f'arg_function_language {lang}'
+                f'Function type {func_type!r} not supported by arg_function_language {lang}'
             )
         return func_type
 
@@ -174,7 +174,7 @@ def arg_from_proto(
     """
     supported = SUPPORTED_FUNCTIONS_FOR_LANGUAGE.get(arg_function_language)
     if supported is None:
-        raise ValueError(f'Unrecognized arg_function_language: ' f'{arg_function_language!r}')
+        raise ValueError(f'Unrecognized arg_function_language: {arg_function_language!r}')
 
     which = arg_proto.WhichOneof('arg')
     if which == 'arg_value':

--- a/cirq/google/engine/calibration.py
+++ b/cirq/google/engine/calibration.py
@@ -112,7 +112,7 @@ class Calibration(abc.Mapping):
         return f'Calibration(keys={list(sorted(self.keys()))})'
 
     def __repr__(self) -> str:
-        return 'cirq.google.Calibration(metrics=' f'{repr(dict(self._metric_dict))})'
+        return f'cirq.google.Calibration(metrics={dict(self._metric_dict)!r})'
 
     def to_proto(self) -> v2.metrics_pb2.MetricsSnapshot:
         """Reconstruct the protobuf message represented by this class."""
@@ -177,11 +177,11 @@ class Calibration(abc.Mapping):
             values are not single floats.
         """
         metrics = self[key]
-        assert all(len(k) == 1 for k in metrics.keys()), (
-            'Heatmaps are only supported if all the targets in a metric' ' are single qubits.'
-        )
-        assert all(len(k) == 1 for k in metrics.values()), (
-            'Heatmaps are only supported if all the values in a metric' ' are single metric values.'
-        )
+        assert all(
+            len(k) == 1 for k in metrics.keys()
+        ), 'Heatmaps are only supported if all the targets in a metric are single qubits.'
+        assert all(
+            len(k) == 1 for k in metrics.values()
+        ), 'Heatmaps are only supported if all the values in a metric are single metric values.'
         value_map = {qubit: value for (qubit,), (value,) in metrics.items()}
         return vis.Heatmap(value_map)

--- a/cirq/google/engine/calibration_test.py
+++ b/cirq/google/engine/calibration_test.py
@@ -92,7 +92,7 @@ def test_calibration_metrics_dictionary():
 
 def test_calibration_str():
     calibration = cg.Calibration(_CALIBRATION_DATA)
-    assert str(calibration) == ("Calibration(keys=['globalMetric', 't1', " "'xeb'])")
+    assert str(calibration) == "Calibration(keys=['globalMetric', 't1', 'xeb'])"
 
 
 def test_calibration_repr():

--- a/cirq/google/engine/client/quantum_v1alpha1/gapic/quantum_engine_service_client.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/gapic/quantum_engine_service_client.py
@@ -136,7 +136,7 @@ class QuantumEngineServiceClient(object):
 
         if channel:
             warnings.warn(
-                'The `channel` argument is deprecated; use ' '`transport` instead.',
+                'The `channel` argument is deprecated; use `transport` instead.',
                 PendingDeprecationWarning,
                 stacklevel=2,
             )

--- a/cirq/google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
+++ b/cirq/google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
@@ -51,7 +51,7 @@ class QuantumEngineServiceGrpcTransport(object):
         # exception (channels come with credentials baked in already).
         if channel is not None and credentials is not None:
             raise ValueError(
-                'The `channel` and `credentials` arguments are mutually ' 'exclusive.',
+                'The `channel` and `credentials` arguments are mutually exclusive.',
             )
 
         # Create the channel.

--- a/cirq/google/engine/engine.py
+++ b/cirq/google/engine/engine.py
@@ -160,9 +160,7 @@ class Engine:
                 this should never be specified.
         """
         if context and (proto_version or service_args or verbose):
-            raise ValueError(
-                'Either provide context or proto_version, service_args' ' and verbose.'
-            )
+            raise ValueError('Either provide context or proto_version, service_args and verbose.')
 
         self.project_id = project_id
         if not context:
@@ -432,7 +430,7 @@ class Engine:
             calibration_results().
         """
         if processor_id and processor_ids:
-            raise ValueError('Only one of processor_id and processor_ids ' 'can be specified.')
+            raise ValueError('Only one of processor_id and processor_ids can be specified.')
         if not processor_ids and not processor_id:
             raise ValueError('Processor id must be specified.')
         if processor_id:

--- a/cirq/google/engine/engine_job_test.py
+++ b/cirq/google/engine/engine_job_test.py
@@ -34,7 +34,7 @@ def _to_any(proto):
 @pytest.fixture(scope='session', autouse=True)
 def mock_grpc_client():
     with mock.patch(
-        'cirq.google.engine.engine_client' '.quantum.QuantumEngineServiceClient'
+        'cirq.google.engine.engine_client.quantum.QuantumEngineServiceClient'
     ) as _fixture:
         yield _fixture
 

--- a/cirq/google/engine/engine_processor_test.py
+++ b/cirq/google/engine/engine_processor_test.py
@@ -127,7 +127,7 @@ _GATE_SET = cg.SerializableGateSet(
 @pytest.fixture(scope='session', autouse=True)
 def mock_grpc_client():
     with mock.patch(
-        'cirq.google.engine.engine_client' '.quantum.QuantumEngineServiceClient'
+        'cirq.google.engine.engine_client.quantum.QuantumEngineServiceClient'
     ) as _fixture:
         yield _fixture
 

--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -496,7 +496,7 @@ class EngineProgram:
         """
         if self.result_type != ResultType.Batch:
             raise ValueError(
-                'Program was not a batch program but instead ' f'was of type {self.result_type}.'
+                f'Program was not a batch program but instead was of type {self.result_type}.'
             )
         import cirq.google.engine.engine as engine_base
 
@@ -507,7 +507,7 @@ class EngineProgram:
         if code_type == 'cirq.google.api.v2.BatchProgram':
             batch = v2.batch_pb2.BatchProgram.FromString(code.value)
             return len(batch.programs)
-        raise ValueError('Program was not a batch program but instead was of ' f'type {code_type}.')
+        raise ValueError(f'Program was not a batch program but instead was of type {code_type}.')
 
     @staticmethod
     def _deserialize_program(
@@ -524,7 +524,7 @@ class EngineProgram:
         elif code_type == 'cirq.google.api.v2.BatchProgram':
             if program_num is None:
                 raise ValueError(
-                    'A program number must be specified when ' 'deserializing a Batch Program'
+                    'A program number must be specified when deserializing a Batch Program'
                 )
             batch = v2.batch_pb2.BatchProgram.FromString(code.value)
             if abs(program_num) >= len(batch.programs):
@@ -555,6 +555,4 @@ class EngineProgram:
         )
 
     def __str__(self) -> str:
-        return (
-            f'EngineProgram(project_id=\'{self.project_id}\', ' f'program_id=\'{self.program_id}\')'
-        )
+        return f'EngineProgram(project_id=\'{self.project_id}\', program_id=\'{self.program_id}\')'

--- a/cirq/google/engine/engine_program_test.py
+++ b/cirq/google/engine/engine_program_test.py
@@ -498,7 +498,7 @@ def test_get_batch_size(get_program):
 @pytest.fixture(scope='session', autouse=True)
 def mock_grpc_client():
     with mock.patch(
-        'cirq.google.engine.engine_client' '.quantum.QuantumEngineServiceClient'
+        'cirq.google.engine.engine_client.quantum.QuantumEngineServiceClient'
     ) as _fixture:
         yield _fixture
 

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -267,7 +267,7 @@ results: [{
 @pytest.fixture(scope='session', autouse=True)
 def mock_grpc_client():
     with mock.patch(
-        'cirq.google.engine.engine_client' '.quantum.QuantumEngineServiceClient'
+        'cirq.google.engine.engine_client.quantum.QuantumEngineServiceClient'
     ) as _fixture:
         yield _fixture
 
@@ -488,7 +488,7 @@ def test_run_circuit_cancelled(client):
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
         RuntimeError,
-        match='Job projects/proj/programs/prog/jobs/job-id' ' failed in state CANCELLED.',
+        match='Job projects/proj/programs/prog/jobs/job-id failed in state CANCELLED.',
     ):
         engine.run(program=_CIRCUIT, gate_set=cg.XMON)
 

--- a/cirq/google/ops/sycamore_gate_test.py
+++ b/cirq/google/ops/sycamore_gate_test.py
@@ -29,7 +29,7 @@ import cirq.google as cg
 def test_consistent_protocols(gate_type, qubit_count):
     cirq.testing.assert_implements_consistent_protocols(
         gate_type,
-        setup_code=('import cirq\n' 'import numpy as np\n' 'import sympy\n'),
+        setup_code='import cirq\nimport numpy as np\nimport sympy\n',
         qubit_count=qubit_count,
     )
 

--- a/cirq/google/optimizers/two_qubit_gates/example.py
+++ b/cirq/google/optimizers/two_qubit_gates/example.py
@@ -76,15 +76,15 @@ def main(samples: int = 1000, max_infidelity: float = 0.01):
             failed_infidelities.append(infidelity)  # coverage: ignore
     t_comp = time() - start
 
-    print(f'Gate compilation time : {t_comp:.3f} seconds ' f'({t_comp / samples:.4f} s per gate)')
+    print(f'Gate compilation time : {t_comp:.3f} seconds ({t_comp / samples:.4f} s per gate)')
 
     infidelities = np.array(infidelities)
     failed_infidelities = np.array(failed_infidelities)
 
     if np.size(failed_infidelities):
         # coverage: ignore
-        print(f'Number of "failed" compilations:' f' {np.size(failed_infidelities)}.')
-        print(f'Maximum infidelity of "failed" compilation: ' f'{np.max(failed_infidelities)}')
+        print(f'Number of "failed" compilations: {np.size(failed_infidelities)}.')
+        print(f'Maximum infidelity of "failed" compilation: {np.max(failed_infidelities)}')
 
     plt.figure()
     plt.hist(infidelities, bins=25, range=[0, max_infidelity * 1.1])

--- a/cirq/google/optimizers/two_qubit_gates/gate_compilation.py
+++ b/cirq/google/optimizers/two_qubit_gates/gate_compilation.py
@@ -130,8 +130,7 @@ class GateTabulation:
         numpy_single_qubit_gates = []
         for single_qubit_gate in self.single_qubit_gates:
             gate_repr = [
-                f"({proper_repr(pair[0])}, " f"{proper_repr(pair[1])})"
-                for pair in single_qubit_gate
+                f"({proper_repr(pair[0])}, {proper_repr(pair[1])})" for pair in single_qubit_gate
             ]
             numpy_single_qubit_gates.append(f"[{','.join(gate_repr)}]")
 
@@ -464,7 +463,7 @@ def gate_product_tabulation(
 
             kak_vecs.append(linalg.kak_vector(base_gate @ actual, check_preconditions=False))
         elif not allow_missed_points:
-            raise ValueError(f'Failed to tabulate a KAK vector near ' f'{missing_vec}')
+            raise ValueError(f'Failed to tabulate a KAK vector near {missing_vec}')
         else:
             missed_points.append(missing_vec)
 

--- a/cirq/google/optimizers/two_qubit_gates/math_utils.py
+++ b/cirq/google/optimizers/two_qubit_gates/math_utils.py
@@ -224,7 +224,7 @@ def weyl_chamber_mesh(spacing: float) -> np.ndarray:
         chamber.
     """
     if spacing < 1e-3:  # memory required ~ 1 GB
-        raise ValueError(f'Generating a mesh with ' f'spacing {spacing} may cause system to crash.')
+        raise ValueError(f'Generating a mesh with spacing {spacing} may cause system to crash.')
 
     # Uniform mesh
     disps = np.arange(-np.pi / 4, np.pi / 4, step=spacing)

--- a/cirq/google/serializable_gate_set.py
+++ b/cirq/google/serializable_gate_set.py
@@ -201,7 +201,7 @@ class SerializableGateSet:
             return circuit if device is None else circuit.with_device(device)
         if which == 'schedule':
             if device is None:
-                raise ValueError('Deserializing schedule requires a device but None was ' 'given.')
+                raise ValueError('Deserializing schedule requires a device but None was given.')
             return self._deserialize_schedule(
                 proto.schedule, device, arg_function_language=proto.language.arg_function_language
             )

--- a/cirq/google/serializable_gate_set_test.py
+++ b/cirq/google/serializable_gate_set_test.py
@@ -200,7 +200,7 @@ def test_deserialize_bad_operation_id():
         ),
     )
     with pytest.raises(
-        ValueError, match='problem in moment 1 handling an ' 'operation with the following'
+        ValueError, match='problem in moment 1 handling an operation with the following'
     ):
         MY_GATE_SET.deserialize(proto)
 

--- a/cirq/interop/quirk/cells/arithmetic_cells.py
+++ b/cirq/interop/quirk/cells/arithmetic_cells.py
@@ -71,7 +71,7 @@ class QuirkArithmeticOperation(ops.ArithmeticOperation):
             if isinstance(input_register, int):
                 continue
             if set(self.target) & set(input_register):
-                raise ValueError(f'Overlapping registers: ' f'{self.target} {self.inputs}')
+                raise ValueError(f'Overlapping registers: {self.target} {self.inputs}')
 
         if self.operation.is_modular:
             r = inputs[-1]
@@ -80,9 +80,7 @@ class QuirkArithmeticOperation(ops.ArithmeticOperation):
             else:
                 over = len(cast(Sequence, r)) > len(target)
             if over:
-                raise ValueError(
-                    'Target too small for modulus.\n' f'Target: {target}\n' f'Modulus: {r}'
-                )
+                raise ValueError(f'Target too small for modulus.\nTarget: {target}\nModulus: {r}')
 
     @property
     def operation(self) -> '_QuirkArithmeticCallable':

--- a/cirq/interop/quirk/cells/arithmetic_cells_test.py
+++ b/cirq/interop/quirk/cells/arithmetic_cells_test.py
@@ -24,7 +24,7 @@ from cirq import quirk_url_to_circuit
 
 def test_arithmetic_comparison_gates():
     with pytest.raises(ValueError, match='Missing input'):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":' '[["^A<B"]]}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["^A<B"]]}')
     assert_url_to_circuit_returns(
         '{"cols":[["^A<B","inputA2",1,"inputB2"]]}',
         diagram="""
@@ -269,7 +269,7 @@ def test_modular_arithmetic_modulus_size():
 
     with pytest.raises(ValueError, match='too small for modulus'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[' '["incmodR2",1,"inputR3"]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["incmodR2",1,"inputR3"]]}'
         )
 
     assert_url_to_circuit_returns('{"cols":[["incmodR3",1,1,"inputR3"]]}')

--- a/cirq/interop/quirk/cells/composite_cell_test.py
+++ b/cirq/interop/quirk/cells/composite_cell_test.py
@@ -99,13 +99,13 @@ def test_custom_circuit_gate():
 
     # With internal input.
     assert_url_to_circuit_returns(
-        '{"cols":[["~a5ls"]],"gates":[{"id":"~a5ls",' '"circuit":{"cols":[["inputA1","+=A1"]]}}]}',
+        '{"cols":[["~a5ls"]],"gates":[{"id":"~a5ls","circuit":{"cols":[["inputA1","+=A1"]]}}]}',
         cirq.Circuit(cirq.interop.quirk.QuirkArithmeticOperation('+=A1', target=[b], inputs=[[a]])),
     )
 
     # With external input.
     assert_url_to_circuit_returns(
-        '{"cols":[["inputA1","~r79k"]],"gates":[{"id":"~r79k",' '"circuit":{"cols":[["+=A1"]]}}]}',
+        '{"cols":[["inputA1","~r79k"]],"gates":[{"id":"~r79k","circuit":{"cols":[["+=A1"]]}}]}',
         cirq.Circuit(cirq.interop.quirk.QuirkArithmeticOperation('+=A1', target=[b], inputs=[[a]])),
     )
 

--- a/cirq/interop/quirk/cells/input_cells_test.py
+++ b/cirq/interop/quirk/cells/input_cells_test.py
@@ -21,7 +21,7 @@ from cirq.interop.quirk.cells.input_cells import SetDefaultInputCell
 
 def test_missing_input_cell():
     with pytest.raises(ValueError, match='Missing input'):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[' '["+=A2"]]}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["+=A2"]]}')
 
 
 def test_input_cell():
@@ -46,7 +46,7 @@ def test_input_cell():
     # Overlaps with effect.
     with pytest.raises(ValueError, match='Overlapping registers'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[' '["+=A3","inputA3"]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["+=A3","inputA3"]]}'
         )
 
 
@@ -73,7 +73,7 @@ def test_reversed_input_cell():
     # Overlaps with effect.
     with pytest.raises(ValueError, match='Overlapping registers'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[' '["+=A3","revinputA3"]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["+=A3","revinputA3"]]}'
         )
 
 
@@ -118,7 +118,7 @@ def test_set_default_input_cell():
 
     # Different values over time.
     assert_url_to_circuit_returns(
-        '{"cols":[' '[{"id":"setA","arg":1}],' '["+=A4"],' '[{"id":"setA","arg":4}],' '["+=A4"]]}',
+        '{"cols":[[{"id":"setA","arg":1}],["+=A4"],[{"id":"setA","arg":4}],["+=A4"]]}',
         maps={
             0: 5,
         },
@@ -126,7 +126,7 @@ def test_set_default_input_cell():
 
     # Broadcast.
     assert_url_to_circuit_returns(
-        '{"cols":[' '[{"id":"setA","arg":1}],' '["+=A2",1,"+=A2"],' '["+=A2",1,"+=A2"]]}',
+        '{"cols":[[{"id":"setA","arg":1}],["+=A2",1,"+=A2"],["+=A2",1,"+=A2"]]}',
         maps={
             0b_00_00: 0b_10_10,
             0b_10_01: 0b_00_11,
@@ -136,7 +136,7 @@ def test_set_default_input_cell():
     # Too late.
     with pytest.raises(ValueError, match='Missing input'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[' '["+=A2"],' '[{"id":"setA","arg":1}]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["+=A2"],[{"id":"setA","arg":1}]]}'
         )
 
 

--- a/cirq/interop/quirk/cells/input_rotation_cells_test.py
+++ b/cirq/interop/quirk/cells/input_rotation_cells_test.py
@@ -23,10 +23,10 @@ from cirq import quirk_url_to_circuit
 def test_input_rotation_cells():
     with pytest.raises(ValueError, match='classical constant'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":' '[["Z^(A/2^n)",{"id":"setA","arg":3}]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["Z^(A/2^n)",{"id":"setA","arg":3}]]}'
         )
     with pytest.raises(ValueError, match="Missing input 'a'"):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":' '[["X^(A/2^n)"]]}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["X^(A/2^n)"]]}')
 
     assert_url_to_circuit_returns(
         '{"cols":[["Z^(A/2^n)","inputA2"]]}',
@@ -107,7 +107,7 @@ def test_input_rotation_cells():
 
 def test_input_rotation_cells_repr():
     circuit = quirk_url_to_circuit(
-        'http://algassert.com/quirk#circuit=' '{"cols":[["•","X^(-A/2^n)","inputA2"]]}'
+        'http://algassert.com/quirk#circuit={"cols":[["•","X^(-A/2^n)","inputA2"]]}'
     )
     op = circuit[0].operations[0]
     cirq.testing.assert_equivalent_repr(op)

--- a/cirq/interop/quirk/cells/swap_cell_test.py
+++ b/cirq/interop/quirk/cells/swap_cell_test.py
@@ -27,10 +27,10 @@ def test_swap():
     )
 
     with pytest.raises(ValueError, match='number of swap gates'):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[[' '"Swap"]]}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["Swap"]]}')
     with pytest.raises(ValueError, match='number of swap gates'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[[' '"Swap","Swap","Swap"]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["Swap","Swap","Swap"]]}'
         )
 
 

--- a/cirq/interop/quirk/cells/unsupported_cells.py
+++ b/cirq/interop/quirk/cells/unsupported_cells.py
@@ -62,7 +62,7 @@ def generate_all_unsupported_cell_makers() -> Iterator[CellMaker]:
 def _unsupported_gate(identifier: str, reason: str) -> CellMaker:
     def fail(_):
         raise NotImplementedError(
-            f'Converting the Quirk gate {identifier} is not implemented yet. ' f'Reason: {reason}'
+            f'Converting the Quirk gate {identifier} is not implemented yet. Reason: {reason}'
         )
 
     return CellMaker(identifier, 0, fail)

--- a/cirq/interop/quirk/cells/unsupported_cells_test.py
+++ b/cirq/interop/quirk/cells/unsupported_cells_test.py
@@ -19,10 +19,10 @@ from cirq import quirk_url_to_circuit
 
 def test_non_physical_operations():
     with pytest.raises(NotImplementedError, match="unphysical operation"):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[' '["__error__"]]}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["__error__"]]}')
     with pytest.raises(NotImplementedError, match="unphysical operation"):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[' '["__unstable__UniversalNot"]]}'
+            'https://algassert.com/quirk#circuit={"cols":[["__unstable__UniversalNot"]]}'
         )
 
 
@@ -31,24 +31,18 @@ def test_not_implemented_gates():
 
     for k in ["X^⌈t⌉", "X^⌈t-¼⌉", "Counting4", "Uncounting4", ">>t3", "<<t3"]:
         with pytest.raises(NotImplementedError, match="discrete parameter"):
-            _ = quirk_url_to_circuit(
-                'https://algassert.com/quirk#circuit={' '"cols":[["' + k + '"]]}'
-            )
+            _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["' + k + '"]]}')
 
     for k in ["add3", "sub3", "c+=ab4", "c-=ab4"]:
         with pytest.raises(NotImplementedError, match="deprecated"):
-            _ = quirk_url_to_circuit(
-                'https://algassert.com/quirk#circuit={' '"cols":[["' + k + '"]]}'
-            )
+            _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["' + k + '"]]}')
 
     for k in ["X", "Y", "Z"]:
         with pytest.raises(NotImplementedError, match="feedback"):
             _ = quirk_url_to_circuit(
-                'https://algassert.com/quirk#circuit={"' 'cols":[["' + k + 'DetectControlReset"]]}'
+                'https://algassert.com/quirk#circuit={"cols":[["' + k + 'DetectControlReset"]]}'
             )
 
     for k in ["|0⟩⟨0|", "|1⟩⟨1|", "|+⟩⟨+|", "|-⟩⟨-|", "|X⟩⟨X|", "|/⟩⟨/|", "0"]:
         with pytest.raises(NotImplementedError, match="postselection"):
-            _ = quirk_url_to_circuit(
-                'https://algassert.com/quirk#circuit={' '"cols":[["' + k + '"]]}'
-            )
+            _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["' + k + '"]]}')

--- a/cirq/interop/quirk/url_to_circuit.py
+++ b/cirq/interop/quirk/url_to_circuit.py
@@ -300,14 +300,10 @@ def _parse_cols_into_composite_cell(
 
 def _register_custom_gate(gate_json: Any, registry: Dict[str, CellMaker]):
     if not isinstance(gate_json, Dict):
-        raise ValueError(
-            f'Custom gate json must be a dictionary.\n' f'Custom gate json={gate_json!r}.'
-        )
+        raise ValueError(f'Custom gate json must be a dictionary.\nCustom gate json={gate_json!r}.')
 
     if 'id' not in gate_json:
-        raise ValueError(
-            f'Custom gate json must have an id key.\n' f'Custom gate json={gate_json!r}.'
-        )
+        raise ValueError(f'Custom gate json must have an id key.\nCustom gate json={gate_json!r}.')
     identifier = gate_json['id']
     if identifier in registry:
         raise ValueError(f'Custom gate with duplicate identifier: {identifier!r}')
@@ -321,7 +317,7 @@ def _register_custom_gate(gate_json: Any, registry: Dict[str, CellMaker]):
     if 'matrix' in gate_json:
         if not isinstance(gate_json['matrix'], str):
             raise ValueError(
-                f'Custom gate matrix json must be a string.\n' f'Custom gate json={gate_json!r}.'
+                f'Custom gate matrix json must be a string.\nCustom gate json={gate_json!r}.'
             )
         gate = ops.MatrixGate(parse_matrix(gate_json['matrix']))
         registry[identifier] = CellMaker(

--- a/cirq/interop/quirk/url_to_circuit_test.py
+++ b/cirq/interop/quirk/url_to_circuit_test.py
@@ -187,19 +187,19 @@ def test_init():
 
 def test_custom_gate_parse_failures():
     with pytest.raises(ValueError, match='must be a list'):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[],' '"gates":5}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[],"gates":5}')
 
     with pytest.raises(ValueError, match='gate json must be a dict'):
-        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[],' '"gates":[5]}')
+        _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[],"gates":[5]}')
 
     with pytest.raises(ValueError, match='Circuit JSON must be a dict'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[],' '"gates":[{"id":"~a","circuit":5}]}'
+            'https://algassert.com/quirk#circuit={"cols":[],"gates":[{"id":"~a","circuit":5}]}'
         )
 
     with pytest.raises(ValueError, match='matrix json must be a string'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[],' '"gates":[{"id":"~a","matrix":5}]}'
+            'https://algassert.com/quirk#circuit={"cols":[],"gates":[{"id":"~a","matrix":5}]}'
         )
 
     with pytest.raises(ValueError, match='Not surrounded by {{}}'):
@@ -226,7 +226,7 @@ def test_custom_gate_parse_failures():
 
     with pytest.raises(ValueError, match='matrix or a circuit'):
         _ = quirk_url_to_circuit(
-            'https://algassert.com/quirk#circuit={"cols":[],' '"gates":[' '{"id":"~a"}' ']}'
+            'https://algassert.com/quirk#circuit={"cols":[],"gates":[{"id":"~a"}]}'
         )
 
     with pytest.raises(ValueError, match='duplicate identifier'):
@@ -243,7 +243,7 @@ def test_custom_matrix_gate():
 
     # Without name.
     assert_url_to_circuit_returns(
-        '{"cols":[["~cv0d"]],' '"gates":[{"id":"~cv0d","matrix":"{{0,1},{1,0}}"}]}',
+        '{"cols":[["~cv0d"]],"gates":[{"id":"~cv0d","matrix":"{{0,1},{1,0}}"}]}',
         cirq.Circuit(
             cirq.MatrixGate(
                 np.array(
@@ -258,7 +258,7 @@ def test_custom_matrix_gate():
 
     # With name.
     assert_url_to_circuit_returns(
-        '{"cols":[["~cv0d"]],' '"gates":[{"id":"~cv0d","name":"test","matrix":"{{0,i},{1,0}}"}]}',
+        '{"cols":[["~cv0d"]],"gates":[{"id":"~cv0d","name":"test","matrix":"{{0,i},{1,0}}"}]}',
         cirq.Circuit(
             cirq.MatrixGate(
                 np.array(

--- a/cirq/ionq/ionq_client.py
+++ b/cirq/ionq/ionq_client.py
@@ -77,9 +77,9 @@ class _IonQClient:
         assert (
             api_version in self.SUPPORTED_VERSIONS
         ), f'Only api v0.1 is accepted but was {api_version}'
-        assert default_target is None or default_target in self.SUPPORTED_TARGETS, (
-            f'Target can only be one of {self.SUPPORTED_TARGETS} but was ' f'{default_target}.'
-        )
+        assert (
+            default_target is None or default_target in self.SUPPORTED_TARGETS
+        ), f'Target can only be one of {self.SUPPORTED_TARGETS} but was {default_target}.'
         assert max_retry_seconds >= 0, 'Negative retry not possible without time machine.'
 
         self.url = f'{url.scheme}://{url.netloc}/{api_version}'
@@ -101,7 +101,7 @@ class _IonQClient:
         return cast(str, target or self.default_target)
 
     def _make_request(self, request: Callable[[], requests.Response]) -> requests.Response:
-        """ "Make a request to the API, retrying if necessary.
+        """Make a request to the API, retrying if necessary.
 
         Args:
             request: A function that returns a `requests.Response`.

--- a/cirq/ionq/job.py
+++ b/cirq/ionq/job.py
@@ -191,7 +191,7 @@ class Job:
             time_waited_seconds += polling_seconds
         if self.status() != 'completed':
             raise RuntimeError(
-                'Job was not completed successful. Instead had' f' status: {self.status()}'
+                f'Job was not completed successful. Instead had status: {self.status()}'
             )
         # IonQ returns results in little endian, Cirq prefers to use big endian,
         # so we convert.

--- a/cirq/ionq/serializer.py
+++ b/cirq/ionq/serializer.py
@@ -64,7 +64,7 @@ class Serializer:
         all_qubits = circuit.all_qubits()
         if any(not isinstance(q, line_qubit.LineQubit) for q in all_qubits):
             raise ValueError(
-                'All qubits must be cirq.LineQubits but were ' f'{set(type(q) for q in all_qubits)}'
+                f'All qubits must be cirq.LineQubits but were {set(type(q) for q in all_qubits)}'
             )
         num_qubits = cast(line_qubit.LineQubit, max(all_qubits)).x + 1
         return {'qubits': num_qubits, 'circuit': self._serialize_circuit(circuit, num_qubits)}
@@ -98,7 +98,7 @@ class Serializer:
                 serialized_op = self._dispatch[gate_mro_type](gate, targets)
                 if serialized_op:
                     return serialized_op
-        raise ValueError(f'Gate {gate} acting on {targets} cannot be ' 'serialized by IonQ API.')
+        raise ValueError(f'Gate {gate} acting on {targets} cannot be serialized by IonQ API.')
 
     def _serialize_x_pow_gate(self, gate: 'cirq.XPowGate', targets: Sequence[int]) -> dict:
         if self._near_mod_n(gate.exponent, 1, 2):

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -140,7 +140,7 @@ def unitary_eig(
          V: the unitary matrix with the eigenvectors as columns
     """
     if check_preconditions and not predicates.is_normal(matrix, atol=atol):
-        raise ValueError('Input must correspond to a normal matrix ' f'.Received input:\n{matrix}')
+        raise ValueError(f'Input must correspond to a normal matrix .Received input:\n{matrix}')
     R, V = scipy.linalg.schur(matrix, output="complex")
     return R.diagonal(), V
 
@@ -834,7 +834,7 @@ def kak_decomposition(
         mat.shape != (4, 4) or not predicates.is_unitary(mat, rtol=rtol, atol=atol)
     ):
         raise ValueError(
-            'Input must correspond to a 4x4 unitary matrix. ' 'Received matrix:\n' + str(mat)
+            'Input must correspond to a 4x4 unitary matrix. Received matrix:\n' + str(mat)
         )
 
     # Diagonalize in magic basis.
@@ -922,7 +922,7 @@ def kak_vector(
 
     if unitary.ndim < 2 or unitary.shape[-2:] != (4, 4):
         raise ValueError(
-            f'Expected input unitary to have shape (...,4,4), but' f'got {unitary.shape}.'
+            f'Expected input unitary to have shape (...,4,4), but got {unitary.shape}.'
         )
 
     if atol < 0:
@@ -1024,7 +1024,7 @@ def num_cnots_required(u: np.ndarray, atol: float = 1e-8) -> int:
         the number of CNOT or CZ gates required to implement the unitary
     """
     if u.shape != (4, 4):
-        raise ValueError(f"Expected unitary of shape (4,4), instead " f"got {u.shape}")
+        raise ValueError(f"Expected unitary of shape (4,4), instead got {u.shape}")
     g = _gamma(transformations.to_special(u))
     # see Fadeev-LeVerrier formula
     a3 = -np.trace(g)

--- a/cirq/linalg/diagonalize_test.py
+++ b/cirq/linalg/diagonalize_test.py
@@ -60,7 +60,7 @@ def random_bi_diagonalizable_pair(
 
 
 def _get_assert_diagonalized_by_str(m, p, d):
-    return 'm.round(3) : {}, p.round(3) : {}, ' 'np.abs(p.T @ m @ p).round(2): {}'.format(
+    return 'm.round(3) : {}, p.round(3) : {}, np.abs(p.T @ m @ p).round(2): {}'.format(
         np.round(m, 3), np.round(p, 3), np.abs(d).round(2)
     )
 

--- a/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq/neutral_atoms/neutral_atom_devices.py
@@ -168,13 +168,13 @@ class NeutralAtomDevice(devices.Device):
         if isinstance(operation, ops.GateOperation):
             if len(operation.qubits) > self._max_parallel_c:
                 raise ValueError(
-                    "Too many qubits acted on in parallel by a " "controlled gate operation"
+                    "Too many qubits acted on in parallel by a controlled gate operation"
                 )
             if len(operation.qubits) > 1:
                 for p in operation.qubits:
                     for q in operation.qubits:
                         if self.distance(p, q) > self._control_radius:
-                            raise ValueError("Qubits {!r}, {!r} are too " "far away".format(p, q))
+                            raise ValueError("Qubits {!r}, {!r} are too far away".format(p, q))
             return
 
         # Verify that a valid number of Z gates are applied in parallel
@@ -238,7 +238,7 @@ class NeutralAtomDevice(devices.Device):
             raise ValueError("Too many qubits acted on by controlled gates")
         if controlled_qubits_lists and (num_parallel_xy or num_parallel_z):
             raise ValueError(
-                "Can't perform non-controlled operations at" " same time as controlled operations"
+                "Can't perform non-controlled operations at same time as controlled operations"
             )
         if self._are_qubit_lists_too_close(*controlled_qubits_lists):
             raise ValueError("Interacting controlled operations")
@@ -251,7 +251,7 @@ class NeutralAtomDevice(devices.Device):
 
         if has_measurement:
             if controlled_qubits_lists or num_parallel_z or num_parallel_xy:
-                raise ValueError("Measurements can't be simultaneous with other" " operations")
+                raise ValueError("Measurements can't be simultaneous with other operations")
 
     def _are_qubit_lists_too_close(self, *qubit_lists: Iterable[raw_types.Qid]) -> bool:
         if len(qubit_lists) < 2:

--- a/cirq/neutral_atoms/neutral_atom_devices_test.py
+++ b/cirq/neutral_atoms/neutral_atom_devices_test.py
@@ -106,7 +106,7 @@ def test_validate_gate_errors():
     d = square_device(1, 1)
 
     d.validate_gate(cirq.IdentityGate(4))
-    with pytest.raises(ValueError, match="controlled gates must have integer " "exponents"):
+    with pytest.raises(ValueError, match="controlled gates must have integer exponents"):
         d.validate_gate(cirq.CNotPowGate(exponent=0.5))
     with pytest.raises(ValueError, match="Unsupported gate"):
         d.validate_gate(cirq.SingleQubitGate())
@@ -132,7 +132,7 @@ def test_validate_operation_errors():
     )
     with pytest.raises(ValueError, match="Qubit not on device"):
         d.validate_operation(not_on_device_op)
-    with pytest.raises(ValueError, match="Too many qubits acted on in parallel " "by"):
+    with pytest.raises(ValueError, match="Too many qubits acted on in parallel by"):
         d.validate_operation(cirq.CCX.on(*d.qubit_list()[0:3]))
     with pytest.raises(ValueError, match="are too far away"):
         d.validate_operation(cirq.CZ.on(cirq.GridQubit(0, 0), cirq.GridQubit(2, 2)))
@@ -165,12 +165,12 @@ def test_validate_moment_errors():
     with pytest.raises(ValueError, match="Non-identical simultaneous "):
         d.validate_moment(m)
     m = cirq.Moment([cirq.CNOT.on(q00, q01), cirq.CNOT.on(q12, q02)])
-    with pytest.raises(ValueError, match="Too many qubits acted on by " "controlled gates"):
+    with pytest.raises(ValueError, match="Too many qubits acted on by controlled gates"):
         d.validate_moment(m)
     m = cirq.Moment([cirq.CNOT.on(q00, q01), cirq.Z.on(q02)])
     with pytest.raises(
         ValueError,
-        match="Can't perform non-controlled " "operations at same time as controlled operations",
+        match="Can't perform non-controlled operations at same time as controlled operations",
     ):
         d.validate_moment(m)
     m = cirq.Moment(cirq.Z.on_each(*d.qubits))
@@ -181,7 +181,7 @@ def test_validate_moment_errors():
         d.validate_moment(m)
     m = cirq.Moment([cirq.MeasurementGate(1).on(q00), cirq.Z.on(q01)])
     with pytest.raises(
-        ValueError, match="Measurements can't be simultaneous " "with other operations"
+        ValueError, match="Measurements can't be simultaneous with other operations"
     ):
         d.validate_moment(m)
     d.validate_moment(cirq.Moment([cirq.X.on(q00), cirq.Z.on(q01)]))

--- a/cirq/ops/clifford_gate.py
+++ b/cirq/ops/clifford_gate.py
@@ -364,9 +364,9 @@ class SingleQubitCliffordGate(gate_features.SingleQubitGate):
                 (pauli_gates.X, 1 if z_rot.flip else -1),
             ]
         # coverage: ignore
-        assert False, (
-            'Impossible condition where this gate only rotates one' ' Pauli to a different Pauli.'
-        )
+        assert (
+            False
+        ), 'Impossible condition where this gate only rotates one Pauli to a different Pauli.'
 
     def equivalent_gate_before(self, after: 'SingleQubitCliffordGate') -> 'SingleQubitCliffordGate':
         """Returns a SingleQubitCliffordGate such that the circuits

--- a/cirq/ops/common_gates.py
+++ b/cirq/ops/common_gates.py
@@ -263,9 +263,7 @@ class XPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             if self._exponent == 1:
                 return 'X'
             return 'X**{}'.format(self._exponent)
-        return ('XPowGate(exponent={}, ' 'global_shift={!r})').format(
-            self._exponent, self._global_shift
-        )
+        return 'XPowGate(exponent={}, global_shift={!r})'.format(self._exponent, self._global_shift)
 
     def __repr__(self) -> str:
         if self._global_shift == -0.5:
@@ -277,7 +275,7 @@ class XPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             if self._exponent == 1:
                 return 'cirq.X'
             return '(cirq.X**{})'.format(proper_repr(self._exponent))
-        return ('cirq.XPowGate(exponent={}, ' 'global_shift={!r})').format(
+        return 'cirq.XPowGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 
@@ -456,9 +454,7 @@ class YPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             if self._exponent == 1:
                 return 'Y'
             return 'Y**{}'.format(self._exponent)
-        return ('YPowGate(exponent={}, ' 'global_shift={!r})').format(
-            self._exponent, self._global_shift
-        )
+        return 'YPowGate(exponent={}, global_shift={!r})'.format(self._exponent, self._global_shift)
 
     def __repr__(self) -> str:
         if self._global_shift == -0.5:
@@ -470,7 +466,7 @@ class YPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             if self._exponent == 1:
                 return 'cirq.Y'
             return '(cirq.Y**{})'.format(proper_repr(self._exponent))
-        return ('cirq.YPowGate(exponent={}, ' 'global_shift={!r})').format(
+        return 'cirq.YPowGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 
@@ -692,9 +688,7 @@ class ZPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             if self._exponent == 1:
                 return 'Z'
             return 'Z**{}'.format(self._exponent)
-        return ('ZPowGate(exponent={}, ' 'global_shift={!r})').format(
-            self._exponent, self._global_shift
-        )
+        return 'ZPowGate(exponent={}, global_shift={!r})'.format(self._exponent, self._global_shift)
 
     def __repr__(self) -> str:
         if self._global_shift == -0.5:
@@ -714,7 +708,7 @@ class ZPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             if self._exponent == 1:
                 return 'cirq.Z'
             return '(cirq.Z**{})'.format(proper_repr(self._exponent))
-        return ('cirq.ZPowGate(exponent={}, ' 'global_shift={!r})').format(
+        return 'cirq.ZPowGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 
@@ -866,7 +860,7 @@ class HPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
             return args.format('h {0};\n', qubits[0])
 
         return args.format(
-            'ry({0:half_turns}) {3};\n' 'rx({1:half_turns}) {3};\n' 'ry({2:half_turns}) {3};\n',
+            'ry({0:half_turns}) {3};\nrx({1:half_turns}) {3};\nry({2:half_turns}) {3};\n',
             0.25,
             self._exponent,
             -0.25,
@@ -1107,7 +1101,7 @@ class CZPowGate(
             if self._exponent == 1:
                 return 'cirq.CZ'
             return '(cirq.CZ**{})'.format(proper_repr(self._exponent))
-        return ('cirq.CZPowGate(exponent={}, ' 'global_shift={!r})').format(
+        return 'cirq.CZPowGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 

--- a/cirq/ops/controlled_gate_test.py
+++ b/cirq/ops/controlled_gate_test.py
@@ -35,7 +35,7 @@ class GateUsingWorkspaceForApplyUnitary(cirq.SingleQubitGate):
         return isinstance(other, type(self))
 
     def __repr__(self):
-        return 'cirq.ops.controlled_gate_test.' 'GateUsingWorkspaceForApplyUnitary()'
+        return 'cirq.ops.controlled_gate_test.GateUsingWorkspaceForApplyUnitary()'
 
 
 class GateAllocatingNewSpaceForResult(cirq.SingleQubitGate):
@@ -57,7 +57,7 @@ class GateAllocatingNewSpaceForResult(cirq.SingleQubitGate):
         return isinstance(other, type(self))
 
     def __repr__(self):
-        return 'cirq.ops.controlled_gate_test.' 'GateAllocatingNewSpaceForResult()'
+        return 'cirq.ops.controlled_gate_test.GateAllocatingNewSpaceForResult()'
 
 
 class RestrictedGate(cirq.SingleQubitGate):

--- a/cirq/ops/controlled_operation.py
+++ b/cirq/ops/controlled_operation.py
@@ -62,7 +62,7 @@ class ControlledOperation(raw_types.Operation):
         for q, val in zip(controls, self.control_values):
             if not all(0 <= v < q.dimension for v in val):
                 raise ValueError(
-                    'Control values <{!r}> outside of range for qubit ' '<{!r}>.'.format(val, q)
+                    'Control values <{!r}> outside of range for qubit <{!r}>.'.format(val, q)
                 )
 
         if not isinstance(sub_operation, ControlledOperation):

--- a/cirq/ops/controlled_operation_test.py
+++ b/cirq/ops/controlled_operation_test.py
@@ -35,7 +35,7 @@ class GateUsingWorkspaceForApplyUnitary(cirq.SingleQubitGate):
         return isinstance(other, type(self))
 
     def __repr__(self):
-        return 'cirq.ops.controlled_operation_test.' 'GateUsingWorkspaceForApplyUnitary()'
+        return 'cirq.ops.controlled_operation_test.GateUsingWorkspaceForApplyUnitary()'
 
 
 class GateAllocatingNewSpaceForResult(cirq.SingleQubitGate):
@@ -57,7 +57,7 @@ class GateAllocatingNewSpaceForResult(cirq.SingleQubitGate):
         return isinstance(other, type(self))
 
     def __repr__(self):
-        return 'cirq.ops.controlled_operation_test.' 'GateAllocatingNewSpaceForResult()'
+        return 'cirq.ops.controlled_operation_test.GateAllocatingNewSpaceForResult()'
 
 
 def test_controlled_operation_init():

--- a/cirq/ops/eigen_gate_test.py
+++ b/cirq/ops/eigen_gate_test.py
@@ -123,7 +123,7 @@ def test_approx_eq():
     assert not cirq.approx_eq(CExpZinGate(1.5), ZGateDef(exponent=1.5), atol=0.1)
     with pytest.raises(
         TypeError,
-        match=re.escape("unsupported operand type(s) for" " -: 'Symbol' and 'PeriodicValue'"),
+        match=re.escape("unsupported operand type(s) for -: 'Symbol' and 'PeriodicValue'"),
     ):
         cirq.approx_eq(ZGateDef(exponent=1.5), ZGateDef(exponent=sympy.Symbol('a')), atol=0.1)
     assert cirq.approx_eq(CExpZinGate(sympy.Symbol('a')), CExpZinGate(sympy.Symbol('a')), atol=0.1)

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -105,7 +105,7 @@ class GateOperation(raw_types.Operation):
         if self == self.gate.on(*self.qubits):
             return f'{gate_repr}.on({qubit_args_repr})'
 
-        return f'cirq.GateOperation(gate={self.gate!r}, ' f'qubits=[{qubit_args_repr}])'
+        return f'cirq.GateOperation(gate={self.gate!r}, qubits=[{qubit_args_repr}])'
 
     def __str__(self) -> str:
         qubits = ', '.join(str(e) for e in self.qubits)

--- a/cirq/ops/identity.py
+++ b/cirq/ops/identity.py
@@ -80,7 +80,7 @@ class IdentityGate(raw_types.Gate):
             gate.
         """
         if len(self._qid_shape) != 1:
-            raise ValueError('IdentityGate only supports on_each when it is a one qubit ' 'gate.')
+            raise ValueError('IdentityGate only supports on_each when it is a one qubit gate.')
         operations: List['cirq.Operation'] = []
         for target in targets:
             if isinstance(target, raw_types.Qid):

--- a/cirq/ops/linear_combinations.py
+++ b/cirq/ops/linear_combinations.py
@@ -483,7 +483,7 @@ class PauliSum:
         # prevent an `apply_unitary` bug.
         # Github issue: https://github.com/quantumlib/Cirq/issues/2041
         if state_vector.dtype.kind != 'c':
-            raise TypeError("Input state dtype must be np.complex64 or " "np.complex128")
+            raise TypeError("Input state dtype must be np.complex64 or np.complex128")
 
         size = state_vector.size
         num_qubits = size.bit_length() - 1
@@ -538,7 +538,7 @@ class PauliSum:
         # FIXME: Avoid enforce specific complex type. This is necessary to
         # prevent an `apply_unitary` bug (Issue #2041).
         if state.dtype.kind != 'c':
-            raise TypeError("Input state dtype must be np.complex64 or " "np.complex128")
+            raise TypeError("Input state dtype must be np.complex64 or np.complex128")
 
         size = state.size
         num_qubits = int(np.sqrt(size)).bit_length() - 1

--- a/cirq/ops/matrix_gates.py
+++ b/cirq/ops/matrix_gates.py
@@ -130,7 +130,7 @@ class MatrixGate(raw_types.Gate):
     def __repr__(self) -> str:
         if all(e == 2 for e in self._qid_shape):
             return f'cirq.MatrixGate({proper_repr(self._matrix)})'
-        return f'cirq.MatrixGate({proper_repr(self._matrix)}, ' f'qid_shape={self._qid_shape})'
+        return f'cirq.MatrixGate({proper_repr(self._matrix)}, qid_shape={self._qid_shape})'
 
     def __str__(self) -> str:
         return str(self._matrix.round(3))

--- a/cirq/ops/parallel_gate_operation.py
+++ b/cirq/ops/parallel_gate_operation.py
@@ -63,7 +63,7 @@ class ParallelGateOperation(raw_types.Operation):
         return ParallelGateOperation(new_gate, self.qubits)
 
     def __repr__(self) -> str:
-        return 'cirq.ParallelGateOperation(' f'gate={self.gate!r}, qubits={list(self.qubits)!r})'
+        return f'cirq.ParallelGateOperation(gate={self.gate!r}, qubits={list(self.qubits)!r})'
 
     def __str__(self) -> str:
         qubits = ', '.join(str(e) for e in self.qubits)

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -530,7 +530,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         # FIXME: Avoid enforce specific complex type. This is necessary to
         # prevent an `apply_unitary` bug (Issue #2041).
         if state_vector.dtype.kind != 'c':
-            raise TypeError("Input state dtype must be np.complex64 or " "np.complex128")
+            raise TypeError("Input state dtype must be np.complex64 or np.complex128")
 
         size = state_vector.size
         num_qubits = size.bit_length() - 1
@@ -632,7 +632,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         # FIXME: Avoid enforcing specific complex type. This is necessary to
         # prevent an `apply_unitary` bug (Issue #2041).
         if state.dtype.kind != 'c':
-            raise TypeError("Input state dtype must be np.complex64 or " "np.complex128")
+            raise TypeError("Input state dtype must be np.complex64 or np.complex128")
 
         size = state.size
         num_qubits = int(np.sqrt(size)).bit_length() - 1
@@ -1038,9 +1038,9 @@ class PauliString(raw_types.Operation, Generic[TKey]):
             quarter_kickback += merge_and_kickback(
                 qubit0, pauli_map.get(qubit0), gate.pauli0, gate.invert0
             )
-        assert quarter_kickback % 2 == 0, (
-            'Impossible condition.  ' 'quarter_kickback is either incremented twice or never.'
-        )
+        assert (
+            quarter_kickback % 2 == 0
+        ), 'Impossible condition.  quarter_kickback is either incremented twice or never.'
         return quarter_kickback % 4 == 2
 
 
@@ -1062,12 +1062,12 @@ def _validate_qubit_mapping(
         isinstance(k, raw_types.Qid) and isinstance(v, int) for k, v in qubit_map.items()
     ):
         raise TypeError(
-            "Input qubit map must be a valid mapping from " "Qubit ID's to integer indices."
+            "Input qubit map must be a valid mapping from Qubit ID's to integer indices."
         )
 
     if not set(qubit_map.keys()) >= set(pauli_qubits):
         raise ValueError(
-            "Input qubit map must be a complete mapping over all " " of this PauliString's qubits."
+            "Input qubit map must be a complete mapping over all of this PauliString's qubits."
         )
 
     used_inds = [qubit_map[q] for q in pauli_qubits]
@@ -1075,7 +1075,7 @@ def _validate_qubit_mapping(
         sorted(used_inds)
     ):
         raise ValueError(
-            'Input qubit map indices must be valid for a state ' f'over {num_state_qubits} qubits.'
+            f'Input qubit map indices must be valid for a state over {num_state_qubits} qubits.'
         )
 
 
@@ -1474,7 +1474,7 @@ def _decompose_into_cliffords(op: 'cirq.Operation') -> List['cirq.Operation']:
         return [out for sub_op in decomposed for out in _decompose_into_cliffords(sub_op)]
 
     raise TypeError(
-        f'Operation is not a known Clifford and did not decompose ' f'into known Cliffords: {op!r}'
+        f'Operation is not a known Clifford and did not decompose into known Cliffords: {op!r}'
     )
 
 

--- a/cirq/ops/permutation_gate.py
+++ b/cirq/ops/permutation_gate.py
@@ -36,9 +36,7 @@ class QubitPermutationGate(raw_types.Gate):
             raise ValueError(f"Invalid permutation (empty): {permutation}")
 
         if len(set(permutation)) < len(permutation):
-            raise ValueError(
-                f"Invalid permutation {permutation} " f"Each index must appear only once."
-            )
+            raise ValueError(f"Invalid permutation {permutation} Each index must appear only once.")
 
         invalid_indices = [x for x in permutation if not 0 <= x < len(permutation)]
         if len(invalid_indices) > 0:
@@ -77,7 +75,7 @@ class QubitPermutationGate(raw_types.Gate):
         return tuple(f'[{i}>{self.permutation[i]}]' for i in range(len(self.permutation)))
 
     def __repr__(self) -> str:
-        return 'cirq.QubitPermutationGate(' f'permutation={repr(self.permutation)})'
+        return f'cirq.QubitPermutationGate(permutation={self.permutation!r})'
 
     def _json_dict_(self) -> Dict[str, Any]:
         return protocols.obj_to_dict_helper(self, attribute_names=['permutation'])

--- a/cirq/ops/random_gate_channel.py
+++ b/cirq/ops/random_gate_channel.py
@@ -144,5 +144,5 @@ class RandomGateChannel(raw_types.Gate):
 
     def __repr__(self):
         if self.probability == 1:
-            return f'cirq.RandomGateChannel(' f'sub_gate={self.sub_gate!r}, ' f'probability=1)'
-        return f'{self.sub_gate!r}.with_probability(' f'{proper_repr(self.probability)})'
+            return f'cirq.RandomGateChannel(sub_gate={self.sub_gate!r}, probability=1)'
+        return f'{self.sub_gate!r}.with_probability({proper_repr(self.probability)})'

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -79,7 +79,7 @@ class Qid(metaclass=abc.ABCMeta):
         """
         if dimension < 1:
             raise ValueError(
-                'Wrong qid dimension. ' 'Expected a positive integer but got {}.'.format(dimension)
+                'Wrong qid dimension. Expected a positive integer but got {}.'.format(dimension)
             )
 
     def with_dimension(self, dimension: int) -> 'Qid':
@@ -736,5 +736,5 @@ def _validate_qid_shape(val: Any, qubits: Sequence['cirq.Qid']) -> None:
         )
     if len(set(qubits)) != len(qubits):
         raise ValueError(
-            'Duplicate qids for <{!r}>. ' 'Expected unique qids but got <{!r}>.'.format(val, qubits)
+            'Duplicate qids for <{!r}>. Expected unique qids but got <{!r}>.'.format(val, qubits)
         )

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -151,7 +151,7 @@ class SwapPowGate(
             if self._exponent == 1:
                 return 'cirq.SWAP'
             return f'(cirq.SWAP**{e})'
-        return f'cirq.SwapPowGate(exponent={e}, ' f'global_shift={self._global_shift!r})'
+        return f'cirq.SwapPowGate(exponent={e}, global_shift={self._global_shift!r})'
 
 
 class ISwapPowGate(
@@ -264,7 +264,7 @@ class ISwapPowGate(
             if self._exponent == 1:
                 return 'cirq.ISWAP'
             return f'(cirq.ISWAP**{e})'
-        return f'cirq.ISwapPowGate(exponent={e}, ' f'global_shift={self._global_shift!r})'
+        return f'cirq.ISwapPowGate(exponent={e}, global_shift={self._global_shift!r})'
 
     def _quil_(self, qubits: Tuple['cirq.Qid', ...], formatter: 'cirq.QuilFormatter') -> str:
         if self._exponent == 1:

--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -158,7 +158,7 @@ class CCZPowGate(
             if self._exponent == 1:
                 return 'cirq.CCZ'
             return '(cirq.CCZ**{})'.format(proper_repr(self._exponent))
-        return ('cirq.CCZPowGate(exponent={}, ' 'global_shift={!r})').format(
+        return 'cirq.CCZPowGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 
@@ -412,7 +412,7 @@ class CCXPowGate(
             if self._exponent == 1:
                 return 'cirq.TOFFOLI'
             return '(cirq.TOFFOLI**{})'.format(proper_repr(self._exponent))
-        return ('cirq.CCXPowGate(exponent={}, ' 'global_shift={!r})').format(
+        return 'cirq.CCXPowGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 

--- a/cirq/pasqal/pasqal_device.py
+++ b/cirq/pasqal/pasqal_device.py
@@ -142,7 +142,7 @@ class PasqalDevice(cirq.devices.Device):
             raise ValueError("Unsupported operation")
 
         if not self.is_pasqal_device_op(operation):
-            raise ValueError('{!r} is not a supported ' 'gate'.format(operation.gate))
+            raise ValueError('{!r} is not a supported gate'.format(operation.gate))
 
         for qub in operation.qubits:
             if not isinstance(qub, self.supported_qubit_type):
@@ -157,7 +157,7 @@ class PasqalDevice(cirq.devices.Device):
         if isinstance(operation.gate, cirq.ops.MeasurementGate):
             if operation.gate.invert_mask != ():
                 raise NotImplementedError(
-                    "Measurements on Pasqal devices " "don't support invert_mask."
+                    "Measurements on Pasqal devices don't support invert_mask."
                 )
 
     def validate_circuit(self, circuit: 'cirq.Circuit') -> None:
@@ -291,7 +291,7 @@ class PasqalVirtualDevice(PasqalDevice):
                 for p in operation.qubits:
                     for q in operation.qubits:
                         if self.distance(p, q) > self.control_radius:
-                            raise ValueError("Qubits {!r}, {!r} are too " "far away".format(p, q))
+                            raise ValueError("Qubits {!r}, {!r} are too far away".format(p, q))
 
     def validate_moment(self, moment: cirq.ops.Moment):
         """Raises an error if the given moment is invalid on this device.
@@ -306,9 +306,7 @@ class PasqalVirtualDevice(PasqalDevice):
         if len(moment) > 1:
             for operation in moment:
                 if not isinstance(operation.gate, cirq.ops.MeasurementGate):
-                    raise ValueError(
-                        "Cannot do simultaneous gates. Use " "cirq.InsertStrategy.NEW."
-                    )
+                    raise ValueError("Cannot do simultaneous gates. Use cirq.InsertStrategy.NEW.")
 
     def minimal_distance(self) -> float:
         """Returns the minimal distance between two qubits in qubits.
@@ -353,7 +351,7 @@ class PasqalVirtualDevice(PasqalDevice):
         return np.sqrt((p.x - q.x) ** 2 + (p.y - q.y) ** 2 + (p.z - q.z) ** 2)
 
     def __repr__(self):
-        return ('pasqal.PasqalVirtualDevice(control_radius={!r}, ' 'qubits={!r})').format(
+        return ('pasqal.PasqalVirtualDevice(control_radius={!r}, qubits={!r})').format(
             self.control_radius, sorted(self.qubits)
         )
 

--- a/cirq/pasqal/pasqal_device_test.py
+++ b/cirq/pasqal/pasqal_device_test.py
@@ -178,7 +178,7 @@ def test_validate_operation_errors():
         d.validate_operation(cirq.X.on(cirq.NamedQubit('q6')))
 
     with pytest.raises(
-        NotImplementedError, match="Measurements on Pasqal devices " "don't support invert_mask."
+        NotImplementedError, match="Measurements on Pasqal devices don't support invert_mask."
     ):
         circuit.append(cirq.measure(*d.qubits, invert_mask=(True, False, False)))
 
@@ -260,10 +260,10 @@ def test_value_equal():
 
 
 def test_repr():
-    assert repr(generic_device(1)) == ("pasqal.PasqalDevice(" "qubits=[cirq.NamedQubit('q0')])")
+    assert repr(generic_device(1)) == ("pasqal.PasqalDevice(qubits=[cirq.NamedQubit('q0')])")
     dev = PasqalVirtualDevice(control_radius=1.0, qubits=[TwoDQubit(0, 0)])
     assert repr(dev) == (
-        "pasqal.PasqalVirtualDevice(" "control_radius=1.0, " "qubits=[pasqal.TwoDQubit(0, 0)])"
+        "pasqal.PasqalVirtualDevice(control_radius=1.0, qubits=[pasqal.TwoDQubit(0, 0)])"
     )
 
 

--- a/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq/protocols/circuit_diagram_info_protocol.py
@@ -417,7 +417,7 @@ def circuit_diagram_info(
         return default
     if getter is None:
         raise TypeError(
-            "object of type '{}' " "has no _circuit_diagram_info_ method.".format(type(val))
+            "object of type '{}' has no _circuit_diagram_info_ method.".format(type(val))
         )
     raise TypeError(
         "object of type '{}' does have a _circuit_diagram_info_ "

--- a/cirq/protocols/decompose_protocol.py
+++ b/cirq/protocols/decompose_protocol.py
@@ -52,7 +52,7 @@ OpDecomposer = Callable[['cirq.Operation'], DecomposeResult]
 
 def _value_error_describing_bad_operation(op: 'cirq.Operation') -> ValueError:
     return ValueError(
-        "Operation doesn't satisfy the given `keep` " "but can't be decomposed: {!r}".format(op)
+        "Operation doesn't satisfy the given `keep` but can't be decomposed: {!r}".format(op)
     )
 
 
@@ -303,7 +303,7 @@ def decompose_once(val: Any, default=RaiseTypeErrorIfNotProvided, *args, **kwarg
     if default is not RaiseTypeErrorIfNotProvided:
         return default
     if method is None:
-        raise TypeError("object of type '{}' " "has no _decompose_ method.".format(type(val)))
+        raise TypeError("object of type '{}' has no _decompose_ method.".format(type(val)))
     raise TypeError(
         "object of type '{}' does have a _decompose_ method, "
         "but it returned NotImplemented or None.".format(type(val))

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -418,7 +418,7 @@ def _cirq_object_hook(d, resolvers: Sequence[JsonResolver]):
             break
     else:
         raise ValueError(
-            "Could not resolve type '{}' " "during deserialization".format(d['cirq_type'])
+            "Could not resolve type '{}' during deserialization".format(d['cirq_type'])
         )
 
     from_json_dict = getattr(cls, '_from_json_dict_', None)

--- a/cirq/protocols/json_serialization_test.py
+++ b/cirq/protocols/json_serialization_test.py
@@ -104,7 +104,7 @@ def test_fail_to_resolve():
 
     with pytest.raises(ValueError) as e:
         cirq.read_json(buffer)
-    assert e.match("Could not resolve type 'MyCustomClass' " "during deserialization")
+    assert e.match("Could not resolve type 'MyCustomClass' during deserialization")
 
 
 QUBITS = cirq.LineQubit.range(5)

--- a/cirq/protocols/measurement_key_protocol.py
+++ b/cirq/protocols/measurement_key_protocol.py
@@ -98,7 +98,7 @@ def measurement_key(val: Any, default: Any = RaiseTypeErrorIfNotProvided):
         return next(iter(result))
 
     if len(result) > 1:
-        raise ValueError(f'Got multiple measurement keys ({result!r}) ' f'from {val!r}.')
+        raise ValueError(f'Got multiple measurement keys ({result!r}) from {val!r}.')
 
     if default is not RaiseTypeErrorIfNotProvided:
         return default

--- a/cirq/protocols/phase_protocol.py
+++ b/cirq/protocols/phase_protocol.py
@@ -86,7 +86,7 @@ def phase_by(
         return default
 
     if getter is None:
-        raise TypeError("object of type '{}' " "has no _phase_by_ method.".format(type(val)))
+        raise TypeError("object of type '{}' has no _phase_by_ method.".format(type(val)))
     raise TypeError(
         "object of type '{}' does have a _phase_by_ method, "
         "but it returned NotImplemented.".format(type(val))

--- a/cirq/protocols/pow_protocol.py
+++ b/cirq/protocols/pow_protocol.py
@@ -89,7 +89,7 @@ def pow(val: Any, exponent: Any, default: Any = RaiseTypeErrorIfNotProvided) -> 
     if default is not RaiseTypeErrorIfNotProvided:
         return default
     if raiser is None:
-        raise TypeError("object of type '{}' " "has no __pow__ method.".format(type(val)))
+        raise TypeError("object of type '{}' has no __pow__ method.".format(type(val)))
     raise TypeError(
         "object of type '{}' does have a __pow__ method, "
         "but it returned NotImplemented.".format(type(val))

--- a/cirq/protocols/qasm.py
+++ b/cirq/protocols/qasm.py
@@ -165,7 +165,7 @@ def qasm(
     if default is not RaiseTypeErrorIfNotProvided:
         return default
     if method is None:
-        raise TypeError("object of type '{}' " "has no _qasm_ method.".format(type(val)))
+        raise TypeError("object of type '{}' has no _qasm_ method.".format(type(val)))
     raise TypeError(
         "object of type '{}' does have a _qasm_ method, "
         "but it returned NotImplemented or None.".format(type(val))

--- a/cirq/protocols/qid_shape_protocol.py
+++ b/cirq/protocols/qid_shape_protocol.py
@@ -132,7 +132,7 @@ def qid_shape(
             "but it returned NotImplemented.".format(type(val))
         )
     raise TypeError(
-        "object of type '{}' has no _num_qubits_ or _qid_shape_ " "methods.".format(type(val))
+        "object of type '{}' has no _num_qubits_ or _qid_shape_ methods.".format(type(val))
     )
 
 
@@ -189,5 +189,5 @@ def num_qubits(
             "but it returned NotImplemented.".format(type(val))
         )
     raise TypeError(
-        "object of type '{}' has no _num_qubits_ or _qid_shape_ " "methods.".format(type(val))
+        "object of type '{}' has no _num_qubits_ or _qid_shape_ methods.".format(type(val))
     )

--- a/cirq/qis/states.py
+++ b/cirq/qis/states.py
@@ -510,7 +510,7 @@ def validate_indices(num_qubits: int, indices: Sequence[int]) -> None:
         raise IndexError('Negative index in indices: {}'.format(indices))
     if any(index >= num_qubits for index in indices):
         raise IndexError(
-            'Out of range indices, must be less than number of ' 'qubits but was {}'.format(indices)
+            'Out of range indices, must be less than number of qubits but was {}'.format(indices)
         )
 
 
@@ -598,7 +598,7 @@ def validate_density_matrix(
         raise ValueError('The density matrix is not hermitian.')
     trace = np.trace(density_matrix)
     if not np.isclose(trace, 1.0, atol=atol):
-        raise ValueError('Density matrix does not have trace 1. Instead, it has ' f'trace {trace}.')
+        raise ValueError(f'Density matrix does not have trace 1. Instead, it has trace {trace}.')
     if not np.all(np.linalg.eigvalsh(density_matrix) > -atol):
         raise ValueError('The density matrix is not positive semidefinite.')
 
@@ -613,7 +613,7 @@ def _qid_shape_from_args(
     """
     if num_qubits is None and qid_shape is None:
         raise ValueError(
-            'Either the num_qubits or qid_shape argument must be ' 'specified. Both were None.'
+            'Either the num_qubits or qid_shape argument must be specified. Both were None.'
         )
     if num_qubits is None:
         return cast(Tuple[int, ...], qid_shape)

--- a/cirq/sim/density_matrix_simulator.py
+++ b/cirq/sim/density_matrix_simulator.py
@@ -555,7 +555,7 @@ class DensityMatrixTrialResult(simulator.SimulationTrialResult):
 
     def __str__(self) -> str:
         samples = super().__str__()
-        return f'measurements: {samples}\n' f'final density matrix:\n{self.final_density_matrix}'
+        return f'measurements: {samples}\nfinal density matrix:\n{self.final_density_matrix}'
 
     def __repr__(self) -> str:
         return (

--- a/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq/sim/density_matrix_simulator_test.py
@@ -1006,7 +1006,7 @@ def test_density_matrix_trial_result_str():
     # Eliminate whitespace to harden tests against this variation
     result_no_whitespace = str(result).replace('\n', '').replace(' ', '')
     assert result_no_whitespace == (
-        'measurements:(nomeasurements)' 'finaldensitymatrix:' '[[0.50.5][0.50.5]]'
+        'measurements:(nomeasurements)finaldensitymatrix:[[0.50.5][0.50.5]]'
     )
 
 

--- a/cirq/sim/density_matrix_utils.py
+++ b/cirq/sim/density_matrix_utils.py
@@ -286,6 +286,6 @@ def _indices_shape(qid_shape: Tuple[int, ...], indices: List[int]) -> Tuple[int,
         raise IndexError('Negative index in indices: {}'.format(indices))
     if any(index >= len(qid_shape) for index in indices):
         raise IndexError(
-            'Out of range indices, must be less than number of ' 'qubits but was {}'.format(indices)
+            'Out of range indices, must be less than number of qubits but was {}'.format(indices)
         )
     return tuple(qid_shape[i] for i in indices)

--- a/cirq/sim/state_vector_simulator_test.py
+++ b/cirq/sim/state_vector_simulator_test.py
@@ -142,7 +142,7 @@ def test_str_big():
         {},
         cirq.StateVectorSimulatorState(np.array([1] * 2 ** 10), {q: q.x for q in qs}),
     )
-    assert str(result).startswith('measurements: (no measurements)\n' 'output vector: [1 1 1 ..')
+    assert str(result).startswith('measurements: (no measurements)\noutput vector: [1 1 1 ..')
 
 
 def test_pretty_print():

--- a/cirq/study/flatten_expressions.py
+++ b/cirq/study/flatten_expressions.py
@@ -290,9 +290,7 @@ class _ParamFlattener(resolver.ParamResolver):
         if self.get_param_name == self.default_get_param_name:
             return f'_ParamFlattener({self.param_dict!r})'
         else:
-            return (
-                f'_ParamFlattener({self.param_dict!r}, ' f'get_param_name={self.get_param_name!r})'
-            )
+            return f'_ParamFlattener({self.param_dict!r}, get_param_name={self.get_param_name!r})'
 
     def flatten(self, val: Any) -> Any:
         """Returns a copy of `val` with any symbols or expressions replaced with

--- a/cirq/study/resolver_test.py
+++ b/cirq/study/resolver_test.py
@@ -91,25 +91,25 @@ def _assert_consistent_resolution(v, resolved, subs_called=False):
 
     # symbol based resolution
     s = SubsAwareSymbol('a')
-    assert r.value_of(s) == resolved, f"expected {resolved}, " f"got {r.value_of(s)}"
-    assert subs_called == s.called, (
-        f"For pass-through type " f"{type(v)} sympy.subs shouldn't have been called."
-    )
-    assert isinstance(r.value_of(s), type(resolved)), (
-        f"expected {type(resolved)} " f"got {type(r.value_of(s))}"
-    )
+    assert r.value_of(s) == resolved, f"expected {resolved}, got {r.value_of(s)}"
+    assert (
+        subs_called == s.called
+    ), f"For pass-through type {type(v)} sympy.subs shouldn't have been called."
+    assert isinstance(
+        r.value_of(s), type(resolved)
+    ), f"expected {type(resolved)} got {type(r.value_of(s))}"
 
     # string based resolution (which in turn uses symbol based resolution)
-    assert r.value_of('a') == resolved, f"expected {resolved}, " f"got {r.value_of('a')}"
-    assert isinstance(r.value_of('a'), type(resolved)), (
-        f"expected {type(resolved)} " f"got {type(r.value_of('a'))}"
-    )
+    assert r.value_of('a') == resolved, f"expected {resolved}, got {r.value_of('a')}"
+    assert isinstance(
+        r.value_of('a'), type(resolved)
+    ), f"expected {type(resolved)} got {type(r.value_of('a'))}"
 
     # value based resolution
-    assert r.value_of(v) == resolved, f"expected {resolved}, " f"got {r.value_of(v)}"
-    assert isinstance(r.value_of(v), type(resolved)), (
-        f"expected {type(resolved)} " f"got {type(r.value_of(v))}"
-    )
+    assert r.value_of(v) == resolved, f"expected {resolved}, got {r.value_of(v)}"
+    assert isinstance(
+        r.value_of(v), type(resolved)
+    ), f"expected {type(resolved)} got {type(r.value_of(v))}"
 
 
 def test_value_of_strings():

--- a/cirq/study/result.py
+++ b/cirq/study/result.py
@@ -268,7 +268,7 @@ class Result:
             '{' + ', '.join([item_repr(e) for e in self.measurements.items()]) + '}'
         )
 
-        return f'cirq.Result(params={self.params!r}, ' f'measurements={measurement_dict_repr})'
+        return f'cirq.Result(params={self.params!r}, measurements={measurement_dict_repr})'
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:
         """Output to show in ipython and Jupyter notebooks."""

--- a/cirq/study/sweepable.py
+++ b/cirq/study/sweepable.py
@@ -63,7 +63,7 @@ def to_sweeps(sweepable: Sweepable) -> List[Sweep]:
             for item in sweepable
             for sweep in to_sweeps(cast(Union[Dict[str, float], ParamResolver, Sweep], item))
         ]
-    raise TypeError(f'Unrecognized sweepable type: {type(sweepable)}.\n' f'sweepable: {sweepable}')
+    raise TypeError(f'Unrecognized sweepable type: {type(sweepable)}.\nsweepable: {sweepable}')
 
 
 def to_sweep(

--- a/cirq/testing/asynchronous.py
+++ b/cirq/testing/asynchronous.py
@@ -66,7 +66,7 @@ class _AwaitBeforeAssert:
 
     def __bool__(self):
         raise RuntimeError(
-            'You forgot the "await" in ' '"assert await cirq.testing.asyncio_pending(...)".'
+            'You forgot the "await" in "assert await cirq.testing.asyncio_pending(...)".'
         )
 
     def __await__(self):

--- a/cirq/testing/circuit_compare.py
+++ b/cirq/testing/circuit_compare.py
@@ -408,11 +408,11 @@ def assert_has_consistent_qid_shape(val: Any) -> None:
     if qid_shape is default or num_qubits is default:
         return  # Nothing to check
     assert all(d >= 1 for d in qid_shape), f'Not all entries in qid_shape are positive: {qid_shape}'
-    assert len(qid_shape) == num_qubits, (
-        f'Length of qid_shape and num_qubits disagree: {qid_shape}, ' f'{num_qubits}'
-    )
+    assert (
+        len(qid_shape) == num_qubits
+    ), f'Length of qid_shape and num_qubits disagree: {qid_shape}, {num_qubits}'
 
     if isinstance(val, ops.Operation):
-        assert num_qubits == len(val.qubits), (
-            f'Length of num_qubits and val.qubits disagrees: {num_qubits}, ' f'{len(val.qubits)}'
-        )
+        assert num_qubits == len(
+            val.qubits
+        ), f'Length of num_qubits and val.qubits disagrees: {num_qubits}, {len(val.qubits)}'

--- a/cirq/testing/consistent_act_on.py
+++ b/cirq/testing/consistent_act_on.py
@@ -112,9 +112,9 @@ def assert_all_implemented_act_on_effects_match_unitary(
 
     tableau = _final_clifford_tableau(circuit, qubit_map)
     if tableau is None:
-        assert not assert_tableau_implemented, (
-            "Failed to generate final " "tableau for the test circuit." "\n\nval: {!r}".format(val)
-        )
+        assert (
+            not assert_tableau_implemented
+        ), "Failed to generate final tableau for the test circuit.\n\nval: {!r}".format(val)
     else:
         assert all(
             state_vector_has_stabilizer(state_vector, stab) for stab in tableau.stabilizers()

--- a/cirq/testing/consistent_act_on_test.py
+++ b/cirq/testing/consistent_act_on_test.py
@@ -63,7 +63,7 @@ def test_assert_act_on_clifford_tableau_effect_matches_unitary():
     )
     with pytest.raises(
         AssertionError,
-        match='act_on clifford tableau is not consistent with ' 'final_state_vector simulation.',
+        match='act_on clifford tableau is not consistent with final_state_vector simulation.',
     ):
         cirq.testing.assert_all_implemented_act_on_effects_match_unitary(BadGate())
 

--- a/cirq/testing/consistent_protocols.py
+++ b/cirq/testing/consistent_protocols.py
@@ -166,7 +166,7 @@ def assert_commutes_magic_method_consistent_with_unitaries(
     *vals: Sequence[Any], atol: Union[int, float] = 1e-8
 ) -> None:
     if any(isinstance(val, ops.Operation) for val in vals):
-        raise TypeError('`_commutes_` need not be consistent with unitaries ' 'for `Operation`.')
+        raise TypeError('`_commutes_` need not be consistent with unitaries for `Operation`.')
     unitaries = [protocols.unitary(val, None) for val in vals]
     pairs = itertools.permutations(zip(vals, unitaries), 2)
     for (left_val, left_unitary), (right_val, right_unitary) in pairs:

--- a/cirq/testing/consistent_protocols_test.py
+++ b/cirq/testing/consistent_protocols_test.py
@@ -194,7 +194,7 @@ class GoodEigenGate(cirq.EigenGate, cirq.SingleQubitGate):
         ]
 
     def __repr__(self):
-        return 'GoodEigenGate' '(exponent={}, global_shift={!r})'.format(
+        return 'GoodEigenGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 
@@ -204,7 +204,7 @@ class BadEigenGate(GoodEigenGate):
         return [0, 0]
 
     def __repr__(self):
-        return 'BadEigenGate' '(exponent={}, global_shift={!r})'.format(
+        return 'BadEigenGate(exponent={}, global_shift={!r})'.format(
             proper_repr(self._exponent), self._global_shift
         )
 

--- a/cirq/testing/equals_tester.py
+++ b/cirq/testing/equals_tester.py
@@ -38,9 +38,7 @@ class EqualsTester:
         eq = v1 == v2
         ne = v1 != v2
 
-        assert eq != ne, "__eq__ is inconsistent with __ne__ " "between {!r} and {!r}".format(
-            v1, v2
-        )
+        assert eq != ne, "__eq__ is inconsistent with __ne__ between {!r} and {!r}".format(v1, v2)
         return eq
 
     def _verify_equality_group(self, *group_items: Any):
@@ -67,7 +65,7 @@ class EqualsTester:
             assert same or v1 is not v2, "{!r} isn't equal to itself!".format(v1)
             assert (
                 same
-            ), "{!r} and {!r} can't be in the same equality group. " "They're not equal.".format(
+            ), "{!r} and {!r} can't be in the same equality group. They're not equal.".format(
                 v1, v2
             )
 
@@ -76,7 +74,7 @@ class EqualsTester:
             for v1, v2 in itertools.product(group_items, other_group):
                 assert not EqualsTester._eq_check(
                     v1, v2
-                ), "{!r} and {!r} can't be in different equality groups. " "They're equal.".format(
+                ), "{!r} and {!r} can't be in different equality groups. They're equal.".format(
                     v1, v2
                 )
 

--- a/cirq/testing/equivalent_repr_eval.py
+++ b/cirq/testing/equivalent_repr_eval.py
@@ -18,9 +18,7 @@ from typing import Any, Dict, Optional
 def assert_equivalent_repr(
     value: Any,
     *,
-    setup_code: str = (
-        'import cirq\n' 'import numpy as np\n' 'import sympy\n' 'import pandas as pd\n'
-    ),
+    setup_code: str = 'import cirq\nimport numpy as np\nimport sympy\nimport pandas as pd\n',
     global_vals: Optional[Dict[str, Any]] = None,
     local_vals: Optional[Dict[str, Any]] = None,
 ) -> None:

--- a/cirq/testing/random_circuit_test.py
+++ b/cirq/testing/random_circuit_test.py
@@ -36,7 +36,7 @@ def test_random_circuit_errors():
 
     with pytest.raises(
         ValueError,
-        match='After removing gates that act on less than 1 qubits, gate_domain ' 'had no gates',
+        match='After removing gates that act on less than 1 qubits, gate_domain had no gates',
     ):
         _ = cirq.testing.random_circuit(
             qubits=1, n_moments=5, op_density=0.5, gate_domain={cirq.CNOT: 2}

--- a/cirq/value/angle.py
+++ b/cirq/value/angle.py
@@ -40,7 +40,7 @@ def chosen_angle_to_half_turns(
     """
 
     if len([1 for e in [half_turns, rads, degs] if e is not None]) > 1:
-        raise ValueError('Redundant angle specification. ' 'Use ONE of half_turns, rads, or degs.')
+        raise ValueError('Redundant angle specification. Use ONE of half_turns, rads, or degs.')
 
     if rads is not None:
         return rads / np.pi

--- a/cirq/value/duration_test.py
+++ b/cirq/value/duration_test.py
@@ -198,11 +198,11 @@ def test_repr_preserves_type_information():
     assert repr(cirq.Duration(millis=1.5)) == 'cirq.Duration(micros=1500.0)'
 
     assert repr(cirq.Duration(micros=1500 * t)) == (
-        "cirq.Duration(micros=sympy.Mul(sympy.Integer(1500), " "sympy.Symbol('t')))"
+        "cirq.Duration(micros=sympy.Mul(sympy.Integer(1500), sympy.Symbol('t')))"
     )
     assert repr(cirq.Duration(micros=1500.0 * t)) == (
-        "cirq.Duration(micros=sympy.Mul(sympy.Float('1500.0', precision=53), " "sympy.Symbol('t')))"
+        "cirq.Duration(micros=sympy.Mul(sympy.Float('1500.0', precision=53), sympy.Symbol('t')))"
     )
     assert repr(cirq.Duration(millis=1.5 * t)) == (
-        "cirq.Duration(micros=sympy.Mul(sympy.Float('1500.0', precision=53), " "sympy.Symbol('t')))"
+        "cirq.Duration(micros=sympy.Mul(sympy.Float('1500.0', precision=53), sympy.Symbol('t')))"
     )

--- a/cirq/value/product_state.py
+++ b/cirq/value/product_state.py
@@ -71,7 +71,7 @@ class ProductState:
 
     def __mul__(self, other: 'cirq.ProductState') -> 'cirq.ProductState':
         if not isinstance(other, ProductState):
-            raise ValueError("Multiplication is only supported " "with other TensorProductStates.")
+            raise ValueError("Multiplication is only supported with other TensorProductStates.")
 
         dupe_qubits = set(other.states.keys()) & set(self.states.keys())
         if len(dupe_qubits) != 0:

--- a/cirq/value/value_equality_attr.py
+++ b/cirq/value/value_equality_attr.py
@@ -196,7 +196,7 @@ def value_equality(
         )
 
     if distinct_child_types and manual_cls:
-        raise ValueError("'distinct_child_types' is " "incompatible with 'manual_cls")
+        raise ValueError("'distinct_child_types' is incompatible with 'manual_cls")
 
     values_getter = getattr(cls, '_value_equality_values_', None)
     if values_getter is None:

--- a/cirq/work/zeros_sampler_test.py
+++ b/cirq/work/zeros_sampler_test.py
@@ -55,7 +55,7 @@ def test_sample():
 class OnlyMeasurementsDevice(cirq.Device):
     def validate_operation(self, operation: 'cirq.Operation') -> None:
         if not cirq.is_measurement(operation):
-            raise ValueError(f'{operation} is not a measurement and this ' f'device only measures!')
+            raise ValueError(f'{operation} is not a measurement and this device only measures!')
 
 
 def test_validate_device():

--- a/dev_tools/auto_merge.py
+++ b/dev_tools/auto_merge.py
@@ -45,7 +45,7 @@ class PullRequestDetails:
         References:
             https://developer.github.com/v3/pulls/#get-a-single-pull-request
         """
-        url = "https://api.github.com/repos/{}/{}/pulls/{}" "?access_token={}".format(
+        url = "https://api.github.com/repos/{}/{}/pulls/{}?access_token={}".format(
             repo.organization, repo.name, pull_id, repo.access_token
         )
 
@@ -195,7 +195,7 @@ def add_comment(repo: GithubRepository, pull_id: int, text: str) -> None:
     References:
         https://developer.github.com/v3/issues/comments/#create-a-comment
     """
-    url = "https://api.github.com/repos/{}/{}/issues/{}/comments" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/issues/{}/comments?access_token={}".format(
         repo.organization, repo.name, pull_id, repo.access_token
     )
     data = {'body': text}
@@ -214,7 +214,7 @@ def edit_comment(repo: GithubRepository, text: str, comment_id: int) -> None:
     References:
         https://developer.github.com/v3/issues/comments/#edit-a-comment
     """
-    url = "https://api.github.com/repos/{}/{}/issues/comments/{}" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/issues/comments/{}?access_token={}".format(
         repo.organization, repo.name, comment_id, repo.access_token
     )
     data = {'body': text}
@@ -233,7 +233,7 @@ def get_branch_details(repo: GithubRepository, branch: str) -> Any:
     References:
         https://developer.github.com/v3/repos/branches/#get-branch
     """
-    url = "https://api.github.com/repos/{}/{}/branches/{}" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/branches/{}?access_token={}".format(
         repo.organization, repo.name, branch, repo.access_token
     )
     response = requests.get(url)
@@ -254,7 +254,7 @@ def get_pr_statuses(pr: PullRequestDetails) -> List[Dict[str, Any]]:
         https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
     """
 
-    url = "https://api.github.com/repos/{}/{}/commits/{}/statuses" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/commits/{}/statuses?access_token={}".format(
         pr.repo.organization, pr.repo.name, pr.branch_sha, pr.repo.access_token
     )
     response = requests.get(url)
@@ -275,7 +275,7 @@ def get_pr_check_status(pr: PullRequestDetails) -> Any:
         https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
     """
 
-    url = "https://api.github.com/repos/{}/{}/commits/{}/status" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/commits/{}/status?access_token={}".format(
         pr.repo.organization, pr.repo.name, pr.branch_sha, pr.repo.access_token
     )
     response = requests.get(url)
@@ -358,7 +358,7 @@ def get_pr_checks(pr: PullRequestDetails) -> Dict[str, Any]:
     References:
         https://developer.github.com/v3/checks/runs/#list-check-runs-for-a-specific-ref
     """
-    url = "https://api.github.com/repos/{}/{}/commits/{}/check-runs" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/commits/{}/check-runs?access_token={}".format(
         pr.repo.organization, pr.repo.name, pr.branch_sha, pr.repo.access_token
     )
     response = requests.get(url, headers={'Accept': 'application/vnd.github.antiope-preview+json'})
@@ -417,7 +417,7 @@ def get_repo_ref(repo: GithubRepository, ref: str) -> Dict[str, Any]:
         https://developer.github.com/v3/git/refs/#get-a-reference
     """
 
-    url = "https://api.github.com/repos/{}/{}/git/refs/{}" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/git/refs/{}?access_token={}".format(
         repo.organization, repo.name, ref, repo.access_token
     )
     response = requests.get(url)
@@ -441,7 +441,7 @@ def list_pr_comments(repo: GithubRepository, pull_id: int) -> List[Dict[str, Any
     References:
         https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
     """
-    url = "https://api.github.com/repos/{}/{}/issues/{}/comments" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/issues/{}/comments?access_token={}".format(
         repo.organization, repo.name, pull_id, repo.access_token
     )
     response = requests.get(url)
@@ -460,7 +460,7 @@ def delete_comment(repo: GithubRepository, comment_id: int) -> None:
     References:
         https://developer.github.com/v3/issues/comments/#delete-a-comment
     """
-    url = "https://api.github.com/repos/{}/{}/issues/comments/{}" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/issues/comments/{}?access_token={}".format(
         repo.organization, repo.name, comment_id, repo.access_token
     )
     response = requests.delete(url)
@@ -517,7 +517,7 @@ def attempt_sync_with_master(pr: PullRequestDetails) -> Union[bool, CannotAutome
     """
     master_sha = get_master_sha(pr.repo)
     remote = pr.remote_repo
-    url = "https://api.github.com/repos/{}/{}/merges" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/merges?access_token={}".format(
         remote.organization, remote.name, remote.access_token
     )
     data = {
@@ -559,7 +559,7 @@ def attempt_squash_merge(pr: PullRequestDetails) -> Union[bool, CannotAutomergeE
     References:
         https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
     """
-    url = "https://api.github.com/repos/{}/{}/pulls/{}/merge" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/pulls/{}/merge?access_token={}".format(
         pr.repo.organization, pr.repo.name, pr.pull_id, pr.repo.access_token
     )
     data = {
@@ -607,7 +607,7 @@ def auto_delete_pr_branch(pr: PullRequestDetails) -> bool:
         )
         return False
 
-    url = "https://api.github.com/repos/{}/{}/git/refs/heads/{}" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/git/refs/heads/{}?access_token={}".format(
         remote.organization, remote.name, pr.branch_name, remote.access_token
     )
     response = requests.delete(url)
@@ -635,7 +635,7 @@ def add_labels_to_pr(
     References:
         https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
     """
-    url = "https://api.github.com/repos/{}/{}/issues/{}/labels" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/issues/{}/labels?access_token={}".format(
         repo.organization, repo.name, pull_id, override_token or repo.access_token
     )
     response = requests.post(url, json=list(labels))
@@ -653,7 +653,7 @@ def remove_label_from_pr(repo: GithubRepository, pull_id: int, label: str) -> bo
     References:
         https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
     """
-    url = "https://api.github.com/repos/{}/{}/issues/{}/labels/{}" "?access_token={}".format(
+    url = "https://api.github.com/repos/{}/{}/issues/{}/labels/{}?access_token={}".format(
         repo.organization, repo.name, pull_id, label, repo.access_token
     )
     response = requests.delete(url)
@@ -915,7 +915,7 @@ def main():
             '{} not set. Trying secret manager.'.format(ACCESS_TOKEN_ENV_VARIABLE), file=sys.stderr
         )
         client = secretmanager_v1beta1.SecretManagerServiceClient()
-        secret_name = f'projects/{project_id}/' f'secrets/cirq-bot-api-key/versions/1'
+        secret_name = f'projects/{project_id}/secrets/cirq-bot-api-key/versions/1'
         response = client.access_secret_version(name=secret_name)
         access_token = response.payload.data.decode('UTF-8')
 

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -89,14 +89,14 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         script_file='check/pytest-changed-files',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD~1',
-        setup='touch file.py\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch file.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert result.out == ''
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD~1'.\n" "Found 0 test files associated with changes.\n"
+            "Comparing against revision 'HEAD~1'.\nFound 0 test files associated with changes.\n"
         ).split()
     )
 
@@ -104,14 +104,14 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         script_file='check/pytest-changed-files',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD~1',
-        setup='touch file_test.py\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch file_test.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert result.out == 'INTERCEPTED pytest file_test.py\n'
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD~1'.\n" "Found 1 test files associated with changes.\n"
+            "Comparing against revision 'HEAD~1'.\nFound 1 test files associated with changes.\n"
         ).split()
     )
 
@@ -128,7 +128,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD~1'.\n" "Found 1 test files associated with changes.\n"
+            "Comparing against revision 'HEAD~1'.\nFound 1 test files associated with changes.\n"
         ).split()
     )
 
@@ -146,7 +146,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD'.\n" "Found 1 test files associated with changes.\n"
+            "Comparing against revision 'HEAD'.\nFound 1 test files associated with changes.\n"
         ).split()
     )
 
@@ -164,7 +164,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD'.\n" "Found 1 test files associated with changes.\n"
+            "Comparing against revision 'HEAD'.\nFound 1 test files associated with changes.\n"
         ).split()
     )
 
@@ -185,7 +185,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD'.\n" "Found 2 test files associated with changes.\n"
+            "Comparing against revision 'HEAD'.\nFound 2 test files associated with changes.\n"
         ).split()
     )
 
@@ -201,7 +201,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD'.\n" "Found 0 test files associated with changes.\n"
+            "Comparing against revision 'HEAD'.\nFound 0 test files associated with changes.\n"
         ).split()
     )
 
@@ -218,7 +218,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'master'.\n" "Found 0 test files associated with changes.\n"
+            "Comparing against revision 'master'.\nFound 0 test files associated with changes.\n"
         ).split()
     )
 
@@ -271,7 +271,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         script_file='check/pytest-changed-files',
         tmpdir_factory=tmpdir_factory,
         arg='file',
-        setup='git checkout -b other --quiet\n' 'git branch -D master --quiet\n',
+        setup='git checkout -b other --quiet\ngit branch -D master --quiet\n',
     )
     assert result.exit_code == 1
     assert result.out == ''
@@ -282,7 +282,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         script_file='check/pytest-changed-files',
         tmpdir_factory=tmpdir_factory,
         arg='file',
-        setup='touch file\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch file\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 1
     assert result.out == ''
@@ -293,28 +293,28 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         script_file='check/pytest-changed-files',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD',
-        setup='touch HEAD\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch HEAD\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert result.out == ''
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD'.\n" "Found 0 test files associated with changes.\n"
+            "Comparing against revision 'HEAD'.\nFound 0 test files associated with changes.\n"
         ).split()
     )
 
     result = run(
         script_file='check/pytest-changed-files',
         tmpdir_factory=tmpdir_factory,
-        setup='touch master\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch master\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert result.out == ''
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'master'.\n" "Found 0 test files associated with changes.\n"
+            "Comparing against revision 'master'.\nFound 0 test files associated with changes.\n"
         ).split()
     )
 
@@ -324,7 +324,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         tmpdir_factory=tmpdir_factory,
         setup='mkdir alt\n'
         'cd alt\n'
-        'git init --quiet\n'
+        'git init --quiet --initial-branch master\n'
         'git config --local user.name \'Me\'\n'
         'git config --local user.email \'<>\'\n'
         'git commit -m tes --quiet --allow-empty --no-gpg-sign\n'
@@ -436,7 +436,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     result = run(
         script_file='check/pytest-and-incremental-coverage',
         tmpdir_factory=tmpdir_factory,
-        setup='git checkout -b other --quiet\n' 'git branch -D master --quiet\n',
+        setup='git checkout -b other --quiet\ngit branch -D master --quiet\n',
         additional_intercepts=['check/pytest'],
     )
     assert result.exit_code == 1
@@ -448,7 +448,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         script_file='check/pytest-and-incremental-coverage',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD',
-        setup='touch HEAD\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch HEAD\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
         additional_intercepts=['check/pytest'],
     )
     assert result.exit_code == 0
@@ -464,7 +464,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     result = run(
         script_file='check/pytest-and-incremental-coverage',
         tmpdir_factory=tmpdir_factory,
-        setup='touch master\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch master\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
         additional_intercepts=['check/pytest'],
     )
     assert result.exit_code == 0
@@ -550,7 +550,7 @@ def test_incremental_format_branch_selection(tmpdir_factory):
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
-        setup='git checkout -b other --quiet\n' 'git branch -D master --quiet\n',
+        setup='git checkout -b other --quiet\ngit branch -D master --quiet\n',
     )
     assert result.exit_code == 1
     assert result.out == ''
@@ -561,7 +561,7 @@ def test_incremental_format_branch_selection(tmpdir_factory):
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD',
-        setup='touch HEAD.py\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch HEAD.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert "No files to format" in result.out
@@ -570,7 +570,7 @@ def test_incremental_format_branch_selection(tmpdir_factory):
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
-        setup='touch master.py\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch master.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert "No files to format" in result.out
@@ -603,7 +603,7 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         script_file='check/pylint-changed-files',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD~1',
-        setup='touch file.py\n' 'git add -A\n' 'git commit -m test --quiet --no-gpg-sign\n',
+        setup='touch file.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
     assert result.out == ''
@@ -686,9 +686,7 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         'git commit -m test --quiet --no-gpg-sign\n',
     )
     assert result.exit_code == 0
-    assert result.out == intercepted_prefix + (
-        'cirq/file.py dev_tools/file.py ' 'examples/file.py\n'
-    )
+    assert result.out == intercepted_prefix + ('cirq/file.py dev_tools/file.py examples/file.py\n')
     assert (
         result.err.split()
         == (

--- a/dev_tools/check_incremental_coverage_annotations.py
+++ b/dev_tools/check_incremental_coverage_annotations.py
@@ -26,7 +26,7 @@ def main():
     if len(sys.argv) < 2:
         print(
             shell_tools.highlight(
-                'Must specify a comparison branch ' '(e.g. "origin/master" or "HEAD~1").',
+                'Must specify a comparison branch (e.g. "origin/master" or "HEAD~1").',
                 shell_tools.RED,
             )
         )

--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -31,7 +31,7 @@ flags.DEFINE_string("output_dir", "/tmp/cirq_api", "Where to output the docs")
 
 flags.DEFINE_string(
     "code_url_prefix",
-    ("https://github.com/quantumlib/cirq/tree/master/" "cirq"),
+    "https://github.com/quantumlib/cirq/tree/master/cirq",
     "The url prefix for links to code.",
 )
 

--- a/examples/bcs_mean_field.py
+++ b/examples/bcs_mean_field.py
@@ -169,7 +169,7 @@ def main():
     print(bog_circuit.to_text_diagram(transpose=True), '\n')
 
     # The inverse fermionic Fourier transformation on the spin-up states
-    print(('Circuit for the inverse fermionic Fourier transformation on the ' 'spin-up states:'))
+    print(('Circuit for the inverse fermionic Fourier transformation on the spin-up states:'))
     fourier_circuit_spin_up = cirq.Circuit(
         fermi_fourier_trans_inverse_4(upper_qubits), strategy=cirq.InsertStrategy.EARLIEST
     )
@@ -177,7 +177,7 @@ def main():
     print(fourier_circuit_spin_up.to_text_diagram(transpose=True), '\n')
 
     # The inverse fermionic Fourier transformation on the spin-down states
-    print(('Circuit for the inverse fermionic Fourier transformation on the ' 'spin-down states:'))
+    print(('Circuit for the inverse fermionic Fourier transformation on the spin-down states:'))
     fourier_circuit_spin_down = cirq.Circuit(
         fermi_fourier_trans_inverse_conjugate_4(lower_qubits), strategy=cirq.InsertStrategy.EARLIEST
     )

--- a/examples/direct_fidelity_estimation.py
+++ b/examples/direct_fidelity_estimation.py
@@ -411,7 +411,7 @@ def direct_fidelity_estimation(
         # sigma in https://arxiv.org/abs/1104.3835
         if not isinstance(sampler, cirq.DensityMatrixSimulator):
             raise TypeError(
-                'sampler is not a cirq.DensityMatrixSimulator ' 'but samples_per_term is zero.'
+                'sampler is not a cirq.DensityMatrixSimulator but samples_per_term is zero.'
             )
         noisy_simulator = cast(cirq.DensityMatrixSimulator, sampler)
         noisy_density_matrix = cast(

--- a/examples/phase_estimator.py
+++ b/examples/phase_estimator.py
@@ -74,7 +74,7 @@ def experiment(qnum, repetitions=100):
         result = run_estimate(example_gate(target), qnum, repetitions)
         mode = result.data['phase'].mode()[0]
         guess = mode / 2 ** qnum
-        print(f'target={target:0.4f}, ' f'estimate={guess:0.4f}={mode}/{2**qnum}')
+        print(f'target={target:0.4f}, estimate={guess:0.4f}={mode}/{2**qnum}')
         errors.append((target - guess) ** 2)
     rms = np.sqrt(sum(errors) / len(errors))
     print(f'RMS Error: {rms:0.4f}\n')

--- a/examples/shor.py
+++ b/examples/shor.py
@@ -136,7 +136,7 @@ class ModularExp(cirq.ArithmeticOperation):
     ) -> None:
         if len(target) < modulus.bit_length():
             raise ValueError(
-                f'Register with {len(target)} qubits is too small ' f'for modulus {modulus}'
+                f'Register with {len(target)} qubits is too small for modulus {modulus}'
             )
         self.target = target
         self.exponent = exponent

--- a/rtd_docs/docs_coverage_test.py
+++ b/rtd_docs/docs_coverage_test.py
@@ -25,7 +25,7 @@ def _all_public() -> Set[str]:
                 old_full_name, old_obj = by_name[name]
                 if obj is not old_obj:
                     # coverage: ignore
-                    raise ValueError(f'Ambiguous name:\n' f'{old_full_name}\n' f'{full_name}\n')
+                    raise ValueError(f'Ambiguous name:\n{old_full_name}\n{full_name}\n')
                 if len(full_name) > len(old_full_name):
                     continue
 
@@ -76,7 +76,7 @@ def test_public_values_equals_documented_values():
     }
     assert (
         not unlisted
-    ), 'Public class/method/value not listed in rtd_docs/api.rst:' '\n    ' + '\n    '.join(
+    ), 'Public class/method/value not listed in rtd_docs/api.rst:\n    ' + '\n    '.join(
         sorted(unlisted)
     )
     assert not hidden, (


### PR DESCRIPTION
As a follow-up to the switch to using black for formatting with increased line length, this merges adjacent string literals that now fit on one line. (Thanks @dabacon for noticing this: https://github.com/quantumlib/Cirq/pull/3516#issuecomment-736198107).