### PR TITLE
Allow CircuitOperations in cirq.optimized_for_sycamore

### DIFF
--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
@@ -97,6 +97,10 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
         ):
             return True
 
+        if gate is None and isinstance(op.untagged, cirq.CircuitOperation):
+            subcircuit = op.untagged.circuit
+            return all(self._is_native_sycamore_op(op) for op in subcircuit.all_operations())
+
         return False
 
     # TODO(#3388) Add summary line to docstring.
@@ -131,12 +135,13 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
             keep=self._is_native_sycamore_op,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=None if self.ignore_failures else on_stuck_raise,
+            preserve_structure=True,  # keep CircuitOps but decompose their contents
         )
 
     def optimization_at(
         self, circuit: cirq.Circuit, index: int, op: cirq.Operation
     ) -> Optional[cirq.PointOptimizationSummary]:
-        if not isinstance(op, cirq.GateOperation):
+        if not isinstance(op, (cirq.GateOperation, cirq.CircuitOperation)):
             return None
 
         gate = op.gate

--- a/docs/google/best_practices.md
+++ b/docs/google/best_practices.md
@@ -49,6 +49,39 @@ my_circuit = cirq.Circuit()
 sycamore_circuit = cg.optimized_for_sycamore(my_circuit, new_device=cg.Sycamore, optimizer_type='sqrt_iswap')
 ```
 
+### Using CircuitOperation to reduce circuit size
+
+Particularly large batches (or sweeps) of circuits may encounter errors when
+sent to Quantum Engine due to an upper limit on request size. If the circuits
+in question have a repetitive structure, `cirq.CircuitOperation`s can be used
+to reduce the request size and avoid this limit.
+
+`optimized_for_sycamore` will preserve `CircuitOperation`s while optimizing
+their contents.
+
+```python
+import cirq
+import cirq_google as cg
+
+# Repeatedly apply Hadamard and measurement to 10 qubits.
+my_circuit = cirq.Circuit()
+qubits = cirq.GridQubit.rect(2, 5)
+for i in range(100):
+    my_circuit.append(cirq.H.on_each(*qubits))
+    for q in qubits:
+        my_circuit.append(cirq.measure(q, key=f'm{q}'))
+
+# The same circuit, but defined using CircuitOperations.
+# This is ~1000x smaller when serialized!
+sub_circuit = cirq.Circuit(cirq.H(qubits[0]), cirq.measure(qubits[0], key='m'))
+circuit_op = cirq.CircuitOperation(sub_circuit.freeze())
+circuit_op = circuit_op.with_qubits([q])
+circuit_op = circuit_op.with_measurement_key_mapping({'m': f'm{q}'})
+circuit_op = circuit_op.repeat(100)
+short_circuit = cirq.Circuit(circuit_op for q in qubits)
+```
+
+
 ## Running circuits faster
 
 The following sections give tips and tricks that allow you to improve your

--- a/docs/google/devices.md
+++ b/docs/google/devices.md
@@ -223,6 +223,15 @@ For decay experiments and other applications, a WaitGate is provided
 that causes the device to idle for a specified amount of time.
 This can be accomplished by specifying a `cirq.WaitGate`.
 
+
+### Subcircuits
+
+Circuits with a repetitive structure can benefit from using
+`cirq.CircuitOperation` to specify "subcircuits" within the overall circuit.
+Using this type condenses the serialized representation of the circuit, which
+may help for circuits that would otherwise run into size limitations.
+
+
 ## Specific Device Layouts
 
 The following devices are provided as part of cirq and can help you get your


### PR DESCRIPTION
_EDIT: This description is outdated - see discussion below for details._
This PR enables serialization of `CircuitOperation`s in the default serializers. Additional changes to make this work smoothly:

* Added `preserve_structure=True` to the Sycamore optimizer. This ensures that the contents of `CircuitOperation`s are converted to a Sycamore-friendly format, but the `CircuitOperation` itself is preserved.
* Updated `cirq.decompose` to support intercepting decomposers alongside `preserve_structure=True`, and removed redundant overloads.
* Documented usage of subcircuits in the context of reducing serialization size of circuits.

#3634 is mostly resolved by this issue, although further optimizations remain possible.