### PR TITLE
Fix EjectPhasedPaulis incorrectly treating X**0 as X**1

### DIFF
--- a/cirq-core/cirq/optimizers/eject_phased_paulis.py
+++ b/cirq-core/cirq/optimizers/eject_phased_paulis.py
@@ -68,7 +68,7 @@ class EjectPhasedPaulis:
                 # Collect, phase, and merge Ws.
                 w = _try_get_known_phased_pauli(op, no_symbolic=not self.eject_parameterized)
                 if w is not None:
-                    if decompositions.is_negligible_turn(w[0] - 1, self.tolerance):
+                    if decompositions.is_negligible_turn((w[0] - 1) / 2, self.tolerance):
                         _potential_cross_whole_w(moment_index, op, self.tolerance, state)
                     else:
                         _potential_cross_partial_w(moment_index, op, state)

--- a/cirq-core/cirq/optimizers/eject_phased_paulis_test.py
+++ b/cirq-core/cirq/optimizers/eject_phased_paulis_test.py
@@ -536,3 +536,16 @@ def test_blocked_by_unknown_and_symbols(sym):
         ),
         compare_unitaries=False,
     )
+
+
+def test_zero_x_rotation():
+    a = cirq.NamedQubit('a')
+
+    assert_optimizes(
+        before=quick_circuit(
+            [cirq.rx(0)(a)],
+        ),
+        expected=quick_circuit(
+            [cirq.rx(0)(a)],
+        ),
+    )


### PR DESCRIPTION
Fixes #4218 and adds a test for the previously failing case.

The code treated the half-turns (exponent) value as whole-turns so both X**1 and X**0 were treated as whole X gates.