### PR TITLE
Remove bad delete char from docstring

### DIFF
--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -137,7 +137,7 @@ def resolve_parameters(
     Returns:
         a gate or operation of the same type, but with all Symbols
         replaced with floats or terminal symbols according to the
-        given ParamResolver. If `val` has no `_resolve_parameters_`
+        given ParamResolver. If `val` has no `_resolve_parameters_`
         method or if it returns NotImplemented, `val` itself is returned.
 
     Raises:


### PR DESCRIPTION
Can't see in the diff, but there was an errant delete character in the docstring causing an unicode issue when rendering the API reference page.