### PR TITLE
Fix tetris_concat docstring align arg and restore FIRST alignment option

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1364,7 +1364,10 @@ class AbstractCircuit(abc.ABC):
             align: When to stop when sliding the circuits together.
                 'left': Stop when the starts of the circuits align.
                 'right': Stop when the ends of the circuits align.
-                'first': Stop the first time either the starts or ends align.
+                'first': Stop the first time either the starts or the ends align. Circuits
+                    are never overlapped more than needed to align their starts (in case
+                    the left circuit is smaller) or to align their ends (in case the right
+                    circuit is smaller)
 
         Returns:
             The concatenated and overlapped circuit.

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -70,8 +70,12 @@ INT_TYPE = Union[int, np.integer]
 
 
 class Alignment(enum.Enum):
+    # Stop when left ends are lined up.
     LEFT = 1
+    # Stop when right ends are lined up.
     RIGHT = 2
+    # Stop the first time left ends are lined up or right ends are lined up.
+    FIRST = 3
 
     def __repr__(self) -> str:
         return f'cirq.Alignment.{self.name}'
@@ -1357,13 +1361,10 @@ class AbstractCircuit(abc.ABC):
 
         Args:
             circuits: The circuits to concatenate.
-            stop_at_first_alignment: Defaults to false. When true, the circuits
-                are never overlapped more than needed to align their starts (in
-                case the left circuit is smaller) or to align their ends (in
-                case the right circuit is smaller). When false, the smaller
-                circuit can be pushed deeper into the larger circuit, past the
-                first time their starts or ends align, until the second time
-                their starts or ends align.
+            align: When to stop when sliding the circuits together.
+                'left': Stop when the starts of the circuits align.
+                'right': Stop when the ends of the circuits align.
+                'first': Stop the first time either the starts or ends align.
 
         Returns:
             The concatenated and overlapped circuit.
@@ -1479,7 +1480,15 @@ def _overlap_collision_time(
     seen_times: Dict['cirq.Qid', int] = {}
 
     # Start scanning from end of first and start of second.
-    upper_bound = len(c1) if align == Alignment.LEFT else len(c2)
+    if align == Alignment.LEFT:
+        upper_bound = len(c1)
+    elif align == Alignment.RIGHT:
+        upper_bound = len(c2)
+    elif align == Alignment.FIRST:
+        upper_bound = min(len(c1), len(c2))
+    else:
+        raise NotImplementedError(f"Unrecognized alignment: {align}")
+
     t = 0
     while t < upper_bound:
         if t < len(c2):

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4612,6 +4612,47 @@ def test_tetris_concat():
     assert type(v) is cirq.FrozenCircuit and v == ha.freeze()
 
 
+def test_tetris_concat_alignment():
+    a, b = cirq.LineQubit.range(2)
+
+    assert cirq.Circuit.tetris_concat(
+        cirq.Circuit(cirq.X(a)),
+        cirq.Circuit(cirq.Y(b)) * 4,
+        cirq.Circuit(cirq.Z(a)),
+        align='first',
+    ) == cirq.Circuit(
+        cirq.Moment(cirq.X(a), cirq.Y(b)),
+        cirq.Moment(cirq.Y(b)),
+        cirq.Moment(cirq.Y(b)),
+        cirq.Moment(cirq.Z(a), cirq.Y(b)),
+    )
+
+    assert cirq.Circuit.tetris_concat(
+        cirq.Circuit(cirq.X(a)),
+        cirq.Circuit(cirq.Y(b)) * 4,
+        cirq.Circuit(cirq.Z(a)),
+        align='left',
+    ) == cirq.Circuit(
+        cirq.Moment(cirq.X(a), cirq.Y(b)),
+        cirq.Moment(cirq.Z(a), cirq.Y(b)),
+        cirq.Moment(cirq.Y(b)),
+        cirq.Moment(cirq.Y(b)),
+    )
+
+    assert cirq.Circuit.tetris_concat(
+        cirq.Circuit(cirq.X(a)),
+        cirq.Circuit(cirq.Y(b)) * 4,
+        cirq.Circuit(cirq.Z(a)),
+        align='right',
+    ) == cirq.Circuit(
+        cirq.Moment(cirq.Y(b)),
+        cirq.Moment(cirq.Y(b)),
+        cirq.Moment(cirq.Y(b)),
+        cirq.Moment(cirq.X(a), cirq.Y(b)),
+        cirq.Moment(cirq.Z(a)),
+    )
+
+
 def test_factorize_one_factor():
     circuit = cirq.Circuit()
     q0, q1, q2 = cirq.LineQubit.range(3)


### PR DESCRIPTION
- The docstring was still talking about the arg that was removed months ago
- FIRST alignment is useful when performing bulk operations