### PR TITLE
Choi representation

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -330,6 +330,7 @@ from cirq.optimizers import (
 
 from cirq.qis import (
     bloch_vector_from_state_vector,
+    choi,
     CliffordTableau,
     density_matrix,
     density_matrix_from_state_vector,

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -330,7 +330,6 @@ from cirq.optimizers import (
 
 from cirq.qis import (
     bloch_vector_from_state_vector,
-    choi,
     CliffordTableau,
     density_matrix,
     density_matrix_from_state_vector,
@@ -339,6 +338,7 @@ from cirq.qis import (
     fidelity,
     kraus_to_choi,
     one_hot,
+    operation_to_choi,
     QUANTUM_STATE_LIKE,
     QuantumState,
     quantum_state,

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -337,6 +337,7 @@ from cirq.qis import (
     dirac_notation,
     eye_tensor,
     fidelity,
+    kraus_to_choi,
     one_hot,
     QUANTUM_STATE_LIKE,
     QuantumState,

--- a/cirq-core/cirq/qis/__init__.py
+++ b/cirq-core/cirq/qis/__init__.py
@@ -15,8 +15,8 @@
 """Tools and methods for quantum information science."""
 
 from cirq.qis.channels import (
-    choi,
     kraus_to_choi,
+    operation_to_choi,
 )
 
 from cirq.qis.clifford_tableau import CliffordTableau

--- a/cirq-core/cirq/qis/__init__.py
+++ b/cirq-core/cirq/qis/__init__.py
@@ -14,6 +14,8 @@
 
 """Tools and methods for quantum information science."""
 
+from cirq.qis.channels import choi
+
 from cirq.qis.clifford_tableau import CliffordTableau
 
 from cirq.qis.measures import (

--- a/cirq-core/cirq/qis/__init__.py
+++ b/cirq-core/cirq/qis/__init__.py
@@ -14,7 +14,10 @@
 
 """Tools and methods for quantum information science."""
 
-from cirq.qis.channels import choi
+from cirq.qis.channels import (
+    choi,
+    kraus_to_choi,
+)
 
 from cirq.qis.clifford_tableau import CliffordTableau
 

--- a/cirq-core/cirq/qis/channels.py
+++ b/cirq-core/cirq/qis/channels.py
@@ -29,6 +29,6 @@ def kraus_to_choi(kraus_operators: Sequence[np.ndarray]) -> np.ndarray:
     return c
 
 
-def choi(operation: 'protocols.SupportsChannel') -> np.ndarray:
+def operation_to_choi(operation: 'protocols.SupportsChannel') -> np.ndarray:
     """Returns the unique Choi matrix associated with a superoperator."""
     return kraus_to_choi(protocols.channel(operation))

--- a/cirq-core/cirq/qis/channels.py
+++ b/cirq-core/cirq/qis/channels.py
@@ -1,0 +1,29 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tools for analyzing and manipulating quantum channels."""
+
+import numpy as np
+
+from cirq import protocols
+
+
+def choi(operation: 'protocols.SupportsChannel') -> np.ndarray:
+    """Returns the unique Choi matrix associated with a superoperator."""
+    ks = protocols.channel(operation)
+    d = np.prod(ks[0].shape)
+    c = np.zeros((d, d), dtype=np.complex128)
+    for k in ks:
+        v = np.reshape(k, d)
+        c += np.outer(v, v.conj())
+    return c

--- a/cirq-core/cirq/qis/channels.py
+++ b/cirq-core/cirq/qis/channels.py
@@ -12,18 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tools for analyzing and manipulating quantum channels."""
+from typing import Sequence
 
 import numpy as np
 
 from cirq import protocols
 
 
-def choi(operation: 'protocols.SupportsChannel') -> np.ndarray:
-    """Returns the unique Choi matrix associated with a superoperator."""
-    ks = protocols.channel(operation)
-    d = np.prod(ks[0].shape)
+def kraus_to_choi(kraus_operators: Sequence[np.ndarray]) -> np.ndarray:
+    """Returns the unique Choi matrix corresponding to a Kraus representation of a channel."""
+    d = np.prod(kraus_operators[0].shape)
     c = np.zeros((d, d), dtype=np.complex128)
-    for k in ks:
+    for k in kraus_operators:
         v = np.reshape(k, d)
         c += np.outer(v, v.conj())
     return c
+
+
+def choi(operation: 'protocols.SupportsChannel') -> np.ndarray:
+    """Returns the unique Choi matrix associated with a superoperator."""
+    return kraus_to_choi(protocols.channel(operation))

--- a/cirq-core/cirq/qis/channels_test.py
+++ b/cirq-core/cirq/qis/channels_test.py
@@ -42,6 +42,33 @@ def expected_choi(channel: cirq.SupportsChannel) -> np.ndarray:
 
 
 @pytest.mark.parametrize(
+    'kraus_operators, expected_choi',
+    (
+        ([np.eye(2)], np.array([[1, 0, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 1]])),
+        (
+            [
+                np.eye(2) / 2,
+                np.array([[0, 1], [1, 0]]) / 2,
+                np.array([[0, -1j], [1j, 0]]) / 2,
+                np.diag([1, -1]) / 2,
+            ],
+            np.eye(4) / 2,
+        ),
+        (
+            [
+                np.array([[1, 0, 0], [0, 0, 1]]) / np.sqrt(2),
+                np.array([[1, 0, 0], [0, 0, -1]]) / np.sqrt(2),
+            ],
+            np.diag([1, 0, 0, 0, 0, 1]),
+        ),
+    ),
+)
+def test_kraus_to_choi(kraus_operators, expected_choi):
+    """Verifies that cirq.kraus_to_choi computes the correct Choi matrix."""
+    assert np.allclose(cirq.kraus_to_choi(kraus_operators), expected_choi)
+
+
+@pytest.mark.parametrize(
     'channel',
     (
         cirq.I,

--- a/cirq-core/cirq/qis/channels_test.py
+++ b/cirq-core/cirq/qis/channels_test.py
@@ -79,10 +79,10 @@ def test_kraus_to_choi(kraus_operators, expected_choi):
         cirq.amplitude_damp(0.2),
     ),
 )
-def test_choi(channel):
+def test_operation_to_choi(channel):
     """Verifies that cirq.choi correctly computes the Choi matrix."""
     n_qubits = cirq.num_qubits(channel)
-    actual = cirq.choi(channel)
+    actual = cirq.operation_to_choi(channel)
     expected = expected_choi(channel)
     assert np.isclose(np.trace(actual), 2 ** n_qubits)
     assert np.all(actual == expected)
@@ -90,4 +90,4 @@ def test_choi(channel):
 
 def test_choi_on_completely_dephasing_channel():
     """Checks that cirq.choi returns the right matrix for the completely dephasing channel."""
-    assert np.all(cirq.choi(cirq.phase_damp(1)) == np.diag([1, 0, 0, 1]))
+    assert np.all(cirq.operation_to_choi(cirq.phase_damp(1)) == np.diag([1, 0, 0, 1]))

--- a/cirq-core/cirq/qis/channels_test.py
+++ b/cirq-core/cirq/qis/channels_test.py
@@ -1,0 +1,66 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for channels."""
+import numpy as np
+import pytest
+
+import cirq
+
+
+def apply_channel(channel: cirq.SupportsChannel, rho: np.ndarray) -> np.ndarray:
+    ks = cirq.channel(channel)
+    d_out, d_in = ks[0].shape
+    assert rho.shape == (d_in, d_in)
+    out = np.zeros((d_out, d_out), dtype=np.complex128)
+    for k in ks:
+        out += k @ rho @ k.conj().T
+    return out
+
+
+def expected_choi(channel: cirq.SupportsChannel) -> np.ndarray:
+    ks = cirq.channel(channel)
+    d_out, d_in = ks[0].shape
+    d = d_in * d_out
+    c = np.zeros((d, d), dtype=np.complex128)
+    for i in range(d_in):
+        for j in range(d_in):
+            e_ij = np.zeros((d_in, d_in))
+            e_ij[i, j] = 1
+            c += np.kron(apply_channel(channel, e_ij), e_ij)
+    return c
+
+
+@pytest.mark.parametrize(
+    'channel',
+    (
+        cirq.I,
+        cirq.X,
+        cirq.CNOT,
+        cirq.depolarize(0.1),
+        cirq.depolarize(0.1, n_qubits=2),
+        cirq.amplitude_damp(0.2),
+    ),
+)
+def test_choi(channel):
+    """Verifies that cirq.choi correctly computes the Choi matrix."""
+    n_qubits = cirq.num_qubits(channel)
+    actual = cirq.choi(channel)
+    expected = expected_choi(channel)
+    assert np.isclose(np.trace(actual), 2 ** n_qubits)
+    assert np.all(actual == expected)
+
+
+def test_choi_on_completely_dephasing_channel():
+    """Checks that cirq.choi returns the right matrix for the completely dephasing channel."""
+    assert np.all(cirq.choi(cirq.phase_damp(1)) == np.diag([1, 0, 0, 1]))


### PR DESCRIPTION
This implements a simple utility for computing the Choi matrix of a channel from its Kraus representation.

Choi representation is more compact than Kraus representations and - unlike the Kraus representation - it is unique for every channel, so we can use this to e.g. compare channels.

The PR is a small step towards #3248. In particular, it does not introduce any new protocols. As discussed on the issue, we might at some point want a protocol to enable channel classes to implement something like `__choi__` if there are cases where folks would prefer to specify channels using their Choi matrix rather than the Kraus operators. If we end up doing this, I suppose the protocol will use the utility in this PR to handle channels that provide Kraus operators.