### PR TITLE
Add docstyle rule to the linter and subsequent refactor.

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_sampler.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler.py
@@ -41,7 +41,8 @@ class AQTSampler(cirq.Sampler):
     """
 
     def __init__(self, remote_host: str, access_token: str):
-        """
+        """Inits AQTSampler.
+
         Args:
             remote_host: Address of the remote device.
             access_token: Access token for the remote api.

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -590,8 +590,7 @@ class AbstractCircuit(abc.ABC):
         start_frontier: Dict['cirq.Qid', int],
         is_blocker: Callable[['cirq.Operation'], bool] = lambda op: False,
     ) -> List[Tuple[int, ops.Operation]]:
-        """
-        Finds all operations until a blocking operation is hit.
+        """Finds all operations until a blocking operation is hit.
 
         An operation is considered blocking if
 

--- a/cirq-core/cirq/circuits/optimization_pass.py
+++ b/cirq-core/cirq/circuits/optimization_pass.py
@@ -36,7 +36,8 @@ class PointOptimizationSummary:
         new_operations: 'cirq.OP_TREE',
         preserve_moments: bool = False,
     ) -> None:
-        """
+        """Inits PointOptimizationSummary.
+
         Args:
             clear_span: Defines the range of moments to affect. Specifically,
                 refers to the indices in range(start, start+clear_span) where
@@ -92,7 +93,8 @@ class PointOptimizer:
             [Sequence['cirq.Operation']], ops.OP_TREE
         ] = lambda op_list: op_list,
     ) -> None:
-        """
+        """Inits PointOptimizer.
+
         Args:
             post_clean_up: This function is called on each set of optimized
                 operations before they are put into the circuit to replace the

--- a/cirq-core/cirq/circuits/quil_output.py
+++ b/cirq-core/cirq/circuits/quil_output.py
@@ -31,7 +31,8 @@ class QuilOneQubitGate(ops.SingleQubitGate):
     """
 
     def __init__(self, matrix: np.ndarray) -> None:
-        """
+        """Inits QuilOneQubitGate.
+
         Args:
             matrix: The 2x2 unitary matrix for this gate.
         """
@@ -61,7 +62,8 @@ class QuilTwoQubitGate(ops.TwoQubitGate):
     """
 
     def __init__(self, matrix: np.ndarray) -> None:
-        """
+        """Inits QuilTwoQubitGate.
+
         Args:
             matrix: The 4x4 unitary matrix for this gate.
         """
@@ -103,7 +105,8 @@ class QuilOutput:
     """
 
     def __init__(self, operations: 'cirq.OP_TREE', qubits: Tuple['cirq.Qid', ...]) -> None:
-        """
+        """Inits QuilOutput.
+
         Args:
             operations: A list or tuple of `cirq.OP_TREE` arguments.
             qubits: The qubits used in the operations.

--- a/cirq-core/cirq/contrib/acquaintance/devices.py
+++ b/cirq-core/cirq/contrib/acquaintance/devices.py
@@ -71,7 +71,7 @@ def get_acquaintance_size(obj: Union[circuits.Circuit, ops.Operation]) -> int:
 
 
 class _UnconstrainedAcquaintanceDevice(AcquaintanceDevice):
-    "An acquaintance device with no constraints other than of the gate types."
+    """An acquaintance device with no constraints other than of the gate types."""
 
     def __repr__(self) -> str:
         return 'UnconstrainedAcquaintanceDevice'  # coverage: ignore

--- a/cirq-core/cirq/contrib/acquaintance/executor.py
+++ b/cirq-core/cirq/contrib/acquaintance/executor.py
@@ -134,7 +134,8 @@ class GreedyExecutionStrategy(ExecutionStrategy):
     def __init__(
         self, gates: LogicalGates, initial_mapping: LogicalMapping, device: 'cirq.Device' = None
     ) -> None:
-        """
+        """Inits GreedyExecutionStrategy.
+
         Args:
             gates: The gates to insert.
             initial_mapping: The initial mapping of qubits to logical indices.

--- a/cirq-core/cirq/contrib/acquaintance/inspection_utils.py
+++ b/cirq-core/cirq/contrib/acquaintance/inspection_utils.py
@@ -28,7 +28,8 @@ class LogicalAnnotator(ExecutionStrategy):
     """Realizes acquaintance opportunities."""
 
     def __init__(self, initial_mapping: LogicalMapping) -> None:
-        """
+        """Inits LogicalAnnotator.
+
         Args:
             initial_mapping: The initial mapping of qubits to logical indices.
         """

--- a/cirq-core/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq-core/cirq/contrib/acquaintance/mutation_utils.py
@@ -57,6 +57,8 @@ def rectify_acquaintance_strategy(circuit: 'cirq.Circuit', acquaint_first: bool 
     circuit._moments = rectified_moments
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def replace_acquaintance_with_swap_network(
     circuit: 'cirq.Circuit',
     qubit_order: Sequence['cirq.Qid'],
@@ -104,6 +106,7 @@ def replace_acquaintance_with_swap_network(
     return reflected
 
 
+# pylint: enable=docstring-first-line-empty
 class ExposeAcquaintanceGates(optimizers.ExpandComposite):
     """Decomposes any permutation gates that provide acquaintance opportunities
     in order to make them explicit."""

--- a/cirq-core/cirq/contrib/acquaintance/strategies/complete.py
+++ b/cirq-core/cirq/contrib/acquaintance/strategies/complete.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     import cirq
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def complete_acquaintance_strategy(
     qubit_order: Sequence['cirq.Qid'], acquaintance_size: int = 0, swap_gate: 'cirq.Gate' = ops.SWAP
 ) -> 'cirq.Circuit':
@@ -61,3 +63,6 @@ def complete_acquaintance_strategy(
         expose_acquaintance_gates(strategy)
         replace_acquaintance_with_swap_network(strategy, qubit_order, size_to_acquaint, swap_gate)
     return strategy
+
+
+# pylint: enable=docstring-first-line-empty

--- a/cirq-core/cirq/contrib/graph_device/graph_device.py
+++ b/cirq-core/cirq/contrib/graph_device/graph_device.py
@@ -125,7 +125,7 @@ class UndirectedGraphDevice(devices.Device):
         device_graph: Optional[UndirectedHypergraph] = None,
         crosstalk_graph: Optional[UndirectedHypergraph] = None,
     ) -> None:
-        """
+        """Inits UndirectedGraphDevice.
 
         Args:
             device_graph: An undirected hypergraph whose vertices correspond to

--- a/cirq-core/cirq/contrib/paulistring/convert_to_clifford_gates.py
+++ b/cirq-core/cirq/contrib/paulistring/convert_to_clifford_gates.py
@@ -40,7 +40,8 @@ class ConvertToSingleQubitCliffordGates(PointOptimizer):
     """
 
     def __init__(self, ignore_failures: bool = False, atol: float = 0) -> None:
-        """
+        """Inits ConvertToSingleQubitCliffordGates.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.

--- a/cirq-core/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
+++ b/cirq-core/cirq/contrib/paulistring/convert_to_pauli_string_phasors.py
@@ -39,7 +39,8 @@ class ConvertToPauliStringPhasors(PointOptimizer):
     def __init__(
         self, ignore_failures: bool = False, keep_clifford: bool = False, atol: float = 1e-14
     ) -> None:
-        """
+        """Inits ConvertToPauliStringPhasors.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.

--- a/cirq-core/cirq/contrib/quimb/mps_simulator.py
+++ b/cirq-core/cirq/contrib/quimb/mps_simulator.py
@@ -466,7 +466,7 @@ class MPSState(ActOnArgs):
         return self.apply_op(op, self.prng)
 
     def estimation_stats(self):
-        "Returns some statistics about the memory usage and quality of the approximation."
+        """Returns some statistics about the memory usage and quality of the approximation."""
 
         num_coefs_used = sum([Mi.data.size for Mi in self.M])
         memory_bytes = sum([Mi.data.nbytes for Mi in self.M])

--- a/cirq-core/cirq/contrib/quirk/quirk_gate.py
+++ b/cirq-core/cirq/contrib/quirk/quirk_gate.py
@@ -28,7 +28,8 @@ class QuirkOp:
     """
 
     def __init__(self, *keys: Any, can_merge: bool = True) -> None:
-        """
+        """Inits QuirkOp.
+
         Args:
             *keys: The JSON object(s) that each qubit is turned into when
                 explaining a gate to Quirk. For example, a CNOT is turned into

--- a/cirq-core/cirq/experiments/google_v2_supremacy_circuit.py
+++ b/cirq-core/cirq/experiments/google_v2_supremacy_circuit.py
@@ -22,8 +22,8 @@ from cirq import circuits, devices, ops
 def generate_boixo_2018_supremacy_circuits_v2(
     qubits: Iterable[devices.GridQubit], cz_depth: int, seed: int
 ) -> circuits.Circuit:
-    """
-    Generates Google Random Circuits v2 as in github.com/sboixo/GRCS cz_v2.
+    """Generates Google Random Circuits v2 as in github.com/sboixo/GRCS cz_v2.
+
     See also https://arxiv.org/abs/1807.10749
 
     Args:
@@ -84,8 +84,8 @@ def generate_boixo_2018_supremacy_circuits_v2(
 def generate_boixo_2018_supremacy_circuits_v2_grid(
     n_rows: int, n_cols: int, cz_depth: int, seed: int
 ) -> circuits.Circuit:
-    """
-    Generates Google Random Circuits v2 as in github.com/sboixo/GRCS cz_v2.
+    """Generates Google Random Circuits v2 as in github.com/sboixo/GRCS cz_v2.
+
     See also https://arxiv.org/abs/1807.10749
 
     Args:
@@ -108,8 +108,8 @@ def generate_boixo_2018_supremacy_circuits_v2_grid(
 def generate_boixo_2018_supremacy_circuits_v2_bristlecone(
     n_rows: int, cz_depth: int, seed: int
 ) -> circuits.Circuit:
-    """
-    Generates Google Random Circuits v2 in Bristlecone.
+    """Generates Google Random Circuits v2 in Bristlecone.
+
     See also https://arxiv.org/abs/1807.10749
 
     Args:
@@ -176,6 +176,8 @@ def _add_cz_layer(layer_index: int, circuit: circuits.Circuit) -> int:
     return layer_index
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def _make_cz_layer(
     qubits: Iterable[devices.GridQubit], layer_index: int
 ) -> Iterable[ops.Operation]:
@@ -233,3 +235,6 @@ def _make_cz_layer(
             continue  # No CZ along this edge for this layer.
 
         yield ops.common_gates.CZ(q, q2)
+
+
+# pylint: enable=docstring-first-line-empty

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -58,7 +58,8 @@ class RabiResult:
     """Results from a Rabi oscillation experiment."""
 
     def __init__(self, rabi_angles: Sequence[float], excited_state_probabilities: Sequence[float]):
-        """
+        """Inits RabiResult.
+
         Args:
             rabi_angles: The rotation angles of the qubit around the x-axis
                 of the Bloch sphere.
@@ -103,7 +104,8 @@ class RandomizedBenchMarkResult:
     """Results from a randomized benchmarking experiment."""
 
     def __init__(self, num_cliffords: Sequence[int], ground_state_probabilities: Sequence[float]):
-        """
+        """Inits RandomizedBenchMarkResult.
+
         Args:
             num_cliffords: The different numbers of Cliffords in the RB
                 study.
@@ -148,7 +150,8 @@ class TomographyResult:
     """Results from a state tomography experiment."""
 
     def __init__(self, density_matrix: np.ndarray):
-        """
+        """Inits TomographyResult.
+
         Args:
             density_matrix: The density matrix obtained from tomography.
         """

--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -89,7 +89,8 @@ class T1DecayResult:
     """Results from a Rabi oscillation experiment."""
 
     def __init__(self, data: pd.DataFrame):
-        """
+        """Inits T1DecayResult.
+
         Args:
             data: A data frame with three columns:
                 delay_ns, false_count, true_count.

--- a/cirq-core/cirq/experiments/t2_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment.py
@@ -278,7 +278,8 @@ class T2DecayResult:
     """
 
     def __init__(self, x_basis_data: pd.DataFrame, y_basis_data: pd.DataFrame):
-        """
+        """Inits T2DecayResult.
+
         Args:
             data: A data frame with three columns:
                 delay_ns, false_count, true_count.

--- a/cirq-core/cirq/interop/quirk/cells/arithmetic_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/arithmetic_cells.py
@@ -54,7 +54,8 @@ class QuirkArithmeticOperation(ops.ArithmeticOperation):
         target: Sequence['cirq.Qid'],
         inputs: Sequence[Union[Sequence['cirq.Qid'], int]],
     ):
-        """
+        """Inits QuirkArithmeticOperation.
+
         Args:
             identifier: The quirk identifier string for this operation.
             target: The target qubit register.
@@ -155,7 +156,8 @@ class _QuirkArithmeticCallable:
     """A callable with parameter-name-dependent behavior."""
 
     def __init__(self, func: _IntsToIntCallable):
-        """
+        """Inits _QuirkArithmeticCallable.
+
         Args:
             func: Maps target int to its output value based on other input ints.
         """

--- a/cirq-core/cirq/interop/quirk/cells/composite_cell.py
+++ b/cirq-core/cirq/interop/quirk/cells/composite_cell.py
@@ -45,7 +45,7 @@ class CompositeCell(Cell):
         *,
         gate_count: int,
     ):
-        """
+        """Inits CompositeCell.
 
         Args:
             height: The number of qubits spanned by this composite cell. Note

--- a/cirq-core/cirq/interop/quirk/cells/qubit_permutation_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/qubit_permutation_cells.py
@@ -29,7 +29,8 @@ class QuirkQubitPermutationGate(ops.QubitPermutationGate):
     """A qubit permutation gate specified by a permutation list."""
 
     def __init__(self, identifier: str, name: str, permutation: Sequence[int]):
-        """
+        """Inits QuirkQubitPermutationGate.
+
         Args:
             identifier: Quirk identifier string.
             name: Label to include in circuit diagram info.

--- a/cirq-core/cirq/interop/quirk/cells/testing.py
+++ b/cirq-core/cirq/interop/quirk/cells/testing.py
@@ -20,6 +20,8 @@ import cirq
 from cirq import quirk_url_to_circuit
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def assert_url_to_circuit_returns(
     json_text: str,
     circuit: 'cirq.Circuit' = None,
@@ -78,3 +80,6 @@ def assert_url_to_circuit_returns(
 
     if maps:
         cirq.testing.assert_equivalent_computational_basis_map(maps, parsed)
+
+
+# pylint: enable=docstring-first-line-empty

--- a/cirq-core/cirq/ion/convert_to_ion_gates.py
+++ b/cirq-core/cirq/ion/convert_to_ion_gates.py
@@ -22,7 +22,8 @@ class ConvertToIonGates:
     """Attempts to convert non-native gates into IonGates."""
 
     def __init__(self, ignore_failures: bool = False) -> None:
-        """
+        """Inits ConvertToIonGates.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.

--- a/cirq-core/cirq/ion/ion_decomposition.py
+++ b/cirq-core/cirq/ion/ion_decomposition.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 """
 Utility methods related to optimizing quantum circuits
 using native iontrap operations.
@@ -20,6 +22,7 @@ Gate compilation methods implemented here are following the paper below:
     'Basic circuit compilation techniques for an ion-trap quantum machine'
     arXiv:1603.07678
 """
+# pylint: enable=docstring-first-line-empty
 
 from typing import Iterable, List, Optional, cast, Tuple, TYPE_CHECKING
 

--- a/cirq-core/cirq/ion/ion_gates.py
+++ b/cirq-core/cirq/ion/ion_gates.py
@@ -61,6 +61,8 @@ class MSGate(ops.XXPowGate):
         return f'cirq.ms({self._exponent!r}*np.pi/2)'
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def ms(rads: float) -> MSGate:
     """
     Args:
@@ -70,3 +72,6 @@ def ms(rads: float) -> MSGate:
         Mølmer–Sørensen gate rotating by the desired amount.
     """
     return MSGate(rads=rads)
+
+
+# pylint: enable=docstring-first-line-empty

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
@@ -42,7 +42,8 @@ class ConvertToNeutralAtomGates(PointOptimizer):
     """
 
     def __init__(self, ignore_failures=False) -> None:
-        """
+        """Inits ConvertToNeutralAtomGates.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -28,9 +28,7 @@ if TYPE_CHECKING:
 
 @value.value_equality
 class NeutralAtomDevice(devices.Device):
-    """
-    A device with qubits placed on a grid.
-    """
+    """A device with qubits placed on a grid."""
 
     def __init__(
         self,
@@ -42,8 +40,7 @@ class NeutralAtomDevice(devices.Device):
         max_parallel_c: int,
         qubits: Iterable[GridQubit],
     ) -> None:
-        """
-        Initializes the description of the AQuA device.
+        """Initializes the description of the AQuA device.
 
         Args:
             measurement_duration: the maximum duration of a measurement.
@@ -91,8 +88,7 @@ class NeutralAtomDevice(devices.Device):
         return convert_to_neutral_atom_gates.ConvertToNeutralAtomGates().convert(operation)
 
     def duration_of(self, operation: ops.Operation):
-        """
-        Provides the duration of the given operation on this device.
+        """Provides the duration of the given operation on this device.
 
         Args:
             operation: the operation to get the duration of
@@ -111,8 +107,7 @@ class NeutralAtomDevice(devices.Device):
         return self._gate_duration
 
     def validate_gate(self, gate: ops.Gate):
-        """
-        Raises an error if the provided gate isn't part of the native gate set.
+        """Raises an error if the provided gate isn't part of the native gate set.
 
         Args:
             gate: the gate to validate
@@ -141,8 +136,7 @@ class NeutralAtomDevice(devices.Device):
                 raise ValueError('controlled gates must have integer exponents')
 
     def validate_operation(self, operation: ops.Operation):
-        """
-        Raises an error if the given operation is invalid on this device.
+        """Raises an error if the given operation is invalid on this device.
 
         Args:
             operation: the operation to validate
@@ -190,8 +184,7 @@ class NeutralAtomDevice(devices.Device):
                 raise ValueError("Bad number of XY gates in parallel")
 
     def validate_moment(self, moment: ops.Moment):
-        """
-        Raises an error if the given moment is invalid on this device
+        """Raises an error if the given moment is invalid on this device.
 
         Args:
             moment: The moment to validate
@@ -264,9 +257,9 @@ class NeutralAtomDevice(devices.Device):
         )
 
     def can_add_operation_into_moment(self, operation: ops.Operation, moment: ops.Moment) -> bool:
-        """
-        Determines if it's possible to add an operation into a moment. An
-        operation can be added if the moment with the operation added is valid
+        """Determines if it's possible to add an operation into a moment.
+
+        An operation can be added if the moment with the operation added is valid.
 
         Args:
             operation: The operation being added.
@@ -287,9 +280,9 @@ class NeutralAtomDevice(devices.Device):
         return True
 
     def validate_circuit(self, circuit: circuits.Circuit):
-        """
-        Raises an error if the given circuit is invalid on this device. A
-        circuit is invalid if any of its moments are invalid or if there is a
+        """Raises an error if the given circuit is invalid on this device.
+
+        A circuit is invalid if any of its moments are invalid or if there is a
         non-empty moment after a moment with a measurement.
 
         Args:

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -504,6 +504,8 @@ class GeneralizedAmplitudeDampingChannel(gate_features.SingleQubitGate):
         )
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def generalized_amplitude_damp(p: float, gamma: float) -> GeneralizedAmplitudeDampingChannel:
     r"""
     Returns a GeneralizedAmplitudeDampingChannel with the given
@@ -552,6 +554,7 @@ def generalized_amplitude_damp(p: float, gamma: float) -> GeneralizedAmplitudeDa
     return GeneralizedAmplitudeDampingChannel(p, gamma)
 
 
+# pylint: enable=docstring-first-line-empty
 @value.value_equality
 class AmplitudeDampingChannel(gate_features.SingleQubitGate):
     """Dampen qubit amplitudes through dissipation.
@@ -633,8 +636,7 @@ class AmplitudeDampingChannel(gate_features.SingleQubitGate):
 
 
 def amplitude_damp(gamma: float) -> AmplitudeDampingChannel:
-    r"""
-    Returns an AmplitudeDampingChannel with the given probability gamma.
+    r"""Returns an AmplitudeDampingChannel with the given probability gamma.
 
     This channel evolves a density matrix via:
 
@@ -874,8 +876,7 @@ class PhaseDampingChannel(gate_features.SingleQubitGate):
 
 
 def phase_damp(gamma: float) -> PhaseDampingChannel:
-    r"""
-    Creates a PhaseDampingChannel with damping constant gamma.
+    r"""Creates a PhaseDampingChannel with damping constant gamma.
 
     This channel evolves a density matrix via:
 
@@ -984,15 +985,12 @@ class PhaseFlipChannel(gate_features.SingleQubitGate):
 
 
 def _phase_flip_Z() -> common_gates.ZPowGate:
-    """
-    Returns a cirq.Z which corresponds to a guaranteed phase flip.
-    """
+    """Returns a cirq.Z which corresponds to a guaranteed phase flip."""
     return common_gates.ZPowGate()
 
 
 def _phase_flip(p: float) -> PhaseFlipChannel:
-    r"""
-    Returns a PhaseFlipChannel that flips a qubit's phase with probability p.
+    r"""Returns a PhaseFlipChannel that flips a qubit's phase with probability p.
 
     This channel evolves a density matrix via:
 
@@ -1025,6 +1023,8 @@ def _phase_flip(p: float) -> PhaseFlipChannel:
     return PhaseFlipChannel(p)
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def phase_flip(p: Optional[float] = None) -> Union[common_gates.ZPowGate, PhaseFlipChannel]:
     r"""
     Returns a PhaseFlipChannel that flips a qubit's phase with probability p
@@ -1064,6 +1064,7 @@ def phase_flip(p: Optional[float] = None) -> Union[common_gates.ZPowGate, PhaseF
     return _phase_flip(p)
 
 
+# pylint: enable=docstring-first-line-empty
 @value.value_equality
 class BitFlipChannel(gate_features.SingleQubitGate):
     r"""Probabilistically flip a qubit from 1 to 0 state or vice versa."""
@@ -1139,6 +1140,8 @@ class BitFlipChannel(gate_features.SingleQubitGate):
         return np.isclose(self._p, other._p, atol=atol).item()
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def _bit_flip(p: float) -> BitFlipChannel:
     r"""
     Construct a BitFlipChannel that flips a qubit state
@@ -1175,6 +1178,7 @@ def _bit_flip(p: float) -> BitFlipChannel:
     return BitFlipChannel(p)
 
 
+# TODO(#3388) Add summary line to docstring.
 def bit_flip(p: Optional[float] = None) -> Union[common_gates.XPowGate, BitFlipChannel]:
     r"""
     Construct a BitFlipChannel that flips a qubit state
@@ -1213,3 +1217,6 @@ def bit_flip(p: Optional[float] = None) -> Union[common_gates.XPowGate, BitFlipC
         return pauli_gates.X
 
     return _bit_flip(p)
+
+
+# pylint: enable=docstring-first-line-empty

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -175,8 +175,7 @@ class XPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
         control_values: Optional[Sequence[Union[int, Collection[int]]]] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> raw_types.Gate:
-        """
-        Returns a controlled `XPowGate`, using a `CXPowGate` where possible.
+        """Returns a controlled `XPowGate`, using a `CXPowGate` where possible.
 
         The `controlled` method of the `Gate` class, of which this class is a
         child, returns a `ControlledGate`. This method overrides this behavior
@@ -644,8 +643,7 @@ class ZPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
         control_values: Optional[Sequence[Union[int, Collection[int]]]] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> raw_types.Gate:
-        """
-        Returns a controlled `ZPowGate`, using a `CZPowGate` where possible.
+        """Returns a controlled `ZPowGate`, using a `CZPowGate` where possible.
 
         The `controlled` method of the `Gate` class, of which this class is a
         child, returns a `ControlledGate`. This method overrides this behavior
@@ -1135,8 +1133,7 @@ class CZPowGate(
         control_values: Optional[Sequence[Union[int, Collection[int]]]] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> raw_types.Gate:
-        """
-        Returns a controlled `CZPowGate`, using a `CCZPowGate` where possible.
+        """Returns a controlled `CZPowGate`, using a `CCZPowGate` where possible.
 
         The `controlled` method of the `Gate` class, of which this class is a
         child, returns a `ControlledGate`. This method overrides this behavior
@@ -1354,8 +1351,7 @@ class CXPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
         control_values: Optional[Sequence[Union[int, Collection[int]]]] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
     ) -> raw_types.Gate:
-        """
-        Returns a controlled `CXPowGate`, using a `CCXPowGate` where possible.
+        """Returns a controlled `CXPowGate`, using a `CCXPowGate` where possible.
 
         The `controlled` method of the `Gate` class, of which this class is a
         child, returns a `ControlledGate`. This method overrides this behavior

--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -27,7 +27,8 @@ class QuantumFourierTransformGate(raw_types.Gate):
     """Switches from the computational basis to the frequency basis."""
 
     def __init__(self, num_qubits: int, *, without_reverse: bool = False):
-        """
+        """Inits QuantumFourierTransformGate.
+
         Args:
             num_qubits: The number of qubits the gate applies to.
             without_reverse: Whether or not to include the swaps at the end

--- a/cirq-core/cirq/ops/fsim_gate.py
+++ b/cirq-core/cirq/ops/fsim_gate.py
@@ -79,7 +79,8 @@ class FSimGate(gate_features.TwoQubitGate, gate_features.InterchangeableQubitsGa
     """
 
     def __init__(self, theta: float, phi: float) -> None:
-        """
+        """Inits FSimGate.
+
         Args:
             theta: Swap angle on the ``|01⟩`` ``|10⟩`` subspace, in radians.
                 Determined by the strength and duration of the XX+YY
@@ -251,7 +252,8 @@ class PhasedFSimGate(gate_features.TwoQubitGate, gate_features.InterchangeableQu
         gamma: Union[float, sympy.Basic] = 0.0,
         phi: Union[float, sympy.Basic] = 0.0,
     ) -> None:
-        """
+        """Inits PhasedFSimGate.
+
         Args:
             theta: Swap angle on the ``|01⟩`` ``|10⟩`` subspace, in radians.
                 See class docstring above for details.

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -52,7 +52,8 @@ class GateOperation(raw_types.Operation):
     """
 
     def __init__(self, gate: 'cirq.Gate', qubits: Sequence['cirq.Qid']) -> None:
-        """
+        """Inits GateOperation.
+
         Args:
             gate: The gate to apply.
             qubits: The qubits to operate on.

--- a/cirq-core/cirq/ops/identity.py
+++ b/cirq-core/cirq/ops/identity.py
@@ -39,7 +39,8 @@ class IdentityGate(raw_types.Gate):
     def __init__(
         self, num_qubits: Optional[int] = None, qid_shape: Optional[Tuple[int, ...]] = None
     ) -> None:
-        """
+        """Inits IdentityGate.
+
         Args:
             num_qubits:
             qid_shape: Specifies the dimension of each qid the measurement

--- a/cirq-core/cirq/ops/measurement_gate.py
+++ b/cirq-core/cirq/ops/measurement_gate.py
@@ -38,7 +38,8 @@ class MeasurementGate(raw_types.Gate):
         invert_mask: Tuple[bool, ...] = (),
         qid_shape: Tuple[int, ...] = None,
     ) -> None:
-        """
+        """Inits MeasurementGate.
+
         Args:
             num_qubits: The number of qubits to act upon.
             key: The string key of the measurement.

--- a/cirq-core/cirq/ops/moment.py
+++ b/cirq-core/cirq/ops/moment.py
@@ -353,6 +353,8 @@ class Moment:
                     ops_to_keep.append(self._qubit_to_op[q])
             return Moment(frozenset(ops_to_keep))
 
+    # TODO(#3388) Add summary line to docstring.
+    # pylint: disable=docstring-first-line-empty
     def to_text_diagram(
         self: 'cirq.Moment',
         *,
@@ -445,6 +447,7 @@ class Moment:
 
         return diagram.render()
 
+    # pylint: enable=docstring-first-line-empty
     def _commutes_(
         self, other: Any, *, atol: Union[int, float] = 1e-8
     ) -> Union[bool, NotImplementedType]:

--- a/cirq-core/cirq/ops/parallel_gate_operation.py
+++ b/cirq-core/cirq/ops/parallel_gate_operation.py
@@ -30,7 +30,8 @@ class ParallelGateOperation(raw_types.Operation):
     """An application of several copies of a gate to a group of qubits."""
 
     def __init__(self, gate: 'cirq.Gate', qubits: Sequence[raw_types.Qid]) -> None:
-        """
+        """Inits ParallelGateOperation.
+
         Args:
             gate: the gate to apply.
             qubits: list of qubits to apply the gate to.

--- a/cirq-core/cirq/ops/pauli_interaction_gate.py
+++ b/cirq-core/cirq/ops/pauli_interaction_gate.py
@@ -55,7 +55,8 @@ class PauliInteractionGate(
         *,
         exponent: value.TParamVal = 1.0,
     ) -> None:
-        """
+        """Inits PauliInteractionGate.
+
         Args:
             pauli0: The interaction axis for the first qubit.
             invert0: Whether to condition on the +1 or -1 eigenvector of the

--- a/cirq-core/cirq/ops/permutation_gate.py
+++ b/cirq-core/cirq/ops/permutation_gate.py
@@ -26,7 +26,8 @@ class QubitPermutationGate(raw_types.Gate):
     """A qubit permutation gate specified by a permutation list."""
 
     def __init__(self, permutation: Sequence[int]):
-        """
+        """Inits QubitPermutationGate.
+
         Args:
             permutation: A shuffled sequence of integers from 0 to
                 len(permutation) - 1. The entry at offset `i` is the result

--- a/cirq-core/cirq/ops/phased_iswap_gate.py
+++ b/cirq-core/cirq/ops/phased_iswap_gate.py
@@ -55,7 +55,8 @@ class PhasedISwapPowGate(eigen_gate.EigenGate, gate_features.TwoQubitGate):
         phase_exponent: Union[float, sympy.Symbol] = 0.25,
         exponent: Union[float, sympy.Symbol] = 1.0,
     ):
-        """
+        """Inits PhasedISwapPowGate.
+
         Args:
             phase_exponent: The exponent on the Z gates. We conjugate by
                 the T gate by default.

--- a/cirq-core/cirq/ops/phased_x_gate.py
+++ b/cirq-core/cirq/ops/phased_x_gate.py
@@ -36,7 +36,8 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         exponent: Union[float, sympy.Symbol] = 1.0,
         global_shift: float = 0.0,
     ) -> None:
-        """
+        """Inits PhasedXPowGate.
+
         Args:
             phase_exponent: The exponent on the Z gates conjugating the X gate.
             exponent: The exponent on the X gate conjugated by Zs.

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -33,7 +33,8 @@ class PhasedXZGate(gate_features.SingleQubitGate):
         z_exponent: Union[numbers.Real, sympy.Basic],
         axis_phase_exponent: Union[numbers.Real, sympy.Basic],
     ) -> None:
-        """
+        """Inits PhasedXZGate.
+
         Args:
             x_exponent: Determines how much to rotate during the
                 axis-in-XY-plane rotation. The $x$ in $Z^z Z^a X^x Z^{-a}$.

--- a/cirq-core/cirq/optimizers/convert_to_cz_and_single_gates.py
+++ b/cirq-core/cirq/optimizers/convert_to_cz_and_single_gates.py
@@ -33,7 +33,8 @@ class ConvertToCzAndSingleGates(circuits.PointOptimizer):
     """
 
     def __init__(self, ignore_failures: bool = False, allow_partial_czs: bool = False) -> None:
-        """
+        """Inits ConvertToCzAndSingleGates.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.

--- a/cirq-core/cirq/optimizers/eject_phased_paulis.py
+++ b/cirq-core/cirq/optimizers/eject_phased_paulis.py
@@ -46,7 +46,8 @@ class EjectPhasedPaulis:
     """
 
     def __init__(self, tolerance: float = 1e-8, eject_parameterized: bool = False) -> None:
-        """
+        """Inits EjectPhasedPaulis.
+
         Args:
             tolerance: Maximum absolute error tolerance. The optimization is
                  permitted to simply drop negligible combinations gates with a

--- a/cirq-core/cirq/optimizers/eject_z.py
+++ b/cirq-core/cirq/optimizers/eject_z.py
@@ -48,7 +48,8 @@ class EjectZ:
     """
 
     def __init__(self, tolerance: float = 0.0, eject_parameterized: bool = False) -> None:
-        """
+        """Inits EjectZ.
+
         Args:
             tolerance: Maximum absolute error tolerance. The optimization is
                  permitted to simply drop negligible combinations of Z gates,

--- a/cirq-core/cirq/optimizers/merge_interactions.py
+++ b/cirq-core/cirq/optimizers/merge_interactions.py
@@ -35,7 +35,8 @@ class MergeInteractionsAbc(circuits.PointOptimizer, metaclass=abc.ABCMeta):
         tolerance: float = 1e-8,
         post_clean_up: Callable[[Sequence[ops.Operation]], ops.OP_TREE] = lambda op_list: op_list,
     ) -> None:
-        """
+        """Inits MergeInteractionsAbc.
+
         Args:
             tolerance: A limit on the amount of absolute error introduced by the
                 construction.
@@ -216,7 +217,8 @@ class MergeInteractions(MergeInteractionsAbc):
         allow_partial_czs: bool = True,
         post_clean_up: Callable[[Sequence[ops.Operation]], ops.OP_TREE] = lambda op_list: op_list,
     ) -> None:
-        """
+        """Inits MergeInteractions.
+
         Args:
             tolerance: A limit on the amount of absolute error introduced by the
                 construction.

--- a/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap.py
+++ b/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap.py
@@ -42,7 +42,8 @@ class MergeInteractionsToSqrtIswap(merge_interactions.MergeInteractionsAbc):
         use_sqrt_iswap_inv: bool = False,
         post_clean_up: Callable[[Sequence[ops.Operation]], ops.OP_TREE] = lambda op_list: op_list,
     ) -> None:
-        """
+        """Inits MergeInteractionsToSqrtIswap.
+
         Args:
             tolerance: A limit on the amount of absolute error introduced by the
                 construction.

--- a/cirq-core/cirq/optimizers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/optimizers/merge_single_qubit_gates.py
@@ -34,7 +34,8 @@ class MergeSingleQubitGates(circuits.PointOptimizer):
         rewriter: Optional[Callable[[List[ops.Operation]], Optional[ops.OP_TREE]]] = None,
         synthesizer: Optional[Callable[[ops.Qid, np.ndarray], Optional[ops.OP_TREE]]] = None,
     ):
-        """
+        """Inits MergeSingleQubitGates.
+
         Args:
             rewriter: Specifies how to merge runs of single-qubit operations
                 into a more desirable form. Takes a list of operations and

--- a/cirq-core/cirq/optimizers/synchronize_terminal_measurements.py
+++ b/cirq-core/cirq/optimizers/synchronize_terminal_measurements.py
@@ -28,7 +28,8 @@ class SynchronizeTerminalMeasurements:
     """
 
     def __init__(self, after_other_operations: bool = True):
-        """
+        """Inits SynchronizeTerminalMeasurements.
+
         Args:
             after_other_operations: Set by default. If the circuit's final
                 moment contains non-measurement operations and this is set then

--- a/cirq-core/cirq/optimizers/two_qubit_to_fsim.py
+++ b/cirq-core/cirq/optimizers/two_qubit_to_fsim.py
@@ -197,6 +197,8 @@ def _decompose_b_gate_into_two_fsims(
     )
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def _decompose_interaction_into_two_b_gates_ignoring_single_qubit_ops(
     qubits: Sequence['cirq.Qid'], kak_interaction_coefficients: Iterable[float]
 ) -> List['cirq.Operation']:
@@ -232,6 +234,7 @@ def _decompose_interaction_into_two_b_gates_ignoring_single_qubit_ops(
     ]
 
 
+# pylint: enable=docstring-first-line-empty
 def _fix_single_qubit_gates_around_kak_interaction(
     *,
     desired: 'cirq.KakDecomposition',

--- a/cirq-core/cirq/protocols/apply_unitary_protocol.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol.py
@@ -75,7 +75,7 @@ class ApplyUnitaryArgs:
     def __init__(
         self, target_tensor: np.ndarray, available_buffer: np.ndarray, axes: Iterable[int]
     ):
-        """
+        """Inits ApplyUnitaryArgs.
 
         Args:
             target_tensor: The input tensor that needs to be left-multiplied by

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
@@ -49,7 +49,8 @@ class CircuitDiagramInfo:
         exponent_qubit_index: Optional[int] = None,
         auto_exponent_parens: bool = True,
     ) -> None:
-        """
+        """Inits CircuitDiagramInfo.
+
         Args:
             wire_symbols: The symbols that should be shown on the qubits
                 affected by this operation. Must match the number of qubits that

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -23,8 +23,8 @@ from cirq import protocols
 
 
 def has_stabilizer_effect(val: Any) -> bool:
-    """
-    Returns whether the input has a stabilizer effect.
+    """Returns whether the input has a stabilizer effect.
+
     For 1-qubit gates always returns correct result. For other operations relies
     on the operation to define whether it has stabilizer effect.
     """
@@ -42,6 +42,8 @@ def has_stabilizer_effect(val: Any) -> bool:
     return False
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def _strat_has_stabilizer_effect_from_has_stabilizer_effect(val: Any) -> Optional[bool]:
     """
     Attempts to infer whether val has stabilizer effect via its
@@ -54,6 +56,7 @@ def _strat_has_stabilizer_effect_from_has_stabilizer_effect(val: Any) -> Optiona
     return None
 
 
+# TODO(#3388) Add summary line to docstring.
 def _strat_has_stabilizer_effect_from_gate(val: Any) -> Optional[bool]:
     """
     Attempts to infer whether val has stabilizer effect via the value of
@@ -64,6 +67,7 @@ def _strat_has_stabilizer_effect_from_gate(val: Any) -> Optional[bool]:
     return None
 
 
+# pylint: enable=docstring-first-line-empty
 def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
     """Attempts to infer whether val has stabilizer effect from its unitary.
     Returns whether unitary of `val` normalizes the Pauli group. Works only for

--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -171,8 +171,7 @@ def json_serializable_dataclass(
     unsafe_hash: bool = False,
     frozen: bool = False,
 ):
-    """
-    Create a dataclass that supports JSON serialization
+    """Create a dataclass that supports JSON serialization.
 
     This function defers to the ordinary ``dataclass`` decorator but appends
     the ``_json_dict_`` protocol method which automatically determines

--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -37,7 +37,8 @@ class QasmArgs(string.Formatter):
         qubit_id_map: Dict['cirq.Qid', str] = None,
         meas_key_id_map: Dict[str, str] = None,
     ) -> None:
-        """
+        """Inits QasmArgs.
+
         Args:
             precision: The number of digits after the decimal to show for
                 numbers in the qasm code.

--- a/cirq-core/cirq/protocols/quil.py
+++ b/cirq-core/cirq/protocols/quil.py
@@ -23,7 +23,8 @@ class QuilFormatter(string.Formatter):
     def __init__(
         self, qubit_id_map: Dict['cirq.Qid', str], measurement_id_map: Dict[str, str]
     ) -> None:
-        """
+        """Inits QuilFormatter.
+
         Args:
             qubit_id_map: A dictionary {qubit, quil_output_string} for
             the proper QUIL output for each qubit.

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -296,10 +296,13 @@ class CliffordTableau:
         self._xs[q1, :] ^= self._xs[q2, :]
         self._zs[q1, :] ^= self._zs[q2, :]
 
+    # TODO(#3388) Add summary line to docstring.
+    # pylint: disable=docstring-first-line-empty
     def _row_to_dense_pauli(self, i: int) -> 'cirq.DensePauliString':
         """
         Args:
             i: index of the row in the tableau.
+
         Returns:
             A DensePauliString representing the row. The length of the string
             is equal to the total number of qubits and each character
@@ -320,6 +323,7 @@ class CliffordTableau:
                 pauli_mask += "I"
         return cirq.DensePauliString(pauli_mask, coefficient=coefficient)
 
+    # pylint: enable=docstring-first-line-empty
     def stabilizers(self) -> List['cirq.DensePauliString']:
         """Returns the stabilizer generators of the state. These
         are n operators {S_1,S_2,...,S_n} such that S_i |psi> = |psi>"""

--- a/cirq-core/cirq/sim/act_on_args.py
+++ b/cirq-core/cirq/sim/act_on_args.py
@@ -50,7 +50,8 @@ class ActOnArgs(OperationTarget[TSelf]):
         axes: Iterable[int] = None,
         log_of_measurement_results: Dict[str, Any] = None,
     ):
-        """
+        """Inits ActOnArgs.
+
         Args:
             prng: The pseudo random number generator to use for probabilistic
                 effects.

--- a/cirq-core/cirq/sim/act_on_args_test.py
+++ b/cirq-core/cirq/sim/act_on_args_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numpy as np
 import pytest
 
 import cirq

--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -66,7 +66,8 @@ class ActOnDensityMatrixArgs(ActOnArgs):
         qubits: Sequence['cirq.Qid'] = None,
         axes: Iterable[int] = None,
     ):
-        """
+        """Inits ActOnDensityMatrixArgs.
+
         Args:
             target_tensor: The state vector to act on, stored as a numpy array
                 with one dimension for each qubit in the system. Operations are

--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -68,7 +68,8 @@ class ActOnStateVectorArgs(ActOnArgs):
         qubits: Sequence['cirq.Qid'] = None,
         axes: Iterable[int] = None,
     ):
-        """
+        """Inits ActOnStateVectorArgs.
+
         Args:
             target_tensor: The state vector to act on, stored as a numpy array
                 with one dimension for each qubit in the system. Operations are

--- a/cirq-core/cirq/sim/clifford/act_on_clifford_tableau_args.py
+++ b/cirq-core/cirq/sim/clifford/act_on_clifford_tableau_args.py
@@ -67,7 +67,8 @@ class ActOnCliffordTableauArgs(ActOnArgs):
         qubits: Sequence['cirq.Qid'] = None,
         axes: Iterable[int] = None,
     ):
-        """
+        """Inits ActOnCliffordTableauArgs.
+
         Args:
             tableau: The CliffordTableau to act on. Operations are expected to
                 perform inplace edits of this object.

--- a/cirq-core/cirq/sim/clifford/stabilizer_sampler.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_sampler.py
@@ -27,7 +27,8 @@ class StabilizerSampler(sampler.Sampler):
     """An efficient sampler for stabilizer circuits."""
 
     def __init__(self, *, seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None):
-        """
+        """Inits StabilizerSampler.
+
         Args:
             seed: The random seed or generator to use when sampling.
         """

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -1169,6 +1169,8 @@ def test_random_seed_mixture_deterministic():
     )
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def test_entangled_reset_does_not_break_randomness():
     """
     A previous version of cirq made the mistake of assuming that it was okay to
@@ -1187,6 +1189,7 @@ def test_entangled_reset_does_not_break_randomness():
     assert 10 <= counts[1] <= 90
 
 
+# pylint: enable=docstring-first-line-empty
 def test_overlapping_measurements_at_end():
     a, b = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -34,7 +34,8 @@ class StateVectorMixin:
 
     # Reason for 'type: ignore': https://github.com/python/mypy/issues/5887
     def __init__(self, qubit_map: Optional[Dict[ops.Qid, int]] = None, *args, **kwargs):
-        """
+        """Inits StateVectorMixin.
+
         Args:
             qubit_map: A map from the Qubits in the Circuit to the the index
                 of this qubit for a canonical ordering. This canonical ordering

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -142,6 +142,8 @@ def test_param_dict_iter():
     assert list(r) == ['a', 'b']
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def test_formulas_in_param_dict():
     """
     Param dicts are allowed to have str or sympy.Symbol as keys and
@@ -165,6 +167,7 @@ def test_formulas_in_param_dict():
     assert sympy.Eq(r.value_of('d'), 2 * e)
 
 
+# pylint: enable=docstring-first-line-empty
 def test_recursive_evaluation():
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
@@ -255,6 +258,8 @@ def test_custom_resolved_value():
     assert r.value_of(c) == 'Baz'
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def test_compose():
     """
     Calling cirq.resolve_paramters on a ParamResolver composes that resolver
@@ -281,6 +286,7 @@ def test_compose():
     assert r13.value_of('a') == b
 
 
+# pylint: enable=docstring-first-line-empty
 @pytest.mark.parametrize(
     'p1, p2, p3',
     [

--- a/cirq-core/cirq/study/result.py
+++ b/cirq-core/cirq/study/result.py
@@ -99,7 +99,8 @@ class Result:
         params: resolver.ParamResolver,
         measurements: Dict[str, np.ndarray],
     ) -> None:
-        """
+        """Inits Result.
+
         Args:
             params: A ParamResolver of settings used for this result.
             measurements: A dictionary from measurement gate key to measurement

--- a/cirq-core/cirq/work/collector.py
+++ b/cirq-core/cirq/work/collector.py
@@ -30,7 +30,8 @@ class CircuitSampleJob:
     """Describes a sampling task."""
 
     def __init__(self, circuit: circuits.Circuit, *, repetitions: int, tag: Any = None):
-        """
+        """Inits CircuitSampleJob.
+
         Args:
             circuit: The circuit to sample from.
             repetitions: How many times to sample the circuit.

--- a/cirq-core/cirq/work/pauli_sum_collector.py
+++ b/cirq-core/cirq/work/pauli_sum_collector.py
@@ -35,7 +35,8 @@ class PauliSumCollector(collector.Collector):
         samples_per_term: int,
         max_samples_per_job: int = 1000000,
     ):
-        """
+        """Inits PauliSumCollector.
+
         Args:
             circuit: Produces the state to be tested.
             observable: The pauli product observables to measure. Their sampled

--- a/cirq-google/cirq_google/devices/serializable_device.py
+++ b/cirq-google/cirq_google/devices/serializable_device.py
@@ -112,6 +112,8 @@ class SerializableDevice(cirq.Device):
     def qubit_set(self) -> FrozenSet[cirq.Qid]:
         return frozenset(self.qubits)
 
+    # TODO(#3388) Add summary line to docstring.
+    # pylint: disable=docstring-first-line-empty
     @classmethod
     def from_proto(
         cls,
@@ -184,6 +186,7 @@ class SerializableDevice(cirq.Device):
             gate_definitions=gates_by_type,
         )
 
+    # pylint: enable=docstring-first-line-empty
     @classmethod
     def _create_target_set(cls, ts: v2.device_pb2.TargetSet) -> Set[Tuple[cirq.Qid, ...]]:
         """Transform a TargetSet proto into a set of qubit tuples"""

--- a/cirq-google/cirq_google/engine/client/quantum_v1alpha1/gapic/enums.py
+++ b/cirq-google/cirq_google/engine/client/quantum_v1alpha1/gapic/enums.py
@@ -19,6 +19,7 @@
 import enum
 
 
+# pylint: disable=docstring-first-line-empty
 class ExecutionStatus(object):
     class State(enum.IntEnum):
         """

--- a/cirq-google/cirq_google/engine/engine_sampler.py
+++ b/cirq-google/cirq_google/engine/engine_sampler.py
@@ -33,7 +33,8 @@ class QuantumEngineSampler(cirq.Sampler):
         processor_id: Union[str, List[str]],
         gate_set: 'cirq_google.SerializableGateSet',
     ):
-        """
+        """Inits QuantumEngineSampler.
+
         Args:
             engine: Quantum engine instance to use.
             processor_id: String identifier, or list of string identifiers,

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
@@ -49,7 +49,8 @@ class CouplerPulse(cirq.ops.gate_features.TwoQubitGate):
         rise_time: Optional[cirq.Duration] = cirq.Duration(nanos=8),
         padding_time: Optional[cirq.Duration] = cirq.Duration(nanos=2.5),
     ):
-        """
+        """Inits CouplerPulse.
+
         Args:
             hold_time: Length of the 'plateau' part of the coupler trajectory.
             coupling_MHz: Target qubit-qubit coupling reached at the plateau.

--- a/cirq-google/cirq_google/optimizers/__init__.py
+++ b/cirq-google/cirq_google/optimizers/__init__.py
@@ -11,9 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Package for optimizers and gate compilers related to Google-specific devices.
-"""
+"""Package for optimizers and gate compilers related to Google-specific devices."""
 from cirq_google.optimizers.two_qubit_gates import (
     gate_product_tabulation,
     GateTabulation,

--- a/cirq-google/cirq_google/optimizers/convert_to_sqrt_iswap.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sqrt_iswap.py
@@ -46,7 +46,8 @@ class ConvertToSqrtIswapGates(cirq.PointOptimizer):
     """
 
     def __init__(self, ignore_failures=False) -> None:
-        """
+        """Inits ConvertToSqrtIswapGates.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.
@@ -54,6 +55,8 @@ class ConvertToSqrtIswapGates(cirq.PointOptimizer):
         super().__init__()
         self.ignore_failures = ignore_failures
 
+    # TODO(#3388) Add summary line to docstring.
+    # pylint: disable=docstring-first-line-empty
     def _convert_one(self, op: cirq.Operation) -> cirq.OP_TREE:
         """
         Decomposer intercept:  Let cirq decompose one-qubit gates,
@@ -83,6 +86,7 @@ class ConvertToSqrtIswapGates(cirq.PointOptimizer):
 
         return NotImplemented
 
+    # pylint: enable=docstring-first-line-empty
     def _on_stuck_raise(self, bad):
         return TypeError(
             f"Don't know how to work with {bad}. "

--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
@@ -48,7 +48,8 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
     """
 
     def __init__(self, tabulation: Optional[GateTabulation] = None, ignore_failures=False) -> None:
-        """
+        """Inits ConvertToSycamoreGates.
+
         Args:
             tabulation: If set, a tabulation for the Sycamore gate to use for
                 decomposing Matrix gates. If unset, an analytic calculation is
@@ -98,6 +99,8 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
 
         return False
 
+    # TODO(#3388) Add summary line to docstring.
+    # pylint: disable=docstring-first-line-empty
     def _convert_one(self, op: cirq.Operation) -> cirq.OP_TREE:
         """
         Decomposer intercept:  Upon cirq.protocols.decompose catch and
@@ -113,6 +116,7 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
             )
         return NotImplemented
 
+    # pylint: enable=docstring-first-line-empty
     def convert(self, op: cirq.Operation) -> List[cirq.Operation]:
         def on_stuck_raise(bad):
             return TypeError(
@@ -175,8 +179,7 @@ def known_two_q_operations_to_sycamore_operations(
     op: cirq.Operation,
     tabulation: Optional[GateTabulation] = None,
 ) -> cirq.OP_TREE:
-    """
-    Synthesize a known gate operation to a sycamore operation
+    """Synthesizes a known gate operation to a sycamore operation.
 
     This function dispatches based on gate type
 
@@ -407,6 +410,8 @@ def decompose_swap_into_syc(a: cirq.Qid, b: cirq.Qid):
     yield (cirq.Z ** -0.7034535141382525).on(a)
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def find_local_equivalents(unitary1: np.ndarray, unitary2: np.ndarray):
     """
     Given two unitaries with the same interaction coefficients but different
@@ -440,6 +445,7 @@ def find_local_equivalents(unitary1: np.ndarray, unitary2: np.ndarray):
     return v_0, v_1, u_0, u_1
 
 
+# pylint: enable=docstring-first-line-empty
 def create_corrected_circuit(
     target_unitary: np.ndarray, program: cirq.Circuit, q0: cirq.Qid, q1: cirq.Qid
 ) -> cirq.OP_TREE:
@@ -496,8 +502,7 @@ def rzz(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
 
 
 def cphase(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
-    """
-    Implement a cphase using the Ising gate generated from 2 Sycamore gates
+    """Implements a cphase using the Ising gate generated from 2 Sycamore gates.
 
     A CPHASE gate has the matrix diag([1, 1, 1, exp(1j * theta)]) and can
     be mapped to the Ising gate by prep and post rotations of Z-pi/4.
@@ -516,8 +521,7 @@ def cphase(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
 
 
 def swap_rzz(theta: float, q0: cirq.Qid, q1: cirq.Qid) -> cirq.OP_TREE:
-    """
-    An implementation of SWAP * EXP(1j theta ZZ) using three sycamore gates.
+    """An implementation of SWAP * EXP(1j theta ZZ) using three sycamore gates.
 
     This builds off of the zztheta method.  A sycamore gate following the
     zz-gate is a SWAP EXP(1j (THETA - pi/24) ZZ).

--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates_test.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates_test.py
@@ -204,9 +204,7 @@ def test_zztheta_zzpow_unsorted_qubits():
 
 
 def test_swap_zztheta():
-    """
-    Construct a Ising gate followed by a swap using a sycamore.
-    """
+    """Construct a Ising gate followed by a swap using a sycamore."""
     qubits = cirq.LineQubit.range(2)
     a, b = qubits
     for theta in np.linspace(0, 2 * np.pi, 10):

--- a/cirq-google/cirq_google/optimizers/convert_to_xmon_gates.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_xmon_gates.py
@@ -32,7 +32,8 @@ class ConvertToXmonGates(cirq.PointOptimizer):
     """
 
     def __init__(self, ignore_failures=False) -> None:
-        """
+        """Inits ConvertToXmonGates.
+
         Args:
             ignore_failures: If set, gates that fail to convert are forwarded
                 unchanged. If not set, conversion failures raise a TypeError.

--- a/cirq-pasqal/cirq_pasqal/pasqal_device.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_device.py
@@ -129,8 +129,7 @@ class PasqalDevice(cirq.devices.Device):
         return valid_op
 
     def validate_operation(self, operation: cirq.ops.Operation):
-        """
-        Raises an error if the given operation is invalid on this device.
+        """Raises an error if the given operation is invalid on this device.
 
         Args:
             operation: the operation to validate

--- a/cirq-pasqal/cirq_pasqal/pasqal_sampler.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_sampler.py
@@ -22,7 +22,8 @@ import cirq_pasqal
 
 class PasqalSampler(cirq.work.Sampler):
     def __init__(self, remote_host: str, access_token: str = '') -> None:
-        """
+        """Inits PasqalSampler.
+
         Args:
             remote_host: Address of the remote device.
             access_token: Access token for the remote api.

--- a/cirq-pasqal/cirq_pasqal/pasqal_sampler_test.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_sampler_test.py
@@ -56,6 +56,8 @@ def test_pasqal_circuit_init():
         assert moment1 == moment2
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 @patch('cirq_pasqal.pasqal_sampler.requests.get')
 @patch('cirq_pasqal.pasqal_sampler.requests.post')
 def test_run_sweep(mock_post, mock_get):
@@ -101,3 +103,6 @@ def test_run_sweep(mock_post, mock_get):
     assert cirq.read_json(json_text=submitted_json) == ex_circuit_odd
     assert mock_post.call_count == 2
     assert data[1] == ex_circuit_odd
+
+
+# pylint: enable=docstring-first-line-empty

--- a/dev_tools/auto_merge.py
+++ b/dev_tools/auto_merge.py
@@ -39,6 +39,8 @@ class PullRequestDetails:
         self.payload = payload
         self.repo = repo
 
+    # TODO(#3388) Add summary line to docstring.
+    # pylint: disable=docstring-first-line-empty
     @staticmethod
     def from_github(repo: GithubRepository, pull_id: int) -> 'PullRequestDetails':
         """
@@ -61,6 +63,7 @@ class PullRequestDetails:
         payload = json.JSONDecoder().decode(response.content.decode())
         return PullRequestDetails(payload, repo)
 
+    # pylint: enable=docstring-first-line-empty
     @property
     def remote_repo(self) -> GithubRepository:
         return GithubRepository(
@@ -114,6 +117,8 @@ class PullRequestDetails:
         return self.payload['body']
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def check_collaborator_has_write(
     repo: GithubRepository, username: str
 ) -> Optional[CannotAutomergeError]:
@@ -142,6 +147,7 @@ def check_collaborator_has_write(
     return None
 
 
+# pylint: enable=docstring-first-line-empty
 def get_all(url_func: Callable[[int], str]) -> List[Any]:
     results: List[Any] = []
     page = 0
@@ -163,6 +169,8 @@ def get_all(url_func: Callable[[int], str]) -> List[Any]:
     return results
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def check_auto_merge_labeler(
     repo: GithubRepository, pull_id: int
 ) -> Optional[CannotAutomergeError]:
@@ -190,6 +198,7 @@ def check_auto_merge_labeler(
     return check_collaborator_has_write(repo, relevant[-1]['actor']['login'])
 
 
+# TODO(#3388) Add summary line to docstring.
 def add_comment(repo: GithubRepository, pull_id: int, text: str) -> None:
     """
     References:
@@ -209,6 +218,7 @@ def add_comment(repo: GithubRepository, pull_id: int, text: str) -> None:
         )
 
 
+# TODO(#3388) Add summary line to docstring.
 def edit_comment(repo: GithubRepository, text: str, comment_id: int) -> None:
     """
     References:
@@ -228,6 +238,7 @@ def edit_comment(repo: GithubRepository, text: str, comment_id: int) -> None:
         )
 
 
+# TODO(#3388) Add summary line to docstring.
 def get_branch_details(repo: GithubRepository, branch: str) -> Any:
     """
     References:
@@ -248,6 +259,7 @@ def get_branch_details(repo: GithubRepository, branch: str) -> Any:
     return json.JSONDecoder().decode(response.content.decode())
 
 
+# TODO(#3388) Add summary line to docstring.
 def get_pr_statuses(pr: PullRequestDetails) -> List[Dict[str, Any]]:
     """
     References:
@@ -269,6 +281,7 @@ def get_pr_statuses(pr: PullRequestDetails) -> List[Dict[str, Any]]:
     return json.JSONDecoder().decode(response.content.decode())
 
 
+# TODO(#3388) Add summary line to docstring.
 def get_pr_check_status(pr: PullRequestDetails) -> Any:
     """
     References:
@@ -290,6 +303,7 @@ def get_pr_check_status(pr: PullRequestDetails) -> Any:
     return json.JSONDecoder().decode(response.content.decode())
 
 
+# pylint: enable=docstring-first-line-empty
 def classify_pr_status_check_state(pr: PullRequestDetails) -> Optional[bool]:
     has_failed = False
     has_pending = False
@@ -317,6 +331,8 @@ def classify_pr_status_check_state(pr: PullRequestDetails) -> Optional[bool]:
     return True
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def classify_pr_synced_state(pr: PullRequestDetails) -> Optional[bool]:
     """
     References:
@@ -331,6 +347,7 @@ def classify_pr_synced_state(pr: PullRequestDetails) -> Optional[bool]:
     return classification.get(state, None)
 
 
+# TODO(#3388) Add summary line to docstring.
 def get_pr_review_status(pr: PullRequestDetails, per_page: int = 100) -> Any:
     """
     References:
@@ -353,6 +370,7 @@ def get_pr_review_status(pr: PullRequestDetails, per_page: int = 100) -> Any:
     return json.JSONDecoder().decode(response.content.decode())
 
 
+# TODO(#3388) Add summary line to docstring.
 def get_pr_checks(pr: PullRequestDetails) -> Dict[str, Any]:
     """
     References:
@@ -374,6 +392,7 @@ def get_pr_checks(pr: PullRequestDetails) -> Dict[str, Any]:
     return json.JSONDecoder().decode(response.content.decode())
 
 
+# pylint: enable=docstring-first-line-empty
 _last_print_was_tick = False
 _tick_count = 0
 
@@ -412,6 +431,8 @@ def absent_status_checks(pr: PullRequestDetails, master_data: Optional[Any] = No
     return set(reqs) - statuses_present - checks_present
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def get_repo_ref(repo: GithubRepository, ref: str) -> Dict[str, Any]:
     """
     References:
@@ -432,11 +453,14 @@ def get_repo_ref(repo: GithubRepository, ref: str) -> Dict[str, Any]:
     return payload
 
 
+# pylint: enable=docstring-first-line-empty
 def get_master_sha(repo: GithubRepository) -> str:
     ref = get_repo_ref(repo, 'heads/master')
     return ref['object']['sha']
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def list_pr_comments(repo: GithubRepository, pull_id: int) -> List[Dict[str, Any]]:
     """
     References:
@@ -456,6 +480,7 @@ def list_pr_comments(repo: GithubRepository, pull_id: int) -> List[Dict[str, Any
     return payload
 
 
+# TODO(#3388) Add summary line to docstring.
 def delete_comment(repo: GithubRepository, comment_id: int) -> None:
     """
     References:
@@ -473,6 +498,7 @@ def delete_comment(repo: GithubRepository, comment_id: int) -> None:
         )
 
 
+# pylint: enable=docstring-first-line-empty
 def update_branch(pr: PullRequestDetails) -> Union[bool, CannotAutomergeError]:
     """Equivalent to hitting the 'update branch' button on a PR.
 
@@ -511,6 +537,8 @@ def update_branch(pr: PullRequestDetails) -> Union[bool, CannotAutomergeError]:
     return True
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def attempt_sync_with_master(pr: PullRequestDetails) -> Union[bool, CannotAutomergeError]:
     """
     References:
@@ -555,6 +583,7 @@ def attempt_sync_with_master(pr: PullRequestDetails) -> Union[bool, CannotAutome
     )
 
 
+# TODO(#3388) Add summary line to docstring.
 def attempt_squash_merge(pr: PullRequestDetails) -> Union[bool, CannotAutomergeError]:
     """
     References:
@@ -588,6 +617,7 @@ def attempt_squash_merge(pr: PullRequestDetails) -> Union[bool, CannotAutomergeE
     )
 
 
+# TODO(#3388) Add summary line to docstring.
 def auto_delete_pr_branch(pr: PullRequestDetails) -> bool:
     """
     References:
@@ -622,6 +652,7 @@ def auto_delete_pr_branch(pr: PullRequestDetails) -> bool:
     return False
 
 
+# pylint: enable=docstring-first-line-empty
 def branch_data_modified_recently(payload: Any) -> bool:
     modified_date = datetime.datetime.strptime(
         payload['commit']['commit']['committer']['date'], '%Y-%m-%dT%H:%M:%SZ'
@@ -629,6 +660,8 @@ def branch_data_modified_recently(payload: Any) -> bool:
     return is_recent_date(modified_date)
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def add_labels_to_pr(
     repo: GithubRepository, pull_id: int, *labels: str, override_token: str = None
 ) -> None:
@@ -649,6 +682,7 @@ def add_labels_to_pr(
         )
 
 
+# TODO(#3388) Add summary line to docstring.
 def remove_label_from_pr(repo: GithubRepository, pull_id: int, label: str) -> bool:
     """
     References:
@@ -675,6 +709,7 @@ def remove_label_from_pr(repo: GithubRepository, pull_id: int, label: str) -> bo
     )
 
 
+# pylint: enable=docstring-first-line-empty
 def list_open_pull_requests(
     repo: GithubRepository, base_branch: Optional[str] = None, per_page: int = 100
 ) -> List[PullRequestDetails]:

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -1,4 +1,5 @@
 [MASTER]
+load-plugins=pylint.extensions.docstyle
 max-line-length=100
 disable=all
 ignore-patterns=.*_pb2\.py,quantum_engine_service_client.py,engine_pb2_grpc.py
@@ -15,6 +16,7 @@ enable=
     consider-merging-isinstance,
     continue-in-finally,
     dangerous-default-value,
+    docstyle,
     duplicate-argument-name,
     expression-not-assigned,
     function-redefined,

--- a/dev_tools/github_repository.py
+++ b/dev_tools/github_repository.py
@@ -19,7 +19,8 @@ class GithubRepository:
     """Details how to access a repository on github."""
 
     def __init__(self, organization: str, name: str, access_token: Optional[str]) -> None:
-        """
+        """Inits GithubRepository.
+
         Args:
             organization: The github organization the repository is under.
             name: The name of the github repository.

--- a/dev_tools/import_test.py
+++ b/dev_tools/import_test.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Locates imports that violate cirq's submodule dependencies.
+"""Locates imports that violate cirq's submodule dependencies.
 
 Specifically, this test treats the modules as a tree structure where `cirq` is
 the root, each submodule is a node and each python file is a leaf node.  While

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -60,8 +60,7 @@ EXPLICIT_OPT_OUT_COMMENT = '#coverage:ignore'
 
 
 def diff_to_new_interesting_lines(unified_diff_lines: List[str]) -> Dict[int, str]:
-    """
-    Extracts a set of 'interesting' lines out of a GNU unified diff format.
+    """Extracts a set of 'interesting' lines out of a GNU unified diff format.
 
     Format:
       gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html
@@ -125,6 +124,8 @@ def fix_line_from_coverage_file(line):
     return line
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def get_incremental_uncovered_lines(
     abs_path: str, base_commit: str, actual_commit: Optional[str]
 ) -> List[Tuple[int, str, str]]:
@@ -169,6 +170,7 @@ def get_incremental_uncovered_lines(
         ]
 
 
+# TODO(#3388) Add summary line to docstring.
 def line_content_counts_as_uncovered_manual(content: str) -> bool:
     """
     Args:
@@ -191,6 +193,7 @@ def line_content_counts_as_uncovered_manual(content: str) -> bool:
     return True
 
 
+# pylint: enable=docstring-first-line-empty
 def determine_ignored_lines(content: str) -> Set[int]:
     lines = content.split('\n')
     result = []  # type: List[int]
@@ -233,11 +236,14 @@ def naive_find_end_of_scope(lines: List[str], i: int) -> int:
     return i
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def line_counts_as_uncovered(line: str, is_from_cover_annotation_file: bool) -> bool:
     """
     Args:
         line: The line of code (including coverage annotation).
         is_from_cover_annotation_file: Whether this line has been annotated.
+
     Returns:
         Does the line count as uncovered?
     """
@@ -268,12 +274,13 @@ def line_counts_as_uncovered(line: str, is_from_cover_annotation_file: bool) -> 
     return is_from_cover_annotation_file or line_content_counts_as_uncovered_manual(content)
 
 
+# pylint: enable=docstring-first-line-empty
 def is_applicable_python_file(rel_path: str) -> bool:
-    """
-    Determines if a file should be included in incremental coverage analysis.
+    """Determines if a file should be included in incremental coverage analysis.
 
     Args:
         rel_path: The repo-relative file path being considered.
+
     Returns:
         Whether to include the file.
     """

--- a/examples/bell_inequality.py
+++ b/examples/bell_inequality.py
@@ -1,3 +1,5 @@
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 """
 Bell's theorem or inequality proves that entanglement based
 observations can't be reproduced with any local realist theory [1].
@@ -53,6 +55,7 @@ y: ____1__111_______1___11_111__1_111______111___11_11_11__1_1_1111_1111__1_11
    11111_11111_11___11111_111_111_11_111111111_1111111_111_1111111111111111111
 Win rate: 84.0%
 """
+# pylint: enable=docstring-first-line-empty
 
 import numpy as np
 

--- a/examples/direct_fidelity_estimation.py
+++ b/examples/direct_fidelity_estimation.py
@@ -68,6 +68,8 @@ def compute_characteristic_function(
     return trace, prob
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 async def estimate_characteristic_function(
     circuit: cirq.Circuit,
     pauli_string: cirq.PauliString,
@@ -102,6 +104,7 @@ async def estimate_characteristic_function(
     return sigma_i
 
 
+# TODO(#3388) Add summary line to docstring.
 def _randomly_sample_from_stabilizer_bases(
     stabilizer_basis: List[cirq.DensePauliString], n_measured_operators: int, n_qubits: int
 ):
@@ -130,6 +133,7 @@ def _randomly_sample_from_stabilizer_bases(
     return dense_pauli_strings
 
 
+# TODO(#3388) Add summary line to docstring.
 def _enumerate_all_from_stabilizer_bases(
     stabilizer_basis: List[cirq.DensePauliString], n_qubits: int
 ):
@@ -155,6 +159,7 @@ def _enumerate_all_from_stabilizer_bases(
     return dense_pauli_strings
 
 
+# TODO(#3388) Add summary line to docstring.
 @dataclass
 class PauliTrace:
     """
@@ -172,14 +177,15 @@ class PauliTrace:
     Pr_i: float
 
 
+# pylint: enable=docstring-first-line-empty
 def _estimate_pauli_traces_clifford(
     n_qubits: int,
     stabilizer_basis: List[cirq.DensePauliString],
     n_measured_operators: Optional[int],
 ) -> List[PauliTrace]:
-    """
-    Estimates the Pauli traces in case the circuit is Clifford. When we have a
-    Clifford circuit, there are 2**n Pauli traces that have probability 1/2**n
+    """Estimates the Pauli traces in case the circuit is Clifford.
+
+    When we have a Clifford circuit, there are 2**n Pauli traces that have probability 1/2**n
     and all the other traces have probability 0. In addition, there is a fast
     way to compute find out what the traces are. See the documentation of
     cirq.CliffordTableau for more detail. This function uses the speedup to sample
@@ -235,9 +241,9 @@ def _estimate_pauli_traces_clifford(
 def _estimate_pauli_traces_general(
     qubits: List[cirq.Qid], circuit: cirq.Circuit, n_measured_operators: Optional[int]
 ) -> List[PauliTrace]:
-    """
-    Estimates the Pauli traces in case the circuit is not Clifford. In this case
-    we cannot use the speedup implemented in the function
+    """Estimates the Pauli traces in case the circuit is not Clifford.
+
+    In this case we cannot use the speedup implemented in the function
     _estimate_pauli_traces_clifford() above, and so do a slow, density matrix
     simulation.
 
@@ -275,8 +281,7 @@ def _estimate_pauli_traces_general(
 
 
 def _estimate_std_devs_clifford(fidelity: float, n: int) -> Tuple[Optional[float], float]:
-    """
-    Estimates the standard deviation of the measurement for Clifford circuits.
+    """Estimates the standard deviation of the measurement for Clifford circuits.
 
     Args:
         fidelity: The measured fidelity
@@ -307,9 +312,7 @@ def _estimate_std_devs_clifford(fidelity: float, n: int) -> Tuple[Optional[float
 
 @dataclass
 class Result:
-    """
-    Contains the results of a trial, either by simulator or actual run
-    """
+    """Contains the results of a trial, either by simulator or actual run."""
 
     # The Pauli trace that was measured
     pauli_trace: PauliTrace
@@ -319,6 +322,8 @@ class Result:
     sigma_i: float
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 @dataclass
 class DFEIntermediateResult:
     """
@@ -340,6 +345,7 @@ class DFEIntermediateResult:
     std_dev_bound: Optional[float]
 
 
+# TODO(#3388) Add summary line to docstring.
 def direct_fidelity_estimation(
     circuit: cirq.Circuit,
     qubits: List[cirq.Qid],
@@ -470,6 +476,7 @@ def direct_fidelity_estimation(
     return estimated_fidelity, dfe_intermediate_result
 
 
+# pylint: enable=docstring-first-line-empty
 def parse_arguments(args):
     """Helper function that parses the given arguments."""
     parser = argparse.ArgumentParser('Direct fidelity estimation.')

--- a/examples/hhl.py
+++ b/examples/hhl.py
@@ -1,3 +1,5 @@
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 """
 Demonstrates the algorithm for solving linear systems by Harrow, Hassidim,
 Lloyd (HHL).
@@ -69,6 +71,7 @@ Example of circuit with 2 register qubits.
 Note: QFT in the above diagram omits swaps, which are included implicitly by
 reversing qubit order for phase kickbacks.
 """
+# pylint: enable=docstring-first-line-empty
 
 import math
 import numpy as np
@@ -77,8 +80,7 @@ import cirq
 
 
 class PhaseEstimation(cirq.Gate):
-    """
-    A gate for Quantum Phase Estimation.
+    """A gate for Quantum Phase Estimation.
 
     unitary is the unitary gate whose phases will be estimated.
     The last qubit stores the eigenvector; all other qubits store the
@@ -100,8 +102,7 @@ class PhaseEstimation(cirq.Gate):
 
 
 class HamiltonianSimulation(cirq.EigenGate, cirq.SingleQubitGate):
-    """
-    A gate that represents e^iAt.
+    """A gate that represents e^iAt.
 
     This EigenGate + np.linalg.eigh() implementation is used here
     purely for demonstrative purposes. If a large matrix is used,
@@ -129,8 +130,7 @@ class HamiltonianSimulation(cirq.EigenGate, cirq.SingleQubitGate):
 
 
 class PhaseKickback(cirq.Gate):
-    """
-    A gate for the phase kickback stage of Quantum Phase Estimation.
+    """A gate for the phase kickback stage of Quantum Phase Estimation.
 
     It consists of a series of controlled e^iAt gates with the memory qubit as
     the target and each register qubit as the control, raised
@@ -153,6 +153,8 @@ class PhaseKickback(cirq.Gate):
             yield cirq.ControlledGate(self.U ** (2 ** i))(qubit, memory)
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 class EigenRotation(cirq.Gate):
     """
     EigenRotation performs the set of rotation on the ancilla qubit equivalent
@@ -201,9 +203,9 @@ class EigenRotation(cirq.Gate):
         return cirq.ry(theta)
 
 
+# pylint: enable=docstring-first-line-empty
 def hhl_circuit(A, C, t, register_size, *input_prep_gates):
-    """
-    Constructs the HHL circuit.
+    """Constructs the HHL circuit.
 
     Args:
         A: The input Hermitian matrix.
@@ -273,6 +275,8 @@ def simulate(circuit):
         print(f'{label} = {expectation}')
 
 
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 def main():
     """
     Simulates HHL with matrix input, and outputs Pauli observables of the
@@ -309,5 +313,6 @@ def main():
     simulate(hhl_circuit(A, C, t, register_size, *input_prep_gates))
 
 
+# pylint: enable=docstring-first-line-empty
 if __name__ == '__main__':
     main()

--- a/examples/noisy_simulation_example.py
+++ b/examples/noisy_simulation_example.py
@@ -1,6 +1,4 @@
-"""
-Creates and simulate a noisy circuit using cirq.ConstantQubitNoiseModel class.
-"""
+"""Creates and simulate a noisy circuit using cirq.ConstantQubitNoiseModel class."""
 import cirq
 
 

--- a/examples/quantum_fourier_transform.py
+++ b/examples/quantum_fourier_transform.py
@@ -1,3 +1,5 @@
+# TODO(#3388) Add summary line to docstring.
+# pylint: disable=docstring-first-line-empty
 """
 Creates and simulates a circuit for Quantum Fourier Transform(QFT)
 on a 4 qubit system.
@@ -20,6 +22,7 @@ FinalState
 [0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j
  0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j 0.25+0.j]
 """
+# pylint: enable=docstring-first-line-empty
 
 import numpy as np
 

--- a/examples/qubit_characterizations_example.py
+++ b/examples/qubit_characterizations_example.py
@@ -3,9 +3,9 @@ import cirq
 
 
 def main(minimum_cliffords=5, maximum_cliffords=20, cliffords_step=5):
-    """
-    Examples of how to run various qubit characterizations.  This example
-    shows various methods on how to characterize a qubit, including a Rabi
+    """Examples of how to run various qubit characterizations.
+
+    This example shows various methods on how to characterize a qubit, including a Rabi
     oscillation experiments, Clifford-based randomized benchmarking, and
     state tomography.
 


### PR DESCRIPTION
Associated to: https://github.com/quantumlib/Cirq/issues/3388

Added the docstyle linter and refactored trivial pydocs.  If the refactor wasn't trivial I just disable the rule for the pydoc.

We'll need to add the docparams plugin in a later PR.