### PR TITLE
Create OperationDecorator class

### DIFF
--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -132,7 +132,7 @@ def test_op():
     op = g(a)
     assert op.controlled_by() is op
     controlled_op = op.controlled_by(b, c)
-    assert controlled_op.sub_operation == op
+    assert controlled_op._sub_operation == op
     assert controlled_op.controls == (b, c)
 
 


### PR DESCRIPTION
Creates an OperationDecorator base class that forwards protocols to the decorated operation by default.

This is PR 1 of https://tinyurl.com/cirq-feedforward, since much of feedforward and flow control will be about creating decorator classes. We didn't want to get into the M*N support where all M decorators require all N protocols to be implemented (usually just forwarding to the suboperation).