### PR TITLE
Adds git-blame-ignore-rev and instructions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# migrating to black
+a61e51b53612735e93b3bb8a7605030c499cd6c7

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
-# migrating to black
+# migrating to the black formatter
 a61e51b53612735e93b3bb8a7605030c499cd6c7
+
+# adding flynt formatting for strings
+7a335e3ef297057b4a12f7c21d4e8dd426b44ca0

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -13,10 +13,22 @@ git clone git@github.com:quantumlib/cirq.git
 cd Cirq
 ```
 
-To do your development in a Docker image, you can build one with Cirq/dev_tools/Dockerfile or pull an existing image:
+## Recommended git setup
+
+The following command will setup large refactoring revisions to be ignored, when using git blame.
+
+```
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+Note that if you are using PyCharm, you might have to Restart & Invalidate Caches to have the change being picked up. 
+
+## Docker
+
+To do your development in a Docker image, you can build one with our `Dockerfile`.
 ```bash
-    docker pull quantumlib/cirq:dev
-    docker run -it quantumlib/cirq:dev python -c "import cirq; print(cirq.google.Foxtail)"
+    docker build -t cirq .
+    docker run -it cirq python -c "import cirq; print(cirq.google.Foxtail)"
 ```
 
 


### PR DESCRIPTION
Adds git-blame-ignore-rev and instructions.

This sets up git blame, PyCharm and other clients that integrate with git well to ignore large scale refactoring revisions. Note that unfortunately this is not yet supported by Github (https://github.community/t/support-ignore-revs-file-in-githubs-blame-view/3256/21). 