### PR TITLE
Fix broken tutorials depending on cirq pre-release

### DIFF
--- a/cirq-google/cirq_google/engine/qcs_notebook.py
+++ b/cirq-google/cirq_google/engine/qcs_notebook.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Cirq Developers
+# Copyright 2021 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq-google/cirq_google/engine/qcs_notebook_test.py
+++ b/cirq-google/cirq_google/engine/qcs_notebook_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Cirq Developers
+# Copyright 2021 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -46,6 +46,7 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
     # get_qcs_objects_for_notebook
     'docs/tutorials/google/calibration_api.ipynb',
     'docs/tutorials/google/colab.ipynb',
+    'docs/tutorials/google/compare_to_calibration.ipynb',
     'docs/tutorials/google/echoes.ipynb',
     'docs/tutorials/google/floquet_calibration_example.ipynb',
     'docs/tutorials/google/reservations.ipynb',

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -43,6 +43,16 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
     'docs/noise.ipynb',
     # Named topologies
     'docs/named_topologies.ipynb',
+    # get_qcs_objects_for_notebook
+    'docs/tutorials/google/calibration_api.ipynb',
+    'docs/tutorials/google/colab.ipynb',
+    'docs/tutorials/google/echoes.ipynb',
+    'docs/tutorials/google/floquet_calibration_example.ipynb',
+    'docs/tutorials/google/reservations.ipynb',
+    'docs/tutorials/google/spin_echoes.ipynb',
+    'docs/tutorials/google/start.ipynb',
+    'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
+    'docs/tutorials/google/xeb_calibration_example.ipynb',
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule

--- a/docs/tutorials/google/calibration_api.ipynb
+++ b/docs/tutorials/google/calibration_api.ipynb
@@ -79,7 +79,8 @@
     "id": "BRfLi9YSMg4v"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -94,7 +95,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install cirq --pre --quiet\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -71,6 +71,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fe7e28f44667"
+   },
+   "source": [
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -90,7 +100,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/compare_to_calibration.ipynb
+++ b/docs/tutorials/google/compare_to_calibration.ipynb
@@ -97,7 +97,9 @@
     "id": "aWqQUXKX3ssB"
    },
    "source": [
-    "First, we install Cirq and import the packages we will use."
+    "First, we install Cirq and import the packages we will use.\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -111,7 +113,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install cirq --quiet"
+    "    !pip install --quiet cirq --pre"
    ]
   },
   {

--- a/docs/tutorials/google/echoes.ipynb
+++ b/docs/tutorials/google/echoes.ipynb
@@ -90,8 +90,7 @@
     "id": "scdu6m_klCk_"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -100,7 +99,9 @@
     "id": "bpBUR4JblClA"
    },
    "source": [
-    "We first install Cirq then import packages we will use."
+    "We first install Cirq then import packages we will use.\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {

--- a/docs/tutorials/google/echoes.ipynb
+++ b/docs/tutorials/google/echoes.ipynb
@@ -90,7 +90,8 @@
     "id": "scdu6m_klCk_"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -113,7 +114,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install cirq --quiet"
+    "    !pip install --quiet cirq --pre"
    ]
   },
   {

--- a/docs/tutorials/google/floquet_calibration_example.ipynb
+++ b/docs/tutorials/google/floquet_calibration_example.ipynb
@@ -79,7 +79,8 @@
     "id": "pigDhoDrO7vr"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -94,7 +95,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install cirq --pre --quiet\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/reservations.ipynb
+++ b/docs/tutorials/google/reservations.ipynb
@@ -63,6 +63,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fe7e28f44667"
+   },
+   "source": [
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -74,7 +84,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/spin_echoes.ipynb
+++ b/docs/tutorials/google/spin_echoes.ipynb
@@ -93,7 +93,8 @@
     "id": "BRfLi9YSMg4v"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -108,7 +109,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install cirq --quiet\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -71,6 +71,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fe7e28f44667"
+   },
+   "source": [
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -90,7 +100,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/visualizing_calibration_metrics.ipynb
+++ b/docs/tutorials/google/visualizing_calibration_metrics.ipynb
@@ -65,6 +65,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fe7e28f44667"
+   },
+   "source": [
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
@@ -78,7 +88,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")\n",
     "import cirq\n",
     "import cirq_google\n",

--- a/docs/tutorials/google/xeb_calibration_example.ipynb
+++ b/docs/tutorials/google/xeb_calibration_example.ipynb
@@ -88,7 +88,9 @@
     "id": "q8VcUax18RtL"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -114,7 +116,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install cirq --pre --quiet"
+    "    !pip install --quiet cirq --pre"
    ]
   },
   {


### PR DESCRIPTION
#4286 introduced a new module (`qcs_notebook`) and utility method (`get_qcs_objects_for_notebook`) to abstract out boilerplate code for notebooks. 

However, all notebooks using the new method now depend on the pre-released version and should `pip install --pre cirq` instead of `pip install cirq` to work correctly. Right now, all these notebooks are broken and this PR fixes it. 

Note: In some notebooks, already existing `--pre` and `--quiet` is reordered because of recent tests which assert that pre released notebooks have the pip install statement: https://github.com/quantumlib/Cirq/blob/6ecaf0793c0d0865b09603e50fcfbc11ce567273/dev_tools/notebooks/isolated_notebook_test.py#L206 
Even though vendor notebooks (`"**/google/*.ipynb",`) are skipped from testing against cirq, I think it's good to add them to the `NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES` so that `--pre` can be removed in the next release. 

cc @AnimeshSinha1309 for future reference. 