### PR TITLE
Fix citation and explanation in Floquet calibration example

### DIFF
--- a/docs/tutorials/google/floquet_calibration_example.ipynb
+++ b/docs/tutorials/google/floquet_calibration_example.ipynb
@@ -212,7 +212,7 @@
     "id": "a0Nrd1pkVWzo"
    },
    "source": [
-    "We run Floquet calibration on a circuit which models the evolution of a fermionic particle on a linear spin chain. The physics of this problem for a closed chain (here we use an open chain) has been studied in [Accurately computing electronic properties of materials using eigenenergies](https://arxiv.org/abs/2012.00921)."
+    "We run Floquet calibration on a circuit which models the evolution of a single electron on 5 sites, starting out from the middle site. This is a highly simplified version of the paper from our group, [Observation of separated dynamics of charge and spin in the Fermi-Hubbard model](https://arxiv.org/pdf/2010.07965). We model only a single fermion in the non-interacting case (with $U=0$). For a single particle, the parasitic controlled phase does not impact the evolution, and we can use a single chain that one can think about it as either up or down. The parameter $\\theta$ for $K(\\theta)$ is fixed to $\\pi/4$. "
    ]
   },
   {

--- a/docs/tutorials/google/floquet_calibration_example.ipynb
+++ b/docs/tutorials/google/floquet_calibration_example.ipynb
@@ -223,7 +223,7 @@
     "\n",
     "This simulation can be looked at as a highly simplified version of the paper from our group, [Observation of separated dynamics of charge and spin in the Fermi-Hubbard model](https://arxiv.org/pdf/2010.07965). We model only a single fermion in the non-interacting case (with $U=0$). For a single particle, the parasitic controlled phase does not impact the evolution, and we can use a single chain that one can think about it as being in either up or down spin states. The parameter $\\theta$ for $K(\\theta)$ is fixed to $\\pi/4$. To smooth out the inhomogeneities of the quantum chip, we are using the technique of _averaging over multiple qubit configurations_ from this paper. The difference is that we pick a line that we segment and run the same circuit in parallel on each segment corresponding to a different qubit configuration. We measure the charge density at each site index (qubit) by averaging the Z densities (see Fig 2.a for comparison). \n",
     "\n",
-    "The physics of this problem for a closed chain (here we use an open chain) has been studied in [Accurately computing electronic properties of materials using eigenenergies](https://arxiv.org/abs/2012.00921) as well. This paper also describes the Floquet calibration fundamentals in Appendix A."
+    "The physics of this problem for a closed chain (here we use an open chain) has been studied in [Accurately computing electronic properties of materials using eigenenergies](https://arxiv.org/abs/2012.00921) as well without the complex hopping term, hence we use no Z rotations between the $\\sqrt{\\text{iSWAP}}$ gates. This paper also describes the Floquet calibration fundamentals in Appendix A."
    ]
   },
   {
@@ -1172,9 +1172,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/docs/tutorials/google/floquet_calibration_example.ipynb
+++ b/docs/tutorials/google/floquet_calibration_example.ipynb
@@ -1172,22 +1172,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/docs/tutorials/google/floquet_calibration_example.ipynb
+++ b/docs/tutorials/google/floquet_calibration_example.ipynb
@@ -212,7 +212,18 @@
     "id": "a0Nrd1pkVWzo"
    },
    "source": [
-    "We run Floquet calibration on a circuit which models the evolution of a single electron on 5 sites, starting out from the middle site. This is a highly simplified version of the paper from our group, [Observation of separated dynamics of charge and spin in the Fermi-Hubbard model](https://arxiv.org/pdf/2010.07965). We model only a single fermion in the non-interacting case (with $U=0$). For a single particle, the parasitic controlled phase does not impact the evolution, and we can use a single chain that one can think about it as either up or down. The parameter $\\theta$ for $K(\\theta)$ is fixed to $\\pi/4$. "
+    "We run Floquet calibration on a circuit which models the evolution of a single electron on 5 sites, realizing the Hamiltonian: \n",
+    "\n",
+    "$$\n",
+    "H=\\sum_{m=0}^{L-1} J(\\sigma_{m}^{+} \\sigma_{m+1}^{-} + \\sigma_{m}^{+} \\sigma_{m+1}^{-}),\n",
+    "$$\n",
+    "\n",
+    "where $\\sigma_{m}^{+}$ ($\\sigma_{m}^{-}$) are the raising (lowering) operators, and the single term describes the kinetic energy related to hopping from one site to the other. This [quirk circuit](https://algassert.com/quirk#circuit={%22cols%22:[[%22X%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22],[%22~qcjg%22,1,%22~qcjg%22],[1,%22~qcjg%22,1,%22~qcjg%22],[%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22,%22Chance%22]],%22gates%22:[{%22id%22:%22~qcjg%22,%22name%22:%22sqrtISWAP%22,%22matrix%22:%22{{1,0,0,0},{0,%E2%88%9A%C2%BD,%E2%88%9A%C2%BDi,0},{0,%E2%88%9A%C2%BDi,%E2%88%9A%C2%BD,0},{0,0,0,1}}%22}]}) shows the evolution of the charge density.\n",
+    "\n",
+    "\n",
+    "This simulation can be looked at as a highly simplified version of the paper from our group, [Observation of separated dynamics of charge and spin in the Fermi-Hubbard model](https://arxiv.org/pdf/2010.07965). We model only a single fermion in the non-interacting case (with $U=0$). For a single particle, the parasitic controlled phase does not impact the evolution, and we can use a single chain that one can think about it as being in either up or down spin states. The parameter $\\theta$ for $K(\\theta)$ is fixed to $\\pi/4$. To smooth out the inhomogeneities of the quantum chip, we are using the technique of _averaging over multiple qubit configurations_ from this paper. The difference is that we pick a line that we segment and run the same circuit in parallel on each segment corresponding to a different qubit configuration. We measure the charge density at each site index (qubit) by averaging the Z densities (see Fig 2.a for comparison). \n",
+    "\n",
+    "The physics of this problem for a closed chain (here we use an open chain) has been studied in [Accurately computing electronic properties of materials using eigenenergies](https://arxiv.org/abs/2012.00921) as well. This paper also describes the Floquet calibration fundamentals in Appendix A."
    ]
   },
   {


### PR DESCRIPTION
The Floquet calibration notebook's connection to our research needed more explanation. There is connection to both the quantum ring paper and the Fermi Hubbard paper. I also explained the motivation behind using segments on the line and added a quirk circuit to demonstrate the evolution of the charge density on a 5 qubit segment.