### PR TITLE
[WIP] Improve API reference

### DIFF
--- a/docs/circuits.ipynb
+++ b/docs/circuits.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "## Conceptual overview\n",
     "\n",
-    "The primary representation of quantum programs in Cirq is the `Circuit` class. A `Circuit` is a collection of `Moments`. A `Moment` is a collection of `Operations` that all act during the same abstract time slice. An `Operation` is a some effect that operates on a specific subset of Qubits, the most common type of `Operation` is a `GateOperation`.\n"
+    "The primary representation of quantum programs in Cirq is the `cirq.Circuit` class. A `cirq.Circuit` is a collection of `Moments`. A `cirq.Moment` is a collection of `Operations` that all act during the same abstract time slice. An `cirq.Operation` is a some effect that operates on a specific subset of Qubits, the most common type of `cirq.Operation` is a `cirq.GateOperation`.\n"
    ]
   },
   {
@@ -137,7 +137,7 @@
     "id": "gpi9rwuiAwCZ"
    },
    "source": [
-    "The next level up is the notion of a `Gate`. A `Gate` represents a physical process that occurs on a `Qubit`. The important property of a `Gate` is that it can be applied to one or more qubits. This can be done via the `Gate.on` method itself or via `()`, and doing this turns the `Gate` into a `GateOperation`."
+    "The next level up is the notion of a `cirq.Gate`. A `cirq.Gate` represents a physical process that occurs on a `Qubit`. The important property of a `cirq.Gate` is that it can be applied to one or more qubits. This can be done via the `Gate.on` method itself or via `()`, and doing this turns the `cirq.Gate` into a `cirq.GateOperation`."
    ]
   },
   {
@@ -171,7 +171,7 @@
     "id": "0N7X3nmFAwCd"
    },
    "source": [
-    "A `Moment` is simply a collection of operations, each of which operates on a different set of qubits, and which conceptually represents these operations as occurring during this abstract time slice. The `Moment` structure itself is not required to be related to the actual scheduling of the operations on a quantum computer, or via a simulator, though it can be. For example, here is a `Moment` in which **Pauli** `X` and a `CZ` gate operate on three qubits:"
+    "A `cirq.Moment` is simply a collection of operations, each of which operates on a different set of qubits, and which conceptually represents these operations as occurring during this abstract time slice. The `cirq.Moment` structure itself is not required to be related to the actual scheduling of the operations on a quantum computer, or via a simulator, though it can be. For example, here is a `cirq.Moment` in which **Pauli** `cirq.X` and a `cirq.CZ` gate operate on three qubits:"
    ]
   },
   {
@@ -203,9 +203,9 @@
     "id": "8TxICnXCAwCh"
    },
    "source": [
-    "The above is not the only way one can construct moments, nor even the typical method, but illustrates that a `Moment` is just a collection of operations on disjoint sets of qubits.\n",
+    "The above is not the only way one can construct moments, nor even the typical method, but illustrates that a `cirq.Moment` is just a collection of operations on disjoint sets of qubits.\n",
     "\n",
-    "Finally, at the top level a `Circuit` is an ordered series of `Moment` objects. The first `Moment` in this series contains the first `Operations that will be applied. Here, for example, is a simple circuit made up of two moments:"
+    "Finally, at the top level a `cirq.Circuit` is an ordered series of `cirq.Moment` objects. The first `cirq.Moment` in this series contains the first `Operations` that will be applied. Here, for example, is a simple circuit made up of two moments:"
    ]
   },
   {
@@ -244,7 +244,7 @@
     "id": "YMXONr0SAwCl"
    },
    "source": [
-    "Note that the above is one of the many ways to construct a `Circuit`, which illustrates the concept that a `Circuit` is an iterable of `Moment` objects."
+    "Note that the above is one of the many ways to construct a `cirq.Circuit`, which illustrates the concept that a `cirq.Circuit` is an iterable of `cirq.Moment` objects."
    ]
   },
   {
@@ -255,9 +255,9 @@
    "source": [
     "## Constructing circuits\n",
     "\n",
-    "Constructing Circuits as a series of `Moment` objects, with each `Moment` being hand-crafted, is tedious. Instead, we provide a variety of different ways to create a `Circuit`.\n",
+    "Constructing Circuits as a series of `cirq.Moment` objects, with each `cirq.Moment` being hand-crafted, is tedious. Instead, we provide a variety of different ways to create a `cirq.Circuit`.\n",
     "\n",
-    "One of the most useful ways to construct a `Circuit` is by appending onto the `Circuit` with the `Circuit.append` method.\n"
+    "One of the most useful ways to construct a `cirq.Circuit` is by appending onto the `cirq.Circuit` with the `Circuit.append` method.\n"
    ]
   },
   {
@@ -363,7 +363,7 @@
     "id": "OQX8FTMyAwCw"
    },
    "source": [
-    "We see that here we have again created two `Moment` objects. How did `Circuit` know how to do this? `Circuit`'s `Circuit.append` method (and its cousin, `Circuit.insert`) both take an argument called the `InsertStrategy`. By default, `InsertStrategy` is `InsertStrategy.NEW_THEN_INLINE`."
+    "We see that here we have again created two `cirq.Moment` objects. How did `cirq.Circuit` know how to do this? `cirq.Circuit`'s `Circuit.append` method (and its cousin, `Circuit.insert`) both take an argument called the `cirq.InsertStrategy`. By default, `cirq.InsertStrategy` is `InsertStrategy.NEW_THEN_INLINE`."
    ]
   },
   {
@@ -374,7 +374,7 @@
    "source": [
     "### InsertStrategies\n",
     "\n",
-    "`InsertStrategy` defines how `Operations` are placed in a `Circuit` when requested to be inserted at a given location. Here, a location is identified by the index of the `Moment` (in the `Circuit`) where the insertion is requested to be placed at (in the case of `Circuit.append`, this means inserting at the `Moment`, at an index one greater than the maximum moment index in the `Circuit`). \n",
+    "`cirq.InsertStrategy` defines how `Operations` are placed in a `cirq.Circuit` when requested to be inserted at a given location. Here, a location is identified by the index of the `cirq.Moment` (in the `cirq.Circuit`) where the insertion is requested to be placed at (in the case of `Circuit.append`, this means inserting at the `cirq.Moment`, at an index one greater than the maximum moment index in the `cirq.Circuit`). \n",
     "\n",
     "There are four such strategies: `InsertStrategy.EARLIEST`, `InsertStrategy.NEW`, `InsertStrategy.INLINE` and `InsertStrategy.NEW_THEN_INLINE`.\n",
     "\n",
@@ -382,7 +382,7 @@
     "\n",
     "*Scans backward from the insert location until a moment with operations touching qubits affected by the operation to insert is found. The operation is added to the moment just after that location.*\n",
     "\n",
-    "For example, if we first create an `Operation` in a single moment, and then use `InsertStrategy.EARLIEST`, `Operation` can slide back to this first ` Moment` if there is space:"
+    "For example, if we first create an `cirq.Operation` in a single moment, and then use `InsertStrategy.EARLIEST`, `cirq.Operation` can slide back to this first `cirq.Moment` if there is space:"
    ]
   },
   {
@@ -420,9 +420,9 @@
     "id": "BGnlt-kPAwCz"
    },
    "source": [
-    "After creating the first moment with a `CZ` gate, the second append uses the `InsertStrategy.EARLIEST` strategy. The `H` on `q0` cannot slide back, while the `H` on `q2` can and so ends up in the first `Moment`.\n",
+    "After creating the first moment with a `cirq.CZ` gate, the second append uses the `InsertStrategy.EARLIEST` strategy. The `cirq.H` on `q0` cannot slide back, while the `cirq.H` on `q2` can and so ends up in the first `cirq.Moment`.\n",
     "\n",
-    "Contrast this with the `InsertStrategy.NEW` `InsertStrategy`:\n",
+    "Contrast this with the `InsertStrategy.NEW` `cirq.InsertStrategy`:\n",
     "\n",
     "*Every operation that is inserted is created in a new moment.*"
    ]
@@ -514,7 +514,7 @@
     "id": "7iDg6j4fAwC7"
    },
    "source": [
-    "After two initial `CZ` between the second and third qubit, we try to insert three `H` `Operations`. We see that the `H` on the first qubit is inserted into the previous `Moment`, but the `H` on the second and third qubits cannot be inserted into the previous `Moment`, so a new `Moment` is created.\n",
+    "After two initial `cirq.CZ` between the second and third qubit, we try to insert three `cirq.H` `Operations`. We see that the `cirq.H` on the first qubit is inserted into the previous `cirq.Moment`, but the `cirq.H` on the second and third qubits cannot be inserted into the previous `cirq.Moment`, so a new `cirq.Moment` is created.\n",
     "\n",
     "Finally, we turn to the default strategy:"
    ]
@@ -561,7 +561,7 @@
     "id": "m2SoYFsFAwC_"
    },
    "source": [
-    "The first append creates a single moment with an `H` on the first qubit. Then, the append with the `InsertStrategy.NEW_THEN_INLINE` strategy begins by inserting the `CZ` in a new `Moment` (the `InsertStrategy.NEW` in `InsertStrategy.NEW_THEN_INLINE`). Subsequent appending is done `InsertStrategy.INLINE`, so the next `H` on the first qubit is appending in the just created `Moment`."
+    "The first append creates a single moment with an `cirq.H` on the first qubit. Then, the append with the `InsertStrategy.NEW_THEN_INLINE` strategy begins by inserting the `cirq.CZ` in a new `cirq.Moment` (the `InsertStrategy.NEW` in `InsertStrategy.NEW_THEN_INLINE`). Subsequent appending is done `InsertStrategy.INLINE`, so the next `cirq.H` on the first qubit is appending in the just created `cirq.Moment`."
    ]
   },
   {
@@ -572,7 +572,7 @@
    "source": [
     "### Patterns for arguments to append and insert\n",
     "\n",
-    "In the above examples, we used a series of `Circuit.append `calls with a list of different `Operations` added to the circuit. However, the argument where we have supplied a list can also take more than just list values. For instance:"
+    "In the above examples, we used a series of `Circuit.append` calls with a list of different `Operations` added to the circuit. However, the argument where we have supplied a list can also take more than just list values. For instance:"
    ]
   },
   {
@@ -643,13 +643,13 @@
     "* or lists of `Operations` mixed with lists of `Operations`. \n",
     "\n",
     "\n",
-    "When we pass an iterator to the `append` method, `Circuit` is able to flatten all of these and pass them as one giant list to `Circuit.append` (this also works for `Circuit.insert`).\n",
+    "When we pass an iterator to the `append` method, `cirq.Circuit` is able to flatten all of these and pass them as one giant list to `Circuit.append` (this also works for `Circuit.insert`).\n",
     "\n",
-    "The above idea uses the concept of `OP_TREE`. An `OP_TREE` is not a class, but a *contract*. The basic idea is that, if the input can be iteratively flattened into a list of operations, then the input is an `OP_TREE`.\n",
+    "The above idea uses the concept of `cirq.OP_TREE`. A `cirq.OP_TREE` is not a class, but a *contract*. The basic idea is that, if the input can be iteratively flattened into a list of operations, then the input is a `cirq.OP_TREE`.\n",
     "\n",
-    "A very nice pattern emerges from this structure: define generators for sub-circuits, which can vary by size or `Operation` parameters.\n",
+    "A very nice pattern emerges from this structure: define generators for sub-circuits, which can vary by size or `cirq.Operation` parameters.\n",
     "\n",
-    "Another useful method to construct a `Circuit` fully formed from an `OP_TREE` is to pass the `OP_TREE` into `Circuit` when initializing it:"
+    "Another useful method to construct a `cirq.Circuit` fully formed from a `cirq.OP_TREE` is to pass the `cirq.OP_TREE` into `cirq.Circuit` when initializing it:"
    ]
   },
   {
@@ -713,7 +713,7 @@
     "id": "8gT1t2drAwDL"
    },
    "source": [
-    "Slicing a `Circuit`, on the other hand, produces a new `Circuit` with only the moments corresponding to the slice:"
+    "Slicing a `cirq.Circuit`, on the other hand, produces a new `cirq.Circuit` with only the moments corresponding to the slice:"
    ]
   },
   {


### PR DESCRIPTION
Updates the documentation page to make it easy to search for class definitions. Replaces `Class` mentions with `cirq.Class`.

Fixes #3667.