### PR TITLE
Observable Measurement - 3.5 - Readout Correction

### DIFF
--- a/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq/experiments/random_quantum_circuit_generation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Code for generating random quantum circuits."""
 
+import dataclasses
 from typing import (
     Any,
     Callable,
@@ -25,8 +26,6 @@ from typing import (
     Tuple,
     Union,
 )
-
-import dataclasses
 
 from cirq import circuits, devices, google, ops, protocols, value
 from cirq._doc import document

--- a/cirq/work/observable_measurement_data.py
+++ b/cirq/work/observable_measurement_data.py
@@ -167,6 +167,10 @@ class BitstringAccumulator:
             arise. The total number of repetitions is the sum of this 1d array.
         timestamps: We record a timestamp for each request/chunk. This
             1d array will have the same length as `chunksizes`.
+        readout_calibration:
+            The result of `calibrate_readout_error`. When requesting
+            means and variances, if this is not None, we will use the
+            calibrated value to correct the requested quantity.
     """
 
     def __init__(
@@ -177,10 +181,12 @@ class BitstringAccumulator:
         bitstrings: np.ndarray = None,
         chunksizes: np.ndarray = None,
         timestamps: np.ndarray = None,
+        readout_calibration: 'BitstringAccumulator' = None,
     ):
         self._meas_spec = meas_spec
         self._simul_settings = simul_settings
         self._qubit_to_index = qubit_to_index
+        self._readout_calibration = readout_calibration
 
         if bitstrings is None:
             n_bits = len(qubit_to_index)
@@ -353,7 +359,8 @@ class BitstringAccumulator:
             f'qubit_to_index={self.qubit_to_index!r}, '
             f'bitstrings={proper_repr(self.bitstrings)}, '
             f'chunksizes={proper_repr(self.chunksizes)}, '
-            f'timestamps={proper_repr(self.timestamps)})'
+            f'timestamps={proper_repr(self.timestamps)}, '
+            f'readout_calibration={self._readout_calibration!r})'
         )
 
     def __str__(self):
@@ -423,12 +430,26 @@ class BitstringAccumulator:
             raise ValueError("No measurements")
         self._validate_setting(setting, what='variance')
 
-        _, var = _stats_from_measurements(
+        mean, var = _stats_from_measurements(
             bitstrings=self.bitstrings,
             qubit_to_index=self._qubit_to_index,
             observable=setting.observable,
             atol=atol,
         )
+
+        if self._readout_calibration is not None:
+            a = mean
+            if np.isclose(a, 0):
+                return np.inf
+            var_a = var
+            b = self._readout_calibration.mean(setting)
+            if np.isclose(b, 0):
+                return np.inf
+            var_b = self._readout_calibration.variance(setting)
+            f = a / b
+
+            # assume cov(a,b) = 0, otherwise there would be another term.
+            var = f ** 2 * (var_a / (a ** 2) + var_b / (b ** 2))
 
         return var
 
@@ -452,6 +473,9 @@ class BitstringAccumulator:
             observable=setting.observable,
             atol=atol,
         )
+
+        if self._readout_calibration is not None:
+            return mean / self._readout_calibration.mean(setting, atol=atol)
 
         return mean
 

--- a/cirq/work/observable_measurement_data.py
+++ b/cirq/work/observable_measurement_data.py
@@ -464,6 +464,7 @@ class BitstringAccumulator:
             var_b = self._readout_calibration.variance(ro_setting)
             f = a / b
 
+            # https://en.wikipedia.org/wiki/Propagation_of_uncertainty#Example_formulae
             # assume cov(a,b) = 0, otherwise there would be another term.
             var = f ** 2 * (var_a / (a ** 2) + var_b / (b ** 2))
 

--- a/cirq/work/observable_measurement_data.py
+++ b/cirq/work/observable_measurement_data.py
@@ -178,15 +178,13 @@ class BitstringAccumulator:
             1d array will have the same length as `chunksizes`.
         readout_calibration:
             The result of `calibrate_readout_error`. When requesting
-            means and variances, if this is not None, we will use the
+            means and variances, if this is not `None`, we will use the
             calibrated value to correct the requested quantity. This is a
-            BitstringAccumulator containing the results of measuring Z
+            `BitstringAccumulator` containing the results of measuring Z
             observables with readout symmetrization enabled. This class
             does *not* validate that both this parameter and the
-            BitstringAccumulator under construction contain measurements taken
-            with readout symmetrization turned on; and we strongly
-            encourage you to avoid initializing this directly. Instead, use
-            `measure_observables` and `calibrate_readout_error`.
+            `BitstringAccumulator` under construction contain measurements taken
+            with readout symmetrization turned on.
 
     """
 
@@ -204,12 +202,6 @@ class BitstringAccumulator:
         self._simul_settings = simul_settings
         self._qubit_to_index = qubit_to_index
         self._readout_calibration = readout_calibration
-
-        # # Extract and cache <Z> observables from `readout_calibration`.
-        # self._readout_cal_dict = {
-        #     q: readout_calibration.mean(InitObsSetting(cirq.KET_ZERO(q), cirq.Z(q)))
-        #     for q in readout_calibration.max_setting.observable.qubits
-        # }
 
         if bitstrings is None:
             n_bits = len(qubit_to_index)
@@ -461,14 +453,14 @@ class BitstringAccumulator:
         )
 
         if self._readout_calibration is not None:
-            ro_setting = _setting_to_z_observable(setting)
             a = mean
-            if np.isclose(a, 0):
-                return np.inf  # coverage: ignore
+            if np.isclose(a, 0, atol=atol):
+                return np.inf
             var_a = var
+            ro_setting = _setting_to_z_observable(setting)
             b = self._readout_calibration.mean(ro_setting)
-            if np.isclose(b, 0):
-                return np.inf  # coverage: ignore
+            if np.isclose(b, 0, atol=atol):
+                return np.inf
             var_b = self._readout_calibration.variance(ro_setting)
             f = a / b
 


### PR DESCRIPTION
This is part 3.5 or 4.5 of #2781 

It comes either before or after #3647 

This extends the vanilla `BitstringAccumulator` to handle readout calibrations which can be used to correct observables and mitigate the effect of readout error. However, users should probably never use this functionality directly; instead passing the appropriate configuration options to the functions defined in #3647. It would make git dependencies if this is merged first.

More sophisticated readout mitigation schemes would be implemented by subclassing `BitstringAccumulator`. Subclasses would (1) modify the constructor to accept the relevant calibration info, if different than this simple scheme and (2) modify the `mean()` and `variance()` functions to correct those quantities using the new scheme. 

