### PR TITLE
Use `NotImplemented` instead of `None` as default value for `TaggedOperation._unitary_`

### DIFF
--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -740,7 +740,7 @@ class TaggedOperation(Operation):
         return protocols.has_unitary(self.sub_operation)
 
     def _unitary_(self) -> Union[np.ndarray, NotImplementedType]:
-        return protocols.unitary(self.sub_operation, default=None)
+        return protocols.unitary(self.sub_operation, NotImplemented)
 
     def _commutes_(
         self, other: Any, *, atol: Union[int, float] = 1e-8

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -610,6 +610,9 @@ def test_tagged_operation_forwards_protocols():
     assert cirq.resolve_parameters_once(parameterized_op, resolver) == cirq.XPowGate(exponent=0.25)(
         q1
     ).with_tags(tag)
+    assert parameterized_op._unitary_() is NotImplemented
+    assert parameterized_op._mixture_() is NotImplemented
+    assert parameterized_op._kraus_() is NotImplemented
 
     y = cirq.Y(q1)
     tagged_y = cirq.Y(q1).with_tags(tag)


### PR DESCRIPTION
This makes the implementation of `_unitary_` method on `TaggedOperation` consistent with other protocols like `_mixture_` and `_kraus_`. 