### PR TITLE
Fix omitted coverage

### DIFF
--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -54,14 +54,13 @@ fi
 source dev_tools/pypath
 
 # Run tests while producing coverage files.
-check/pytest cirq-core/cirq cirq-google \
-    --actually-quiet \
-    --cov \
-    --cov-report=annotate \
-    --cov-config=dev_tools/conf/.coveragerc
+check/pytest --actually-quiet \
+             --cov \
+             --cov-report=annotate \
+             --cov-config=dev_tools/conf/.coveragerc
 pytest_result=$?
 
-# Analyze coverage files.
+# Analyze coverage files./
 python dev_tools/check_incremental_coverage_annotations.py "${rev}"
 cover_result=$?
 

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -60,7 +60,7 @@ check/pytest --actually-quiet \
              --cov-config=dev_tools/conf/.coveragerc
 pytest_result=$?
 
-# Analyze coverage files./
+# Analyze coverage files.
 python dev_tools/check_incremental_coverage_annotations.py "${rev}"
 cover_result=$?
 

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -355,7 +355,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py HEAD\n'
@@ -379,7 +379,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py master\n'
@@ -395,7 +395,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py origin/master\n'
@@ -411,7 +411,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py upstream/master\n'
@@ -427,7 +427,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py upstream/master\n'
@@ -455,7 +455,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py HEAD\n'
@@ -471,7 +471,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out == (
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py master\n'
@@ -494,7 +494,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.exit_code == 0
     assert result.out.startswith(
         'INTERCEPTED check/pytest '
-        'cirq-core/cirq cirq-google --actually-quiet --cov --cov-report=annotate '
+        '--actually-quiet --cov --cov-report=annotate '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'INTERCEPTED python '
         'dev_tools/check_incremental_coverage_annotations.py '


### PR DESCRIPTION
Ensures that `pytest-and-incremental-coverage` runs all code in the repo.

Code lines outside of cirq-google and cirq-core were not tested, so coverage check was failing. See https://github.com/quantumlib/Cirq/runs/2387098464 as an example that modifies the examples directory. 