### PR TITLE
Roll forward "Enable CircuitOp serialization"

### DIFF
--- a/cirq-google/cirq_google/devices/known_devices_test.py
+++ b/cirq-google/cirq_google/devices/known_devices_test.py
@@ -102,6 +102,9 @@ valid_gate_sets {
     gate_duration_picos: 4000000
     valid_targets: "meas_targets"
   }
+  valid_gates {
+    id: "circuit"
+  }
 }
 valid_qubits: "0_0"
 valid_qubits: "0_1"
@@ -388,6 +391,9 @@ valid_gate_sets {
     }
     gate_duration_picos: 14141
     valid_targets: "meas_targets"
+  }
+  valid_gates {
+    id: "circuit"
   }
 }
 valid_gate_sets {

--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates.py
@@ -100,6 +100,10 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
         ):
             return True
 
+        if gate is None and isinstance(op.untagged, cirq.CircuitOperation):
+            subcircuit = op.untagged.circuit
+            return all(self._is_native_sycamore_op(op) for op in subcircuit.all_operations())
+
         return False
 
     # TODO(#3388) Add summary line to docstring.
@@ -134,12 +138,13 @@ class ConvertToSycamoreGates(cirq.PointOptimizer):
             keep=self._is_native_sycamore_op,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=None if self.ignore_failures else on_stuck_raise,
+            preserve_structure=True,  # keep CircuitOps but decompose their contents
         )
 
     def optimization_at(
         self, circuit: cirq.Circuit, index: int, op: cirq.Operation
     ) -> Optional[cirq.PointOptimizationSummary]:
-        if not isinstance(op, cirq.GateOperation):
+        if not isinstance(op, (cirq.GateOperation, cirq.CircuitOperation)):
             return None
 
         gate = op.gate

--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates_test.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates_test.py
@@ -78,13 +78,52 @@ def test_single_qubit_gate_phased_xz():
     assert ops[0].gate == gate
 
 
+def test_circuit_operation_inspection():
+    q0, q1 = cirq.LineQubit.range(2)
+    gate = cirq.PhasedXZGate(axis_phase_exponent=0.2, x_exponent=0.3, z_exponent=0.4)
+    cop = cirq.CircuitOperation(cirq.FrozenCircuit(gate(q0)))
+    assert cgoc.ConvertToSycamoreGates()._is_native_sycamore_op(cop)
+
+    cop2 = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.SWAP(q0, q1)))
+    assert not cgoc.ConvertToSycamoreGates()._is_native_sycamore_op(cop2)
+
+
+def test_circuit_operation_conversion():
+    q0, q1 = cirq.LineQubit.range(2)
+    subcircuit = cirq.FrozenCircuit(cirq.X(q0), cirq.SWAP(q0, q1))
+    circuit = cirq.Circuit(cirq.CircuitOperation(subcircuit))
+    converted_circuit = circuit.copy()
+    cgoc.ConvertToSycamoreGates().optimize_circuit(converted_circuit)
+    # Verify that the CircuitOperation was preserved.
+    ops = list(converted_circuit.all_operations())
+    assert isinstance(ops[0], cirq.CircuitOperation)
+    # Verify that the contents of the CircuitOperation were optimized.
+    reconverted_subcircuit = ops[0].circuit.unfreeze().copy()
+    cgoc.ConvertToSycamoreGates().optimize_circuit(reconverted_subcircuit)
+    assert ops[0].circuit == reconverted_subcircuit
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        circuit, converted_circuit, atol=1e-8
+    )
+
+
 def test_unsupported_gate():
     class UnknownGate(cirq.testing.TwoQubitGate):
         pass
 
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(UnknownGate()(q0, q1))
+    with pytest.raises(ValueError, match='Unrecognized gate: '):
+        cgoc.ConvertToSycamoreGates().optimize_circuit(circuit)
+
+
+def test_nested_unsupported_gate():
+    class UnknownGate(cirq.TwoQubitGate):
+        pass
+
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQubit(1)
-    circuit = cirq.Circuit(UnknownGate()(q0, q1))
+    subcircuit = cirq.FrozenCircuit(UnknownGate()(q0, q1))
+    circuit = cirq.Circuit(cirq.CircuitOperation(subcircuit))
     with pytest.raises(ValueError, match='Unrecognized gate: '):
         cgoc.ConvertToSycamoreGates().optimize_circuit(circuit)
 

--- a/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates_test.py
+++ b/cirq-google/cirq_google/optimizers/convert_to_sycamore_gates_test.py
@@ -117,7 +117,7 @@ def test_unsupported_gate():
 
 
 def test_nested_unsupported_gate():
-    class UnknownGate(cirq.TwoQubitGate):
+    class UnknownGate(cirq.testing.TwoQubitGate):
         pass
 
     q0 = cirq.LineQubit(0)

--- a/cirq-google/cirq_google/serialization/gate_sets.py
+++ b/cirq-google/cirq_google/serialization/gate_sets.py
@@ -33,6 +33,8 @@ from cirq_google.serialization.common_serializers import (
     COUPLER_PULSE_DESERIALIZER,
     WAIT_GATE_SERIALIZER,
     WAIT_GATE_DESERIALIZER,
+    CIRCUIT_OP_SERIALIZER,
+    CIRCUIT_OP_DESERIALIZER,
 )
 
 SYC_GATESET = serializable_gate_set.SerializableGateSet(
@@ -43,6 +45,7 @@ SYC_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_HALF_PI_SERIALIZERS,
         MEASUREMENT_SERIALIZER,
         WAIT_GATE_SERIALIZER,
+        CIRCUIT_OP_SERIALIZER,
     ],
     deserializers=[
         SYC_DESERIALIZER,
@@ -50,6 +53,7 @@ SYC_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_HALF_PI_DESERIALIZERS,
         MEASUREMENT_DESERIALIZER,
         WAIT_GATE_DESERIALIZER,
+        CIRCUIT_OP_DESERIALIZER,
     ],
 )
 document(SYC_GATESET, """Gate set with fsim(pi/2, pi/6) as the core 2 qubit interaction.""")
@@ -61,12 +65,14 @@ SQRT_ISWAP_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_SERIALIZERS,
         MEASUREMENT_SERIALIZER,
         WAIT_GATE_SERIALIZER,
+        CIRCUIT_OP_SERIALIZER,
     ],
     deserializers=[
         *SQRT_ISWAP_DESERIALIZERS,
         *SINGLE_QUBIT_DESERIALIZERS,
         MEASUREMENT_DESERIALIZER,
         WAIT_GATE_DESERIALIZER,
+        CIRCUIT_OP_DESERIALIZER,
     ],
 )
 document(SQRT_ISWAP_GATESET, """Gate set with sqrt(iswap) as the core 2 qubit interaction.""")
@@ -79,12 +85,14 @@ FSIM_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_SERIALIZERS,
         MEASUREMENT_SERIALIZER,
         WAIT_GATE_SERIALIZER,
+        CIRCUIT_OP_SERIALIZER,
     ],
     deserializers=[
         LIMITED_FSIM_DESERIALIZER,
         *SINGLE_QUBIT_DESERIALIZERS,
         MEASUREMENT_DESERIALIZER,
         WAIT_GATE_DESERIALIZER,
+        CIRCUIT_OP_DESERIALIZER,
     ],
 )
 document(FSIM_GATESET, """Gate set that combines sqrt(iswap) and syc as one fsim id.""")
@@ -98,6 +106,7 @@ EXPERIMENTAL_PULSE_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_SERIALIZERS,
         MEASUREMENT_SERIALIZER,
         WAIT_GATE_SERIALIZER,
+        CIRCUIT_OP_SERIALIZER,
     ],
     deserializers=[
         COUPLER_PULSE_DESERIALIZER,
@@ -105,6 +114,7 @@ EXPERIMENTAL_PULSE_GATESET = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_DESERIALIZERS,
         MEASUREMENT_DESERIALIZER,
         WAIT_GATE_DESERIALIZER,
+        CIRCUIT_OP_DESERIALIZER,
     ],
 )
 document(
@@ -120,11 +130,13 @@ XMON = serializable_gate_set.SerializableGateSet(
         *SINGLE_QUBIT_SERIALIZERS,
         CZ_POW_SERIALIZER,
         MEASUREMENT_SERIALIZER,
+        CIRCUIT_OP_SERIALIZER,
     ],
     deserializers=[
         *SINGLE_QUBIT_DESERIALIZERS,
         CZ_POW_DESERIALIZER,
         MEASUREMENT_DESERIALIZER,
+        CIRCUIT_OP_DESERIALIZER,
     ],
 )
 document(XMON, """Gate set for XMON devices.""")

--- a/cirq-google/cirq_google/serialization/gate_sets_test.py
+++ b/cirq-google/cirq_google/serialization/gate_sets_test.py
@@ -527,3 +527,50 @@ def test_serialize_deserialize_wait_gate():
     assert cg.SYC_GATESET.deserialize_op(proto) == op
     assert cg.SQRT_ISWAP_GATESET.serialize_op(op) == proto
     assert cg.SQRT_ISWAP_GATESET.deserialize_op(proto) == op
+
+
+def default_circuit_proto():
+    op1 = v2.program_pb2.Operation()
+    op1.gate.id = 'x_pow'
+    op1.args['half_turns'].arg_value.string_value = 'k'
+    op1.qubits.add().id = '1_1'
+
+    return v2.program_pb2.Circuit(
+        scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
+        moments=[
+            v2.program_pb2.Moment(
+                operations=[op1],
+            ),
+        ],
+    )
+
+
+def default_circuit():
+    return cirq.FrozenCircuit(
+        cirq.X(cirq.GridQubit(1, 1)) ** sympy.Symbol('k'),
+        cirq.measure(cirq.GridQubit(1, 1), key='m'),
+    )
+
+
+@pytest.mark.parametrize('gateset', [cg.XMON, cg.SYC_GATESET, cg.SQRT_ISWAP_GATESET])
+def test_serialize_deserialize_circuit_op(gateset):
+    circuit_op = cirq.CircuitOperation(default_circuit())
+    proto = v2.program_pb2.CircuitOperation()
+    proto.circuit_constant_index = 0
+    proto.repetition_specification.repetition_count = 1
+
+    constants = [default_circuit_proto()]
+    raw_constants = {default_circuit(): 0}
+    assert (
+        gateset.serialize_op(circuit_op, constants=constants, raw_constants=raw_constants) == proto
+    )
+
+    constants = [default_circuit_proto()]
+    deserialized_constants = [default_circuit()]
+
+    assert (
+        gateset.deserialize_op(
+            proto, constants=constants, deserialized_constants=deserialized_constants
+        )
+        == circuit_op
+    )

--- a/docs/google/best_practices.md
+++ b/docs/google/best_practices.md
@@ -49,6 +49,39 @@ my_circuit = cirq.Circuit()
 sycamore_circuit = cg.optimized_for_sycamore(my_circuit, new_device=cg.Sycamore, optimizer_type='sqrt_iswap')
 ```
 
+### Using CircuitOperation to reduce circuit size
+
+Particularly large batches (or sweeps) of circuits may encounter errors when
+sent to Quantum Engine due to an upper limit on request size. If the circuits
+in question have a repetitive structure, `cirq.CircuitOperation`s can be used
+to reduce the request size and avoid this limit.
+
+`optimized_for_sycamore` will preserve `CircuitOperation`s while optimizing
+their contents.
+
+```python
+import cirq
+import cirq_google as cg
+
+# Repeatedly apply Hadamard and measurement to 10 qubits.
+my_circuit = cirq.Circuit()
+qubits = cirq.GridQubit.rect(2, 5)
+for i in range(100):
+    my_circuit.append(cirq.H.on_each(*qubits))
+    for q in qubits:
+        my_circuit.append(cirq.measure(q, key=f'm{q}'))
+
+# The same circuit, but defined using CircuitOperations.
+# This is ~1000x smaller when serialized!
+sub_circuit = cirq.Circuit(cirq.H(qubits[0]), cirq.measure(qubits[0], key='m'))
+circuit_op = cirq.CircuitOperation(sub_circuit.freeze())
+circuit_op = circuit_op.with_qubits([q])
+circuit_op = circuit_op.with_measurement_key_mapping({'m': f'm{q}'})
+circuit_op = circuit_op.repeat(100)
+short_circuit = cirq.Circuit(circuit_op for q in qubits)
+```
+
+
 ## Running circuits faster
 
 The following sections give tips and tricks that allow you to improve your

--- a/docs/google/devices.md
+++ b/docs/google/devices.md
@@ -223,6 +223,15 @@ For decay experiments and other applications, a WaitGate is provided
 that causes the device to idle for a specified amount of time.
 This can be accomplished by specifying a `cirq.WaitGate`.
 
+
+### Subcircuits
+
+Circuits with a repetitive structure can benefit from using
+`cirq.CircuitOperation` to specify "subcircuits" within the overall circuit.
+Using this type condenses the serialized representation of the circuit, which
+may help for circuits that would otherwise run into size limitations.
+
+
 ## Specific Device Layouts
 
 The following devices are provided as part of cirq and can help you get your


### PR DESCRIPTION
This PR rolls forward ("un-reverts"?) #4344 and #4336. It relies on server-side changes in QCS to prevent the backwards-compatibility issues seen in the original submission of those PRs.

DO NOT MERGE until the server-side changes are complete.