### PR TITLE
Update Gate's __call__ args so documentation is correct

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -24,7 +24,7 @@ The native gate set consists of the local gates: X,Y, and XX entangling gates
 
 """
 import json
-from typing import Any, cast, Dict, Optional, Sequence, List, Tuple, Union
+from typing import Any, cast, Dict, Optional, Sequence, List, Tuple, Type, Union
 import numpy as np
 import cirq
 
@@ -177,17 +177,17 @@ class AQTSimulator:
         """
         self.circuit = cirq.Circuit()
         json_obj = json.loads(json_string)
-        gate: Union[cirq.PhasedXPowGate, cirq.EigenGate]
+        gate: Union[Type[cirq.PhasedXPowGate], Type[cirq.EigenGate]]
         for circuit_list in json_obj:
             op_str = circuit_list[0]
             if op_str == 'R':
-                gate = cast(cirq.PhasedXPowGate, gate_dict[op_str])
+                gate = cast(Type[cirq.PhasedXPowGate], gate_dict[op_str])
                 theta = circuit_list[1]
                 phi = circuit_list[2]
                 qubits = [self.qubit_list[i] for i in circuit_list[3]]
                 self.circuit.append(gate(phase_exponent=phi, exponent=theta).on(*qubits))
             else:
-                gate = cast(cirq.EigenGate, gate_dict[op_str])
+                gate = cast(Type[cirq.EigenGate], gate_dict[op_str])
                 angle = circuit_list[1]
                 qubits = [self.qubit_list[i] for i in circuit_list[2]]
                 self.circuit.append(gate.on(*qubits) ** angle)

--- a/cirq-core/cirq/contrib/quil_import/quil.py
+++ b/cirq-core/cirq/contrib/quil_import/quil.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, Union
+from typing import cast, Callable, Dict, Union, Type
 
 import numpy as np
 from pyquil.parser import parse
@@ -189,7 +189,7 @@ RESET directives have special meaning on QCS, to enable active reset.
 """
 
 # Parameterized gates map to functions that produce Gate constructors.
-SUPPORTED_GATES: Dict[str, Union[Gate, Callable[..., Gate]]] = {
+SUPPORTED_GATES: Dict[str, Union[Gate, Type[Gate], Callable[..., Gate]]] = {
     "CCNOT": CCNOT,
     "CNOT": CNOT,
     "CSWAP": CSWAP,
@@ -258,7 +258,9 @@ def circuit_from_quil(quil: str) -> Circuit:
                 raise UndefinedQuilGate(f"Quil gate {quil_gate_name} not supported in Cirq.")
             cirq_gate_fn = defined_gates[quil_gate_name]
             if quil_gate_params:
-                circuit += cirq_gate_fn(*quil_gate_params)(*line_qubits)
+                circuit += cast(Union[Type[Gate], Callable[..., Gate]], cirq_gate_fn)(
+                    *quil_gate_params
+                )(*line_qubits)
             else:
                 circuit += cirq_gate_fn(*line_qubits)
 

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -320,7 +320,7 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
 
         return NotImplemented
 
-    def __call__(self, *qubits: Qid) -> 'cirq.Operation':
+    def __call__(self, *qubits: 'cirq.Qid'):
         return self.on(*qubits)
 
     def with_probability(self, probability: 'cirq.TParamVal') -> 'cirq.Gate':

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -202,7 +202,7 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         """
         _validate_qid_shape(self, qubits)
 
-    def on(self, *qubits: Qid) -> 'Operation':
+    def on(self, *qubits: Qid) -> 'cirq.Operation':
         """Returns an application of this gate to the given qubits.
 
         Args:
@@ -320,8 +320,8 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
 
         return NotImplemented
 
-    def __call__(self, *args, **kwargs):
-        return self.on(*args, **kwargs)
+    def __call__(self, *qubits: Qid) -> 'cirq.Operation':
+        return self.on(*qubits)
 
     def with_probability(self, probability: 'cirq.TParamVal') -> 'cirq.Gate':
         from cirq.ops.random_gate_channel import RandomGateChannel


### PR DESCRIPTION
See #4633 

This uncovered another bug, which is that it looks like the docs are dropping some type annotations.  Will investigate this separately.

