### PR TITLE
narrow qiskit dependency

### DIFF
--- a/dev_tools/conf/pip-list-dev-tools.txt
+++ b/dev_tools/conf/pip-list-dev-tools.txt
@@ -25,7 +25,7 @@ twine
 pyquil~=2.21.0
 
 # For verifying behavior of qasm output.
-qiskit~=0.20.0
+qiskit-aer~=0.7.6
 
 # For generating notebooks in documentation
 ipython


### PR DESCRIPTION
Narrows qiskit dependency for dev tools. 
We don't need the whole qiskit suite for testing, quiskit-aer (and terra transitively) is sufficient.