### PR TITLE
back to python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq@googlegroups.com',
-    python_requires=('>=3.7.0'),
+    python_requires=('>=3.6.0'),
     install_requires=requirements,
     extras_require={
         'contrib': contrib_requirements,


### PR DESCRIPTION
Due to colab having 3.6 we'll have to relax the 3.7>= requirement.