### PR TITLE
Remove deprecated use of `cirq.google` in install guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -51,7 +51,7 @@ To be informed of deprecations and breaking changes, subscribe to the
 4. Check that it works!
 
     ```bash
-    python -c 'import cirq; print(cirq.google.Foxtail)'
+    python -c 'import cirq_google; print(cirq_google.Foxtail)'
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │
@@ -92,7 +92,7 @@ To be informed of deprecations and breaking changes, subscribe to the
 4. Check that it works!
 
     ```bash
-    python -c 'import cirq; print(cirq.google.Foxtail)'
+    python -c 'import cirq_google; print(cirq_google.Foxtail)'
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │
@@ -125,7 +125,7 @@ To be informed of deprecations and breaking changes, subscribe to the
 4. Check that it works!
 
     ```bash
-    python -c "import cirq; print(cirq.google.Foxtail)"
+    python -c "import cirq_google; print(cirq_google.Foxtail)"
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │


### PR DESCRIPTION
Very minor fix.  The install guide at https://quantumai.google/cirq/install has a validation step that references `cirq.google` which is a deprecated usage on new installs, example:

```
[amcnamara] > python -c 'import cirq; print(cirq.google.Foxtail)'
<string>:1: DeprecationWarning: cirq.google was used but is deprecated.
 it will be removed in cirq v0.14.
 Use cirq_google instead.

(0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
│        │        │        │        │        │        │        │        │        │        │
│        │        │        │        │        │        │        │        │        │        │
(1, 0)───(1, 1)───(1, 2)───(1, 3)───(1, 4)───(1, 5)───(1, 6)───(1, 7)───(1, 8)───(1, 9)───(1, 10)
[amcnamara] > python -c 'import cirq_google; print(cirq_google.Foxtail)'
(0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
│        │        │        │        │        │        │        │        │        │        │
│        │        │        │        │        │        │        │        │        │        │
(1, 0)───(1, 1)───(1, 2)───(1, 3)───(1, 4)───(1, 5)───(1, 6)───(1, 7)───(1, 8)───(1, 9)───(1, 10)
```