### PR TITLE
pylint print version + verbose mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,10 @@ jobs:
           architecture: 'x64'
       - name: Install pylint
         run: cat dev_tools/conf/pip-list-dev-tools.txt | grep "pylint" | grep -v "#" | xargs pip install
+      - name: Display version
+        run: check/pylint --version
       - name: Lint
-        run: check/pylint
+        run: check/pylint -v
   doc_test:
     name: Doc test
     runs-on: ubuntu-16.04


### PR DESCRIPTION
Enabling pylint version print in CI + verbose mode for more debugging information when pylint flakes occur.