### PR TITLE
Deprecate qubits and _qubits

### DIFF
--- a/cirq/_compat.py
+++ b/cirq/_compat.py
@@ -117,6 +117,16 @@ def _validate_deadline(deadline: str):
     assert re.match(DEADLINE_REGEX, deadline), "deadline should match vX.Y"
 
 
+def deprecation_warning(deprecation: str, deadline:str, fix: str):
+    _validate_deadline(deadline)
+
+    _warn_or_error(
+                f'{deprecation}.\n'
+                f'It will be removed in cirq {deadline}.\n'
+                f'{fix}\n'
+            )
+
+
 def deprecated(
     *, deadline: str, fix: str, name: Optional[str] = None
 ) -> Callable[[Callable], Callable]:

--- a/cirq/devices/device.py
+++ b/cirq/devices/device.py
@@ -15,6 +15,8 @@
 import abc
 from typing import TYPE_CHECKING, Optional, AbstractSet
 
+from cirq._compat import deprecation_warning
+
 if TYPE_CHECKING:
     import cirq
 
@@ -38,6 +40,11 @@ class Device(metaclass=abc.ABCMeta):
         # method was defined.
         for name in ['qubits', '_qubits']:
             if hasattr(self, name):
+                deprecation_warning(
+                    f"{type(self)} class implements {name} method, which is deprecated",
+                    deadline="v0.12",
+                    fix="Implement qubit_set instead",
+                )
                 val = getattr(self, name)
                 if callable(val):
                     val = val()

--- a/cirq/devices/device_test.py
+++ b/cirq/devices/device_test.py
@@ -30,3 +30,19 @@ def test_qubit_set():
             return cirq.LineQubit.range(6)
 
     assert PrivateQubitMethodDevice().qubit_set() == frozenset(cirq.LineQubit.range(6))
+
+
+def test_deprecation():
+    class QubitFieldDevice(cirq.Device):
+        def __init__(self):
+            self.qubits = cirq.LineQubit.range(1)
+
+    with cirq.testing.assert_deprecated("qubits", "deprecated", deadline="v0.12"):
+        _ = QubitFieldDevice().qubit_set()
+
+    class PrivateQubitFieldDevice(cirq.Device):
+        def __init__(self):
+            self._qubits = cirq.LineQubit.range(1)
+
+    with cirq.testing.assert_deprecated("_qubits", "deprecated", deadline="v0.12"):
+        _ = PrivateQubitFieldDevice().qubit_set()


### PR DESCRIPTION
Creates a new generic `def deprecation_warning(deprecation: str, deadline:str, fix: str)` in `cirq._compat`. This method uses the `_warn_or_error` method in `_compat` and it validates the `deadline` argument (_v0.12_ in this case) like the other deprecators.

It also adds a test in `device_test.py` that tests the warning emitted with `cirq.testing.assert_deprecated` from a `Device` subclass implementing `qubits` and another implementing `_qubits`.

Fixes #3080.