### PR TITLE
Add docker and docker compose to dev install

### DIFF
--- a/dev_tools/conf/apt-list-dev-tools.txt
+++ b/dev_tools/conf/apt-list-dev-tools.txt
@@ -1,2 +1,4 @@
 virtualenvwrapper
 pandoc
+docker-ce
+docker-compose

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -97,6 +97,10 @@ See the previous section for instructions.
     ```bash
     cat apt-system-requirements.txt dev_tools/conf/apt-list-dev-tools.txt | xargs sudo apt-get install --yes
     ```
+    
+    This installs docker and docker-compose among other things. You may need to restart
+    docker or configure permissions, see 
+    [docker install instructions](https://docs.docker.com/engine/install/ubuntu/)
 
     There are some extra steps if protocol buffers are changed; see the next section.
 


### PR DESCRIPTION
We have docker tests and rigetti requires docker. This adds these to the dev apt-get list and explains that you need to install docker. 