### PR TITLE
Re-add `all_measurement_keys` and deprecate it

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -50,6 +50,7 @@ import networkx
 import numpy as np
 
 import cirq._version
+from cirq._compat import deprecated
 from cirq import devices, ops, protocols, qis
 from cirq.circuits._bucket_priority_queue import BucketPriorityQueue
 from cirq.circuits.circuit_operation import CircuitOperation
@@ -907,6 +908,10 @@ class AbstractCircuit(abc.ABC):
     ) -> Tuple[int, ...]:
         qids = ops.QubitOrder.as_qubit_order(qubit_order).order_for(self.all_qubits())
         return protocols.qid_shape(qids)
+
+    @deprecated(deadline='v0.13', fix='use all_measurement_key_names instead')
+    def all_measurement_keys(self) -> AbstractSet[str]:
+        return self.all_measurement_key_names()
 
     def all_measurement_key_names(self) -> AbstractSet[str]:
         return {key for op in self.all_operations() for key in protocols.measurement_key_names(op)}

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4309,6 +4309,8 @@ def test_all_measurement_key_names(circuit_cls):
 
     # Big case.
     assert c.all_measurement_key_names() == {'x', 'y', 'xy', 'test'}
+    with cirq.testing.assert_deprecated(deadline="v0.13"):
+        assert c.all_measurement_key_names() == c.all_measurement_keys()
 
     # Empty case.
     assert circuit_cls().all_measurement_key_names() == set()


### PR DESCRIPTION
It was erroneously removed in #4403 without deprecating.

Part of #4040.