### PR TITLE
Move on_each to Gate, and deprecate SupportsOnEachGate

### DIFF
--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -246,7 +246,7 @@ def asymmetric_depolarize(
 
 
 @value.value_equality
-class DepolarizingChannel(gate_features.SupportsOnEachGate, raw_types.Gate):
+class DepolarizingChannel(raw_types.Gate):
     """A channel that depolarizes one or several qubits."""
 
     def __init__(self, p: float, n_qubits: int = 1) -> None:

--- a/cirq-core/cirq/ops/gate_features.py
+++ b/cirq-core/cirq/ops/gate_features.py
@@ -44,7 +44,7 @@ class SupportsOnEachGate(raw_types.Gate, metaclass=_SupportsOnEachGateMeta):
     pass
 
 
-class SingleQubitGate(SupportsOnEachGate, metaclass=abc.ABCMeta):
+class SingleQubitGate(raw_types.Gate, metaclass=abc.ABCMeta):
     """A gate that must be applied to exactly one qubit."""
 
     def _num_qubits_(self) -> int:

--- a/cirq-core/cirq/ops/gate_features.py
+++ b/cirq-core/cirq/ops/gate_features.py
@@ -19,7 +19,7 @@ For example: some gates are reversible, some have known matrices, etc.
 
 import abc
 
-from cirq import value
+from cirq import value, ops
 from cirq._compat import deprecated_class
 from cirq.ops import raw_types
 
@@ -34,12 +34,16 @@ class InterchangeableQubitsGate(metaclass=abc.ABCMeta):
 
 class _SupportsOnEachGateMeta(value.ABCMetaImplementAnyOneOf):
     def __instancecheck__(cls, instance):
-        return isinstance(instance, SingleQubitGate) or issubclass(
+        return isinstance(instance, (SingleQubitGate, ops.DepolarizingChannel)) or issubclass(
             type(instance), SupportsOnEachGate
         )
 
 
-@deprecated_class(deadline='v0.14', fix='None, this feature is in `Gate` now.')
+@deprecated_class(
+    deadline='v0.14',
+    fix='Remove `SupportsOnEachGate` from the list of parent classes. '
+    '`on_each` is now directly supported in the `Gate` base class.',
+)
 class SupportsOnEachGate(raw_types.Gate, metaclass=_SupportsOnEachGateMeta):
     pass
 

--- a/cirq-core/cirq/ops/gate_features.py
+++ b/cirq-core/cirq/ops/gate_features.py
@@ -18,8 +18,9 @@ For example: some gates are reversible, some have known matrices, etc.
 """
 
 import abc
-from typing import Union, Iterable, Any, List, Sequence
 
+from cirq import value
+from cirq._compat import deprecated_class
 from cirq.ops import raw_types
 
 
@@ -31,54 +32,16 @@ class InterchangeableQubitsGate(metaclass=abc.ABCMeta):
         return 0
 
 
-class SupportsOnEachGate(raw_types.Gate, metaclass=abc.ABCMeta):
-    """A gate that can be applied to exactly one qubit."""
+class _SupportsOnEachGateMeta(value.ABCMetaImplementAnyOneOf):
+    def __instancecheck__(cls, instance):
+        return isinstance(instance, SingleQubitGate) or issubclass(
+            type(instance), SupportsOnEachGate
+        )
 
-    def on_each(self, *targets: Union[raw_types.Qid, Iterable[Any]]) -> List[raw_types.Operation]:
-        """Returns a list of operations applying the gate to all targets.
-        Args:
-            *targets: The qubits to apply this gate to. For single-qubit gates
-            this can be provided as varargs or a combination of nested
-            iterables. For multi-qubit gates this must be provided as an
-            `Iterable[Sequence[Qid]]`, where each sequence has `num_qubits`
-            qubits.
-        Returns:
-            Operations applying this gate to the target qubits.
-        Raises:
-            ValueError if targets are not instances of Qid or Iterable[Qid].
-            ValueError if the gate qubit number is incompatible.
-        """
-        operations: List[raw_types.Operation] = []
-        if self._num_qubits_() > 1:
-            iterator: Iterable = targets
-            if len(targets) == 1:
-                if not isinstance(targets[0], Iterable):
-                    raise TypeError(f'{targets[0]} object is not iterable.')
-                t0 = list(targets[0])
-                iterator = [t0] if t0 and isinstance(t0[0], raw_types.Qid) else t0
-            for target in iterator:
-                if not isinstance(target, Sequence):
-                    raise ValueError(
-                        f'Inputs to multi-qubit gates must be Sequence[Qid].'
-                        f' Type: {type(target)}'
-                    )
-                if not all(isinstance(x, raw_types.Qid) for x in target):
-                    raise ValueError(f'All values in sequence should be Qids, but got {target}')
-                if len(target) != self._num_qubits_():
-                    raise ValueError(f'Expected {self._num_qubits_()} qubits, got {target}')
-                operations.append(self.on(*target))
-            return operations
 
-        for target in targets:
-            if isinstance(target, raw_types.Qid):
-                operations.append(self.on(target))
-            elif isinstance(target, Iterable) and not isinstance(target, str):
-                operations.extend(self.on_each(*target))
-            else:
-                raise ValueError(
-                    f'Gate was called with type different than Qid. Type: {type(target)}'
-                )
-        return operations
+@deprecated_class(deadline='v0.14', fix='None, this feature is in `Gate` now.')
+class SupportsOnEachGate(raw_types.Gate, metaclass=_SupportsOnEachGateMeta):
+    pass
 
 
 class SingleQubitGate(SupportsOnEachGate, metaclass=abc.ABCMeta):

--- a/cirq-core/cirq/ops/gate_features_test.py
+++ b/cirq-core/cirq/ops/gate_features_test.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Iterator
-from typing import Any
-
 import pytest
 
 import cirq
+from cirq.testing import assert_deprecated
 
 
 def test_single_qubit_gate_validate_args():
@@ -137,41 +135,6 @@ def test_three_qubit_gate_validate():
         g.validate_args([a, b, c, d])
 
 
-def test_on_each():
-    class CustomGate(cirq.SingleQubitGate):
-        pass
-
-    a = cirq.NamedQubit('a')
-    b = cirq.NamedQubit('b')
-    c = CustomGate()
-
-    assert c.on_each() == []
-    assert c.on_each(a) == [c(a)]
-    assert c.on_each(a, b) == [c(a), c(b)]
-    assert c.on_each(b, a) == [c(b), c(a)]
-
-    assert c.on_each([]) == []
-    assert c.on_each([a]) == [c(a)]
-    assert c.on_each([a, b]) == [c(a), c(b)]
-    assert c.on_each([b, a]) == [c(b), c(a)]
-    assert c.on_each([a, [b, a], b]) == [c(a), c(b), c(a), c(b)]
-
-    with pytest.raises(ValueError):
-        c.on_each('abcd')
-    with pytest.raises(ValueError):
-        c.on_each(['abcd'])
-    with pytest.raises(ValueError):
-        c.on_each([a, 'abcd'])
-
-    def iterator(qubits):
-        for i in range(len(qubits)):
-            yield qubits[i]
-
-    qubit_iterator = iterator([a, b, a, b])
-    assert isinstance(qubit_iterator, Iterator)
-    assert c.on_each(qubit_iterator) == [c(a), c(b), c(a), c(b)]
-
-
 def test_qasm_output_args_validate():
     args = cirq.QasmArgs(version='2.0')
     args.validate_version('2.0')
@@ -231,16 +194,39 @@ def test_multi_qubit_gate_validate():
         g.validate_args([a, b, c, d])
 
 
-def test_on_each_iterable_qid():
-    class QidIter(cirq.Qid):
-        @property
-        def dimension(self) -> int:
-            return 2
+def test_supports_on_each_inheritance_shim():
+    class NotOnEach(cirq.Gate):
+        def num_qubits(self):
+            return 1  # coverage: ignore
 
-        def _comparison_key(self) -> Any:
-            return 1
+    class OnEach(cirq.ops.gate_features.SupportsOnEachGate):
+        def num_qubits(self):
+            return 1  # coverage: ignore
 
-        def __iter__(self):
-            raise NotImplementedError()
+    class SingleQ(cirq.SingleQubitGate):
+        pass
 
-    assert cirq.H.on_each(QidIter())[0] == cirq.H.on(QidIter())
+    class TwoQ(cirq.TwoQubitGate):
+        pass
+
+    not_on_each = NotOnEach()
+    single_q = SingleQ()
+    two_q = TwoQ()
+    with assert_deprecated(deadline="v0.14"):
+        on_each = OnEach()
+
+    assert not isinstance(not_on_each, cirq.ops.gate_features.SupportsOnEachGate)
+    assert isinstance(on_each, cirq.ops.gate_features.SupportsOnEachGate)
+    assert isinstance(single_q, cirq.ops.gate_features.SupportsOnEachGate)
+    assert not isinstance(two_q, cirq.ops.gate_features.SupportsOnEachGate)
+    assert isinstance(cirq.X, cirq.ops.gate_features.SupportsOnEachGate)
+    assert not isinstance(cirq.CX, cirq.ops.gate_features.SupportsOnEachGate)
+
+
+def test_supports_on_each_deprecation():
+    class CustomGate(cirq.ops.gate_features.SupportsOnEachGate):
+        def num_qubits(self):
+            return 1  # coverage: ignore
+
+    with assert_deprecated(deadline="v0.14"):
+        assert isinstance(CustomGate(), cirq.ops.gate_features.SupportsOnEachGate)

--- a/cirq-core/cirq/ops/gate_features_test.py
+++ b/cirq-core/cirq/ops/gate_features_test.py
@@ -221,6 +221,7 @@ def test_supports_on_each_inheritance_shim():
     assert not isinstance(two_q, cirq.ops.gate_features.SupportsOnEachGate)
     assert isinstance(cirq.X, cirq.ops.gate_features.SupportsOnEachGate)
     assert not isinstance(cirq.CX, cirq.ops.gate_features.SupportsOnEachGate)
+    assert isinstance(cirq.DepolarizingChannel(0.01), cirq.ops.gate_features.SupportsOnEachGate)
 
 
 def test_supports_on_each_deprecation():

--- a/cirq-core/cirq/ops/identity.py
+++ b/cirq-core/cirq/ops/identity.py
@@ -20,14 +20,14 @@ import sympy
 
 from cirq import protocols, value
 from cirq._doc import document
-from cirq.ops import gate_features, raw_types
+from cirq.ops import raw_types
 
 if TYPE_CHECKING:
     import cirq
 
 
 @value.value_equality
-class IdentityGate(gate_features.SupportsOnEachGate, raw_types.Gate):
+class IdentityGate(raw_types.Gate):
     """A Gate that perform no operation on qubits.
 
     The unitary matrix of this gate is a diagonal matrix with all 1s on the

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -23,6 +23,8 @@ from typing import (
     Collection,
     Dict,
     Hashable,
+    Iterable,
+    List,
     Optional,
     Sequence,
     Tuple,
@@ -210,6 +212,52 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         from cirq.ops import gate_operation
 
         return gate_operation.GateOperation(self, list(qubits))
+
+    def on_each(self, *targets: Union[Qid, Iterable[Any]]) -> List['cirq.Operation']:
+        """Returns a list of operations applying the gate to all targets.
+        Args:
+            *targets: The qubits to apply this gate to. For single-qubit gates
+            this can be provided as varargs or a combination of nested
+            iterables. For multi-qubit gates this must be provided as an
+            `Iterable[Sequence[Qid]]`, where each sequence has `num_qubits`
+            qubits.
+        Returns:
+            Operations applying this gate to the target qubits.
+        Raises:
+            ValueError if targets are not instances of Qid or Iterable[Qid].
+            ValueError if the gate qubit number is incompatible.
+        """
+        operations: List['cirq.Operation'] = []
+        if self._num_qubits_() > 1:
+            iterator: Iterable = targets
+            if len(targets) == 1:
+                if not isinstance(targets[0], Iterable):
+                    raise TypeError(f'{targets[0]} object is not iterable.')
+                t0 = list(targets[0])
+                iterator = [t0] if t0 and isinstance(t0[0], Qid) else t0
+            for target in iterator:
+                if not isinstance(target, Sequence):
+                    raise ValueError(
+                        f'Inputs to multi-qubit gates must be Sequence[Qid].'
+                        f' Type: {type(target)}'
+                    )
+                if not all(isinstance(x, Qid) for x in target):
+                    raise ValueError(f'All values in sequence should be Qids, but got {target}')
+                if len(target) != self._num_qubits_():
+                    raise ValueError(f'Expected {self._num_qubits_()} qubits, got {target}')
+                operations.append(self.on(*target))
+            return operations
+
+        for target in targets:
+            if isinstance(target, Qid):
+                operations.append(self.on(target))
+            elif isinstance(target, Iterable) and not isinstance(target, str):
+                operations.extend(self.on_each(*target))
+            else:
+                raise ValueError(
+                    f'Gate was called with type different than Qid. Type: {type(target)}'
+                )
+        return operations
 
     def wrap_in_linear_combination(
         self, coefficient: Union[complex, float, int] = 1

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -801,7 +801,7 @@ def test_on_each():
 
 
 def test_on_each_two_qubits():
-    class CustomGate(cirq.ops.gate_features.SupportsOnEachGate, cirq.TwoQubitGate):
+    class CustomGate(cirq.TwoQubitGate):
         pass
 
     a = cirq.NamedQubit('a')
@@ -855,7 +855,7 @@ def test_on_each_two_qubits():
 
 
 def test_on_each_three_qubits():
-    class CustomGate(cirq.ops.gate_features.SupportsOnEachGate, cirq.ThreeQubitGate):
+    class CustomGate(cirq.ThreeQubitGate):
         pass
 
     a = cirq.NamedQubit('a')


### PR DESCRIPTION
Part of #4034. (See https://github.com/quantumlib/Cirq/issues/4034#issuecomment-832913708), moves the on_each functionality to cirq.Gate, and deprecates SupportsOnEachGate.

Note the tests that are deleted here had already been duplicated in raw_types_test.py by https://github.com/quantumlib/Cirq/pull/4281/files.