### PR TITLE
Fix reference to np.random.poisson

### DIFF
--- a/cirq-core/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/gates_test.py
@@ -232,8 +232,9 @@ def test_swap_network_init_error():
         cca.SwapNetworkGate((3,))
 
 
+rng = np.random.default_rng()
 part_lens_and_acquaintance_sizes = [
-    [[l + 1 for l in np.random.poisson(size=n_parts, lam=lam)], np.random.poisson(4)]
+    [[l + 1 for l in rng.poisson(size=n_parts, lam=lam)], rng.poisson(4)]
     for n_parts, lam in product(range(2, 20, 3), range(1, 4))
 ]
 

--- a/cirq-core/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/gates_test.py
@@ -17,7 +17,7 @@ from random import randint
 from string import ascii_lowercase as alphabet
 from typing import Optional, Sequence, Tuple
 
-from numpy.random import poisson
+import numpy as np
 import pytest
 
 import cirq
@@ -233,7 +233,7 @@ def test_swap_network_init_error():
 
 
 part_lens_and_acquaintance_sizes = [
-    [[l + 1 for l in poisson(size=n_parts, lam=lam)], poisson(4)]
+    [[l + 1 for l in np.random.poisson(size=n_parts, lam=lam)], np.random.poisson(4)]
     for n_parts, lam in product(range(2, 20, 3), range(1, 4))
 ]
 


### PR DESCRIPTION
Fixes mypy's complaint:

```
$ ./check/mypy 
cirq-core/cirq/contrib/acquaintance/gates_test.py:20: error: Module 'numpy.random' has no attribute 'poisson'
Found 1 error in 1 file (checked 925 source files)
```

See the code snippet in [this document](https://numpy.org/doc/stable/reference/random/index.html#random-quick-start) for background on this change.