### PR TITLE
Use concise JSON serialization for FrozenCircuit.

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -124,7 +124,9 @@ class AbstractCircuit(abc.ABC):
 
         if isinstance(self, FrozenCircuit):
             return self
-        return FrozenCircuit(self, strategy=InsertStrategy.EARLIEST, device=self.device, name=self.name)
+        return FrozenCircuit(
+            self, strategy=InsertStrategy.EARLIEST, device=self.device, name=self.name
+        )
 
     def unfreeze(self) -> 'cirq.Circuit':
         """Creates a Circuit from this circuit.
@@ -141,10 +143,7 @@ class AbstractCircuit(abc.ABC):
     def __eq__(self, other):
         if not isinstance(other, type(self)):
             return NotImplemented
-        return (
-            (self.moments, self.device, self.name) ==
-            (other.moments, other.device, other.name)
-        )
+        return (self.moments, self.device, self.name) == (other.moments, other.device, other.name)
 
     def _approx_eq_(self, other: Any, atol: Union[int, float]) -> bool:
         """See `cirq.protocols.SupportsApproximateEquality`."""
@@ -1265,7 +1264,9 @@ class AbstractCircuit(abc.ABC):
 
     @classmethod
     def _from_json_dict_(cls, moments, device, **kwargs):
-        return cls(moments, strategy=InsertStrategy.EARLIEST, device=device, name=kwargs.get('name', None))
+        return cls(
+            moments, strategy=InsertStrategy.EARLIEST, device=device, name=kwargs.get('name', None)
+        )
 
 
 class Circuit(AbstractCircuit):
@@ -1374,14 +1375,14 @@ class Circuit(AbstractCircuit):
     def device(self) -> devices.Device:
         return self._device
 
-    @property
-    def name(self) -> Optional[str]:
-        return self._name
-
     @device.setter
     def device(self, new_device: 'cirq.Device') -> None:
         new_device.validate_circuit(self)
         self._device = new_device
+
+    @property
+    def name(self) -> Optional[str]:
+        return self._name
 
     def __copy__(self) -> 'Circuit':
         return self.copy()

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -1260,6 +1260,8 @@ class AbstractCircuit(abc.ABC):
         self._to_qasm_output(header, precision, qubit_order).save(file_path)
 
     def _json_dict_(self):
+        if self.name is None:
+            return protocols.obj_to_dict_helper(self, ['moments', 'device'])
         return protocols.obj_to_dict_helper(self, ['moments', 'device', 'name'])
 
     @classmethod

--- a/cirq/circuits/circuit_operation.py
+++ b/cirq/circuits/circuit_operation.py
@@ -213,7 +213,7 @@ class CircuitOperation(ops.Operation):
 
     def __str__(self):
         # TODO: support out-of-line subcircuit definition in string format.
-        header = self.circuit.serialization_key() + ':'
+        header = self.circuit.diagram_name() + ':'
         msg_lines = str(self.circuit).split('\n')
         msg_width = max([len(header) - 4] + [len(line) for line in msg_lines])
         circuit_msg = '\n'.join(

--- a/cirq/circuits/circuit_operation_test.py
+++ b/cirq/circuits/circuit_operation_test.py
@@ -282,7 +282,7 @@ def test_string_format():
     assert (
         str(op0)
         == f"""\
-{op0.circuit.serialization_key()}:
+{op0.circuit.diagram_name()}:
 [                         ]"""
     )
 
@@ -291,7 +291,7 @@ def test_string_format():
     assert (
         str(op1)
         == f"""\
-{op1.circuit.serialization_key()}:
+{op1.circuit.diagram_name()}:
 [ 0: ───X───────M('m')─── ]
 [               │         ]
 [ 1: ───H───@───M──────── ]
@@ -324,7 +324,7 @@ cirq.CircuitOperation(
     assert (
         str(op2)
         == f"""\
-{op2.circuit.serialization_key()}:
+{op2.circuit.diagram_name()}:
 [ 0: ───X───X───          ]
 [           │             ]
 [ 1: ───H───@───          ](qubit_map={{1: 2}}, repetition_ids=['a', 'b', 'c'])"""
@@ -362,7 +362,7 @@ cirq.CircuitOperation(
     assert (
         str(op3)
         == f"""\
-{op3.circuit.serialization_key()}:
+{op3.circuit.diagram_name()}:
 [ 0: ───X^b───M('m')───   ](qubit_map={{0: 1}}, \
 key_map={{m: p}}, params={{b: 2}})"""
     )

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -4032,7 +4032,7 @@ def test_operation_shape_validation(circuit_cls):
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
 def test_json_dict(circuit_cls):
     q0, q1 = cirq.LineQubit.range(2)
-    c = circuit_cls(cirq.CNOT(q0, q1), name='test_circuit')
+    c = circuit_cls(cirq.CNOT(q0, q1))
     moments = [cirq.Moment([cirq.CNOT(q0, q1)])]
     if circuit_cls == cirq.FrozenCircuit:
         moments = tuple(moments)
@@ -4041,9 +4041,18 @@ def test_json_dict(circuit_cls):
         'cirq_type': circuit_cls.__name__,
         'moments': moments,
         'device': cirq.UNCONSTRAINED_DEVICE,
-        'name': 'test_circuit',
     }
     assert circuit_cls._from_json_dict_(**c_json) == c
+
+    c_named = circuit_cls(c, name='test_circuit')
+    c_named_json = c_named._json_dict_()
+    assert c_named_json == {
+        'cirq_type': circuit_cls.__name__,
+        'moments': moments,
+        'device': cirq.UNCONSTRAINED_DEVICE,
+        'name': 'test_circuit',
+    }
+    assert circuit_cls._from_json_dict_(**c_named_json) == c_named
 
 
 def test_with_noise():

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -4032,15 +4032,18 @@ def test_operation_shape_validation(circuit_cls):
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])
 def test_json_dict(circuit_cls):
     q0, q1 = cirq.LineQubit.range(2)
-    c = circuit_cls(cirq.CNOT(q0, q1))
+    c = circuit_cls(cirq.CNOT(q0, q1), name='test_circuit')
     moments = [cirq.Moment([cirq.CNOT(q0, q1)])]
     if circuit_cls == cirq.FrozenCircuit:
         moments = tuple(moments)
-    assert c._json_dict_() == {
+    c_json = c._json_dict_()
+    assert c_json == {
         'cirq_type': circuit_cls.__name__,
         'moments': moments,
         'device': cirq.UNCONSTRAINED_DEVICE,
+        'name': 'test_circuit',
     }
+    assert circuit_cls._from_json_dict_(**c_json) == c
 
 
 def test_with_noise():

--- a/cirq/circuits/circuit_test.py
+++ b/cirq/circuits/circuit_test.py
@@ -14,7 +14,7 @@
 import os
 from collections import defaultdict
 from random import randint, random, sample, randrange
-from typing import Tuple, cast, AbstractSet, Iterable
+from typing import Tuple, cast, AbstractSet
 
 import numpy as np
 import pytest

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -49,6 +49,7 @@ class FrozenCircuit(AbstractCircuit):
         *contents: 'cirq.OP_TREE',
         strategy: 'cirq.InsertStrategy' = InsertStrategy.EARLIEST,
         device: 'cirq.Device' = devices.UNCONSTRAINED_DEVICE,
+        name: Optional[str] = None,
     ) -> None:
         """Initializes a frozen circuit.
 
@@ -62,10 +63,13 @@ class FrozenCircuit(AbstractCircuit):
                 from `contents`, this determines how the operations are packed
                 together.
             device: Hardware that the circuit should be able to run on.
+            name: A user-specified name to identify this circuit in diagrams
+                and serialization.
         """
-        base = Circuit(contents, strategy=strategy, device=device)
+        base = Circuit(contents, strategy=strategy, device=device, name=name)
         self._moments = tuple(base.moments)
         self._device = base.device
+        self._name = base.name
 
         # These variables are memoized when first requested.
         self._num_qubits: Optional[int] = None
@@ -85,13 +89,19 @@ class FrozenCircuit(AbstractCircuit):
     def device(self) -> devices.Device:
         return self._device
 
-    def __hash__(self):
-        return hash((self.moments, self.device))
+    @property
+    def name(self) -> Optional[str]:
+        return self._name
 
-    def serialization_key(self):
-        # TODO: use this key in serialization and support user-specified keys.
+    def __hash__(self):
+        return hash((self.moments, self.device, self.name))
+
+    def _serialization_name_(self):
+        return self._name or 'Circuit'
+
+    def diagram_name(self):
         key = hash(self) & 0xFFFF_FFFF_FFFF_FFFF
-        return f'Circuit_0x{key:016x}'
+        return f'{self.name or "Circuit"}_0x{key:016x}'
 
     # Memoized methods for commonly-retrieved properties.
 

--- a/cirq/circuits/frozen_circuit_test.py
+++ b/cirq/circuits/frozen_circuit_test.py
@@ -23,7 +23,7 @@ import cirq
 
 def test_freeze_and_unfreeze():
     a, b = cirq.LineQubit.range(2)
-    c = cirq.Circuit(cirq.X(a), cirq.H(b))
+    c = cirq.Circuit(cirq.X(a), cirq.H(b), name='test_circuit')
 
     f = c.freeze()
     assert f.moments == tuple(c.moments)
@@ -43,6 +43,27 @@ def test_freeze_and_unfreeze():
     fcc = cc.freeze()
     assert fcc.moments == f.moments
     assert fcc is not f
+
+
+def test_names():
+    a, b = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.X(a), cirq.H(b), name='testname')
+
+    f = c.freeze()
+    assert f.name == c.name
+    assert f.name == f._serialization_name_()
+
+    ff = c.freeze()
+    assert ff.name == f.name
+    # Since the two are identical, this is acceptable.
+    assert ff.diagram_name() == f.diagram_name()
+
+    c.append(cirq.CX(b, a))
+    fff = c.freeze()
+    assert fff.name == f.name
+    # Hash values are appended to diagram names.
+    # Since ff2.moments != f2.moments, these will differ.
+    assert fff.diagram_name() != f.diagram_name()
 
 
 def test_immutable():

--- a/cirq/google/json_test_data/CalibrationLayer.json
+++ b/cirq/google/json_test_data/CalibrationLayer.json
@@ -25,7 +25,8 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": null
   },
   "args": {
     "type": "full",

--- a/cirq/google/json_test_data/CalibrationLayer.json
+++ b/cirq/google/json_test_data/CalibrationLayer.json
@@ -25,8 +25,7 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    },
-    "name": null
+    }
   },
   "args": {
     "type": "full",

--- a/cirq/protocols/json_test_data/Circuit.json
+++ b/cirq/protocols/json_test_data/Circuit.json
@@ -116,7 +116,8 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": "group_measure"
   },
   {
     "cirq_type": "Circuit",
@@ -170,7 +171,8 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": null
   },
   {
     "cirq_type": "Circuit",
@@ -200,6 +202,7 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    }
+    },
+    "name": null
   }
 ]

--- a/cirq/protocols/json_test_data/Circuit.json_inward
+++ b/cirq/protocols/json_test_data/Circuit.json_inward
@@ -116,8 +116,7 @@
     ],
     "device": {
       "cirq_type": "_UnconstrainedDevice"
-    },
-    "name": "group_measure"
+    }
   },
   {
     "cirq_type": "Circuit",

--- a/cirq/protocols/json_test_data/Circuit.repr
+++ b/cirq/protocols/json_test_data/Circuit.repr
@@ -9,7 +9,8 @@
     cirq.Moment(
         cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
     ),
-]), cirq.Circuit([
+], name="group_measure",
+), cirq.Circuit([
     cirq.Moment(
         cirq.TOFFOLI(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2)),
     ),

--- a/cirq/protocols/json_test_data/Circuit.repr_inward
+++ b/cirq/protocols/json_test_data/Circuit.repr_inward
@@ -1,0 +1,23 @@
+[cirq.Circuit([
+    cirq.Moment(
+        cirq.H(cirq.LineQubit(0)),
+        cirq.H(cirq.LineQubit(1)),
+        cirq.H(cirq.LineQubit(2)),
+        cirq.H(cirq.LineQubit(3)),
+        cirq.H(cirq.LineQubit(4)),
+    ),
+    cirq.Moment(
+        cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
+    ),
+]), cirq.Circuit([
+    cirq.Moment(
+        cirq.TOFFOLI(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2)),
+    ),
+    cirq.Moment(
+        (cirq.X**0.123).on(cirq.LineQubit(0)),
+    ),
+]), cirq.Circuit([
+    cirq.Moment(
+        (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
+    ),
+])]

--- a/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq/protocols/json_test_data/CircuitOperation.json
@@ -153,8 +153,7 @@
         ],
         "device": {
           "cirq_type": "_UnconstrainedDevice"
-        },
-        "name": null
+        }
       }
     },
     {
@@ -188,8 +187,7 @@
         ],
         "device": {
           "cirq_type": "_UnconstrainedDevice"
-        },
-        "name": null
+        }
       }
     },
     [

--- a/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq/protocols/json_test_data/CircuitOperation.json
@@ -127,7 +127,7 @@
     },
     {
       "cirq_type": "_SerializedContext",
-      "key": "None_2",
+      "key": "Circuit_2",
       "obj": {
         "cirq_type": "FrozenCircuit",
         "moments": [
@@ -159,7 +159,7 @@
     },
     {
       "cirq_type": "_SerializedContext",
-      "key": "None_3",
+      "key": "Circuit_3",
       "obj": {
         "cirq_type": "FrozenCircuit",
         "moments": [
@@ -216,7 +216,7 @@
         "cirq_type": "CircuitOperation",
         "circuit": {
           "cirq_type": "_SerializedKey",
-          "key": "None_2"
+          "key": "Circuit_2"
         },
         "repetitions": -2,
         "qubit_map": [
@@ -245,7 +245,7 @@
         "cirq_type": "CircuitOperation",
         "circuit": {
           "cirq_type": "_SerializedKey",
-          "key": "None_3"
+          "key": "Circuit_3"
         },
         "repetitions": 1,
         "qubit_map": [],

--- a/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq/protocols/json_test_data/CircuitOperation.json
@@ -1,232 +1,269 @@
-[
-  {
-    "cirq_type": "CircuitOperation",
-    "circuit": {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1.0,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "MeasurementGate",
-                "num_qubits": 5,
-                "key": "0,1,2,3,4",
-                "invert_mask": []
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
-      }
-    },
-    "repetitions": 1,
-    "qubit_map": [],
-    "measurement_key_map": {
-      "0,1,2,3,4": "mixed_state"
-    },
-    "param_resolver": {
-      "cirq_type": "ParamResolver",
-      "param_dict": []
-    },
-    "repetition_ids": ["0"]
-  },
-  {
-    "cirq_type": "CircuitOperation",
-    "circuit": {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "ZPowGate",
-                "exponent": 0.5,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
-      }
-    },
-    "repetitions": -2,
-    "qubit_map": [
-      [
-        {
-          "cirq_type": "LineQubit",
-          "x": 0
-        },
-        {
-          "cirq_type": "LineQubit",
-          "x": 1
-        }
-      ]
-    ],
-    "measurement_key_map": {},
-    "param_resolver": {
-      "cirq_type": "ParamResolver",
-      "param_dict": []
-    },
-    "repetition_ids": ["a", "b"]
-  },
-  {
-    "cirq_type": "CircuitOperation",
-    "circuit": {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "XPowGate",
-                "exponent": {
-                  "cirq_type": "sympy.Symbol",
-                  "name": "theta"
-                },
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
-      }
-    },
-    "repetitions": 1,
-    "qubit_map": [],
-    "measurement_key_map": {},
-    "param_resolver": {
-      "cirq_type": "ParamResolver",
-      "param_dict": [
-        [
+{
+  "cirq_type": "_ContextualSerialization",
+  "object_dag": [
+    {
+      "cirq_type": "_SerializedContext",
+      "key": "group_measure_1",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
           {
-            "cirq_type": "sympy.Symbol",
-            "name": "theta"
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  }
+                ]
+              },
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
           },
-          1.5
-        ]
-      ]
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "MeasurementGate",
+                  "num_qubits": 5,
+                  "key": "0,1,2,3,4",
+                  "invert_mask": []
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": "group_measure"
+      }
     },
-    "repetition_ids": null
-  }
-]
+    {
+      "cirq_type": "_SerializedContext",
+      "key": "None_2",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "ZPowGate",
+                  "exponent": 0.5,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": null
+      }
+    },
+    {
+      "cirq_type": "_SerializedContext",
+      "key": "None_3",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "XPowGate",
+                  "exponent": {
+                    "cirq_type": "sympy.Symbol",
+                    "name": "theta"
+                  },
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": null
+      }
+    },
+    [
+      {
+        "cirq_type": "CircuitOperation",
+        "circuit": {
+          "cirq_type": "_SerializedKey",
+          "key": "group_measure_1"
+        },
+        "repetitions": 1,
+        "qubit_map": [],
+        "measurement_key_map": {
+          "0,1,2,3,4": "mixed_state"
+        },
+        "param_resolver": {
+          "cirq_type": "ParamResolver",
+          "param_dict": []
+        },
+        "repetition_ids": [
+          "0"
+        ]
+      },
+      {
+        "cirq_type": "CircuitOperation",
+        "circuit": {
+          "cirq_type": "_SerializedKey",
+          "key": "None_2"
+        },
+        "repetitions": -2,
+        "qubit_map": [
+          [
+            {
+              "cirq_type": "LineQubit",
+              "x": 0
+            },
+            {
+              "cirq_type": "LineQubit",
+              "x": 1
+            }
+          ]
+        ],
+        "measurement_key_map": {},
+        "param_resolver": {
+          "cirq_type": "ParamResolver",
+          "param_dict": []
+        },
+        "repetition_ids": [
+          "a",
+          "b"
+        ]
+      },
+      {
+        "cirq_type": "CircuitOperation",
+        "circuit": {
+          "cirq_type": "_SerializedKey",
+          "key": "None_3"
+        },
+        "repetitions": 1,
+        "qubit_map": [],
+        "measurement_key_map": {},
+        "param_resolver": {
+          "cirq_type": "ParamResolver",
+          "param_dict": [
+            [
+              {
+                "cirq_type": "sympy.Symbol",
+                "name": "theta"
+              },
+              1.5
+            ]
+          ]
+        },
+        "repetition_ids": null
+      }
+    ]
+  ]
+}

--- a/cirq/protocols/json_test_data/CircuitOperation.repr
+++ b/cirq/protocols/json_test_data/CircuitOperation.repr
@@ -9,7 +9,8 @@
     cirq.Moment(
         cirq.MeasurementGate(5, '0,1,2,3,4', ()).on(cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2), cirq.LineQubit(3), cirq.LineQubit(4)),
     ),
-]),
+], name='group_measure',
+),
 repetition_ids=['0'],
 measurement_key_map={'0,1,2,3,4': 'mixed_state'}),
 cirq.CircuitOperation(circuit=cirq.FrozenCircuit([

--- a/cirq/protocols/json_test_data/FrozenCircuit.json
+++ b/cirq/protocols/json_test_data/FrozenCircuit.json
@@ -118,8 +118,7 @@
         ],
         "device": {
           "cirq_type": "_UnconstrainedDevice"
-        },
-        "name": null
+        }
       }
     },
     {
@@ -212,8 +211,7 @@
         ],
         "device": {
           "cirq_type": "_UnconstrainedDevice"
-        },
-        "name": null
+        }
       }
     },
     [

--- a/cirq/protocols/json_test_data/FrozenCircuit.json
+++ b/cirq/protocols/json_test_data/FrozenCircuit.json
@@ -1,205 +1,234 @@
-[
+{
+  "cirq_type": "_ContextualSerialization",
+  "object_dag": [
     {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+      "cirq_type": "_SerializedContext",
+      "key": "None_1",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [          {            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  }
+                ]
               },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                }
-              ]
-            },
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "HPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "HPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "MeasurementGate",
+                  "num_qubits": 5,
+                  "key": "0,1,2,3,4",
+                  "invert_mask": []
+                },
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 3
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 4
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
         },
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "MeasurementGate",
-                "num_qubits": 5,
-                "key": "0,1,2,3,4",
-                "invert_mask": []
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 3
-                },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 4
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
+        "name": null
       }
     },
     {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "CCXPowGate",
-                "exponent": 1,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
+      "cirq_type": "_SerializedContext",
+      "key": "Partial_Toffoli_2",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "CCXPowGate",
+                  "exponent": 1.0,
+                  "global_shift": 0.0
                 },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 1
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 1
+                  },
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 2
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "XPowGate",
+                  "exponent": 0.123,
+                  "global_shift": 0.0
                 },
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 2
-                }
-              ]
-            }
-          ]
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
         },
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "XPowGate",
-                "exponent": 0.123,
-                "global_shift": 0.0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
+        "name": "Partial_Toffoli"
       }
     },
     {
-      "cirq_type": "FrozenCircuit",
-      "moments": [
-        {
-          "cirq_type": "Moment",
-          "operations": [
-            {
-              "cirq_type": "GateOperation",
-              "gate": {
-                "cirq_type": "XPowGate",
-                "exponent": {
-                  "cirq_type": "sympy.Symbol",
-                  "name": "theta"
+      "cirq_type": "_SerializedContext",
+      "key": "None_3",
+      "obj": {
+        "cirq_type": "FrozenCircuit",
+        "moments": [
+          {
+            "cirq_type": "Moment",
+            "operations": [
+              {
+                "cirq_type": "GateOperation",
+                "gate": {
+                  "cirq_type": "XPowGate",
+                  "exponent": {
+                    "cirq_type": "sympy.Symbol",
+                    "name": "theta"
+                  },
+                  "global_shift": 0.0
                 },
-                "global_shift": 0
-              },
-              "qubits": [
-                {
-                  "cirq_type": "LineQubit",
-                  "x": 0
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "device": {
-        "cirq_type": "_UnconstrainedDevice"
+                "qubits": [
+                  {
+                    "cirq_type": "LineQubit",
+                    "x": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "device": {
+          "cirq_type": "_UnconstrainedDevice"
+        },
+        "name": null
       }
-    }
+    },
+    [
+      {
+        "cirq_type": "_SerializedKey",
+        "key": "None_1"
+      },
+      {
+        "cirq_type": "_SerializedKey",
+        "key": "Partial_Toffoli_2"
+      },
+      {
+        "cirq_type": "_SerializedKey",
+        "key": "None_3"
+      }
+    ]
   ]
+}

--- a/cirq/protocols/json_test_data/FrozenCircuit.json
+++ b/cirq/protocols/json_test_data/FrozenCircuit.json
@@ -3,7 +3,7 @@
   "object_dag": [
     {
       "cirq_type": "_SerializedContext",
-      "key": "None_1",
+      "key": "Circuit_1",
       "obj": {
         "cirq_type": "FrozenCircuit",
         "moments": [          {            "cirq_type": "Moment",
@@ -183,7 +183,7 @@
     },
     {
       "cirq_type": "_SerializedContext",
-      "key": "None_3",
+      "key": "Circuit_3",
       "obj": {
         "cirq_type": "FrozenCircuit",
         "moments": [
@@ -219,7 +219,7 @@
     [
       {
         "cirq_type": "_SerializedKey",
-        "key": "None_1"
+        "key": "Circuit_1"
       },
       {
         "cirq_type": "_SerializedKey",
@@ -227,7 +227,7 @@
       },
       {
         "cirq_type": "_SerializedKey",
-        "key": "None_3"
+        "key": "Circuit_3"
       }
     ]
   ]

--- a/cirq/protocols/json_test_data/FrozenCircuit.repr
+++ b/cirq/protocols/json_test_data/FrozenCircuit.repr
@@ -16,7 +16,8 @@
     cirq.Moment(
         (cirq.X**0.123).on(cirq.LineQubit(0)),
     ),
-]), cirq.FrozenCircuit([
+], name='Partial_Toffoli',
+), cirq.FrozenCircuit([
     cirq.Moment(
         (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
     ),


### PR DESCRIPTION
Fixes #3633. This is a rewrite of #3655 that avoids using hash values in serialization; this is possible due to #3673 dynamically applying unique identifiers to each `SerializableByKey` object as it appears.

This PR continues to use FrozenCircuit hashes in circuit diagrams, where hash collision is a less serious issue.