### PR TITLE
Fix assumption about order in MPSSimulator

### DIFF
--- a/cirq/sim/mps_simulator.py
+++ b/cirq/sim/mps_simulator.py
@@ -284,10 +284,15 @@ class MPSState:
             n = idx[0]
             self.M[n] = np.einsum('ij,mnj->mni', U, self.M[n])
         elif len(idx) == 2:
-            n = idx[0]
-            p = idx[1]
-            if abs(n - p) != 1:
+            if abs(idx[0] - idx[1]) != 1:
                 raise ValueError('Can only handle continguous qubits')
+            elif idx[0] < idx[1]:
+                n = idx[0]
+                p = idx[1]
+            else:
+                n = idx[1]
+                p = idx[0]
+                U = np.swapaxes(np.swapaxes(U, 0, 1), 2, 3)
             T = np.einsum('klij,mni,npj->mkpl', U, self.M[n], self.M[p])
             X, S, Y = np.linalg.svd(T.reshape([T.shape[0] * T.shape[1], T.shape[2] * T.shape[3]]))
             X = X.reshape([T.shape[0], T.shape[1], -1])

--- a/cirq/sim/mps_simulator.py
+++ b/cirq/sim/mps_simulator.py
@@ -287,11 +287,9 @@ class MPSState:
             if abs(idx[0] - idx[1]) != 1:
                 raise ValueError('Can only handle continguous qubits')
             elif idx[0] < idx[1]:
-                n = idx[0]
-                p = idx[1]
+                n, p = idx
             else:
-                n = idx[1]
-                p = idx[0]
+                p, n = idx
                 U = np.swapaxes(np.swapaxes(U, 0, 1), 2, 3)
             T = np.einsum('klij,mni,npj->mkpl', U, self.M[n], self.M[p])
             X, S, Y = np.linalg.svd(T.reshape([T.shape[0] * T.shape[1], T.shape[2] * T.shape[3]]))

--- a/cirq/sim/mps_simulator_test.py
+++ b/cirq/sim/mps_simulator_test.py
@@ -35,17 +35,14 @@ def test_various_gates_1d():
 
 
 def test_various_gates_1d_flip():
-    q2, q3 = cirq.LineQubit.range(2)
-
-    q3_gate_op = cirq.H
-    cross_gate_op2 = cirq.CNOT
+    q0, q1 = cirq.LineQubit.range(2)
 
     circuit = cirq.Circuit(
-        q3_gate_op(q3),
-        cross_gate_op2(q3, q2),
+        cirq.H(q1),
+        cirq.CNOT(q1, q0),
     )
 
-    assert_same_output_as_dense(circuit=circuit, qubit_order=[q2, q3])
+    assert_same_output_as_dense(circuit=circuit, qubit_order=[q0, q1])
 
 
 def test_empty():

--- a/cirq/sim/mps_simulator_test.py
+++ b/cirq/sim/mps_simulator_test.py
@@ -18,16 +18,34 @@ def assert_same_output_as_dense(circuit, qubit_order, initial_state=0):
     assert len(actual.measurements) == 0
 
 
-def test_various_gates():
-    gate_cls = [cirq.I, cirq.H, cirq.X, cirq.Y, cirq.Z, cirq.T]
-    cross_gate_cls = [cirq.CNOT, cirq.SWAP]
+def test_various_gates_1d():
+    gate_op_cls = [cirq.I, cirq.H, cirq.X, cirq.Y, cirq.Z, cirq.T]
+    cross_gate_op_cls = [cirq.CNOT, cirq.SWAP]
 
-    for q0_gate in gate_cls:
-        for q1_gate in gate_cls:
-            for cross_gate in cross_gate_cls:
-                q0, q1 = cirq.LineQubit.range(2)
-                circuit = cirq.Circuit(q0_gate(q0), q1_gate(q1), cross_gate(q0, q1))
-                assert_same_output_as_dense(circuit=circuit, qubit_order=[q0, q1])
+    q0, q1 = cirq.LineQubit.range(2)
+
+    for q0_gate_op in gate_op_cls:
+        for q1_gate_op in gate_op_cls:
+            for cross_gate_op in cross_gate_op_cls:
+                circuit = cirq.Circuit(q0_gate_op(q0), q1_gate_op(q1), cross_gate_op(q0, q1))
+                for initial_state in range(2 * 2):
+                    assert_same_output_as_dense(
+                        circuit=circuit, qubit_order=[q0, q1], initial_state=initial_state
+                    )
+
+
+def test_various_gates_1d_flip():
+    q2, q3 = cirq.LineQubit.range(2)
+
+    q3_gate_op = cirq.H
+    cross_gate_op2 = cirq.CNOT
+
+    circuit = cirq.Circuit(
+        q3_gate_op(q3),
+        cross_gate_op2(q3, q2),
+    )
+
+    assert_same_output_as_dense(circuit=circuit, qubit_order=[q2, q3])
 
 
 def test_empty():


### PR DESCRIPTION
My unit testing didn't test the case when the order of qubits is inverted. I added a test and this causes an error that this PRs attempts to fix.

The error isn't too bad I think, because I had added some asserts (so no bad results), but it should be fixed nonetheless. I apologize for this mistake.