### PR TITLE
[POC] Factor a circuit into entanglement sets

### DIFF
--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -1,0 +1,93 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An optimization pass that factors the circuit into non-entangled subcircuits."""
+from typing import Mapping, List, FrozenSet, Iterator
+
+from cirq import CircuitOperation, Moment, Qid, Operation
+from cirq.circuits import AbstractCircuit, FrozenCircuit
+
+
+# todo: rewrite optimizers in functional style
+
+
+def factor_circuit(circuit: AbstractCircuit):
+    new_circuit: List[Iterator[List[Iterator[Operation]]]] = []
+    subcircuits = {frozenset([q]): [] for q in circuit.all_qubits()}
+    print()
+    for moment in circuit.moments:
+        subcircuits = _get_new_subcircuits(moment.operations, subcircuits)
+        print(f"new_subcircuits.count:{len(subcircuits)}")
+        _add_moment(new_circuit, moment, subcircuits)
+    return _to_circuit(new_circuit)
+
+
+def _get_new_subcircuits(
+    operations: Iterator[Operation],
+    current_subcircuits: Mapping[FrozenSet[Qid], List[Iterator[Operation]]],
+):
+    new_subcircuits: dict[FrozenSet[Qid], List[Moment]] = dict(current_subcircuits)
+    current_qids = {qubit: k for k in current_subcircuits.keys() for qubit in k}
+    for op in operations:
+        # todo: measurement gate
+        distinct_sets: FrozenSet[FrozenSet[Qid]] = frozenset(
+            [current_qids[qubit] for qubit in op.qubits]
+        )
+        if len(distinct_sets) > 1:
+            print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
+            new_set = frozenset.union(*distinct_sets)
+            new_subcircuits[new_set] = []
+            for old_set in distinct_sets:
+                new_subcircuits.pop(old_set)
+    return new_subcircuits
+
+
+# circuit is a list of moments
+# moment is an iterator of subcircuits
+# subcircuit is a list of submoments
+# submoment is an iterator of operations
+def _add_moment(
+    new_circuit: List[Iterator[List[Iterator[Operation]]]],
+    old_moment: Moment,
+    new_subcircuits: Mapping[FrozenSet[Qid], List[Iterator[Operation]]],
+):
+
+    new_ops = [circuit for circuit in new_subcircuits.values() if len(circuit) == 0]
+    new_circuit.append(new_ops)
+
+    for qubits, subcircuit in new_subcircuits.items():
+        operations = filter(lambda op: next(iter(op.qubits)) in qubits, old_moment.operations)
+        subcircuit.append(Moment(operations))
+
+
+def _to_subcircuit(submoments: Iterator[Iterator[Operation]]):
+    print()
+    print(f"submoments.count:{len(submoments)}")
+    circuit = FrozenCircuit([Moment(submoment) for submoment in submoments])
+    print("circuit")
+    print(circuit)
+    op = CircuitOperation(circuit)
+    print("op")
+    print(op)
+    return op
+
+
+def _to_moment(subcircuits: Iterator[Iterator[Iterator[Operation]]]):
+    print(f"subcircuits.count:{len(subcircuits)}")
+    return Moment([_to_subcircuit(subcircuit) for subcircuit in subcircuits])
+
+
+def _to_circuit(moments: Iterator[Iterator[Iterator[Iterator[Operation]]]]):
+    print(f"moments.count:{len(moments)}")
+    return FrozenCircuit([_to_moment(moment) for moment in moments])

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -79,7 +79,8 @@ def _add_moment(
     subcircuits: Mapping[EntanglementSet, TempSubcircuit],
 ):
     new_subcircuits = [subcircuit for subcircuit in subcircuits.values() if len(subcircuit) == 0]
-    circuit.append(new_subcircuits)
+    if len(new_subcircuits) != 0:
+        circuit.append(new_subcircuits)
     for qubits, subcircuit in subcircuits.items():
         relevant_operations = filter(lambda op: next(iter(op.qubits)) in qubits, operations)
         subcircuit.append(list(relevant_operations))

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -74,13 +74,13 @@ def _with_measurements_removed(
 
 
 def _add_moment(
-    new_circuit: TempCircuit,
+    circuit: TempCircuit,
     operations: Iterable[Operation],
-    new_subcircuits: Mapping[EntanglementSet, TempSubcircuit],
+    subcircuits: Mapping[EntanglementSet, TempSubcircuit],
 ):
-    new_ops = [circuit for circuit in new_subcircuits.values() if len(circuit) == 0]
-    new_circuit.append(new_ops)
-    for qubits, subcircuit in new_subcircuits.items():
+    new_subcircuits = [subcircuit for subcircuit in subcircuits.values() if len(subcircuit) == 0]
+    circuit.append(new_subcircuits)
+    for qubits, subcircuit in subcircuits.items():
         relevant_operations = filter(lambda op: next(iter(op.qubits)) in qubits, operations)
         subcircuit.append(list(relevant_operations))
 

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -13,37 +13,37 @@
 # limitations under the License.
 
 """An optimization pass that factors the circuit into non-entangled subcircuits."""
-from typing import Mapping, List, FrozenSet, Dict, Iterable
+from typing import Mapping, List, FrozenSet, Iterable
 
 from cirq import CircuitOperation, Moment, Qid, Operation, MeasurementGate
 from cirq.circuits import AbstractCircuit, FrozenCircuit
 
-
-# todo: rewrite optimizers in functional style
+TempSubcircuit = List[List[Operation]]
+TempMoment = List[TempSubcircuit]
+TempCircuit = List[TempMoment]
+EntanglementSet = FrozenSet[Qid]
 
 
 def factor_circuit(circuit: AbstractCircuit) -> FrozenCircuit:
-    new_circuit: List[Iterable[List[Iterable[Operation]]]] = []
-    subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]] = {
+    new_circuit: TempCircuit = []
+    subcircuits: Mapping[EntanglementSet, TempSubcircuit] = {
         frozenset([q]): [] for q in circuit.all_qubits()
     }
     for moment in circuit.moments:
-        subcircuits = _get_new_subcircuits(moment.operations, subcircuits)
+        subcircuits = _with_new_entanglements(subcircuits, moment.operations)
         _add_moment(new_circuit, moment.operations, subcircuits)
-        subcircuits = _remove_measurements(moment.operations, subcircuits)
+        subcircuits = _with_measurements_removed(subcircuits, moment.operations)
     return _to_circuit(new_circuit)
 
 
-def _get_new_subcircuits(
+def _with_new_entanglements(
+    current_subcircuits: Mapping[EntanglementSet, TempSubcircuit],
     operations: Iterable[Operation],
-    current_subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]],
-) -> Mapping[FrozenSet[Qid], List[Iterable[Operation]]]:
-    new_subcircuits: Dict[FrozenSet[Qid], List[Iterable[Operation]]] = dict(current_subcircuits)
-    current_qids = {qubit: k for k in current_subcircuits.keys() for qubit in k}
+) -> Mapping[EntanglementSet, TempSubcircuit]:
+    new_subcircuits = dict(current_subcircuits)
+    entanglement_sets = {qubit: k for k in current_subcircuits.keys() for qubit in k}
     for op in operations:
-        distinct_sets: FrozenSet[FrozenSet[Qid]] = frozenset(
-            [current_qids[qubit] for qubit in op.qubits]
-        )
+        distinct_sets = frozenset(entanglement_sets[qubit] for qubit in op.qubits)
         if len(distinct_sets) > 1:
             new_set = frozenset.union(*distinct_sets)
             new_subcircuits[new_set] = []
@@ -52,49 +52,43 @@ def _get_new_subcircuits(
     return new_subcircuits
 
 
-def _remove_measurements(
+def _with_measurements_removed(
+    current_subcircuits: Mapping[EntanglementSet, TempSubcircuit],
     operations: Iterable[Operation],
-    current_subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]],
 ):
-    new_subcircuits: Dict[FrozenSet[Qid], List[Iterable[Operation]]] = dict(current_subcircuits)
-    current_qids = {qubit: k for k in current_subcircuits.keys() for qubit in k}
+    new_subcircuits = dict(current_subcircuits)
+    entanglement_sets = {qubit: k for k in current_subcircuits.keys() for qubit in k}
     for op in operations:
         if isinstance(op.gate, MeasurementGate):
             for qubit in op.qubits:
-                new_subcircuits.pop(current_qids[qubit])
-                current_qids[qubit] = current_qids[qubit].difference([qubit])
-                new_subcircuits[current_qids[qubit]] = []
+                new_subcircuits.pop(entanglement_sets[qubit])
+                entanglement_sets[qubit] = entanglement_sets[qubit].difference([qubit])
+                new_subcircuits[entanglement_sets[qubit]] = []
                 new_subcircuits[frozenset([qubit])] = []
-                current_qids[qubit] = frozenset([qubit])
+                entanglement_sets[qubit] = frozenset([qubit])
     return new_subcircuits
 
 
-# circuit is a list of moments
-# moment is an iterator of subcircuits
-# subcircuit is a list of submoments
-# submoment is an iterator of operations
 def _add_moment(
-    new_circuit: List[Iterable[List[Iterable[Operation]]]],
+    new_circuit: TempCircuit,
     operations: Iterable[Operation],
-    new_subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]],
+    new_subcircuits: Mapping[EntanglementSet, TempSubcircuit],
 ):
-
     new_ops = [circuit for circuit in new_subcircuits.values() if len(circuit) == 0]
     new_circuit.append(new_ops)
-
     for qubits, subcircuit in new_subcircuits.items():
         relevant_operations = filter(lambda op: next(iter(op.qubits)) in qubits, operations)
         subcircuit.append(list(relevant_operations))
 
 
-def _to_subcircuit(submoments: Iterable[Iterable[Operation]]):
+def _to_subcircuit(submoments: TempSubcircuit) -> CircuitOperation:
     circuit = FrozenCircuit([Moment(submoment) for submoment in submoments])
     return CircuitOperation(circuit)
 
 
-def _to_moment(subcircuits: Iterable[Iterable[Iterable[Operation]]]):
+def _to_moment(subcircuits: TempMoment) -> Moment:
     return Moment([_to_subcircuit(subcircuit) for subcircuit in subcircuits])
 
 
-def _to_circuit(moments: Iterable[Iterable[Iterable[Iterable[Operation]]]]) -> FrozenCircuit:
+def _to_circuit(moments: TempCircuit) -> FrozenCircuit:
     return FrozenCircuit([_to_moment(moment) for moment in moments])

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -61,11 +61,15 @@ def _with_measurements_removed(
     for op in operations:
         if isinstance(op.gate, MeasurementGate):
             for qubit in op.qubits:
-                new_subcircuits.pop(entanglement_sets[qubit])
-                entanglement_sets[qubit] = entanglement_sets[qubit].difference([qubit])
-                new_subcircuits[entanglement_sets[qubit]] = []
-                new_subcircuits[frozenset([qubit])] = []
-                entanglement_sets[qubit] = frozenset([qubit])
+                old_entanglement_set = entanglement_sets[qubit]
+                new_subcircuits.pop(old_entanglement_set)
+                new_entanglement_set = old_entanglement_set.difference([qubit])
+                for other in new_entanglement_set:
+                    entanglement_sets[other] = new_entanglement_set
+                new_subcircuits[new_entanglement_set] = []
+                singleton_entanglement_set = frozenset([qubit])
+                new_subcircuits[singleton_entanglement_set] = []
+                entanglement_sets[qubit] = singleton_entanglement_set
     return new_subcircuits
 
 

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -37,11 +37,11 @@ def factor_circuit(circuit: AbstractCircuit) -> FrozenCircuit:
 
 
 def _with_new_entanglements(
-    current_subcircuits: Mapping[EntanglementSet, TempSubcircuit],
+    subcircuits: Mapping[EntanglementSet, TempSubcircuit],
     operations: Iterable[Operation],
 ) -> Mapping[EntanglementSet, TempSubcircuit]:
-    new_subcircuits = dict(current_subcircuits)
-    entanglement_sets = {qubit: k for k in current_subcircuits.keys() for qubit in k}
+    new_subcircuits = dict(subcircuits)
+    entanglement_sets = {qubit: es for es in subcircuits.keys() for qubit in es}
     for op in operations:
         distinct_sets = frozenset(entanglement_sets[qubit] for qubit in op.qubits)
         if len(distinct_sets) > 1:
@@ -53,11 +53,11 @@ def _with_new_entanglements(
 
 
 def _with_measurements_removed(
-    current_subcircuits: Mapping[EntanglementSet, TempSubcircuit],
+    subcircuits: Mapping[EntanglementSet, TempSubcircuit],
     operations: Iterable[Operation],
 ):
-    new_subcircuits = dict(current_subcircuits)
-    entanglement_sets = {qubit: k for k in current_subcircuits.keys() for qubit in k}
+    new_subcircuits = dict(subcircuits)
+    entanglement_sets = {qubit: es for es in subcircuits.keys() for qubit in es}
     for op in operations:
         if isinstance(op.gate, MeasurementGate):
             for qubit in op.qubits:

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """An optimization pass that factors the circuit into non-entangled subcircuits."""
-from typing import Mapping, List, FrozenSet, Tuple, Dict, Iterable
+from typing import Mapping, List, FrozenSet, Dict, Iterable
 
 from cirq import CircuitOperation, Moment, Qid, Operation, MeasurementGate
 from cirq.circuits import AbstractCircuit, FrozenCircuit
@@ -35,7 +35,7 @@ def factor_circuit(circuit: AbstractCircuit) -> FrozenCircuit:
 
 
 def _get_new_subcircuits(
-    operations: Tuple[Operation, ...],
+    operations: Iterable[Operation],
     current_subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]],
 ) -> Mapping[FrozenSet[Qid], List[Iterable[Operation]]]:
     new_subcircuits: Dict[FrozenSet[Qid], List[Iterable[Operation]]] = dict(current_subcircuits)
@@ -53,7 +53,7 @@ def _get_new_subcircuits(
 
 
 def _remove_measurements(
-    operations: Tuple[Operation, ...],
+    operations: Iterable[Operation],
     current_subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]],
 ):
     new_subcircuits: Dict[FrozenSet[Qid], List[Iterable[Operation]]] = dict(current_subcircuits)
@@ -75,7 +75,7 @@ def _remove_measurements(
 # submoment is an iterator of operations
 def _add_moment(
     new_circuit: List[Iterable[List[Iterable[Operation]]]],
-    operations: Tuple[Operation, ...],
+    operations: Iterable[Operation],
     new_subcircuits: Mapping[FrozenSet[Qid], List[Iterable[Operation]]],
 ):
 

--- a/cirq/optimizers/factor.py
+++ b/cirq/optimizers/factor.py
@@ -33,8 +33,8 @@ def factor_circuit(circuit: AbstractCircuit):
 
 
 def _get_new_subcircuits(
-        operations: Iterator[Operation],
-        current_subcircuits: Mapping[FrozenSet[Qid], List[Iterator[Operation]]],
+    operations: Iterator[Operation],
+    current_subcircuits: Mapping[FrozenSet[Qid], List[Iterator[Operation]]],
 ):
     new_subcircuits: dict[FrozenSet[Qid], List[Iterator[Operation]]] = dict(current_subcircuits)
     current_qids = {qubit: k for k in current_subcircuits.keys() for qubit in k}

--- a/cirq/optimizers/factor_test.py
+++ b/cirq/optimizers/factor_test.py
@@ -12,21 +12,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cirq import NamedQubit, Circuit, X, Y, Moment, measure, CNOT
+from cirq import NamedQubit, Circuit, X, Y, Moment, measure, CNOT, CircuitOperation, FrozenCircuit
 from cirq.optimizers.factor import factor_circuit
 
 
 def assert_optimizes(before, after):
     factored = factor_circuit(before)
-    print()
-    print()
-    print()
-    print(factored)
-    # assert factored == after
+    assert factored == after
 
 
-def test_align_left():
-    print()
+def test_factor_simple():
+    q1 = NamedQubit('q1')
+    assert_optimizes(
+        before=Circuit(
+            [
+                Moment([X(q1)]),
+            ]
+        ),
+        after=FrozenCircuit(
+            [
+                Moment([CircuitOperation(FrozenCircuit([X(q1)]))]),
+            ]
+        ),
+    )
+
+
+def test_factor_medium():
+    q1 = NamedQubit('q1')
+    q2 = NamedQubit('q2')
+    assert_optimizes(
+        before=Circuit(
+            [
+                Moment([X(q1)]),
+                Moment([X(q1), X(q2)]),
+                Moment([Y(q1)]),
+            ]
+        ),
+        after=FrozenCircuit(
+            [
+                Moment(
+                    [
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment([X(q1)]),
+                                    Moment([X(q1)]),
+                                    Moment([Y(q1)]),
+                                ]
+                            )
+                        ),
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment(),
+                                    Moment([X(q2)]),
+                                    Moment(),
+                                ]
+                            )
+                        ),
+                    ]
+                ),
+                Moment(),
+                Moment(),
+            ]
+        ),
+    )
+
+
+def test_factor_complex():
     q1 = NamedQubit('q1')
     q2 = NamedQubit('q2')
     assert_optimizes(
@@ -45,13 +98,75 @@ def test_align_left():
                 Moment([Y(q1)]),
             ]
         ),
-        after=Circuit(
+        after=FrozenCircuit(
             [
-                Moment([X(q1), X(q2)]),
-                Moment([Y(q1), Y(q2)]),
-                Moment([X(q1)]),
-                Moment([Y(q1)]),
-                measure(*[q1, q2], key='a'),
+                Moment(
+                    [
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment([X(q1)]),
+                                    Moment([X(q1)]),
+                                    Moment([Y(q1)]),
+                                ]
+                            )
+                        ),
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment(),
+                                    Moment([X(q2)]),
+                                    Moment(),
+                                ]
+                            )
+                        ),
+                    ]
+                ),
+                Moment(),
+                Moment(),
+                Moment(
+                    [
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment([CNOT(q1, q2)]),
+                                    Moment([X(q1)]),
+                                    Moment([X(q1), X(q2)]),
+                                    Moment([Y(q1)]),
+                                    measure(*[q1], key='a'),
+                                ]
+                            )
+                        )
+                    ]
+                ),
+                Moment(),
+                Moment(),
+                Moment(),
+                Moment(),
+                Moment(
+                    [
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment([X(q1)]),
+                                    Moment([X(q1)]),
+                                    Moment([Y(q1)]),
+                                ]
+                            )
+                        ),
+                        CircuitOperation(
+                            FrozenCircuit(
+                                [
+                                    Moment(),
+                                    Moment([X(q2)]),
+                                    Moment(),
+                                ]
+                            )
+                        ),
+                    ]
+                ),
+                Moment(),
+                Moment(),
             ]
         ),
     )

--- a/cirq/optimizers/factor_test.py
+++ b/cirq/optimizers/factor_test.py
@@ -39,7 +39,7 @@ def test_align_left():
                 Moment([X(q1)]),
                 Moment([X(q1), X(q2)]),
                 Moment([Y(q1)]),
-                measure(*[q1, q2], key='a'),
+                measure(*[q1], key='a'),
                 Moment([X(q1)]),
                 Moment([X(q1), X(q2)]),
                 Moment([Y(q1)]),

--- a/cirq/optimizers/factor_test.py
+++ b/cirq/optimizers/factor_test.py
@@ -1,0 +1,53 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cirq import NamedQubit, Circuit, X, Y, Moment, measure, CNOT
+from cirq.optimizers.factor import factor_circuit
+
+
+def assert_optimizes(before, after):
+    factored = factor_circuit(before)
+    print()
+    print()
+    print()
+    print(factored)
+    # assert factored == after
+
+
+def test_align_left():
+    print()
+    q1 = NamedQubit('q1')
+    q2 = NamedQubit('q2')
+    assert_optimizes(
+        before=Circuit(
+            [
+                Moment([X(q1)]),
+                Moment([X(q1), X(q2)]),
+                Moment([Y(q1)]),
+                Moment([CNOT(q1, q2)]),
+                Moment([X(q1)]),
+                Moment([X(q1), X(q2)]),
+                Moment([Y(q1)]),
+            ]
+        ),
+        after=Circuit(
+            [
+                Moment([X(q1), X(q2)]),
+                Moment([Y(q1), Y(q2)]),
+                Moment([X(q1)]),
+                Moment([Y(q1)]),
+                measure(*[q1, q2], key='a'),
+            ]
+        ),
+    )

--- a/cirq/optimizers/factor_test.py
+++ b/cirq/optimizers/factor_test.py
@@ -39,6 +39,10 @@ def test_align_left():
                 Moment([X(q1)]),
                 Moment([X(q1), X(q2)]),
                 Moment([Y(q1)]),
+                measure(*[q1, q2], key='a'),
+                Moment([X(q1)]),
+                Moment([X(q1), X(q2)]),
+                Moment([Y(q1)]),
             ]
         ),
         after=Circuit(

--- a/cirq/optimizers/factor_test.py
+++ b/cirq/optimizers/factor_test.py
@@ -72,8 +72,6 @@ def test_factor_medium():
                         ),
                     ]
                 ),
-                Moment(),
-                Moment(),
             ]
         ),
     )
@@ -122,8 +120,6 @@ def test_factor_complex():
                         ),
                     ]
                 ),
-                Moment(),
-                Moment(),
                 Moment(
                     [
                         CircuitOperation(
@@ -139,10 +135,6 @@ def test_factor_complex():
                         )
                     ]
                 ),
-                Moment(),
-                Moment(),
-                Moment(),
-                Moment(),
                 Moment(
                     [
                         CircuitOperation(
@@ -165,8 +157,6 @@ def test_factor_complex():
                         ),
                     ]
                 ),
-                Moment(),
-                Moment(),
             ]
         ),
     )


### PR DESCRIPTION
Closes #3675

Optimizer that factors a circuit into subcircuits such that each subcircuit represents a set of qubits that are all entangled with each other, for the duration of that entanglement, and such that there is no entanglement across subcircuits.

Completed: Join into new circuit when entanglement is detected, split into multiple circuits on measurement.

Some things not done: Correctly identify entangling gates (Id(2) would be considered "entangling", just noticed Reset gate is not handled -- maybe there should be a protocol where a gate definition specifies what it entangles/detangles, rather than explicitly placing that logic here).