### PR TITLE
Speed up notebook tests by adding extra replacements file

### DIFF
--- a/cirq-core/cirq/contrib/quimb/Cirq-To-Tensor-Networks.tst
+++ b/cirq-core/cirq/contrib/quimb/Cirq-To-Tensor-Networks.tst
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+max_qubits = 6->max_qubits = 4
+max_moments = 500->max_moments = 10

--- a/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
@@ -324,8 +324,10 @@
    "outputs": [],
    "source": [
     "records = []\n",
-    "for n_qubits in [3, 6]:\n",
-    "    for n_moments in list(range(1, 500, 50)):\n",
+    "max_qubits = 6\n",
+    "max_moments = 500\n",
+    "for n_qubits in [3, max_qubits]:\n",
+    "    for n_moments in range(1, max_moments, 50):\n",
     "        record = profile(n_qubits=n_qubits, n_moments=n_moments)\n",
     "        records.append(record)\n",
     "        print('.', end='', flush=True)\n",
@@ -380,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -153,7 +153,17 @@ def _create_base_env(proto_dir):
     "notebook_path", filter_notebooks(_list_changed_notebooks(), SKIP_NOTEBOOKS)
 )
 def test_notebooks_against_released_cirq(notebook_path, base_env):
-    """Tests the notebooks in isolated virtual environments."""
+    """Tests the notebooks in isolated virtual environments.
+
+    In order to speed up the execution of these tests an auxiliary file may be supplied which
+    performs substitutions on the notebook to make it faster.
+
+    Specifically for a notebook file notebook.ipynb, one can supply a file notebook.tst which
+    contains the substitutes.  The substitutions are provide in the form `pattern->replacement`
+    where the pattern is what is matched and replaced. While the pattern is compiled as a
+    regular expression, it is considered best practice to not use complicated regular expressions.
+    Lines in this file that do not have `->` are ignored.
+    """
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))
     out_path = f"out/{notebook_rel_dir}/{notebook_file[:-6]}.out.ipynb"

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -77,6 +77,8 @@ PACKAGES = [
     "seaborn~=0.11.1",
     # https://github.com/nteract/papermill/issues/519
     'ipykernel==5.3.4',
+    # https://github.com/ipython/ipython/issues/12941
+    'ipython==7.22',
     # to ensure networkx works nicely
     # https://github.com/networkx/networkx/issues/4718 pinned networkx 2.5.1 to 4.4.2
     # however, jupyter brings in 5.0.6

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -161,12 +161,15 @@ def test_notebooks_against_released_cirq(notebook_path, base_env):
     dir_name = notebook_file.rstrip(".ipynb")
 
     notebook_env = os.path.join(tmpdir, f"{dir_name}")
+
+    rewritten_notebook_descriptor, rewritten_notebook_path = rewrite_notebook(notebook_path)
+
     cmd = f"""
 mkdir -p out/{notebook_rel_dir}
 {proto_dir}/bin/virtualenv-clone {proto_dir} {notebook_env}
 cd {notebook_env}
 . ./bin/activate
-papermill {notebook_path} {os.getcwd()}/{out_path}"""
+papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
     _, stderr, status = shell_tools.run_shell(
         cmd=cmd,
         log_run_to_stderr=False,
@@ -182,3 +185,6 @@ papermill {notebook_path} {os.getcwd()}/{out_path}"""
             f"notebook (in Github Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs')"
         )
+
+    if rewritten_notebook_descriptor:
+        os.close(rewritten_notebook_descriptor)

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -30,7 +30,7 @@ from filelock import FileLock
 
 from dev_tools import shell_tools
 from dev_tools.env_tools import create_virtual_env
-from dev_tools.notebooks import list_all_notebooks, filter_notebooks
+from dev_tools.notebooks import list_all_notebooks, filter_notebooks, rewrite_notebook
 
 # these notebooks rely on features that are not released yet
 # after every release we should raise a PR and empty out this list

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,7 +24,7 @@ import os
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import filter_notebooks, list_all_notebooks
+from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_notebook
 
 SKIP_NOTEBOOKS = [
     # skipping vendor notebooks as we don't have auth sorted out
@@ -44,11 +44,23 @@ SKIP_NOTEBOOKS = [
 @pytest.mark.slow
 @pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
 def test_notebooks_against_released_cirq(notebook_path):
+    """Test that jupyter notebooks execute.
+
+    In order to speed up the execution of these tests an auxiliary file may be supplied which
+    performs substitutions on the notebook to make it faster.
+
+    Specifically for a notebook file notebook.ipynb, one can supply a file notebook.tst which
+    contains the substitutes.  The substitutions are provide in the form `pattern->replacement`
+    where the pattern is what is matched and replaced. While the pattern is compiled, it is
+    considered best practice to not sure complicated regular expressions.  Lines in this file that
+    do not have `->` are ignored.
+    """
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))
     out_path = f"out/{notebook_rel_dir}/{notebook_file[:-6]}.out.ipynb"
+    rewritten_notebook_descriptor, rewritten_notebook_path = rewrite_notebook(notebook_path)
     cmd = f"""mkdir -p out/{notebook_rel_dir}
-papermill {notebook_path} {out_path}"""
+papermill {rewritten_notebook_path} {out_path}"""
 
     _, stderr, status = shell_tools.run_shell(
         cmd=cmd,
@@ -65,3 +77,6 @@ papermill {notebook_path} {out_path}"""
             f"notebook (in Github Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs')"
         )
+
+    if rewritten_notebook_descriptor:
+        os.close(rewritten_notebook_descriptor)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -51,9 +51,9 @@ def test_notebooks_against_released_cirq(notebook_path):
 
     Specifically for a notebook file notebook.ipynb, one can supply a file notebook.tst which
     contains the substitutes.  The substitutions are provide in the form `pattern->replacement`
-    where the pattern is what is matched and replaced. While the pattern is compiled, it is
-    considered best practice to not sure complicated regular expressions.  Lines in this file that
-    do not have `->` are ignored.
+    where the pattern is what is matched and replaced. While the pattern is compiled as a
+    regular expression, it is considered best practice to not use complicated regular expressions.
+    Lines in this file that do not have `->` are ignored.
     """
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))

--- a/dev_tools/notebooks/requirements-notebook-tests.txt
+++ b/dev_tools/notebooks/requirements-notebook-tests.txt
@@ -10,3 +10,5 @@ ipykernel==5.3.4
 
 # assumed to be part of colab
 seaborn~=0.11.1
+
+ipython~=7.22

--- a/dev_tools/notebooks/requirements-notebook-tests.txt
+++ b/dev_tools/notebooks/requirements-notebook-tests.txt
@@ -11,4 +11,4 @@ ipykernel==5.3.4
 # assumed to be part of colab
 seaborn~=0.11.1
 
-ipython~=7.22
+ipython==7.22

--- a/dev_tools/notebooks/requirements-notebook-tests.txt
+++ b/dev_tools/notebooks/requirements-notebook-tests.txt
@@ -8,6 +8,9 @@ notebook~=6.2.0
 # https://github.com/nteract/papermill/issues/519
 ipykernel==5.3.4
 
+# https://github.com/ipython/ipython/issues/12941
+ipython==7.22
+
 # assumed to be part of colab
 seaborn~=0.11.1
 

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -1,0 +1,106 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+import dev_tools.notebooks as dt
+
+
+def write_test_data(ipynb_txt, tst_txt):
+    directory = tempfile.mkdtemp()
+    ipynb_path = os.path.join(directory, 'test.ipynb')
+    with open(ipynb_path, 'w') as f:
+        f.write(ipynb_txt)
+
+    tst_path = os.path.join(directory, 'test.tst')
+    with open(tst_path, 'w') as f:
+        f.write(tst_txt)
+
+    return directory, ipynb_path
+
+
+def test_rewrite_notebook():
+    directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3')
+
+    descriptor, path = dt.rewrite_notebook(ipynb_path)
+
+    assert path != ipynb_path
+    with open(path, 'r') as f:
+        rewritten = f.read()
+        assert rewritten == 'd = 3\nd = 4'
+
+    os.close(descriptor)
+    shutil.rmtree(directory)
+
+
+def test_rewrite_notebook_multiple():
+    directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\nd = 4->d = 1')
+
+    descriptor, path = dt.rewrite_notebook(ipynb_path)
+
+    with open(path, 'r') as f:
+        rewritten = f.read()
+        assert rewritten == 'd = 3\nd = 1'
+
+    os.close(descriptor)
+    shutil.rmtree(directory)
+
+
+def test_rewrite_notebook_ignore_non_seperator_lines():
+    directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\n# comment')
+
+    descriptor, path = dt.rewrite_notebook(ipynb_path)
+
+    with open(path, 'r') as f:
+        rewritten = f.read()
+        assert rewritten == 'd = 3\nd = 4'
+
+    os.close(descriptor)
+    shutil.rmtree(directory)
+
+
+def test_rewrite_notebook_no_tst_file():
+    directory = tempfile.mkdtemp()
+    ipynb_path = os.path.join(directory, 'test.ipynb')
+    with open(ipynb_path, 'w') as f:
+        f.write('d = 5\nd = 4')
+
+    descriptor, path = dt.rewrite_notebook(ipynb_path)
+
+    assert descriptor is None
+    assert path == ipynb_path
+
+    shutil.rmtree(directory)
+
+
+def test_rewrite_notebook_extra_seperator():
+    directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3->d = 1')
+
+    with pytest.raises(AssertionError, match='only contain one'):
+        _ = dt.rewrite_notebook(ipynb_path)
+
+    shutil.rmtree(directory)
+
+
+def test_rewrite_notebook_unused_patterns():
+    directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 2->d = 3')
+
+    with pytest.raises(AssertionError, match='re.compile'):
+        _ = dt.rewrite_notebook(ipynb_path)
+
+    shutil.rmtree(directory)

--- a/docs/dev/notebooks.md
+++ b/docs/dev/notebooks.md
@@ -37,12 +37,15 @@ See the [`dev_tools/notebooks`](https://github.com/quantumlib/Cirq/tree/master/d
 - [notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/notebook_test.py) - to test notebooks against the current branch
 - [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/isolated_notebook_test.py) - to test notebooks against the latest released version of Cirq.
 
-In order to speed up the execution of these tests an auxiliary file may be supplied which performs substitutions on the notebook to make it faster.
+In order to speed up the execution of these tests an auxiliary file may be supplied which performs substitutions on the notebook to make it faster (for example it is often useful
+to reduce the number of repetitions in sampling from a simulator).
 
-Specifically for a notebook file notebook.ipynb, one can supply a file notebook.tst which contains the substitutes.
-The substitutions are provide in the form `pattern->replacement` where the pattern is what is matched and replaced.
+Tod do this, for a notebook file notebook.ipynb, one can supply a file notebook.tst which contains the substitutes.
+The substitutions are provide in the form `pattern->replacement` where the pattern is what is matched and will be replaced.
 While the pattern is compiled, it is considered best practice to not sure complicated regular expressions.
-Lines in this file that do not have `->` are ignored.
+Lines in this file that do not have `->` are ignored.  Note that because the pattern is
+compiled, it may be necessary to escape the pattern, however it is best to try to avoid
+such complicated expressions.
 
 
 ## Notebooks with external dependencies

--- a/docs/dev/notebooks.md
+++ b/docs/dev/notebooks.md
@@ -1,20 +1,20 @@
-# Notebooks guidelines 
+# Notebooks guidelines
 
-Our guides and tutorials are frequently written using iPython Notebooks. The notebooks require specific formatting, are continuously tested (when possible) and we have a specific process to manage the lifecycle of a notebook before and after a Cirq release.    
+Our guides and tutorials are frequently written using iPython Notebooks. The notebooks require specific formatting, are continuously tested (when possible) and we have a specific process to manage the lifecycle of a notebook before and after a Cirq release.
 
-## Formatting 
+## Formatting
 
 Formatting is easy, the script `check/nbformat` should tell you if your notebooks are formatted or not.
-You can apply the changes in one go with `check/nbformat --apply`. It is recommended to add this to your [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), to save feedback time and CI resources. 
+You can apply the changes in one go with `check/nbformat --apply`. It is recommended to add this to your [git pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks), to save feedback time and CI resources.
 
-## Output cells 
+## Output cells
 
 Output cells typically should not be saved in the notebook. They will be generated for the final site.
-The exception to this rule are notebooks with external dependencies ([see below](#notebooks-with-external-dependencies)). 
+The exception to this rule are notebooks with external dependencies ([see below](#notebooks-with-external-dependencies)).
 
 ## Header
 
-We also expect a standard header to be included in all of our notebooks: 
+We also expect a standard header to be included in all of our notebooks:
 - the links to colab, github and the main site ([quantumai.google/cirq](https://quantumai.google/cirq))
 - optional package installation (you can assume Colab dependencies exist)
 
@@ -30,33 +30,41 @@ You can use [our template notebook](https://storage.googleapis.com/tensorflow_do
 
 If you are placing a guide or a tutorial on the site, please make sure you add an entry to the right place in the nav tree in [docs/_book.yaml](https://github.com/quantumlib/Cirq/blob/master/docs/_book.yaml).
 
-## Testing 
+## Testing
 
-Those notebooks that don't have any external dependencies (e.g. API calls, authentication) are tested on a continuous basis. 
-See the [`dev_tools/notebooks`](https://github.com/quantumlib/Cirq/tree/master/dev_tools/notebooks) directory for the two tests: 
+Those notebooks that don't have any external dependencies (e.g. API calls, authentication) are tested on a continuous basis.
+See the [`dev_tools/notebooks`](https://github.com/quantumlib/Cirq/tree/master/dev_tools/notebooks) directory for the two tests:
 - [notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/notebook_test.py) - to test notebooks against the current branch
-- [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/isolated_notebook_test.py) - to test notebooks against the latest released version of Cirq
+- [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/isolated_notebook_test.py) - to test notebooks against the latest released version of Cirq.
 
-## Notebooks with external dependencies 
+In order to speed up the execution of these tests an auxiliary file may be supplied which performs substitutions on the notebook to make it faster.
 
-Unfortunately we have no easy way to test notebooks with external API dependencies, e.g. cirq.google's Engine API. 
-These notebooks should be excluded from both tests. 
+Specifically for a notebook file notebook.ipynb, one can supply a file notebook.tst which contains the substitutes.
+The substitutions are provide in the form `pattern->replacement` where the pattern is what is matched and replaced.
+While the pattern is compiled, it is considered best practice to not sure complicated regular expressions.
+Lines in this file that do not have `->` are ignored.
 
-The site that generates the outputs for notebooks also can't handle external dependencies. 
 
-Thus, for notebooks with external dependencies, **all cells must have their outputs saved in the notebook file**. This ensures that the site pipeline will skip these notebooks.  
+## Notebooks with external dependencies
 
-## Lifecycle 
+Unfortunately we have no easy way to test notebooks with external API dependencies, e.g. cirq.google's Engine API.
+These notebooks should be excluded from both tests.
 
-You should configure notebooks differently depending on whether they rely on features in the pre-release build of cirq or not. 
+The site that generates the outputs for notebooks also can't handle external dependencies.
+
+Thus, for notebooks with external dependencies, **all cells must have their outputs saved in the notebook file**. This ensures that the site pipeline will skip these notebooks.
+
+## Lifecycle
+
+You should configure notebooks differently depending on whether they rely on features in the pre-release build of cirq or not.
 
 ### Pre-release notebooks
 
-When you introduce a notebook that depends on pre-release features of Cirq, make sure to 
- 
- - mark the notebook at the top that `Note: this notebook relies on unreleased Cirq features. If you want to try these feature, make sure you install cirq via pip install cirq --pre`. 
- - use `pip install cirq —pre`  in the installation instructions 
- - make sure [notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/notebook_test.py) covers the notebook 
+When you introduce a notebook that depends on pre-release features of Cirq, make sure to
+
+ - mark the notebook at the top that `Note: this notebook relies on unreleased Cirq features. If you want to try these feature, make sure you install cirq via pip install cirq --pre`.
+ - use `pip install cirq —pre`  in the installation instructions
+ - make sure [notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/notebook_test.py) covers the notebook
  - exclude the notebook from the [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/isolated_notebook_test.py) by adding it to `NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES`
 
 ### Stable notebooks
@@ -64,17 +72,17 @@ When you introduce a notebook that depends on pre-release features of Cirq, make
 When you introduce a notebook that only uses already released features of Cirq, make sure to
  - use `pip install cirq` (NOT `pip install cirq --pre`)
  - ensure the notebook is not excluded from either [notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/notebook_test.py) or [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/isolated_notebook_test.py)  (except if the notebook has external dependencies, in which case you should exclude this from both!)
- 
-### Release 
 
-At release time, we change all the **pre-release notebooks** in bulk: 
+### Release
+
+At release time, we change all the **pre-release notebooks** in bulk:
  - remove the pre-release notices
  - change `pip install cirq —pre` to `pip install cirq`
  - remove the exclusions in [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/master/dev_tools/notebooks/isolated_notebook_test.py) by making `NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES=[]`
- 
-As all the notebooks have been tested continuously up to this point, the release notebook PR should pass without issues. 
 
-### Modifying stable notebooks 
- 
+As all the notebooks have been tested continuously up to this point, the release notebook PR should pass without issues.
+
+### Modifying stable notebooks
+
 Modifications to stable notebooks are tested with dev_tools/notebooks/isolated_notebook_test.py.
-However, a stable notebook will become a pre-release notebook if a modification introduces dependency on unreleased features. In this case, follow the pre-release notebook guidelines accordingly. 
+However, a stable notebook will become a pre-release notebook if a modification introduces dependency on unreleased features. In this case, follow the pre-release notebook guidelines accordingly.

--- a/docs/operators_and_observables.ipynb
+++ b/docs/operators_and_observables.ipynb
@@ -923,22 +923,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/docs/operators_and_observables.ipynb
+++ b/docs/operators_and_observables.ipynb
@@ -923,9 +923,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/operators_and_observables.tst
+++ b/docs/operators_and_observables.tst
@@ -14,6 +14,4 @@
 
 # Replacements to apply during testing. See devtools/notebook_test.py for syntax.
 
-num_rounds = 1000->num_rounds = 2
-N = 128->N = 4
-samples = 1000->samples = 2
+samples_per_term=10_000,samples_per_term=10

--- a/docs/qcvv/isolated_xeb.ipynb
+++ b/docs/qcvv/isolated_xeb.ipynb
@@ -131,7 +131,8 @@
    "outputs": [],
    "source": [
     "# We will truncate to these lengths\n",
-    "cycle_depths = np.arange(3, 100, 20)\n",
+    "max_depth = 100\n",
+    "cycle_depths = np.arange(3, max_depth, 20)\n",
     "cycle_depths"
    ]
   },
@@ -192,6 +193,7 @@
     "    sampler=sampler,\n",
     "    circuits=circuits,\n",
     "    cycle_depths=cycle_depths,\n",
+    "    repetitions=10_000,\n",
     ")\n",
     "sampled_df"
    ]
@@ -304,7 +306,8 @@
     "    options,\n",
     "    pool=pool,\n",
     "    # ease tolerance so it converges faster:\n",
-    "    fatol=5e-3, xatol=5e-3\n",
+    "    fatol=5e-3, \n",
+    "    xatol=5e-3\n",
     ")"
    ]
   },

--- a/docs/qcvv/isolated_xeb.tst
+++ b/docs/qcvv/isolated_xeb.tst
@@ -1,0 +1,9 @@
+# Replacements to apply to notebook when testing the notebook.
+# See devtools/notebook_test.py for syntax.
+
+n_library_circuits=20->n_library_circuits=1
+repetitions=10_000->repetitions=10
+max_depth = 100->max_depth = 10
+fatol=5e-3->fatol=100
+xatol=5e-3->xatol=100
+

--- a/docs/qcvv/parallel_xeb.ipynb
+++ b/docs/qcvv/parallel_xeb.ipynb
@@ -129,7 +129,8 @@
    "outputs": [],
    "source": [
     "# We will truncate to these lengths\n",
-    "cycle_depths = np.arange(3, 100, 20)\n",
+    "max_depth = 100\n",
+    "cycle_depths = np.arange(3, max_depth, 20)\n",
     "cycle_depths"
    ]
   },
@@ -262,6 +263,7 @@
     "    cycle_depths=cycle_depths,\n",
     "    combinations_by_layer=combs_by_layer,\n",
     "    shuffle=np.random.RandomState(52),\n",
+    "    repetitions=10_000,\n",
     ")\n",
     "sampled_df"
    ]
@@ -407,7 +409,8 @@
     "    options,\n",
     "    pool=pool,\n",
     "    # ease tolerance so it converges faster:\n",
-    "    fatol=1e-2, xatol=1e-2\n",
+    "    fatol=1e-2, \n",
+    "    xatol=1e-2\n",
     ")"
    ]
   },

--- a/docs/qcvv/parallel_xeb.tst
+++ b/docs/qcvv/parallel_xeb.tst
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+n_library_circuits=20->n_library_circuits=1
+max_depth = 100->max_depth = 12
+n_combinations=10->n_combinations=1
+repetitions=10_000->repetitions=10
+fatol=1e-2->fatol=10
+xatol=1e-2->xatol=10

--- a/docs/qcvv/xeb_coherent_noise.ipynb
+++ b/docs/qcvv/xeb_coherent_noise.ipynb
@@ -155,13 +155,14 @@
    "outputs": [],
    "source": [
     "# Make long circuits (which we will truncate)\n",
+    "n_circuits = 10\n",
     "circuits = [\n",
     "    rqcg.random_rotations_between_two_qubit_circuit(\n",
     "        q0, q1, \n",
     "        depth=100, \n",
     "        two_qubit_op_factory=lambda a, b, _: SQRT_ISWAP(a, b), \n",
     "        single_qubit_gates=SINGLE_QUBIT_GATES)\n",
-    "    for _ in range(10)\n",
+    "    for _ in range(n_circuits)\n",
     "]"
    ]
   },
@@ -174,7 +175,8 @@
    "outputs": [],
    "source": [
     "# We will truncate to these lengths\n",
-    "cycle_depths = np.arange(3, 100, 9)\n",
+    "max_depth = 100\n",
+    "cycle_depths = np.arange(3, max_depth, 9)\n",
     "cycle_depths"
    ]
   },
@@ -387,7 +389,14 @@
     "    characterize_zeta=False\n",
     ")\n",
     "p_circuits = [parameterize_circuit(circuit, options) for circuit in circuits]\n",
-    "res = characterize_phased_fsim_parameters_with_xeb(sampled_df, p_circuits, cycle_depths, options, pool=pool)"
+    "res = characterize_phased_fsim_parameters_with_xeb(\n",
+    "    sampled_df, \n",
+    "    p_circuits, \n",
+    "    cycle_depths, \n",
+    "    options, \n",
+    "    pool=pool,\n",
+    "    xatol=1e-3,\n",
+    "    fatol=1e-3)"
    ]
   },
   {

--- a/docs/qcvv/xeb_coherent_noise.tst
+++ b/docs/qcvv/xeb_coherent_noise.tst
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+n_circuits = 10->n_circuits = 2
+max_depth = 100->max_depth = 12
+repetitions=10_000->repetitions=100
+xatol=1e-3->xatol=10
+fatol=1e-3->fatol=10

--- a/docs/qcvv/xeb_theory.ipynb
+++ b/docs/qcvv/xeb_theory.ipynb
@@ -231,13 +231,14 @@
    "source": [
     "# Make long circuits (which we will truncate)\n",
     "MAX_DEPTH = 100\n",
+    "N_CIRCUITS = 10\n",
     "circuits = [\n",
     "    rqcg.random_rotations_between_two_qubit_circuit(\n",
     "        q0, q1, \n",
     "        depth=MAX_DEPTH, \n",
     "        two_qubit_op_factory=lambda a, b, _: SQRT_ISWAP(a, b), \n",
     "        single_qubit_gates=SINGLE_QUBIT_GATES)\n",
-    "    for _ in range(10)\n",
+    "    for _ in range(N_CIRCUITS)\n",
     "]"
    ]
   },

--- a/docs/qcvv/xeb_theory.tst
+++ b/docs/qcvv/xeb_theory.tst
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+MAX_DEPTH = 100->MAX_DEPTH = 12
+N_CIRCUITS = 10->N_CIRCUITS = 2
+repetitions=10_000->repetitions=100

--- a/docs/tutorials/educators/intro.ipynb
+++ b/docs/tutorials/educators/intro.ipynb
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "id": "RlJBDvNgC00H"
    },
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "id": "FTrmLyq4C2gf"
    },
@@ -249,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "id": "pE88WsFeDGfs"
    },
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "cellView": "form",
     "id": "6a5TEN5bKAPz"
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "cellView": "form",
     "id": "Q52e1pX_JIdi"
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "id": "YKfg575v1DQB"
    },
@@ -401,10 +401,8 @@
        "       [ 0.70710678+0.j, -0.70710678+0.j]])"
       ]
      },
-     "execution_count": 7,
-     "metadata": {
-      "tags": []
-     },
+     "execution_count": 6,
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -441,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "id": "hH-y4JiEMv25"
    },
@@ -504,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "id": "2Y6zG_peQG1y"
    },
@@ -585,7 +583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "id": "QFoV-eOE1tGN"
    },
@@ -603,10 +601,8 @@
        "b: ───X───@───X───"
       ]
      },
-     "execution_count": 10,
-     "metadata": {
-      "tags": []
-     },
+     "execution_count": 9,
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -641,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "cellView": "form",
     "id": "LbIZIMINEzD9"
@@ -653,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "cellView": "form",
     "id": "5oqmyccsE1kK"
@@ -729,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {
     "id": "wNek1WjpX4MR"
    },
@@ -797,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {
     "id": "qWVDhLxFYuRp"
    },
@@ -866,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {
     "cellView": "form",
     "id": "-HXXD801OFGF"
@@ -878,7 +874,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {
     "cellView": "form",
     "id": "jP4VkPeHcjJT"
@@ -935,7 +931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "id": "V6tZk3qGqBoH"
    },
@@ -983,7 +979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {
     "id": "KmGuMjvGw_Ef"
    },
@@ -993,7 +989,7 @@
      "output_type": "stream",
      "text": [
       "Measurement results:\n",
-      "a,b=0, 0\n"
+      "a,b=1, 0\n"
      ]
     }
    ],
@@ -1032,7 +1028,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {
     "id": "Apj7WiFZ0WFm"
    },
@@ -1119,7 +1115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {
     "id": "QxkmBlo21lrQ"
    },
@@ -1128,7 +1124,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Counter({0: 263, 2: 252, 1: 247, 3: 238})\n"
+      "Counter({2: 265, 0: 250, 3: 247, 1: 238})\n"
      ]
     }
    ],
@@ -1158,7 +1154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {
     "id": "rPqVUsD9snYf"
    },
@@ -1167,7 +1163,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Counter({'agree': 501, 'disagree': 499})\n"
+      "Counter({'disagree': 503, 'agree': 497})\n"
      ]
     }
    ],
@@ -1272,7 +1268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {
     "id": "YtWiBHonly69"
    },
@@ -1334,7 +1330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {
     "id": "aMHzLxztj-gq"
    },
@@ -1394,7 +1390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {
     "id": "ImffrBgJvLme"
    },
@@ -1451,7 +1447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {
     "id": "V5ZCXGCrxl4k"
    },
@@ -1491,7 +1487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {
     "cellView": "form",
     "id": "qJP_e68e1JBs"
@@ -1520,7 +1516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {
     "id": "81da6ec6fc5a"
    },
@@ -1561,7 +1557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "metadata": {
     "cellView": "form",
     "id": "mUvm9rmRFb4p"
@@ -1598,7 +1594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {
     "id": "c1b1e989dab2"
    },
@@ -1663,7 +1659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {
     "id": "iIpoDaqK4yjV"
    },
@@ -1721,7 +1717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {
     "id": "7SUAT5F17afR"
    },
@@ -1767,21 +1763,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {
     "id": "UgoNBN1H8B6h"
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEDCAYAAAA2k7/eAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO2dfVxUZdrHfwMMAoIiBqZDZlkpARb4sqam5qKEmuFLSiupu5a12YuJkbomluJrurtk++w+5larrJLEErlt9KQ+bSViIagQ2qN+JBxdhQCVN2HwPH/QjAycM4cZ5sycc9/X9/PxI3OGOXPd1/07F+fc93Vft04QBAEEQRAE83i42wCCIAjCNVDAJwiC4AQK+ARBEJxAAZ8gCIITKOATBEFwAgV8giAITvBytwG2KCgocLcJBEEQmmTo0KEdjqk64APiRneG0tJShIWFOdmarkN22Y9abSO77EOtdgHqtc1Ru6RulmlIhyAIghMo4BMEQXACBXyCIAhOoIBPEATBCYoG/B9++AExMTHYvXt3h/cOHz6MWbNmYc6cOXjnnXeUNIMgCIKAglk69fX1WLt2LR566CHR99etW4edO3eiT58+SExMRGxsLO65554uf292oRFbck/jYk0D+gVewquxgxAfZejyeQm+yS40Yk1OCWoamgEAHjrgpgAYSGOEk2ivsV5+ejw9NBDOTB5SLOB7e3tjx44d2LFjR4f3ysvL0bNnT/Tt2xcAMG7cOOTl5XU54GcXGrEi6yQamlsAAMaaBizJKMKSjCIYAn3pwiTsov0F2JabPxcVJ40RXcGWxqrrm/H7bypg6Gd0mqYUG9Lx8vKCj4+P6HsVFRUICgqyvA4KCkJFRUWXv3NL7mlLsG+PsaYBK7JOIrvQ2OXvIdgnu9CIV/cdF70QpSCNEfbQGY2ZbrbGNWeh+oVXpaWlnf7dizUNNt9vaG7B0g+LYLxoxIS7A7pqmkM0Njba1SZXoVa7ANfbdvDcdWz9usJyF28PDc0teP0fxzHI55rzDeskau1LtdoFqFtjF2sanGabWwJ+SEgIKisrLa8vX76MkJAQ0d+1Z5VZv8BLMMoE/ZsCsP1IFQz9DG559GZtRZ8rcKVt2YVGbD9S5lCwN3O9ScDpxh5uG9pRa1+q1S5A3RrrF+hrt22qWmkbGhqK2tpaXLhwASaTCYcOHcLo0aO7fN5XYwdB14nfa2huwZqcki5/H8Eeb3xSIjksaA9JHx6noR1CFHs05uXRGtechWJ3+MXFxdi0aROMRiO8vLyQm5uLCRMmIDQ0FBMnTsSaNWuQlJQEAJg8eTLuuuuuLn9nfJQB35VVIf3Ij5D741nT0IzsQudNhhDaJ7vQiOr6zo/Z26JFELAi6yQAkMYIC/ZozJyl40z9KBbwIyIisGvXLsn3hw8fjoyMDKd/77r4SAy7Mwjr9xfjSp3J5u8mfXgcAF2QROuFaNaDFL389Eh5LBzxUQZkFxplNdbQ3EIaIyzYqzHAvjnMzqD6SVtHiI8yYJDPNYSFhSG70IglGUWiv0d3YQRwK523RZB+LvzDnAetNGLW2OnGHlapwO0hjRGAYxpTAuZLK8RHGdDLTy/5Po3nE3JjqoG+eskLMT7KgA0zIuGpk549Io0RXdGYM2E+4ANAymPh8NV7Sr5vHs8n+ENuTNVX74k108JtniM+yoCtsx8gjRGiOENjzoKLgN+ZuzBnLm4gtIOtfvfU6bBhRmSn7rxIY4QUztKYM+Ai4AO37sKkMNY00B0YZ2QXGm2u29g6+wG7LkTSGNEeZ2usq3AT8AH58XxaFs8P5kk0KRwdUyWNEWaU0lhX4CrgA7bH8xuaW+ixmxNs1V3q6pgqaYwAlNWYozCZlmkL819UqVRNudIMBBvY6ueujqmSxghAWY05Cnd3+EDrBWkI9BV9TwfQIzfjZBcaJUtwGAJ9nXIhksb4xhUacwQuAz4gXXdHAGVTsM6W3NOipTd0cG7dEtIYv7hKY/bCbcCPjzJI1tuRK7NMaBup/hXg3NWwpDF+cZXG7IXbgA9A8pHbQ6ejR25GyS40wkMiV15KD12BNMYfrtaYPXAd8F+NHSSaTWGuf0IXJFvYqmfiq/dU5FGbNMYX7tCYPXAd8G2tjqT0OfaQSpNTcrUjaYwv3KExe+A64AOtF+RNiQp2lD7HFlL9eVMQFL0QSWN8YGtVrdIa6yzcB3ygdQsxMSh9jh1spclJ9b8zIY2xjdyqWldorDNQwAelz/GAu9PkSGNsI7eq1t1j92Yo4IPS53jA3WlypDG2sdWHahi7N0MB/2ek0qXU8ihGdA2pfnRlmhxpjF1s6UstwR6ggG9BKn2uvslEY6waJ7vQiLobHfeedfWjNmmMXR4ZHNxhyE5NQzlmuCueJoX5r/CanBLUNNzanaa6vpn2JNUw5sm09uOr7TeLdgWkMTbJLjTiowKj1ZCdDsDMoQbV9Sfd4bchPsqA7t06/g2kfGntIjWZ5uft5ZaLkTTGHmIaEwAcOlXhHoNsQAG/HVKTLzSxpk3U2J9qtIlwHC31JwX8dkhNvvT0ld7FiFAntmqauHOilDTGDmrVmBQU8Nvxauwg6D06dmAdTaxpCjXXNCGNsYGaNSYFBfx2xEcZ4O/TcYy1uUWgMVYNoeaaJqQxNlCzxqSggC9CTX2z6HE1jskR4kj1lVpqmpDGtI/aNSYGBXwRpMbe1DgmR4ij9j5Uu32EPFrsQwr4ItACGe2j9oUwpDHto3aNiUEBXwRzDfPAdlkT5gUydEGqGy0shCGNaRstaEwMCvgS0AIZ7aKVhTCkMe2iFY21R9HSCuvXr8fx48eh0+mwcuVKDBkyxPJeeno6cnJy4OHhgYiICPzud79T0hSH0NKCCuIWWuo3LdlK3EKr/abYHf7Ro0dRVlaGjIwMpKamIjU11fJebW0tdu7cifT0dOzZswdnz55FUVGRUqY4DC2Q0R5aWwhDGtMeWtNYWxQL+Hl5eYiJiQEADBw4EFevXkVtbS0AQK/XQ6/Xo76+HiaTCQ0NDejZs6dSpjgMLZDRFlpcCEMa0xZa1FhbFBvSqaysRHh4uOV1UFAQKioq4O/vj27dumHx4sWIiYlBt27dMGXKFNx1112i5yktLXXo+xsbGx3+rJlBPoCvXofmG9ad29wiYP3+YgzyueYWu5RArXYBnbdt/f4fRRfCeOiAF0YGYZDPNZSW2t9nXbXLFqQxdcCyxtrisvLIQpu/iLW1tfjLX/6Czz77DP7+/pg/fz5OnTqFwYMHd/hcWFiYQ99XWlrq8Gfbcv3GOdHjFXUmh87vLLucjVrtAjpvW0WdeF8JArB4yghnm0UasxO12gWwp7GCggLR44oN6YSEhKCystLy+sqVKwgODgYAnD17FnfccQeCgoLg7e2NYcOGobi4WClTuoQWF1fwilb7Sqt284jW+6pTAf8///kPvvvuOwBAU1NTp048evRo5ObmAgBKSkoQEhICf39/AIDBYMDZs2fR2NgIACguLsaAAQPstd0liC2Q0cJYHY9ota+0ajePaL2vZId03n//fXz22Weor69HTk4OtmzZguDgYCxatMjm56KjoxEeHo6EhATodDqkpKQgKysLAQEBmDhxIhYuXIh58+bB09MTUVFRGDZsmNMa5UzMiyi25J6GsaYBnjqdVZ60mhdZ8Eg3Lw/LGKs7drVyBNKYttCixszIBvwvvvgCe/fuxVNPPQUAWLlyJRISEmQDPgAsW7bM6nXbMfqEhAQkJCTYa69bMHdm263yjDUNtC2dihDbyrCx+aYbLbIP0pj60brGgE4M6bS0tDZO93Pe6Y0bN2AyddwQmnXEVtbRikj1wEL/sNAGlmGhf2Tv8KdOnYp58+ahrKwMKSkpyM/Px/z5811hm6rQ6so6XmChf1hoA8uw0D+yAX/OnDkYN24cTpw4AW9vbzz33HPw9dXGjLQz6RfoC6NIx2pldp51WOgfFtrAMiz0j+SQjslkQn19PRYsWIDbbrsNjzzyCEaPHo2AgADLeD5PiM3O69BaIpVwL9mFRtTd6DjMqKXsCYA0pmZY0ZjkHf6///1vvPfeezhx4gSmTJliWTjl4eGBESOcv8BA7cRHGfBdWRXSj/xoKYkqAPiowIhhdwbRpJqbEJtIA7SXPQGQxtQKSxqTDPgTJkzAhAkT8PHHH+Pxxx+3eu/w4cOKG6ZGDp2qQPsKGuZJGy11OktI7Svq5+2lyT4hjakPljQmO4YfHR2NTZs2oaamBgDQ3NyMb7/9Fl9++aXixqkNFiZtWIO1PmGtPSzAUp/IpmUuX74c99xzD0pKSjB+/Hh4eHjgzTffdIVtqkPry6pZhLU+Ya09LMBSn8gGfC8vL8ycORM9evRAbGwsNm/ejN27d7vCNtVB+5CqDy3uK2oL0pj6YEljskM6giDg6NGjCAwMREZGBvr3748LFy64wjbVYR6vW5NTgpqGZstx8z6kbX+HUB6t7itqC9KYumBNY7J3+Fu2bIGvry9WrVqFoqIifPDBB1i+fLkrbFMltA+petDqvqJykMbUA2sakw34H330ESIjI3H77bdjw4YN+POf/4y8vDxX2KZaWJrE0TIs9wPLbdMSrPWD5JDO559/jv379+O7777D6dO37ipMJhNKS0u5vstnYcUdC7DcDyy3TUuw1g+Sd/iTJk1CcnIyIiMjMXfuXMu/X//618jMzHSljapD6zWxWYHlfmC5bVqCtX6wOaQTGhqKlJQU+Pj4YMSIEbh06RJyc3MtOfm8Eh9lwIYZkQj01VuO+egV2zyMECG70GgZX/X8uZKrIdAXG2ZEanIyrT2kMffDosZkFZScnAy9Xo+ioiJ89NFHePTRR5GamuoK21TPDdOtWtjmLApKnVMe81J386N2iyBY7rq0eiFKQRpzD6xqTDbge3p6IiwsDLm5uZg/fz6GDh3KZT389rBQG1ur8OJ7XtqpRlj1fac2QPmv//ovHDx4EGPGjMGJEydQX1/vCttUDWuz91qCF9/z0k41wqrvO52Hv337dnTr1g0XLlzAG2+84QrbVA1Ly621Bi++56WdaoRV38sG/L59+2LBggW49957AQCTJ0/G/fffr7hhaoe12XstwYvveWmnGmHV97KlFQhxzBM3W3JPw1jTAE+dzmqMT8sTO1qgm5eHZYxVi3XJOwNpzL2wqDHK8+oC8VEGy51Ay88bxBhrGiiTQkHM2RNt68w0Nt+08QltQxpzPSxrTPIOf8WKFTY/uGHDBqcbo0VszeZr/W5AjfDobx7b7E5Y9rdkwI+NjQUAHDx40LKtoSAIyM/Ph7e3t8sMVDuszuarFR79zWOb3QnL/pYM+OPHjwcAfPDBB3jvvfcsx6dMmYJnn31WccO0Amu1NtQOj/7msc3uhGV/y47h19TU4NChQ6iursbVq1fx9ddf4z//+Y8rbNMErM7mqxUe/c1jm90Jy/6WzdLZtGkT/vSnP2Hbtm0QBAF33303jd+3gTIpXEf72iYtggBDoK/ml7vLIbYpCtXVUQbWNSYb8O+77z6sW7cO165dgyAI0Onab/ZFmIWwIuukZbLHnEnR9n3CccyZE2b/slLbxB7E6uoApC9nwYPGZAP+qlWr8O9//xshISEAYAn6vJdIbg/LM/tqgHf/8t5+V8CDj2UD/vfff48vv/yS7uxlYHlmXw3w7l/e2+8KePCx7EDg4MGDUV1d7dDJ169fjzlz5iAhIQEnTpyweu/SpUt48sknMWvWLKxevdqh86sJVmtvqAXe/ct7+10BDz6WDfjl5eWIiYnB9OnTMWvWLMycOROzZs2SPfHRo0dRVlaGjIwMpKamdqihv3HjRvzmN79BZmYmPD09cfHiRcdboQJYntlXA7z7l/f2uwIefCw7pLNx40aHTpyXl4eYmBgAwMCBA3H16lXU1tbC398fN2/eREFBAbZt2wYASElJceg71ARlUigPi7VNOgtlg7kG1jUmG/C3b98uelwuNbOyshLh4eGW10FBQaioqIC/vz+qqqrQvXt3bNiwASUlJRg2bBiSkpLsNF2dUCaF8zl47jq2HymzmlBjpbaJPVA2mHLwojHZgG8usQAAJpMJBQUF0Ov1Nj4hjvBz4Sfzz5cvX8a8efNgMBiwaNEi/O///q9ldW9bSktL7f4uAGhsbHT4s46yfv+PorP86/cXY5DPNbfZ1RnUahcAvF9QJetXd0Aasw+12gXwozHZgN8+CMfExOCZZ56RPXFISAgqKystr69cuYLg4GAAQK9evdCvXz/0798fAPDQQw/h//7v/0QDflhYmOx3iVFaWurwZx2lou6cxHGTxRZ32NUZ1GoXAFTWy/vVHZDG7EOtdgHsaaygoED0uOwg85dffmn1b9++fSgvL5f9wtGjRyM3NxcAUFJSgpCQEPj7+wMAvLy8cMcdd+D8+fOW9++6667OtkW18DDL7w6Cu4vfl/DoV9KYMvCiMdk7/M8++8zqtb+/P9566y3ZE0dHRyM8PBwJCQnQ6XRISUlBVlYWAgICMHHiRKxcuRLLly+HIAi47777MGHCBMdboRJejR1kNb4KsDfL7w7mR/fC9iNV5FeQxpSCF43JBvwNGzagvLwcp06dgoeHB+6//3707du3UydftmyZ1evBgwdbfr7zzjuxZ88eO81VN5RJ4XyyC4344Fg1s7VN7IU05nx40phswH/33Xfx6aefIjo6Gk1NTdi+fTueeOIJ/OpXv3KFfZpDLpNikI/bTNMcPNQ2cQTSmPPgTWOyY/hffPEF9u3bh1WrVuHNN9/Evn37kJOT4wrbNIutmhxE5yE/SkO+cQ68+bFTK4M8PDysfqa6OrbhoSaHKyA/SkO+cQ68+VF2SCcuLg4zZ87EAw88AEEQUFRUhNmzZ7vCNs3C8o45roT8KA35xjnw5kfZO/y4uDikpaVh1KhRGDNmDN555x0av5eBh5ocroD8KA35xjnw5kfZO/ylS5di9+7dCA0NdYU9TEB1dZwH67VNHIU05jx40phswA8ODkZCQgIiIyOtSiokJycrahgLiNXVeWFkEFS62FBVtM+eANisbdJVSGOOw6PGZAP+2LFjXWEHc0jN/n9wrBqLp7jJKA3Bw+5DXYU01jV41FinngF1Op3VP09PTxQVFSltm6aRmuWvqDO52BJtwlv2hCOQxroGjxqTvcM/cuQIvvvuO4waNQpA68YmERERqKmpwYABA/D6668rbqQWkZr9l6rZQVjDW/aEI5DGugaPGpO9w6+pqcH+/fuxdu1arF27Fh9//DGampqwc+dO1ZY6VQNSs//zo3u5ySJtwVv2hCOQxroGjxqTvRW4ePEiGhoa4Ovb+levubkZ58+fx7Vr11BfX6+4gVqlbc2TizUN6PdzbQ531tbWElL+Y3Vs1RFIY12DR43JBvyFCxdi+vTpCAgIgE6nQ01NDX77298iLy8PCxYscIGJ2iU+yoD4KAOyC43Yknsar2QUIbi7F1ZO7cG0qLqK2V/mi3DZw8FYPGWEu81SJaQxx+BVY7IBPz4+Ho8//jiqq6shCAICAwPh6ekp9zHiZ9qnfl2pM9GWdDZo7y9jTQPSDjfC0M9I/pKANGYfPGus01k6QUFB6N27NwV7O+GtOFNXEfPXjRaB/GUD0ph98KwxWpqnMDymfnUF8pf9kM/sg2d/SQb83//+91b/E45BW9LZB/nLfshn9sGzvyTH8A8cOICzZ8/i2LFjlr1n2/LHP/5RSbuYgbaksw8xf3Xz1JG/bEAasw+eNSYZ8Hft2oUzZ87g4sWLmDt3rittYgoqcmU/7YtZPT00kPnJtK5AGrMfXjUmqYpevXph+PDhyMrKAgB8//33OHXqFLy8vDBiBPvpS85GrMhVdqHRjRapD3P2hDloAewXs3ImpDF5eNeY7G3A+vXr8de//hWCIKCxsRF/+tOfaFzfTiiLonPYKgZG2IY01jl415hsHn5JSQnS09MtrxctWoTExERFjWINnrMC7IGKgTkOaaxz8K4x2Tt8k8mExsZGy+v6+nq0tLTY+ATRHp6zAuxByh9UDEwe0ljn4F1jsgF//vz5mDZtGhYtWoSnn34a8fHxWLhwoStsYwYeizQ5AhUDcxzSWOfgXWOyf9YmT56M8ePH4/z589DpdBgwYIClkBrROdoWaTLWNMBTp7MaX+UhO0AOc22ThuYWeOp0aBEEGKgYWKchjclDGuvkSls/Pz/cf//9CAsLo2DvIPFRBrwaOwjdPFuFBrTW8KBMiluZE+ba5C2CYLk7pUDVeUhj0pDGWqFkXReyJfc0brQIVscok4IyTJwJaUwc0lgrsgF/9+7dqKqqcoUtzEOZFOKQX5wH+VIc8ksrsgG/trYWzz//PJ555hlkZ2fTpiddgDIpxCG/OA/ypTjkl1ZkA/5zzz2HvXv3IjU1FTdu3MAzzzyDpUuX4ujRo66wjynM46ttoUwKyjBxJqQxcUhjrXRqDP/y5cv49NNP8cknnyAwMBDjx49HVlYWUlNTlbaPKeKjDHhp1G0I9NVbjlHNk1a6ed3yQy8/PTbMiORqMs1ZkMY60j47BwAMgb5cakw2LXPu3Llobm7GtGnTkJaWhqCgIADAtGnTMGfOHJufXb9+PY4fPw6dToeVK1diyJAhHX5n69atKCoqwq5duxxsgvYQq3kC8Jk61373IYCv2iZKQRprpb2+eM3OMSP7pz82NhYffvghEhMTLcF+//79AGAzSB89ehRlZWXIyMhAamqq6NPAmTNn8O233zpquyb54Fg1ZQu0gbInnA9p7BakL2sk7/BPnDiBkydPIj093WpbQ5PJhJ07d2Lq1Knw9vaWPHFeXh5iYmIAAAMHDsTVq1dRW1sLf39/y+9s3LgRr7zyCrZv3+6MtmgCqZodvGULmKHsCedDGrsF6csayYAfHBwMPz8/NDc3o7r6ViU5nU6HjRs3yp64srIS4eHhltdBQUGoqKiwBPysrCyMGDECBoPtx6rS0lLZ7xKjsbHR4c8qyW1+nqio71iLKLi7l1vtdZe/grt74YpIgGrrD7X2pVrtIo3dojP6AtTbl862SzLg9+7dG9OnT8eoUaPQo0ePLn+RINxaDFJTU4OsrCy89957uHz5ss3PhYWFOfR9paWlDn9WSRYMvY7tR6o67E60cmoEwsLcN6boLn+tnNpDdLemtv5Qa1+q1S7S2C06oy932dYZHLWroKBA9LhkwF+xYgW2bt2KJ598EjqdDoIgWP1/4MABm18YEhKCyspKy+srV64gODgYAHDkyBFUVVVh7ty5aGpqwo8//oj169dj5cqVdjdMa0y4OwCGfgaqeQLbtU148oOzIY1Z0353q5THwrnzgRnJgL9161YAwMGDBx068ejRo/H2228jISEBJSUlCAkJsQznPProo3j00UcBABcuXMCKFSu4CPZmzGJre+dhrnnS9n2WoewJZSGNUQaYGJIBf+bMmdDpdFJvIzMz0+aJo6OjER4ejoSEBOh0OqSkpCArKwsBAQGYOHGi4xYzgq3sAR4uRt7b7wp49zHv7RdDMuCnpaV1+eTLli2zej148OAOvxMaGspVDr4Z3rMHeG+/K+Ddx7y3XwzJgP/VV18hISEBmzZtEr3TT05OVtQw1ukX6Gsp1dr+OA/w3n5XwLuPeW+/GJILr8zpkvfddx/uvffeDv+IrsF7bQ/e2+8KePcx7+0XQzLgP/zwwwCAiRMnoq6uDiUlJSgpKUFjYyMmTZrkMgNZJT7KgA0zIrmseUK1TVwDaYw01h7Z3l+8eDEuXryIoUOHYujQoSgrK8OLL77oCtu4QKzmCcu7E9HOQ66HNEYaMyMb8E0mE5KTkxEXF4e4uDgsX77cahEV4Tg81vngsc3uhEd/89jmziI5advQ0PrXcdiwYfjXv/6FX/ziFwBaV3ANHz7cNdYxDo9ZBDy22Z3w6G8e29xZJAP+lClTLCtrP/nkE6v3dDodnn/+ecWNYx0eswh4bLM74dHfPLa5s0gGfFsrbLOyshQxhjdejR0kWueD5SwCHtvsTnj0N49t7iyyG6CcPHkSO3bsQE1NDQCgubkZlZWVmDFjhuLGsY55Aom3midU28R1kMZIY22RnbRdt24dfvWrX6G+vh7JyckYMWIEV3VvlCY+ymDJF275eTLcXPOEtUwKc/ZETUOz5RjvtU1cAWmMNGZGNuD7+Phg5MiR8Pb2RkREBF555RXs3r3bFbZxAy9ZBby0U43w4nte2ukoskM6vr6+OHDgAEJDQ7Ft2zbccccduHTpkits4wZesgp4aaca4cX3vLTTUWTv8N966y3cc889WL16Nby9vXH69Gls2rTJFbZxg1T2AGtZBby0U43w4nte2ukonVpn/fXXX+MPf/gDampqMHDgQNx9991K28UVvNT84KWdaoQX3/PSTkfpVGmFCxcuUGkFBeGh5gnVNnEvpDHSGNCJMXyTyYTXXnvN8jouLg6//vWvFTWKV8RqngDaT52j3a3UA2mMbyT/xDc0NKChocFSWqGqqgpVVVX4n//5HyqtoAAsZxew3DYtwXI/sNw2Z0KlFVQCy9kFLLdNS7DcDyy3zZl0urTC1atX4eHhgYCAAMWN4hGW63+w3DYtwXI/sNw2ZyI7a3P48GHExsbiqaeewuzZszFlyhQUFBS4wjauEMsuAID6JpPmV0M+MjgY7TfJpMwJ10MaI2QnbdPS0rBr1y6EhIQAAC5duoSkpCT8/e9/V9w4njBPLK3JKbFaFq71ibXsQiM+KjCi7Q4KOgAzhxo02R4tQxojZO/w9Xq9JdgDQN++feHlJft3gnCA+CgDunfr6FstTz6JTaYJAA6dqnCPQZxDGuMb2cgdGhqKN954AyNGjIAgCMjPz0f//v1dYRuXsDb5xFp7WIC1PmGtPUoiG/DXrl2L/fv3o6CgADqdDkOHDsWUKVNcYRuXsDb5xFp7WIC1PmGtPUoiO6SzdOlSxMfHY9WqVfjd736HadOmwdOz48QP4RxYWxrOWntYgLU+Ya09SiJ7hx8YGIht27ZhyJAh0OtvLcseN26coobxitjEmlaXwLdf6t4iCDAE+tLqRzdDGuMX2YDf3NyMiooKHDhwwOo4BXxl0foSeFrqrn5IY/xhM+A3NTXhhXS8hM8AABGaSURBVBdeQN++feHhoc07AC1ia5m4VoTMQhtYhoX+YaENrkYyin/xxRd49NFHkZSUhLi4OJw4ccKVdnENC1kHLLSBZVjoHxba4GokA/67776Lf/zjH9i7dy927tyJtLQ0V9rFNSxs4sBCG1iGhf5hoQ2uRjLg6/V69OzZE0BrLv6NGzfsPvn69esxZ84cJCQkdHhCOHLkCGbPno2EhASsWLECN2/SRsNmWFgCT0vd1Q1pjE8kA75Op7P5Wo6jR4+irKwMGRkZSE1NRWpqqtX7q1evRlpaGvbu3Yu6ujp89dVXdp2fZcQ2qwBuTayp/YKkpe7qhzTGJ5IBv7i4GLNmzcKsWbMwc+ZMy+uZM2di1qxZsifOy8tDTEwMAGDgwIG4evUqamtrLe9nZWXh9ttvBwAEBQWhurq6q21hCi0vgael7tqANMYfklk67Wvg20tlZSXCw8Mtr4OCglBRUQF/f38AsPx/5coVfPPNN3j55Ze79H0sotVJKa3azSNa7Sut2u1uJAO+weDcxyJBEDoc++mnn/Dcc88hJSUFvXr1Ev1caWmpQ9/X2Njo8GeVxB67grt74UqdSfS4s9vmTH85224W+tKVkMZIY1IoVvYyJCQElZWVltdXrlxBcHCw5XVtbS2eeeYZLFmyBGPGjJE8T1hYmEPfX1pa6vBnlcQeu1ZO7WG1sARoHaecFNnP6W1zlr+yC41outlxvsdX74mVUyMQFmb/jQQLfelKSGOkMak9SxRbTTV69Gjk5uYCAEpKShASEmIZxgGAjRs3Yv78+Rg7dqxSJmie+CgDZg41WGUiCAA+KjCqclLNvPKxba11AOjlp8eGGZE0maZCSGN8odgdfnR0NMLDw5GQkACdToeUlBRkZWUhICAAY8aMQXZ2NsrKypCZmQkAmDp1KubMmaOUOZrl0KkKtB8MU+tqQrGJNADw8/ZSna3ELUhj/KDoTibLli2zej148GDLz8XFxUp+NTNoaXJKS7YSt9BSv2nJVjVCBXJUjtSqQQ+dTnWP3IF+etHjtPJR3ZDG+IECvsqRWhHZIgiqWiCTXWhEbWPHrAm9p45WPqoc0hg/UMBXOeYVkZ4iK53VtEBmS+5pNN/smHrbncZWVQ9pjB8o4GuA+CgDboqsYwDUM3YpZcfVdtkUhDohjfEBBXyNoPbKgGq3j5BH7X2odvu0AAV8jaDm6obZhUbU3eg4tkqVC7WFmMZ0aK1K6W5IY86BAr5GUGt1Q1oIww5qXYRFGnMeFPA1hBqrG9JCGLawtQjLXZDGnAcFfI2htoUnarOH6Bpq7E812qRVKOBrDKkJqp6+4gtSlIYWwrCFGhdhkcacBwV8jfFq7CDoPTrmS9e5YfKWFsKwh9oWYZHGnAsFfI0RH2WAv0/HcfzmFsHl46y0EIY91LYIizTmXCjga5CaevGFJq4e06SFMGyipkVYpDHnQgFfg6hhnDW70AgPiY3taWxV+5DG2IQCvgZx9zirOS+6ReQukBbCsAFpjE0o4GsQd4+zSuVFe+p0tBCGEUhjbEIBX6PYGmc1KjzOKnX+m4JAFyJDkMbYgwK+hpEax9QBij1yZxcaIT6qSuOqLEIaYwsK+Brm1dhBoheGACj2yL0l93SHpfdAawCgcVX2II2xBQV8DRMfZRC9MIDWR2Jn34FlFxolH7WFn+0h2II0xhYU8DWOwcYjrjOzKcxZE47YQWgb0hg7UMDXOFLpc4BzsymksiYASpNjHdIYO3Rco09oCvMj7pKMItH3nZVNYes8lCbHNqQxdqA7fAaIjzJIPu46I5vCVtaEIdCXLkQOII2xAQV8RrCVTZH04XGHL8jsQiOSPjxOWRMEaYwBKOAzgq1sCkeXw9ta3g5Q1gRvkMa0DwV8hrCVxeDI5JqtSTS57yPYhDSmbSjgM4StbArA/sk1W79PWRN84kyN2cq5B0hjSkABnyFsFbwyE/Xm57KP3dmFRjz4xueS71MBK35xlsZWZZ/EKxJZPwBpTCkoLZMxzBfIKxlFouOt1fXNlsUtYheTeUxV6jFbB2Dr7AfoQuQYZ2gs/ciPkvMBvnpPCvYKQXf4DGJrcg1oHWtdk1PS4bg5W8LWmCpNohFA1zVm67MU7JVD0Tv89evX4/jx49DpdFi5ciWGDBliee/w4cPYtm0bPD09MXbsWCxevFhJU7jDEOhrc3y0pqEZA5b/06HzEgSgjMYo515ZFLvDP3r0KMrKypCRkYHU1FSkpqZavb9u3Tq8/fbb2LNnD7755hucOXNGKVO4RG5yzRFoEo1oi7M1Rjn3yqNYwM/Ly0NMTAwAYODAgbh69Spqa2sBAOXl5ejZsyf69u0LDw8PjBs3Dnl5eUqZwiXmybVAX71TztfLT0+P2oQVztSYDsDckf1JXwqj2JBOZWUlwsPDLa+DgoJQUVEBf39/VFRUICgoyOq98vJy0fOUlpY69P2NjY0Of1ZJXGnXIB9gz+w7MGfveVy7cdOhc3jogKQxwZhwdwCAaygtveZcIzsB9aV9aFdjXm7zJy996bIsHUFiJZ0cYWFhDn2utLTU4c8qiTvsejO+h83MGyl0ALbNftDtd13Ul/ZBGrMf1vqyoKBA9LhiQzohISGorKy0vL5y5QqCg4NF37t8+TJCQkKUMoV7HHn0pkdswh5IY9pAsYA/evRo5ObmAgBKSkoQEhICf39/AEBoaChqa2tx4cIFmEwmHDp0CKNHj1bKFAKtF2RRyiT8Yc6Dkhelx89raQyBvvj9nAexLj7ShRYSWoc0pn4UG9KJjo5GeHg4EhISoNPpkJKSgqysLAQEBGDixIlYs2YNkpKSAACTJ0/GXXfdpZQpRBviowyid1RqfaQltAdpTL0oOoa/bNkyq9eDBw+2/Dx8+HBkZGQo+fUEQRBEG2ilLUEQBCdQwCcIguAECvgEQRCcQAGfIAiCE3SCoyuiXIDU4gGCIAjCNkOHDu1wTNUBnyAIgnAeNKRDEATBCRTwCYIgOIG5LQ5tbbriDjZv3oyCggKYTCY8++yzOHjwIEpKShAYGAgAWLhwIcaPH+9Sm/Lz8/Hyyy/j3nvvBQDcd999ePrpp5GcnIyWlhYEBwdjy5Yt8Pb2dqldALBv3z7k5ORYXhcXFyMiIgL19fXw8/MDALz22muIiIhwiT0//PADnn/+eSxYsACJiYm4dOmSqJ9ycnLwwQcfwMPDA7Nnz8YTTzzhcrtWrFgBk8kELy8vbNmyBcHBwQgPD0d0dLTlc++//z48PZ27T4KcbcuXLxfVvLt99tJLL6G6uhoAUFNTgwcffBDPPvssHnvsMYu+evXqhbS0NEXtah8jIiMjldOYwBD5+fnCokWLBEEQhDNnzgizZ892qz15eXnC008/LQiCIFRVVQnjxo0TXnvtNeHgwYNutevIkSPCiy++aHVs+fLlwqeffioIgiBs3bpVSE9Pd4dpVuTn5wtr1qwREhMThdOnT7v8++vq6oTExERh1apVwq5duwRBEPdTXV2dMGnSJOHatWtCQ0ODMGXKFKG6utqldiUnJwv//Oc/BUEQhN27dwubNm0SBEEQRowYoZgdnbVNTPNq8Flbli9fLhw/flwoLy8Xpk+frpgd7RGLEUpqjKkhHVubrriD4cOH449//CMAoEePHmhoaEBLi33lY11Ffn4+fvnLXwIAHnnkEVVsSPPOO+/g+eefd9v3e3t7Y8eOHVaVXMX8dPz4cURGRiIgIAA+Pj6Ijo7GsWPHXGpXSkoKYmNjAbTeldbU1Cj2/fbaJoYafGbm3LlzuH79ultGA8RihJIaYyrgV1ZWolevXpbX5k1X3IWnp6dlGCIzMxNjx46Fp6cndu/ejXnz5uGVV15BVVWVW2w7c+YMnnvuOTz55JP45ptv0NDQYBnC6d27t1v9BgAnTpxA3759LSW109LSMHfuXKxevRqNjY0uscHLyws+Pj5Wx8T8VFlZ2WFDHyX9J2aXn58fPD090dLSgr///e947LHHAABNTU1ISkpCQkIC3nvvPcVssmUbgA6aV4PPzPztb39DYmKi5XVlZSVeeuklJCQkWA0vKoFYjFBSY8yN4bdFUEnG6RdffIHMzEz89a9/RXFxMQIDAxEWFob//u//xvbt27F69WqX2jNgwAC88MILiIuLQ3l5OebNm2f15KEGv2VmZmL69OkAgHnz5mHQoEHo378/UlJSkJ6ejoULF7rZQmk/uct/LS0tSE5OxsiRI/HQQw8BAJKTkzFt2jTodDokJiZi2LBhiIx0bUnixx9/vIPmo6KirH7HXT5rampCQUEB1qxZAwAIDAzEyy+/jGnTpuH69et44oknMHLkSMX362gbIyZNmmQ57myNMXWHb2vTFXfx1Vdf4c9//jN27NiBgIAAPPTQQ5YSsRMmTMAPP/zgcpv69OmDyZMnQ6fToX///rjttttw9epVy52zGjakyc/PtwSFiRMnon///gDc5zMzfn5+Hfwkpjt3+G/FihW488478cILL1iOPfnkk+jevTv8/PwwcuRIt/hOTPNq8dm3335rNZTj7++PmTNnQq/XIygoCBERETh37pyiNrSPEUpqjKmAb2vTFXdw/fp1bN68GX/5y18sGQovvviiZf/e/Px8S6aMK8nJycHOnTsBABUVFfjpp58wY8YMi+8+//xzPPzwwy63y8zly5fRvXt3eHt7QxAELFiwANeute6l6y6fmRk1alQHPz3wwAM4efIkrl27hrq6Ohw7dgzDhg1zqV05OTnQ6/V46aWXLMfOnTuHpKQkCIIAk8mEY8eOucV3YppXg88A4OTJk1Zl248cOYINGzYAAOrr63Hq1ClF9+oQixFKaoypIR2xTVfcyaefforq6mosWbLEcmzGjBlYsmQJfH194efnZxGXK5kwYQKWLVuGAwcOoLm5GWvWrEFYWBhee+01ZGRkoF+/foiPj3e5XWbabnKv0+kwe/ZsLFiwAL6+vujTpw9efPFFl9hRXFyMTZs2wWg0wsvLC7m5uXjrrbewfPlyKz/p9XokJSVh4cKF0Ol0WLx4MQICAlxq108//YRu3brhqaeeAtCatLBmzRrcfvvtmDVrFjw8PDBhwgTFJybFbEtMTOygeR8fH7f77O2330ZFRYXl6REAhg0bhuzsbMyZMwctLS1YtGgR+vTpo5hdYjFi48aNWLVqlSIao9IKBEEQnMDUkA5BEAQhDQV8giAITqCATxAEwQkU8AmCIDiBAj5BEAQnMJWWSRDOID09HR9//DG8vb3R2NiIpUuXIigoCN26dVM0J5sglIYCPkG04cKFC/jwww+RmZkJvV6P8+fPY9WqVfjFL36BiIgICviEpqGATxBtqK2txY0bN9Dc3Ay9Xo8BAwbg9ddfx29+8xsEBQWhd+/eaGpqwrZt2+Dl5YW+ffti7dq1KCwsxI4dO+Dt7Y2LFy8iNjYWv/3tb93dHIKwggI+QbRh8ODBGDJkCH75y19i3LhxGDt2LCZNmoSHH34YsbGxGDJkCOLj4/H+++8jMDAQmzdvxmeffYY+ffqguLgYBw4cgJeXF+Li4pCQkGBVvZUg3A0FfIJox+bNm3H27Fl89dVXePfdd7Fnzx7069cPQGvp3LKyMkt5h/r6evTq1Qt9+vTBAw88gO7duwMA7r33XpSXl1PAJ1QFBXyCaIMgCGhqasLAgQMxcOBAPPXUU4iLi7O8r9frERISgl27dll9Lj8/Hzdv3rQ6D0GoDUrLJIg2ZGZm4vXXX7cE7OvXr+PmzZsIDQ1FS0sLevbsCaB1AxkA2LVrF06dOgUA+P7779HQ0IAbN27gzJkzGDBggFvaQBBSUPE0gmhDS0sL3nrrLXz77bfw8/ODyWTCokWL8NNPP+Htt9/Ghg0boNfrsWnTJsvd/ubNm1FYWIh33nkHvXv3xvnz5xEXF4dFixa5uzkEYQUFfIJwAvn5+UhPT0daWpq7TSEISWhIhyAIghPoDp8gCIIT6A6fIAiCEyjgEwRBcAIFfIIgCE6ggE8QBMEJFPAJgiA4gQI+QRAEJ/w/rxVbHJe8TokAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXsAAAEBCAYAAACZhwWsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAAwnElEQVR4nO3de3wTZboH8F+aNG1oqKUWEArl0hWsWKUFPKhcdmERFoFWLqWAikd08YIcsHIrArWUFkEuu4Dg7aAil7IFu4goLoU9yEUPloIUSz2Wim5g5VpLSu+Z80dJ6CWTaUJmMvO+z/fz8WObkOSZd548nXnnfd/RCYIggBBCCNP8fB0AIYQQ+VGxJ4QQDlCxJ4QQDlCxJ4QQDlCxJ4QQDlCxJ4QQDhh8HYCY3NxcX4dACCGa06tXL6ePq7bYA+JBSykoKEBUVJSXo7l9FJf71BobxeUeist9nsTm6iCZunEIIYQDVOwJIYQDVOwJIYQDVOwJIYQDVOwJIYQDso3GOXnyJN58801s2rSpweP79+/HunXrYDAYMGbMGCQkJHjtM7PzLFi+txDnS8rRPuQCZg3tjviYcK+9P+FTdp4FKbtOo6S8GgDgpwNsAhBOOUa8pHGOtWrhj2d7hcCbA4VkKfbvvvsudu3aBZPJ1ODx6upqZGRkICsrCyaTCRMmTMCgQYMQFhZ225+ZnWfBvJ2nUF5dCwCwlJRjRuYJzMg8gfAQE30piVsaf/nqs91cFJxyjNwOVzl27UY1Vh2+hPD2Fq/llCzdOBEREVizZk2Tx4uKihAREYE77rgDRqMRvXr1wrFjx7zymcv3FjoKfWOWknLM23kK2XkWr3wWYVt2ngWz/nbS6ZdQDOUYcUdzcqzGVlfXvEWWI/uhQ4fiX//6V5PHrVYrWrZs6fg9KCgIVqtV9H0KCgqa/ZnnS8pdPl9eXYsFn5xE98DSZr+nt1VUVLi1TUpRa1yA8rHtP3sdKw5dchy9u4NyTBzFdYs7OXa+pNxr8Sk6g9ZsNqOsrMzxe1lZWYPi35g7s8fah1yARaLgX68SUFgR7LNTbbXO1lNrXICysWXnWbD263MeFXo7yjHnKK467uZY+xCTW/GpZgZtZGQkzp07h5KSElRVVeHbb79FTEyMV9571tDu0DXj3yVtP0mn2sSp1z89LdoV6A7KMSLGnRwz+NXVNW9R5Mj+008/xY0bNzB+/HjMnTsXU6ZMgSAIGDNmDNq2beuVz4iPCce3565i89c/w9UfzVpBwLydpxyvIQSoO+K6dqP5ffSuUI4RZ9zJMftoHG/mj2zFvkOHDti+fTsAYOTIkY7HBw0ahEGDBsnymWnx0ejdKRTpu/NxsaxG9N+VV9ciZddp+iISAHVfwqTtJ13+m1Yt/LFoZA/Ex4QjO89COUbc4m6OAe5ds2wOVa966Yn4mHB0DyxFYUVwg6GYjZWUVyM7z3vDmog22Yfs1gri54Orx/dskCeUY8QdnuSYHJgr9nb2hkvaflK0ke1/aenLyC+pPtQQk79oflCOESn2I3pXhd5VjnkTs8UeuPUFm5F5wunz1LfKN6k+VJO/Himjerh8D8oxIqY5R/TNyTFvYX5tnPiYcLRq4S/6fHl1rVcnLhDtcLXf9TodMkZHN6tAU44RZ1xN9ATcyzFvYL7YA8CikT1g8teLPi81Pp+wJzvP4nK/r0h4wK0vIeUYaczVPjf5693OsdvFRbGPjwlHxuho6HXOR+LrABoXzRH76bUYT/pQKcdIfdl5FtF5P0of0dtxUeyBui/jioQHnO4AAd5dg4Kom6vT69vpQ6UcI3bL9xY6ne+jg/tnjd7CTbEH6r6MYpdKLCXldOTFAanum9s94qIcI65yTIDvLtRzVewBIDzEJPocrVrINqnum/AQk1e+iJRj/GpOjvkKd8V+1tDuohfSaNQE26S6b7y1DgnlGL+UyjFPMD3O3hmpcdFSSyUT7XK1b715wYxyjF9K5ZgnuDuyB+q+jGKnU346HZ1mMypEZCy8t7pv6qMc45OSOeYuLos9IH6qbZ/xSF9GtmTnWWCtaLpwmb9eJ9upNeUYX3yRY+7gtti7GhdN/arsWb63ENVO7hgRZDTIdsRFOcYXX+SYO7gt9kDdl9Emsm4FzXhkh6uhcL+5cZ9ZT1CO8cGXOdZcXBd7oO62X87QjEc2SA2FE9v/3kQ5xjY15FhzcF/sxW5nSDMe2aCGoXCUY2xTQ441B/fF3tWMRxoip31qGApHOcY2NeRYc3Bf7AHxWW1qOf0inhPbh0oPhaMcY5dackwKFXuID5G7UVVDfaoa94d7WjfpQvHFqTXlGLvUkmNSqNjj1hC5EFPDCRHXblTTeGgNy86zYEeupUEXig7AmF7hih9xUY6xSU05JoWK/U3xMeEICmi6egSNh9YuZxfOBAAHzlzySTyUY+xRW465QsW+HrELLXQRTZvUuD/VGBPxnJb2JxX7esQutNxhEr+/KFGn7DwL/ETuGuXLi6KUY+xQa46JoWJfz6yh3eHv13TnldFFNE2xT3KpdTJz1dcXzijH2KDmHBNDxb6e+JhwmAOb9qlW1wrUp6ohYpNcfHXvz/oox9ig5hwTQ8W+kZIbztexUGMfHHFObF/ZBEEVX0LKMe1Te445Q8W+EbG+NjX2wRHn1L4P1R4fkabFfUjFvhGa/KJ9ap/kQjmmfWrPMWeo2DdCk1+0TQuTXCjHtE0LOeYMFXsnaPKLdmllkgvlmHZpJccak6XY22w2LFy4EOPHj8eTTz6Jc+fONXj+v//7vzF69GiMGTMG//jHP+QI4bZpabIEuUVL+01LsZJbtLrfmh5aeMG+fftQVVWFzMxMnDhxAkuXLsX69esBAKWlpfjoo4/w5Zdfory8HPHx8RgyZIgcYdyW9iEmp3eeockv6mWf5OJs7LMaL5xRjmmP1nKsPlmO7HNzc9G/f38AQM+ePZGfn+94zmQyoX379igvL0d5eTl0IjPQfI0mv2iLFie5UI5pixZzrD5ZjuytVivMZrPjd71ej5qaGhgMdR/Xrl07PPbYY6itrcXUqVNF36egoMCjz6+oqPD4tXbdAwGTvw7VlQ13bHWtgPTd+egeWOqTuOSg1riA5seWvvtnp5Nc/HTAtL6h6B5YioIC9/fZ7cblCuWY77kTlxZzrD5Zir3ZbEZZWZnjd5vN5ij0Bw8exMWLF5GTkwMAmDJlCmJjY3H//fc3eZ+oqCiPPr+goMDj19Z3vfKs08cvldV49P7eisvb1BoX0PzYLpU531eCALz02IPeDotyzE0sxKWFHMvNzRV9TrIbx2q1YtWqVZg3bx6+/PLLJhdbnYmNjcXBgwcBACdOnEC3bt0cz91xxx0IDAyE0WhEQEAAWrZsidJS7/019CYtTpzglVb3lVbj5pHW95VksU9OTkbHjh1x7tw5hIWFYf78+ZJvOmTIEBiNRiQmJiIjIwPz5s3Dxo0bkZOTg969eyM6OhoJCQkYP348OnfujEceecQrG+Ntzia/aKFvjkda3VdajZtHWt9Xkt04JSUlGDt2LHbt2oXY2FjYbDbJN/Xz80NqamqDxyIjIx0/T58+HdOnT/cgXGXZJ0gs31sIS0k59Dpdg3HQap5AwaMAg5+jT7VVC38sGtlD9fuIckxbtJhjds0ajVNUVAQA+Pe//w29vuk0b5bFx4Q7/qLbr8JbSspppqOK2EdJlJTfWmCsolr6oEQtKMfUT+s5BjSj2L/22mtITk7G999/j+nTp2PevHlKxKUqzmbM0UxH9WBh/7CwDSxjYf9IduNYLBZkZmY6ft+zZw/uvfdeWYNSG63OmOMFC/uHhW1gGQv7R7TYHzhwAMePH8dnn32GvLw8AHVDKHNycjB8+HDFAlQDsZmOWrkKzzoW9g8L28AyFvaPaDfOPffcg65duyIgIABdunRBly5d8Lvf/Q4rV65UMj5VcHYVXoe6ZU6Jb2XnWVBWWdPkcS2NkgAox9SMlRwTPbJv164dHn/8ccTFxcHP79bfhIsXLyoSmJrEx4Tj23NXsfnrnx3LmgoAduRa0LtTqGauxrPGftGscV+q1kZJAJRjasVSjkleoF2zZg369u2LXr16oUePHvjP//xPJeJSnQNnLqHxihhau0DDGrH7gLYwGjT1JbSjHFMflnJMstjv378fBw8exMiRI7Fnzx60bdtWibhUh4ULNKxhbZ+wtj0sYGmfSBb71q1bw2g0oqysDJ06dUJ1tfObJbNO61OlWcTaPmFte1jA0j6RLPZ33XUXsrKyYDKZsGLFCtWuYyM3um+o+mjxPqCuUI6pD0s5JjnOPjU1FRcuXMCwYcPwySefcDkaB7g1bT1l1+kGs+js9w2t/2+I/LR6H1BXKMfUhbUcEz2yr62tRVVVFaZPn442bdrAaDRi3LhxeP3115WMT1XovqHqodX7gEqhHFMP1nJM9Mh+x44d2LBhAy5fvoxhw4ZBEATo9Xr06tVLyfhUh6ULNlrG8n5gedu0hLX9IFrsExISkJCQgKysLIwdO1bJmFSNhZl0LGB5P7C8bVrC2n6QvEB73333IS8vDydPnsTkyZNx9OhRJeJSLa2vac0KlvcDy9umJaztB8lin5KSAqPRiPXr12PmzJlYu3atEnGpVnxMODJGRyPE5O94LNBflvu2ExHZeRZHf6r+5g3rw0NMyBgdrckLZ41RjvkeizkmORrHaDTi7rvvRnV1NXr27Nlg6QSeVdbcWsuaRksop/H09VpBcBxtsdb2lGO+wWqOSVZunU6H2bNnY8CAAdizZw/8/f2lXsI8Fta21ipe2p6X7VQjVtte8sh+1apVOHXqFAYMGIBvvvmG23H29bF2lV5LeGl7XrZTjVhte8kj+9DQUAwcOBA6nQ59+/ZFSEiIAmGpG0tTqLWGl7bnZTvViNW2pw54D7B2lV5LeGl7XrZTjVhte8luHNKU/SLN8r2FsJSUQ6/TNejT0/JFHC0IMPg5+lS1uK54c1CO+RaLOSZa7F3dWDwjI0OWYLTEvuPrX7W3lJTTiAkZObuRREW1zcUrtI1yTHks55hoN87w4cMxfPhw/Pbbb+jatSvGjh2L7t27o6qqSsn4VI3Vq/ZqxWN787jNvsRye4sW+/79+6N///6oqKjAc889h169euHpp5/G1atXlYxP1Vi9aq9WPLY3j9vsSyy3t+QF2hs3buDo0aOwWq346quvUFlZqURcmsDqVXu14rG9edxmX2K5vSWL/ZIlS/Dhhx9izJgxyMzMxBtvvKFEXJrA6lV7teKxvXncZl9iub0lR+NERkZiw4YNSsSiOc5uNkFrmMij8VoltYKA8BCT5qewS6EcUw7rOSZZ7Dds2ID33nsPgYGBjscOHToka1BaQ2uYyIvVtUrcQTkmLx5yTPIQYc+ePfjqq69w6NAhx3/kFpav3qsF723M+/YrgYc2liz2HTp0aHBUTxpi+eq9WvDexrxvvxJ4aGPJbpzq6mqMHDkS3bp1A1C3CuaKFStkD0wrWLubjRrx3sa8b78SeGhjyWL/3HPPuf2mNpsNKSkpKCwshNFoRFpaGjp16uR4/n/+53+wbt06CIKAHj16YNGiRdDdvEGA1swa2r3JjDtWrt6rBe9tzPv2K4GHNpYs9ufPn3f7Tfft24eqqipkZmbixIkTWLp0KdavXw8AsFqtWL58OT766COEhobi3XffxbVr1xAaGup+9CpAa5gog8W1SpqLckwZrOeYZLEvKioCAAiCgIKCAoSEhCA+Pt7la3Jzc9G/f38AQM+ePZGfn+94Li8vD926dcMbb7yBX375BePGjdNsobejNUzks//sdaz9+hyTa5W4g3JMPiyvh1OfZLFPSkpy/CwIAqZOnSr5plarFWaz2fG7Xq9HTU0NDAYDrl27hm+++QbZ2dlo0aIFJk2ahJ49e6JLly5N3qegoKC529FARUWFx6/1VPrun51ezU/fnY/ugaU+i6s51BoXAHyQe1WyXX2Bcsw9ao6rOe3qC95uM8liX3/hs0uXLuFf//qX5JuazWaUlZU5frfZbDAY6j4qJCQE0dHRaN26NQCgd+/eKCgocFrso6KipLfAiYKCAo9f66lLZWdFHq9xxOKLuJpDrXEBwOUb0u3qC5Rj7lFzXJfKapw+p8Ucy83NFX1OstgPGzbM8XNgYCCmTJki+YGxsbE4cOAAhg8fjhMnTjhG8gBAjx498MMPP+Dq1asIDg7GyZMnkZCQIPmeasfD1XxfaB1kwEUnX0Ye25VyTB68tKtksd+/fz8A4MqVK2jVqhX8/KSnag8ZMgSHDx9GYmIiBEFAeno6Nm7ciIiICAwePBhJSUl49tlnAdT9Man/x0CreLia7wuTY1th7ddXqV1BOSYXXtpVsth/8803mD9/PsxmM0pLS7F48WI88sgjLl/j5+eH1NTUBo9FRkY6fn7sscfw2GOPeRiyOtEaJt6XnWfBh8evMbtWibsox7xv/9nr2HLqAhc5JlnsV69ejc2bN6Nt27b49ddfMW3aNMlizzNaw8Q7eFirxFOUY96RnWfBX49cRmWtAID9HJM8LNDr9Wjbti0AoG3btggICJA9KK3iYX0NpVBbOkft4j3L9xY6Cr0dy20peWRvNpuxadMm9OnTB8eOHcMdd9yhRFyaxMP6GkqhtnSO2sV7eGtLySP75cuX4/z581i1ahUuXLiA9PR0JeLSJJbvcqM0akvnqF28h7e2lCz2KSkpmDNnDt5++23Mnj2bjuxdYPkuN0qjtnSO2sV7Zg3tjgB9wzW5WG7LZk2qOnPmDLp06eJYrMxoNMoemBZJrWHSnVaKdgvra5V4gnLMO+x3paqsFZgfhWMnWeyLi4vx4osvOn7X6XTIycmRNSgtc7WGybS+oVDhJELV4WWtEk9Rjt0eXkd6SRb73bt3KxEHU8RGTHx4/BpeYmt6gSxcjThh+cvoDsoxz/GaX5LF/tFHH0Vt7a2GMRgMaNeuHWbNmoUePXrIGpxWiV3NF1uDgzTE2ygJT1COeY7X/JK8QNu3b18sXrwYn3/+OdLT0xEdHY2pU6ciLS1Nifg0Sexqfusgyb+tBPyNkvAE5ZjneM0vyWJfXFyMhx9+GEajEf/xH/+BS5cu4aGHHmrWGjm8EhsxMTm2lY8i0hYacSKNcsxzvOaX5GGA0WjE1q1bERMTg7y8PBiNRuTn5zfo2iEN1R8xcb6kHO1vXuX35drYWiLWfiz3p7qLcsxzvOaXZLF/8803sWHDBuTk5KBbt25YtmwZvvvuOyxZskSJ+DQrPiYc8THhjiFeMzNPoHWQAckjgplPqtthby/7l/DV/q3x0mMP+josVWpctJbvLcTEaDONxpFQP8daBxm4KPRAM4p9q1atMG/evAaPDRw4ULaAWNJ4iNfFshpatMqFxu1lKSnHX49UILy9hdrLCWov9/H8naSOdxnRolXucdZelbUCtZcIai/38fydFC32x44dA9DwtoTEPbwO8fIUtZd7qL3cx3ObiRb7tLQ03LhxA1OmTEF1dTWqqqoc/5Hm4XWIl6eovdxD7eU+nttMtNj369cPo0aNwsmTJzF06FAMGzYMw4YNw5/+9Ccl49M0Xod4ecpZewXoddReIqi93Mfzd1L0Au2sWbMwa9YsrFu3Di+99JKSMTGDbiPXfPYREo1vDzcx2sz8hTNPOVsUrX6fPbVbQ85yrE2QAckj7uOirSRH44wePRrTp09HUVEROnfujOTkZISHs98w3kS3kXPN1cJUNG7cNVeLotV/nndiOTY5thU3bSR5mLlgwQLExcVh69atePzxx5GcnKxEXMzg+ep/c1Eb3R5qP2muFo7jhWSxr6ysxODBgxEcHIw//vGPNHPWTTxf/W8uaqPbQ+0njRaOa0axr62tRWFh3RGC/f+k+Xi++t9c1Ea3h9pPGi0c18xunOTkZAwYMADz58/Ha6+9pkRczOD56n9zURvdHmo/abRwXDMu0EZFRWHHjh1KxMIkqdvI8XJxSIrYLQgLCugCrRTKseZxlmM8DQCgcYAKiI8Jd9zcuFYQANwaMZGdZ/FxdL5lHyVhH5oK0C0IPUE5Jo5yrA4Ve4XYb25cH42YoJEk3kQ55hzlWB3JYp+amoqCggIlYmEajZhwjtrFe6gtnaN2qSNZ7H//+99jw4YNSExMxJYtW2C1WpWIizk0YsI5ahfvobZ0jtqljmSxHzBgAP7yl7/grbfeQm5uLvr374+5c+fi559/ViI+Ztj7U+ujERM0ksSbKMecoxyrI1nsi4qKsHz5cjzxxBMIDg7G5s2bMXHiRMyYMUOB8NgRHxOO6Q+HIcTk73iM93VyGq9VAgDhISZkjI6mESQeoBxrinLsFsmhl6+99hrGjRuHadOmwWS6ddozZswY0dfYbDakpKSgsLAQRqMRaWlp6NSpU5N/8+c//xmDBw/GhAkTbmMTtIXWyanjaj0c3trC2yjH6lCONST5Z79///4YPXq0o9CvWLECADBp0iTR1+zbtw9VVVXIzMxEUlISli5d2uTfrF69GqWl/IxxBYAPj1+jUQE30QgJeVCO3UI51pDokf3f/vY3ZGVloaioCAcPHgRQt3RCTU0NkpKSXL6pvW8fAHr27In8/PwGz3/xxRfQ6XSOf8MLsXU4eBsVANAICblQjt1COdaQaLGPi4vDQw89hLfffhvPP/88AMDPzw933nmn5JtarVaYzWbH73q9HjU1NTAYDPjhhx+we/du/PWvf8W6detcvo+nQz4rKipUOVw0rIUel240XUiudZDBp/H6or1aBxlw0UlhatwWat2Xao2LcuyW5uSYWvcj4P3YRIt9YWEhoqOj8eijj6K4uNjxeFFREfr16+fyTc1mM8rKyhy/22w2GAx1H5WdnY1ff/0VkydPhsVigb+/P8LDwzFgwIAm7xMVFeX2BgF1fyQ8fa2cnu51HWu/vtrg1NLkr0fyiPsQFeW7PkRftFfyiOAG/amA87ZQ675Ua1yUY7c0J8fUuh8Bz2LLzc0VfU602B89ehTR0dHYs2dPk+ekin1sbCwOHDiA4cOH48SJE+jWrZvjudmzZzt+XrNmDcLCwpwWehYN6toS4e3DaQ2Tm8TWwyGeoxxriHLsFtFi//TTT6Oqqgqvv/662286ZMgQHD58GImJiRAEAenp6di4cSMiIiIwePDg2wpY6+jOQk1HSQB8rlUiF8oxyjFnRIv9sGHDoNM1nKAhCAJ0Oh1ycnJcvqmfnx9SU1MbPBYZGdnk37388svuxMoMV6MEePgi8r79SuC9jXnffmdEi/3+/fuVjIMrvI8S4H37lcB7G/O+/c6IFvvU1FQsXLgQ48ePb3KEv23bNtkDY1n7EBMsTpKOl7U6eN9+JfDexrxvvzOixf7FF18EAKxcuVKxYHgxa2h3p6MEeFmrg/ftVwLvbcz79jsjWuzDwsIA1A2bXLZsGX766SfcfffdmDVrlmLBscreZ5iy67Tjhgq8rGHSeK2SWkFAeIiJ2ynscqEcoxxrTHLvJycnY+zYsdiyZQtGjBiB5ORkJeLigrM1TFi+q5B9hIT99Jr3tUqUQDlGOWYnWez1ej0GDhyIli1bYtCgQbDZ+B6+5C08rtvB4zb7Eo/tzeM2N5doN86hQ4cAACaTCe+++y769OmD7777ztG9Q24Pj6MFeNxmX+KxvXnc5uYSLfafffYZACAkJARnz57F2bNnAQBGo1GZyBjH42gBHrfZl3hsbx63ublEi31GRobTxy9evChbMDzhcbQAj9vsSzy2N4/b3FySNy/5y1/+gq1bt6K6uhoVFRXo3Lmz46ifeM5+sYi3NUxorRLlUI5RjtUneYF2//79OHjwIEaOHIk9e/agbdu2SsTFhfiYcMf9MWsFAcCtNUxYGzFhHyVhHwYI0FolSqAcoxyzkyz2rVu3htFoRFlZGTp16oTq6mqplxA38DJ6gJftVCNe2p6X7fSUZLG/6667kJWVBZPJhBUrVnB3K0G58TJ6gJftVCNe2p6X7fSUZLFPTU3Fww8/jNmzZ6NNmzaOe9AS7xAbJcDa6AFetlONeGl7XrbTU5LF/rfffsNHH32EV199FRcvXqQ+ey+z96fWx+LoAV62U414aXtettNTksV+zpw5iIiIwIwZM9C2bVvMmTNHibi4ER8TjozR0Qgx+TseY20Nk8ZrlQBAeIgJGaOjaZSEAijHKMeAZgy9rKysxMSJEwEA99xzD/bu3St7UDxytoYJoP3hcY3vGERrlfgO5RjfRP+8FxcXo7i4GK1atcLnn3+OS5cuIScnBx06dFAyPi6wPIqA5W3TEpb3A8vb5k2iR/YLFy50/LxlyxZs3brVcVtC4l0sjyJgedu0hOX9wPK2eZNosd+0aZPj52vXruGXX35Bhw4dEBoaqkhgPGF5PQ+Wt01LWN4PLG+bN0lepfn888+RmJiIDRs2YPz48fj73/+uRFxccTaKAABuVNVofpbjH+5pjcbngjRCQnmUY0TyAu0HH3yAnTt3IigoCFarFZMnT0ZcXJwSsXHD2V2FAO1fRMvOs2BHrgVCvcd0AMb0Ctfk9mgZ5RiRPLLX6XQICgoCAJjNZgQEBMgeFI/iY8IRFND0b6+WLzQ5u3AmADhw5pJvAuIc5RjfJI/sO3bsiKVLl6J379749ttvERERoURcXGLtQhNr28MC1vYJa9sjJ8kj+yVLlqBjx444cuQIOnbsiMWLFysRF5dYm+7N2vawgLV9wtr2yEmy2D///POYNGkSFi5ciEmTJsHf31/qJcRDrE33Zm17WMDaPmFte+Qk2Y0THByMnJwcdO7cGX5+dX8bunTpIntgPHJ2EU2r09obT1+vFQSEh5hoVqOPUY7xS7LYX7lyBR988IHjd51Oh48++kjOmLin9WntNH1d/SjH+OOy2FutVrzzzjswmaj/Symupn5rJYlZ2AaWsbB/WNgGpYmev3388ccYNWoU4uLi8NVXXykZE9dYGF3AwjawjIX9w8I2KE202O/evRtffPEFtm3bhg8//FDJmLjGwugCFraBZSzsHxa2QWmixd5oNMJoNCI0NJTuO6sgFqa10/R1daMc45PkBVoAEARB+h/VY7PZkJKSgsLCQhiNRqSlpaFTp06O5z/44AN89tlnAICBAwdi2rRpbr0/y7Q+rZ2mr6sf5RifRI/sf/zxRyQlJeGVV15x/Gz/T8q+fftQVVWFzMxMJCUlYenSpY7nfvnlF+zatQvbtm3D9u3bcejQIZw5c8Y7W8MILU9rp+nr2kA5xh/RI/vVq1c7fk5MTHTrTXNzc9G/f38AQM+ePZGfn+947q677sJ7770Hvb7uNLKmpobW23FCqxegtBo3j7S6r7Qat6+JFvsHH3zQ4ze1Wq0wm82O3/V6PWpqamAwGODv74/Q0FAIgoBly5bh3nvvFZ2kVVBQ4NHnV1RUePxaObkTV+sgAy6W1Th93Nvb5s328nbcLOxLJVGOufcZat2PgPdja1afvbvMZjPKysocv9tsNhgMtz6qsrISycnJCAoKwqJFi0TfJyoqyqPPLygo8Pi1cnInruQRwQ0mjQB1/ZKPRrf3+rZ5q72y8yyosjW9k5nJX4/kEfchKsr9/lQW9qWSKMfcyzG17kfAs9hyc3NFn5NlnnRsbCwOHjwIADhx4gS6devmeE4QBLz44ovo3r07UlNTHd05pKH4mHCM6RXeYMSBAGBHrkWVIybsMxrrX/ADgFYt/JExOpounKkQ5RhfZDmyHzJkCA4fPozExEQIgoD09HRs3LgRERERsNls+N///V9UVVU5Jmu98soriImJkSMUTTtw5hIaj4NS6yxBZxfNAKCF0aC6WMktlGP8kKXY+/n5ITU1tcFjkZGRjp9PnTolx8cyR0sXorQUK7lFS/tNS7GqkTaXu+OE2GxAP51OdafZIS2cL31NMxrVjXKMH1TsVUxspmOtIGDezlOq+TJm51lgrWg6OsJfr6MZjSpHOcYPKvYqFh8TjozR0dDrmo4+UNPkl+V7C1FtazrLOoj6UlWPcowfVOxVLj4mHDaR5SrU0lcpFsdv5bSmkhZQjvGBir0GqH2FP7XHR6SpfR+qPT4toGKvAc76VXWoW/nP17LzLCirbNqXSisQagvlGPuo2GuAWie/0CQXdlCOsY+KvUa4mvziKzTJhS2UY2yjYq8RapxQosaYiOfUuD/VGJNWUbHXCDVOfqFJLmyhHGMbFXuNUNvkF5rkwh7KMbZRsdcItU1+oUku7KEcYxsVew1R0+QXmuTCJsoxdlGx1xixvso7TM77NuWQnWeBn5OjP4D6UllAOcYmKvYaM2tod/j7Nf0SlFXVKNKnah/3XOvk6I8mubCBcoxNVOw1Jj4mHObAprchqK4VFOlTFRv3rNfpaJILIyjH2ETFXoNKbjjvs7SUlMt+5GUR6Ue1CQJ9CRniqxzLzrNQjsmEir0GueqzlHOIXHaeBc57UakflTW+yDF7940nMRFpVOw1SGw8NCDvELnlewubTKcH6hbMon5Utvgix8S6bwDqq/cGKvYaZB8PLUaOU21Xp9fCzZgIO5qTY97m6j2pr/72UbHXqPiYcIQrdKotdXrtKg6iXa5yTAd49YDCVRdheIiJCr0XULHXMKVOten0ml+zhnZ3WoQFwKtdOdRFKD8q9hqmxKm2q+4bgE6vWRcfE+60CAPe6y6kLkJlULHXODlPtZvTfUNfRPbJ2V1IXYTKoWLPAFen2knbT3r8ZXz909PUfUMkuwspx7SBij0DXJ1qe7o8bXaeBddEJtYA1H3DE6nuQsoxbaBizwhXp7ueXKx19e+p+4Y/UqO/KMfUj4o9I1ydagPuXayVuihLp9Z8ohzTNir2jHB14wm7mNQvJU+1X8s+hZmZJ0SfDzH50xEXpyjHtI2KPUPiY8KxIuEB0ckp125Uu+xbzc6zYPPXP4v2/5v89UgZ1cMrsRJtohzTLir2jHF1sRao61tN2XW6yePZeRYkbT/p8rV0wYwAlGNa1XTRai+w2WxISUlBYWEhjEYj0tLS0KlTJ8fz27dvx7Zt22AwGPDCCy/gD3/4gxxhcCs8xOSyP7SkvBqd537m9nvSl5DYUY5pjyxH9vv27UNVVRUyMzORlJSEpUuXOp67dOkSNm3ahG3btuH999/HypUrUVVVJUcY3JK6kOYumrJOGqMc0x5Zin1ubi769+8PAOjZsyfy8/Mdz3333XeIiYmB0WhEy5YtERERgTNnzsgRBrfsF9JCvHDPUB2ASX0j6IiLNEA5pj2ydONYrVaYzWbH73q9HjU1NTAYDLBarWjZsqXjuaCgIFitVqfvU1BQ4NHnV1RUePxaOSkZV/dAYGtCR4zf9hNKK20evYefDkjq1xqDuhp81p60L91DOeYete5HwPuxyVLszWYzysrKHL/bbDYYDAanz5WVlTUo/vVFRUV59PkFBQUev1ZOvogrNT4Y83aeEp2SLkYHYGVCT58fbdG+dA/lmHvUuh8Bz2LLzc0VfU6WbpzY2FgcPHgQAHDixAl069bN8dz999+P3NxcVFZW4vr16ygqKmrwPPEuT0636bSauINyTBtkObIfMmQIDh8+jMTERAiCgPT0dGzcuBEREREYPHgwnnzySUycOBGCIGDmzJkICAiQIwxyU3xMOOJjwpGdZ0HKrtMoKW+6HomfDrAJdSMiZg3tTl9C4hbKMfWTpdj7+fkhNTW1wWORkZGOnxMSEpCQkCDHRxMX7F/IxtR8Kku0hXJMvWhSFSGEcICKPSGEcICKPSGEcICKPSGEcICKPSGEcEAnCIKrReh8xtXkAEIIIc716tXL6eOqLfaEEEK8h7pxCCGEA1TsCSGEA7LMoPUFqRumKK26uhrJycmwWCyoqqrCCy+8gHbt2mHq1Kno3LkzAGDChAkYPny44rE9/vjjjlVJO3TogPHjx2PJkiXQ6/Xo168fpk2bpnhMALBz50588sknAIDKykoUFBRg5cqVeOONN9CuXTsAwMsvv4wHH3xQsZhOnjyJN998E5s2bcK5c+cwd+5c6HQ63H333Vi0aBH8/Pywdu1a/POf/4TBYEBycjLuv/9+ReMqKCjA4sWLodfrYTQa8cYbbyAsLAxpaWk4fvw4goKCAABvvfWW6KKDcsT1/fffO813X7fXzJkzcfnyZQCAxWLBAw88gFWrVuGFF17AtWvX4O/vj4CAALz33nuyxuSsRvzud7+TL8cERuzdu1eYM2eOIAiCkJeXJzz//PM+jScrK0tIS0sTBEEQrl27JgwcOFDYvn278P777/s0roqKCiEuLq7BY6NGjRLOnTsn2Gw24dlnnxVOnz7tm+DqSUlJEbZt2yasXLlS+OKLL3wSwzvvvCOMGDFCGDdunCAIgjB16lTh66+/FgRBEBYsWCB8+eWXQn5+vvDkk08KNptNsFgswujRoxWPa9KkScL3338vCIIgbN26VUhPTxcEQRASExOFK1euyB6PWFzO8l0N7WVXUlIijBo1Svj1118FQRCEP/3pT4LNZpM9HjtnNULOHGOmG8fVDVN8YdiwYfiv//ovAIAgCNDr9cjPz8c///lPTJo0CcnJyaLr+MvpzJkzKC8vxzPPPIOnnnoKx44dQ1VVFSIiIqDT6dCvXz8cOXJE8bjqO3XqFH788UeMHz8ep0+fxo4dOzBx4kQsXboUNTU1isURERGBNWvWOH4/ffq046xiwIABOHLkCHJzc9GvXz/odDq0b98etbW1uHr1qqJxrVy50rHuTG1tLQICAmCz2XDu3DksXLgQiYmJyMrKkjUmZ3E5y3c1tJfdmjVr8MQTT6BNmza4fPkySktL8fzzz2PChAk4cOCArDEBzmuEnDnGTLEXu2GKrwQFBcFsNsNqtWL69OmYMWMG7r//fsyePRubN29Gx44dsW7dOsXjCgwMxJQpU/D+++/j9ddfx7x582AymRrEff36dcXjqu/tt9/GSy+9BAB45JFHsGDBAmzevBk3btzAtm3bFItj6NChjvswAHVfSJ1OB+BWOzXOOyXar3Fcbdq0AQAcP34cH3/8MZ5++mncuHEDTzzxBJYvX4733nsPW7Zskf2OcI3jcpbvamgvALhy5QqOHj2K0aNHA6jrUnnmmWewbt06rF27FhkZGbhy5YqscTmrEXLmGDPF3tUNU3zlwoULeOqppxAXF4eRI0diyJAhuO+++wDULQP9/fffKx5Tly5dMGrUKOh0OnTp0gUtW7ZESUmJ4/mysjIEBwcrHpddaWkpiouL0bdvXwDAmDFj0LFjR+h0OgwePNgnbWbn53fr62JvJ3duxiOnPXv2YNGiRXjnnXcQGhoKk8mEp556CiaTCWazGX379lX89p/O8l0t7fXFF19gxIgR0Ovr7qMbFhaGxMREGAwG3HnnnYiKikJxcbHscTSuEXLmGDPF3tUNU3zh8uXLeOaZZzBr1iyMHTsWADBlyhR89913AICjR4+iR48eiseVlZXluAH8r7/+ivLycrRo0QI///wzBEHAoUOH0Lt3b8Xjsjt27BgeeughAHVH0qNGjcK///1vAL5rM7t7770X33zzDQDg4MGD6N27N2JjY3Ho0CHYbDacP38eNpsNoaGhisb197//HR9//DE2bdqEjh07AgB++uknTJgwAbW1taiursbx48cVbztn+a6G9rLHM2DAAMfvR44ccXSplJWV4f/+7//QtWtXWWNwViPkzDFmRuM4u2GKL23YsAGlpaV466238NZbbwEA5s6di/T0dPj7+yMsLAyLFy9WPK6xY8di3rx5mDBhAnQ6HdLT0+Hn54dXX30VtbW16NevHx544AHF47IrLi5Ghw4dAAA6nQ5paWmYNm0aAgMDERkZ6dP7IMyZMwcLFizAypUr0bVrVwwdOhR6vR69e/fG+PHjYbPZsHDhQkVjqq2txZIlS9CuXTu8/PLLAIA+ffpg+vTpiIuLQ0JCAvz9/REXF4e7775b0dhSUlKwePHiBvluNpt92l52xcXFjj+MADBw4EAcOnQICQkJ8PPzwyuvvCL7HyFnNWL+/PlIS0uTJcdoBi0hhHCAmW4cQggh4qjYE0IIB6jYE0IIB6jYE0IIB6jYE0IIB5gZekmIN7zzzjs4cuQIampqoNPpMGfOHPj7+6O0tBR9+vTxdXiEeIyKPSE3/fjjj9i/fz+2bt0KnU6HgoICzJkzB0OGDEFYWBgVe6JpVOwJually5Y4f/48srKyMGDAAERFRWH9+vV48skn4e/vjx49eqCiogKrVq2CXq9Hx44dkZqaik8//RT79u1DWVkZrl27hpdeeglDhw719eYQ0gBNqiKkntOnT+Pjjz/G0aNHERgYiJkzZ+KHH35wrJ0ybNgwbNmyBXfeeSdWr16N9u3bw2Aw4NNPP8X777+Pq1evYty4cfjHP/7h87WZCKmPspGQm86dOwez2YyMjAwAdUstP/fccxgxYgTCwsJw9epVXLx4ETNmzAAAVFRU4OGHH0anTp3Qp08f+Pn5ISwsDMHBwbh69apjNUpC1ICKPSE3FRYWIjMzE+vXr4fRaESXLl0QHByMkJAQ2Gw2tGrVCnfddZfjjk85OTlo0aIFLly4gNOnTwOoW9zKarXizjvv9PHWENIQFXtCbnr00UdRVFSEsWPHokWLFhAEAbNnz4bBYMCyZcsQGRmJ+fPn489//jMEQUBQUBCWLVuGCxcu4PLly5g8eTKuX7+ORYsWOZbOJUQtqM+ekNu0c+dOnD17Fq+++qqvQyFEFE2qIoQQDtCRPSGEcICO7AkhhANU7AkhhANU7AkhhANU7AkhhANU7AkhhANU7AkhhAP/D1Lf64p4lP3pAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "tags": []
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -1791,7 +1785,8 @@
     "a = cirq.NamedQubit('a')\n",
     "\n",
     "# Get a circuit of a bunch of X rotations.\n",
-    "circuit = cirq.Circuit([cirq.Rx(rads=np.pi / 50.0)(a) for theta in range(200)])\n",
+    "num_angles = 200\n",
+    "circuit = cirq.Circuit([cirq.Rx(rads=np.pi / 50.0)(a) for theta in range(num_angles)])\n",
     "\n",
     "# List to store probabilities of the ground state.\n",
     "probs = []\n",
@@ -1819,21 +1814,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {
     "id": "iynhJEvoCIro"
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEDCAYAAAA2k7/eAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO2de1xU9db/P3uGQUBIxMAUMy+dlFBLvGRR6SGN1DJSU0xSn0zrZJrmDXkstIuipP0O2rk8Zpej1qGIh+zyRK+kp1OKaAgoRPaoaTh2FJRRcUBmhv37A2cchn2ZGWbP7Mt6v169cm57r9l7sWZ913ddGJZlWRAEQRCqRxdoAQiCIAj/QAafIAhCI5DBJwiC0Ahk8AmCIDQCGXyCIAiNQAafIAhCIwQFWgAhSktLAy0CQRCEIhk2bFi752Rt8AFuod2huroacXFxPpam45BcniNX2Uguz5CrXIB8ZfNWLj5nmUI6BEEQGoEMPkEQhEYgg08QBKERyOATBEFoBEkN/i+//IKxY8di586d7V7bt28fpk6diunTp+Ott96SUgyCIAgCEmbpmM1mvPrqq7j77rs5X3/ttdewfft2dO/eHWlpaUhOTsatt94qlTiap6DMiOzCozCaGqFnGNhYFpGhBjRbbTBbWgAAOuYEWlggNjIUy5MHIGVobIClJpSEs44xALja8IYZTqKTQQ+T2YKepGd+RzIPPzg4GNu2bUNMTEy712pqatClSxf06NEDOp0Oo0ePRnFxsVSiaJ6CMiNW5R+B0dQIALBd64htarQ4jD0AtFz7CzWaGrEq/wgKyox+l5VQJq46xtdz3WxpQb3ZAhakZ4FAMg8/KCgIQUHch6+trUVUVJTjcVRUFGpqaqQSRbM4e1ye0mixYXFuObILj2J58gAAQHbhUZwxNZJnRrQju/AoGi02jz9n17O1n1Uh85F40imJkX3hVXV1tVefa2pq8vqzUuIvuYpOXEbOvjpctXVsvo3R1IilH5WDYQBry/XnVuZVwHjGiKR+ET6QVhit30tPCYRcZ7xwKpypN1uw7ONyv+mUK1q5lwEx+DExMairq3M8Pnv2LGfoB4DX1W9qq5zzlKc/LeqwsbdjY9FujX7VxmLbjyYsmDjSJ+cQQuv30lMCIVdkWA3qzZYOHcPaAnxwpMEvOuWK2u6lrCpte/XqhYaGBpw+fRpWqxXffvstEhMTAyGKaumox+UOpkYLxV8JFJQZ0dBk9cmx/KG3WkYyD7+yshIbNmyA0WhEUFAQCgsLkZSUhF69emHcuHFYs2YNli5dCgCYMGEC+vbtK5UomsEesz9jaoTuWiaO1GQXHqW4q8Zw1rMuoQZcarI4Nvw7Ss/IUN8ciOBEMoM/aNAg7Nixg/f1ESNGIDc3V6rTaw57loR948wTYx9q0COpXxiKTpg93ngjj0xbuOqZqZE/jMMA+DVrouNzK/MqBMOMBj3jSBAgpIEqbVWCWJaEjmn9f2xkKNJG9UZsZCiYa4/XTx6Mg6cbvcqyII9MW6z9rMptPXHWjZShsVh0z40OvYsMNSDMcN38dA0zYPqIm5FdeBR9079AYlYRhQslQPZZOoR7iHnanYL0WD95MG/4ZUluucfnDDXoySPTEAVlRrc3Zrl0I6lfBO+GrOvKwZ6jD4BChj6EPHyVIOZpN1psyC48yvt6dGf3fvuZaysFPcM4jkmemDYQ0h9n9Awj6Fy4UlBmxNKPKtqtHMR0lvAcMvgqYXnyAIQa9ILvEVoFzE7oKvr5UIMeM+/qjVCD3rFHQNWS2sGd/ZpQgx6bpt3hkbFflX+Ed8+J9oh8Cxl8lZAyNBbrJw9GrICnL7QKSOoX4fi8PbbPFev/9uda8sQ0Cp/+MAza6IgnIRixvSfaI/ItFMNXESlDY5EyNLZdPBRwL95u/7wQfLF+8sTUz/LkAZx65amRd0ZIb2iPyPeQh69CnL19bz0vPvg8LvLE1I09977RYoP+2kaOL/SKd9UAgAGLxbnl6JP+BYa+8jWFDX0AefgqxR1v3Rv4vDzyxNQLV42H/Z53VMe49Mmgay0adO7kWm+2YHleBQDK2ukI5OETHiHl6oGQJ1xxdl/t27jqU2SoATaW5azctdhY2ivqIOThEx4j1eqBkCd8cXZf7du47j0JtWmgvaKOQQZfBbj2NmEY0EQhwmf0jAzlnKnQJdSAxKwin81IcKenPu0VdQwK6Sgc50lDLFp7m9BEIcKXcNV4GHQMrjRbHXrnC10T896p107HIQ9f4Yh5RfZYq6+9fK4ZuTQLV124zqi10zXMAADt2ix0VNf4VhL2c9JErI5DHr7CcWd8oa/jnnwzcmlFoR6EZtQ2XZtLy0VHdI1rJRFq0CNtVG+EBQdhSW45NVXrIGTwFUxBmbGN58WHr+OeQqsKqrpVB2L32J6L70pHdI0rA2zKsFh8Umr0aehIy1BIR0FwDZ4Q63ovRY68mBdnNDWib/oXtGmsYMTusT0X39f1GK4ZYIlZRbwpoaRXnkMevkLg2pwVSl+TMkfeHS+OvDFlI3aP7boldT2G1CmhWoM8fIXgTsqandjIUOxNT5JMFq7qSD7IG1MmQvfYucpW6vvKt5GrYxhaRXoBefgKwV2Pxh9tDtzpzOkMeWPKw/Ue+7J/jifwtf22sSytIr2APHyFIJSyZsfTwRMdwe7dJWYVicpFxTLKwXmfSA7es/3cdpl011KAnaFVpPuQh68QxAaceDp4wleIee/UWE05uO4TycV7Thkai73pSfg1ayJaaFBKhyCDrxC4mkx1DTMEvIGZkPdOjdWUBV+TtDW7qwIkUXuoPXfHoJCOgpBj0zIphmIQgYHPSzY1WlBQZpTF/aT23B2DPHyiQ1C7ZPUg5CXLpZiO9K1jkIdPdBg5rjwIz1mePACLFTDCkvTNe8jDVyAFZUYkZhWhb/oX1FuE8BkpQ2MdjdFcoRi5OiCDrzDkmklBqIPMR+I5G5hRjFwdUEhHpvDlQwuNmwv0MlduOdyE57jmvdN9VBdk8GWI69BouxcPyLe3iJDMZCyUBcXI1QsZfBki5MXzVdwGOsYq55UHoXy4Vo8AsGZ3FUyNrb35aUiKOGTwZYiQF//m9DtlmYcs15UHoXy4Vo/LP66AjWXbdIytN1uwPK8CAK0q+ZDU4K9btw4VFRVgGAYZGRkYMmSI47Vdu3Zh9+7d0Ol0GDRoEP7zP/9TSlEUhZAXL9cYq1xXHgQ3rrMVmq02mC0tAOTnKXOtHi08vcEtNpZWlQJIZvAPHDiAU6dOITc3F8ePH0dGRgZyc3MBAA0NDdi+fTu+/vprBAUF4amnnkJ5eTnuvPNOqcRRFGLVhHKMsVIFpHJw9ZjtIRE7cvOUPV0l0qqSH8nSMouLizF27FgAQP/+/XHx4kU0NDQAAAwGAwwGA8xmM6xWKxobG9GlSxepRFEcSqwmVKLMWsWd2Qp2T1kOeLpKpFUlP5J5+HV1dYiPj3c8joqKQm1tLcLDw9GpUycsWLAAY8eORadOnTBx4kT07duX8zjV1dVenb+pqcnrz0qJu3INCAHefrSH0zOXUF19KeByCSGVzEq/l/5GTC53PeAzpkaffj9vr9cTg8ORs68JV23Xwzh6Bmhh0W7EZ5Cu9f2enkep99JT/LZpyzq1NW1oaMDf//53fPXVVwgPD8fs2bPx888/Y+DAge0+FxcX59X5qqurvf6slJBcniNX2ZQqV8/I30VnGLS+L9Sn38/b6xUXB8T2lDZLR6n3ko/S0lLO5yUz+DExMairq3M8PnfuHKKjowEAx48fx80334yoqCgAwPDhw1FZWclp8AmC8C3ujKg06BlZ7b/w7VtRyNAz3Irh//vf/8aPP/4IAGhubnbrwImJiSgsLAQAVFVVISYmBuHh4QCA2NhYHD9+HE1NTQCAyspK9OnTx1PZNQP1ziF8CddshTDDdVPQNcyA7Kn+H6ZDSI+oh//ee+/hq6++gtlsxu7du5GdnY3o6GjMnz9f8HMJCQmIj49HamoqGIZBZmYm8vPzERERgXHjxmHu3LmYNWsW9Ho9hg4diuHDh/vsS6kJqmAlpECOmV6E9Iga/G+++Qb//Oc/8eSTTwIAMjIykJqaKmrwAWDZsmVtHjuHbFJTU5GamuqpvJqDKlgJ4jp8/ZoKyoxUdesGogbfZms1Nsy1qfVXr16F1WqVVirCAVWwEkQrfKvdH09dQO6BmjbFWHKrJZALojH8hx9+GLNmzcKpU6eQmZmJlJQUTJ061R+yEVDnDE/akyC8gW+1+2FJDWflrZxqCeSCqIc/ffp0jB49GocPH0ZwcDCeffZZhIYq19goDbVVsNKeBOEtfKtaG8vdZkHoM1qF18O3Wq0wm82YM2cObrzxRvzxj39EYmIiIiIiHPF8QnqUWsHK58UL7UkQ0qPk1RXfqlZ/LdzsyWe0Cq+H/69//QvvvvsuDh8+jIkTJzoKp3Q6HUaOHOk3AQnlZVQosZ+/FlD66opvtTtlWGy7GD4gv1oCOcBr8JOSkpCUlIRPP/0Ujz76aJvX9u3bJ7lgWkQtE6OU2M9fCyg940uoU+zwW6IoS8cNRGP4CQkJ2LBhA0wmEwDAYrHg4MGD+O677yQXTkso3ftyRon9/LWAGlZXQhW3Svs7CQSiWTrp6em49dZbUVVVhTFjxkCn0+GVV17xh2yags/7WvpRhaLirAC/t86i9XtOGRaruD0JNSB0X5QWzye8Q9TgBwUFYcqUKbjhhhuQnJyMjRs3YufOnf6QTVMIZSCsyj+iqD/G5ckDEGrQc75mNDXik1IjlicPwK9ZE7E3PYmMvZ8Quy9K0zPCc0QNPsuyOHDgACIjI5Gbm4vi4mKcPn3aH7JpCqEYdqPFhsW55Yrxwpwzi7igrJzAQPeFEDX42dnZCA0NxerVq1FeXo73338f6enp/pBNUwh5X3aU5IWlDI3F3vQk8CXMKSlurCbovmgbUYP/ySefYPDgwbjpppuwfv16/O1vf0NxcbE/ZNMUdu9LKKcYUJ4XpsZKYTVA90Wb8GbpfP311/j888/x448/4ujR6wbGarWiurqavHwJsMeyxXqVK8kLU1ulsFqg+6JNeA3+gw8+iNtvvx2vvvoqZs6c6Xhep9OhX79+fhFOizjnGvNNJVKSFyaUO00EDrov2kQwD79Xr17IzMxEXV0dhgwZgk8//RSVlZWYMWOGY1oV4XvsOcWuufmAMr0wypGWJ3RftIdoDH/FihUwGAwoLy/HJ598goceegivv/66P2TTPErto0MQhDwRrbTV6/WIi4vDhg0bMHv2bAwbNoz64fsR8sIIgvAVoh6+zWbDX//6VxQVFeHee+/F4cOHYTab/SEbQRAE4UPczsPfunUrOnXqhNOnT2Pt2rX+kI0gCILwIaIhnR49emDOnDmOxxMmTJBSHkJFqKX7J6FsSA+vI2rwCcIb1NT9k1AupIdtEQ3pEIQ38HX/VFJPIEL50IS1tvB6+KtWrRL84Pr1630uDKEehKqBte5lEf5DDTMAfAmvwU9OTgYAFBUVOcYasiyLkpISBAcH+01AtaPW+CLfZCs7Spq0pGSc9atLqAEMA5jMFlXpmhA0Ya0tvAZ/zJgxAID3338f7777ruP5iRMn4plnnpFcMC2g5vgiV68WV7TqZfkLV/2yj/8D1KVrQlDPoLaIxvBNJhO+/fZb1NfX4+LFi/jhhx/w73//2x+yqR41xxfFeq8D2vWy/AWXfjmjFl0TgqrV2yKapbNhwwb85S9/webNm8GyLPr160fxex+h9vii2noCKQ139EgtuiYEVatfR9Tg33bbbXjttddw6dIlsCwLRqRfO+E+kWEG1Jst7Z7XMQwKyoyqUVLqzBgYxPZR7O8htIOowV+9ejX+9a9/ISYmBgAcRj8vL09y4dRMQZkRDU3cPYnsc2wB9cRXycvyP8uTB2Bxbjnv67TK0h6iBv+nn37Cd999R569DykoM2LpRxWwsSzve7SUxaLWTKVAkzI0Fms/q+JcReoZRtWxbNIpbkQ3bQcOHIj6+nqvDr5u3TpMnz4dqampOHz4cJvXfv/9d8yYMQNTp07Fyy+/7NXxlUjRictYlX9E0Njb0UJ81R7fN5oawUJZc3uVQOYj8e1mJYca9Ng07Q7VGkDSKX5EPfyamhqMHTsWt9xyC/R6vdshnQMHDuDUqVPIzc3F8ePHkZGRgdzcXMfrWVlZeOqppzBu3DisXbsWZ86cQc+ePTv+jWTO+4fqBTMnnNFCfFUoU0mtBsmfaHH/hE+nln5UAUA9YVJvEDX4WVlZXh24uLgYY8eOBQD0798fFy9eRENDA8LDw9HS0oLS0lJs3rwZAJCZmenVOZRI7RX3ZgloJb6q9kwlOaC1/RM+3VHj3piniBr8rVu3cj4vlppZV1eH+Ph4x+OoqCjU1tYiPDwcFy5cQOfOnbF+/XpUVVVh+PDhWLp0qYeiKwt7TJEvkMOgNWtH7VWQXJWfXNEtLaxupETLMWy+7DeAVo+iBt/eYgEArFYrSktLYTAYPD4R6/RXzbIszp49i1mzZiE2Nhbz58/H//7v/zqqe52prq72+FwA0NTU5PVnfU3RicvI2VeHqzZucx+kA5YkRiOpX4TTs5dQXX3JPwLCP9fL9To4V34600nP4InB4Q555HQvnZGrXIVHL+CvB391XGejqREr8ypgPGN00TH/4i8du8SjV3bOmBrbySHXe+lruUQNvqsRHjt2LObNmyd64JiYGNTV1Tkenzt3DtHR0QCArl27omfPnujduzcA4O6778b//d//cRr8uLg40XNxUV1d7fVnfc3TnxbxGnsACO9kwIKJI/0oUXv8cb3ErgPQmj2yYWrbDUU53Utn5CrX7LzCdtf5qo3FB0caAqpn/tIxERVDz8jQdnLI9V56K1dpaSnn86IG/7vvvmvz+Ny5c6ipqRE9YWJiIrZs2YLU1FRUVVUhJiYG4eHhrScNCsLNN9+MkydPok+fPqiqqsLEiRPd+R6KRCwefVHEI1EL7sTlW1hWs8ttX8G3T6SFfRGx76iVvTE+RA3+V1991eZxeHg43njjDdEDJyQkID4+HqmpqWAYBpmZmcjPz0dERATGjRuHjIwMpKeng2VZ3HbbbUhKSvL+W8gcsYpHrcSrqfJTWsT2ibRwbYV0LFZjexlciBr89evXo6amBj///DN0Oh1uv/129OjRw62DL1u2rM3jgQMHOv59yy234MMPP/RQXGUi1DlSSx6HWAdNLV0LX8PVr8gZg57RxLXl646p5iIzTxA1+G+//Ta+/PJLJCQkoLm5GVu3bsXjjz+OJ554wh/yqQLnXGijqRF6hoGNZTXncbjmhGuxP7tUrP2sSrC+o3NwkCaurRbrDjxB1OB/8803+Pjjj6HXt1brWa1WpKWlkcH3EHsutFw3h/yF1nLC/UFBmZE3DdGOVvaJANIxIdwaYq7T6dr8m/rqEIR8cKenvRbi9+7CVaMwICTQUvkHUYM/fvx4TJkyBXfccQdYlkV5eTmmTZvmD9kIgnADykxxH74pc8+PioIWFt5uGfwHHngA1dXVYBgG8+bNQ2wsLZcIQi5QZor78PXZef9QPRaoNzPcgajBf/HFF7Fz50706tXLH/IQBOEhlJniPnyrIXd7XCkdUYMfHR2N1NRUDB48uE1LhRUrVkgqGKEttNz7paO4ZqZEdw5CxsOD6PpxwLcaiu7s1nam4hH9lvfff78/5CA0DF9cFdBuV0NPcc5Mac0Eo+vGBd9qaHZC1wBK5T9EB6AAAMMwbf7T6/UoL+cfnUYQnsAXV12cW47ErCIUnbgcIMkItZEyNBbrJw9GbGQoGLTucayfPDigTeX8iaiHv3//fvz444+45557ALQONhk0aBBMJhP69OmDl156SXIhCXUjlGViNDUiZ18TYnuqZ6g7EVi48vT92Zk2kIgafJPJhM8//xyhoa15vE1NTVi+fDm2b99OxVeETxDrsXPVxmq6hznhe1z3jJ4YHK6JtEzRkM6ZM2fQ2Hj9j9FiseDkyZO4dOkSzGazpMIR2mB58oB2c1dd0UKnR8I/cM28zdlXp4mZt6Ie/ty5c/HYY48hIiICDMPAZDLhT3/6E4qLizFnzhw/iKh8nL2J1gyKG8hbdcK11xAXVClK+AquPSOtrCJFDX5KSgoeffRR1NfXg2VZREZGOvrqEOK4ZqCcu2KlDBQO7HFVrq6PnTTS6ZHwD1qeo+x2lk5UVBS6detGxt5D+DJQ3Ol/okW4sigW3XMj/TgSPoNvtahjGNWHdbRRbRBAtOxNeItrFoUcZ40SyoVvLoONZVW/+ub18N988802/ye8g8+boJg0NwVlRiRmFaFv+hdIzCpSvcdF+A+7bi3JLUenIB10HE1/1b765vXw9+zZg+PHj+PQoUM4efJku9f//Oc/SymXauCr7KOYdHu03smQkA5X3TIJzAdQ8+qb1+Dv2LEDx44dw5kzZzBz5kx/yqQqqM+J+2i9kyEhHVy6xYeaV9+8Br9r164YMWIE8vPzceDAAfz000/Q6XQYNGgQEhIS/CmjouBrAkZ9TsTReidDQjrc9drVvvoWzdJZt24d3nnnHbAsi6amJvzlL3+huD4PXAUdq/KPUBzaTfg8K610MiSkg0+3IkMN7frqqHn1LfqXVFVVhV27djkez58/H2lpaZIKpVSEUjDVrES+gmu/w6Bj0GRtQd/0L6htMuE1fHtpaybFa2rWtKjBt1qtaGpqQkhI69BHs9kMm829WJjWoBTMjuG639El1IArzVZcutoCgNomE97jqltadR5EDf7s2bMxadIk9OnTBy0tLfjtt99o+AkPfE3A1LwJ5Guc9zuGvvI1LDa2zeu0YqJhMd7C1SVTa4ga/AkTJmDMmDE4efIkGIZBnz59HJ0zibZQCqbvKCgzot7MnTqn5RUTDYshOoJbrRXCwsJw++23Iy4ujoy9AK5tASJDDQgx6LDk2iAP2rx1H6HiFy2vmMSGxZCOEUK4ZfAJ90kZGou96Ul4c/qduGptQb3Z0iZjh6Y3uYeQF6/lFZPYsBjSMUIIUYO/c+dOXLhwwR+yqAqhIiJCHKE0Oi2HLsRWN6RjhBCiBr+hoQHPPfcc5s2bh4KCAhp64iZURNQxuIai2NPotIw7w2JIxwg+RDdtn332WTz77LM4d+4cvv32W8ybNw/du3dHamoqRo4c6Q8ZFQlfxg4VEbkHpdFx486wGNIxgg+3Yvhnz57Fl19+ic8++wyRkZEYM2YM8vPz8frrr0stn2Lh81BnJ3QNkETKw74f8uXsftibnqR5Y2/Hfl3+3/Q7SccIjxB1BWbOnAmLxYJJkyYhJycHUVFRAIBJkyZh+vTpgp9dt24dKioqwDAMMjIyMGTIkHbv2bRpE8rLy7Fjxw4vv4J86RSkc8Txu4YZkPlIPAaEXAqwVIRa4FsFkY4RfIga/OTkZMyaNavNc59//jkefvhhQSN94MABnDp1Crm5uTh+/DgyMjKQm5vb5j3Hjh3DwYMHYTAYvBRfnnCN6WuytARQIkKtcBUTVVeTwSe44TX4hw8fxpEjR7Br1642Yw2tViu2b9+Ohx9+GMHBwbwHLi4uxtixYwEA/fv3x8WLF9HQ0IDw8HDHe7KysrBkyRJs3brVF99FNgj11Hn70R4BkkrZUHUpIRUFZUas+/w3nLtyAnqGgY1lEatSHeM1+NHR0QgLC4PFYkF9/fU0L4ZhkJWVJXrguro6xMdfz6iIiopCbW2tw+Dn5+dj5MiRiI0VvqDejrdramoK2Gg8oZ46gZRLCLnKBQCFRy/grwd/xdVrbRaMpkaszKuA8YwRSf0iAiaXXK8ZyeU+RScuI2dfnUO3bKy6dYzX4Hfr1g2PPfYY7rnnHtxwww0dPhHLXu+JYjKZkJ+fj3fffRdnz54V/Jy3HewC0f3O7oWyPK/3jAxFSEiILLvyyblb4Oy8QscfpJ2rNhYfHGnAgomByxTz5zXjWuEA3FlMcr2XcpTr6U+L2umWHSXrWGlpKefzvAZ/1apV2LRpE2bMmAGGYcCybJv/79mzR/CEMTExqKurczw+d+4coqOjAQD79+/HhQsXMHPmTDQ3N+O3337DunXrkJGR4fEXkwtccXtnrvfUofiqp/DllWulpw5X/5zlH1cADBzN5Zx76gwICZioikNMh9SmY7wGf9OmTQCAoqIirw6cmJiILVu2IDU1FVVVVYiJiXGEcx566CE89NBDAIDTp09j1apVijb2gPAItdg23hcZfE+J7hyEcxxGX8cwmuiTz6Vblpb2XintE3kOX72MnS6h6koo4TX4U6ZMAcNwjHW/Rl5enuCBExISEB8fj9TUVDAMg8zMTOTn5yMiIgLjxo3zXmKZwucJMAD2pif5VxiVMTuhK7buv9DO6DnHW9XcMdITL1NtHqnUcHW4deZKsxUFZUbV6BWvwc/JyenwwZctW9bm8cCBA9u9p1evXorPwS8oM0J3bXffFS13dvQVSf0iENsz1hGv5rrWau6TL+aFur6XcB+7vqz7vJJzFWmxsarSK16D//333yM1NRUbNmzg9PRpCEor9vgql7GnXvi+wznfvG/6F5zvUat3yzf60TmGD9A+kbekDI3FgJBLmPD+Cc6ECzXpFa/Bt6dL3nbbbX4TRonwxe71DKP6gciBQmuTxfgqarmeo30i79GCXvEa/Pvuuw8AMG7cOBQUFODkyZMAWouoJk2a5BfhlADfr38Ly5KxlwgtThbjG89HOuY7tKBXos3TFixYgDNnzmDYsGEYNmwYTp06hYULF/pDNkXA9+uvJq9AbrhOFouNDKXVFNFhtKBXor10rFZrm3j9+PHj8R//8R+SCqUktOAVyBEaSE1Igdr1itfgNza2hiqGDx+O//mf/8Fdd90FoLWCa8SIEf6RTgFQ33bC11DfIEIqeA3+xIkTHZW1n332WZvXGIbBc889J7lwSkHtXgHhP7iqatVcY0D4F16DL1Rhm5+fL4kwBCGEFjxfoU6r9tfV/P0JaRGN4R85cgTbtm2DyWQCAFgsFtTV1WHy5MmSC0cQdrTi+fJlfdm/r9q/PyEtolk6r732Gp544gmYzWasWLECI0eOVHzfG0J58Hm+Sz+qQEGZMUBS+XrwfyYAABfWSURBVB6+7C49wwh6/gThDqIGPyQkBKNGjUJwcDAGDRqEJUuWYOfOnf6QjSAc8Hm+NpbFqvwjqjH6fLOQuSq5AXVVgRLSI2rwQ0NDsWfPHvTq1QubN2/Gxx9/jN9//90fshGEA6G6BjV5uny54LFU70H4ANEY/htvvIHz58/jrrvuwnvvvYejR49iw4YN/pCNIByIdTVUk6fLl/VF9R5ERxE1+ADwww8/4NdffwXQ2lqhX79+kgpFEK7YDeDSjyo02ZWU6j0CR0GZEWt2V8HUaAEAdA0zIPOReEVee1GDv2DBAtx+++0YNmwYAKCiogILFy7EO++8I7lwBOGM/Q9Mq54u1Xv4n4IyI5Z/XNFm4Ey92YLleRUAlJch5VZrhZUrVzoeU2uF62ghL1xuaM3TJR0LLNmFRzmniym1Tz61VvASreSFyxGteLqkY4FHaG9IiftG1FrBS4QqIumPkfAFpGOBRWiSHaDMfSO3WytcvHgROp0OERERkgulBPh+3ZX4q0/IE9KxwCE0yQ4ADHpGkftGojH8ffv2Ye3atejUqRMsFgt0Oh1eeeUVxyauVokMM6DebGn3vBJ/9Ql5ooUJTHKFb5IdoPIsnZycHOzYsQMxMTEAgN9//x1Lly7FBx98ILlwcqWgzIiGpvYDj5X6q0/IE5q1EDj4VlEMgLKXH/SvMD5E1OAbDAaHsQeAHj16ICjIrfR91cK3c985OEiRv/qEfOkUpHMYfCV7lkqDb3XVJdSAxKwixWZNiVruXr16Ye3atRg5ciRYlkVJSQl69+7tD9lkC9+v/8XG9iEegvAG1wwdAGiytARQIm3Btboy6BhcabY6CrCUmDUlavBfffVVfP755ygtLQXDMBg2bBgmTpzoD9lkC8VWCV8glGNPGTqBhavew9xsbbdvp7R7ImrwX3zxReTk5CAlJcUf8igCiq0SHUUsx54ydAKPa71H3/QvON+npHsiavAjIyOxefNmDBkyBAaDwfH86NGjJRVMzmit2pPwPWIePK0i5Yca7omowbdYLKitrcWePXvaPK9lgw9op9qTkAYxD55WkfJDDfdE0OA3Nzfj+eefR48ePaDTibbOVz3U14TwFXzeIgAMfeVrmMwWdAk1IMSgg8lsIX3zM2L7K0q1AbwG/5tvvsG6desQExOD+vp6ZGdnY8iQIf6UTVZQXxPCl/D192cBx8agqdGCUIMeb06/k3TMj4j9rSv5XvC67W+//Tb++7//G//85z+xfft25OTk+FMu2SEUcyUIT7FPttIzjOD7SMf8j5r/1nkNvsFgQJcuXQC05uJfvXrV44OvW7cO06dPR2pqKg4fPtzmtf3792PatGlITU3FqlWr0NIi7xxjypogfE3K0Fi08PRqcYZ0zL+o+W+dN6TDuHgero/FOHDgAE6dOoXc3FwcP34cGRkZyM3Ndbz+8ssv4x//+AduuukmLFq0CN9//72sN4LVsEOvVuzxVqOpEfpr3Q1jFRJfFYrlO7+H8B9q/lvnNfiVlZWYOnUqAIBlWfz666+YOnUqWJYFwzDIy8sTPHBxcTHGjh0LoHUs4sWLF9HQ0IDw8HAAQH5+vuPfUVFRqK+v98kXkgo17NCrEdd4q727oVL2WMRm9ZKO+R81/63zGnzXHvieUldXh/j4eMfjqKgo1NbWOoy8/f/nzp3D3r178cILL3TofL6Ga5d+/eTBbWZbhhgocynQrP2sitdYNlpsWLO7StYG3zXzo0uoAQwDyswJIGLZOErO1mNY1o0gohe89NJLGD16tMPLnzFjBtatW4e+ffs63nP+/HnMmzcPL774Iu699952xygtLUVYWJhX529qakJISIhXny06cRk5++pw1Xb90nTSMxh7azi+OdbQ7vlF99yIpH7uzQnoiFxSIle5AH7Zik5cRvb3taKfX35ftNv3xxdyBRqSy3PclY3PNnhiA6SQyxWz2czZwl6ytpcxMTGoq6tzPD537hyio6MdjxsaGjBv3jwsXryY09jbiYuL8+r81dXVXn/26U+L2txQALhqY/HF0cvt3nvVxuKDIw1YMHGk5HJJiVzlAvhle/rTIo53t8eT++MJcr1mJJfnuCsbn22Qm46VlpZyPi9ZTCIxMRGFhYUAgKqqKsTExDjCOACQlZWF2bNn4/7775dKBK/xdDdeDbv3SsTd6073h/AVSs/gkczDT0hIQHx8PFJTU8EwDDIzM5Gfn4+IiAjce++9KCgowKlTpxybvw8//DCmT58ulTge4U7mhOv7Cf/j7n3SMQwKyoyyiLMqOf5L8OucnHRMCEknmSxbtqzN44EDBzr+XVlZKeWpO4RY5oQzatm9VyLu3icby8oiY4eqtZUPn87JRcfEoDQTHjoF8V8aPcOAARAbGYr1kwfL+garGXu1amxkqON+pI3qzVm9KodKSTVXcGoFoQppJdxLbc8q5IBr0pAzoQY9GXkZwdXbZNf+3zjfG+g4q9Ljv0QrKUNjsSS3nPM1ud9LMvguCE2rV0r1ptZxp1IyELF0NVdwag2hmbdyhkI6LghNq9+bnkTGXgEsTx6AUIO+zXPOey32VZzR1AgW12PpBWXGgMpFKIflyQNg0LUP61xptkquRx2BDL4LfN4WeWHKwTW2H3mtr/yS3HIkZhVxVuf6I/7KtedgDw8WlBmRmFWEvulfIDGrSNZGg2i9l+Eh7QMkFhsr6zg+hXRcUHMfDS1hj+1zZcbw4Y/4K9eeA2XvKBOTy0BzO3KO45OH74KQF0Yoi4IyI5Z+VOFWei0QuFUcZe8oEyVGA8jD50DpU22I616zzc1WUYFcxVH2jjJRYjSADL4TVAWpHoSyrVwJdPYVZe8oE+eumvZZDM4rMznaDgrpXCNQmRuENLjrHcsh+4qyd5RLytBYx/1zncUgR9tBBv8aFEdVF+56x3LwomnfSNnw2Y7F17LC5GT4KaRzDYqjqgt3+uzIyYumfSPlImQj5JZxRR7+NZS4407ww9dnJ9KpEjKQE8so7149iNkIOUUKyOBfg+Ko6iNlaCz2pifh16yJ2JuehOG3ROGqtcXxer3ZEpBYK+0XqQsu2+GKXCIFZPCvQXFU9RPofRq7V784t5z2i1SE3XZECvTRkUukgGL4TlAcVd0Ecp9GrAurv+QgpMN59eiMnCIFZPCvIZSDT/n56iBQ+e72il+xIjC5eIGE5/DVfegZRlaRAjL4EO5lAoD6nKiEQFRGulvxKycvkPAcvtVZC8vKyk6QwYd4bJfvNTndSEIc58pIf63W3Kn4DXSlL9FxlFItTQYf3sV2Kd6qTPy9TyOkJzQ9TT0opa8OZelAOAef8vOJjhAZxp25IbfYLtExuLL8pgyLRXbhUVnVWpCHD/FfZyX8chPyo6DMiIYma7vnDXoG2VPvIGOvMpxXj3KdcaA5g++ccdMl1ACGaR1k0OXaVCST2cIZ26UsHfUiVRZWduFRWFrab9Z2Dg4i/VE5fPuCa3ZXkcH3F66/uqbG6xNrTI0WhBr0eHP6ne1uCOXnqxcpPTG++P1FJ70j1AnfvTc1WlBQZgyYPdFMDN+d6Uf2X2BCG/DpREerXu0VtXyJmLT/o36E7nEgK6o14eGvLjiCXft/4/0DdCbQv8CEfxDLjxeafct1LOcw4ZVmKyw27uPS/o82WJ48AItzyzlfC2SGn+o9/IIyo9vG3g71NFE/YvnxDOBWVoVrIzRTo4XX2FN/Ju2QMjQWXXkytAK5wlO9wc8uPOqRsQcox14LiN1jFsDi3HIMfeVrQcO/9rMqt0YpymGyFuFfMh+Jl10HXtUbfG+MN8VY1Y+797jebMHyvApOo1904jLqze5twJJOaQ85duBVdQy/oMwIHcOI9jFxJtC/wIR/cGcilh2LjcXi3HKs/awKmY/EO/5g3z9U79a5SKe0iz3Dr6DMiDW7q7A4t7xdbF/HAC2sf1psqNbgF524jK37T/Ea+87BepibbW1y8SnHXjs499UxmhrBAKKhP7u3b/987ZX2RVVcBNqrIwJLQZkRyz+u4KzJAFqNPeCf4ixJDf66detQUVEBhmGQkZGBIUOGOF7bt28fNm/eDL1ej/vvvx8LFizwyTntv6QmnlxnPcNg0zSqciTaV0a608LY7u3zZWBwYU8CIJ3TJnwFeFzYh58vzi1H1zADnh4Wibg438kiWQz/wIEDOHXqFHJzc/H666/j9ddfb/P6a6+9hi1btuDDDz/E3r17cezYsQ6f0/5LymfsAfm1KyXkQcrQWGyadgcMOsbnx6YRhtrG2ySQerMFb+6t9aneSGbwi4uLMXbsWABA//79cfHiRTQ0NAAAampq0KVLF/To0QM6nQ6jR49GcXFxh8/pzi8pbZ4RfKQMjUX243cIjqoTggF4U/FohKF26YjNsbb4Nk1cspBOXV0d4uPjHY+joqJQW1uL8PBw1NbWIioqqs1rNTU1nMeprq52+5xiv6Sd9AyeGBzu0TF9TVNTU0DPz4dc5QL8K9uAEODDaTej6MRlbP6hFjwp9bx88PjNmPD+Cc79gDOmRr98D7neS7nKBUgr2xODw7H5h0aPdcmOL/XGb5u2rAeZMs7EeRDA6hn5O2+FpJ5hsEEGHQqrq6s9+k7+Qq5yAYGRLS4OiO0pvB/kSs/IUMTFxfHqof11qZHrvZSrXIC0snmjS854ozelpaWcz0tm8GNiYlBXV+d4fO7cOURHR3O+dvbsWcTExHT4nMuTB3DuhlM7WsIbnFPqhLIsgFYds6deKmUYBuE/+Bowig23D9LBp3ojWQw/MTERhYWFAICqqirExMQgPDwcANCrVy80NDTg9OnTsFqt+Pbbb5GYmNjhc3LFYLuGGcjYEx1CLLbvqmNyLLgh5ImzrgCt+0B2uoYZsCQx2qd6I5mHn5CQgPj4eKSmpoJhGGRmZiI/Px8REREYN24c1qxZg6VLlwIAJkyYgL59+/rkvPZfUjkvHwnlweWhCekYtdQm3EVIV3y9ryBpDH/ZsmVtHg8cONDx7xEjRiA3N1fK0xMEQRBOqL6XDkEQBNEKGXyCIAiNQAafIAhCI5DBJwiC0AgM621FlB/gKx4gCIIghBk2bFi752Rt8AmCIAjfQSEdgiAIjUAGnyAIQiOobuKV0NCVQLBx40aUlpbCarXimWeeQVFREaqqqhAZGQkAmDt3LsaMGeNXmUpKSvDCCy/gD3/4AwDgtttuw9NPP40VK1bAZrMhOjoa2dnZCA4O9qtcAPDxxx9j9+7djseVlZUYNGgQzGYzwsLCAAArV67EoEGD/CLPL7/8gueeew5z5sxBWloafv/9d87rtHv3brz//vvQ6XSYNm0aHn/8cb/LtWrVKlitVgQFBSE7OxvR0dGIj49HQkKC43Pvvfce9Hq9wJF9L1t6ejqnzgf6mi1atAj19a1jKk0mE+68804888wzeOSRRxz61bVrV+Tk5Egql6uNGDx4sHQ6xqqIkpISdv78+SzLsuyxY8fYadOmBVSe4uJi9umnn2ZZlmUvXLjAjh49ml25ciVbVFQUULn279/PLly4sM1z6enp7JdffsmyLMtu2rSJ3bVrVyBEa0NJSQm7Zs0aNi0tjT169Kjfz3/lyhU2LS2NXb16Nbtjxw6WZbmv05UrV9gHH3yQvXTpEtvY2MhOnDiRra+v96tcK1asYL/44guWZVl2586d7IYNG1iWZdmRI0dKJoe7snHpvByumTPp6elsRUUFW1NTwz722GOSyeEKl42QUsdUFdIRGroSCEaMGIE///nPAIAbbrgBjY2NsNnEh2YHgpKSEjzwwAMAgD/+8Y8+GUjTUd566y0899xzATt/cHAwtm3b1qaTK9d1qqiowODBgxEREYGQkBAkJCTg0KFDfpUrMzMTycnJAFq9UpPJJNn5PZWNCzlcMzsnTpzA5cuXAxIN4LIRUuqYqgx+XV0dunbt6nhsH7oSKPR6vSMMkZeXh/vvvx96vR47d+7ErFmzsGTJEly4cCEgsh07dgzPPvssZsyYgb1796KxsdERwunWrVtArxsAHD58GD169HC01M7JycHMmTPx8ssvo6mpyS8yBAUFISQkpM1zXNeprq6u3UAfKa8fl1xhYWHQ6/Ww2Wz44IMP8MgjjwAAmpubsXTpUqSmpuLdd9+VTCYh2QC003k5XDM7//jHP5CWluZ4XFdXh0WLFiE1NbVNeFEKuGyElDqmuhi+M6xMMk6/+eYb5OXl4Z133kFlZSUiIyMRFxeH//qv/8LWrVvx8ssv+1WePn364Pnnn8f48eNRU1ODWbNmtVl5yOG65eXl4bHHHgMAzJo1CwMGDEDv3r2RmZmJXbt2Ye7cuQGWkP86Ber62Ww2rFixAqNGjcLdd98NAFixYgUmTZoEhmGQlpaG4cOHY/DgwX6V69FHH22n80OHDm3znkBds+bmZpSWlmLNmjUAgMjISLzwwguYNGkSLl++jMcffxyjRo3yybwOIZxtxIMPPuh43tc6pioPX2joSqD4/vvv8be//Q3btm1DREQE7r77bkdL3aSkJPzyyy9+l6l79+6YMGECGIZB7969ceONN+LixYsOz9lXA2k6QklJicMojBs3Dr179wYQuGtmJywsrN114tK7QFy/VatW4ZZbbsHzzz/veG7GjBno3LkzwsLCMGrUqIBcOy6dl8s1O3jwYJtQTnh4OKZMmQKDwYCoqCgMGjQIJ06ckFQGVxshpY6pyuALDV0JBJcvX8bGjRvx97//3ZGhsHDhQsf83pKSEkemjD/ZvXs3tm/fDgCora3F+fPnMXnyZMe1+/rrr3Hffff5XS47Z8+eRefOnREcHAyWZTFnzhxcunQJQOCumZ177rmn3XW64447cOTIEVy6dAlXrlzBoUOHMHz4cL/KtXv3bhgMBixatMjx3IkTJ7B06VKwLAur1YpDhw4F5Npx6bwcrhkAHDlypE3b9v3792P9+vUAALPZjJ9//tlnszq44LIRUuqYqkI6XENXAsmXX36J+vp6LF682PHc5MmTsXjxYoSGhiIsLMyhXP4kKSkJy5Ytw549e2CxWLBmzRrExcVh5cqVyM3NRc+ePZGSkuJ3uew4D7lnGAbTpk3DnDlzEBoaiu7du2PhwoV+kaOyshIbNmyA0WhEUFAQCgsL8cYbbyA9Pb3NdTIYDFi6dCnmzp0LhmGwYMECRERE+FWu8+fPo1OnTnjyyScBtCYtrFmzBjfddBOmTp0KnU6HpKQkyTcmuWRLS0trp/MhISEBv2ZbtmxBbW2tY/UIAMOHD0dBQQGmT58Om82G+fPno3v37pLJxWUjsrKysHr1akl0jForEARBaARVhXQIgiAIfsjgEwRBaAQy+ARBEBqBDD5BEIRGIINPEAShEVSVlkkQvmDXrl349NNPERwcjKamJrz44ouIiopCp06dJM3JJgipIYNPEE6cPn0aH330EfLy8mAwGHDy5EmsXr0ad911FwYNGkQGn1A0ZPAJwomGhgZcvXoVFosFBoMBffr0wUsvvYSnnnoKUVFR6NatG5qbm7F582YEBQWhR48eePXVV1FWVoZt27YhODgYZ86cQXJyMv70pz8F+usQRBvI4BOEEwMHDsSQIUPwwAMPYPTo0bj//vvx4IMP4r777kNycjKGDBmClJQUvPfee4iMjMTGjRvx1VdfoXv37qisrMSePXsQFBSE8ePHIzU1tU33VoIINGTwCcKFjRs34vjx4/j+++/x9ttv48MPP0TPnj0BtLbOPXXqlKO9g9lsRteuXdG9e3fccccd6Ny5MwDgD3/4A2pqasjgE7KCDD5BOMGyLJqbm9G/f3/0798fTz75JMaPH+943WAwICYmBjt27GjzuZKSErS0tLQ5DkHIDUrLJAgn8vLy8NJLLzkM9uXLl9HS0oJevXrBZrOhS5cuAFoHyADAjh078PPPPwMAfvrpJzQ2NuLq1as4duwY+vTpE5DvQBB8UPM0gnDCZrPhjTfewMGDBxEWFgar1Yr58+fj/Pnz2LJlC9avXw+DwYANGzY4vP2NGzeirKwMb731Frp164aTJ09i/PjxmD9/fqC/DkG0gQw+QfiAkpIS7Nq1Czk5OYEWhSB4oZAOQRCERiAPnyAIQiOQh08QBKERyOATBEFoBDL4BEEQGoEMPkEQhEYgg08QBKERyOATBEFohP8PwBjm1CGbOWkAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXsAAAEBCAYAAACZhwWsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAAA2yklEQVR4nO3de2ATVb4H8O8kTWjaAAWLCIVi6QWsCLYFXZTXXVgsikAFbAuKeAXXB8oF2UIpCrXyqKDAFRF8LQoKFCtbQVhxoexFHrpsbSvUWq+ArBtYEGi39J0mc/8oCWk6k0nSzGQev88/0KRJfpmc/HrmzO+cw7Asy4IQQoiq6YIdACGEEPFRsieEEA2gZE8IIRpAyZ4QQjSAkj0hhGgAJXtCCNGAkGAHwKewsDDYIRBCiOIMGjSI83bZJnuAP2ghZWVliIuLC3A0bUdx+U6usVFcvqG4fOdPbJ46yTSMQwghGkDJnhBCNICSPSGEaAAle0II0QBK9oQQogGiVeOUlJTgtddew9atW1vcXlBQgA0bNiAkJASTJ09GSkqKWCGQ6/KLLFi9vxznK+vQ0WQAwwAVtVYwABxLnuqYM7CzQMT1+ytrregeYUJ6Uj8kJ0QFM3yiMI72Zqmsa9HGOoX9gqXj+1N7ChJRkv27776L3bt3w2QytbjdarVi5cqVyMvLg8lkwtSpUzFq1ChERkaKEQZB8xdv0a6TqLPaAACVdVbnfa5rW9uv/+B6v6WyDot2nQQA+oISr7i3N9c2VlFrRXpeCQBqT8EgSrKPjo7G+vXrsWDBgha3nz59GtHR0ejYsSOA5jr6EydO4P777xcjDE1z7V21RZ3VhtX7y+nLSVpxbWN6hoGNZZ3/8rHaWMzLLcbLe0rp7FFioiT7pKQk/POf/2x1e3V1Ndq3b+/8OTw8HNXV1bzPU1ZW5tfr19fX+/1YMUkVV8GZa3jj2GU02AKzL835yrqgHU+tf5a+ClYbcyR4T4negUVzLx9oPntcmFcCy3kLRvVu7/mBIpDr5wgEPjZJZ9CazWbU1NQ4f66pqWmR/N35O7NNrrPipIpr1mcFAUv0ANA9whS046n1z9JXSmxjDTYW205WY/a4uwPyfL6Q6+cIKHwGbWxsLM6dO4fKyko0Njbi73//OxISEqQMQRPOt3HoxpXJoEd6Ur+APR9Rh0C2MTGej7QmSc9+z549qK2tRWpqKjIyMjBz5kywLIvJkyeja9euUoSgKRFhBudpclswABiwmJtbjLm5xegUZqBqCo1yrejqHmFCmFGPmkZbwJ6/e4RJ+JdIm4iW7Hv06IGdO3cCAMaPH++8fdSoURg1apRYL6t5+UUWVNc3tbpdxwB6HQOry6m3yaDHykkDYDlvwZtfX3VWUACAQdd8oa3WanfeRtUU2uReYePPRX89A/CN+tDZozRkveol8d3q/eWw2lt/q+ws0MEYwllDXxZahajuUS16brWNTZxnB1YbS9U5GrN6f3mLjoCvoiJMuFbXgKoGe6v7GAChBh3m5RYja3cpzfEQESV7lfE09llZZ4XJoMfa1PhWX6LkhKgWt8Vk7PXrNYj6tOXzdvTa5+UWc97vWplDczzERcslqIzQ2Kejbt6T/CILdAzj92sQdfH289ZfbzOOf6MiTFg5aQCSE6LQJdz3fqU3bZV4j3r2KpOe1K/F+CoXTz01x/gsX720Qc/Q+KrGeNOmHNd/+HrhMxI7tbou5A06iwwc6tmrTHJCFFZOGoAoD70xTz01T+OzncIMWD3lTjqt1hjXNsWgucf+6JDoFj97SvQAMKp3e8F2yYXOIgOHevYq5Bh/d6+iAIQrH/h6UgyAoiX3BTpUohDu13Ta8hwxGXvhzXQsqtIJLEr2KuFeB+1aycB3O5fuESbO0jpHD4trBU2qnlAPT+0oUPjaGNBcImxnm88WqD0FFiV7FeCqg3atZPDlC8M1PuvoYXlaQZOqJ5RPqB0FiqdrAHb2RnujdhRYNGavcPlFFszfWdLqi1NntSFrd6nPz8c1Prty0gAA4Hwd99ek6gnl4rpe4/6Z5hdZMDSnADEZezE0pwD5RRafX0fouhK1I3FQz17BhCpnKuusyC+y+NxDcj8bEHodV1Q9oVx8n53j9kD2/IXG76kdBR717BWKr0fvLhA9JF9mUFL1hHLxfXaO273p+QfqNVnA7zMHwo2SvQJJ3dP29jmoekLZ0pP6wWTQt7jN9TMV6vkH6jUdHGcOlPADg5K9Aknd0/bmOfQMI1hrTeSN73qN4zMV6vm39TW51FltmJtbjFvbcI2ANKNkryCOi2PerjoYqJ62p96Xg51lKdGrQHJCFI5mjMLa1HgAwLzcYmeSFer5t/U1+RfoaEY9/bahZK8QjqEbT4meQfMsV29nNXqrrbNyibK4tjUWLS/Eeur5t5U3bYgqdfxH1TgKITR0I7Q2SVu1ZVYuURZPF2KPZowSrY15swYPQJU6/qJkrxCeGriUsw39mZVLlEWMC7HecLSh+TtLPBYf0FmkfyjZKwTfFPOoCBOOZki781cg1kkh8sXX1jqaDKK/tqNd8fXw6SzSfzRmrxBiXRwjxF16Uj8YdK0vl9Y0NklycdT9GhHX+vjEd9Szlzn3hcdCDTpU1FqhZ5gWF6voC0ACJTkhCi/vKW21LaXVxmL+Tmn2IKazx8CjZC9jXAuPGXQMDPobG4fTAmREDJUc+w8DgI1lqb0pFA3jyBhXVYTVzjoTvQOVo5FA83QRlNqbMlGylzFfqh+oHI0EktBEOmpvykPDODLmaZMHrt8NBik2uyDSEyqDpPJH5aGevYxx9a4cY/auglWVwzfTkqazq0NyQhReT7mTqsBUgnr2MuY6gclSWQc9w8BqZxEhk+0A+WZazs0txur95dTLVwE5TKJznD06vgM2lqVtC/1AyV7muCaZVNZZYTLosTY1PqiN3dO4LVUJqUcwyyDdK9IcQ0rUvnxHwzgKIMamEYEgNG4rhxiJsnlaE8pxFklLH3uHkr0CBGutEiHeLH0c7BiJsnnTfuhakXco2SuAGJtGBAItfawOgdhEXCzeth86ixRGyV4B5LwujmPjiXWp8bKNkfCTe0WVN2ePDnQW6Zkoyd5ut2PJkiVITU3F9OnTce7cuRb3//GPf8SkSZMwefJk/OUvfxEjBFUR2i5OLtqF3GhOOuZGb0suiYO0JtfrQQ7enD06SLEqp5KJUo1z4MABNDY2Ijc3F8XFxcjJycHGjRsBAFVVVdiyZQu+/PJL1NXVITk5GWPGjBEjDFWR88JQXBua2K/Pw6GqCXmT6/UgV462H5OxF/yr3N9YlZPaGTdRevaFhYUYPnw4ACA+Ph6nTp1y3mcymdC9e3fU1dWhrq4ODCO08ySRO6FdtOTUUyQtRYRx94Z1DCO7MzKh8XurjaV25oEoPfvq6mqYzWbnz3q9Hk1NTQgJaX65bt26Ydy4cbDZbHjqqad4n6esrMyv16+vr/f7sWJSa1ze9ALPV9b59RpqPWZi8SWugjPXUFXHv7rlwrwSWM5bMKp3e0nj4jNtgBlvHKtHg42/f+9rO5Pr5wgEPjZRkr3ZbEZNTY3zZ7vd7kz0hw8fxqVLl3Dw4EEAwMyZM5GYmIiBAwe2ep64uDi/Xr+srMzvx4rJ27ikXm+mrcere8QFwTV8dAyDBz484/P7UfpnKTVf4pr1WQE85E002FhsO1mN2ePuljQuPnFxQFT3G7NpuegYBuX1HRTfvgD/YissLOS9T3AYp7q6GmvXrsWiRYvw5ZdftrrYyiUxMRGHDx8GABQXF6Nv377O+zp27IjQ0FAYjUa0a9cO7du3R1VVlTfvQxPkXh3BxZuKCRvLKub9aIW3Z2Ry4qn6C7ix3j61r9YEk31mZiZ69uyJc+fOITIyEosXLxZ80jFjxsBoNCItLQ0rV67EokWLsHnzZhw8eBCDBw/GgAEDkJKSgtTUVNx6660YOnRoQN6MGry8p5SzOmL+zhLZNmD3aqEIkwGdwgxgcGNLOVc0hh98+UUW6Ly4XibXeRKONkfty3uCwziVlZWYMmUKdu/ejcTERNjtdsEn1el0yM7ObnFbbGys8/9z5szBnDlz/AhX3fKLLK22gnOQ+w5BfNVCMRl7OX9fbj1GLXGcPXItXexK7vMkkhOiMC+3mPM+al+teVWNc/r0aQDAv/71L+j13k1wIL4T6o0oscci19m/WsZXPcUAzjMyuc7lcEfty3uCPfsXX3wRmZmZOH36NObMmYOsrCwJwtImJY6hCklP6teqBl/uPUa189SGipbcJ2EkbUfty3uCyd5isSA3N9f58759+3D77beLGpRWebMzldJ6LHJYD520rPDSXV8T3p3S2hZA7csXvMn+0KFD+Pbbb7F3714UFRUBaC6hPHjwIB544AHJAtQSrl6KK6X2WOQ8+1cL+NaEd6XUtgVQ+/IWb7K/7bbbUFlZiXbt2iEmJgYAwDAMxo0bJ1lwWuLoedVZbc7deOSyIxVRNr4xej3DwM6y1LY0gjfZd+vWDQ899BAmTpwIne7GddxLly5JEpiWcPW8TAY9sib0py8gaTO+MXo7y+JsDnXetEKwGmf9+vUYMmQIBg0ahP79++O//uu/pIhLU+S+8iBRNqpYIYAXyb6goACHDx/G+PHjsW/fPnTt2lWKuDRFCSsPEuWS834IRDqCyb5Lly4wGo2oqalBr169YLVyT/oh/qOeFxGTUvZDIOISLL285ZZbkJeXB5PJhNdff53WsREB1QoTsVHFChFM9tnZ2bhw4QLGjh2LP/3pT1izZo0UcWmKGmuFHdVFlso6Z3VRlAreFyFKxZvsbTYbbDYbXnjhBaxduxYsy+Lhhx/G73//e2zZskXKGDVBTT0vvrpu2rWKkODhTfaffvopNm3ahMuXL2Ps2LFgWRZ6vR6DBg2SMj6iQJ52rqqz2jA3txir95dTL5+IQur9IJSCN9mnpKQgJSUFeXl5mDJlipQxEYXzpoqIevlEDO5nldTObhCsxrnjjjtQVFSEkpISzJgxA8ePH5ciLk3IL7JgaE4BYjL2YmhOgWzXq/eVt1VEdVYbsnaXihwN0RKas8JPMNlnZWXBaDRi48aNmDdvHt58800p4lI9Je5I5S1vdq5yqKyzquI9E3mgOSv8BKtxjEYj+vTpA6vVivj4+BZLJxD/eeqBKP1007W6yLUah48a3rMSqLlCyvHe+FoZzVnxItkzDIMFCxZgxIgR2LdvHwwGgxRxqZ7aeyDu1UX5RRbMpV2FgkbNFVLu782dQc/QnBV4MYyzdu1aPPTQQ3jsscfQuXNnqrMPEK3Nmk1OiEKnMO6Oglrfs5wIVUgpeUzb03sDgHBjiGL/kAWSYLLv3LkzRo4cCYZhMGTIEEREREgQlvppcb2SpeP7a+49y4XQ2ZOSz66EYv93HS3xAni5By0JPC2uV6LF9ywXQmdPSj67UvN7CyTBMXsiHjXNmvWWFt+zHHjaBU3pZ1dqfm+BxJvsFy1axPuglStXihKMVml9xp/W37+YXI9tR5MBoQYdKmqtqqrG4av+UsN7CyTeZO/YZ3b79u1ISEhAYmIiTp48iZMnT0oWnBZofcaf1t+/mNyPbWWdFSaDHutS41V3bOmMURjvmP3w4cMxfPhw1NfX48knn8SgQYPw+OOP4+rVq1LGp1qO2bNzc4s1PeOPZjyKh44tcSV4gba2thbHjx9HdXU1vvrqKzQ0NEgRl6q5zp7lo+TqCF+ofb5BMNGxJa4EL9AuX74cq1evxtmzZ9GnTx+8+uqrUsSlakJ1wYB2Kgi6R5g4/+hp5f2LiY4tcSWY7GNjY7Fp0yYpYtEMoZ6VlioIaJcu8dCxJa4Ek/2mTZvw3nvvITQ01HnbkSNHRA1K7fh6XAA0V0Ggxl265IKOLXElmOz37duHr776CiYTnfoFCl+PS6sTjKiSQjx0bImDYLLv0aNHi149aTvqcVFtvRToGBNXgsnearVi/Pjx6Nu3L4DmVTBff/110QNTOy33uKi2Xnx0jIk7wWT/5JNP+vykdrsdWVlZKC8vh9FoxLJly9CrVy/n/f/7v/+LDRs2gGVZ9O/fH0uXLgXDMD6/DlEmNa/lLxd0jIk7wWR//vx5n5/0wIEDaGxsRG5uLoqLi5GTk4ONGzcCAKqrq7F69Wps2bIFnTt3xrvvvouKigp07tzZ9+iJIlH9t/joGBN3gsn+9OnTAACWZVFWVoaIiAgkJyd7fExhYSGGDx8OAIiPj8epU6ec9xUVFaFv37549dVX8csvv+Dhhx9WfaJvOXZ6QfNjp1T/LT46xsSdYLKfP3++8/8sy+Kpp54SfNLq6mqYzWbnz3q9Hk1NTQgJCUFFRQW++eYb5OfnIywsDI888gji4+MRExPT6nnKysq8fR8t1NfX+/3YQCs4cw1vHLuMBtuNnYEW5pXAct6CUb3bBzm6ZlIfr2kDzHjjWL3zmABAOz2DaQPMreKQ02fpSu5x+XKMpYxLbuQaFxD42ASTfWNjo/P/v/76K/75z38KPqnZbEZNTY3zZ7vdjpCQ5peKiIjAgAED0KVLFwDA4MGDUVZWxpns4+LihN8Bh7KyMr8fG2izPito8YUDgAYbi20nqzF73N1BiqolqY9XXBwQ1d27ShE5fZau5B6XL8dYyrjkRq5xAf7FVlhYyHufYLIfO3as8/+hoaGYOXOm4AsmJibi0KFDeOCBB1BcXOys5AGA/v3748cff8TVq1fRoUMHlJSUICUlRfA5lYrGTrlpuRpJKnSMiSvBZF9QUAAAuHLlCjp16gSdTnhzqzFjxuDo0aNIS0sDy7JYsWIFNm/ejOjoaIwePRrz58/HrFmzADT/MXH9Y6A2NHZKCJEDwWT/zTffYPHixTCbzaiqqsIrr7yCoUOHenyMTqdDdnZ2i9tiY2Od/x83bhzGjRvnZ8jKQuuTEELkQDDZr1u3Dh9//DG6du2Kixcv4rnnnhNM9uQGrl10XNcUp9PsZjTbkwSa+y5dDANU1lo1274Ek71er0fXrl0BAF27dkW7du1ED0ptHI1qYV5Ji6ocmtHYzNNsz360UgfxA9cuXQ5abV+CA/Bmsxlbt27FDz/8gK1bt6Jjx45SxKU6q/eXt6rK0fquQbRbFxGL0J4RdVYbsnaXShhR8Akm+9WrV+P8+fNYu3YtLly4gBUrVkgRl+pQVU5LtFsXEZM3baeyzoqCM9ckiEYeBIdxsrKyaOGzAOCryuloMgQhmuCj3bqImDztGeHqw28rMFsbtSLCPfvGxkb88MMPaGhoQGNjY4tJVsR76Un9oOdY662msQn5RRbpAwoy2q2LiMnbtvNrTZPIkciHYLI/e/Ysnn32Wdx///0YO3Ys7r//finiUp3khCiEG1sfbquN1eTYtKdeu2vFkpZOswPFcS0kJmMvhuYUaLIzkZwQhU5hwmfNXcIFBzdUQ/Cdfv7551LEoQnXGuyct2txbJpr/oFBxwBM8x9AoLlq4o1j9YjqbtF8xZK3Cs5cw5tfn6N17AEsHd+/VRtzZTLoMSOxk8RRBY9gsr/vvvtgs904WCEhIejWrRvS09PRv39/UYNTmy7hIbjEcdqoxbFprt26ahubUFFrbfF7DdfPfLSWqPz19t+uoM7aslOh1XXs3dsYV619v9CqIEcpHcFkP2TIEIwdOxaDBw9GUVERPvnkE0yePBnLli3D9u3bpYhRNWYkdsKbX1+l2bTXua/dEpOxl/P3tHjm44/8Iguq6OyxBaH1gcrKtJPsvRqzv/fee2E0GvGb3/wGv/76K+655x6v1sghLY3q3R4rJw1AVIQJDICoCJNmNxnnwneGo8UzH1/lF1kwf2cJ7/10DIlgz95oNGL79u1ISEhAUVERjEYjTp061WJoh3iPViLkxzWO307PaPbMx1uOOQs2luX9HTqGRLB7/tprr+Hnn3/Ga6+9hl9++QWrVq3ClStXsHz5ciniIxqSnBDV6sxnzr2R9MfRA0eP3tOchQiTgY4hEe7Zd+rUCYsWLWpx28iRI0ULiGib+5mPXHcRkgNvevQmgx5ZE6iQgniR7Il/uFZx1NKiS21F+/YKE5qFrGcYuiZEnHiHcU6cOAEANGPWD67rvrC4UetME4S8w3f8tDg5yBNPFTYmgx6vp9xJiZ448Sb7ZcuWoba2FjNnzoTVanUulUDJXxhXj6vOasOH31YEKSJl4Tt+Wpxp7AlfhQ316AkX3mGcYcOGYcKECbh06RKSkpKctzMMg4MHD0oSnFLx9bi0tA5HW9AKod7hq156dQr16ElrvMk+PT0d6enp2LBhA2bPni1lTIrHt+KeltbhaAvat9c7XLOQpw0wU6IX4Ho9qEt4CDIf7KCJYyZYejlp0iTMmTMH48aNw+zZs2Gx0LipkPSkfjAZ9K1ur2+y07izF7iOn5ZnGvPhKgIY1bt9sMOSNffrQZdqmjRzPUgw2b/00kuYOHEitm/fjoceegiZmZlSxKVojnrxCLe16qsa7JppWG3BVW9PY9AtURGAf7R8PUgw2Tc0NGD06NHo0KEDfve739HMWS8lJ0QhvF3rYRutNKy2Sk6IwtGMUdg3ozeOZoyiRO+GigD8w3fdx5uNTpROMNnbbDaUlzcnJ8e/xDt0oZGIhYoA/MN33YcBVH/G7dUwTmZmJkaMGIHFixfjxRdflCIuVaCFvYhY+NoQFQF4lp7UDxwbxoEFVH/GLZjs4+Li8Omnn+Lw4cPIy8vDbbfdJkVcqkAXGolY+NqWljbj8EdyQhT4FpdQ+xk3dQNE5F4a11zmdQeNP5M24yq71NpmHP6K0mhpLyV7kbku7FVWVoa4OEr0JDC4lsvW0mYc/uKajKaFM27BYZzs7GxaedBLtNEzIfLnWtoLtNzgXs3fWcGe/X/+539i06ZNuHjxIiZMmIAJEybAbDZLEZuiOOqeaaNnQuTP8Z1cmFeCBpcN7tX8nRVM9iNGjMCIESNw9epVLF++HKtXr0ZSUhKeffZZREdHSxGjIniarKHGhiOF/CILVnz+D1yqOQMGcF5Y6xRmwNLx/em4kjZZvb/cmegd1PydFUz2p0+fxq5du3Do0CH85je/wccff4ympibMnTsXu3btkiJGRaCa+sByP1Ny/UpW1FqRnte836oav5REGlr7zgqO2b/44ouIjY3Fp59+iqVLl+L222/HwIEDMXnyZN7H2O12LFmyBKmpqZg+fTrOnTvH+TuzZs3C9u3b2/YOZCC/yAIdw1W9q/4r/GIR2pjDamNVXxdNxKW1eTCCyX748OGYNGkSTKbmA/D6668DAB555BHexxw4cACNjY3Izc3F/PnzkZOT0+p31q1bh6oq5VcOeNoaTgtX+MXiTe9KrT0wIo30pH5op2/ZSVPzd5Z3GOeTTz5BXl4eTp8+jcOHDwNoXjqhqakJ8+fP9/ikhYWFGD58OAAgPj4ep06danH/F198AYZhnL+jZHw9UNpAom34ljl21dFkwNCcghZ15nS8ibeSE6JgOW/BtpPVsFTWtajKcdyvJrzJfuLEibjnnnvw9ttv4+mnnwYA6HQ63HTTTYJPWl1d3aJiR6/Xo6mpCSEhIfjxxx/x+eef44033sCGDRs8Po+/JZ/19fWSlYvy9S7tLIt+oVUt6p6ljMsXcoxr2gAz3jhW3+oCmgMDoLrBiso6K4DmSoqFeSWwnLdIssyvHI8ZQHH56t7uBgAt25rUbYlPoI8Zb7IvLy/HgAEDcN999+Hs2bPO20+fPo1hw4Z5fFKz2Yyamhrnz3a7HSEhzS+Vn5+PixcvYsaMGbBYLDAYDIiKisKIESNaPU9cXJzPbwhwTF7y77G+6h5xgbMHygKY9VnLjbKljMsXcowrLg6I6m7Bis9P4VJNU6tqHKD5Qq2rBhuLbSerMXvc3aLHJ8Ux41qvXqi3KcfPEpB3XNtOVrTqVEjZlvj4c8wKCwt57+NN9sePH8eAAQOwb9++VvcJJfvExEQcOnQIDzzwAIqLi9G3b1/nfQsWLHD+f/369YiMjORM9ErBNRvPQe11u2JLTohCv9AqzgYfk7GX8zFqGceneRvS0UpVDm+yf/zxx9HY2IiXX37Z5ycdM2YMjh49irS0NLAsixUrVmDz5s2Ijo7G6NGj2xSw3LiuUcLVw1dz3W4wqX3rQpq3IR2+tsQCGJpToJprQbzJfuzYsWDcyglZlvVqw3GdTofs7OwWt8XGxrb6veeff96XWGXLsUZJTMZezhX11NZDkAO1r2+ild6mHGjl7Jw32RcUFEgZh2K5jqvqGIazBFMtvU054Vv1UelfSAe1n7nIiVbOznmTfXZ2tnNilHsPf8eOHaIHpgTu46pUay8trlUf1ULtZy5yo4Wzc95k/+yzzwIA1qxZI1kwSuOpxt7OsqrrbRLpuJ+5dDQZwDDA3NxizMstpnWCRKLmMyreZB8ZGQmguWxy1apV+Pnnn9GnTx+kp6dLFpzceaqxP5szTuJoiNo4epu0TpB01HxGJbgQWmZmJmbNmoXExEScOHECmZmZ2Lx5sxSxyZ6aewEkuLy5FuTgWCeIkn3bqflakGCy1+v1GDlyJABg1KhR+PDDD0UPSinU3AsgwePNtSB3ahhTlgu1XgviTfZHjhwBAJhMJrz77ru466678N133zmHd7TO0fOqs9qgv97zilJRL4AEj9CKn1zobLLt/JmxrCS8yX7v3uYZihEREThz5gzOnDkDADAajdJEJmNcPS9Hj15NjYMEh6+9dIOeobPJNtLCjGXeZL9y5UrO2y9duiRaMEpBsxuJmLxZ8dOBqnECg+87PTe3GKv3l6uiIyc4Zv8///M/2L59O6xWK+rr63Hrrbc6e/1aRbMbiZg8zegEmq8L0fLZgeXpu6uWXr7g5iUFBQU4fPgwxo8fj3379qFr165SxCVrEddXXXRH46biyy+yYGhOAWIy9mJoTgHyiyzBDingkhOisHLSAETxtCfXNddJYAh9d9VwzAWTfZcuXWA0GlFTU4NevXrBarUKPUTV8ossqK5vanU7jZuKzzGuaqmsA4sbPS61JvyjGaPAvdklnUUGWnpSP5gMeo+/o/RjLpjsb7nlFuTl5cFkMuH1119XxVaCbbF6fzms9talcOHGEEWf4ikB37hq1u7SIEUkPq3tkxosQmdTAKBjGEV3LASTfXZ2Nu69914sWLAAN998s3MPWq3i++v+7zptn/FIge/YV9ZZFf0l9ISrx0lzOcThOJtalxrP2cu3sayizyQFL9D++9//xpYtW5zLJWh9zJ5mzQaPpyqVrN2lqqyRVvOMTrlyHNv5O0taTWhTctWdYM9+4cKFiI6Oxty5c9G1a1csXLhQirhki3pawePpGFfWWVU7lu/ocZ7NGYejGaMUmWiUJjkhCnaemctKHbsX7Nk3NDRg2rRpAIDbbrsN+/fvFz0oufA0o456WtJLTojCy3tKW+09y0XJPTAiD2o7i+dN9o5Nxjt16oQ///nPGDx4ML777jv06NFDsuCCSWhGHSWR4Fg6vr/HGnRXSu2BEXlQ29pXvMl+yZIlzv9v27YN27dvd25LqAV8lR/zd5ZgXm4x9eiDhGud96p6KzgKpBTbAyPyoLazeN5kv3XrVuf/Kyoq8Msvv6BHjx7o3LmzJIEFG1+v0HHBRi2z6pTIfZ13rkSv5B4YkQ81ncULXqD985//jLS0NGzatAmpqan47LPPpIgr6LzpFaphVp2SedopTKnLCWhhhjAJDsELtB988AF27dqF8PBwVFdXY8aMGZg4caIUsQWV0PokDjQuHDyedgpTaqJX+8qLJHgEe/YMwyA8PBwAYDab0a5dO9GDkgPXGXUMmnuLXGhcOHjUNrvU02qqhLSVYM++Z8+eyMnJweDBg/H3v/8d0dHRUsQlC67jde69LoDGhYNNbdUStJoqEZNgsl++fDk++eQTHDt2DLGxsZg/f74UccmO2q7Mq4HaPhO11XWrhVp2sBJM9k8//TT++Mc/ShGL7KnpyrxaqOkzUduZihqo6TqKYLLv0KEDDh48iFtvvRU6XfMQf0xMjOiBEaJmNDtbGYSuoyjpsxJM9leuXMEHH3zg/JlhGGzZskXMmAhRNZqdrRx810scn5mSevwek311dTXeeecdmEw0ZkiURc7jrJ72O3WstBgls5i1iu86ip5heGfYA/JM+Lyllx999BEmTJiAiRMn4quvvpIyJkLaRO47WnmqrnGfoS2XmLWKb5Vb96WPHeS85j1vsv/888/xxRdfYMeOHfjwww+ljIkQvzhmn87NLZZ1vbq31TVyilmr3OfbREWYBHe0kuvnxjuMYzQaYTQa0blzZ83vO0vkj2sehDu51Kt7OzsbkE/MWsZ3HcXTZyjHz03wAi0AsDynLHzsdjuysrJQXl4Oo9GIZcuWoVevXs77P/jgA+zduxcAMHLkSDz33HM+PT8h7vjWyXEll3p116obvp23HOQSM2nuUGTtLkXl9S1Iwww66BgoZsVV3mT/008/Yf78+WBZ1vl/B6F9aA8cOIDGxkbk5uaiuLgYOTk52LhxIwDgl19+we7du/HJJ59Ap9Nh6tSp+N3vfofbbrstQG+JaJFQT0pu9eqOhJ/+SQnnBvaA/GLWsvwiS6vPqtZqh44BDHoGVtuN2+X6ufEm+3Xr1jn/n5aW5tOTFhYWYvjw4QCA+Ph4nDp1ynnfLbfcgvfeew96ffNFj6amJkWstyPn6g7ieX/aTmEGLB3fX3af1+r95byJnqpx5IXvs7KzAGtj0SnMgMpaq6xzA2+yv/vuu/1+0urqapjNZufPer0eTU1NCAkJgcFgQOfOncGyLFatWoXbb7+dd5JWWVmZX69fX1/v92O5FJy5hjeOXUaD7UalxMK8EljOWzCqd/ugxRUoco0L8D62aQPMeONYvfMzclXb0ATLeQvKQqskj8sTvrMRBsB7E7sBqEJZmW8xy/WzVHpcns4cWTS3sT8M73I9H/j+ubUlNm95NWbvK7PZjJqaGufPdrsdISE3XqqhoQGZmZkIDw/H0qVLeZ8nLi7Or9cvKyvz+7FcZn1W0CqJNNhYbDtZjdnjvP+jGOi4AkWucQHexxYXB0R1tzjr1F3581kFKi5Pukdc4F0LRy5tP1CUHhffZ+UglzZWWFjIe5/gEsf+SExMxOHDhwEAxcXF6Nu3r/M+lmXx7LPPol+/fsjOznYO58gZrUaoDMkJUbDzFBPI8bPiq+GW43iv1qUn9YNB53lLVjm2MVei9OzHjBmDo0ePIi0tDSzLYsWKFdi8eTOio6Nht9vxt7/9DY2Njc7JWi+88AISEhLECCUgaDVC5VDSZ0Vr4SiH4zNxrcZxp2MYxGTsle3nKEqy1+l0yM7ObnFbbGys8/8nT54U42VFQ6sRKofSPitaC0c53Pc+di/1lfv+1KIM46iJowqnzmpz7lblmEUnpw+SNHOf8RhhMiDUoMO83OKg7+lK+8uqgze72MlxFq0oPXu1cP8LbmNZZy+REr188fXAgtnjklMspO1cz8hiMvZy/o7cxvCpZ89BKWusEM/ktKernGIhgaWUvZAp2btxXTGRj9z+YhNucqqiklMsJLCUUlVFyd7Ny3tKFbPGCvFMTj0uvtfUMQyN3Ssc38qYchueozF7F/lFFlTUel7hU45/sQk3OVXm8K106Vj/HKCxeyVTQlUV9exdCI2fyvUvNuEmp8ocRyxKqdwg6kPJ3oWn8dN1qfE4mjGKEr3CJCdE4WjGKKxNjUdDkx0Vtdag7V6ltBm+RF0o2bvgG1eNMBkoySucXKph5HQdgWgLJXsXfFfVsyb0D1JEJFDkUg2jlMoNoj50gdYFrVWiXnJZM4famLrJed8LSvZulHBVnfhOTpU51MbUSe6zpGkYh2iCnCpziDrJ5boQH0r2RDPkVJlD1Ecu14X4ULInmiP3HhhRJrlXWlGyJ5oj9x4YUSa5V1rRBdrr5HwVnbSN+2cbEWbgXBYjUD0wakvaJPdKK0r2kP9VdOI/rs/WoGNg0DOwumwiH6geGLUlbZNzpRUle3gew5XrB0e8w/XZWu3NSV7PMLCxLKIC2AOjtkRcz+w6mgxgGKCy1hr0nj4le9AYrpp5+gzF2HmM2pK2uZ/ZuW5OHuyzPE1foHXsSMW9NJV8rqIT/wl9hoGuwpF7RQYRF9eZnas6qw3zd5YEpcxXs8leaEcqOV1FJ/7jqpBwF8het9wrMoi4vGlLjj0MpE74mh3G8fQXuFOYAUvH96cxVhVwrZDg+8MeiF53q3FasKi12gEAoQYd/n7uqmyrNEjg8K3B5C4Y13E027P39Be4/vqXlKiDY+bsutR4UXrdrmeJLJrHaWtd2lBFrRUfff0P5/00Y1e9vDmTdJD6Oo5mevbe1loDVD2hVmLVQQuN03KhNqZO7meSDCCba4KaSPZctc9CqHpCnbjqoNtaKudvW6E2pk6O9sK157BDMK7jaCLZ+9PzouoJbQhEqZy347RcjyPq5CnnBHJehy80MWbvaw+Kqie04+U9pX6XyuUXWRD/8pd+JXpqY+rmKefUNDRhbm4xbs3Yi4TsLyW7dqOJZO9ND6pTmAEMmv/qrpw0gMZSNSC/yMJ73cYVV6lcwZlrSP+kpMWZgLf0DENtTOU85RzXNlNRa0V6njR196obxskvsmDF5//ArzVnnGOuXLsUuQszhqBoyX0SRkqCzZfJVHVWG+bmFmP1/nL89rYu2PbNr7DzXXlz4X6BzmTQU6LXAK6cw3ex1mpjMTe3GC/sLIadvTHM0y80sDGpqmfvGH+9VNPUosQNAFZOGoAIk4H3sXSxTHv8+cwtlXX46Ot/eJXogeYvt2N3LDpr1A73ndGiIky8VTkOjjblyFsFZ64FNCZRevZ2ux1ZWVkoLy+H0WjEsmXL0KtXL+f9O3fuxI4dOxASEoJnnnkGv/3tbwPyulzjr44emY5pPpgMA7AcR50ulmmPvxdWfREVYcLRjFGivgaRJ/fKr6E5BV63tzqrDZu+uYzZ4wIXjyg9+wMHDqCxsRG5ubmYP38+cnJynPf9+uuv2Lp1K3bs2IH3338fa9asQWNjY5tfU2j81fFXkyvR08UybfJlAow/qF0RV+lJ/WDQMV7//rVGNqBj+aIk+8LCQgwfPhwAEB8fj1OnTjnv++6775CQkACj0Yj27dsjOjoaP/zwQ5tf09fFrPQMQ6fWGse1CbnjQj3j/XfSKcygowv9hFdyQhRWP3ynx+Fkd4FcpE+UYZzq6mqYzWbnz3q9Hk1NTQgJCUF1dTXat2/vvC88PBzV1dWcz1NWVub1a/o6/mpnWeyb0fv6T1UoK6vy6fH+qK+v9+k9SUWucQHix9YvFHhvYrdWtz/w4Rmfnid9eBeM6t3e7VZp2pUruX6WFFezfqHA9pSeKDhzDWuO/AqbwED++cq6gMUnSrI3m82oqalx/my32xESEsJ5X01NTYvk7youLs7r1+weccGn8dfuESafnj8QysrKJH9Nb8g1LiB4sfnSniJMBswed7fIEXlHrp8lxdVSXBwQ1d2CrN2lHst3fc1ThYWFvPeJMoyTmJiIw4cPAwCKi4vRt29f530DBw5EYWEhGhoacO3aNZw+fbrF/f7yZfyVxlKJEG/bk8mgR9aE/hJERNQmOSEKxUvvw8854zgX6WunZwKap0Tp2Y8ZMwZHjx5FWloaWJbFihUrsHnzZkRHR2P06NGYPn06pk2bBpZlMW/ePLRr167Nr+m+yFVHkwGNTTbn6oOOapxgTVUmysLVnhimeRKMGNsZEm3jWqRv2gBzQNuWKMlep9MhOzu7xW2xsbHO/6ekpCAlJSXgr+sodZLrKSNRFk+bR1MbI4Hm3t4CfS1BVZOqCCGEcKNkTwghGkDJnhBCNICSPSGEaAAle0II0QCGZblWiwk+T5MDCCGEcBs0aBDn7bJN9oQQQgKHhnEIIUQDKNkTQogGqGZbQqENU6RmtVqRmZkJi8WCxsZGPPPMM+jWrRueeuop3HrrrQCAqVOn4oEHHpA8toceesi5KmmPHj2QmpqK5cuXQ6/XY9iwYXjuueckjwkAdu3ahT/96U8AgIaGBpSVlWHNmjV49dVX0a1b88qUzz//PO6+W7pFx0pKSvDaa69h69atOHfuHDIyMsAwDPr06YOlS5dCp9PhzTffxF//+leEhIQgMzMTAwcOlDSusrIyvPLKK9Dr9TAajXj11VcRGRmJZcuW4dtvv0V4eDgA4K233uJddFCMuL7//nvO9h7s4zVv3jxcvnwZAGCxWHDnnXdi7dq1eOaZZ1BRUQGDwYB27drhvffeEzUmrhzxH//xH+K1MVYl9u/fzy5cuJBlWZYtKipin3766aDGk5eXxy5btoxlWZatqKhgR44cye7cuZN9//33gxpXfX09O3HixBa3TZgwgT137hxrt9vZWbNmsaWlpcEJzkVWVha7Y8cOds2aNewXX3wRlBjeeecd9sEHH2QffvhhlmVZ9qmnnmK//vprlmVZ9qWXXmK//PJL9tSpU+z06dNZu93OWiwWdtKkSZLH9cgjj7Dff/89y7Isu337dnbFihUsy7JsWloae+XKFdHj4YuLq73L4Xg5VFZWshMmTGAvXrzIsizL3n///azdbhc9HgeuHCFmG1PNMI6nDVOCYezYsfjv//5vAADLstDr9Th16hT++te/4pFHHkFmZibvOv5i+uGHH1BXV4cnnngCjz32GE6cOIHGxkZER0eDYRgMGzYMx44dkzwuVydPnsRPP/2E1NRUlJaW4tNPP8W0adOQk5ODpqYmyeKIjo7G+vXrnT+XlpY6zypGjBiBY8eOobCwEMOGDQPDMOjevTtsNhuuXr0qaVxr1qxxrtNjs9nQrl072O12nDt3DkuWLEFaWhry8vJEjYkrLq72Lofj5bB+/Xo8+uijuPnmm3H58mVUVVXh6aefxtSpU3Ho0CFRYwK4c4SYbUw1yZ5vw5RgCQ8Ph9lsRnV1NebMmYO5c+di4MCBWLBgAT7++GP07NkTGzZskDyu0NBQzJw5E++//z5efvllLFq0CCbTjf13w8PDce1aYDc69tXbb7+N2bNnAwCGDh2Kl156CR9//DFqa2uxY8cOyeJISkpy7sMANH8hmetbWDmOk3u7k+L4ucd18803AwC+/fZbfPTRR3j88cdRW1uLRx99FKtXr8Z7772Hbdu2BWRHOF/i4mrvcjheAHDlyhUcP34ckyZNAtA8pPLEE09gw4YNePPNN7Fy5UpcuXJF1Li4coSYbUw1yd7ThinBcuHCBTz22GOYOHEixo8fjzFjxuCOO+4A0LwM9Pfffy95TDExMZgwYQIYhkFMTAzat2+PyspK5/01NTXo0KGD5HE5VFVV4ezZsxgyZAgAYPLkyejZsycYhsHo0aODcswcdLobXxfHcfJlMx4x7du3D0uXLsU777yDzp07w2Qy4bHHHoPJZILZbMaQIUNET/buuNq7XI7XF198gQcffBB6ffMa8pGRkUhLS0NISAhuuukmxMXF4ezZs6LH4Z4jxGxjqkn2njZMCYbLly/jiSeeQHp6OqZMmQIAmDlzJr777jsAwPHjx9G/v/SbXuTl5Tk3gL948SLq6uoQFhaGf/zjH2BZFkeOHMHgwYMlj8vhxIkTuOeeewA096QnTJiAf/3rXwCCd8wcbr/9dnzzzTcAgMOHD2Pw4MFITEzEkSNHYLfbcf78edjtdnTu3FnSuD777DN89NFH2Lp1K3r27AkA+PnnnzF16lTYbDZYrVZ8++23kh87rvYuh+PliGfEiBHOn48dO+YcUqmpqcH//d//oXfv3nwPDwiuHCFmG1NNNQ7XhinBtGnTJlRVVeGtt97CW2+9BQDIyMjAihUrYDAYEBkZiVdeeUXyuKZMmYJFixZh6tSpYBgGK1asgE6nwx/+8AfYbDYMGzYMd955p+RxOZw9exY9evQAADAMg2XLluG5555DaGgoYmNjRdkHwVsLFy7ESy+9hDVr1qB3795ISkqCXq/H4MGDkZqaCrvdjiVLlkgak81mw/Lly9GtWzc8//zzAIC77roLc+bMwcSJE5GSkgKDwYCJEyeiT58+ksaWlZWFV155pUV7N5vNQT1eDmfPnnX+YQSAkSNH4siRI0hJSYFOp8MLL7wg+h8hrhyxePFiLFu2TJQ2RjNoCSFEA1QzjEMIIYQfJXtCCNEASvaEEKIBlOwJIUQDKNkTQogGqKb0kpBAeOedd3Ds2DE0NTWBYRgsXLgQBoMBVVVVuOuuu4IdHiF+o2RPyHU//fQTCgoKsH37djAMg7KyMixcuBBjxoxBZGQkJXuiaJTsCbmuffv2OH/+PPLy8jBixAjExcVh48aNmD59OgwGA/r374/6+nqsXbsWer0ePXv2RHZ2Nvbs2YMDBw6gpqYGFRUVmD17NpKSkoL9dghpgSZVEeKitLQUH330EY4fP47Q0FDMmzcPP/74o3PtlLFjx2Lbtm246aabsG7dOnTv3h0hISHYs2cP3n//fVy9ehUPP/ww/vKXvwR9bSZCXFFrJOS6c+fOwWw2Y+XKlQCal1p+8skn8eCDDyIyMhJXr17FpUuXMHfuXABAfX097r33XvTq1Qt33XUXdDodIiMj0aFDB1y9etW5GiUhckDJnpDrysvLkZubi40bN8JoNCImJgYdOnRAREQE7HY7OnXqhFtuucW549PBgwcRFhaGCxcuoLS0FEDz4lbV1dW46aabgvxuCGmJkj0h19133304ffo0pkyZgrCwMLAsiwULFiAkJASrVq1CbGwsFi9ejN///vdgWRbh4eFYtWoVLly4gMuXL2PGjBm4du0ali5d6lw6lxC5oDF7Qtpo165dOHPmDP7whz8EOxRCeNGkKkII0QDq2RNCiAZQz54QQjSAkj0hhGgAJXtCCNEASvaEEKIBlOwJIUQDKNkTQogG/D9s0iyXp1vZFgAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "tags": []
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -1890,7 +1883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {
     "id": "Y2a7t2qmLDTb"
    },
@@ -1917,7 +1910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {
     "id": "28f06d1baf9b"
    },
@@ -1948,7 +1941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {
     "id": "x9dHKNfgMoyz"
    },
@@ -1977,7 +1970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {
     "id": "_RXBrSQ8PWnu"
    },
@@ -2036,7 +2029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {
     "cellView": "form",
     "id": "9htgTzqAYHsA"
@@ -2069,7 +2062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {
     "cellView": "form",
     "id": "XaG8n5bdGgf2"
@@ -2079,10 +2072,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[1.+0.j 0.+0.j 0.+0.j 0.+0.j]\n",
-      " [0.+0.j 1.+0.j 0.+0.j 0.+0.j]\n",
-      " [0.+0.j 0.+0.j 0.707+0.j 0.-0.707j]\n",
-      " [0.+0.j 0.+0.j 0.-0.707j 0.707+0.j]]\n"
+      "[[1.   +0.j    0.   +0.j    0.   +0.j    0.   +0.j   ]\n",
+      " [0.   +0.j    1.   +0.j    0.   +0.j    0.   +0.j   ]\n",
+      " [0.   +0.j    0.   +0.j    0.707+0.j    0.   -0.707j]\n",
+      " [0.   +0.j    0.   +0.j    0.   -0.707j 0.707+0.j   ]]\n"
      ]
     }
    ],
@@ -2120,7 +2113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {
     "id": "a1cd089df7ba"
    },
@@ -2167,7 +2160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {
     "id": "9G-9_29h09Mx"
    },
@@ -2194,7 +2187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "metadata": {
     "id": "370e8528c762"
    },
@@ -2227,7 +2220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "metadata": {
     "id": "47ec94cdecf3"
    },
@@ -2256,7 +2249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "metadata": {
     "id": "AS-YMmAv6zUg"
    },
@@ -2285,7 +2278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 44,
    "metadata": {
     "id": "0sJ1uY6X7l3t"
    },
@@ -2299,10 +2292,8 @@
        "a: ───Z───Y^0.5───X───"
       ]
      },
-     "execution_count": 45,
-     "metadata": {
-      "tags": []
-     },
+     "execution_count": 44,
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -2329,7 +2320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 45,
    "metadata": {
     "id": "KQ2in0ol05S9"
    },
@@ -2376,7 +2367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 46,
    "metadata": {
     "id": "0afe36a32636"
    },
@@ -2424,7 +2415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "metadata": {
     "id": "TIaVRzCD4deU"
    },
@@ -2469,7 +2460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "metadata": {
     "id": "Gj_Y3Lrh49o9"
    },
@@ -2484,19 +2475,19 @@
       "\n",
       "params: OrderedDict([('s', 0.125)])\n",
       "a=0000000000\n",
-      "b=0001000000\n",
+      "b=1000000000\n",
       "\n",
       "params: OrderedDict([('s', 0.25)])\n",
-      "a=0101000001\n",
-      "b=0000000000\n",
+      "a=0000000000\n",
+      "b=1000101001\n",
       "\n",
       "params: OrderedDict([('s', 0.375)])\n",
-      "a=0110001110\n",
-      "b=1010100001\n",
+      "a=0000000100\n",
+      "b=0000000101\n",
       "\n",
       "params: OrderedDict([('s', 0.5)])\n",
-      "a=1010000111\n",
-      "b=1100101000\n",
+      "a=1010111000\n",
+      "b=1011010110\n",
       "\n"
      ]
     }
@@ -2531,7 +2522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "metadata": {
     "id": "074f9fd5cdcd"
    },
@@ -2567,67 +2558,67 @@
        "      <th>count</th>\n",
        "      <td>50.000000</td>\n",
        "      <td>50.000000</td>\n",
-       "      <td>50.00000</td>\n",
+       "      <td>50.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>mean</th>\n",
        "      <td>0.250000</td>\n",
+       "      <td>0.200000</td>\n",
        "      <td>0.260000</td>\n",
-       "      <td>0.30000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>std</th>\n",
        "      <td>0.178571</td>\n",
+       "      <td>0.404061</td>\n",
        "      <td>0.443087</td>\n",
-       "      <td>0.46291</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>min</th>\n",
        "      <td>0.000000</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.00000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25%</th>\n",
        "      <td>0.125000</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.00000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>50%</th>\n",
        "      <td>0.250000</td>\n",
        "      <td>0.000000</td>\n",
-       "      <td>0.00000</td>\n",
+       "      <td>0.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>75%</th>\n",
        "      <td>0.375000</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>0.750000</td>\n",
-       "      <td>1.00000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>max</th>\n",
        "      <td>0.500000</td>\n",
        "      <td>1.000000</td>\n",
-       "      <td>1.00000</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "               s          a         b\n",
-       "count  50.000000  50.000000  50.00000\n",
-       "mean    0.250000   0.260000   0.30000\n",
-       "std     0.178571   0.443087   0.46291\n",
-       "min     0.000000   0.000000   0.00000\n",
-       "25%     0.125000   0.000000   0.00000\n",
-       "50%     0.250000   0.000000   0.00000\n",
-       "75%     0.375000   0.750000   1.00000\n",
-       "max     0.500000   1.000000   1.00000"
+       "               s          a          b\n",
+       "count  50.000000  50.000000  50.000000\n",
+       "mean    0.250000   0.200000   0.260000\n",
+       "std     0.178571   0.404061   0.443087\n",
+       "min     0.000000   0.000000   0.000000\n",
+       "25%     0.125000   0.000000   0.000000\n",
+       "50%     0.250000   0.000000   0.000000\n",
+       "75%     0.375000   0.000000   0.750000\n",
+       "max     0.500000   1.000000   1.000000"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2653,7 +2644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "metadata": {
     "id": "zOymGxlb72Fk"
    },
@@ -2696,7 +2687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 51,
    "metadata": {
     "cellView": "form",
     "id": "8yW2e3sq9JM8"
@@ -2725,7 +2716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 52,
    "metadata": {
     "cellView": "form",
     "id": "sl1UGhThC6rn"
@@ -2737,20 +2728,18 @@
        "<AxesSubplot:xlabel='theta'>"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAEDCAYAAADDbTRuAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOydeXzU1dX/3zOTTPZ1kslGEkhCQha2ACoRRFb3rVbRWNQ+drG1VlvbPv1ZrbUudenTx10f94LihoIKWIIgi7ITCGQjIUD2TBayJ5NlZn5/3Ez2dZhkMsl9v155fTPf7/3eOV8SPnNy7jnnKkwmkwmJRCKR2CVKWxsgkUgkEsuRIi6RSCR2jBRxiUQisWOkiEskEokdI0VcIpFI7Bgp4hKJRGLHOIz1Gx49enSs31IikUjsnnnz5vV7fsxFHAY2ZiiysrKIjY21sjVjh73bD/b/DPZuP9j/M0j7R85gzq8Mp0gkEokdI0VcIpFI7Bgp4hKJRGLHSBGXSCQSO2ZYIp6Tk8OKFSv44IMPACgtLWXNmjUkJyfzwAMP0NraCsBXX33FzTffzC233MJnn302elZLJBKJBBiGiDc1NfHEE0+wcOHCznMvvfQSycnJrF+/nvDwcDZs2EBTUxOvvvoq77//PuvWrePf//43NTU1o2q8RCKRTHaGFHG1Ws1bb72FVqvtPHfw4EGWL18OwNKlS9m/fz9paWnMnDkTDw8PnJ2dSUxMJDU11WqGmkwmjCYTRqNlXwN13B3OGIlEMkG4kP/jJhMYjWAyiuNgY/r7GiV9GTJP3MHBAQeHnsOam5tRq9UAaDQaKioqqKysxNfXt3OMr68vFRUVVjM0+a2D7D9TBZy16P4pPi78/YZ4ls0IAKC6sZUnt2Sx8VgRxo5/Ww8nB363Mpq7kqaiUiqsZLlEIhkXpH8OKX+F1esgJHFk92Z+Cd/8GepL6MwQj1gK1/4LfCPE65Jj8PWDUHq8/zlirobbP7LU+gG54GKfgbzXwbzarKysEb/PqqkOhLt69PlAGRYm2JvfwH+9f4TLp7kxN8iVd1OraGgxclW0Jz4uKgCyK/T8fXMmnxzI48Ekf6b6qEf+XoOg1+stevbxhL0/g73bD/b/DLaw36kmj6nf/hqlQU/rh7dzbtW/MTh5DXmfQ3MFAUf/iWfxbpp9YmhI+Dnt7e040oZP3kYUr15CRcLPcWipxvfUR7Q7+VIb91NMyr461ewbT+MoPLdFIu7q6oper8fZ2RmdTodWq0Wr1VJZWdk5pry8nDlz5vR7vyXVTrGxF1Yp1dpu5LVdp3n1u9PsOtvI7ClePHPzLGKDPDvHmEwmvkor4fGvM3lgSwnfPLiYSH93i96vP+y9Ug3s/xns3X6w/2cYdfuP/ht2PgkrHoM5d0BLHbx5B7h4wXXvo/70TqJPPgd3fAZKVf9zGI1wbK3w3A0tsOJxXBb+BheVQ5f9dX+BLQ8RkPaKuCfxLhxX/h0/F2/rP5K1KzaTkpLYtm0bACkpKSxevJjZs2dz8uRJ6urqaGxsJDU1lfnz51tm8SigdlDy4IpovnlgMS+snsMXv760h4ADKBQKbpgTwtf3L6LNaGRzWqmNrJVIJBZhMsG+l6H5PHx5H6y9AT7/GVSfg1veh5ir4KrnIG8H7H62/zmq8mDt9fD1AxA0C361DxY9CKpePq9nMNy2HpI/hZ/+B65/CUZBwIdiSE88PT2dZ599luLiYhwcHNi2bRv//Oc/+fOf/8wnn3xCcHAwN954I46Ojjz00EPcc889KBQK7rvvPjw8PMbiGUZElNaDKO3gdoV4u5AY5sP2rDIeWDF9jCyTSCRD8vWDUF8GyR/3f73gAFTlwvWvgKEVtj8GrfVwxdMQniTGzLsbig4LEW9rgssfBrUrGNrEB8DuZ0HlBNe/DHPXgGKQ9TGFAqKvsPpjjoQhRTwhIYF169b1Of/ee+/1OXfllVdy5ZVXWscyG7MyLoBnvsmmuKaZEG+Xfse0thtRO8h6KYlkzMjdDnXF0FAB7v59rx9bB2oPSPgRqN0g+koh2HE3dI1RKOCaf4HKUYh21tew+CE49CaUnYTY6+Dqf4JH4Ng91wUgFWgAVsWJLJZvM3V9rrUbjPzf7jxmPb6Nn/37MKW1zWNtnkQy+WisgroiwAQ53/S9rq+FjI0w82Yh4ABeIRB/Y19v2tEZrnsR7t4CChV8dT80lMOt62D1B3Yj4CBFfEAi/N2J9HcjJbOsx/n04lpuePUH/vFNNrOnePP96UpW/msP6w7kYzTKPHOJZNQoSxNHhRKyt/S9nv65CI/MvXP4c05dBL/6AW5+B+47BHHXW8fWMUSK+CCsig/kwJnz1Da1AXDwTBU3vfYDuroWXrsjkY9/cQkpDy5hTqg3j25K590fLMthl0gkw6C0Q8Rn3gp530FLQ8/rqetAGz/yHHBHF5j5Y5ssSloDKeKDsDIuAIPRxHenyimv0/Obj44R6uPK9t9dxtUzg1AoFIRpXFl3z0VEB7izJ7dy6EklEolllKaBdxjMvUOk/eXt7LpWlg4lqZA4xELkBESK+CDMmeKNv4cTW06Wct/6VBr07byxZh4+bj2LgBQKBfPCfTheUC1DKhLJaFF6AoJmQ1gSOHt3hVRMJtj9DKjUMGu1bW20AVLEB0GpVLAyLoDtmToOn6vm2R/PIjqg//TEuWE+1OnbOVPZ0O91iURyAejr4HyeEHGVg8g6yfkPGNrhwGsiw2TpX8DVd+i5JhhSxIfginixSn130lSunx084LjEMB8AUvNl50aJxOqUnRTHwNniOOMa0NfA3v+BlEdhxrVw6QO2s8+GSBEfgsum+7H+ZxfzyDWDlwlH+Lnh5eJIakH1gGP0bUaaWw2DztNuMFKvb7PIVonEHlDpq0fe0c+8qBnUIeJRy8HBGXY9DT5T4cbXJl0s3IwU8SFQKBQkRfnhoBr8n0qpVDA3zHtAEa/Tt3H/5mIWP7eTr9NK+m0QdjT/PFe+uJfl/7ObNsMArS4lEnumMpeor2+AfS+N7L6yE+AeCB6ifgO1G0QuB0dXkdftPHQzq4nKBXcxlHQxN9SH3TkV1Onb8HR27DxvMpn4w6dplNS3ER3gwf0fHePL48X8emkU6o4Ph8+OFLL2QD4ujiqaWg2cLK7tDNFIJBOG755GaWwVYZDEu3qm9TWdh9rCrtf+seDQkURQmtblhZu57gVorgb/mNG3exwjRdyKJIZ7YzLB8YIaLovuKgl+Y/cZUjJ1/GK+L3+66WLe33eOf6ac4tus8s4xCgXctXAq9yyaxuLnvmPf6Uop4pKJRdlJyPiC+pAleBTvhv2vwLJHxLXK0/DWMmip7RofejHctRmM7VCRLeLe3XHXiq9JjhRxKzIn1BuFAlILqjtFfN/pSp7fls01s4K4Mc4ZB5WSny2O4OqZQaQXd/3ChmvciAkUmS+xQZ7sy6viN8surPlWaW0zAR7OKOUGF5LxwHdPg5MXJRf9hZhT3nDgdbj4XlFs8+ka0Rb2lvdFqmBVHmx/FFL+ItIGTUbRUVDSByniVsTD2ZForQepBSJDpbS2mfs/OsY0PzeevXkWhWdyO8cGe7sQPEBjraRIDesO5KNvM+DsOEC/4yE4W9nIyn/t5qmbEli9IMyiOSQSq1F0BE5thWWPYFR7inTArK/h+/+FBh2UZ8GaLyByWdc9DTrhrVfmiNe9wykSQC5sWp3EcG+OFVTT0m7gvg9T0bcZ+L8183B3Gv7n5aVRGlrbjYNmugzFJ4cLaTea+C7belvkSSQWs/MJcPWDi38lXvvHCA97/6tw8jNY9peeAg6w4m+isOfMLnDxAa/QMTbaPpAibmXmhvlQr2/n3nVHSS2o4bkfzx6yf3lvFkz1RaVUsO90lUU2tBmMfJ5aBMD+M1UYZBWpxJYUHxVCvOh34NRtp6wl/y1CJ9FXwqKH+t6nchThFfdAmLJg0qYQDoUUcStjXoz87lQFP1s0jWtmBY14Dg9nR2ZN8WJfXv+9WNoNRk6XD1wZ+l12ORX1LVwzK4ja5jaySutGbINEMmJMJqjI6Xs+da1IBUzs1V3Qdxr8NhVWfwjKAaTIIwDu3Qs3/Z/17Z0gSBG3MhF+bvh7OHHRVF/++6oZFs+TFKkhraiWhpb2HuczSmq56bV9rPjXbnbn9B8q+fRIIVoPJx6+WhQoDfRhIJFYldwUeHUB5GzrOtfaCCc/h7gbwdmz7z1eU/pue9Ybd+2kLKcfLlLErYxSqeDr3yxi7T0X4ThEgdBgXBrph8Fo4tBZEVLRtxl47j/ZXP/KDyLrxNOJf2471adoSFenZ2d2OT+eN4UQbxci/d34wcKwjEQyIgoPieOOJ8RGwwAZm8T2aL29cInVkCI+CgR6OVucVWImMdwHtYOSfaerOHCmiqte3Mtru/L40dwQvv39Ev54xQxOFteyLaPnzkMbjhZhNMGt88UiUFKkH4fPnae1XVaASkaZ0jRQOoDuJGR9Kc6lrgXNdAi7xLa2TWCkiI9TnB1VzAvzYf2hAm578wDtRiMf3HMxz98yG29XNTfOCSbC341/bT/VuXBpNJr49Eghl0T4MtVPbE91aZSGplYDJ4pkYy7JCGmuhvNnhjfWZILS45DwY/CfIXLCy7Og8MCk7PE9lkgRH8esiAtA32bgF5dFkPLgEhZN9+u85qBS8vuV0eToGth8ooS8igZue/MA+VVNJF8c3jnukggNCgUypCIZOdv/Cm+vBOPgTdsAsQN9Y4XYVWfpwyK3+9M7hWc++/bRt3USI4t9xjE/TZrKTXND8O21CYWZqxOCiA3K4+9fZ1Lf0o6zg5Lnbp7Fdd0yYrxd1cQHe7Ivr5IHVlxYBahkklF0BJoqRbl88Jyu823NUHGq57myE+IYOEuEToJmi/DKjGtlafwoIz3xcYxSqRhQwM3X/3RlDOebWlkZG8C3Dy3h1gWhKHr96ZoU6cexgpoh2+BKJJ2YhRrg7O6e177/X3hrKdQWdZ0rTQMUEJggQifLHxOvF9wzVhZPWqSI2zlLY7Qce3Qlr96RiNbDud8xCyM1tBqMHMk/P8bWSewWXSaYOj70z+7peS3zK9HL5NQ3XedK00ATBU4dhW1Ry+GPeX2rMCVWR4r4BMDbdWBvHeCiqb4oFXD4nOVl/JJJRulxcYy+CvL3Q3ureF2VBxVZ4nvzHpfQ0Sq2V4MqN83o2ymRIj4ZcHNyYKrGjVNlsnJTMkxK08RmxHOSoa1RlM6DaGIFEP8jOLcXmmu6+oDLBlU2QYr4JCE6wIMcndzEWTJMzJswTF0EKLpCKtlbIWAmXPIr0ec7d3vfrdMkY4oU8UlCTKAH56oa0bfJxU3JEBjaoDxTiLKrrzie3Q0NFSLve8Y1EDIf3LRwakuXiAfKft+2QIr4JCEm0AOTiUEbZ0kkgNhFx9Da5VlPu0yU1GdsFAuaM64RDatmXC088aLD4BUm+5vYCCnik4ToAJE1kF1Wb2NLJOOezvBIRx74tCVgbIM9zwmxDpwpzsdcA60NIk4ud92xGVLEJwlTNa6oHZTk6KSIS4agNA3U7uAbIV6HLxSVl40Vwvs21yFMu0yMMxm7BF8y5lhUsdnY2Mh///d/U1tbS1tbG/fddx/+/v787W9/AyAmJobHH3/cmnZKLhAHlZIof3dODdMTzyypw2gykRDiNcqWSWxOyXGREx4yT7wuTRPetrnHt9pNbMpQsF+EUsw4OkPUCsjcJD1xG2KRiG/cuJFp06bx0EMPodPpuOuuu/D39+fhhx9m1qxZPPTQQ+zevZslS5ZY217JBRAT6MGBM0P3UNG3Gfjp+4fwdHZk++/lz3BCYzLB5/eI3ic/3ykKdsrSRdOq7sTdKPa8DEvqeX7OHSJzJWT+2Nks6YFF4RQfHx9qakRXvLq6Ory9vSkuLmbWLPFpvHTpUvbv3289KyVWITrAg9JaPbXNbYOO++BAPrq6FnLLG6htGnysmdqmNv6TXmoNMyVjSWUOVJ0Wse1P1ggvvK2xb7rgJffCb4/13cAhehX891lZ2GNDLPLEr7nmGr744gtWrlxJXV0dr7/+On//+987r2s0GioqBt6gNysry5K3Ra/XW3zveMDW9ru2NQGQcjCdhID+S/Sb2oy89G0BPi4qqpsNfLXvBPNDXDuvD/QMH52oZu2xat65KZRgT8fReQArYOufgTWw5jNoMv+NFii++DGCDz1B+4e34QicafagZZT+nez9ZzDe7LdIxL/88kuCg4N55513yM7O5r777sPDo2sz4N67zfQmNjbWkrclKyvL4nvHA7a23zOomcd2lNHi7EtsbHi/Y17ekUtdi5EPf3Yxa945SIXJg9jY6M7rAz2D7sgRAOrUviyPnTI6D2AFbP0zsAbDfgZDu4hXhyeBZ3D/Y74/DMGJhFz1e3AHxx2Pg4MzERddNfS2aRZi7z8DW9h/9OjRAa9ZFE5JTU1l0aJFAMyYMYOWlhaqq7v6cuh0OrRa2X5yvBHs5Yy7k8OAGSq1TW28ufcMK2IDuDTKj+gAD44VDK/fSnqxKOlPzZebT4wLStNEp8HP74EfXup/TF0pFB/pWqxc9DuYeQtMXzlqAi6xPhaJeHh4OGlpIpe0uLgYNzc3IiMjOdLhjaWkpLB48WLrWSmxCgqFguiA/jNUTCYTL+zIoV7fzu9XCs87MdyH4wU1GI2D/2VV3dhKcU0zAKm9RF/fZmDd/nO0GeT2cGNCWzNsfwzeXCoWIt0DRMy7P3I6uhDOuFYcFQq4+W1Y/cHY2CqxChZ93K5evZqHH36Yn/zkJ7S3t/O3v/0Nf39//vrXv2I0Gpk9ezZJSUlDTyQZc2ICPfkmvRSTydTZd7ygqomHN57k+9OV3DJvCnHBYlfyxDAf1h8sILe8gZhAjwHnzCip6xjvTVpRLU2t7biqxa/W56lFPPplBt6uaq6bPcCf9BLrcHYvfP1bsaXa3J/Aqifh6wfFpg79kb1F5IL7x4ytnRKrYpGIu7m58eKLL/Y5v379+gs2SDK6xAS489GhNirqW9C4O/HeD2f5n5QcVEoFT9yYwB0XhXWOTQzzBuBYQfWgIp5eUgvAmoXhpH6SRlphLQsjRbZCSsdGztszdVLERwujEbb+AY68Az7T4M6vIKIjNdQ3ArI3i/h49xCJvg7O7BZZJ3L/S7tGBr4mGdEdYvzl8RI2nyghraiW5TO0PHFjAsHeLj3GTvNzw8fVkdSCam7rJu69ySipI8TbhaUxYh0ktaCahZEa6vVt7M+rQqVU8F12Oa3tRtQOskjY6uR/LwR8wc9g5ROg7somwjdCdBusLQTfaV3nT38rSunNoRSJ3SL/R00yYjp6qDy1NYui6mZevn0ub981v4+Ag4ihzw3zIbVg8MXKjOJaEkI88XZVE+HvxrGO8btzKmg1GPnZomnUt7QPq9BIYgHZW8HBGVb+vaeAQ1fpfO9d67O3gKufqMSU2DVSxCcZGncnVsRquWXeFL79/RKumx3cZ0/O7iSGeXN6kKKfen0bZyobiQ8W5flzQ304VlCNyWRie6YOXzc1v10+HRdHFdszdaPyTJMak0kIcsTlojy+N5pIcewt4uf2ii3UlKrRtlAyykgRn4S8fdcCnr9lNj6DbMJsJjHMB4BjhSLr5HBRE58eLuy8nlUqMl0SQjoWQ8O9qWpsJa+ikZ3Z5SyfocXNyYHLov3YnqkbMtNFMkJ06VBb0LOnSXfcA8DRtaeI15eJzJXgxLGxUTKqyJi4ZFBmhXqjVMC3WTo2HC1i84kyoIzYIE9mTvEivVgsaiZ0eOJm0X99Vx71+nZWxgUAsCoukG0ZOk4W1zI71NsmzzIhyd4CKCD6yv6vKxQipNJdxOVOPBMK6YlLBsXdyYHoAA8+OFBASoaO5NneeLs68j/bTwFiUdPfwwmtpyjjjw7wwN3JgS+OFeHsqGTxdH8Als3QolIqZEjlQtDXwo4nULZ22ys1ewuEXgzugxTX+U7rR8QVEJgwaqZKxg4p4pIhSb44jGUztGx9YBFr5vhy75JIdp2q4Mi582SU1JLQkVcOoFIqmB3qhckEl033x0UtYq4+bmoWTPUhJbPMVo9h/6R9Anv/SfCBx0VaYU0BlJ0YOJRixjcCqs+BsWNrvtI0ESt3GjhtVGI/SBGXDMmdC6fy7t0LiNJ6dLwOx8/diX98k01ueUPnoqYZc0jFHEoxsyoukBxdA+cqG8fG8IlG9mZwcMaj9AfY+0+RlQLDEPFIsd1abZF4XXpChlImEFLEJSPGVe3Ab5ZGcjS/GoPR1LmoaeaaWUEsjNCwKi6wx/krEgJRKGDjseKxNHdi0FwN576Hi++lNvxK+O5p2P8K+M/oykAZiO5phk3nxUKoFPEJgxRxiUXcfnEYwV4iDt7bE58R6MlHv7gEL9eeLWlDvF1YFOXHhqNFGGSWysjI3S5235lxLaXz/wzaOFHAE3P10Pd2F/GyE+J7uTP9hEGKuMQinBxUPH5DAlfPDGSKT99CoYFYvSCU4ppmvj9dOYrWTUCyN4t0wZB5mBycYfU6mLpY7KwzFB5Bohjo/BmZmTIBkSmGEotZGRfQJ+49nHt8XB359HAhS6L9R8myCUabHk7vgJk/7tr3UhMJd28e3v1Kpeipcv4s1JeKHetdfUfPXsmYIj1xyZji5KDiprlTSMkso6qhxdbm2Adn94jt0y6kz4kmEs7ndSxqylDKREKKuGTMWb0glDaDSS5wDkRVHmx5qCu3O3szqN1h2mWWz2nOFa86LUMpEwwp4pIxJybQg7lh3nxyuHDIrfwmJRlfwOG34bUksSvPqW8gagU4OFk+p2+ESDPEJEV8giFFXGITVs8PJbe8YcgOiZOSmkJw9obIZbD9UWgsv/CWseYMFZAiPsGQIi6xCdfODsZVrerRTEvSgbn3920fwi3vi30vY666sDnNIu4eAB6Bg4+V2BVSxCU2wd3JgWtnBfH1iRIaWtptbc74orYIvEJF86r4m8S+l07uFzanZwio1NILn4BIEZfYjNULwmhqNbDlRImtTRk/mEwinOIVat15lSq47E+w4OfWnVdic6SIS2xGYpg307XufGzPIZXtf4W8ndabr6kK2pvB28oiDrDkjxC9yvrzSmyKFHGJzVAoFKxeEMqxghpydfW2NmfktNTDDy9C+hfWm7O24wPN2p64ZMIiKzYlNuWmuSE8+59sPjlcyCPXxnG6vIFnvslGV6cHRFj43iWRXD0zyMaW9kN5tjg2WrGFQI1ZxKdYb07JhEaKuMSmaNydWBkXwBfHivFwduTV707jolYxL1y0s00tqObTI4XjVMQzxbGxwnpzmtvFeodZb07JhEaKuMTmrF4QxtaTZfzvtzlcOyuIx66Lx99DFLY89Gkau3PKMZlMg27obBPKs8TRqiJeCI5u4OJjvTklExop4hKbsyjKj19fHklimA8rejXUSgjx5PPUIsrrWwjo2AJu3NDpiVsznFIgQinj7QNLMm6RIi6xOSqlgj9dOaPfawkhold5Rknt+BXxtkZobQS124XPWVs0OpkpkgmLzE6RjGtigzxRKCC9uG7owWNJQ4UIo2jjxWtreeO1o5AjLpnQSBGXjGvcnRyYpnEjvbjW1qb0pKIjHm7uLGiJiJ/4FD7vVnzT2ijyxGVmimQESBGXjHviQ7zIKBlnnnh5bxG3YHFz/ytw8tOutMLajta8MjNFMgKkiEvGPQnBnhTXNFPd2GprU7oozxQZJAHmcEr5yO6vLeraKu3sno5zBeIowymSEWCxiH/11Vdcf/31/OhHP2LXrl2UlpayZs0akpOTeeCBB2htHUf/4SR2Tdfi5jjyxnWZIh7u1rHF3Eg98eyt4ujg0k3EO3LEZThFMgIsEvHq6mpeffVV1q9fzxtvvMGOHTt46aWXSE5OZv369YSHh7NhwwZr2yqZpMQHewKQXjJO4uImkwinaGNB7Sp23RksJr7jCfj6gZ7nTm0Bv2jRYvbsnq7GVwqV2NhYIhkmFon4/v37WbhwIe7u7mi1Wp544gkOHjzI8uXLAVi6dCn79++3qqGSyYu3q5oQb5fxs7hZWwSt9ULEAdz8BvbE21vh0Jtw9H0oPCTONVfDue8h5moRU68vEdum1RZ2tIyVmb+S4WORiBcVFaHX67n33ntJTk5m//79NDc3o1arAdBoNFRUWLGKTTLpSQjxHPVwSklNM1e+sIfC802DDzQvamrjxNHNf2ARP7cXWuqEh73zCXEudzsY28VuPRFLxLmzuzv6iMtQimRkWPyRX1NTwyuvvEJJSQl33nlnj70Sh9o3MSsry6L31Ov1Ft87HrB3+8F2zxDg2Mq2ykaOpGXgprZ8PX4w+3eeqSe7rJ6NP6SzMspjwDk0Wd+hBU7VqDA2ZTHF6IxjVRFn+5k34OiHeKucqYz/L7QnXiN/1zp88jbi6qwht94V6vVEuQbSnLYZ5/N5NPvPoWSIf197/z2S9lsXi0Rco9Ewd+5cHBwcCAsLw83NDZVKhV6vx9nZGZ1Oh1arHfD+2NhYi4zNysqy+N7xgL3bD7Z7hssVOtYeP4LRMwiliyN/+yqDGUEePHZd/IjmGcz+rYWngAqaHDyJje2/glRMUgWeIcTMvki8zo2AnJy+8xqNsHU/RK9Ee91jcO5LwnPehcocmPljYuM6bM9ZjuOpraCvQx0Wj9cQ/772/nsk7R85R48eHfCaRS7NokWLOHDgAEajkerqapqamkhKSmLbtm0ApKSksHjxYsuslUj6ISFYZKg8800W1768l/1nqvjoUAHNrQarvUdeRUOP44CUZ3bFw6EjnFIpRLs7pcdEvDvmGnB0hsv+CCWp0NrQc+PjaUtEnNxkkOmFdkJDQwN33303t99+Oy+++CLLli2zmS0WiXhAQABXXHEFt956Kz//+c955JFHuP/++9m0aRPJycnU1NRw4403WttWySRG6+mMv4cTqQU1XDMziJdun4u+zcje3EHWXnY9A29eLjI/hkFeeaM4DibihjaoyOkr4iYD6Gt6js3eKmLh0VeI13N/Aj5TRTaLuUgIYFo3h0f2TbELvvzyS2JjY/noo4+IioqyqS0Wx8Rvu+02brvtth7n3nvvvQs2SCIZiBdvmwMmSIryo1ogA9IAACAASURBVM1gxMPZge2ZOlbF97N7e9bXsOsf4vv6MvAcPG3PYDRxtqoRpQIKqppoMxhxVPXj4+jSwdACwXO7zrn5iWNjBbj6dp3P3gLhSV3nVI5w61rRd8XBqWucZzBopkNVrvTE7YS8vDwuukiE08xHWyErNiV2Q1KkH0lRQjAdVUqWzdDybZaOdkOvMEbladj4K3DtEFdzt8FBKK5uprXdyEXTfGk3msivGiBDpfCwOE5Z0HXOXPDT0K1qsypP9FeZcU3P+4Nmw/QVfeeNWAIoZHaKndC9v71KpbKpLVLEJXbLqrhAqpvaOJpf3XWytRE+XSO83jUde1+WD51JYA6hrIwTXv2ZgUIqRYfAPbCnx9xf1eapjorMmKuH9Sxc9kdY/YF12tlKRp2IiAjS0kTbBFvXxEgRl9gtS2L8UauUbM/UdZ3c87wQ7ZvfFl6ve8DIRDw2oON1Y/8DCw9B6IKemzZ0ini3qs1T/4GAmeATPryH8QiE2GuHHicZF9xwww2cPHmSO+64g1OnTtnUFiniErvF3cmBpCgNKZm6rtqEoiMQMg+iRPUw2lgozxhyrryKBnzd1IRpXNF6OPW/uNlQDjX5MKVXDNTVF1B0eeLtrVB8pOfipWRC4enpybp16/jwww/55S9/aVNbpIhL7JpVcYEUnG8iR9chupW54B/TNUAbJ3al753+14u88kYi/UUoI9LfvX8RL+qIh4f2EnGlClw1XSKuOwnteuGxSySjjBRxiV2zIlYUlaVklIG+FhrKwG961wBtHLQ3Q825Hvf1XgzNq2gg0t8dgEitG3nlDX0rjwsPgdIRgub0NcRd2yXinYufts1akIwNbm5u7Ny502bvL0VcYtdoPZ2ZE+rNjuxykZUCojtg54CO/ibd4uJfpBYx5+/bKa1tBqCmqZWqxlYiOjzxCD936vTtVDb0aqdcdBiCZonCnd64+XXFxIsOiUZWXiFWeUaJZDCkiEvsnjmh3uTo6jFVdiwwabp54ubQik6kGbYajDy/7RQNLe18dkT07zYvYnZ54uLYI0PF0AbFqQN7192bYBUe7pmCKJGMIlLEJXZPpL8bTa0GGkuyQekAvtO6Ljq5g3d4Z674Nzn1lNbqCfJy5tMjhRiNps74d6eId3jkPTJUdOkiLDNlfv9GmEvv68vEDj294+YSySghRVxi95jFV1+aDT7TRI54dwLioTyLptZ2Pj5Rw8IIDf/v6liKqpvZl1dFXkUDapWSKT4uAAR7ueDsqOy5uFk4wKKmGTc/aKkVfcJBxsMlY4bsPi+xe8zhD4fzuTCln+5y2ljITWHt97nU6A384YoY4oM98XJx5OPDBejbjIRrXHHoKLNXKhVM8+uVodJfkU93zLnip7aCSi1i5xJJPzz99NOkpaWhUCh4+OGHmTXrwn5XpCcusXu0Hk54OSlwbyromZnSOSAOjO1s3/M9F01xZV64D86OKm6aG0JKho6TxTWd3ryZSH+3Xp54P0U+3ekQcVNuiigy6t4bRSLp4NChQ+Tn5/PJJ5/w1FNP8dRTT13wnFLEJXaPQqFgoW89Dqb2AURceOchredYM8en8/TqBaG0Gozo6lqI1PYsd4/0d6eouhl9Uz2kPCKKfMIWDmxEh4grWuplKEUyIPv372fFCtE7JzIyktraWhoahmh9PAQynCKZEMx3q4JqeqYXmtFMx4CKuc4lRGm6POTYIE9mT/Eiv6ioryeudWehIh3lG3+GugKYdzfM++nABpg7GYIs8rETPj9axKdHCkd8X1NTE657avq9duv8UG6eN3ATs8rKSuLjuzYy8fX1paKiAnd39wHvGQrpiUsmBLGOZQA0ekzre9FBTZEqhNlOpX0uPRR+mqNO9zLTpedu9Qmu1ax1fIaqRgPlP/ocrntR7Gw/AM1qTef31Zq5A46TSLoz1FaWw0F64pIJQZipmAqTJ7pGNQnePa8ZjCbS20JIcsinrNd9i6s3oVCYmG7IA7oqMSPa8kBh5MG2X3Pis3Yeqj3DTy+dhkrZf0y8qtUBjUlNNe5kVbuwvJ8W55Lxxc3zpgzqNQ/EhWzPptVqqazschjKy8vx9/e3aC4z0hOXTAj89PmcMQX32/Mkv6qRDEMoPi0lODaUdF2ozkdx5jvxfWVuz5sqcwB44TerWRip4cktWXx+tGjA969qbKPI5M9BYyypBdUDjpNMbi699NLObSwzMjLQarUXFEoBKeKSCYJzbR5nTEHklfcV8RxdPZ8bLsOocsIv452uC8c/BBTg7N1XxKtOg0cwQVp/3rlrPloPJ/bl9Qy59Bje2MLdrX/iadNPSc3vP14qkSQmJhIfH89tt93Gk08+yWOPPXbBc8pwisT+aaxC0Xye8y5T++0DfqqsgXKFL4Z59+B1+A2xR6YmEo59AJHLRNpgh+fdSWVOZ6aLQqFgbpg3qQUDi3NlQyvF+LMsSsuBM1UYjKYBQy+Syc0f/vAHq84nPXGJ/VMlvOhW76h+wyk5unrCfV1xXPIQRpUz7Hoa8r6DumJIvFNktFSd7mpXazIJz7xbpktimA8F55uobGjp34SOZlkr4wJoajVwqqzeyg8pkfSPFHGJ/dPhRasDYjhb2YjB2HPFP7usjugAD3Dzozp6NWRshB2Pix7gMVcLj7utSYg6QIMOWup65Jwnhov88mMDeOOVDS24qlVcGilSDWVcXDJWSBGX2D+VOaBywm9KFC3tRkpqmjsv6dsMnKtqIibQA4CqmGRw9oKyEzD7dnBQd3U9NIdUzMduIj4zxAsHpWJAca5qaEHjribU1wU/d7UUccmYIUVcYv+UngC/6UQEeAFwultI5UyF8MyjA4SIG9UecOmDoFDC3DVikDlsUtXRj9y8yNktnOLsqCI+2JPU/AFEvLEVjZtTR/zcZ0CPXSKxNlLEJfZNcw3k/wBRyzurLrtnqOToRGx6RocnDggRvz8VtDPEa3ctOHl188RzwdENPIJ7vNXcMB9OFNX22RUIxMKmn7saEPHzs5WNnG9s7TNOIrE2UsQl9k3udjC2w4xr8XVT4+Pq2CNDJbusHkeVgql+3XqjKJU9e44rFCJ00j2c4hclxnUjMdyH5jYD2f0sWlY1tKBxEyX9iWGi2uiYDKlIxgAp4hL75tQWcNNCiNisIcLfvceOPDm6eiL93XFUDfGr7hfdFUbplZliZm6oEOfe8W6j0cT5xlb8PIQnPmuKN6pB4ueSyU1OTg4rVqzggw8+sMp8UsQl9kt7i/DEY67q9Jpjgzw4XlhDVmkdAKfK6jvj4YPiNx3qS6GhAmoLe27x1sEUHxf8PZz6xMXr9G20G02dnriLWsTPD545f4EPKJloNDU18cQTT7Bw4SAdMUeIFHGJ/XJ2L7Q2wIxrO0/9dvl0vFwc+dUHRympaaa4prkzM2VQzJkoOd8Apn5b2ioUChL7Kfoxb6is6YiJAyyN0XK0oHrAvPLeNLW2d37wSCYuarWat956C61Wa7U5ZcWmxH7J3iwWIKdd1nlK6+HMq3ckcvubB7jr3UMAxAzLE+8In2Rv6fm6F4lhPmzL0FHZ0IKfu/C8qzqE2vwaYFV8AC/uyGVnVjm3LhhgN6BuvLzzNO9+f5YTf1uFk4NqaHslF87xj0TV7ggJa2qEA279X5z7E5hz+4D3Ojg44OBgXdmVnrjEfqjKg+pz4nujUWyFNn0FODr3GLZgqi//7+pYcjuyVIbliftMA4VKVHKiEGX5/dBf0U9/nnhckCch3i6kZPbsm6ir05Or67swuje3gpZ2I6U1+qFtlUi6IT1xif3w4S0iXr3kTxC+SFRWdguldOe/Lp1KWmEN+89UEeLtMvTcDmqRsVJ1GrzDwbH/e2aGeKFSKkgrrGFlXAAgml8BnTFxEKGXlXEBfHSogKbWdlzVDphMJn6+9gglNc0cfHhFZ2+VmqZWMkpEKKWkprlnJo1k9Jhz+6Be80AUXEAr2tHggjxxvV7PihUr+OKLLygtLWXNmjUkJyfzwAMP0Noqc2QlVqTpPJzPA/cA2PkkrLtJeM7TV/Y7XKFQ8MLqOXz3h8tRDrcRlTmE0t8Wbx04O6qY5ufGqW7edGVDKwoF+Lg69hi7Kj6AlnYje3JE98NtGTpOFNVS2dDaI3PlwJkqzHsDFHWrNpVIhsMFifjrr7+Ol5eoknvppZdITk5m/fr1hIeHs2HDBqsYKJEAokwe4PqX4Lb14OIjslJcfAa8RalU4O40gj82NVHiOEA83ExMgEdnERGImLiPqxqHXmmMF031xcvFkZTMMgxGE//afopwjStqlZKUjK4wy768KlwcVSgUUFwtRXwik56ezpo1a9i4cSNr165lzZo11NRcWHWvxeGUvLw8Tp8+zeWXXw7AwYMHefzxxwFYunQp7777LsnJyRdknETSSWmHiAfOBjcNRF8Jpr6VkxfEMDxxgOgAD7aml3aGSaoaWtG4qfuMc1ApWT5Dy87scjYdKyZH18DLt89lw9EiUjJ1PHx1LAqFgn15VVwc4UtWaV2Pvi+SiUdCQgLr1q2z6pwWi/izzz7Lo48+yqZNmwBobm5GrRa/yBqNhoqKigHvzcrKsug99Xq9xfeOB+zdfrDdMwSf2ourawCnC8qBcovnGcx+dZuGaUo159r8aBnkGd3aGzGZIOXgSWL8nCmsqMFV2f/vdaxXG180tfHIxhNM81ET4VjDLF8Tu3Oa2Lb/BO5OSk6XN7AkVI3OCXKKK4f897X33yNpv3WxSMQ3bdrEnDlzCA3tP3VqqM0/LV0UuJC97cYD9m4/2PAZvj0LofMv+L0Htz8WFpQRoRw8xc/Zv5End+lodfEjNjaU5i064gI9+503LKKd57/fTnO7kYevm0V8XAB+U/S8fGAHp/WuTHFxBQq4KSkOXVseJ4trh3xGe/89kvaPnKNHjw54zSIR37VrF4WFhezatYuysjLUajWurq7o9XqcnZ3R6XRWTWaXTHJa6kXWyMxbRv+9hhBwgDBfV5wclOR09FDpnjPeGzcnB65KCERXp2dFrPg/EeDpzJxQb1IydcwI9MDLxVGkJPq4kJKhw2g0DX8xVjLpsUjEX3jhhc7vX375ZUJCQjh27Bjbtm3jhhtuICUlhcWLF1vNSMkkpywdMEHQbFtbAoBKqWB6gDundPW0thup07f3GxM388LqORhNImPGzMq4AJ7fdorC800sjNCgVCqY4u1Cq8FIZUMLWk/nAeeTSLpjtWKf+++/n02bNpGcnExNTQ033nijtaaWTHbMmSnjRMRBLG6eKqvvyhEfwBMHId6999u8Il7kmFc3tXFplAaA4I58dplmKBkJF1zsc//993d+/957713odBJJX0rTwM0fPAJtbUknMwI9+CK1mNMdVaHdqzWHQ6S/OxF+bpypbGRhx5ZuIT5CxEtqmkkMGzh1UiLpjiy7l4x/StOEF64YP3Fic2fE/XlVAJ0bQgwXhULBrQtCmRniRaS/qNA0V5bKXHHJSJBl95LxTZseyrMg+gpbW9IDcz+WfR0i3r3kfrjcuySSe5d09WjxcHbEw9lB5opLRoT0xCXjm/JMMBnGVTwcINDTGQ9nB04UiWq7kYZTBiLE24ViKeKSESBFXGJ7TCZI+1h43L0pTRPHwFlja9MQKBQKZgR6YDSB2kE5svL+QQjxdqFIhlMkI0CKuMT2FB+Fjb+ENxbDd/8QO/aYKU0Tmxj7TLWZeQNhjov7uzv1SB+8EEJ8XGQ4RTIiZExcYntS/y02d4i5CnY/A5mburoTnv4WgmaNq0VNM+a4uLVCKSA88Tp9O/X6NjycHYe+QTLpkZ64xLa0NED6F5BwE/z4HUj+DAxtcPgd8dV0fsCe4bbG7IkPVugzUsy54jIuLhku0hOX2JaMjWKfzLl3itfRq8SXHWDe9m2wQp+R0j1XfEagp9XmlUxcpCcusS2pa0UL2NCLbG3JiPFxU7MiNoCkSI3V5pwic8UlI0R64hLbUZ4NRYdg1ZPjMuY9HN6+a75V5/Nzd0KtUo5K6f1XaSVE+LmREOJl9bkltkN64hLbcWwdKB1g1m22tmTcoFQqCPJ2psTKGyabTCb+/PkJXt6Za9V5JbZHirjENrS3QtpHEHM1uPvb2ppxRbCXC8XVTQCkF9fy8o5c2gwXtotRRX0LTa2Gzg2ZJRMHGU6R2IZTW6GpChLvtLUl444QHxd2nargmW+yeWvvGQxGE7FBnqyIC7B4znNV4kOhqLqZmqZWvF2tl1EjsS3SE5fYhmPrwDMEIpfZ2pJxR4i3C5UNLbyxO4+bE0PwcHIgJbNs6BsH4VxVY+f30hufWEhPXDL21BTC6R1w2R+HtZPOZGPZDC2Hzp7n/mVRJEX5oW8zsiOrHIPR1Kcv+XDJr2pEqQCjSYRoLo3ys7LVElshPXHJ2HP8Q3Gc+xPb2jFOmR3qzUe/uISkDqFdGRdAVWMrqQXVFs95rrKJcI0bId4u0hOfYEgRl4wtRgMc+wAiLgefcFtbYxdcHuOPo0pBSoblIZVzVY2Ea1yJD/YkvaTWitZJbI0UcYnlFB2FnU+N7J4zu6C2EBLXjIpJExEPZ0eSIv1IydRhMpkAON/YyiObTlJeP3QqoslkIr+qiakakSN+trKRhpb20TZbMkZIEZdYhtEIX/8W9jwH9SPwEI+tAxefcdsPZbyyMi6A/KomcssbMBhNPPDxMT44UMBnR4qGvLeqsZWGlnbCNa4khHhiMkFWqQypTBSkiEssI+ML0KWL70tP9LxWUwibfw9tvaoOG6sga7Mo7nGwXr+RycDKjvTClIwyPkyrZm9uZUfWim7Ie/M7MlOmatyIDxbVmhnFMqQyUZAiLhk5hnbY9Q/QRInX5o0bzJz4BI68A7kpPc+f2gLGNpgtKzRHSoCnM7NDvXl/3zk+OlHDrfOncO/lkaQV1qCrGzykcrZS5IhP9XND6+GEn7sT6XJxc8IgRVwyNNlbIOURaO7IjjjxMVSdhhWPg28klPUS8aLDHfdt7TXPVvAKG3dbrdkLq+ICqGxoJcpXzd9vSOj0zrcP4Y3nVzWiUioI8XZBoVCQEOJJuvTEJwxSxCVD8/3/wr6X4ZWL8CzYDrueheC5MOMaIcjdPXGTqUvEc/4jeoMDtDbCme9gxtV22+zK1tycOIUr4wN5ZGkAzo4qpmvdmapxHVLEz1U1EeLtgtpB/HdPCPYit7wBfZthLMyWjDJSxCWD094iRHrGteAZRMj+R6G2AJY9IsQ4aBbUFIjNGwDOnxHl9FErQV8D+fvE+byd0K4Xwi+xiEAvZ95YM48Ad7Hjj0KhYGVcAPvyKqnXtw14X35HeqGZ+GBPDEYTp8rqR91myegjRVwyOKVpYGgVceyf7UQ357eQ9FuIXC6um0MjZR2Lm4WHxPHyP4ODs+iRAiIk4+wNYUlja/8EZ1V8IG0GE7tzKvq9bjKZOFvZyFSNW+c5cytaWfQzMZAiPhlJeRR+eLEr1DEYZlGechGoHDgfkwyrnugKiQR2iLg5pFJ0GJw8ITgRIpYK8Ta0idBK9JWgkp0erElimA8aNzUpGf2HVKqb2qjXtzPVr0vEp/i44OnswEkZF58QSBGfbOhrYd9LsP2v8NZSKDk2+PiiQ+AdBh4DdNBz04BXaFeaYdEhCEkEpVLEv2sL4dBbYlFUhlKsjkqpYHmslu+yy2lt79uu9lxnemFXOEWhULBgqi97cys6i4ck9osU8clGebY4XvQLaKiAt5aJzJPWpv7HFx4WXvhgmBc3WxpAl9E1PvoqQAHfPQUqJ9mxcJRYFRdIfUs7a/ef6yPK5hzx8G7hFIBV8QEUVTeTVSrj4vaOFPHJRnmmOC78Ddx3EOauEZknryfBmd09x9YWQX0JTFkw+JyBs0TK4bm9YDJ27Zfp7g9hl4iNkCOXgpO79Z9HwuJoPxZGaHhySxY/eedgp3CDaHylUECor0uPe5bHBqBQDJ2eKBn/SBGfbJRngdpdhEBcvOH6l+Cur0WMe+31sPv5rrHmeHjoECIeNBswwZF3xesp3fadjLm651FidZwcVHz4s4t56qYEThTWcsULe3hzTx7tBiP5VY0Ee7ng5NCz5a+fuxPzwnwuuE+5xPZYvMr03HPPcfToUdrb2/nlL3/JzJkz+dOf/oTBYMDf35/nn38etVruHjLuKM8EbayIWZuZdhn8ah988QvY/SzMXi3i4EWHRYZJwMzB5zRnqORuFzvXu/h0XZtzh/Do42+y/rNIOlEqFdxxcTjLZwTwyKZ0nt6azddppdTp25jm59bvPaviA3h6azZF1U1M8XHtd4xk/GORJ37gwAFyc3P55JNPePvtt3n66ad56aWXSE5OZv369YSHh7NhwwZr2yq5UEwmEbPWxva95ugCV/5DeOS7nxPnCg+Joh6HIT6MPQLBTQuY+sbP3TRw9XPg7GmVR5AMTqCXM2/dOY9XkxMprW0mv6qpR454d1bGBQLwbbeQyks7cvnH1qwxsVViHSwS8QULFvDiiy8C4OnpSXNzMwcPHmT5cpE7vHTpUvbv3289KyXWobECms+DNq7/615TYP5/wfH1oMsUi5VDxcOho+inwxvvHkqR2ASFQsE1s4L49vdL+O2yKO64uP++7dP83Jiude9sovXl8WL+tT2HDw8WYDTKrBV7wSIRV6lUuLqKT/cNGzZw2WWX0dzc3Bk+0Wg0VFT0X3wgsSHmRc3+PHEzix8SHQY3/FQ0qwodIjPFTNAscRzueMmo4+2q5verYogLHvivoFXxARw8e57D587z589P4qZW0dDSTv75AbKVJOOOC6q8+Pbbb9mwYQPvvvsuq1at6jw/VO5pVpZlf67p9XqL7x0P2Np+n1PfEQjk1DpiGMQO/6gf45e1FoCcZp8eYwd6BkevS/Gc2UhVFXB+/P6MbP0zsAbWfIbpLnoMRhN3vHUAN0clD17qz2M7yth2KJMl00Ynm8jefwbjzX6LRXzv3r288cYbvP3223h4eODq6oper8fZ2RmdTodWqx3w3tjYQTzBQcjKyrL43vGAze3PqQJXP6LnXjr4uPDH4cwmcPEmOnFRj0sDP0MszF/OwD/18YHNfwZWwJrPEBNj4h/fV1HZ0Mrrdy4gMcyHp3Zto1rh3uM9tpwoZeOxIt66cz6Kbg3MjhfW8OTmTN7/r4twdxqenNj7z8AW9h89enTAaxaJeH19Pc899xzvv/8+3t7eACQlJbFt2zZuuOEGUlJSWLx4sWXWSkaP8qzBQylmXH3h5rfBKLfwmugolQqevHEmre1GLonQABAd6E5Gcc++Kh8fLmBvbiUni2uZNcW78/z6g/kcya8mrbCGSzs2dpaMLRaJ+NatW6murubBBx/sPPfMM8/wyCOP8MknnxAcHMyNN95oNSMlVsBohIpskfI3HKKvGF17JOMGc19yMwnBXmzLKMNkMqFQKGhtN3L4nOhSmZKh6xRxg9HEt1nlAGSU1EoRtxEWifjq1atZvXp1n/PvvffeBRskGSVqC0Tl5HA8ccmkJj7Ei48PF1JSqyfE24XjhTXo24y4OKpIySzjD1fEAHA0v5rzja0ApBfLjoi2QlZsThbKOxZiAuJta4dk3JPQkc1i3v1nX14lSgX8ckkEOboGzlWKsv7tmWWoVUoWRmhIL5EdEW2FFPHJgjm90H+Gbe2QjHtigzxRKRWdmynvO11FQogXNydOAUS/FZPJREqmjqQoDZdEaDhb2Uhji1xDsQVSxCcL5VmiX4qsnJQMgbOjikh/N9JL6mhqbedYYTULIzWE+roSF+RJSmYZOboG8quaWBUXSEKIJyYTZJXKkIotkCI+WdBlyni4ZNgkBHuRXlzLkXPVtBlMXBopFi1XxgVwNL+ajw4VALAiVkt8sNgpSG6+bBukiE8G2lugMkeKuGTYxId4UV7fwpfHS3BUKZg/VTQ1WxUfgNEEa/efY26YN1pPZwI8nfBzV5Mut3uzCVLEJwNFRzpK6C+2tSUSO8G8uPlVWjFzQ31wVYtEtrggT0K8XTCaxGYUIHq1xAd7yT07bYQUcXunOBWenw47nxQed3+c3QMKJYQPUakpkXRg7rfSZjCRFKXpPK9QKDrzyrvnlyeEeJKrq0ffZgBEaGX+k9s5WSRDLKONFHF759u/iX0z9zwPbyyCggN9x5zdLboMunj3vSaR9IOHs2NnH/KkyJ5FPL9ZFsXLt88lStvVWyUh2It2o4kcndju7bltp6hsaGXt/nNjZfKkRYr4eObEZ8LLPvpv0Qu8N2f3CIFe+Tj85HNo08O7V8KZXV1jWhvF5g7TloyZ2ZKJQUKIFy6OKuaE9vzw93N34rrZwT3OmRc3M0rqOHT2PHtyKtC4qdl8opR6fduY2TwZkSI+nknfAI3l8PVv4d/XQVVe1zWTSYRQPENg3k8hagX8ej+4+cPBN7vG5e8XPVCmXTb29kvsmj+uiuHduxegdhhaJkJ9XfBwduBkcS3/3HYKrYcTryQn0txmYPOJ0jGwdvIiRXy8YmiHcz/AvLvhuhfFBg2vJ8H3L4hruduh8CBc9kdwdBb3OLnDnNsh5z9Q37Fby9ndoHQUGxZLJCMgTOPKwkjN0AMRsfKEYC++Pl7CoXPnuX9ZFJdE+BId4M7HhwtH2dLJjRTx0cDQ3n/4YySUHIPWeoi4XAj5fYeEt/3tY/DWUtj+KPhMg7k/6Xnf3DVgMkDaevH67B6xUYO6/30WJRJrkRDiSX1LOyHeLqxeEIZCoWD1gjDSCmvILpOZK6OFFHFrYzIJj3njvRcm5Gd3i+PUjpa+nkGw+gO4dS3Ul4mOhJf/P1A59rzPbzqEJcGxD6DpvPDgZShFMgbM7Ohu+MCK6Z0hmJvmhuCoUvCJ9MZHDSni1qa2ECpPwYmP4eD/WT7P2T0QkABu3TIDFAqIuwF+cwhWfwgzb+n/3sQ1UHUa9vwTMMlFTcmYcFVCIP+3Zh4/7uixAuDrpmZVfCAbjxXT0m7oc0+bKT7Q2wAAECtJREFUwTjkvG0Go9zzcxCkiFubwkPiGJAAKX/pP+VvKNr0It49kPi6+EDstaAc4McXdwM4ecKB18DRFULmjdwGiWSEOKqUXBEfiFKp6HF+9fxQapra2JzWc4HzfGMrSc/s5InNmQPO2dTazvWv/MDvPj0+KjZPBKSIW5uiw+DgAnd+JRpOfXY3NJSPcI5D0K63PAyidoOEmwEThC0EB7Vl80gkVmBRlB9xQZ68uCO3h+f9+q7TVNS38M73Z9l0rLjPfSaTiT9/fpKs0joOnKkaS5PtCini1qbwEIQkgptGxLCba+Czn4rFzuFydg8oVBCeZLkdiXeKY+RSy+eQSKyAUqngD1dEU3C+ic+OFAGgq9Ozdn8+N8wJ5qJpvvz5ixN9Fj//ve8cX6WVEKV1R1fXQnm93hbmj3ukiFuTtmYoOwFTFojXgQlw7f9C/vew4/FeY/VQebrrS9+tPPnMbvFBcCFtY0MS4e4tsOBnls8hkViJpTFa5oZ58/LOXFoNRl7ZeRqD0cRDK2N4JXkuns6O3LvuKKfK6jlT0cCOLB1PbsliRayWJ25IAJC9WQbA4t3uJf1QclwU1oRe1HVuzu0ixLLvJTwuDYLYWMhJgc2/g7qirnFqD1j5N7FYWXwUFj3YZ/oRM3XR0GMkkjFAoVDwx1UxJL99kPeOnmdLTj23LgglTOMKwKt3JHL7mwe44oU9nfeEa1z5n1vnoOgIsWeW1LE0RmsL88c1UsStSVHHouaUi3qev/IfUHqcoINPQPUByPwS/GPhhldB5QSY4PiHsOUh+OElkect0wIlE4ykKD+SIjVsyqpC7aDk/mVRndcWTPVl032XklfR0DU+0g8vF5FCO1Xj2qdfeUu7gdZ2Ix7OvdJsJxlSxK1J0WHwmQru/j3POzjBrWsxvXYpZG8V+d2Lft9zwXHmLXB8PWx7GBzdZNtYyYTkD1fE8KPX9rHmknCCvFx6XEsI8SIhxKvf++JDvDhRVNPj3F82prM7p4LN9y8iwNN51Gwe70gRHw51paLYZjBMJig8PLAH7TWFcyveJSoyAnyn9b2uUMDcOyD6ClGk4+jSd4xEYuckhvnwwtXBXLkwZkT3xQd7suVEKbVNbXi5OtLabmRbehn1Le3c92EqH/3iEhxVk3OJb3I+9UgoOgL/mgH7Xx18XG0hNJT1jIf3os09uH8B746bH/hHW2CoRGIfxPg74+yoGtE9CZ1dEkVI5eDZKupb2vlRYghH8qv5x9Zsq9tpL0gRH4qMjeKY8qhoSDUQ5iIfc2aKRCKxGvEdm1SYM1RSMnS4OKp4+qaZ3J00lXd/OMvmEyW2NNFmSBEfDJMJsreIghnfabDhp6JvSX+Yi3wC4sfWRolkEqBxdyLYy5n0klpMJhPbM3VcFu2Hs6OKh6+OZV64D//vi5M0tY6gHmOCIEV8MCqyofqsWHRc/QG01IsKTEM/Te7NRT69G1JJJBKrEBfsRXpxLSeLaymr07OyY49PtYOSP10RQ72+na0nB3CyJjBSxAcje4s4xlwtdoq//mUo2A9vL4fSE+JaSz1s/SOUpMo9LCWSUSQhxJMzlY1sOlaCUgHLZ3TljF80zZdpfm58Ogm7JUoRH4zsLaJ5lDkzZeaPRSvYulJ483JRsPPqJXDoLbj4Xlj0O5uaK5FMZBKCvTCZYP2hfC6a5ouPW1eKruhdHsqhc+d75JoPB5PJREZJLe3D6Kg4HpEiPhB1JcK7nnFNz/NxN8B9B0Ul5pF3wckD7tkOVz0Lalfb2CqRTAL+f3v3HhV1mQZw/MswghcQhGBE0RLWVCwozC7HBCWl0HZlOydEVq3jjbNeaC07mZdjp130iGipW2mmaWxeWrTLLptslh11ZUFoV0RQBI3lpoCgh9s4gL/9gxxDZgbEkZmfPZ9/UN6Z8Xl4PA+/eef3vu+Ne8j1TdeNUyk/90LwQBw1DnyW2fmr8eLqBmbuyGDypmO88MFx8srVt7Rfmrg5Z//R+nXY5PZjvT1aV1su+gFij8AguSNFiLtN19cZz5+uvsMDdO3GvV178sxwb/ZnlRh3S9Q3tXD2Ym27x16/rrD92AXC3znCD0U1zAvxo7SmkV9vPsa61DPom9rvfW6vpImbcyYFPPzBy8KiBE9/2eZViG7i4ODA6Ac8CBrkziAP0+96p44eRFWdge/OVHC8sIpn3z3Cs+8e4WBO273MN313jj/+PZen/D355tVQlk0awaFXQ5nyyEDeO1zIpE1HybhQ3R1p3TGrN/HVq1czdepUoqOjyc7OtvbL37nGmtbzKy3RX4ULR1unUhwcLD9WCNFt1kcF8cks8wvqQh/0QtfXmeWfnyJmWzoAAT59WfLXbONc+fdnK9j47TleCB7I9pceY4B76+rofn2cWB8VRNLsxzE0XydqaxrLPz9Frd7E3Wg/U1hZR9mVRitlePus2sQzMjIoKipi3759xMfHEx8fb82XvzOKAjn74c+jWz+U3D8H6qvaP640C3ZEwPUmCIjs9jCFEOb1cdYaN8UyReuoIebx+6lpaCI21I/UP4Tw0UuP4aTV8Pu/ZJF/qZZX9v6XYTpX4iMfxsHERdrYoV78c3EIc54ewp6M/zFxwxG+yb3U7nH6phbWfJ1H+DtHCFv/PR8dPU+LDY6Rs+reKWlpaUyYMAEAf39/rl69Sl1dHS4uLnf+4hV5uBZ/C9e7sLxWUSD7M8j/GgY8CkHT4N8fQMG3MG4puPx0q1JxBqRvARcdRO8BXznWTAi1WRj2K6Y/ORhPF2cABrj3YlP0o8zckc7zm47h3EPD1hmj6OVkful/byctK54P4PmgASzdn83cTzKZHOhDxEP9KSutI6e+mPcOF/Dj5QaiHvOlut7An1Ly+NvJMmY9PQStiaMTR/i44udlhV54CwdFuZMj2dtauXIloaGhxkYeExNDfHw8Q4bc3C8kKyuL3r1v/y6OIQd/R8+rhV2O7bqjM5UPx1I9NAo0WpyunsfnxGp6X85p87ga/99SEbiA607W/2Hr9Xp69lT3bmtqz0Ht8YP6c7BV/J+dusKu/1SzcryOJwf16fTzmloUkk9fYffJGpp/dheij6uWuKe8eMSnF4qicOTHej7IqOKq3vStigFezqyfNLBLsTc0NDBqlOmLyru6i6G53w8jRoy4/Rd74DsKT/4Lfz+/LsWicdGh6+3Bzc+0R8DjEa2nwis/fRLt7Eo/N1/6delf6FheXl7Xcrcjas9B7fGD+nOwVfyrRsDi3zTRtwv7jwc+BK9MvsblegPnC8/j5+/H/Z69cdbevJoPCIAZzzRTamZ+fIB7L1ycu9Zys7KyzI5ZtYl7e3tTVXVznrmiogIvLy8Lz7gNvdwxuPm1rpy0Fo1GdgwU4hekKw38Bk8XZzxdnGmpduJBnavJx/Rx1podu1us+sHmmDFjSE1NBeD06dN4e3tbZz5cCCGESVa9Eg8ODmbkyJFER0fj4ODAqlWrrPnyQgghbmH1OfElS5ZY+yWFEEKYISs2hRBCxaSJCyGEikkTF0IIFZMmLoQQKmbVFZudYemmdSGEEKaZW7HZ7U1cCCGE9ch0ihBCqJg0cSGEULG7ugFWV61evZqTJ0/i4ODAsmXLCAwMNI4dP36cDRs24OjoSEhICAsWLLBhpOZZyiEsLIz+/fvj6Ni6eU5iYiI6XfvjpmwpPz+f+fPn8/LLLzN9+vQ2Y2qpgaUc1FCDhIQEsrKyaG5uJjY2lvDwcOOYWmpgKQd7r0FjYyNLly7l8uXLXLt2jfnz5zN+/HjjuN3UQLEz6enpyrx58xRFUZSCggIlKiqqzXhERIRSVlamtLS0KNOmTVPOnTtnizAt6iiH8ePHK3V1dbYIrVPq6+uV6dOnKytWrFCSkpLajauhBh3lYO81SEtLU+bMmaMoiqJUV1croaGhbcbVUIOOcrD3GqSkpCgffvihoiiKUlJSooSHh7cZt5ca2N10irmDJQCKi4txc3PDx8cHjUZDaGgoaWlptgzXJEs5qIGTkxPbtm3D29u73ZhaamApBzUYPXo0GzduBKBv3740NjbS0tK6ZbJaamApBzWYNGkSc+fOBaC8vLzNuwR7qoHdTadUVVUxcuRI4989PDyorKzExcWFyspKPDw82owVFxfbIkyLLOVww6pVqygtLWXUqFG89tprJo+JshWtVotWa/q/hlpqYCmHG+y5Bo6OjsbDU5KTkwkJCTFOO6ilBpZyuMGea3BDdHQ0Fy9eZMuWLcbv2VMN7K6J30q5B+6AvDWHuLg4xo4di5ubGwsWLCA1NZXnnnvORtH9MqmlBocOHSI5OZkdO3bYOpQuM5eDWmqwd+9e8vLyeP311/nqq6/s7heN3U2nWDpY4taxS5cu2eXb5Y4Ox4iMjMTT0xOtVktISAj5+fm2CLNL1FKDjqihBkePHmXLli1s27YNV9ebBw2oqQbmcgD7r0FOTg7l5eVA62lkLS0tVFdXA/ZVA7tr4pYOlvD19aWuro6SkhKam5s5fPgwY8aMsWW4JlnKoba2ltmzZ2MwGAA4ceIEQ4cOtVmst0stNbBEDTWora0lISGBrVu34u7u3mZMLTWwlIMaapCZmWl891BVVUVDQwP9+rUe3mhPNbDLFZuJiYlkZmYaD5bIzc3F1dWViRMncuLECRITEwEIDw9n9uzZNo7WNEs57Nq1iy+++AJnZ2cCAgJYuXKlXb1Fy8nJYe3atZSWlqLVatHpdISFheHr66uaGnSUg73XYN++fWzevLnNIeNPPPEEw4YNU00NOsrB3mug1+tZvnw55eXl6PV6Fi5cyJUrV+yuF9llExdCCNE5djedIoQQovOkiQshhIpJExdCCBWTJi6EEComTVwIIVRMmri456WmpnLgwAHWrl3b6eccPHjwLkYkhPVIExf3tJKSElJSUm7rOQaDgZ07d96dgISwMmni4p729ttvk5GRQVlZGRUVFSxatIiIiAiSk5OB1lV5MTExzJw5kzfeeAODwcCaNWs4e/Ysb731FnV1dcTGxjJjxgxefPFFsrOzbZyREG3JYh9xT0tPT+fTTz9l3Lhx7N27lz179lBUVMTixYv58ssviYyMZOfOnbi7u5OQkMDw4cMJDg4mLi6OAwcOcOHCBQoLC5kwYQJpaWns3r2bzZs32zotIYzsfhdDIawlKCgIR0dHdDodtbW1VFVVUVRUxKJFiwDa7I1xw3333cf777/P9u3bMRgMxq1VhbAX0sTFL8at+4v36NEDb29vkpKS2ny/pKTE+Oddu3ah0+lYt24dp06dIiEhoVtiFaKzZE5c3NM0Gg3Nzc0mx9zc3AAoKCgAICkpiTNnzqDRaIwn0NTU1DB48GCgdV/spqambohaiM6TJi7uaf7+/uTm5rJmzRqT4/Hx8bz55pvExMSQlZWFn58fXl5eNDU1ERcXx5QpU/j444+ZNWsWgYGBVFZWsn///m7OQgjz5INNIYRQMbkSF0IIFZMmLoQQKiZNXAghVEyauBBCqJg0cSGEUDFp4kIIoWLSxIUQQsWkiQshhIr9H85xsIbrb5ldAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAEBCAYAAACOpZVlAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAABOW0lEQVR4nO3dd3zU9f3A8dfdJZe99wQSIIOwwt4OhgMXIiMKVm2rrQtLXa1iW3e11srPWWutIhXcWicCioIGSJghA0LI3nvncvf9/fHJJTly2eNyyef5eORxyXfl/eWSN5+8v5+hUhRFQZIkSbJKaksHIEmSJPWdTOKSJElWTCZxSZIkKyaTuCRJkhWTSVySJMmKySQuSZJkxWyG8pslJCQM5beTJEkaMWbMmGF2+5Amceg8kJ5ITk4mKipqAKMZWjJ+y7P2e7D2+MH678ES8XfVAJblFEmSJCsmk7gkSZIVk0lckiTJiskkLkmSZMVkEpckSbJiPUrix44dY8OGDQBkZmayfv164uLieOSRRzAYDAD83//9H6tXr2bdunUcP3588CKWJEmSWnXbxfCf//wnn376KQ4ODgA8+eSTbNq0iTlz5rBlyxZ2795NYGAgBw8e5L333iM/P58777yTDz74YEADVRQFg6JgMIiZc9Vq1YBeX5IkqU8URXx0Rz04hY9uk3hoaChbt27lvvvuAyApKYnZs2cDsHjxYvbv38+4ceNYuHAhKpWKwMBA9Ho9ZWVleHp6DkiQFXVNXPjsd5TX6YAMNGoVcbNDue+SCFzsbQfke5hTWtPIo/87xfHcSj67YyFOdkPerV6SpOGsNB3eXAnVed0fu+IJmHf7gIfQbVZasWIFOTk5rV8rioJKJVrBTk5OVFdXU1NTg7u7e+sxxu3mknhycnKvg9QbFOImu1Fa24iNjQ3Ftc1s+zmTL4/ncPtcb2IDHXp1PVu1qvUezFEUhb1na3j1UCk1TQYMCvzz6wRWTHDtdeztNTQ09On+hwtrjx+s/x6sPX6wgnvQ61Bh6LBZUWlAbdMav6q5nrHf/hKbxhrKJ/0SusgpAFXqMJoG4b573bRUt/uToLa2FldXV5ydnamtrTXZ7uLiYvb8vo50iplkOlLqSFY5D3xwgj/vKez1tSL9XXhy1WSmh3p02JdTXscfPzrJ92nFTA915+lrp/DbdxLZl9PMpiv7N0pLjlSzPGu/B2uPH4b4Hr64DwqOwy++6Fk548g2+GwTGHQd96ltYPatpAStJjIyEj66FSrPwg3v4zN+abeX9ul99K26GrHZ6yQeHR1NfHw8c+bMYd++fcydO5fQ0FCeeeYZbrnlFgoKCjAYDANWSunM9FAPPrtzIR8dyaG0tqnH5zXrFf57MItVLx/gpvnjuP3CcLQ2ahTg/cM5PPtNKgCPXBHNxnlj0ahVrJ0ZwuNfJHO6sJoJfub/c5IkaZipr4DEt6C5Hk59DDGrTPcbDKaJPTcB/ncPBM+ECcs7Xq/0DPz8ImFOH0H2FXB8B1zwB+hBAh9MvU7i999/Pw8//DDPPfccYWFhrFixAo1Gw8yZM1m7di0Gg4EtW7YMRqwdaG3UrJ0V2uvzblowlr9+lcob+zN4Y3+Gyb4LInx47OoYgj0cW7ddExvEX79OYcehbB5aGd3vuCVJGgIn3xcJ3MkX9j4BUVeCpiXlffMwHHkblv0Fpm+AujLYeSM4+8O67eDYSSN0+g0o798KB18ViX7xvUN3P53oURIPDg5m586dAIwbN45t27Z1OObOO+/kzjvvHNjoBomLvS2PXh3DqtggEjLLW7eP9XLi4ijfDvVyb2c7lkX78eGRXO67JBKtjexeL0nDXuJb4DcZltwHOzeIlvP06+HE+3DgBZGwP70TTrwnjq8phJu/7jyBA4yZT8aKt4k0nIaJKwatx0lvjOruFtNDPczWxc1ZMzOEL04U8G1yIZdNDhjkyCRJ6pf8Y+Lj0r9C1BUQMA2+fwr8J8Ond0HIXLjxUzj6Dux6BBqr4Ip/QFBst5dWNHYQc93g30MPjeok3huLJvgQ6GbP9vgsZo4Rid/OVoObw+B1cZQk6Tx6HWh68DuX+DZo7GDydaLXyEUPwzvXwhsrQOsM170JNnYw82aYeAnkHxctayskk3gPadQqrpsZwj92n2b2E7sBUKvgF/PH8fsVE3HUyn9KSRpUDVXw8nwYfzGsfL7zLn26ejixE6KvbCuNjL8YQudB9kG4/j1wbffXtGug+LBSMvP0wq8XhxHk7oCuZaqBk7mVvLE/g29OFfDnKycR4d+x54pWo8bX1b7L6zbo9Nhq1GjkKFRJ6txPL0JlNiS8KcojM28yf1zyZ9BQKR5YGqlUsOZtqMyCoL4vTDMcySTeC052NqyZFWKybVVsMPd/cJxb/nO40/PuWTqRu5dO6LBdURTeS8jh8c+TmR7qzr9unCUTuSSZU1cmknjkSmhugC/vg4ApHRNy2tewawt4jIWxi0z3OfuIjxFGJvF+mjXWky/uWsSuU4XU6/Qd9u9NKeLv36YRE+RK+z/YskrrePCj4+w/U0q4jxPfpRbzj2/T+N3yiKELXpKsxf7noakGLnoInP3g1SWiS+D6d8HWAZob4Ydn4eQH4BsN17wyLHqODAWZxAeAva2GK6aar6ldOTWQrLID3LPjKM9fFsAEvYE39mfw3K40bNRqHrs6hrjZodz/wXFe2HOGqSHuXBzlN8R3IEnDWHUBxL8mHlL6toz0XPsW/GsFvLKg7TiNFi78IyzYBDZai4RqCTKJDzJ7Ww0vXz+DlVt/4C97C3E9WMXxnEqWRvny2NWT8XcT9fJHr47hVH4V9+w4yus3zsLdUTyBD3R3wFlOvCWNZj88B/omuOCBtm2B0+HXe6EwqW1b0AzwCh/6+CxMZochEOrlyPPrpnHzm4fx1sGLcbFcNtnfZFBR+2S/5tWfWrdPDXHnk9sXmLusJI18FdmQ8G8xSOf8BO03SXyMcjKJD5GLIv14YWUQS2In4eZovp9rqJcjn9+1iOM5lQAcOlfGmwfOcTK3kpggt6EMV5IGh6JgU1/S8+O/f1q8Lr5vcOIZAUZH5X+YmOBl12kCNwrxdOTyKQFcPiWAe5ZORGujZseh7CGKUJIGWeqXTPh0JSR93P2xpelwdLsYkOMe0v3xo5RM4sOYm6Mtl8X48/HRXBrM9HyRJKuTsU+8fnI7FKeZ7is7K2YWNPruSTGqctHmoYvPCskkPsytnRVKdUMzX57Mt3QoktR/OQdpcAsXyXnHDdBYI3qf7LgBXpgO/1kJJaeh8JSYqGrOreDsa+mohzWZxIe5uWGejPFy5N2DbSWVuqZmiqobenWdzNLa7g+SpMGka4D849QEzIfVb0Dpadh2LfzfbEj7RpRNCk/CywvgvRvBzgXm32XpqIc9mcSHOZVKxZqZIcRnlJFRUss3SQVc+Ox3XPr8DzQ1d1xCypwfThez5Jnv+DqpYJCjlaQu5B8Dg456rxgIu0BMSpX9s5hZ8Lc/wcq/w+2HIOISKEkTCbyraWElQPZOsQqrZwTzt29SueH1eHIr6vFxsaO0ton4jFIWTeh+GPHelGIA/vZNKkuj/OTQfmnwNTdCZY5pt8CcgwDUe8eIrxfeAxGXgndE2+hKFz9Y85aol3uNH+KgrZNsiVsBP1d7lkf7U1zdyO+XT2TP5iU42Gr4Jqln64seSC/Bxd6GtMIaPjvWg1W5Jam/vv4jvDRX1LuNsg+C+xj09l7ia5VKjMA0NzzeZ+KoGTbfX/JfyUr8bc1U9j9wEXdcNAEXe1uWTPRh16lCFEXp8rzSmkZSCqr59aIwIv1deP7bNHT6npVhJKlb9eVQfs50W/k5MdOgvkl0EQRQFMg5BCGzhzjAkU8mcSvhZGeDj4td69fLov0oqGrgRG5ll+f9dLYUgIUTvNm8PIJzpXV8kJAzqLFKo8iX94sHke27C37/V1CpwS9GrGOpKKK0Up0PwTKJDzSZxK3URZG+aNSqbksqB9JLcbazYXKQG0ujfJka4s4Lu0/T2Cz7nUsDIPOAmF3Q2F2wOA2O/Rdm/wrm3SH6fmfub62HEzLLsvGOQDKJWykPJy2zxnqw61Q3SfxMCXPGeWKjUaNSqbhvRQR5lQ0881XqEEUqjVhV+WKRhsiVorvgp3fCd0+AjYOYSTD6KrBzFUulZR8S2/1iLB31iCOTuBVbHu1PamE150pEH/DqBh1Hsyta9+dW1HOutI75471bty0Y783GeWN4/ccMPj8uBxBJXSg5AzVFne83tq4X3iPm+U76EJI+grm/EYsvaB1h8mo49TGk7xEzD/ZkfUypV2QSt2LLosW847tOFbLrVCHLntvH1S/u55OjuQD8lC7q4fPDvUzOe+jyaKaHunPf+8c4U1Q9tEFL1sGghzcvh/+uFzVtc7IPisWI/afAgnvEqvJOPjD/jrZjYjeKlXhKUmUpZZDIJG7FQjwdiQpw5e/fpvGrtw7j7mjL1GA3HvjgBGmF1Rw4U4Knk5YIP9O1P7U2al66PhY7Ww23bUuktrHZQncgDVs5h6GmAHIPQ9pXnRxzCAKniQUY1GqxhuVdR8DBo+2YgGngN1l8Lh9qDgqZxK3cNdMDadYrbF42kU/vWMhrG2fiZGfDbW8n8OOZEuaFe6E2M7gnwM2Bv6+dxpmiGv53XPYdl86T+jmobcB9DOx5zHRiKoDmJsg7CsHtWtcqlRgq355KBXN+DbaOEDp30MMejWQSt3K/XBjG0UeWcefFE9DaqPFztefFuOlkltVRVN3YoZTS3sLx3mg1as6WyHlVpHYUBZL/JxYavuhhMZ/JqY9Mjyk4DvpG0yTemekbYHMqOHl3f6zUazKJWzm1WoWj1nT2hDlhXvzhsii0GjWLuxiWr1GrCPVybH0wKkmAmLekLB0iL4eYa8XCw3ufAH27slu2sctgD0okKhXYuw5OrJJM4iPVLQvHcfSRZYR4OnZ53FgvRzJL64YoKsmiTn8ryiDdSflcvEZcJmrdF/4RSs/A8Xfbjsk5CK7B4Gp+gXBp6MgkPoKd30I3Z4yXE+dKa7sdvi9Zuax4eOdaOL6j+2NTPofAWHALEl9HXg5BM+Gbh6EiS2zLOSx7mwwTMomPcmO9HGnQGSiqbrR0KNJgSvlMvOYd6fq4qnzRIyXysrZtKhWseg0MzbBzo5gbpTJb9jYZJmQSH+XGeDkByLr4SGZ8UAliTu+upH0pXiNXmm73CodrXhH/CWxfK7b15KGmNOj6lMR1Oh2bN29m3bp1xMXFkZ6eTmZmJuvXrycuLo5HHnkEw/ldkqRhaZx3SxI/b+WfvalF5FfWd3nuqbwqkvOrujymqKqBA2d6sbq5NPCKU6A8Axy9RU8TfRfjAlI+B88w8InsuC/ycjE6szgFNFoImDJ4MUs91qck/v3339Pc3My7777L7bffzvPPP8+TTz7Jpk2b2L59O4qisHv37oGOVRoEAW722GpUnGv3cLOmsZlf/ucwG/51sNOBQHqDwq/eOsxDH5/s8vovfZfOxjcOUt8kJ9yyGOODygV3tYyeTDN/XNrXcOZbmLRKlFDMufAhGL8Mwi8W62RKFtenJD5u3Dj0ej0Gg4GamhpsbGxISkpi9mxRI1u8eDEHDhwY0EClwWGjURPi4WiyBuex7Ar0BoUzRTXc/8Fxsw89fzxTQm5FfbdrdybnV9FsUEgp6LrFLg2ilM/Fg8kJK8TXBcc7HlOWAR/+SiyVtvj3nV9LYwNxO2H9fwcnVqnX+rQ8m6OjI7m5uVx66aWUl5fzyiuvcOjQIVQt/3s7OTlRXW1+To7k5OQ+B9vQ0NCv8y1tuMbvZWcgJbesNbavj5UDsCbGnZ3H8wm0a+KaaDeT+F//TsyeWFLTxJHjSdjbdmwPKIrCqbwKAL5NSMO+1vJ9hYfre9BTvY3fpq6ICXmJFE3+DaXFzURo7ChP2kuRdmrrMarmBsbu/jW2egMZM/6E7sy5QYi8zWh7DwZbn5L4m2++ycKFC9m8eTP5+fnceOON6HS61v21tbW4upr/hY2KiupbpIj/APpzvqUN1/gnnTbw3uFsIiMjUalUZP98kAm+zjx9/XzK307gjYQils2YiDOFREVFUVrTyM85GQS5O5BbUY+TXygTz5ufBUQ9vLoxA4BSg8OwuPfh+h70VK/jP7QfAN/FN+HrEwE/TcWrMRuv9tf45HaoSIP1OxgfsXSAI+5o1L0HAyAhIaHTfX0qp7i6uuLiIn5p3dzcaG5uJjo6mvj4eAD27dvHzJkz+3JpyQLGeTtR26SnuKYRRVE4kl1BbKgHKpWKv62ZSrCHA7e/k0hZvaiPf3QkF51e4a6LxUK22WXmBwulFoq/xpztbDiZ1/UKRNIgSflcLDjsPVF8HTAF8o+3zYVSnAZHtomV5SMusVycUp/1KYn/4he/ICkpibi4OG688UbuuecetmzZwtatW1m7di06nY4VK1YMdKzSIBnjJUZ1ZpbWcbakloo6HbFj3AFwtbfl5RtmUNWg48nvi9DpDew4lM20EHcujhJT4WZ1lsQLRBK/NMaftIIampplj6UhVV8BGT+IkZfGB5UBU6GpWvRWATjylpjoat4dnV5GGt76VE5xcnLiH//4R4ft27Zt63dA0tAb266vuLG/eGxo23SiUQGuPLlqMvfsOMYv/3OY00U1PLVqMl5OWhxsNWSXme+KmFpQjbezlsUTfXgvIYfTRdVMCnQb/BuSRN/wL+8TA3Rirm3bHtBSC88/Cm4hcOxdmHgJuPhZJEyp/+RgH4kgDwc0ahWZpXUkZlXgYm9DuI+zyTHXTA/mighXvk8rxlGrYeXUQFQqFSGeDmSXm2+JpxVWM9HPhZggkbiTcmUPlQFTXQBH3ul8/6HXxRD7C/8g5vw28okCta0oqaR9BbXFYuEGyWr1qSUujSy2GjXBHg6cK63lTFEN00Lczc5B/qtZXjRoHJgU6IqznfjRCfFwNFsTNxgU0gprWDsrhDGejq118TWEDPr9jAqH/w3fPwVhS8At2HRf9iH46kGYsBwWnddd0EYLvlFi5GbRKXAJFH2+Jaslk7gEiJJKUl4V50prWTHJ3+wxthoV/9xo+sA6xNOR+IwyFEVp7WIKkFNeT71OT6S/C2q1iugAV07myoebA6akZaHromTTJF5XBu/dCK4BcM2rYhbC8wVMFWth6upg4e9E32/JaslyigSIibAySmpRFIgd49H9CS2CPRyoaWymok5nst3YM2Wiv+jFNCnIleT8avQGOVvigCg5I14Lk0y3p34JVbmw6p/g6Gn+3ICp0FQDigGm3zC4cUqDTiZxCWibCAtgWoh7j88LbZmv/PweKqktIzQn+IraekygG/U6PRklNf2MVMJggNLT4vOi8wad5B8DW6euJ6cyPtwctxg8xw1OjNKQkUlcAmCst0jGE3ydcXOw7fF5xkUnzn+4mVpYQ5C7Ay724lrGh5sn5cPN/qvMFnOggKhrt5d/TAydV2s6P99/CoTMEZNZSVZPJnEJaOtm2L5rYU+0JvHzuhmmFVQT6d82ijPcxwk7G7Wsiw+EkpZWeNBMKE4FQ8vkYgY9FJxoa2l3xtYebvkGwi8a3DilISGTuASIZLxogjdXTevdclvOdjZ4ONqatMSbmg2kF9e01sNBTLQVGeAqR24OBOMshNFXicWKy86Kr8vOgq5WThE7ysgkLgGim+Hbt8xh/vjer0ge4mnazTCjpJZmg0LEefOpxAS6kpRXhUE+3Oy5nMOQ8KbpttLTYO8OYxeKr40lFeOCD921xKURRSZxqd9CPBzJKW8rp7T2TDkvic8e50l1QzPxGWVDGp9Vi38FPt8Mje0eCJecFnOh+EQCqraHm/lHxWIN5hZ0kEYsmcSlfgvxdCSnvK61+2BqQRUatYpwXyeT41ZM8sfF3oadh7MtEaZ1qsoTQ+ezfmrbVpImkrjWUazC074l7jcJND1/MC1ZP5nEpX4L8XRAp1corGqgQafnw8RcYkPdsbMx7SFhb6vh6mlBfHEin8rz+pVLnajMEa9nvwNA3VQDNYXgPUFs942CwlNirpT847KUMgrJJC71W4iHsYdKHdvjs8ivbGDT0olmj107K4TGZgOfHMsdyhCtk8EA1fni84x9AGirM8XXxqllfaOhLF2UWBoqZBIfhWQSl/rN2M0wrbCal747w7wwLxZ08oA0JsiNSYGu7DgkSyrdqisBfRO4BIiug3Vl2FWdn8SjxMjLE++Jr/1lEh9tZBKX+i3Q3R6VCl7Yc4aSmiZ+v8J8K9xo7awQkvKqZJ/x7lS1/LUyZQ2gwLkfREtcbQseY8Q+v0ni9fi7oNKAX7RFQpUsRyZxqd/sbDT4u9pTXN3IhRE+zBjTyZwdLa6aGoSdjVq2xrtT2ZLEI68QQ+nPfo+26px4mGl8eOkZJnqkVGSJXim2DhYLV7IMmcSlAWEsqWxeHtHtsW6Otlwa48/HR3Np0OkHOzTrVZUnXj3Gwpj5kLEPu+rMtoeaIJJ569JrspQyGskkLg2I9bNDuGfpxNY5UrqzfJI/1Q3NnCmSE2J1qipHtLIdvcS84aWn0VZnmSZxEHVxkEl8lJITCUsD4prpwd0f1M4475Yl4Upre5z4R52qPHANFHOCj1sMgEoxtLW8jXxb6uByuP2oJJO4ZBHtF2eWOlGVB65B4nO/yeDgAfXlHZP4pKtFN8OgGUMeomR5spwiWYSj1gZfF7vWhZklMypz2pK4Wg1jF4nPvcabHucZBle9CDZ2QxufNCzIlrhkMWO9nWRLvDPGgT6u7WaVnHcHJXjg7eBusbCk4Ucmcclixno5sje12NJhDE/GgT7GljhA6ByKa13p/TyT0kgmyymSxYzxcqK4upHaxmZLhzL8GAf6uAV1fZw06smWuGQxxtWEMkvriA50BaCouoHb3k6grkn0H9faqHn2uqkdprVt7w8fnWDxBB8uifEf/KD74oNfmS5ovOBumLq263OMA31ce7dIhzT6yJa4ZDFtPVTaHm5+l1JMYlYFAW72hHo6ciK3kq9OFnR6jbyKerbHZ/HWT+cGO9y+aayGEztBpRKLEtcWQeJ/uj/PONDHtXddN6XRRyZxyWLGtvYVb3u4eSS7HFd7G/514yxe2ziTCb7OJGaVd3qNn9JLATicWT48R3+Wt0xYtWgzrHsHYq6F3ETQdzMVb/uBPpLUBZnEJYtxtrPB29m0m2FiZgXTQz1Qq1WAWLj5SFZFp0u67U8vAcS6nl0le4upaEnixgmrgmdBcz0Unuz6vPYDfSSpC/InRLKosV6OnGspp1Q16EgrqiY21KN1//RQdyrrdZw1059cURR+Si9l8UQfNGoVB86UDlncPVZ+Trx6jBOvIbPFa87hrs9rP9BHkrogk7hkUWO82vqKH8uuQFFE4jYyJvQjZlrZ50rryK9sYHm0H1OC3TjQ0iofVsozQesiRlsCuIWAsx9kH+z6vPYDfSSpCzKJSxY11suRgqoG6pv0JGZWoFLBtHZJPNzHGVd7GxKzKjqcu/+MSNoLxnuzINybYzmV1Ay37ooVmaKUohLlIVQqUVLJ6SKJmxvoI0mdkElcsijjw82ssjqOZJczwdcZV/u2hX7VahXTQj3MtsR/Si8lwM2esV6OzA/3Qm9QOJgxzEoq5ZngPsZ0W8hsUWap6WSgk7mBPpLUiT4n8VdffZW1a9eyatUq3nvvPTIzM1m/fj1xcXE88sgjGAyGgYxTGqGMfcUzSmo4klVhUg83ig11J7WwmuqGth4dBoPCT2dLmRfuhUqlInaMB1obdf/q4qlfwVtXi5bwQFCUtpZ4e8HGungnrXE50EfqhT4l8fj4eI4cOcJ///tf3n77bQoKCnjyySfZtGkT27dvR1EUdu/ePdCxSiNQaEtf8T0pRVTW6zpJ4h4oChzLblvOLaWgmrLaJhaEi0Ho9rYaZo7x4EB6P5J40kdwdi/Ul/X9Gu3VloCurmNLPHAaqG06r4vLgT5SL/Qpif/4449MnDiR22+/ndtuu40LLriApKQkZs8WLYzFixdz4MCBAQ1UGpncHGzxdNLy5QkxoCd2jHuHY6aGiG3tuxAaH2LOC2/rRz0/3ItT+VWU1Tb1LZj8Y+LVONCmv1p7pow13W7rAP5TIOeQ+fPkQB+pF/o07L68vJy8vDxeeeUVcnJy+M1vfoOiKKhaHt44OTlRXV1t9tzk5OQ+B9vQ0NCv8y1Nxm+er6OKlOJmnLVqGkuySS5VdTgm1M2WfaeyWRYoHlx+c6yAIFdbKvPPUZkvjgnUNADw/r5jLBrr3Kt7UDU3EFGSigrIPnWQmgrbjif3kmvmAYKA9HI9Ted9Tz+n8bif/YTUpBOiVd6OT8YxPNW2pGYVgcq0x421/wyB9d/DcIu/T0nc3d2dsLAwtFotYWFh2NnZUVDQNjS6trYWV1dXs+dGRUX1LVLEfwD9Od/SZPzmRR9vJKU4lxljvZgUbX619nlJOr5KKiAiIpJvkws5UZjJNbFBJvFMmGhgy54i/vpDMc8dEMlv/exQHrliUvf3kHMYFFELD3G3gYG4z+LPAQiPvQC0Tqb7mlfA6Z1EeTRD4OS27WUZUHYE3IKIip7E+az9Zwis/x4sEX9CQkKn+/pUTpkxYwY//PADiqJQWFhIfX098+bNIz4+HoB9+/Yxc+bMvkUrjTpjWh5umquHG8WOEYN+Nr5xkF+/ncAYL0duXRxmcoyNRs2z103hloXjuHHeWKICXHnvcA6NzT0Yjp9/tO3zqvy+3EZHFZng5NMxgUPboJ/slpKKvhkObIWX5omV6y9+ZGBikEa8PrXEL7zwQg4dOsTq1atRFIUtW7YQHBzMww8/zHPPPUdYWBgrVqwY6FilEWqst3i4aa4ebmRM8Aczyvj98oncuiQcW03HNsglMQFcEhMAwN6UIm568xA/pZdyQYRv10HkHwMHT1BrRB/tgWCue6GRWwg4+8OX98JXDwCK+Etg4qVw+d9kz5Rhrra2ls2bN1NVVcX48eM5cuQIn332mUVi6fNUtPfdd1+Hbdu2betXMNLotGKSP09cM5n54Z0vdzDe15m/r53K5CB3xvuar3efb164F45aDbtOFfYsiQdMgbqyAUzi5yC4k79IVSqxpFrWT23bAqdD5OVtA4OkYWv79u1ERERwzz33kJiYyI8//mixWOR84pLF2dtqiJsT2uUxKpWKa6b3rreGva2GCyJ82HWqkEevimmdVKuD5iYoSoa5v4GiFKgegN4p+mYxdH7y6s6PmbBUfEhWJycnh0WLxJqnsbGxaLVai8UiR2xKI9ryaH+Kqhs5llPRuk1RFBSl3ayIxSlihGTAVHANGJiaeFUuKPrOyymSVYuIiGh92JiamkpTUx+7tQ4AmcSlEe3CCF80ahW7ThUCIoH/bucxrn89vu0gY//wgGngEiiGvTf34Jey5Az8NQxyzPQcOH8KWmlEue666ygtLeX666/n9ddft2gsspwijWhujrbMDfPkm1OF3HdJJB+equSjI2Vo1Coam/XY2WhEEte6iOliXVqWeKspAPeuSzwk/BvqSuH01xA8w3SfcTEI2RIfkWxtbfnrX/8KQGNjI5deeqnFYpEtcWnEWx7tz5miGt49mMUbCWX4u9qjNyicLW6Zozz/GPhPFgswGIe6V3e+JBwgWurH/is+NzfysiITVGpwk6MupcElk7g04i2N9gPggQ9PEOBiy4vXxwKQVlgNBr1YZSdgqjjY2BKvyjOtm+vPm+I29QvRCvcaL8op50+aVX5ODJvX9H/kpzS82dnZsWfPHot9f5nEpREvyN2BmCBXHGw1PHyBH5OD3LDVqEgpqIbSM2KSqtYkLlriKafTiH10F5X1Ojj7PTwVAufadSNLfEsk6YX3QGMllKSaftNyM7MXStIgkElcGhWeXzuNHbfOZYyHFq2NmjBvZ9IKqts91JwiXh09QaOluiiL8jodJ3MrIWOfSPTv3SR6rlRkQ/oemH49hMwV550/I6G5KWglaRDIJC6NCuN9XZgS7N769UR/F1ILW5K4xg68J4odKhW4+KOpFTXxk7mV4hiXAGiqgfd+AQlvimOnXQ9e4WLptfZzg9eVQU1hx9kLJWkQyCQujUqR/i7klNfTXJAEvpGmtWuXAOwbxKo7SXlVUHAcwi6EK7dC9s/ww98g7IK2ZdeCZ7XNgQJwfKd4nWi5HgvS6CGTuDQqTfRzAcBQeAp8z5s50SUAV51I4nk5GaJVHTBVjL6ccxugQOzGtuODZ4uaeH25WM0n8S0xhN4/ZojuRrIWBoOBLVu2sHbtWjZs2EBmZma/rymTuDQqRfi54EYN2rrCjkncNRAPQykqFbhWnBLbjA8+lz8ON38Nk65pOz5kFgB1GfGQlwhFSaZJXpJafPvttzQ1NbFjxw42b97MU0891e9rysE+0qgU7OHAFNuWZdDOS+LNTr440cDcQC2TCjJQUKEytqo1NhA61/RiQTNQVGreeHcnl43TEGbjADHXDsFdSNYmISGhdc6VadOmcfLkyX5fUyZxaVRSq1UscC2CWsDXdIL/ShsfvIDLx4JP0TmqHENxs3Pp/GJ2LlS7TmBO+Qn8s7JhyjVg7zaY4UsD4IOEHHYezu71eXV1dTjuqzC7b83MEK6d0fkAr5qaGpyd22bh1Gg0NDc3Y2PT91QsyynSqDXFLp9qHDssSFyMJwAxrrVM1mRy1mZ8t9dKs41iljoNR6WezLGyFS6Z5+zsTG1tbevXBoOhXwkcZEtcGsXGGTJJNoQQVtuEt7Nd6/Z8xZ1IIKDxLH4U80VTKNO7udb+xjBmAmeVQN7O9ueR7k6QLO7aGcFdtpo705/l2WJjY9m7dy+XXXYZR48eZeLEiX26TnuyJS6NToqCd106aYZgMfy+ncwmUQrxzN0LwPfVATToOl/irUGn59OyUBRUHPO5ko+O5vVsSThp1Fm2bBlarZZ169bx5JNP8uCDD/b7mrIlLo1O1fnYNlWRqoTQXFBtsqpQXp2aKsURl+wDAJzQjyGtsLp1sFBpTSNe7VruSXmVpOt9OXDpR3j7RFLx70S+SSrkiqmmZRpJUqvV/OUvfxnYaw7o1STJWhSJroP52rFi5GY7BZUNlKk9URmaaXYJpgIXTuZWAfCvHzOY+fi3HDhT0np8YmYFABOmzmPBBH+C3B3Ycaj3D8wkqS9kEpdGp6JkABTfaFILTJN4YVUDVbY+AGiCpuFqb8PJvEoOZpTxxBfJKAq8E5/VevyR7HKCPRzwdbFHrVaxZmYIP54pIbusbujuRxq1ZBKXRqfCU+DsT1BgEKkF1RgMbdPOFlY1UG8vkrgqYCqTAt34Ob2U27cnEurpyJqZwXxzqoDSmkZAtMRjQz1az189Uzws++pkN3OSS9IAkElcGh1qS6G6sO3rolPgG8WkQFdqm/RktrSaFUWhsKqRZseWecUDphIT5MrZklpqGpp55YYZ3LIwDJ1e4aMjueRV1FNQ1UBsqHvrpYPcHfBwtCWjtBZJGmwyiUujw/s3wSsLsakvEQtBFKeCbzSTAkVPlKS8SgCqGpqp1+nReYwXsxsGTmfGGNHKfnLVZCL8XYjwd2FaiDs7DmWTmFUOQOwYD5NvF+LpKMsp0pCQSVwa+WpL4dwPUFtE0IE/ioUgmuvBL5qJfi7YalStDy4LqxoAqIpYBXclgrMvy6P92XfvhVw9Paj1kutmhXC6qIY3fszAzkZNVICrybcM8XAkp7x+6O5RGrVkEpdGvrSvQDHA/DtxLDkGH9witvtGobVRM9HPpbUlbkzifq6OretjqtUqQr0cTS65cmogjloNiVkVTAl2w1Zj+qsU7OlAbnk9+na1dkkyOnbsGBs2bBiQa8kkLo18qV+IpdSWPUrZ+NVQcEJs94kEICbQjZO5lSiKQkGlSOL+bvZdXtLZzoaVUwIATB5qGoV4ONKkN7T+pyBJRv/85z956KGHaGxsHJDrySQujWxNdXBmN0ReBioVhdPuhpA5YuZCrRMAMUGulNfpyK9soKha/GL5uXadxAHi5oxBrYIF47077Av1FC13WReXzhcaGsrWrVsH7HpyxKY0sp3dK+rfkZeLrzW2sPFTsa3FpCDxcPNkbiUFlQ24Odhib6vp9tLTQtyJ/8NSfFzsOuwLMSbx8nrmDMBtSIPg6H/hyLZenxZaVws/O5nfOf0GmLa+y/NXrFhBTk5Or79vZ2QSl0a2lC/EtLBjFrRts7UXHy2i/F1Rq+BkXhWFVQ34uXZMyp0xl8ABAt3tUalkS1wafDKJS5ZnMIi1K8fM7/q4nISWhYnde3hdPaR9CRNWmK6heR4HrYZwH2eScispqWnsUSmlO3Y2Gvxd7cku7zyJpxVWcyqvqvXr6EDX1mXjpCEwbX23rWZzsvoxi+FgkElcsry0L+HdOLhlF4TMNn9MRRa8fjE4+8Jlz0D0Vd1fNzse6krbSildiAly46f0UoABS6QhHo7klHXezfDWtxPIKGkbEKRRq/jlwnFsWjoRB2335RxJgn4+2CwtLWXJkiWkp6eTmZnJ+vXriYuL45FHHsFgMAxUjNJIV5wqXrN+6vyYrHhAAVsH2LkR3r0e6so6Hpd3RNQ5j2yDn14EjRbGX9xtCJMCXSmoaqCgqmFAWuIg6uJZnZRTSmoaySip5bcXhLP39xfw7e8Wc92MYF7dd5ZL/rGPhEwz9yaNGMHBwezcuXNArtXnJK7T6diyZQv29uIH/sknn2TTpk1s374dRVHYvXv3gAQojQJl6eI1+2Dnx+QcBFsn+G08LP2T6Pv943OmxxgM8M518Mnt4iPlfzBxBXS1tFqLmKC25dT8uule2FMhng4UVjeYnVs8MVOM9Lww0pdx3k6M93XhqWunsP1Xc9A1G3jwwxMDEoM08vU5iT/99NOsW7cOX19fAJKSkpg9W/wpvHjxYg4cODAwEUojX1mGeM05BEong2OyD0JQrHggufAeCJ0HZ78zPaboFNQWwyVPwaYT4mP1v3sUQnRg24hLv04eVvZWiIcjigK5ZkZuJmZVYKNWMTnIdC3O+eHeXDY5gOyyepTO/i0kqZ0+1cQ//PBDPD09WbRoEa+99hogJg5SqVQAODk5UV1dbfbc5OTkPoYKDQ0N/Trf0mT85o0vSkOjtkVdU8iZhD3onEwXU1A1NxBRcILSyBsobvn+Xs5R+J57jbSjP6O3E4nQI/U9/IHTtlE057fUmvPP9PgeAlxsyK9upr6sgOTk8n7fl6FaJO8Dx1JpDDId8fljSh5hHloyzqR1OE/dUEm9Ts+hY0m42JnWxq39Zwis/x6GW/x9SuIffPABKpWKn376ieTkZO6//37KytpqeLW1tbi6upo9tz9Pdfuztt1wIOM3o6kW6ovFg8pTnzDerhyizqthZx4ARY/3tEvxjmj5/s7XwcnXmGhbAFFzxbYjKeAZzoQZF/TpHmLH1vP5iXzmTo0ckLq4e2A9fJUPzt5ERY1p3a7TGziz/RzrZoWajSWjOR8Ol+HiF9phThZr/xkC678HS8SfkJDQ6b4+lVPeeecdtm3bxttvv01UVBRPP/00ixcvJj4+HoB9+/Yxc+bMvkUrjS7l58Rr5BVg62i+Lm7cFjyrbVvgdNA6Q8Y+8bW+Gc7th3GL+xzK4oneBLrZmyya3B9+LvZoNeoO3QxT8qtp0Bk6zHxoZBzyn18pJ9CSujdgw+7vv/9+tm7dytq1a9HpdKxYsWKgLi2NZKUtDzW9J0BgrHiAeb6cQ+AZBk7thrdrbEW/cmMSzz8KTdUQtqTPoayZGcKBBy9Go1b1+RrtqdUqgj0cOgz4aZ2+tt0c5O0FujkAkF8p512RutfvfuJvv/126+fbtvV+CKs0ypWdFa+e4yBkFhzYCrp60ZUQxIPO7IMQfmHHc8ctgdPfQFVe20POsYv6HIrxmc5ACvZ0JPu8vuKJWeX4utgR5O5g9hwfFzs0alXrZFyS1BU5AZZkWWVnwdFbDI0Png2GZsg72ra/IhNqi0xLKUbG0knGPvHhF2PaWh8GQjwcOpRTjmSJ5dw6+09Do1bh52JHXoVM4lL3ZBKXLKvsrCiVQFuibl9SyT4kXs2N5PSLAQdP0RrPjhct82EmxNORijod1Q06QAzyySqrY3onpRQjfzd7CqpkTVzqnkzikmWVZYj5UACcfcBjnOnDzZxDYpCP76SO56rVMG4RJH0EzQ39eqg5WEI8jFPSioRsHOTT2UNNowA3B/JlS1zqAZnEJcvR1UNVTltLHERrvP2gn5yWQT6aTh7fjFssVu1RabqfQMsCQjxF3dtYUulskM/5Atzsya9skAN+pG7JCbAkyzF2L2yfxENmw4md8PUfwcZOrMIz/67Or2EsoQROB3vzYxMsybg4xDvxWRzPqeCrk/lMCnTtdr5yfzd76nV6Kut1uDtqhyJUyUrJJC5ZTvueKUbhF4mHnAdfFV9r7MT8J53xGi/mCp90zeDF2Q9uDrbEBLly4EwJB86UALB2Vmi35wW6t3UzlElc6opM4pLltCbxdi1xr3B4IKvn11Cp4KYvBjauAaRSqfjfnb3v9th+wM/5ozYlqT1ZE5csp+ys6F3i0PVDvtFIDviRekomcclyStNNW+FSK3MDfjJKavk23fzEctLoJZO4ZDllGTKJd8LcgJ+te07ztx+LqWtqtmBk0nAjk7hkGc2NUJktk3gX2g/4URSFA2fE8nFni2tNjiurbeLV79MxGGR3xNFIJnHJMsozAUUm8S60H/CTUVJLQZX4/GyJaRL/MDGHJ79M4URu5ZDHKFmeTOLSwMjYB8ff6/nxxiXZjKM1pQ7aD/g50LKIM0B6UY3JcWmFok6elFc1pPFJw4PsYigNjH3PQuZ+MROhx9jujz+zW/QB95446KFZq/YDfg6klxDgZo+ibya92DSJpxaIJH4yT7bERyPZEpcGRkWmmIHw+792f6yuXozKjL5yWI6yHC6MA35yK+r5Kb2U+eHehLprSW9XEzcYFNIKRVJPkuWUUUkmcan/9M1QmSMmqjr2XyjuuG6kieTPoKESpm8YmvislHHAz3epxZTX6Zgf7kWwqy1ni2taH2LmlNdTr9Pj5aQluaAand5gyZAlC5BJXOq/qlzRCl/0O7BxgO+e6Pr4xLdEyaUfCziMBsYBPx8k5AAwf7wXwW62NDYbyK0QvVZSCkQd/IqpgTQ1GzhzXr1cGvlkEpf6ryJTvAbPhLm/EVPD5h83f2xpOpz7QbTC1fLHryvGAT9nS2oJ83YiwM2BEDdbgNa6uPGh5jXTgwD5cHM0kr9FUv+VtyRx9zEw/04xgdV3T5o/9sg2UKlhWtzQxWeljAN+QLTCAYLdxGRYxrp4amENwR4OxAS54ajVcFLWxUcdmcSl/qvIFInZLRgc3GHa9aL3if68kYX6Zji6HSYsB9dAi4RqbYx18fnhYtk5Nzs17o6iLg6QVlBNpL8LGrWK6ABXkmQPlVFHJnGp/8ozwTVYrEAP4D8Z9I1tsxQanfkWagrkA81eCGipi88NEy1xlUpFuI8z6cU1NDUbSC+uYaKfCwCTAl1JyquSIzdHGZnEpf6ryASPMW1f+0aJ16JTpsdlfC8efHY1P7hk4qppgdy6OAxPp7Y5xcO8nUgvriWjpJZmg0KEf0sSD3KjrklPRmltZ5eTRiCZxCXBYIAvH4CCk70/t/ycaRL3iQRUUJRselz+MfCPaWuxS91aPsmfBy+LMtkW7utMcXUjh86VAbS2xGMCxZJvsi4+usgkLgmVWRD/MiT+p3fn6eqhphDcx7Zts3UQc6K0b4kbDKLHSsDUAQl3NAv3cQbgq5MF2KhVrV9P8HNGq1FzSvZQGVVkEpcEY/26/UrzPVHRsgpP+5Y4iJJK+yRengFN1TKJD4BwHycAfjpbyjhvJ7Q24tfYVqMmwt+l2+H3zXoD979/XD4EHSFkEpcEYxIvPAlNdT0/r333wvZ8o8U1dWJQCvnHxKtM4v0W4umIjVqF3qAwsaUebhQT5MrJ3CoUpfOHmykF1ew4nM3W3WcGO1RpCMgkLgllGeLV0Ax5R3p+nnGgz/ktcb9oUAxQ0jIEP/8YqG3Bx7S+K/WerUbNGC9HACL8TJP4pEA3Kut1HSbJas9Ybvk2uZCSmsbBC1QaEjKJS0JpOrgEiM9zelFSKT8HNvbg7Ge63TdavBofbuYfEyUWG7ly+0Aw1sEjzmuJXxjpi7OdDZt3HqOxWW/23JN5ldhqVDQbFD5MzBn0WKXBJZO4JJSdhaAZ4oFk9iHzxygK7HpEDNgxKj8nSikqlemxnmGg0Yq6uKJAgXyoOZDCfVuS+Hkt8SB3B569bgrHcip59H+nzJ3KydxKpod4MGOMBzsOZXdZepGGP5nEJTDoxYNHzzAIng05h0TiPY9n6juw/3n45iFobhIbz+8jbqSxFXOFF54SE2TVlcokPoBWTQ/i1iVhhHo6dth3SUwAty4OY9vPWR1a2nqDQnJ+NZOCXFk7K4T04loSMsuHKmxpEMgkLkFVHuibRBIPmQW1RW21bqOMH/A9/pKoadeVQuoXYnt5VseHmka+0aKc0vpQc9qg3cJoM8HPhQcvjUKtVpndf++KCOaGefKHj06Q2W7wT0ZJDfU6PTGBblw+OQAnrYZ3D2UPVdjSIJBJXGrrmWJsiYNpSaUqD96/iSbnELj5KzHEPvEtqC+HxkrzLXEQNfCqHMj4Qcyt4jdpcO9DamWjUfP3tdNobDbwydG81u0nc8VDzUlBrjjZ2XDltEA+P55PdYPOUqFK/dSnJK7T6bj33nuJi4tj9erV7N69m8zMTNavX09cXByPPPIIBoOcnN5qtF/v0jdaLO5gfLjZ3ATv/QKa6shZ8JSY4Gr69ZC+B87tF8d01RIHOPm+KK1oO/7pLw2eADcHpoe4882pgtZtJ3MrsbNRM77lweiamSHU6/TskK1xq9WnJP7pp5/i7u7O9u3bef3113n00Ud58skn2bRpE9u3b0dRFHbv3j3QsUqDpeysWO/SJRA0NhAU2zboZ9fDkB0PV22lyW2c2DbtevFqnG62szU1jXOo1BbLeriFLJ/kz8ncKvJaFpFIyqsiMsAVG4341Z8W4s6iCd789etUTuTIwT/WqE9J/JJLLuHuu+8GQFEUNBoNSUlJzJ4t/hRfvHgxBw4cGLgopcFVlgGe49oWaQiZLQb9JL4N8a/A3N9CzLVtx3uMgbALxDHGr81xCwGtaPHJJG4Zy6NF189dpwpRFIWTeZXEBLata6pSqXh+7TS8nbT85p0EKuqaLBWq1Ed9Wu3eyUkM+62pqeGuu+5i06ZNPP3006haupk5OTlRXV1t9tzk5GSz23uioaGhX+db2nCNf1x+MjqnQHJaYnMmgBBDM8qnd1LvPZXMkDhITjaJ38XvIoLP7kWvdSUtIw/IM3vtMS5jcSw9SWaTO3XD4N6H63vQU32JP8TNlo8OnSXEporqhma81HUdrnHvAk/u/SqPX/7rR/58sT/q87uMDqDR+B4Mpj4lcYD8/Hxuv/124uLiuOKKK3jmmWda99XW1uLqan4V86iovo/YS05O7tf5ljYs4zcY4IM87KMvbYst1Ad++D0qJx8cb9xJlIs/cF78E8Lg6HNo3EO7vqfTsVB6kjFzVooVfyxsWL4HvdCX+FdmqvjnvrMU4Q5ks3RGBFHB7ibHREVBjdaThz8+yc9lDtyycJzZaymKwmOfJ6MosOWK6CG7h+HEEvEnJCR0uq9P5ZSSkhJuvvlm7r33XlavXg1AdHQ08fHxAOzbt4+ZM2f25dLSUKvOh+Z60TPFyMkbLnkart8JLQm8Axs7uPpluOjhrq8/97ew8u/DIoGPVsuj/Wg2KLz8fTo2alXr1LXnu2FOKLGh7l2O4tx+MIt//ZjBjkNZ6OXiE8NCn5L4K6+8QlVVFS+99BIbNmxgw4YNbNq0ia1bt7J27Vp0Oh0rVsiJ/61C++6F7c29DQKnd31uxKUwYVnXx/hGwcyb+x6f1G9Tg93xdbEjs7SOCX4u2NtqzB6nUqm4JMafpLwqcso7ToJ2LLuCP396Ci8nLbVN+tZFmiXL6lM55aGHHuKhhx7qsH3btm39DkgaYp0lcWnEUKtVLI32Y3t8lslDTXOWRfvzxBcp7DpVyE0L2koqZbVN/GZbAr6udrwYF8tVL+4nMaucqICurycNPjnYZ7QrOytmF3QLtnQk0iAy9lKZ1E0SH+ftxARfZ75JKjTZfv8HxympbeKVG2YwJdgNTyctiZkVgxWu1AsyiY92ZWdFP2+1+T+xpZFh0QQfHro8imtiu//PevkkPw6eK2vtbnj4XBm7ThWyaekEYoLcUKlUxIa6cyRLzrkyHMgkPlIl/w9eiIWa4q6PKzsrRmpKI5pGreKXi8Jwc+h+fdPl0f7oDQp7UopQFIVnvk7Fx8WOm+a3lVemh3pwtqSW8lrZr9zSZBIfiYrT4KNbxXD69D2dH6coIonLerjUzuQgN/xc7fgmqZD9Z0qJzyjjjgvH46Bt+2stNtQDgCPZsjVuaTKJW7vjO+GF6ZD0sUjKjTWw4waxUIO9G2R83/m5BcdBVyeTuGRCrVaxLNqP79OKefqrFILcHVg3O8TkmKkhbmjUKo5kVXR7vT0phVz47Hdykq1BIpO4tTv8hmhNv3ejSN4f3Qqlp2H1GzBuCWTsMzs3OA1V8P7N4OQLUVcOfdzSsLY82p96nZ4TuZXcffEE7GxMn5k4am2I9Hch8by6uLkFJl79/iwZJbUk9iDhS70nk7g1qymGrJ9h8b2w9M9w5ltI+Z8YgBO2BMYthspsseBDe4oCn/xWzJly3b/Bxc/89aVRa26YFy52NozzdmJVbJDZY2JDPTiaVdE66OevX6Vw5f/tp0HXtixcRkkt8RllACTKxScGRZ+H3UvDQNpXgCJa0gFTIOoKMePglHVif9gF4vXs96YlkwNbIfkzWP4YjF041FFLVkBro+aVDTPwdNK2znh4vtgx7rz9cyZphdWkFVbz0ndiSuPt8Vnc3DJsf+fhbNQq8He179BqlwaGTOLWLOVzcAsF/8nia69w054mXuPF4scZ+2DmTWJbwQn49k8QfRXMu2PIQ5asx4Lx3l3uNz7c3HEomx2Hspk5xgONWsVL351h3ewQtBo17yfkcFGkLz4u9vzveB4GOVR/wMlyirVqqoWzeyHy8o6LFBupVKKk0r4uvucxsHOGK/7R+XmS1AOhno54OWl588A5nOxseOn6WO67JJKSmibePHCOvanFFFc3smZmCLGh7lQ3NJNeXGPpsEccmcStVfoeaG6AyMu6Pm7cEqgrEavOZx8SJZgFd4ODx9DEKY1YKpWK2JbW94tx0/F1tWfGGA8uivTl1e/P8saPGfi42HFhpC+xY8TPmyypDDyZxK2FwWDayyTlc7B3h9D5XZ83bpF4zdgHe/4CTj4w+9ZBC1MaXf54WRTbbpnDnDCv1m2bl0+ksl7HT2dLuTY2GFuNmjBvJ9wdbeVQ/UEgk7i1+PJe+FsknPoE9M2iRR1xqVhOrSvuoeAxDn56USTyhb8T5RRJGgBjvZ2YF+5lsm1SoBuXTw4AYM1MMcxfpVIxPcRdtsQHgUzi1qC+Ao5sg4YK2LkR3lghVpqP6KaUYhS2RHQ1dAmU08JKQ+Kxq2N46+bZhPm0NRhiQz04XVRDTVNbF8TGZr2502lqlgut95RM4tbg5Pui/v2Lz0V/8MKTYOMA4Rf17HxjV8Ml94Kt/aCFKUlGHk5aFk/0Mdk2vaU3S2pxIwCfHctj0pavefDDE1S1jOZs0On52zepTHrkK3Yezh7aoK2U7GJoDRLfAr/JEDQDgmfCpKuhrrTnZZGoK2H9DpiwfFDDlKSuTA1xQ6WClOJG0gqrue/94/i52rPjUBZ7Ugq5dXE478Rnkl5ci7ujLX/7JpUrpwZ2uoiFJMiW+HCXf0x8xG5s6xLoMVYk9J5SayDikrbV7CXJAlzsbYnwcyExv47b3k7Ayc6Gj347n49vX4CHo5a//O8UDToD/7l5Nq/cMIPCqka2/Zxp6bCHPdkSH+4S3waNHUy5ztKRSFK/TQ/14L8Hs9Com9j+yzn4utrj62rPZ3cuZF9aMXPDvHCyE2lp0QRvXvounXWzQ3G2k6mqM7JpNpzp6sUshdFXyn7d0ogwa6z4OX7gkkiTbom2GjUXR/m1JnCAzcsjKKtt4t8/ZnS4jtRG/vc2hNSNlWDQd72KTlMdlJ8Tn5/9DhorRSlFkkaAK6YGoqssYs2icd0eOy3EnaVRfrz2w1k2zhuLm2P3C1qMRrIlPlTyjjLhsyvhtQsg76j5Y+rK4OX58PI88fH1g6KP9xg5SZU0Mthq1Ezxd0DVwykfNi+fSHVDM6/9kD7IkVkv2RIfCnVlsHMDelsX1DWF8M+LYP4dsOQB0DqKYwwGMRd4ZQ6sfL6tfOI/WT6QlEatqABXVk4J4N/7z3HTgnF4O9u17qus05FdXtf69Vhvp1FZOx99dzzUjMm5Kp+ci15m3IylsGsL7P8HnPoUrnxBTFK17xk4/Q1c/re2GQclSeKeZRP54kQ+L+1NZ8sV0QBkl9Vx1Yv7KWu3xqe3sx1/vnISl03273FLfySQSXwgKAoUJokHkedL+aw1OTc4x4gW9pVbIWY1fHY3/OcKiLgcUr8Q84DPvGXo45ekYSzcx5lrY4PZFp/JrxaPw8NRy2/fSUSnN7B1/XTsbTU0NRt45ft0bt+eyLJoPx67OgY/19ExsE0m8f6qyIL//Q7O7Or8GGNyTklp2xa2BH5zAL5/Cg78H/hNgpV/l9PDSpIZd108gY+P5rJ1zxkUReFEbiX/3DiTZdFtq1KtmOTHG/szeG5XGr966zCf3jE6niXJJN4b+mbISwR9y4KveUdg7xPi82WPgm90x3NstGKmQXPJWesIy/4CM34hWujG+rgkSSZCPB1ZNyuUbfGZKAr89oJwkwQOYKNR8+vF4djbatjySRIncyuJCXJr3d/UbKCqQWdSVx8JZBLvjUOvw1f3m24bv1S0oN1D+35dudq8JHXrjovG80FiDtND3dm8PKLT466aGsTjnyfz7qEsHgua3Lp9044jfJ9azCd3LGS878iZyVMm8Z5SFEh4EwKmilY3iLlLAmNlCUSShoCfqz17Nl+Ap5MWjbrz3zk3R1sujfHnk6N5/PGyaBy0Go7nVPDFiQIAbtuWwCe3L2gdWNSg05Nf2cA4b6chuY+BJvuu9VTOYShOFrXtsCXiI2iGTOCSNIT83ezR2nSfttbOCqW6oZkvT+YD8Ow3aXg42vLahhmcLa7hvg+OoygKP6WXcsnz+7job9/xXWrRYIc/KEZ3S7y6QCwcbOQ+Bnwmmj/2yFtg6wQxq4YmNkmS+mxumCdjvBzZcSibYA9H9qUV8+ClkSyf5M+9KyJ5+qsUiqoaOHSunFBPR8J9nNm04yif3bGQEM+un00pisLJ3Eoi/V2w0Vi+HTw6k7hBL+rb3/4ZdLVt21VqmPMbuOiPoG33p1VjNZz4AGKuATuXoY9XkqReUalUrJkZwjNfp/LHj07g42LHxnljAbhtSRhHs8vZdaqQXy8O456lEymsauCK//uR376TyHu3zet0+tuc8joe/raAhLwMrp8TyuPXTDZ73FAa0CRuMBj405/+RGpqKlqtlscee4wxY8YM5LcwpSiQfVAsBNxTep1YqiznIIRfDIs2g42duNax/8LPL4q+3Vf8o23RhaSPRLKPvXFw7kOSpAG3ekYwz+1K43RRDX+5ahIOWpGYVSoVL8bFUlLThL+b6Es+1tuJv6+Zxi/fOsz9HxxvXV6uvbMltbyw+zQGg4HFE314Jz6L2FAPrp0RPKT3db4BTeLffvstTU1N7Nixg6NHj/LUU0/x8ssvD+S3aFOVB59vFoNkesvBE655DaasMa1ph8yCyavh0zvh7WtgahyseFxMB+sdAcGzBi5+SZIGlZ+rPcuj/UjKq2LtrBCTfTYadWsCN1oa7cedF41n654zfHI0z+w1L4jw4aYYBxbETuKGf8Xzh49OEBXgSnSg66DdR3cGNIknJCSwaJFYXX3atGmcPHlyYC6sKHDuR1yyj4EhBSqyxTB1vU4sVxZ+Ye+u5zEW7N3M7xszH27bL66//3mxIHF9GSx/XD7ElCQr89yaaTTpDdjZ9Gx1oM3LI7hqWhANuo5rf9rbqgn3cSYlJQUbjZqt62NZufUHfvNOAveuiEBF1/lhwXgv3B21fbqPrgxoEq+pqcHZua3/pUajobm5GRubtm+TnJzc6+tqGsqY8OlVBCtt/7C1vjPJn/UAOudgqOjlBSvyAPP/07YKXI3dsqkEHHoSra6BdIdY9H2Ivb2GhoY+3f9wYe3xg/Xfg7XHD5a5h25+2zswl/J1QEqpafz3LfDiga/zuWP7kW6vuXayO7+I9exlJN0b0CTu7OxMbW3bg0KDwWCSwAGioqL6dvHwJNJPJRIeFgZqW5y8whk/6C3jKJhzOTTVMLGzlnsvJCcn9/3+hwFrjx+s/x6sPX6w/ntoH39UFFwwI5rSdhNxdSbcx7nL/u1dSUhI6HTfgCbx2NhY9u7dy2WXXcbRo0eZOLGT7np94RpAk1sY+A7xm6/WdF56kSRp1PNytsPLgkP5BzSJL1u2jP3797Nu3ToUReGJJ54YyMtLkiRJ5xnQJK5Wq/nLX/4ykJeUJEmSumD54UaSJElSn8kkLkmSZMVkEpckSbJiMolLkiRZMZnEJUmSrJhKURRlqL5ZVx3WJUmSpM7NmDHD7PYhTeKSJEnSwJLlFEmSJCsmk7gkSZIVG3ZJ3GAwsGXLFtauXcuGDRvIzMw02b9z505WrVrFmjVr2Lt3r4Wi7Fx38T/22GOsWrWKDRs2sGHDBqqrqy0UafeOHTvGhg0bOmzfs2cP1157LWvXrmXnzp0WiKxnOov/zTff5PLLL299D86ePWuB6Lqm0+m49957iYuLY/Xq1ezevdtk/3B/D7qL3xreA71ez4MPPsi6detYv349aWlpJvuHzXugDDNff/21cv/99yuKoihHjhxRbrvtttZ9RUVFysqVK5XGxkalqqqq9fPhpKv4FUVR1q1bp5SWlloitF557bXXlJUrVyrXXXedyfampiZl6dKlSkVFhdLY2KisWrVKKS4utlCUnessfkVRlM2bNysnTpywQFQ99/777yuPPfaYoiiKUl5erixZsqR1nzW8B13FryjW8R7s2rVLeeCBBxRFUZSff/7Z5Hd5OL0Hw64l3tXCEsePH2f69OlotVpcXFwIDQ0lJSXFUqGa1VX8BoOBzMxMtmzZwrp163j//fctFWa3QkND2bp1a4ft6enphIaG4ubmhlarZcaMGRw6dMgCEXats/gBkpKSeO2111i/fj2vvvrqEEfWM5dccgl33303IBbm1WjaZri2hvegq/jBOt6DpUuX8uijjwKQl5eHq2vb6j3D6T0Ydgsld7WwRE1NDS4ubQsVOzk5UVNTY4kwO9VV/HV1ddxwww3cdNNN6PV6Nm7cSExMDJGRkRaM2LwVK1aQk5PTYbs1vAfQefwAl19+OXFxcTg7O3PHHXewd+9eLrywl6tDDTInJ7FQd01NDXfddRebNm1q3WcN70FX8YN1vAcANjY23H///ezatYsXXnihdftweg+GXUu8q4Ulzt9XW1tr8g85HHQVv4ODAxs3bsTBwQFnZ2fmzp077P6S6I41vAddURSFG2+8EU9PT7RaLUuWLOHUqVOWDsus/Px8Nm7cyFVXXcUVV1zRut1a3oPO4rem9wDg6aef5uuvv+bhhx+mrq4OGF7vwbBL4rGxsezbtw+gw8ISU6ZMISEhgcbGRqqrq0lPTx/YhScGQFfxnzt3jvXr16PX69HpdCQmJjJp0iRLhdon4eHhZGZmUlFRQVNTE4cPH2b69OmWDqvHampqWLlyJbW1tSiKQnx8PDExMZYOq4OSkhJuvvlm7r33XlavXm2yzxreg67it5b34OOPP24t9Tg4OKBSqVCrRcocTu/BsCunmFtY4t///jehoaFcfPHFbNiwgbi4OBRF4Z577sHOznIrapjTXfxXXXUVa9aswdbWlquuuooJEyZYOuQe+eyzz6irq2Pt2rU88MAD3HLLLSiKwrXXXoufn5+lw+tW+/jvueceNm7ciFarZd68eSxZssTS4XXwyiuvUFVVxUsvvcRLL70EwHXXXUd9fb1VvAfdxW8N78Hy5ct58MEHuf7662lubuYPf/gDu3btGna/B3LEpiRJkhUbduUUSZIkqedkEpckSbJiMolLkiRZMZnEJUmSrJhM4pIkSVZs2HUxlKSB1NjYyKeffkpBQQHe3t6sX7++23MqKir44YcfTAaoSNJwJVvi0ohWXFzMe++916tzUlNT2bNnzyBFJEkDS/YTl0a0hx56iC+++IK6ujoWLlyITqejoqKCu+++m4suuogvv/ySN998E7VazYwZM/j973/PTTfdREpKCps2bWL69Ok89dRT6PV6ysvL+dOf/kRsbKylb0uSWskkLo1oOTk5/O53v2PRokUUFBTw+OOPEx8fz+uvv84zzzxDXFwcH3zwAQ4ODtx7771cffXV2NjY8O677/L3v/+dL774gvDwcCIiIvjss8+Ij4/nscces/RtSVIrWROXRg3jPDXe3t40NDSQlZVFWVkZv/71rwExiVFWVhZhYWGt5/j6+vLSSy9hb29PbW2tyQyVkjQcyCQujWhqtRqDwQCASqUy2RccHExAQABvvPEGtra2fPjhh0RFRVFTU9N6zuOPP86zzz5LeHg4L7zwArm5uUN+D5LUFZnEpRHNy8sLnU5HQ0NDh32enp784he/YMOGDej1eoKCgrj00kupqqoiLS2NN998kyuvvJK7774bV1dX/P39KS8vt8BdSFLnZE1ckiTJiskuhpIkSVZMJnFJkiQrJpO4JEmSFZNJXJIkyYrJJC5JkmTFZBKXJEmyYjKJS5IkWTGZxCVJkqzY/wOS22kkGXgwggAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "tags": []
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -2808,7 +2797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 53,
    "metadata": {
     "id": "YclVFbKZ0aD4"
    },
@@ -2838,7 +2827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 54,
    "metadata": {
     "id": "0ig_NSrS12PE"
    },
@@ -2882,7 +2871,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 55,
    "metadata": {
     "id": "a2e5258ae33d"
    },
@@ -2923,7 +2912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 56,
    "metadata": {
     "id": "skLIvXYq4yvX"
    },
@@ -2966,7 +2955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 57,
    "metadata": {
     "id": "_SjPRrIX5F4O"
    },
@@ -3020,7 +3009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 58,
    "metadata": {
     "id": "9Pt7o-Tq2SNz"
    },
@@ -3069,7 +3058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 59,
    "metadata": {
     "id": "HvhpBD334o1v"
    },
@@ -3106,7 +3095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 60,
    "metadata": {
     "id": "vDEhGG0v-UJy"
    },
@@ -3115,7 +3104,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "a=1000011100\n"
+      "a=1000010001\n"
      ]
     }
    ],
@@ -3158,7 +3147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 61,
    "metadata": {
     "id": "PfRP7K598wNQ"
    },
@@ -3205,7 +3194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 62,
    "metadata": {
     "id": "uzxaFCGIz2aQ"
    },
@@ -3227,10 +3216,10 @@
       " [0.17089382+0.j 0.        +0.j 0.        +0.j 0.34859255+0.j]]\n",
       "\n",
       "After step 2 state was\n",
-      "[[0.75111103+0.j 0.        +0.j 0.        +0.j 0.        +0.j]\n",
-      " [0.        +0.j 0.11555554+0.j 0.        +0.j 0.        +0.j]\n",
-      " [0.        +0.j 0.        +0.j 0.11555553+0.j 0.        +0.j]\n",
-      " [0.        +0.j 0.        +0.j 0.        +0.j 0.01777777+0.j]]\n",
+      "[[0.01777777+0.j 0.        +0.j 0.        +0.j 0.        +0.j]\n",
+      " [0.        +0.j 0.11555553+0.j 0.        +0.j 0.        +0.j]\n",
+      " [0.        +0.j 0.        +0.j 0.11555554+0.j 0.        +0.j]\n",
+      " [0.        +0.j 0.        +0.j 0.        +0.j 0.75111103+0.j]]\n",
       "\n"
      ]
     }
@@ -3273,7 +3262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 63,
    "metadata": {
     "id": "BmzxGpDB9jJ4"
    },
@@ -3333,7 +3322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 64,
    "metadata": {
     "id": "HAwdWkprAPXN"
    },
@@ -3364,7 +3353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 65,
    "metadata": {
     "id": "r5F4FUtmA5kW"
    },
@@ -3420,7 +3409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 66,
    "metadata": {
     "id": "5BOBUIEIBeQ5"
    },
@@ -3466,7 +3455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 67,
    "metadata": {
     "cellView": "form",
     "id": "zDE-19I_a3on"
@@ -3478,7 +3467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 68,
    "metadata": {
     "cellView": "form",
     "id": "DuOcTG3XZfmb"
@@ -3529,7 +3518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 69,
    "metadata": {
     "id": "l7eFMVe1GEe2"
    },
@@ -3603,7 +3592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 70,
    "metadata": {
     "cellView": "form",
     "id": "S0PThmctKFxl"
@@ -3628,7 +3617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 71,
    "metadata": {
     "cellView": "form",
     "id": "O8pnDlAngS80"
@@ -3754,7 +3743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 72,
    "metadata": {
     "id": "feb179abdf97"
    },
@@ -3765,7 +3754,7 @@
        "True"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3790,7 +3779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 73,
    "metadata": {
     "id": "d168c7619994"
    },
@@ -3801,7 +3790,7 @@
        "False"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3822,7 +3811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 74,
    "metadata": {
     "id": "AdqDGjqL2lI2"
    },
@@ -3858,7 +3847,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 75,
    "metadata": {
     "id": "ePc0hrEU2_yy"
    },
@@ -3892,7 +3881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 76,
    "metadata": {
     "id": "od6ofvow4EoD"
    },
@@ -3924,7 +3913,7 @@
        "}"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3954,28 +3943,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 77,
    "metadata": {
     "id": "Ih8YgwX19h2-"
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/bacon/code/github/Cirq/cirq-core/cirq/experiments/qubit_characterizations.py:98: UserWarning: Matplotlib is currently using module://ipykernel.pylab.backend_inline, which is a non-GUI backend, so cannot show the figure.\n",
+      "  fig.show()\n"
+     ]
+    },
+    {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAewAAAHgCAYAAABn6F4bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXxTVfo/8E/SBSgtSwuFUmgLKAIFHBYdEUYcRR2FGR2HGYoBUUaUL7ghOINUQcGyCOoIOoobIkTFQUZHdERF/LkhKMxYqYjCQGjZ2pRSKF3okt8fh5s07b1J2iZ3/bxfL143uTekJ6HkyTnnOc+xeTweD4iIiEjX7Fo3gIiIiIJjwCYiIjIABmwiIiIDYMAmIiIyAAZsIiIiA2DAJiIiMoCIBuyffvoJo0ePxrp16xpd++qrrzBu3DiMHz8ezzzzTCSbQUREZHgRC9jl5eVYuHAhhg8fLnv90UcfxcqVK/H666/jyy+/xL59+yLVFCIiIsOLWMCOjY3FCy+8gOTk5EbX8vPz0b59e6SkpMBut2PUqFHYtm1bpJpCRERkeNERe+LoaERHyz99UVEREhMTvfcTExORn5/f6HE7d+6MVPOIiIh0aejQobLnIxaww0Wp4c2xZ88e9OvXL2zPZ0RWfw8s9fqdTmDyZKC2Vt2fGxcHPP884HCo+3NDZKnfAQV8D/T7HgTqqGqSJZ6cnAy32+29f/z4cdmhcyJqJqcTuP129YM1AJSXA9nZ6v9cIpPTJGB3794dZWVlKCgoQE1NDbZu3YoRI0Zo0RQi83A6gYwMwG4XPevycu3acuiQdj+byKQiFrB3796NSZMm4Z///CdeffVVTJo0CatXr8ZHH30EAHj44Ycxa9YsOBwOXHfddejZs2ekmkJkflKP2uUCPJ6APWsPIII6AERF+R/T04F168RzrFsn7gOAzda09tjt4k9GhmgbEbVYxOawBwwYgLVr1ypev+iii7B+/fpI/Xgia8nODq1HHRWFI4sXI/X++4M/1uHwn4d2OsXPcblEAA+0M6/0hcHlEl8kpOcjomZjpTMiMwhlCDouDlizBqfGjm3ez3A4gIMHRaCuq/PvgUs9dDmc0yYKCwZsIqNzOkMbsg535nb9AL5mDdC6tfJjDx3yn2PnUDlRk+l+WRcRBSDNXdfVBX5cenpkh6Szs4HKSuXriYmindKwPYfKiZqMPWwiI2nYS73nnuBz13FxQE5OZNsVaEg+Lk4cG7aTQ+VETcKATWQUDTPBXS6guFj58Tab6FmrUcQkLU35Wnm5cju5/IsoZAzYREYRaiY4IAJ1XZ2YY1ZjyDknx9eTbopAgZ6I/DBgExlFqL1RNYbAG3I4RE8+PV307ANljUu0aCeRgTFgExlFKL1RtYbA5UhZ43V1wZPgAGDpUiacETUBAzaRntVPMisrA2JjlR9rs6k3BB5MoC8X0i5+d93F5V1ETcCATaRHTifQqRMwcaIvyay4OHDPVU/zwYHmtGtqfLddLvEaO3Vi4CYKguuwifRGygaXSzCTgl2bNkBFhe+83uaDpV7+xImhPb64mOuyiYJgD5tIb0LJBr/lFl+Cl5bz1oE4HL7SpaEoLxe7jLGnTSSLAZtIb0LJBl+zRvSo1Vy61RxNXe5VWyt62gzaRI0wYBPpTShz0UapEtZwuVdSUuDEOUC8tokTmZBG1AADNpHe5OSIOepgjFIlrP5yL7cbePllEbiDkeqNM2gTAWDAJtIfhwP4y1/E7UBFSPSUFd4UDocI3OvWBS+wYpSRBCIVMGAT6VGHDuJ4+LCYr244D6y3rPDmcDjkX1tDRhlJIIowBmwiPdqxA+jRA0hJaTwPrNes8Oao/9qU2O0cFicCAzaRvkiVzV5/XQwbS4Gq/jywnrPCm0N6bevWyfe2mTlOBIABm0g/6m+fCYjCKFYKVFJvW25em3PZRAzYRLohVzDFaoHK4VAuv8q5bLI4BmwivVAKSFYLVErZ70bNiicKEwZsIr1goBKUqqPl54ukOxZUIYtiwCbSkpRkZrPJ96TNsHyrqaS57MRE//PSUDkLqpBFMWATaaVhkpnH4389Kck8y7eayuEAEhKUr1ttbp8IDNhE2gm2K1d8vDWDtSTY3L3V5vbJ8hiwibTCgBRYsLl7FlQhi2HAJtJKsIBktWSzhoJtzcmCKmQxDNhEWsnJUd5q0orJZg2FUraUc9lkIQzYRFpwOkWgOXvWd06q8GWmWuEtJZUt9XhEJr0cq08dkGVEa90AIsuRssPrJ5zFxTFIB5OW5suob3ieyALYwyZSG0uQNo/cnDanDshCGLCJ1OR0yvcSAQ7tBiPNacfHi/tpaRyVIEvhkDiRGpxO4J57gOJi5cdwaDc4hwMoKQHuugvYvh3o2lXrFhGphj1sokiT5qwDBWsO7Yaub19x/PFHbdtBpDIGbKJIC1bRDODQblMwYJNFMWATRVqwuen0dAbrpkhNBdq2FQFb2jzFbucuXmR6DNhEkRZobppD4U1ns4le9ief+DZP8Xi4ixeZHgM2UaTl5ACtWzc+b+XduFqqb1/ghx+4PI4shQGbKNIcDtHzA0TvMD0dWLcOcLsZrJurqkrUEpfD5XFkUlzWRaSGjh1FsC4rC7yhBQXndAL/+pfydS6PI5NiD5tIDbt3A+edx2AdDg1rsNfHnAAyMQZsIjV8/z0wYIDWrTCHQEPezAkgE2PAJoqE+suN0tKAn34CBg7UulXmoDTk3bYtgzWZGgM2UbhJlc2k5Ub5+eL8k09yyVE4yG0CYrMBFRVcj02mxoBNFG5Klc1On+Y64XCQNgFJTxeBOilJBOq6Oq7HJlNjwCYKt0BzrFwnHB4OB3DwoAjS8fGNl3iVlwOTJ7PHTabCgE0UbsGWFXGdcHgpvZ+1texxk6kwYBOFm1JlMwnXCYdXKO8nRzbIBBiwicLN4QCmT5e/xnXC4SeXhCaHIxtkcAzYRJHQqZM4vvCCLzkqPZ3rhCNBSkLr3l3ct9nkH8eRDTI4BmyiSMjLA3r0AG67zZccdfAgg3WkOBxi+Vy/fvLXObJBJsCATRQJeXlAZqbWrbAWpxPYt08kmtUXF8eRDTIFBmyicKutBX78kQFbbdnZQHV14/MeD4M1mQIDNlG4HTgAVFYyYKtNKamMFdDIJBiwicLJ6QQuvVTcnjuXAUJNgZLK6q3Hbrdpk3ptIgojBmyicJFqiBcVifvHjrFgh5pCWd5VXo7OTz6pTnuIwowBmyhc5GqIs2CHehrWGFcQc+yYio0iCh8GbKJwcDrFkKscFuxQT/0a4+npsg+p7tpV3TYRhQkDNlFLSUPhSliwQxtyQ+RxcSiaOVOb9hC1EAM2UUspbacJsGCHluoPkUukOWzmFZABRWvdACLDCzTkzYId2pLe+1tv9a7Rjj161Dciwn8bMhD2sImaw+kU63rtdvFHTno6A4IeyBVUYTIgGRB72ERNJc1ZS8PgtbWNH8OhcP1QGgFhMiAZDHvYRE2lNGdts3FXLj1SSvqz2zmXTYbCgE3UVEo9M48HWLuWu3LpjVJBldpaFrYhQ2HAJmqqQMu0GAD0R8oWj4pqfI1z2WQgDNhETZWTA7RuLX+NAUCfHA5RTEUO57LJIBiwiZrK4QDuuEP5OgOAPimNjLCwDRkEAzZRc/TooXyNAUCfFCqfMZufjIIBm6g5DhwA2rRhADCSc3PZNR07ivspKczmJ0NhwCYKRf1CKRkZwBdfABdc4L87FJdz6Z/Dgfy//13cfuEFcaz/78qEQdIxFk4hCqZhoRSXS8xTDx0qgjMDtKHUSLt1bdgAvPmm/78rS5aSjrGHTRSMXKEUjwfYu1eb9lCL1HTqBERHAxs3cv9yMhQGbKJglLK+T59Wtx0UHlFRQGoqcOqU/HVm+ZNOMWATBaOU9Z2crG47KHx69ABatZK/xix/0ikGbKJgcnJEUllDs2er3xYKjx49gISExkGbWf6kYwzYRMGMHi3mrNu39z9/113atIdaLi0NKC0FbrzRd659e2b5k65FNGAvWrQI48ePR1ZWFnJzc/2uOZ1OjB8/HhMmTEAOv9GSXjmdQGamuN2mDXD++b5rfftyGZBR9egh9sh2u4Fu3YA+fYArr2SwJl2L2LKuHTt2wOVyYf369di/fz/mzp2L9evXAwDKysrw0ksv4cMPP0R0dDSmTJmC//73v/jFL34RqeYQNV3D5VzHjok/Ei4DMi6pUt2nnwJXXSVqw+/erWmTiIKJWA9727ZtGD16NACgd+/eKC0tRVlZGQAgJiYGMTExKC8vR01NDSoqKtC+4XAjkdaU9r2uj8uAjEkK2NXVwC9+AQwcCOzbB1RUaNsuogAi1sN2u93IlIYSASQmJqKoqAjx8fFo1aoVZsyYgdGjR6NVq1YYM2YMevbsKfs8e/bsCVubKisrw/p8RmT196Apr7/voUOQSTVrxHPoEH400HvK34FKHH3nHaScu1/z7LMove46JNXV4cD776Oyf39N26cGq/8OAMZ8D1SrdObxeLy3y8rKsGrVKnzwwQeIj4/H5MmT8eOPP6Jv376N/l6/fv3C1oY9e/aE9fmMyOrvQZNef1qaGPYOwpaWZqj31Oq/A4eXLUPKsmXe+9ElJUg6N13Xc9w4UWI2J8fU0xxW/x0A9Pse7Ny5U/FaxIbEk5OT4Xa7vfcLCwvRuXNnAMD+/fvRo0cPJCYmIjY2FsOGDcNuzh+R3uTkiIpYgXAZkOF0fvLJxlMdNTW+21JuAhMKSWciFrBHjBiBzZs3AwDy8vKQnJyM+Ph4AEBqair279+PyspKAMDu3buRkZERqaYQNY/DIbLCY2N9m3v83/9xsw+Di6mfOKiEuQmkQxEbEh8yZAgyMzORlZUFm82G+fPnY+PGjUhISMBVV12FP//5z7j55psRFRWFwYMHY9iwYZFqClHz1NUBBQXA1KnA009r3RoKk+quXRF79GjwB7JEKelMROewZzeoBFV/jjorKwtZWVmR/PFELfPTT6JeOL9MmkrRzJlIffjh4CsAWKKUdIaVzoiUfPutODJgm8qpsWP99zFPShLTHvUxN4F0iAGbSI7TCUyfLm6PGcMEJLNxOICDB8W0h9sNvPwyIO2T3akTcxNIlxiwydqcTiAjA7DbxdHp9FU4k7bPPHSIWcNm53CIKRAAmDWLwZp0SbV12ES607D0qLScp02bxvObUtYwP8jNKyFB9LKlwE2kMwzYZF1ypUfLy5WTkZg1bH59+gA//6x1K4hkcUicrKupAZhZw+Z3/vnsYZNuMWCTdSkF4KQkMaddH7OGraFPH6CwUOyVTaQzDNhkXTk5jZfzAIDHI7KH27dnRTOrkfY757A46RADNlmXwwFMmND4/IkTvttr14rlPwzW1tCnjzhyWJx0iAGbrK1XL+VrpaVczmU133wjjg6Hb5kfkU4wYJO1FRcHvs5NIKzD6QRmzPDdd7mAiRNFIRUGbtIBBmyytuJiICoq8GO4nMsa5Jb5AeJ3hCMtpAMM2GRtbrfIFo+LU34Ml3NZQ6AvZhxpIR1gwCZrKy4GLrhAZIEnJTW+zuVc1hHsixlHWkhjDNhkbW63mKN0OMTtdet8uzhxOZe15OQEHmmx2zksTppiaVKytuJi/561w8EAbVXSv/s998gnI9bWirns+o8lUhF72GRdZ8+KHbnkhsLJmuqPtMglI5aXA5Mns6dNmmDAJuuSelGdOmnbDtIfh0NUu5Mj9bQZtEllDNhkXVLAZg+b5ARKQmPWOGmAAZusiwGbAgmWhMascVIZk87IutxuceSQOMmREssmTxbD4A1xfT6pjD1ssi72sCkYhwNYs6ZxT5vr80kDDNhkXQzYFAqHQ6zHT08X96OjuT6fNMGATdbldoueUps2WreE9M7hENusPvYYUFMDXHWV1i0iC2LAJktpt2mT2DbRbgdWrQJat9a6SWQkl14qjtu2adsOsiQGbLIOpxMp8+aJbRM9HuDMGaCkhOtpKXQ//yyON9zA/bJJdQzYZB3Z2bBXVvqf83i4npZCI7dfNguokIoYsMk6lNbNcj0thUJuv2wWUCEVMWCTdXTvLn+e62kpFPzCRxpjwCbzczrFfGN+vvz1sjIOa1JwSl/s+IWPVMKATebldIoqZhMnivlGJcXFnIuk4ORKlbKACqmIAZvMyekUQVhuX2M5nIukYKQCKj16iPsdOrCACqmKAZvMSS5BKBjORVIwDof4PUlKArKyGKxJVQzYZE7NCb6ci6RQpaXxCx6pjgGbzClQ8I2JAWJj/c9xLpKaggGbNMCATeaksJdxTYcOwOrVwMsvi80cbDZx5FwkNQUDNmmA+2GTOUnB9/bbxVx2ejqQk4OfhwxBv379/B9D1FRpacCpU0BpKdC+vdatIYtgD5vMy+EAhgwBRo0SOy0xQFO4SFMu7GWTihiwydyOHgVSUrRuBZkNAzZpgAGbzMvjYcCmyGDAJg0wYJN5nT4t5q8ZsCncunYVqw0YsElFDNhkXkePiiMDNoWb3S4qnjFgk4oYsMm8GLApUpxO4PBh4LXXxMYyrENPKmDAJvNiwKZIkOrUV1WJ+y4XN48hVTBgk3kxYFMkyNWpLy8HJk9m0KaIYsAm8zp6FGjVSuyqRBQuSvPWtbXsaVNEMWCTeUlLumw2rVtCZhKoTj23aaUIYsAm8+IabIoEhTr1Xi4Xe9kUEQzYZF4M2BQJDofYLCYqSvkxHBqnCGDAJvNiwKZIcTiANWuUe9ocGqcI4G5dZE4VFcDJkwzYFDnSZjITJ8pfZ1EVCjP2sMl8nE7gvPPE7Sef5NAkRY7DIbZulRMoOY2oGRiwyVykohZHjoj7xcWcT6TIkktCi4sT54nCiAGbzEWpqAXnEylSpCQ0qacdHS3uc/91CjMGbDIXpXlDzidSJDkcwMGDwIIFQE0N8Nvfat0iMiEGbDIXpXlDzieSGoYMEcfvvtO2HWRKDNhkHk4nUFbW+DznE0ktUsDetUvbdpApMWCTOUjJZsXF/ueTkjifSOr55BOxV/a993LbTQo7BmwyB7lkMwCIj2ewJnVIXxrr6sR9brtJYcaATebAZDPSGrfdpAhjwCZzYLIZaY3bblKEMWCTObB4BWmN225ShDFgk3E5nSKxx24XH4aTJ/v2vk5PZ7IZqSvYtpucnqEW4uYfZExSgo80Z+hyAa+8Ang8wFNPAXffrWnzyIKkL4eTJ4th8IY4PUMtxB42GZNcgk9FhThKG38QqU1p201Oz1AYMGCTMQUaXmTAJi01rC0OAM895+uB15/K4VptagIGbDKmQMOLGRmqNYNIllRbfO1acX/wYHGUpnJcLjF9w7Xa1AQM2GRMcgk+UVFA585AbKw2bSJqqGGpUu4mRy3AgE3GJA07RkWJ+1FRQI8evg9IIj244AKgTRtfwGaBH2oBBmwyrqwsMQ/YqZPIys3P5/w16UtUFJCaKuaw7XbxRw4zyCkEDNhkXMePA9XVwLBh4n5tLfDaa5wPJP1wOsVcdlWVmLOWW+7FDHIKEQM2GZc0jLh1q+9cSQmTeEg/srOBmhrl69xNjpogaMBet24dTpw4oUZbiJpGCthVVf7nmcRDehFsbpq7yVETBK10VlZWhunTpyMhIQFjxozB1VdfjbhA5feI1BLow5BJPKQHaWli6ZYS/p5SEwTtYU+bNg1vvPEGcnJyUFVVhalTp+K+++7Djh071GgfkbJDh3y1wxtiEg/pQbD64vw9pSYIaQ77+PHjeP/99/Huu++iQ4cOuPzyy7Fx40bkMFGCtHTokMjAZRlI0itp+WFSkvz1hQvVbQ8ZWtCA7XA4cNdddyE6OhorVqzAM888g9/97ndYsmQJcnNz1WgjkbxDh4BBg3xlIG027tJF+uNwAG43sG6d7/e0Y0dx7ZprtG0bGUrQgH3NNdfgzTffxMSJE5GYmAgA2LRpEwBgrVR2j0gLhw6JIUWpDGRdnTgyWJMe1f89fe45ca6wUNMmkbEoJp3l5ubi+++/h9PpRJRUTQpATU0NXnrpJYwdOxaxQUpALlq0CN999x1sNhvmzp2LQYMGea8dPXoU9913H6qrq9G/f38sWLAgDC+HLKO8HCgu5hwgGVOXLuJ4/DgwYIC2bSHDUOxhd+7cGXFxcaiurkZJSYn3T1lZGZYsWRL0iXfs2AGXy4X169cjJyen0Xz3kiVLMGXKFGzYsAFRUVE4cuRIy18NWUd+vjgyYJMRJSeL4/Hj2raDDEWxh52UlITf//73uPTSS9GuXbsmP/G2bdswevRoAEDv3r1RWlqKsrIyxMfHo66uDjt37sQTTzwBAJg/f34zm0+W5HQC990nbs+aJY4cBicjqd/DJgqRYsB+4IEH8Pjjj2PChAmw2WzweDx+xy1btgR8YrfbjczMTO/9xMREFBUVIT4+HidOnEDbtm2xePFi5OXlYdiwYZglffA2sGfPnma+tMYqKyvD+nxGZMT3oN2mTej85JOIOXYMte3awV5eDnt1tbh4/DjqbrsNR48cwamxY4M+lxFff7hZ/T3Qxev3eNA3OhrFP/yAqmXLvL/f1V27omjmzJB+l1tCF++Bxgz5Hngi5MEHH/R89NFH3vtZWVme//3vfx6Px+MpLCz0XHjhhR6Xy+WpqanxTJkyxbN169ZGz/Htt9+GtU0//PBDWJ/PiAz3Hqxb5/HExXk8ohKz8p/09JCeznCvPwKs/h7o5vV36+bxXHZZ49/vuDjxex9BunkPNKTX9yBQ3FPsYf/hD3+ATakoBYANGzYE/CKQnJwMt9vtvV9YWIjOnTsDADp27Ihu3boh7dz84/Dhw/Hzzz/j8ssvb8p3DbICuf2D5bBiFBlNly7Ajh1AZaX/eam0Lqd5qAHFgL1ixYoWPfGIESOwcuVKZGVlIS8vD8nJyYiPjxc/NDoaPXr0wMGDB5GRkYG8vDyMGTOmRT+PTCrUQMzkMzKaLl2A//xH/hq/gJIMxYD9+eefIysrC0uXLpXtaf/lL38J+MRDhgxBZmYmsrKyYLPZMH/+fGzcuBEJCQm46qqrMHfuXMyZMwcejwd9+vTBFVdc0fJXQ+YTrBYzwMpmZEzJyWK/bLktN/kFlGQoBuzU1FQAQJ8+fZr95LNnz/a737dvX+/t9PR0vP76681+brKInByxXabSsHhUFCubkTFJmeI2m5i9lvALKClQXIf9q1/9CgBw1VVX4cyZM8jLy0NeXh4qKytx9dVXq9ZAsjipFrOSujoGazKmLl1E77p+sGZpXQogaGnSGTNm4MiRIxg6dCiGDh0Kl8uFu+66S422EQk33qh8jUOHZFT79vlut24NxMQABw4wWJOioPth19TU+M1XX3vttbj11lsj2igiP1IVvNhY4OxZ33kOHZJROZ3A6tW++1Km+IsvAlOnatMm0j3FHnZFRQUqKiowbNgw/Pvf/8aJEydw4sQJfPTRR7jooovUbCNZnRSwZ87krlxkDtnZQFVV4/Os+kgBKPawx4wZ461s9u677/pds9lsmD59esQbRwQAOHxYHG++GQihjj2R7ikt2zp2TN12kKEoBuxPPvlE8S9t3LgxIo0hkiUF7G7dtG0HUbgoLVc8t4UxkZygc9jff/89XnjhBZw8eRIAUF1dDbfbjRsDJQIRhdORI2K+un17rVtCFB5KyxVZj4ICCJol/uijj+Kmm25CeXk5/vKXv+Diiy/G3Llz1WgbkXD4sOhdByiVS2Qo0nLF+jkZbdsC58o3E8kJGrBbt26NSy65BLGxsRgwYABmzpyJdevWqdE2IuHwYeBcIR8i03A4gIMHRS2BgweBnj190z9EMoIOibdp0wZbtmxB9+7d8cQTT6BHjx44evSoGm0jEo4cAS65ROtWEEVWaqpvRQSRjKA97OXLl+O8887DvHnzEBsbi71792Lp0qVqtI2syukEMjIAu10MFbpcTDgj80tNZQ+bAgrawwaAL774AgcOHAAA9O7dG7169Ypoo8jCnE7/ZBxp+QtHdcjsunUTy7pqaoDokD6ayWJCKk1aUFDA0qSkDqX9rzdvVr8tRGpKTRXz2YWFWreEdCqk0qR//etfvfdZmpQiSqmgRHGxuu0gUtvPP4tj9+5inXZODiv5kR+WJiV9UdrMw24Xw+VEZuR0An//u7jt8Yi8jdtv5+88+WFpUtKXnBzgttt8myFIamvFBxjAXgeZT3Z249/58nJxnr/vdE7IpUlLS0tht9uRkJAQ8UaRhTkcwBdfAM891/gaP8DIrJSmgpTOkyUFncP+6quv8Mgjj6BVq1aorq6G3W7HggULMHToUDXaR1bUurXyNX6AkRkp1Rbnfu9UT9CAvWLFCqxduxbJyckAgKNHj2LWrFl47bXXIt44sqhduxrvfS3hBxiZkVxtce73Tg0EXdYVExPjDdYAkJKSgmiuEaRIqasD/vMfYNQo8YFVHz/AyKyk2uLSbl2pqdzvnRoJGnm7d++ORx55BBdffDE8Hg+2b9+ONPZyKFL27wdOnwaysoDJk8Wc9aFDXOZC5udwAOedJ8rwPvMMcP31WreIdCZoD3vhwoW48MILsXPnTvznP//B0KFD8cgjj6jRNrIapxO49FJx+8EHxbH+5ggM1mR2AweKJYz//a/WLSEdCtrDvu+++7BixQrccMMNarSHrKphSdKjR7mMi6wnLg7o04cBm2QFDdgdOnTAE088gUGDBiEmJsZ7ftSoURFtGFmMXElSLuMiK/rFL4Cvv9a6FaRDQQN2dXU1ioqKsGXLFr/zDNgUVlyHSiR4PGIKyG5n7gb5CRiwz549izvvvBMpKSmw24NOdxM1j9MpPpxqaxtfY4IjWYnTCbz9trhdv0QpwKBNyklnH3/8MX7zm99g1qxZuPbaa5Gbm6tmu8gqpLlruWDNZVxkNdnZQFWV/zlpaogsT7GH/eKLL+Kf//wn2rdvj4KCAjz88MN48cUX1WwbWYHSdppRUVyHStbDqSEKQLGHHRMTg/bt2wMQa7GrGn7rIwoHpQ+iujoGa7IepSkgTg0RAgRsm80W8D5RWPADisgnJ4cV/kiR4pD47t27MW7cOACAx+PBgQMHMG7cOHg8HthsNmzYsEG1RpKJsYYykY80qjR3rm/0qf4cNkedLE0xYDfcA5soIotaPYQAACAASURBVBwOoLQUmDFD3E9P5zIWsjbpd/+WW4CaGnGb2eKEAAE7NTVVzXaQlf3yl+L4z38CrKhHJHrUUrCWsJCQ5XFxNWnv8GFx5JdEIoHZ4iSDAZu0x4BN5E8p6dJuF38yMkQNA7KUoAG7rKwMzz33HHLOJQF9/fXXOHXqVMQbRhZy5Ij4EKq37zqRpclliwOiwFD9CmgM2pYSNGDPmTMH7dq1w/fffw8AOHHiBGbNmhXxhpGFHD4MdO0KRActbU9kDQ6HKBwkfYmVKw3NCmiWEzRgnzlzBjfddJN3p67rrrsOlZWVEW8YWcjhwxwOJ2rI4QB+/FHcrquTfwzntC0laMCuq6vDoUOHvIVTPvvsM9Qp/fIQNceRI0C3blq3gkh/OnYEzjsPaNNG/joLDFlK0DHIefPmYd68edi9ezdGjhyJCy64AAsXLlSjbWQVhw8Dl12mdSuI9GnYMODECeDsWf9NclhgyHKCBuxDhw7hlVde8Tu3adMm9OrVK1JtIiupqABKSjgkTqTEZhMBW7rt8QDt2wPPPMM12RajGLBzc3Px/fff49VXX8WRI0e852tra/Hiiy9i7NixqjSQTMjpFMkyhw4BKSniHIfEiRpzOoGNG333PR6RgJaUxGBtQYpz2J07d0ZcXByqq6tRUlLi/XP69GksXbpUzTaSmUj7X7tc4sNH+jIoJdcQkY/c/th1dcD//sf12Bak2MNOSUnB73//e4waNQqJiYne89XV1XjkkUcwfPhwVRpIJuJ0ApMn+8/DSV59FViyRP02EelZoCzw+uuxAfa4LSBolvgnn3yCX/3qVxgwYACGDBmCiy66CGVlZWq0jcxE6lnLBWsAOHZM3fYQGUEoWeBcj20ZQQP2G2+8gY8//hiDBw/Grl278Pjjj2Pw4MFqtI3MJDvbfwvNhux2Du0RNaRU8awhrse2hKABu1WrVmjVqhWqq6tRV1eHK6+8Eh9//LEabSMzCfaBUlvLUotEDUkVz9LTRYZ4VJT847ge2xKCBuyBAwdi3bp1GDlyJCZPnoz777+flc6o6Ti0R9Q8Dgdw8KBINluzpnGPm+uxLSPoOuzZs2ejrq4OsbGx+OUvf4mSkhIMHDhQjbaRmeTkAFOmiOIPgXBoj0iZlFg2YwZQWiq+CC9axIQzi1DsYdfU1KC8vBy33HIL6urqUFFRgQEDBmD48OG4XcpKJAqVwwGMGiWG9Ti0R9R8DoevR71jB4O1hSj2sD/77DOsXr0aubm5GDNmDDweDwDAbrfj4osvVq2BZCKVlcDw4cCXX/qyxusnonFojyg0XbqI4/HjvttkeooB+4orrsAVV1yBd955B9dff72abSIz8niA3FxgwgRxX+oVSBXP0tJEsGZvgSg4advN48e1bQepSnFI/NixY3jiiSe8wfrpp5/G6NGjceutt8LlcqnWQDKJ/Hwx5zZokO9c/WSagwcZrIlCJfWqCwu1bQepSjFgz5kzx7vBx86dO/HWW2/h1VdfxZ133olHH31UtQaSSeTmiuOFF2rbDiIzqD8kTpYRMOnshhtuAAB8+OGHuOGGG9CtWzcMHToU1dXVqjWQTMDpBCZNErezsrjWmqil2rcHYmPZw7aYgAFb8tlnn2HkyJHe+wzYFDIpuezkSXE/P58FUohaymYT89jsYVuKYtJZnz59sGDBApw5cwatW7fG0KFD4fF4sGHDBr/NQIgCkitJKhVI4Zw1UfMxYFuOYg973rx5GDRoEDIzM7F69WoAote9Y8cOLFiwQLUGksEpFUJhgRSilunShUPiFqPYw46OjvbOYUtiYmKwbNmyiDeKTCQtTWwBKHeeiJqvSxfg+++1bgWpKGgtcaIWyckBWrXyP8cCKUQtl5wsethOJ5CRIXa8y8hgfoiJMWBTZDkcwE03ids2m9h16PnnOX9N1FJduoja/FOnilEsj0ccmdRpWopD4m+//XbAv9hwuJxIUVKS6GWXl4teABG1nLQWu6LC/zyTOk1LMWDv3bsXAFBQUACXy4UhQ4agrq4O//nPf9CnTx8GbFLmdPqXHO3cGejVi8GaKJyk8qRymNRpSooB+69//SsA4Pbbb8fGjRsRHS0eWl1djXvvvVed1pHxNNzUw+USHx6scEYUXoE2/WBSpykF7fIcPXoUp0+f9t6vqqpCQUFBRBtFBia37trjAfbv16Y9RGal1MNmUqdpKfawJbfddhtuvPFGxMfHAwDOnDmDO++8M+INI4NSGoqr96WPiMLgo48an0tKAp56ivPXJhU0YF9//fW4/vrrUVJSAo/Hg44dO8Jms6nRNjIipXXXgebbiKhpnE5g2rTG54cN8wXrhrkk3L7W8IIOif/000+YMmUKpk2bhsTERKxZswZ5eXlqtI2MKCdHbErQ0F/+on5biMxKbuoJAD79VBylXBIu9zKVoAF74cKFyM7ORuy5D+GRI0dye01S5nAA113X+Pxdd6nfFiKzUpp6qqoSATpQDX8yrKABOzo6Gr179/beP++882Dn8hwKpE0bUXHpkkt85/r04bd7onAJlAV+8CBr+JtU0MibkJCADRs2oKKiAt999x2WL1+OpKQkNdpGRrV/P9C2LbBrl+8ch+SIwicnR2SD13du6S1691auecDlXoYWNGAvXrwYhYWF6NixI1atWoWEhAQsWbJEjbaRUe3fLwL02bP+5zkkRxQeDoco8ZueLkr+JiX5grTHA9TWNv47XO5leEGzxNesWYPp06f7nVuyZAnmzJkTsUaRgZ08CRQXK1/nkBxReDgcvqzvjIzA/++6dQMee4xZ4ganGLA//PBDbNq0Cd9++623TCkg9sTes2cPAzbJkwqkdO4MFBU1vs4hOaLwC/ZF+M03gREj1GkLRYxiwL766qvRv39/LFy4EI5638rsdjt69eqlSuPIgKSAPXMm8Oij/pmqHJIjigyl+gcSuS/PZDiKc9jfffcdunfvjgkTJqCiosL758yZM/iem6aTEilg33WX/xwbt9Ukihy5JLSoKJH8CTBgm4RiD3v79u248MILsXnzZtnro0aNilijyMD27QO6dgXi4/3n2IgocqT/Z3PniuHxuDjxZ+RI4O23GbBNQjFg33777QCAnJwc7N69G4MGDQIAbNu2DZfUX19L1tWw9OF114lzVVUiCYalEInUI31BdjiAzZsBtxsYMgT4+GMGbJMIuqxrzpw5+PDDD733v/nmm5ATzhYtWoTx48cjKysLubm5so95/PHHMWnSpBCbS7ohV/rw2WdFsAa47ppIK61b+zLGV6wQ9xmwTSFowD5y5Ahmz57tvX/33XfjyJEjQZ94x44dcLlcWL9+PXJycpAjk2y0b98+fPPNN01sMumCUi3j+rjumkhdTifw2mu++243cOIE8N132rWJwiZowLbZbPj0009RWlqKkpIS/Pvf/0Z0dNDl29i2bRtGjx4NAOjduzdKS0tRVlbm95glS5Zg5syZzWw6aSrU9dRcd02knuxsoLLS/1xdHVBvaS4ZV9DIu3TpUjz55JNYtmwZoqKiMHDgwJAqnbndbmRmZnrvJyYmoqioyLuv9saNG3HxxRcjNTU14PPs2bMn6M8KVWVlZVifz4jC9R707toVsUePBn3c2a5dsV9H7zl/B/gemPn19z10CHKbH3uqq/Fjvdds5vcgVEZ8D4IG7MLCQixbtszv3ObNm3HNNdc06Qd5PB7v7ZMnT2Ljxo1YvXo1jh8/HvDv9evXr0k/J5A9e/aE9fmMKGzvwbJlwJQpjcuP1hcXh9hly3T1nvN3gO+BqV+/wnpsG4B+u3Z5k0TPdu2K2GXLLJ0Uqtffg507dypeCzokvnLlSsybNw9lZWUoKCjAHXfcga1btwb9ocnJyXC73d77hYWF6Ny5MwDg66+/xokTJ+BwOHDnnXciLy8PixYtCuW1kF44HMC4cb77KSlAq1Zi3SfXXRNpQ249dkyMOE6d6k0SjT16lEmhBhQ0YL/00kv49a9/jRtvvBHTpk3DjBkzQhoSHzFihHcNd15eHpKTk73D4b/5zW/w/vvv480338TTTz+NzMxMzJ07t4UvhVTXpYsIzgBw000iQ/zJJ8Wc2cGDDNZEamu4KUh6OnDrreJaRYX/Y5kUajhBA/bu3bvx6quvYsyYMRg8eDBWr14dUpb4kCFDkJmZiaysLDz66KOYP38+Nm7ciI8++igsDScdKCgAzj9f9K5XrRLnhg/Xtk1EVudwiC/M0hfn3/1O+bFMCjWUoHPYTzzxBObNm4eePXsCAHbt2oWZM2di/fr1QZ+8/nIwAOjbt2+jx3Tv3h1r164Ntb2kJwUFQI8e4pv6tm3i3JgxwKJF7F0T6cW5qUhZ3IzHUBR72KdOnQIAvPzyy95gDYieczaHUQgQAfvsWaB+ksShQ5wbI9ITKWA3XI7LzXgMRzFg33nnnX7358+f7729fPnyyLWIjKG2FjhyRBRkaJgpzrkxIv2QAnZiovdUTfv2TAo1IMWAXX8ZFgD873//U7xGFnT8uAja50ZiGuHcGJE+tG0rypMWFoqgHRWFk1lZDNYGpBiwbTa55ffBr5FFHD4sjkrzY5wbI9IHm833//TSS4HUVESHUPSI9CdolriEQZr8FBSI4z33NF73ybkxIv1wOoFjx8TtL74A2rRBTAgrfUh/FLPEd+/ejXHnCmN4PB4cOHAA48aNg8fjwcGDB9VqH+mVFLBvv11spVl/m01uq0mkD9KuetXV4v7Jk8Dp02iVkKBtu6hZFAP2u+++q2Y7yAjq73+dkABERQGdOvn24CUifZHbVa+2FlEnTwI1NY0zx0nXFP+1gm3KQRYjfVOX/vOfOiXmxl57jcGaSK8Ukj9tgFjlwVwTQwl5DpssTu6busfD5VtEehYoIHMlh+EwYFNolP5zu1wskkKkV3KbgbRuLY4yu3qRvjFgU2gCfVNnZTMifZLbDOTvfxfXGLANhwGbQpOTA8TGyl9jZTMi/Wq4Gcitt6ImMZEB24AYsCk0Dfe/bojzYUTG4HTCfvq06HlnZHB0zEAYsCl0vXopX2O2KZH+nVvtYZfWZbtcnNIyEAZsCl1JiUhgYWUzImOSW+3BKS3DYMCm0JWUAF27Nk5i4a4/RMagNHXFKS1DYJkbCl1JCdCxIyubERlVWpp8shmntAyBPWwK3cmTImATkTHJrcvmlJZhMGBT6KQeNhEZ07l12WdTUsT9tm05pWUgDNgUupISoEMHrVtBRC3hcGD/li3AlVcC/fszWBsIAzaFxuNhD5vITDIzgR9+ANatE+ux7Xauy9Y5Jp1RaCoqgLNnGbCJzKJ/f+DMGbEOu6JCnJPWZQPseesQe9gkz+n0/9b98sviPAM2kTlkZoqjFKwlXJetW+xhU2MN9752uYD77xe3GbCJzEEK2HK4LluX2MOmxuSqIVVWiiMDNpE5vP++8jWuy9YlBmzy53QG3sWHAZvI8Npt2uSbq26I67J1iwGbfKSh8EAYsIkMr/OTTzYeRZNwXbZuMWCTj9xQuCQmRhy5DpvI8GKOHVO+OGGCeg2hJmHAJp9AiSa//a04MmATGV51167KFw8cUK8h1CQM2OSjlGgSHQ107w60awdERanbJiIKu6KZMxvXFG/dWhxzc9VvEIWEAZt85DYGiI4G6uoAt5vz10QmcWrs2Mbb5P7976LuAgO2bjFgk8+5jQG837TT04FbbhEB+7vvGLCJzMThAA4eFP+/Dx4EYmNFwH74YZYo1SkGbPLncIih8T/+UfwnnjRJnP/hBwZsIrOSVojU1Ij7UolSBm1dYcAmfx4PkJ8P9Ogh7p93nu88AzaROcmtEGGJUt1hwCZ/J06I2sJSwE5J8c1rM2ATmZPSChGWKNUVBmzyJ/0HlTLGbTZfL5tLuojMSWmFCEuU6goDNvnLzxdHqYcNAOefL47sYROZk9wKEZYo1R0GbPInF7CrqsTxwQeZPUpkRtIKkfR0cT8ujiVKdYgBm/zl54sypMnJ4r7TCXz4oe86s0eJzEla5nXttcAFFzBY6xADNvk7dEhUNbOf+9XIzgbOnvV/DLNHicyrTx/gp5/El/KMDPFZwJE1XYjWugGkM/n5/okmzB4lspYLLgDOnAGmThUrRgDfyBrAnreG2MMmf/XXYAPMHiWymgsuEEcpWEs4sqY5Bmzyqa0FDh/2D9jMHiWylj59lK9xZE1TDNgkOJ0iQ7SmBli1yjdfVT97VNokgNmjROaVmir+r8vhyJqmOIdNvjrCUmnCEyf856ukP0Rkfq+9JgK2x+N/niNrmmMPm1hHmIgE6ct7XZ3/+datObKmAwzYVud0igxQOZyvIrIWuS/vEgZrzTFgW5n0bVoJ56uIrEXpS3plpbrtIFkM2FbldAKTJyt/m+Z8FZH1KH1Jl5vTJtUxYFuR1LOurVV+DOeriKxHbhlnTIwI1iUl2rSJvBiwrSjQPBUglm4xWBNZj9wyzv/7P3FNKdeFVMOAbUWBksk4FE5kbdImIHV14jhpkjjPJFTNMWBbkdI8VVQUh8KJyJ+05SZ72JpjwLYipXKja9YwWBORv06dgDZtRMDmDl6aYsC2IocDmDVL3Ga5USIKxGYTo3Kffy6SVV0ukYQm7eDFoK0aBmyrio0Vx6IiMU/FYE1EStLTge++Y0VEjTFgW9X/+3/AwIFAUpLWLSEiPXM6ga++As6elb/OZDTVMGBbTLtNm8S35Y8/Fj1rDmcRkRKpZkNZmfJjWBFRNdyty0qcTqTMm+crM3j6tP+uXERE9QWr2cBloKpiD9tKsrNhb1gTmHNQRKQk0HA3k1VVxx62lSj95+McFBHJSUuTX39tswEHDogjqYY9bCtRmmviHBQRyQlUW/zECW3aZGEM2FaSk4O61q39z3EOioiUyNUWv+sucW3/fm3bZkEM2FbicODoI4/4hrE4B0VEwTSsLT5lijjPgK06zmFbzJmRI8Vw1t/+Btxzj9bNISKj6dVLHBmwVccettk1qP3b4Y03xHmpoD8RUVO0aQOkpgL79mndEsthD9vMpKIH0jpKlwudnntO3M7I0KxZRGRwvXuzh60B9rDNTKbogb26WtxgD5uIWuKrr0Q+THS0OHL3rohjwDazQOurO3RQrx1EZB5OJ7Btm0hCA4DaWnHk7l0Rx4BtZkrrq2NiWPCAiJonOxuQRuoaYuXEiGLANiunU7Zgv8dmAwYM0KBBRGQKwSojsnJixDBgm5GUbFZc7H8+Kgqe2Fhg5Eht2kVExhesMiIrJ0YMA7YZKe2wU1sLe1UVE86IqPnkypVKWDkxohiwzSjYkNSSJUwMIaLmqV+uFPDlw6SlsXJihDFgm1GwISm3m9mcRNR8UrlSjwdYtUqc+/RTcaxXqImfMeHFgG1GOTmiGlEgzOYkonCQklifflp0BFwuEci5zCvsGLDNyOEA7r5b3A60fIvZnETUUpmZ4vjyy41zZ9gxCCsGbLPq2FEc3W7lJDNmcxJRS7VrJz5jTp6Uv86OQdhENGAvWrQI48ePR1ZWFnJzc/2uff311/jTn/6ErKwsPPDAA6iTquZQeOzaJeaQEhPlszqZzUlE4TJwoChRKocdg7CJWMDesWMHXC4X1q9fj5ycHOQ0CA7z5s3DihUr8MYbb+DMmTP4/PPPI9UUa9q1CxgyRNyul9XpkTahZzYnEYWLzQbU1DQ+z45BWEUsYG/btg2jR48GAPTu3RulpaUoq1d5a+PGjejatSsAIDExESUlJZFqirU4neIb7b59wJYtvoSPc1mdP+bliexOBmsiCgenE9i8ufH5pCR2DMIsYttrut1uZErJCBBBuaioCPHx8QDgPRYWFuLLL7/EPffcI/s8e/bsCVubKisrw/p8etNu0yakzJsHe2WlOFFairrbbsPRI0dwauxYAOZ/D4Kx+usH+B5Y/fUD4X0Pet9/P2LPnm10/mxsLPYPGQLo9L024u+BavthezyeRueKi4sxbdo0zJ8/Hx2lJKkG+vXrF7Y27NmzJ6zPpytOJ/DAA76dc86xV1Yi9ZlnkHr//QBM/h6EwOqvH+B7YPXXD4T5PTh2TPZ07LFjun6f9fp7sHPnTsVrERsST05Ohtvt9t4vLCxE586dvffLysowdepU3HvvvRjJ2tYtI9UObxCsvZilSUSRopRU1q2buu2wgIgF7BEjRmDzuXmNvLw8JCcne4fBAWDJkiWYPHkyLrvsskg1wTqUaodLmKVJRJGiVFt86lT122JyERsSHzJkCDIzM5GVlQWbzYb58+dj48aNSEhIwMiRI/H222/D5XJhw4YNAICxY8di/PjxkWqOuQXqQTNLk4giSUoqy84Wn0VduwJHjwKDBmnbLhOK6Bz27Nmz/e737dvXe3v37t2R/NHWkpYmygA2FBXFLE0iijyHw/c5c+wYkJICHDniu+50+gJ6WproRPBzqclY6cwM5GqHx8UBa9bwPwURqatzZ9FZOHpU3JdybFhjvMUYsM3A4fDV62VhFCLSUlQU0KWLr4ctl2PDGuPNotqyLoqw888Xx//+l3NHRKStbt1ED9vplJ+uA7h6pRnYwzaLn38Wx969tW0HEVFKCpCXJ4a+lXD1SpMxYBuV0+m/UfzmzeJbbdu2WreMiKyuWzfg8GHl5aZcvdIsHBI3IimJQ/rP4HIB+fm+YXEiIi2lpACBdmBkjk2zsIdtRHJJHHV1QEGBNu0hIqovUJWz5GQG62ZiwDYipWSNM2fUbQcRkZy9e5WvndvFkZqOAduIlJI1OnVStx1ERA05ncAzzzQ+n5QEJCQArVur3yaTYMA2opwcIDa28fmaGhYjICJtZWcD0ha/9cXHA0OHAj/8oH6bTIIB24gcDuDqqxufP3mSFYSISFtKU3aHDgGZmSJgy2y3TMExYBtVZaV8L5sVhIhIS0pTdmlpIs/m1ClRDS0jg52LJmLANiKPB9i1Czh7Vv46KwgRkVbkttuMiwOuuw54/XVxnzXFm4UB24gOHQJOnAASE+Wvs4IQEWnF4RDrrNPT/fc2eP99oKrK/7EcEWwSBmyjkCqb2WxAr17iXE1N42FxVhAiIq05HMDBg6I+xMGD4n6guW0KCQO2EdTfng7wVRA6dUoMLSUlcZcuItK3QHPbFBKWJjUCucpmkupqsVzC7Va3TURETZGT419SGeCIYBOxh613gbank3BIiYj0TprbTkoS91NSOCLYRAzYeiYNhQfDISUiMgKHA9iyRdx+8kkG6yZiwNazQEPhEg4pEZGR9O0LREcDublat8RwGLD1LNhQN5PMiMhoWrUSQZsBu8mYdKZnaWny89fp6WKpBBGREQ0aBHzxhdatMBz2sPVMbpMPDoETkdENGiRGEEtKtG6JoTBg65nDAYwYIdZYc501EZlFcbE4JiWxpngTcEhc744dA669FnjvPa1bQkTUck4n8PTT4nb9muIAOyNBsIetZ243sGcPMHKk1i0hIgqP7GygosL/HGuKh4QBW6+cTqB/f3H7qac4ZERE5sCa4s3GgK1HUsGUoiJx//hxbkNHRObAmuLNxoCtR3IFUzhkRERmILdfdkwMUFYG2O0iCW36dHGU7rOzAoBJZ/rEISMiMispsWzOHKCgAGjTBqit9WWOu1zAs8/6Hs+kNC/2sPWIQ0ZEZGYOB5CfD/TsKZasnj0b+PEcYQTAgK1POTlAVJT/ORZMISKzufji4PslSDjCyICtSxMmiAAdF8eCKURkXtFNmJXlCCMDtu44nUBqKnD6tAjYa9eKuuEM1kRkJk4nsGFDaI/lCCMABmx9kZZzHTsm7rvdXM5FROaUnQ1UVclf69DBdzslhSOM5zBg6wmXcxGRVQSakz550rf066WXGKzPYcDWEy7nIiKrCDYnLXVe3nor8m0xCAZsPeFyLiKyCrkCKnJCnee2AAZsvXA6gVOnGp9nsgURmZHDIeam09PFahglpaXqtUnnGLD1QEo2a7iZe1ISky2IyLwcDrEKpq5OBG45rVur2iQ9Y8DWA7lkMwCIj2ewJiJrkBsij4oSHRcCwICtHafTV9ze5ZJ/DJPNiMgqGg6Rp6cDV1whNgUhAAzY2pCGwF0uwONRfhyTzYjISuoPkR88CFx5pZjDPn1a65bpAgO2FpSGwOtjshkRWV337uJ4+LC27dAJBmwtBBvqZrIZEZEvYBcUaNsOnWDA1kKwoW4mmxER+QL2P/7hy/nJyLBsuWYGbLXUTzILlkTBZDMiIrEREgCsXu3L+XG5LLvHAgO2GhommRUXi/NKxQKYbEZE5CtLWl3tf96ieywwYKshUJJZbKz/fSabERH5OjpKLDgSyYCtBqVfLI9H/ElK8q07ZLIZEVHw1TR2u+WGxaO1boAlpKUpF0eprhZJZm63um0iItKzYD3o2lpfD9winRz2sCOlfpJZsEX/FhzaISIKKJRcHovNZTNgR0LDJLMTJ8R5JpkREYUm1O03XS7LDI0zYEcCk8yIiFqmYW3xqCjlx1pkmRcDdiQwyYyIqOXq1xZfs0a5x22RoXEG7EgINMQtJZlJxe0ZrImIgpN63EosMDTOgB0JOTki2UwJk8yIiJrO4RAjk0pMPjTOgB0J48aJIW8mmRERhVegZDSTD40zYEdCbq5YI3jXXY1/sZhkRkTUfMGGxk08gsmAHQnbt4vj7Nn+WY5MMiMiarlAQ+MmHsFkwA43pxOYM0fcHjlSHKUsRyaZERGFh9LQeFmZaeexGbDDSSqYcuaMuH/okOmTIIiINCENjScl+Z8vLjbt5y4DdjhIZUgnTmxcMMXkSRBERJpxOMQy2YZM+rnLgN1S9cuQKjFxEgQRkaaUPl9NuC6bAbulgm0BB5g6CYKISFOBPl8nTgQ6dTJN4GbAbqlgvWcu4yIiipxgm4SYaE6bAbulAn274zIuIqLICrYuGzDNnDYDdks4nWIJQUNxccC6dVzGRUSkhmAlSwExGiolCNvt6H3llYbrdTNgN5eUbFZcl2XBNwAADW1JREFU7H8+KYm9aiIitQUbGk9M9CUIezyIPXrUcEPlDNjNpZRsFh/PYE1EpDalddmS4mLDL7tlwA6FNIxiswHR0eKotIyLS7iIiLThcABut5iSVArcDRnoM5sBO5iG66xrawM/nku4iIi0pVRQRY7dbphhcQbsYEJZZy3hEi4iIn0ItedcW2uYuWwG7GBC/UePimKyGRGRXjRltNMgc9kM2IE4nWK4JBR1dQzWRER6ESxrvCGXS+Qq6binzYAtx+kU5ewmTgw+Zy3h3DURkX5IWePS+uyoKP+jHJdL18PjDNj11Q/UDddXB8K5ayIi/XE4RAErjweoqRHHNWsC97zLy4HJk4Hp071FVvTS82bABpoWqG02sWQgPV3cZvlRIiLjONfzPpuSovyY2lrg2We9RVbgculiI5GIBuxFixZh/PjxyMrKQm5urt+1r776CuPGjcP48ePxzDPPRLIZ3nXUffv3962jlo52e9N61Glpvm9tdXUsP0pEZDQOB/Zv2RK8nGlDxcUiXkRF+ccRlXrgEQvYO3bsgMvlwvr165GTk4OcBkPGjz76KFauXInXX38dX375Jfbt2xeZhtRbR20DfHPS0tHjCf25OPRNRGQeTU1Mk9TViaMUR1Sa+45YwN62bRtGjx4NAOjduzdKS0tRdm6jjPz8fLRv3x4pKSmw2+0YNWoUtm3bFpmGNGUddSCsEU5EZC5SYlqgRLRQqbA0LDpST+x2u5GZmem9n5iYiKKiIsTHx6OoqAiJiYl+1/Lz82WfZ+fOnS1ryFtvtezvN9TS9uhAi99Tg7P66wf4Hlj99QN8D4Bz70HfvsD27eF80vA9VwMRC9gNeZoy9HzO0KFDI9ASIiIi44nYkHhycjLcbrf3fmFhITp37ix77fjx40hOTo5UU4iIiAwvYgF7xIgR2Lx5MwAgLy8PycnJiD9XjL179+4oKytDQUEBampqsHXrVowYMSJSTSEiIjI8m6c5Y9UhWr58Ob799lvYbDbMnz8fP/zwAxISEnDVVVfhm2++wfLlywEAV199Nf785z9HqhlERESGF9GArSeLFi3Cd999B5vNhrlz52LQoEFaN0l1P/30E6ZPn45bbrkFEydO1Lo5qnvsscewc+dO1NTU4I477sDVV1+tdZNUU1FRgTlz5qC4uBhVVVWYPn06fv3rX2vdLE1UVlZi7NixmD59Om688Uatm6Oq7du345577sH5558PAOjTpw8eeughjVulrn/961948cUXER0djbvvvhuXX3651k0KmWpJZ1qqvyZ8//79mDt3LtavX691s1RVXl6OhQsXYvjw4Vo3RRNff/01fv75Z6xfvx4lJSX4/e9/b6mAvXXrVgwYMABTp07F4cOHMWXKFMsG7GeffRbt27fXuhmaufjii7FixQqtm6GJkpISPPPMM3jrrbdQXl6OlStXMmDrjdKa8PhQNzg3gdjYWLzwwgt44YUXtG6KJi666CLvqEq7du1QUVGB2tpaRIVj/aUBXHfddd7bR48eRZcuXTRsjXb279+Pffv2GepDmsJn27ZtGD58OOLj4xEfH4+FCxdq3aQmsUQtcbfbjY4dO3rvS2vCrSQ6OhqtW7fWuhmaiYqKQty5ikYbNmzAZZddZplgXV9WVhZmz56NuXPnat0UTSxduhRz5szRuhma2rdvH6ZNm4YJEybgyy+/1Lo5qiooKEBlZSWmTZuGm266KXIFuyLEEj3shiwybU8yPv74Y2zYsAEvv/yy1k3RxBtvvIE9e/bg/vvvx7/+9S/YbDatm6Sat99+G7/4xS/Qo0cPrZuimYyMDNx555249tprkZ+fj5tvvhkffvghYmNjtW6aak6ePImnn34aR44cwc0334ytW7ca5v+BJQJ2oDXhZB2ff/45nnvuObz44otISEjQujmq2r17N5KSkpCSkoJ+/fqhtrYWJ06cQFJSktZNU82nn36K/Px8fPrppzh27BhiY2PRtWtXXHrppVo3TTVdunTxTo+kpaWhU6dOOH78uGW+xCQlJWHw4MGIjo5GWloa2rZta6j/B5YYEg+0Jpys4fTp03jsscewatUqdOjQQevmqO7bb7/1jiq43W6Ul5f7TRNZwd/+9je89dZbePPNN/HHP/4R06dPt1SwBkSG9EsvvQQAKCoqQnFxsaXyGUaOHImvv/4adXV1KCkpMdz/A0v0sIcMGYLMzExkZWV514Rbze7du7F06VIcPnwY0dHR2Lx5M1auXGmZ4PX++++jpKQE9957r/fc0qVL0a1bNw1bpZ6srCxkZ2fjpptuQmVlJebNmwe73RLf16meK664ArNnz8aWLVtQXV2Nhx9+2FLD4V26dME111yDP/3pTwCABx980FD/DyyzDpuIiMjIjPPVgoiIyMIYsImIiAyAAZuIiMgAGLCJiIgMgAGbiIjIABiwiSKsoKAAgwcPxqRJkzBp0iSMHz8eDz30EGpraxX/zpw5c7B161a/c0VFRZg3b57s4+fNm4frr7++2W385S9/GfJjz5w5g5tvvhmlpaWYNGkS/vCHP2DSpEmYOHEiJk2ahH379jX55+bk5CA/P79Jbb7vvvuQm5vbpL9DZGSWWIdNpLWePXti7dq13vtz5szBu+++ixtuuCHk5+jcuTMWLFjQ6Hx1dTU++eQTxMbGYv/+/ejdu3dY2qzk6aefxp/+9CfvjleLFy9Gnz59AIjtGxcuXIg1a9Y06Tmzs7Ob3I45c+Zg+vTp+Mc//mGY0pJELcGATaSBQYMGweVyARABLzc3F1VVVZgwYQL++Mc/AhBbYq5ZswYnTpzA4sWL0b59e9x9993YuHGj33N9/vnn6N+/P/r164f33nsPd999NwDgqquuwujRo7Fr1y4kJCTg+eefR2FhIe655x7ExMRg2LBh2Llzp98XiX379mHBggWw2Wxo27YtlixZgnbt2nmvV1VVYfPmzZg9e7bs67rwwgu9r+urr77CU089hZiYGLRr1w5/+9vfYLfbMWvWLBw7dgwDBw70/r1JkybhoYceQrt27XD//fcDAGpqarB06VKkpaXJvpbk5GRkZGRg27ZtlqtYRtbEIXEilVVXV2PLli3IzMxEVVUVUlNT8frrr+O1117DU0895ffYV155BTNnzsRzzz2n+HybNm3CddddhzFjxuC9997zns/Pz8f111+P9evX49SpU9i7dy9eeeUVXHvttVi3bh3Onj3b6LkWLlyIBQsWYM2aNRgxYgScTqff9dzcXPTp00dxp7MPPvgA/fv3BwCUlpZi+fLlWLduHeLj4/HFF1/gyy+/RE1NDdavX4/f/va3OHnypN/fLywsxIwZM7B27Vr84Q9/wGuvvab4WgCxber27dsV3xsiM2EPm0gFBw4cwKRJkwAAe/fuxW233ebdo720tBRZWVmIiYlBSUmJ9+9ccsklAERv/PHHH5d93vLycnz55ZdYsGAB4uPjERsbi7y8PGRmZiI+Ph59+/YFAHTt2hWnT5/G/v37vZs/XHHFFfj+++/9ni83NxcPPfQQAODs2bN+vWBABNSuXbv6nXvggQcQFxeHwsJCdO/eHYsXLwYgtrF98MEHUVtbi/z8fFxyySUoKSnB4MGDAYjeeMMtXzt37oxHH30UK1euxKlTp5CZmQkAsq9Fur1z584A7zyReTBgE6mg/hz23XffjZ49ewIAduzYga+//hpr165FTEyMN5g1pDRH+/HHH6O2thYOhwMAUFJSgvfeew+ZmZmNesEejwcej8f7XHLP2aZNG7z66qsB54QbXpPmsLdu3Yo333wTycnJAIC5c+fi+eefR+/evb1z7x6Px692c11dnd9zrVixAiNHjsSECRPwwQcf4NNPPwUA2ddCZDUcEidS2f3334/ly5ejoqICJSUl6Nq1K2JiYrBlyxbU1tZ6h6qlnuN///tf9OrVS/a5Nm3ahMceewzvvPMO3nnnHbzxxhv44IMPFANaWloadu/eDQD47LPPGl3v27ev9/x7772Hbdu2+V1PTk7GsWPHZJ/717/+Nc6ePesNsmVlZUhJScGpU6ewfft2VFdXo2fPnt6fv2vXrkbD8iUlJUhLS4PH4/FuUBHI8ePHG/X4icyKAZtIZT169MA111yDZ599FpdeeilcLhcmTpyI/Px8XH755Xj44Ye9j502bRpWrFiB6dOnN3qekpIS7N27F5dddpn3XPfu3dGjRw/s2rVL9mfffPPNWL9+PW655RYAaLRTUXZ2NlatWoWJEydi48aN6Nevn9/1QYMGYe/evYpL0h544AEsXrwYVVVVuOmmmzBhwgQ89NBDuO2227Bq1Sr0798flZWVmDhxIt5///1GWzuOHz8eCxcuxG233YYxY8Zgx44d+OKLLxTfy2+++aZJS9KIjIy7dRFZyM8//4xTp05h6NCh2LRpk3cZVlMsXrwYF154oXcuXCtutxt33HEHNmzYwGVdZAkM2EQWcuTIEcyaNQs2mw12ux2LFy9Gjx49mvQcZWVlmDFjBlasWOFdi62FWbNm4eabb8aFF16oWRuI1MSATUREZACcwyYiIjIABmwiIiIDYMAmIiIyAAZsIiIiA2DAJiIiMoD/DyfMVeEvdiYrAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAesAAAHeCAYAAAC7RCO/AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAABKD0lEQVR4nO3deXSTZdo/8G+StlAoexfK0rAjor5QnFF+AzojoI6iDspSJ1Rm3NcqMMhSRWQIoryIIzPugIhBylHHwzCjvi/gC+gcGakURAsIQgVa2lLA0n1Jfn/cPk3S5klSmjzr93OO50nyxPRKSHLl3q7b4vF4PCAiIiLNsqodABEREQXHZE1ERKRxTNZEREQax2RNRESkcUzWREREGsdkTUREpHFRS9b79u1DZmZmi9u3b9+OO+64A9OmTcOmTZui9eeJiIgMIyYaD/rmm29i8+bNiI+P97u9vr4ezz33HN5//33Ex8fjzjvvxHXXXYfExMRohEFERGQIUWlZp6WlYdWqVS1uP3r0KNLS0tClSxfExcVh1KhR+Oqrr6IRAhERkWFEpWV9ww034OTJky1ur6ioQKdOnZqud+zYERUVFQEfIzc3NxqhERERadaoUaMC3h6VZC0nISEBlZWVTdcrKyv9kndzckFfjPz8fAwbNixij6c3Zn/+gMFfA5cLuP9+oKrKe1uHDsAbbwDZ2UBBgXKx2O2A0wk4HMr9zTAZ+j0QJrO/Blp+/sEaqYrOBh84cCAKCgpw/vx51NXVYc+ePRg5cqSSIRAZU3a2f6IGxPXp05VN1ID4e/ffL35AEFFEKNKy/sc//oGqqipMmzYN8+bNwz333AOPx4M77rgDKSkpSoRAZGw//hi5x7LZgMbGtj1GVZX4AaHB1jWRHkUtWffp06dpadYtt9zSdPt1112H6667Llp/lsic0tLa1oKWusx9k2ugrvXWKCgQj8GETdRmLIpCpHcuFyAzUTMom00c7faWiRoQ1994Q5y3WIAePYC4uNb9DXaHE0UEkzWRnkmt37Ky8P8fux3weICGBnE8fly+9etwiPNuN3DmDLBmTeuSt9QdTkRtwmRNpGeBJpYBIpkG4G7fXszUvlhyyTsYqTuciC4akzWRnslNLPN4vEnUp7u7aPHiyI4hS8nb9+8Fwu5wojZhsibSs7S0wLfb7d4k6tPdXT5xYvRicTrFRLVA2B1O1CZM1kRa53IB/fqJru2YGP9joJZ1hw5t6+q+WNKENDkFBSLmfv3YyiZqJSZrIi2TJpBJy7Kk9c/S0ePxv3+PHoFndivF4QhvDJvd4kStwmRNpGVyE8jkJCSov645WHe4hN3iRK2iaG1wImql1lYmi2Qls4sl/ViYPj34/bQQK5FOsGVNpGVyE8gidf9oCac7XCuxEukAkzWRljmdQHx8ePdVa2KZnFDd4RUVHLcmChOTNZGWORzAvfd6r0trppsf5UqGqsm3XCnQslBLWZnoKk9MZNImCoFj1kRaV1UFdOkiKobF6Owj63B4f0D06xd4s5GyMjE7XLo/EbXAljWR1jRfV716NVBXB+TkqB1Z2wSbUCbtvc112EQBMVkTaYncuurqav2vTQ53QhnXYRO1wGRNpCXB1lXrfW1yOOuvJXp/rkQRxmRNpCWh1h7reW2yNOGsR4/w7q/n50oUYUzWRFoSqqtY72uTHQ4xUe7dd70z2eXo/bkSRRCTNZGWOJ1AbGzgc1pbR90WDgewbp18t7iRnitRBDBZE2mFywUsWADU13tv0/I66rZqvg5beq4WC/Daa8Z6rkRtxGRNpAXSLHDfcdoOHUTr8+e9qA2ZvBwO/323331XXB4+XO3IiDSFyZpICwLNAjfjjOhrrxXHHTvUjYNIY5isibRAbuaz2WZE79ghCsHMmsXiKEQ+mKyJ1OZyAVaZj6KZZkRLQwENDeI6i6MQNWGyJlKTlKCkSmW+zDYjmkMBRLKYrInUJFexzGYz3uzvUOS6/AsKxM5cViu7xsm0mKyJ1CSXoNxucyVqIHiXf1mZmCXOrnEyKSZrIjXJJSgzjVVLwq0dzq5xMiEmayI1BapYZraxaolUJCUcZpslT6bHZE2klkAVy4xYqaw1HA5vRbNgzNjzQKbGZE2kNJdLTJiaPr1lxTKn07yJWhKqO9ysPQ9kakzWREqSlmqVlbU8x7FYwbdmuMUittSMixPnzN7zQKbFZE2kJLmlWhKOxQpSzXC3W2yp+cwz4vZ9+5ioyZSYrImUFCoZcyw2sPR0cczLUzUMIrUwWRMpJVhZUYBjscGMHCmOX3+tbhxEKmGyJlJCsLKigBiX5VisvJQUoHdvIDdX7UiIVMFkTaSEYGVF331XjMsyUQeXnAzk5LDsKJlSjNoBEJkCy4q2jcsFHDjQckcugK8fmQJb1kRKYFnRtsnO9i8eA4ieihkz2NImU2DLmijaXC7gwoWWt3NCWfjkeiakOQBsaZPBsWVNFE3SxLKzZ/1v54Sy1gmnB4JFZcjAmKyJokluYllCAhN1a4S7IxeLypBBMVkTRZNc8mBSaR2pBKnNFvx+VivHrsmQmKyJookTyyLH4RCz54NpbBTDDkzYZDBM1kTR5HQCMc3mcXJi2cXj2DWZFJM1UaS5XGIpkdUqkkZ8PNC+vdhBirtGtQ3HrsmkuHSLKJKk2d/SpLKCAnHs2BFYv55Juq2k1y87WyRkqzVwCVcOM5DBsGVNFElys78rKzmWGim+22euW9eypc1hBjIgJmuiSArW/cqx1MiTZol36iSup6VxmIEMicmaKJJCdb9yLDXyHA5g6VJx+csvvYnad+4Ay5GSzjFZE0WS0xl8LTDHUqNj6FBxPHRIHKW5AwUFgMfTVI6085Yt6sVI1AZM1kSR9Pvfi8lksbEtz3EsNXqaJ+tAcweqqpC0cqWycRFFCJM1UaS4XEDv3kB5uRhDfeghsVSLS7air08fsUTu8GFxXWa4Ifb0aQWDIoocLt0iioTmS7bOnhUzlZmglWG1AoMHe1vWaWneZXM+6nv2RJzCoRFFAlvWRJEg0+3K2d8KGjrUm6ydzpZDER06oHTmTOXjIooAtqyJIoEbdqivrg44ckS0stPSgF69vK1rux1wOlGeno7e6kZJdFGYrIkiQabblbO/FeJyAR9/LC5Ls78lffuKIioAkJ+veGhEkcBucKJIcDqBuGajoZz9rZzsbNGybs5qBYqLRQIn0jEma6JIcDiAX/xCJAfO/lae3HCD2y2SeHm5svEQRRiTNVGknDoF3HGHSBDHjzNRK0luuMH681dcSYlysRBFAZM1USScPCkS9JgxakdiTnJbZ7rd4vjuu8rGQxRhTNZEbeVyASNHisvPPcca1GqQNvSQK/X6yivKxkMUYUzWRG0hFUM5c0ZcP32aW2GqxeHwtqSbk/59iHSKyZqoLVgMRVvkxq67dFE2DqIIY7ImClegLRdZDEVb5Mauf/lL5WMhiiAWRSEKR/Pa3wUFwB//KJZpBVrDy2Io6pBm4Gdnix9MaWli6RZb1qRzbFkThSNQd3d9feAxUhZDUZfDIWbmS0voBg/m0i3SPSZronCE261ts7EYitakpDBZk+4xWROFI9xubbebiVprkpOZrEn3mKyJwuF0AjFhTPHgWLX2JCeL/cXr69WOhOiiMVkThcPhAHr29Jav7NRJTC7zxbFqbUpOFsfSUnXjIGoDJmuicJSXi9rff/oTEBsL3Hef2GUrIYEbd2hdSoo4vv02Bo4b57/0jkgnmKyJwvGf/4glWuPGiS/6lSuB2lqgfXtg/Xpu3KFlUst68WLEFRV597tmpTnSESZrolBcLmDyZHH5zjuBH37wrq0+c4Zf+lr35ZfiWFvrfzsrzZGOMFkTBSMVQ/npJ3H97FmgsdH/PvzS1y6XC3j6afnzrDRHOsFkTRRMoGIogfBLX5uys4HqavnznL1POsFkTSTH5RJjm+Hgl742hfoRVVHBIQzSBSZrokCk7u9wcMmWdoX6EVVWxjkHpAtM1kSBBOv+jo0FevTgki09kNuFyxfnHJAORGXXLbfbjUWLFuHQoUOIi4vDkiVLYLfbm86vWbMGW7ZsgcViwYMPPogJEyZEIwyiixes+3TtWiZnvWi2C5fH44El0P0454A0Liot661bt6Kurg45OTmYPXs2li1b1nSuvLwc77zzDjZu3Ig1a9Zg6dKl0QiBqG3kuk/tdiZqvfHZhas+NTXwfTjngDQuKsk6NzcXY8eOBQCMGDECBw4caDoXHx+PXr16obq6GtXV1bA0L9lIpAVOp9hByxfHpnWvdObMlt3i/HclHYhKN3hFRQUSEhKarttsNjQ0NCDm540QUlNTcfPNN6OxsREPPPCA7OPk5+dHLKaampqIPp7emP35A618DdLTMahrV9gqK2GprUV9z54onTkT5enpgI5fR7O/D2rGjwcAJK9ciZiiIrg7dsTpZ57R/b9ra5j+PaDT5x+VZJ2QkIDKysqm6263uylR79y5EyUlJdi2bRsA4J577kF6ejquuOKKFo8zbNiwiMWUn58f0cfTG7M/f6CVr0F5uZgpvGQJkJ2NOAC9f/5Pz8z+PsjPz0fvOXOAOXOAX/8atooK9J4zR/f/rq3B94B2n39ubq7suah0g6enp2Pnzp0AgLy8PAwZMqTpXJcuXdC+fXvExcWhXbt26NSpE8rLy6MRBtHFy8sTx/R0VcOgKOreHcjN5cYepAtRaVlPmDABX3zxBTIyMuDxeLB06VKsXbsWaWlpGDduHP79739j6tSpsFqtSE9Px69+9atohEF08b7+WhyZrI3J5QL+9S9x2XdjD4ATCEmTopKsrVYrFi9e7HfbwIEDmy5nZWUhKysrGn+aqO1cLuCpp8Tlq64Sk4/4BW4s2dmBN/aYMUNc5r83aUxUkjWRbkmVy6SCKGxxGZPcuurGRv57kyaxghmRxOUSLavmlctY4cp4gq2r5r83aRCTNRHgbVE33/5SwgpXxhKqDCn/vUlj2A1OBITeCpMVroxF6uKeMSPwDzT+e5PGsGVNBARvSbHClTE5HMC6daxoRrrAZE0EyLekbDbuqmVkDof49+3VS1zv0YP/3qRJTNZEgHwt8HXr+MVtdA4HcOIE0KkTMG0a/71Jk5isyZxcLlG1SqpeBQB9+wLt23OfajOyWoFRo4A9e9SOhCggJmsyH2nmd0GBf/WqU6eABx8E3G6xpSITtblceSWwbx9QV6d2JEQtMFmT+QSa+V1VBdTXA8OHqxMTqa+mRlQ1a9+etcJJc5isyXyCzfxmsjYnlwtYvVpc9u1tYcImjWCyJvMJtoZWo1vnUZRlZwPV1f63sZIZaQiTNZmP0wnEx/vfZrUCXbuK/8h85HpbCgrYuiZNYLIm83E4gIcf9r/N7RZjlvxiNqdgvS3sDicNYLImc3K7gZgY/+pVNTX8YjarYLXC2R1OGsBkTeYira9euRJoaOAOWyRIlczkcGMPUhmTNZlG5y1bvOurg+EXszk5HKIYTiBWK3tcSFVM1mQaSStXBt9ZS8Idl8xLrju8sZFDJKQqJmsyjdjTp0PfiTsumZvUHd68TjzAIRJSFZM1mUZ9z56BT9hsrAdOXg6HmIAYCIdISCVM1mQapTNnBt67eN061gMnf3JDIRwiIZUwWZNplE+cKFrO7dqJG9iSJjmBxq45REIqYrImc3E4gNRUYPp0tqRJnjR2Lc0Ot1qB117j+4VUw2RN5uJ2i60w+/RROxLSOodD/KB79FHxvrnrLlFIx2LhrlykOCZrMpfSUrEVJpM1hcN3Ny5ALOECuCsXKY7Jmszl5ElxZLKmcATajUvCpVykICZrMhcma2qNUEu1uJSLFMJkTebCZE2tEWqpFpdykUKYrMlcTp4EYmOBpCS1IyE9CLYbF5dykYKYrMlcTp4EevcWS3GIQmm+hEsqQ9q5M9fok6L4jUXmcvIku8CpdaQlXB6P2FZ15Ejg6quZqElRTNZkLkzW1FYjRwJ794rkTaQQJmsyNpdLFLCwWjFw3DjRQmKyprYYMUKs1w9nFzeiCGGyJuNyuUThioICwONBXFGR6MZ89VUWs6CLN2KEOOblqRkFmQyTNRlXdrYoXNFcZSWrT9HFO3RIHG+6iWVHSTFM1mRcwQpWsPoUXQyXC3j8ce91lh0lhTBZk3GFKljB6lPUWoF6a/jDjxTAZE3GFaygBcDqU9R6cj/w+MOPoozJmoxLKmgRCKtP0cWQ+4HHH34UZUzWZGzXXy+ODgfqUlPFXsR2O6tP0cUJ1FvDH36kACZrMrbvvhPHzEwc3bYNcLvFWmsmaroYzcuPAt4xa04yoyiKUTsAoqjKzxfHYcPEki2itpJ+6N13n3eva2lWuO95oghiy5qM7bvvgIQEoG9ftSMhI8nO9iZqCWeFUxQxWZOx5ecDl1wixqqJIoWzwklhTNZkbPn5wKWXqh0FGQ1nhZPCmKzJWKSNOywWICYGOHUK2LyZk38osjgrnBTGZE3G4btxBwA0Norj+fPA/fej85YtqoVGBiPNCu/dW1zv3p3LASmqmKzJOOQ27gCAqiokrVypbDxkbA6HWAZoswEPPcRETVHFZE3GEWJyTyz3H6ZIi4kRrWupN4coSpisyThCTO6p79lToUDIVOx2kayl+RJWK7fOpIhjsibjcDqBdu0Cn+vQAaUzZyobD5mD3Q58+613voTHw60zKeKYrMk4HA5g/HjvdZtNHH+uBV4+caI6cZGx2e3A2bPcOpOiismajEHqgvznP0Xr+t13gYYG0cphLXCKpmDDLyySQhHC2uCkf9KSLallU1vLOs2kHN9NPZpjkRSKELasSf8CLdliFyQpRUrWsbH+t7NICkUQkzXpH+s0k5qk1nNqqve2du1YJIUiisma9I91mklNHToASUnix2HHjmLrzLg44M471Y6MDITJmvSPdZpJTS4X8NNP4nJjI+B2AxcuiImNRBHCZE365FuAIjsbmDHDO2b481ItdkFS1EmTG+vqxPWaGu/a6rw81cIi42GyJv3x3bBDKkCxbh0QHw/cey+XapFyAk1urKkRRyZriiAma9Ifudnf5eVASoo6MZE5BZvE+Oc/s+woRQyTNelPsC9IJmtSUqhJjCw7ShHCZE36E+wLksmalBRocmNzXPNPEcBkTfrjdIrxaV/SBh5M1qQkh0NMZrTbAYtF/n5c809txGRN+uNwAPPne68nJgJ33y0uM1mT0hwOManR7ZYvPco1/9RGTNakTwMGeC/Png0MGiQuM1mTmrjmn6KEyZr06fBhsca6c2fRxVhcLKpGde2qdmRkZr7d4pLnn+dSQmozJmvSp0OHxLKYAQO8yTo5Ofi4IZESpG7xvXvF9S5dVA2HjIHJmvTp0CFg6FAxFigla3aBk5YcOCB6f+66i+utqc2YrEl/3G7RDT5kiH+y7tlT7ciIBJcLeOAB8V4FuN6a2ozJmvSnsFCsXZVa1j/9BBw5wpY1aQf3WKcIY7ImfXG5gFGjxOVFi7zrVy9cYLIm7eAe6xRhTNakH9IGHiUl4npJCfDmm97zTNakFXLrqq1WdoXTRQmZrFevXo2zZ88qEQtRcIG6FmtrvZeZrEkr5MqQNjZy7JouSshk3aFDBzzyyCPIysrCjh074PF4lIiLqKVQXYhM1qQV0nprm63lOY5d00UImazvvPNOvPfee3jsscewefNm/OY3v8GqVavw008/KREfkVeoko0OB1sspB0Oh3c2eHMcu6ZWCpmsy8vL8d577+Hpp59GeXk5srOzMXjwYDzwwANKxEfkFWqHo6IidjGStnDsmiIkJtQdJk+ejFtvvRUvvvgievXq1XR7fn5+VAMjasHhAM6eBbKyxHWbTYwB+pK6GFnekbTA6RQ/IJvPtZDGrgG+VyksIVvW9957Lx599NGmRP3OO+8AAGbOnBndyIgC+a//EsdPP2UXI2kfx64pQmRb1lu2bMH27duxe/du7N69GwDQ2NiI77//HnfddVfQB3W73Vi0aBEOHTqEuLg4LFmyBHafwvY7duzA3/72N3g8HgwfPhzPPPMMLKzpTOH44QdxHDBAdDEWFLS8D7cjJC1xOIDMzMDn+MOSwiSbrMeOHYukpCScP38e06ZNAwBYrVb07ds35INu3boVdXV1yMnJQV5eHpYtW4ZXX30VAFBRUYHly5fjnXfeQffu3fHmm2/i3Llz6N69e4SeEhna0aNivM9uD9zFyO0ISYv4w5LaSDZZV1dX46qrrkJycrLf7VXNx14CyM3NxdixYwEAI0aMwIEDB5rO7d27F0OGDMHzzz+PEydOYMqUKUzUFL4ffhBfcLGx3rG+7GzRQklLE4maY4CkNfxhSW0km6zXrFmDBQsWYOHChX63WyyWpnFrORUVFUhISGi6brPZ0NDQgJiYGJw7dw67d+/GRx99hA4dOsDhcGDEiBHo379/i8eJ5CS2mpoaU0+KM8rzt3/7LTwpKfhRei7p6cDHH/vfSeZ5GuU1aAuzvwaqPf/0dHRetAhJK1citqgIAFA0bx5+Sk+Xfb9GC98D+nz+ssl6wYIFAID169e3+kETEhJQWVnZdN3tdiMmRvyprl274vLLL0dSUhIA4Morr0R+fn7AZD1s2LBW/205+fn5EX08vTHM8y8sBH73u4t6LoZ5DdrA7K+Bqs9/2DBgzhxg2zZg/Hj0uvJK9FIhFr4HtPv8c3NzZc/JJusxY8bI/k+ff/550D+Ynp6Ozz77DDfddBPy8vIwZMiQpnPDhw/H4cOHcfbsWXTu3Bn79u3D1KlTgz4eEQCxWUdpqZhcRqRXo0eLYZwdO4Df/lbtaEgnZJN1qIQczIQJE/DFF18gIyMDHo8HS5cuxdq1a5GWloZx48Zh9uzZuPfeewEAN954o18yJ5J17Jg4MlmTnnXoAPTrB6xcCbzwAudaUFhkk/Urr7yChx9+GLNmzWqxrGrFihVBH9RqtWLx4sV+tw0cOLDp8s0334ybb775YuIls3K5AGlt/+OPA/X1/HIjfXK5xA/PhgZxvaCABVIoJNlkfd111wEAMjIyFAuGKCBpa0xpJu3p0/xyI/3KzvYmagkr71EIshXMLrnkEgDA4MGDsX37dqxZswa7du3S7MA8GVigrTFZ/Yn0Sq4QSkGBqCHQrx/rhlMLIcuNzp07F2lpaXjiiSeQkpKCuXPnKhEXkZfclxurP5EeBSuE4vF4u8WZsMlHyGRdW1uL3//+97jkkkswffp0XLhwQYm4iLzkvtxY/Yn0KNTucQB7jqgF2WR97NgxHDt2DN26dcPHH3+M0tJSbNu2DX369FEyPiLx5RYf738bqz+RXkmbe3TuHPx+7DkiH7ITzHwrl23YsAEbNmwAAG64QcpzOIC9e4EVKwCLhUtdSP+k9+706UBqqtiLvTn2HJEP2WQtV7msvr4+asEQyerWTRzPnw/dIiHSgyuuEMdJk4BXXxXj1RL2HFEzsslasnHjRqxduxYNDQ3weDyIjY3Fp59+qkRsRF55ecDAgUzUZBxDh4pKZrW1/ola2lGOPUfkI+QEM5fLhfXr1+Oaa67Bc88951fchEgxeXnAiBFqR0EUOXFxol64NOu7fXtRfvT4cSZqaiFksk5OTkZycjIqKytx1VVXcTY4Ke/CBeDIESZrMp5OnYCaGu/1gwfVi4U0LWSy7tSpE7Zu3QqLxYKNGzfi/PnzCoRF9DOXCxg8WFx++WWuPSXjcLmA//zHe72mRrSq+R6nAEIm6yVLlqB3796YNWsWjh8/jqeeekqJuIi8ZUaLi8X10lIWiyDjyM4WNe59eTxcX00BhZxgFhcXhz179uD48eMYPHgwrrzySiXiIgpeZpRjeqR3rMxHrRBWudHi4mKMHj0aBQUFWLBggRJxEfHLjIxNbh11r17KxkG6EDJZnzlzBn/6058wfvx4zJ07F6dOnVIiLiKWGSVjkys7+tBDysdCmiebrOvq6lBXV4c+ffpg//79AICDBw+iX79+SsVGZud0inWovlgsgoxCKjtqt4vKfCkp4nYONVIAsmPWN954IywWCzweD3bv3o24uDjU1dWhXbt2SsZHZuZwAMuWieUsjY0sM0rG43B438+HD4tCKaWl6sZEmiSbrLdv3+53vaysDN26dYPVGrLnnKjtXC5g/nzgxAmxFvXVV5mkydiSksTxzBl14yBNCpl5d+/ejXHjxuGee+7B+PHj8cUXXygRF5mZtGTrxAlx/cIFLtki4+vSBbDZ2LKmgEIu3XrppZewYcMGpKSkoLi4GI8++ih+9atfKREbmZHLBcyYIbq9fXHJFhmd1QokJjJZU0AhW9Y2mw0pP098SElJ4Zg1RY/Uom6eqCVcskVGl5TEbnAKKGTLOiEhAevXr8cvfvELfPXVV+jSpYsScZHZyLWofXHJFhldUhJb1hRQyJb18uXLUVhYiJUrV6KoqAhLly5VIi4yk1AtaoBLtsgc2A1OMkK2rBctWoQVK1YoEQuZVaCyor5sNrEelePVZHTsBicZIVvWdXV1OHjwIGpra5sKpRBFVLCx6A4dgHXrmKjJHJKSgLNng/cykSmFbFkfO3YMDz/8cFOBFIvFgm3btikRG5lFWhpQUNDydraoyWwSE8XOW2VlQHKy2tGQhoRM1lu2bFEiDjIzpxP44x/9twvs0IGJmszn0CFxTEkRP1YbG71Hu50V/ExMthv8448/xrXXXosbbrihqTY4UVQ4HMDIkeJLyWIRX0pM1GQ2Lhfw5pve61JXuHQsKGBxIBOTTdbr1q3D5s2b8dZbb+GVV15RMiYyG49HVCvLyADcbuD4cSZqMp/sbKC2Nvh9pOJAZDqy3eBxcXHo0qULunTpgurqaiVjIrM5dgwoKgLGjFE7EiL1hFv0h8WBTCmsXTk8Hk+04yCzcrmAX/5SXF68mF18ZF7hFv1hcSBTkm1ZnzhxAi+++CI8Hk/TZcmsWbMUCY4MTiqGIq2xLioS1wF2g5P5OJ3+n4dAWBzItGSTdVZWVsDLRBETqBgKN+wgs5Le89nZYjKZNAvcYhHzOtLSgKVL+dkwKdlkPWnSJCXjIDOSG3vjmByZlcPRMhmvWgVkZQG7dwM9e6oTF6kurDFroqiQG3vjmByR1+DB4vj99+rGQapisib1OJ2iq88Xx+SI/A0ZIo6HD6sbB6kqZAWziooKvPnmmygpKcFvfvMbDB06FHa7XYnYyOgyMsSEGotFjFWnpbFCE1FzdjsQG8uWtcmFbFkvWLAAffv2RUFBARITE5HNBfkUCS4X0KePSNLx8cD69SyGQhSIzQYMHMiWtcmFTNbnz5/H5MmTERMTg/T0dLjdbiXiIiOTlmydPi2unznDMopEwQwZIlrWLhfQrx9gtYojPzOmEdaY9dGjRwEAp0+fhq35GCNRawVbskVELQ0eDBw8KH7UFhSIpVysFW4qIZP1U089hQULFuC7775DVlYW5s+fr0RcZGRcskXUOufOAQ0N/JFrYiGT9alTp5CTk4M9e/Zg06ZNOH78uAJhkWEE6rbjki2i8LlcwVvP/JFrCrKzwT/77DN8/fXX+Oc//4m9e/cCANxuN7Zt24abbrpJsQBJx5qXE5W67WbMAFavBurqvPflki2iwELtxsUfuaYgm6wvueQSnD9/Hu3atUP//v0BABaLBTfffLNiwZHOyY1Nv/GG2L96zx6xbItLtojkBWs580euacgm69TUVEyaNAm33XYbrFZvb3lJSYkigZEByH3JNDYCe/cCSUkA309EwaWliV6p5mw28cOXP3JNIeSY9apVq3D11Vdj1KhRGD58OP74xz8qERcZQbDuucZGoKJCuViI9MrpFC3o5tatY6I2kZDJevv27di5cyduueUW/Otf/0JKSooScZERBCon6qu6WrlYiPTK4RAtaLtdDBt17Spuv/12VcMiZYVM1klJSYiLi0NlZSXsdjvq6+uViIuMwOEAuncXXzCB9OihbDxEeuVwiAp/bjewfLm4rbRU1ZBIWSGTdc+ePfH+++8jPj4eK1asQHl5uRJxkREUFoovlDvvDNyNN3Om8jER6V1SkjgyWZtKyGS9ePFijB49Gk8++SSSk5Px4osvKhEXGcEXX4jj44+LbrzmY9ivv87qS0StxWRtSrLJurGxEXV1dcjKykJycjLi4uIwZcoUPPvss0rGR3rlcgH33CMuT5kijkuXAjE+CxBOnGC5RKLWkpI1V1KYiuzSrQ8++ACvvfYazpw5gxtvvBEejwc2mw2jRo1SMj7So+bFUH78UVyPjxclE31J5RI5q5UoPGxZm5Jssp46dSqmTp2K999/H5MnT1YyJtI7uWIozW+TsFwiUfi6dBH7WzNZm4psN3hdXR3WrVuHO+64A8XFxcjKysKf/vQnlPINQqG0NvmyXCJR+CwWIDGRydpkZJP14sWLUVhYCLfbjUWLFuGSSy7BDTfcgEWLFikYHumSXPLt0aPlrHCWSyRqvaQkJmuTkU3WR44cwfz589HQ0IDc3Fzcd999mDBhAs6ePatkfKRHTqf/RDJAJOW//MW/uIPdznKJRBeDydp0ZMesO3bsCAD4+uuvcfnllyM2NhYAUBts9xciQCTfF14A8vPFhLLmG3UwORO1TVKSKJJCphE0Wefk5ODTTz/FxIkT4Xa7sXnzZqSmpioZH+nVuXNiyRaXZRFFXnIyW9YmI9sNvmjRIvz4448YO3YsJk2ahN27d+PTTz/lmDWFVl4u1lAPH652JETGlJQkPmfs6TQN2ZZ19+7dMWfOnKbro0ePxujRoxUJinTuu+/EkcmaKDqktdZnzgC9e6sbCykiZLlRolb79ltxZLImig4pWa9bB/TrB1it4shhJ8OSbVkTXbRvvwXatwf691c7EiJjkpL14sXervCCAlEpEOAkTgOSTdaFhYWy/1OvXr2iEgwZgMsFvPoqUFMDDBzoPwuciCLjyy/FsfmYdVUVMGOGuMzPnaHIJuuZP29feP78eVRWVmLw4ME4cuQIEhMT8fe//12xAElHpJrgNTXiOn/pE0WeywU884z8+cZGfu4MSHbMOicnBzk5ORg0aBA++eQTrF27Fp9++ilSUlKUjI/0RK4meHa2OvEQGVF2NlBdHfw+/NwZTsgJZqdPn0ZCQgIAoEOHDqwNTvLkaoJzow6iyAn388TPnaGEnGA2ZswYTJ8+HZdddhn279+P8ePHKxEX6VFamuj6DnQ7EUWG3Ocs0P3IMEK2rGfOnIl58+bh8ssvx8KFC/HQQw8pERfphcvlXTpSUQHYbP7nuVEHUWQ5nS03xAmkooJLuQwkZLIuLi7G22+/jQ8++AD79+/Hvn37lIiL9ECaUFZQAHg8QFkZ4HaLTTq4UQdRdDgcLTfEeeghsaudr7Iy8flkwjaEkMn66aefxh133IH6+npceeWVcLKVRJJAE8o8HiA2ViTt48eZqImiweEQny/pc/bKK8DPc4v8cKKZYYRM1jU1NRg9ejQsFgsGDBiAdu3aKREX6YHcBJa6OmXjICJO8DS4kMm6Xbt22LVrF9xuN/Ly8hAXF6dEXKQHchNYunRRNg4ikv88cqKZIYRM1n/+85/x4Ycf4ty5c1izZg2effZZJeIiPXA6gUA/3qZOVT4WIrMLNPGMEzwNI2Sy3rVrF1auXIl//vOfePnll7F9+3Yl4iI9cDiAiRO916V6xRynJlKeNPGsWzdxvU8fTvA0ENl11lu2bMH27duxe/dufPlzHVq3243Dhw/jrrvuUixA0rjkZO/l224D3npL1AQnIuU5HGITncmTgS1bgP/6L7UjogiRTdZjx45FUlISzp8/j2nTpgEArFYr+vbtq1hwpAOnT4sx6p9+Aj78UHSLc6MXIvWkpopjYSGTtYHIJuvq6mpcddVVSPZtOQGoar5Uh8ytuBgYNQrYt0+s6xw6VBRIISJ1SD+Wi4rUjYMiSjZZr127FvPnz8fChQthsVjg8XgAABaLBe+8845iAZLGFRcDV10lviDKyoBDh0RFM26NSaQO35Y1GYZssp4/fz4A4K233sLRo0dx6aWXYuvWrbj22msVC450oLgYOHcOyM/33satMYnU064d0L07W9YGE7K/cs6cOcj/+Yv42LFjmDdvXsgHdbvdWLhwIaZNm4bMzEwUBCg673a7ce+99+K99967iLBJEyorxX9ffgk0NPifY+UkIvX06sWWtcGEVRv8jjvuAADcd999KCkpCfmgW7duRV1dHXJycjB79mwsW7asxX1eeukllJeXX0TIpBnFxeJ4/nzg86ycRKSO1FS2rA0mZLK2WCw4duwYAODHH3+E2+0O+aC5ubkYO3YsAGDEiBE4cOCA3/lPPvkEFoul6T6kU1KybjYJsQkrJxGpgy1rwwm5n/X8+fMxc+ZMnDlzBsnJyVi8eHHIB62oqECCT1F5m82GhoYGxMTE4PDhw9iyZQtefvll/O1vfwv6OPm+46BtVFNTE9HH05toPP+EPXvQF0BJRgYS33gD1pqapnPu9u1R9MgjKNfQa2729wDA18Aszz8pNhY9iopw8NtvW6zOMMtrIEevzz9ksu7Zsyc++uijpuvffvttyAdNSEhAZWVl03W3242YGPGnPvroIxQXF2PGjBk4deoUYmNj0bt3b1xzzTUtHmfYsGHhPIew5OfnR/Tx9CYqz3/nTgBA8pNPAr/8pRij/vFHIC0NVqcTvR0O9I7sX2wTs78HAL4Gpnn+V1wBNDRgWHKyt7Lgz0zzGsjQ8vPPzc2VPRcyWd9zzz2YN28exowZgzVr1mDz5s1+yTuQ9PR0fPbZZ7jpppuQl5eHIUOGNJ178sknmy6vWrUKiYmJARM16cDp0+KYnCxmfXPmN5E2SMu3iopaJGvSp5Bj1uvWrcOaNWvwu9/9DoWFhdi0aVPIB50wYQLi4uKQkZGB5557DvPnz8fatWuxbdu2iARNGlFcLJaIxMaqHQkR+ZIKo3Dc2jBCtqwPHjyI0tJSpKenIz8/H6dPn0ZaiIlDVqu1xdj2wAD1oh977LFWhkuaUlwMpKSoHQURNefbsiZDCNmyXrVqFV5//XU8++yzmDNnDh555BEl4iI9YLIm0qYdO8Tx7rtFRUGXS9VwqO1CtqxdLhdsNhsAsQyLRUyoiVQXnIi0w+UCfBtVrChoCLIt6yeeeAKAWHa1Zs2aptsffvjhqAdFOlFcDPTsqXYUROQrO1tUEPTFioK6J5usy8rKmi7/3//9X9NlaUMPMrm1a4ELF4C//IXdbERaIlc5sKCAn1MdC2svQ98EbbFYohYM6YRcNxu/CIjUF2wC8P33o/OWLcrFQhEjm6x9kzITtMm5XKL1bLWK4+OPA9XV/vdhNxuRNjidQIcOgc9VVSFp5Upl46GIkJ1gduTIEcyePRsej8fv8tGjR5WMj9TmcolWszQGFmAHtSbcuINIfdIksunTA56OlYoZka7IJuuXXnqp6XJGRkbAy2QCgSaryOHGHUTa4HCIz26AH9f1PXsiToWQqG1kk/Uvf/lLJeMgrQq3tdyhg+h+IyJtcDr9e8UAoEMHlM6cqama/RSesCaYkYkFay1LcxnsduCNN7iGk0hLHA7xuezTR1zv1g144w2UT5yoblx0UZisKTinE4iPD3zO4xGJ+vhxJmoiLXI4gBMnxGY7kybxc6pjTNYUXKjdtDipjEj7Lr8cOHBA7SioDZisSZ60ZOutt+Tvw0llRNp32WXAt98CbrfakdBFClkbnEyq+ZKtQDipjEgfLrsMqKwUQ1akS2xZU2ByS7ZsNjGxjJPKiPTj8svFkV3husWWNQUmNxbtdrMrjUhvpCR9220YmJoKLF/OH9o6w5Y1BSY3Fs0xaiJ9cbmArKymq3FFRazlr0NM1hRYoCVbHKMm0h+5LTNnzPDW+2fi1jwmawrM4QAyM8VljlET6ZfckFZjo6iVwF3zdIHJmlqSlmy98Yb45f3OOyx8QqRX4Qxdcdc8zWOyJn/Ski1pAwC3G3jgAf7qJtKrYFtm+mKBI01jsiZ/cuNb/NVNpE9SjXC7Pfj9OHlU07h0i/zJ/brmr24i/ZKGsO67D6iubnmek0c1jy1r8sclW0TGlJ0dOFEDnDyqA0zW5C/Q+BZ/dRPpX7DesWuvVS4OuihM1uTP4QBWrvRe55ItImMI1jvWty/XW2sckzW1NGCAOP7P/3DJFpFRhJoVzvXWmsZkTS3t2SOOo0apGwcRRc7Ps8LrUlNFoSObreV9uPJDs5isqaU9e4CBA4Hu3dWOhIgiyeHA0W3bgm/Iw5UfmsRkTV5S5bIPPgCKitgdRmRkXPmhK0zWJDSvXFZVxfErIiOTG8OuqODnXoOYrElg5TIic5Eqm/Xo4X97WRl/qGsQkzUJrFxGZD4OB5CQ0PJ2/lDXHCZrEjh+RWRO/KGuC0zWJDidQLt2/rexchmR8fGHui4wWZMYm8rOBmprvbexchmROXCimS5w1y2zk2aB+04uk1rUTNRExid9zh9/XEwuk0gTzXzvQ6phy9rsOAuciDjRTPOYrM2Ok0uICOB3gcYxWZsdJ5cQEcDvAo1jsjY77l9NRAC/CzSOydrspCpG0g48nAVOZE7Sd4Hd7r1t1Sp+F2gEkzUBGRnimJ3N/auJzMzhEN8BH38srvftq2o45MVkTWKHrcZGfjCJSDh1Shyvv17sxMf11qpjsibvbE9OJCEilwvIyvJeLyjgxh4awGRNwIkT4siWNRGx9oImMVkTkzUReXG9tSYxWZP4EHbuDHTponYkRKQ2rrfWJCZrEi1rtqqJCOB6a41isiYmayLyar7eOi6OtRc0gMnajFwusRzDahXHw4eZrInIS1pv/eST4npjo/93BmeGK45bZJpN8y0xCwrE8dw59WIiIm1KTwfq6oAHHgBqasRt0lIugK1tBbFlbTaBlmUAwGefKR8LEWlbero4SolawqVcimOyNhu55RdlZezaIiJ/u3fLn+NSLkUxWZtNsOUXrFJERBKXS3R/y+FSLkUxWZuJywVUVMifZ9cWEUnkhswALuVSAZO1SXTeskW0nMvKgt+RXVtEBAT/LuBSLsUxWZtE0sqV8r+SfbFri4gA+e+CTp2YqFXAZG0SsadPh74Tu7aISBKokpnFAlx2mTrxmByTtUnU9+wZ+ITNJj6Adju7tojIy7eSmfQdMWgQ0L692pGZEpO1SZTOnBm43u+6dYDbLaoVMVETkS+pkpn0HXHFFUBRkdpRmRKTtUmUT5wofiVL2JImotZKTQXCGVKjiGO5UTMZP14cX34ZeOwxdWMhIv3p2RM4fx6orgbi49WOxlTYsjYTqQ64tJsOEVFrpKaKY3GxunGYEJO1mUjrJpmsiehiSBNVOW6tOCZrM5Fa1lxLTUQXQ2pZc9xacUzWZlJQIAoadO2qdiREpEdSsmbLWnFM1mZSUOBdM0lE1FpJSYDVymStAiZrM5GSNRHRxbDZgORk4PPPgX79ROLu14+79SmAS7fM5McfgV/9Su0oiEjP4uKAXbuAxkZxvaBAbBIEsG5DFLFlbRLWykrg3DlOLiOitikp8SZqCbfXjToma5OILSwUF9gNTkQXy+UCamoCn+P2ulHFZG1kLpcYT7JY0H/SJHHbE09wfImIWs/l8nZ3B8Jeu6jimLVRSR+sn/ewtrjd4vbiYo4vEVHrZWc3fZ+0wO11o44ta6MK9sHi+BIRtVawbm5uChR1TNZGFWr8iONLRNQawbq5MzKUi8OkmKyNKtT4EceXiKg1nE7R3e0rLk4cf/hB+XhMhsnaqJxOIDY28DmOLxFRazkcortbqoJotwMLFohz336rbmwmwGRtRC6XGJOur2+6yWP9+Z/abuf4EhFdHIcDOH4ccLvFcdYscTuTddRFJVm73W4sXLgQ06ZNQ2ZmJgqk3Z5+9vbbb2PKlCmYMmUK/vrXv0YjBPOSZoH7vuYdOqBw2TLA4xEfMCZqIoqETp3EkNq333qXirIEaVREJVlv3boVdXV1yMnJwezZs7Fs2bKmcydOnMDmzZuxceNGbNq0CZ9//jkOHjwYjTDMKdAs8KoqJK1cqU48RGRsXbsCOTnA9OmikeDxeEuQMmFHTFSSdW5uLsaOHQsAGDFiBA4cONB0rmfPnnjrrbdgs9lgsVjQ0NCAdu3aRSMM83G5/FvUPmK5/ywRRZrLBXz3negWb45LRCMqKkVRKioqkJCQ0HTdZrOhoaEBMTExiI2NRffu3eHxePDCCy/g0ksvRf/+/QM+Tn5+fsRiqqmpiejjaU3nLVuQunCh7K+v+p49cdTAzz8cRn8PhMPsr4HZnz8Q2ddg4Jw5iGtokD3v+fFHHNTY663X90BUknVCQgIqKyubrrvdbsTEeP9UbW0tFixYgI4dO+KZZ56RfZxhw4ZFLKb8/PyIPp7m/Pa38jV7O3RA6cyZxn7+YTD8eyAMZn8NzP78gQi/BiF67CxpaZp7vbX8HsjNzZU9F5Vu8PT0dOzcuRMAkJeXhyFDhjSd83g8ePjhhzF06FAsXrwYNpstGiGYT4jqQuUTJyoXCxGZQ7B6DVwiGlFRaVlPmDABX3zxBTIyMuDxeLB06VKsXbsWaWlpcLvd+M9//oO6ujrs2rULADBr1iyMHDkyGqGYR1pa4PFqu13M/tZhtw8RaZzT6bcHQZMePYC//IUrTyIoKsnaarVi8eLFfrcNHDiw6fI333wTjT9rboE+NPxlS0TRJCXj7GzRu5eQIIbjSktF4RSKGBZFMQqHA1i0yHudxU+ISAm+hVKee04UY+Lqk4hjstYjueIDw4eL4xdfsPgJESlv0CBx/P57deMwICZrvfGtUCYVH5g+HUhMFIUJAMBnyIGISDFSsj5yRN04DIjJWm/k9qkuKwM2bBCbdyQnKx8XEZHdDsTEMFlHAZO13gRboiUVJ+DEDiJSQ0wM0L8/k3UUMFnricslxqmD8dlpi4hIcYMGiTFrbuwRUVFZukVRII1VNzYGv1+nTsrEQ0QUiNsN5OWJuTQSaWMPgBNfLxJb1nohN1bd3KRJ0Y+FiCgQlwvYvj3wOW7s0SZM1noRbKwaEGNFADBtWvRjISIKJDs7+FBcqO8xksVkrRdyNXjtdiAjwzu5jMu2iEgtoZJxsFriFBSTtV44nUD79v63SeVEO3b03jZhAidyEJE6uLFH1DBZ64XDATz+uLhssXjLiQJifbXkxAkxkYMJm4iU5nSKpNxcQgLLH7cRk7WeXHKJOH7/vbecaHY2UF3tfz9O5CAiNTgcIinb7aJRkZYmEnVjI5CZySVcbcBkrSeFheLYq5f3NrkxIk7kICI1+G7ssXSp2IWrutpbHpk9fxeFyVpPCguBbt2A+HjvbXJjRJzIQURqy872Tn6VsOfvojBZ60lhoX+rGgg8RsSJHESkBez5ixgmaz0JlKybjxFxH2si0gr2/EUMk7WeBErWgP8YEfexJiKtYM9fxDBZ64XbDRQVBU7WRERaJPX8SS1pi8U7Zs1JZq3CjTz04swZMVGDyZqI9ETq6fvDH7yTzbixR6uxZa1lvlvMjRghbmOyJiK94azwNmOy1ippS8yCArE+sahI3P7NN+rGRUTUWpwV3mZM1loltyXmm28qHwsRUVtwVnibMVlrldwvTqmKGRGRXnBWeJsxWWsVf4kSkVFIs8L79hXXubFHqzFZa5XTKZY5NFdRwSUPRKQ/DofoMbzySlErnBt7tAqTtRa5XMCTT4qJZc2VlbEQPhHpk8sF7N8vduGSNvaYPh1ITOR3WghM1lojzQIPNjbNJQ9EpEfZ2UBdXcvb2QgJiclaa+RmgTfHJQ9EpDfBvrfYCAmKyVprwk3CnGhGRHoT6nuLjRBZTNZaE04S5pIHItKjQEu4fLERIovJWktcLuDChZa3x8YCPXpwC0wi0jdpCVePHi3PsRESFJO1VkgTy86e9b+9Rw9g7VqxkQe3wCQivXM4xPfZu++KxoeEu3EFxWStBS4XMGNG4IllCQlMzkRkPA6HaEnHxnpv41IuWUzWapNa1I2Ngc9zwgURGVV2NlBf3/J2LuVqgclabaGWanHCBREZVailXNOni7k6rHTGZK26YG9WTrggIiMLtzFSUGD6ljaTtdrk3qw2G2d9E5GxhVrK5cvkRVOYrNXWfIIFIN6869YxURORsQVbyhWIiefwMFmrzeEArr5atKS5jpqIzMZ3KZfNFvy+Jp7DE6N2AASx+8z/+3/Azp1qR0JEpA6pgXL//YEn3Zp8Dg9b1lpw9CgwaJDaURARqUvqFpeKpVh/TlGpqabvcWSyVltVFVBUBAwcqHYkRETqczhEpUaPB9i9W9z217+aOlEDTNbq++EHcWSyJiLyN2SIOB46pG4cGsBkrbYjR8SR3eBERP46dxZd4IcPqx2J6pis1eByiYo8Vivwxz+K29iyJiJqaehQ0bL2/d40YUUzJmulSbXACwrEmMz58+L2f/1L1bCIiDRpyBBg/37/700TVjRjslaaXC1wE1fmISKSNXQoUFnZ8nvTZBXNmKyVJleBp6DAVL8SiYjCMnSo/DkTVTRjslZasAo8JuvWISIKKdhMcBNVNGOyVtqTT8qfM1m3DhFRUC4X8PTTgc+ZrKIZk3W0BJq5GOyNJzFRtw4RUVByc3wAb+PGJL2RrA0eDdKMb+lNVlAglmhZLEBdXfD/10TdOkREQYVqvEizwgHDVzhjyzoaAv0arK8PnahN1q1DRBRUOI0XkwwfMllHQ2u7srk1JhFRS06naMSEYoLhQybraGhNV7bdDrjdonA9EzURkZfvLlwWi/x+11ar4ceumayjwekE2rULfT92exMRBSftwuV2A+vWBW5pNzYafukrk3WkuVxi/KS2Nvj92O1NRNQ6Uks7UAvb4GPXnA0eSc1ngcux28UvRSIiah2HA8jMDHzOwGPXbFlHUrA1gRJ2fRMRtY3cvCADj10zWUdSsF91nPFNRBQZcrPEDTx2zW7wSHG5xK+6xsaW59jtTUQUOVKDZ8aMlt+50ti1wRpFbFlHgjRWHShRs9ubiCjyHA4xQzyQggLg4YdblnzWMbasI0FurNpmY7c3EVG0pKWJxBzIq696L/uWJU1Pj35cUcCWdVu5XPJvFrebiZqIKFrCrXAG6H5pF1vWbSF1f8vhphxERNEjNYamTw/v/jpe2sWWdVsEW6rFsWoiouhzOMQk3nBYrei8ZUt044kSJuvW8t2nWq77G+BYNRGRUsLtDm9sROrChbqcbMZk3RpSt3dBAeDxyN/PbmeiJiJSSrAypM1Ya2p0OXbNZB0ul0us6WOFMiIi7Qm2lKu5ggLdta6ZrMMRbB21Ly7VIiJST2sm9eqs0hmTdTjCqfkNcKkWEZGaDLyUi8k6HOFO9+dSLSIi9Uhj13a7dz+Ghx6Sv7+OusOZrOX4zvq2hvEycayaiEh9DofYi8HtFsdXXgm+tGv6dCAxUfNJm8m6OZdL/MNNn+6d9R1orDo2FujRg7tpERFpXaju8bIyzY9hM1n7kiaSlZUFv5/dDqxdC5w54/31xkRNRKRNUvd4MBofw2ay9hXORDKpu5vJmYhIP8KpdKbhcqRM1r7C+YfS+K8vIiKS4XTC3b69/HmPRwxtJiaK/ywWICZGHFXeZtN8yVqaOOb7jyAdg1Ul86XhX19ERCTD4UDR4sVivlEwZWXe4VBpzpK0zaZKCTsqydrtdmPhwoWYNm0aMjMzUdCshvamTZtw++23Y+rUqfjss8+iEYLXz8n5kksvFbO6pYljgPcfIVSxk+a4RIuISJfKJ04U843efTes8qR+qqpEDlGhxR2VZL1161bU1dUhJycHs2fPxrJly5rOlZaWYv369di4cSNWr16NF198EXV1ddEIw6+WtwUIv+UssViAuDj/27hEi4hI/1pTnjQQhVvcUUnWubm5GDt2LABgxIgROHDgQNO5/fv3Y+TIkYiLi0OnTp2QlpaGgwcPRiOM8CuPBbNmjf8Cey7RIiIyhkj1kiowlykmGg9aUVGBhISEpus2mw0NDQ2IiYlBRUUFOnXq1HSuY8eOqKioCPg4ubm5bQvkgw/a9v/LPU5b41JJm19PA+BrwNfA7M8f4GvQ9PwjlSO8DxzZx/MRlWSdkJCAysrKpututxsxMTEBz1VWVvolb8moUaOiERoREZHuRKUbPD09HTt37gQA5OXlYciQIU3nrrjiCuTm5qK2thYXLlzA0aNH/c4TERGRP4vH09pZV6G53W4sWrQIhw8fhsfjwdKlS7Fz506kpaVh3Lhx2LRpE3JycuDxePDAAw/ghhtuiHQIREREhhGVZK0V0o+GQ4cOIS4uDkuWLIE9VAUbg9q3bx/++7//G+vXr1c7FMXV19djwYIFOHXqFOrq6vDQQw9h3LhxaoelmMbGRjz11FM4duwYLBYLnn32WdP2ZpWVleH222/HmjVrMHDgQLXDUdSkSZOa5hL16dMHzz33nMoRKe/111/H9u3bUV9fjzvvvBNTpkxRO6SwRWXMWit8l5Dl5eVh2bJlePXVV9UOS3FvvvkmNm/ejPj4eLVDUcXmzZvRtWtXLF++HOfPn8fvfvc7UyVrqZbBxo0bsXv3bqxcudKUn4P6+nosXLgQ7YNVsDKo2tpaeDweU/5Yl+zevRt79+7Fe++9h+rqaqxZs0btkFrF0BXMgi0hM5O0tDSsWrVK7TBUc+ONN+Lxxx8HAHg8HthaWwhB58aPH48///nPAIDCwkJ07txZ5YjU8fzzzyMjIwPJyclqh6K4gwcPorq6GnfffTfuuusu5OXlqR2S4j7//HMMGTIEjzzyCB588EH8+te/VjukVjF0yzrYEjIzueGGG3Dy5Em1w1BNx44dAYj3Q1ZWFp544gl1A1JBTEwM5s6di//93//Fyy+/rHY4ivvwww/RvXt3jB07Fm+E2n3JgNq3b4977rkHU6ZMwfHjx3Hffffhk08+MdV34blz51BYWIjXXnsNJ0+exEMPPYRPPvkEFotF7dDCYuiWdbAlZGQuRUVFuOuuu3DbbbfhlltuUTscVTz//PP49NNP8fTTT6OqrcWCdOaDDz7Av//9b2RmZiI/Px9z585FaWmp2mEppn///rj11lthsVjQv39/dO3a1VTPHwC6du2KMWPGIC4uDgMGDEC7du1w9uxZtcMKm6GTdbAlZGQeZ86cwd133405c+Zg8uTJaoejuI8++givv/46ACA+Ph4WiwVWq6E/+i24XC68++67WL9+PYYNG4bnn38eSUlJaoelmPfff7+p7HNxcTEqKipM9fwBUbtj165d8Hg8KC4uRnV1Nbp27ap2WGEzdDNzwoQJ+OKLL5CRkdG0hIzM57XXXkN5eTleeeUVvPLKKwDEpDuzTDS6/vrrMX/+fDgcDjQ0NGDBggWmee4kTJ48GfPnz8edd94Ji8WCpUuXmq6X8Te/+Q2++uorTJ48GR6PBwsXLtTV/BVDL90iIiIyAnP1hREREekQkzUREZHGMVkTERFpHJM1ERGRxjFZExERaRyTNVEU7d69G6NHj0ZmZiYyMzNx++23IysrC3V1dbL/z7x585rqA0hKS0uxaNGigPd/8MEH8cADD1x0jJmZmTh69GhY962rq8OcOXPgdruRmZmJyZMnIzMzEw6HA7fccgt27NgR9t+dOnUqTp48iQ8//BDbtm1rddzPPvsszpw50+r/j0iPzLXQjkgFV199NVauXNl0ffbs2di+fTtuvPHGsB8jKSkpYLIuLCxEVVUVGhoacOLECfTt2zcSIct6++238dvf/rapqMrzzz/ftHvVDz/8gKysLFx77bWteszbb7/9omLJzMzEihUrTLl7FJkPkzWRgurq6lBSUoIuXbqgsbERCxcuxOnTp1FSUoLrrrsOM2fOBABs2LABq1evRmNjI5xOJ2w2G2bNmoVNmzb5Pd4HH3yAcePGoX379tiwYQPmzp0LQBRCSU9Px7Fjx9CjRw+sWrUK9fX1ePLJJ1FSUoLU1FR89dVX+Pzzz5se68KFC8jOzsa5c+cAAE899RSGDh3adN7j8WDz5s34+9//HvC5+W4S8p///Ad//etf4fF4UFlZiRUrVqB///5YuXIldu3ahZ49ezb9nVWrViExMRFTp04N+HrMmzcPcXFxOHXqFEpKSrBs2TIMHz4cAwYMwA8//IBz586hW7duEfoXItImJmuiKPvyyy+RmZmJsrIyWK1WTJ06FaNHj8bJkycxYsQITJkyBbW1tbjmmmuaknV6ejruv/9+7NixA8uXL8e8efNaPK7b7caWLVuQk5ODmJgY3HzzzXj88cfRvn17nDhxAuvWrUNqaioyMjLwzTffYN++fejTpw9efvllHD16FBMnTvR7vNdeew1XX301fv/73+P48eOYP38+3nvvvabzx48fR0JCAmJjY5tumzt3LmJiYlBYWIgRI0Y0tXK///57LF++HCkpKXjttdfwySefYMyYMfjqq6/w/vvvo6qqCtdff73f3y8qKpJ9PXr16oXFixdj06ZNyMnJweLFiwEAAwYMwNdff22qLU/JnJisiaJM6gY/d+4c7r77bvTp0weA2Fjgm2++wZdffomEhAS/cewrr7wSADBy5Ei88MILAR93165dqKysxOzZswGI5P2Pf/wDU6ZMQbdu3ZCamgoASE1NRW1tLY4ePYprrrkGADBw4EB0797d7/EOHz6ML7/8Eh9//DEA4KeffvI7f+7cOSQmJvrdJnWDb9y4EVu2bGn6mykpKXA6nejQoQOKi4uRnp6O48eP47LLLoPVakVCQkKLWv3BXo9hw4YBAHr27Imvv/666fakpCScP38+4OtDZCScYEakkG7dumH58uV46qmnUFJSgg8//BCdOnXCihUrcPfdd6OmpgZS9d/9+/cDAPbs2YPBgwcHfLz3338fS5YswerVq7F69Wq89NJL2LBhAwAE3PZvyJAh2Lt3LwDgxx9/bOqGlgwYMAB/+MMfsH79erz00ku49dZb/c736NED5eXlAWPJyMhAampq09j8008/jaVLl2LZsmVITk6Gx+PBoEGDsH//frjdblRVVeHIkSN+jxHs9ZDbxvCnn35Cjx49Ap4jMhK2rIkUNGjQIGRmZmLJkiV47LHHMHv2bOTl5SEuLg52ux0lJSUAgH379uGuu+5q2nSheQn/M2fOYN++fX4T10aNGoXa2lq/lqevyZMnY968eXA4HOjVqxfatWvnd/7BBx9EdnY2Nm3ahIqKCjz66KN+5+12O86ePSu7J3x2djZuvfVW3Hbbbbj11lvhcDgQHx+PxMRElJSUYNiwYbjmmmswefJkJCcnt0iyo0ePln095OTn52POnDlB70NkBNzIg8gkvv76a1RVVWHMmDE4fvw47r33XmzdurVVj/H6669jwIABmDBhQpSiDN+RI0ewdu1aOJ1OtUMhijomayKTKC0txaxZs1BfX4+GhgZkZWU1jWGHq6amBtnZ2Vi+fLnqe2I/88wzeOSRR5CcnKxqHERKYLImIiLSOE4wIyIi0jgmayIiIo1jsiYiItI4JmsiIiKNY7ImIiLSOCZrIiIijfv/7an0vh5mFCcAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 576x576 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "tags": []
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
     "result = cirq.experiments.rabi_oscillations(\n",
     "    sampler=cirq.Simulator(),  # In case of Google QCS or other hardware providers, sampler could point at real hardware.\n",
-    "    qubit=cirq.LineQubit(0)\n",
+    "    qubit=cirq.LineQubit(0),\n",
+    "    num_points=200,\n",
+    "    repetitions=1000,\n",
     ")\n",
     "result.plot();"
    ]
@@ -3991,7 +3988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 78,
    "metadata": {
     "id": "j7FoZGKv90qe"
    },
@@ -4021,7 +4018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 79,
    "metadata": {
     "id": "qH7xB-vZ-Jsn"
    },
@@ -4070,7 +4067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 80,
    "metadata": {
     "id": "951a57e8e0fd"
    },
@@ -4107,7 +4104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 81,
    "metadata": {
     "id": "Ydst5b0S9IGE"
    },

--- a/docs/tutorials/educators/intro.ipynb
+++ b/docs/tutorials/educators/intro.ipynb
@@ -4135,22 +4135,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/docs/tutorials/educators/intro.ipynb
+++ b/docs/tutorials/educators/intro.ipynb
@@ -2442,7 +2442,8 @@
     "simulator = cirq.Simulator()\n",
     "\n",
     "# Simulate the circuit for several values of the parameter.\n",
-    "for y in range(5):\n",
+    "num_params = 5\n",
+    "for y in range(num_params):\n",
     "    result = simulator.simulate(circuit, param_resolver={\"s\": y / 4.0})\n",
     "    print(\"s={}: {}\\n\".format(y, np.around(result.final_state_vector, 2)))"
    ]
@@ -2495,7 +2496,8 @@
    "source": [
     "\"\"\"Simulate the circuit at multiple parameter values.\"\"\"\n",
     "# Get a list of param resolvers.\n",
-    "resolvers = [cirq.ParamResolver({'s': y / 8.0}) for y in range(5)]\n",
+    "num_params = 5\n",
+    "resolvers = [cirq.ParamResolver({'s': y / 8.0}) for y in range(num_params)]\n",
     "\n",
     "# Add measurements to the circuit.\n",
     "circuit.append([cirq.measure(a), cirq.measure(b)])\n",
@@ -2703,11 +2705,12 @@
     "    cirq.measure(q)\n",
     ")\n",
     "# replace None with something else\n",
-    "param_resolvers = None \n",
+    "param_resolvers = None\n",
+    "repetitions = 100\n",
     "results = cirq.Simulator().sample(\n",
     "    program=parameterized_circuit,\n",
     "    params=param_resolvers,\n",
-    "    repetitions=100\n",
+    "    repetitions=repetitions\n",
     ")\n",
     "\n",
     "# You can test with the following plot\n",
@@ -2752,7 +2755,7 @@
     "results = cirq.Simulator().sample(\n",
     "    program=parameterized_circuit,\n",
     "    params=param_resolvers,\n",
-    "    repetitions=100\n",
+    "    repetitions=repetitions\n",
     ")\n",
     "pandas.crosstab(results.theta, results.q).plot()"
    ]
@@ -4132,9 +4135,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/tutorials/educators/intro.tst
+++ b/docs/tutorials/educators/intro.tst
@@ -14,6 +14,10 @@
 
 # Replacements to apply during testing. See devtools/notebook_test.py for syntax.
 
-num_angles = 200->num_angles = 4
-num_points=200->num_points=4
-repetitions=1000->repetitions=10
+num_angles = 200->num_angles = 2
+num_points=200->num_points=2
+repetitions=1000->repetitions=2
+repetitions = 100->repetitions=2
+repetitions=10->repetitions=2
+length=100->length=4
+num_params = 5->num_params = 2

--- a/docs/tutorials/educators/intro.tst
+++ b/docs/tutorials/educators/intro.tst
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+num_angles = 200->num_angles = 4
+num_points=200->num_points=4
+repetitions=1000->repetitions=10

--- a/docs/tutorials/educators/neutral_atom.ipynb
+++ b/docs/tutorials/educators/neutral_atom.ipynb
@@ -966,9 +966,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/tutorials/educators/neutral_atom.ipynb
+++ b/docs/tutorials/educators/neutral_atom.ipynb
@@ -966,22 +966,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/docs/tutorials/educators/qaoa_ising.ipynb
+++ b/docs/tutorials/educators/qaoa_ising.ipynb
@@ -1137,7 +1137,7 @@
    "outputs": [],
    "source": [
     "\"\"\"Sample from the QAOA circuit.\"\"\"\n",
-    "num_reps = 10**3  # Try different numbers of repetitions.\n",
+    "num_reps = 1000  # Try different numbers of repetitions.\n",
     "gamma_value, beta_value = 0.2, 0.25  # Try different values of the parameters.\n",
     "\n",
     "# Sample from the circuit.\n",

--- a/docs/tutorials/educators/qaoa_ising.tst
+++ b/docs/tutorials/educators/qaoa_ising.tst
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+num_steps = 150->num_steps = 2
+num_reps = 1000->num_reps = 10
+grid_size = 50->grid_size = 4

--- a/docs/tutorials/educators/textbook_algorithms.ipynb
+++ b/docs/tutorials/educators/textbook_algorithms.ipynb
@@ -1575,22 +1575,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/docs/tutorials/educators/textbook_algorithms.ipynb
+++ b/docs/tutorials/educators/textbook_algorithms.ipynb
@@ -1136,7 +1136,8 @@
     "# Set the value of theta. Try different values.\n",
     "theta = 0.123456\n",
     "\n",
-    "nvals = np.arange(1, 16, step=1)\n",
+    "max_nvals = 16\n",
+    "nvals = np.arange(1, max_nvals, step=1)\n",
     "\n",
     "# Get the estimates at each value of n.\n",
     "estimates = []\n",
@@ -1574,9 +1575,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/tutorials/educators/textoobk_algorithms.tst
+++ b/docs/tutorials/educators/textoobk_algorithms.tst
@@ -14,6 +14,4 @@
 
 # Replacements to apply during testing. See devtools/notebook_test.py for syntax.
 
-num_rounds = 1000->num_rounds = 2
-N = 128->N = 4
-samples = 1000->samples = 2
+max_nvals = 16->max_nvals = 2

--- a/docs/tutorials/fourier_checking.ipynb
+++ b/docs/tutorials/fourier_checking.ipynb
@@ -889,22 +889,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/docs/tutorials/fourier_checking.ipynb
+++ b/docs/tutorials/fourier_checking.ipynb
@@ -808,7 +808,8 @@
    "source": [
     "res = pd.DataFrame()\n",
     "repetitions = 100\n",
-    "for _ in range(1000):\n",
+    "num_rounds = 1000\n",
+    "for _ in range(num_rounds):\n",
     "    if np.random.rand() > 0.5:\n",
     "        fs, gs, _, _ = draw_two_distribution_from_f_set(N)\n",
     "        source = \"F set\"\n",

--- a/docs/tutorials/fourier_checking.ipynb
+++ b/docs/tutorials/fourier_checking.ipynb
@@ -231,9 +231,10 @@
    "source": [
     "N = 128\n",
     "K = 3\n",
+    "samples = 1000\n",
     "\n",
     "res = pd.DataFrame()\n",
-    "for _ in range(1000):\n",
+    "for _ in range(samples):\n",
     "    if np.random.rand() > 0.5:\n",
     "        f = gen_balanced_function(N)\n",
     "        dist = \"B\"\n",
@@ -274,9 +275,10 @@
     "N = 128\n",
     "K = 3\n",
     "repetitions = 3\n",
+    "samples = 1000\n",
     "\n",
     "res = pd.DataFrame()\n",
-    "for _ in range(1000):\n",
+    "for _ in range(samples):\n",
     "    if np.random.rand() > 0.5:\n",
     "        f = gen_balanced_function(N)\n",
     "        dist = \"B\"\n",
@@ -887,9 +889,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/docs/tutorials/fourier_checking.tst
+++ b/docs/tutorials/fourier_checking.tst
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+num_rounds = 1000->num_rounds = 2

--- a/docs/tutorials/hidden_linear_function.ipynb
+++ b/docs/tutorials/hidden_linear_function.ipynb
@@ -552,7 +552,8 @@
    "source": [
     "def test_problem(problem):\n",
     "    problem.bruteforce_solve()\n",
-    "    for _ in range(100):\n",
+    "    tries = 100\n",
+    "    for _ in range(tries):\n",
     "        z = solve_problem(problem)\n",
     "        assert problem.is_z(z)\n",
     "    \n",
@@ -637,7 +638,8 @@
    ],
    "source": [
     "%%time\n",
-    "problem = random_problem(200, seed=0)\n",
+    "tries = 200\n",
+    "problem = random_problem(tries, seed=0)\n",
     "solve_problem(problem, print_circuit=False)"
    ]
   },

--- a/docs/tutorials/hidden_linear_function.tst
+++ b/docs/tutorials/hidden_linear_function.tst
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+tries = 200->tries = 2
+tries = 100->tries = 2

--- a/docs/tutorials/qaoa.tst
+++ b/docs/tutorials/qaoa.tst
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+repetitions=20_000->repetitions=10
+grid_size = 5->grid_size = 2

--- a/docs/tutorials/quantum_walks.ipynb
+++ b/docs/tutorials/quantum_walks.ipynb
@@ -408,12 +408,9 @@
     }
    ],
    "source": [
-    "dist(50, N)\n",
-    "dist(100, N)\n",
-    "dist(500, N)\n",
-    "dist(1000, N)\n",
-    "dist(5000, N)\n",
-    "dist(10000, N)"
+    "run_range = [50, 100, 500, 1000, 5000, 10000]\n",
+    "for run in run_range:\n",
+    "    dist(run, N)"
    ]
   },
   {

--- a/docs/tutorials/quantum_walks.tst
+++ b/docs/tutorials/quantum_walks.tst
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+iterator = 30->iterator = 2
+sample_number = 5000->sample_number=100
+run_range = \[50, 100, 500, 1000, 5000, 10000\]->run_range = [50]

--- a/docs/tutorials/quantum_walks.tst
+++ b/docs/tutorials/quantum_walks.tst
@@ -14,6 +14,6 @@
 
 # Replacements to apply during testing. See devtools/notebook_test.py for syntax.
 
-iterator = 30->iterator = 2
-sample_number = 5000->sample_number=100
+iterator = 30->iterator = 1
+sample_number = 5000->sample_number=10
 run_range = \[50, 100, 500, 1000, 5000, 10000\]->run_range = [50]

--- a/docs/tutorials/variational_algorithm.ipynb
+++ b/docs/tutorials/variational_algorithm.ipynb
@@ -855,9 +855,9 @@
    ],
    "source": [
     "sweep_size = 10\n",
-    "sweep = (cirq.Linspace(key='alpha', start=0.0, stop=1.0, length=10)\n",
-    "         * cirq.Linspace(key='beta', start=0.0, stop=1.0, length=10)\n",
-    "         * cirq.Linspace(key='gamma', start=0.0, stop=1.0, length=10))\n",
+    "sweep = (cirq.Linspace(key='alpha', start=0.0, stop=1.0, length=sweep_size)\n",
+    "         * cirq.Linspace(key='beta', start=0.0, stop=1.0, length=sweep_size)\n",
+    "         * cirq.Linspace(key='gamma', start=0.0, stop=1.0, length=sweep_size))\n",
     "results = simulator.run_sweep(circuit, params=sweep, repetitions=100)\n",
     "\n",
     "min = None\n",

--- a/docs/tutorials/variational_algorithm.tst
+++ b/docs/tutorials/variational_algorithm.tst
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+sweep_size = 10->sweep_size = 2

--- a/examples/advanced/quantum_volume.ipynb
+++ b/examples/advanced/quantum_volume.ipynb
@@ -60,7 +60,9 @@
     "import cirq\n",
     "\n",
     "num_repetitions = 10  # This is supposed to be >= 100.\n",
-    "depths = range(2, 5)  # The depths and number of qubits\n",
+    "max_depth = 5\n",
+    "depths = range(2, max_depth)  # The depths and number of qubits\n",
+    "repetitions = 10_000  # The number of times to sample per circuit\n",
     "optimize = cirq_google.optimized_for_xmon\n",
     "\n",
     "# Here is the important set-up: the samplers and their plot configurations.\n",
@@ -128,7 +130,8 @@
     "            routed_probability = quantum_volume.sample_heavy_set(\n",
     "                compilation_result,\n",
     "                heavy_set,\n",
-    "                sampler=sampler['sampler'])\n",
+    "                sampler=sampler['sampler'],\n",
+    "                repetitions=repetitions)\n",
     "            sampler['routed-probabilities'][depth] += routed_probability\n",
     "            print(\n",
     "                f\"        {sampler['label']} HOG routed probability: {routed_probability}\"\n",
@@ -218,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/advanced/quantum_volume.tst
+++ b/examples/advanced/quantum_volume.tst
@@ -1,0 +1,3 @@
+num_repetitions = 10->num_repetitions = 2
+max_depth = 5->max_depth = 3
+repetitions = 10_000->repetitions=100

--- a/examples/advanced/quantum_volume_errors.ipynb
+++ b/examples/advanced/quantum_volume_errors.ipynb
@@ -38,6 +38,7 @@
     "depth = 4\n",
     "num_samplers = 50\n",
     "device = cirq_google.Bristlecone\n",
+    "repetitions = 10_000\n",
     "compiler = lambda circuit: cirq_google.optimized_for_xmon(\n",
     "    circuit=circuit,\n",
     "    new_device=device)\n",
@@ -63,12 +64,14 @@
     "        qubit_noise_gate=cirq.DepolarizingChannel(p=error)))\n",
     "    for error in errors]\n",
     "\n",
-    "result = quantum_volume.calculate_quantum_volume(num_circuits=num_circuits,\n",
-    "                            depth=depth,\n",
-    "                            num_qubits=depth,\n",
-    "                            device_graph=routing.gridqubits_to_graph_device(device.qubits),\n",
-    "                            samplers=samplers,\n",
-    "                            compiler=compiler)"
+    "result = quantum_volume.calculate_quantum_volume(\n",
+    "    num_circuits=num_circuits,\n",
+    "    depth=depth,\n",
+    "    num_qubits=depth,\n",
+    "    device_graph=routing.gridqubits_to_graph_device(device.qubits),\n",
+    "    samplers=samplers,\n",
+    "    compiler=compiler,\n",
+    "    repetitions=repetitions)"
    ]
   },
   {
@@ -123,7 +126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/advanced/quantum_volume_errors.tst
+++ b/examples/advanced/quantum_volume_errors.tst
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+num_circuits = 10->num_circuits = 2
+num_samplers = 50->num_samplers = 2
+repetitions = 10_000->repetitions = 10

--- a/examples/advanced/quantum_volume_routing.ipynb
+++ b/examples/advanced/quantum_volume_routing.ipynb
@@ -36,7 +36,9 @@
     "# Configuration parameters. Feel free to mess with these!\n",
     "num_circuits = 10\n",
     "depth = 4\n",
-    "routing_attempts = range(1, 100, 10) # [1, 6, 11, 16, 21, 26, 31]\n",
+    "max_routing_attempts = 100\n",
+    "routing_attempts = range(1, max_routing_attempts, 10)\n",
+    "repetitions = 10_000\n",
     "qubits = cirq.GridQubit.rect(3,2)\n",
     "\n",
     "compiler = cirq_google.optimized_for_xmon\n",
@@ -70,6 +72,7 @@
     "                            samplers=samplers,\n",
     "                            compiler=compiler,\n",
     "                            random_state=np.random.RandomState(52),\n",
+    "                            repetitions=repetitions,\n",
     "                            routing_attempts=r))"
    ]
   },
@@ -122,7 +125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.9"
   }
  },
  "nbformat": 4,

--- a/examples/advanced/quantum_volume_routing.tst
+++ b/examples/advanced/quantum_volume_routing.tst
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-)
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+num_circuits = 10->num_circuits = 1
+max_routing_attempts = 100->max_routing_attempts = 5
+repetitions = 10_000->repetitions = 100


### PR DESCRIPTION
Provides the ability to speed up notebook execution tests by substituting smaller values for parameters that impact the runtime of the notebook.  To do this one supplies a file for a given `.ipynb` test with the same prefix but the `.tst` suffix.  This file contains replacements of the form `pattern->replacement`.  Some notes

* Suffix `.tst` chosen instead of `.test` because the later has the potential to make some grepping for tests less reliable and more noise prone
* All the patterns must be applied during the test. This avoids the common case of a pattern being a typo and not being applied.
* Open to different syntax than `->`.  Used it because it seemed unlikely to conflict with actual patterns and was indicative of what the replacement is actually doing.  

Notebook tests are taking up to 30 minutes in Google Actions.  This PR gets that down to around 11.  Nearly as fast as the Windows test :) 

Addresses #3603 