### PR TITLE
Replace `from numpy.random import poisson` with `import numpy as np` in `cirq-core/cirq/contrib/acquaintance/gates_test.py`

### DIFF
--- a/cirq-core/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/gates_test.py
@@ -17,7 +17,7 @@ from random import randint
 from string import ascii_lowercase as alphabet
 from typing import Optional, Sequence, Tuple
 
-from numpy.random import poisson
+import numpy as np
 import pytest
 
 import cirq
@@ -233,7 +233,7 @@ def test_swap_network_init_error():
 
 
 part_lens_and_acquaintance_sizes = [
-    [[l + 1 for l in poisson(size=n_parts, lam=lam)], poisson(4)]
+    [[l + 1 for l in np.random.poisson(size=n_parts, lam=lam)], np.random.poisson(4)]
     for n_parts, lam in product(range(2, 20, 3), range(1, 4))
 ]
 

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -13,6 +13,7 @@ ignore_missing_imports = true
 [mypy-numpy.*]
 follow_imports = skip
 follow_imports_for_stubs = true
+ignore_missing_imports = True
 
 #Adding "sympy.* or mypy-sympy to the above list (3rd-party libs for which we don't have stubs) doesn't ignore "cannot find module 'sympy' error
 [mypy-sympy.*]

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -13,7 +13,6 @@ ignore_missing_imports = true
 [mypy-numpy.*]
 follow_imports = skip
 follow_imports_for_stubs = true
-ignore_missing_imports = True
 
 #Adding "sympy.* or mypy-sympy to the above list (3rd-party libs for which we don't have stubs) doesn't ignore "cannot find module 'sympy' error
 [mypy-sympy.*]


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/4448