### PR TITLE
[Docs] Fix links in Floquet tutorial

### DIFF
--- a/docs/tutorials/google/floquet.ipynb
+++ b/docs/tutorials/google/floquet.ipynb
@@ -50,16 +50,16 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/google/floquet\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/tutorials/google/floquet\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/google/floquet.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/tutorials/google/floquet.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/google/floquet.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/tutorials/google/floquet.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/google/floquet.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/tutorials/google/floquet.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]


### PR DESCRIPTION
I moved the tutorial in #3826 but forgot to update the header links, so they're currently broken on the site. This fixes it.