### PR TITLE
Fix DepolarizingChannel documentation

### DIFF
--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -372,7 +372,7 @@ def depolarize(p: float, n_qubits: int = 1) -> DepolarizingChannel:
     This channel evolves a density matrix via
 
         $$
-        \rho \rightarrow (1 - p) \rho + 1 / (4**n - 1) \sum _i P_i X P_i
+        \rho \rightarrow (1 - p) \rho + p / (4**n - 1) \sum _i P_i \rho P_i
         $$
 
     where $P_i$ are the $4^n - 1$ Pauli gates (excluding the identity).

--- a/cirq/ops/common_channels.py
+++ b/cirq/ops/common_channels.py
@@ -263,7 +263,7 @@ class DepolarizingChannel(gate_features.SupportsOnEachGate, raw_types.Gate):
         This channel evolves a density matrix via
 
             $$
-            \rho \rightarrow (1 - p) \rho + 1 / (4**n - 1) \sum _i P_i X P_i
+            \rho \rightarrow (1 - p) \rho + p / (4**n - 1) \sum _i P_i \rho P_i
             $$
 
         where $P_i$ are the $4^n - 1$ Pauli gates (excluding the identity).


### PR DESCRIPTION
In commit fa995853b6902eaa48afe6eab1058f9e9bae2ef6 the formula for `DepolarizingChannel` got changed, and I'm pretty sure it should be ` p / (4**n - 1) \sum _i P_i \rho P_i` instead, given that's what the ` AsymmetricDepolarizingChannel` does.