### PR TITLE
Remove unused dependency

### DIFF
--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -17,7 +17,6 @@ from typing import (
     TYPE_CHECKING,
     AbstractSet,
     Callable,
-    Dict,
     FrozenSet,
     Iterator,
     Optional,


### PR DESCRIPTION
Amusing story.  `pylint` has a flag `-j` which allows for parallel linting.  When I ran it in this mode it entered an infinite loops stuck on this.  Normal `pylint` did not seem to uncover it.  ¯\\\_(ツ)\_/¯