### PR TITLE
Tests pypi upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/deps/packaging.txt
       - name: Run packaging test
+        env:
+          TEST_TWINE_USERNAME: ${{ secrets.TEST_PYPI_USER }}
+          TEST_TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASS }}
         run: ./dev_tools/packaging/packaging_test.sh
   format:
     name: Format check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
           python-version: '3.7'
@@ -253,7 +255,7 @@ jobs:
     strategy:
       matrix:
         # partitions should be named partition-0 to partition-(NOTEBOOK_PARTITIONS-1)
-        partition: [partition-0, partition-1, partition-2, partition-3]
+        partition: [ partition-0, partition-1, partition-2, partition-3 ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -78,7 +78,10 @@ export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh
 out_dir=${tmp_dir}/dist
 dev_tools/packaging/produce-package.sh ${out_dir} $CIRQ_PRE_RELEASE_VERSION
 
-# test installation 
+echo =========================================
+echo Testing local installation of wheel files
+echo =========================================
+
 "${tmp_dir}/env/bin/python" -m pip install ${out_dir}/*
 
 echo ===========================

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -23,8 +23,6 @@
 # $TEST_TWINE_USERNAME and $TEST_TWINE_PASSWORD environment variables.
 ################################################################################
 
-set -e
-
 # Get the working directory to the repo root.
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(git rev-parse --show-toplevel)"
@@ -56,9 +54,17 @@ fi
 
 # only run if setup.py or txt changes are observed, to avoid too frequent uploads to test pypi
 changed=$(git diff --name-only ${rev} -- \
-    | grep -E "^.*(setup.py|.txt)$"
+    | grep -E "^.*(setup.py|.txt|dev_tools.*)$"
 )
 
+num_changed=$(echo -e "${changed[@]}" | wc -w)
+
+echo "Found ${num_changed} changed files relevant to packaging." >&2
+if [ "${num_changed}" -eq 0 ]; then
+    exit 0
+fi
+
+set -e
 
 # Temporary workspace.
 tmp_dir=$(mktemp -d)


### PR DESCRIPTION
Adds pypi upload testing to packaging test - but now only runs when there are possibly relevant file changes to packaging (setup.py, requirements, or dev_tools changes).

I tried with a local installation of `pypiserver` but unfortunately, pypiserver does **_not_** throw the error that I am fixing currently: 
```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid value for requires_dist. Error: Can't have direct dependency: "tensorflow-docs @ git+https://github.com/tensorflow/docs@a90bcd30eb550f8d4ee335ff3daf18de5ca84b70 ; extra == 'dev_env'"
Error: Process completed with exit code 1.
```

Fixes #4222.