### PR TITLE
Fix broken Floquet tutorial

### DIFF
--- a/docs/tutorials/google/floquet_calibration_example.ipynb
+++ b/docs/tutorials/google/floquet_calibration_example.ipynb
@@ -94,7 +94,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install cirq --quiet\n",
+    "    !pip install cirq --pre --quiet\n",
     "    print(\"installed cirq.\")"
    ]
   },


### PR DESCRIPTION
https://quantumai.google/cirq/tutorials/google/floquet_calibration_example broke after #4286 (because it was missing a `--pre` flag).

Without the `--pre` flag this tutorial wouldn't pull in the latest changes and broke.

Added the `--pre` to fix this.