### PR TITLE
Adding files for virtual emulation

### DIFF
--- a/cirq-google/cirq_google/devices/specifications/__init__.py
+++ b/cirq-google/cirq_google/devices/specifications/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cirq-google/cirq_google/engine/__init__.py
+++ b/cirq-google/cirq_google/engine/__init__.py
@@ -110,3 +110,10 @@ from cirq_google.engine.engine_sampler import (
 from cirq_google.engine.validating_sampler import (
     ValidatingSampler,
 )
+
+from cirq_google.engine.virtual_engine_factory import (
+    create_noiseless_virtual_engine_from_device,
+    create_noiseless_virtual_engine_from_proto,
+    create_noiseless_virtual_engine_from_templates,
+    create_noiseless_virtual_engine_from_latest_templates,
+)

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -72,6 +72,7 @@ setup(
         'cirq_google': ['py.typed'],
         'cirq_google.api.v2': ['*'],
         'cirq_google.api.v1': ['*'],
+        'cirq_google.devices.specifications': ['*'],
         'cirq_google.json_test_data': ['*'],
     },
 )


### PR DESCRIPTION
- Add virtual_engine_factory to cirq_google.engine namespace
- Add device/specifications to package_files so that device templates
are packaged.