### PR TITLE
Add py39 testing to CI test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     name: Pytest Ubuntu
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
     name: Pytest Windows
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2

--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -7,6 +7,8 @@ pylatex~=1.3.0
 quimb
 opt_einsum
 autoray
+# required for py39 opcodes.
+numba>=0.53.0
 
 # quil import
 pyquil~=2.21.0


### PR DESCRIPTION
Adds py39 to windows, mac and linux pytest matrices.
Fixes #3772 
Fixes #3769 