### PR TITLE
Make assert_logs levels interval based

### DIFF
--- a/cirq/testing/deprecation.py
+++ b/cirq/testing/deprecation.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import os
 from contextlib import contextmanager
 
@@ -37,7 +38,12 @@ def assert_deprecated(*msgs: str, deadline: str, allow_multiple_warnings: bool =
 
     os.environ[ALLOW_DEPRECATION_IN_TEST] = 'True'
     try:
-        with assert_logs(*(msgs + (deadline,)), count=None if allow_multiple_warnings else 1):
+        with assert_logs(
+            *(msgs + (deadline,)),
+            min_level=logging.WARNING,
+            max_level=logging.WARNING,
+            count=None if allow_multiple_warnings else 1,
+        ):
             yield True
     finally:
         del os.environ[ALLOW_DEPRECATION_IN_TEST]

--- a/cirq/testing/logs.py
+++ b/cirq/testing/logs.py
@@ -16,7 +16,19 @@
 import logging
 from typing import ContextManager, List, Optional
 
+from cirq._compat import deprecated_parameter
 
+
+@deprecated_parameter(
+    deadline="v0.12",
+    fix="use min_level instead",
+    parameter_desc="level",
+    match=lambda args, kwargs: 'level' in kwargs,
+    rewrite=lambda args, kwargs: (
+        args,
+        {('min_level' if k == 'level' else k): v for k, v in kwargs.items()},
+    ),
+)
 def assert_logs(
     *matches: str,
     count: Optional[int] = 1,
@@ -58,6 +70,8 @@ def assert_logs(
         for code executed within the entered context. This ContextManager
         checks that the asserts for the logs are true on exit.
     """
+    if min_level > max_level:
+        raise ValueError("min_level should be less than or equal to max_level")
     records = []
 
     class Handler(logging.Handler):

--- a/cirq/testing/logs.py
+++ b/cirq/testing/logs.py
@@ -20,7 +20,8 @@ from typing import ContextManager, List, Optional
 def assert_logs(
     *matches: str,
     count: Optional[int] = 1,
-    level: int = logging.WARNING,
+    min_level: int = logging.WARNING,
+    max_level: int = logging.CRITICAL,
     capture_warnings: bool = True,
 ) -> ContextManager[List[logging.LogRecord]]:
     """A context manager for testing logging and warning events.
@@ -42,7 +43,7 @@ def assert_logs(
             any of the captures log messages.
         count: The expected number of messages in logs. Defaults to 1. If None is passed in counts
             are not checked.
-        level: The level at which to capture the logs. See the python logging
+        min_level: The level at which to capture the logs. See the python logging
             module for valid levels. By default this captures at the
             `logging.WARNING` level, so this does not capture `logging.INFO`
             or `logging.DEBUG` logs by default.
@@ -58,12 +59,15 @@ def assert_logs(
 
     class Handler(logging.Handler):
         def emit(self, record):
-            records.append(record)
+            # filter only the ones interesting
+            if max_level >= record.levelno >= min_level:
+                records.append(record)
 
         def __enter__(self):
             logging.captureWarnings(capture_warnings)
             logger = logging.getLogger()
-            logger.setLevel(level)
+            # we capture all the logs
+            logger.setLevel(logging.DEBUG)
             logger.addHandler(self)
             return records
 

--- a/cirq/testing/logs.py
+++ b/cirq/testing/logs.py
@@ -43,10 +43,13 @@ def assert_logs(
             any of the captures log messages.
         count: The expected number of messages in logs. Defaults to 1. If None is passed in counts
             are not checked.
-        min_level: The level at which to capture the logs. See the python logging
+        min_level: The minimum level at which to capture the logs. See the python logging
             module for valid levels. By default this captures at the
-            `logging.WARNING` level, so this does not capture `logging.INFO`
+            `logging.WARNING` level and above, so this does not capture `logging.INFO`
             or `logging.DEBUG` logs by default.
+        max_level: The maxium level at which to capture the logs. See the python logging
+            module for valid levels. By default this captures to the `logging.CRITICAL` level
+            thus, all the errors and critical messages will be captured as well.
         capture_warnings: Whether warnings from the python's `warnings` module
             are redirected to the logging system and captured.
 
@@ -59,7 +62,7 @@ def assert_logs(
 
     class Handler(logging.Handler):
         def emit(self, record):
-            # filter only the ones interesting
+            # filter only the interesting ones
             if max_level >= record.levelno >= min_level:
                 records.append(record)
 

--- a/cirq/testing/logs_test.py
+++ b/cirq/testing/logs_test.py
@@ -131,6 +131,22 @@ def test_assert_logs_log_level():
             logging.warning("info warning 1")
 
 
+def test_invalid_levels():
+    with pytest.raises(ValueError, match="min_level.*max_level"):
+        cirq.testing.assert_logs("test", min_level=logging.CRITICAL, max_level=logging.WARNING)
+
+
+def test_deprecated():
+    with cirq.testing.assert_deprecated(
+        'level parameter of assert_logs was used but is deprecated',
+        'use min_level instead',
+        deadline="v0.12",
+    ):
+        # pylint: disable=unexpected-keyword-arg
+        with cirq.testing.assert_logs("hello critical", level=logging.CRITICAL):
+            logging.critical("hello critical")
+
+
 def test_assert_logs_warnings():
     # Capture all warnings in one context, so that test cases that will
     # display a warning do not do so when the test is run.

--- a/cirq/testing/logs_test.py
+++ b/cirq/testing/logs_test.py
@@ -108,7 +108,7 @@ def test_assert_logs_invalid_multiple_logs():
 
 
 def test_assert_logs_log_level():
-    # Default is warning
+    # Default minlevel is WARNING, max level CRITICAL
     with cirq.testing.assert_logs('apple'):
         logging.error('orange apple fruit')
         logging.debug('should not')
@@ -118,10 +118,17 @@ def test_assert_logs_log_level():
         logging.error('orange apple fruit')
         logging.debug('should not')
         logging.info('count')
-    with cirq.testing.assert_logs('apple', level=logging.INFO, count=2):
+    with cirq.testing.assert_logs('apple', min_level=logging.INFO, count=2):
         logging.error('orange apple fruit')
         logging.debug('should not')
         logging.info('count')
+
+    with cirq.testing.assert_logs('info only 1', min_level=logging.INFO, max_level=logging.INFO):
+        with cirq.testing.assert_logs(
+            'info warning 1', min_level=logging.WARNING, max_level=logging.WARNING
+        ):
+            logging.info("info only 1")
+            logging.warning("info warning 1")
 
 
 def test_assert_logs_warnings():


### PR DESCRIPTION
Renames cirq.testing.assert_logs parameter `level` -> `min_level` and adds a new parameter `max_level`. 
This is to enable more sophisticated logs assertions based on multiple levels.

===== Release note ======

- `cirq.testing.assert_logs` parameter `level` is now deprecated and will be removed in Cirq v0.12. Please use instead `min_level`.

======================