### PR TITLE
Fix MeasurementKey repr s.t. `eval(repr(k)) == k`

### DIFF
--- a/cirq-core/cirq/protocols/json_test_data/MeasurementKey.repr
+++ b/cirq-core/cirq/protocols/json_test_data/MeasurementKey.repr
@@ -1,1 +1,5 @@
-[cirq.MeasurementKey('key'), cirq.MeasurementKey('key', ('outer',)), cirq.MeasurementKey('key', ('nested','path'))]
+[
+    cirq.MeasurementKey(name="key"),
+    cirq.MeasurementKey(path=('outer',), name='key'),
+    cirq.MeasurementKey(path=('nested', 'path'), name='key'),
+]

--- a/cirq-core/cirq/value/measurement_key.py
+++ b/cirq-core/cirq/value/measurement_key.py
@@ -61,9 +61,9 @@ class MeasurementKey:
 
     def __repr__(self):
         if self.path:
-            return f'cirq.MeasurementKey(path={self.path}, name={self.name})'
+            return f"cirq.MeasurementKey(path={self.path!r}, name='{self.name}')"
         else:
-            return f'cirq.MeasurementKey(name={self.name})'
+            return f"cirq.MeasurementKey(name='{self.name}')"
 
     def __str__(self):
         if self._str is None:

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -59,9 +59,11 @@ def test_str(key_string):
 
 def test_repr():
     mkey = cirq.MeasurementKey('key_string')
-    assert repr(mkey) == f'cirq.MeasurementKey(name=key_string)'
+    assert repr(mkey) == f"cirq.MeasurementKey(name='key_string')"
+    assert eval(repr(mkey)) == mkey
     mkey = cirq.MeasurementKey.parse_serialized('nested:key')
-    assert repr(mkey) == f'cirq.MeasurementKey(path=(\'nested\',), name=key)'
+    assert repr(mkey) == f"cirq.MeasurementKey(path=('nested',), name='key')"
+    assert eval(repr(mkey)) == mkey
 
 
 def test_json_dict():


### PR DESCRIPTION
Fixes first part of #4440