### PR TITLE
Revert "Updated secretmanager ref to v1"

### DIFF
--- a/dev_tools/auto_merge.py
+++ b/dev_tools/auto_merge.py
@@ -7,7 +7,7 @@ import os
 import time
 import sys
 
-from google.cloud import secretmanager
+from google.cloud import secretmanager_v1beta1
 import requests
 
 from dev_tools.github_repository import GithubRepository
@@ -914,9 +914,9 @@ def main():
         print(
             '{} not set. Trying secret manager.'.format(ACCESS_TOKEN_ENV_VARIABLE), file=sys.stderr
         )
-        client = secretmanager.SecretManagerServiceClient()
-        secret_version_name = f'projects/{project_id}/secrets/cirq-bot-api-key/versions/1'
-        response = client.access_secret_version(request={"name": secret_version_name})
+        client = secretmanager_v1beta1.SecretManagerServiceClient()
+        secret_name = f'projects/{project_id}/secrets/cirq-bot-api-key/versions/1'
+        response = client.access_secret_version(name=secret_name)
         access_token = response.payload.data.decode('UTF-8')
 
     repo = GithubRepository(


### PR DESCRIPTION
Reverts quantumlib/Cirq#3762

We have to do more testing on this (maybe write actual tests for automerge!)
Currently automerge is down because of this: 
```
File "dev_tools/auto_merge.py", line 937, in <module> main() File "dev_tools/auto_merge.py", line 919, in main response = client.access_secret_version(request={"name": secret_version_name}) TypeError: access_secret_version() got an unexpected keyword argument 'request'
```