### PR TITLE
Add missing code for ProjectorSum serialization in TFQ

### DIFF
--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -767,6 +767,11 @@ class ProjectorSum:
     def _value_equality_values_(self):
         return self._linear_dict
 
+    @property
+    def qubits(self) -> Tuple[raw_types.Qid, ...]:
+        qs = {q for k in self._linear_dict.keys() for q, _ in k}
+        return tuple(sorted(qs))
+
     def _json_dict_(self) -> Dict[str, Any]:
         linear_dict = []
         for projector_dict, scalar in dict(self._linear_dict).items():

--- a/cirq-core/cirq/ops/linear_combinations_test.py
+++ b/cirq-core/cirq/ops/linear_combinations_test.py
@@ -1947,3 +1947,17 @@ def test_projector_sum_division():
 
     with pytest.raises(TypeError):
         _ = zero_projector_sum / 'not_the_correct_type'
+
+
+@pytest.mark.parametrize(
+    'terms, expected_qubits',
+    (
+        ([], ()),
+        ([cirq.ProjectorString({q0: 0})], (q0,)),
+        ([cirq.ProjectorString({q0: 0}), cirq.ProjectorString({q1: 0})], (q0, q1)),
+        ([cirq.ProjectorString({q0: 0, q1: 1})], (q0, q1)),
+    ),
+)
+def test_projector_sum_has_correct_qubits(terms, expected_qubits):
+    combination = cirq.ProjectorSum.from_projector_strings(terms)
+    assert combination.qubits == expected_qubits

--- a/cirq-core/cirq/ops/projector.py
+++ b/cirq-core/cirq/ops/projector.py
@@ -23,7 +23,7 @@ def _check_qids_dimension(qids):
             raise ValueError(f"Only qubits are supported, but {qid} has dimension {qid.dimension}")
 
 
-@value.value_equality
+@value.value_equality(approximate=True)
 class ProjectorString:
     def __init__(
         self,


### PR DESCRIPTION
For issue #3288 I noticed that some code was missing when working on integrating with TFQ:
https://github.com/tensorflow/quantum/pull/623