### PR TITLE
Add SVG Visualizations for Custom Gates (class `Matrixgate`)

### DIFF
--- a/cirq-core/cirq/contrib/svg/example.ipynb
+++ b/cirq-core/cirq/contrib/svg/example.ipynb
@@ -60,12 +60,58 @@
     "    cirq.CNOT(cirq.GridQubit(0,1), cirq.GridQubit(1,1)),\n",
     "))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Gates Visualizations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cirq\n",
+    "import numpy as np\n",
+    "\n",
+    "from svg import SVGCircuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"354.2021484375\" height=\"150.0\"><line x1=\"32.246796875\" x2=\"324.2021484375\" y1=\"25.0\" y2=\"25.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"324.2021484375\" y1=\"75.0\" y2=\"75.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"32.246796875\" x2=\"324.2021484375\" y1=\"125.0\" y2=\"125.0\" stroke=\"#1967d2\" stroke-width=\"1\" /><line x1=\"94.49359375\" x2=\"94.49359375\" y1=\"25.0\" y2=\"75.0\" stroke=\"black\" stroke-width=\"3\" /><line x1=\"219.34787109375003\" x2=\"219.34787109375003\" y1=\"75.0\" y2=\"125.0\" stroke=\"black\" stroke-width=\"3\" /><rect x=\"10.0\" y=\"5.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 0): </text><rect x=\"10.0\" y=\"55.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(0, 1): </text><rect x=\"10.0\" y=\"105.0\" width=\"44.49359375\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"0\" /><text x=\"32.246796875\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">(1, 1): </text><circle cx=\"94.49359375\" cy=\"25.0\" r=\"10.0\" /><rect x=\"74.49359375\" y=\"55.0\" width=\"40\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"94.49359375\" y=\"75.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text><rect x=\"134.49359375\" y=\"5.0\" width=\"169.70855468750003\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"219.34787109375003\" y=\"25.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"14px\" font-family=\"Arial\">┌   ┐\n│0 1│\n│1 0│\n└   ┘</text><circle cx=\"219.34787109375003\" cy=\"75.0\" r=\"10.0\" /><rect x=\"134.49359375\" y=\"105.0\" width=\"169.70855468750003\" height=\"40\" stroke=\"black\" fill=\"white\" stroke-width=\"1\" /><text x=\"219.34787109375003\" y=\"125.0\" dominant-baseline=\"middle\" text-anchor=\"middle\" font-size=\"18px\" font-family=\"Arial\">X</text></svg>",
+      "text/plain": [
+       "<svg.SVGCircuit at 0x7f4b3e33d820>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "SVGCircuit(cirq.Circuit(\n",
+    "    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(0,1)),\n",
+    "    cirq.MatrixGate(np.array([ [0, 1], [1, 0] ])).on(cirq.GridQubit(0,0)),\n",
+    "    cirq.CNOT(cirq.GridQubit(0,1), cirq.GridQubit(1,1)),\n",
+    "))"
+   ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "2dabcc995172ad2c5fa1fdafb3af14a26b944e90184aa53df7cea19f7bfca813"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3.8.5 64-bit ('qdev': conda)",
    "name": "python3"
   },
   "language_info": {
@@ -78,7 +124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -13,9 +13,7 @@ EMPTY_MOMENT_COLWIDTH = float(21)  # assumed default column width
 
 def fixup_text(text: str):
     if '\n' in text:
-        # https://github.com/quantumlib/Cirq/issues/4499
-        # TODO: Visualize Custom MatrixGate
-        return '?'
+        return text  # text is the matrix string
     if '[<virtual>]' in text:
         # https://github.com/quantumlib/Cirq/issues/2905
         # TODO: escape angle brackets when you actually want to display tags


### PR DESCRIPTION
This PR aims to add SVG visualizations for the custom gates as requested by @mpharrigan over at https://github.com/quantumlib/Cirq/issues/2313.

- [ ] **[DESIGN]** Come up with a way to visualize custom gates (`MatrixGate`).

This is part of the https://github.com/quantumlib/Cirq/issues/4499 which plans on solving some bugs in the `SVGCircuit` class and finally paving the way to integrate the SVGCircuit into `cirq.AbstractCircuit` as `_repr_svg_`. 

## Demo

Relevant Notebook: [`cirq-core/cirq/contrib/svg/example.ipynb`](https://github.com/freyam/Cirq/blob/2495f15a45196c2e58cb70972dee393a9385cb48/cirq-core/cirq/contrib/svg/example.ipynb)

```py
SVGCircuit(cirq.Circuit(
    cirq.CNOT(cirq.GridQubit(0,0), cirq.GridQubit(0,1)),
    cirq.MatrixGate(np.array([ [0, 1], [1, 0] ])).on(cirq.GridQubit(0,0)),
    cirq.CNOT(cirq.GridQubit(0,1), cirq.GridQubit(1,1)),
))
```

### Before

![image](https://user-images.githubusercontent.com/62539811/140506750-4d9dff58-bf36-4429-b916-7f68ce9ceaf0.png)

### After

_to be discussed_


cc @tanujkhattar 