### PR TITLE
Wrap input json_dict entries in np.array to avoid wrong type deduction

### DIFF
--- a/cirq/sim/clifford/clifford_tableau.py
+++ b/cirq/sim/clifford/clifford_tableau.py
@@ -61,9 +61,9 @@ class CliffordTableau:
     @classmethod
     def _from_json_dict_(cls, n, rs, xs, zs, **kwargs):
         state = cls(n)
-        state.rs = rs
-        state.xs = xs
-        state.zs = zs
+        state.rs = np.array(rs)
+        state.xs = np.array(xs)
+        state.zs = np.array(zs)
         return state
 
     def __eq__(self, other):

--- a/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -73,18 +73,18 @@ class StabilizerStateChForm:
     def _from_json_dict_(cls, n, G, F, M, gamma, v, s, omega, **kwargs):
         copy = StabilizerStateChForm(n)
 
-        copy.G = G.copy()
-        copy.F = F.copy()
-        copy.M = M.copy()
-        copy.gamma = gamma.copy()
-        copy.v = v.copy()
-        copy.s = s.copy()
+        copy.G = np.array(G.copy())
+        copy.F = np.array(F.copy())
+        copy.M = np.array(M.copy())
+        copy.gamma = np.array(gamma.copy())
+        copy.v = np.array(v.copy())
+        copy.s = np.array(s.copy())
         copy.omega = omega
 
         return copy
 
     def _value_equality_values_(self) -> Any:
-        return (self.n, self.G, self.F, self.M, self.gamma, self.v, self.v, self.s, self.omega)
+        return (self.n, self.G, self.F, self.M, self.gamma, self.v, self.s, self.omega)
 
     def copy(self) -> 'cirq.StabilizerStateChForm':
         copy = StabilizerStateChForm(self.n)


### PR DESCRIPTION
Not doing this caused an issue where the JSON was parsed without issue but when using the object, certain methods would break since they expected an np.array and got a list.

Example: https://github.com/quantumlib/Cirq/pull/3645#discussion_r557795288

Dynamic typing strikes again!