### PR TITLE
Change the remaining format string to f-string

### DIFF
--- a/check/format-incremental
+++ b/check/format-incremental
@@ -110,8 +110,7 @@ if (( only_print == 1 )); then
     flynt_args+=("--dry-run")
 fi
 
-# TODO: Remove '-e cirq/ops/pauli_string.py' once the line is covered (https://github.com/quantumlib/Cirq/issues/3804)
-flynt ${format_files} "${flynt_args[@]}"  -e cirq/ops/pauli_string.py
+flynt ${format_files} "${flynt_args[@]}"
 FLYNTSTATUS=$?
 
 echo "Running the black formatter..."

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -959,7 +959,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
                     cast(TKey, op.qubits[1]),
                     after_to_before=after_to_before,
                 )
-        raise TypeError('Unsupported operation: {!r}'.format(op))
+        raise TypeError(f'Unsupported operation: {op!r}')
 
     @staticmethod
     def _pass_single_clifford_gate_over(

--- a/cirq/ops/pauli_string.py
+++ b/cirq/ops/pauli_string.py
@@ -959,7 +959,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
                     cast(TKey, op.qubits[1]),
                     after_to_before=after_to_before,
                 )
-        raise TypeError(f'Unsupported operation: {op!r}')
+        raise NotImplementedError(f'Unsupported operation: {op!r}')
 
     @staticmethod
     def _pass_single_clifford_gate_over(


### PR DESCRIPTION
Changes the remaining format string to `f-string` using Flynt:
```
$ pip install flynt
$ flynt .
```

Fixes #3804.