### PR TITLE
[Obs] 4.5 - High-level API

### DIFF
--- a/cirq-core/cirq/work/observable_grouping.py
+++ b/cirq-core/cirq/work/observable_grouping.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Dict, List, TYPE_CHECKING, cast
+from typing import Iterable, Dict, List, TYPE_CHECKING, cast, Callable
 
 from cirq import ops, value
 from cirq.work.observable_settings import InitObsSetting, _max_weight_state, _max_weight_observable
 
 if TYPE_CHECKING:
     pass
+
+GROUPER_T = Callable[[Iterable[InitObsSetting]], Dict[InitObsSetting, List[InitObsSetting]]]
 
 
 def group_settings_greedy(


### PR DESCRIPTION
Provide two very similar high-level entries into the observable measurement framework. This provides more sensible defaults for some of the execution details and can return nicer values

```python
    df = measure_observables_df(
        circuit,
        [observable],
        cirq.Simulator(),
        stopping_criteria='variance',
        stopping_criteria_val=1e-3 ** 2,
    )
```

------------------

`measure_grouped_settings` lets you control how settings are grouped and returns "raw" data in one container (`BitstringAccumulator`) per group. This level of control is probably desirable for people seriously executing and expensive experiment on the device. The high-level API makes some simplifying assumptions

 - The qubits are the union of circuit and observable qubits
 - We will group the settings using a `GROUPER_T` function, by default "greedy"
 - We'll always initialize settings into the `|00..00>` state, so you can just provide `PauliString`s
 - You'll probably be using one of the two built-in stopping criteria and can just provide a name and a value instead of grokking these objects.
 - (for the second entrypoint) you really don't care about how things were grouped and executed, you'd just like the observable values in a dataframe table