### PR TITLE
fix aqt ref in book.yaml

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -236,10 +236,13 @@ upper_tabs:
       - title: "All symbols"
         path: /reference/python/cirq/all_symbols
       - include: /reference/python/cirq/_toc.yaml
-      - heading: "cirq-aqt"
-      - title: "All symbols"
-        path: /reference/python/cirq_aqt/all_symbols
-      - include: /reference/python/cirq_aqt/_toc.yaml
+
+# uncomment after v0.12 is released
+#      - heading: "cirq-aqt"
+#      - title: "All symbols"
+#        path: /reference/python/cirq_aqt/all_symbols
+#      - include: /reference/python/cirq_aqt/_toc.yaml
+
       - heading: "cirq-google"
       - title: "All symbols"
         path: /reference/python/cirq_google/all_symbols


### PR DESCRIPTION
Adding cirq_aqt reference API while it doesn't exist broke the devsite publishing, so removing it for now, we'll have to add it after the release of v0.12.