### PR TITLE
Circuit creation perf improvements

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2001,14 +2001,13 @@ class Circuit(AbstractCircuit):
                 self._moments.insert(k, moment_or_op)
                 k += 1
             else:
-                op = cast(ops.Operation, moment_or_op)
-                p = self._pick_or_create_inserted_op_moment_index(k, op, strategy)
+                p = self._pick_or_create_inserted_op_moment_index(k, moment_or_op, strategy)
                 while p > len(self._moments):
                     self._moments.append(ops.Moment())
                 if p == len(self._moments):
-                    self._moments.append(ops.Moment(op))
+                    self._moments.append(ops.Moment(moment_or_op))
                 else:
-                    self._moments[p] = self._moments[p].with_operation(op)
+                    self._moments[p] = self._moments[p].with_operation(moment_or_op)
                 self._device.validate_moment(self._moments[p])
                 if k < p + 1:
                     k = p + 1

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2010,7 +2010,8 @@ class Circuit(AbstractCircuit):
                 else:
                     self._moments[p] = self._moments[p].with_operation(op)
                 self._device.validate_moment(self._moments[p])
-                k = max(k, p + 1)
+                if k < p + 1:
+                    k = p + 1
                 if strategy is InsertStrategy.NEW_THEN_INLINE:
                     strategy = InsertStrategy.INLINE
         return k

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2003,9 +2003,12 @@ class Circuit(AbstractCircuit):
             else:
                 op = cast(ops.Operation, moment_or_op)
                 p = self._pick_or_create_inserted_op_moment_index(k, op, strategy)
-                while p >= len(self._moments):
+                while p > len(self._moments):
                     self._moments.append(ops.Moment())
-                self._moments[p] = self._moments[p].with_operation(op)
+                if p == len(self._moments):
+                    self._moments.append(ops.Moment(op))
+                else:
+                    self._moments[p] = self._moments[p].with_operation(op)
                 self._device.validate_moment(self._moments[p])
                 k = max(k, p + 1)
                 if strategy is InsertStrategy.NEW_THEN_INLINE:

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -108,7 +108,7 @@ class _BaseLineQid(ops.Qid):
         return int(self.x)
 
     def __hash__(self) -> int:
-        return int(self._x)
+        return self._x
 
 
 class LineQid(_BaseLineQid):

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -34,7 +34,7 @@ class _BaseLineQid(ops.Qid):
         self._x = x
 
     def _comparison_key(self):
-        return self.x
+        return self._x
 
     @property
     def x(self) -> int:

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -31,7 +31,7 @@ class _BaseLineQid(ops.Qid):
 
     def __init__(self, x: int) -> None:
         """Initializes a line qubit at the given x coordinate."""
-        self._x = x
+        self._x = int(x)
 
     def _comparison_key(self):
         return self._x

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -107,6 +107,9 @@ class _BaseLineQid(ops.Qid):
     def __int__(self) -> int:
         return int(self.x)
 
+    def __hash__(self) -> int:
+        return int(self._x)
+
 
 class LineQid(_BaseLineQid):
     """A qid on a 1d lattice with nearest-neighbor connectivity.

--- a/cirq-core/cirq/ops/moment.py
+++ b/cirq-core/cirq/ops/moment.py
@@ -137,7 +137,10 @@ class Moment:
         Returns:
             Whether this moment has operations involving the qubits.
         """
-        return bool(set(qubits) & self.qubits)
+        for q in qubits:
+            if q in self._qubits:
+                return True
+        return False
 
     def operation_at(self, qubit: raw_types.Qid) -> Optional['cirq.Operation']:
         """Returns the operation on a certain qubit for the moment.

--- a/cirq-core/cirq/ops/moment.py
+++ b/cirq-core/cirq/ops/moment.py
@@ -90,11 +90,18 @@ class Moment:
         Raises:
             ValueError: A qubit appears more than once.
         """
-        self._operations = contents if contents == () else tuple(op_tree.flatten_to_ops(contents))
+        self._operations = (
+            contents
+            if not contents
+            or len(contents) == 1
+            and isinstance(contents[0], ops.Operation)
+            or all(isinstance(c, raw_types.Operation) for c in contents)
+            else tuple(op_tree.flatten_to_ops(contents))
+        )
 
         # An internal dictionary to support efficient operation access by qubit.
         self._qubit_to_op: Dict['cirq.Qid', 'cirq.Operation'] = {}
-        for op in self.operations:
+        for op in self._operations:
             for q in op.qubits:
                 # Check that operations don't overlap.
                 if q in self._qubit_to_op:

--- a/cirq-core/cirq/ops/moment.py
+++ b/cirq-core/cirq/ops/moment.py
@@ -90,8 +90,8 @@ class Moment:
         Raises:
             ValueError: A qubit appears more than once.
         """
-        self._operations = (
-            contents
+        self._operations: Tuple['cirq.Operation', ...] = (
+            contents  # type: ignore
             if not contents
             or len(contents) == 1
             and isinstance(contents[0], ops.Operation)

--- a/cirq-core/cirq/ops/moment.py
+++ b/cirq-core/cirq/ops/moment.py
@@ -100,7 +100,7 @@ class Moment:
         )
 
         # An internal dictionary to support efficient operation access by qubit.
-        self._qubit_to_op: Dict['cirq.Qid', 'cirq.Operation'] = {}
+        self._qubit_to_op: Dict['cirq.Qid', 'cirq.Operation'] = dict()
         for op in self._operations:
             for q in op.qubits:
                 # Check that operations don't overlap.

--- a/cirq-core/cirq/protocols/control_key_protocol.py
+++ b/cirq-core/cirq/protocols/control_key_protocol.py
@@ -58,7 +58,7 @@ def control_keys(val: Any) -> AbstractSet['cirq.MeasurementKey']:
     if result is not NotImplemented and result is not None:
         return set(result)
 
-    return set()
+    return frozenset()
 
 
 def measurement_keys_touched(val: Any) -> AbstractSet['cirq.MeasurementKey']:


### PR DESCRIPTION
A few micro-optimizations, but in total reduces time to construct a long narrow (1-qubit) circuit by 60%. Probably not as dramatic for real-world circuits, but should still be some improvement.

If anyone has big real-world circuits they want to test this against before committing, LMK.