### PR TITLE
Add run method to IonQ service

### DIFF
--- a/cirq/ionq/ionq_client.py
+++ b/cirq/ionq/ionq_client.py
@@ -162,8 +162,9 @@ class _IonQClient:
         Args:
             serialized_program: The `cirq.ionq.SerializedProgram` containing the serialized
                 information about the circuit to run.
-            repetitions: The number of times to repeat the circuit. For simulation these
-                repetitions are not done on the server.
+            repetitions: The number of times to repeat the circuit. For simulation the repeated
+                sampling is not done on the server, but is passed as metadata to be recovered
+                from the returned job.
             target: If supplied the target to run on. Supports one of `qpu` or `simulator`. If not
                 set, uses `default_target`.
             name: An optional name of the job. Different than the `job_id` of the job.

--- a/cirq/ionq/ionq_client.py
+++ b/cirq/ionq/ionq_client.py
@@ -162,8 +162,8 @@ class _IonQClient:
         Args:
             serialized_program: The `cirq.ionq.SerializedProgram` containing the serialized
                 information about the circuit to run.
-            repetitions: The number of times to repeat the circuit. Only can be set if the target
-                is `qpu`. If not specified and target is `qpu`, number of repetitions is 100.
+            repetitions: The number of times to repeat the circuit. For simulation these
+                repetitions are not done on the server.
             target: If supplied the target to run on. Supports one of `qpu` or `simulator`. If not
                 set, uses `default_target`.
             name: An optional name of the job. Different than the `job_id` of the job.
@@ -176,13 +176,6 @@ class _IonQClient:
             An IonQException if the request fails.
         """
         actual_target = self._target(target)
-        assert (
-            actual_target != 'qpu' or repetitions is not None
-        ), 'If the target is qpu, repetitions must be specified.'
-        assert actual_target != 'simulator' or repetitions is None, (
-            'If the target is simulator, repetitions should not be specified as the simulator is '
-            'a full wavefunction simulator.'
-        )
 
         json: Dict[str, Any] = {
             'target': actual_target,
@@ -193,10 +186,11 @@ class _IonQClient:
             json['name'] = name
         # We have to pass measurement keys through the metadata.
         json['metadata'] = serialized_program.metadata
-        if repetitions:
-            # API does not return number of shots, only histogram of
-            # percentages, so we set it as metadata.
-            json['metadata']['shots'] = str(repetitions)
+
+        # Shots are ignored by simulator, but pass them anyway.
+        json['shots'] = str(repetitions)
+        # API does not return number of shots so pass this through as metadata.
+        json['metadata']['shots'] = str(repetitions)
 
         def request():
             return requests.post(f'{self.url}/jobs', json=json, headers=self.headers)

--- a/cirq/ionq/ionq_client_test.py
+++ b/cirq/ionq/ionq_client_test.py
@@ -103,6 +103,7 @@ def test_ionq_client_create_job(mock_post):
         'body': {'job': 'mine'},
         'lang': 'json',
         'name': 'bacon',
+        'shots': '200',
         'metadata': {'shots': '200', 'a': '0,1'},
     }
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
@@ -144,25 +145,6 @@ def test_ionq_client_create_job_no_targets():
     with pytest.raises(AssertionError, match='neither were set'):
         _ = client.create_job(
             serialized_program=ionq.SerializedProgram(body={'job': 'mine'}, metadata={})
-        )
-
-
-def test_ionq_client_create_job_qpu_but_no_repetitions():
-    client = ionq.ionq_client._IonQClient(remote_host='http://example.com', api_key='to_my_heart')
-    with pytest.raises(AssertionError, match='qpu'):
-        _ = client.create_job(
-            serialized_program=ionq.SerializedProgram(body={'job': 'mine'}, metadata={}),
-            target='qpu',
-        )
-
-
-def test_ionq_client_create_job_simulator_but_repetitions():
-    client = ionq.ionq_client._IonQClient(remote_host='http://example.com', api_key='to_my_heart')
-    with pytest.raises(AssertionError, match='simulator'):
-        _ = client.create_job(
-            serialized_program=ionq.SerializedProgram(body={'job': 'mine'}, metadata={}),
-            target='simulator',
-            repetitions=10,
         )
 
 

--- a/cirq/ionq/job_test.py
+++ b/cirq/ionq/job_test.py
@@ -37,17 +37,6 @@ def test_job_fields():
     assert job.measurement_dict() == {'a': [0, 1]}
 
 
-def test_job_fields_simulator_repetitions():
-    job_dict = {
-        'id': 'my_id',
-        'target': 'simulator',
-        'qubits': '5',
-        'status': 'completed',
-    }
-    job = ionq.Job(None, job_dict)
-    assert job.repetitions() is None
-
-
 def test_job_status_refresh():
     for status in ionq.Job.NON_TERMINAL_STATES:
         mock_client = mock.MagicMock()
@@ -139,10 +128,11 @@ def test_job_results_simulator():
         'qubits': '1',
         'target': 'simulator',
         'data': {'histogram': {'0': '0.6', '1': '0.4'}},
+        'metadata': {'shots': '100'},
     }
     job = ionq.Job(None, job_dict)
     results = job.results()
-    assert results == ionq.SimulatorResult({0: 0.6, 1: 0.4}, 1, {})
+    assert results == ionq.SimulatorResult({0: 0.6, 1: 0.4}, 1, {}, 100)
 
 
 def test_job_results_simulator_endianness():
@@ -152,10 +142,11 @@ def test_job_results_simulator_endianness():
         'qubits': '2',
         'target': 'simulator',
         'data': {'histogram': {'0': '0.6', '1': '0.4'}},
+        'metadata': {'shots': '100'},
     }
     job = ionq.Job(None, job_dict)
     results = job.results()
-    assert results == ionq.SimulatorResult({0: 0.6, 2: 0.4}, 2, {})
+    assert results == ionq.SimulatorResult({0: 0.6, 2: 0.4}, 2, {}, 100)
 
 
 def test_job_cancel():

--- a/cirq/ionq/results.py
+++ b/cirq/ionq/results.py
@@ -112,12 +112,9 @@ class QPUResult:
             )
         measurements = {}
         for key, targets in self.measurement_dict().items():
-            simulated_results = list(self.counts(key).elements())
+            qpu_results = list(self.counts(key).elements())
             measurements[key] = np.array(
-                list(
-                    digits.big_endian_int_to_bits(x, bit_count=len(targets))
-                    for x in simulated_results
-                )
+                list(digits.big_endian_int_to_bits(x, bit_count=len(targets)) for x in qpu_results)
             )
         return study.Result(params=params or study.ParamResolver({}), measurements=measurements)
 
@@ -228,7 +225,7 @@ class SimulatorResult:
                 If an integer, `np.random.RandomState(seed) is used. Otherwise if another
                 randomness generator is used, it will be used.
             override_repetitions: Repetitions were supplied when the IonQ API ran the simulation,
-                but different repetitions can be supplied here.
+                but different repetitions can be supplied here and will override.
 
         Returns:
             A `cirq.Result` corresponding to a sample from the probability distribution returned

--- a/cirq/ionq/results.py
+++ b/cirq/ionq/results.py
@@ -14,9 +14,15 @@
 
 import collections
 
-from typing import Dict, Counter, Optional, Sequence
+from typing import Dict, Counter, Optional, Sequence, TYPE_CHECKING
 
+import numpy as np
+
+from cirq import study, value
 from cirq.value import digits
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class QPUResult:
@@ -28,6 +34,7 @@ class QPUResult:
         self._counts = counts
         self._num_qubits = num_qubits
         self._measurement_dict = measurement_dict
+        self._repetitions = sum(self._counts.values())
 
     def num_qubits(self) -> int:
         """Returns the number of qubits the circuit was run on."""
@@ -35,7 +42,7 @@ class QPUResult:
 
     def repetitions(self) -> int:
         """Returns the number of times the circuit was run."""
-        return sum(self._counts.values())
+        return self._repetitions
 
     def counts(self, key: Optional[str] = None) -> Counter[int]:
         """Returns the raw counts of the measurement results.
@@ -76,6 +83,44 @@ class QPUResult:
         """Returns a map from measurement keys to target qubit indices for this measurement."""
         return self._measurement_dict
 
+    def to_cirq_result(
+        self,
+        params: Optional[study.ParamResolver] = None,
+    ) -> study.Result:
+        """Returns a `cirq.Result` for these results.
+
+        `cirq.Result` contains a less dense representation of results than that returned by
+        the IonQ API.  Technically these results are also ordered by when they were run, though
+        that contract is implicit.  Because the IonQ API loses that ordering information, the
+        order of these `cirq.Result` objects should *not* be interpetted as representing the
+        order in which the circuit was run.
+
+        Args:
+            params: The `cirq.ParamResolver` used to generate these results.
+
+        Returns:
+            The `cirq.Result` for these results.
+
+        Raises:
+            ValueError: If the circuit used to produce this result had no measurement gates
+                (and hence no measurement keys).
+        """
+        if len(self.measurement_dict()) == 0:
+            raise ValueError(
+                'Can convert to cirq results only if the circuit had measurement gates '
+                'with measurement keys.'
+            )
+        measurements = {}
+        for key, targets in self.measurement_dict().items():
+            simulated_results = list(self.counts(key).elements())
+            measurements[key] = np.array(
+                list(
+                    digits.big_endian_int_to_bits(x, bit_count=len(targets))
+                    for x in simulated_results
+                )
+            )
+        return study.Result(params=params or study.ParamResolver({}), measurements=measurements)
+
     def __eq__(self, other):
         if not isinstance(other, QPUResult):
             return NotImplemented
@@ -83,17 +128,13 @@ class QPUResult:
             self._counts == other._counts
             and self._num_qubits == other._num_qubits
             and self._measurement_dict == other._measurement_dict
+            and self._repetitions == other._repetitions
         )
 
     def __str__(self) -> str:
         return _pretty_str_dict(self._counts, self._num_qubits)
 
-    # TODO: Convert his to cirq result objects.
-    # https://github.com/quantumlib/Cirq/issues/3479
 
-
-# TODO: Implement the sampler interface.
-# https://github.com/quantumlib/Cirq/issues/3479
 class SimulatorResult:
     """The results of running on an IonQ simulator.
 
@@ -106,14 +147,24 @@ class SimulatorResult:
         probabilities: Dict[int, float],
         num_qubits: int,
         measurement_dict: Dict[str, Sequence[int]],
+        repetitions: int,
     ):
         self._probabilities = probabilities
         self._num_qubits = num_qubits
         self._measurement_dict = measurement_dict
+        self._repetitions = repetitions
 
     def num_qubits(self) -> int:
         """Returns the number of qubits the circuit was run on."""
         return self._num_qubits
+
+    def repetitions(self) -> int:
+        """Returns the number of times the circuit was run.
+
+        For IonQ API simulations this is used when generating `cirq.Result`s, where a different
+        number of repetitions can also be specified.
+        """
+        return self._repetitions
 
     def probabilities(self, key: Optional[str] = None) -> Dict[int, float]:
         """Returns the probabilities of the measurement results.
@@ -157,6 +208,56 @@ class SimulatorResult:
         """Returns a map from measurement keys to target qubit indices for this measurement."""
         return self._measurement_dict
 
+    def to_cirq_result(
+        self,
+        params: study.ParamResolver = None,
+        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        override_repetitions=None,
+    ) -> study.Result:
+        """Samples from the simulation probability result, producing a `cirq.Result`.
+
+        The IonQ simulator returns the probabilities of different bitstrings. This converts such
+        a representation to a randomly generated sample from the simulator. Note that it does this
+        on every subsequent call of this method, so repeated calls to not produce the same
+        `cirq.Result`s. When a job was created by the IonQ API, it had a number of repetitions and
+        this is used, unless `repetitions` is set here.
+
+        Args:
+            params: Any parameters which were used to generated this result.
+            seed: What to use for generating the randomness. If None, then `np.random` is used.
+                If an integer, `np.random.RandomState(seed) is used. Otherwise if another
+                randomness generator is used, it will be used.
+            override_repetitions: Repetitions were supplied when the IonQ API ran the simulation,
+                but different repetitions can be supplied here.
+
+        Returns:
+            A `cirq.Result` corresponding to a sample from the probability distribution returned
+            from the simulator.
+
+        Raises:
+            ValueError: If the circuit used to produce this result had no measurement gates
+                (and hence no measurement keys).
+        """
+        if len(self.measurement_dict()) == 0:
+            raise ValueError(
+                'Can convert to cirq results only if the circuit had measurement gates '
+                'with measurement keys.'
+            )
+        rand = value.parse_random_state(seed)
+        measurements = {}
+        values, weights = zip(*list(self.probabilities().items()))
+        indices = rand.choice(
+            range(len(values)), p=weights, size=override_repetitions or self.repetitions()
+        )
+        rand_values = np.array(values)[indices]
+        for key, targets in self.measurement_dict().items():
+            bits = [
+                [(value >> (self.num_qubits() - target - 1)) & 1 for target in targets]
+                for value in rand_values
+            ]
+            measurements[key] = bits
+        return study.Result(params=params or study.ParamResolver({}), measurements=measurements)
+
     def __eq__(self, other):
         if not isinstance(other, SimulatorResult):
             return NotImplemented
@@ -164,6 +265,7 @@ class SimulatorResult:
             self._probabilities == other._probabilities
             and self._num_qubits == other._num_qubits
             and self._measurement_dict == other._measurement_dict
+            and self._repetitions == other._repetitions
         )
 
     def __str__(self) -> str:

--- a/cirq/ionq/results.py
+++ b/cirq/ionq/results.py
@@ -90,10 +90,10 @@ class QPUResult:
         """Returns a `cirq.Result` for these results.
 
         `cirq.Result` contains a less dense representation of results than that returned by
-        the IonQ API.  Technically these results are also ordered by when they were run, though
-        that contract is implicit.  Because the IonQ API loses that ordering information, the
-        order of these `cirq.Result` objects should *not* be interpetted as representing the
-        order in which the circuit was run.
+        the IonQ API.  Typically these results are also ordered by when they were run, though
+        that contract is implicit.  Because the IonQ API does not retain that ordering information,
+        the order of these `cirq.Result` objects should *not* be interpetted as representing the
+        order in which the circuit was repeated.
 
         Args:
             params: The `cirq.ParamResolver` used to generate these results.
@@ -161,8 +161,8 @@ class SimulatorResult:
     def repetitions(self) -> int:
         """Returns the number of times the circuit was run.
 
-        For IonQ API simulations this is used when generating `cirq.Result`s, where a different
-        number of repetitions can also be specified.
+        For IonQ API simulations this is used when generating `cirq.Result`s from `to_cirq_result`.
+        The sampling is not done on the IonQ API but is done in `to_cirq_result`.
         """
         return self._repetitions
 
@@ -218,9 +218,9 @@ class SimulatorResult:
 
         The IonQ simulator returns the probabilities of different bitstrings. This converts such
         a representation to a randomly generated sample from the simulator. Note that it does this
-        on every subsequent call of this method, so repeated calls to not produce the same
+        on every subsequent call of this method, so repeated calls do not produce the same
         `cirq.Result`s. When a job was created by the IonQ API, it had a number of repetitions and
-        this is used, unless `repetitions` is set here.
+        this is used, unless `override_repetitions` is set here.
 
         Args:
             params: Any parameters which were used to generated this result.

--- a/cirq/ionq/results_test.py
+++ b/cirq/ionq/results_test.py
@@ -40,6 +40,9 @@ def test_qpu_result_eq():
         ionq.QPUResult({0: 10, 1: 20}, num_qubits=1, measurement_dict={'a': [0]})
     )
     equals_tester.add_equality_group(
+        ionq.QPUResult({0: 15, 1: 15}, num_qubits=1, measurement_dict={'a': [0]})
+    )
+    equals_tester.add_equality_group(
         ionq.QPUResult({0: 10, 1: 10}, num_qubits=2, measurement_dict={'a': [0]})
     )
     equals_tester.add_equality_group(
@@ -91,75 +94,146 @@ def test_qpu_result_bad_measurement_key():
         result.counts('bad')
 
 
+def test_qpu_result_to_cirq_result():
+    result = ionq.QPUResult({0b00: 1, 0b01: 2}, num_qubits=2, measurement_dict={'x': [0, 1]})
+    assert result.to_cirq_result() == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0, 0], [0, 1], [0, 1]]}
+    )
+    params = cirq.ParamResolver({'a': 0.1})
+    assert result.to_cirq_result(params) == cirq.Result(
+        params=params, measurements={'x': [[0, 0], [0, 1], [0, 1]]}
+    )
+    result = ionq.QPUResult({0b00: 1, 0b01: 2}, num_qubits=2, measurement_dict={'x': [0]})
+    assert result.to_cirq_result() == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0], [0], [0]]}
+    )
+    result = ionq.QPUResult({0b00: 1, 0b01: 2}, num_qubits=2, measurement_dict={'x': [1]})
+    assert result.to_cirq_result() == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0], [1], [1]]}
+    )
+
+
+def test_qpu_result_to_cirq_result_multiple_keys():
+    result = ionq.QPUResult(
+        {0b000: 2, 0b101: 3}, num_qubits=3, measurement_dict={'x': [1], 'y': [2, 0]}
+    )
+    assert result.to_cirq_result() == cirq.Result(
+        params=cirq.ParamResolver({}),
+        measurements={
+            'x': [[0], [0], [0], [0], [0]],
+            'y': [[0, 0], [0, 0], [1, 1], [1, 1], [1, 1]],
+        },
+    )
+
+
+def test_qpu_result_to_cirq_result_no_keys():
+    result = ionq.QPUResult({0b00: 1, 0b01: 2}, num_qubits=2, measurement_dict={})
+    with pytest.raises(ValueError, match='cirq results'):
+        _ = result.to_cirq_result()
+
+
 def test_simulator_result_fields():
-    result = ionq.SimulatorResult({0: 0.4, 1: 0.6}, num_qubits=1, measurement_dict={'a': [0]})
+    result = ionq.SimulatorResult(
+        {0: 0.4, 1: 0.6},
+        num_qubits=1,
+        measurement_dict={'a': [0]},
+        repetitions=100,
+    )
     assert result.probabilities() == {0: 0.4, 1: 0.6}
     assert result.num_qubits() == 1
     assert result.measurement_dict() == {'a': [0]}
+    assert result.repetitions() == 100
 
 
 def test_simulator_result_str():
-    result = ionq.SimulatorResult({0: 0.4, 1: 0.6}, num_qubits=2, measurement_dict={'a': [0]})
+    result = ionq.SimulatorResult(
+        {0: 0.4, 1: 0.6}, num_qubits=2, measurement_dict={'a': [0]}, repetitions=100
+    )
     assert str(result) == '00: 0.4\n01: 0.6'
 
 
 def test_simulator_result_eq():
     equals_tester = cirq.testing.EqualsTester()
     equals_tester.add_equality_group(
-        ionq.SimulatorResult({0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0]}),
-        ionq.SimulatorResult({0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0]}),
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0]}, repetitions=100
+        ),
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0]}, repetitions=100
+        ),
     )
     equals_tester.add_equality_group(
-        ionq.SimulatorResult({0: 0.4, 1: 0.6}, num_qubits=1, measurement_dict={'a': [0]})
+        ionq.SimulatorResult(
+            {0: 0.4, 1: 0.6}, num_qubits=1, measurement_dict={'a': [0]}, repetitions=100
+        )
     )
     equals_tester.add_equality_group(
-        ionq.SimulatorResult({0: 0.5, 1: 0.5}, num_qubits=2, measurement_dict={'a': [0]})
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=2, measurement_dict={'a': [0]}, repetitions=100
+        )
     )
     equals_tester.add_equality_group(
-        ionq.SimulatorResult({0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'b': [0]})
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'b': [0]}, repetitions=100
+        )
     )
     equals_tester.add_equality_group(
-        ionq.SimulatorResult({0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [1]})
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [1]}, repetitions=100
+        )
     )
     equals_tester.add_equality_group(
-        ionq.SimulatorResult({0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0, 1]})
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0, 1]}, repetitions=100
+        )
+    )
+    equals_tester.add_equality_group(
+        ionq.SimulatorResult(
+            {0: 0.5, 1: 0.5}, num_qubits=1, measurement_dict={'a': [0, 1]}, repetitions=10
+        )
     )
 
 
 def test_simulator_result_measurement_key():
-    result = ionq.SimulatorResult({0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0]})
+    result = ionq.SimulatorResult(
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0]}, repetitions=100
+    )
     assert result.probabilities() == {0b00: 0.2, 0b01: 0.8}
-    result = ionq.SimulatorResult({0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0]})
+    result = ionq.SimulatorResult(
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0]}, repetitions=100
+    )
     assert result.probabilities('a') == {0b0: 1.0}
 
-    result = ionq.SimulatorResult({0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [1]})
+    result = ionq.SimulatorResult(
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [1]}, repetitions=100
+    )
     assert result.probabilities('a') == {0b0: 0.2, 0b1: 0.8}
     result = ionq.SimulatorResult(
-        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0, 1]}
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0, 1]}, repetitions=100
     )
     assert result.probabilities('a') == {0b00: 0.2, 0b01: 0.8}
     result = ionq.SimulatorResult(
-        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [1, 0]}
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [1, 0]}, repetitions=100
     )
     assert result.probabilities('a') == {0b00: 0.2, 0b10: 0.8}
     result = ionq.SimulatorResult(
-        {0b000: 0.2, 0b111: 0.8}, num_qubits=3, measurement_dict={'a': [2]}
+        {0b000: 0.2, 0b111: 0.8}, num_qubits=3, measurement_dict={'a': [2]}, repetitions=100
     )
     assert result.probabilities('a') == {0b0: 0.2, 0b1: 0.8}
     result = ionq.SimulatorResult(
-        {0b000: 0.2, 0b100: 0.8}, num_qubits=3, measurement_dict={'a': [1, 2]}
+        {0b000: 0.2, 0b100: 0.8}, num_qubits=3, measurement_dict={'a': [1, 2]}, repetitions=100
     )
     assert result.probabilities('a') == {0b00: 1.0}
 
 
 def test_simulator_result_measurement_multiple_key():
     result = ionq.SimulatorResult(
-        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0], 'b': [1]}
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0], 'b': [1]}, repetitions=100
     )
     assert result.probabilities('a') == {0b0: 1.0}
     assert result.probabilities('b') == {0b0: 0.2, 0b1: 0.8}
     result = ionq.SimulatorResult(
-        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [1], 'b': [0]}
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [1], 'b': [0]}, repetitions=100
     )
     assert result.probabilities('a') == {0b0: 0.2, 0b1: 0.8}
     assert result.probabilities('b') == {0b0: 1.0}
@@ -167,7 +241,60 @@ def test_simulator_result_measurement_multiple_key():
 
 def test_simulator_result_bad_measurement_key():
     result = ionq.SimulatorResult(
-        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0], 'b': [1]}
+        {0b00: 0.2, 0b01: 0.8}, num_qubits=2, measurement_dict={'a': [0], 'b': [1]}, repetitions=100
     )
     with pytest.raises(ValueError, match='bad'):
         result.probabilities('bad')
+
+
+def test_simulator_result_to_cirq_result():
+    result = ionq.SimulatorResult(
+        {0b00: 0.25, 0b01: 0.75}, num_qubits=2, measurement_dict={'x': [0, 1]}, repetitions=3
+    )
+    assert result.to_cirq_result(seed=2) == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0, 1], [0, 0], [0, 1]]}
+    )
+    assert result.to_cirq_result(seed=3) == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0, 1], [0, 1], [0, 1]]}
+    )
+    params = cirq.ParamResolver({'a': 0.1})
+    assert result.to_cirq_result(seed=3, params=params) == cirq.Result(
+        params=params, measurements={'x': [[0, 1], [0, 1], [0, 1]]}
+    )
+    assert result.to_cirq_result(seed=2, override_repetitions=2) == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0, 1], [0, 0]]}
+    )
+
+    result = ionq.SimulatorResult(
+        {0b00: 0.25, 0b01: 0.75}, num_qubits=2, measurement_dict={'x': [0]}, repetitions=3
+    )
+    assert result.to_cirq_result(seed=2) == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[0], [0], [0]]}
+    )
+    result = ionq.SimulatorResult(
+        {0b00: 0.25, 0b01: 0.75}, num_qubits=2, measurement_dict={'x': [1]}, repetitions=3
+    )
+    assert result.to_cirq_result(seed=2) == cirq.Result(
+        params=cirq.ParamResolver({}), measurements={'x': [[1], [0], [1]]}
+    )
+
+
+def test_simulator_result_to_cirq_result_multiple_keys():
+    result = ionq.SimulatorResult(
+        {0b000: 0.25, 0b011: 0.75},
+        num_qubits=3,
+        measurement_dict={'x': [1], 'y': [2, 0]},
+        repetitions=3,
+    )
+    assert result.to_cirq_result(seed=2) == cirq.Result(
+        params=cirq.ParamResolver({}),
+        measurements={'x': [[1], [0], [1]], 'y': [[1, 0], [0, 0], [1, 0]]},
+    )
+
+
+def test_simulator_result_to_cirq_result_no_keys():
+    result = ionq.SimulatorResult(
+        {0b00: 1, 0b01: 2}, num_qubits=2, measurement_dict={}, repetitions=3
+    )
+    with pytest.raises(ValueError, match='cirq results'):
+        _ = result.to_cirq_result()

--- a/cirq/ionq/service_test.py
+++ b/cirq/ionq/service_test.py
@@ -12,9 +12,56 @@
 # limitations under the License.
 
 from unittest import mock
+import pytest
+
+import sympy
 
 import cirq
 import cirq.ionq as ionq
+
+
+@pytest.mark.parametrize(
+    'target,expected_results', [('qpu', [[0], [1], [1], [1]]), ('simulator', [[1], [0], [1], [1]])]
+)
+def test_service_run(target, expected_results):
+    service = ionq.Service(remote_host='http://example.com', api_key='key')
+    mock_client = mock.MagicMock()
+    mock_client.create_job.return_value = {
+        'id': 'job_id',
+        'status': 'ready',
+    }
+    mock_client.get_job.return_value = {
+        'id': 'job_id',
+        'status': 'completed',
+        'target': target,
+        'metadata': {'shots': '4', 'measurement0': f'a{chr(31)}0'},
+        'qubits': '1',
+        'data': {'histogram': {'0': '0.25', '1': '0.75'}},
+        'status': 'completed',
+    }
+    service._client = mock_client
+
+    a = sympy.Symbol('a')
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit((cirq.X ** a)(q), cirq.measure(q, key='a'))
+    params = cirq.ParamResolver({'a': 0.5})
+    result = service.run(
+        circuit=circuit,
+        repetitions=4,
+        target=target,
+        name='bacon',
+        param_resolver=params,
+        seed=2,
+    )
+    assert result == cirq.Result(params=params, measurements={'a': expected_results})
+
+    create_job_kwargs = mock_client.create_job.call_args[1]
+    # Serialization induces a float, so we don't validate full circuit.
+    assert create_job_kwargs['serialized_program'].body['qubits'] == 1
+    assert create_job_kwargs['serialized_program'].metadata == {'measurement0': f'a{chr(31)}0'}
+    assert create_job_kwargs['repetitions'] == 4
+    assert create_job_kwargs['target'] == target
+    assert create_job_kwargs['name'] == 'bacon'
 
 
 def test_service_get_job():


### PR DESCRIPTION
This returns `cirq.Result` objects in contrast to `create_job` which returns ionq bespoke result objects.  Note that this involves creating measurement results whose order is not the order in which the circuit was run (technically even over in engine land such a contract is not enforced).

A couple of other changes of note:
* Instead of enforcing no repetitions in creating a job for a simulator, these are passed along through the metadata.  This then makes the interface for the user less complicated, though the user may end up with the false impression that the sample occurs server side.
* For simulations you can override the repetitions to obtain a new sample.