### PR TITLE
Fix release scripts

### DIFF
--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -5,7 +5,7 @@ virtualenv
 black==20.8b1
 mypy~=0.782.0
 pylint~=2.6.0
-pytest~=5.4.1
+pytest~=6.2.2
 pytest-asyncio~=0.12.0
 pytest-cov~=2.5.0
 filelock~=3.0.12

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -83,8 +83,7 @@ for PYTHON_VERSION in python3; do
     # Install package.
     if [ "${PYPI_REPO_NAME}" == "TEST" ]; then
         echo "Pre-installing dependencies since they don't all exist in TEST pypi"
-        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${RUNTIME_DEPS_FILE}"
-        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${DEV_DEPS_FILE}"
+        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${RUNTIME_DEPS_FILE}" -r "${DEV_DEPS_FILE}"
     fi
     echo Installing "${PYPI_PROJECT_NAME}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi"
     "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet ${PIP_FLAGS} "${PYPI_PROJECT_NAME}==${PROJECT_VERSION}"

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -74,6 +74,7 @@ for PYTHON_VERSION in python3; do
     # Prepare.
     RUNTIME_DEPS_FILE="${REPO_ROOT}/requirements.txt"
     CONTRIB_DEPS_FILE="${REPO_ROOT}/cirq/contrib/contrib-requirements.txt"
+    DEV_DEPS_FILE="${REPO_ROOT}/dev_tools/conf/pip-list-dev-tools.txt"
 
     echo -e "\n\033[32m${PYTHON_VERSION}\033[0m"
     echo "Working in a fresh virtualenv at ${tmp_dir}/${PYTHON_VERSION}"
@@ -83,6 +84,7 @@ for PYTHON_VERSION in python3; do
     if [ "${PYPI_REPO_NAME}" == "TEST" ]; then
         echo "Pre-installing dependencies since they don't all exist in TEST pypi"
         "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${RUNTIME_DEPS_FILE}"
+        "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${DEV_DEPS_FILE}"
     fi
     echo Installing "${PYPI_PROJECT_NAME}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi"
     "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet ${PIP_FLAGS} "${PYPI_PROJECT_NAME}==${PROJECT_VERSION}"
@@ -93,8 +95,6 @@ for PYTHON_VERSION in python3; do
     "${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import cirq; print(cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))))"
 
     # Run tests.
-    echo Installing pytest requirements
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet pytest pytest-asyncio
     PY_VER=$(ls "${tmp_dir}/${PYTHON_VERSION}/lib")
     echo Running cirq tests
     cirq_dir="${tmp_dir}/${PYTHON_VERSION}/lib/${PY_VER}/site-packages/${PROJECT_NAME}"

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,6 @@ setup(
         'cirq.google.api.v1': ['*.proto', '*.pyi'],
         'cirq.google.api.v2': ['*.proto', '*.pyi'],
         'cirq.protocols.json_test_data': ['*'],
+        'cirq.google.json_test_data': ['*'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'cirq': ['py.typed'],
         'cirq.google.api.v1': ['*.proto', '*.pyi'],
         'cirq.google.api.v2': ['*.proto', '*.pyi'],
-        'cirq.protocols.json_test_data': ['*'],
         'cirq.google.json_test_data': ['*'],
+        'cirq.protocols.json_test_data': ['*'],
     },
 )


### PR DESCRIPTION
- Updates pytest version because existing version has a bug where --ignore= doesn't work. 
- Fixed verify-published-package script to install pip dev dependencies. 
- Updated setup.py to include `cirq.google.json_test_data`