### PR TITLE
Don't invoke json_cirq_type if cirq_type is defined...for now.

### DIFF
--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -286,6 +286,7 @@ def _json_dict_with_cirq_type(obj: Any):
             "an error starting in Cirq v0.15.",
             DeprecationWarning,
         )
+        return base_dict
     return {'cirq_type': json_cirq_type(type(obj)), **base_dict}
 
 


### PR DESCRIPTION
Fixes a backwards-incompatibility in #4704.

This alternate return path is necessary until the deprecation cycle for this change is complete.