### PR TITLE
Always use bash arrays for changed files and directories

### DIFF
--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -53,16 +53,17 @@ else
     rev="${base}"
 fi
 
-changed=$(git diff --name-only ${rev} -- \
+typeset -a changed
+IFS=$'\n' read -r -d '' -a changed < \
+    <(git diff --name-only ${rev} -- \
     | grep -E "^(cirq|dev_tools|examples).*.py$"
 )
 
-num_changed=$(echo -e "${changed[@]}" | wc -w)
+num_changed=${#changed[@]}
 
 # Run it.
 echo "Found ${num_changed} lintable files associated with changes." >&2
 if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
-env PYTHONPATH=dev_tools pylint --rcfile=dev_tools/conf/.pylintrc ${changed[@]}
-
+env PYTHONPATH=dev_tools pylint --rcfile=dev_tools/conf/.pylintrc "${changed[@]}"

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -53,7 +53,9 @@ fi
 echo "Comparing against revision '${rev}'." >&2
 
 # Get the _test version of changed python files.
-changed=$(git diff --name-only ${rev} -- \
+typeset -a changed
+IFS=$'\n' read -r -d '' -a changed < \
+    <(git diff --name-only ${rev} -- \
     | grep "\.py$" \
     | sed -e "s/\.py$/_test.py/" \
     | sed -e "s/_test_test\.py$/_test.py/" \
@@ -65,7 +67,7 @@ if git diff --name-only "${rev}" -- | grep "__init__\.py$" > /dev/null; then
   # Include global API tests when an __init__ file is touched.
   changed+=('cirq-core/cirq/protocols/json_serialization_test.py')
 fi
-num_changed=$(echo -e "${changed[@]}" | wc -w)
+num_changed=${#changed[@]}
 
 # Run it.
 echo "Found ${num_changed} test files associated with changes." >&2
@@ -75,4 +77,4 @@ fi
 
 source dev_tools/pypath
 
-pytest ${rest} ${changed[@]}
+pytest ${rest} "${changed[@]}"

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -58,7 +58,9 @@ else
 fi
 
 # Find involved files.
-cov_changed_python_file_dirs=$(git diff --name-only "${rev}" -- \
+typeset -a cov_changed_python_file_dirs
+IFS=$'\n' read -r -d '' -a cov_changed_python_file_dirs < \
+    <(git diff --name-only "${rev}" -- \
     | grep "\.py$" \
     | grep -v "_pb2\.py$" \
     | xargs -I {} dirname {} \
@@ -66,7 +68,9 @@ cov_changed_python_file_dirs=$(git diff --name-only "${rev}" -- \
     | sort \
     | uniq \
 )
-changed_python_tests=$(git diff --name-only "${rev}" -- \
+typeset -a changed_python_tests
+IFS=$'\n' read -r -d '' -a changed_python_tests < \
+    <(git diff --name-only "${rev}" -- \
     | grep "\.py$" \
     | sed -e "s/\.py$/_test.py/" \
     | sed -e "s/_test_test\.py$/_test.py/" \


### PR DESCRIPTION
Store changed paths in bash arrays by splitting diff output at newlines.
Avoid scalars that need to be split and may perform wildcard expansion.

Ref: https://www.baeldung.com/linux/reading-output-into-array#using-theread-command