### PR TITLE
Make Resolver (more) immutable.

### DIFF
--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -64,7 +64,9 @@ class ParamResolver:
             return  # Already initialized. Got wrapped as part of the __new__.
 
         self._param_hash: Optional[int] = None
-        self.param_dict = cast(ParamDictType, {} if param_dict is None else copy.copy(param_dict))
+        self.param_dict = cast(
+            ParamDictType, {} if param_dict is None else copy.copy(cast(Any, param_dict))
+        )
         self._deep_eval_map: ParamDictType = {}
 
     def value_of(

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Resolves ParameterValues to assigned values."""
+import copy
 import numbers
 from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
 
@@ -63,7 +64,7 @@ class ParamResolver:
             return  # Already initialized. Got wrapped as part of the __new__.
 
         self._param_hash: Optional[int] = None
-        self.param_dict = cast(ParamDictType, {} if param_dict is None else param_dict)
+        self.param_dict = cast(ParamDictType, {} if param_dict is None else copy.copy(param_dict))
         self._deep_eval_map: ParamDictType = {}
 
     def value_of(

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Resolves ParameterValues to assigned values."""
-import copy
 import numbers
 from typing import Any, Dict, Iterator, Mapping, Optional, TYPE_CHECKING, Union, cast
 

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -65,7 +65,7 @@ class ParamResolver:
 
         self._param_hash: Optional[int] = None
         self.param_dict = cast(
-            ParamDictType, {} if param_dict is None else copy.copy(cast(Any, param_dict))
+            ParamDictType, {} if param_dict is None else dict(param_dict)
         )
         self._deep_eval_map: ParamDictType = {}
 

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -15,7 +15,7 @@
 """Resolves ParameterValues to assigned values."""
 import copy
 import numbers
-from typing import Any, Dict, Iterator, Optional, TYPE_CHECKING, Union, cast
+from typing import Any, Dict, Iterator, Mapping, Optional, TYPE_CHECKING, Union, cast
 
 import numpy as np
 import sympy
@@ -65,7 +65,7 @@ class ParamResolver:
 
         self._param_hash: Optional[int] = None
         self.param_dict = cast(
-            ParamDictType, {} if param_dict is None else dict(param_dict)
+            ParamDictType, {} if param_dict is None else dict(cast(Mapping[Any, Any], param_dict))
         )
         self._deep_eval_map: ParamDictType = {}
 

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -232,6 +232,15 @@ def test_resolve_unknown_type():
     assert r.value_of(cirq.X) == cirq.X
 
 
+def test_param_dict_shallow_copy():
+    pdict = {'beta': 0.11, 'gamma': 0.3}
+    p = cirq.ParamResolver(pdict)
+    assert p.param_dict == {'beta': 0.11, 'gamma': 0.3}
+    pdict['beta'] = 5
+    # ensure a shallow copy is made to immutable types.
+    assert p.param_dict == {'beta': 0.11, 'gamma': 0.3}
+
+
 def test_custom_resolved_value():
     class Foo:
         def _resolved_value_(self):
@@ -253,6 +262,7 @@ def test_custom_resolved_value():
     b = sympy.Symbol('b')
     c = sympy.Symbol('c')
     r = cirq.ParamResolver({a: foo, b: bar, c: baz})
+    # ensure a shallow copy is made to mutable types.
     assert r.value_of(a) is foo
     assert r.value_of(b) is b
     assert r.value_of(c) == 'Baz'

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -406,7 +406,7 @@ def _get_job_results_v1(result: v1.program_pb2.Result) -> List[cirq.Result]:
 
             trial_results.append(
                 cirq.Result.from_single_parameter_set(
-                    params=cirq.ParamResolver(result.params.assignments),
+                    params=cirq.ParamResolver(dict(result.params.assignments)),
                     measurements=measurements,
                 )
             )


### PR DESCRIPTION
Fixes #4327 , but does not completely solve the problem. Looking at the tests for the `resolver.py` module we have:

```python3
def test_custom_resolved_value():
    class Foo:
        def _resolved_value_(self):
            return self

    class Bar:
        def _resolved_value_(self):
            return NotImplemented

    class Baz:
        def _resolved_value_(self):
            return 'Baz'

    foo = Foo()
    bar = Bar()
    baz = Baz()

    a = sympy.Symbol('a')
    b = sympy.Symbol('b')
    c = sympy.Symbol('c')
    r = cirq.ParamResolver({a: foo, b: bar, c: baz})
    # ensure a shallow copy is made to mutable types.
    assert r.value_of(a) is foo
    assert r.value_of(b) is b
    assert r.value_of(c) == 'Baz'
```
Which appears to want `a` to point to `foo`. Meaning that `foo` could still be mutable over the lifetime of `r`. Which I'm guessing is a behavior we want to preserve ? If this is the case, I think we should open up a follow up issue to deprecate `param_dict` so that the only way a user could affect the contents of a resolver is to modify a pre-existing pointer to a mutable type contained in that resolver to begin with. I understand the docstring says don't change `param_dict`, but it doesn't actually stop you from changing it and so the issue in #4327 could very easily turn into:

```python3
pdict = {'beta': 0.11, 'gamma': 0.3}
p = cirq.ParamResolver(pdict)
assert p.param_dict == {'beta': 0.11, 'gamma': 0.3}
x = hash(p)
p.param_dict['beta'] = 5
x2 = hash(p)
x == x2
True
```
Which doesn't seem great.