### PR TITLE
pylint - enable check for f-string-without-interpolation

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -106,7 +106,7 @@ class CircuitOperation(ops.Operation):
             try:
                 protocols.inverse(self.circuit.unfreeze())
             except TypeError:
-                raise ValueError(f'repetitions are negative but the circuit is not invertible')
+                raise ValueError('repetitions are negative but the circuit is not invertible')
 
         # Initialize repetition_ids to default, if unspecified. Else, validate their length.
         loop_size = abs(self.repetitions)

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -359,7 +359,7 @@ def test_string_format():
     )
     assert (
         repr(op1)
-        == f"""\
+        == """\
 cirq.CircuitOperation(
     circuit=cirq.FrozenCircuit([
         cirq.Moment(
@@ -448,7 +448,7 @@ cirq.CircuitOperation(
     op5 = cirq.CircuitOperation(fc5)
     assert (
         repr(op5)
-        == f"""\
+        == """\
 cirq.CircuitOperation(
     circuit=cirq.FrozenCircuit([
         cirq.Moment(

--- a/cirq-core/cirq/contrib/routing/router.py
+++ b/cirq-core/cirq/contrib/routing/router.py
@@ -62,5 +62,5 @@ def route_circuit(
     if algo_name is not None:
         router = ROUTERS[algo_name]
     elif router is None:
-        raise ValueError(f'No routing algorithm specified.')
+        raise ValueError('No routing algorithm specified.')
     return router(circuit, device_graph, **kwargs)

--- a/cirq-core/cirq/interop/quirk/cells/input_rotation_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_rotation_cells.py
@@ -90,7 +90,7 @@ class InputRotationCell(Cell):
 
     def operations(self) -> 'cirq.OP_TREE':
         if self.register is None:
-            raise ValueError(f"Missing input 'a'")
+            raise ValueError("Missing input 'a'")
         return QuirkInputRotationOperation(
             self.identifier, self.register, self.base_operation, self.exponent_sign
         )

--- a/cirq-core/cirq/linalg/decompositions_test.py
+++ b/cirq-core/cirq/linalg/decompositions_test.py
@@ -564,7 +564,7 @@ def test_scatter_plot_normalized_kak_interaction_coefficients():
     ax = cirq.scatter_plot_normalized_kak_interaction_coefficients(data)
     assert ax is not None
     ax2 = cirq.scatter_plot_normalized_kak_interaction_coefficients(
-        data, s=1, c='blue', ax=ax, include_frame=False, label=f'test'
+        data, s=1, c='blue', ax=ax, include_frame=False, label='test'
     )
     assert ax2 is ax
 

--- a/cirq-core/cirq/ops/common_gate_families_test.py
+++ b/cirq-core/cirq/ops/common_gate_families_test.py
@@ -48,8 +48,8 @@ def test_any_unitary_gate_family():
                 assert f'{init_num_qubits}' in gate_family.description
                 assert UnitaryGate(num_qubits + 1) not in gate_family
             else:
-                assert f'Any-Qubit' in gate_family.name
-                assert f'any unitary' in gate_family.description
+                assert 'Any-Qubit' in gate_family.name
+                assert 'any unitary' in gate_family.description
 
     assert cirq.SingleQubitGate() not in cirq.AnyUnitaryGateFamily()
 

--- a/cirq-core/cirq/ops/state_preparation_channel_test.py
+++ b/cirq-core/cirq/ops/state_preparation_channel_test.py
@@ -114,7 +114,7 @@ def test_gate_params():
 def test_gate_error_handling():
     with pytest.raises(ValueError, match='`target_state` must be a 1d numpy array.'):
         cirq.StatePreparationChannel(np.eye(2))
-    with pytest.raises(ValueError, match=f'Matrix width \\(5\\) is not a power of 2'):
+    with pytest.raises(ValueError, match='Matrix width \\(5\\) is not a power of 2'):
         cirq.StatePreparationChannel(np.ones(shape=5))
 
 

--- a/cirq-core/cirq/optimizers/clifford_decomposition.py
+++ b/cirq-core/cirq/optimizers/clifford_decomposition.py
@@ -107,9 +107,7 @@ def decompose_clifford_tableau_to_operations(
         ValueError: The length of input qubit mismatch with the size of tableau.
     """
     if len(qubits) != clifford_tableau.n:
-        raise ValueError(
-            "The number of qubits must be the same as the number of Clifford Tableau."
-        )
+        raise ValueError("The number of qubits must be the same as the number of Clifford Tableau.")
     assert (
         clifford_tableau._validate()
     ), "The provided clifford_tableau must satisfy the symplectic property."

--- a/cirq-core/cirq/optimizers/clifford_decomposition.py
+++ b/cirq-core/cirq/optimizers/clifford_decomposition.py
@@ -108,7 +108,7 @@ def decompose_clifford_tableau_to_operations(
     """
     if len(qubits) != clifford_tableau.n:
         raise ValueError(
-            f"The number of qubits must be the same as the number of Clifford Tableau."
+            "The number of qubits must be the same as the number of Clifford Tableau."
         )
     assert (
         clifford_tableau._validate()

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -588,15 +588,11 @@ def test_invalid_type_deserialize():
             return SerializableTypeObject
 
     test_resolvers = [custom_resolver] + cirq.DEFAULT_RESOLVERS
-    invalid_json = (
-        '{\n  "cirq_type": "SerializableTypeObject",\n  "test_type": "bad_type"\n}'
-    )
+    invalid_json = '{\n  "cirq_type": "SerializableTypeObject",\n  "test_type": "bad_type"\n}'
     with pytest.raises(ValueError, match='Could not resolve type'):
         _ = cirq.read_json(json_text=invalid_json, resolvers=test_resolvers)
 
-    factory_json = (
-        '{\n  "cirq_type": "SerializableTypeObject",\n  "test_type": "sympy.Add"\n}'
-    )
+    factory_json = '{\n  "cirq_type": "SerializableTypeObject",\n  "test_type": "sympy.Add"\n}'
     with pytest.raises(ValueError, match='maps to a factory method'):
         _ = cirq.read_json(json_text=factory_json, resolvers=test_resolvers)
 

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -589,13 +589,13 @@ def test_invalid_type_deserialize():
 
     test_resolvers = [custom_resolver] + cirq.DEFAULT_RESOLVERS
     invalid_json = (
-        f'{{\n  "cirq_type": "SerializableTypeObject",\n' f'  "test_type": "bad_type"\n}}'
+        '{\n  "cirq_type": "SerializableTypeObject",\n  "test_type": "bad_type"\n}'
     )
     with pytest.raises(ValueError, match='Could not resolve type'):
         _ = cirq.read_json(json_text=invalid_json, resolvers=test_resolvers)
 
     factory_json = (
-        f'{{\n  "cirq_type": "SerializableTypeObject",\n' f'  "test_type": "sympy.Add"\n}}'
+        '{\n  "cirq_type": "SerializableTypeObject",\n  "test_type": "sympy.Add"\n}'
     )
     with pytest.raises(ValueError, match='maps to a factory method'):
         _ = cirq.read_json(json_text=factory_json, resolvers=test_resolvers)

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op.py
@@ -26,7 +26,7 @@ def assert_controlled_and_controlled_by_identical(
     """Checks that gate.on().controlled_by() == gate.controlled().on()"""
     if control_values is not None:
         if len(num_controls) != len(control_values):
-            raise ValueError(f"len(num_controls) != len(control_values)")
+            raise ValueError("len(num_controls) != len(control_values)")
     for i, num_control in enumerate(num_controls):
         control_value = control_values[i] if control_values else None
         if control_value is not None and len(control_value) != num_control:

--- a/cirq-core/cirq/testing/no_identifier_qubit.py
+++ b/cirq-core/cirq/testing/no_identifier_qubit.py
@@ -33,7 +33,7 @@ class NoIdentifierQubit(raw_types.Qid):
         return 2
 
     def __repr__(self) -> str:
-        return f'cirq.testing.NoIdentifierQubit()'
+        return 'cirq.testing.NoIdentifierQubit()'
 
     def _json_dict_(self) -> Dict[str, Any]:
         return protocols.obj_to_dict_helper(self, [])

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -63,10 +63,10 @@ def test_str(key_string):
 
 def test_repr():
     mkey = cirq.MeasurementKey('key_string')
-    assert repr(mkey) == f"cirq.MeasurementKey(name='key_string')"
+    assert repr(mkey) == "cirq.MeasurementKey(name='key_string')"
     assert eval(repr(mkey)) == mkey
     mkey = cirq.MeasurementKey.parse_serialized('nested:key')
-    assert repr(mkey) == f"cirq.MeasurementKey(path=('nested',), name='key')"
+    assert repr(mkey) == "cirq.MeasurementKey(path=('nested',), name='key')"
     assert eval(repr(mkey)) == mkey
 
 

--- a/cirq-google/cirq_google/calibration/phased_fsim.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim.py
@@ -379,7 +379,7 @@ def merge_matching_results(
             )
 
         if not all_parameters.keys().isdisjoint(result.parameters):
-            raise ValueError(f'Only results with disjoint parameters sets can be merged')
+            raise ValueError('Only results with disjoint parameters sets can be merged')
 
         all_parameters.update(result.parameters)
 

--- a/cirq-google/cirq_google/calibration/workflow.py
+++ b/cirq-google/cirq_google/calibration/workflow.py
@@ -220,8 +220,8 @@ def _list_moment_pairs_to_characterize(
         return None
     elif not permit_mixed_moments and other_operation:
         raise IncompatibleMomentError(
-            f'Moment contains mixed two-qubit operations and either single-qubit measurement or '
-            f'wait operations. See permit_mixed_moments option to relax this restriction.'
+            'Moment contains mixed two-qubit operations and either single-qubit measurement or '
+            'wait operations. See permit_mixed_moments option to relax this restriction.'
         )
 
     if sort_pairs:

--- a/cirq-ionq/cirq_ionq/service.py
+++ b/cirq-ionq/cirq_ionq/service.py
@@ -67,8 +67,8 @@ class Service:
         self.api_key = api_key or os.getenv('IONQ_API_KEY')
         if not self.api_key:
             raise EnvironmentError(
-                f'Parameter api_key was not specified and the environment variable '
-                f'IONQ_API_KEY was also not set.'
+                'Parameter api_key was not specified and the environment variable '
+                'IONQ_API_KEY was also not set.'
             )
 
         self._client = ionq_client._IonQClient(

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -169,13 +169,13 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
                     )
                 if not ((index % 10) <= 7):
                     raise UnsupportedQubit(
-                        f'this Aspen device only supports qubit indices mod 10 <= 7'
+                        'this Aspen device only supports qubit indices mod 10 <= 7'
                     )
                 return
 
             except ValueError:
                 raise UnsupportedQubit(
-                    f'Aspen devices only support named qubits by octagonal index'
+                    'Aspen devices only support named qubits by octagonal index'
                 )
 
         if isinstance(qubit, (OctagonalQubit, AspenQubit)):
@@ -495,7 +495,7 @@ class AspenQubit(OctagonalQubit):
             index = int(qubit.name)
             return AspenQubit.from_aspen_index(index)
         except ValueError:
-            raise UnsupportedQubit(f'Aspen devices only support named qubits by octagonal index')
+            raise UnsupportedQubit('Aspen devices only support named qubits by octagonal index')
 
     @staticmethod
     def from_aspen_index(index: int) -> 'AspenQubit':

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -174,9 +174,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
                 return
 
             except ValueError:
-                raise UnsupportedQubit(
-                    'Aspen devices only support named qubits by octagonal index'
-                )
+                raise UnsupportedQubit('Aspen devices only support named qubits by octagonal index')
 
         if isinstance(qubit, (OctagonalQubit, AspenQubit)):
             if not (qubit.index < self._maximum_qubit_number):

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -19,6 +19,7 @@ enable=
     docstyle,
     duplicate-argument-name,
     expression-not-assigned,
+    f-string-without-interpolation
     function-redefined,
     inconsistent-mro,
     init-is-generator,

--- a/dev_tools/modules_test.py
+++ b/dev_tools/modules_test.py
@@ -155,7 +155,7 @@ def test_get_version_on_no_modules():
 def test_get_version_on_inconsistent_version_modules():
     modules.replace_version(search_dir=Path("./mod2"), old="1.2.3.dev", new="1.2.4.dev")
     assert modules.get_version(search_dir=Path("./mod2")) == "1.2.4.dev"
-    with pytest.raises(ValueError, match=f"Versions should be the same, instead:"):
+    with pytest.raises(ValueError, match="Versions should be the same, instead:"):
         modules.get_version(search_dir=Path("."))
 
 


### PR DESCRIPTION
Use plain strings when brace expansion is not needed.