### PR TITLE
POC for CircuitGate

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -591,9 +591,6 @@ class CircuitOperation(ops.Operation):
         return gate
 
 
-TSelf = TypeVar('TSelf', bound='ContainerGate')
-
-
 @dataclasses.dataclass(frozen=True)
 class ContainerGate(ops.Gate, abc.ABC):
     @abc.abstractmethod
@@ -687,21 +684,21 @@ class WrapperGate(ContainerGate, abc.ABC):
     def _qid_shape_(self):
         return protocols.qid_shape(self.gate)
 
-    def __pow__(self: TSelf, power: int) -> TSelf:
+    def __pow__(self, power: int) -> 'cirq.Gate':
         return dataclasses.replace(self, gate=self.gate * power)
 
-    def _with_key_path_(self: TSelf, path: Tuple[str, ...]) -> TSelf:
+    def _with_key_path_(self, path: Tuple[str, ...]) -> 'cirq.Gate':
         return dataclasses.replace(self, gate=protocols.with_key_path(self.gate, path))
 
-    def _with_key_path_prefix_(self: TSelf, prefix: Tuple[str, ...]) -> TSelf:
+    def _with_key_path_prefix_(self, prefix: Tuple[str, ...]) -> 'cirq.Gate':
         return dataclasses.replace(self, gate=protocols.with_key_path_prefix(self.gate, prefix))
 
-    def _with_measurement_key_mapping_(self: TSelf, key_map: Dict[str, str]) -> TSelf:
+    def _with_measurement_key_mapping_(self, key_map: Dict[str, str]) -> 'cirq.Gate':
         return dataclasses.replace(
             self, gate=protocols.with_measurement_key_mapping(self.gate, key_map)
         )
 
-    def _resolve_parameters_(self: TSelf, resolver: 'cirq.ParamResolver', recursive: bool) -> TSelf:
+    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'cirq.Gate':
         return dataclasses.replace(
             self, gate=protocols.resolve_parameters(self.gate, resolver, recursive)
         )

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -572,9 +572,13 @@ class CircuitOperation(ops.Operation):
 
     @property
     def gate(self):
-        axis_map = {q: i for i, q in enumerate(self.circuit.all_qubits())}
-        ops = self.circuit.all_operations()
-        gates = tuple((op.gate, tuple(axis_map[q] for q in op.qubits)) for op in ops)
+        circuit_qubits = ops.QubitOrder.DEFAULT.order_for(self.circuit.all_qubits())
+        axis_map = {q: i for i, q in enumerate(circuit_qubits)}
+        circuit_ops = tuple(self.circuit.all_operations())
+        gateless_ops = [op for op in circuit_ops if op.gate is None]
+        if gateless_ops:
+            raise ValueError(f'Subcircuit contains gateless operations: {gateless_ops}.')
+        gates = tuple((op.gate, tuple(axis_map[q] for q in op.qubits)) for op in circuit_ops)
         gate = CircuitGate(gates)  # type: cirq.Gate
         if self.repetitions != 1:
             gate = RepeatGate(gate, self.repetitions)

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -570,6 +570,18 @@ class CircuitOperation(ops.Operation):
             )
         return self.with_params(resolver.param_dict)
 
+    @property
+    def gate(self):
+        axis_map = {q: i for i, q in enumerate(self.circuit.all_qubits())}
+        ops = self.circuit.all_operations()
+        gates = tuple((op.gate, tuple(axis_map[q] for q in op.qubits)) for op in ops)
+        gate = CircuitGate(gates)  # type: cirq.Gate
+        if self.repetitions != 1:
+            gate = RepeatGate(gate, self.repetitions)
+        if self.measurement_key_map:
+            gate = KeyMapGate(gate, self.measurement_key_map)
+        return protocols.resolve_parameters(gate, self.param_resolver)
+
 
 @dataclasses.dataclass(frozen=True)
 class CircuitGate(ops.Gate):

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -752,7 +752,7 @@ def test_decompose_nested():
     # Verify that mapped_circuit gives the same operations.
     assert final_op.mapped_circuit(deep=True) == expected_circuit
 
-    assert cirq.Circuit(cirq.decompose(final_op.gate.on(a, b, c, d))) == expected_circuit
+    assert cirq.Circuit(cirq.decompose(final_op.gate.on(*final_op.qubits))) == expected_circuit
 
 
 def test_decompose_nested1():

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -752,6 +752,8 @@ def test_decompose_nested():
     # Verify that mapped_circuit gives the same operations.
     assert final_op.mapped_circuit(deep=True) == expected_circuit
 
+    assert cirq.Circuit(cirq.decompose(final_op.gate.on(a, b, c, d))) == expected_circuit
+
 
 def test_decompose_nested1():
     a, b, c, d = q = cirq.LineQubit.range(4)

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -17,7 +17,7 @@ import pytest, sympy
 import cirq
 from cirq.circuits.circuit_operation import _full_join_string_lists
 
-from cirq.circuits.circuit_operation import CircuitGate, RepeatGate, KeyMapGate
+from cirq.circuits.circuit_operation import CircuitGate, RepeatGate, KeyMapGate, ResolverGate
 
 
 def test_properties():
@@ -762,19 +762,23 @@ def test_decompose_nested1():
     exp_one = sympy.Symbol('exp_one')
     exp_two = sympy.Symbol('exp_two')
     gate1 = CircuitGate(((cirq.X ** exp1, (0,)), (cirq.MeasurementGate(1, 'm1'), (0,))))
-    gate2 = CircuitGate((
-        (KeyMapGate(gate1, {'m1': 'ma'}), (0,)),
-        (KeyMapGate(gate1, {'m1': 'mb'}), (1,)),
-        (KeyMapGate(gate1, {'m1': 'mc'}), (2,)),
-        (KeyMapGate(gate1, {'m1': 'md'}), (3,)),
-    ))
-    gate3 = CircuitGate((
-        (cirq.resolve_parameters(gate2, {exp1: exp_half}), (0, 1, 2, 3)),
-        (cirq.resolve_parameters(gate2, {exp1: exp_one}), (0, 1, 2, 3)),
-        (cirq.resolve_parameters(gate2, {exp1: exp_two}), (0, 1, 2, 3)),
-    ))
+    gate2 = CircuitGate(
+        (
+            (KeyMapGate(gate1, {'m1': 'ma'}), (0,)),
+            (KeyMapGate(gate1, {'m1': 'mb'}), (1,)),
+            (KeyMapGate(gate1, {'m1': 'mc'}), (2,)),
+            (KeyMapGate(gate1, {'m1': 'md'}), (3,)),
+        )
+    )
+    gate3 = CircuitGate(
+        (
+            (ResolverGate(gate2, {exp1: exp_half}), (0, 1, 2, 3)),
+            (ResolverGate(gate2, {exp1: exp_one}), (0, 1, 2, 3)),
+            (ResolverGate(gate2, {exp1: exp_two}), (0, 1, 2, 3)),
+        )
+    )
 
-    final_gate = cirq.resolve_parameters(gate3, {exp_half: 0.5, exp_one: 1.0, exp_two: 2.0})
+    final_gate = ResolverGate(gate3, {exp_half: 0.5, exp_one: 1.0, exp_two: 2.0})
     final_op = final_gate.on(*q)
 
     expected_circuit1 = cirq.Circuit(

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -339,7 +339,14 @@ class Gateset:
                 )
                 return True
 
-        return any(item in gate_family for gate_family in self._gates)
+        if any(item in gate_family for gate_family in self._gates):
+            return True
+
+        from cirq.circuits.circuit_operation import ContainerGate
+        if isinstance(g, ContainerGate) and self._unroll_circuit_op:
+            return all(g0 in self for g0 in g._get_gates())
+
+        return False
 
     def validate(
         self,

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -343,6 +343,7 @@ class Gateset:
             return True
 
         from cirq.circuits.circuit_operation import ContainerGate
+
         if isinstance(g, ContainerGate) and self._unroll_circuit_op:
             return all(g0 in self for g0 in g._get_gates())
 

--- a/cirq-core/cirq/protocols/measurement_key_protocol.py
+++ b/cirq-core/cirq/protocols/measurement_key_protocol.py
@@ -278,7 +278,7 @@ def with_measurement_key_mapping(val: Any, key_map: Dict[str, str]):
     assign measurement keys from a higher-level object (such as a Circuit).
     """
     getter = getattr(val, '_with_measurement_key_mapping_', None)
-    return NotImplemented if getter is None else getter(key_map)
+    return val if getter is None else getter(key_map)
 
 
 def with_key_path(val: Any, path: Tuple[str, ...]):
@@ -289,7 +289,7 @@ def with_key_path(val: Any, path: Tuple[str, ...]):
     differentiate the actual measurement keys.
     """
     getter = getattr(val, '_with_key_path_', None)
-    return NotImplemented if getter is None else getter(path)
+    return val if getter is None else getter(path)
 
 
 def with_key_path_prefix(val: Any, prefix: Tuple[str, ...]):
@@ -304,4 +304,4 @@ def with_key_path_prefix(val: Any, prefix: Tuple[str, ...]):
         prefix: The prefix to apply to the value's path.
     """
     getter = getattr(val, '_with_key_path_prefix_', None)
-    return NotImplemented if getter is None else getter(prefix)
+    return val if getter is None else getter(prefix)


### PR DESCRIPTION
@tanujkhattar @95-martin-orion Made a gate that behaves like a CircuitOp, and use it as `CircuitOp.gate`.

Added some tests that shows it functions just like a CircuitOp (they each do the same thing as the corresponding CircuitOp test above it). And a test showing `decompose(circuitop.gate.on(circuitop.qubits)) == decompose(circuitop)`.

This isn't complete by any means: also needs a ResolverGate and maybe some other, but also seems not too far off. However I'm thinking of this as more of a conversation starter than a real PR at this point. Is this something we'd want to do, and the approach we'd want to take?