### PR TITLE
Fix cirq_google notebooks

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -45,6 +45,11 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES = [
     # the device_or_qubits parameter is deprecated
     'examples/advanced/quantum_volume_routing.ipynb',
     'examples/advanced/quantum_volume_errors.ipynb',
+
+    # these notebooks use cirq_google and hence depend on cirq pre-releases
+    'docs/qcvv/xeb_coherent_noise.ipynb',
+    'docs/qcvv/xeb_theory.ipynb',
+    'docs/tutorials/google/floquet.ipynb',
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -45,7 +45,6 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES = [
     # the device_or_qubits parameter is deprecated
     'examples/advanced/quantum_volume_routing.ipynb',
     'examples/advanced/quantum_volume_errors.ipynb',
-
     # these notebooks use cirq_google and hence depend on cirq pre-releases
     'docs/qcvv/xeb_coherent_noise.ipynb',
     'docs/qcvv/xeb_theory.ipynb',

--- a/docs/qcvv/xeb_coherent_noise.ipynb
+++ b/docs/qcvv/xeb_coherent_noise.ipynb
@@ -65,7 +65,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/qcvv/xeb_theory.ipynb
+++ b/docs/qcvv/xeb_theory.ipynb
@@ -65,7 +65,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/floquet.ipynb
+++ b/docs/tutorials/google/floquet.ipynb
@@ -136,7 +136,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install cirq --quiet\n",
+    "    !pip install cirq --quiet --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },


### PR DESCRIPTION
Makes notebooks using cirq_google install pre-release cirq. 

These notebooks were failing in the devsite pipeline as they were just installing cirq, not `cirq --pre`. 