### PR TITLE
Remove cirq.IonDevice.can_add_operation_into_moment

### DIFF
--- a/cirq-core/cirq/ion/ion_device.py
+++ b/cirq-core/cirq/ion/ion_device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, cast, FrozenSet, Iterable, Optional, Set, TYPE_CHECKING
+from typing import Any, FrozenSet, Iterable, Optional, Set, TYPE_CHECKING
 
 from cirq import circuits, value, devices, ops, protocols
 from cirq.ion import convert_to_ion_gates
@@ -104,36 +104,9 @@ class IonDevice(devices.Device):
             if q not in self.qubits:
                 raise ValueError(f'Qubit not on device: {q!r}')
 
-    def _check_if_XXPow_operation_interacts_with_any(
-        self, XXPow_op: ops.GateOperation, others: Iterable[ops.GateOperation]
-    ) -> bool:
-        return any(self._check_if_XXPow_operation_interacts(XXPow_op, op) for op in others)
-
-    def _check_if_XXPow_operation_interacts(
-        self, XXPow_op: ops.GateOperation, other_op: ops.GateOperation
-    ) -> bool:
-        if isinstance(
-            other_op.gate,
-            (ops.XPowGate, ops.YPowGate, ops.PhasedXPowGate, ops.MeasurementGate, ops.ZPowGate),
-        ):
-            return False
-
-        return any(q == p for q in XXPow_op.qubits for p in other_op.qubits)
-
     def validate_circuit(self, circuit: circuits.Circuit):
         super().validate_circuit(circuit)
         _verify_unique_measurement_keys(circuit.all_operations())
-
-    def can_add_operation_into_moment(self, operation: ops.Operation, moment: ops.Moment) -> bool:
-
-        if not super().can_add_operation_into_moment(operation, moment):
-            return False
-        if isinstance(operation.gate, ops.XXPowGate):
-            return not self._check_if_XXPow_operation_interacts_with_any(
-                cast(ops.GateOperation, operation),
-                cast(Iterable[ops.GateOperation], moment.operations),
-            )
-        return True
 
     def at(self, position: int) -> Optional[devices.LineQubit]:
         """Returns the qubit at the given position, if there is one, else None."""

--- a/cirq-core/cirq/ion/ion_device_test.py
+++ b/cirq-core/cirq/ion/ion_device_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from datetime import timedelta
-import pytest
 
 import numpy as np
+import pytest
 
 import cirq
 import cirq.ion as ci
@@ -162,7 +162,6 @@ def test_can_add_operation_into_moment():
         assert d.can_add_operation_into_moment(cirq.Z(q3), moment)
     circuit = cirq.Circuit([cirq.X(q0)])
     assert d.can_add_operation_into_moment(cirq.XX(q1, q2), circuit[0])
-
 
 
 def test_ion_device_eq():

--- a/cirq-core/cirq/ion/ion_device_test.py
+++ b/cirq-core/cirq/ion/ion_device_test.py
@@ -160,6 +160,9 @@ def test_can_add_operation_into_moment():
         assert not d.can_add_operation_into_moment(cirq.XX(q1, q2), moment)
         assert d.can_add_operation_into_moment(cirq.XX(q2, q3), moment)
         assert d.can_add_operation_into_moment(cirq.Z(q3), moment)
+    circuit = cirq.Circuit([cirq.X(q0)])
+    assert d.can_add_operation_into_moment(cirq.XX(q1, q2), circuit[0])
+
 
 
 def test_ion_device_eq():


### PR DESCRIPTION
Removes `cirq.IonDevice.can_add_operation_into_moment` as it doesn't add any value. 

I noticed that `cirq.IonDevice.can_add_operation_into_moment` implementation was doing a complicated version of a simple qubit overlap testing.