### PR TITLE
Allow mapping fully qualified measurement keys

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -116,12 +116,12 @@ class CircuitOperation(ops.Operation):
             )
 
         # Disallow mapping to keys containing the `MEASUREMENT_KEY_SEPARATOR`
-        for mapped_key in self.measurement_key_map.values():
-            if value.MEASUREMENT_KEY_SEPARATOR in mapped_key:
-                raise ValueError(
-                    f'Mapping to invalid key: {mapped_key}. "{value.MEASUREMENT_KEY_SEPARATOR}" '
-                    'is not allowed for measurement keys in a CircuitOperation'
-                )
+        # for mapped_key in self.measurement_key_map.values():
+        #     if value.MEASUREMENT_KEY_SEPARATOR in mapped_key:
+        #         raise ValueError(
+        #             f'Mapping to invalid key: {mapped_key}. "{value.MEASUREMENT_KEY_SEPARATOR}" '
+        #             'is not allowed for measurement keys in a CircuitOperation'
+        #         )
 
         # Disallow qid mapping dimension conflicts.
         for q, q_new in self.qubit_map.items():
@@ -523,10 +523,8 @@ class CircuitOperation(ops.Operation):
                 keys than this operation.
         """
         new_map = {}
-        for k in self.circuit.all_measurement_key_names():
-            k = value.MeasurementKey.parse_serialized(k).name
-            k_new = self.measurement_key_map.get(k, k)
-            k_new = key_map.get(k_new, k_new)
+        for k in self.mapped_circuit(True).all_measurement_key_names():
+            k_new = key_map.get(k, k)
             if k_new != k:
                 new_map[k] = k_new
         new_op = self.replace(measurement_key_map=new_map)

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -522,11 +522,11 @@ class CircuitOperation(ops.Operation):
             ValueError: The new operation has a different number of measurement
                 keys than this operation.
         """
-        new_map = {}
-        for k in self.mapped_circuit(True).all_measurement_key_names():
-            k_new = key_map.get(k, k)
-            if k_new != k:
-                new_map[k] = k_new
+        new_map = self.measurement_key_map.copy()
+        for k, v in new_map.items():
+            new_map[k] = key_map.get(v, v)
+        for k, v in key_map.items():
+            new_map[k] = v
         new_op = self.replace(measurement_key_map=new_map)
         if len(new_op._measurement_key_names_()) != len(self._measurement_key_names_()):
             raise ValueError(

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -115,14 +115,6 @@ class CircuitOperation(ops.Operation):
                 f'got: {self.repetition_ids}'
             )
 
-        # Disallow mapping to keys containing the `MEASUREMENT_KEY_SEPARATOR`
-        # for mapped_key in self.measurement_key_map.values():
-        #     if value.MEASUREMENT_KEY_SEPARATOR in mapped_key:
-        #         raise ValueError(
-        #             f'Mapping to invalid key: {mapped_key}. "{value.MEASUREMENT_KEY_SEPARATOR}" '
-        #             'is not allowed for measurement keys in a CircuitOperation'
-        #         )
-
         # Disallow qid mapping dimension conflicts.
         for q, q_new in self.qubit_map.items():
             if q_new.dimension != q.dimension:

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -83,6 +83,20 @@ class _MomentAndOpTypeValidatingDeviceType(cirq.Device):
 moment_and_op_type_validating_device = _MomentAndOpTypeValidatingDeviceType()
 
 
+def test_thing():
+    print()
+    q = cirq.LineQubit(0)
+    l2 = cirq.Circuit(cirq.measure(q, key='a'))
+    l1 = cirq.Circuit(cirq.CircuitOperation(l2.freeze(), repetitions=3), cirq.measure(q, key='b'))
+    l0 = cirq.Circuit(cirq.CircuitOperation(l1.freeze(), repetitions=3), cirq.measure(q, key='c'))
+    print(l0)
+    print(cirq.measurement_key_names(l0))
+    print()
+    la = cirq.with_measurement_key_mapping(l0, {'2:2:a':'2:2:d'})
+    print()
+    print(la[0].operations[0].measurement_key_map)
+    print(cirq.measurement_key_names(la))
+
 def test_alignment():
     assert repr(cirq.Alignment.LEFT) == 'cirq.Alignment.LEFT'
     assert repr(cirq.Alignment.RIGHT) == 'cirq.Alignment.RIGHT'

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -83,20 +83,6 @@ class _MomentAndOpTypeValidatingDeviceType(cirq.Device):
 moment_and_op_type_validating_device = _MomentAndOpTypeValidatingDeviceType()
 
 
-def test_thing():
-    print()
-    q = cirq.LineQubit(0)
-    l2 = cirq.Circuit(cirq.measure(q, key='a'))
-    l1 = cirq.Circuit(cirq.CircuitOperation(l2.freeze(), repetitions=3), cirq.measure(q, key='b'))
-    l0 = cirq.Circuit(cirq.CircuitOperation(l1.freeze(), repetitions=3), cirq.measure(q, key='c'))
-    print(l0)
-    print(cirq.measurement_key_names(l0))
-    print()
-    la = cirq.with_measurement_key_mapping(l0, {'2:2:a':'2:2:d'})
-    print()
-    print(la[0].operations[0].measurement_key_map)
-    print(cirq.measurement_key_names(la))
-
 def test_alignment():
     assert repr(cirq.Alignment.LEFT) == 'cirq.Alignment.LEFT'
     assert repr(cirq.Alignment.RIGHT) == 'cirq.Alignment.RIGHT'

--- a/cirq-core/cirq/value/measurement_key.py
+++ b/cirq-core/cirq/value/measurement_key.py
@@ -114,6 +114,8 @@ class MeasurementKey:
         return self._with_key_path_((path_component,) + self.path)
 
     def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        if self.name not in key_map:
-            return self
-        return self.replace(name=key_map[self.name])
+        if self in key_map or str(self) in key_map:
+            return self.parse_serialized(key_map[str(self)])
+        if self.name in key_map:
+            return self.replace(name=key_map[self.name])
+        return self

--- a/cirq-core/cirq/value/measurement_key.py
+++ b/cirq-core/cirq/value/measurement_key.py
@@ -114,7 +114,7 @@ class MeasurementKey:
         return self._with_key_path_((path_component,) + self.path)
 
     def _with_measurement_key_mapping_(self, key_map: Dict[str, str]):
-        if self in key_map or str(self) in key_map:
+        if str(self) in key_map:
             return self.parse_serialized(key_map[str(self)])
         if self.name in key_map:
             return self.replace(name=key_map[self.name])


### PR DESCRIPTION
@smitsanghavi @95-martin-orion Here's an implementation of fully qualified measurement key mapping. We'll eventually want to include allowing proper MeasurementKey types also, but that is a bigger change and this is enough to unblock control keys.

One behavior change is that it doesn't trim unmatched keys (see line 192 of circuit_operation_test), since that now would require unrolling the whole subcircuit, which may be expensive if there are many repetitions.