### PR TITLE
docs: fix simple typo, sigificant -> significant

### DIFF
--- a/cirq/experiments/fidelity_estimation.py
+++ b/cirq/experiments/fidelity_estimation.py
@@ -165,7 +165,7 @@ def xeb_fidelity(
             most to least significant qubit, i.e. in the order consistent with
             `cirq.final_state_vector`.
         qubit_order: Qubit order used to construct bitstrings enumerating
-            qubits starting with the most sigificant qubit.
+            qubits starting with the most significant qubit.
         amplitudes: Optional mapping from bitstring to output amplitude.
             If provided, simulation is skipped. Useful for large circuits
             when an offline simulation had already been peformed.


### PR DESCRIPTION
There is a small typo in cirq/experiments/fidelity_estimation.py.

Should read `significant` rather than `sigificant`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md