### PR TITLE
[WIP] Use concise JSON serialization for FrozenCircuit.

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -135,7 +135,7 @@ class AbstractCircuit(abc.ABC):
         """
         if isinstance(self, Circuit):
             return Circuit.copy(self)
-        return Circuit(self, strategy=InsertStrategy.EARLIEST, device=self.device)
+        return Circuit(self, strategy=InsertStrategy.EARLIEST, device=self.device, name=self.name)
 
     def __bool__(self):
         return bool(self.moments)

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -3935,7 +3935,7 @@ def test_operation_shape_validation(circuit_cls):
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
 def test_json_dict(circuit_cls):
     q0, q1 = cirq.LineQubit.range(2)
-    c = circuit_cls(cirq.CNOT(q0, q1))
+    c = circuit_cls(cirq.CNOT(q0, q1), name='test_circuit')
     moments = [cirq.Moment([cirq.CNOT(q0, q1)])]
     if circuit_cls == cirq.FrozenCircuit:
         moments = tuple(moments)
@@ -3943,6 +3943,7 @@ def test_json_dict(circuit_cls):
         'cirq_type': circuit_cls.__name__,
         'moments': moments,
         'device': cirq.UNCONSTRAINED_DEVICE,
+        'name': 'test_circuit',
     }
 
 

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -96,11 +96,11 @@ class FrozenCircuit(AbstractCircuit):
     def __hash__(self):
         return hash((self.moments, self.device, self.name))
 
-    def serialization_key(self):
+    def serialization_key(self) -> str:
         key = hash(self) & 0xFFFF_FFFF_FFFF_FFFF
         return f'{self.name or "Circuit"}_0x{key:016x}'
 
-    def _serialization_key_(self):
+    def _serialization_key_(self) -> str:
         return self.serialization_key()
 
     # Memoized methods for commonly-retrieved properties.

--- a/cirq/circuits/frozen_circuit_test.py
+++ b/cirq/circuits/frozen_circuit_test.py
@@ -45,6 +45,24 @@ def test_freeze_and_unfreeze():
     assert fcc is not f
 
 
+def test_names():
+    a, b = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.X(a), cirq.H(b), name='testname')
+
+    f = c.freeze()
+    assert f.name == c.name
+
+    ff = c.freeze()
+    assert ff.name == f.name
+    # Since the two are identical, this is acceptable.
+    assert ff.serialization_key() == f.serialization_key()
+
+    c.append(cirq.CX(b, a))
+    fff = c.freeze()
+    assert fff.name == f.name
+    assert fff.serialization_key() != f.serialization_key()
+
+
 def test_immutable():
     q = cirq.LineQubit(0)
     c = cirq.FrozenCircuit(cirq.X(q), cirq.H(q))

--- a/cirq/circuits/frozen_circuit_test.py
+++ b/cirq/circuits/frozen_circuit_test.py
@@ -23,7 +23,7 @@ import cirq
 
 def test_freeze_and_unfreeze():
     a, b = cirq.LineQubit.range(2)
-    c = cirq.Circuit(cirq.X(a), cirq.H(b))
+    c = cirq.Circuit(cirq.X(a), cirq.H(b), name='testname')
 
     f = c.freeze()
     assert f.moments == tuple(c.moments)

--- a/cirq/protocols/json_serialization.py
+++ b/cirq/protocols/json_serialization.py
@@ -453,6 +453,9 @@ class SerializableByKey(SupportsJSON):
         This should only return the same value for two objects if they are
         equal; otherwise, an error will occur if both are serialized into the
         same JSON string.
+
+        Tests will ignore a single hash value ("0x" + 16 hex digits) in each
+        serialization key to allow for variance between Python sessions.
         """
 
 

--- a/cirq/protocols/json_test_data/CalibrationLayer.json
+++ b/cirq/protocols/json_test_data/CalibrationLayer.json
@@ -25,7 +25,8 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": null
   },
   "args": {
     "type": "full",

--- a/cirq/protocols/json_test_data/Circuit.json
+++ b/cirq/protocols/json_test_data/Circuit.json
@@ -116,7 +116,8 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": "group_measure"
   },
   {
     "cirq_type": "Circuit",
@@ -170,7 +171,8 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": null
   },
   {
     "cirq_type": "Circuit",
@@ -200,6 +202,7 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": null
   }
 ]

--- a/cirq/protocols/json_test_data/Circuit.repr
+++ b/cirq/protocols/json_test_data/Circuit.repr
@@ -9,7 +9,8 @@
     cirq.Moment(
         cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
     ),
-]), cirq.Circuit([
+], name="group_measure",
+), cirq.Circuit([
     cirq.Moment(
         cirq.TOFFOLI(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2)),
     ),

--- a/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq/protocols/json_test_data/CircuitOperation.json
@@ -1,229 +1,261 @@
-[
-  {
-    "cirq_type": "CircuitOperation",
-    "circuit": {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "MeasurementGate",
-                "num_qubits": 5,
-                "key": "0,1,2,3,4",
-                "invert_mask": []
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
-      }
-    },
-    "repetitions": 1,
-    "qubit_map": [],
-    "measurement_key_map": {
-      "0,1,2,3,4": "mixed_state"
-    },
-    "param_resolver": {
-      "cirq_type": "ParamResolver",
-      "param_dict": []
-    }
-  },
-  {
-    "cirq_type": "CircuitOperation",
-    "circuit": {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "ZPowGate",
-                "exponent": 0.5,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
-      }
-    },
-    "repetitions": -2,
-    "qubit_map": [
-      [
-        {
-          "cirq_type": "LineQubit",
-          "x": 0
-        },
-        {
-          "cirq_type": "LineQubit",
-          "x": 1
-        }
-      ]
-    ],
-    "measurement_key_map": {},
-    "param_resolver": {
-      "cirq_type": "ParamResolver",
-      "param_dict": []
-    }
-  },
-  {
-    "cirq_type": "CircuitOperation",
-    "circuit": {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "XPowGate",
-                "exponent": {
-                  "cirq_type": "sympy.Symbol",
-                  "name": "theta"
-                },
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
-      }
-    },
-    "repetitions": 1,
-    "qubit_map": [],
-    "measurement_key_map": {},
-    "param_resolver": {
-      "cirq_type": "ParamResolver",
-      "param_dict": [
-        [
+{
+  "cirq_type": "_ContextualSerialization",
+  "object_dag": [
+    {
+      "cirq_type": "_SerializedContext",
+      "key": "group_measure_0xe868f31c760aeccc",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
           {
-            "cirq_type": "sympy.Symbol",
-            "name": "theta"
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
           },
-          1.5
-        ]
-      ]
-    }
-  }
-]
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "MeasurementGate",
+                  "num_qubits": 5,
+                  "key": "0,1,2,3,4",
+                  "invert_mask": []
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": "group_measure"
+      }
+    },
+    {
+      "cirq_type": "_SerializedContext",
+      "key": "Circuit_0x9b3eb91d438ec1af",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "ZPowGate",
+                  "exponent": 0.5,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": null
+      }
+    },
+    {
+      "cirq_type": "_SerializedContext",
+      "key": "Circuit_0x17daf308f310490b",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "XPowGate",
+                  "exponent": {
+                    "cirq_type": "sympy.Symbol",
+                    "name": "theta"
+                  },
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": null
+      }
+    },
+    [
+      {
+        "cirq_type": "CircuitOperation",
+        "circuit": {
+          "cirq_type": "_SerializedKey",
+          "key": "group_measure_0xe868f31c760aeccc"
+        },
+        "repetitions": 1,
+        "qubit_map": [],
+        "measurement_key_map": {
+          "0,1,2,3,4": "mixed_state"
+        },
+        "param_resolver": {
+          "cirq_type": "ParamResolver",
+          "param_dict": []
+        }
+      },
+      {
+        "cirq_type": "CircuitOperation",
+        "circuit": {
+          "cirq_type": "_SerializedKey",
+          "key": "Circuit_0x9b3eb91d438ec1af"
+        },
+        "repetitions": -2,
+        "qubit_map": [
+          [
+            {
+              "cirq_type": "LineQubit",
+              "x": 0
+            },
+            {
+              "cirq_type": "LineQubit",
+              "x": 1
+            }
+          ]
+        ],
+        "measurement_key_map": {},
+        "param_resolver": {
+          "cirq_type": "ParamResolver",
+          "param_dict": []
+        }
+      },
+      {
+        "cirq_type": "CircuitOperation",
+        "circuit": {
+          "cirq_type": "_SerializedKey",
+          "key": "Circuit_0x17daf308f310490b"
+        },
+        "repetitions": 1,
+        "qubit_map": [],
+        "measurement_key_map": {},
+        "param_resolver": {
+          "cirq_type": "ParamResolver",
+          "param_dict": [
+            [
+              {
+                "cirq_type": "sympy.Symbol",
+                "name": "theta"
+              },
+              1.5
+            ]
+          ]
+        }
+      }
+    ]
+  ]
+}

--- a/cirq/protocols/json_test_data/CircuitOperation.repr
+++ b/cirq/protocols/json_test_data/CircuitOperation.repr
@@ -9,7 +9,8 @@
     cirq.Moment(
         cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
     ),
-]),
+], name='group_measure',
+),
 measurement_key_map={'0,1,2,3,4': 'mixed_state'}),
 cirq.CircuitOperation(circuit=cirq.FrozenCircuit([
     cirq.Moment(

--- a/cirq/protocols/json_test_data/FrozenCircuit.json
+++ b/cirq/protocols/json_test_data/FrozenCircuit.json
@@ -1,205 +1,237 @@
-[
+{
+  "cirq_type": "_ContextualSerialization",
+  "object_dag": [
     {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+      "cirq_type": "_SerializedContext",
+      "key": "Circuit_0xc82bf6c40b85dfca",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "MeasurementGate",
+                  "num_qubits": 5,
+                  "key": "0,1,2,3,4",
+                  "invert_mask": []
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
         },
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "MeasurementGate",
-                "num_qubits": 5,
-                "key": "0,1,2,3,4",
-                "invert_mask": []
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
+        "name": null
       }
     },
     {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "CCXPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
+      "cirq_type": "_SerializedContext",
+      "key": "Partial_Toffoli_0xe701be1a1edc20ea",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "CCXPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
                 },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "XPowGate",
+                  "exponent": 0.123,
+                  "global_shift": 0.0
                 },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                }
-              ]
-            }
-          ]
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
         },
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "XPowGate",
-                "exponent": 0.123,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
+        "name": "Partial_Toffoli"
       }
     },
     {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "XPowGate",
-                "exponent": {
-                  "cirq_type": "sympy.Symbol",
-                  "name": "theta"
+      "cirq_type": "_SerializedContext",
+      "key": "Circuit_0xf2fc47571ba0605e",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "XPowGate",
+                  "exponent": {
+                    "cirq_type": "sympy.Symbol",
+                    "name": "theta"
+                  },
+                  "global_shift": 0.0
                 },
-                "global_shift": 0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": null
       }
-    }
+    },
+    [
+      {
+        "cirq_type": "_SerializedKey",
+        "key": "Circuit_0xc82bf6c40b85dfca"
+      },
+      {
+        "cirq_type": "_SerializedKey",
+        "key": "Partial_Toffoli_0xe701be1a1edc20ea"
+      },
+      {
+        "cirq_type": "_SerializedKey",
+        "key": "Circuit_0xf2fc47571ba0605e"
+      }
+    ]
   ]
+}

--- a/cirq/protocols/json_test_data/FrozenCircuit.repr
+++ b/cirq/protocols/json_test_data/FrozenCircuit.repr
@@ -16,7 +16,8 @@
     cirq.Moment(
         (cirq.X**0.123).on(cirq.LineQubit(0)),
     ),
-]), cirq.FrozenCircuit([
+], name='Partial_Toffoli',
+), cirq.FrozenCircuit([
     cirq.Moment(
         (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
     ),


### PR DESCRIPTION
Fixes #3633. This PR applies the following changes:
- `FrozenCircuit` uses the efficient JSON serialization format.
- Users can optionally assign names to `Circuit` and `FrozenCircuit` objects. These have no special behavior for `Circuit`s, but `FrozenCircuit`s use their name and hash value as their serialization key.
- The JSON serialization test is now agnostic to hash values (`0x` + 16 hex characters) in serialization keys. This allows hardcoded JSON to match the JSON generated from code despite hash values not being consistent between Python sessions.

Note that since names are preserved across the `Circuit`/`FrozenCircuit` boundary, it is possible to e.g. call `freeze()` twice on the same `Circuit`, producing two `FrozenCircuit`s with identical names. This is the desired behavior, as shown below:
- If the `Circuit` has not been mutated, the `FrozenCircuit`s will have matching serialization keys and will be deduped in serialization.
- If the `Circuit` _has_ been mutated, the `FrozenCircuit`s' serialization keys will differ, and they will appear separately in serialization.