### PR TITLE
Remove extraneous copies in StabilizerStateChForm JSON parsing

### DIFF
--- a/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -73,12 +73,12 @@ class StabilizerStateChForm:
     def _from_json_dict_(cls, n, G, F, M, gamma, v, s, omega, **kwargs):
         copy = StabilizerStateChForm(n)
 
-        copy.G = np.array(G.copy())
-        copy.F = np.array(F.copy())
-        copy.M = np.array(M.copy())
-        copy.gamma = np.array(gamma.copy())
-        copy.v = np.array(v.copy())
-        copy.s = np.array(s.copy())
+        copy.G = np.array(G)
+        copy.F = np.array(F)
+        copy.M = np.array(M)
+        copy.gamma = np.array(gamma)
+        copy.v = np.array(v)
+        copy.s = np.array(s)
         copy.omega = omega
 
         return copy


### PR DESCRIPTION
As pointed out in https://github.com/quantumlib/Cirq/pull/3679#discussion_r558495240