### PR TITLE
Fix: tutorial index headings do not match tutorial content page

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -127,21 +127,21 @@ upper_tabs:
 
       ####  INTERMEDIATE  ####
       - heading: "Intermediate"
-      - title: "Shor's algorithm"
-        path: /cirq/tutorials/shor
+      - title: "Quantum variational algorithm"
+        path: /cirq/tutorials/variational_algorithm
+      - title: "Approximate optimization"
+        path: /cirq/tutorials/qaoa
+      - title: "Quantum walks"
+        path: /cirq/tutorials/quantum_walks
 
       ####  ADVANCED  ####
       - heading: "Advanced"
-      - title: "Quantum variational algorithm"
-        path: /cirq/tutorials/variational_algorithm
-      - title: "QAOA experiment"
-        path: /cirq/tutorials/qaoa
       - title: "Hidden linear function problem"
         path: /cirq/tutorials/hidden_linear_function
-      - title: "Quantum walks"
-        path: /cirq/tutorials/quantum_walks
       - title: "Rabi oscillation experiment"
         path: /cirq/tutorials/rabi_oscillations
+      - title: "Shor's algorithm"
+        path: /cirq/tutorials/shor
 
       ####  GOOGLE HARDWARE  ####
       - heading: "Google hardware"


### PR DESCRIPTION
Index does not match content on tutorials page. This fixes that. I haven't worked the examples myself, so whether this is the correct fix or whether the content should be changed to match the index, is beyond my ability to judge. 