### PR TITLE
Add `SupportsKraus` to `cirq/__init__.py`

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -541,6 +541,7 @@ from cirq.protocols import (
     SupportsExplicitQidShape,
     SupportsExplicitNumQubits,
     SupportsJSON,
+    SupportsKraus,
     SupportsMeasurementKey,
     SupportsMixture,
     SupportsParameterization,

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -143,6 +143,7 @@ TestSpec = ModuleJsonTestSpec(
         'SupportsExplicitNumQubits',
         'SupportsExplicitQidShape',
         'SupportsJSON',
+        'SupportsKraus',
         'SupportsMeasurementKey',
         'SupportsMixture',
         'SupportsParameterization',


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/4425