### PR TITLE
pylint recognizes cirq_google as known third_party

### DIFF
--- a/check/pylint
+++ b/check/pylint
@@ -11,4 +11,4 @@
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
 
-pylint --rcfile=dev_tools/conf/.pylintrc $@ cirq-core/cirq platforms dev_tools examples
+pylint --rcfile=dev_tools/conf/.pylintrc $@ cirq-core/cirq cirq-google/cirq_google dev_tools examples

--- a/cirq-google/cirq_google/calibration/engine_simulator.py
+++ b/cirq-google/cirq_google/calibration/engine_simulator.py
@@ -21,7 +21,6 @@ from cirq.ops import (
     Operation,
     PhasedFSimGate,
     Qid,
-    QubitOrderOrList,
     SingleQubitGate,
     WaitGate,
 )
@@ -34,7 +33,6 @@ from cirq.sim import (
 )
 from cirq.study import ParamResolver
 from cirq.value import RANDOM_STATE_OR_SEED_LIKE, parse_random_state
-
 from cirq_google.calibration.phased_fsim import (
     FloquetPhasedFSimCalibrationRequest,
     PhaseCalibratedFSimGate,
@@ -45,7 +43,6 @@ from cirq_google.calibration.phased_fsim import (
     SQRT_ISWAP_INV_PARAMETERS,
     try_convert_sqrt_iswap_to_fsim,
 )
-
 
 ParametersDriftGenerator = Callable[[Qid, Qid, FSimGate], PhasedFSimCharacterization]
 PhasedFsimDictParameters = Dict[

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -64,3 +64,9 @@ ignore-long-lines=^(.*#\w*pylint: disable.*|\s*(# )?<?https?://\S+>?)$
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
 generated-members=numpy.*
+
+
+[IMPORTS]
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=cirq,cirq_google


### PR DESCRIPTION
Fixes three things: 

* check/pylint was pointing to the wrong folders (platform -> cirq-google/cirq_google)
* pylint (and the underlying isort) needs to know about cirq_google and cirq as not third_party libraries for import sorting to work properly
* there was an unused import in cirq_google that is now removed