### PR TITLE
Bump version of qiskit-aer in dev-tools

### DIFF
--- a/dev_tools/requirements/deps/dev-tools.txt
+++ b/dev_tools/requirements/deps/dev-tools.txt
@@ -11,7 +11,7 @@
 asv
 
 # For verifying behavior of qasm output.
-qiskit-aer~=0.7.6
+qiskit-aer~=0.9.1
 
 # For verifying rst
 rstcheck~=3.3.1


### PR DESCRIPTION
On a clean install and older version of this was burping on parsing qasm.  This seems to fix it.

This is just for dev-tools which is what is recommended to install for developers.