### PR TITLE
Add hash values to tags in cirq.google

### DIFF
--- a/cirq/google/ops/calibration_tag.py
+++ b/cirq/google/ops/calibration_tag.py
@@ -40,3 +40,6 @@ class CalibrationTag:
 
     def __eq__(self, other) -> bool:
         return isinstance(other, CalibrationTag) and self.token == other.token
+
+    def __hash__(self) -> int:
+        return hash(self.token)

--- a/cirq/google/ops/calibration_tag_test.py
+++ b/cirq/google/ops/calibration_tag_test.py
@@ -20,6 +20,16 @@ def test_equality():
     eq.add_equality_group(cirq.google.CalibrationTag('blah2'))
 
 
+def test_hash():
+    s = set()
+    s.add(cirq.google.CalibrationTag('foo'))
+    assert len(s) == 1
+    s.add(cirq.google.CalibrationTag('foo'))
+    assert len(s) == 1
+    s.add(cirq.google.CalibrationTag('bar'))
+    assert len(s) == 2
+
+
 def test_str_repr():
     example_tag = cirq.google.CalibrationTag('foo')
     assert str(example_tag) == 'CalibrationTag(\'foo\')'

--- a/cirq/google/ops/physical_z_tag.py
+++ b/cirq/google/ops/physical_z_tag.py
@@ -42,3 +42,6 @@ class PhysicalZTag:
 
     def __eq__(self, other) -> bool:
         return isinstance(other, PhysicalZTag)
+
+    def __hash__(self) -> int:
+        return 123

--- a/cirq/google/ops/physical_z_tag_test.py
+++ b/cirq/google/ops/physical_z_tag_test.py
@@ -16,6 +16,7 @@ import cirq
 
 def test_equality():
     assert cirq.google.PhysicalZTag() == cirq.google.PhysicalZTag()
+    assert hash(cirq.google.PhysicalZTag()) == hash(cirq.google.PhysicalZTag())
 
 
 def test_syc_str_repr():


### PR DESCRIPTION
- By mypy definitions, tags should be hashable.
- Add __hash__ fucntions so they actually are hashable.