### PR TITLE
Fix measurement keys in subcircuits with parent_path

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -178,6 +178,10 @@ class CircuitOperation(ops.Operation):
     def _measurement_key_objs_(self) -> AbstractSet[value.MeasurementKey]:
         if self._cached_measurement_key_objs is None:
             circuit_keys = protocols.measurement_key_objs(self.circuit)
+            circuit_keys = {
+                key._with_key_path_(self.parent_path + key.path)
+                for key in circuit_keys
+            }
             if self.repetition_ids is not None:
                 circuit_keys = {
                     key.with_key_path_prefix(repetition_id)

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -758,6 +758,15 @@ def test_decompose_repeated_nested_measurements():
     assert op3.mapped_circuit(deep=True) == expected_circuit
 
 
+def test_keys_under_parent_path():
+    a = cirq.LineQubit(0)
+
+    op1 = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.measure(a, key='A')))
+    assert cirq.measurement_key_names(op1) == {'A'}
+    op2 = op1.with_key_path(('B',))
+    assert cirq.measurement_key_names(op2) == {'B:A'}
+
+
 def test_mapped_circuit_preserves_moments():
     q0, q1 = cirq.LineQubit.range(2)
     fc = cirq.FrozenCircuit(cirq.Moment(cirq.X(q0)), cirq.Moment(cirq.X(q1)))


### PR DESCRIPTION
Applies any parent path in subcircuit to measurement key before returning