### PR TITLE
Removes direct URL requirements from cirq[dev-env]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ assert __version__, 'Version string cannot be empty'
 requirements = [f'{p.name}=={p.version}' for p in modules.list_modules()]
 
 dev_requirements = explode('dev_tools/requirements/deps/dev-tools.txt')
-dev_requirements = [r.strip() for r in dev_requirements]
+dev_requirements = [r.strip() for r in dev_requirements if "git+http" not in r]
 
 setup(
     name=name,

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ assert __version__, 'Version string cannot be empty'
 requirements = [f'{p.name}=={p.version}' for p in modules.list_modules()]
 
 dev_requirements = explode('dev_tools/requirements/deps/dev-tools.txt')
+
+# filter out direct urls (https://github.com/pypa/pip/issues/6301)
 dev_requirements = [r.strip() for r in dev_requirements if "git+http" not in r]
 
 setup(


### PR DESCRIPTION
Removes direct URL requirements from cirq[dev-env].

Fixes #4222.
This is hard to test automatically as it would need to involve uploading to test pypi which in turn requires secrets on Github Actions (see https://github.com/quantumlib/Cirq/pull/4247). 
