### PR TITLE
Skip measurement gates in DropNegligible optimizer

### DIFF
--- a/cirq/optimizers/drop_negligible.py
+++ b/cirq/optimizers/drop_negligible.py
@@ -36,6 +36,8 @@ class DropNegligible:
         deletions: List[Tuple[int, ops.Operation]] = []
         for moment_index, moment in enumerate(circuit):
             for op in moment.operations:
-                if op is not None and protocols.trace_distance_bound(op) <= self.tolerance:
+                if protocols.is_measurement(op):
+                    continue
+                if protocols.trace_distance_bound(op) <= self.tolerance:
                     deletions.append((moment_index, op))
         circuit.batch_remove(deletions)


### PR DESCRIPTION
Fixes #3732

This is a simple approach to fixing `optimized_for_sycamore`, which currently barfs on large measurement gates when `DropNegligible` tries to compute their trace distance bound. There may be other approaches that are more general, but as @mpharrigan said it's somewhat embarrassing that this doesn't work currently, so I think a quick fix is warranted and we can generalize later.