### PR TITLE
Add tags to MeasureInfo

### DIFF
--- a/cirq/google/api/v2/results.py
+++ b/cirq/google/api/v2/results.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import (
     cast,
     Dict,
@@ -19,13 +18,12 @@ from typing import (
     Iterable,
     Iterator,
     List,
-    NamedTuple,
     Optional,
     Set,
     TYPE_CHECKING,
 )
-
 from collections import OrderedDict
+import dataclasses
 import numpy as np
 
 from cirq.google.api import v2
@@ -39,18 +37,8 @@ if TYPE_CHECKING:
     import cirq
 
 
-class MeasureInfo(
-    NamedTuple(
-        'MeasureInfo',
-        [
-            ('key', str),
-            ('qubits', List['cirq.GridQubit']),
-            ('slot', int),
-            ('invert_mask', List[bool]),
-            ('tags', List[Hashable]),
-        ],
-    )
-):
+@dataclasses.dataclass
+class MeasureInfo:
     """Extra info about a single measurement within a circuit.
 
     Attributes:
@@ -64,6 +52,12 @@ class MeasureInfo(
         invert_mask: a list of booleans describing whether the results should
             be flipped for each of the qubits in the qubits field.
     """
+
+    key: str
+    qubits: List['cirq.GridQubit']
+    slot: int
+    invert_mask: List[bool]
+    tags: List[Hashable]
 
 
 def find_measurements(program: 'cirq.Circuit') -> List[MeasureInfo]:

--- a/cirq/google/api/v2/results.py
+++ b/cirq/google/api/v2/results.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, Dict, Iterable, Iterator, List, NamedTuple, Optional, Set, TYPE_CHECKING
+from typing import (
+    cast,
+    Dict,
+    Hashable,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    TYPE_CHECKING,
+)
 
 from collections import OrderedDict
 import numpy as np
@@ -36,6 +47,7 @@ class MeasureInfo(
             ('qubits', List['cirq.GridQubit']),
             ('slot', int),
             ('invert_mask', List[bool]),
+            ('tags', List[Hashable]),
         ],
     )
 ):
@@ -86,6 +98,7 @@ def _circuit_measurements(circuit: 'cirq.Circuit') -> Iterator[MeasureInfo]:
                     qubits=_grid_qubits(op),
                     slot=i,
                     invert_mask=list(op.gate.full_invert_mask()),
+                    tags=list(op.tags),
                 )
 
 


### PR DESCRIPTION
- When we call cirq.google.api.v2.find_measurements, we need a way
to retrieve tags that were originally on the circuit.
- This adds tags to the NamedTuple that is returned by this function
that includes tags.

This does change the output of this function, but, since it is an
additive change, it should be minimally breaking.