### PR TITLE
Add parameter resolution and other utility methods to _InverseCompositeGate

### DIFF
--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -819,6 +819,19 @@ class _InverseCompositeGate(Gate):
             for op in protocols.decompose_once_with_qubits(self._original, qubits)
         )
 
+    def _is_parameterized_(self) -> bool:
+        return protocols.is_parameterized(self._original)
+
+    def _parameter_names_(self) -> AbstractSet[str]:
+        return protocols.parameter_names(self._original)
+
+    def _resolve_parameters_(
+        self, resolver: 'cirq.ParamResolver', recursive: bool
+    ) -> '_InverseCompositeGate':
+        return _InverseCompositeGate(
+            protocols.resolve_parameters(self._original, resolver, recursive)
+        )
+
     def _value_equality_values_(self):
         return self._original
 

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -730,9 +730,7 @@ def test_inverse_composite_standards():
     assert cirq.is_parameterized(g)
     assert cirq.parameter_names(g) == {'a'}
     assert cirq.resolve_parameters(g, {a: 0}) == Gate(0) ** -1
-    cirq.testing.assert_implements_consistent_protocols(
-        g, global_vals={'C': Gate, 'a': sympy.Symbol("a")}
-    )
+    cirq.testing.assert_implements_consistent_protocols(g, global_vals={'C': Gate, 'a': a})
 
 
 def test_tagged_act_on():

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -698,6 +698,9 @@ def test_tagged_operation_resolves_parameterized_tags(resolve_fn):
 def test_inverse_composite_standards():
     @cirq.value_equality
     class Gate(cirq.Gate):
+        def __init__(self, param: 'cirq.TParamVal'):
+            self._param = param
+
         def _decompose_(self, qubits):
             return cirq.S.on(qubits[0])
 
@@ -708,13 +711,27 @@ def test_inverse_composite_standards():
             return True
 
         def _value_equality_values_(self):
-            return ()
+            return (self._param,)
+
+        def _parameter_names_(self) -> AbstractSet[str]:
+            return cirq.parameter_names(self._param)
+
+        def _is_parameterized_(self) -> bool:
+            return cirq.is_parameterized(self._param)
+
+        def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'Gate':
+            return Gate(cirq.resolve_parameters(self._param, resolver, recursive))
 
         def __repr__(self):
-            return 'C()'
+            return f'C({self._param})'
 
+    a = sympy.Symbol("a")
+    g = cirq.inverse(Gate(a))
+    assert cirq.is_parameterized(g)
+    assert cirq.parameter_names(g) == {'a'}
+    assert cirq.resolve_parameters(g, {a: 0}) == Gate(0) ** -1
     cirq.testing.assert_implements_consistent_protocols(
-        cirq.inverse(Gate()), global_vals={'C': Gate}
+        g, global_vals={'C': Gate, 'a': sympy.Symbol("a")}
     )
 
 


### PR DESCRIPTION
Fixes #4655

This PR adds functionality to `_InverseCompositeGate` to forward requests like `resolve_parameters`, `is_parameterized` and `parameter_names` to the underlying `original_gate`. 