### PR TITLE
Set default remote host for IonQ API

### DIFF
--- a/cirq-core/cirq/ionq/service.py
+++ b/cirq-core/cirq/ionq/service.py
@@ -48,7 +48,7 @@ class Service:
         Args:
             remote_host: The location of the api in the form of an url. If this is None,
                 then this instance will use the environment variable `IONQ_REMOTE_HOST`. If that
-                variable is not set, then this use `https://api.ionq.co/{api_version}` where
+                variable is not set, then this uses `https://api.ionq.co/{api_version}`, where
                 `{api_version}` is the `api_version` specified below.
             api_key: A string key which allows access to the api. If this is None,
                 then this instance will use the environment variable  `IONQ_API_KEY`. If that
@@ -65,20 +65,15 @@ class Service:
             EnvironmentError: if the `api_key` is None and has no corresponding environment
                 variable set.
         """
-
-        def init_possibly_from_env(param, env_name, var_name):
-            param = param or os.getenv(env_name)
-            if not param:
-                raise EnvironmentError(
-                    f'Parameter {var_name} was not specified and the environment variable '
-                    f'{env_name} was also not set.'
-                )
-            return param
-
         self.remote_host = (
             remote_host or os.getenv('IONQ_REMOTE_HOST') or f'https://api.ionq.co/{api_version}'
         )
-        self.api_key = init_possibly_from_env(api_key, 'IONQ_API_KEY', 'api_key')
+        self.api_key = api_key or os.getenv('IONQ_API_KEY')
+        if not self.api_key:
+            raise EnvironmentError(
+                f'Parameter api_key was not specified and the environment variable '
+                f'IONQ_API_KEY was also not set.'
+            )
 
         self._client = ionq_client._IonQClient(
             remote_host=self.remote_host,

--- a/cirq-core/cirq/ionq/service.py
+++ b/cirq-core/cirq/ionq/service.py
@@ -48,7 +48,8 @@ class Service:
         Args:
             remote_host: The location of the api in the form of an url. If this is None,
                 then this instance will use the environment variable `IONQ_REMOTE_HOST`. If that
-                variable is not set, then this will raise an `EnvironmentError`.
+                variable is not set, then this use `https://api.ionq.co/{api_version}` where
+                `{api_version}` is the `api_version` specified below.
             api_key: A string key which allows access to the api. If this is None,
                 then this instance will use the environment variable  `IONQ_API_KEY`. If that
                 variable is not set, then this will raise an `EnvironmentError`.
@@ -61,8 +62,8 @@ class Service:
             verbose: Whether to print to stdio and stderr on retriable errors.
 
         Raises:
-            EnvironmentError: if `remote_host` or `api_key` are None and have no corresponding
-                environment variable set.
+            EnvironmentError: if the `api_key` is None and has no corresponding environment
+                variable set.
         """
 
         def init_possibly_from_env(param, env_name, var_name):
@@ -74,7 +75,9 @@ class Service:
                 )
             return param
 
-        self.remote_host = init_possibly_from_env(remote_host, 'IONQ_REMOTE_HOST', 'remote_host')
+        self.remote_host = (
+            remote_host or os.getenv('IONQ_REMOTE_HOST') or f'https://api.ionq.co/{api_version}'
+        )
         self.api_key = init_possibly_from_env(api_key, 'IONQ_API_KEY', 'api_key')
 
         self._client = ionq_client._IonQClient(

--- a/cirq-core/cirq/ionq/service_test.py
+++ b/cirq-core/cirq/ionq/service_test.py
@@ -181,5 +181,8 @@ def test_service_remote_host_via_env():
 def test_service_no_param_or_env_variable():
     with pytest.raises(EnvironmentError):
         _ = ionq.Service(remote_host='http://example.com')
-    with pytest.raises(EnvironmentError):
-        _ = ionq.Service(api_key='tomyheart')
+
+
+def test_service_no_url_default():
+    service = ionq.Service(api_key='tomyheart')
+    assert service.remote_host == 'https://api.ionq.co/v0.1'

--- a/docs/ionq/access.md
+++ b/docs/ionq/access.md
@@ -18,7 +18,7 @@ import cirq.ionq as ionq
 service = ionq.Service(api_key='tomyheart')
 ```
 
-Alternatively, you can use environment variables to set this value. These environment variables for the api key is `IONQ_API_KEY`.  Details of how to set environment variables vary by operating system.  For example in bash, you would do
+Alternatively, you can use environment variables to set this value. These environment variable for the api key is `IONQ_API_KEY`.  Details of how to set environment variables vary by operating system.  For example in bash, you would do
 ```bash
 export IONQ_API_KEY=tomyheart
 ```

--- a/docs/ionq/access.md
+++ b/docs/ionq/access.md
@@ -7,26 +7,19 @@ about partnerships can be found at [ionq.com/get-started](https://ionq.com/get-s
 
 ## Authentication
 
-To use Cirq with the IonQ API, two pieces of information are required.  The first is the
-url of the API frontend.  This should be specified as something like `https://example.com/`
-(the actual url will be provided to partners). The second is the API key, which is just a
-random looking string.
+To use Cirq with the IonQ API, one needs an API key.  This is a random looking string.
 
-Given that you have the remote host and the API key, there are two ways to use these to
+Given that you have the API key, there are two ways to use these to
 get an object in python to access the API. The object that you construct to access
-the API are instances of the `cirq.ionq.Service` class. You can directly use the remote host
-and API key in constructing this instances of this class. Here is an example of this pattern:
+the API are instances of the `cirq.ionq.Service` class. You can directly use the API key in constructing this instances of this class. Here is an example of this pattern:
 ```python
 import cirq.ionq as ionq
 
-service = ionq.Service(remote_host='http://example.com/', api_key='tomyheart')
+service = ionq.Service(api_key='tomyheart')
 ```
 
-Alternatively, you can use environment variables for these values. These environment variables
-are `IONQ_REMOTE_HOST` and `IONQ_API_KEY`.  Details of how to set environment variables vary
-by operating system.  For example in bash, you would do
+Alternatively, you can use environment variables to set this value. These environment variables for the api key is `IONQ_API_KEY`.  Details of how to set environment variables vary by operating system.  For example in bash, you would do
 ```bash
-export IONQ_REMOTE_HOST=http://example.com/v1
 export IONQ_API_KEY=tomyheart
 ```
 In the case that you have set these environment variables, you can just perform

--- a/docs/ionq/service.md
+++ b/docs/ionq/service.md
@@ -7,7 +7,7 @@ See [Access and Authentication](access.md) for details of access.
 ## Service class
 
 The main entrance for accessing IonQ's API are instances of the `cirq.ionq.Service` class.
-These objects can need to be initialized with an api key, see
+These objects need to be initialized with an api key, see
 [Access and Authentication](access.md) for details.
 
 The basic flow of running a quantum circuit in a blocking manner is

--- a/docs/ionq/service.md
+++ b/docs/ionq/service.md
@@ -1,13 +1,13 @@
 # IonQ API Service
 
 IonQ's API provides a way to execute quantum circuits on IonQ's trapped ion quantum computers
-or on cloud based simulators.  As of January 2021 this access is restricted to partners.
+or on cloud based simulators.  As of April 2021 this access is restricted to partners.
 See [Access and Authentication](access.md) for details of access.
 
 ## Service class
 
 The main entrance for accessing IonQ's API are instances of the `cirq.ionq.Service` class.
-These objects can need to be initialized with the remote host url and api key, see
+These objects can need to be initialized with an api key, see
 [Access and Authentication](access.md) for details.
 
 The basic flow of running a quantum circuit in a blocking manner is
@@ -30,10 +30,10 @@ circuit = cirq.Circuit(
 )
 
 # Create a ionq.Service object.
-# Replace REMOTE_HOST and API_KEY with your values.
-# Or alternatively if you have the IONQ_REMOTE_HOST and IONQ_API_KEY
-# environment variables set, you can omit specifying these parameters.
-service = ionq.Service(remote_host=REMOTE_HOST, api_key=API_KEY)
+# Replace API_KEY with your api key.
+# Or alternatively if you have the IONQ_API_KEY environment
+# variables set, you can omit specifying thee api_key parameters.
+service = ionq.Service(api_key=API_KEY)
 
 # Run a program against the service. This method will block execution
 # until the result is returned and periodically polls the IonQ API.

--- a/docs/tutorials/ionq/getting_started.ipynb
+++ b/docs/tutorials/ionq/getting_started.ipynb
@@ -98,7 +98,7 @@
     "id": "11b21e6193ae"
    },
    "source": [
-    "The main object that you use to access the IonQ API is an instance of the `cirq.ionq.Service` class.  To construct this you need two pieces of information: the location of the remote host for accessing the API and also an API key. Both should be supplied to partners. Please be careful when using notebooks and version control to not save your API key in a public location!\n",
+    "The main object that you use to access the IonQ API is an instance of the `cirq.ionq.Service` class.  To construct this you need an API key. Both should be supplied to partners. Please be careful when using notebooks and version control to not save your API key in a public location!\n",
     "\n",
     "Given these bits of information you get a service object by simply running"
    ]
@@ -111,11 +111,9 @@
    },
    "outputs": [],
    "source": [
-    "REMOTE_HOST = 'https://example.com/'  # Replace with the IonQ host.\n",
     "API_KEY = 'tomyheart' # Replace with your IonQ API key\n",
     "\n",
-    "service = ionq.Service(remote_host=REMOTE_HOST, \n",
-    "                       api_key=API_KEY, \n",
+    "service = ionq.Service(api_key=API_KEY, \n",
     "                       default_target='simulator')"
    ]
   },


### PR DESCRIPTION
The remote host is now public information, so setting the default to be this url.  

Also updates the documentation around this.  