### PR TITLE
[XEB] Enable characterizing other gates

### DIFF
--- a/cirq/experiments/xeb_fitting_test.py
+++ b/cirq/experiments/xeb_fitting_test.py
@@ -25,7 +25,7 @@ import cirq.experiments.random_quantum_circuit_generation as rqcg
 from cirq.experiments.xeb_fitting import (
     SQRT_ISWAP,
     benchmark_2q_xeb_fidelities,
-    parameterize_phased_fsim_circuit,
+    parameterize_circuit,
     SqrtISwapXEBOptions,
     characterize_phased_fsim_parameters_with_xeb,
     characterize_phased_fsim_parameters_with_xeb_by_pair,
@@ -144,7 +144,7 @@ def test_parameterize_phased_fsim_circuit():
         q0, q1, depth=3, two_qubit_op_factory=lambda a, b, _: SQRT_ISWAP(a, b), seed=52
     )
 
-    p_circuit = parameterize_phased_fsim_circuit(circuit, SqrtISwapXEBOptions())
+    p_circuit = parameterize_circuit(circuit, SqrtISwapXEBOptions())
     cirq.testing.assert_has_diagram(
         p_circuit,
         """\
@@ -205,13 +205,13 @@ def test_characterize_phased_fsim_parameters_with_xeb():
         characterize_zeta=False,
         characterize_phi=False,
     )
-    p_circuits = [parameterize_phased_fsim_circuit(circuit, options) for circuit in circuits]
+    p_circuits = [parameterize_circuit(circuit, options) for circuit in circuits]
     with multiprocessing.Pool() as pool:
         result = characterize_phased_fsim_parameters_with_xeb(
             sampled_df=sampled_df,
             parameterized_circuits=p_circuits,
             cycle_depths=cycle_depths,
-            phased_fsim_options=options,
+            options=options,
             # speed up with looser tolerances:
             fatol=1e-2,
             xatol=1e-2,
@@ -264,13 +264,13 @@ def test_parallel_full_workflow(use_pool):
     options = SqrtISwapXEBOptions(
         characterize_zeta=False, characterize_gamma=False, characterize_chi=False
     )
-    p_circuits = [parameterize_phased_fsim_circuit(circuit, options) for circuit in circuits]
+    p_circuits = [parameterize_circuit(circuit, options) for circuit in circuits]
 
     result = characterize_phased_fsim_parameters_with_xeb_by_pair(
         sampled_df=sampled_df,
         parameterized_circuits=p_circuits,
         cycle_depths=cycle_depths,
-        phased_fsim_options=options,
+        options=options,
         # super loose tolerances
         fatol=5e-2,
         xatol=5e-2,

--- a/docs/qcvv/isolated_xeb.ipynb
+++ b/docs/qcvv/isolated_xeb.ipynb
@@ -279,7 +279,7 @@
    "outputs": [],
    "source": [
     "from cirq.experiments.xeb_fitting import (\n",
-    "    parameterize_phased_fsim_circuit, \n",
+    "    parameterize_circuit, \n",
     "    characterize_phased_fsim_parameters_with_xeb, \n",
     "    SqrtISwapXEBOptions,\n",
     ")\n",
@@ -293,7 +293,7 @@
     "    characterize_phi = True\n",
     ")\n",
     "# Parameterize the sqrt(iswap)s in our circuit library\n",
-    "pcircuits = [parameterize_phased_fsim_circuit(circuit, options) for circuit in circuits]\n",
+    "pcircuits = [parameterize_circuit(circuit, options) for circuit in circuits]\n",
     "\n",
     "# Run the characterization loop\n",
     "characterization_result = characterize_phased_fsim_parameters_with_xeb(\n",

--- a/docs/qcvv/parallel_xeb.ipynb
+++ b/docs/qcvv/parallel_xeb.ipynb
@@ -382,7 +382,7 @@
    "outputs": [],
    "source": [
     "from cirq.experiments.xeb_fitting import (\n",
-    "    parameterize_phased_fsim_circuit, \n",
+    "    parameterize_circuit, \n",
     "    characterize_phased_fsim_parameters_with_xeb_by_pair, \n",
     "    SqrtISwapXEBOptions,\n",
     ")\n",
@@ -396,7 +396,7 @@
     "    characterize_phi = True\n",
     ")\n",
     "# Parameterize the sqrt(iswap)s in our circuit library\n",
-    "pcircuits = [parameterize_phased_fsim_circuit(circuit, options) for circuit in circuit_library]\n",
+    "pcircuits = [parameterize_circuit(circuit, options) for circuit in circuit_library]\n",
     "\n",
     "# Run the characterization loop\n",
     "characterization_result = characterize_phased_fsim_parameters_with_xeb_by_pair(\n",

--- a/docs/qcvv/xeb_coherent_noise.ipynb
+++ b/docs/qcvv/xeb_coherent_noise.ipynb
@@ -377,7 +377,7 @@
    "outputs": [],
    "source": [
     "from cirq.experiments.xeb_fitting import \\\n",
-    "    parameterize_phased_fsim_circuit, characterize_phased_fsim_parameters_with_xeb, SqrtISwapXEBOptions\n",
+    "    parameterize_circuit, characterize_phased_fsim_parameters_with_xeb, SqrtISwapXEBOptions\n",
     "\n",
     "options = SqrtISwapXEBOptions(\n",
     "    characterize_theta=True, \n",
@@ -386,7 +386,7 @@
     "    characterize_gamma=False,\n",
     "    characterize_zeta=False\n",
     ")\n",
-    "p_circuits = [parameterize_phased_fsim_circuit(circuit, options) for circuit in circuits]\n",
+    "p_circuits = [parameterize_circuit(circuit, options) for circuit in circuits]\n",
     "res = characterize_phased_fsim_parameters_with_xeb(sampled_df, p_circuits, cycle_depths, options, pool=pool)"
    ]
   },


### PR DESCRIPTION
We don't provide sensible defaults for anything other than sqrt(iswap) but with these changes, you can write your own XEBCalibrationOptions subclass to characterize whatever you want.