### PR TITLE
remove cirq[dev-env] extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,6 @@ assert __version__, 'Version string cannot be empty'
 # This is a pure metapackage that installs all our packages
 requirements = [f'{p.name}=={p.version}' for p in modules.list_modules()]
 
-dev_requirements = explode('dev_tools/requirements/deps/dev-tools.txt')
-dev_requirements = [r.strip() for r in dev_requirements]
-
 setup(
     name=name,
     version=__version__,
@@ -64,9 +61,6 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     python_requires='>=3.6.0',
     install_requires=requirements,
-    extras_require={
-        'dev_env': dev_requirements,
-    },
     license='Apache 2',
     description=description,
     long_description=long_description,


### PR DESCRIPTION
Removes cirq[dev-env] extras_require from the cirq metapackage.

cirq[dev-env] is a convenience method to install dev time dependencies via `pip install cirq[dev-env]` . It basically pulls in all the dev tools represented in `dev_tools/requirements/deps/dev-tools.txt`. 

As the dev-tools depend on tensorflow-docs, which is a direct URL dependency, we have to filter out these type of dependencies. This makes `pip install cirq[dev-env]` different from `pip install -r dev_tools/requirements/deps/dev-tools.txt`. Assuming that not many people used `cirq[dev-env]`, I think we can just remove it, instead of keeping a confusing / inconsistent setup.

Fixes #4222. 