### PR TITLE
Replace _get_op_circuit with op.untagged

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -773,10 +773,11 @@ class AbstractCircuit(abc.ABC):
             given predicate are terminal. Also checks within any CircuitGates
             the circuit may contain.
         """
+        from cirq.circuits import CircuitOperation
         if not all(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
-            if getattr(op.untagged, 'circuit', None) is None
+            if not isinstance(op.untagged, CircuitOperation)
         ):
             return False
 
@@ -813,10 +814,11 @@ class AbstractCircuit(abc.ABC):
             given predicate are terminal. Also checks within any CircuitGates
             the circuit may contain.
         """
+        from cirq.circuits import CircuitOperation
         if any(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
-            if getattr(op.untagged, 'circuit', None) is None
+            if not isinstance(op.untagged, CircuitOperation)
         ):
             return True
 

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -774,6 +774,7 @@ class AbstractCircuit(abc.ABC):
             the circuit may contain.
         """
         from cirq.circuits import CircuitOperation
+
         if not all(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
@@ -815,6 +816,7 @@ class AbstractCircuit(abc.ABC):
             the circuit may contain.
         """
         from cirq.circuits import CircuitOperation
+
         if any(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)

--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -776,13 +776,13 @@ class AbstractCircuit(abc.ABC):
         if not all(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
-            if _get_op_circuit(op) is None
+            if getattr(op.untagged, 'circuit', None) is None
         ):
             return False
 
         for i, moment in enumerate(self.moments):
             for op in moment.operations:
-                circuit = _get_op_circuit(op)
+                circuit = getattr(op.untagged, 'circuit', None)
                 if circuit is None:
                     continue
                 if not circuit.are_all_matches_terminal(predicate):
@@ -816,13 +816,13 @@ class AbstractCircuit(abc.ABC):
         if any(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
-            if _get_op_circuit(op) is None
+            if getattr(op.untagged, 'circuit', None) is None
         ):
             return True
 
         for i, moment in reversed(list(enumerate(self.moments))):
             for op in moment.operations:
-                circuit = _get_op_circuit(op)
+                circuit = getattr(op.untagged, 'circuit', None)
                 if circuit is None:
                     continue
                 if not circuit.are_any_matches_terminal(predicate):
@@ -2199,15 +2199,6 @@ class Circuit(AbstractCircuit):
             # Keep moments aligned
             c_noisy += Circuit(op_tree)
         return c_noisy
-
-
-def _get_op_circuit(op: ops.Operation) -> Optional['cirq.FrozenCircuit']:
-    """Retrieves the circuit contained by an operation, if there is one."""
-    from cirq.circuits import CircuitOperation
-
-    while isinstance(op, ops.TaggedOperation):
-        op = op.sub_operation
-    return op.circuit if isinstance(op, CircuitOperation) else None
 
 
 def _resolve_operations(


### PR DESCRIPTION
Since `Operation` provides a canonical way to get the untagged version of itself, we should use it instead of writing a new method to do the same thing.

Using `op.untagged` in #3634 removes any residual blocking effects from #3678, although I'm still in favor of finding a proper resolution to #3678.