### PR TITLE
Consistent parameter indentation in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ circuits and running them against quantum computers and simulators.
   :alt: Build Status
 
 .. image:: https://badge.fury.io/py/cirq.svg
-    :target: https://badge.fury.io/py/cirq
+  :target: https://badge.fury.io/py/cirq
 
 .. image:: https://readthedocs.org/projects/cirq/badge/?version=latest
-    :target: https://readthedocs.org/projects/cirq/versions/
-    :alt: Documentation Status
+  :target: https://readthedocs.org/projects/cirq/versions/
+  :alt: Documentation Status
 
 
 Installation and Documentation


### PR DESCRIPTION
The reStructured Text parameters for image directives are indented inconsistently in README.rst. All directives (`image` and `code-block`) aside from two cases have indentation of two spaces. The inconsistent cases currently have four spaces. This PR applies consistent two space indentation.