### PR TITLE
adding standard header to characterization notebooks

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -37,7 +37,7 @@ from dev_tools.env_tools import create_virtual_env
 # after every release we should raise a PR and empty out this list
 # note that these notebooks are still tested in dev_tools/notebook_test.py
 NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES = [
-    'docs/characterization/*.ipynb',
+    'docs/qcvv/*.ipynb',
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule

--- a/docs/qcvv/isolated_xeb.ipynb
+++ b/docs/qcvv/isolated_xeb.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "gXXhctqjgXO7"
+    "id": "SzKwuqYESWwm"
    },
    "source": [
     "##### Copyright 2021 The Cirq Developers"
@@ -14,7 +14,7 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "id": "z2RJVa8qgXou"
+    "id": "4yPUsdJxSXFq"
    },
    "outputs": [],
    "source": [
@@ -29,6 +29,44 @@
     "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zC1qlUJoSXhm"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/qcvv/isolated_xeb>\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/qcvv/isolated_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/qcvv/isolated_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/qcvv/isolated_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bd9529db1c0b"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import cirq\n",
+    "except ImportError:\n",
+    "    print(\"installing cirq...\")\n",
+    "    !pip install --quiet cirq --pre\n",
+    "    print(\"installed cirq.\")"
    ]
   },
   {

--- a/docs/qcvv/parallel_xeb.ipynb
+++ b/docs/qcvv/parallel_xeb.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "gXXhctqjgXO7"
+    "id": "SzKwuqYESWwm"
    },
    "source": [
     "##### Copyright 2021 The Cirq Developers"
@@ -14,7 +14,7 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "id": "z2RJVa8qgXou"
+    "id": "4yPUsdJxSXFq"
    },
    "outputs": [],
    "source": [
@@ -29,6 +29,44 @@
     "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zC1qlUJoSXhm"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/qcvv/parallel_xeb>\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/qcvv/parallel_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/qcvv/parallel_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/qcvv/parallel_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bd9529db1c0b"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import cirq\n",
+    "except ImportError:\n",
+    "    print(\"installing cirq...\")\n",
+    "    !pip install --quiet cirq --pre\n",
+    "    print(\"installed cirq.\")"
    ]
   },
   {

--- a/docs/qcvv/xeb_coherent_noise.ipynb
+++ b/docs/qcvv/xeb_coherent_noise.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "gXXhctqjgXO7"
+    "id": "SzKwuqYESWwm"
    },
    "source": [
     "##### Copyright 2021 The Cirq Developers"
@@ -14,7 +14,7 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "id": "z2RJVa8qgXou"
+    "id": "4yPUsdJxSXFq"
    },
    "outputs": [],
    "source": [
@@ -29,6 +29,44 @@
     "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zC1qlUJoSXhm"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/qcvv/xeb_coherent_noise>\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/qcvv/xeb_coherent_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/qcvv/xeb_coherent_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/qcvv/xeb_coherent_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bd9529db1c0b"
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import cirq\n",
+    "except ImportError:\n",
+    "    print(\"installing cirq...\")\n",
+    "    !pip install --quiet cirq --pre\n",
+    "    print(\"installed cirq.\")"
    ]
   },
   {

--- a/docs/qcvv/xeb_theory.ipynb
+++ b/docs/qcvv/xeb_theory.ipynb
@@ -3,19 +3,61 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "07034e5e3982"
+    "id": "SzKwuqYESWwm"
    },
    "source": [
-    "# Cross Entropy Benchmarking Theory\n",
-    "\n",
-    "Cross entropy benchmarking uses the properties of random quantum programs to determine the fidelity of a wide variety of circuits. When applied to circuits with many qubits, XEB can characterize the performance of a large device. When applied to deep, two-qubit circuits it can be used to accurately characterize a two-qubit interaction potentially leading to better calibration."
+    "##### Copyright 2021 The Cirq Developers"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "806c2989d819"
+    "cellView": "form",
+    "id": "4yPUsdJxSXFq"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zC1qlUJoSXhm"
+   },
+   "source": [
+    "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/qcvv/xeb_theory>\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/qcvv/xeb_theory.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/qcvv/xeb_theory.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/qcvv/xeb_theory.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bd9529db1c0b"
    },
    "outputs": [],
    "source": [
@@ -25,6 +67,17 @@
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "07034e5e3982"
+   },
+   "source": [
+    "# Cross Entropy Benchmarking Theory\n",
+    "\n",
+    "Cross entropy benchmarking uses the properties of random quantum programs to determine the fidelity of a wide variety of circuits. When applied to circuits with many qubits, XEB can characterize the performance of a large device. When applied to deep, two-qubit circuits it can be used to accurately characterize a two-qubit interaction potentially leading to better calibration."
    ]
   },
   {


### PR DESCRIPTION
Also moved them to the qcvv folder. 

They were failing on the devsite pipeline, this fixes them. 