### PR TITLE
Fixed test_clifford_circuit_3

### DIFF
--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -394,7 +394,7 @@ def test_clifford_circuit_3():
     np.testing.assert_almost_equal(
         clifford_simulator.simulate(circuit).final_state.state_vector(),
         state_vector_simulator.simulate(circuit).final_state_vector,
-        6
+        decimal=6
     )
 
 

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -394,7 +394,7 @@ def test_clifford_circuit_3():
     np.testing.assert_almost_equal(
         clifford_simulator.simulate(circuit).final_state.state_vector(),
         state_vector_simulator.simulate(circuit).final_state_vector,
-        decimal=6
+        decimal=6,
     )
 
 

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -375,8 +375,6 @@ def test_clifford_circuit_3():
     (q0, q1) = (cirq.LineQubit(0), cirq.LineQubit(1))
     circuit = cirq.Circuit()
 
-    np.random.seed(0)
-
     def random_clifford_gate():
         matrix = np.eye(2)
         for _ in range(10):
@@ -396,6 +394,7 @@ def test_clifford_circuit_3():
     np.testing.assert_almost_equal(
         clifford_simulator.simulate(circuit).final_state.state_vector(),
         state_vector_simulator.simulate(circuit).final_state_vector,
+        6
     )
 
 


### PR DESCRIPTION
This PR is a followup to Issue #4263 (@95-martin-orion). 

`test_clifford_circuit_3` in `Cirq/cirq-core/cirq/sim/clifford/clifford_simulator_test.py` also appears to be flaky when all seed-setting code is removed. In commit 8cef3d9dc16b27e3b10184e1b72afa764efe590d (version 0.11.0), `test_clifford_circuit_3` fails ~12% of the time (out of 500 runs) compared to 0% of the time (out of 500 runs) when no seed-setting code is removed.

### Solution
One method of reducing the flakiness of tests is to adjust how strict the assertions are. We reduced the precision of the assertion in `test_clifford_circuit_3` from 7 decimal places (the default precision of `np.testing.assert_almost_equal`) to 6 decimal places. We also removed the seed-setting code (this will allow more paths of execution to be tested). 

We ran `test_clifford_circuit_3` over 11000 times and there were 0 failures.

Please let us know if there is anything else that should be done to fix this test. Thank you.