### PR TITLE
Retain log_of_measurement_results throughout simulation

### DIFF
--- a/cirq-core/cirq/sim/simulator_base.py
+++ b/cirq-core/cirq/sim/simulator_base.py
@@ -224,7 +224,6 @@ class SimulatorBase(
             step_result = self._create_step_result(sim_state)
             yield step_result
             sim_state = step_result._sim_state
-            sim_state.log_of_measurement_results.clear()
 
     # pylint: enable=missing-raises-doc
     def _run(
@@ -274,10 +273,11 @@ class SimulatorBase(
                 sim_state=act_on_args.copy() if i < repetitions - 1 else act_on_args,
             )
             for step_result in all_step_results:
-                for k, v in step_result.measurements.items():
-                    if k not in measurements:
-                        measurements[k] = []
-                    measurements[k].append(np.array(v, dtype=np.uint8))
+                pass
+            for k, v in step_result.measurements.items():
+                if k not in measurements:
+                    measurements[k] = []
+                measurements[k].append(np.array(v, dtype=np.uint8))
         return {k: np.array(v) for k, v in measurements.items()}
 
     def _create_act_on_args(


### PR DESCRIPTION
Breaking change: Step results will include all measurements from previous moments in the simulation.

Part of https://tinyurl.com/cirq-feedforward, PR 4

Rationale: with feedforward and flow control, classical state is just as much part of the simulation as quantum state. The ActOnArgs *must* contain the full classical state to check whether gates should be applied. For step results, each step result contains the aggregate quantum state, and should also contain the aggregate classical state, hence the breaking change.

This also simplifies analyzing results, as you can look only at the final step result to get all measurements rather than having to traverse them all.