### PR TITLE
filter pre-release job for only main repo

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -6,6 +6,7 @@ on:
       - master
 jobs:
   push_to_pypi:
+    if: github.repository == 'quantumlib/Cirq'
     name: Push to PyPi
     runs-on: ubuntu-16.04
     env:


### PR DESCRIPTION
Filter pre-release job to only run in the main repo (quantumlib/Cirq). 

This avoids noise in forks who use the master branch.