### PR TITLE
Update noise docs

### DIFF
--- a/docs/noise.ipynb
+++ b/docs/noise.ipynb
@@ -154,7 +154,7 @@
     "id": "f1f501177e53"
    },
    "source": [
-    "To see the Kraus operators of a channel, the `cirq.channel` protocol can be used."
+    "To see the Kraus operators of a channel, the `cirq.channel` protocol can be used. (See the [protocols guide](./protocols.ipynb).)"
    ]
   },
   {

--- a/docs/noise.ipynb
+++ b/docs/noise.ipynb
@@ -383,7 +383,7 @@
     "id": "67c8ddbc10f3"
    },
    "source": [
-    "For concrete examples, `cirq.X`, consider `cirq.BitFlipChannel`, and `cirq.AmplitudeDampingChannel` which are all subclasses of `cirq.Gate`.\n",
+    "For concrete examples, consider `cirq.X`, `cirq.BitFlipChannel`, and `cirq.AmplitudeDampingChannel` which are all subclasses of `cirq.Gate`.\n",
     "\n",
     "* `cirq.X` defines the `_unitary_` method. \n",
     "  - As a result, it supports the `cirq.unitary` protocol, the `cirq.mixture` protocol, and the `cirq.channel` protocol.\n",

--- a/docs/noise.ipynb
+++ b/docs/noise.ipynb
@@ -374,8 +374,7 @@
     "  - If magic method `_channel_` is not defined, `cirq.channel` looks for `_mixture_` then for `_unitary_`.\n",
     "* A subset of channels which support `cirq.channel` also support the `cirq.mixture` protocol.\n",
     "  - If magic method `_mixture_` is not defined, `cirq.mixture` looks for `_unitary_`.\n",
-    "* A subset of channels which support `cirq.mixture` also support the `cirq.unitary` protocol.\n",
-    "  - If `_unitary_` is not defined for an object, the object is probably not meant for a circuit!"
+    "* A subset of channels which support `cirq.mixture` also support the `cirq.unitary` protocol."
    ]
   },
   {
@@ -384,7 +383,7 @@
     "id": "67c8ddbc10f3"
    },
    "source": [
-    "For concrete examples, `cirq.X`, `cirq.BitFlipChannel`, and `cirq.AmplitudeDampingChannel` are all subclasses of `cirq.Gate`.\n",
+    "For concrete examples, `cirq.X`, consider `cirq.BitFlipChannel`, and `cirq.AmplitudeDampingChannel` which are all subclasses of `cirq.Gate`.\n",
     "\n",
     "* `cirq.X` defines the `_unitary_` method. \n",
     "  - As a result, it supports the `cirq.unitary` protocol, the `cirq.mixture` protocol, and the `cirq.channel` protocol.\n",
@@ -409,7 +408,7 @@
     "id": "360d5a316769"
    },
    "source": [
-    "Channels not defined in `cirq.ops.common_channels` can be user-defined. Defining custom channels is similar to defining custom gates.\n",
+    "Channels not defined in `cirq.ops.common_channels` can be user-defined. Defining custom channels is similar to defining [custom gates](./custom_gates.ipynb).\n",
     "\n",
     "A minimal example for defining the channel\n",
     "\n",
@@ -583,6 +582,15 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "d51d993ae869"
+   },
+   "source": [
+    "### Density matrix simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "38dfcb60ef79"
    },
    "source": [
@@ -630,6 +638,15 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "0c659bb20098"
+   },
+   "source": [
+    "### Monte Carlo wavefunction simulation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "6f3caf9cea92"
    },
    "source": [
@@ -655,7 +672,7 @@
     "print(\"Simulating circuit:\")\n",
     "print(circuit)\n",
     "\n",
-    "# Simulate with the density matrix simulator.\n",
+    "# Simulate with the cirq.Simulator.\n",
     "sim = cirq.Simulator()\n",
     "psi = sim.simulate(circuit).dirac_notation()\n",
     "\n",
@@ -696,7 +713,7 @@
     "id": "0f123f0e3c55"
    },
    "source": [
-    "### Adding noise to circuits"
+    "## Adding noise to circuits"
    ]
   },
   {
@@ -755,6 +772,73 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "029509de9787"
+   },
+   "source": [
+    "The `with_noise` method creates a `cirq.NoiseModel` from its input and adds noise to each moment. A `cirq.NoiseModel` can be explicitly created and used to add noise to a single operation, single moment, or series of moments as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "10a2cd41bfe4"
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Add noise to an operation, moment, or sequence of moments.\"\"\"\n",
+    "# Create a noise model.\n",
+    "noise_model = cirq.NoiseModel.from_noise_model_like(cirq.depolarize(p=0.01))\n",
+    "\n",
+    "# Get a qubit register.\n",
+    "qreg = cirq.LineQubit.range(2)\n",
+    "\n",
+    "# Add noise to an operation.\n",
+    "op = cirq.CNOT(*qreg)\n",
+    "noisy_op = noise_model.noisy_operation(op)\n",
+    "\n",
+    "# Add noise to a moment.\n",
+    "moment = cirq.Moment(cirq.H.on_each(qreg))\n",
+    "noisy_moment = noise_model.noisy_moment(moment, system_qubits=qreg)\n",
+    "\n",
+    "# Add noise to a sequence of moments.\n",
+    "circuit = cirq.Circuit(cirq.H(qreg[0]), cirq.CNOT(*qreg))\n",
+    "noisy_circuit = noise_model.noisy_moments(circuit, system_qubits=qreg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a440a2aefdcf"
+   },
+   "source": [
+    "Note: In the last two examples, the argument `system_qubits` can be a subset of the qubits in the moment(s)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "61cf807b3737"
+   },
+   "source": [
+    "The output of each \"noisy method\" is a `cirq.OP_TREE` which can be converted to a circuit by passing it into the `cirq.Circuit` constructor. For example, we create a circuit from the `noisy_moment` below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3e84e3e17421"
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Creating a circuit from a noisy cirq.OP_TREE.\"\"\"\n",
+    "cirq.Circuit(noisy_moment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "11b18c640767"
    },
    "source": [
@@ -773,6 +857,15 @@
     "noisy_dsim = cirq.DensityMatrixSimulator(\n",
     "    noise=cirq.generalized_amplitude_damp(p=0.1, gamma=0.5)\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0dcd4cf202be"
+   },
+   "source": [
+    "This will not explicitly add channels to the circuit being simulated, but the circuit will be simulated as though these channels were present."
    ]
   },
   {


### PR DESCRIPTION
This PR addresses remaining comments from #3569 which was merged due to time constraints.

- Adds link to protocols guide (and custom gates guide) to address comment from @balopat.
- Adds example using `cirq.NoiseModel` and addresses other remaining comments from @obriente.

Also adds section headers to density matrix simulation and monte carlo simulation to make them more apparent in the nav.