### PR TITLE
Clean up _resolve_parameters_ method signatures

### DIFF
--- a/cirq/circuits/circuit.py
+++ b/cirq/circuits/circuit.py
@@ -2170,12 +2170,10 @@ class Circuit(AbstractCircuit):
             if 0 <= k < len(self._moments):
                 self._moments[k] = self._moments[k].without_operations_touching(qubits)
 
-    def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
-    ) -> 'Circuit':
+    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'Circuit':
         resolved_moments = []
         for moment in self:
-            resolved_operations = _resolve_operations(moment.operations, param_resolver, recursive)
+            resolved_operations = _resolve_operations(moment.operations, resolver, recursive)
             new_moment = ops.Moment(resolved_operations)
             resolved_moments.append(new_moment)
         resolved_circuit = Circuit(resolved_moments, device=self.device)

--- a/cirq/circuits/circuit_operation.py
+++ b/cirq/circuits/circuit_operation.py
@@ -534,11 +534,11 @@ class CircuitOperation(ops.Operation):
 
     # TODO: handle recursive parameter resolution gracefully
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'CircuitOperation':
         if recursive:
             raise ValueError(
                 'Recursive resolution of CircuitOperation parameters is prohibited. '
                 'Use "recursive=False" to prevent this error.'
             )
-        return self.with_params(param_resolver.param_dict)
+        return self.with_params(resolver.param_dict)

--- a/cirq/circuits/frozen_circuit.py
+++ b/cirq/circuits/frozen_circuit.py
@@ -171,9 +171,9 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
         return self.unfreeze().with_device(new_device, qubit_mapping).freeze()
 
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'FrozenCircuit':
-        return self.unfreeze()._resolve_parameters_(param_resolver, recursive).freeze()
+        return self.unfreeze()._resolve_parameters_(resolver, recursive).freeze()
 
     def tetris_concat(
         *circuits: 'cirq.AbstractCircuit', align: Union['cirq.Alignment', str] = Alignment.LEFT

--- a/cirq/ops/controlled_gate.py
+++ b/cirq/ops/controlled_gate.py
@@ -172,8 +172,10 @@ class ControlledGate(raw_types.Gate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self.sub_gate)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        new_sub_gate = protocols.resolve_parameters(self.sub_gate, param_resolver, recursive)
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'ControlledGate':
+        new_sub_gate = protocols.resolve_parameters(self.sub_gate, resolver, recursive)
         return ControlledGate(
             new_sub_gate,
             self.num_controls(),

--- a/cirq/ops/controlled_operation.py
+++ b/cirq/ops/controlled_operation.py
@@ -192,7 +192,9 @@ class ControlledOperation(raw_types.Operation):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self.sub_operation)
 
-    def _resolve_parameters_(self, resolver, recursive) -> 'ControlledOperation':
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'ControlledOperation':
         new_sub_op = protocols.resolve_parameters(self.sub_operation, resolver, recursive)
         return ControlledOperation(self.controls, new_sub_op, self.control_values)
 

--- a/cirq/ops/dense_pauli_string.py
+++ b/cirq/ops/dense_pauli_string.py
@@ -170,7 +170,7 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self.coefficient)
 
-    def _resolve_parameters_(self, resolver, recursive):
+    def _resolve_parameters_(self: TCls, resolver: 'cirq.ParamResolver', recursive: bool) -> TCls:
         return self.copy(
             coefficient=protocols.resolve_parameters(self.coefficient, resolver, recursive)
         )
@@ -350,10 +350,10 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def copy(
-        self,
+        self: TCls,
         coefficient: Optional[complex] = None,
         pauli_mask: Union[None, str, Iterable[int], np.ndarray] = None,
-    ) -> 'BaseDensePauliString':
+    ) -> TCls:
         """Returns a copy with possibly modified contents.
 
         Args:

--- a/cirq/ops/diagonal_gate.py
+++ b/cirq/ops/diagonal_gate.py
@@ -90,10 +90,10 @@ class DiagonalGate(raw_types.Gate):
         }
 
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'DiagonalGate':
         return DiagonalGate(
-            protocols.resolve_parameters(self._diag_angles_radians, param_resolver, recursive)
+            protocols.resolve_parameters(self._diag_angles_radians, resolver, recursive)
         )
 
     def _has_unitary_(self) -> bool:

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -22,6 +22,7 @@ from typing import (
     NamedTuple,
     Optional,
     Tuple,
+    TYPE_CHECKING,
     TypeVar,
     Union,
 )
@@ -36,6 +37,8 @@ from cirq import value, protocols
 from cirq.ops import raw_types
 from cirq.type_workarounds import NotImplementedType
 
+if TYPE_CHECKING:
+    import cirq
 
 TSelf = TypeVar('TSelf', bound='EigenGate')
 
@@ -349,8 +352,10 @@ class EigenGate(raw_types.Gate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self._exponent)
 
-    def _resolve_parameters_(self: TSelf, param_resolver, recursive: bool) -> 'EigenGate':
-        return self._with_exponent(exponent=param_resolver.value_of(self._exponent, recursive))
+    def _resolve_parameters_(
+        self: TSelf, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'EigenGate':
+        return self._with_exponent(exponent=resolver.value_of(self._exponent, recursive))
 
     def _equal_up_to_global_phase_(self, other, atol):
         if not isinstance(other, EigenGate):

--- a/cirq/ops/eigen_gate.py
+++ b/cirq/ops/eigen_gate.py
@@ -352,9 +352,7 @@ class EigenGate(raw_types.Gate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self._exponent)
 
-    def _resolve_parameters_(
-        self: TSelf, resolver: 'cirq.ParamResolver', recursive: bool
-    ) -> 'EigenGate':
+    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'EigenGate':
         return self._with_exponent(exponent=resolver.value_of(self._exponent, recursive))
 
     def _equal_up_to_global_phase_(self, other, atol):

--- a/cirq/ops/fourier_transform.py
+++ b/cirq/ops/fourier_transform.py
@@ -146,7 +146,9 @@ class PhaseGradientGate(raw_types.Gate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return cirq.parameter_names(self.exponent)
 
-    def _resolve_parameters_(self, resolver, recursive):
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'PhaseGradientGate':
         new_exponent = cirq.resolve_parameters(self.exponent, resolver, recursive)
         if new_exponent is self.exponent:
             return self

--- a/cirq/ops/fsim_gate.py
+++ b/cirq/ops/fsim_gate.py
@@ -137,11 +137,11 @@ class FSimGate(gate_features.TwoQubitGate, gate_features.InterchangeableQubitsGa
         )
 
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'cirq.FSimGate':
         return FSimGate(
-            protocols.resolve_parameters(self.theta, param_resolver, recursive),
-            protocols.resolve_parameters(self.phi, param_resolver, recursive),
+            protocols.resolve_parameters(self.theta, resolver, recursive),
+            protocols.resolve_parameters(self.phi, resolver, recursive),
         )
 
     def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs') -> Optional[np.ndarray]:
@@ -364,14 +364,14 @@ class PhasedFSimGate(gate_features.TwoQubitGate, gate_features.InterchangeableQu
         )
 
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'cirq.PhasedFSimGate':
         return PhasedFSimGate(
-            protocols.resolve_parameters(self.theta, param_resolver, recursive),
-            protocols.resolve_parameters(self.zeta, param_resolver, recursive),
-            protocols.resolve_parameters(self.chi, param_resolver, recursive),
-            protocols.resolve_parameters(self.gamma, param_resolver, recursive),
-            protocols.resolve_parameters(self.phi, param_resolver, recursive),
+            protocols.resolve_parameters(self.theta, resolver, recursive),
+            protocols.resolve_parameters(self.zeta, resolver, recursive),
+            protocols.resolve_parameters(self.chi, resolver, recursive),
+            protocols.resolve_parameters(self.gamma, resolver, recursive),
+            protocols.resolve_parameters(self.phi, resolver, recursive),
         )
 
     def _apply_unitary_(self, args: 'cirq.ApplyUnitaryArgs') -> Optional[np.ndarray]:

--- a/cirq/ops/gate_operation.py
+++ b/cirq/ops/gate_operation.py
@@ -230,7 +230,9 @@ class GateOperation(raw_types.Operation):
             return getter()
         return NotImplemented
 
-    def _resolve_parameters_(self, resolver, recursive):
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'cirq.Operation':
         resolved_gate = protocols.resolve_parameters(self.gate, resolver, recursive)
         return self.with_gate(resolved_gate)
 

--- a/cirq/ops/linear_combinations.py
+++ b/cirq/ops/linear_combinations.py
@@ -151,7 +151,7 @@ class LinearCombinationOfGates(value.LinearDict[raw_types.Gate]):
         return {name for gate in self.keys() for name in protocols.parameter_names(gate)}
 
     def _resolve_parameters_(
-        self, resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'LinearCombinationOfGates':
         return self.__class__(
             {
@@ -266,7 +266,7 @@ class LinearCombinationOfOperations(value.LinearDict[raw_types.Operation]):
         return {name for op in self.keys() for name in protocols.parameter_names(op)}
 
     def _resolve_parameters_(
-        self, resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'LinearCombinationOfOperations':
         return self.__class__(
             {

--- a/cirq/ops/parallel_gate_operation.py
+++ b/cirq/ops/parallel_gate_operation.py
@@ -113,7 +113,9 @@ class ParallelGateOperation(raw_types.Operation):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self.gate)
 
-    def _resolve_parameters_(self, resolver, recursive):
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'ParallelGateOperation':
         resolved_gate = protocols.resolve_parameters(self.gate, resolver, recursive)
         return self.with_gate(resolved_gate)
 

--- a/cirq/ops/pauli_string_phasor.py
+++ b/cirq/ops/pauli_string_phasor.py
@@ -156,11 +156,13 @@ class PauliStringPhasor(pauli_string_raw_types.PauliStringGateOperation):
             self.exponent_pos
         )
 
-    def _resolve_parameters_(self, param_resolver, recursive) -> 'PauliStringPhasor':
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'PauliStringPhasor':
         return PauliStringPhasor(
             self.pauli_string,
-            exponent_neg=param_resolver.value_of(self.exponent_neg, recursive),
-            exponent_pos=param_resolver.value_of(self.exponent_pos, recursive),
+            exponent_neg=resolver.value_of(self.exponent_neg, recursive),
+            exponent_pos=resolver.value_of(self.exponent_pos, recursive),
         )
 
     def pass_operations_over(

--- a/cirq/ops/pauli_sum_exponential.py
+++ b/cirq/ops/pauli_sum_exponential.py
@@ -79,11 +79,11 @@ class PauliSumExponential:
         return PauliSumExponential(self._pauli_sum.with_qubits(*new_qubits), self._exponent)
 
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'PauliSumExponential':
         return PauliSumExponential(
             self._pauli_sum,
-            exponent=protocols.resolve_parameters(self._exponent, param_resolver, recursive),
+            exponent=protocols.resolve_parameters(self._exponent, resolver, recursive),
         )
 
     def __iter__(self) -> Iterator['cirq.PauliStringPhasor']:

--- a/cirq/ops/phased_iswap_gate.py
+++ b/cirq/ops/phased_iswap_gate.py
@@ -98,7 +98,7 @@ class PhasedISwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
         )
 
     def _resolve_parameters_(
-        self, resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'PhasedISwapPowGate':
         return self.__class__(
             phase_exponent=protocols.resolve_parameters(self.phase_exponent, resolver, recursive),

--- a/cirq/ops/phased_x_gate.py
+++ b/cirq/ops/phased_x_gate.py
@@ -151,11 +151,13 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
             self._phase_exponent
         )
 
-    def _resolve_parameters_(self, param_resolver, recursive) -> 'PhasedXPowGate':
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'PhasedXPowGate':
         """See `cirq.SupportsParameterization`."""
         return PhasedXPowGate(
-            phase_exponent=param_resolver.value_of(self._phase_exponent, recursive),
-            exponent=param_resolver.value_of(self._exponent, recursive),
+            phase_exponent=resolver.value_of(self._phase_exponent, recursive),
+            exponent=resolver.value_of(self._exponent, recursive),
             global_shift=self._global_shift,
         )
 

--- a/cirq/ops/phased_x_z_gate.py
+++ b/cirq/ops/phased_x_z_gate.py
@@ -172,12 +172,14 @@ class PhasedXZGate(gate_features.SingleQubitGate):
             | protocols.parameter_names(self._axis_phase_exponent)
         )
 
-    def _resolve_parameters_(self, param_resolver, recursive) -> 'cirq.PhasedXZGate':
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'cirq.PhasedXZGate':
         """See `cirq.SupportsParameterization`."""
         return PhasedXZGate(
-            z_exponent=param_resolver.value_of(self._z_exponent, recursive),
-            x_exponent=param_resolver.value_of(self._x_exponent, recursive),
-            axis_phase_exponent=param_resolver.value_of(self._axis_phase_exponent, recursive),
+            z_exponent=resolver.value_of(self._z_exponent, recursive),
+            x_exponent=resolver.value_of(self._x_exponent, recursive),
+            axis_phase_exponent=resolver.value_of(self._axis_phase_exponent, recursive),
         )
 
     def _phase_by_(self, phase_turns, qubit_index) -> 'cirq.PhasedXZGate':

--- a/cirq/ops/random_gate_channel.py
+++ b/cirq/ops/random_gate_channel.py
@@ -69,7 +69,9 @@ class RandomGateChannel(raw_types.Gate):
             self.sub_gate
         )
 
-    def _resolve_parameters_(self, resolver, recursive):
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'RandomGateChannel':
         return RandomGateChannel(
             sub_gate=protocols.resolve_parameters(self.sub_gate, resolver, recursive),
             probability=protocols.resolve_parameters(self.probability, resolver, recursive),

--- a/cirq/ops/raw_types.py
+++ b/cirq/ops/raw_types.py
@@ -690,7 +690,9 @@ class TaggedOperation(Operation):
         tag_params = {name for tag in self.tags for name in protocols.parameter_names(tag)}
         return protocols.parameter_names(self.sub_operation) | tag_params
 
-    def _resolve_parameters_(self, resolver, recursive):
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'TaggedOperation':
         resolved_op = protocols.resolve_parameters(self.sub_operation, resolver, recursive)
         resolved_tags = (
             protocols.resolve_parameters(tag, resolver, recursive) for tag in self._tags

--- a/cirq/ops/raw_types_test.py
+++ b/cirq/ops/raw_types_test.py
@@ -658,7 +658,9 @@ class ParameterizableTag:
     def _parameter_names_(self) -> AbstractSet[str]:
         return cirq.parameter_names(self.value)
 
-    def _resolve_parameters_(self, resolver, recursive) -> 'ParameterizableTag':
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> 'ParameterizableTag':
         return ParameterizableTag(cirq.resolve_parameters(self.value, resolver, recursive))
 
 

--- a/cirq/ops/three_qubit_gates.py
+++ b/cirq/ops/three_qubit_gates.py
@@ -194,7 +194,7 @@ class ThreeQubitDiagonalGate(gate_features.ThreeQubitGate):
         }
 
     def _resolve_parameters_(
-        self, resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'ThreeQubitDiagonalGate':
         return self.__class__(
             [

--- a/cirq/ops/two_qubit_diagonal_gate.py
+++ b/cirq/ops/two_qubit_diagonal_gate.py
@@ -55,10 +55,10 @@ class TwoQubitDiagonalGate(gate_features.TwoQubitGate):
         }
 
     def _resolve_parameters_(
-        self, param_resolver: 'cirq.ParamResolver', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'TwoQubitDiagonalGate':
         return TwoQubitDiagonalGate(
-            protocols.resolve_parameters(self._diag_angles_radians, param_resolver, recursive)
+            protocols.resolve_parameters(self._diag_angles_radians, resolver, recursive)
         )
 
     def _has_unitary_(self) -> bool:

--- a/cirq/ops/wait_gate.py
+++ b/cirq/ops/wait_gate.py
@@ -65,8 +65,8 @@ class WaitGate(raw_types.Gate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self.duration)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        return WaitGate(protocols.resolve_parameters(self.duration, param_resolver, recursive))
+    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'WaitGate':
+        return WaitGate(protocols.resolve_parameters(self.duration, resolver, recursive))
 
     def _qid_shape_(self) -> Tuple[int, ...]:
         return self._qid_shape

--- a/cirq/protocols/resolve_parameters.py
+++ b/cirq/protocols/resolve_parameters.py
@@ -48,7 +48,7 @@ class SupportsParameterization(Protocol):
         """
 
     @doc_private
-    def _resolve_parameters_(self: T, param_resolver: 'cirq.ParamResolver', recursive: bool) -> T:
+    def _resolve_parameters_(self: T, resolver: 'cirq.ParamResolver', recursive: bool) -> T:
         """Resolve the parameters in the effect."""
 
 

--- a/cirq/protocols/resolve_parameters_test.py
+++ b/cirq/protocols/resolve_parameters_test.py
@@ -118,7 +118,7 @@ def test_parameter_names():
 )
 def test_skips_empty_resolution(resolve_fn):
     class Tester:
-        def _resolve_parameters_(self, param_resolver, recursive):
+        def _resolve_parameters_(self, resolver, recursive):
             return 5
 
     t = Tester()
@@ -154,8 +154,8 @@ def test_backwards_compatible():
         def __init__(self, *syms):
             self.syms = [*syms]
 
-        def _resolve_parameters_(self, pr):
-            return sum([cirq.resolve_parameters(s, pr) for s in self.syms])
+        def _resolve_parameters_(self, resolver):
+            return sum([cirq.resolve_parameters(s, resolver) for s in self.syms])
 
     ssum = SymbolSum(a, b, c)
     assert cirq.resolve_parameters(ssum, resolver) == 10

--- a/cirq/study/resolver.py
+++ b/cirq/study/resolver.py
@@ -185,12 +185,10 @@ class ParamResolver:
             self._deep_eval_map[value] = self.value_of(v, recursive)
         return self._deep_eval_map[value]
 
-    def _resolve_parameters_(
-        self, param_resolver: 'ParamResolver', recursive: bool
-    ) -> 'ParamResolver':
-        new_dict = {k: k for k in param_resolver}
+    def _resolve_parameters_(self, resolver: 'ParamResolver', recursive: bool) -> 'ParamResolver':
+        new_dict = {k: k for k in resolver}
         new_dict.update({k: self.value_of(k, recursive) for k in self})
-        new_dict.update({k: param_resolver.value_of(v, recursive) for k, v in new_dict.items()})
+        new_dict.update({k: resolver.value_of(v, recursive) for k, v in new_dict.items()})
         if recursive and self.param_dict:
             new_resolver = ParamResolver(new_dict)
             # Resolve down to single-step mappings.

--- a/cirq/testing/consistent_phase_by_test.py
+++ b/cirq/testing/consistent_phase_by_test.py
@@ -29,8 +29,8 @@ class GoodPhaser:
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return GoodPhaser(self.e + phase_turns * 4)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        return GoodPhaser(param_resolver.value_of(self.e, recursive))
+    def _resolve_parameters_(self, resolver, recursive):
+        return GoodPhaser(resolver.value_of(self.e, recursive))
 
 
 class GoodQuditPhaser:
@@ -52,8 +52,8 @@ class GoodQuditPhaser:
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return GoodQuditPhaser(self.e + phase_turns * 4)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        return GoodQuditPhaser(param_resolver.value_of(self.e, recursive))
+    def _resolve_parameters_(self, resolver, recursive):
+        return GoodQuditPhaser(resolver.value_of(self.e, recursive))
 
 
 class BadPhaser:
@@ -66,8 +66,8 @@ class BadPhaser:
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return BadPhaser(self.e + phase_turns * 4)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        return BadPhaser(param_resolver.value_of(self.e, recursive))
+    def _resolve_parameters_(self, resolver, recursive):
+        return BadPhaser(resolver.value_of(self.e, recursive))
 
 
 class NotPhaser:
@@ -92,8 +92,8 @@ class SemiBadPhaser:
         r[qubit_index] += phase_turns * 4
         return SemiBadPhaser(r)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        return SemiBadPhaser([param_resolver.value_of(val, recursive) for val in self.e])
+    def _resolve_parameters_(self, resolver, recursive):
+        return SemiBadPhaser([resolver.value_of(val, recursive) for val in self.e])
 
 
 def test_assert_phase_by_is_consistent_with_unitary():

--- a/cirq/testing/consistent_protocols_test.py
+++ b/cirq/testing/consistent_protocols_test.py
@@ -108,10 +108,10 @@ class GoodGate(cirq.SingleQubitGate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return cirq.parameter_names(self.exponent) | cirq.parameter_names(self.phase_exponent)
 
-    def _resolve_parameters_(self, param_resolver, recursive) -> 'GoodGate':
+    def _resolve_parameters_(self, resolver, recursive) -> 'GoodGate':
         return GoodGate(
-            phase_exponent=param_resolver.value_of(self.phase_exponent, recursive),
-            exponent=param_resolver.value_of(self.exponent, recursive),
+            phase_exponent=resolver.value_of(self.phase_exponent, recursive),
+            exponent=resolver.value_of(self.exponent, recursive),
         )
 
     def _identity_tuple(self):

--- a/cirq/value/duration.py
+++ b/cirq/value/duration.py
@@ -90,8 +90,8 @@ class Duration:
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self._picos)
 
-    def _resolve_parameters_(self, param_resolver, recursive):
-        return Duration(picos=protocols.resolve_parameters(self._picos, param_resolver, recursive))
+    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'Duration':
+        return Duration(picos=protocols.resolve_parameters(self._picos, resolver, recursive))
 
     def total_picos(self) -> Union[sympy.Basic, float]:
         """Returns the number of picoseconds that the duration spans."""

--- a/cirq/value/periodic_value.py
+++ b/cirq/value/periodic_value.py
@@ -101,7 +101,7 @@ class PeriodicValue:
         return parameter_names(self.value) | parameter_names(self.period)
 
     def _resolve_parameters_(
-        self, resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool
+        self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'PeriodicValue':
         # HACK: Avoids circular dependencies.
         from cirq.protocols import resolve_parameters


### PR DESCRIPTION
Follow-up to #3922. Clean up `_resolve_parameters_` method signatures by adding types where appropriate and using consistent argument names.