### PR TITLE
Ensure 3 qubit gate decomposition returns unique CNOTs

### DIFF
--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -98,20 +98,20 @@ class CCZPowGate(
                 a, b = b, a
 
         p = common_gates.T ** self._exponent
-        sweep_abc = [common_gates.CNOT(a, b), common_gates.CNOT(b, c)]
+        cnot = common_gates.CNOT
 
         return [
             p(a),
             p(b),
             p(c),
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
             p(b) ** -1,
             p(c),
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
             p(c) ** -1,
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
             p(c) ** -1,
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
         ]
 
     def _apply_unitary_(self, args: 'protocols.ApplyUnitaryArgs') -> np.ndarray:
@@ -266,7 +266,6 @@ class ThreeQubitDiagonalGate(gate_features.ThreeQubitGate):
                 b, c = c, b
             elif not b.is_adjacent(c):
                 a, b = b, a
-        sweep_abc = [common_gates.CNOT(a, b), common_gates.CNOT(b, c)]
         phase_matrix_inverse = 0.25 * np.array(
             [
                 [-1, -1, -1, 1, 1, 1, 1],
@@ -283,19 +282,19 @@ class ThreeQubitDiagonalGate(gate_features.ThreeQubitGate):
         ]
         phase_solutions = phase_matrix_inverse.dot(shifted_angles_tail)
         p_gates = [pauli_gates.Z ** (solution / np.pi) for solution in phase_solutions]
-
+        cnot = common_gates.CNOT
         return [
             p_gates[0](a),
             p_gates[1](b),
             p_gates[2](c),
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
             p_gates[3](b),
             p_gates[4](c),
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
             p_gates[5](c),
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
             p_gates[6](c),
-            sweep_abc,
+            [cnot(a,b), cnot(b,c)],
         ]
 
     def _value_equality_values_(self):
@@ -521,19 +520,19 @@ class CSwapGate(gate_features.ThreeQubitGate, gate_features.InterchangeableQubit
         a, b, c = control, near_target, far_target
 
         t = common_gates.T
-        sweep_abc = [common_gates.CNOT(a, b), common_gates.CNOT(b, c)]
+        cnot = common_gates.CNOT
 
         yield common_gates.CNOT(c, b)
         yield pauli_gates.Y(c) ** -0.5
         yield t(a), t(b), t(c)
-        yield sweep_abc
+        yield [cnot(a,b), cnot(b,c)]
         yield t(b) ** -1, t(c)
-        yield sweep_abc
+        yield [cnot(a,b), cnot(b,c)]
         yield t(c) ** -1
-        yield sweep_abc
+        yield [cnot(a,b), cnot(b,c)]
         yield t(c) ** -1
         yield pauli_gates.X(b) ** 0.5
-        yield sweep_abc
+        yield [cnot(a,b), cnot(b,c)]
         yield common_gates.S(c)
         yield pauli_gates.X(b) ** 0.5
         yield pauli_gates.X(c) ** -0.5

--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -104,14 +104,14 @@ class CCZPowGate(
             p(a),
             p(b),
             p(c),
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
             p(b) ** -1,
             p(c),
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
             p(c) ** -1,
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
             p(c) ** -1,
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
         ]
 
     def _apply_unitary_(self, args: 'protocols.ApplyUnitaryArgs') -> np.ndarray:
@@ -287,14 +287,14 @@ class ThreeQubitDiagonalGate(gate_features.ThreeQubitGate):
             p_gates[0](a),
             p_gates[1](b),
             p_gates[2](c),
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
             p_gates[3](b),
             p_gates[4](c),
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
             p_gates[5](c),
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
             p_gates[6](c),
-            [cnot(a,b), cnot(b,c)],
+            [cnot(a, b), cnot(b, c)],
         ]
 
     def _value_equality_values_(self):
@@ -525,14 +525,14 @@ class CSwapGate(gate_features.ThreeQubitGate, gate_features.InterchangeableQubit
         yield common_gates.CNOT(c, b)
         yield pauli_gates.Y(c) ** -0.5
         yield t(a), t(b), t(c)
-        yield [cnot(a,b), cnot(b,c)]
+        yield [cnot(a, b), cnot(b, c)]
         yield t(b) ** -1, t(c)
-        yield [cnot(a,b), cnot(b,c)]
+        yield [cnot(a, b), cnot(b, c)]
         yield t(c) ** -1
-        yield [cnot(a,b), cnot(b,c)]
+        yield [cnot(a, b), cnot(b, c)]
         yield t(c) ** -1
         yield pauli_gates.X(b) ** 0.5
-        yield [cnot(a,b), cnot(b,c)]
+        yield [cnot(a, b), cnot(b, c)]
         yield common_gates.S(c)
         yield pauli_gates.X(b) ** 0.5
         yield pauli_gates.X(c) ** -0.5

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -330,9 +330,8 @@ def unique_ops(op_list):
     """
 
     unique = []
-    while op_list:
-        op = op_list.pop(0)
-        if not sum([op is ele for ele in unique]):
+    for op in op_list:
+        if all(op is not elem for elem in unique):
             unique.append(op)
 
     return unique

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -319,3 +319,55 @@ def test_resolve(resolve_fn):
     diagonal_gate = resolve_fn(diagonal_gate, {'b': 19})
     assert diagonal_gate == cirq.ThreeQubitDiagonalGate(diagonal_angles)
     assert not cirq.is_parameterized(diagonal_gate)
+
+def unique_ops(op_list):
+    """
+    Helper function for test_unique_gate_decomp.
+
+    Returns a list of unique ops from a list. Unique in the sense of op1 is op2.
+    The original list is used up by this function
+    """
+
+    unique = []
+    while op_list:
+        op = op_list.pop(0)
+        if not sum([op is ele for ele in unique]):
+            unique.append(op)
+
+    return unique
+
+def test_unique_gate_decomp():
+    """
+    Test to check that 3-qubit decompose methods return unique operations
+
+    The test is checking that no two gates in the decomposition
+    refer to the same object.
+    """
+    qubits = [cirq.GridQubit(i, 0) for i in range(3)]
+
+    ccz = cirq.CCZ.on(*qubits)
+    ccz_decomp = ccz._decompose_()
+    ccz_decomp_count = len(ccz_decomp)
+
+    ccx = cirq.CCX.on(*qubits)
+    ccx_decomp = ccx._decompose_()
+    ccx_decomp_count = len(ccx_decomp)
+
+    cs = cirq.CSWAP.on(*qubits)
+    cs_decomp = cs._decompose_()
+    cs_decomp_count = len(cs_decomp)
+
+    diagonal_angles = [2, 3, 5, 7, 11, 13, 17, 19]
+    tqd = cirq.ThreeQubitDiagonalGate(diagonal_angles)
+    tqd_decomp = tqd._decompose_(qubits)
+    tqd_decomp_count = len(tqd_decomp)
+
+    ccz_unique_count = len(unique_ops(ccz_decomp))
+    ccx_unique_count = len(unique_ops(ccx_decomp))
+    cs_unique_count = len(unique_ops(cs_decomp))
+    tqd_unique_count = len(unique_ops(tqd_decomp))
+
+    assert ccz_unique_count == ccz_decomp_count
+    assert ccx_unique_count == ccx_decomp_count
+    assert cs_unique_count == cs_decomp_count
+    assert tqd_unique_count == tqd_decomp_count

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -320,6 +320,7 @@ def test_resolve(resolve_fn):
     assert diagonal_gate == cirq.ThreeQubitDiagonalGate(diagonal_angles)
     assert not cirq.is_parameterized(diagonal_gate)
 
+
 def unique_ops(op_list):
     """
     Helper function for test_unique_gate_decomp.
@@ -335,6 +336,7 @@ def unique_ops(op_list):
             unique.append(op)
 
     return unique
+
 
 def test_unique_gate_decomp():
     """


### PR DESCRIPTION
This PR is a fix for the decompose method of three qubit gates returning multiple CNOTs which are the same object.

For example [CCZPowGate.\__decompose\__](https://github.com/quantumlib/Cirq/blob/master/cirq-core/cirq/ops/three_qubit_gates.py#L77)  returns an OP_TREE that leads to the following circuit :
```python
 0: ───p───@──────────────@───────@──────────@──────────
           │              │       │          │
 1: ───p───X───@───p^-1───X───@───X──────@───X──────@───
               │              │          │          │
 2: ───p───────X───p──────────X───p^-1───X───p^-1───X───
```
The unexpected behaviour is that there are only two unique CNOTs in the list returned. All the CNOTs between qubits 0 and 1 are the same object. This is also true for all the CNOTs between qubits 1 and 2. Looking at the [source code](https://github.com/quantumlib/Cirq/blob/master/cirq-core/cirq/ops/three_qubit_gates.py#L100), it is clear why this is the case -

```python
p = common_gates.T ** self._exponent
sweep_abc = [common_gates.CNOT(a, b), common_gates.CNOT(b, c)]

return [
      p(a),
      p(b),
      p(c),
      sweep_abc,
      p(b) ** -1,
      p(c),
      sweep_abc,
      p(c) ** -1,
      sweep_abc,
      p(c) ** -1,
      sweep_abc,
]
```
I don't think this can be desired behavior or all circuits would just have one object for an operation acting on a particular set of qubits.

This leads to problems in decomposition methods for example if you try to do a custom decomposition of the operations returned by this method there is no way to distinguish the pairs of CNOTs in the decomposition above since they are the same object.

It looks like this behaviour was introduced in an attempt to optimise three qubit gates in this issue quantumlib/Cirq#814. 