### PR TITLE
Fix contrib-requirements

### DIFF
--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -46,7 +46,7 @@ if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
-contrib_requirements = open('cirq/contrib/contrib-requirements.txt').readlines()
+contrib_requirements = open('cirq/contrib/requirements.txt').readlines()
 contrib_requirements = [r.strip() for r in contrib_requirements]
 
 


### PR DESCRIPTION
cirq-core/setup.py was referring to the old version of contrib requirements.
This currently causes the cirq pre-release job to fail. 

Fixes https://github.com/quantumlib/Cirq/issues/4154. 