### PR TITLE
Fix SWAP and ResetChannel not working with CliffordSimulator

### DIFF
--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -674,11 +674,20 @@ class ResetChannel(gate_features.SingleQubitGate):
         """
         self._dimension = dimension
 
+    def _has_stabilizer_effect_(self) -> Optional[bool]:
+        return True
+
     def _qid_shape_(self):
         return (self._dimension,)
 
     def _act_on_(self, args: Any):
-        from cirq import sim
+        from cirq import sim, ops
+
+        if isinstance(args, sim.ActOnStabilizerCHFormArgs):
+            (axe,) = args.axes
+            if args.state._measure(axe, args.prng):
+                ops.X._act_on_(args)
+            return True
 
         if isinstance(args, sim.ActOnStateVectorArgs):
             # Do a silent measurement.

--- a/cirq/ops/common_channels_test.py
+++ b/cirq/ops/common_channels_test.py
@@ -682,3 +682,7 @@ def test_multi_asymmetric_depolarizing_channel_text_diagram():
     assert cirq.circuit_diagram_info(a, args=round_to_2_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('A(II:0.67, XX:0.33)',)
     )
+
+
+def test_reset_stabilizer():
+    assert cirq.has_stabilizer_effect(cirq.reset(cirq.LineQubit(0)))

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -85,6 +85,19 @@ class SwapPowGate(
             return None
         return abs(np.sin(self._exponent * 0.5 * np.pi))
 
+    def _act_on_(self, args):
+        from cirq import ops, sim, protocols
+
+        if isinstance(args, sim.ActOnStabilizerCHFormArgs):
+            protocols.act_on(ops.CNOT, args)
+            args.axes = args.axes[::-1]
+            protocols.act_on(ops.CNOT, args)
+            args.axes = args.axes[::-1]
+            protocols.act_on(ops.CNOT, args)
+            return True
+
+        return NotImplemented
+
     def _apply_unitary_(self, args: 'protocols.ApplyUnitaryArgs') -> Optional[np.ndarray]:
         if self._exponent != 1:
             return NotImplemented

--- a/cirq/ops/swap_gates.py
+++ b/cirq/ops/swap_gates.py
@@ -88,7 +88,8 @@ class SwapPowGate(
     def _act_on_(self, args):
         from cirq import ops, sim, protocols
 
-        if isinstance(args, sim.ActOnStabilizerCHFormArgs):
+        if isinstance(args, sim.ActOnStabilizerCHFormArgs) and self._exponent % 2 == 1:
+            args.state.omega *= 1j ** (2 * self.global_shift * self._exponent)
             protocols.act_on(ops.CNOT, args)
             args.axes = args.axes[::-1]
             protocols.act_on(ops.CNOT, args)

--- a/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq/sim/clifford/clifford_simulator.py
@@ -100,16 +100,15 @@ class CliffordSimulator(simulator.SimulatesSamples, simulator.SimulatesIntermedi
             return
 
         state = CliffordState(qubit_map, initial_state=initial_state)
+        ch_form_args = clifford.ActOnStabilizerCHFormArgs(
+            state.ch_form,
+            [],
+            self._prng,
+            {},
+        )
 
         for moment in circuit:
-            ch_form_args = clifford.ActOnStabilizerCHFormArgs(
-                state.ch_form,
-                [],
-                self._prng,
-                {},
-            )
-            measurements: Dict[str, List[np.ndarray]] = collections.defaultdict(list)
-            ch_form_args.log_of_measurement_results = collections.defaultdict(list)
+            ch_form_args.log_of_measurement_results = {}
 
             for op in moment:
                 try:

--- a/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq/sim/clifford/clifford_simulator.py
@@ -113,7 +113,7 @@ class CliffordSimulator(simulator.SimulatesSamples, simulator.SimulatesIntermedi
 
             for op in moment:
                 try:
-                    ch_form_args.axes = [state.qubit_map[i] for i in op.qubits]
+                    ch_form_args.axes = tuple(state.qubit_map[i] for i in op.qubits)
                     act_on(op, ch_form_args)
                 except TypeError:
                     raise ValueError(

--- a/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq/sim/clifford/clifford_simulator.py
@@ -115,8 +115,8 @@ class CliffordSimulator(simulator.SimulatesSamples, simulator.SimulatesIntermedi
                     ch_form_args.axes = tuple(state.qubit_map[i] for i in op.qubits)
                     act_on(op, ch_form_args)
                 except TypeError:
-                    raise ValueError(
-                        '%s cannot be run with Clifford simulator.' % str(op.gate)
+                    raise NotImplementedError(
+                        f"CliffordSimulator doesn't support {op!r}"
                     )  # type: ignore
 
             yield CliffordSimulatorStepResult(

--- a/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq/sim/clifford/clifford_simulator.py
@@ -29,7 +29,6 @@ The quantum state is specified in two forms:
     to state vector amplitudes.
 """
 
-import collections
 from typing import Any, Dict, List, Iterator, Sequence
 
 import numpy as np

--- a/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq/sim/clifford/clifford_simulator_test.py
@@ -387,18 +387,21 @@ def test_non_clifford_circuit():
     q0 = cirq.LineQubit(0)
     circuit = cirq.Circuit()
     circuit.append(cirq.T(q0))
-    with pytest.raises(ValueError, match="T cannot be run with Clifford simulator."):
+    with pytest.raises(NotImplementedError, match="support cirq.T"):
         cirq.CliffordSimulator().simulate(circuit)
 
 
-def test_gate_not_supported():
-    q = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit()
-    circuit.append(cirq.SWAP(q[0], q[1]))
-
-    # This is a Clifford gate, but it's not supported yet.
-    with pytest.raises(ValueError, match="SWAP cannot be run with Clifford simulator."):
-        cirq.CliffordSimulator().simulate(circuit)
+def test_swap():
+    a, b = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.X(a),
+        cirq.SWAP(a, b),
+        cirq.measure(a, key="a"),
+        cirq.measure(b, key="b"),
+    )
+    r = cirq.CliffordSimulator().sample(circuit)
+    assert not r["a"][0]
+    assert r["b"][0]
 
 
 def test_sample_seed():

--- a/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq/sim/clifford/clifford_simulator_test.py
@@ -524,3 +524,13 @@ def test_deprecated():
     ):
         # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
         _ = clifford_state.perform_measurement([q], prng=0, collapse_wavefunction=True)
+
+
+def test_reset():
+    q = cirq.LineQubit(0)
+    c = cirq.Circuit(cirq.X(q), cirq.reset(q), cirq.measure(q, key="out"))
+    assert cirq.CliffordSimulator().sample(c)["out"][0] == 0
+    c = cirq.Circuit(cirq.H(q), cirq.reset(q), cirq.measure(q, key="out"))
+    assert cirq.CliffordSimulator().sample(c)["out"][0] == 0
+    c = cirq.Circuit(cirq.reset(q), cirq.measure(q, key="out"))
+    assert cirq.CliffordSimulator().sample(c)["out"][0] == 0

--- a/cirq/testing/consistent_act_on.py
+++ b/cirq/testing/consistent_act_on.py
@@ -136,6 +136,8 @@ def assert_all_implemented_act_on_effects_match_unitary(
             np.reshape(stabilizer_ch_form.state_vector(), protocols.qid_shape(qubits)),
             state_vector,
             atol=1e-07,
+            err_msg=f"stabilizer_ch_form.state_vector disagrees with state_vector for {val!r}",
+            verbose=True,
         )
 
 


### PR DESCRIPTION
- Just call `act_on` instead of doing type inspection in CliffordSimulator's _base_iterator
- Add ActOnStabilizerCHFormArgs case to ResetChannel
- Add ActOnStabilizerCHFormArgs case to SwapPowGate
- Remove unit test asserting swap gate doesn't work (!)