### PR TITLE
Minor improvements in calibration heatmap api

### DIFF
--- a/cirq/google/engine/calibration.py
+++ b/cirq/google/engine/calibration.py
@@ -245,9 +245,9 @@ class Calibration(abc.Mapping):
             )
         value_map = {self.key_to_qubits(k): self.value_to_float(v) for k, v in metrics.items()}
         if all(len(k) == 1 for k in value_map.keys()):
-            return vis.Heatmap(value_map)
+            return vis.Heatmap(value_map, title=key.replace('_', ' ').title())
         elif all(len(k) == 2 for k in value_map.keys()):
-            return vis.TwoQubitInteractionHeatmap(value_map)
+            return vis.TwoQubitInteractionHeatmap(value_map, title=key.replace('_', ' ').title())
         raise ValueError(
             'Heatmaps are only supported if all the targets in a metric are one or two qubits.'
             + f'{key} has target qubits {value_map.keys()}'

--- a/cirq/google/engine/calibration_test.py
+++ b/cirq/google/engine/calibration_test.py
@@ -163,11 +163,13 @@ def test_calibration_heatmap():
     figure = mpl.figure.Figure()
     axes = figure.add_subplot(111)
     heatmap.plot(axes)
+    assert axes.get_title() == 'T1'
 
     heatmap = calibration.heatmap('xeb')
     figure = mpl.figure.Figure()
     axes = figure.add_subplot(999)
     heatmap.plot(axes)
+    assert axes.get_title() == 'Xeb'
 
     with pytest.raises(ValueError, match="one or two qubits.*multi_qubit"):
         multi_qubit_data = Merge(

--- a/cirq/google/engine/calibration_test.py
+++ b/cirq/google/engine/calibration_test.py
@@ -26,13 +26,13 @@ _CALIBRATION_DATA = Merge(
     """
     timestamp_ms: 1562544000021,
     metrics: [{
-        name: 'xeb',
+        name: 'two_qubit_xeb',
         targets: ['0_0', '0_1'],
         values: [{
             double_val: .9999
         }]
     }, {
-        name: 'xeb',
+        name: 'two_qubit_xeb',
         targets: ['0_0', '1_0'],
         values: [{
             double_val: .9998
@@ -92,7 +92,7 @@ def test_calibration_metrics_dictionary():
 
 def test_calibration_str():
     calibration = cg.Calibration(_CALIBRATION_DATA)
-    assert str(calibration) == "Calibration(keys=['globalMetric', 't1', 'xeb'])"
+    assert str(calibration) == "Calibration(keys=['globalMetric', 't1', 'two_qubit_xeb'])"
 
 
 def test_calibration_repr():
@@ -165,11 +165,11 @@ def test_calibration_heatmap():
     heatmap.plot(axes)
     assert axes.get_title() == 'T1'
 
-    heatmap = calibration.heatmap('xeb')
+    heatmap = calibration.heatmap('two_qubit_xeb')
     figure = mpl.figure.Figure()
     axes = figure.add_subplot(999)
     heatmap.plot(axes)
-    assert axes.get_title() == 'Xeb'
+    assert axes.get_title() == 'Two Qubit Xeb'
 
     with pytest.raises(ValueError, match="one or two qubits.*multi_qubit"):
         multi_qubit_data = Merge(

--- a/cirq/vis/heatmap.py
+++ b/cirq/vis/heatmap.py
@@ -151,10 +151,11 @@ class Heatmap:
             invalid_args = ", ".join([k for k in kwargs if k not in valid_kwargs])
             raise ValueError(f"Received invalid argument(s): {invalid_args}")
 
-    def update_config(self, **kwargs) -> None:
+    def update_config(self, **kwargs) -> 'Heatmap':
         """Add/Modify **kwargs args passed during initialisation."""
         self._validate_kwargs(kwargs)
         self._config.update(kwargs)
+        return self
 
     def _qubits_to_polygon(self, qubits: QubitTuple) -> Tuple[Polygon, Point]:
         qubit = qubits[0]

--- a/cirq/vis/heatmap_test.py
+++ b/cirq/vis/heatmap_test.py
@@ -262,11 +262,10 @@ def test_colorbar(ax, position, size, pad):
     random_heatmap = heatmap.Heatmap(test_value_map, plot_colorbar=False)
     fig1, ax1 = plt.subplots()
     random_heatmap.plot(ax1)
+    fig2, ax2 = plt.subplots()
     random_heatmap.update_config(
         plot_colorbar=True, colorbar_position=position, colorbar_size=size, colorbar_pad=pad
-    )
-    fig2, ax2 = plt.subplots()
-    random_heatmap.plot(ax2)
+    ).plot(ax2)
 
     # We need to call savefig() explicitly for updating axes position since the figure
     # object has been altered in the HeatMap._plot_colorbar function.


### PR DESCRIPTION
- Adds a default title in calibration heatmaps.
- Return self from update_config to support chaining of operations. Eg: heatmap.update_config(title='a').plot()