### PR TITLE
fix versioning of new modules

### DIFF
--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -29,4 +29,4 @@ if sys.version_info < (3, 6, 0):
         'of cirq (e.g. "python -m pip install cirq==0.5.*")'
     )
 
-__version__ = "0.10.0.dev"
+__version__ = "0.11.0.dev"

--- a/dev_tools/version_test.py
+++ b/dev_tools/version_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Dict, Any
 
 
 def test_versions_are_the_same():
@@ -27,7 +28,7 @@ def test_versions_are_the_same():
 
 def _get_version(package: str):
     version_file = f'{package}/_version.py'
-    resulting_locals = {}
+    resulting_locals: Dict[str, Any] = {}
     exec(open(version_file).read(), globals(), resulting_locals)
     __version__ = resulting_locals['__version__']
     assert __version__, f"__version__ should be defined in {version_file}"

--- a/dev_tools/version_test.py
+++ b/dev_tools/version_test.py
@@ -19,14 +19,16 @@ def test_versions_are_the_same():
     packages = ["cirq-google/cirq_google"]
 
     for p in packages:
+        print(p)
         assert (
             _get_version(p) == core_version
         ), f"{p}/_version.py is different from cirq-core/cirq/_version.py!"
 
 
 def _get_version(package: str):
-    __version__ = ''
     version_file = f'{package}/_version.py'
-    exec(open(version_file).read())
-    assert __version__ is not None, f"__version__ should be defined in {version_file}"
+    resulting_locals = {}
+    exec(open(version_file).read(), globals(), resulting_locals)
+    __version__ = resulting_locals['__version__']
+    assert __version__, f"__version__ should be defined in {version_file}"
     return __version__

--- a/dev_tools/version_test.py
+++ b/dev_tools/version_test.py
@@ -20,7 +20,6 @@ def test_versions_are_the_same():
     packages = ["cirq-google/cirq_google"]
 
     for p in packages:
-        print(p)
         assert (
             _get_version(p) == core_version
         ), f"{p}/_version.py is different from cirq-core/cirq/_version.py!"


### PR DESCRIPTION
Fixes a bug in the version test and the actual _version.py for cirq-google.