### PR TITLE
update the zenodo metadata + removing confusing bibtex

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -5,9 +5,9 @@
     "upload_type": "software",
     "creators": [
         {
-            "affiliation": "Google Inc",
-            "name": "Quantum AI team and collaborators"
+            "name": "Cirq Developers"
         }
     ],
-    "access_right": "open"
+    "access_right": "open",
+    "notes": "See full list of authors on Github: https://github.com/quantumlib/Cirq/graphs/contributors"
 }

--- a/README.rst
+++ b/README.rst
@@ -89,21 +89,6 @@ Cirq is uploaded to Zenodo automatically. Click on the badge below to see all th
   :target: https://doi.org/10.5281/zenodo.4062499
   :alt: DOI
 
-An equivalent BibTex format reference is below for all the versions:
-
-.. code-block::
-
-    @software{quantum_ai_team_and_collaborators_2020_4062499,
-      author       = {Quantum AI team and collaborators},
-      title        = {Cirq},
-      month        = Oct,
-      year         = 2020,
-      publisher    = {Zenodo},
-      doi          = {10.5281/zenodo.4062499},
-      url          = {https://doi.org/10.5281/zenodo.4062499}
-    }
-
-
 Cirq Contributors Community
 ---------------------------
 


### PR DESCRIPTION
Updated zenodo metadata to reflect Cirq Developers as the authors. I also updated the latest versions on Zenodo too accordingly. I also removed the bibtex from the readme as it was incorrect - it is simplest to rely on the zenodo link for the different formats.

Fixes #3490.