### PR TITLE
Fix warning on array creation from ragged sequences

### DIFF
--- a/cirq-core/cirq/ops/boolean_hamiltonian_test.py
+++ b/cirq-core/cirq/ops/boolean_hamiltonian_test.py
@@ -128,9 +128,9 @@ def test_gray_code_sorting(n_bits, expected_hs):
         hs = hs_template.copy()
         random.shuffle(hs)
 
-        sorted_hs = sorted(list(hs), key=functools.cmp_to_key(bh._gray_code_comparator))
+        sorted_hs = sorted(hs, key=functools.cmp_to_key(bh._gray_code_comparator))
 
-        np.testing.assert_array_equal(sorted_hs, expected_hs)
+        assert sorted_hs == expected_hs
 
 
 @pytest.mark.parametrize(

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -333,7 +333,7 @@ def test_merge_operations_complexity(op_density):
         lambda _, __: None,
         lambda op1, _: op1,
         lambda _, op2: op2,
-        lambda op1, op2: prng.choice([op1, op2, None]),
+        lambda op1, op2: (op1, op2, None)[prng.choice(3)],
     ]:
 
         def wrapped_merge_func(op1, op2):


### PR DESCRIPTION
Avoid conversion of ragged nested sequences to numpy array.
Use simple equality check to compare lists of tuples.
Use RandomState.choice to get item index instead of the item itself
which implies conversion to numpy.array.

Fixes  check/pytest -Werror:'Creating an ndarray from ragged'