### PR TITLE
Use gatesets in cirq/ion, cirq/neutral_atoms, cirq_pasqal and cirq_ionq

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -176,6 +176,8 @@ from cirq.linalg import (
 from cirq.ops import (
     amplitude_damp,
     AmplitudeDampingChannel,
+    AnyIntegerPowerGateFamily,
+    AnyUnitaryGateFamily,
     ArithmeticOperation,
     asymmetric_depolarize,
     AsymmetricDepolarizingChannel,
@@ -245,6 +247,7 @@ from cirq.ops import (
     OP_TREE,
     Operation,
     ParallelGate,
+    ParallelGateFamily,
     parallel_gate_op,
     ParallelGateOperation,
     Pauli,

--- a/cirq-core/cirq/ion/convert_to_ion_gates.py
+++ b/cirq-core/cirq/ion/convert_to_ion_gates.py
@@ -15,7 +15,7 @@
 import numpy as np
 
 from cirq import ops, protocols, optimizers, circuits
-from cirq.ion import ms, two_qubit_matrix_to_ion_operations
+from cirq.ion import ms, two_qubit_matrix_to_ion_operations, ion_device
 
 
 class ConvertToIonGates:
@@ -47,7 +47,7 @@ class ConvertToIonGates:
         if not isinstance(op, ops.GateOperation):
             raise TypeError(f"{op!r} is not a gate operation.")
 
-        if is_native_ion_gate(op.gate):
+        if op in ion_device.IonDevice.gateset:
             return [op]
         # one choice of known Hadamard gate decomposition
         if isinstance(op.gate, ops.HPowGate) and op.gate.exponent == 1:
@@ -88,25 +88,3 @@ class ConvertToIonGates:
         optimizers.merge_single_qubit_gates_into_phased_x_z(new_circuit)
 
         return new_circuit
-
-
-def is_native_ion_gate(gate: ops.Gate) -> bool:
-    """Check if a gate is a native ion gate.
-
-    Args:
-        gate: Input gate.
-
-    Returns:
-        True if the gate is native to the ion, false otherwise.
-    """
-    return isinstance(
-        gate,
-        (
-            ops.XXPowGate,
-            ops.MeasurementGate,
-            ops.XPowGate,
-            ops.YPowGate,
-            ops.ZPowGate,
-            ops.PhasedXPowGate,
-        ),
-    )

--- a/cirq-core/cirq/ion/ion_device.py
+++ b/cirq-core/cirq/ion/ion_device.py
@@ -28,6 +28,17 @@ class IonDevice(devices.Device):
     Qubits have all-to-all connectivity.
     """
 
+    gateset = ops.Gateset(
+        ops.XXPowGate,
+        ops.MeasurementGate,
+        ops.XPowGate,
+        ops.YPowGate,
+        ops.ZPowGate,
+        ops.PhasedXPowGate,
+        unroll_circuit_op=False,
+        accept_global_phase=False,
+    )
+
     def __init__(
         self,
         measurement_duration: 'cirq.DURATION_LIKE',
@@ -79,17 +90,7 @@ class IonDevice(devices.Device):
         raise ValueError(f'Unsupported gate type: {operation!r}')
 
     def validate_gate(self, gate: ops.Gate):
-        if not isinstance(
-            gate,
-            (
-                ops.XPowGate,
-                ops.YPowGate,
-                ops.ZPowGate,
-                ops.PhasedXPowGate,
-                ops.XXPowGate,
-                ops.MeasurementGate,
-            ),
-        ):
+        if gate not in IonDevice.gateset:
             raise ValueError(f'Unsupported gate type: {gate!r}')
 
     def validate_operation(self, operation):

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
@@ -18,6 +18,7 @@ from cirq.circuits.optimization_pass import (
     PointOptimizationSummary,
     PointOptimizer,
 )
+from cirq.neutral_atoms import neutral_atom_devices
 from cirq import optimizers
 
 if TYPE_CHECKING:
@@ -50,6 +51,7 @@ class ConvertToNeutralAtomGates(PointOptimizer):
         """
         super().__init__()
         self.ignore_failures = ignore_failures
+        self.gateset = neutral_atom_devices.neutral_atom_gateset()
 
     def _convert_one(self, op: ops.Operation) -> ops.OP_TREE:
         # Known matrix?
@@ -75,7 +77,7 @@ class ConvertToNeutralAtomGates(PointOptimizer):
 
         return protocols.decompose(
             op,
-            keep=is_native_neutral_atom_op,
+            keep=self.gateset._validate_operation,
             intercepting_decomposer=self._convert_one,
             on_stuck_raise=None if self.ignore_failures else on_stuck_raise,
         )
@@ -92,32 +94,8 @@ class ConvertToNeutralAtomGates(PointOptimizer):
 
 
 def is_native_neutral_atom_op(operation: ops.Operation) -> bool:
-    if isinstance(operation, (ops.GateOperation, ops.ParallelGateOperation)):
-        gate = operation.gate
-        if isinstance(gate, ops.ParallelGate):
-            gate = gate.sub_gate
-        return is_native_neutral_atom_gate(gate)
-    return False
+    return operation in neutral_atom_devices.neutral_atom_gateset()  # coverage: ignore
 
 
 def is_native_neutral_atom_gate(gate: ops.Gate) -> bool:
-    if not isinstance(
-        gate,
-        (
-            ops.CCXPowGate,
-            ops.CCZPowGate,
-            ops.CZPowGate,
-            ops.CNotPowGate,
-            ops.XPowGate,
-            ops.YPowGate,
-            ops.PhasedXPowGate,
-            ops.MeasurementGate,
-            ops.ZPowGate,
-            ops.IdentityGate,
-        ),
-    ):
-        return False
-    if isinstance(gate, (ops.CNotPowGate, ops.CZPowGate, ops.CCXPowGate, ops.CCZPowGate)):
-        if not gate.exponent.is_integer():
-            return False
-    return True
+    return gate in neutral_atom_devices.neutral_atom_gateset()  # coverage: ignore

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -18,7 +18,7 @@ from typing import Any, Iterable, cast, DefaultDict, TYPE_CHECKING, FrozenSet
 from numpy import sqrt
 from cirq import devices, ops, circuits, value
 from cirq.devices.grid_qubit import GridQubit
-from cirq.ops import MeasurementGate, raw_types
+from cirq.ops import raw_types
 from cirq.value import Duration
 from cirq.neutral_atoms import convert_to_neutral_atom_gates
 
@@ -29,6 +29,21 @@ if TYPE_CHECKING:
 def _subgate_if_parallel_gate(gate: 'cirq.Gate') -> 'cirq.Gate':
     """Returns gate.sub_gate if gate is a ParallelGate, else returns gate"""
     return gate.sub_gate if isinstance(gate, ops.ParallelGate) else gate
+
+
+def neutral_atom_gateset(max_parallel_z=None, max_parallel_xy=None):
+    return ops.Gateset(
+        ops.AnyIntegerPowerGateFamily(ops.CNotPowGate),
+        ops.AnyIntegerPowerGateFamily(ops.CCNotPowGate),
+        ops.AnyIntegerPowerGateFamily(ops.CZPowGate),
+        ops.AnyIntegerPowerGateFamily(ops.CCZPowGate),
+        ops.ParallelGateFamily(ops.ZPowGate, max_parallel_allowed=max_parallel_z),
+        ops.ParallelGateFamily(ops.XPowGate, max_parallel_allowed=max_parallel_xy),
+        ops.ParallelGateFamily(ops.YPowGate, max_parallel_allowed=max_parallel_xy),
+        ops.ParallelGateFamily(ops.PhasedXPowGate, max_parallel_allowed=max_parallel_xy),
+        ops.MeasurementGate,
+        ops.IdentityGate,
+    )
 
 
 @value.value_equality
@@ -78,6 +93,18 @@ class NeutralAtomDevice(devices.Device):
                 "min of max_parallel_z and max_parallel_xy"
             )
         self._max_parallel_c = max_parallel_c
+        self.xy_gateset_all_allowed = ops.Gateset(
+            ops.ParallelGateFamily(ops.XPowGate),
+            ops.ParallelGateFamily(ops.YPowGate),
+            ops.ParallelGateFamily(ops.PhasedXPowGate),
+        )
+        self.controlled_gateset = ops.Gateset(
+            ops.AnyIntegerPowerGateFamily(ops.CNotPowGate),
+            ops.AnyIntegerPowerGateFamily(ops.CCNotPowGate),
+            ops.AnyIntegerPowerGateFamily(ops.CZPowGate),
+            ops.AnyIntegerPowerGateFamily(ops.CCZPowGate),
+        )
+        self.gateset = neutral_atom_gateset(max_parallel_z, max_parallel_xy)
         for q in qubits:
             if not isinstance(q, GridQubit):
                 raise ValueError(f'Unsupported qubit type: {q!r}')
@@ -107,7 +134,7 @@ class NeutralAtomDevice(devices.Device):
         """
         self.validate_operation(operation)
         if isinstance(operation, (ops.GateOperation, ops.ParallelGateOperation)):
-            if isinstance(operation.gate, MeasurementGate):
+            if isinstance(operation.gate, ops.MeasurementGate):
                 return self._measurement_duration
         return self._gate_duration
 
@@ -120,25 +147,10 @@ class NeutralAtomDevice(devices.Device):
         Raises:
             ValueError: If the given gate is not part of the native gate set.
         """
-        if not isinstance(
-            gate,
-            (
-                ops.CCXPowGate,
-                ops.CCZPowGate,
-                ops.CZPowGate,
-                ops.CNotPowGate,
-                ops.XPowGate,
-                ops.YPowGate,
-                ops.PhasedXPowGate,
-                MeasurementGate,
-                ops.ZPowGate,
-                ops.IdentityGate,
-            ),
-        ):
-            raise ValueError(f'Unsupported gate: {gate!r}')
-        if isinstance(gate, (ops.CNotPowGate, ops.CZPowGate, ops.CCXPowGate, ops.CCZPowGate)):
-            if not gate.exponent.is_integer():
+        if gate not in self.gateset:
+            if isinstance(gate, (ops.CNotPowGate, ops.CZPowGate, ops.CCXPowGate, ops.CCZPowGate)):
                 raise ValueError('controlled gates must have integer exponents')
+            raise ValueError(f'Unsupported gate: {gate!r}')
 
     def validate_operation(self, operation: ops.Operation):
         """Raises an error if the given operation is invalid on this device.
@@ -152,43 +164,21 @@ class NeutralAtomDevice(devices.Device):
         if not isinstance(operation, (ops.GateOperation, ops.ParallelGateOperation)):
             raise ValueError(f'Unsupported operation: {operation!r}')
 
-        gate = operation.gate
-        if isinstance(gate, ops.ParallelGate):
-            if isinstance(gate.sub_gate, ops.MeasurementGate):
-                raise ValueError(
-                    f'ParallelGate over MeasurementGate is not supported: {operation!r}'
-                )
-            gate = gate.sub_gate
-
-        # The gate must be valid
-        self.validate_gate(gate)
-
         # All qubits the operation acts on must be on the device
         for q in operation.qubits:
             if q not in self.qubits:
                 raise ValueError(f'Qubit not on device: {q!r}')
 
-        if isinstance(gate, (ops.MeasurementGate, ops.IdentityGate)):
-            return
+        if operation not in self.gateset and not (
+            operation in self.xy_gateset_all_allowed and len(operation.qubits) == len(self.qubits)
+        ):
+            raise ValueError(f'Unsupported operation: {operation!r}')
 
-        # Verify that a valid number of Z gates are applied in parallel
-        if isinstance(gate, ops.ZPowGate):
-            if len(operation.qubits) > self._max_parallel_z:
-                raise ValueError("Too many Z gates in parallel")
-            return
-
-        # Verify that a valid number of XY gates are applied in parallel
-        if isinstance(gate, (ops.XPowGate, ops.YPowGate, ops.PhasedXPowGate)):
-            if len(operation.qubits) > self._max_parallel_xy and len(operation.qubits) != len(
-                self.qubits
-            ):
-                raise ValueError("Bad number of XY gates in parallel")
-            return
-
-        # Verify that a controlled gate operation is valid
-        if len(operation.qubits) > self._max_parallel_c:
-            raise ValueError("Too many qubits acted on in parallel by a controlled gate operation")
-        if len(operation.qubits) > 1:
+        if operation in self.controlled_gateset:
+            if len(operation.qubits) > self._max_parallel_c:
+                raise ValueError(
+                    'Too many qubits acted on in parallel by a controlled gate operation'
+                )
             for p in operation.qubits:
                 for q in operation.qubits:
                     if self.distance(p, q) > self._control_radius:

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -43,6 +43,8 @@ def neutral_atom_gateset(max_parallel_z=None, max_parallel_xy=None):
         ops.ParallelGateFamily(ops.PhasedXPowGate, max_parallel_allowed=max_parallel_xy),
         ops.MeasurementGate,
         ops.IdentityGate,
+        unroll_circuit_op=False,
+        accept_global_phase=False,
     )
 
 
@@ -97,12 +99,16 @@ class NeutralAtomDevice(devices.Device):
             ops.ParallelGateFamily(ops.XPowGate),
             ops.ParallelGateFamily(ops.YPowGate),
             ops.ParallelGateFamily(ops.PhasedXPowGate),
+            unroll_circuit_op=False,
+            accept_global_phase=False,
         )
         self.controlled_gateset = ops.Gateset(
             ops.AnyIntegerPowerGateFamily(ops.CNotPowGate),
             ops.AnyIntegerPowerGateFamily(ops.CCNotPowGate),
             ops.AnyIntegerPowerGateFamily(ops.CZPowGate),
             ops.AnyIntegerPowerGateFamily(ops.CCZPowGate),
+            unroll_circuit_op=False,
+            accept_global_phase=False,
         )
         self.gateset = neutral_atom_gateset(max_parallel_z, max_parallel_xy)
         for q in qubits:

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices_test.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices_test.py
@@ -136,11 +136,11 @@ def test_validate_operation_errors():
         d.validate_operation(cirq.CCX.on(*d.qubit_list()[0:3]))
     with pytest.raises(ValueError, match="are too far away"):
         d.validate_operation(cirq.CZ.on(cirq.GridQubit(0, 0), cirq.GridQubit(2, 2)))
-    with pytest.raises(ValueError, match="Too many Z gates in parallel"):
+    with pytest.raises(ValueError, match="Unsupported operation"):
         d.validate_operation(cirq.parallel_gate_op(cirq.Z, *d.qubits))
-    with pytest.raises(ValueError, match="Bad number of XY gates in parallel"):
+    with pytest.raises(ValueError, match="Unsupported operation"):
         d.validate_operation(cirq.parallel_gate_op(cirq.X, *d.qubit_list()[1:]))
-    with pytest.raises(ValueError, match="ParallelGate over MeasurementGate is not supported"):
+    with pytest.raises(ValueError, match="Unsupported operation"):
         d.validate_operation(
             cirq.ParallelGate(cirq.MeasurementGate(1, key='a'), 4)(*d.qubit_list()[:4])
         )

--- a/cirq-core/cirq/ops/__init__.py
+++ b/cirq-core/cirq/ops/__init__.py
@@ -76,6 +76,12 @@ from cirq.ops.common_gates import (
     ZPowGate,
 )
 
+from cirq.ops.common_gate_families import (
+    AnyUnitaryGateFamily,
+    AnyIntegerPowerGateFamily,
+    ParallelGateFamily,
+)
+
 from cirq.ops.controlled_gate import (
     ControlledGate,
 )

--- a/cirq-core/cirq/ops/common_gate_families.py
+++ b/cirq-core/cirq/ops/common_gate_families.py
@@ -1,0 +1,108 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common Gate Families used in cirq-core"""
+
+from typing import cast, Optional, Type, Union
+
+from cirq.ops import gateset, raw_types, parallel_gate, eigen_gate
+from cirq import protocols
+
+
+class AnyUnitaryGateFamily(gateset.GateFamily):
+    def __init__(self, num_qubits: Optional[int] = None) -> None:
+        self._num_qubits = num_qubits
+        if num_qubits:
+            name = f'{num_qubits}-Qubit UnitaryGateFamily'
+            description = f'Accepts any {num_qubits}-qubit unitary gate.'
+        else:
+            name = 'Any-Qubit UnitaryGateFamily'
+            description = 'Accepts any unitary gate.'
+        super().__init__(raw_types.Gate, name=name, description=description)
+
+    def _predicate(self, g: raw_types.Gate) -> bool:
+        return (
+            self._num_qubits is None or protocols.num_qubits(g) == self._num_qubits
+        ) and protocols.has_unitary(g)
+
+    def __repr__(self) -> str:
+        return f'cirq.AnyUnitaryGateFamily(num_qubits = {self._num_qubits})'
+
+
+class AnyIntegerPowerGateFamily(gateset.GateFamily):
+    def __init__(self, gate: Type[eigen_gate.EigenGate]) -> None:
+        if not (isinstance(gate, type) and issubclass(gate, eigen_gate.EigenGate)):
+            raise ValueError(f'{gate} must be a subclass of `cirq.EigenGate`.')
+        super().__init__(
+            gate,
+            name=f'AnyIntegerPowerGateFamily: {gate}',
+            description=f'Accepts any instance `g` of `{gate}` s.t. `g.exponent` is an integer.',
+        )
+
+    def _predicate(self, g: raw_types.Gate) -> bool:
+        if protocols.is_parameterized(g) or not super()._predicate(g):
+            return False
+        exp = cast(eigen_gate.EigenGate, g).exponent  # for mypy
+        return int(exp) == exp
+
+    def __repr__(self) -> str:
+        return f'cirq.AnyIntegerPowerGateFamily({self._gate_str()})'
+
+
+class ParallelGateFamily(gateset.GateFamily):
+    def __init__(
+        self,
+        gate: Union[Type[raw_types.Gate], raw_types.Gate],
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        max_parallel_allowed=None,
+    ) -> None:
+        if isinstance(gate, parallel_gate.ParallelGate):
+            gate = cast(parallel_gate.ParallelGate, gate).sub_gate
+        self._max_parallel_allowed = max_parallel_allowed
+        super().__init__(gate, name=name, description=description)
+
+    def _max_parallel_str(self):
+        return self._max_parallel_allowed if self._max_parallel_allowed is not None else 'INF'
+
+    def _default_name(self) -> str:
+        return f'{self._max_parallel_str()} Parallel ' + super()._default_name()
+
+    def _default_description(self) -> str:
+        check_type = r'g == {}' if isinstance(self.gate, raw_types.Gate) else r'isinstance(g, {})'
+        return (
+            f'Accepts\n'
+            f'1. `cirq.Gate` instances `g` s.t. `{check_type.format(self._gate_str())}` OR\n'
+            f'2. `cirq.ParallelGate` instance `g` s.t. `g.sub_gate` satisfies 1. and '
+            f'`cirq.num_qubits(g) <= {self._max_parallel_str()}` OR\n'
+            f'3. `cirq.Operation` instance `op` s.t. `op.gate` satisfies 1. or 2.'
+        )
+
+    def _predicate(self, gate: raw_types.Gate) -> bool:
+        if (
+            self._max_parallel_allowed is not None
+            and protocols.num_qubits(gate) > self._max_parallel_allowed
+        ):
+            return False
+        gate = gate.sub_gate if isinstance(gate, parallel_gate.ParallelGate) else gate
+        return super()._predicate(gate)
+
+    def __repr__(self) -> str:
+        return (
+            f'cirq.ParallelGateFamily(gate={self._gate_str(repr)},'
+            f'name="{self.name}", '
+            f'description=r\'\'\'' + self.description + '\'\'\','
+            f'max_parallel_allowed="{self._max_parallel_allowed}")'
+        )

--- a/cirq-core/cirq/ops/common_gate_families_test.py
+++ b/cirq-core/cirq/ops/common_gate_families_test.py
@@ -1,0 +1,63 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import cirq
+
+
+def test_any_unitary_gate_family():
+    for gate in [cirq.X, cirq.MatrixGate(cirq.testing.random_unitary(8)), cirq.CNOT ** 0.2]:
+        q = cirq.LineQubit.range(cirq.num_qubits(gate))
+        for num_qubits in [None, cirq.num_qubits(gate)]:
+            gate_family = cirq.AnyUnitaryGateFamily(num_qubits)
+            cirq.testing.assert_equivalent_repr(gate_family)
+            assert gate in gate_family
+            assert gate(*q) in gate_family
+            if num_qubits:
+                assert f'{num_qubits}' in gate_family.name
+                assert f'{num_qubits}' in gate_family.description
+            else:
+                assert f'Any-Qubit' in gate_family.name
+                assert f'any unitary' in gate_family.description
+
+    assert cirq.MeasurementGate(num_qubits=2) not in cirq.AnyUnitaryGateFamily()
+
+
+def test_any_integer_power_gate_family():
+    with pytest.raises(ValueError, match='subclass of `cirq.EigenGate`'):
+        cirq.AnyIntegerPowerGateFamily(gate=cirq.FSimGate)
+    gate_family = cirq.AnyIntegerPowerGateFamily(cirq.CXPowGate)
+    cirq.testing.assert_equivalent_repr(gate_family)
+    assert cirq.CX in gate_family
+    assert cirq.CX ** 2 in gate_family
+    assert cirq.CX ** 1.5 not in gate_family
+    assert 'CXPowGate' in gate_family.name
+    assert '`g.exponent` is an integer' in gate_family.description
+
+
+@pytest.mark.parametrize('gate', [cirq.X, cirq.ParallelGate(cirq.X, 2), cirq.XPowGate])
+@pytest.mark.parametrize('name,description', [(None, None), ("Custom Name", "Custom Description")])
+def test_parallel_gate_family(gate, name, description):
+    gate_family = cirq.ParallelGateFamily(
+        gate, name=name, description=description, max_parallel_allowed=3
+    )
+    cirq.testing.assert_equivalent_repr(gate_family)
+    for gate_to_test in [cirq.X, cirq.ParallelGate(cirq.X, 2)]:
+        assert gate_to_test in gate_family
+        assert gate_to_test(*cirq.LineQubit.range(cirq.num_qubits(gate_to_test))) in gate_family
+    assert cirq.ParallelGate(cirq.X, 4) not in gate_family
+    str_to_search = 'Custom' if name else 'Parallel'
+    assert str_to_search in gate_family.name
+    assert str_to_search in gate_family.description

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -25,6 +25,8 @@ TestSpec = ModuleJsonTestSpec(
     resolver_cache=_class_resolver_dictionary(),
     not_yet_serializable=[
         'Alignment',
+        'AnyIntegerPowerGateFamily',
+        'AnyUnitaryGateFamily',
         'AxisAngleDecomposition',
         'CircuitDag',
         'CircuitDiagramInfo',
@@ -48,6 +50,7 @@ TestSpec = ModuleJsonTestSpec(
         'ListSweep',
         'DiagonalGate',
         'NeutralAtomDevice',
+        'ParallelGateFamily',
         'PauliInteractionGate',
         'PauliStringPhasor',
         'PauliSum',

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -47,6 +47,8 @@ class IonQAPIDevice(cirq.Device):
         cirq.YYPowGate,
         cirq.ZZPowGate,
         cirq.MeasurementGate,
+        unroll_circuit_op=False,
+        accept_global_phase=False,
     )
 
     def __init__(self, qubits: Union[Sequence[cirq.LineQubit], int], atol=1e-8):

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 """Devices for IonQ hardware."""
 
-from typing import AbstractSet, Callable, Dict, Sequence, Type, Union
+from typing import AbstractSet, Sequence, Union
 
 import numpy as np
 
@@ -36,6 +36,19 @@ class IonQAPIDevice(cirq.Device):
         * `cirq.MeasurementGate`
     """
 
+    gateset = cirq.Gateset(
+        cirq.H,
+        cirq.CNOT,
+        cirq.SWAP,
+        cirq.XPowGate,
+        cirq.YPowGate,
+        cirq.ZPowGate,
+        cirq.XXPowGate,
+        cirq.YYPowGate,
+        cirq.ZZPowGate,
+        cirq.MeasurementGate,
+    )
+
     def __init__(self, qubits: Union[Sequence[cirq.LineQubit], int], atol=1e-8):
         """Construct the device.
 
@@ -50,20 +63,6 @@ class IonQAPIDevice(cirq.Device):
         else:
             self.qubits = frozenset(qubits)
         self.atol = atol
-        all_gates_valid = lambda x: True
-        near_1_mod_2 = lambda x: abs(x.gate.exponent % 2 - 1) < self.atol
-        self._is_api_gate_dispatch: Dict[Type['cirq.Gate'], Callable] = {
-            cirq.XPowGate: all_gates_valid,
-            cirq.YPowGate: all_gates_valid,
-            cirq.ZPowGate: all_gates_valid,
-            cirq.XXPowGate: all_gates_valid,
-            cirq.YYPowGate: all_gates_valid,
-            cirq.ZZPowGate: all_gates_valid,
-            cirq.CNotPowGate: near_1_mod_2,
-            cirq.HPowGate: near_1_mod_2,
-            cirq.SwapPowGate: near_1_mod_2,
-            cirq.MeasurementGate: all_gates_valid,
-        }
 
     def qubit_set(self) -> AbstractSet['cirq.Qid']:
         return self.qubits
@@ -79,11 +78,7 @@ class IonQAPIDevice(cirq.Device):
             raise ValueError(f'Operation with qubits not on the device. Qubits: {operation.qubits}')
 
     def is_api_gate(self, operation: cirq.Operation) -> bool:
-        gate = operation.gate
-        for gate_mro_type in type(gate).mro():
-            if gate_mro_type in self._is_api_gate_dispatch:
-                return self._is_api_gate_dispatch[gate_mro_type](operation)
-        return False
+        return operation in self.gateset
 
     def decompose_operation(self, operation: cirq.Operation) -> cirq.OP_TREE:
         if self.is_api_gate(operation):
@@ -97,7 +92,7 @@ class IonQAPIDevice(cirq.Device):
             return self._decompose_single_qubit(operation)
         if num_qubits == 2:
             return self._decompose_two_qubit(operation)
-        raise ValueError('Operation {operation} not supported by IonQ API.')
+        raise ValueError(f'Operation {operation} not supported by IonQ API.')
 
     def _decompose_single_qubit(self, operation: cirq.Operation) -> cirq.OP_TREE:
         qubit = operation.qubits[0]

--- a/cirq-pasqal/cirq_pasqal/pasqal_device.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_device.py
@@ -46,6 +46,8 @@ class PasqalDevice(cirq.devices.Device):
         cirq.AnyIntegerPowerGateFamily(cirq.CCZPowGate),
         cirq.IdentityGate,
         cirq.MeasurementGate,
+        unroll_circuit_op=False,
+        accept_global_phase=False,
     )
 
     # TODO(#3388) Add documentation for Raises.

--- a/cirq-pasqal/cirq_pasqal/pasqal_device.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_device.py
@@ -34,6 +34,20 @@ class PasqalDevice(cirq.devices.Device):
     execution on the specified device are handled internally by Pasqal.
     """
 
+    gateset = cirq.Gateset(
+        cirq.ParallelGateFamily(cirq.H),
+        cirq.ParallelGateFamily(cirq.PhasedXPowGate),
+        cirq.ParallelGateFamily(cirq.XPowGate),
+        cirq.ParallelGateFamily(cirq.YPowGate),
+        cirq.ParallelGateFamily(cirq.ZPowGate),
+        cirq.AnyIntegerPowerGateFamily(cirq.CNotPowGate),
+        cirq.AnyIntegerPowerGateFamily(cirq.CCNotPowGate),
+        cirq.AnyIntegerPowerGateFamily(cirq.CZPowGate),
+        cirq.AnyIntegerPowerGateFamily(cirq.CCZPowGate),
+        cirq.IdentityGate,
+        cirq.MeasurementGate,
+    )
+
     # TODO(#3388) Add documentation for Raises.
     # pylint: disable=missing-raises-doc
     def __init__(self, qubits: Sequence[cirq.ops.Qid]) -> None:
@@ -96,43 +110,9 @@ class PasqalDevice(cirq.devices.Device):
         return decomposition
 
     def is_pasqal_device_op(self, op: cirq.ops.Operation) -> bool:
-
         if not isinstance(op, cirq.ops.Operation):
             raise ValueError('Got unknown operation:', op)
-
-        if isinstance(op.gate, cirq.ops.MeasurementGate):
-            return True
-
-        op_gate = op.gate.sub_gate if isinstance(op.gate, cirq.ops.ParallelGate) else op.gate
-
-        if isinstance(
-            op_gate,
-            (
-                cirq.ops.IdentityGate,
-                cirq.ops.PhasedXPowGate,
-                cirq.ops.XPowGate,
-                cirq.ops.YPowGate,
-                cirq.ops.ZPowGate,
-            ),
-        ):
-            return True
-
-        if (
-            isinstance(
-                op_gate,
-                (
-                    cirq.ops.HPowGate,
-                    cirq.ops.CNotPowGate,
-                    cirq.ops.CZPowGate,
-                    cirq.ops.CCZPowGate,
-                    cirq.ops.CCXPowGate,
-                ),
-            )
-            and not cirq.is_parameterized(op)
-        ):
-            expo = op_gate.exponent
-            return np.isclose(expo, np.around(expo, decimals=0))
-        return False
+        return op in self.gateset
 
     # TODO(#3388) Add documentation for Raises.
     # pylint: disable=missing-raises-doc
@@ -267,6 +247,15 @@ class PasqalVirtualDevice(PasqalDevice):
                 )
 
         self.control_radius = control_radius
+        self.exclude_gateset = cirq.Gateset(
+            cirq.AnyIntegerPowerGateFamily(cirq.CNotPowGate),
+            cirq.AnyIntegerPowerGateFamily(cirq.CCNotPowGate),
+            cirq.AnyIntegerPowerGateFamily(cirq.CCZPowGate),
+        )
+        self.controlled_gateset = cirq.Gateset(
+            *self.exclude_gateset.gates,
+            cirq.AnyIntegerPowerGateFamily(cirq.CZPowGate),
+        )
 
     @property
     def supported_qubit_type(self):
@@ -278,9 +267,7 @@ class PasqalVirtualDevice(PasqalDevice):
         )
 
     def is_pasqal_device_op(self, op: cirq.ops.Operation) -> bool:
-        return super().is_pasqal_device_op(op) and not isinstance(
-            op.gate, (cirq.ops.CNotPowGate, cirq.ops.CCZPowGate, cirq.ops.CCXPowGate)
-        )
+        return super().is_pasqal_device_op(op) and op not in self.exclude_gateset
 
     def validate_operation(self, operation: cirq.ops.Operation):
         """Raises an error if the given operation is invalid on this device.
@@ -293,14 +280,11 @@ class PasqalVirtualDevice(PasqalDevice):
         super().validate_operation(operation)
 
         # Verify that a controlled gate operation is valid
-        if isinstance(operation, cirq.ops.GateOperation):
-            if len(operation.qubits) > 1 and not isinstance(
-                operation.gate, (cirq.ops.MeasurementGate, cirq.ops.ParallelGate)
-            ):
-                for p in operation.qubits:
-                    for q in operation.qubits:
-                        if self.distance(p, q) > self.control_radius:
-                            raise ValueError(f"Qubits {p!r}, {q!r} are too far away")
+        if operation in self.controlled_gateset:
+            for p in operation.qubits:
+                for q in operation.qubits:
+                    if self.distance(p, q) > self.control_radius:
+                        raise ValueError(f"Qubits {p!r}, {q!r} are too far away")
 
     def validate_moment(self, moment: cirq.ops.Moment):
         """Raises an error if the given moment is invalid on this device.


### PR DESCRIPTION
This PR adopts the use of newly added `cirq.GateFamily` and `cirq.Gateset` classes in `cirq/ion`, `cirq/neutral_atoms`, `cirq_pasqal` and `cirq_ionq`. 

Note that functions `is_native_neutral_atom_op` and `is_native_neutral_atom_gate` are now moot, but are part of the public API and hence are not removed. We can deprecate them later -- though, IMO, both `cirq/ion` and `cirq/neutral_atoms` modules should be deprecated :)

Follow up PRs will further adopt the use of Gatesets in `cirq/optimizers` and `cirq_google/`

This is part of the roadmap item #3243