### PR TITLE
[Named Topologies] LineTopology nodes_as_linequbits

### DIFF
--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Tuple, Any, Sequence, Union, Iterable, TYPE_CHECKING
 
 import networkx as nx
-from cirq.devices import GridQubit
+from cirq.devices import GridQubit, LineQubit
 from cirq.protocols.json_serialization import obj_to_dict_helper
 from matplotlib import pyplot as plt
 
@@ -118,6 +118,10 @@ class LineTopology(NamedTopology):
             [(i1, i2) for i1, i2 in zip(range(self.n_nodes), range(1, self.n_nodes))]
         )
         object.__setattr__(self, 'graph', graph)
+
+    def nodes_as_linequbits(self) -> List['cirq.LineQubit']:
+        """Get the graph nodes as cirq.LineQubit"""
+        return [LineQubit(x) for x in sorted(self.graph.nodes)]
 
     def draw(self, ax=None, tilted: bool = True, **kwargs) -> Dict[Any, Tuple[int, int]]:
         """Draw this graph using Matplotlib.

--- a/cirq-core/cirq/devices/named_topologies_test.py
+++ b/cirq-core/cirq/devices/named_topologies_test.py
@@ -78,6 +78,13 @@ def test_line_topology():
     assert LineTopology(2).graph.number_of_nodes() == 2
 
 
+def test_line_topology_nodes_as_qubits():
+    with pytest.raises(ValueError, match='greater than 1.*'):
+        _ = LineTopology(1)
+    for n in range(2, 10, 2):
+        assert LineTopology(n).nodes_as_linequbits() == cirq.LineQubit.range(n)
+
+
 @pytest.mark.parametrize('tilted', [True, False])
 def test_draw_gridlike(tilted):
     graph = nx.grid_2d_graph(3, 3)

--- a/cirq-core/cirq/devices/named_topologies_test.py
+++ b/cirq-core/cirq/devices/named_topologies_test.py
@@ -79,8 +79,6 @@ def test_line_topology():
 
 
 def test_line_topology_nodes_as_qubits():
-    with pytest.raises(ValueError, match='greater than 1.*'):
-        _ = LineTopology(1)
     for n in range(2, 10, 2):
         assert LineTopology(n).nodes_as_linequbits() == cirq.LineQubit.range(n)
 


### PR DESCRIPTION
This little helper function makes explicit the conversion between topology graphs and line qubits. This is analogous to `TiltedSquareLattice.nodes_as_gridqubits()`