### PR TITLE
pauli_sum_collector.estimate_energy() should return float when energy.imag == 0

### DIFF
--- a/cirq-core/cirq/work/pauli_sum_collector.py
+++ b/cirq-core/cirq/work/pauli_sum_collector.py
@@ -91,9 +91,9 @@ class PauliSumCollector(collector.Collector):
             if a + b:
                 energy += coef * (a - b) / (a + b)
         energy = complex(energy)
+        energy += self._identity_offset
         if energy.imag == 0:
             energy = energy.real
-        energy += self._identity_offset
         return energy
 
 

--- a/cirq-core/cirq/work/pauli_sum_collector_test.py
+++ b/cirq-core/cirq/work/pauli_sum_collector_test.py
@@ -22,12 +22,16 @@ async def test_pauli_string_sample_collector():
     a, b = cirq.LineQubit.range(2)
     p = cirq.PauliSumCollector(
         circuit=cirq.Circuit(cirq.H(a), cirq.CNOT(a, b), cirq.X(a), cirq.Z(b)),
-        observable=cirq.X(a) * cirq.X(b) - 16 * cirq.Y(a) * cirq.Y(b) + 4 * cirq.Z(a) * cirq.Z(b),
+        observable=(1 + 0j) * cirq.X(a) * cirq.X(b)
+        - 16 * cirq.Y(a) * cirq.Y(b)
+        + 4 * cirq.Z(a) * cirq.Z(b)
+        + (1 - 0j),
         samples_per_term=100,
     )
     completion = p.collect_async(sampler=cirq.Simulator())
     assert await completion is None
-    assert p.estimated_energy() == 11
+    energy = p.estimated_energy()
+    assert isinstance(energy, float) and energy == 12
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
For chemistry hamiltonians generated via `openfermion.qubit_operator_to_pauli_sum(qubit_hamiltonian)`, even though the pauli sum has only real terms (complex with imag == 0), using `p.estimated_energy()` returns a complex (with imag  == 0) and hence cannot be directly used with scipy optimizers which expect a flaot (eg: `Nelder-Mead`, `SLSQP` etc.)

See https://github.com/quantumlib/OpenFermion/issues/732 for an example.