### PR TITLE
Fix `NameError` in visualizing calibration metrics tutorial

### DIFF
--- a/docs/tutorials/google/visualizing_calibration_metrics.ipynb
+++ b/docs/tutorials/google/visualizing_calibration_metrics.ipynb
@@ -80,7 +80,8 @@
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
-    "    import cirq\n",
+    "import cirq\n",
+    "import cirq_google\n",
     "import os\n",
     "import matplotlib.pyplot as plt"
    ]


### PR DESCRIPTION
`cirq_google` is used to get calibrations in line 181 but never imported, leading to `NameError: name cirq_google is not defined` (189945709).