### PR TITLE
Add Circuit.are_any_matches_terminal()

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -833,7 +833,7 @@ class AbstractCircuit(abc.ABC):
                     continue
                 if not circuit.are_any_matches_terminal(predicate):
                     continue
-                if i < len(self.moments) - 1 and any(
+                if i == len(self.moments) - 1 or any(
                     self.next_moment_operating_on(op.qubits, i + 1) is None
                     for _, op in circuit.findall_operations(predicate)
                 ):

--- a/cirq/circuits/circuit_operation_test.py
+++ b/cirq/circuits/circuit_operation_test.py
@@ -369,27 +369,35 @@ def test_terminal_matches():
 
     c = cirq.Circuit(cirq.X(a), op)
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = cirq.Circuit(cirq.X(b), op)
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = cirq.Circuit(cirq.measure(a), op)
     assert not c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = cirq.Circuit(cirq.measure(b), op)
     assert not c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = cirq.Circuit(op, cirq.X(a))
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = cirq.Circuit(op, cirq.X(b))
     assert not c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
     c = cirq.Circuit(op, cirq.measure(a))
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = cirq.Circuit(op, cirq.measure(b))
     assert not c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
 
 def test_nonterminal_in_subcircuit():
@@ -403,11 +411,13 @@ def test_nonterminal_in_subcircuit():
     c = cirq.Circuit(cirq.X(a), op)
     assert isinstance(op, cirq.CircuitOperation)
     assert not c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
     op = op.with_tags('test')
     c = cirq.Circuit(cirq.X(a), op)
     assert not isinstance(op, cirq.CircuitOperation)
     assert not c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
 
 def test_decompose_applies_maps():

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -1657,7 +1657,7 @@ def test_has_measurements(circuit_cls):
 
 
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
-def test_are_all_measurements_terminal(circuit_cls):
+def test_are_all_or_any_measurements_terminal(circuit_cls):
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -1669,40 +1669,51 @@ def test_are_all_measurements_terminal(circuit_cls):
 
     c = circuit_cls()
     assert c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
     c = circuit_cls(xa, xb)
     assert c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
     c = circuit_cls(ma)
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = circuit_cls(ma, mb)
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = circuit_cls(xa, ma)
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = circuit_cls(xa, ma, xb, mb)
     assert c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = circuit_cls(ma, xa)
     assert not c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
     c = circuit_cls(ma, xa, mb)
     assert not c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = circuit_cls(xa, ma, xb, xa)
     assert not c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
     c = circuit_cls(ma, ma)
     assert not c.are_all_measurements_terminal()
+    assert c.are_any_measurements_terminal()
 
     c = circuit_cls(xa, ma, xa)
     assert not c.are_all_measurements_terminal()
+    assert not c.are_any_measurements_terminal()
 
 
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
-def test_all_terminal(circuit_cls):
+def test_all_or_any_terminal(circuit_cls):
     def is_x_pow_gate(op):
         return isinstance(op.gate, cirq.XPowGate)
 
@@ -1717,36 +1728,47 @@ def test_all_terminal(circuit_cls):
 
     c = circuit_cls()
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert not c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(xa)
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(xb)
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(ya)
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert not c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(ya, yb)
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert not c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(ya, yb, xa)
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(ya, yb, xa, xb)
     assert c.are_all_matches_terminal(is_x_pow_gate)
+    assert c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(xa, xa)
     assert not c.are_all_matches_terminal(is_x_pow_gate)
+    assert c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(xa, ya)
     assert not c.are_all_matches_terminal(is_x_pow_gate)
+    assert not c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(xb, ya, yb)
     assert not c.are_all_matches_terminal(is_x_pow_gate)
+    assert not c.are_any_matches_terminal(is_x_pow_gate)
 
     c = circuit_cls(xa, ya, xa)
     assert not c.are_all_matches_terminal(is_x_pow_gate)
+    assert c.are_any_matches_terminal(is_x_pow_gate)
 
     def is_circuit_op(op):
         isinstance(op, cirq.CircuitOperation)
@@ -1756,6 +1778,7 @@ def test_all_terminal(circuit_cls):
     c = circuit_cls(cop_2, yb)
     # are_all_matches_terminal treats CircuitOperations as transparent.
     assert c.are_all_matches_terminal(is_circuit_op)
+    assert not c.are_any_matches_terminal(is_circuit_op)
 
 
 def test_clear_operations_touching():


### PR DESCRIPTION
Exactly what it says in the title. This is the "any" analog to `Circuit.are_all_matches_terminal()`; it will be used for the expectation value API ([RFC](https://tinyurl.com/cirq-expectation-value-api)).