### PR TITLE
Fixes for older envs

### DIFF
--- a/cirq/experiments/qubit_characterizations.py
+++ b/cirq/experiments/qubit_characterizations.py
@@ -20,6 +20,9 @@ import numpy as np
 import sympy
 
 from matplotlib import pyplot as plt
+
+# this is for older systems with matplotlib <3.2 otherwise 3d projections fail
+from mpl_toolkits import mplot3d  # pylint: disable=unused-import
 from cirq import circuits, ops, protocols, study
 
 if TYPE_CHECKING:

--- a/cirq/linalg/decompositions.py
+++ b/cirq/linalg/decompositions.py
@@ -32,6 +32,9 @@ from typing import (
 )
 
 import matplotlib.pyplot as plt
+
+# this is for older systems with matplotlib <3.2 otherwise 3d projections fail
+from mpl_toolkits import mplot3d  # pylint: disable=unused-import
 import numpy as np
 import scipy
 

--- a/cirq/testing/random_circuit.py
+++ b/cirq/testing/random_circuit.py
@@ -148,7 +148,7 @@ def random_two_qubit_circuit_with_czs(
     q1 = ops.NamedQubit('q1') if q1 is None else q1
 
     def random_one_qubit_gate():
-        return ops.PhasedXPowGate(phase_exponent=prng.random(), exponent=prng.random())
+        return ops.PhasedXPowGate(phase_exponent=prng.rand(), exponent=prng.rand())
 
     def one_cz():
         return [


### PR DESCRIPTION
These are failing on older envs, so adding them here for now. 

1. importing mpl_toolkits plot3d: Old matplotlib versions cause failures: `ValueError: Unknown projection '3d'`
2. older numpy versions didn't have `random()` on `RandomState` only `rand()`, otherwise the failure is: `AttributeError: 'mtrand.RandomState' object has no attribute 'random'`