### PR TITLE
Support decompose protocol on `cirq.Moment`

### DIFF
--- a/cirq-core/cirq/ops/moment.py
+++ b/cirq-core/cirq/ops/moment.py
@@ -278,6 +278,10 @@ class Moment:
     def __str__(self) -> str:
         return self.to_text_diagram()
 
+    def _decompose_(self) -> 'cirq.OP_TREE':
+        """See `cirq.SupportsDecompose`."""
+        return self._operations
+
     def transform_qubits(
         self: TSelf_Moment,
         qubit_map: Union[Dict['cirq.Qid', 'cirq.Qid'], Callable[['cirq.Qid'], 'cirq.Qid']],

--- a/cirq-core/cirq/ops/moment_test.py
+++ b/cirq-core/cirq/ops/moment_test.py
@@ -335,6 +335,25 @@ def test_container_methods():
     assert len(m) == 2
 
 
+def test_decompose():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    m = cirq.Moment(cirq.X(a), cirq.X(b))
+    assert list(cirq.decompose(m)) == list(m.operations)
+
+
+def test_measurement_keys():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    m = cirq.Moment(cirq.X(a), cirq.X(b))
+    assert cirq.measurement_keys(m) == set()
+    assert not cirq.is_measurement(m)
+
+    m2 = cirq.Moment(cirq.measure(a, b, key='foo'))
+    assert cirq.measurement_keys(m2) == {'foo'}
+    assert cirq.is_measurement(m2)
+
+
 def test_bool():
     assert not cirq.Moment()
     a = cirq.NamedQubit('a')


### PR DESCRIPTION
This also enables other protocols on Moment, such as the measurement keys protocol, which currently does not work.