### PR TITLE
[WIP] Demo for measuring selected op in channels

### DIFF
--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -213,6 +213,9 @@ def _strat_act_on_state_vector_from_mixture(action: Any, args: 'cirq.ActOnStateV
     unitary = unitaries[index].astype(args.target_tensor.dtype).reshape(shape)
     linalg.targeted_left_multiply(unitary, args.target_tensor, args.axes, out=args.available_buffer)
     args.swap_target_tensor_for(args.available_buffer)
+    if protocols.is_measurement(action):
+        key = protocols.measurement_key(action)
+        args.log_of_measurement_results[key] = [index]
     return True
 
 
@@ -234,13 +237,13 @@ def _strat_act_on_state_vector_from_channel(action: Any, args: 'cirq.ActOnStateV
     p = args.prng.random()
     weight = None
     fallback_weight = 0
-    fallback_weight_i = 0
-    for i in range(len(kraus_tensors)):
-        prepare_into_buffer(i)
+    fallback_weight_index = 0
+    for index in range(len(kraus_tensors)):
+        prepare_into_buffer(index)
         weight = np.linalg.norm(args.available_buffer) ** 2
 
         if weight > fallback_weight:
-            fallback_weight_i = i
+            fallback_weight_index = index
             fallback_weight = weight
 
         p -= weight
@@ -251,9 +254,13 @@ def _strat_act_on_state_vector_from_channel(action: Any, args: 'cirq.ActOnStateV
     if p >= 0 or weight == 0:
         # Floating point error resulted in a malformed sample.
         # Fall back to the most likely case.
-        prepare_into_buffer(fallback_weight_i)
+        prepare_into_buffer(fallback_weight_index)
         weight = fallback_weight
+        index = fallback_weight_index
 
     args.available_buffer /= np.sqrt(weight)
     args.swap_target_tensor_for(args.available_buffer)
+    if protocols.is_measurement(action):
+        key = protocols.measurement_key(action)
+        args.log_of_measurement_results[key] = [index]
     return True


### PR DESCRIPTION
This minor change enables most of the functionality requested in #3241, and includes a demonstration of how to implement it.

Notes:
- Other ActOnArgs are not affected, as CH form and Clifford do not support channels and density matrices do not "select" operators (they apply all operators simultaneously).
- A proper treatment of this will likely require a full-fledged class for Channels (Measured or not), since expecting users to implement their own channel every time is a recipe for toil and errors.