### PR TITLE
Update cirq_google to import from cirq directly

### DIFF
--- a/cirq-google/cirq_google/api/v1/params.py
+++ b/cirq-google/cirq_google/api/v1/params.py
@@ -13,50 +13,51 @@
 # limitations under the License.
 from typing import cast
 
-from cirq_google.api.v1 import params_pb2
+import cirq
 from cirq.study import sweeps
+from cirq_google.api.v1 import params_pb2
 
 
-def sweep_to_proto(sweep: sweeps.Sweep, repetitions: int = 1) -> params_pb2.ParameterSweep:
+def sweep_to_proto(sweep: cirq.Sweep, repetitions: int = 1) -> params_pb2.ParameterSweep:
     """Converts sweep into an equivalent protobuf representation."""
     product_sweep = None
-    if not sweep == sweeps.UnitSweep:
+    if sweep != cirq.UnitSweep:
         sweep = _to_zip_product(sweep)
         product_sweep = params_pb2.ProductSweep(
-            factors=[_sweep_zip_to_proto(cast(sweeps.Zip, factor)) for factor in sweep.factors]
+            factors=[_sweep_zip_to_proto(cast(cirq.Zip, factor)) for factor in sweep.factors]
         )
     msg = params_pb2.ParameterSweep(repetitions=repetitions, sweep=product_sweep)
     return msg
 
 
-def _to_zip_product(sweep: sweeps.Sweep) -> sweeps.Product:
+def _to_zip_product(sweep: cirq.Sweep) -> cirq.Product:
     """Converts sweep to a product of zips of single sweeps, if possible."""
-    if not isinstance(sweep, sweeps.Product):
-        sweep = sweeps.Product(sweep)
-    if not all(isinstance(f, sweeps.Zip) for f in sweep.factors):
-        factors = [f if isinstance(f, sweeps.Zip) else sweeps.Zip(f) for f in sweep.factors]
-        sweep = sweeps.Product(*factors)
+    if not isinstance(sweep, cirq.Product):
+        sweep = cirq.Product(sweep)
+    if not all(isinstance(f, cirq.Zip) for f in sweep.factors):
+        factors = [f if isinstance(f, cirq.Zip) else cirq.Zip(f) for f in sweep.factors]
+        sweep = cirq.Product(*factors)
     for factor in sweep.factors:
-        for term in cast(sweeps.Zip, factor).sweeps:
+        for term in cast(cirq.Zip, factor).sweeps:
             if not isinstance(term, sweeps.SingleSweep):
                 raise ValueError(f'cannot convert to zip-product form: {sweep}')
     return sweep
 
 
-def _sweep_zip_to_proto(sweep: sweeps.Zip) -> params_pb2.ZipSweep:
+def _sweep_zip_to_proto(sweep: cirq.Zip) -> params_pb2.ZipSweep:
     sweep_list = [_single_param_sweep_to_proto(cast(sweeps.SingleSweep, s)) for s in sweep.sweeps]
     return params_pb2.ZipSweep(sweeps=sweep_list)
 
 
 def _single_param_sweep_to_proto(sweep: sweeps.SingleSweep) -> params_pb2.SingleSweep:
-    if isinstance(sweep, sweeps.Linspace):
+    if isinstance(sweep, cirq.Linspace):
         return params_pb2.SingleSweep(
             parameter_key=sweep.key,
             linspace=params_pb2.Linspace(
                 first_point=sweep.start, last_point=sweep.stop, num_points=sweep.length
             ),
         )
-    elif isinstance(sweep, sweeps.Points):
+    elif isinstance(sweep, cirq.Points):
         return params_pb2.SingleSweep(
             parameter_key=sweep.key, points=params_pb2.Points(points=sweep.points)
         )
@@ -64,31 +65,31 @@ def _single_param_sweep_to_proto(sweep: sweeps.SingleSweep) -> params_pb2.Single
         raise ValueError(f'invalid single-parameter sweep: {sweep}')
 
 
-def sweep_from_proto(param_sweep: params_pb2.ParameterSweep) -> sweeps.Sweep:
+def sweep_from_proto(param_sweep: params_pb2.ParameterSweep) -> cirq.Sweep:
     if param_sweep.HasField('sweep') and len(param_sweep.sweep.factors) > 0:
-        return sweeps.Product(
+        return cirq.Product(
             *[_sweep_from_param_sweep_zip_proto(f) for f in param_sweep.sweep.factors]
         )
-    return sweeps.UnitSweep
+    return cirq.UnitSweep
 
 
-def _sweep_from_param_sweep_zip_proto(param_sweep_zip: params_pb2.ZipSweep) -> sweeps.Sweep:
+def _sweep_from_param_sweep_zip_proto(param_sweep_zip: params_pb2.ZipSweep) -> cirq.Sweep:
     if len(param_sweep_zip.sweeps) > 0:
-        return sweeps.Zip(
+        return cirq.Zip(
             *[_sweep_from_single_param_sweep_proto(sweep) for sweep in param_sweep_zip.sweeps]
         )
-    return sweeps.UnitSweep
+    return cirq.UnitSweep
 
 
 def _sweep_from_single_param_sweep_proto(
     single_param_sweep: params_pb2.SingleSweep,
-) -> sweeps.Sweep:
+) -> cirq.Sweep:
     key = single_param_sweep.parameter_key
     if single_param_sweep.HasField('points'):
         points = single_param_sweep.points
-        return sweeps.Points(key, list(points.points))
+        return cirq.Points(key, list(points.points))
     if single_param_sweep.HasField('linspace'):
         sl = single_param_sweep.linspace
-        return sweeps.Linspace(key, sl.first_point, sl.last_point, sl.num_points)
+        return cirq.Linspace(key, sl.first_point, sl.last_point, sl.num_points)
 
     raise ValueError('Single param sweep type undefined')

--- a/cirq-google/cirq_google/api/v2/program.py
+++ b/cirq-google/cirq_google/api/v2/program.py
@@ -14,7 +14,7 @@
 import re
 from typing import TYPE_CHECKING
 
-from cirq import devices, ops
+import cirq
 
 if TYPE_CHECKING:
     import cirq
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 GRID_QUBIT_ID_PATTERN = r'^q?(-?\d+)_(-?\d+)$'
 
 
-def qubit_to_proto_id(q: 'cirq.Qid') -> str:
+def qubit_to_proto_id(q: cirq.Qid) -> str:
     """Return a proto id for a `cirq.Qid`.
 
     For `cirq.GridQubit`s this id `{row}_{col}` where `{row}` is the integer
@@ -32,17 +32,17 @@ def qubit_to_proto_id(q: 'cirq.Qid') -> str:
 
     For `cirq.LineQubit`s this is string of the `x` attribute.
     """
-    if isinstance(q, devices.GridQubit):
+    if isinstance(q, cirq.GridQubit):
         return f'{q.row}_{q.col}'
-    elif isinstance(q, ops.NamedQubit):
+    elif isinstance(q, cirq.NamedQubit):
         return q.name
-    elif isinstance(q, devices.LineQubit):
+    elif isinstance(q, cirq.LineQubit):
         return f'{q.x}'
     else:
         raise ValueError(f'Qubits of type {type(q)} do not support proto id')
 
 
-def qubit_from_proto_id(proto_id: str) -> 'cirq.Qid':
+def qubit_from_proto_id(proto_id: str) -> cirq.Qid:
     """Return a `cirq.Qid` for a proto id.
 
     Proto IDs of the form {int}_{int} are parsed as GridQubits.
@@ -78,7 +78,7 @@ def qubit_from_proto_id(proto_id: str) -> 'cirq.Qid':
     return named_q
 
 
-def grid_qubit_from_proto_id(proto_id: str) -> 'cirq.GridQubit':
+def grid_qubit_from_proto_id(proto_id: str) -> cirq.GridQubit:
     """Parse a proto id to a `cirq.GridQubit`.
 
     Proto ids for grid qubits are of the form `{row}_{col}` where `{row}` is
@@ -101,10 +101,10 @@ def grid_qubit_from_proto_id(proto_id: str) -> 'cirq.GridQubit':
             f'GridQubit proto id must be of the form [q]<int>_<int> but was {proto_id}'
         )
     row, col = match.groups()
-    return devices.GridQubit(row=int(row), col=int(col))
+    return cirq.GridQubit(row=int(row), col=int(col))
 
 
-def line_qubit_from_proto_id(proto_id: str) -> 'cirq.LineQubit':
+def line_qubit_from_proto_id(proto_id: str) -> cirq.LineQubit:
     """Parse a proto id to a `cirq.LineQubit`.
 
     Proto ids for line qubits are integer strings representing the `x`
@@ -120,14 +120,14 @@ def line_qubit_from_proto_id(proto_id: str) -> 'cirq.LineQubit':
         ValueError: If the string is not an integer.
     """
     try:
-        return devices.LineQubit(x=int(proto_id))
+        return cirq.LineQubit(x=int(proto_id))
     except ValueError:
         raise ValueError(f'Line qubit proto id must be an int but was {proto_id}')
 
 
-def named_qubit_from_proto_id(proto_id: str) -> 'cirq.NamedQubit':
+def named_qubit_from_proto_id(proto_id: str) -> cirq.NamedQubit:
     """Parse a proto id to a `cirq.NamedQubit'
 
     This simply returns a `cirq.NamedQubit` with a name equal to `proto_id`.
     """
-    return ops.NamedQubit(proto_id)
+    return cirq.NamedQubit(proto_id)

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -18,8 +18,8 @@ import pytest
 import sympy
 
 import cirq
-from cirq_google.api import v2
 from cirq.study import sweeps
+from cirq_google.api import v2
 
 
 class UnknownSweep(sweeps.SingleSweep):

--- a/cirq-google/cirq_google/calibration/engine_simulator.py
+++ b/cirq-google/cirq_google/calibration/engine_simulator.py
@@ -13,28 +13,8 @@ from typing import (
 
 import numpy as np
 
-from cirq.circuits import Circuit, PointOptimizer, PointOptimizationSummary
-from cirq.ops import (
-    FSimGate,
-    Gate,
-    MeasurementGate,
-    Operation,
-    PhasedFSimGate,
-    Qid,
-    QubitOrder,
-    QubitOrderOrList,
-    SingleQubitGate,
-    WaitGate,
-)
-from cirq.sim import (
-    ActOnStateVectorArgs,
-    SimulatesIntermediateStateVector,
-    Simulator,
-    SparseSimulatorStep,
-    StateVectorTrialResult,
-)
-from cirq.study import ParamResolverOrSimilarType, Result, Sweepable
-from cirq.value import RANDOM_STATE_OR_SEED_LIKE, parse_random_state
+import cirq
+from cirq import value
 from cirq_google.calibration.phased_fsim import (
     FloquetPhasedFSimCalibrationRequest,
     PhaseCalibratedFSimGate,
@@ -46,13 +26,13 @@ from cirq_google.calibration.phased_fsim import (
     try_convert_sqrt_iswap_to_fsim,
 )
 
-ParametersDriftGenerator = Callable[[Qid, Qid, FSimGate], PhasedFSimCharacterization]
+ParametersDriftGenerator = Callable[[cirq.Qid, cirq.Qid, cirq.FSimGate], PhasedFSimCharacterization]
 PhasedFsimDictParameters = Dict[
-    Tuple[Qid, Qid], Union[Dict[str, float], PhasedFSimCharacterization]
+    Tuple[cirq.Qid, cirq.Qid], Union[Dict[str, float], PhasedFSimCharacterization]
 ]
 
 
-class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulatorStep]):
+class PhasedFSimEngineSimulator(cirq.SimulatesIntermediateStateVector[cirq.SparseSimulatorStep]):
     """Wrapper on top of cirq.Simulator that allows to simulate calibration requests.
 
     This simulator introduces get_calibrations which allows to simulate
@@ -67,11 +47,11 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
 
     def __init__(
         self,
-        simulator: Simulator,
+        simulator: cirq.Simulator,
         *,
         drift_generator: ParametersDriftGenerator,
         gates_translator: Callable[
-            [Gate], Optional[PhaseCalibratedFSimGate]
+            [cirq.Gate], Optional[PhaseCalibratedFSimGate]
         ] = try_convert_sqrt_iswap_to_fsim,
     ) -> None:
         """Initializes the PhasedFSimEngineSimulator.
@@ -86,14 +66,16 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         super().__init__()
         self._simulator = simulator
         self._drift_generator = drift_generator
-        self._drifted_parameters: Dict[Tuple[Qid, Qid, FSimGate], PhasedFSimCharacterization] = {}
+        self._drifted_parameters: Dict[
+            Tuple[cirq.Qid, cirq.Qid, cirq.FSimGate], PhasedFSimCharacterization
+        ] = {}
         self.gates_translator = gates_translator
 
     @classmethod
     def create_with_ideal_sqrt_iswap(
         cls,
         *,
-        simulator: Optional[Simulator] = None,
+        simulator: Optional[cirq.Simulator] = None,
     ) -> 'PhasedFSimEngineSimulator':
         """Creates a PhasedFSimEngineSimulator that simulates ideal FSimGate(theta=π/4, phi=0).
 
@@ -105,8 +87,10 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
             New PhasedFSimEngineSimulator instance.
         """
 
-        def sample_gate(_1: Qid, _2: Qid, gate: FSimGate) -> PhasedFSimCharacterization:
-            assert isinstance(gate, FSimGate), f'Expected FSimGate, got {gate}'
+        def sample_gate(
+            _1: cirq.Qid, _2: cirq.Qid, gate: cirq.FSimGate
+        ) -> PhasedFSimCharacterization:
+            assert isinstance(gate, cirq.FSimGate), f'Expected FSimGate, got {gate}'
             assert np.isclose(gate.theta, np.pi / 4) and np.isclose(
                 gate.phi, 0.0
             ), f'Expected ISWAP ** -0.5 like gate, got {gate}'
@@ -115,7 +99,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
             )
 
         if simulator is None:
-            simulator = Simulator()
+            simulator = cirq.Simulator()
 
         return cls(
             simulator, drift_generator=sample_gate, gates_translator=try_convert_sqrt_iswap_to_fsim
@@ -126,11 +110,11 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         cls,
         mean: PhasedFSimCharacterization = SQRT_ISWAP_INV_PARAMETERS,
         *,
-        simulator: Optional[Simulator] = None,
+        simulator: Optional[cirq.Simulator] = None,
         sigma: PhasedFSimCharacterization = PhasedFSimCharacterization(
             theta=0.02, zeta=0.05, chi=0.05, gamma=0.05, phi=0.02
         ),
-        random_or_seed: RANDOM_STATE_OR_SEED_LIKE = None,
+        random_or_seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ) -> 'PhasedFSimEngineSimulator':
         """Creates a PhasedFSimEngineSimulator that introduces a random deviation from the mean.
 
@@ -154,7 +138,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         if mean.any_none():
             raise ValueError(f'All mean values must be provided, got mean of {mean}')
 
-        rand = parse_random_state(random_or_seed)
+        rand = value.parse_random_state(random_or_seed)
 
         def sample_value(gaussian_mean: Optional[float], gaussian_sigma: Optional[float]) -> float:
             assert gaussian_mean is not None
@@ -162,8 +146,10 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
                 return gaussian_mean
             return rand.normal(gaussian_mean, gaussian_sigma)
 
-        def sample_gate(_1: Qid, _2: Qid, gate: FSimGate) -> PhasedFSimCharacterization:
-            assert isinstance(gate, FSimGate), f'Expected FSimGate, got {gate}'
+        def sample_gate(
+            _1: cirq.Qid, _2: cirq.Qid, gate: cirq.FSimGate
+        ) -> PhasedFSimCharacterization:
+            assert isinstance(gate, cirq.FSimGate), f'Expected FSimGate, got {gate}'
             assert np.isclose(gate.theta, np.pi / 4) and np.isclose(
                 gate.phi, 0.0
             ), f'Expected ISWAP ** -0.5 like gate, got {gate}'
@@ -177,7 +163,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
             )
 
         if simulator is None:
-            simulator = Simulator()
+            simulator = cirq.Simulator()
 
         return cls(
             simulator, drift_generator=sample_gate, gates_translator=try_convert_sqrt_iswap_to_fsim
@@ -188,7 +174,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         cls,
         parameters: PhasedFsimDictParameters,
         *,
-        simulator: Optional[Simulator] = None,
+        simulator: Optional[cirq.Simulator] = None,
         ideal_when_missing_gate: bool = False,
         ideal_when_missing_parameter: bool = False,
     ) -> 'PhasedFSimEngineSimulator':
@@ -212,8 +198,10 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
             New PhasedFSimEngineSimulator instance.
         """
 
-        def sample_gate(a: Qid, b: Qid, gate: FSimGate) -> PhasedFSimCharacterization:
-            assert isinstance(gate, FSimGate), f'Expected FSimGate, got {gate}'
+        def sample_gate(
+            a: cirq.Qid, b: cirq.Qid, gate: cirq.FSimGate
+        ) -> PhasedFSimCharacterization:
+            assert isinstance(gate, cirq.FSimGate), f'Expected FSimGate, got {gate}'
             assert np.isclose(gate.theta, np.pi / 4) and np.isclose(
                 gate.phi, 0.0
             ), f'Expected ISWAP ** -0.5 like gate, got {gate}'
@@ -250,7 +238,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
                 )
 
         if simulator is None:
-            simulator = Simulator()
+            simulator = cirq.Simulator()
 
         return cls(
             simulator, drift_generator=sample_gate, gates_translator=try_convert_sqrt_iswap_to_fsim
@@ -261,7 +249,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         cls,
         characterizations: Iterable[PhasedFSimCalibrationResult],
         *,
-        simulator: Optional[Simulator] = None,
+        simulator: Optional[cirq.Simulator] = None,
         ideal_when_missing_gate: bool = False,
         ideal_when_missing_parameter: bool = False,
     ) -> 'PhasedFSimEngineSimulator':
@@ -289,7 +277,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         for characterization in characterizations:
             gate = characterization.gate
             if (
-                not isinstance(gate, FSimGate)
+                not isinstance(gate, cirq.FSimGate)
                 or not np.isclose(gate.theta, np.pi / 4)
                 or not np.isclose(gate.phi, 0.0)
             ):
@@ -307,7 +295,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
                 parameters[(a, b)] = pair_parameters
 
         if simulator is None:
-            simulator = Simulator()
+            simulator = cirq.Simulator()
 
         return cls.create_from_dictionary_sqrt_iswap(
             parameters,
@@ -316,7 +304,7 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
             ideal_when_missing_parameter=ideal_when_missing_parameter,
         )
 
-    def final_state_vector(self, program: Circuit) -> np.array:
+    def final_state_vector(self, program: cirq.Circuit) -> np.array:
         result = self.simulate(program)
         return result.state_vector()
 
@@ -367,8 +355,8 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
         return results
 
     def create_gate_with_drift(
-        self, a: Qid, b: Qid, gate_calibration: PhaseCalibratedFSimGate
-    ) -> PhasedFSimGate:
+        self, a: cirq.Qid, b: cirq.Qid, gate_calibration: PhaseCalibratedFSimGate
+    ) -> cirq.PhasedFSimGate:
         """Generates a gate with drift for a given gate.
 
         Args:
@@ -392,50 +380,50 @@ class PhasedFSimEngineSimulator(SimulatesIntermediateStateVector[SparseSimulator
 
     def run_sweep_iter(
         self,
-        program: Circuit,
-        params: Sweepable,
+        program: cirq.Circuit,
+        params: cirq.Sweepable,
         repetitions: int = 1,
-    ) -> Iterator[Result]:
+    ) -> Iterator[cirq.Result]:
         converted = _convert_to_circuit_with_drift(self, program)
         yield from self._simulator.run_sweep_iter(converted, params, repetitions)
 
     def simulate(
         self,
-        program: Circuit,
-        param_resolver: ParamResolverOrSimilarType = None,
-        qubit_order: QubitOrderOrList = QubitOrder.DEFAULT,
+        program: cirq.Circuit,
+        param_resolver: cirq.ParamResolverOrSimilarType = None,
+        qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
         initial_state: Any = None,
-    ) -> StateVectorTrialResult:
+    ) -> cirq.StateVectorTrialResult:
         converted = _convert_to_circuit_with_drift(self, program)
         return self._simulator.simulate(converted, param_resolver, qubit_order, initial_state)
 
     def _create_act_on_args(
         self,
-        initial_state: Union[int, ActOnStateVectorArgs],
-        qubits: Sequence[Qid],
-    ) -> ActOnStateVectorArgs:
+        initial_state: Union[int, cirq.ActOnStateVectorArgs],
+        qubits: Sequence[cirq.Qid],
+    ) -> cirq.ActOnStateVectorArgs:
         # Needs an implementation since it's abstract but will never actually be called.
         raise NotImplementedError()
 
     def _create_step_result(
         self,
-        sim_state: ActOnStateVectorArgs,
-        qubit_map: Dict[Qid, int],
-    ) -> SparseSimulatorStep:
+        sim_state: cirq.ActOnStateVectorArgs,
+        qubit_map: Dict[cirq.Qid, int],
+    ) -> cirq.SparseSimulatorStep:
         # Needs an implementation since it's abstract but will never actually be called.
         raise NotImplementedError()
 
 
-class _PhasedFSimConverter(PointOptimizer):
+class _PhasedFSimConverter(cirq.PointOptimizer):
     def __init__(self, simulator: PhasedFSimEngineSimulator) -> None:
         super().__init__()
         self._simulator = simulator
 
     def optimization_at(
-        self, circuit: Circuit, index: int, op: Operation
-    ) -> Optional[PointOptimizationSummary]:
+        self, circuit: cirq.Circuit, index: int, op: cirq.Operation
+    ) -> Optional[cirq.PointOptimizationSummary]:
 
-        if isinstance(op.gate, (MeasurementGate, SingleQubitGate, WaitGate)):
+        if isinstance(op.gate, (cirq.MeasurementGate, cirq.SingleQubitGate, cirq.WaitGate)):
             new_op = op
         else:
             if op.gate is None:
@@ -449,13 +437,15 @@ class _PhasedFSimConverter(PointOptimizer):
             a, b = op.qubits
             new_op = self._simulator.create_gate_with_drift(a, b, translated).on(a, b)
 
-        return PointOptimizationSummary(clear_span=1, clear_qubits=op.qubits, new_operations=new_op)
+        return cirq.PointOptimizationSummary(
+            clear_span=1, clear_qubits=op.qubits, new_operations=new_op
+        )
 
 
 def _convert_to_circuit_with_drift(
-    simulator: PhasedFSimEngineSimulator, circuit: Circuit
-) -> Circuit:
-    circuit_with_drift = Circuit(circuit)
+    simulator: PhasedFSimEngineSimulator, circuit: cirq.Circuit
+) -> cirq.Circuit:
+    circuit_with_drift = cirq.Circuit(circuit)
     converter = _PhasedFSimConverter(simulator)
     converter.optimize_circuit(circuit_with_drift)
     return circuit_with_drift

--- a/cirq-google/cirq_google/calibration/workflow.py
+++ b/cirq-google/cirq_google/calibration/workflow.py
@@ -24,23 +24,10 @@ from typing import (
     Tuple,
     Union,
     cast,
-    TYPE_CHECKING,
 )
 
-from cirq.circuits import Circuit
+import cirq
 from cirq.experiments import HALF_GRID_STAGGERED_PATTERN
-from cirq.ops import (
-    FSimGate,
-    Gate,
-    GateOperation,
-    MeasurementGate,
-    Moment,
-    Operation,
-    Qid,
-    SingleQubitGate,
-    WaitGate,
-)
-from cirq.work import Sampler
 from cirq_google.calibration.engine_simulator import PhasedFSimEngineSimulator
 from cirq_google.calibration.phased_fsim import (
     FloquetPhasedFSimCalibrationOptions,
@@ -62,10 +49,7 @@ from cirq_google.calibration.xeb_wrapper import run_local_xeb_calibration
 from cirq_google.engine import Engine, QuantumEngineSampler
 from cirq_google.serializable_gate_set import SerializableGateSet
 
-if TYPE_CHECKING:
-    import cirq
-
-_CALIBRATION_IRRELEVANT_GATES = MeasurementGate, SingleQubitGate, WaitGate
+_CALIBRATION_IRRELEVANT_GATES = cirq.MeasurementGate, cirq.SingleQubitGate, cirq.WaitGate
 
 
 @dataclasses.dataclass(frozen=True)
@@ -78,16 +62,16 @@ class CircuitWithCalibration:
             request or response. None means that there is no characterization data for that moment.
     """
 
-    circuit: Circuit
+    circuit: cirq.Circuit
     moment_to_calibration: Sequence[Optional[int]]
 
 
 def prepare_characterization_for_moment(
-    moment: Moment,
+    moment: cirq.Moment,
     options: PhasedFSimCalibrationOptions[RequestT],
     *,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     canonicalize_pairs: bool = False,
     sort_pairs: bool = False,
@@ -125,10 +109,10 @@ def prepare_characterization_for_moment(
 
 
 def prepare_floquet_characterization_for_moment(
-    moment: Moment,
+    moment: cirq.Moment,
     options: FloquetPhasedFSimCalibrationOptions,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     canonicalize_pairs: bool = False,
     sort_pairs: bool = False,
@@ -163,11 +147,11 @@ def prepare_floquet_characterization_for_moment(
 
 
 def _list_moment_pairs_to_characterize(
-    moment: Moment,
-    gates_translator: Callable[[Gate], Optional[PhaseCalibratedFSimGate]],
+    moment: cirq.Moment,
+    gates_translator: Callable[[cirq.Gate], Optional[PhaseCalibratedFSimGate]],
     canonicalize_pairs: bool,
     permit_mixed_moments: bool,
-) -> Optional[Tuple[List[Tuple[Qid, Qid]], Gate]]:
+) -> Optional[Tuple[List[Tuple[cirq.Qid, cirq.Qid]], cirq.Gate]]:
     """Helper function to describe a given moment in terms of a characterization request.
 
     Args:
@@ -188,11 +172,11 @@ def _list_moment_pairs_to_characterize(
         by gates_translator, or it mixes a single qubit and two qubit gates.
     """
     other_operation = False
-    gate: Optional[FSimGate] = None
+    gate: Optional[cirq.FSimGate] = None
     pairs = []
 
     for op in moment:
-        if not isinstance(op, GateOperation):
+        if not isinstance(op, cirq.GateOperation):
             raise IncompatibleMomentError('Moment contains operation different than GateOperation')
 
         if isinstance(op.gate, _CALIBRATION_IRRELEVANT_GATES):
@@ -213,7 +197,8 @@ def _list_moment_pairs_to_characterize(
                 gate = translated.engine_gate
 
             pair = cast(
-                Tuple[Qid, Qid], tuple(sorted(op.qubits) if canonicalize_pairs else op.qubits)
+                Tuple[cirq.Qid, cirq.Qid],
+                tuple(sorted(op.qubits) if canonicalize_pairs else op.qubits),
             )
             pairs.append(pair)
 
@@ -230,11 +215,11 @@ def _list_moment_pairs_to_characterize(
 
 
 def prepare_characterization_for_moments(
-    circuit: Circuit,
+    circuit: cirq.Circuit,
     options: PhasedFSimCalibrationOptions[RequestT],
     *,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     merge_subsets: bool = True,
     initial: Optional[Sequence[RequestT]] = None,
@@ -304,11 +289,11 @@ def prepare_characterization_for_moments(
 
 
 def prepare_characterization_for_circuits_moments(
-    circuits: List[Circuit],
+    circuits: List[cirq.Circuit],
     options: PhasedFSimCalibrationOptions[RequestT],
     *,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     merge_subsets: bool = True,
     initial: Optional[Sequence[RequestT]] = None,
@@ -366,10 +351,10 @@ def prepare_characterization_for_circuits_moments(
 
 
 def prepare_floquet_characterization_for_moments(
-    circuit: Circuit,
+    circuit: cirq.Circuit,
     options: FloquetPhasedFSimCalibrationOptions = WITHOUT_CHI_FLOQUET_PHASED_FSIM_CHARACTERIZATION,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     merge_subsets: bool = True,
     initial: Optional[Sequence[FloquetPhasedFSimCalibrationRequest]] = None,
@@ -425,11 +410,11 @@ def prepare_floquet_characterization_for_moments(
 
 
 def prepare_characterization_for_operations(
-    circuit: Union[Circuit, Iterable[Circuit]],
+    circuit: Union[cirq.Circuit, Iterable[cirq.Circuit]],
     options: PhasedFSimCalibrationOptions[RequestT],
     *,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     permit_mixed_moments: bool = False,
 ) -> List[RequestT]:
@@ -468,7 +453,7 @@ def prepare_characterization_for_operations(
         operations matched by gates_translator, or it mixes a single qubit and two qubit gates.
     """
 
-    circuits = [circuit] if isinstance(circuit, Circuit) else circuit
+    circuits = [circuit] if isinstance(circuit, cirq.Circuit) else circuit
     pairs, gate = _extract_all_pairs_to_characterize(
         circuits, gates_translator, permit_mixed_moments
     )
@@ -491,10 +476,10 @@ def prepare_characterization_for_operations(
 
 
 def prepare_floquet_characterization_for_operations(
-    circuit: Union[Circuit, Iterable[Circuit]],
+    circuit: Union[cirq.Circuit, Iterable[cirq.Circuit]],
     options: FloquetPhasedFSimCalibrationOptions = WITHOUT_CHI_FLOQUET_PHASED_FSIM_CHARACTERIZATION,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     permit_mixed_moments: bool = False,
 ) -> List[FloquetPhasedFSimCalibrationRequest]:
@@ -542,10 +527,10 @@ def prepare_floquet_characterization_for_operations(
 
 
 def _extract_all_pairs_to_characterize(
-    circuits: Iterable[Circuit],
-    gates_translator: Callable[[Gate], Optional[PhaseCalibratedFSimGate]],
+    circuits: Iterable[cirq.Circuit],
+    gates_translator: Callable[[cirq.Gate], Optional[PhaseCalibratedFSimGate]],
     permit_mixed_moments: bool,
-) -> Tuple[Set[Tuple[Qid, Qid]], Optional[Gate]]:
+) -> Tuple[Set[Tuple[cirq.Qid, cirq.Qid]], Optional[cirq.Gate]]:
     """Extracts the set of all two-qubit operations from the circuits.
 
     Args:
@@ -590,7 +575,7 @@ def _extract_all_pairs_to_characterize(
 def _append_into_calibrations_if_missing(
     calibration: RequestT,
     calibrations: List[RequestT],
-    pairs_map: Dict[Tuple[Tuple[Qid, Qid], ...], int],
+    pairs_map: Dict[Tuple[Tuple[cirq.Qid, cirq.Qid], ...], int],
 ) -> int:
     """Adds calibration to the calibrations list if not already present.
 
@@ -619,7 +604,7 @@ def _append_into_calibrations_if_missing(
 def _merge_into_calibrations(
     calibration: RequestT,
     calibrations: List[RequestT],
-    pairs_map: Dict[Tuple[Tuple[Qid, Qid], ...], int],
+    pairs_map: Dict[Tuple[Tuple[cirq.Qid, cirq.Qid], ...], int],
     options: PhasedFSimCalibrationOptions[RequestT],
 ) -> int:
     """Merges a calibration into list of calibrations.
@@ -707,7 +692,7 @@ def _run_calibrations_via_engine(
 
 def _run_local_calibrations_via_sampler(
     calibration_requests: Sequence[PhasedFSimCalibrationRequest],
-    sampler: 'cirq.Sampler',
+    sampler: cirq.Sampler,
 ):
     """Helper function used by `run_calibrations` to run Local calibrations with a Sampler."""
     return [
@@ -720,7 +705,7 @@ def _run_local_calibrations_via_sampler(
 
 def run_calibrations(
     calibrations: Sequence[PhasedFSimCalibrationRequest],
-    sampler: Union[Engine, Sampler],
+    sampler: Union[Engine, cirq.Sampler],
     processor_id: Optional[str] = None,
     gate_set: Optional[SerializableGateSet] = None,
     max_layers_per_request: int = 1,
@@ -792,7 +777,9 @@ def run_calibrations(
         )
 
     if calibration_request_type == LocalXEBPhasedFSimCalibrationRequest:
-        return _run_local_calibrations_via_sampler(calibrations, sampler=cast(Sampler, sampler))
+        return _run_local_calibrations_via_sampler(
+            calibrations, sampler=cast(cirq.Sampler, sampler)
+        )
 
     if isinstance(sampler, PhasedFSimEngineSimulator):
         return sampler.get_calibrations(calibrations)
@@ -807,7 +794,7 @@ def make_zeta_chi_gamma_compensation_for_moments(
     circuit_with_calibration: CircuitWithCalibration,
     characterizations: List[PhasedFSimCalibrationResult],
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
 ) -> CircuitWithCalibration:
     """Compensates circuit moments against errors in zeta, chi and gamma angles.
@@ -840,13 +827,13 @@ def make_zeta_chi_gamma_compensation_for_moments(
 
 
 def make_zeta_chi_gamma_compensation_for_operations(
-    circuit: Circuit,
+    circuit: cirq.Circuit,
     characterizations: List[PhasedFSimCalibrationResult],
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     permit_mixed_moments: bool = False,
-) -> Circuit:
+) -> cirq.Circuit:
     """Compensates circuit operations against errors in zeta, chi and gamma angles.
 
     This method creates a new circuit with a single-qubit Z gates added in a such way so that
@@ -895,7 +882,7 @@ def make_zeta_chi_gamma_compensation_for_operations(
 def _make_zeta_chi_gamma_compensation(
     circuit_with_calibration: CircuitWithCalibration,
     characterizations: List[PhasedFSimCalibrationResult],
-    gates_translator: Callable[[Gate], Optional[PhaseCalibratedFSimGate]],
+    gates_translator: Callable[[cirq.Gate], Optional[PhaseCalibratedFSimGate]],
     permit_mixed_moments: bool,
 ) -> CircuitWithCalibration:
 
@@ -907,7 +894,7 @@ def _make_zeta_chi_gamma_compensation(
 
     default_phases = PhasedFSimCharacterization(zeta=0.0, chi=0.0, gamma=0.0)
 
-    compensated = Circuit()
+    compensated = cirq.Circuit()
     compensated_moment_to_calibration: List[Optional[int]] = []
     for moment, characterization_index in zip(
         circuit_with_calibration.circuit, circuit_with_calibration.moment_to_calibration
@@ -916,11 +903,11 @@ def _make_zeta_chi_gamma_compensation(
         if characterization_index is not None:
             parameters = characterizations[characterization_index]
 
-        decompositions: List[Tuple[Tuple[Operation, ...], ...]] = []
-        other: List[Operation] = []
+        decompositions: List[Tuple[Tuple[cirq.Operation, ...], ...]] = []
+        other: List[cirq.Operation] = []
         new_moment_moment_to_calibration: Optional[List[Optional[int]]] = None
         for op in moment:
-            if not isinstance(op, GateOperation):
+            if not isinstance(op, cirq.GateOperation):
                 raise IncompatibleMomentError(
                     'Moment contains operation different than GateOperation'
                 )
@@ -962,11 +949,11 @@ def _make_zeta_chi_gamma_compensation(
         if other and decompositions:
             raise IncompatibleMomentError(f'Moment {moment} contains mixed operations')
         elif other:
-            compensated += Moment(other)
+            compensated += cirq.Moment(other)
             compensated_moment_to_calibration.append(characterization_index)
         elif decompositions:
             for operations in itertools.zip_longest(*decompositions, fillvalue=()):
-                compensated += Moment(operations)
+                compensated += cirq.Moment(operations)
             assert new_moment_moment_to_calibration is not None  # Required for mypy
             compensated_moment_to_calibration += new_moment_moment_to_calibration
 
@@ -984,13 +971,13 @@ class FSimPhaseCorrections:
             composed operation.
     """
 
-    operations: Tuple[Tuple[Operation, ...], ...]
+    operations: Tuple[Tuple[cirq.Operation, ...], ...]
     moment_to_calibration: List[Optional[int]]
 
     @classmethod
     def from_characterization(
         cls,
-        qubits: Tuple[Qid, Qid],
+        qubits: Tuple[cirq.Qid, cirq.Qid],
         gate_calibration: PhaseCalibratedFSimGate,
         parameters: PhasedFSimCharacterization,
         characterization_index: Optional[int],
@@ -1010,18 +997,18 @@ class FSimPhaseCorrections:
 
         return cls(operations, moment_to_calibration)
 
-    def as_circuit(self) -> Circuit:
-        return Circuit(self.operations)
+    def as_circuit(self) -> cirq.Circuit:
+        return cirq.Circuit(self.operations)
 
 
 def run_floquet_characterization_for_moments(
-    circuit: Circuit,
-    sampler: Union[Engine, Sampler],
+    circuit: cirq.Circuit,
+    sampler: Union[Engine, cirq.Sampler],
     processor_id: Optional[str] = None,
     gate_set: Optional[SerializableGateSet] = None,
     options: FloquetPhasedFSimCalibrationOptions = WITHOUT_CHI_FLOQUET_PHASED_FSIM_CHARACTERIZATION,
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     merge_subsets: bool = True,
     max_layers_per_request: int = 1,
@@ -1079,15 +1066,15 @@ def run_floquet_characterization_for_moments(
 
 
 def run_zeta_chi_gamma_compensation_for_moments(
-    circuit: Circuit,
-    sampler: Union[Engine, Sampler],
+    circuit: cirq.Circuit,
+    sampler: Union[Engine, cirq.Sampler],
     processor_id: Optional[str] = None,
     gate_set: Optional[SerializableGateSet] = None,
     options: FloquetPhasedFSimCalibrationOptions = (
         THETA_ZETA_GAMMA_FLOQUET_PHASED_FSIM_CHARACTERIZATION
     ),
     gates_translator: Callable[
-        [Gate], Optional[PhaseCalibratedFSimGate]
+        [cirq.Gate], Optional[PhaseCalibratedFSimGate]
     ] = try_convert_sqrt_iswap_to_fsim,
     merge_subsets: bool = True,
     max_layers_per_request: int = 1,

--- a/cirq-google/cirq_google/calibration/workflow_test.py
+++ b/cirq-google/cirq_google/calibration/workflow_test.py
@@ -1407,7 +1407,7 @@ def test_run_local(sampler_engine, monkeypatch):
 
     def myfunc(
         calibration: LocalXEBPhasedFSimCalibrationRequest,
-        sampler: 'cirq.Sampler',
+        sampler: cirq.Sampler,
     ):
         nonlocal called_times
         assert isinstance(calibration, LocalXEBPhasedFSimCalibrationRequest)

--- a/cirq-google/cirq_google/calibration/xeb_wrapper.py
+++ b/cirq-google/cirq_google/calibration/xeb_wrapper.py
@@ -44,7 +44,7 @@ def _maybe_multiprocessing_pool(
 
 def run_local_xeb_calibration(
     calibration: LocalXEBPhasedFSimCalibrationRequest,
-    sampler: 'cirq.Sampler',
+    sampler: cirq.Sampler,
 ) -> PhasedFSimCalibrationResult:
     """Run a calibration request using `cirq.experiments` XEB utilities and a sampler rather
     than `Engine.run_calibrations`.

--- a/cirq-google/cirq_google/common_serializers.py
+++ b/cirq-google/cirq_google/common_serializers.py
@@ -27,7 +27,7 @@ from typing import cast, List, Union
 import numpy as np
 import sympy
 
-from cirq import ops, protocols, value
+import cirq
 from cirq_google import op_deserializer, op_serializer
 from cirq_google.api import v2
 from cirq_google.ops import PhysicalZTag
@@ -65,7 +65,7 @@ def _near_mod_2(e, t, atol=_DEFAULT_ATOL):
     return _near_mod_n(e, t, n=2, atol=atol)
 
 
-def _convert_physical_z(op: ops.Operation, proto: v2.program_pb2.Operation):
+def _convert_physical_z(op: cirq.Operation, proto: v2.program_pb2.Operation):
     if 'type' in proto.args:
         if proto.args['type'].arg_value.string_value == PHYSICAL_Z:
             return op.with_tags(PhysicalZTag())
@@ -83,7 +83,7 @@ def _convert_physical_z(op: ops.Operation, proto: v2.program_pb2.Operation):
 #
 SINGLE_QUBIT_SERIALIZERS = [
     op_serializer.GateOpSerializer(
-        gate_type=ops.PhasedXPowGate,
+        gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy',
         args=[
             op_serializer.SerializingArg(
@@ -99,7 +99,7 @@ SINGLE_QUBIT_SERIALIZERS = [
         ],
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.XPowGate,
+        gate_type=cirq.XPowGate,
         serialized_gate_id='xy',
         args=[
             op_serializer.SerializingArg(
@@ -115,7 +115,7 @@ SINGLE_QUBIT_SERIALIZERS = [
         ],
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.YPowGate,
+        gate_type=cirq.YPowGate,
         serialized_gate_id='xy',
         args=[
             op_serializer.SerializingArg(
@@ -131,7 +131,7 @@ SINGLE_QUBIT_SERIALIZERS = [
         ],
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.ZPowGate,
+        gate_type=cirq.ZPowGate,
         serialized_gate_id='z',
         args=[
             op_serializer.SerializingArg(
@@ -147,7 +147,7 @@ SINGLE_QUBIT_SERIALIZERS = [
         ],
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.PhasedXZGate,
+        gate_type=cirq.PhasedXZGate,
         serialized_gate_id='xyz',
         args=[
             op_serializer.SerializingArg(
@@ -175,7 +175,7 @@ SINGLE_QUBIT_SERIALIZERS = [
 SINGLE_QUBIT_DESERIALIZERS = [
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='xy',
-        gate_constructor=ops.PhasedXPowGate,
+        gate_constructor=cirq.PhasedXPowGate,
         args=[
             op_deserializer.DeserializingArg(
                 serialized_name='axis_half_turns',
@@ -191,7 +191,7 @@ SINGLE_QUBIT_DESERIALIZERS = [
     ),
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='z',
-        gate_constructor=ops.ZPowGate,
+        gate_constructor=cirq.ZPowGate,
         args=[
             op_deserializer.DeserializingArg(
                 serialized_name='half_turns',
@@ -203,7 +203,7 @@ SINGLE_QUBIT_DESERIALIZERS = [
     ),
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='xyz',
-        gate_constructor=ops.PhasedXZGate,
+        gate_constructor=cirq.PhasedXZGate,
         args=[
             op_deserializer.DeserializingArg(
                 serialized_name='x_exponent',
@@ -229,11 +229,11 @@ SINGLE_QUBIT_DESERIALIZERS = [
 # Measurement Serializer and Deserializer
 #
 MEASUREMENT_SERIALIZER = op_serializer.GateOpSerializer(
-    gate_type=ops.MeasurementGate,
+    gate_type=cirq.MeasurementGate,
     serialized_gate_id='meas',
     args=[
         op_serializer.SerializingArg(
-            serialized_name='key', serialized_type=str, op_getter=protocols.measurement_key
+            serialized_name='key', serialized_type=str, op_getter=cirq.measurement_key
         ),
         op_serializer.SerializingArg(
             serialized_name='invert_mask', serialized_type=List[bool], op_getter='invert_mask'
@@ -242,7 +242,7 @@ MEASUREMENT_SERIALIZER = op_serializer.GateOpSerializer(
 )
 MEASUREMENT_DESERIALIZER = op_deserializer.GateOpDeserializer(
     serialized_gate_id='meas',
-    gate_constructor=ops.MeasurementGate,
+    gate_constructor=cirq.MeasurementGate,
     args=[
         op_deserializer.DeserializingArg(serialized_name='key', constructor_arg_name='key'),
         op_deserializer.DeserializingArg(
@@ -260,7 +260,7 @@ MEASUREMENT_DESERIALIZER = op_deserializer.GateOpDeserializer(
 #
 SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
     op_serializer.GateOpSerializer(
-        gate_type=ops.PhasedXPowGate,
+        gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy_pi',
         args=[
             op_serializer.SerializingArg(
@@ -268,59 +268,59 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
             ),
         ],
         can_serialize_predicate=lambda op: _near_mod_2(
-            cast(ops.PhasedXPowGate, op.gate).exponent, 1
+            cast(cirq.PhasedXPowGate, op.gate).exponent, 1
         ),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.XPowGate,
+        gate_type=cirq.XPowGate,
         serialized_gate_id='xy_pi',
         args=[
             op_serializer.SerializingArg(
                 serialized_name='axis_half_turns',
                 serialized_type=float,
-                op_getter=lambda op: (cast(ops.XPowGate, op.gate).exponent - 1) / 2,
+                op_getter=lambda op: (cast(cirq.XPowGate, op.gate).exponent - 1) / 2,
             )
         ],
-        can_serialize_predicate=lambda op: _near_mod_2(cast(ops.XPowGate, op.gate).exponent, 1),
+        can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.XPowGate, op.gate).exponent, 1),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.YPowGate,
+        gate_type=cirq.YPowGate,
         serialized_gate_id='xy_pi',
         args=[
             op_serializer.SerializingArg(
                 serialized_name='axis_half_turns',
                 serialized_type=float,
-                op_getter=lambda op: cast(ops.YPowGate, op.gate).exponent / 2,
+                op_getter=lambda op: cast(cirq.YPowGate, op.gate).exponent / 2,
             )
         ],
-        can_serialize_predicate=lambda op: _near_mod_2(cast(ops.YPowGate, op.gate).exponent, 1),
+        can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.YPowGate, op.gate).exponent, 1),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.XPowGate,
+        gate_type=cirq.XPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
             op_serializer.SerializingArg(
                 serialized_name='axis_half_turns',
                 serialized_type=float,
-                op_getter=lambda op: cast(ops.XPowGate, op.gate).exponent - 0.5,
+                op_getter=lambda op: cast(cirq.XPowGate, op.gate).exponent - 0.5,
             )
         ],
-        can_serialize_predicate=lambda op: _near_mod_2(cast(ops.XPowGate, op.gate).exponent, 0.5),
+        can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.XPowGate, op.gate).exponent, 0.5),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.YPowGate,
+        gate_type=cirq.YPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
             op_serializer.SerializingArg(
                 serialized_name='axis_half_turns',
                 serialized_type=float,
-                op_getter=lambda op: cast(ops.YPowGate, op.gate).exponent,
+                op_getter=lambda op: cast(cirq.YPowGate, op.gate).exponent,
             )
         ],
-        can_serialize_predicate=lambda op: _near_mod_2(cast(ops.YPowGate, op.gate).exponent, 0.5),
+        can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.YPowGate, op.gate).exponent, 0.5),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.PhasedXPowGate,
+        gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
             op_serializer.SerializingArg(
@@ -328,7 +328,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
             ),
         ],
         can_serialize_predicate=lambda op: _near_mod_2(
-            cast(ops.PhasedXPowGate, op.gate).exponent, 0.5
+            cast(cirq.PhasedXPowGate, op.gate).exponent, 0.5
         ),
     ),
 ]
@@ -339,7 +339,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
 SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='xy_pi',
-        gate_constructor=ops.PhasedXPowGate,
+        gate_constructor=cirq.PhasedXPowGate,
         args=[
             op_deserializer.DeserializingArg(
                 serialized_name='axis_half_turns',
@@ -354,7 +354,7 @@ SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
     ),
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='xy_half_pi',
-        gate_constructor=ops.PhasedXPowGate,
+        gate_constructor=cirq.PhasedXPowGate,
         args=[
             op_deserializer.DeserializingArg(
                 serialized_name='axis_half_turns', constructor_arg_name='phase_exponent'
@@ -382,7 +382,7 @@ _phase_match_arg = op_serializer.SerializingArg(
 )
 
 
-def _add_phase_match(op: ops.Operation, proto: v2.program_pb2.Operation):
+def _add_phase_match(op: cirq.Operation, proto: v2.program_pb2.Operation):
     if 'phase_match' in proto.args:
         if proto.args['phase_match'].arg_value.string_value == PHASE_MATCH_PHYS_Z:
             return op.with_tags(PhysicalZTag())
@@ -395,7 +395,7 @@ def _add_phase_match(op: ops.Operation, proto: v2.program_pb2.Operation):
 
 # Only CZ
 CZ_SERIALIZER = op_serializer.GateOpSerializer(
-    gate_type=ops.CZPowGate,
+    gate_type=cirq.CZPowGate,
     serialized_gate_id='cz',
     args=[
         op_serializer.SerializingArg(
@@ -403,12 +403,12 @@ CZ_SERIALIZER = op_serializer.GateOpSerializer(
         ),
         _phase_match_arg,
     ],
-    can_serialize_predicate=lambda op: _near_mod_2(cast(ops.CZPowGate, op.gate).exponent, 1.0),
+    can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.CZPowGate, op.gate).exponent, 1.0),
 )
 
 # CZ to any power
 CZ_POW_SERIALIZER = op_serializer.GateOpSerializer(
-    gate_type=ops.CZPowGate,
+    gate_type=cirq.CZPowGate,
     serialized_gate_id='cz',
     args=[
         op_serializer.SerializingArg(
@@ -420,7 +420,7 @@ CZ_POW_SERIALIZER = op_serializer.GateOpSerializer(
 
 CZ_POW_DESERIALIZER = op_deserializer.GateOpDeserializer(
     serialized_gate_id='cz',
-    gate_constructor=ops.CZPowGate,
+    gate_constructor=cirq.CZPowGate,
     args=[
         op_deserializer.DeserializingArg(
             serialized_name='half_turns',
@@ -435,18 +435,18 @@ CZ_POW_DESERIALIZER = op_deserializer.GateOpDeserializer(
 # Sycamore Gate Serializer and deserializer
 #
 SYC_SERIALIZER = op_serializer.GateOpSerializer(
-    gate_type=ops.FSimGate,
+    gate_type=cirq.FSimGate,
     serialized_gate_id='syc',
     args=[_phase_match_arg],
     can_serialize_predicate=(
-        lambda op: _near_mod_2pi(cast(ops.FSimGate, op.gate).theta, np.pi / 2)
-        and _near_mod_2pi(cast(ops.FSimGate, op.gate).phi, np.pi / 6)
+        lambda op: _near_mod_2pi(cast(cirq.FSimGate, op.gate).theta, np.pi / 2)
+        and _near_mod_2pi(cast(cirq.FSimGate, op.gate).phi, np.pi / 6)
     ),
 )
 
 SYC_DESERIALIZER = op_deserializer.GateOpDeserializer(
     serialized_gate_id='syc',
-    gate_constructor=lambda: ops.FSimGate(theta=np.pi / 2, phi=np.pi / 6),
+    gate_constructor=lambda: cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6),
     args=[],
     op_wrapper=lambda op, proto: _add_phase_match(op, proto),
 )
@@ -457,37 +457,37 @@ SYC_DESERIALIZER = op_deserializer.GateOpDeserializer(
 #
 SQRT_ISWAP_SERIALIZERS = [
     op_serializer.GateOpSerializer(
-        gate_type=ops.FSimGate,
+        gate_type=cirq.FSimGate,
         serialized_gate_id='fsim_pi_4',
         args=[_phase_match_arg],
         can_serialize_predicate=(
-            lambda op: _near_mod_2pi(cast(ops.FSimGate, op.gate).theta, np.pi / 4)
-            and _near_mod_2pi(cast(ops.FSimGate, op.gate).phi, 0)
+            lambda op: _near_mod_2pi(cast(cirq.FSimGate, op.gate).theta, np.pi / 4)
+            and _near_mod_2pi(cast(cirq.FSimGate, op.gate).phi, 0)
         ),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.ISwapPowGate,
+        gate_type=cirq.ISwapPowGate,
         serialized_gate_id='fsim_pi_4',
         args=[_phase_match_arg],
         can_serialize_predicate=(
-            lambda op: _near_mod_n(cast(ops.ISwapPowGate, op.gate).exponent, -0.5, 4)
+            lambda op: _near_mod_n(cast(cirq.ISwapPowGate, op.gate).exponent, -0.5, 4)
         ),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.FSimGate,
+        gate_type=cirq.FSimGate,
         serialized_gate_id='inv_fsim_pi_4',
         args=[_phase_match_arg],
         can_serialize_predicate=(
-            lambda op: _near_mod_2pi(cast(ops.FSimGate, op.gate).theta, -np.pi / 4)
-            and _near_mod_2pi(cast(ops.FSimGate, op.gate).phi, 0)
+            lambda op: _near_mod_2pi(cast(cirq.FSimGate, op.gate).theta, -np.pi / 4)
+            and _near_mod_2pi(cast(cirq.FSimGate, op.gate).phi, 0)
         ),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.ISwapPowGate,
+        gate_type=cirq.ISwapPowGate,
         serialized_gate_id='inv_fsim_pi_4',
         args=[_phase_match_arg],
         can_serialize_predicate=(
-            lambda op: _near_mod_n(cast(ops.ISwapPowGate, op.gate).exponent, +0.5, 4)
+            lambda op: _near_mod_n(cast(cirq.ISwapPowGate, op.gate).exponent, +0.5, 4)
         ),
     ),
 ]
@@ -495,13 +495,13 @@ SQRT_ISWAP_SERIALIZERS = [
 SQRT_ISWAP_DESERIALIZERS = [
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='fsim_pi_4',
-        gate_constructor=lambda: ops.FSimGate(theta=np.pi / 4, phi=0),
+        gate_constructor=lambda: cirq.FSimGate(theta=np.pi / 4, phi=0),
         args=[],
         op_wrapper=lambda op, proto: _add_phase_match(op, proto),
     ),
     op_deserializer.GateOpDeserializer(
         serialized_gate_id='inv_fsim_pi_4',
-        gate_constructor=lambda: ops.FSimGate(theta=-np.pi / 4, phi=0),
+        gate_constructor=lambda: cirq.FSimGate(theta=-np.pi / 4, phi=0),
         args=[],
         op_wrapper=lambda op, proto: _add_phase_match(op, proto),
     ),
@@ -575,7 +575,7 @@ def _can_serialize_limited_iswap(exponent: float):
 
 LIMITED_FSIM_SERIALIZERS = [
     op_serializer.GateOpSerializer(
-        gate_type=ops.FSimGate,
+        gate_type=cirq.FSimGate,
         serialized_gate_id='fsim',
         args=[
             op_serializer.SerializingArg(
@@ -588,19 +588,19 @@ LIMITED_FSIM_SERIALIZERS = [
         ],
         can_serialize_predicate=(
             lambda op: _can_serialize_limited_fsim(
-                cast(ops.FSimGate, op.gate).theta, cast(ops.FSimGate, op.gate).phi
+                cast(cirq.FSimGate, op.gate).theta, cast(cirq.FSimGate, op.gate).phi
             )
         ),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.ISwapPowGate,
+        gate_type=cirq.ISwapPowGate,
         serialized_gate_id='fsim',
         args=[
             op_serializer.SerializingArg(
                 serialized_name='theta',
                 serialized_type=float,
                 # Note that ISWAP ** 0.5 is Fsim(-pi/4,0)
-                op_getter=(lambda op: cast(ops.ISwapPowGate, op.gate).exponent * -np.pi / 2),
+                op_getter=(lambda op: cast(cirq.ISwapPowGate, op.gate).exponent * -np.pi / 2),
             ),
             op_serializer.SerializingArg(
                 serialized_name='phi', serialized_type=float, op_getter=lambda e: 0
@@ -608,11 +608,11 @@ LIMITED_FSIM_SERIALIZERS = [
             _phase_match_arg,
         ],
         can_serialize_predicate=(
-            lambda op: _can_serialize_limited_iswap(cast(ops.ISwapPowGate, op.gate).exponent)
+            lambda op: _can_serialize_limited_iswap(cast(cirq.ISwapPowGate, op.gate).exponent)
         ),
     ),
     op_serializer.GateOpSerializer(
-        gate_type=ops.CZPowGate,
+        gate_type=cirq.CZPowGate,
         serialized_gate_id='fsim',
         args=[
             op_serializer.SerializingArg(
@@ -623,14 +623,14 @@ LIMITED_FSIM_SERIALIZERS = [
             ),
             _phase_match_arg,
         ],
-        can_serialize_predicate=lambda op: _near_mod_2(cast(ops.CZPowGate, op.gate).exponent, 1.0),
+        can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.CZPowGate, op.gate).exponent, 1.0),
     ),
 ]
 
 
 LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(
     serialized_gate_id='fsim',
-    gate_constructor=ops.FSimGate,
+    gate_constructor=cirq.FSimGate,
     args=[
         op_deserializer.DeserializingArg(
             serialized_name='theta',
@@ -656,24 +656,24 @@ LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(
 # WaitGate serializer and deserializer
 #
 WAIT_GATE_SERIALIZER = op_serializer.GateOpSerializer(
-    gate_type=ops.WaitGate,
+    gate_type=cirq.WaitGate,
     serialized_gate_id='wait',
     args=[
         op_serializer.SerializingArg(
             serialized_name='nanos',
             serialized_type=float,
-            op_getter=lambda op: cast(ops.WaitGate, op.gate).duration.total_nanos(),
+            op_getter=lambda op: cast(cirq.WaitGate, op.gate).duration.total_nanos(),
         ),
     ],
 )
 WAIT_GATE_DESERIALIZER = op_deserializer.GateOpDeserializer(
     serialized_gate_id='wait',
-    gate_constructor=ops.WaitGate,
+    gate_constructor=cirq.WaitGate,
     args=[
         op_deserializer.DeserializingArg(
             serialized_name='nanos',
             constructor_arg_name='duration',
-            value_func=lambda nanos: value.Duration(
+            value_func=lambda nanos: cirq.Duration(
                 nanos=cast(Union[int, float, sympy.Basic], nanos)
             ),
         )

--- a/cirq-google/cirq_google/devices/known_devices.py
+++ b/cirq-google/cirq_google/devices/known_devices.py
@@ -12,26 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Collection, Dict, Optional, Iterable, List, Set, Tuple, TYPE_CHECKING
+from typing import Any, Collection, Dict, Optional, Iterable, List, Set, Tuple
 
+import cirq
 from cirq._doc import document
-from cirq.devices import GridQubit
 from cirq_google import gate_sets, op_serializer, serializable_gate_set
 from cirq_google.api import v2
 from cirq_google.api.v2 import device_pb2
 from cirq_google.devices.serializable_device import SerializableDevice
 from cirq_google.devices.xmon_device import XmonDevice
-from cirq.ops import MeasurementGate, SingleQubitGate, WaitGate
-from cirq.value import Duration
-
-if TYPE_CHECKING:
-    import cirq
 
 _2_QUBIT_TARGET_SET = "2_qubit_targets"
 _MEAS_TARGET_SET = "meas_targets"
 
 
-def _parse_device(s: str) -> Tuple[List[GridQubit], Dict[str, Set[GridQubit]]]:
+def _parse_device(s: str) -> Tuple[List[cirq.GridQubit], Dict[str, Set[cirq.GridQubit]]]:
     """Parse ASCIIart device layout into info about qubits and connectivity.
 
     Args:
@@ -47,12 +42,12 @@ def _parse_device(s: str) -> Tuple[List[GridQubit], Dict[str, Set[GridQubit]]]:
         on that measurement line.
     """
     lines = s.strip().split('\n')
-    qubits = []  # type: List[GridQubit]
-    measurement_lines = {}  # type: Dict[str, Set[GridQubit]]
+    qubits = []  # type: List[cirq.GridQubit]
+    measurement_lines = {}  # type: Dict[str, Set[cirq.GridQubit]]
     for row, line in enumerate(lines):
         for col, c in enumerate(line.strip()):
             if c != '-':
-                qubit = GridQubit(row, col)
+                qubit = cirq.GridQubit(row, col)
                 qubits.append(qubit)
                 measurement_line = measurement_lines.setdefault(c, set())
                 measurement_line.add(qubit)
@@ -81,7 +76,7 @@ def create_device_proto_from_diagram(
 
     # Create a list of all adjacent pairs on the grid for two-qubit gates.
     qubit_set = frozenset(qubits)
-    pairs: List[Tuple['cirq.Qid', 'cirq.Qid']] = []
+    pairs: List[Tuple[cirq.Qid, cirq.Qid]] = []
     for qubit in qubits:
         for neighbor in sorted(qubit.neighbors()):
             if neighbor > qubit and neighbor in qubit_set:
@@ -91,8 +86,8 @@ def create_device_proto_from_diagram(
 
 
 def create_device_proto_for_qubits(
-    qubits: Collection['cirq.Qid'],
-    pairs: Collection[Tuple['cirq.Qid', 'cirq.Qid']],
+    qubits: Collection[cirq.Qid],
+    pairs: Collection[Tuple[cirq.Qid, cirq.Qid]],
     gate_sets: Optional[Iterable[serializable_gate_set.SerializableGateSet]] = None,
     durations_picos: Optional[Dict[str, int]] = None,
     out: Optional[device_pb2.DeviceSpecification] = None,
@@ -153,15 +148,15 @@ def create_device_proto_for_qubits(
 
                 # Note: if it is not a measurement gate and doesn't inherit
                 # from SingleQubitGate, it's assumed to be a two qubit gate.
-                if gate_type == MeasurementGate:
+                if gate_type == cirq.MeasurementGate:
                     gate.valid_targets.append(_MEAS_TARGET_SET)
-                elif gate_type == WaitGate:
+                elif gate_type == cirq.WaitGate:
                     # TODO: Refactor gate-sets / device to eliminate the need
                     # to keep checking type here.
                     # Github issue:
                     # https://github.com/quantumlib/Cirq/issues/2537
                     gate.number_of_qubits = 1
-                elif issubclass(gate_type, SingleQubitGate):
+                elif issubclass(gate_type, cirq.SingleQubitGate):
                     gate.number_of_qubits = 1
                 else:
                     # This must be a two-qubit gate
@@ -218,9 +213,9 @@ class _NamedConstantXmonDevice(XmonDevice):
 
 Foxtail = _NamedConstantXmonDevice(
     'cirq_google.Foxtail',
-    measurement_duration=Duration(nanos=4000),
-    exp_w_duration=Duration(nanos=20),
-    exp_11_duration=Duration(nanos=50),
+    measurement_duration=cirq.Duration(nanos=4000),
+    exp_w_duration=cirq.Duration(nanos=20),
+    exp_11_duration=cirq.Duration(nanos=50),
     qubits=_parse_device(_FOXTAIL_GRID)[0],
 )
 document(
@@ -262,9 +257,9 @@ ABCDEFGHIJKL
 
 Bristlecone = _NamedConstantXmonDevice(
     'cirq_google.Bristlecone',
-    measurement_duration=Duration(nanos=4000),
-    exp_w_duration=Duration(nanos=20),
-    exp_11_duration=Duration(nanos=50),
+    measurement_duration=cirq.Duration(nanos=4000),
+    exp_w_duration=cirq.Duration(nanos=20),
+    exp_11_duration=cirq.Duration(nanos=50),
     qubits=_parse_device(_BRISTLECONE_GRID)[0],
 )
 document(

--- a/cirq-google/cirq_google/devices/xmon_device.py
+++ b/cirq-google/cirq_google/devices/xmon_device.py
@@ -14,24 +14,23 @@
 
 from typing import Any, cast, Iterable, List, Optional, Set, TYPE_CHECKING, FrozenSet
 
-from cirq import circuits, devices, ops, protocols, value
+import cirq
 from cirq_google.optimizers import convert_to_xmon_gates
-from cirq.devices.grid_qubit import GridQubit
 
 if TYPE_CHECKING:
     import cirq
 
 
-@value.value_equality
-class XmonDevice(devices.Device):
+@cirq.value_equality
+class XmonDevice(cirq.Device):
     """A device with qubits placed in a grid. Neighboring qubits can interact."""
 
     def __init__(
         self,
-        measurement_duration: 'cirq.DURATION_LIKE',
-        exp_w_duration: 'cirq.DURATION_LIKE',
-        exp_11_duration: 'cirq.DURATION_LIKE',
-        qubits: Iterable[GridQubit],
+        measurement_duration: cirq.DURATION_LIKE,
+        exp_w_duration: cirq.DURATION_LIKE,
+        exp_11_duration: cirq.DURATION_LIKE,
+        qubits: Iterable[cirq.GridQubit],
     ) -> None:
         """Initializes the description of an xmon device.
 
@@ -41,55 +40,55 @@ class XmonDevice(devices.Device):
             exp_11_duration: The maximum duration of an ExpZ operation.
             qubits: Qubits on the device, identified by their x, y location.
         """
-        self._measurement_duration = value.Duration(measurement_duration)
-        self._exp_w_duration = value.Duration(exp_w_duration)
-        self._exp_z_duration = value.Duration(exp_11_duration)
+        self._measurement_duration = cirq.Duration(measurement_duration)
+        self._exp_w_duration = cirq.Duration(exp_w_duration)
+        self._exp_z_duration = cirq.Duration(exp_11_duration)
         self.qubits = frozenset(qubits)
 
-    def qubit_set(self) -> FrozenSet['cirq.GridQubit']:
+    def qubit_set(self) -> FrozenSet[cirq.GridQubit]:
         return self.qubits
 
-    def decompose_operation(self, operation: 'cirq.Operation') -> 'cirq.OP_TREE':
+    def decompose_operation(self, operation: cirq.Operation) -> cirq.OP_TREE:
         return convert_to_xmon_gates.ConvertToXmonGates().convert(operation)
 
-    def neighbors_of(self, qubit: GridQubit):
+    def neighbors_of(self, qubit: cirq.GridQubit):
         """Returns the qubits that the given qubit can interact with."""
         possibles = [
-            GridQubit(qubit.row + 1, qubit.col),
-            GridQubit(qubit.row - 1, qubit.col),
-            GridQubit(qubit.row, qubit.col + 1),
-            GridQubit(qubit.row, qubit.col - 1),
+            cirq.GridQubit(qubit.row + 1, qubit.col),
+            cirq.GridQubit(qubit.row - 1, qubit.col),
+            cirq.GridQubit(qubit.row, qubit.col + 1),
+            cirq.GridQubit(qubit.row, qubit.col - 1),
         ]
         return [e for e in possibles if e in self.qubits]
 
     def duration_of(self, operation):
-        if isinstance(operation.gate, ops.CZPowGate):
+        if isinstance(operation.gate, cirq.CZPowGate):
             return self._exp_z_duration
-        if isinstance(operation.gate, ops.MeasurementGate):
+        if isinstance(operation.gate, cirq.MeasurementGate):
             return self._measurement_duration
-        if isinstance(operation.gate, (ops.XPowGate, ops.YPowGate, ops.PhasedXPowGate)):
+        if isinstance(operation.gate, (cirq.XPowGate, cirq.YPowGate, cirq.PhasedXPowGate)):
             return self._exp_w_duration
-        if isinstance(operation.gate, ops.ZPowGate):
+        if isinstance(operation.gate, cirq.ZPowGate):
             # Z gates are performed in the control software.
-            return value.Duration()
+            return cirq.Duration()
         raise ValueError(f'Unsupported gate type: {operation!r}')
 
     @classmethod
-    def is_supported_gate(cls, gate: 'cirq.Gate'):
+    def is_supported_gate(cls, gate: cirq.Gate):
         """Returns true if the gate is allowed."""
         return isinstance(
             gate,
             (
-                ops.CZPowGate,
-                ops.XPowGate,
-                ops.YPowGate,
-                ops.PhasedXPowGate,
-                ops.MeasurementGate,
-                ops.ZPowGate,
+                cirq.CZPowGate,
+                cirq.XPowGate,
+                cirq.YPowGate,
+                cirq.PhasedXPowGate,
+                cirq.MeasurementGate,
+                cirq.ZPowGate,
             ),
         )
 
-    def validate_gate(self, gate: 'cirq.Gate'):
+    def validate_gate(self, gate: cirq.Gate):
         """Raises an error if the given gate isn't allowed.
 
         Raises:
@@ -98,81 +97,85 @@ class XmonDevice(devices.Device):
         if not self.is_supported_gate(gate):
             raise ValueError(f'Unsupported gate type: {gate!r}')
 
-    def validate_operation(self, operation: 'cirq.Operation'):
-        if not isinstance(operation, ops.GateOperation):
+    def validate_operation(self, operation: cirq.Operation):
+        if not isinstance(operation, cirq.GateOperation):
             raise ValueError(f'Unsupported operation: {operation!r}')
 
         self.validate_gate(operation.gate)
 
         for q in operation.qubits:
-            if not isinstance(q, GridQubit):
+            if not isinstance(q, cirq.GridQubit):
                 raise ValueError(f'Unsupported qubit type: {q!r}')
             if q not in self.qubits:
                 raise ValueError(f'Qubit not on device: {q!r}')
 
-        if len(operation.qubits) == 2 and not isinstance(operation.gate, ops.MeasurementGate):
+        if len(operation.qubits) == 2 and not isinstance(operation.gate, cirq.MeasurementGate):
             p, q = operation.qubits
-            if not cast(GridQubit, p).is_adjacent(q):
+            if not cast(cirq.GridQubit, p).is_adjacent(q):
                 raise ValueError(f'Non-local interaction: {operation!r}.')
 
     def _check_if_exp11_operation_interacts_with_any(
-        self, exp11_op: 'cirq.GateOperation', others: Iterable['cirq.GateOperation']
+        self, exp11_op: cirq.GateOperation, others: Iterable[cirq.GateOperation]
     ) -> bool:
         return any(self._check_if_exp11_operation_interacts(exp11_op, op) for op in others)
 
     def _check_if_exp11_operation_interacts(
-        self, exp11_op: 'cirq.GateOperation', other_op: 'cirq.GateOperation'
+        self, exp11_op: cirq.GateOperation, other_op: cirq.GateOperation
     ) -> bool:
         if isinstance(
             other_op.gate,
-            (ops.XPowGate, ops.YPowGate, ops.PhasedXPowGate, ops.MeasurementGate, ops.ZPowGate),
+            (
+                cirq.XPowGate,
+                cirq.YPowGate,
+                cirq.PhasedXPowGate,
+                cirq.MeasurementGate,
+                cirq.ZPowGate,
+            ),
         ):
             return False
 
         return any(
-            cast(GridQubit, q).is_adjacent(cast(GridQubit, p))
+            cast(cirq.GridQubit, q).is_adjacent(cast(cirq.GridQubit, p))
             for q in exp11_op.qubits
             for p in other_op.qubits
         )
 
-    def validate_circuit(self, circuit: 'cirq.Circuit'):
+    def validate_circuit(self, circuit: cirq.Circuit):
         super().validate_circuit(circuit)
         _verify_unique_measurement_keys(circuit.all_operations())
 
-    def validate_moment(self, moment: 'cirq.Moment'):
+    def validate_moment(self, moment: cirq.Moment):
         super().validate_moment(moment)
         for op in moment.operations:
-            if isinstance(op.gate, ops.CZPowGate):
+            if isinstance(op.gate, cirq.CZPowGate):
                 for other in moment.operations:
                     if other is not op and self._check_if_exp11_operation_interacts(
-                        cast(ops.GateOperation, op), cast(ops.GateOperation, other)
+                        cast(cirq.GateOperation, op), cast(cirq.GateOperation, other)
                     ):
                         raise ValueError(f'Adjacent Exp11 operations: {moment}.')
 
-    def can_add_operation_into_moment(
-        self, operation: 'cirq.Operation', moment: 'cirq.Moment'
-    ) -> bool:
+    def can_add_operation_into_moment(self, operation: cirq.Operation, moment: cirq.Moment) -> bool:
         self.validate_moment(moment)
 
         if not super().can_add_operation_into_moment(operation, moment):
             return False
-        if isinstance(operation.gate, ops.CZPowGate):
+        if isinstance(operation.gate, cirq.CZPowGate):
             return not self._check_if_exp11_operation_interacts_with_any(
-                cast(ops.GateOperation, operation),
-                cast(Iterable['cirq.GateOperation'], moment.operations),
+                cast(cirq.GateOperation, operation),
+                cast(Iterable[cirq.GateOperation], moment.operations),
             )
         return True
 
-    def at(self, row: int, col: int) -> Optional[GridQubit]:
+    def at(self, row: int, col: int) -> Optional[cirq.GridQubit]:
         """Returns the qubit at the given position, if there is one, else None."""
-        q = GridQubit(row, col)
+        q = cirq.GridQubit(row, col)
         return q if q in self.qubits else None
 
-    def row(self, row: int) -> List[GridQubit]:
+    def row(self, row: int) -> List[cirq.GridQubit]:
         """Returns the qubits in the given row, in ascending order."""
         return sorted(q for q in self.qubits if q.row == row)
 
-    def col(self, col: int) -> List[GridQubit]:
+    def col(self, col: int) -> List[cirq.GridQubit]:
         """Returns the qubits in the given column, in ascending order."""
         return sorted(q for q in self.qubits if q.col == col)
 
@@ -186,7 +189,7 @@ class XmonDevice(devices.Device):
         )
 
     def __str__(self) -> str:
-        diagram = circuits.TextDiagramDrawer()
+        diagram = cirq.TextDiagramDrawer()
 
         for q in self.qubits:
             diagram.write(q.col, q.row, str(q))
@@ -199,11 +202,11 @@ class XmonDevice(devices.Device):
         return (self._measurement_duration, self._exp_w_duration, self._exp_z_duration, self.qubits)
 
 
-def _verify_unique_measurement_keys(operations: Iterable['cirq.Operation']):
+def _verify_unique_measurement_keys(operations: Iterable[cirq.Operation]):
     seen: Set[str] = set()
     for op in operations:
-        if protocols.is_measurement(op):
-            key = protocols.measurement_key(op)
+        if cirq.is_measurement(op):
+            key = cirq.measurement_key(op)
             if key in seen:
                 raise ValueError(f'Measurement key {key} repeated')
             seen.add(key)

--- a/cirq-google/cirq_google/engine/calibration.py
+++ b/cirq-google/cirq_google/engine/calibration.py
@@ -16,21 +16,18 @@
 from collections import abc, defaultdict
 import datetime
 from itertools import cycle
-
-from typing import Any, Dict, Iterator, List, Optional, Tuple, TYPE_CHECKING, Union, Sequence
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, Sequence
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import google.protobuf.json_format as json_format
-from cirq import devices, vis
-from cirq_google.api import v2
 
-if TYPE_CHECKING:
-    import cirq
+import cirq
+from cirq_google.api import v2
 
 
 # Calibration Metric types
-METRIC_KEY = Tuple[Union[devices.GridQubit, str], ...]
+METRIC_KEY = Tuple[Union[cirq.GridQubit, str], ...]
 METRIC_VALUE = List[Union[str, int, float]]
 METRIC_DICT = Dict[METRIC_KEY, METRIC_VALUE]
 ALL_METRICS = Dict[str, METRIC_DICT]
@@ -174,7 +171,7 @@ class Calibration(abc.Mapping):
         dt += datetime.timedelta(microseconds=self.timestamp % 1000000)
         return dt.isoformat(sep=' ', timespec=timespec)
 
-    def str_to_key(self, target: str) -> Union[devices.GridQubit, str]:
+    def str_to_key(self, target: str) -> Union[cirq.GridQubit, str]:
         """Turns a string into a calibration key.
 
         Attempts to parse it as a GridQubit.  If this fails,
@@ -186,18 +183,18 @@ class Calibration(abc.Mapping):
             return target
 
     @staticmethod
-    def key_to_qubit(target: METRIC_KEY) -> devices.GridQubit:
+    def key_to_qubit(target: METRIC_KEY) -> cirq.GridQubit:
         """Returns a single qubit from a metric key.
 
         Raises:
            ValueError if the metric key is a tuple of strings.
         """
-        if target and isinstance(target, tuple) and isinstance(target[0], devices.GridQubit):
+        if target and isinstance(target, tuple) and isinstance(target[0], cirq.GridQubit):
             return target[0]
         raise ValueError(f'The metric target {target} was not a tuple of qubits')
 
     @staticmethod
-    def key_to_qubits(target: METRIC_KEY) -> Tuple[devices.GridQubit, ...]:
+    def key_to_qubits(target: METRIC_KEY) -> Tuple[cirq.GridQubit, ...]:
         """Returns a tuple of qubits from a metric key.
 
         Raises:
@@ -206,7 +203,7 @@ class Calibration(abc.Mapping):
         if (
             target
             and isinstance(target, tuple)
-            and all(isinstance(q, devices.GridQubit) for q in target)
+            and all(isinstance(q, cirq.GridQubit) for q in target)
         ):
             return target  # type: ignore
         raise ValueError(f'The metric target {target} was not a tuple of grid qubits.')
@@ -227,7 +224,7 @@ class Calibration(abc.Mapping):
             raise ValueError('Metric Value was empty')
         return float(value[0])
 
-    def heatmap(self, key: str) -> vis.Heatmap:
+    def heatmap(self, key: str) -> cirq.Heatmap:
         """Return a heatmap for metrics that target single qubits.
 
         Args:
@@ -248,9 +245,9 @@ class Calibration(abc.Mapping):
             )
         value_map = {self.key_to_qubits(k): self.value_to_float(v) for k, v in metrics.items()}
         if all(len(k) == 1 for k in value_map.keys()):
-            return vis.Heatmap(value_map, title=key.replace('_', ' ').title())
+            return cirq.Heatmap(value_map, title=key.replace('_', ' ').title())
         elif all(len(k) == 2 for k in value_map.keys()):
-            return vis.TwoQubitInteractionHeatmap(value_map, title=key.replace('_', ' ').title())
+            return cirq.TwoQubitInteractionHeatmap(value_map, title=key.replace('_', ' ').title())
         raise ValueError(
             'Heatmaps are only supported if all the targets in a metric are one or two qubits.'
             + f'{key} has target qubits {value_map.keys()}'
@@ -292,7 +289,7 @@ class Calibration(abc.Mapping):
                     + 'are single metric values.'
                     + f'{key} has metric values {metrics.values()}'
                 )
-            vis.integrated_histogram(
+            cirq.integrated_histogram(
                 [self.value_to_float(v) for v in metrics.values()],
                 ax,
                 label=label,

--- a/cirq-google/cirq_google/engine/calibration_layer.py
+++ b/cirq-google/cirq_google/engine/calibration_layer.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 #
 import dataclasses
-from typing import Any, Dict, TYPE_CHECKING, Union
+from typing import Any, Dict, Union
 
-from cirq import protocols
-
-if TYPE_CHECKING:
-    import cirq
+import cirq
 
 
 @dataclasses.dataclass
@@ -28,8 +25,8 @@ class CalibrationLayer:
     in Engine calls."""
 
     calibration_type: str
-    program: 'cirq.Circuit'
+    program: cirq.Circuit
     args: Dict[str, Union[str, float]]
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return protocols.obj_to_dict_helper(self, ['calibration_type', 'program', 'args'])
+        return cirq.obj_to_dict_helper(self, ['calibration_type', 'program', 'args'])

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -31,9 +31,10 @@ import string
 from typing import Dict, Iterable, List, Optional, Sequence, Set, TypeVar, Union, TYPE_CHECKING
 
 from google.protobuf import any_pb2
+
+import cirq
 from cirq_google.engine.client import quantum
 from cirq_google.engine.result_type import ResultType
-from cirq import circuits, study, value
 from cirq_google import serializable_gate_set as sgs
 from cirq_google.api import v2
 from cirq_google.arg_func_langs import arg_to_proto
@@ -47,7 +48,6 @@ from cirq_google.engine import (
 
 if TYPE_CHECKING:
     import cirq_google
-    import cirq
     import google.protobuf
 
 TYPE_PREFIX = 'type.googleapis.com/'
@@ -70,7 +70,7 @@ def _make_random_id(prefix: str, length: int = 16):
     return f'{prefix}{suffix}'
 
 
-@value.value_equality
+@cirq.value_equality
 class EngineContext:
     """Context for running against the Quantum Engine API. Most users should
     simply create an Engine object instead of working with one of these
@@ -178,10 +178,10 @@ class Engine:
 
     def run(
         self,
-        program: 'cirq.Circuit',
+        program: cirq.Circuit,
         program_id: Optional[str] = None,
         job_id: Optional[str] = None,
-        param_resolver: study.ParamResolver = study.ParamResolver({}),
+        param_resolver: cirq.ParamResolver = cirq.ParamResolver({}),
         repetitions: int = 1,
         processor_ids: Sequence[str] = ('xmonsim',),
         gate_set: Optional[sgs.SerializableGateSet] = None,
@@ -189,7 +189,7 @@ class Engine:
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-    ) -> study.Result:
+    ) -> cirq.Result:
         """Runs the supplied Circuit via Quantum Engine.
 
         Args:
@@ -239,10 +239,10 @@ class Engine:
 
     def run_sweep(
         self,
-        program: 'cirq.Circuit',
+        program: cirq.Circuit,
         program_id: Optional[str] = None,
         job_id: Optional[str] = None,
-        params: study.Sweepable = None,
+        params: cirq.Sweepable = None,
         repetitions: int = 1,
         processor_ids: Sequence[str] = ('xmonsim',),
         gate_set: Optional[sgs.SerializableGateSet] = None,
@@ -300,10 +300,10 @@ class Engine:
 
     def run_batch(
         self,
-        programs: List['cirq.Circuit'],
+        programs: List[cirq.Circuit],
         program_id: Optional[str] = None,
         job_id: Optional[str] = None,
-        params_list: List[study.Sweepable] = None,
+        params_list: List[cirq.Sweepable] = None,
         repetitions: int = 1,
         processor_ids: Sequence[str] = (),
         gate_set: Optional[sgs.SerializableGateSet] = None,
@@ -450,7 +450,7 @@ class Engine:
 
     def create_program(
         self,
-        program: 'cirq.Circuit',
+        program: cirq.Circuit,
         program_id: Optional[str] = None,
         gate_set: Optional[sgs.SerializableGateSet] = None,
         description: Optional[str] = None,
@@ -493,7 +493,7 @@ class Engine:
 
     def create_batch_program(
         self,
-        programs: List['cirq.Circuit'],
+        programs: List[cirq.Circuit],
         program_id: Optional[str] = None,
         gate_set: Optional[sgs.SerializableGateSet] = None,
         description: Optional[str] = None,
@@ -596,9 +596,9 @@ class Engine:
         )
 
     def _serialize_program(
-        self, program: 'cirq.Circuit', gate_set: sgs.SerializableGateSet
+        self, program: cirq.Circuit, gate_set: sgs.SerializableGateSet
     ) -> any_pb2.Any:
-        if not isinstance(program, circuits.Circuit):
+        if not isinstance(program, cirq.Circuit):
             raise TypeError(f'Unrecognized program type: {type(program)}')
         program.device.validate_circuit(program)
 
@@ -799,7 +799,7 @@ def get_engine_device(
     processor_id: str,
     project_id: Optional[str] = None,
     gatesets: Iterable[sgs.SerializableGateSet] = (),
-) -> 'cirq.Device':
+) -> cirq.Device:
     """Returns a `Device` object for a given processor.
 
     This is a short-cut for creating an engine object, getting the

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -16,6 +16,7 @@ import datetime
 from typing import Iterable, List, Optional, TYPE_CHECKING, Union
 from pytz import utc
 
+import cirq
 from cirq_google.engine.client.quantum import types as qtypes
 from cirq_google.engine.client.quantum import enums as qenums
 from cirq_google import serializable_gate_set
@@ -26,7 +27,6 @@ from cirq_google.engine.engine_timeslot import EngineTimeSlot
 
 if TYPE_CHECKING:
     import cirq_google.engine.engine as engine_base
-    import cirq
 
 
 class EngineProcessor:
@@ -112,7 +112,7 @@ class EngineProcessor:
 
     def get_device(
         self, gate_sets: Iterable[serializable_gate_set.SerializableGateSet]
-    ) -> 'cirq.Device':
+    ) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 
         This method queries the processor to retrieve the device specification,

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -15,7 +15,7 @@
 import datetime
 from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
 
-from cirq import study
+import cirq
 from cirq_google.engine.client import quantum
 from cirq_google.engine.client.quantum import types as qtypes
 from cirq_google.engine.result_type import ResultType
@@ -25,7 +25,6 @@ from cirq_google.engine import engine_job
 
 if TYPE_CHECKING:
     import cirq_google.engine.engine as engine_base
-    from cirq import Circuit
 
 
 class EngineProgram:
@@ -65,7 +64,7 @@ class EngineProgram:
     def run_sweep(
         self,
         job_id: Optional[str] = None,
-        params: study.Sweepable = None,
+        params: cirq.Sweepable = None,
         repetitions: int = 1,
         processor_ids: Sequence[str] = ('xmonsim',),
         description: Optional[str] = None,
@@ -99,7 +98,7 @@ class EngineProgram:
             raise ValueError('Please use run_batch() for batch mode.')
         if not job_id:
             job_id = engine_base._make_random_id('job-')
-        sweeps = study.to_sweeps(params or study.ParamResolver({}))
+        sweeps = cirq.to_sweeps(params or cirq.ParamResolver({}))
         run_context = self._serialize_run_context(sweeps, repetitions)
 
         created_job_id, job = self.context.client.create_job(
@@ -118,7 +117,7 @@ class EngineProgram:
     def run_batch(
         self,
         job_id: Optional[str] = None,
-        params_list: List[study.Sweepable] = None,
+        params_list: List[cirq.Sweepable] = None,
         repetitions: int = 1,
         processor_ids: Sequence[str] = (),
         description: Optional[str] = None,
@@ -174,7 +173,7 @@ class EngineProgram:
         # Pack the run contexts into batches
         batch = v2.batch_pb2.BatchRunContext()
         for param in params_list:
-            sweeps = study.to_sweeps(param)
+            sweeps = cirq.to_sweeps(param)
             current_context = batch.run_contexts.add()
             for sweep in sweeps:
                 sweep_proto = current_context.parameter_sweeps.add()
@@ -264,12 +263,12 @@ class EngineProgram:
     def run(
         self,
         job_id: Optional[str] = None,
-        param_resolver: study.ParamResolver = study.ParamResolver({}),
+        param_resolver: cirq.ParamResolver = cirq.ParamResolver({}),
         repetitions: int = 1,
         processor_ids: Sequence[str] = ('xmonsim',),
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
-    ) -> study.Result:
+    ) -> cirq.Result:
         """Runs the supplied Circuit via Quantum Engine.
 
         Args:
@@ -301,7 +300,7 @@ class EngineProgram:
 
     def _serialize_run_context(
         self,
-        sweeps: List[study.Sweep],
+        sweeps: List[cirq.Sweep],
         repetitions: int,
     ) -> qtypes.any_pb2.Any:
         import cirq_google.engine.engine as engine_base
@@ -469,7 +468,7 @@ class EngineProgram:
         )
         return self
 
-    def get_circuit(self, program_num: Optional[int] = None) -> 'Circuit':
+    def get_circuit(self, program_num: Optional[int] = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the Quantum Engine program. This is only
         supported if the program was created with the V2 protos.
 
@@ -509,7 +508,7 @@ class EngineProgram:
     @staticmethod
     def _deserialize_program(
         code: qtypes.any_pb2.Any, program_num: Optional[int] = None
-    ) -> 'Circuit':
+    ) -> cirq.Circuit:
         import cirq_google.engine.engine as engine_base
 
         code_type = code.type_url[len(engine_base.TYPE_PREFIX) :]

--- a/cirq-google/cirq_google/engine/engine_sampler.py
+++ b/cirq-google/cirq_google/engine/engine_sampler.py
@@ -13,15 +13,14 @@
 # limitations under the License.
 from typing import List, TYPE_CHECKING, Union, Optional, cast
 
-from cirq import work, circuits
+import cirq
 from cirq_google import engine, gate_sets
 
 if TYPE_CHECKING:
     import cirq_google
-    import cirq
 
 
-class QuantumEngineSampler(work.Sampler):
+class QuantumEngineSampler(cirq.Sampler):
     """A sampler that samples from processors managed by the Quantum Engine.
 
     Exposes a `cirq_google.Engine` instance as a `cirq.Sampler`.
@@ -48,17 +47,17 @@ class QuantumEngineSampler(work.Sampler):
 
     def run_sweep(
         self,
-        program: Union['cirq.Circuit', 'cirq_google.EngineProgram'],
-        params: 'cirq.Sweepable',
+        program: Union[cirq.Circuit, 'cirq_google.EngineProgram'],
+        params: cirq.Sweepable,
         repetitions: int = 1,
-    ) -> List['cirq.Result']:
+    ) -> List[cirq.Result]:
         if isinstance(program, engine.EngineProgram):
             job = program.run_sweep(
                 params=params, repetitions=repetitions, processor_ids=self._processor_ids
             )
         else:
             job = self._engine.run_sweep(
-                program=cast(circuits.Circuit, program),
+                program=cast(cirq.Circuit, program),
                 params=params,
                 repetitions=repetitions,
                 processor_ids=self._processor_ids,
@@ -68,10 +67,10 @@ class QuantumEngineSampler(work.Sampler):
 
     def run_batch(
         self,
-        programs: List['cirq.Circuit'],
-        params_list: Optional[List['cirq.Sweepable']] = None,
+        programs: List[cirq.Circuit],
+        params_list: Optional[List[cirq.Sweepable]] = None,
         repetitions: Union[int, List[int]] = 1,
-    ) -> List[List['cirq.Result']]:
+    ) -> List[List[cirq.Result]]:
         """Runs the supplied circuits.
 
         In order to gain a speedup from using this method instead of other run

--- a/cirq-google/cirq_google/experimental/noise_models/noise_models_test.py
+++ b/cirq-google/cirq_google/experimental/noise_models/noise_models_test.py
@@ -18,7 +18,6 @@ import pytest
 from google.protobuf.text_format import Merge
 
 import cirq
-from cirq import ops
 from cirq.testing import assert_equivalent_op_tree
 import cirq_google
 from cirq_google.api import v2
@@ -131,7 +130,7 @@ def test_per_qubit_depol_noise_from_data():
         cirq.Moment([cirq.H(qubits[0])]),
         cirq.Moment([cirq.CNOT(qubits[0], qubits[1])]),
         cirq.Moment([cirq.CNOT(qubits[0], qubits[2])]),
-        cirq.Moment([cirq.Z(qubits[1]).with_tags(ops.VirtualTag())]),
+        cirq.Moment([cirq.Z(qubits[1]).with_tags(cirq.VirtualTag())]),
         cirq.Moment(
             [
                 cirq.measure(qubits[0], key='q0'),
@@ -160,7 +159,7 @@ def test_per_qubit_depol_noise_from_data():
                 cirq.DepolarizingChannel(DEPOL_003).on(qubits[2]),
             ]
         ),
-        cirq.Moment([cirq.Z(qubits[1]).with_tags(ops.VirtualTag())]),
+        cirq.Moment([cirq.Z(qubits[1]).with_tags(cirq.VirtualTag())]),
         cirq.Moment(
             [
                 cirq.measure(qubits[0], key='q0'),

--- a/cirq-google/cirq_google/line/placement/anneal.py
+++ b/cirq-google/cirq_google/line/placement/anneal.py
@@ -16,7 +16,7 @@ from typing import Callable, List, Optional, Tuple, Set, Any, TYPE_CHECKING
 
 import numpy as np
 
-from cirq.devices import GridQubit
+import cirq
 from cirq_google.line.placement import place_strategy, optimization
 from cirq_google.line.placement.chip import (
     above,
@@ -29,7 +29,7 @@ from cirq_google.line.placement.sequence import GridQubitLineTuple, LineSequence
 if TYPE_CHECKING:
     import cirq_google
 
-_STATE = Tuple[List[List[GridQubit]], Set[EDGE]]
+_STATE = Tuple[List[List[cirq.GridQubit]], Set[EDGE]]
 
 
 class AnnealSequenceSearch:
@@ -143,8 +143,8 @@ class AnnealSequenceSearch:
         return (self._force_edge_active(seqs, edge, lambda: bool(self._rand.randint(2))), edges)
 
     def _force_edge_active(
-        self, seqs: List[List[GridQubit]], edge: EDGE, sample_bool: Callable[[], bool]
-    ) -> List[List[GridQubit]]:
+        self, seqs: List[List[cirq.GridQubit]], edge: EDGE, sample_bool: Callable[[], bool]
+    ) -> List[List[cirq.GridQubit]]:
         """Move which forces given edge to appear on some sequence.
 
         Args:
@@ -242,7 +242,7 @@ class AnnealSequenceSearch:
           Valid search state.
         """
 
-        def extract_sequences() -> List[List[GridQubit]]:
+        def extract_sequences() -> List[List[cirq.GridQubit]]:
             """Creates list of sequences for initial state.
 
             Returns:
@@ -300,7 +300,7 @@ class AnnealSequenceSearch:
           position.
         """
 
-        def lower(n: GridQubit, m: GridQubit) -> bool:
+        def lower(n: cirq.GridQubit, m: cirq.GridQubit) -> bool:
             return n.row < m.row or (n.row == m.row and n.col < m.col)
 
         n1, n2 = edge

--- a/cirq-google/cirq_google/line/placement/chip.py
+++ b/cirq-google/cirq_google/line/placement/chip.py
@@ -14,16 +14,16 @@
 
 from typing import Dict, List, Tuple, TYPE_CHECKING
 
-from cirq.devices import GridQubit
+import cirq
 
 if TYPE_CHECKING:
     import cirq_google
 
 
-EDGE = Tuple[GridQubit, GridQubit]
+EDGE = Tuple[cirq.GridQubit, cirq.GridQubit]
 
 
-def above(qubit: GridQubit) -> GridQubit:
+def above(qubit: cirq.GridQubit) -> cirq.GridQubit:
     """Gives qubit with one unit less on the second coordinate.
 
     Args:
@@ -32,10 +32,10 @@ def above(qubit: GridQubit) -> GridQubit:
     Returns:
         New translated qubit.
     """
-    return GridQubit(qubit.row, qubit.col - 1)
+    return cirq.GridQubit(qubit.row, qubit.col - 1)
 
 
-def left_of(qubit: GridQubit) -> GridQubit:
+def left_of(qubit: cirq.GridQubit) -> cirq.GridQubit:
     """Gives qubit with one unit less on the first coordinate.
 
     Args:
@@ -44,10 +44,10 @@ def left_of(qubit: GridQubit) -> GridQubit:
     Returns:
         New translated qubit.
     """
-    return GridQubit(qubit.row - 1, qubit.col)
+    return cirq.GridQubit(qubit.row - 1, qubit.col)
 
 
-def below(qubit: GridQubit) -> GridQubit:
+def below(qubit: cirq.GridQubit) -> cirq.GridQubit:
     """Gives qubit with one unit more on the second coordinate.
 
     Args:
@@ -56,10 +56,10 @@ def below(qubit: GridQubit) -> GridQubit:
     Returns:
         New translated qubit.
     """
-    return GridQubit(qubit.row, qubit.col + 1)
+    return cirq.GridQubit(qubit.row, qubit.col + 1)
 
 
-def right_of(qubit: GridQubit) -> GridQubit:
+def right_of(qubit: cirq.GridQubit) -> cirq.GridQubit:
     """Gives node with one unit more on the first coordinate.
 
     Args:
@@ -68,12 +68,12 @@ def right_of(qubit: GridQubit) -> GridQubit:
     Returns:
         New translated node.
     """
-    return GridQubit(qubit.row + 1, qubit.col)
+    return cirq.GridQubit(qubit.row + 1, qubit.col)
 
 
 def chip_as_adjacency_list(
     device: 'cirq_google.XmonDevice',
-) -> Dict[GridQubit, List[GridQubit]]:
+) -> Dict[cirq.GridQubit, List[cirq.GridQubit]]:
     """Gives adjacency list representation of a chip.
 
     The adjacency list is constructed in order of above, left_of, below and
@@ -87,7 +87,7 @@ def chip_as_adjacency_list(
         given qubit.
     """
     c_set = set(device.qubits)
-    c_adj = {}  # type: Dict[GridQubit, List[GridQubit]]
+    c_adj: Dict[cirq.GridQubit, List[cirq.GridQubit]] = {}
     for n in device.qubits:
         c_adj[n] = []
         for m in [above(n), left_of(n), below(n), right_of(n)]:

--- a/cirq-google/cirq_google/line/placement/sequence.py
+++ b/cirq-google/cirq_google/line/placement/sequence.py
@@ -14,11 +14,10 @@
 
 from typing import List, Iterable
 
-from cirq.circuits import TextDiagramDrawer
-from cirq.devices import GridQubit
+import cirq
 
 
-LineSequence = List[GridQubit]
+LineSequence = List[cirq.GridQubit]
 
 
 class NotFoundError(Exception):
@@ -37,7 +36,7 @@ class GridQubitLineTuple(tuple):
         return GridQubitLineTuple(longest[:length])
 
     def __str__(self) -> str:
-        diagram = TextDiagramDrawer()
+        diagram = cirq.TextDiagramDrawer()
         dx = min(q.col for q in self)
         dy = min(q.row for q in self)
 

--- a/cirq-google/cirq_google/op_deserializer.py
+++ b/cirq-google/cirq_google/op_deserializer.py
@@ -19,21 +19,17 @@ from typing import (
     List,
     Optional,
     Sequence,
-    TYPE_CHECKING,
 )
 from dataclasses import dataclass
 
 import abc
 import sympy
 
-from cirq import circuits
+import cirq
 from cirq._compat import deprecated
 from cirq_google import arg_func_langs
 from cirq_google.api import v2
 from cirq_google.ops.calibration_tag import CalibrationTag
-
-if TYPE_CHECKING:
-    import cirq
 
 
 class OpDeserializer(abc.ABC):
@@ -61,7 +57,7 @@ class OpDeserializer(abc.ABC):
         arg_function_language: str = '',
         constants: List[v2.program_pb2.Constant] = None,
         deserialized_constants: List[Any] = None,
-    ) -> 'cirq.Operation':
+    ) -> cirq.Operation:
         """Converts a proto-formatted operation into a Cirq operation.
 
         Args:
@@ -117,7 +113,7 @@ class GateOpDeserializer(OpDeserializer):
         args: Sequence[DeserializingArg],
         num_qubits_param: Optional[str] = None,
         op_wrapper: Callable[
-            ['cirq.Operation', v2.program_pb2.Operation], 'cirq.Operation'
+            [cirq.Operation, v2.program_pb2.Operation], cirq.Operation
         ] = lambda x, y: x,
         deserialize_tokens: Optional[bool] = True,
     ):
@@ -163,7 +159,7 @@ class GateOpDeserializer(OpDeserializer):
         arg_function_language: str = '',
         constants: List[v2.program_pb2.Constant] = None,
         deserialized_constants: List[Any] = None,  # unused
-    ) -> 'cirq.Operation':
+    ) -> cirq.Operation:
         """Turns a cirq_google.api.v2.Operation proto into a GateOperation.
 
         Args:
@@ -242,7 +238,7 @@ class CircuitOpDeserializer(OpDeserializer):
         arg_function_language: str = '',
         constants: List[v2.program_pb2.Constant] = None,
         deserialized_constants: List[Any] = None,
-    ) -> 'cirq.CircuitOperation':
+    ) -> cirq.CircuitOperation:
         """Turns a cirq.google.api.v2.CircuitOperation proto into a CircuitOperation.
 
         Args:
@@ -269,7 +265,7 @@ class CircuitOpDeserializer(OpDeserializer):
                 f'(length {len(deserialized_constants)}).'
             )
         circuit = deserialized_constants[proto.circuit_constant_index]
-        if not isinstance(circuit, circuits.FrozenCircuit):
+        if not isinstance(circuit, cirq.FrozenCircuit):
             raise ValueError(
                 f'Constant at index {proto.circuit_constant_index} was expected to be a circuit, '
                 f'but it has type {type(circuit)} in the deserialized_constants list.'
@@ -319,7 +315,7 @@ class CircuitOpDeserializer(OpDeserializer):
                     f'\nFull arg: {arg}'
                 )
 
-        return circuits.CircuitOperation(
+        return cirq.CircuitOperation(
             circuit,
             repetitions,
             qubit_map,

--- a/cirq-google/cirq_google/ops/calibration_tag.py
+++ b/cirq-google/cirq_google/ops/calibration_tag.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from typing import Any, Dict
 
-from cirq import protocols
+import cirq
 
 
 class CalibrationTag:
@@ -36,7 +36,7 @@ class CalibrationTag:
         return f'cirq_google.CalibrationTag({self.token!r})'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return protocols.obj_to_dict_helper(self, ['token'])
+        return cirq.obj_to_dict_helper(self, ['token'])
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, CalibrationTag):

--- a/cirq-google/cirq_google/ops/physical_z_tag.py
+++ b/cirq-google/cirq_google/ops/physical_z_tag.py
@@ -14,7 +14,7 @@
 """A class that can be used to denote a physical Z gate."""
 from typing import Any, Dict
 
-from cirq import protocols
+import cirq
 
 
 class PhysicalZTag:
@@ -38,7 +38,7 @@ class PhysicalZTag:
         return 'cirq_google.PhysicalZTag()'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return protocols.obj_to_dict_helper(self, [])
+        return cirq.obj_to_dict_helper(self, [])
 
     def __eq__(self, other) -> bool:
         return isinstance(other, PhysicalZTag)

--- a/cirq-google/cirq_google/ops/sycamore_gate.py
+++ b/cirq-google/cirq_google/ops/sycamore_gate.py
@@ -13,18 +13,13 @@
 # limitations under the License.
 """An instance of FSimGate that works naturally on Google's Sycamore chip"""
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 
-from cirq import ops, protocols
+import cirq
 from cirq._doc import document
 
-if TYPE_CHECKING:
-    import cirq
 
-
-class SycamoreGate(ops.FSimGate):
+class SycamoreGate(cirq.FSimGate):
     """The Sycamore gate is a two-qubit gate equivalent to FSimGate(π/2, π/6).
 
     The unitary of this gate is
@@ -49,11 +44,11 @@ class SycamoreGate(ops.FSimGate):
     def __str__(self) -> str:
         return 'SYC'
 
-    def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs'):
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs):
         return 'SYC', 'SYC'
 
     def _json_dict_(self):
-        return protocols.obj_to_dict_helper(self, [])
+        return cirq.obj_to_dict_helper(self, [])
 
 
 SYC = SycamoreGate()

--- a/cirq-google/cirq_google/optimizers/convert_to_sqrt_iswap.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sqrt_iswap.py
@@ -11,19 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional
 
 import numpy as np
 import sympy
 
-from cirq import ops, circuits, protocols
+import cirq
 
-
-if TYPE_CHECKING:
-    import cirq
-
-SQRT_ISWAP = ops.ISWAP ** 0.5
-SQRT_ISWAP_INV = ops.ISWAP ** -0.5
+SQRT_ISWAP = cirq.ISWAP ** 0.5
+SQRT_ISWAP_INV = cirq.ISWAP ** -0.5
 
 
 # TODO: Combine this with the equivalent functions in google/gate_set.py
@@ -37,7 +33,7 @@ def _near_mod_2pi(e, t, atol=1e-8):
     return _near_mod_n(e, t, 2 * np.pi, atol=atol)
 
 
-class ConvertToSqrtIswapGates(circuits.PointOptimizer):
+class ConvertToSqrtIswapGates(cirq.PointOptimizer):
     """Attempts to convert gates into ISWAP**-0.5 gates.
 
     Since we have Z rotations and arbitrary XY rotations, we
@@ -58,12 +54,12 @@ class ConvertToSqrtIswapGates(circuits.PointOptimizer):
         super().__init__()
         self.ignore_failures = ignore_failures
 
-    def _convert_one(self, op: 'cirq.Operation') -> 'cirq.OP_TREE':
+    def _convert_one(self, op: cirq.Operation) -> cirq.OP_TREE:
         """
         Decomposer intercept:  Let cirq decompose one-qubit gates,
         intercept on 2-qubit gates if they are known gates.
         """
-        if isinstance(op, ops.GlobalPhaseOperation):
+        if isinstance(op, cirq.GlobalPhaseOperation):
             return []
 
         gate = op.gate
@@ -73,16 +69,16 @@ class ConvertToSqrtIswapGates(circuits.PointOptimizer):
 
         q0, q1 = op.qubits
 
-        if isinstance(gate, ops.CZPowGate):
+        if isinstance(gate, cirq.CZPowGate):
             if isinstance(gate.exponent, sympy.Basic):
                 return cphase_symbols_to_sqrt_iswap(q0, q1, gate.exponent)
             else:
                 return cphase_to_sqrt_iswap(q0, q1, gate.exponent)
-        if isinstance(gate, ops.SwapPowGate):
+        if isinstance(gate, cirq.SwapPowGate):
             return swap_to_sqrt_iswap(q0, q1, gate.exponent)
-        if isinstance(gate, ops.ISwapPowGate):
+        if isinstance(gate, cirq.ISwapPowGate):
             return iswap_to_sqrt_iswap(q0, q1, gate.exponent)
-        if isinstance(gate, ops.FSimGate):
+        if isinstance(gate, cirq.FSimGate):
             return fsim_gate(q0, q1, gate.theta, gate.phi)
 
         return NotImplemented
@@ -95,32 +91,30 @@ class ConvertToSqrtIswapGates(circuits.PointOptimizer):
             "or composite."
         )
 
-    def convert(self, op: 'cirq.Operation') -> List['cirq.Operation']:
-
-        a = protocols.decompose(
+    def convert(self, op: cirq.Operation) -> List[cirq.Operation]:
+        return cirq.decompose(
             op,
             keep=is_sqrt_iswap_compatible,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=(None if self.ignore_failures else self._on_stuck_raise),
         )
-        return a
 
     def optimization_at(
-        self, circuit: 'cirq.Circuit', index: int, op: 'cirq.Operation'
-    ) -> Optional['cirq.PointOptimizationSummary']:
-        if isinstance(op.gate, ops.MatrixGate) and len(op.qubits) == 1:
+        self, circuit: cirq.Circuit, index: int, op: cirq.Operation
+    ) -> Optional[cirq.PointOptimizationSummary]:
+        if isinstance(op.gate, cirq.MatrixGate) and len(op.qubits) == 1:
             return None
 
         converted = self.convert(op)
         if len(converted) == 1 and converted[0] is op:
             return None
 
-        return circuits.PointOptimizationSummary(
+        return cirq.PointOptimizationSummary(
             clear_span=1, new_operations=converted, clear_qubits=op.qubits
         )
 
 
-def is_sqrt_iswap_compatible(op: 'cirq.Operation') -> bool:
+def is_sqrt_iswap_compatible(op: cirq.Operation) -> bool:
     """Check if the given operation is compatible with the sqrt_iswap gateset
     gate set.
 
@@ -133,25 +127,25 @@ def is_sqrt_iswap_compatible(op: 'cirq.Operation') -> bool:
     return is_basic_gate(op.gate) or is_sqrt_iswap(op.gate)
 
 
-def is_sqrt_iswap(gate: Optional['cirq.Gate']) -> bool:
+def is_sqrt_iswap(gate: Optional[cirq.Gate]) -> bool:
     """Checks if this is a ± sqrt(iSWAP) gate specified using either
     ISwapPowGate or with the equivalent FSimGate.
     """
     if (
-        isinstance(gate, ops.FSimGate)
+        isinstance(gate, cirq.FSimGate)
         and not isinstance(gate.theta, sympy.Basic)
         and _near_mod_2pi(abs(gate.theta), np.pi / 4)
         and _near_mod_2pi(gate.phi, 0)
     ):
         return True
     return (
-        isinstance(gate, ops.ISwapPowGate)
+        isinstance(gate, cirq.ISwapPowGate)
         and not isinstance(gate.exponent, sympy.Basic)
         and _near_mod_n(abs(gate.exponent), 0.5, 4)
     )
 
 
-def is_basic_gate(gate: Optional['cirq.Gate']) -> bool:
+def is_basic_gate(gate: Optional[cirq.Gate]) -> bool:
     """Check if a gate is a basic supported one-qubit gate.
 
     Args:
@@ -163,12 +157,12 @@ def is_basic_gate(gate: Optional['cirq.Gate']) -> bool:
     return isinstance(
         gate,
         (
-            ops.MeasurementGate,
-            ops.PhasedXZGate,
-            ops.PhasedXPowGate,
-            ops.XPowGate,
-            ops.YPowGate,
-            ops.ZPowGate,
+            cirq.MeasurementGate,
+            cirq.PhasedXZGate,
+            cirq.PhasedXPowGate,
+            cirq.XPowGate,
+            cirq.YPowGate,
+            cirq.ZPowGate,
         ),
     )
 
@@ -205,18 +199,18 @@ def cphase_to_sqrt_iswap(a, b, turns):
         phi = np.arcsin(np.sqrt(2) * np.sin(theta_prime / 4))
         xi = np.arctan(np.tan(phi) / np.sqrt(2))
 
-    yield ops.rz(sign * 0.5 * theta_prime).on(a)
-    yield ops.rz(sign * 0.5 * theta_prime).on(b)
-    yield ops.rx(xi).on(a)
-    yield ops.X(b) ** (-sign * 0.5)
+    yield cirq.rz(sign * 0.5 * theta_prime).on(a)
+    yield cirq.rz(sign * 0.5 * theta_prime).on(b)
+    yield cirq.rx(xi).on(a)
+    yield cirq.X(b) ** (-sign * 0.5)
     yield SQRT_ISWAP_INV(a, b)
-    yield ops.rx(-2 * phi).on(a)
+    yield cirq.rx(-2 * phi).on(a)
     yield SQRT_ISWAP(a, b)
 
-    yield ops.rx(xi).on(a)
-    yield ops.X(b) ** (sign * 0.5)
+    yield cirq.rx(xi).on(a)
+    yield cirq.X(b) ** (sign * 0.5)
     # Corrects global phase
-    yield ops.GlobalPhaseOperation(np.exp(sign * theta_prime * 0.25j))
+    yield cirq.GlobalPhaseOperation(np.exp(sign * theta_prime * 0.25j))
 
 
 def cphase_symbols_to_sqrt_iswap(a, b, turns):
@@ -236,15 +230,15 @@ def cphase_symbols_to_sqrt_iswap(a, b, turns):
     phi = sympy.asin(np.sqrt(2) * sympy.sin(theta_prime / 4))
     xi = sympy.atan(sympy.tan(phi) / np.sqrt(2))
 
-    yield ops.rz(sign * 0.5 * theta_prime).on(a)
-    yield ops.rz(sign * 0.5 * theta_prime).on(b)
-    yield ops.rx(xi).on(a)
-    yield ops.X(b) ** (-sign * 0.5)
+    yield cirq.rz(sign * 0.5 * theta_prime).on(a)
+    yield cirq.rz(sign * 0.5 * theta_prime).on(b)
+    yield cirq.rx(xi).on(a)
+    yield cirq.X(b) ** (-sign * 0.5)
     yield SQRT_ISWAP_INV(a, b)
-    yield ops.rx(-2 * phi).on(a)
+    yield cirq.rx(-2 * phi).on(a)
     yield SQRT_ISWAP(a, b)
-    yield ops.rx(xi).on(a)
-    yield ops.X(b) ** (sign * 0.5)
+    yield cirq.rx(xi).on(a)
+    yield cirq.X(b) ** (sign * 0.5)
 
 
 def iswap_to_sqrt_iswap(a, b, turns):
@@ -261,14 +255,14 @@ def iswap_to_sqrt_iswap(a, b, turns):
         b: the second qubit
         t: Exponent that specifies the evolution time in number of rotations.
     """
-    yield ops.Z(a) ** 0.75
-    yield ops.Z(b) ** 0.25
+    yield cirq.Z(a) ** 0.75
+    yield cirq.Z(b) ** 0.25
     yield SQRT_ISWAP_INV(a, b)
-    yield ops.Z(a) ** (-turns / 2 + 1)
-    yield ops.Z(b) ** (turns / 2)
+    yield cirq.Z(a) ** (-turns / 2 + 1)
+    yield cirq.Z(b) ** (turns / 2)
     yield SQRT_ISWAP_INV(a, b)
-    yield ops.Z(a) ** 0.25
-    yield ops.Z(b) ** -0.25
+    yield cirq.Z(a) ** 0.25
+    yield cirq.Z(b) ** -0.25
 
 
 def swap_to_sqrt_iswap(a, b, turns):
@@ -287,28 +281,28 @@ def swap_to_sqrt_iswap(a, b, turns):
     """
     if not isinstance(turns, sympy.Basic) and _near_mod_n(turns, 1.0, 2):
         # Decomposition for cirq.SWAP
-        yield ops.Y(a) ** 0.5
-        yield ops.Y(b) ** 0.5
+        yield cirq.Y(a) ** 0.5
+        yield cirq.Y(b) ** 0.5
         yield SQRT_ISWAP(a, b)
-        yield ops.Y(a) ** -0.5
-        yield ops.Y(b) ** -0.5
+        yield cirq.Y(a) ** -0.5
+        yield cirq.Y(b) ** -0.5
         yield SQRT_ISWAP(a, b)
-        yield ops.X(a) ** -0.5
-        yield ops.X(b) ** -0.5
+        yield cirq.X(a) ** -0.5
+        yield cirq.X(b) ** -0.5
         yield SQRT_ISWAP(a, b)
-        yield ops.X(a) ** 0.5
-        yield ops.X(b) ** 0.5
+        yield cirq.X(a) ** 0.5
+        yield cirq.X(b) ** 0.5
         return
 
-    yield ops.Z(a) ** 1.25
-    yield ops.Z(b) ** -0.25
-    yield ops.ISWAP(a, b) ** -0.5
-    yield ops.Z(a) ** (-turns / 2 + 1)
-    yield ops.Z(b) ** (turns / 2)
-    yield ops.ISWAP(a, b) ** -0.5
-    yield ops.Z(a) ** (turns / 2 - 0.25)
-    yield ops.Z(b) ** (turns / 2 + 0.25)
-    yield ops.CZ.on(a, b) ** (-turns)
+    yield cirq.Z(a) ** 1.25
+    yield cirq.Z(b) ** -0.25
+    yield cirq.ISWAP(a, b) ** -0.5
+    yield cirq.Z(a) ** (-turns / 2 + 1)
+    yield cirq.Z(b) ** (turns / 2)
+    yield cirq.ISWAP(a, b) ** -0.5
+    yield cirq.Z(a) ** (turns / 2 - 0.25)
+    yield cirq.Z(b) ** (turns / 2 + 0.25)
+    yield cirq.CZ.on(a, b) ** (-turns)
 
 
 def fsim_gate(a, b, theta, phi):
@@ -316,6 +310,6 @@ def fsim_gate(a, b, theta, phi):
     which is an awkward decomposition for this gate set.
     Decompose into ISWAP and CZ instead."""
     if theta != 0.0:
-        yield ops.ISWAP(a, b) ** (-2 * theta / np.pi)
+        yield cirq.ISWAP(a, b) ** (-2 * theta / np.pi)
     if phi != 0.0:
-        yield ops.CZPowGate(exponent=-phi / np.pi)(a, b)
+        yield cirq.CZPowGate(exponent=-phi / np.pi)(a, b)

--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
@@ -11,29 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Iterator, List, Optional, TYPE_CHECKING
-
 import math
+from typing import Iterator, List, Optional
+
 import numpy as np
 import scipy.linalg
-from cirq import circuits, linalg, ops, optimizers, protocols
+
+import cirq
 import cirq_google as google
 from cirq_google.ops import SycamoreGate
 from cirq_google.optimizers.two_qubit_gates.gate_compilation import GateTabulation
 
-if TYPE_CHECKING:
-    import cirq
 
-UNITARY_ZZ = np.kron(protocols.unitary(ops.Z), protocols.unitary(ops.Z))
+UNITARY_ZZ = np.kron(cirq.unitary(cirq.Z), cirq.unitary(cirq.Z))
 PAULI_OPS = [
     np.eye(2),
-    protocols.unitary(ops.X),
-    protocols.unitary(ops.Y),
-    protocols.unitary(ops.Z),
+    cirq.unitary(cirq.X),
+    cirq.unitary(cirq.Y),
+    cirq.unitary(cirq.Z),
 ]
 
 
-class ConvertToSycamoreGates(circuits.PointOptimizer):
+class ConvertToSycamoreGates(cirq.PointOptimizer):
     """Attempts to convert non-native gates into SycamoreGates.
 
     First, checks if the given operation is already a native sycamore operation.
@@ -65,7 +64,7 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
             raise ValueError("provided tabulation must be of type GateTabulation")
         self.tabulation = tabulation
 
-    def _is_native_sycamore_op(self, op: ops.Operation) -> bool:
+    def _is_native_sycamore_op(self, op: cirq.Operation) -> bool:
         """Check if the given operation is native to a Sycamore device.
 
         Args:
@@ -80,18 +79,18 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
             gate,
             (
                 SycamoreGate,
-                ops.MeasurementGate,
-                ops.PhasedXZGate,
-                ops.PhasedXPowGate,
-                ops.XPowGate,
-                ops.YPowGate,
-                ops.ZPowGate,
+                cirq.MeasurementGate,
+                cirq.PhasedXZGate,
+                cirq.PhasedXPowGate,
+                cirq.XPowGate,
+                cirq.YPowGate,
+                cirq.ZPowGate,
             ),
         ):
             return True
 
         if (
-            isinstance(gate, ops.FSimGate)
+            isinstance(gate, cirq.FSimGate)
             and math.isclose(gate.theta, np.pi / 2)
             and math.isclose(gate.phi, np.pi / 6)
         ):
@@ -99,7 +98,7 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
 
         return False
 
-    def _convert_one(self, op: ops.Operation) -> ops.OP_TREE:
+    def _convert_one(self, op: cirq.Operation) -> cirq.OP_TREE:
         """
         Decomposer intercept:  Upon cirq.protocols.decompose catch and
         return new OP_Tree
@@ -107,14 +106,14 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
         This should decompose based on number of qubits.
         """
         if len(op.qubits) == 1:
-            return _phased_x_z_ops(protocols.unitary(op, None), op.qubits[0])
-        elif len(op.qubits) == 2 and isinstance(op, ops.GateOperation):
+            return _phased_x_z_ops(cirq.unitary(op, None), op.qubits[0])
+        elif len(op.qubits) == 2 and isinstance(op, cirq.GateOperation):
             return known_two_q_operations_to_sycamore_operations(
                 op.qubits[0], op.qubits[1], op, self.tabulation
             )
         return NotImplemented
 
-    def convert(self, op: ops.Operation) -> List[ops.Operation]:
+    def convert(self, op: cirq.Operation) -> List[cirq.Operation]:
         def on_stuck_raise(bad):
             return TypeError(
                 "Don't know how to work with {!r}. "
@@ -123,7 +122,7 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
                 "or composite.".format(bad)
             )
 
-        return protocols.decompose(
+        return cirq.decompose(
             op,
             keep=self._is_native_sycamore_op,
             intercepting_decomposer=self._convert_one,
@@ -131,31 +130,31 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
         )
 
     def optimization_at(
-        self, circuit: 'cirq.Circuit', index: int, op: 'cirq.Operation'
-    ) -> Optional['cirq.PointOptimizationSummary']:
-        if not isinstance(op, ops.GateOperation):
+        self, circuit: cirq.Circuit, index: int, op: cirq.Operation
+    ) -> Optional[cirq.PointOptimizationSummary]:
+        if not isinstance(op, cirq.GateOperation):
             return None
 
         gate = op.gate
 
         # Check for a SWAP and ZZPowGate together
-        if isinstance(gate, ops.ZZPowGate) or gate == ops.SWAP:
+        if isinstance(gate, cirq.ZZPowGate) or gate == cirq.SWAP:
             gate2 = None
             rads = None
             next_index = circuit.next_moment_operating_on(op.qubits, index + 1)
             if next_index is not None:
                 ops_in_front = list({circuit.operation_at(q, next_index) for q in op.qubits})
-                if len(ops_in_front) == 1 and isinstance(ops_in_front[0], ops.GateOperation):
+                if len(ops_in_front) == 1 and isinstance(ops_in_front[0], cirq.GateOperation):
                     gate2 = ops_in_front[0].gate
             else:
                 next_index = 0
 
-            if isinstance(gate, ops.SwapPowGate) and isinstance(gate2, ops.ZZPowGate):
+            if isinstance(gate, cirq.SwapPowGate) and isinstance(gate2, cirq.ZZPowGate):
                 rads = gate2.exponent * np.pi / 2
-            if isinstance(gate, ops.ZZPowGate) and gate2 == ops.SWAP:
+            if isinstance(gate, cirq.ZZPowGate) and gate2 == cirq.SWAP:
                 rads = gate.exponent * np.pi / 2
             if rads is not None:
-                return circuits.PointOptimizationSummary(
+                return cirq.PointOptimizationSummary(
                     clear_span=next_index - index + 1,
                     clear_qubits=op.qubits,
                     new_operations=swap_rzz(rads, op.qubits[0], op.qubits[1]),
@@ -165,17 +164,17 @@ class ConvertToSycamoreGates(circuits.PointOptimizer):
         if len(converted) == 1 and converted[0] is op:
             return None
 
-        return circuits.PointOptimizationSummary(
+        return cirq.PointOptimizationSummary(
             clear_span=1, new_operations=converted, clear_qubits=op.qubits
         )
 
 
 def known_two_q_operations_to_sycamore_operations(
-    qubit_a: ops.Qid,
-    qubit_b: ops.Qid,
-    op: ops.Operation,
+    qubit_a: cirq.Qid,
+    qubit_b: cirq.Qid,
+    op: cirq.Operation,
     tabulation: Optional[GateTabulation] = None,
-) -> ops.OP_TREE:
+) -> cirq.OP_TREE:
     """
     Synthesize a known gate operation to a sycamore operation
 
@@ -191,7 +190,7 @@ def known_two_q_operations_to_sycamore_operations(
         New operations iterable object
     """
     gate = op.gate
-    if isinstance(gate, ops.PhasedISwapPowGate):
+    if isinstance(gate, cirq.PhasedISwapPowGate):
         if math.isclose(gate.exponent, 1):
             return decompose_phased_iswap_into_syc(gate.phase_exponent, qubit_a, qubit_b)
         elif math.isclose(gate.phase_exponent, 0.25):
@@ -203,25 +202,25 @@ def known_two_q_operations_to_sycamore_operations(
                 "To decompose PhasedISwapPowGate, it must have a phase_exponent"
                 " of .25 OR an exponent of 1.0, but got: {!r}".format(op)
             )
-    if isinstance(gate, ops.CNotPowGate):
+    if isinstance(gate, cirq.CNotPowGate):
         return [
-            ops.Y(qubit_b) ** -0.5,
+            cirq.Y(qubit_b) ** -0.5,
             cphase(gate.exponent * np.pi, qubit_a, qubit_b),
-            ops.Y(qubit_b) ** 0.5,
+            cirq.Y(qubit_b) ** 0.5,
         ]
-    elif isinstance(gate, ops.CZPowGate):
+    elif isinstance(gate, cirq.CZPowGate):
         if math.isclose(gate.exponent, 1):  # check if CZ or CPHASE
             return decompose_cz_into_syc(qubit_a, qubit_b)
         else:
             # because CZPowGate == diag([1, 1, 1, e^{i pi phi}])
             return cphase(gate.exponent * np.pi, qubit_a, qubit_b)
-    elif isinstance(gate, ops.SwapPowGate) and math.isclose(gate.exponent, 1):
+    elif isinstance(gate, cirq.SwapPowGate) and math.isclose(gate.exponent, 1):
         return decompose_swap_into_syc(qubit_a, qubit_b)
-    elif isinstance(gate, ops.ISwapPowGate) and math.isclose(gate.exponent, 1):
+    elif isinstance(gate, cirq.ISwapPowGate) and math.isclose(gate.exponent, 1):
         return decompose_iswap_into_syc(qubit_a, qubit_b)
-    elif isinstance(gate, ops.ZZPowGate):
+    elif isinstance(gate, cirq.ZZPowGate):
         return rzz(gate.exponent * np.pi / 2, *op.qubits)
-    elif protocols.unitary(gate, None) is not None:
+    elif cirq.unitary(gate, None) is not None:
         if tabulation:
             return decompose_arbitrary_into_syc_tabulation(qubit_a, qubit_b, op, tabulation)
         else:
@@ -230,7 +229,9 @@ def known_two_q_operations_to_sycamore_operations(
         raise ValueError(f"Unrecognized gate: {op!r}")
 
 
-def decompose_phased_iswap_into_syc(phase_exponent: float, a: ops.Qid, b: ops.Qid) -> ops.OP_TREE:
+def decompose_phased_iswap_into_syc(
+    phase_exponent: float, a: cirq.Qid, b: cirq.Qid
+) -> cirq.OP_TREE:
     """Decompose PhasedISwap with an exponent of 1.
 
     This should only be called if the Gate has an exponent of 1 - otherwise,
@@ -247,16 +248,16 @@ def decompose_phased_iswap_into_syc(phase_exponent: float, a: ops.Qid, b: ops.Qi
 
     """
 
-    yield ops.Z(a) ** phase_exponent,
-    yield ops.Z(b) ** -phase_exponent,
+    yield cirq.Z(a) ** phase_exponent,
+    yield cirq.Z(b) ** -phase_exponent,
     yield decompose_iswap_into_syc(a, b),
-    yield ops.Z(a) ** -phase_exponent,
-    yield ops.Z(b) ** phase_exponent,
+    yield cirq.Z(a) ** -phase_exponent,
+    yield cirq.Z(b) ** phase_exponent,
 
 
 def decompose_phased_iswap_into_syc_precomputed(
-    theta: float, a: ops.Qid, b: ops.Qid
-) -> ops.OP_TREE:
+    theta: float, a: cirq.Qid, b: cirq.Qid
+) -> cirq.OP_TREE:
     """Decompose PhasedISwap into sycamore gates using precomputed coefficients.
 
     This should only be called if the Gate has a phase_exponent of .25. If the
@@ -278,35 +279,35 @@ def decompose_phased_iswap_into_syc_precomputed(
 
     """
 
-    yield ops.PhasedXPowGate(phase_exponent=0.41175161497166024, exponent=0.5653807577895922).on(a)
-    yield ops.PhasedXPowGate(phase_exponent=1.0, exponent=0.5).on(b),
-    yield (ops.Z ** 0.7099892314883478).on(b),
-    yield (ops.Z ** 0.6746023442550453).on(a),
+    yield cirq.PhasedXPowGate(phase_exponent=0.41175161497166024, exponent=0.5653807577895922).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=1.0, exponent=0.5).on(b),
+    yield (cirq.Z ** 0.7099892314883478).on(b),
+    yield (cirq.Z ** 0.6746023442550453).on(a),
     yield SycamoreGate().on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.5154334589432878, exponent=0.5228733015013345).on(b)
-    yield ops.PhasedXPowGate(phase_exponent=0.06774925307475355).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.5154334589432878, exponent=0.5228733015013345).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=0.06774925307475355).on(a)
     yield SycamoreGate().on(a, b),
-    yield ops.PhasedXPowGate(phase_exponent=-0.5987667922766213, exponent=0.4136540654256824).on(a)
-    yield (ops.Z ** -0.9255092746611595).on(b)
-    yield (ops.Z ** -1.333333333333333).on(a)
-    yield ops.rx(-theta).on(a)
-    yield ops.rx(-theta).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.5987667922766213, exponent=0.4136540654256824).on(a)
+    yield (cirq.Z ** -0.9255092746611595).on(b)
+    yield (cirq.Z ** -1.333333333333333).on(a)
+    yield cirq.rx(-theta).on(a)
+    yield cirq.rx(-theta).on(b)
 
-    yield ops.PhasedXPowGate(phase_exponent=0.5678998743900456, exponent=0.5863459345743176).on(a)
-    yield ops.PhasedXPowGate(phase_exponent=0.3549946157441739).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=0.5678998743900456, exponent=0.5863459345743176).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=0.3549946157441739).on(b)
     yield SycamoreGate().on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.5154334589432878, exponent=0.5228733015013345).on(b)
-    yield ops.PhasedXPowGate(phase_exponent=0.06774925307475355).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.5154334589432878, exponent=0.5228733015013345).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=0.06774925307475355).on(a)
     yield SycamoreGate().on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.8151665352515929, exponent=0.8906746535691492).on(a)
-    yield ops.PhasedXPowGate(phase_exponent=-0.07449072533884049, exponent=0.5).on(b)
-    yield (ops.Z ** -0.9255092746611595).on(b)
-    yield (ops.Z ** -0.9777346353961884).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.8151665352515929, exponent=0.8906746535691492).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.07449072533884049, exponent=0.5).on(b)
+    yield (cirq.Z ** -0.9255092746611595).on(b)
+    yield (cirq.Z ** -0.9777346353961884).on(a)
 
 
 def decompose_arbitrary_into_syc_tabulation(
-    qubit_a: ops.Qid, qubit_b: ops.Qid, op: ops.Operation, tabulation: GateTabulation
-) -> ops.OP_TREE:
+    qubit_a: cirq.Qid, qubit_b: cirq.Qid, op: cirq.Operation, tabulation: GateTabulation
+) -> cirq.OP_TREE:
     """Synthesize an arbitrary 2 qubit operation to a sycamore operation using
     the given Tabulation.
 
@@ -318,7 +319,7 @@ def decompose_arbitrary_into_syc_tabulation(
     Returns:
         New operations iterable object
     """
-    result = tabulation.compile_two_qubit_gate(protocols.unitary(op))
+    result = tabulation.compile_two_qubit_gate(cirq.unitary(op))
     local_gates = result.local_unitaries
     for i, (gate_a, gate_b) in enumerate(local_gates):
         yield from _phased_x_z_ops(gate_a, qubit_a)
@@ -328,8 +329,8 @@ def decompose_arbitrary_into_syc_tabulation(
 
 
 def decompose_arbitrary_into_syc_analytic(
-    qubit_a: ops.Qid, qubit_b: ops.Qid, op: ops.Operation
-) -> ops.OP_TREE:
+    qubit_a: cirq.Qid, qubit_b: cirq.Qid, op: cirq.Operation
+) -> cirq.OP_TREE:
     """Synthesize an arbitrary 2 qubit operation to a sycamore operation using
     the given Tabulation.
 
@@ -341,63 +342,69 @@ def decompose_arbitrary_into_syc_analytic(
         Returns:
             New operations iterable object
     """
-    new_ops = optimizers.two_qubit_matrix_to_operations(
-        qubit_a, qubit_b, op, allow_partial_czs=True
-    )
+    new_ops = cirq.two_qubit_matrix_to_operations(qubit_a, qubit_b, op, allow_partial_czs=True)
     for new_op in new_ops:
         num_qubits = len(new_op.qubits)
         if num_qubits == 1:
             (a,) = new_op.qubits
-            yield from _phased_x_z_ops(protocols.unitary(new_op), a)
+            yield from _phased_x_z_ops(cirq.unitary(new_op), a)
         elif num_qubits == 2:
             a, b = op.qubits
-            yield from ops.flatten_to_ops(
+            yield from cirq.flatten_to_ops(
                 known_two_q_operations_to_sycamore_operations(a, b, new_op)
             )
 
 
-def decompose_cz_into_syc(a: ops.Qid, b: ops.Qid):
+def decompose_cz_into_syc(a: cirq.Qid, b: cirq.Qid):
     """Decompose CZ into sycamore gates using precomputed coefficients"""
-    yield ops.PhasedXPowGate(phase_exponent=0.5678998743900456, exponent=0.5863459345743176).on(a)
-    yield ops.PhasedXPowGate(phase_exponent=0.3549946157441739).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=0.5678998743900456, exponent=0.5863459345743176).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=0.3549946157441739).on(b)
     yield google.SYC.on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.5154334589432878, exponent=0.5228733015013345).on(b)
-    yield ops.PhasedXPowGate(phase_exponent=0.06774925307475355).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.5154334589432878, exponent=0.5228733015013345).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=0.06774925307475355).on(a)
     yield google.SYC.on(a, b),
-    yield ops.PhasedXPowGate(phase_exponent=-0.5987667922766213, exponent=0.4136540654256824).on(a),
-    yield (ops.Z ** -0.9255092746611595).on(b),
-    yield (ops.Z ** -1.333333333333333).on(a),
+    yield cirq.PhasedXPowGate(phase_exponent=-0.5987667922766213, exponent=0.4136540654256824).on(
+        a
+    ),
+    yield (cirq.Z ** -0.9255092746611595).on(b),
+    yield (cirq.Z ** -1.333333333333333).on(a),
 
 
-def decompose_iswap_into_syc(a: ops.Qid, b: ops.Qid):
+def decompose_iswap_into_syc(a: cirq.Qid, b: cirq.Qid):
     """Decompose ISWAP into sycamore gates using precomputed coefficients"""
-    yield ops.PhasedXPowGate(phase_exponent=-0.27250925776964596, exponent=0.2893438375555899).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.27250925776964596, exponent=0.2893438375555899).on(
+        a
+    )
     yield google.SYC.on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=0.8487591858680898, exponent=0.9749387200813147).on(b),
-    yield ops.PhasedXPowGate(phase_exponent=-0.3582574564210601).on(a),
+    yield cirq.PhasedXPowGate(phase_exponent=0.8487591858680898, exponent=0.9749387200813147).on(b),
+    yield cirq.PhasedXPowGate(phase_exponent=-0.3582574564210601).on(a),
     yield google.SYC.on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=0.9675022326694225, exponent=0.6908986856555526).on(a),
+    yield cirq.PhasedXPowGate(phase_exponent=0.9675022326694225, exponent=0.6908986856555526).on(a),
     yield google.SYC.on(a, b),
-    yield ops.PhasedXPowGate(phase_exponent=0.9161706861686068, exponent=0.14818318325264102).on(b),
-    yield ops.PhasedXPowGate(phase_exponent=0.9408341606787907).on(a),
-    yield (ops.Z ** -1.1551880579397293).on(b),
-    yield (ops.Z ** 0.31848343246696365).on(a),
+    yield cirq.PhasedXPowGate(phase_exponent=0.9161706861686068, exponent=0.14818318325264102).on(
+        b
+    ),
+    yield cirq.PhasedXPowGate(phase_exponent=0.9408341606787907).on(a),
+    yield (cirq.Z ** -1.1551880579397293).on(b),
+    yield (cirq.Z ** 0.31848343246696365).on(a),
 
 
-def decompose_swap_into_syc(a: ops.Qid, b: ops.Qid):
+def decompose_swap_into_syc(a: cirq.Qid, b: cirq.Qid):
     """Decompose SWAP into sycamore gates using precomputed coefficients"""
-    yield ops.PhasedXPowGate(phase_exponent=0.44650378384076217, exponent=0.8817921214052824).on(a)
-    yield ops.PhasedXPowGate(phase_exponent=-0.7656774060816165, exponent=0.6628666504604785).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=0.44650378384076217, exponent=0.8817921214052824).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.7656774060816165, exponent=0.6628666504604785).on(b)
     yield google.SYC.on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.6277589946716742, exponent=0.5659160932099687).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.6277589946716742, exponent=0.5659160932099687).on(a)
     yield google.SYC.on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=0.28890767199499257, exponent=0.4340839067900317).on(b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.22592784059288928).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=0.28890767199499257, exponent=0.4340839067900317).on(b)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.22592784059288928).on(a)
     yield google.SYC.on(a, b)
-    yield ops.PhasedXPowGate(phase_exponent=-0.4691261557936808, exponent=0.7728525693920243).on(a)
-    yield ops.PhasedXPowGate(phase_exponent=-0.8150261316932077, exponent=0.11820787859471782).on(b)
-    yield (ops.Z ** -0.7384700844660306).on(b)
-    yield (ops.Z ** -0.7034535141382525).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.4691261557936808, exponent=0.7728525693920243).on(a)
+    yield cirq.PhasedXPowGate(phase_exponent=-0.8150261316932077, exponent=0.11820787859471782).on(
+        b
+    )
+    yield (cirq.Z ** -0.7384700844660306).on(b)
+    yield (cirq.Z ** -0.7034535141382525).on(a)
 
 
 def find_local_equivalents(unitary1: np.ndarray, unitary2: np.ndarray):
@@ -417,8 +424,8 @@ def find_local_equivalents(unitary1: np.ndarray, unitary2: np.ndarray):
         four 2x2 unitaries.  first two are pre-rotations last two are post
         rotations.
     """
-    kak_u1 = linalg.kak_decomposition(unitary1)
-    kak_u2 = linalg.kak_decomposition(unitary2)
+    kak_u1 = cirq.kak_decomposition(unitary1)
+    kak_u2 = cirq.kak_decomposition(unitary2)
 
     u_0 = kak_u1.single_qubit_operations_after[0] @ kak_u2.single_qubit_operations_after[0].conj().T
     u_1 = kak_u1.single_qubit_operations_after[1] @ kak_u2.single_qubit_operations_after[1].conj().T
@@ -434,11 +441,11 @@ def find_local_equivalents(unitary1: np.ndarray, unitary2: np.ndarray):
 
 
 def create_corrected_circuit(
-    target_unitary: np.ndarray, program: circuits.Circuit, q0: ops.Qid, q1: ops.Qid
-) -> ops.OP_TREE:
+    target_unitary: np.ndarray, program: cirq.Circuit, q0: cirq.Qid, q1: cirq.Qid
+) -> cirq.OP_TREE:
     # Get the local equivalents
     b_0, b_1, a_0, a_1 = find_local_equivalents(
-        target_unitary, program.unitary(qubit_order=ops.QubitOrder.explicit([q0, q1]))
+        target_unitary, program.unitary(qubit_order=cirq.QubitOrder.explicit([q0, q1]))
     )
 
     # Apply initial corrections
@@ -453,13 +460,13 @@ def create_corrected_circuit(
     yield from _phased_x_z_ops(a_1, q1)
 
 
-def _phased_x_z_ops(mat: np.ndarray, q: 'cirq.Qid') -> Iterator['cirq.Operation']:
-    gate = optimizers.single_qubit_matrix_to_phxz(mat)
+def _phased_x_z_ops(mat: np.ndarray, q: cirq.Qid) -> Iterator[cirq.Operation]:
+    gate = cirq.single_qubit_matrix_to_phxz(mat)
     if gate:
         yield gate(q)
 
 
-def rzz(theta: float, q0: ops.Qid, q1: ops.Qid) -> ops.OP_TREE:
+def rzz(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
     """Generate exp(-1j * theta * zz) from Sycamore gates.
 
     Args:
@@ -481,14 +488,14 @@ def rzz(theta: float, q0: ops.Qid, q1: ops.Qid) -> ops.OP_TREE:
         c2 = abs(np.cos(theta)) / c_phi
 
     # Prepare program that has same Schmidt coeffs as exp(1j theta ZZ)
-    program = circuits.Circuit(
-        google.SYC.on(q0, q1), ops.rx(2 * np.arccos(c2)).on(q1), google.SYC.on(q0, q1)
+    program = cirq.Circuit(
+        google.SYC.on(q0, q1), cirq.rx(2 * np.arccos(c2)).on(q1), google.SYC.on(q0, q1)
     )
 
     yield create_corrected_circuit(target_unitary, program, q0, q1)
 
 
-def cphase(theta: float, q0: ops.Qid, q1: ops.Qid) -> ops.OP_TREE:
+def cphase(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
     """
     Implement a cphase using the Ising gate generated from 2 Sycamore gates
 
@@ -504,11 +511,11 @@ def cphase(theta: float, q0: ops.Qid, q1: ops.Qid) -> ops.OP_TREE:
         a cirq program implementing cphase
     """
     yield rzz(-theta / 4, q0, q1)
-    yield ops.rz(theta / 2).on(q0)
-    yield ops.rz(theta / 2).on(q1)
+    yield cirq.rz(theta / 2).on(q0)
+    yield cirq.rz(theta / 2).on(q1)
 
 
-def swap_rzz(theta: float, q0: ops.Qid, q1: ops.Qid) -> ops.OP_TREE:
+def swap_rzz(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
     """
     An implementation of SWAP * EXP(1j theta ZZ) using three sycamore gates.
 
@@ -524,14 +531,14 @@ def swap_rzz(theta: float, q0: ops.Qid, q1: ops.Qid) -> ops.OP_TREE:
     """
 
     # Set interaction part.
-    circuit = circuits.Circuit()
+    circuit = cirq.Circuit()
     angle_offset = np.pi / 24 - np.pi / 4
     circuit.append(google.SYC(q0, q1))
     circuit.append(rzz(theta - angle_offset, q0, q1))
 
     # Get the intended circuit.
-    intended_circuit = circuits.Circuit(
-        ops.SWAP(q0, q1), ops.ZZPowGate(exponent=2 * theta / np.pi, global_shift=-0.5).on(q0, q1)
+    intended_circuit = cirq.Circuit(
+        cirq.SWAP(q0, q1), cirq.ZZPowGate(exponent=2 * theta / np.pi, global_shift=-0.5).on(q0, q1)
     )
 
     yield create_corrected_circuit(intended_circuit, circuit, q0, q1)

--- a/cirq-google/cirq_google/optimizers/optimize_for_xmon.py
+++ b/cirq-google/cirq_google/optimizers/optimize_for_xmon.py
@@ -14,20 +14,19 @@
 """A combination of several optimizations targeting XmonDevice."""
 from typing import Callable, cast, Optional, TYPE_CHECKING
 
-from cirq import devices
+import cirq
 from cirq_google.optimizers import optimized_for_sycamore
 
 if TYPE_CHECKING:
     import cirq_google
-    import cirq
 
 
 def optimized_for_xmon(
-    circuit: 'cirq.Circuit',
+    circuit: cirq.Circuit,
     new_device: Optional['cirq_google.XmonDevice'] = None,
-    qubit_map: Callable[['cirq.Qid'], devices.GridQubit] = lambda e: cast(devices.GridQubit, e),
+    qubit_map: Callable[[cirq.Qid], cirq.GridQubit] = lambda e: cast(cirq.GridQubit, e),
     allow_partial_czs: bool = False,
-) -> 'cirq.Circuit':
+) -> cirq.Circuit:
     if allow_partial_czs:
         return optimized_for_sycamore(
             circuit, new_device=new_device, qubit_map=qubit_map, optimizer_type='xmon_partial_cz'

--- a/cirq-google/cirq_google/optimizers/two_qubit_gates/example.py
+++ b/cirq-google/cirq_google/optimizers/two_qubit_gates/example.py
@@ -22,7 +22,7 @@ from time import time
 import numpy as np
 from matplotlib import pyplot as plt
 
-from cirq import FSimGate, unitary
+import cirq
 from cirq_google.optimizers.two_qubit_gates.gate_compilation import gate_product_tabulation
 from cirq_google.optimizers.two_qubit_gates.math_utils import unitary_entanglement_fidelity
 from cirq.testing import random_special_unitary
@@ -40,7 +40,7 @@ def main(samples: int = 1000, max_infidelity: float = 0.01):
     # Define a base gate for compilation
     theta = np.pi / 4
     phi = np.pi / 24
-    base = unitary(FSimGate(theta, phi))
+    base = cirq.unitary(cirq.FSimGate(theta, phi))
 
     # The GateTabulation object is essentially a tabulation of many randomly
     # generated gate products (of the form A k A or A k A k A), along with their

--- a/cirq-google/cirq_google/optimizers/two_qubit_gates/gate_compilation_test.py
+++ b/cirq-google/cirq_google/optimizers/two_qubit_gates/gate_compilation_test.py
@@ -2,7 +2,8 @@
 import numpy as np
 import pytest
 
-from cirq import unitary, FSimGate, value
+import cirq
+from cirq import value
 from cirq_google.optimizers.two_qubit_gates.gate_compilation import (
     gate_product_tabulation,
     GateTabulation,
@@ -13,11 +14,11 @@ from cirq.testing import random_special_unitary, assert_equivalent_repr
 _rng = value.parse_random_state(11)  # for determinism
 
 sycamore_tabulation = gate_product_tabulation(
-    unitary(FSimGate(np.pi / 2, np.pi / 6)), 0.2, random_state=_rng
+    cirq.unitary(cirq.FSimGate(np.pi / 2, np.pi / 6)), 0.2, random_state=_rng
 )
 
 sqrt_iswap_tabulation = gate_product_tabulation(
-    unitary(FSimGate(np.pi / 4, np.pi / 24)), 0.1, random_state=_rng
+    cirq.unitary(cirq.FSimGate(np.pi / 4, np.pi / 24)), 0.1, random_state=_rng
 )
 
 _random_2Q_unitaries = np.array([random_special_unitary(4, random_state=_rng) for _ in range(100)])
@@ -64,7 +65,7 @@ def test_gate_compilation_missing_points_raises_error():
 
 @pytest.mark.parametrize('seed', [0, 1])
 def test_sycamore_gate_tabulation(seed):
-    base_gate = unitary(FSimGate(np.pi / 2, np.pi / 6))
+    base_gate = cirq.unitary(cirq.FSimGate(np.pi / 2, np.pi / 6))
     tab = gate_product_tabulation(
         base_gate, 0.1, sample_scaling=2, random_state=np.random.RandomState(seed)
     )

--- a/cirq-google/cirq_google/optimizers/two_qubit_gates/math_utils_test.py
+++ b/cirq-google/cirq_google/optimizers/two_qubit_gates/math_utils_test.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from cirq import kak_canonicalize_vector, value
+import cirq
+from cirq import value
 from cirq_google.optimizers.two_qubit_gates.math_utils import (
     weyl_chamber_mesh,
     kak_vector_infidelity,
@@ -16,8 +17,8 @@ def test_weyl_chamber_mesh_spacing_too_small_throws_error():
 
 def test_kak_vector_infidelity_ignore_equivalent_nontrivial():
     x, y, z = np.pi / 4, 1, 0.5
-    kak_0 = kak_canonicalize_vector(x, y, z).interaction_coefficients
-    kak_1 = kak_canonicalize_vector(x - 1e-3, y, z).interaction_coefficients
+    kak_0 = cirq.kak_canonicalize_vector(x, y, z).interaction_coefficients
+    kak_1 = cirq.kak_canonicalize_vector(x - 1e-3, y, z).interaction_coefficients
 
     inf_check_equivalent = kak_vector_infidelity(kak_0, kak_1, False)
     inf_ignore_equivalent = kak_vector_infidelity(kak_0, kak_1, True)


### PR DESCRIPTION
Now that cirq-google is a separate package from cirq-core, we can import cirq like a separate library. We use the top-level `cirq` namespace wherever possible instead of importing subpackages, and also remove some of the `if TYPE_CHECKING` guards and unquote cirq type annotations.