### PR TITLE
Delay import of scipy stats and optimize

### DIFF
--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -19,7 +19,6 @@ import pandas as pd
 import sympy
 from matplotlib import pyplot as plt
 import numpy as np
-from scipy import optimize
 
 
 from cirq import circuits, ops, study, value
@@ -131,7 +130,10 @@ class T1DecayResult:
 
         # Fit to exponential decay to find the t1 constant
         try:
-            popt, _ = optimize.curve_fit(exp_decay, xs, probs, p0=[t1_guess])
+            # Import scipy.optimize here to avoid costly module level import.
+            import scipy.optimize
+
+            popt, _ = scipy.optimize.curve_fit(exp_decay, xs, probs, p0=[t1_guess])
             t1 = popt[0]
             return t1
         except RuntimeError:

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -34,6 +34,7 @@ from cirq.experiments.xeb_simulation import simulate_2q_xeb_circuits
 if TYPE_CHECKING:
     import cirq
     import multiprocessing
+    import scipy.optimize
 
 THETA_SYMBOL, ZETA_SYMBOL, CHI_SYMBOL, GAMMA_SYMBOL, PHI_SYMBOL = sympy.symbols(
     'theta zeta chi gamma phi'

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -26,8 +26,6 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-import scipy.optimize
-import scipy.stats
 import sympy
 from cirq import ops, protocols
 from cirq.circuits import Circuit
@@ -354,7 +352,7 @@ class XEBCharacterizationResult:
             fitting the characterization.
     """
 
-    optimization_results: Dict[QPair_T, scipy.optimize.OptimizeResult]
+    optimization_results: Dict[QPair_T, 'scipy.optimize.OptimizeResult']
     final_params: Dict[QPair_T, Dict[str, float]]
     fidelities_df: pd.DataFrame
 
@@ -410,6 +408,9 @@ def characterize_phased_fsim_parameters_with_xeb(
         if verbose:
             print(f"Loss: {loss:7.3g}", flush=True)
         return loss
+
+    # Import scipy.optimize here to avoid costly top level moule import.
+    import scipy.optimize
 
     optimization_result = scipy.optimize.minimize(
         _mean_infidelity,
@@ -571,6 +572,10 @@ def _fit_exponential_decay(
         return 0, 0, np.inf, np.inf
     cycle_depths_pos = cycle_depths[positives]
     log_fidelities = np.log(fidelities[positives])
+
+    # We import here to avoid costly module level load time dependency on scipy.stats.
+    import scipy.stats
+
     slope, intercept, _, _, _ = scipy.stats.linregress(cycle_depths_pos, log_fidelities)
     layer_fid_0 = np.clip(np.exp(slope), 0, 1)
     a_0 = np.clip(np.exp(intercept), 0, 1)

--- a/cirq-core/cirq/linalg/decompositions.py
+++ b/cirq-core/cirq/linalg/decompositions.py
@@ -36,7 +36,6 @@ import matplotlib.pyplot as plt
 # this is for older systems with matplotlib <3.2 otherwise 3d projections fail
 from mpl_toolkits import mplot3d  # pylint: disable=unused-import
 import numpy as np
-import scipy
 
 from cirq import value, protocols
 from cirq._compat import proper_repr
@@ -146,6 +145,9 @@ def unitary_eig(
     """
     if check_preconditions and not predicates.is_normal(matrix, atol=atol):
         raise ValueError(f'Input must correspond to a normal matrix .Received input:\n{matrix}')
+    # Lazy import to avoid costly global module import.
+    import scipy.linalg
+
     R, V = scipy.linalg.schur(matrix, output="complex")
     return R.diagonal(), V
 

--- a/cirq-google/cirq_google/calibration/xeb_wrapper_test.py
+++ b/cirq-google/cirq_google/calibration/xeb_wrapper_test.py
@@ -103,7 +103,7 @@ def test_run_calibration(monkeypatch, fsim_options, x0_should_be):
     def _minimize_patch_2(*args, **kwargs):
         return _minimize_patch(*args, **kwargs, x0_should_be=x0_should_be)
 
-    monkeypatch.setattr('cirq.experiments.xeb_fitting.scipy.optimize.minimize', _minimize_patch_2)
+    monkeypatch.setattr('scipy.optimize.minimize', _minimize_patch_2)
     monkeypatch.setattr(
         'cirq_google.calibration.xeb_wrapper.xebf.benchmark_2q_xeb_fidelities', _benchmark_patch
     )

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -52,4 +52,4 @@ def test_isolated_packages(cloned_env, module):
         err=shell_tools.TeeCapture(),
         raise_on_fail=False,
     )
-    assert result.exit_code == 0, f"Failed isolated tests for {module.name}:\n{result.stdout}"
+    assert result.exit_code == 0, f"Failed isolated tests for {module.name}:\n{result.out}"

--- a/docs/tutorials/quantum_walks.ipynb
+++ b/docs/tutorials/quantum_walks.ipynb
@@ -101,7 +101,8 @@
     "import random\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
-    "import scipy"
+    "import scipy\n",
+    "import scipy.special"
    ]
   },
   {


### PR DESCRIPTION
This speeds up top level import.

Note that we had previously done this for another use of scipy.stats, but this one got added.  Also doing it for scipy.optimize.  Both of these can slow down the resulting experiments, probably a case for moving experiments out of cirq-core?