### PR TITLE
Made the Circuit Dag representation

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -68,6 +68,7 @@ from cirq.circuits import (
     Alignment,
     Circuit,
     CircuitDag,
+    CircuitDagRepresentation,
     CircuitOperation,
     FrozenCircuit,
     InsertStrategy,

--- a/cirq-core/cirq/circuits/__init__.py
+++ b/cirq-core/cirq/circuits/__init__.py
@@ -49,3 +49,7 @@ from cirq.circuits.optimization_pass import (
     PointOptimizer,
     PointOptimizationSummary,
 )
+
+from cirq.circuits.representation_dag import (
+    CircuitDagRepresentation,
+)

--- a/cirq-core/cirq/circuits/representation_dag.py
+++ b/cirq-core/cirq/circuits/representation_dag.py
@@ -16,9 +16,9 @@ import typing
 
 import networkx
 
-from cirq.ops.raw_types import Qid
 from cirq.circuits.circuit import Circuit
 from cirq.ops.moment import Moment
+from cirq.ops.raw_types import Qid, Operation
 
 
 class CircuitDagRepresentation(networkx.DiGraph):
@@ -65,10 +65,10 @@ class CircuitDagRepresentation(networkx.DiGraph):
         Returns:
             The representation converted back to the circuit
         """
-        moments_list = [[] for _ in range(self.num_moments)]
+        operations_list: typing.List[typing.List[Operation]] = [[] for _ in range(self.num_moments)]
         for _node_idx, node in self.nodes(data=True):
-            moments_list[node['moment']].append(node['op'])
-        moments_list = list(map(Moment, moments_list))
+            operations_list[node['moment']].append(node['op'])
+        moments_list: typing.List[Moment] = list(map(Moment, operations_list))
         circuit = Circuit(moments_list)
         return circuit
 

--- a/cirq-core/cirq/circuits/representation_dag.py
+++ b/cirq-core/cirq/circuits/representation_dag.py
@@ -27,14 +27,26 @@ class CircuitDagRepresentation(networkx.DiGraph):
     they act on the same qubit, and the moments they belong to are labelled.
     """
 
-    def __init__(self, circuit=None):
+    def __init__(self, circuit: Circuit = None):
+        """Initializes a Circuit Dag representation.
+
+        Args:
+            circuit: The circuit for which we need to get the representation
+        """
         super().__init__()
         self.num_moments = 0
         self.device = None
         if circuit is not None:
             self.from_circuit(circuit)
 
-    def from_circuit(self, circuit: Circuit):
+    def from_circuit(self, circuit: Circuit) -> None:
+        """Loads the circuit into a DAG representation, clears out whatever
+        graph existed before it.
+
+        Args:
+            circuit: The circuit for which we need to get the representation
+        """
+        self.clear()
         frontier: typing.Dict[Qid, int] = dict()
         operation_id = 0
         for idx, moment in enumerate(circuit.moments):
@@ -47,9 +59,14 @@ class CircuitDagRepresentation(networkx.DiGraph):
                     frontier[qubit_operands] = operation_id
         self.num_moments = max(self.num_moments, len(circuit.moments))
 
-    def to_circuit(self):
+    def to_circuit(self) -> Circuit:
+        """Initializes a Circuit Dag representation.
+
+        Returns:
+            The representation converted back to the circuit
+        """
         moments_list = [[] for _ in range(self.num_moments)]
-        for node_idx, node in self.nodes(data=True):
+        for _node_idx, node in self.nodes(data=True):
             moments_list[node['moment']].append(node['op'])
         moments_list = list(map(Moment, moments_list))
         circuit = Circuit(moments_list)

--- a/cirq-core/cirq/circuits/representation_dag.py
+++ b/cirq-core/cirq/circuits/representation_dag.py
@@ -1,0 +1,74 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+import networkx
+
+from cirq.ops.raw_types import Qid
+from cirq.circuits.circuit import Circuit
+from cirq.ops.moment import Moment
+
+
+class CircuitDagRepresentation(networkx.DiGraph):
+    """A Directed Acyclic Graph representation of the Circuit
+    The DAG is built on the operations, two operations are connected if
+    they act on the same qubit, and the moments they belong to are labelled.
+    """
+
+    def __init__(self, circuit=None):
+        super().__init__()
+        self.num_moments = 0
+        self.device = None
+        if circuit is not None:
+            self.from_circuit(circuit)
+
+    def from_circuit(self, circuit: Circuit):
+        frontier: typing.Dict[Qid, int] = dict()
+        operation_id = 0
+        for idx, moment in enumerate(circuit.moments):
+            for op in moment.operations:
+                operation_id += 1
+                self.add_node(operation_id, op=op, moment=idx)
+                for qubit_operands in op.qubits:
+                    if qubit_operands in frontier:
+                        self.add_edge(operation_id, frontier[qubit_operands])
+                    frontier[qubit_operands] = operation_id
+        self.num_moments = max(self.num_moments, len(circuit.moments))
+
+    def to_circuit(self):
+        moments_list = [[] for _ in range(self.num_moments)]
+        for node_idx, node in self.nodes(data=True):
+            moments_list[node['moment']].append(node['op'])
+        moments_list = list(map(Moment, moments_list))
+        circuit = Circuit(moments_list)
+        return circuit
+
+    def __repr__(self):
+        return f'cirq.{self.__class__.__name__}({repr(self.to_circuit())})'
+
+    def _json_dict_(self):
+        return {'cirq_type': self.__class__.__name__, 'circuit': self.to_circuit()}
+
+    @classmethod
+    def _from_json_dict_(cls, circuit, **kwargs):
+        return cls(circuit=circuit)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.to_circuit() == other.to_circuit()
+        elif isinstance(other, Circuit):
+            return self.to_circuit() == other
+        else:
+            return False

--- a/cirq-core/cirq/circuits/representation_dag_test.py
+++ b/cirq-core/cirq/circuits/representation_dag_test.py
@@ -1,0 +1,74 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import cirq
+import numpy as np
+
+
+def test_circuit_dag_equivalence():
+    circuit = cirq.Circuit(
+        [
+            cirq.H(cirq.LineQubit(0)),
+            cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)),
+            cirq.X(cirq.LineQubit(1)),
+        ]
+    )
+    dag = cirq.CircuitDagRepresentation(circuit=circuit)
+    new_circuit = dag.to_circuit()
+    assert circuit == new_circuit
+
+
+def test_dag_repr():
+    circuit = cirq.Circuit(
+        [
+            cirq.H(cirq.LineQubit(0)),
+            cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)),
+            cirq.X(cirq.LineQubit(1)),
+        ]
+    )
+    dag = cirq.CircuitDagRepresentation(circuit=circuit)
+    repr_dag = repr(dag)
+    new_dag: cirq.CircuitDagRepresentation = eval(repr_dag)
+    assert circuit == new_dag.to_circuit()
+
+
+def test_dag_json():
+    circuit = cirq.Circuit(
+        [
+            cirq.H(cirq.LineQubit(0)),
+            cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)),
+            cirq.X(cirq.LineQubit(1)),
+        ]
+    )
+    dag = cirq.CircuitDagRepresentation(circuit=circuit)
+    repr_dag = cirq.to_json(dag)
+    new_dag: cirq.CircuitDagRepresentation = cirq.read_json(json_text=repr_dag)
+    assert circuit == new_dag.to_circuit()
+
+
+def test_equality():
+    circuit = cirq.Circuit(
+        [
+            cirq.H(cirq.LineQubit(0)),
+            cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)),
+            cirq.X(cirq.LineQubit(1)),
+        ]
+    )
+    dag = cirq.CircuitDagRepresentation(circuit=circuit)
+    repr_dag = cirq.to_json(dag)
+    new_dag: cirq.CircuitDagRepresentation = cirq.read_json(json_text=repr_dag)
+    assert dag == circuit
+    assert dag == new_dag
+    assert dag != np.zeros(shape=6)

--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -67,6 +67,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'CrossEntropyResultDict': CrossEntropyResultDict,
         'Circuit': cirq.Circuit,
         'CircuitOperation': cirq.CircuitOperation,
+        'CircuitDagRepresentation': cirq.CircuitDagRepresentation,
         'CliffordState': cirq.CliffordState,
         'CliffordTableau': cirq.CliffordTableau,
         'DepolarizingChannel': cirq.DepolarizingChannel,

--- a/cirq-core/cirq/protocols/json_test_data/CircuitDagRepresentation.json
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitDagRepresentation.json
@@ -1,0 +1,70 @@
+{
+  "cirq_type": "CircuitDagRepresentation",
+  "circuit": {
+    "cirq_type": "Circuit",
+    "moments": [
+      {
+        "cirq_type": "Moment",
+        "operations": [
+          {
+            "cirq_type": "GateOperation",
+            "gate": {
+              "cirq_type": "HPowGate",
+              "exponent": 1.0,
+              "global_shift": 0.0
+            },
+            "qubits": [
+              {
+                "cirq_type": "LineQubit",
+                "x": 0
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "cirq_type": "Moment",
+        "operations": [
+          {
+            "cirq_type": "GateOperation",
+            "gate": {
+              "cirq_type": "CXPowGate",
+              "exponent": 1.0,
+              "global_shift": 0.0
+            },
+            "qubits": [
+              {
+                "cirq_type": "LineQubit",
+                "x": 0
+              },
+              {
+                "cirq_type": "LineQubit",
+                "x": 1
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "cirq_type": "Moment",
+        "operations": [
+          {
+            "cirq_type": "SingleQubitPauliStringGateOperation",
+            "pauli": {
+              "cirq_type": "_PauliX",
+              "exponent": 1.0,
+              "global_shift": 0.0
+            },
+            "qubit": {
+              "cirq_type": "LineQubit",
+              "x": 1
+            }
+          }
+        ]
+      }
+    ],
+    "device": {
+      "cirq_type": "_UnconstrainedDevice"
+    }
+  }
+}

--- a/cirq-core/cirq/protocols/json_test_data/CircuitDagRepresentation.repr
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitDagRepresentation.repr
@@ -1,0 +1,11 @@
+cirq.CircuitDagRepresentation(cirq.Circuit([
+    cirq.Moment(
+        cirq.H(cirq.LineQubit(0)),
+    ),
+    cirq.Moment(
+        cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)),
+    ),
+    cirq.Moment(
+        cirq.X(cirq.LineQubit(1)),
+    ),
+]))


### PR DESCRIPTION
Equivalent representation to circuit, is a directed graph, uses circuit for serialization and deserialization.
The circuit is represented as a networkx directed graph for easy implementation of compiler optimizations.

One step in one possible way to fixing #4494.