### PR TITLE
Include py.typed files in cirq-core and cirq-google

### DIFF
--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -73,6 +73,7 @@ setup(
     long_description=long_description,
     packages=cirq_packages,
     package_data={
+        'cirq': ['py.typed'],
         'cirq.protocols.json_test_data': ['*'],
     },
 )

--- a/cirq-google/cirq_google/py.typed
+++ b/cirq-google/cirq_google/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The cirq package uses inline types.

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -69,6 +69,7 @@ setup(
     long_description=long_description,
     packages=packs,
     package_data={
+        'cirq_google': ['py.typed'],
         'cirq_google.api.v2': ['*'],
         'cirq_google.api.v1': ['*'],
         'cirq_google.json_test_data': ['*'],


### PR DESCRIPTION
These are needed to enable type-checking for users who install cirq-core and cirq-google.