### PR TITLE
Add modules to book yaml

### DIFF
--- a/dev_tools/docs/Dockerfile
+++ b/dev_tools/docs/Dockerfile
@@ -34,13 +34,23 @@ RUN mkdir /cirq
 
 WORKDIR /cirq
 
+# Adding requirements at the beginning separately for faster rebuilds
+
 ADD cirq-core/requirements.txt cirq-core/requirements.txt
+ADD cirq-core/cirq/contrib/requirements.txt cirq-core/cirq/contrib/requirements.txt
 ADD cirq-google/requirements.txt cirq-google/requirements.txt
 ADD cirq-aqt/requirements.txt cirq-aqt/requirements.txt
-RUN pip install -r cirq-core/requirements.txt -r cirq-google/requirements.txt  -r cirq-aqt/requirements.txt
+ADD cirq-ionq/requirements.txt cirq-ionq/requirements.txt
+ADD cirq-web/requirements.txt cirq-web/requirements.txt
+ADD cirq-rigetti/requirements.txt cirq-rigetti/requirements.txt
+ADD cirq-pasqal/requirements.txt cirq-pasqal/requirements.txt
+ADD dev_tools dev_tools
+RUN pip install -r dev_tools/requirements/deps/cirq-all.txt
+
+# Adding the whole cirq directory
 
 ADD . /cirq
-RUN PYTHONPATH=/cirq/cirq-core:/cirq/cirq-google:/cirq/cirq-aqt python3 dev_tools/docs/build_api_docs.py --output_dir=docs/api_docs
+RUN PYTHONPATH=/cirq/cirq-core:/cirq/cirq-google:/cirq/cirq-aqt:/cirq/cirq-pasqal:/cirq/cirq-rigetti:/cirq/cirq-web:/cirq/cirq-ionq python3 dev_tools/docs/build_api_docs.py --output_dir=docs/api_docs
 
 WORKDIR /cirq/docs/api_docs
 CMD ["markserv", "-b=false", "-p=8080", "-a=0.0.0.0"]

--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -34,7 +34,12 @@ from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import public_api
 
 import cirq
+import cirq_aqt
 import cirq_google
+import cirq_ionq
+import cirq_pasqal
+import cirq_rigetti
+import cirq_web
 
 from cirq import _doc
 
@@ -75,7 +80,9 @@ def main(unused_argv):
     generate_cirq_google()
     generate_cirq_aqt()
     generate_cirq_ionq()
+    generate_cirq_pasqal()
     generate_cirq_rigetti()
+    generate_cirq_web()
 
 
 def generate_cirq():
@@ -96,14 +103,6 @@ def generate_cirq():
 
 
 def generate_cirq_aqt():
-    # This try-catch can go after v0.12 is released
-    try:
-        # should be present in the nightly (pre-release) build
-        import cirq_aqt
-    except ImportError:
-        # as cirq.aqt is under cirq, it should be generated correctly
-        return
-
     doc_generator = generate_lib.DocGenerator(
         root_title="Cirq-aqt",
         py_modules=[("cirq_aqt", cirq_aqt)],
@@ -122,14 +121,6 @@ def generate_cirq_aqt():
 
 
 def generate_cirq_ionq():
-    # This try-catch can go after v0.12 is released
-    try:
-        # should be present in the nightly (pre-release) build
-        import cirq_ionq
-    except ImportError:
-        # as cirq.ionq is under cirq, it should be generated correctly
-        return
-
     doc_generator = generate_lib.DocGenerator(
         root_title="Cirq_ionq",
         py_modules=[("cirq_ionq", cirq_ionq)],
@@ -147,15 +138,25 @@ def generate_cirq_ionq():
     doc_generator.build(output_dir=FLAGS.output_dir)
 
 
-def generate_cirq_rigetti():
-    # This try-catch can go after v0.12 is released
-    try:
-        # should be present in the nightly (pre-release) build
-        import cirq_rigetti
-    except ImportError:
-        # as cirq-rigetti is not released yet, this should be a no-op
-        return
+def generate_cirq_pasqal():
+    doc_generator = generate_lib.DocGenerator(
+        root_title="Cirq-pasqal",
+        py_modules=[("cirq_pasqal", cirq_pasqal)],
+        base_dir=os.path.dirname(cirq_pasqal.__file__),
+        code_url_prefix=FLAGS.code_url_prefix + "/cirq-pasqal/cirq_pasqal",
+        search_hints=FLAGS.search_hints,
+        site_path=FLAGS.site_path,
+        callbacks=[public_api.local_definitions_filter, filter_unwanted_inherited_methods],
+        extra_docs=_doc.RECORDED_CONST_DOCS,
+    )
+    doc_controls.decorate_all_class_attributes(
+        doc_controls.do_not_doc_inheritable, networkx.DiGraph, skip=[]
+    )
 
+    doc_generator.build(output_dir=FLAGS.output_dir)
+
+
+def generate_cirq_rigetti():
     doc_generator = generate_lib.DocGenerator(
         root_title="Cirq_rigetti",
         py_modules=[("cirq_rigetti", cirq_rigetti)],
@@ -190,6 +191,24 @@ def generate_cirq_google():
         },
         extra_docs=_doc.RECORDED_CONST_DOCS,
     )
+    doc_generator.build(output_dir=FLAGS.output_dir)
+
+
+def generate_cirq_web():
+    doc_generator = generate_lib.DocGenerator(
+        root_title="Cirq_web",
+        py_modules=[("cirq_web", cirq_web)],
+        base_dir=os.path.dirname(cirq_web.__file__),
+        code_url_prefix=FLAGS.code_url_prefix + "/cirq-web/cirq_web",
+        search_hints=FLAGS.search_hints,
+        site_path=FLAGS.site_path,
+        callbacks=[public_api.local_definitions_filter, filter_unwanted_inherited_methods],
+        extra_docs=_doc.RECORDED_CONST_DOCS,
+    )
+    doc_controls.decorate_all_class_attributes(
+        doc_controls.do_not_doc_inheritable, networkx.DiGraph, skip=[]
+    )
+
     doc_generator.build(output_dir=FLAGS.output_dir)
 
 

--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -255,14 +255,34 @@ upper_tabs:
         path: /reference/python/cirq/all_symbols
       - include: /reference/python/cirq/_toc.yaml
 
-# uncomment after v0.12 is released
-#      - heading: "cirq-aqt"
-#      - title: "All symbols"
-#        path: /reference/python/cirq_aqt/all_symbols
-#      - include: /reference/python/cirq_aqt/_toc.yaml
+      - heading: "cirq-aqt"
+      - title: "All symbols"
+        path: /reference/python/cirq_aqt/all_symbols
+      - include: /reference/python/cirq_aqt/_toc.yaml
 
       - heading: "cirq-google"
       - title: "All symbols"
         path: /reference/python/cirq_google/all_symbols
       - include: /reference/python/cirq_google/_toc.yaml
+
+      - heading: "cirq-ionq"
+      - title: "All symbols"
+        path: /reference/python/cirq_ionq/all_symbols
+      - include: /reference/python/cirq_ionq/_toc.yaml
+
+      - heading: "cirq-pasqal"
+      - title: "All symbols"
+        path: /reference/python/cirq_pasqal/all_symbols
+      - include: /reference/python/cirq_pasqal/_toc.yaml
+
+      - heading: "cirq-rigetti"
+      - title: "All symbols"
+        path: /reference/python/cirq_rigetti/all_symbols
+      - include: /reference/python/cirq_rigetti/_toc.yaml
+
+      - heading: "cirq-web"
+      - title: "All symbols"
+        path: /reference/python/cirq_web/all_symbols
+      - include: /reference/python/cirq_web/_toc.yaml
+
 - include: /_book/upper_tabs_right.yaml


### PR DESCRIPTION
Add new cirq modules to `_book.yaml`, and `cirq_pasqal`, `cirq_web` to the reference doc generation.
This is one of the post v0.12 release cleanup activities.