### PR TITLE
Drop python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     name: Pytest Ubuntu
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8']
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
@@ -175,7 +175,7 @@ jobs:
     name: Pytest Windows
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8' ]
+        python-version: [ '3.7', '3.8' ]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -194,7 +194,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8' ]
+        python-version: [ '3.7', '3.8' ]
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.8
   install:
       - requirements: requirements.txt
       - requirements: dev_tools/conf/pip-list-dev-tools.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 100
-target_version = ['py36', 'py37', 'py38']
+target_version = ['py37', 'py38']
 skip-string-normalization = true

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     extras_require={
         'contrib': contrib_requirements,


### PR DESCRIPTION
Drop support (CI tests) for python 3.6.

Following #3347 we can safely drop python 3.6 support. This is also motivated by current breakages in Mac 3.6 and RTD #3554. This will not finalize #3347, we'll need to add some more documentation around the python support to close it fully.

Fixes #3554. See the successful build from my fork: https://readthedocs.org/projects/balopat-cirq-rtd/builds/12481463/