### PR TITLE
Move "cirq_type" responsibility to protocols

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -329,7 +329,6 @@ class CircuitOperation(ops.Operation):
 
     def _json_dict_(self):
         return {
-            'cirq_type': 'CircuitOperation',
             'circuit': self.circuit,
             'repetitions': self.repetitions,
             # JSON requires mappings to have keys of basic types.

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -484,7 +484,6 @@ def test_json_dict():
     )
 
     assert op._json_dict_() == {
-        'cirq_type': 'CircuitOperation',
         'circuit': circuit,
         'repetitions': 1,
         'qubit_map': sorted([(k, v) for k, v in op.qubit_map.items()]),

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4212,7 +4212,6 @@ def test_json_dict(circuit_cls):
     if circuit_cls == cirq.FrozenCircuit:
         moments = tuple(moments)
     assert c._json_dict_() == {
-        'cirq_type': circuit_cls.__name__,
         'moments': moments,
         'device': cirq.UNCONSTRAINED_DEVICE,
     }

--- a/cirq-core/cirq/devices/device.py
+++ b/cirq-core/cirq/devices/device.py
@@ -164,7 +164,6 @@ class SymmetricalQidPair:
     def _json_dict_(self):
         return {
             'qids': sorted(self.qids),
-            'cirq_type': self.__class__.__name__,
         }
 
     @classmethod

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -321,13 +321,11 @@ def test_neg():
 
 def test_to_json():
     assert cirq.GridQubit(5, 6)._json_dict_() == {
-        'cirq_type': 'GridQubit',
         'row': 5,
         'col': 6,
     }
 
     assert cirq.GridQid(5, 6, dimension=3)._json_dict_() == {
-        'cirq_type': 'GridQid',
         'row': 5,
         'col': 6,
         'dimension': 3,

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -214,11 +214,9 @@ def test_neg():
 
 def test_json_dict():
     assert cirq.LineQubit(5)._json_dict_() == {
-        'cirq_type': 'LineQubit',
         'x': 5,
     }
     assert cirq.LineQid(5, 3)._json_dict_() == {
-        'cirq_type': 'LineQid',
         'x': 5,
         'dimension': 3,
     }

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -13,22 +13,17 @@
 # limitations under the License.
 
 import abc
-import dataclasses
 import warnings
 from dataclasses import dataclass
 from typing import Dict, List, Tuple, Any, Sequence, Union, Iterable, TYPE_CHECKING
 
 import networkx as nx
 from cirq.devices import GridQubit, LineQubit
-from cirq.protocols.json_serialization import obj_to_dict_helper
+from cirq.protocols.json_serialization import dataclass_json_dict
 from matplotlib import pyplot as plt
 
 if TYPE_CHECKING:
     import cirq
-
-
-def dataclass_json_dict(obj: Any, namespace: str = None) -> Dict[str, Any]:
-    return obj_to_dict_helper(obj, [f.name for f in dataclasses.fields(obj)], namespace=namespace)
 
 
 class NamedTopology(metaclass=abc.ABCMeta):

--- a/cirq-core/cirq/experiments/cross_entropy_benchmarking.py
+++ b/cirq-core/cirq/experiments/cross_entropy_benchmarking.py
@@ -253,7 +253,6 @@ class CrossEntropyResultDict(Mapping[Tuple['cirq.Qid', ...], CrossEntropyResult]
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'results': list(self.results.items()),
         }
 

--- a/cirq-core/cirq/experiments/single_qubit_readout_calibration.py
+++ b/cirq-core/cirq/experiments/single_qubit_readout_calibration.py
@@ -45,7 +45,6 @@ class SingleQubitReadoutCalibrationResult:
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'zero_state_errors': list(self.zero_state_errors.items()),
             'one_state_errors': list(self.one_state_errors.items()),
             'repetitions': self.repetitions,

--- a/cirq-core/cirq/ops/boolean_hamiltonian.py
+++ b/cirq-core/cirq/ops/boolean_hamiltonian.py
@@ -94,7 +94,6 @@ class BooleanHamiltonian(raw_types.Operation):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'qubit_map': self._qubit_map,
             'boolean_strs': self._boolean_strs,
             'theta': self._theta,

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -488,7 +488,6 @@ class SingleQubitCliffordGate(gate_features.SingleQubitGate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         json_dict = self._clifford_tableau._json_dict_()
-        json_dict['cirq_type'] = self.__class__.__name__
         return json_dict
 
     def _circuit_diagram_info_(

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -318,7 +318,6 @@ class Rx(XPowGate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'rads': self._rads,
         }
 
@@ -539,7 +538,6 @@ class Ry(YPowGate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'rads': self._rads,
         }
 
@@ -825,7 +823,6 @@ class Rz(ZPowGate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'rads': self._rads,
         }
 

--- a/cirq-core/cirq/ops/controlled_gate.py
+++ b/cirq-core/cirq/ops/controlled_gate.py
@@ -260,7 +260,6 @@ class ControlledGate(raw_types.Gate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'control_values': self.control_values,
             'control_qid_shape': self.control_qid_shape,
             'sub_gate': self.sub_gate,

--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -254,7 +254,6 @@ class ControlledOperation(raw_types.Operation):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'controls': self.controls,
             'control_values': self.control_values,
             'sub_operation': self.sub_operation,

--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -42,7 +42,6 @@ class QuantumFourierTransformGate(raw_types.Gate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'num_qubits': self._num_qubits,
             'without_reverse': self._without_reverse,
         }
@@ -98,7 +97,6 @@ class PhaseGradientGate(raw_types.Gate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'num_qubits': self._num_qubits,
             'exponent': self.exponent,
         }

--- a/cirq-core/cirq/ops/fsim_gate_test.py
+++ b/cirq-core/cirq/ops/fsim_gate_test.py
@@ -278,7 +278,6 @@ def test_fsim_repr():
 
 def test_fsim_json_dict():
     assert cirq.FSimGate(theta=0.123, phi=0.456)._json_dict_() == {
-        'cirq_type': 'FSimGate',
         'theta': 0.123,
         'phi': 0.456,
     }
@@ -799,7 +798,6 @@ def test_phased_fsim_json_dict():
     assert cirq.PhasedFSimGate(
         theta=0.12, zeta=0.34, chi=0.56, gamma=0.78, phi=0.9
     )._json_dict_() == {
-        'cirq_type': 'PhasedFSimGate',
         'theta': 0.12,
         'zeta': 0.34,
         'chi': 0.56,

--- a/cirq-core/cirq/ops/global_phase_op_test.py
+++ b/cirq-core/cirq/ops/global_phase_op_test.py
@@ -268,6 +268,5 @@ global phase:   -0.5π
 
 def test_global_phase_op_json_dict():
     assert cirq.GlobalPhaseOperation(-1j)._json_dict_() == {
-        'cirq_type': 'GlobalPhaseOperation',
         'coefficient': -1j,
     }

--- a/cirq-core/cirq/ops/identity.py
+++ b/cirq-core/cirq/ops/identity.py
@@ -115,7 +115,6 @@ class IdentityGate(raw_types.Gate):
         if not all(d == 2 for d in self._qid_shape):
             other['qid_shape'] = self._qid_shape
         return {
-            'cirq_type': self.__class__.__name__,
             'num_qubits': len(self._qid_shape),
             **other,
         }

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -783,7 +783,6 @@ class ProjectorSum:
             key = [[k, v] for k, v in dict(projector_dict).items()]
             linear_dict.append([key, scalar])
         return {
-            'cirq_type': self.__class__.__name__,
             'linear_dict': linear_dict,
         }
 

--- a/cirq-core/cirq/ops/matrix_gates.py
+++ b/cirq-core/cirq/ops/matrix_gates.py
@@ -84,7 +84,6 @@ class MatrixGate(raw_types.Gate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'matrix': self._matrix.tolist(),
             'qid_shape': self._qid_shape,
         }

--- a/cirq-core/cirq/ops/measurement_gate.py
+++ b/cirq-core/cirq/ops/measurement_gate.py
@@ -229,7 +229,6 @@ class MeasurementGate(raw_types.Gate):
         if not all(d == 2 for d in self._qid_shape):
             other['qid_shape'] = self._qid_shape
         return {
-            'cirq_type': self.__class__.__name__,
             'num_qubits': len(self._qid_shape),
             'key': self.key,
             'invert_mask': self.invert_mask,

--- a/cirq-core/cirq/ops/moment_test.py
+++ b/cirq-core/cirq/ops/moment_test.py
@@ -374,7 +374,7 @@ def test_json_dict():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     mom = cirq.Moment([cirq.CZ(a, b)])
-    assert mom._json_dict_() == {'cirq_type': 'Moment', 'operations': (cirq.CZ(a, b),)}
+    assert mom._json_dict_() == {'operations': (cirq.CZ(a, b),)}
 
 
 def test_inverse():

--- a/cirq-core/cirq/ops/named_qubit_test.py
+++ b/cirq-core/cirq/ops/named_qubit_test.py
@@ -136,12 +136,10 @@ def test_named_qid_range():
 
 def test_to_json():
     assert cirq.NamedQubit('c')._json_dict_() == {
-        'cirq_type': 'NamedQubit',
         'name': 'c',
     }
 
     assert cirq.NamedQid('c', dimension=3)._json_dict_() == {
-        'cirq_type': 'NamedQid',
         'name': 'c',
         'dimension': 3,
     }

--- a/cirq-core/cirq/ops/pauli_measurement_gate.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate.py
@@ -149,7 +149,6 @@ class PauliMeasurementGate(raw_types.Gate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'observable': self._observable,
             'key': self.key,
         }

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -177,7 +177,6 @@ class PauliString(raw_types.Operation, Generic[TKey]):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             # JSON requires mappings to have string keys.
             'qubit_pauli_map': list(self._qubit_pauli_map.items()),
             'coefficient': self.coefficient,
@@ -1294,7 +1293,6 @@ class MutablePauliString(Generic[TKey]):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             # JSON requires mappings to have string keys.
             'pauli_int_dict': list(self.pauli_int_dict.items()),
             'coefficient': self.coefficient,

--- a/cirq-core/cirq/ops/permutation_gate_test.py
+++ b/cirq-core/cirq/ops/permutation_gate_test.py
@@ -71,7 +71,6 @@ def test_permutation_gate_diagram():
 
 def test_permutation_gate_json_dict():
     assert cirq.QubitPermutationGate([0, 1, 2])._json_dict_() == {
-        'cirq_type': 'QubitPermutationGate',
         'permutation': (0, 1, 2),
     }
 

--- a/cirq-core/cirq/ops/phased_iswap_gate.py
+++ b/cirq-core/cirq/ops/phased_iswap_gate.py
@@ -76,7 +76,6 @@ class PhasedISwapPowGate(eigen_gate.EigenGate):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'phase_exponent': self._phase_exponent,
             'exponent': self._exponent,
         }

--- a/cirq-core/cirq/ops/projector.py
+++ b/cirq-core/cirq/ops/projector.py
@@ -148,7 +148,6 @@ class ProjectorString:
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'projector_dict': list(self._projector_dict.items()),
             'coefficient': self._coefficient,
         }

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -73,7 +73,6 @@ def test_wrapped_qid():
     assert str(ValidQubit('a').with_dimension(3)) == 'TQ_a (d=3)'
 
     assert ValidQubit('zz').with_dimension(3)._json_dict_() == {
-        'cirq_type': '_QubitAsQid',
         'qubit': ValidQubit('zz'),
         'dimension': 3,
     }
@@ -370,9 +369,7 @@ def test_operation_shape():
 
 def test_gate_json_dict():
     g = cirq.CSWAP  # not an eigen gate (which has its own _json_dict_)
-    assert g._json_dict_() == {
-        'cirq_type': 'CSwapGate',
-    }
+    assert g._json_dict_() == {}
 
 
 def test_inverse_composite_diagram_info():

--- a/cirq-core/cirq/ops/state_preparation_channel.py
+++ b/cirq-core/cirq/ops/state_preparation_channel.py
@@ -60,7 +60,6 @@ class StatePreparationChannel(raw_types.Gate):
     def _json_dict_(self) -> Dict[str, Any]:
         """Converts the gate object into a serializable dictionary"""
         return {
-            'cirq_type': self.__class__.__name__,
             'target_state': self._state.tolist(),
             'name': self._name,
         }

--- a/cirq-core/cirq/ops/tags.py
+++ b/cirq-core/cirq/ops/tags.py
@@ -33,4 +33,4 @@ class VirtualTag:
         return 'cirq.VirtualTag()'
 
     def _json_dict_(self) -> Dict[str, str]:
-        return {'cirq_type': self.__class__.__name__}
+        return {}

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -75,6 +75,76 @@ def _get_testspecs_for_modules() -> List[ModuleJsonTestSpec]:
 MODULE_TEST_SPECS = _get_testspecs_for_modules()
 
 
+def test_deprecated_cirq_type_in_json_dict():
+    class HasOldJsonDict:
+        def __eq__(self, other):
+            return isinstance(other, HasOldJsonDict)
+
+        def _json_dict_(self):
+            return {'cirq_type': 'cirq.testing.HasOldJsonDict'}
+
+        @classmethod
+        def _from_json_dict_(cls, **kwargs):
+            return cls()
+
+    def custom_resolver(name):
+        if name == 'cirq.testing.HasOldJsonDict':
+            return HasOldJsonDict
+
+    test_resolvers = [custom_resolver] + cirq.DEFAULT_RESOLVERS
+    with cirq.testing.assert_deprecated("Found 'cirq_type'", deadline='v0.15'):
+        assert_json_roundtrip_works(HasOldJsonDict(), resolvers=test_resolvers)
+
+
+def test_deprecated_obj_to_dict_helper_namespace():
+    class HasOldJsonDict:
+        def __init__(self, x):
+            self.x = x
+
+        def __eq__(self, other):
+            return isinstance(other, HasOldJsonDict) and other.x == self.x
+
+        def _json_dict_(self):
+            return json_serialization.obj_to_dict_helper(self, ['x'], namespace='cirq.testing')
+
+        @classmethod
+        def _from_json_dict_(cls, x, **kwargs):
+            return cls(x)
+
+    def custom_resolver(name):
+        if name == 'cirq.testing.HasOldJsonDict':
+            return HasOldJsonDict
+
+    test_resolvers = [custom_resolver] + cirq.DEFAULT_RESOLVERS
+    with cirq.testing.assert_deprecated(
+        "Found 'cirq_type'", 'Define obj._json_namespace_', deadline='v0.15', count=3
+    ):
+        assert_json_roundtrip_works(HasOldJsonDict(1), resolvers=test_resolvers)
+
+
+def test_deprecated_dataclass_json_dict_namespace():
+    @dataclasses.dataclass
+    class HasOldJsonDict:
+        x: int
+
+        def _json_dict_(self):
+            return json_serialization.dataclass_json_dict(self, namespace='cirq.testing')
+
+        @classmethod
+        def _from_json_dict_(cls, x, **kwargs):
+            return cls(x)
+
+    def custom_resolver(name):
+        if name == 'cirq.testing.HasOldJsonDict':
+            return HasOldJsonDict
+
+    test_resolvers = [custom_resolver] + cirq.DEFAULT_RESOLVERS
+    with cirq.testing.assert_deprecated(
+        "Found 'cirq_type'", 'Define obj._json_namespace_', deadline='v0.15', count=5
+    ):
+        assert_json_roundtrip_works(HasOldJsonDict(1), resolvers=test_resolvers)
+
+
 def test_line_qubit_roundtrip():
     q1 = cirq.LineQubit(12)
     assert_json_roundtrip_works(

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -360,7 +360,6 @@ class SBKImpl(cirq.SerializableByKey):
 
     def _json_dict_(self):
         return {
-            "cirq_type": "SBKImpl",
             "name": self.name,
             "data_list": self.data_list,
             "data_tuple": self.data_tuple,
@@ -540,7 +539,6 @@ class SerializableTypeObject:
 
     def _json_dict_(self):
         return {
-            # 'cirq_type': 'SerializableTypeObject',
             'test_type': json_serialization.json_cirq_type(self.test_type),
         }
 

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -540,7 +540,7 @@ class SerializableTypeObject:
 
     def _json_dict_(self):
         return {
-            'cirq_type': 'SerializableTypeObject',
+            # 'cirq_type': 'SerializableTypeObject',
             'test_type': json_serialization.json_cirq_type(self.test_type),
         }
 

--- a/cirq-core/cirq/qis/clifford_tableau_test.py
+++ b/cirq-core/cirq/qis/clifford_tableau_test.py
@@ -234,7 +234,6 @@ def test_json_dict():
     assert t.stabilizers()[0] == cirq.DensePauliString('Z', coefficient=1)
     json_dict = t._json_dict_()
     except_json_dict = {
-        'cirq_type': 'CliffordTableau',
         'n': 1,
         'rs': [False, False],
         'xs': [[True], [False]],

--- a/cirq-core/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator.py
@@ -208,7 +208,6 @@ class CliffordState:
 
     def _json_dict_(self):
         return {
-            'cirq_type': self.__class__.__name__,
             'qubit_map': [(k, v) for k, v in self.qubit_map.items()],
             'ch_form': self.ch_form,
         }

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -233,7 +233,6 @@ class ParamResolver:
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             # JSON requires mappings to have keys of basic types.
             'param_dict': list(self.param_dict.items()),
         }

--- a/cirq-core/cirq/study/result.py
+++ b/cirq-core/cirq/study/result.py
@@ -324,7 +324,6 @@ class Result:
                 'shape': digits.shape,
             }
         return {
-            'cirq_type': self.__class__.__name__,
             'params': self.params,
             'measurements': packed_measurements,
         }

--- a/cirq-core/cirq/testing/no_identifier_qubit_test.py
+++ b/cirq-core/cirq/testing/no_identifier_qubit_test.py
@@ -27,6 +27,4 @@ def test_comparsion_key():
 
 
 def test_to_json():
-    assert cirq.testing.NoIdentifierQubit()._json_dict_() == {
-        'cirq_type': 'NoIdentifierQubit',
-    }
+    assert cirq.testing.NoIdentifierQubit()._json_dict_() == {}

--- a/cirq-core/cirq/value/duration.py
+++ b/cirq-core/cirq/value/duration.py
@@ -242,7 +242,7 @@ class Duration:
         return f'cirq.Duration({unit}={proper_repr(amount)})'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return {'cirq_type': self.__class__.__name__, 'picos': self.total_picos()}
+        return {'picos': self.total_picos()}
 
 
 def _attempt_duration_like_to_duration(value: Any) -> Optional[Duration]:

--- a/cirq-core/cirq/value/duration_test.py
+++ b/cirq-core/cirq/value/duration_test.py
@@ -177,7 +177,7 @@ def test_div():
 
 def test_json_dict():
     d = Duration(picos=6)
-    assert d._json_dict_() == {'cirq_type': 'Duration', 'picos': 6}
+    assert d._json_dict_() == {'picos': 6}
 
 
 def test_str():

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -312,7 +312,6 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
         if self._has_validator:
             raise ValueError('LinearDict with a validator is not json serializable.')
         return {
-            'cirq_type': self.__class__.__name__,
             'keys': [k for k in self._terms.keys()],
             'values': [v for v in self._terms.values()],
         }

--- a/cirq-core/cirq/value/measurement_key.py
+++ b/cirq-core/cirq/value/measurement_key.py
@@ -79,7 +79,6 @@ class MeasurementKey:
 
     def _json_dict_(self):
         return {
-            'cirq_type': 'MeasurementKey',
             'name': self.name,
             'path': self.path,
         }

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -72,9 +72,9 @@ def test_repr():
 
 def test_json_dict():
     mkey = cirq.MeasurementKey('key')
-    assert mkey._json_dict_() == {'cirq_type': 'MeasurementKey', 'name': 'key', 'path': tuple()}
+    assert mkey._json_dict_() == {'name': 'key', 'path': tuple()}
     mkey = cirq.MeasurementKey.parse_serialized('nested:key')
-    assert mkey._json_dict_() == {'cirq_type': 'MeasurementKey', 'name': 'key', 'path': ('nested',)}
+    assert mkey._json_dict_() == {'name': 'key', 'path': ('nested',)}
 
 
 def test_with_key_path():

--- a/cirq-core/cirq/value/product_state.py
+++ b/cirq-core/cirq/value/product_state.py
@@ -114,7 +114,6 @@ class ProductState:
 
     def _json_dict_(self):
         return {
-            'cirq_type': self.__class__.__name__,
             'states': list(self.states.items()),
         }
 

--- a/cirq-core/cirq/work/observable_measurement_data.py
+++ b/cirq-core/cirq/work/observable_measurement_data.py
@@ -316,7 +316,6 @@ class BitstringAccumulator:
             return _pack_digits(a, pack_bits='never')[0]
 
         return {
-            'cirq_type': self.__class__.__name__,
             'meas_spec': self.meas_spec,
             'simul_settings': self.simul_settings,
             'qubit_to_index': list(self.qubit_to_index.items()),

--- a/cirq-google/cirq_google/calibration/phased_fsim.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim.py
@@ -331,7 +331,6 @@ class PhasedFSimCalibrationResult:
     def _json_dict_(self) -> Dict[str, Any]:
         """Magic method for the JSON serialization protocol."""
         return {
-            'cirq_type': 'PhasedFSimCalibrationResult',
             'gate': self.gate,
             'parameters': [(q_a, q_b, params) for (q_a, q_b), params in self.parameters.items()],
             'options': self.options,
@@ -747,7 +746,6 @@ class FloquetPhasedFSimCalibrationRequest(PhasedFSimCalibrationRequest):
     def _json_dict_(self) -> Dict[str, Any]:
         """Magic method for the JSON serialization protocol."""
         return {
-            'cirq_type': 'FloquetPhasedFSimCalibrationRequest',
             'pairs': [(pair[0], pair[1]) for pair in self.pairs],
             'gate': self.gate,
             'options': self.options,

--- a/cirq-google/cirq_google/devices/known_devices.py
+++ b/cirq-google/cirq_google/devices/known_devices.py
@@ -206,7 +206,6 @@ class _NamedConstantXmonDevice(XmonDevice):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'constant': self._repr,
         }
 

--- a/cirq-google/cirq_google/devices/known_devices_test.py
+++ b/cirq-google/cirq_google/devices/known_devices_test.py
@@ -464,12 +464,10 @@ valid_targets {
 
 def test_json_dict():
     assert cirq_google.Foxtail._json_dict_() == {
-        'cirq_type': '_NamedConstantXmonDevice',
         'constant': 'cirq_google.Foxtail',
     }
 
     assert cirq_google.Bristlecone._json_dict_() == {
-        'cirq_type': '_NamedConstantXmonDevice',
         'constant': 'cirq_google.Bristlecone',
     }
 

--- a/cirq-google/cirq_google/engine/calibration.py
+++ b/cirq-google/cirq_google/engine/calibration.py
@@ -154,7 +154,7 @@ class Calibration(abc.Mapping):
 
     def _json_dict_(self) -> Dict[str, Any]:
         """Magic method for the JSON serialization protocol."""
-        return {'cirq_type': 'Calibration', 'metrics': json_format.MessageToDict(self.to_proto())}
+        return {'metrics': json_format.MessageToDict(self.to_proto())}
 
     def timestamp_str(self, tz: Optional[datetime.tzinfo] = None, timespec: str = 'auto') -> str:
         """Return a string for the calibration timestamp.

--- a/cirq-google/cirq_google/engine/calibration_result.py
+++ b/cirq-google/cirq_google/engine/calibration_result.py
@@ -66,7 +66,6 @@ class CalibrationResult:
             else None
         )
         return {
-            'cirq_type': 'CalibrationResult',
             'code': self.code,
             'error_message': self.error_message,
             'token': self.token,

--- a/cirq-google/cirq_google/optimizers/two_qubit_gates/gate_compilation.py
+++ b/cirq-google/cirq_google/optimizers/two_qubit_gates/gate_compilation.py
@@ -113,7 +113,6 @@ class GateTabulation:
 
     def _json_dict_(self):
         return {
-            'cirq_type': self.__class__.__name__,
             'base_gate': self.base_gate.tolist(),
             'kak_vecs': self.kak_vecs.tolist(),
             'single_qubit_gates': self.single_qubit_gates,

--- a/cirq-google/cirq_google/workflow/io.py
+++ b/cirq-google/cirq_google/workflow/io.py
@@ -71,7 +71,7 @@ class ExecutableGroupResultFilesystemRecord:
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')

--- a/cirq-google/cirq_google/workflow/quantum_executable.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable.py
@@ -58,7 +58,7 @@ class KeyValueExecutableSpec(ExecutableSpec):
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return cirq.dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return cirq.dataclass_json_dict(self)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any], *, executable_family: str) -> 'KeyValueExecutableSpec':
@@ -99,7 +99,7 @@ class BitstringsMeasurement:
         return 'cirq.google'
 
     def _json_dict_(self):
-        return cirq.dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return cirq.dataclass_json_dict(self)
 
     def __repr__(self):
         return cirq._compat.dataclass_repr(self, namespace='cirq_google')
@@ -211,7 +211,7 @@ class QuantumExecutable:
         return 'cirq.google'
 
     def _json_dict_(self):
-        return cirq.dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return cirq.dataclass_json_dict(self)
 
 
 @dataclass(frozen=True)
@@ -265,4 +265,4 @@ class QuantumExecutableGroup:
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return cirq.dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return cirq.dataclass_json_dict(self)

--- a/cirq-google/cirq_google/workflow/quantum_runtime.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime.py
@@ -48,7 +48,7 @@ class SharedRuntimeInfo:
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')
@@ -72,7 +72,7 @@ class RuntimeInfo:
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')
@@ -98,7 +98,7 @@ class ExecutableResult:
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return dataclass_json_dict(self, namespace=cirq.json_namespace(type(self)))
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')
@@ -122,8 +122,12 @@ class ExecutableGroupResult:
     shared_runtime_info: SharedRuntimeInfo
     executable_results: List[ExecutableResult]
 
+    @classmethod
+    def _json_namespace_(cls) -> str:
+        return 'cirq.google'
+
     def _json_dict_(self) -> Dict[str, Any]:
-        return dataclass_json_dict(self, namespace='cirq.google')
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')
@@ -144,8 +148,12 @@ class QuantumRuntimeConfiguration:
     processor: AbstractEngineProcessorShim
     run_id: Optional[str] = None
 
+    @classmethod
+    def _json_namespace_(cls) -> str:
+        return 'cirq.google'
+
     def _json_dict_(self) -> Dict[str, Any]:
-        return dataclass_json_dict(self, namespace='cirq.google')
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')

--- a/cirq-google/cirq_google/workflow/quantum_runtime_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime_test.py
@@ -33,8 +33,12 @@ class _MockEngineProcessor(AbstractEngineProcessorShim):
     def get_sampler(self) -> cirq.Sampler:
         return cirq.ZerosSampler()
 
+    @classmethod
+    def _json_namespace_(cls) -> str:
+        return 'cirq.google.testing'
+
     def _json_dict_(self):
-        return cirq.obj_to_dict_helper(self, attribute_names=[], namespace='cirq.google.testing')
+        return cirq.obj_to_dict_helper(self, attribute_names=[])
 
 
 def cg_assert_equivalent_repr(value):

--- a/cirq-pasqal/cirq_pasqal/pasqal_device_test.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_device_test.py
@@ -271,11 +271,10 @@ def test_repr():
 def test_to_json():
     dev = PasqalDevice(qubits=[cirq.NamedQubit('q4')])
     d = dev._json_dict_()
-    assert d == {"cirq_type": "PasqalDevice", "qubits": [cirq.NamedQubit('q4')]}
+    assert d == {"qubits": [cirq.NamedQubit('q4')]}
     vdev = PasqalVirtualDevice(control_radius=2, qubits=[TwoDQubit(0, 0)])
     d = vdev._json_dict_()
     assert d == {
-        "cirq_type": "PasqalVirtualDevice",
         "control_radius": 2,
         "qubits": [cirq_pasqal.TwoDQubit(0, 0)],
     }

--- a/cirq-pasqal/cirq_pasqal/pasqal_qubits_test.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_qubits_test.py
@@ -165,7 +165,6 @@ def test_to_json():
     q = ThreeDQubit(1.3, 1, 1)
     d = q._json_dict_()
     assert d == {
-        'cirq_type': 'ThreeDQubit',
         'x': 1.3,
         'y': 1,
         'z': 1,
@@ -173,7 +172,6 @@ def test_to_json():
     q = TwoDQubit(1.3, 1)
     d = q._json_dict_()
     assert d == {
-        'cirq_type': 'TwoDQubit',
         'x': 1.3,
         'y': 1,
     }

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -231,7 +231,6 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
 
     def _json_dict_(self):
         return {
-            'cirq_type': 'RigettiQCSAspenDevice',
             'isa': self.isa.to_dict(),
         }
 
@@ -386,7 +385,6 @@ class OctagonalQubit(cirq.ops.Qid):
 
     def _json_dict_(self):
         return {
-            'cirq_type': 'OctagonalQubit',
             'octagon_position': self.octagon_position,
         }
 
@@ -526,7 +524,6 @@ class AspenQubit(OctagonalQubit):
 
     def _json_dict_(self):
         return {
-            'cirq_type': 'AspenQubit',
             'octagon': self.octagon,
             'octagon_position': self.octagon_position,
         }


### PR DESCRIPTION
Fixes #4698.

This enforces the `'cirq_type': [<namespace>.]<classname>` convention for JSON serialization by assigning the "cirq_type" field in our protocols instead of in each class. Any external users who define a "cirq_type" will see a warning about this; after a deprecation cycle, we will begin raising errors to prevent explicit definition of "cirq_type" in classes.