### PR TITLE
Add Sampler API for expectation values

### DIFF
--- a/cirq/work/sampler_test.py
+++ b/cirq/work/sampler_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for cirq.Sampler."""
+from typing import List
 import pytest
 
 import numpy as np
@@ -130,6 +131,128 @@ def test_sampler_sample_inconsistent_keys():
                 {'a': 1, 'b': 2},
             ],
         )
+
+
+def test_sampler_simple_sample_expectation_values():
+    a = cirq.LineQubit(0)
+    sampler = cirq.Simulator()
+    circuit = cirq.Circuit(cirq.H(a))
+    obs = cirq.X(a)
+    results = sampler.sample_expectation_values(circuit, [obs], num_samples=1000)
+
+    assert np.allclose(results, [[1]])
+
+
+def test_sampler_sample_expectation_values_calculation():
+    class DeterministicImbalancedStateSampler(cirq.Sampler):
+        """A simple, deterministic mock sampler.
+
+        Pretends to sample from a state vector with a 3:1 balance between the
+        probabilities of the |0) and |1) state.
+        """
+
+        def run_sweep(
+            self,
+            program: 'cirq.Circuit',
+            params: 'cirq.Sweepable',
+            repetitions: int = 1,
+        ) -> List['cirq.Result']:
+            results = np.zeros((repetitions, 1), dtype=bool)
+            for idx in range(repetitions // 4):
+                results[idx][0] = 1
+            return [
+                cirq.Result(params=pr, measurements={'z': results})
+                for pr in cirq.study.to_resolvers(params)
+            ]
+
+    a = cirq.LineQubit(0)
+    sampler = DeterministicImbalancedStateSampler()
+    # This circuit is not actually sampled, but the mock sampler above gives
+    # a reasonable approximation of it.
+    circuit = cirq.Circuit(cirq.X(a) ** (1 / 3))
+    obs = cirq.Z(a)
+    results = sampler.sample_expectation_values(circuit, [obs], num_samples=1000)
+
+    # (0.75 * 1) + (0.25 * -1) = 0.5
+    assert np.allclose(results, [[0.5]])
+
+
+def test_sampler_sample_expectation_values_multi_param():
+    a = cirq.LineQubit(0)
+    t = sympy.Symbol('t')
+    sampler = cirq.Simulator(seed=1)
+    circuit = cirq.Circuit(cirq.X(a) ** t)
+    obs = cirq.Z(a)
+    results = sampler.sample_expectation_values(
+        circuit, [obs], num_samples=5, params=cirq.Linspace('t', 0, 2, 3)
+    )
+
+    assert np.allclose(results, [[1], [-1], [1]])
+
+
+def test_sampler_sample_expectation_values_multi_qubit():
+    q = cirq.LineQubit.range(3)
+    sampler = cirq.Simulator(seed=1)
+    circuit = cirq.Circuit(cirq.X(q[0]), cirq.X(q[1]), cirq.X(q[2]))
+    obs = cirq.Z(q[0]) + cirq.Z(q[1]) + cirq.Z(q[2])
+    results = sampler.sample_expectation_values(circuit, [obs], num_samples=5)
+
+    assert np.allclose(results, [[-3]])
+
+
+def test_sampler_sample_expectation_values_composite():
+    # Tests multi-{param,qubit} sampling together in one circuit.
+    q = cirq.LineQubit.range(3)
+    t = [sympy.Symbol(f't{x}') for x in range(3)]
+
+    sampler = cirq.Simulator(seed=1)
+    circuit = cirq.Circuit(
+        cirq.X(q[0]) ** t[0],
+        cirq.X(q[1]) ** t[1],
+        cirq.X(q[2]) ** t[2],
+    )
+
+    obs = [cirq.Z(q[x]) for x in range(3)]
+    # t0 is in the inner loop to make bit-ordering easier below.
+    params = ([{'t0': t0, 't1': t1, 't2': t2} for t2 in [0, 1] for t1 in [0, 1] for t0 in [0, 1]],)
+    results = sampler.sample_expectation_values(
+        circuit,
+        obs,
+        num_samples=5,
+        params=params,
+    )
+    print('\n'.join(str(r) for r in results))
+
+    assert len(results) == 8
+    assert np.allclose(
+        results,
+        [
+            [+1, +1, +1],
+            [-1, +1, +1],
+            [+1, -1, +1],
+            [-1, -1, +1],
+            [+1, +1, -1],
+            [-1, +1, -1],
+            [+1, -1, -1],
+            [-1, -1, -1],
+        ],
+    )
+
+
+def test_sampler_simple_sample_expectation_requirements():
+    a = cirq.LineQubit(0)
+    sampler = cirq.Simulator(seed=1)
+    circuit = cirq.Circuit(cirq.H(a))
+    obs = cirq.X(a)
+    with pytest.raises(ValueError, match='at least one sample'):
+        _ = sampler.sample_expectation_values(circuit, [obs], num_samples=0)
+
+    with pytest.raises(ValueError, match='At least one observable'):
+        _ = sampler.sample_expectation_values(circuit, [], num_samples=1)
+
+    circuit.append(cirq.measure(a, key='out'))
+    with pytest.raises(ValueError, match='permit_terminal_measurements'):
+        _ = sampler.sample_expectation_values(circuit, [obs], num_samples=1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Stage 2 of the Expectation Value API (#3492). This is a rewrite of #3700.

This PR introduces the sample_expectation_values method and its default implementation, which injects gates to ensure measurement occurs in the correct basis. Hardware and software samplers can use this method as-is or implement their own version for custom behavior (e.g. server-side calculation of expectation values).