### PR TITLE
Run black as a package instead of script

### DIFF
--- a/check/format-incremental
+++ b/check/format-incremental
@@ -113,7 +113,7 @@ fi
 # Once that is fixed upstream, we can just do:
 # black "${args[@]}" ${format_files}
 # exit $?
-LOGS="$(black "${args[@]}" ${format_files} 2>&1)"
+LOGS="$(python3 -m black "${args[@]}" ${format_files} 2>&1)"
 STATUS=$?
 echo "${LOGS}"
 if [[ "$STATUS" == "123" && "$LOGS" =~ ^.*"INTERNAL ERROR: Black produced different code on the second pass of the formatter.".*$ ]]; then


### PR DESCRIPTION
https://github.com/psf/black#usage seems to say that running as a script might not always work. I have been encountering the same issue on Mac. Running as a package works.