### PR TITLE
Integrate Quirk Editor Embed in Cirq

### DIFF
--- a/cirq-core/cirq/contrib/quirk/example.ipynb
+++ b/cirq-core/cirq/contrib/quirk/example.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cirq\n",
+    "\n",
+    "from cirq.contrib.quirk.export_to_quirk import circuit_to_quirk_url\n",
+    "from cirq import circuits\n",
+    "from pyQuirk import Quirk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def circuit_to_quirk(circuit: circuits.Circuit):\n",
+    "    \"\"\"Returns a Quirk Editor embed for the given circuit.\n",
+    "\n",
+    "    Args:\n",
+    "        circuit: The circuit to open in Quirk.\n",
+    "\n",
+    "    Returns:\n",
+    "        A Quirk embed with the given circuit.\n",
+    "    \"\"\"\n",
+    "    circuit_qasm = circuit.to_qasm(header=\"\")\n",
+    "\n",
+    "    # Format the qasm string to fit the Quirk's requirements\n",
+    "    quirk_qasm = \"\\n\".join(\n",
+    "        [\n",
+    "            line.rstrip()\n",
+    "            for line in circuit_qasm.splitlines()\n",
+    "            if (line.strip() and not line.startswith('//'))\n",
+    "            # TODO: some keywords cause an Error. (eg: `reset`)\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    # TODO: Return a Quirk embed instead of the QASM string\n",
+    "    return quirk_qasm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a, b = cirq.LineQubit.range(2)\n",
+    "c = cirq.Circuit(cirq.H(a), cirq.CNOT(a, b))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 2.0;\n",
+      "include \"qelib1.inc\";\n",
+      "qreg q[2];\n",
+      "h q[0];\n",
+      "cx q[0],q[1];\n"
+     ]
+    }
+   ],
+   "source": [
+    "modified_qasm = circuit_to_quirk(c)\n",
+    "print(modified_qasm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be21b6dae38443fab3651d2b2a52600f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Quirk(scale=0.8)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Launches an instance of the Quirk Editor as an embed\n",
+    "quirk = Quirk(scale=0.8)\n",
+    "quirk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports the QASM into the embed\n",
+    "quirk.update_from_qasm(modified_qasm)"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "459065f83c55c5ec87435afb9cf974e2bae185d60e66b2525285e1b3ed864f05"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/cirq-core/cirq/contrib/quirk/export_to_quirk.py
+++ b/cirq-core/cirq/contrib/quirk/export_to_quirk.py
@@ -25,6 +25,8 @@ from cirq.contrib.quirk.quirk_gate import (
     single_qubit_matrix_gate,
 )
 
+from pyQuirk import Quirk
+
 
 def _try_convert_to_quirk_gate(op: ops.Operation, prefer_unknown_gate_to_failure: bool) -> QuirkOp:
     quirk_gate = known_quirk_op_for_operation(op)
@@ -71,6 +73,7 @@ def circuit_to_quirk_url(
             bar).
 
     Returns:
+        A URL to open the given circuit in Quirk.
 
     """
     circuit = circuit.copy()
@@ -101,3 +104,28 @@ def circuit_to_quirk_url(
     else:
         suffix = circuit_json
     return f'http://algassert.com/quirk#circuit={suffix}'
+
+
+def circuit_to_quirk(circuit: circuits.Circuit):
+    """Returns a Quirk Editor embed for the given circuit.
+
+    Args:
+        circuit: The circuit to open in Quirk.
+
+    Returns:
+        A Quirk embed with the given circuit.
+    """
+    circuit_qasm = circuit.to_qasm(header="")
+
+    # Format the qasm string to fit the Quirk's requirements
+    quirk_qasm = "\n".join(
+        [
+            line.rstrip()
+            for line in circuit_qasm.splitlines()
+            if (line.strip() and not line.startswith('//'))
+            # TODO: some keywords cause an Error. (eg: `reset`)
+        ]
+    )
+
+    # TODO: Return a Quirk embed instead of the QASM string
+    return quirk_qasm

--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -13,3 +13,6 @@ numba>=0.53.0
 # quil import
 pyquil~=2.28.2; python_version < "3.7"
 pyquil~=3.0.0; python_version >= "3.7"
+
+# quirk editor
+pyquirk


### PR DESCRIPTION
This PR aims to solve Issue #4489 by integrating [Quirk](https://algassert.com/quirk) editor in Cirq.

### Proposed Changes

-   [x] **[CORE]** Users should be able to pull up the Quirk editor in IPython notebooks from within Cirq.
    -   Added `pyQuirk` widget (`from pyQuirk import Quirk`).
    -   Users can launch the editor within a notebook by `Quirk()`.
-   [ ] **[CORE]** Convert a `cirq.Circuit` to a Quirk circuit from within the notebook.
-   [ ] **[FEATURE]** Allow modifying an existing circuit / build a new circuit using Quirk and export as `cirq.Circuit` from within the notebook.
-   [ ] **[FEATURE]** `cirq.contrib.circuit_to_quirk_url` which can convert a Quirk URL to a `cirq.Circuit`.
-   [ ] ... (_to be discussed_)

This PR is part of the [Cirq Visualizations Roadmap](https://docs.google.com/document/d/1oqJMq-VF8bsRF9EfHdtODUEtJMrwnzKW_x5Q8-W0xuA/edit#heading=h.2nfg3hb3jqb).
