### PR TITLE
fix networkx / decorator dependency issue

### DIFF
--- a/dev_tools/notebooks/__init__.py
+++ b/dev_tools/notebooks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dev_tools.notebooks.utils import filter_notebooks, list_all_notebooks

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -98,19 +98,10 @@ def _find_base_revision():
 def _list_all_notebooks() -> Set[str]:
     try:
         output = subprocess.check_output(['git', 'ls-files', '*.ipynb'])
-        all_notebooks = set(output.decode('utf-8').splitlines())
+        return set(output.decode('utf-8').splitlines())
     except subprocess.CalledProcessError as ex:
         warning("It seems that tests are run from not a git repo, notebook tests are skipped", ex)
         return set()
-
-    skipped_notebooks = functools.reduce(
-        lambda a, b: a.union(b), list(set(glob.glob(g, recursive=True)) for g in SKIP_NOTEBOOKS)
-    )
-
-    # sorted is important otherwise pytest-xdist will complain that
-    # the workers have different parametrization:
-    # https://github.com/pytest-dev/pytest-xdist/issues/432
-    return sorted(os.path.abspath(n) for n in all_notebooks.difference(skipped_notebooks))
 
 
 def _list_changed_notebooks() -> Set[str]:

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -19,13 +19,10 @@
 # excercised in an isolated virtual environment for each notebook. This is also the path that is
 # tested in the devsite workflows, these tests meant to provide earlier feedback.
 
-import functools
-import glob
 import os
 import subprocess
 import sys
 import warnings
-from logging import warning
 from typing import Set
 
 import pytest
@@ -33,10 +30,12 @@ from filelock import FileLock
 
 from dev_tools import shell_tools
 from dev_tools.env_tools import create_virtual_env
+from dev_tools.notebooks import list_all_notebooks, filter_notebooks
 
 # these notebooks rely on features that are not released yet
 # after every release we should raise a PR and empty out this list
 # note that these notebooks are still tested in dev_tools/notebook_test.py
+
 NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES = [
     # the notebook depends on new `cirq.R*` gates.
     'docs/tutorials/educators/intro.ipynb',
@@ -95,50 +94,26 @@ def _find_base_revision():
     raise ValueError("Can't find a base revision to compare the files with.")
 
 
-def _list_all_notebooks() -> Set[str]:
-    try:
-        output = subprocess.check_output(['git', 'ls-files', '*.ipynb'])
-        return set(output.decode('utf-8').splitlines())
-    except subprocess.CalledProcessError as ex:
-        warning("It seems that tests are run from not a git repo, notebook tests are skipped", ex)
-        return set()
-
-
 def _list_changed_notebooks() -> Set[str]:
-    rev = _find_base_revision()
-    output = subprocess.check_output(f'git diff --name-only {rev}'.split())
-    lines = output.decode('utf-8').splitlines()
-    if any(l for l in lines if l.endswith("isolated_notebook_test.py")):
-        return _list_all_notebooks()
-    return set(l for l in lines if l.endswith(".ipynb"))
-
-
-def _tested_notebooks():
-    changed_notebooks = set()
-
-    # It would be nicer if we could somehow automatically skip the execution of this completely,
-    # however, in order to be able to rely on parallel pytest (xdist) we need parametrization to
-    # work, thus this will be executed during the collection phase even when the notebook tests
-    # are not included (the "-m slow" flag is not passed to pytest). So, in order to not break the
-    # complete test collection phase in other tests where there is no git history (fetch-depth:1),
-    # we'll just swallow the error here with a warning.
-
     try:
-        changed_notebooks = _list_changed_notebooks()
+        rev = _find_base_revision()
+        output = subprocess.check_output(f'git diff --name-only {rev}'.split())
+        lines = output.decode('utf-8').splitlines()
+        if any(l for l in lines if l.endswith("isolated_notebook_test.py")):
+            return list_all_notebooks()
+        return set(l for l in lines if l.endswith(".ipynb"))
     except ValueError as e:
+        # It would be nicer if we could somehow automatically skip the execution of this completely,
+        # however, in order to be able to rely on parallel pytest (xdist) we need parametrization to
+        # work, thus this will be executed during the collection phase even when the notebook tests
+        # are not included (the "-m slow" flag is not passed to pytest). So, in order to not break
+        # the complete test collection phase in other tests where there is no git history
+        # (fetch-depth:1), we'll just swallow the error here with a warning.
         warnings.warn(
             f"No changed notebooks are tested "
             f"(this is expected in non-notebook tests in CI): {e}"
         )
-
-    skipped_notebooks = functools.reduce(
-        lambda a, b: a.union(b), list(set(glob.glob(g, recursive=True)) for g in SKIP_NOTEBOOKS)
-    )
-
-    # sorted is important otherwise pytest-xdist will complain that
-    # the workers have different parametrization:
-    # https://github.com/pytest-dev/pytest-xdist/issues/432
-    return sorted(os.path.abspath(n) for n in changed_notebooks.difference(skipped_notebooks))
+        return set()
 
 
 @pytest.mark.slow
@@ -168,7 +143,9 @@ def _create_base_env(proto_dir):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("notebook_path", _tested_notebooks())
+@pytest.mark.parametrize(
+    "notebook_path", filter_notebooks(_list_changed_notebooks(), SKIP_NOTEBOOKS)
+)
 def test_notebooks_against_released_cirq(notebook_path, base_env):
     """Tests the notebooks in isolated virtual environments."""
     notebook_file = os.path.basename(notebook_path)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -19,16 +19,12 @@
 # main focus and it is executed in a shared virtual environment for the notebooks. Thus, these
 # tests ensure that notebooks are still working with the latest version of cirq.
 
-import functools
-import glob
 import os
-import subprocess
-from logging import warning
-from typing import Set
 
 import pytest
 
 from dev_tools import shell_tools
+from dev_tools.notebooks import filter_notebooks, list_all_notebooks
 
 SKIP_NOTEBOOKS = [
     # skipping vendor notebooks as we don't have auth sorted out
@@ -45,31 +41,8 @@ SKIP_NOTEBOOKS = [
 ]
 
 
-def _list_all_notebooks() -> Set[str]:
-    try:
-        output = subprocess.check_output(['git', 'ls-files', '*.ipynb'])
-        return set(output.decode('utf-8').splitlines())
-    except subprocess.CalledProcessError as ex:
-        warning("It seems that tests are run from not a git repo, notebook tests are skipped", ex)
-        return set()
-
-
-def _tested_notebooks():
-    """We list all notebooks here, even those that are not """
-
-    all_notebooks = _list_all_notebooks()
-    skipped_notebooks = functools.reduce(
-        lambda a, b: a.union(b), list(set(glob.glob(g, recursive=True)) for g in SKIP_NOTEBOOKS)
-    )
-
-    # sorted is important otherwise pytest-xdist will complain that
-    # the workers have different parametrization:
-    # https://github.com/pytest-dev/pytest-xdist/issues/432
-    return sorted(os.path.abspath(n) for n in all_notebooks.difference(skipped_notebooks))
-
-
 @pytest.mark.slow
-@pytest.mark.parametrize("notebook_path", _tested_notebooks())
+@pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
 def test_notebooks_against_released_cirq(notebook_path):
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -22,7 +22,7 @@ from typing import Set, List
 
 
 def list_all_notebooks() -> Set[str]:
-    """Returns the relative path to all notebooks in the git repo.
+    """Returns the relative paths to all notebooks in the git repo.
 
     In case the folder is not a git repo, it returns an empty set.
     """

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -1,0 +1,57 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+import glob
+import os
+import subprocess
+from logging import warning
+from typing import Set, List
+
+
+def list_all_notebooks() -> Set[str]:
+    """Returns the relative path to all notebooks in the git repo.
+
+    In case the folder is not a git repo, it returns an empty set.
+    """
+    try:
+        output = subprocess.check_output(['git', 'ls-files', '*.ipynb'])
+        return set(output.decode('utf-8').splitlines())
+    except subprocess.CalledProcessError as ex:
+        warning("It seems that tests are not running in a git repo, skipping notebook tests", ex)
+        return set()
+
+
+def filter_notebooks(all_notebooks: Set[str], skip_list: List[str]):
+    """Returns the absolute path for notebooks except those that are skipped.
+
+    Args:
+        all_notebooks: set of interesting relative notebook paths.
+        skip_list: list of glob patterns. Notebooks matching any of these glob
+            in `all_notebooks` will not be returned.
+
+    Returns:
+        a sorted list of absolute paths to the notebooks that don't match any of
+        the `skip_list` glob patterns.
+    """
+
+    skipped_notebooks = functools.reduce(
+        lambda a, b: a.union(b), list(set(glob.glob(g, recursive=True)) for g in skip_list)
+    )
+
+    # sorted is important otherwise pytest-xdist will complain that
+    # the workers have different parametrization:
+    # https://github.com/pytest-dev/pytest-xdist/issues/432
+    return sorted(os.path.abspath(n) for n in all_notebooks.difference(skipped_notebooks))


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/4012 which was caused by https://github.com/networkx/networkx/issues/4718. 

Also ensures that isolated notebook test runs for all notebooks (not just changed ones) if the test itself changes.