### PR TITLE
Remove remaining uses of cirq.google in docs/ .

### DIFF
--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -279,7 +279,7 @@ def some_method(a: int, b: str) -> float:
     Notice that this docstring is an r-string, since the latex has backslashes.
     We can also include example code:
 
-        print(cirq.google.Foxtail)
+        print(cirq_google.Foxtail)
 
     You can also do inline latex like $y = x^2$ and inline code like
     `cirq.unitary(cirq.X)`.
@@ -416,6 +416,6 @@ python dev_tools/requirements/reqs.py dev_tools/requirements/dev.env.txt
 
     ```bash
     python -m pip install cirq
-    python -c "import cirq; print(cirq.google.Foxtail)"
+    python -c "import cirq; print(cirq_google.Foxtail)"
     python -c "import cirq; print(cirq.__version__)"
     ```

--- a/docs/dev/notebooks.md
+++ b/docs/dev/notebooks.md
@@ -50,7 +50,7 @@ such complicated expressions.
 
 ## Notebooks with external dependencies
 
-Unfortunately we have no easy way to test notebooks with external API dependencies, e.g. cirq.google's Engine API.
+Unfortunately we have no easy way to test notebooks with external API dependencies, e.g. cirq_google's Engine API.
 These notebooks should be excluded from both tests.
 
 The site that generates the outputs for notebooks also can't handle external dependencies.

--- a/docs/google/calibration.md
+++ b/docs/google/calibration.md
@@ -21,7 +21,7 @@ metrics from a previous run.  Calibration metrics can also be retrieved
 programmatically using an engine instance or with a job.
 
 ```
-import cirq.google as cg
+import cirq_google as cg
 
 # Create an Engine object to use.
 # Replace YOUR_PROJECT_ID with the id from your cloud project.

--- a/docs/google/devices.md
+++ b/docs/google/devices.md
@@ -125,7 +125,7 @@ This can be done by applying a PhysicalZTag to the Z gate,
 such as in the following example:
 
 ```
-cirq.Z(cirq.GridQubit(5, 5)).with_tags(cirq.google.PhysicalZTag())
+cirq.Z(cirq.GridQubit(5, 5)).with_tags(cirq_google.PhysicalZTag())
 ```
 
 Physical Z gates have a duration of 20 ns on most Google devices.
@@ -144,7 +144,7 @@ and may drift over time.
 #### Sycamore Gate
 
 The hardware provides a gate known as the Sycamore gate that can
-be accessed using `cirq.google.SYC`.  This gate is equivalent to
+be accessed using `cirq_google.SYC`.  This gate is equivalent to
 an FSimGate(π/2, π/6).  That is, it does both a partial swap and
 controlled phase rotation of the |11⟩ state.
 
@@ -162,8 +162,8 @@ $$
 \right]
 $$
 
-This gate has a duration of 12ns and can be used in `cirq.google.SYC_GATESET`
-or in the `cirq.google.FSIM_GATESET`.
+This gate has a duration of 12ns and can be used in `cirq_google.SYC_GATESET`
+or in the `cirq_google.FSIM_GATESET`.
 
 #### Square root of iSWAP
 
@@ -186,7 +186,7 @@ $$
 $$
 
 This gate has a duration of 32ns and can be used in
-`cirq.google.SQRT_ISWAP_GATESET` or in the `cirq.google.FSIM_GATESET`.
+`cirq_google.SQRT_ISWAP_GATESET` or in the `cirq_google.FSIM_GATESET`.
 
 This gate is implemented by using an entangling gate surrounding by
 Z gates.  The preceding Z gates are physical Z gates and will absorb
@@ -268,14 +268,14 @@ It can be accessed using `cirq.GridQubit(row, col)` using grid coordinates speci
 9 ----I-----
 ```
 
-It can be accessing by using `cirq.google.Sycamore`. This device has two possible
+It can be accessing by using `cirq_google.Sycamore`. This device has two possible
 two-qubits gates that can be used.
 
 *  Square root of ISWAP. The gate `cirq.ISWAP ** 0.5` or `cirq.ISWAP ** -0.5` can be
-used on `cirq.google.optimized_for_sycamore` with optimizer type `sqrt_iswap`
-*  Sycamore gate. This gate, equivalent to FSimGate(π/2, π/6) can be used as `cirq.google.SYC`
+used on `cirq_google.optimized_for_sycamore` with optimizer type `sqrt_iswap`
+*  Sycamore gate. This gate, equivalent to FSimGate(π/2, π/6) can be used as `cirq_google.SYC`
 or by using `cirq.FsimGate(numpy.pi/2,numpy.pi/6)`. Circuits can be compiled to use this gate
-by using `cirq.google.optimized_for_sycamore` with optimizer type `sycamore`
+by using `cirq_google.optimized_for_sycamore` with optimizer type `sycamore`
 
 
 ### Sycamore23
@@ -298,7 +298,7 @@ with and presents less hardware-related complications than using the full Sycamo
 9 ----I-----
 ```
 
-This grid can be accessed using `cirq.google.Sycamore23` and uses the same gate sets and
+This grid can be accessed using `cirq_google.Sycamore23` and uses the same gate sets and
 compilation as the Sycamore device.
 
 
@@ -325,8 +325,8 @@ The device is arrayed on a grid in a diamond pattern like this.
 10-----KL-----
 ```
 
-It can be accessing by using `cirq.google.Bristlecone`. Circuits can be compiled to it by using
-`cirq.google.optimized_for_xmon` or by using `cirq.google.optimized_for_sycamore` with
+It can be accessing by using `cirq_google.Bristlecone`. Circuits can be compiled to it by using
+`cirq_google.optimized_for_xmon` or by using `cirq_google.optimized_for_sycamore` with
 optimizer_type `xmon`.
 
 ### Foxtail
@@ -337,6 +337,6 @@ super-conducting quantum devices announced by Google. Due to the small number of
 and limited connectivity, it is still interesting for exploring the space of constrained
 algorithms on NISQ devices.
 
-It can be accessing by using `cirq.google.Foxtail`. Circuits can be compiled to it by using
-`cirq.google.optimized_for_xmon` or by using `cirq.google.optimized_for_sycamore` with
+It can be accessing by using `cirq_google.Foxtail`. Circuits can be compiled to it by using
+`cirq_google.optimized_for_xmon` or by using `cirq_google.optimized_for_sycamore` with
 optimizer_type `xmon`.

--- a/docs/google/engine.md
+++ b/docs/google/engine.md
@@ -3,7 +3,7 @@
 Google's Quantum Computing Service provides the Quantum Engine API to execute 
 circuits on Google's quantum processor or simulator backends and 
 to access or manage the jobs, programs, reservations and calibrations. As of Cirq is 
-the only supported client for this API, using the `cirq.google.Engine` class. 
+the only supported client for this API, using the `cirq_google.Engine` class. 
 For other use cases (e.g. from a different language), contact 
 [cirq-maintainers@googlegroups.com](mailto:cirq-maintainers@googlegroups.com) 
 with a short proposal or submit an [RFC](../dev/rfc_process.md). 
@@ -53,7 +53,7 @@ print.results.idx.*
 print()
 --->
 <!---test_substitution
-engine = cirq.google.Engine(.*)
+engine = cirq_google.Engine(.*)
 engine = MockEngine()
 --->
 <!---test_substitution
@@ -66,7 +66,7 @@ sampler = engine
 --->
 ```python
 import cirq
-import cirq.google as cg
+import cirq_google as cg
 
 # A simple sample circuit
 qubit = cirq.GridQubit(5, 2)
@@ -96,7 +96,7 @@ print(results.data)
 
 ## Device Specification
 
-Several public devices have been released and can be found in the `cirq.google`
+Several public devices have been released and can be found in the `cirq_google`
 package.  These are documented further on the [Google Device](devices.md) page. 
 
 However, you can also retrieve the device using the `get_device_specification` of an
@@ -105,7 +105,7 @@ message that contains information about the qubits on the device, the
 connectivity, and the supported gates.
 
 This proto can be queried directly to get information about the device or can be transformed
-into a `cirq.Device` by using `cirq.google.SerializableDevice.from_proto()` that will
+into a `cirq.Device` by using `cirq_google.SerializableDevice.from_proto()` that will
 enforce constraints imposed by the hardware.
 
 See the [Device Specification](specification.md) page for more information on
@@ -188,12 +188,12 @@ for circuit_num in range(num_circuits_in_batch):
 
 # Create an Engine object.
 # Replace YOUR_PROJECT_ID with the id from your cloud project.
-engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
+engine = cirq_google.Engine(project_id='YOUR_PROJECT_ID')
 
 # Create a sampler from the engine
 job = engine.run_batch(circuit_list,
                        processor_ids=['PROCESSOR_ID'],
-                       gate_set=cirq.google.FSIM_GATESET,
+                       gate_set=cirq_google.FSIM_GATESET,
                        repetitions=1000,
                        params_list=param_list)
 results = job.results()
@@ -236,7 +236,7 @@ See below for an example:
 
 ```python
 # Initialize the engine object
-engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
+engine = cirq_google.Engine(project_id='YOUR_PROJECT_ID')
 
 # Create an example circuit
 qubit = cirq.GridQubit(5, 2)
@@ -279,14 +279,14 @@ by using our list methods.
 
 ### Listing jobs 
 
-To list the executions of your circuit, i.e. the jobs, you can use `cirq.google.Engine.list_jobs()`. 
+To list the executions of your circuit, i.e. the jobs, you can use `cirq_google.Engine.list_jobs()`. 
 You can search in all the jobs within your project using filtering criteria on creation time, execution state and labels.  
 
 ```python
-from cirq.google.engine.client.quantum import enums
+from cirq_google.engine.client.quantum import enums
 
 # Initialize the engine object
-engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
+engine = cirq_google.Engine(project_id='YOUR_PROJECT_ID')
 
 # List all the jobs on the project since 2020/09/20 that succeeded:
 jobs = engine.list_jobs(created_after=datetime.date(2020,9,20),
@@ -297,15 +297,15 @@ for j in jobs:
 
 ### Listing programs
 
-To list the different instances of your circuits uploaded, i.e. the programs, you can use `cirq.google.Engine.list_programs()`.
+To list the different instances of your circuits uploaded, i.e. the programs, you can use `cirq_google.Engine.list_programs()`.
 Similar to jobs, filtering makes it possible to list programs by creation time and labels.
-With an existing `cirq.google.EngineProgram` object, you can list any jobs that were run using that program. 
+With an existing `cirq_google.EngineProgram` object, you can list any jobs that were run using that program. 
 
 ```python
-from cirq.google.engine.client.quantum import enums
+from cirq_google.engine.client.quantum import enums
 
 # Initialize the engine object
-engine = cirq.google.Engine(project_id='YOUR_PROJECT_ID')
+engine = cirq_google.Engine(project_id='YOUR_PROJECT_ID')
 
 # List all the programs on the project since 2020/09/20 that have 
 # the "variational" label with any value and the "experiment" label 

--- a/docs/google/specification.md
+++ b/docs/google/specification.md
@@ -10,7 +10,7 @@ processor.  For instance, there may be one or more qubit "drop-outs" that are
 non-functional for whatever reason.   There could also be new or experimental
 features enabled on some devices but not on others.
 
-This specification is defined in the Device proto within `cirq.google.api.v2`.
+This specification is defined in the Device proto within `cirq_google.api.v2`.
 
 ## Gate Set Specifications
 
@@ -40,7 +40,7 @@ device is shown below:
 import cirq
 
 # Create an Engine object to use.
-engine = cirq.google.Engine(project_id='your_project_id')
+engine = cirq_google.Engine(project_id='your_project_id')
 
 # Replace the processor id to get the device specification with that id.
 spec = engine.get_processor('processor_id').get_device_specification()
@@ -92,11 +92,11 @@ For instance, "Do not apply two CZ gates in a row."
 
 ## Serializable Devices
 
-The `cirq.google.SerializableDevice` class allows someone to take this
+The `cirq_google.SerializableDevice` class allows someone to take this
 device specification and turn it into a `cirq.Device` that can be used to
 verify a circuit.
 
-The `cirq.google.SerializableDevice` combines a `DeviceSpecification` protocol
+The `cirq_google.SerializableDevice` combines a `DeviceSpecification` protocol
 buffer (defining the device) with a `SerializableGateSet` (that defines the
 translation from serialized id to cirq) to produce a `cirq.Device` that can
 be used to validate a circuit.
@@ -106,11 +106,11 @@ from the engine and then using it to validate a circuit.
 
 ```
 import cirq
-import cirq.google as cg
+import cirq_google as cg
 
 # Create an Engine object to use.
 engine = cg.Engine(project_id='your_project_id',
-                   proto_version=cirq.google.ProtoVersion.V2)
+                   proto_version=cirq_google.ProtoVersion.V2)
 
 # Replace the processor id to get the device with that id.
 device = engine.get_processor('processor_id').get_device(

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,7 +51,7 @@ To be informed of deprecations and breaking changes, subscribe to the
 4. Check that it works!
 
     ```bash
-    python -c 'import cirq; print(cirq.google.Foxtail)'
+    python -c 'import cirq; print(cirq_google.Foxtail)'
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │
@@ -92,7 +92,7 @@ To be informed of deprecations and breaking changes, subscribe to the
 4. Check that it works!
 
     ```bash
-    python -c 'import cirq; print(cirq.google.Foxtail)'
+    python -c 'import cirq; print(cirq_google.Foxtail)'
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │
@@ -125,7 +125,7 @@ To be informed of deprecations and breaking changes, subscribe to the
 4. Check that it works!
 
     ```bash
-    python -c "import cirq; print(cirq.google.Foxtail)"
+    python -c "import cirq; print(cirq_google.Foxtail)"
     # should print:
     # (0, 0)───(0, 1)───(0, 2)───(0, 3)───(0, 4)───(0, 5)───(0, 6)───(0, 7)───(0, 8)───(0, 9)───(0, 10)
     # │        │        │        │        │        │        │        │        │        │        │


### PR DESCRIPTION
Follow up from #4647 replacing the rest of the uses of `cirq.google` in the `docs`.