### PR TITLE
Fixed test_clifford_circuit_2

### DIFF
--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -343,21 +343,26 @@ def test_clifford_circuit():
 def test_clifford_circuit_2(qubits):
     circuit = cirq.Circuit()
 
-    np.random.seed(2)
+    x_list = [0, 5, 0, 6, 3, 2, 3, 0, 2, 1, 3, 5, 2, 4, 4, 4, 5, 3, 6, 4, 2, 3, 3, 6, 2, 1, 2, 4, 3, 5, 0, 4, 6, 6, 3, 1, 2, 0, 4, 6, 4, 2, 4, 2, 1, 6, 0, 2, 5, 2]
+    if(len(qubits) == 4):
+        in_qubits = [0, 3, 1, 0, 2, 3, 2, 3, 0, 3, 2, 1, 3, 3, 1, 3, 3, 3, 2, 0, 0, 0, 1, 3, 3, 2, 0, 2, 3, 3, 3, 2, 2, 1, 2, 0, 3, 3, 1, 0, 0, 2, 2, 3, 3, 1, 3, 2, 0, 0]
+    else:
+        in_qubits = [0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0]
 
-    for _ in range(50):
-        x = np.random.randint(7)
+    for x in x_list:
+        if x != 5 and x != 6:
+            in_qubit = qubits[in_qubits.pop(0)]
 
         if x == 0:
-            circuit.append(cirq.X(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.X(in_qubit))  # coverage: ignore
         elif x == 1:
-            circuit.append(cirq.Z(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.Z(in_qubit))  # coverage: ignore
         elif x == 2:
-            circuit.append(cirq.Y(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.Y(in_qubit))  # coverage: ignore
         elif x == 3:
-            circuit.append(cirq.S(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.S(in_qubit))  # coverage: ignore
         elif x == 4:
-            circuit.append(cirq.H(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.H(in_qubit))  # coverage: ignore
         elif x == 5:
             circuit.append(cirq.CNOT(qubits[0], qubits[1]))  # coverage: ignore
         elif x == 6:

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -343,26 +343,21 @@ def test_clifford_circuit():
 def test_clifford_circuit_2(qubits):
     circuit = cirq.Circuit()
 
-    x_list = [0, 5, 0, 6, 3, 2, 3, 0, 2, 1, 3, 5, 2, 4, 4, 4, 5, 3, 6, 4, 2, 3, 3, 6, 2, 1, 2, 4, 3, 5, 0, 4, 6, 6, 3, 1, 2, 0, 4, 6, 4, 2, 4, 2, 1, 6, 0, 2, 5, 2]
-    if(len(qubits) == 4):
-        in_qubits = [0, 3, 1, 0, 2, 3, 2, 3, 0, 3, 2, 1, 3, 3, 1, 3, 3, 3, 2, 0, 0, 0, 1, 3, 3, 2, 0, 2, 3, 3, 3, 2, 2, 1, 2, 0, 3, 3, 1, 0, 0, 2, 2, 3, 3, 1, 3, 2, 0, 0]
-    else:
-        in_qubits = [0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0]
+    # ensures simulator always runs on the same circuit without creating global effects
+    RNG_state = np.random.RandomState(2)
 
-    for x in x_list:
-        if x != 5 and x != 6:
-            in_qubit = qubits[in_qubits.pop(0)]
-
+    for _ in range(50):
+        x = RNG_state.randint(7)
         if x == 0:
-            circuit.append(cirq.X(in_qubit))  # coverage: ignore
+            circuit.append(cirq.X(RNG_state.choice(qubits)))  # coverage: ignore
         elif x == 1:
-            circuit.append(cirq.Z(in_qubit))  # coverage: ignore
+            circuit.append(cirq.Z(RNG_state.choice(qubits)))  # coverage: ignore
         elif x == 2:
-            circuit.append(cirq.Y(in_qubit))  # coverage: ignore
+            circuit.append(cirq.Y(RNG_state.choice(qubits)))  # coverage: ignore
         elif x == 3:
-            circuit.append(cirq.S(in_qubit))  # coverage: ignore
+            circuit.append(cirq.S(RNG_state.choice(qubits)))  # coverage: ignore
         elif x == 4:
-            circuit.append(cirq.H(in_qubit))  # coverage: ignore
+            circuit.append(cirq.H(RNG_state.choice(qubits)))  # coverage: ignore
         elif x == 5:
             circuit.append(cirq.CNOT(qubits[0], qubits[1]))  # coverage: ignore
         elif x == 6:


### PR DESCRIPTION
This PR is a followup to Issue #4263 (@95-martin-orion). We have adjusted `test_clifford_circuit_2` by storing the values of the circuit components in a list. (This ensures the simulator will always run on the same circuit.) We also removed the seed-setting code (this will allow more paths of execution to be tested). 

The value checked by the assertions does fluctuate slightly from run to run (due to randomness in the simulator itself). However, the test was run more than 5000 times and there were no failures.

Please let us know if there is anything else that should be done to fix this test. Thank you.