### PR TITLE
Add concise serialization tools.

### DIFF
--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -170,6 +170,10 @@ def _cirq_class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'YYPowGate': cirq.YYPowGate,
         'ZPowGate': cirq.ZPowGate,
         'ZZPowGate': cirq.ZZPowGate,
+        # internal contextual-serialization types
+        '_ContextualSerialization': _ContextualSerialization,
+        '_SerializedContext': _SerializedContext,
+        '_SerializedKey': _SerializedKey,
         # not a cirq class, but treated as one:
         'pandas.DataFrame': pd.DataFrame,
         'pandas.Index': pd.Index,
@@ -408,7 +412,7 @@ class CirqEncoder(json.JSONEncoder):
         return super().default(o)  # coverage: ignore
 
 
-def _cirq_object_hook(d, resolvers: Sequence[JsonResolver]):
+def _cirq_object_hook(d, resolvers: Sequence[JsonResolver], context_map: Dict[str, Any]):
     if 'cirq_type' not in d:
         return d
 
@@ -421,12 +425,147 @@ def _cirq_object_hook(d, resolvers: Sequence[JsonResolver]):
             "Could not resolve type '{}' during deserialization".format(d['cirq_type'])
         )
 
+    if cls == _SerializedKey:
+        read_from_context = getattr(cls, 'read_from_context', lambda x, y: None)
+        return read_from_context(context_map, **d)
+
+    if cls == _SerializedContext:
+        update_context = getattr(cls, 'update_context', lambda x, y: None)
+        update_context(context_map, **d)
+        return None
+
+    if cls == _ContextualSerialization:
+        deserialize_with_context = getattr(cls, 'deserialize_with_context', lambda x: None)
+        return deserialize_with_context(**d)
+
     from_json_dict = getattr(cls, '_from_json_dict_', None)
     if from_json_dict is not None:
         return from_json_dict(**d)
 
     del d['cirq_type']
     return cls(**d)
+
+
+class SerializableByKey(SupportsJSON):
+    """Interface for objects that can be serialized to a key + context."""
+
+    @doc_private
+    def _serialization_key_(self):
+        pass
+
+
+class _SerializedKey(SupportsJSON):
+    """Internal object for holding a SerializableByKey key.
+
+    This is a private type used in contextual serialization. Its deserialization
+    is context-dependent, and is not expected to match the original; in other
+    words, `cls._from_json_dict_(obj._json_dict_())` does not return
+    the original `obj` for this type.
+    """
+
+    def __init__(self, obj: SerializableByKey):
+        self.key = obj._serialization_key_()
+
+    def _json_dict_(self):
+        return obj_to_dict_helper(self, ['key'])
+
+    @classmethod
+    def _from_json_dict_(cls, **kwargs):
+        raise TypeError(f'Internal error: {cls} should never deserialize with _from_json_dict_.')
+
+    @classmethod
+    def read_from_context(cls, context_map, key, **kwargs):
+        return context_map[key]
+
+
+class _SerializedContext(SupportsJSON):
+    """Internal object for a single SerializableByKey key-to-object mapping.
+
+    This is a private type used in contextual serialization. Its deserialization
+    is context-dependent, and is not expected to match the original; in other
+    words, `cls._from_json_dict_(obj._json_dict_())` does not return
+    the original `obj` for this type.
+    """
+
+    def __init__(self, obj: SerializableByKey):
+        self.key = obj._serialization_key_()
+        self.obj = obj
+
+    def _json_dict_(self):
+        return obj_to_dict_helper(self, ['key', 'obj'])
+
+    @classmethod
+    def _from_json_dict_(cls, **kwargs):
+        raise TypeError(f'Internal error: {cls} should never deserialize with _from_json_dict_.')
+
+    @classmethod
+    def update_context(cls, context_map, key, obj, **kwargs):
+        context_map.update({key: obj})
+
+
+class _ContextualSerialization(SupportsJSON):
+    """Internal object for serializing an object with its context.
+
+    This is a private type used in contextual serialization. Its deserialization
+    is context-dependent, and is not expected to match the original; in other
+    words, `cls._from_json_dict_(obj._json_dict_())` does not return
+    the original `obj` for this type.
+    """
+
+    def __init__(self, obj: Any):
+        self.context_list = []
+        context_keys = set()
+        for sbk in get_serializable_by_keys(obj):
+            new_sc = _SerializedContext(sbk)
+            if new_sc.key not in context_keys:
+                self.context_list.append(new_sc)
+                context_keys.add(new_sc.key)
+        self.context_list += [obj]
+
+    def _json_dict_(self):
+        return obj_to_dict_helper(self, ['context_list'])
+
+    @classmethod
+    def _from_json_dict_(cls, **kwargs):
+        raise TypeError(f'Internal error: {cls} should never deserialize with _from_json_dict_.')
+
+    @classmethod
+    def deserialize_with_context(cls, context_list, **kwargs):
+        return context_list[-1]
+
+
+def has_serializable_by_keys(obj: Any) -> bool:
+    """Returns true if obj contains one or more SerializableByKey objects."""
+    if hasattr(obj, '_serialization_key_'):
+        return True
+    json_dict = getattr(obj, '_json_dict_', lambda: None)()
+    if isinstance(json_dict, Dict):
+        return any(has_serializable_by_keys(v) for v in json_dict.values())
+    return False
+
+
+def get_serializable_by_keys(obj: Any) -> List[SerializableByKey]:
+    """Returns all SerializableByKeys contained by obj.
+
+    Objects are ordered such that nested objects appear before the object they
+    are nested inside. This is required for hooks in json.load().
+    """
+    result = []
+    if hasattr(obj, '_serialization_key_'):
+        result.append(obj)
+    json_dict = getattr(obj, '_json_dict_', lambda: None)()
+    if isinstance(json_dict, Dict):
+        for v in json_dict.values():
+            result = get_serializable_by_keys(v) + result
+    if result:
+        return result
+
+    # Handle primitive container types.
+    if isinstance(obj, Dict):
+        return [sbk for pair in obj.items() for sbk in get_serializable_by_keys(pair)]
+    if hasattr(obj, '__iter__') and not isinstance(obj, str):
+        return [sbk for v in obj for sbk in get_serializable_by_keys(v)]
+    return []
 
 
 # pylint: disable=function-redefined
@@ -468,6 +607,31 @@ def to_json(
             party classes, prefer adding the _json_dict_ magic method
             to your classes rather than overriding this default.
     """
+    if cls == CirqEncoder and has_serializable_by_keys(obj):
+        class ContextualEncoder(CirqEncoder):
+            """An encoder with a context list for concise serialization."""
+
+            # This map is populated gradually during serialization. An object
+            # with components defined in this map will represent those
+            # components using their keys instead of inline definition.
+            context_map: Dict[str, 'SerializableByKey'] = {}
+
+            def default(self, o):
+                skey = getattr(o, '_serialization_key_', lambda: None)()
+                if skey in ContextualEncoder.context_map:
+                    if ContextualEncoder.context_map[skey] == o._json_dict_():
+                        return _SerializedKey(o)._json_dict_()
+                    raise ValueError(
+                        'Found different objects with the same serialization key:'
+                        f'\n{ContextualEncoder.context_map[skey]}\n{o}'
+                    )
+                if skey is not None:
+                    ContextualEncoder.context_map[skey] = o._json_dict_()
+                return super().default(o)
+
+        obj = _ContextualSerialization(obj)
+        cls = ContextualEncoder
+
     if file_or_fn is None:
         return json.dumps(obj, indent=indent, cls=cls)
 
@@ -513,8 +677,9 @@ def read_json(
     if resolvers is None:
         resolvers = DEFAULT_RESOLVERS
 
+    context_map: Dict[str, 'SerializableByKey'] = {}
     def obj_hook(x):
-        return _cirq_object_hook(x, resolvers)
+        return _cirq_object_hook(x, resolvers, context_map)
 
     if json_text is not None:
         return json.loads(json_text, object_hook=obj_hook)

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -447,11 +447,16 @@ def _cirq_object_hook(d, resolvers: Sequence[JsonResolver], context_map: Dict[st
 
 
 class SerializableByKey(SupportsJSON):
-    """Interface for objects that can be serialized to a key + context."""
+    """Protocol for objects that can be serialized to a key + context."""
 
     @doc_private
-    def _serialization_key_(self):
-        pass
+    def _serialization_key_(self) -> str:
+        """Returns a unique string identifier for this object.
+
+        This should only return the same value for two objects if they are
+        equal; otherwise, an error will occur if both are serialized into the
+        same JSON string.
+        """
 
 
 class _SerializedKey(SupportsJSON):

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -608,6 +608,7 @@ def to_json(
             to your classes rather than overriding this default.
     """
     if cls == CirqEncoder and has_serializable_by_keys(obj):
+
         class ContextualEncoder(CirqEncoder):
             """An encoder with a context list for concise serialization."""
 
@@ -678,6 +679,7 @@ def read_json(
         resolvers = DEFAULT_RESOLVERS
 
     context_map: Dict[str, 'SerializableByKey'] = {}
+
     def obj_hook(x):
         return _cirq_object_hook(x, resolvers, context_map)
 

--- a/cirq/protocols/json_serialization_test.py
+++ b/cirq/protocols/json_serialization_test.py
@@ -340,14 +340,6 @@ NOT_YET_SERIALIZABLE = [
 ]
 
 
-# These types are internal-only and should not be serialized directly.
-INTERNAL_SERIALIZATION_TYPES = [
-    '_ContextualSerialization',
-    '_SerializedContext',
-    '_SerializedKey',
-]
-
-
 def _find_classes_that_should_serialize() -> Set[Tuple[str, Optional[type]]]:
     result: Set[Tuple[str, Optional[type]]] = set()
     result.update(_get_all_public_classes(cirq))
@@ -355,8 +347,6 @@ def _find_classes_that_should_serialize() -> Set[Tuple[str, Optional[type]]]:
     result.update(_get_all_public_classes(cirq.work))
 
     for k, v in json_serialization._cirq_class_resolver_dictionary().items():
-        if k in INTERNAL_SERIALIZATION_TYPES:
-            continue
         t = v if isinstance(v, type) else None
         result.add((k, t))
     return result
@@ -520,6 +510,12 @@ def test_context_serialization():
       "key": "sbki_dict"
     }"""
     )
+
+    list_sbki = [sbki_dict]
+    assert_json_roundtrip_works(list_sbki, resolvers=test_resolvers)
+
+    dict_sbki = {'a': sbki_dict}
+    assert_json_roundtrip_works(dict_sbki, resolvers=test_resolvers)
 
     assert sbki_list != json_serialization._SerializedKey(sbki_list)
     sbki_other_list = SBKImpl('sbki_list', data_list=[sbki_list])

--- a/cirq/protocols/json_serialization_test.py
+++ b/cirq/protocols/json_serialization_test.py
@@ -539,11 +539,11 @@ def test_internal_serializer_types():
 
     context_json = test_context._json_dict_()
     with pytest.raises(TypeError, match='_from_json_dict_'):
-        _ = json_serialization._SerializedKey._from_json_dict_(**context_json)
+        _ = json_serialization._SerializedContext._from_json_dict_(**context_json)
 
     serialization_json = test_serialization._json_dict_()
     with pytest.raises(TypeError, match='_from_json_dict_'):
-        _ = json_serialization._SerializedKey._from_json_dict_(**serialization_json)
+        _ = json_serialization._ContextualSerialization._from_json_dict_(**serialization_json)
 
 
 def _write_test_data(key: str, *test_instances: Any):

--- a/cirq/protocols/json_serialization_test.py
+++ b/cirq/protocols/json_serialization_test.py
@@ -443,50 +443,49 @@ def test_sympy():
     assert_json_roundtrip_works(4 * t + 3 * s + 2)
 
 
+class SBKImpl:
+    """A test implementation of SerializableByKey."""
+
+    def __init__(
+        self,
+        name: str,
+        data_list: Optional[List] = None,
+        data_tuple: Optional[Tuple] = None,
+        data_dict: Optional[Dict] = None,
+    ):
+        self.name = name
+        self.data_list = data_list or []
+        self.data_tuple = data_tuple or ()
+        self.data_dict = data_dict or {}
+
+    def __eq__(self, other):
+        if not isinstance(other, SBKImpl):
+            return False
+        return (
+            self.name == other.name
+            and self.data_list == other.data_list
+            and self.data_tuple == other.data_tuple
+            and self.data_dict == other.data_dict
+        )
+
+    def _json_dict_(self):
+        return {
+            "cirq_type": "SBKImpl",
+            "name": self.name,
+            "data_list": self.data_list,
+            "data_tuple": self.data_tuple,
+            "data_dict": self.data_dict,
+        }
+
+    def _serialization_key_(self):
+        return self.name
+
+    @classmethod
+    def _from_json_dict_(cls, name, data_list, data_tuple, data_dict, **kwargs):
+        return cls(name, data_list, tuple(data_tuple), data_dict)
+
+
 def test_context_serialization():
-    class SBKImpl:
-        def __init__(
-            self,
-            name: str,
-            data_list: Optional[List] = None,
-            data_tuple: Optional[Tuple] = None,
-            data_dict: Optional[Dict] = None,
-        ):
-            self.name = name
-            self.data_list = data_list or []
-            self.data_tuple = data_tuple or ()
-            self.data_dict = data_dict or {}
-
-        def __eq__(self, other):
-            if not isinstance(other, SBKImpl):
-                return False
-            return (
-                self.name == other.name
-                and self.data_list == other.data_list
-                and self.data_tuple == other.data_tuple
-                and self.data_dict == other.data_dict
-            )
-
-        def __repr__(self):
-            # For debugging.
-            return f'SBKImpl({self._json_dict_()})'
-
-        def _json_dict_(self):
-            return {
-                "cirq_type": "SBKImpl",
-                "name": self.name,
-                "data_list": self.data_list,
-                "data_tuple": self.data_tuple,
-                "data_dict": self.data_dict,
-            }
-
-        def _serialization_key_(self):
-            return self.name
-
-        @classmethod
-        def _from_json_dict_(cls, name, data_list, data_tuple, data_dict, **kwargs):
-            return cls(name, data_list, tuple(data_tuple), data_dict)
-
     def custom_resolver(name):
         if name == 'SBKImpl':
             return SBKImpl
@@ -521,6 +520,30 @@ def test_context_serialization():
       "key": "sbki_dict"
     }"""
     )
+
+    assert sbki_list != json_serialization._SerializedKey(sbki_list)
+    sbki_other_list = SBKImpl('sbki_list', data_list=[sbki_list])
+    with pytest.raises(ValueError, match='different objects with the same serialization key'):
+        _ = cirq.to_json(sbki_other_list)
+
+
+def test_internal_serializer_types():
+    sbki = SBKImpl('test_key')
+    test_key = json_serialization._SerializedKey(sbki)
+    test_context = json_serialization._SerializedContext(sbki)
+    test_serialization = json_serialization._ContextualSerialization(sbki)
+
+    key_json = test_key._json_dict_()
+    with pytest.raises(TypeError, match='_from_json_dict_'):
+        _ = json_serialization._SerializedKey._from_json_dict_(**key_json)
+
+    context_json = test_context._json_dict_()
+    with pytest.raises(TypeError, match='_from_json_dict_'):
+        _ = json_serialization._SerializedKey._from_json_dict_(**context_json)
+
+    serialization_json = test_serialization._json_dict_()
+    with pytest.raises(TypeError, match='_from_json_dict_'):
+        _ = json_serialization._SerializedKey._from_json_dict_(**serialization_json)
 
 
 def _write_test_data(key: str, *test_instances: Any):


### PR DESCRIPTION
Part of #3235. Also contributes to #3438.

This PR adds a `SerializableByKey` interface which any Cirq object can implement to enable more concise JSON serialization of repeated objects. Enabling this behavior for various types is left to future PRs.

For comparison, consider MatrixGate:
```
a, b, c = cirq.LineQubit.range(3)
op = cirq.MatrixGate(some_big_matrix)
circuit = cirq.Circuit(op.on(a), op.on(b), op.on(c))
cirq.to_json(circuit)
```

Without concise serialization for MatrixGate:
<details>

```
{
  "cirq_type": "Circuit",
  "moments": [
    {
      "cirq_type": "GateOperation",
      "gate": {
        "cirq_type": "MatrixGate",
        "matrix": some_big_matrix
      }
      "qubits": a
    }
    {
      "cirq_type": "GateOperation",
      "gate": {
        "cirq_type": "MatrixGate",
        "matrix": some_big_matrix
      }
      "qubits": b
    }
    {
      "cirq_type": "GateOperation",
      "gate": {
        "cirq_type": "MatrixGate",
        "matrix": some_big_matrix
      }
      "qubits": c
    }
  ]
}
```
</details>

With concise serialization for MatrixGate:

<details>

```
# If MatrixGate implements SerializableByKey, this becomes:
{
  "cirq_type": "_ContextualSerialization",
  "context_list": [
    {
      "cirq_type": "_SerializedContext",
      "key": op._serialization_key_()
      "value": {
        "cirq_type": "MatrixGate",
        "matrix": some_big_matrix
      },
    },
    {
      "cirq_type": "Circuit",
      "moments": [
        {
          "cirq_type": "GateOperation",
          "gate": {
            "cirq_type": "_SerializedKey",
            "key": op._serialization_key_()
          },
          "qubits": a
        },
        {
          "cirq_type": "GateOperation",
          "gate": {
            "cirq_type": "_SerializedKey",
            "key": op._serialization_key_()
          },
          "qubits": b
        },
        {
          "cirq_type": "GateOperation",
          "gate": {
            "cirq_type": "_SerializedKey",
            "key": op._serialization_key_()
          },
          "qubits": c
        },
      ]
    }
  ]
}
```
</details>

Note that `some_big_matrix` appears three times in the current serialization, but only once with concise serialization.