### PR TITLE
Remove stale rtd_docs/docs_coverage_test.py references from check/* scripts

### DIFF
--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -63,7 +63,6 @@ changed=$(git diff --name-only ${rev} -- \
 )
 if git diff --name-only "${rev}" -- | grep "__init__\.py$" > /dev/null; then
   # Include global API tests when an __init__ file is touched.
-  changed+=('rtd_docs/docs_coverage_test.py')
   changed+=('cirq/protocols/json_serialization_test.py')
 fi
 num_changed=$(echo -e "${changed[@]}" | wc -w)

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -76,7 +76,6 @@ changed_python_tests=$(git diff --name-only "${rev}" -- \
 )
 if git diff --name-only "${rev}" -- | grep "__init__\.py$" > /dev/null; then
   # Include global API tests when an __init__ file is touched.
-  changed_python_tests+=('rtd_docs/docs_coverage_test.py')
   changed_python_tests+=('cirq/protocols/json_serialization_test.py')
 fi
 if [ "${#changed_python_tests[@]}" -eq 0 ]; then

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -179,13 +179,12 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
     )
     assert result.exit_code == 0
     assert result.out == (
-        'INTERCEPTED pytest rtd_docs/docs_coverage_test.py '
-        'cirq/protocols/json_serialization_test.py\n'
+        'INTERCEPTED pytest cirq/protocols/json_serialization_test.py\n'
     )
     assert (
         result.err.split()
         == (
-            "Comparing against revision 'HEAD'.\nFound 2 test files associated with changes.\n"
+            "Comparing against revision 'HEAD'.\nFound 1 test files associated with changes.\n"
         ).split()
     )
 

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -178,9 +178,7 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         'echo x > __init__.py\n',
     )
     assert result.exit_code == 0
-    assert result.out == (
-        'INTERCEPTED pytest cirq/protocols/json_serialization_test.py\n'
-    )
+    assert result.out == ('INTERCEPTED pytest cirq/protocols/json_serialization_test.py\n')
     assert (
         result.err.split()
         == (


### PR DESCRIPTION
rtd_docs/docs_coverage_test.py file was deleted in PR3587 but some references to the file were left in check/* scripts because of which the scripts now fail. This PR removes those stale references. 