### PR TITLE
Sort PauliString items in __format__ so that it's less brittle

### DIFF
--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -662,7 +662,8 @@ class PauliSum:
 
     def __format__(self, format_spec: str) -> str:
         terms = [
-            (_pauli_string_from_unit(v), self._linear_dict[v]) for v in self._linear_dict.keys()
+            (_pauli_string_from_unit(v), self._linear_dict[v])
+            for v in sorted(self._linear_dict.keys())
         ]
         return _format_terms(terms=terms, format_spec=format_spec)
 

--- a/cirq-core/cirq/ops/linear_combinations_test.py
+++ b/cirq-core/cirq/ops/linear_combinations_test.py
@@ -1178,7 +1178,7 @@ def test_pauli_sum_formatting():
     paulistr = cirq.X(q[0]) * cirq.X(q[1])
     assert str(paulistr) == 'X(0)*X(1)'
     paulisum1 = cirq.X(q[0]) * cirq.X(q[1]) + 4
-    assert str(paulisum1) == '1.000*X(0)*X(1)+4.000*I'
+    assert str(paulisum1) == '4.000*I+1.000*X(0)*X(1)'
     paulisum2 = cirq.X(q[0]) * cirq.X(q[1]) + cirq.Z(q[0])
     assert str(paulisum2) == '1.000*X(0)*X(1)+1.000*Z(0)'
     paulisum3 = cirq.X(q[0]) * cirq.X(q[1]) + cirq.Z(q[0]) * cirq.Z(q[1])


### PR DESCRIPTION
It seems we should have a more stable representation, so sorting the keys.