### PR TITLE
Remove repetition number in calibration calls

### DIFF
--- a/cirq/google/engine/engine_program.py
+++ b/cirq/google/engine/engine_program.py
@@ -238,14 +238,11 @@ class EngineProgram:
             raise ValueError('No processors specified')
 
         # Default run context
-        # Note that Quantum Engine currently requires at least one repetition
+        # Note that Quantum Engine currently requires a valid type url
         # on a run context in order to succeed validation.
-        # Remove this once that validation is removed for calibration.
         any_context = qtypes.any_pb2.Any()
-        rc = v2.run_context_pb2.RunContext()
-        rc.parameter_sweeps.add().repetitions = 1
+        any_context.Pack(v2.run_context_pb2.RunContext())
 
-        any_context.Pack(rc)
         created_job_id, job = self.context.client.create_job(
             project_id=self.project_id,
             program_id=self.program_id,

--- a/cirq/google/engine/engine_test.py
+++ b/cirq/google/engine/engine_test.py
@@ -748,11 +748,7 @@ def test_run_calibration(client):
         program_id='prog',
         job_id='job-id',
         processor_ids=['mysim'],
-        run_context=_to_any(
-            v2.run_context_pb2.RunContext(
-                parameter_sweeps=[v2.run_context_pb2.ParameterSweep(repetitions=1)]
-            )
-        ),
+        run_context=_to_any(v2.run_context_pb2.RunContext()),
         description=None,
         labels={'calibration': ''},
     )


### PR DESCRIPTION
- No longer needed by validation and is meaningless.