### PR TITLE
[XEB] Error bars for vs. depth plots

### DIFF
--- a/docs/qcvv/xeb_coherent_noise.ipynb
+++ b/docs/qcvv/xeb_coherent_noise.ipynb
@@ -155,13 +155,17 @@
    "outputs": [],
    "source": [
     "# Make long circuits (which we will truncate)\n",
-    "n_circuits = 10\n",
+    "n_circuits = 20\n",
+    "max_depth = 80\n",
+    "rs = np.random.RandomState(52)\n",
     "circuits = [\n",
     "    rqcg.random_rotations_between_two_qubit_circuit(\n",
     "        q0, q1, \n",
-    "        depth=100, \n",
+    "        depth=max_depth, \n",
     "        two_qubit_op_factory=lambda a, b, _: SQRT_ISWAP(a, b), \n",
-    "        single_qubit_gates=SINGLE_QUBIT_GATES)\n",
+    "        single_qubit_gates=SINGLE_QUBIT_GATES,\n",
+    "        seed=rs,\n",
+    "    )\n",
     "    for _ in range(n_circuits)\n",
     "]"
    ]
@@ -175,8 +179,7 @@
    "outputs": [],
    "source": [
     "# We will truncate to these lengths\n",
-    "max_depth = 100\n",
-    "cycle_depths = np.arange(3, max_depth, 9)\n",
+    "cycle_depths = np.arange(5, max_depth + 1, 15)\n",
     "cycle_depths"
    ]
   },
@@ -289,7 +292,7 @@
    "source": [
     "from cirq.experiments.xeb_sampling import sample_2q_xeb_circuits\n",
     "sampled_df = sample_2q_xeb_circuits(sampler=noisy_sim, circuits=circuits, \n",
-    "                                    cycle_depths=cycle_depths, repetitions=10_000)\n",
+    "                                    cycle_depths=cycle_depths, repetitions=15_000)\n",
     "sampled_df.head()"
    ]
   },
@@ -328,14 +331,28 @@
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
+    "ref_decay = 5e-3\n",
     "xx = np.linspace(0, fids['cycle_depth'].max())\n",
-    "plt.plot(xx, (1-5e-3)**(4*xx), label=r'Exponential Reference')\n",
+    "plt.axhline(1, color='grey', ls='--')\n",
+    "plt.plot(xx, (1-ref_decay)**(4*xx), label=r'Exponential Reference')\n",
     "\n",
-    "plt.plot(fids['cycle_depth'], fids['fidelity'], 'o-', label='Perturbed fSim')\n",
+    "plt.errorbar(\n",
+    "    x=fids['cycle_depth']+1,\n",
+    "    y=fids['fidelity'], \n",
+    "    yerr=fids['fidelity_std'],\n",
+    "    marker='o', capsize=5,\n",
+    "    label='OLS')\n",
+    "\n",
+    "plt.errorbar(\n",
+    "    x=fids['cycle_depth']-1,\n",
+    "    y=fids['naive_fidelity'], \n",
+    "    yerr=fids['naive_fidelity_std'],\n",
+    "    marker='o', capsize=5,\n",
+    "    label='Naive')\n",
     "\n",
     "plt.ylabel('Circuit fidelity')\n",
     "plt.xlabel('Cycle Depth $d$')\n",
-    "plt.legend(loc='best')"
+    "_ = plt.legend(loc='best')"
    ]
   },
   {
@@ -347,15 +364,6 @@
     "## Optimize `PhasedFSimGate` parameters\n",
     "\n",
     "We know what circuits we requested, and in this simulated example, we know what coherent error has happened. But in a real experiment, there is likely unknown coherent error that you would like to characterize. Therefore, we make the five angles in `PhasedFSimGate` free parameters and use a classical optimizer to find which set of parameters best describes the data we collected from the noisy simulator (or device, if this was a real experiment)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "c175576bf0d6"
-   },
-   "source": [
-    "fids_opt = simulate_2q_xeb_fids(sampled_df, pcircuits, cycle_depths, param_resolver={'theta': -np.pi/4, 'phi': 0.1})"
    ]
   },
   {
@@ -408,12 +416,22 @@
    "outputs": [],
    "source": [
     "xx = np.linspace(0, fids['cycle_depth'].max())\n",
-    "p_depol = 5e-3 # from above\n",
-    "plt.plot(xx, (1-p_depol)**(4*xx), label=r'Exponential Reference')\n",
+    "plt.plot(xx, (1-ref_decay)**(4*xx), label=r'Exponential Reference')\n",
     "plt.axhline(1, color='grey', ls='--')\n",
     "\n",
-    "plt.plot(fids['cycle_depth'], fids['fidelity'], 'o-', label='Perturbed fSim')\n",
-    "plt.plot(res.fidelities_df['cycle_depth'], res.fidelities_df['fidelity'], 'o-', label='Refit fSim')\n",
+    "plt.errorbar(\n",
+    "    x=fids['cycle_depth'],\n",
+    "    y=fids['naive_fidelity'], \n",
+    "    yerr=fids['naive_fidelity_std'],\n",
+    "    marker='o', capsize=5,\n",
+    "    label='Perturbed fSim')\n",
+    "\n",
+    "plt.errorbar(\n",
+    "    x=res.fidelities_df['cycle_depth'],\n",
+    "    y=res.fidelities_df['naive_fidelity'], \n",
+    "    yerr=res.fidelities_df['naive_fidelity_std'],\n",
+    "    marker='o', capsize=5,\n",
+    "    label='Refit fSim')\n",
     "\n",
     "plt.ylabel('Circuit fidelity')\n",
     "plt.xlabel('Cycle Depth')\n",

--- a/docs/qcvv/xeb_coherent_noise.tst
+++ b/docs/qcvv/xeb_coherent_noise.tst
@@ -14,8 +14,8 @@
 
 # Replacements to apply during testing. See devtools/notebook_test.py for syntax.
 
-n_circuits = 10->n_circuits = 2
-max_depth = 100->max_depth = 12
-repetitions=10_000->repetitions=100
-xatol=1e-3->xatol=10
-fatol=1e-3->fatol=10
+n_circuits = 20->n_circuits = 2
+max_depth = 80->max_depth = 20
+repetitions=15_000->repetitions=100
+xatol=1e-3->xatol=1
+fatol=1e-3->fatol=1


### PR DESCRIPTION
It would be nice to have a measure of uncertainty in the fidelity due to variance in the implied fidelity from various circuit instantiations that need to be averaged together to get a fidelity.

We use least squares to fit a line of the form `y = f*x` where f is the fidelity and you can read my nice xeb theory notebook to figure out what y and x are (tldr: experimental and true (cross-)entropies). I tried to use the OLS formula for variance of parameter estimates to get a standard deviation in our estimate of `f`, but it looks way too small (try running the updated "coherent noise xeb" notebook modified by this PR)

I'm not sure why you can't just divide `y/x` for each instance and then average them and take the std.dev. That gives more reasonable error bars. I've included these quantities as part of this PR as `raw_fidelity` and `raw_fidelity_std`.

If someone knows the theory behind what we should be doing here, please get in contact with me.