### PR TITLE
Fix operator_spaces.py::kron_bases initial value

### DIFF
--- a/cirq-core/cirq/linalg/operator_spaces.py
+++ b/cirq-core/cirq/linalg/operator_spaces.py
@@ -31,7 +31,7 @@ document(PAULI_BASIS, """The four Pauli matrices (including identity) keyed by c
 
 def kron_bases(*bases: Dict[str, np.ndarray], repeat: int = 1) -> Dict[str, np.ndarray]:
     """Creates tensor product of bases."""
-    product_basis = {'': np.ones(1)}
+    product_basis = {'': np.array([[1.0]])}
     for basis in bases * repeat:
         product_basis = {
             name1 + name2: np.kron(matrix1, matrix2)

--- a/cirq-core/cirq/linalg/operator_spaces.py
+++ b/cirq-core/cirq/linalg/operator_spaces.py
@@ -31,7 +31,7 @@ document(PAULI_BASIS, """The four Pauli matrices (including identity) keyed by c
 
 def kron_bases(*bases: Dict[str, np.ndarray], repeat: int = 1) -> Dict[str, np.ndarray]:
     """Creates tensor product of bases."""
-    product_basis = {'': np.array([[1.0]])}
+    product_basis = {'': np.array([[1]])}
     for basis in bases * repeat:
         product_basis = {
             name1 + name2: np.kron(matrix1, matrix2)

--- a/cirq-core/cirq/linalg/operator_spaces_test.py
+++ b/cirq-core/cirq/linalg/operator_spaces_test.py
@@ -120,9 +120,7 @@ def test_kron_bases_consistency(basis1, basis2):
         assert np.all(basis1[name] == basis2[name])
 
 
-@pytest.mark.parametrize(
-    'basis,repeat', itertools.product((PAULI_BASIS, STANDARD_BASIS), range(1, 5))
-)
+@pytest.mark.parametrize('basis,repeat', itertools.product((PAULI_BASIS, STANDARD_BASIS), range(5)))
 def test_kron_bases_repeat_sanity_checks(basis, repeat):
     product_basis = cirq.kron_bases(basis, repeat=repeat)
     assert len(product_basis) == 4 ** repeat


### PR DESCRIPTION
Fix dimensionality of initial array in kron_bases.

This was causing failures when working with zero-qubit gates: empty pauli strings, Identity(0), and the new GlobalPhaseGate.

cc @viathor to review