### PR TITLE
Do not sort qubits by default in pauli_string to fix inconsistencies with pauli_string.gate

### DIFF
--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -325,7 +325,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
 
     @property
     def qubits(self) -> Tuple[TKey, ...]:
-        return tuple(sorted(self.keys()))
+        return tuple(self.keys())
 
     def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs') -> List[str]:
         if not len(self._qubit_pauli_map):

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -860,7 +860,7 @@ def test_decompose():
         cirq.X(a),
         cirq.Z(b),
     ]
-    assert cirq.decompose_once(cirq.Y(b) * cirq.Z(a)) == [cirq.Z(a), cirq.Y(b)]
+    assert cirq.decompose_once(cirq.Y(b) * cirq.Z(a)) == [cirq.Y(b), cirq.Z(a)]
 
 
 def test_rejects_non_paulis():
@@ -1348,6 +1348,16 @@ def test_dense():
         _ = p.dense([a, b])
     with pytest.raises(ValueError, match=r'not self.keys\(\) <= set\(qubits\)'):
         _ = p.dense([a, b, d])
+
+
+@pytest.mark.parametrize('qubits', [*itertools.permutations(cirq.LineQubit.range(3))])
+def test_gate_consistent(qubits):
+    g = cirq.DensePauliString('XYZ')
+    print(qubits)
+    assert g == g(*qubits).gate
+    a, b, c = cirq.GridQubit.rect(1, 3)
+    ps = cirq.X(a) * cirq.Y(b) * cirq.Z(c)
+    assert ps.gate == ps.with_qubits(*qubits).gate
 
 
 def test_conjugated_by_incorrectly_powered_cliffords():

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -1353,7 +1353,6 @@ def test_dense():
 @pytest.mark.parametrize('qubits', [*itertools.permutations(cirq.LineQubit.range(3))])
 def test_gate_consistent(qubits):
     g = cirq.DensePauliString('XYZ')
-    print(qubits)
     assert g == g(*qubits).gate
     a, b, c = cirq.GridQubit.rect(1, 3)
     ps = cirq.X(a) * cirq.Y(b) * cirq.Z(c)


### PR DESCRIPTION
Fixes #4270

Note that the fix relies on the fact that python dicts maintain insertion order from python 3.6+ [[link](https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6)]