### PR TITLE
Boolean Hamiltonian gate yields fewer gates

### DIFF
--- a/cirq-core/cirq/ops/boolean_hamiltonian.py
+++ b/cirq-core/cirq/ops/boolean_hamiltonian.py
@@ -20,6 +20,8 @@ References:
 [2] https://www.youtube.com/watch?v=AOKM9BkweVU is a useful intro
 [3] https://github.com/rsln-s/IEEE_QW_2020/blob/master/Slides.pdf
 """
+import itertools
+import functools
 
 from typing import cast, Any, Dict, Generator, List, Sequence, Tuple
 
@@ -106,6 +108,171 @@ class BooleanHamiltonian(raw_types.Operation):
         )
 
 
+def _gray_code_comparator(k1: Tuple[int, ...], k2: Tuple[int, ...], flip: bool = False) -> int:
+    """Compares two Gray-encoded binary numbers.
+
+    Args:
+        k1: A tuple of ints, representing the bits that are one. For example, 6 would be (1, 2).
+        k2: The second number, represented similarly as k1.
+        flip: Whether to flip the comparison.
+
+    Returns:
+        -1 if k1 < k2 (or +1 if flip is true)
+        0 if k1 == k2
+        +1 if k1 > k2 (or -1 if flip is true)
+    """
+    max_1 = k1[-1] if k1 else -1
+    max_2 = k2[-1] if k2 else -1
+    if max_1 != max_2:
+        return -1 if (max_1 < max_2) ^ flip else 1
+    if max_1 == -1:
+        return 0
+    return _gray_code_comparator(k1[0:-1], k2[0:-1], not flip)
+
+
+def _simplify_commuting_cnots(
+    cnots: List[Tuple[int, int]], flip_control_and_target: bool
+) -> Tuple[bool, List[Tuple[int, int]]]:
+    """Attempts to commute CNOTs and remove cancelling pairs.
+
+    Commutation relations are based on 9 (flip_control_and_target=False) or 10
+    (flip_control_target=True) of [4]:
+    When flip_control_target=True:
+
+         CNOT(j, i) @ CNOT(j, k) = CNOT(j, k) @ CNOT(j, i)
+    ───X───────       ───────X───
+       │                     │
+    ───@───@───   =   ───@───@───
+           │             │
+    ───────X───       ───X───────
+
+    When flip_control_target=False:
+
+    CNOT(i, j) @ CNOT(k, j) = CNOT(k, j) @ CNOT(i, j)
+    ───@───────       ───────@───
+       │                     │
+    ───X───X───   =   ───X───X───
+           │             │
+    ───────@───       ───@───────
+
+    Args:
+        cnots: A list of CNOTS, encoded as integer tuples (control, target).
+        flip_control_and_target: Whether to flip control and target.
+
+    Returns:
+        A Boolean that tells whether a simplification has been performed.
+        The CNOT list, potentially simplified.
+    """
+
+    target, control = (0, 1) if flip_control_and_target else (1, 0)
+
+    i = 0
+    qubit_to_index: Dict[int, int] = {cnots[i][control]: i} if cnots else {}
+    for j in range(1, len(cnots)):
+        if cnots[i][target] != cnots[j][target]:
+            # The targets (resp. control) don't match, so we reset the search.
+            i = j
+            qubit_to_index = {cnots[j][control]: j}
+            continue
+
+        if cnots[j][control] in qubit_to_index:
+            k = qubit_to_index[cnots[j][control]]
+            # The controls (resp. targets) are the same, so we can simplify away.
+            cnots = [cnots[n] for n in range(len(cnots)) if n != j and n != k]
+            return True, cnots
+
+        qubit_to_index[cnots[j][control]] = j
+
+    return False, cnots
+
+
+def _simplify_cnots_triplets(
+    cnots: List[Tuple[int, int]], flip_control_and_target: bool
+) -> Tuple[bool, List[Tuple[int, int]]]:
+    """Simplifies CNOT pairs according to equation 11 of [4].
+
+    CNOT(i, j) @ CNOT(j, k) == CNOT(j, k) @ CNOT(i, k) @ CNOT(i, j)
+    ───@───────       ───────@───@───
+       │                     │   │
+    ───X───@───   =   ───@───┼───X───
+           │             │   │
+    ───────X───       ───X───X───────
+
+    Args:
+        cnots: A list of CNOTS, encoded as integer tuples (control, target).
+        flip_control_and_target: Whether to flip control and target.
+
+    Returns:
+        A Boolean that tells whether a simplification has been performed.
+        The CNOT list, potentially simplified.
+    """
+    target, control = (0, 1) if flip_control_and_target else (1, 0)
+
+    # We investigate potential pivots sequentially.
+    for j in range(1, len(cnots) - 1):
+        # First, we look back for as long as the targets (resp. controls) are the same.
+        # They all commute, so all are potential candidates for being simplified.
+        common_a: Dict[int, int] = {}
+        for i in range(j - 1, -1, -1):
+            if cnots[i][control] != cnots[j][control]:
+                break
+            # We take a note of the control (resp. target).
+            common_a[cnots[i][target]] = i
+
+        # Next, we look forward for as long as the controls (resp. targets) are the
+        # same. They all commute, so all are potential candidates for being simplified.
+        common_b: Dict[int, int] = {}
+        for k in range(j + 1, len(cnots)):
+            if cnots[j][target] != cnots[k][target]:
+                break
+            # We take a note of the target (resp. control).
+            common_b[cnots[k][control]] = k
+
+        # Among all the candidates, find if they have a match.
+        keys = common_a.keys() & common_b.keys()
+        for key in keys:
+            assert common_a[key] != common_b[key]
+            # We perform the swap which removes the pivot.
+            new_idx: List[int] = (
+                [idx for idx in range(0, j) if idx != common_a[key]]
+                + [common_b[key], common_a[key]]
+                + [idx for idx in range(j + 1, len(cnots)) if idx != common_b[key]]
+            )
+            # Since we removed the pivot, the length should be one fewer.
+            assert len(new_idx) == len(cnots) - 1
+            cnots = [cnots[idx] for idx in new_idx]
+            return True, cnots
+
+    return False, cnots
+
+
+def _simplify_cnots(cnots: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    """Takes a series of CNOTs and tries to applies rule to cancel out gates.
+
+    Algorithm based on "Efficient quantum circuits for diagonal unitaries without ancillas" by
+    Jonathan Welch, Daniel Greenbaum, Sarah Mostame, Alán Aspuru-Guzik
+    https://arxiv.org/abs/1306.3991
+
+    Args:
+        cnots: A list of CNOTs represented as tuples of integer (control, target).
+
+    Returns:
+        A Boolean saying whether a simplification has been found.
+        The simplified list of CNOTs.
+    """
+
+    found_simplification = True
+    while found_simplification:
+        for simplify_fn, flip_control_and_target in itertools.product(
+            [_simplify_commuting_cnots, _simplify_cnots_triplets], [False, True]
+        ):
+            found_simplification, cnots = simplify_fn(cnots, flip_control_and_target)
+            if found_simplification:
+                break
+
+    return cnots
+
+
 def _get_gates_from_hamiltonians(
     hamiltonian_polynomial_list: List['cirq.PauliSum'],
     qubit_map: Dict[str, 'cirq.Qid'],
@@ -139,16 +306,18 @@ def _get_gates_from_hamiltonians(
         cnots.extend((prevh[i], prevh[-1]) for i in range(len(prevh) - 1))
         cnots.extend((currh[i], currh[-1]) for i in range(len(currh) - 1))
 
-        # TODO(tonybruguier): At this point, some CNOT gates can be cancelled out according to:
-        # "Efficient quantum circuits for diagonal unitaries without ancillas" by Jonathan Welch,
-        # Daniel Greenbaum, Sarah Mostame, Alán Aspuru-Guzik
-        # https://arxiv.org/abs/1306.3991
+        cnots = _simplify_cnots(cnots)
 
         for gate in (cirq.CNOT(qubits[c], qubits[t]) for c, t in cnots):
             yield gate
 
+    sorted_hamiltonian_keys = sorted(
+        hamiltonians.keys(), key=functools.cmp_to_key(_gray_code_comparator)
+    )
+
     previous_h: Tuple[int, ...] = ()
-    for h, w in hamiltonians.items():
+    for h in sorted_hamiltonian_keys:
+        w = hamiltonians[h]
         yield _apply_cnots(previous_h, h)
 
         if len(h) >= 1:

--- a/cirq-core/cirq/ops/boolean_hamiltonian_test.py
+++ b/cirq-core/cirq/ops/boolean_hamiltonian_test.py
@@ -11,14 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import functools
 import itertools
 import math
+import random
 
 import numpy as np
 import pytest
 import sympy.parsing.sympy_parser as sympy_parser
 
 import cirq
+import cirq.ops.boolean_hamiltonian as bh
 
 
 @pytest.mark.parametrize(
@@ -83,3 +86,95 @@ def test_circuit(boolean_str):
 
     # Compare the two:
     np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    'n_bits,expected_hs',
+    [
+        (1, [(), (0,)]),
+        (2, [(), (0,), (0, 1), (1,)]),
+        (3, [(), (0,), (0, 1), (1,), (1, 2), (0, 1, 2), (0, 2), (2,)]),
+    ],
+)
+def test_gray_code_sorting(n_bits, expected_hs):
+    hs = []
+    for x in range(2 ** n_bits):
+        h = []
+        for i in range(n_bits):
+            if x % 2 == 1:
+                h.append(i)
+                x -= 1
+            x //= 2
+        hs.append(tuple(sorted(h)))
+    random.shuffle(hs)
+
+    sorted_hs = sorted(list(hs), key=functools.cmp_to_key(bh._gray_code_comparator))
+
+    np.testing.assert_array_equal(sorted_hs, expected_hs)
+
+
+@pytest.mark.parametrize(
+    'seq_a,seq_b,expected',
+    [
+        ((), (), 0),
+        ((), (0,), -1),
+        ((0,), (), 1),
+        ((0,), (0,), 0),
+    ],
+)
+def test_gray_code_comparison(seq_a, seq_b, expected):
+    assert bh._gray_code_comparator(seq_a, seq_b) == expected
+
+
+@pytest.mark.parametrize(
+    'input_cnots,input_flip_control_and_target,expected_simplified,expected_output_cnots',
+    [
+        # Empty inputs don't get simplified.
+        ([], False, False, []),
+        ([], True, False, []),
+        # Single CNOTs don't get simplified.
+        ([(0, 1)], False, False, [(0, 1)]),
+        ([(0, 1)], True, False, [(0, 1)]),
+        # Simplify away two CNOTs that are identical:
+        ([(0, 1), (0, 1)], False, True, []),
+        ([(0, 1), (0, 1)], True, True, []),
+        # Also simplify away if there's another CNOT in between.
+        ([(0, 1), (2, 1), (0, 1)], False, True, [(2, 1)]),
+        ([(0, 1), (0, 2), (0, 1)], True, True, [(0, 2)]),
+        # However, the in-between has to share the same target/control.
+        ([(0, 1), (0, 2), (0, 1)], False, False, [(0, 1), (0, 2), (0, 1)]),
+        ([(0, 1), (2, 1), (0, 1)], True, False, [(0, 1), (2, 1), (0, 1)]),
+    ],
+)
+def test_simplify_commuting_cnots(
+    input_cnots, input_flip_control_and_target, expected_simplified, expected_output_cnots
+):
+    actual_simplified, actual_output_cnots = bh._simplify_commuting_cnots(
+        input_cnots, input_flip_control_and_target
+    )
+    assert actual_simplified == expected_simplified
+    assert actual_output_cnots == expected_output_cnots
+
+
+@pytest.mark.parametrize(
+    'input_cnots,input_flip_control_and_target,expected_simplified,expected_output_cnots',
+    [
+        # Empty inputs don't get simplified.
+        ([], False, False, []),
+        ([], True, False, []),
+        # Single CNOTs don't get simplified.
+        ([(0, 1)], False, False, [(0, 1)]),
+        ([(0, 1)], True, False, [(0, 1)]),
+        # Simplify according to equation 11 of [4].
+        ([(2, 1), (2, 0), (1, 0)], False, True, [(1, 0), (2, 1)]),
+        ([(1, 2), (0, 2), (0, 1)], True, True, [(0, 1), (1, 2)]),
+    ],
+)
+def test_simplify_cnots_triplets(
+    input_cnots, input_flip_control_and_target, expected_simplified, expected_output_cnots
+):
+    actual_simplified, actual_output_cnots = bh._simplify_cnots_triplets(
+        input_cnots, input_flip_control_and_target
+    )
+    assert actual_simplified == expected_simplified
+    assert actual_output_cnots == expected_output_cnots


### PR DESCRIPTION
This is a follow-up on #4309. The intent is to have the output of he gate unchanged by doing the same operation using fewer CNOTs.