### PR TITLE
Fix pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dataclasses; python_version < '3.7'
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
 matplotlib~=3.0
 networkx~=2.4
-numpy~=1.16.1
+numpy~=1.17
 pandas
 protobuf~=3.13.0
 requests~=2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dataclasses; python_version < '3.7'
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
 matplotlib~=3.0
 networkx~=2.4
-numpy~=1.16
+numpy~=1.16.1
 pandas
 protobuf~=3.13.0
 requests~=2.18


### PR DESCRIPTION
Error highlighted by @akushnarov: `pandas requires NumPy >= 1.6.1 due to datetime64 dependency`.