### PR TITLE
Fix num_qubits property on AsymetricDepolarizing Channel

### DIFF
--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, 
 
 import numpy as np
 
-from cirq import protocols, value, _compat
+from cirq import protocols, value
 from cirq.ops import raw_types, common_gates, pauli_gates, gate_features, identity
 
 
@@ -53,6 +53,10 @@ class AsymmetricDepolarizingChannel(gate_features.SingleQubitGate):
         where i varies from 0 to 4**n-1 and Pi represents n-qubit Pauli operator
         (including identity). The input $\rho$ is the density matrix before the
         depolarization.
+
+        Note: prior to Cirq v0.14, this class contained `num_qubits` as a property.
+        This violates the contract of `cirq.Gate` so it was removed.  One can
+        instead get the number of qubits by calling the method `num_qubits`.
 
         Args:
             p_x: The probability that a Pauli X and no other gate occurs.
@@ -178,13 +182,6 @@ class AsymmetricDepolarizingChannel(gate_features.SingleQubitGate):
         if self._num_qubits != 1:
             raise ValueError('num_qubits should be 1')
         return self._error_probabilities.get('Z', 0.0)
-
-    # The following property was deprecated in Cirq v0.14. Please use the num_qubits methos instead.
-    #
-    # @property
-    # def num_qubits(self) -> int:
-    #     """"The number of qubits"""
-    #     return self._num_qubits
 
     @property
     def error_probabilities(self) -> Dict[str, float]:

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -179,6 +179,13 @@ class AsymmetricDepolarizingChannel(gate_features.SingleQubitGate):
             raise ValueError('num_qubits should be 1')
         return self._error_probabilities.get('Z', 0.0)
 
+    # The following property was deprecated in Cirq v0.14. Please use the num_qubits methos instead.
+    #
+    # @property
+    # def num_qubits(self) -> int:
+    #     """"The number of qubits"""
+    #     return self._num_qubits
+
     @property
     def error_probabilities(self) -> Dict[str, float]:
         """A dictionary from Pauli gates to probability"""

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -19,8 +19,9 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, 
 
 import numpy as np
 
-from cirq import protocols, value
+from cirq import protocols, value, _compat
 from cirq.ops import raw_types, common_gates, pauli_gates, gate_features, identity
+
 
 if TYPE_CHECKING:
     import cirq
@@ -179,11 +180,6 @@ class AsymmetricDepolarizingChannel(gate_features.SingleQubitGate):
         return self._error_probabilities.get('Z', 0.0)
 
     @property
-    def num_qubits(self) -> int:
-        """The number of qubits"""
-        return self._num_qubits
-
-    @property
     def error_probabilities(self) -> Dict[str, float]:
         """A dictionary from Pauli gates to probability"""
         return self._error_probabilities
@@ -193,7 +189,7 @@ class AsymmetricDepolarizingChannel(gate_features.SingleQubitGate):
 
     def _approx_eq_(self, other: Any, atol: float) -> bool:
         return (
-            self.num_qubits == other.num_qubits
+            self._num_qubits == other._num_qubits
             and np.isclose(self.p_i, other.p_i, atol=atol).item()
             and np.isclose(self.p_x, other.p_x, atol=atol).item()
             and np.isclose(self.p_y, other.p_y, atol=atol).item()

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -64,6 +64,8 @@ def test_asymmetric_depolarizing_channel():
     )
     assert cirq.has_kraus(d)
 
+    assert cirq.AsymmetricDepolarizingChannel(p_x=0, p_y=0.1, p_z=0).num_qubits() == 1
+
 
 def test_asymmetric_depolarizing_mixture():
     d = cirq.asymmetric_depolarize(0.1, 0.2, 0.3)
@@ -729,7 +731,7 @@ def test_default_asymmetric_depolarizing_channel():
     assert d.p_x == 0.0
     assert d.p_y == 0.0
     assert d.p_z == 0.0
-    assert d.num_qubits == 1
+    d.num_qubits() == 1
 
 
 def test_bad_error_probabilities_gate():

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -731,7 +731,7 @@ def test_default_asymmetric_depolarizing_channel():
     assert d.p_x == 0.0
     assert d.p_y == 0.0
     assert d.p_z == 0.0
-    d.num_qubits() == 1
+    assert d.num_qubits() == 1
 
 
 def test_bad_error_probabilities_gate():


### PR DESCRIPTION
`num_qubits` was mistakenly added as a property to AsymetricDepolarizingChannel See #4185

I don't believe there is an easy way to deprecate this because one cannot have both a property and a method on the class, the last one define is called.  

I propose that we just hard break this, but if someone has a better idea, I'm all ears.  I kept the code commented out in case someone goes looking for this, and we can remove this after v0.15.

#4215 which also fixes this seems to have stalled.