### PR TITLE
Fix the deprecation warning for `ClassicallyControlledOperation`

### DIFF
--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -171,7 +171,6 @@ class ClassicallyControlledOperation(raw_types.Operation):
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {
-            'cirq_type': self.__class__.__name__,
             'conditions': self._conditions,
             'sub_operation': self._sub_operation,
         }

--- a/docs/dev/serialization.md
+++ b/docs/dev/serialization.md
@@ -89,10 +89,8 @@ There are several steps needed to support an object's serialization and deserial
 and pass `cirq-core/cirq/protocols/json_serialization_test.py`:
 
 1. The object should have a `_json_dict_` method that returns a dictionary
-containing a `"cirq_type"` key as well as keys for each of the value's
-attributes. If these keys do not match the names of the class' initializer 
-arguments, a `_from_json_dict_` class method must also be defined.
-Typically the `"cirq_type"` will be the name of your class.
+containing keys for each of the value's attributes. If these keys do not match the names of
+the class' initializer arguments, a `_from_json_dict_` class method must also be defined.
 
 2. In `class_resolver_dictionary` within the packages's `json_resolver_cache.py` file,
 for each serializable class, the `cirq_type` of the class should be mapped to the imported class 


### PR DESCRIPTION
The `_json_dict_` method of `ClassicallyControlledOperation` contains a `cirq_type` key, which causes a deprecation warning:

https://github.com/quantumlib/Cirq/blob/01ae51eebf3b18a5cbee9fc0c697d4e1511c07f2/cirq-core/cirq/protocols/json_serialization.py#L281-L288

It is easy to fix by removing this item. Nevertheless, the real problem is in the manual for serialization, which says:

https://github.com/quantumlib/Cirq/blob/01ae51eebf3b18a5cbee9fc0c697d4e1511c07f2/docs/dev/serialization.md?plain=1#L91-L95

It says a `cirq_type` is required, which contradicts the code. To avoid confusing developers in the future, I have modified it.

close #4763