### PR TITLE
Fix FSim serialization for zeros and ints

### DIFF
--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -528,7 +528,9 @@ class CircuitSerializer(serializer.Serializer):
                 arg_function_language=arg_function_language,
                 required_arg_name=None,
             )
-            if isinstance(theta, (float, sympy.Basic)) and isinstance(phi, (float, sympy.Basic)):
+            if isinstance(theta, (int, float, sympy.Basic)) and isinstance(
+                phi, (int, float, sympy.Basic)
+            ):
                 op = cirq.FSimGate(theta=theta, phi=phi)(*qubits)
             else:
                 raise ValueError('theta and phi must be specified for FSimGate')

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -218,6 +218,23 @@ OPERATIONS = [
         ),
     ),
     (
+        cirq.FSimGate(theta=2 + sympy.Symbol('a'), phi=1)(Q0, Q1),
+        op_proto(
+            {
+                'fsimgate': {
+                    'theta': {
+                        'func': {
+                            'type': 'add',
+                            'args': [{'arg_value': {'float_value': 2.00}}, {'symbol': 'a'}],
+                        }
+                    },
+                    'phi': {'float_value': 1.0},
+                },
+                'qubit_constant_index': [0, 1],
+            }
+        ),
+    ),
+    (
         cirq.FSimGate(theta=0.5, phi=0.25)(Q0, Q1),
         op_proto(
             {
@@ -231,6 +248,15 @@ OPERATIONS = [
         op_proto(
             {
                 'fsimgate': {'theta': {'float_value': 0.5}, 'phi': {'float_value': 0.0}},
+                'qubit_constant_index': [0, 1],
+            }
+        ),
+    ),
+    (
+        cirq.FSimGate(theta=2, phi=1)(Q0, Q1),
+        op_proto(
+            {
+                'fsimgate': {'theta': {'float_value': 2.0}, 'phi': {'float_value': 1.0}},
                 'qubit_constant_index': [0, 1],
             }
         ),

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -227,6 +227,15 @@ OPERATIONS = [
         ),
     ),
     (
+        cirq.FSimGate(theta=0.5, phi=0.0)(Q0, Q1),
+        op_proto(
+            {
+                'fsimgate': {'theta': {'float_value': 0.5}, 'phi': {'float_value': 0.0}},
+                'qubit_constant_index': [0, 1],
+            }
+        ),
+    ),
+    (
         cirq.WaitGate(duration=cirq.Duration(nanos=15))(Q0),
         op_proto(
             {


### PR DESCRIPTION
- Conversion of float args changes 0.0 to a int of 0,
so this fails validation, since the current code
checks isinstance float.
- This PR adds ints to the type checking to fix this.