### PR TITLE
Make SimulatesExpectationValues public

### DIFF
--- a/cirq/__init__.py
+++ b/cirq/__init__.py
@@ -372,6 +372,7 @@ from cirq.sim import (
     sample_state_vector,
     sample_sweep,
     SimulatesAmplitudes,
+    SimulatesExpectationValues,
     SimulatesFinalState,
     SimulatesIntermediateState,
     SimulatesIntermediateStateVector,

--- a/cirq/sim/__init__.py
+++ b/cirq/sim/__init__.py
@@ -49,6 +49,7 @@ from cirq.sim.mux import (
 
 from cirq.sim.simulator import (
     SimulatesAmplitudes,
+    SimulatesExpectationValues,
     SimulatesFinalState,
     SimulatesIntermediateState,
     SimulatesSamples,


### PR DESCRIPTION
I forgot to make the `SimulatesExpectationValues` interface visible at the top level of Cirq :(

You can still use this type in Cirq v0.10, but it must be referenced as `cirq.sim.simulator.SimulatesExpectationValues`.