### PR TITLE
Fix remaining documentation lint

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -589,8 +589,6 @@ class DeprecatedModuleImportError(ImportError):
     pass
 
 
-# TODO(#3388) Add documentation for Args.
-# pylint: disable=missing-param-doc
 def deprecated_submodule(
     *, new_module_name: str, old_parent: str, old_child: str, deadline: str, create_attribute: bool
 ):
@@ -606,10 +604,11 @@ def deprecated_submodule(
     cache.
 
     Args:
-        new_module_name: absolute module name for the new module
-        old_parent: the current module that had the original submodule
-        old_child: the submodule that is being relocated
-        create_attribute: if True, the submodule will be added as a deprecated attribute to the
+        new_module_name: Absolute module name for the new module
+        old_parent: The current module that had the original submodule
+        old_child: The submodule that is being relocated
+        deadline: The version of Cirq where the module will be removed.s
+        create_attribute: If True, the submodule will be added as a deprecated attribute to the
             old_parent module
 
     Returns:
@@ -662,7 +661,6 @@ def deprecated_submodule(
     sys.meta_path = [wrap(finder) for finder in sys.meta_path]
 
 
-# pylint: enable=missing-param-doc
 def _setup_deprecated_submodule_attribute(
     new_module_name: str,
     old_parent: str,

--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -604,12 +604,12 @@ def deprecated_submodule(
     cache.
 
     Args:
-        new_module_name: Absolute module name for the new module
-        old_parent: The current module that had the original submodule
-        old_child: The submodule that is being relocated
-        deadline: The version of Cirq where the module will be removed.s
+        new_module_name: Absolute module name for the new module.
+        old_parent: The current module that had the original submodule.
+        old_child: The submodule that is being relocated.
+        deadline: The version of Cirq where the module will be removed.
         create_attribute: If True, the submodule will be added as a deprecated attribute to the
-            old_parent module
+            old_parent module.
 
     Returns:
         None

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1853,8 +1853,7 @@ class Circuit(AbstractCircuit):
                 function, and with an updated device (if specified).
 
         Raises:
-            TypeError: If `qubit_function` is not a function of dict of the correct
-                type.
+            TypeError: If `qubit_function` is not a function or a dict.
         """
         if callable(qubit_map):
             transform = qubit_map

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1141,8 +1141,6 @@ class AbstractCircuit(abc.ABC):
             use_unicode_characters=use_unicode_characters,
         )
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
     def to_text_diagram_drawer(
         self,
         *,
@@ -1164,6 +1162,7 @@ class AbstractCircuit(abc.ABC):
                 allowed (as opposed to ascii-only diagrams).
             qubit_namer: Names qubits in diagram. Defaults to str.
             transpose: Arranges qubit wires vertically instead of horizontally.
+            include_tags: Whether to include tags in the operation.
             draw_moment_groups: Whether to draw moment symbol or not
             precision: Number of digits to use when representing numbers.
             qubit_order: Determines how qubits are ordered in the diagram.
@@ -1214,7 +1213,6 @@ class AbstractCircuit(abc.ABC):
 
         return diagram
 
-    # pylint: enable=missing-param-doc
     def _is_parameterized_(self) -> bool:
         return any(protocols.is_parameterized(op) for op in self.all_operations())
 
@@ -1303,8 +1301,6 @@ class AbstractCircuit(abc.ABC):
     def _from_json_dict_(cls, moments, device, **kwargs):
         return cls(moments, strategy=InsertStrategy.EARLIEST, device=device)
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
     def zip(
         *circuits: 'cirq.AbstractCircuit', align: Union['cirq.Alignment', str] = Alignment.LEFT
     ) -> 'cirq.AbstractCircuit':
@@ -1323,14 +1319,14 @@ class AbstractCircuit(abc.ABC):
 
         Args:
             circuits: The circuits to merge together.
+            align: The alignment for the zip, see `cirq.Alignment`.
 
         Returns:
             The merged circuit.
 
         Raises:
-            ValueError:
-                The zipped circuits have overlapping operations occurring at the
-                same moment index.
+            ValueError: If the zipped circuits have overlapping operations occurring
+                at the same moment index.
 
         Examples:
             >>> import cirq
@@ -1380,7 +1376,6 @@ class AbstractCircuit(abc.ABC):
                 ) from ex
         return result
 
-    # pylint: enable=missing-param-doc
     def tetris_concat(
         *circuits: 'cirq.AbstractCircuit', align: Union['cirq.Alignment', str] = Alignment.LEFT
     ) -> 'cirq.AbstractCircuit':
@@ -1834,8 +1829,6 @@ class Circuit(AbstractCircuit):
 
     zip.__doc__ = AbstractCircuit.zip.__doc__
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def transform_qubits(
         self,
         qubit_map: Union[Dict['cirq.Qid', 'cirq.Qid'], Callable[['cirq.Qid'], 'cirq.Qid']],
@@ -1858,6 +1851,10 @@ class Circuit(AbstractCircuit):
         Returns:
             The receiving circuit but with qubits transformed by the given
                 function, and with an updated device (if specified).
+
+        Raises:
+            TypeError: If `qubit_function` is not a function of dict of the correct
+                type.
         """
         if callable(qubit_map):
             transform = qubit_map
@@ -1869,7 +1866,6 @@ class Circuit(AbstractCircuit):
             new_device=self.device if new_device is None else new_device, qubit_mapping=transform
         )
 
-    # pylint: enable=missing-raises-doc
     def _prev_moment_available(self, op: 'cirq.Operation', end_moment_index: int) -> Optional[int]:
         last_available = end_moment_index
         k = end_moment_index
@@ -2108,8 +2104,6 @@ class Circuit(AbstractCircuit):
                 self._moments[moment_index].operations + tuple(new_ops)
             )
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def insert_at_frontier(
         self, operations: 'cirq.OP_TREE', start: int, frontier: Dict['cirq.Qid', int] = None
     ) -> Dict['cirq.Qid', int]:
@@ -2120,6 +2114,9 @@ class Circuit(AbstractCircuit):
             start: The moment at which to start inserting the operations.
             frontier: frontier[q] is the earliest moment in which an operation
                 acting on qubit q can be placed.
+
+        Raises:
+            ValueError: If the frontier given is after start.
         """
         if frontier is None:
             frontier = defaultdict(lambda: 0)
@@ -2143,7 +2140,6 @@ class Circuit(AbstractCircuit):
 
         return frontier
 
-    # pylint: enable=missing-raises-doc
     def batch_remove(self, removals: Iterable[Tuple[int, 'cirq.Operation']]) -> None:
         """Removes several operations from a circuit.
 

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -50,8 +50,6 @@ class QasmGateStatement:
     `cirq.GateOperation`s in the `on` method.
     """
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
     def __init__(
         self,
         qasm_gate: str,
@@ -62,10 +60,11 @@ class QasmGateStatement:
         """Initializes a Qasm gate statement.
 
         Args:
-            qasm_gate: the symbol of the QASM gate
-            cirq_gate: the gate class on the cirq side
-            num_args: the number of qubits (used in validation) this
-                        gate takes
+            qasm_gate: The symbol of the QASM gate.
+            cirq_gate: The gate class on the cirq side.
+            num_params: The number of params taken by this gate.
+            num_args: The number of qubits (used in validation) this
+                gate takes.
         """
         self.qasm_gate = qasm_gate
         self.cirq_gate = cirq_gate
@@ -75,7 +74,6 @@ class QasmGateStatement:
         assert num_args >= 1
         self.num_args = num_args
 
-    # pylint: enable=missing-param-doc
     def _validate_args(self, args: List[List[ops.Qid]], lineno: int):
         if len(args) != self.num_args:
             raise QasmException(
@@ -355,7 +353,7 @@ class QasmParser:
         p[0] = p[3]
 
     def p_params_single(self, p):
-        """params : expr """
+        """params : expr"""
         p[0] = [p[1]]
 
     # expr : term
@@ -417,7 +415,7 @@ class QasmParser:
     #     | ID '[' NATURAL_NUMBER ']'
 
     def p_quantum_arg_register(self, p):
-        """qarg : ID """
+        """qarg : ID"""
         reg = p[1]
         if reg not in self.qregs.keys():
             raise QasmException(f'Undefined quantum register "{reg}" at line {p.lineno(1)}')
@@ -433,7 +431,7 @@ class QasmParser:
     #     | ID '[' NATURAL_NUMBER ']'
 
     def p_classical_arg_register(self, p):
-        """carg : ID """
+        """carg : ID"""
         reg = p[1]
         if reg not in self.cregs.keys():
             raise QasmException(f'Undefined classical register "{reg}" at line {p.lineno(1)}')
@@ -444,7 +442,7 @@ class QasmParser:
         return str(reg) + "_" + str(idx)
 
     def p_quantum_arg_bit(self, p):
-        """qarg : ID '[' NATURAL_NUMBER ']' """
+        """qarg : ID '[' NATURAL_NUMBER ']'"""
         reg = p[1]
         idx = p[3]
         arg_name = self.make_name(idx, reg)
@@ -462,7 +460,7 @@ class QasmParser:
         p[0] = [self.qubits[arg_name]]
 
     def p_classical_arg_bit(self, p):
-        """carg : ID '[' NATURAL_NUMBER ']' """
+        """carg : ID '[' NATURAL_NUMBER ']'"""
         reg = p[1]
         idx = p[3]
         arg_name = self.make_name(idx, reg)

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -213,8 +213,6 @@ class SwapPermutationReplacer(cirq.PointOptimizer):
         return None  # Don't make changes to other gates.
 
 
-# TODO(#3388) Add documentation for Args.
-# pylint: disable=missing-param-doc
 def compile_circuit(
     circuit: cirq.Circuit,
     *,
@@ -238,6 +236,9 @@ def compile_circuit(
         routing_attempts: See doc for calculate_quantum_volume.
         compiler: An optional function to deconstruct the model circuit's
             gates down to the target devices gate set and then optimize it.
+        routing_algo_name: The name of the rougint algorithm, currently only
+            supports GREEDY.
+        router: The function that actually does the routing.
         add_readout_error_correction: If true, add some parity bits that will
             later be used to detect readout error.
 
@@ -308,7 +309,6 @@ def compile_circuit(
     )
 
 
-# pylint: enable=missing-param-doc
 @dataclass
 class QuantumVolumeResult:
     """Stores one run of the results and test information used when running the

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -236,8 +236,8 @@ def compile_circuit(
         routing_attempts: See doc for calculate_quantum_volume.
         compiler: An optional function to deconstruct the model circuit's
             gates down to the target devices gate set and then optimize it.
-        routing_algo_name: The name of the rougint algorithm, currently only
-            supports GREEDY.
+        routing_algo_name: The name of the routing algorithm, see ROUTING in
+            `route_circuit.py`.
         router: The function that actually does the routing.
         add_readout_error_correction: If true, add some parity bits that will
             later be used to detect readout error.
@@ -458,8 +458,8 @@ def calculate_quantum_volume(
         depth: The number of gate layers to generate.
         num_circuits: The number of random circuits to run.
         random_state: Random state or random state seed.
-        device_graph: A graph whose nodes are qubits and edges represent two qubit interactions to
-            run the compiled circuit on.
+        device_graph: A graph whose nodes are qubits and edges represent two
+            qubit interactions to run the compiled circuit on.
         samplers: The samplers to run the algorithm on.
         compiler: An optional function to compiler the model circuit's
             gates down to the target devices gate set and the optimize it.

--- a/cirq-core/cirq/contrib/routing/greedy.py
+++ b/cirq-core/cirq/contrib/routing/greedy.py
@@ -42,8 +42,6 @@ SWAP = cca.SwapPermutationGate()
 QidPair = Tuple[ops.Qid, ops.Qid]
 
 
-# TODO(#3388) Add documentation for Args.
-# pylint: disable=missing-param-doc
 def route_circuit_greedily(
     circuit: circuits.Circuit, device_graph: nx.Graph, **kwargs
 ) -> SwapNetwork:
@@ -75,15 +73,16 @@ def route_circuit_greedily(
         device_graph: The device's graph, in which each vertex is a qubit
             and each edge indicates the ability to do an operation on those
             qubits.
-        max_search_radius: The maximum number of disjoint device edges to
-            consider routing on.
-        max_num_empty_steps: The maximum number of swap sets to apply without
-            allowing a new logical operation to be performed.
-        initial_mapping: The initial mapping of physical to logical qubits
-            to use. Defaults to a greedy initialization.
-        can_reorder: A predicate that determines if two operations may be
-            reordered.
-        random_state: Random state or random state seed.
+        **kwargs: Further keyword args, including
+            max_search_radius: The maximum number of disjoint device edges to
+                consider routing on.
+            max_num_empty_steps: The maximum number of swap sets to apply
+                without allowing a new logical operation to be performed.
+            initial_mapping: The initial mapping of physical to logical qubits
+                to use. Defaults to a greedy initialization.
+            can_reorder: A predicate that determines if two operations may be
+                reordered.
+            random_state: Random state or random state seed.
     """
 
     router = _GreedyRouter(circuit, device_graph, **kwargs)
@@ -96,7 +95,6 @@ def route_circuit_greedily(
     return swap_network
 
 
-# pylint: enable=missing-param-doc
 class _GreedyRouter:
     """Keeps track of the state of a greedy circuit routing procedure."""
 

--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -203,11 +203,9 @@ class GridQid(_BaseGridQid):
             for col in range(left, left + cols)
         ]
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
     @staticmethod
     def from_diagram(diagram: str, dimension: int) -> List['GridQid']:
-        """Parse ASCII art device layout into info about qids and
+        r"""Parse ASCII art device layout into info about qids and
         connectivity. As an example, the below diagram will create a list of
         GridQid in a pyramid structure.
         ---A---
@@ -240,6 +238,8 @@ class GridQid(_BaseGridQid):
                 than alphanumerics, spacers, and newlines ('\n'), an error will
                 be thrown. The top-left corner of the diagram will be have
                 coordinate (0,0).
+            dimension: The dimension of the qubits in the `GridQid`s used
+                in this construction.
 
         Returns:
             A list of GridQid corresponding to qids in the provided diagram
@@ -250,7 +250,6 @@ class GridQid(_BaseGridQid):
         coords = _ascii_diagram_to_coords(diagram)
         return [GridQid(*c, dimension=dimension) for c in coords]
 
-    # pylint: enable=missing-param-doc
     def __repr__(self) -> str:
         return f"cirq.GridQid({self.row}, {self.col}, dimension={self.dimension})"
 

--- a/cirq-core/cirq/experiments/cross_entropy_benchmarking.py
+++ b/cirq-core/cirq/experiments/cross_entropy_benchmarking.py
@@ -28,7 +28,6 @@ from typing import (
 )
 import dataclasses
 import numpy as np
-import scipy
 from matplotlib import pyplot as plt
 from cirq import _import, circuits, devices, ops, protocols, sim, value, work
 

--- a/cirq-core/cirq/experiments/cross_entropy_benchmarking.py
+++ b/cirq-core/cirq/experiments/cross_entropy_benchmarking.py
@@ -30,13 +30,15 @@ import dataclasses
 import numpy as np
 import scipy
 from matplotlib import pyplot as plt
-from cirq import circuits, devices, ops, protocols, sim, value, work
+from cirq import _import, circuits, devices, ops, protocols, sim, value, work
 
 if TYPE_CHECKING:
     import cirq
 
 CrossEntropyPair = NamedTuple('CrossEntropyPair', [('num_cycle', int), ('xeb_fidelity', float)])
 SpecklePurityPair = NamedTuple('SpecklePurityPair', [('num_cycle', int), ('purity', float)])
+
+optimize = _import.LazyLoader("optimize", globals(), "scipy.optimize")
 
 
 @dataclasses.dataclass
@@ -166,8 +168,6 @@ class CrossEntropyResult:
             spam_depolarization=params[0], cycle_depolarization=params[1], covariance=covariance
         )
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def purity_depolarizing_model(self) -> CrossEntropyDepolarizingModel:
         """Fit a depolarizing error model for a cycle to purity data.
 
@@ -182,6 +182,9 @@ class CrossEntropyResult:
             representing the covariance in the estimation of S and p in that
             order. It also has the property `purity` representing the purity
             p**2.
+
+        Raises:
+            ValueError: If no `purity_data` has been supplied to this class.
         """
         if self.purity_data is None:
             raise ValueError(
@@ -195,7 +198,6 @@ class CrossEntropyResult:
             spam_depolarization=params[0], cycle_depolarization=params[1], covariance=covariance
         )
 
-    # pylint: enable=missing-raises-doc
     @classmethod
     def _from_json_dict_(cls, data, repetitions, **kwargs):
         purity_data = kwargs.get('purity_data', None)
@@ -236,7 +238,7 @@ def _fit_exponential_decay(x: Sequence[int], y: Sequence[float]) -> Tuple[np.nda
     def f(a, S, p):
         return S * p ** a
 
-    return scipy.optimize.curve_fit(f, x, y, p0=p0)
+    return optimize.curve_fit(f, x, y, p0=p0)
 
 
 @dataclasses.dataclass

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -74,7 +74,7 @@ def benchmark_2q_xeb_fidelities(
 
     Raises:
         ValueError: If `cycle_depths` is not a non-empty array or if the `cycle_depths` provided
-            include some not available in `sampled_df`.
+            includes some values not available in `sampled_df`.
     """
     sampled_cycle_depths = (
         sampled_df.index.get_level_values('cycle_depth').drop_duplicates().sort_values()

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -44,8 +44,7 @@ THETA_SYMBOL, ZETA_SYMBOL, CHI_SYMBOL, GAMMA_SYMBOL, PHI_SYMBOL = sympy.symbols(
     'theta zeta chi gamma phi'
 )
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
+
 def benchmark_2q_xeb_fidelities(
     sampled_df: pd.DataFrame,
     circuits: Sequence['cirq.Circuit'],
@@ -72,6 +71,10 @@ def benchmark_2q_xeb_fidelities(
 
     Returns:
         A DataFrame with columns 'cycle_depth' and 'fidelity'.
+
+    Raises:
+        ValueError: If `cycle_depths` is not a non-empty array or if the `cycle_depths` provided
+            include some not available in `sampled_df`.
     """
     sampled_cycle_depths = (
         sampled_df.index.get_level_values('cycle_depth').drop_duplicates().sort_values()
@@ -136,7 +139,6 @@ def benchmark_2q_xeb_fidelities(
     return df.groupby(groupby_names).apply(per_cycle_depth).reset_index()
 
 
-# pylint: enable=missing-raises-doc
 class XEBCharacterizationOptions(ABC):
     @staticmethod
     @abstractmethod

--- a/cirq-core/cirq/linalg/predicates.py
+++ b/cirq-core/cirq/linalg/predicates.py
@@ -216,8 +216,6 @@ def allclose_up_to_global_phase(
     return np.allclose(a=a, b=b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def slice_for_qubits_equal_to(
     target_qubit_axes: Sequence[int],
     little_endian_qureg_value: int = 0,
@@ -271,6 +269,11 @@ def slice_for_qubits_equal_to(
     Returns:
         An index object that will slice out a mutable view of the desired subset
         of a tensor.
+
+    Raises:
+        ValueError: If the `qid_shape` mismatches `num_qubits` or exactly one of
+            `little_endian_qureg_value` and `big_endian_qureg_value` is not
+            specified.
     """
     qid_shape_specified = qid_shape is not None
     if qid_shape is not None or num_qubits is not None:
@@ -307,6 +310,3 @@ def slice_for_qubits_equal_to(
     for axis, digit in zip(target_qubit_axes, digits):
         result[axis] = digit
     return tuple(result)
-
-
-# pylint: enable=missing-raises-doc

--- a/cirq-core/cirq/ops/eigen_gate.py
+++ b/cirq-core/cirq/ops/eigen_gate.py
@@ -73,8 +73,6 @@ class EigenGate(raw_types.Gate):
     method.
     """
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def __init__(
         self, *, exponent: value.TParamVal = 1.0, global_shift: float = 0.0  # Forces keyword args.
     ) -> None:
@@ -114,6 +112,10 @@ class EigenGate(raw_types.Gate):
                 For example, `cirq.X**t` uses a `global_shift` of 0 but
                 `cirq.rx(t)` uses a `global_shift` of -0.5, which is why
                 `cirq.unitary(cirq.rx(pi))` equals -iX instead of X.
+
+        Raises:
+            ValueError: If the supplied exponent is a complex number with an
+                imaginary component.
         """
         if isinstance(exponent, complex):
             if exponent.imag:
@@ -123,7 +125,6 @@ class EigenGate(raw_types.Gate):
         self._global_shift = global_shift
         self._canonical_exponent_cached = None
 
-    # pylint: enable=missing-raises-doc
     @property
     def exponent(self) -> value.TParamVal:
         return self._exponent

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -213,17 +213,15 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
 
         return gate_operation.GateOperation(self, list(qubits))
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def on_each(self, *targets: Union[Qid, Iterable[Any]]) -> List['cirq.Operation']:
         """Returns a list of operations applying the gate to all targets.
 
         Args:
             *targets: The qubits to apply this gate to. For single-qubit gates
-            this can be provided as varargs or a combination of nested
-            iterables. For multi-qubit gates this must be provided as an
-            `Iterable[Sequence[Qid]]`, where each sequence has `num_qubits`
-            qubits.
+                this can be provided as varargs or a combination of nested
+                iterables. For multi-qubit gates this must be provided as an
+                `Iterable[Sequence[Qid]]`, where each sequence has `num_qubits`
+                qubits.
 
         Returns:
             Operations applying this gate to the target qubits.
@@ -231,6 +229,7 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         Raises:
             ValueError: If targets are not instances of Qid or Iterable[Qid].
                 If the gate qubit number is incompatible.
+            TypeError: If a single target is supplied and it is not iterable.
         """
         operations: List['cirq.Operation'] = []
         if self._num_qubits_() > 1:
@@ -264,7 +263,6 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
                 )
         return operations
 
-    # pylint: enable=missing-raises-doc
     def wrap_in_linear_combination(
         self, coefficient: Union[complex, float, int] = 1
     ) -> 'cirq.LinearCombinationOfGates':

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
 class CircuitDiagramInfo:
     """Describes how to draw an operation in a circuit diagram."""
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def __init__(
         self,
         wire_symbols: Iterable[str],
@@ -70,6 +68,10 @@ class CircuitDiagramInfo:
                 add parentheses around exponents whose contents could look
                 ambiguous (e.g. if the exponent contains a dash character that
                 could be mistaken for an identity wire). Defaults to True.
+
+        Raises:
+            ValueError: If `wire_symbols` is a string, and not an interable
+                of strings.
         """
         if isinstance(wire_symbols, str):
             raise ValueError('Expected an Iterable[str] for wire_symbols but got a str.')
@@ -79,7 +81,6 @@ class CircuitDiagramInfo:
         self.exponent_qubit_index = exponent_qubit_index
         self.auto_exponent_parens = auto_exponent_parens
 
-    # pylint: enable=missing-raises-doc
     def with_wire_symbols(self, new_wire_symbols: Iterable[str]):
         return CircuitDiagramInfo(
             wire_symbols=new_wire_symbols,

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -298,10 +298,9 @@ class CliffordTableau:
         self._xs[q1, :] ^= self._xs[q2, :]
         self._zs[q1, :] ^= self._zs[q2, :]
 
-    # TODO(#3388) Add summary line to docstring.
-    # pylint: disable=docstring-first-line-empty
     def _row_to_dense_pauli(self, i: int) -> 'cirq.DensePauliString':
-        """
+        """Return a dense pauli string for the given row in the tableau.
+
         Args:
             i: index of the row in the tableau.
 
@@ -327,7 +326,6 @@ class CliffordTableau:
                 pauli_mask += "I"
         return DensePauliString(pauli_mask, coefficient=coefficient)
 
-    # pylint: enable=docstring-first-line-empty
     def stabilizers(self) -> List['cirq.DensePauliString']:
         """Returns the stabilizer generators of the state. These
         are n operators {S_1,S_2,...,S_n} such that S_i |psi> = |psi>"""

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -299,7 +299,7 @@ class CliffordTableau:
         self._zs[q1, :] ^= self._zs[q2, :]
 
     def _row_to_dense_pauli(self, i: int) -> 'cirq.DensePauliString':
-        """Return a dense pauli string for the given row in the tableau.
+        """Return a dense Pauli string for the given row in the tableau.
 
         Args:
             i: index of the row in the tableau.

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -32,9 +32,6 @@ from cirq.qis import STATE_VECTOR_LIKE  # pylint: disable=unused-import,wrong-im
 class StateVectorMixin:
     """A mixin that provide methods for objects that have a state vector."""
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
-    # Reason for 'type: ignore': https://github.com/python/mypy/issues/5887
     def __init__(self, qubit_map: Optional[Dict[ops.Qid, int]] = None, *args, **kwargs):
         """Inits StateVectorMixin.
 
@@ -42,13 +39,15 @@ class StateVectorMixin:
             qubit_map: A map from the Qubits in the Circuit to the the index
                 of this qubit for a canonical ordering. This canonical ordering
                 is used to define the state (see the state_vector() method).
+            *args: Passed on to the class that this is mixed in with.
+            **kwargs: Passed on to the class that this is mixed in with.
         """
+        # Reason for 'type: ignore': https://github.com/python/mypy/issues/5887
         super().__init__(*args, **kwargs)  # type: ignore
         self._qubit_map = qubit_map or {}
         qid_shape = simulator._qubit_map_to_shape(self._qubit_map)
         self._qid_shape = None if qubit_map is None else qid_shape
 
-    # pylint: enable=missing-param-doc
     @property
     def qubit_map(self) -> Dict[ops.Qid, int]:
         return self._qubit_map

--- a/cirq-core/cirq/study/result.py
+++ b/cirq-core/cirq/study/result.py
@@ -337,8 +337,6 @@ class Result:
         )
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def _pack_digits(digits: np.ndarray, pack_bits: str = 'auto') -> Tuple[str, bool]:
     """Returns a string of packed digits and a boolean indicating whether the
     digits were packed as binary values.
@@ -349,6 +347,9 @@ def _pack_digits(digits: np.ndarray, pack_bits: str = 'auto') -> Tuple[str, bool
             using `np.packbits` to save space. If 'never', do not pack binary
             digits. If 'force', use `np.packbits` without checking for
             compatibility.
+
+    Raises:
+        ValueError: If `pack_bits` is not `auto`, `force`, or `never`.
     """
     # If digits are binary, pack them better to save space
 
@@ -370,7 +371,6 @@ def _pack_digits(digits: np.ndarray, pack_bits: str = 'auto') -> Tuple[str, bool
     return packed_digits, False
 
 
-# pylint: enable=missing-raises-doc
 def _pack_bits(bits: np.ndarray) -> str:
     return np.packbits(bits).tobytes().hex()
 

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -403,14 +403,16 @@ class Linspace(SingleSweep):
 class ListSweep(Sweep):
     """A wrapper around a list of `ParamResolver`s."""
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def __init__(self, resolver_list: Iterable[resolver.ParamResolverOrSimilarType]):
         """Creates a `Sweep` over a list of `ParamResolver`s.
 
         Args:
             resolver_list: The list of parameter resolvers to use in the sweep.
                 All resolvers must resolve the same set of parameters.
+
+        Raises:
+            TypeError: If `resolver_list` is not a `cirq.ParamResolver` or a
+                dict.
         """
         self.resolver_list: List[resolver.ParamResolver] = []
         for r in resolver_list:
@@ -418,7 +420,6 @@ class ListSweep(Sweep):
                 raise TypeError(f'Not a ParamResolver or dict: <{r!r}>')
             self.resolver_list.append(resolver.ParamResolver(r))
 
-    # pylint: enable=missing-raises-doc
     def __eq__(self, other):
         if not isinstance(other, type(self)):
             return NotImplemented

--- a/cirq-core/cirq/testing/circuit_compare.py
+++ b/cirq-core/cirq/testing/circuit_compare.py
@@ -299,8 +299,6 @@ def assert_has_consistent_apply_unitary(val: Any, *, atol: float = 1e-8) -> None
         )
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def _assert_apply_unitary_works_when_axes_transposed(val: Any, *, atol: float = 1e-8) -> None:
     """Tests whether a value's _apply_unitary_ handles out-of-order axes.
 
@@ -313,6 +311,10 @@ def _assert_apply_unitary_works_when_axes_transposed(val: Any, *, atol: float = 
     Args:
         val: The operation, gate, or other unitary object to test.
         atol: Absolute error tolerance.
+
+    Raises:
+        AssertionError: If `_apply_unitary_` acted differently on the
+            out-of-order axes than on the in-order axes.
     """
 
     # Only test custom apply unitary methods.
@@ -369,7 +371,6 @@ def _assert_apply_unitary_works_when_axes_transposed(val: Any, *, atol: float = 
         )
 
 
-# pylint: enable=missing-raises-doc
 def assert_has_consistent_apply_unitary_for_various_exponents(
     val: Any, *, exponents=(0, 1, -1, 0.5, 0.25, -0.5, 0.1, sympy.Symbol('s'))
 ) -> None:

--- a/cirq-core/cirq/work/observable_measurement.py
+++ b/cirq-core/cirq/work/observable_measurement.py
@@ -379,8 +379,6 @@ def _to_sweep(param_tuples):
     return to_sweep
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def _parse_checkpoint_options(
     checkpoint: bool, checkpoint_fn: Optional[str], checkpoint_other_fn: Optional[str]
 ) -> Tuple[Optional[str], Optional[str]]:
@@ -392,6 +390,11 @@ def _parse_checkpoint_options(
     Returns:
         checkpoint_fn, checkpoint_other_fn: Parsed or default filenames for primary and previous
             checkpoint files.
+
+    Raises:
+        ValueError: If a `checkpoint_fn` was specified, but `checkpoint` was False, if the
+            `checkpoint_fn` is not of the form filename.json, or if `checkout_fn` and
+            `checkpoint_other_fn` are the same filename.
     """
     if not checkpoint:
         if checkpoint_fn is not None or checkpoint_other_fn is not None:
@@ -481,7 +484,6 @@ class CheckpointFileOptions:
         protocols.to_json(obj, self.checkpoint_fn)
 
 
-# pylint: enable=missing-raises-doc
 def _needs_init_layer(grouped_settings: Dict[InitObsSetting, List[InitObsSetting]]) -> bool:
     """Helper function to go through init_states and determine if any of them need an
     initialization layer of single-qubit gates."""
@@ -491,8 +493,6 @@ def _needs_init_layer(grouped_settings: Dict[InitObsSetting, List[InitObsSetting
     return False
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def measure_grouped_settings(
     circuit: 'cirq.AbstractCircuit',
     grouped_settings: Dict[InitObsSetting, List[InitObsSetting]],
@@ -535,6 +535,10 @@ def measure_grouped_settings(
             data for each iteration of the sampling loop. See the documentation
             for `CheckpointFileOptions` for more. Load in these results with
             `cirq.read_json`.
+
+    Raises:
+        ValueError: If readout calibration is specified, but `readout_symmetrization
+            is not True.
     """
     if readout_calibrations is not None and not readout_symmetrization:
         raise ValueError("Readout calibration only works if `readout_symmetrization` is enabled.")
@@ -602,9 +606,6 @@ def measure_grouped_settings(
         checkpoint.maybe_to_json(list(accumulators.values()))
 
     return list(accumulators.values())
-
-
-# pylint: enable=missing-raises-doc
 
 
 _GROUPING_FUNCS: Dict[str, GROUPER_T] = {

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -303,7 +303,7 @@ class Sampler(metaclass=abc.ABCMeta):
             observable measured in the second sweep.
 
         Raises:
-            ValueError: If the number of samples was not positive, if not observables were
+            ValueError: If the number of samples was not positive, if empty observables were
                 supplied, or if the provided circuit has terminal measurements and
                 `permit_terminal_measurements` is true.
         """

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -142,7 +142,6 @@ class Sampler(metaclass=abc.ABCMeta):
 
         return pd.concat(results)
 
-    # pylint: enable=missing-raises-doc
     @abc.abstractmethod
     def run_sweep(
         self,
@@ -207,8 +206,6 @@ class Sampler(metaclass=abc.ABCMeta):
         """
         return self.run_sweep(program, params=params, repetitions=repetitions)
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def run_batch(
         self,
         programs: Sequence['cirq.AbstractCircuit'],
@@ -248,6 +245,10 @@ class Sampler(metaclass=abc.ABCMeta):
             the circuits, while each inner list contains the TrialResults
             for the corresponding circuit, in the order imposed by the
             associated parameter sweep.
+
+        Raises:
+            ValueError: If length of `programs` is not equal to the length
+                of `params_list` or the length of `repetitions`.
         """
         if params_list is None:
             params_list = [None] * len(programs)
@@ -300,6 +301,11 @@ class Sampler(metaclass=abc.ABCMeta):
             A list of expectation-value lists. The outer index determines the sweep, and the inner
             index determines the observable. For instance, results[1][3] would select the fourth
             observable measured in the second sweep.
+
+        Raises:
+            ValueError: If the number of samples was not positive, if not observables were
+                supplied, or if the provided circuit has terminal measurements and
+                `permit_terminal_measurements` is true.
         """
         if num_samples <= 0:
             raise ValueError(

--- a/cirq-google/cirq_google/api/v1/programs.py
+++ b/cirq-google/cirq_google/api/v1/programs.py
@@ -285,8 +285,6 @@ def is_native_xmon_gate(gate: cirq.Gate) -> bool:
     )
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def xmon_op_from_proto(proto: operations_pb2.Operation) -> cirq.Operation:
     """Convert the proto to the corresponding operation.
 
@@ -297,6 +295,9 @@ def xmon_op_from_proto(proto: operations_pb2.Operation) -> cirq.Operation:
 
     Returns:
         The operation.
+
+    Raises:
+        ValueError: If the proto has an operation that is invalid.
     """
     param = _parameterized_value_from_proto
     qubit = _qubit_from_proto
@@ -321,7 +322,6 @@ def xmon_op_from_proto(proto: operations_pb2.Operation) -> cirq.Operation:
     raise ValueError(f'invalid operation: {proto}')
 
 
-# pylint: enable=missing-raises-doc
 def _qubit_from_proto(proto: operations_pb2.Qubit):
     return cirq.GridQubit(row=proto.row, col=proto.col)
 

--- a/cirq-google/cirq_google/calibration/phased_fsim.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim.py
@@ -341,8 +341,6 @@ class PhasedFSimCalibrationResult:
         }
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def merge_matching_results(
     results: Iterable[PhasedFSimCalibrationResult],
 ) -> Optional[PhasedFSimCalibrationResult]:
@@ -356,6 +354,10 @@ def merge_matching_results(
     Returns:
         New PhasedFSimCalibrationResult that contains all the parameters from every result in
         results or None when the results list is empty.
+
+    Raises:
+        ValueError: If the gate and options fields are not all equal, or if the
+            results have shared keys.
     """
     all_parameters: Dict[Tuple[cirq.Qid, cirq.Qid], PhasedFSimCharacterization] = {}
     common_gate = None
@@ -387,7 +389,6 @@ def merge_matching_results(
     return PhasedFSimCalibrationResult(all_parameters, common_gate, common_options)
 
 
-# pylint: enable=missing-raises-doc
 class PhasedFSimCalibrationError(Exception):
     """Error that indicates the calibration failure."""
 

--- a/cirq-google/cirq_google/engine/calibration.py
+++ b/cirq-google/cirq_google/engine/calibration.py
@@ -253,8 +253,6 @@ class Calibration(abc.Mapping):
             + f'{key} has target qubits {value_map.keys()}'
         )
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
     def plot_histograms(
         self,
         keys: Sequence[str],
@@ -267,6 +265,7 @@ class Calibration(abc.Mapping):
         Args:
             keys: List of metric keys for which an integrated histogram should be plot
             ax: The axis to plot on. If None, we generate one.
+            labels: Optional label that will be used in the legend.
 
         Returns:
             The axis that was plotted on.
@@ -303,7 +302,6 @@ class Calibration(abc.Mapping):
 
         return ax
 
-    # pylint: enable=missing-param-doc
     def plot(
         self, key: str, fig: Optional[mpl.figure.Figure] = None
     ) -> Tuple[mpl.figure.Figure, List[plt.Axes]]:

--- a/cirq-google/cirq_google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
+++ b/cirq-google/cirq_google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
@@ -30,8 +30,6 @@ class QuantumEngineServiceGrpcTransport(object):
     # in this service.
     _OAUTH_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def __init__(self, channel=None, credentials=None, address='quantum.googleapis.com:443'):
         """Instantiate the transport class.
 
@@ -45,6 +43,9 @@ class QuantumEngineServiceGrpcTransport(object):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
             address (str): The address where the service is hosted.
+
+        Raises:
+            ValueError: If both `channel` and `credentials` are given.
         """
         # If both `channel` and `credentials` are specified, raise an
         # exception (channels come with credentials baked in already).
@@ -72,7 +73,6 @@ class QuantumEngineServiceGrpcTransport(object):
             'quantum_engine_service_stub': engine_pb2_grpc.QuantumEngineServiceStub(channel),
         }
 
-    # pylint: enable=missing-raises-doc
     @classmethod
     def create_channel(cls, address='quantum.googleapis.com:443', credentials=None, **kwargs):
         """Create and return a gRPC channel object.

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -77,9 +77,6 @@ class EngineContext:
     simply create an Engine object instead of working with one of these
     directly."""
 
-    # TODO(#3388) Add documentation for Args.
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-param-doc,missing-raises-doc
     def __init__(
         self,
         proto_version: Optional[ProtoVersion] = None,
@@ -97,8 +94,14 @@ class EngineContext:
                 configure options on the underlying client.
             verbose: Suppresses stderr messages when set to False. Default is
                 true.
+            client: The engine client to use, if not supplied one will be
+                created.
             timeout: Timeout for polling for results, in seconds.  Default is
                 to never timeout.
+
+        Raises:
+            ValueError: If either `service_args` and `verbose` were supplied
+                or `client` was supplied, or if proto version 1 is specified.
         """
         if (service_args or verbose) and client:
             raise ValueError('either specify service_args and verbose or client')

--- a/cirq-google/cirq_google/optimizers/two_qubit_gates/gate_compilation.py
+++ b/cirq-google/cirq_google/optimizers/two_qubit_gates/gate_compilation.py
@@ -298,8 +298,6 @@ def _tabulate_kak_vectors(
     return _TabulationStepResult(kept_kaks, kept_cycles)
 
 
-# TODO(#3388) Add documentation for Raises.
-# pylint: disable=missing-raises-doc
 def gate_product_tabulation(
     base_gate: np.ndarray,
     max_infidelity: float,
@@ -328,6 +326,10 @@ def gate_product_tabulation(
     Returns:
         A GateTabulation object used to compile new two-qubit gates from
         products of the base gate with 1-local unitaries.
+
+    Raises:
+        ValueError: If `allow_missed_points` is False and not all points
+            in the Weyl chamber were compilable using 2 or 3 base gates.
     """
     rng = value.parse_random_state(random_state)
 
@@ -478,6 +480,3 @@ def gate_product_tabulation(
     return GateTabulation(
         base_gate, kak_vecs, sq_cycles, max_infidelity, summary, tuple(missed_points)
     )
-
-
-# pylint: enable=missing-raises-doc

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -132,8 +132,6 @@ class GateOpSerializer(OpSerializer):
             on the Operation proto.  Defaults to True.
     """
 
-    # TODO(#3388) Add documentation for Args.
-    # pylint: disable=missing-param-doc
     def __init__(
         self,
         *,
@@ -148,14 +146,16 @@ class GateOpSerializer(OpSerializer):
         Args:
             gate_type: The type of the gate that is being serialized.
             serialized_gate_id: The string id of the gate when serialized.
+            args: A list of specification of the arguments to the gate when
+                serializing, including how to get this information from the
+                gate of the given gate type.
             can_serialize_predicate: Sometimes an Operation can only be
                 serialized for particular parameters. This predicate will be
                 checked before attempting to serialize the Operation. If the
                 predicate is False, serialization will result in a None value.
                 Default value is a lambda that always returns True.
-            args: A list of specification of the arguments to the gate when
-                serializing, including how to get this information from the
-                gate of the given gate type.
+            serialize_tokens: Whether to convert calibration tags into tokens
+                on the Operation proto.
         """
         self._gate_type = gate_type
         self._serialized_gate_id = serialized_gate_id
@@ -163,7 +163,6 @@ class GateOpSerializer(OpSerializer):
         self._can_serialize_predicate = can_serialize_predicate
         self._serialize_tokens = serialize_tokens
 
-    # pylint: enable=missing-param-doc
     @property
     def internal_type(self):
         return self._gate_type

--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -261,8 +261,6 @@ class _IonQClient:
         )
         return cast(str, target or self.default_target)
 
-    # TODO(#3388) Add documentation for Raises.
-    # pylint: disable=missing-raises-doc
     def _make_request(self, request: Callable[[], requests.Response]) -> requests.Response:
         """Make a request to the API, retrying if necessary.
 
@@ -274,7 +272,9 @@ class _IonQClient:
 
         Raises:
             IonQException: If there was a not-retriable error from the API.
+            IonQNotFoundException: If the api returned not found.
             TimeoutError: If the requests retried for more than `max_retry_seconds`.
+
         """
         # Initial backoff of 100ms.
         delay_seconds = 0.1
@@ -315,7 +315,6 @@ class _IonQClient:
             time.sleep(delay_seconds)
             delay_seconds *= 2
 
-    # pylint: enable=missing-raises-doc
     def _list(
         self, resource_path: str, params: dict, response_key: str, limit: int, batch_size: int
     ) -> List[Dict]:


### PR DESCRIPTION
Believe this is the last of the lint.

* Note that `GridQid` needed to use a raw string due to the `\n` in the text.

Fixes: #3388 