### PR TITLE
Support serialization of Gatesets

### DIFF
--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -85,6 +85,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'ObservableMeasuredResult': cirq.work.ObservableMeasuredResult,
         'GateFamily': cirq.GateFamily,
         'GateOperation': cirq.GateOperation,
+        'Gateset': cirq.Gateset,
         'GeneralizedAmplitudeDampingChannel': cirq.GeneralizedAmplitudeDampingChannel,
         'GlobalPhaseOperation': cirq.GlobalPhaseOperation,
         'GridInteractionLayer': GridInteractionLayer,

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -170,7 +170,7 @@ class GateFamily:
             self._ignore_global_phase,
         )
 
-    def _json_dict_(self):
+    def _json_dict_(self) -> Dict[str, Any]:
         return {
             'gate': self._gate_json(),
             'name': self.name,
@@ -179,7 +179,9 @@ class GateFamily:
         }
 
     @classmethod
-    def _from_json_dict_(cls, gate, name, description, ignore_global_phase, **kwargs):
+    def _from_json_dict_(
+        cls, gate, name, description, ignore_global_phase, **kwargs
+    ) -> 'GateFamily':
         if isinstance(gate, str):
             gate = protocols.cirq_type_from_json(gate)
         return cls(
@@ -422,3 +424,22 @@ class Gateset:
         if self.name:
             header += self.name
         return f'{header}\n' + self._gates_str_str
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {
+            'gates': list(self.gates),
+            'name': self.name,
+            'unroll_circuit_op': self._unroll_circuit_op,
+            'accept_global_phase_op': self._accept_global_phase_op,
+        }
+
+    @classmethod
+    def _from_json_dict_(
+        cls, gates, name, unroll_circuit_op, accept_global_phase_op, **kwargs
+    ) -> 'Gateset':
+        return cls(
+            *gates,
+            name=name,
+            unroll_circuit_op=unroll_circuit_op,
+            accept_global_phase_op=accept_global_phase_op,
+        )

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -242,7 +242,7 @@ class Gateset:
                     self._instance_gate_families[g.gate] = g
                 else:
                     self._type_gate_families[g.gate] = g
-        self._gates_str_str = "\n\n".join([str(g) for g in unique_gate_list])
+        self._unique_gate_list = unique_gate_list
         self._gates = frozenset(unique_gate_list)
 
     @property
@@ -423,11 +423,11 @@ class Gateset:
         header = 'Gateset: '
         if self.name:
             header += self.name
-        return f'{header}\n' + self._gates_str_str
+        return f'{header}\n' + "\n\n".join([str(g) for g in self._unique_gate_list])
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'gates': list(self.gates),
+            'gates': self._unique_gate_list,
             'name': self.name,
             'unroll_circuit_op': self._unroll_circuit_op,
             'accept_global_phase_op': self._accept_global_phase_op,

--- a/cirq-core/cirq/protocols/json_test_data/Gateset.json
+++ b/cirq-core/cirq/protocols/json_test_data/Gateset.json
@@ -3,15 +3,15 @@
     "cirq_type": "Gateset",
     "gates": [
       {
-        "cirq_type": "AnyUnitaryGateFamily",
-        "num_qubits": 2
-      },
-      {
         "cirq_type": "GateFamily",
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
         "ignore_global_phase": true
+      },
+      {
+        "cirq_type": "AnyUnitaryGateFamily",
+        "num_qubits": 2
       },
       {
         "cirq_type": "GateFamily",
@@ -33,17 +33,6 @@
     "cirq_type": "Gateset",
     "gates": [
       {
-        "cirq_type": "AnyUnitaryGateFamily",
-        "num_qubits": 2
-      },
-      {
-        "cirq_type": "GateFamily",
-        "gate": "YPowGate",
-        "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
-        "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true
-      },
-      {
         "cirq_type": "GateFamily",
         "gate": {
           "cirq_type": "_PauliX",
@@ -53,6 +42,17 @@
         "name": "Instance GateFamily: X",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
         "ignore_global_phase": true
+      },
+      {
+        "cirq_type": "GateFamily",
+        "gate": "YPowGate",
+        "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
+        "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
+        "ignore_global_phase": true
+      },
+      {
+        "cirq_type": "AnyUnitaryGateFamily",
+        "num_qubits": 2
       }
     ],
     "name": "Custom Name",

--- a/cirq-core/cirq/protocols/json_test_data/Gateset.json
+++ b/cirq-core/cirq/protocols/json_test_data/Gateset.json
@@ -1,0 +1,62 @@
+[
+  {
+    "cirq_type": "Gateset",
+    "gates": [
+      {
+        "cirq_type": "AnyUnitaryGateFamily",
+        "num_qubits": 2
+      },
+      {
+        "cirq_type": "GateFamily",
+        "gate": "YPowGate",
+        "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
+        "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
+        "ignore_global_phase": true
+      },
+      {
+        "cirq_type": "GateFamily",
+        "gate": {
+          "cirq_type": "_PauliX",
+          "exponent": 1.0,
+          "global_shift": 0.0
+        },
+        "name": "Instance GateFamily: X",
+        "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
+        "ignore_global_phase": true
+      }
+    ],
+    "name": null,
+    "unroll_circuit_op": true,
+    "accept_global_phase_op": true
+  },
+  {
+    "cirq_type": "Gateset",
+    "gates": [
+      {
+        "cirq_type": "AnyUnitaryGateFamily",
+        "num_qubits": 2
+      },
+      {
+        "cirq_type": "GateFamily",
+        "gate": "YPowGate",
+        "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
+        "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
+        "ignore_global_phase": true
+      },
+      {
+        "cirq_type": "GateFamily",
+        "gate": {
+          "cirq_type": "_PauliX",
+          "exponent": 1.0,
+          "global_shift": 0.0
+        },
+        "name": "Instance GateFamily: X",
+        "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
+        "ignore_global_phase": true
+      }
+    ],
+    "name": "Custom Name",
+    "unroll_circuit_op": false,
+    "accept_global_phase_op": false
+  }
+]

--- a/cirq-core/cirq/protocols/json_test_data/Gateset.repr
+++ b/cirq-core/cirq/protocols/json_test_data/Gateset.repr
@@ -1,0 +1,17 @@
+[
+    cirq.Gateset(
+        cirq.ops.common_gates.YPowGate,
+        cirq.AnyUnitaryGateFamily(num_qubits=2),
+        cirq.X,
+        unroll_circuit_op=True,
+        accept_global_phase_op=True,
+    ),
+    cirq.Gateset(
+        cirq.X,
+        cirq.ops.common_gates.YPowGate,
+        cirq.AnyUnitaryGateFamily(num_qubits=2),
+        name="Custom Name",
+        unroll_circuit_op=False,
+        accept_global_phase_op=False,
+    ),
+]

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -37,7 +37,6 @@ TestSpec = ModuleJsonTestSpec(
         'DensityMatrixStepResult',
         'DensityMatrixTrialResult',
         'ExpressionMap',
-        'Gateset',
         'InsertStrategy',
         'IonDevice',
         'KakDecomposition',


### PR DESCRIPTION
This PR adds json serialization to `cirq.Gateset` objects. This is made possible after the recent #4715 which adds serialization support for `cirq.GateFamily`'s. 