### PR TITLE
Fix operator spaces test which fails due to precision 

### DIFF
--- a/cirq-core/cirq/linalg/operator_spaces_test.py
+++ b/cirq-core/cirq/linalg/operator_spaces_test.py
@@ -175,7 +175,9 @@ def test_hilbert_schmidt_inner_product_is_linear(a, m1, b, m2):
 @pytest.mark.parametrize('m', (I, X, Y, Z, H, SQRT_X, SQRT_Y, SQRT_Z))
 def test_hilbert_schmidt_inner_product_is_positive_definite(m):
     v = cirq.hilbert_schmidt_inner_product(m, m)
-    assert np.isreal(v)
+    # Cannot check using np.is_real due to bug in aarch64.
+    # See https://github.com/quantumlib/Cirq/issues/4379
+    assert np.isclose(np.imag(v), 1e-16)
     assert v.real > 0
 
 


### PR DESCRIPTION
See #4379 for failure which occurs only on some architectures.