### PR TITLE
Format links in simulation docs

### DIFF
--- a/docs/simulation.ipynb
+++ b/docs/simulation.ipynb
@@ -87,8 +87,8 @@
     "Cirq comes with built-in Python simulators for testing\n",
     "small circuits. The two main types of simulations that Cirq\n",
     "supports are pure state and mixed state. The pure state simulations\n",
-    "are supported by ``cirq.Simulator`` and the mixed state\n",
-    "simulators are supported by ``cirq.DensityMatrixSimulator``.\n",
+    "are supported by `cirq.Simulator` and the mixed state\n",
+    "simulators are supported by `cirq.DensityMatrixSimulator`.\n",
     "\n",
     "The names *pure state simulator* and *mixed state\n",
     "simulators* refer to the fact that these simulations are\n",
@@ -134,7 +134,6 @@
     }
    ],
    "source": [
-    "!pip install cirq --quiet\n",
     "import cirq\n",
     "\n",
     "q0 = cirq.GridQubit(0, 0)\n",
@@ -194,11 +193,11 @@
     "id": "31212f98dfa7"
    },
    "source": [
-    "The method `run()` returns an ``Result``.  As you can see, the object `result` contains the result of any measurements for the simulation run.\n",
+    "The method `run()` returns an `Result`.  As you can see, the object `result` contains the result of any measurements for the simulation run.\n",
     "\n",
-    "The actual measurement results depend on the seeding from `random` seed generator (`numpy`) . You can set this using ``numpy.random_seed``.\n",
+    "The actual measurement results depend on the seeding from `random` seed generator (`numpy`) . You can set this using `numpy.random_seed`.\n",
     "\n",
-    "Another run, can result in a different set of measurement results:"
+    "Another run can result in a different set of measurement results:"
    ]
   },
   {
@@ -232,9 +231,9 @@
     "The simulator is designed to mimic what running a program\n",
     "on a quantum computer is actually like.  \n",
     "\n",
-    "In particular, the ``run()`` methods (``run()`` and ``run_sweep()``) on the simulator do not give access to the wave function of the quantum computer (since one doesn't have access to this on the actual quantum\n",
-    "hardware). Instead, the ``simulate()`` methods (``simulate()``,\n",
-    "``simulate_sweep()``, ``simulate_moment_steps()``) should be used\n",
+    "In particular, the `run()` methods (`run()` and `run_sweep()`) on the simulator do not give access to the wave function of the quantum computer (since one doesn't have access to this on the actual quantum\n",
+    "hardware). Instead, the `simulate()` methods (`simulate()`,\n",
+    "`simulate_sweep()`, `simulate_moment_steps()`) should be used\n",
     "if one wants to debug the circuit and get access to the full\n",
     "wave function:"
    ]
@@ -269,8 +268,8 @@
     "id": "2f16e46f0c9a"
    },
    "source": [
-    "Note that the simulator uses numpy's ``float32`` precision\n",
-    "(which is ``complex64`` for complex numbers) by default,\n",
+    "Note that the simulator uses numpy's `float32` precision\n",
+    "(which is `complex64` for complex numbers) by default,\n",
     "but that the simulator can take in a  `dtype` of `np.complex128`\n",
     "if higher precision is needed.\n"
    ]
@@ -431,7 +430,7 @@
     "state of the system at different steps in the circuit.  \n",
     "\n",
     "To support this, Cirq provides a method to return an iterator\n",
-    "over a ``Moment`` by ``Moment`` simulation.  This method is named ``simulate_moment_steps``:"
+    "over a `Moment` by `Moment` simulation.  This method is named `simulate_moment_steps`:"
    ]
   },
   {
@@ -465,13 +464,13 @@
     "id": "ef682175a07b"
    },
    "source": [
-    "The object returned by the ``moment_steps`` iterator is a\n",
-    "``StepResult``. This object has the state along with any\n",
+    "The object returned by the `moment_steps` iterator is a\n",
+    "`StepResult`. This object has the state along with any\n",
     "measurements that occurred **during** that step (so does\n",
-    "not include measurement results from previous ``Moments``).\n",
+    "not include measurement results from previous `Moments`).\n",
     "\n",
-    "In addition, the ``StepResult`` contains ``set_state()``,\n",
-    "which  can be used to set the ``state``. One can pass a valid\n",
+    "In addition, the `StepResult` contains `set_state()`,\n",
+    "which  can be used to set the `state`. One can pass a valid\n",
     "full state to this method by passing a numpy array. Or,\n",
     "alternatively, one can pass an integer, and then the state\n",
     "will be set lie entirely in the computation basis state\n",
@@ -487,13 +486,13 @@
     "## Parameterized values and studies\n",
     "\n",
     "In addition to circuit gates with fixed values, Cirq also\n",
-    "supports gates which can have ``Symbol`` value (see\n",
+    "supports gates which can have `Symbol` value (see\n",
     "[Gates](gates.ipynb)). These are values that can be resolved\n",
     "at *run-time*. \n",
     "\n",
     "For simulators, these values are resolved by\n",
-    "providing a ``ParamResolver``.  A ``ParamResolver`` provides\n",
-    "a map from the ``Symbol``'s name to its assigned value."
+    "providing a `cirq.ParamResolver`.  A `cirq.ParamResolver` provides\n",
+    "a map from the `Symbol`'s name to its assigned value."
    ]
   },
   {
@@ -532,13 +531,13 @@
     "id": "10617793bfd2"
    },
    "source": [
-    "Here we see that the ``Symbol`` is used in two gates, and then the resolver provides this value at run time.\n",
+    "Here we see that the `Symbol` is used in two gates, and then the resolver provides this value at run time.\n",
     "\n",
     "Parameterized values are most useful in defining what we call a\n",
-    "``sweep``.  A ``sweep`` is a sequence of trials, where each\n",
+    "`sweep`.  A `sweep` is a sequence of trials, where each\n",
     "trial is a run with a particular set of parameter values.\n",
     "\n",
-    "Running a ``sweep`` returns a ``Result`` for each set of fixed parameter values and repetitions.  \n",
+    "Running a `sweep` returns a `Result` for each set of fixed parameter values and repetitions.  \n",
     "\n",
     "For instance:"
    ]
@@ -583,7 +582,7 @@
    "source": [
     "Above we see that assigning different values to gate parameters yields\n",
     "different results for each trial in the sweep, and that each trial is repeated\n",
-    "``repetitions`` times."
+    "`repetitions` times."
    ]
   },
   {
@@ -604,7 +603,7 @@
     "can do). \n",
     "\n",
     "Mixed state simulation is supported by the\n",
-    "``cirq.DensityMatrixSimulator`` class.\n",
+    "`cirq.DensityMatrixSimulator` class.\n",
     "\n",
     "Here is a simple example of simulating a channel using the\n",
     "mixed state simulator:"
@@ -647,13 +646,13 @@
     "around 60 percent in the 0 state.\n",
     "\n",
     "Like the pure state simulators, the mixed state simulator\n",
-    "supports ``run()`` and ``run_sweeps()`` methods. \n",
+    "supports `run()` and `run_sweeps()` methods. \n",
     "\n",
-    "The ``cirq.DensityMatrixSimulator`` also supports getting access\n",
+    "The `cirq.DensityMatrixSimulator` also supports getting access\n",
     "to the density matrix of the circuit at the end of simulating\n",
     "the circuit, or when stepping through the circuit.  These are\n",
-    "done by the ``simulate()`` and ``simulate_sweep()`` methods, or,\n",
-    "for stepping through the circuit, via the ``simulate_moment_steps``\n",
+    "done by the `simulate()` and `simulate_sweep()` methods, or,\n",
+    "for stepping through the circuit, via the `simulate_moment_steps`\n",
     "method.   For example, we can simulate creating an equal\n",
     "superposition followed by an amplitude damping channel with a\n",
     "gamma of 0.2 by:"
@@ -690,7 +689,7 @@
    },
    "source": [
     "We see that we have access to the density matrix at the\n",
-    "end of the simulation via ``final_density_matrix``."
+    "end of the simulation via `final_density_matrix`."
    ]
   },
   {
@@ -702,7 +701,7 @@
     "## External simulators\n",
     "\n",
     "There are a few high-performance circuit simulators which\n",
-    "provide an interface for simulating Cirq ``Circuit``s.\n",
+    "provide an interface for simulating Cirq `Circuit`s.\n",
     "These projects are listed below, along with their PyPI package\n",
     "name and a description of simulator methods that they support.\n",
     "\n",
@@ -712,9 +711,9 @@
     "\n",
     "| Project name | PyPI package | Description |\n",
     "| --- | --- | --- |\n",
-    "| [qsim](https://github.com/quantumlib/qsim) | qsimcirq | Implements ``SimulatesAmplitudes`` and ``SimulatesFinalState``. Recommended for deep circuits with up to 30 qubits (consumes 8GB RAM). Larger circuits are possible, but RAM usage doubles with each additional qubit. |\n",
-    "| [qsimh](https://github.com/quantumlib/qsim/blob/master/qsimcirq/qsimh_simulator.py) | qsimcirq | Implements ``SimulatesAmplitudes``. Intended for heavy parallelization across several computers; Cirq users should generally prefer qsim. |\n",
-    "| [qFlex](https://github.com/ngnrsaa/qflex) | qflexcirq | Implements ``SimulatesAmplitudes``. Recommended for shallow / low-entanglement circuits with more than 30 qubits. RAM usage is highly dependent on the number of two-qubit gates in the circuit. |\n",
+    "| [qsim](https://github.com/quantumlib/qsim) | qsimcirq | Implements `cirq.SimulatesAmplitudes` and `cirq.SimulatesFinalState`. Recommended for deep circuits with up to 30 qubits (consumes 8GB RAM). Larger circuits are possible, but RAM usage doubles with each additional qubit. |\n",
+    "| [qsimh](https://github.com/quantumlib/qsim/blob/master/qsimcirq/qsimh_simulator.py) | qsimcirq | Implements `cirq.SimulatesAmplitudes`. Intended for heavy parallelization across several computers; Cirq users should generally prefer qsim. |\n",
+    "| [qFlex](https://github.com/ngnrsaa/qflex) | qflexcirq | Implements `cirq.SimulatesAmplitudes`. Recommended for shallow / low-entanglement circuits with more than 30 qubits. RAM usage is highly dependent on the number of two-qubit gates in the circuit. |\n",
     "| [quimb](https://quimb.readthedocs.io/en/latest/) | quimb | Cirq-to-quimb translation layer provided in `contrib/quimb`. In addition to circuit simulation, this allows the use of quimb circuit-analysis tools on Cirq circuits. |\n"
    ]
   }


### PR DESCRIPTION
Some links on the site are not rendering well for the [simulation docs](https://quantumai.google/cirq/simulation):

![image](https://user-images.githubusercontent.com/32416820/101688527-26e52e00-3a3a-11eb-9052-3ee7be5e29ba.png)

This PR fixes this by changing to one tick for inline code instead of two which renders well for other docs (e.g., [noise](https://quantumai.google/cirq/noise)).  Also removes extra Cirq install and fixes small typo.
