### PR TITLE
Upgrade pinned `black` version

### DIFF
--- a/dev_tools/requirements/deps/format.txt
+++ b/dev_tools/requirements/deps/format.txt
@@ -1,2 +1,2 @@
 -r flynt.txt
-black==20.8b1
+black==21.12b0


### PR DESCRIPTION
The old version of `black` started producing the following error when calling `check/format-incremental --apply`:
```
ImportError: {...}/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so:
undefined symbol: _PyUnicode_DecodeUnicodeEscape
```
Upgrading resolves the issue.