### PR TITLE
Close matplotlib figures after testing

### DIFF
--- a/cirq-core/cirq/experiments/cross_entropy_benchmarking_test.py
+++ b/cirq-core/cirq/experiments/cross_entropy_benchmarking_test.py
@@ -26,6 +26,7 @@ from cirq.experiments import (
 from cirq.experiments.cross_entropy_benchmarking import CrossEntropyPair, SpecklePurityPair
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_cross_entropy_benchmarking():
     # Check that the fidelities returned from a four-qubit XEB simulation are
     # close to 1 (deviations from 1 is expected due to finite number of

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -188,6 +188,7 @@ def test_two_qubit_state_tomography():
     np.testing.assert_almost_equal(act_rho_yx, tar_rho_yx, decimal=1)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_tomography_plot_raises_for_incorrect_number_of_axes():
     simulator = sim.Simulator()
     qubit = GridQubit(0, 0)

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -34,6 +34,7 @@ def test_init_result():
     assert result.data is data
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_plot_does_not_raise_error():
     class _TimeDependentDecay(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):
@@ -167,6 +168,7 @@ def test_all_off_results():
     )
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_curve_fit_plot_works():
     good_fit = cirq.experiments.T1DecayResult(
         data=pd.DataFrame(
@@ -184,6 +186,7 @@ def test_curve_fit_plot_works():
     good_fit.plot(include_fit=True)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_curve_fit_plot_warning():
     bad_fit = cirq.experiments.T1DecayResult(
         data=pd.DataFrame(

--- a/cirq-core/cirq/experiments/t2_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment_test.py
@@ -55,6 +55,7 @@ def test_init_t2_decay_result():
         cirq.experiments.T2DecayResult(x_data, bad_data)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_plot_does_not_raise_error():
     class _TimeDependentDecay(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):

--- a/cirq-core/cirq/linalg/decompositions_test.py
+++ b/cirq-core/cirq/linalg/decompositions_test.py
@@ -252,6 +252,7 @@ def test_kak_vector_empty():
     assert len(cirq.kak_vector([])) == 0
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_kak_plot_empty():
     cirq.scatter_plot_normalized_kak_interaction_coefficients([])
 
@@ -553,6 +554,7 @@ def test_axis_angle_init():
         cirq.AxisAngleDecomposition(angle=1, axis=(0, 0.5, 0), global_phase=1)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_scatter_plot_normalized_kak_interaction_coefficients():
     a, b = cirq.LineQubit.range(2)
     data = [

--- a/cirq-core/cirq/vis/density_matrix_test.py
+++ b/cirq-core/cirq/vis/density_matrix_test.py
@@ -24,6 +24,7 @@ from cirq.vis.density_matrix import plot_density_matrix
 from cirq.vis.density_matrix import _plot_element_of_density_matrix
 
 
+@pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize('show_text', [True, False])
 @pytest.mark.parametrize('size', [2, 4, 8, 16])
 def test_density_matrix_plotter(size, show_text):
@@ -47,6 +48,7 @@ def test_density_matrix_plotter(size, show_text):
         )
 
 
+@pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize('show_text', [True, False])
 @pytest.mark.parametrize('size', [2, 4, 8, 16])
 def test_density_matrix_circle_sizes(size, show_text):
@@ -90,6 +92,7 @@ def test_density_matrix_circle_sizes(size, show_text):
         )
 
 
+@pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize('show_rect', [True, False])
 @pytest.mark.parametrize('value', [0.0, 1.0, 0.5 + 0.3j, 0.2 + 0.1j, 0.5 + 0.5j])
 def test_density_element_plot(value, show_rect):

--- a/cirq-core/cirq/vis/heatmap_test.py
+++ b/cirq-core/cirq/vis/heatmap_test.py
@@ -311,6 +311,7 @@ def test_colorbar(ax, position, size, pad):
     plt.close(fig2)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_plot_updates_local_config():
     value_map_2d = {
         (grid_qubit.GridQubit(3, 2), grid_qubit.GridQubit(4, 2)): 0.004619111460557768,

--- a/cirq-core/cirq/vis/histogram_test.py
+++ b/cirq-core/cirq/vis/histogram_test.py
@@ -21,6 +21,7 @@ import matplotlib.pyplot as plt
 from cirq.vis import integrated_histogram
 
 
+@pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize('data', [range(10), {f'key_{i}': i for i in range(10)}])
 def test_integrated_histogram(data):
     ax = integrated_histogram(
@@ -39,6 +40,7 @@ def test_integrated_histogram(data):
         assert line.get_color() == 'r'
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_multiple_plots():
     _, ax = plt.subplots(1, 1)
     n = 53

--- a/cirq-core/cirq/vis/state_histogram_test.py
+++ b/cirq-core/cirq/vis/state_histogram_test.py
@@ -17,6 +17,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib as mpl
+import pytest
 
 import cirq
 from cirq.devices import GridQubit
@@ -64,6 +65,7 @@ def test_get_state_histogram_multi_2():
     np.testing.assert_equal(values_to_plot, expected_values)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_plot_state_histogram_result():
     qubits = cirq.LineQubit.range(4)
     c = cirq.Circuit(
@@ -80,6 +82,7 @@ def test_plot_state_histogram_result():
             assert str(r1) == str(r2)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_plot_state_histogram_collection():
     qubits = cirq.LineQubit.range(4)
     c = cirq.Circuit(

--- a/cirq-google/cirq_google/engine/calibration_test.py
+++ b/cirq-google/cirq_google/engine/calibration_test.py
@@ -191,6 +191,7 @@ def test_calibration_heatmap():
         cg.Calibration(multi_qubit_data).heatmap('multi_value')
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_calibration_plot_histograms():
     calibration = cg.Calibration(_CALIBRATION_DATA)
     _, ax = mpl.pyplot.subplots(1, 1)
@@ -208,6 +209,7 @@ def test_calibration_plot_histograms():
         cg.Calibration(multi_qubit_data).plot_histograms('multi_value')
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_calibration_plot():
     calibration = cg.Calibration(_CALIBRATION_DATA)
     _, axs = calibration.plot('two_qubit_xeb')

--- a/cirq-google/cirq_google/optimizers/two_qubit_gates/example_test.py
+++ b/cirq-google/cirq_google/optimizers/two_qubit_gates/example_test.py
@@ -1,9 +1,11 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
 from matplotlib import pyplot as plt
+import pytest
 
 from cirq_google.optimizers.two_qubit_gates import example
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_gate_compilation_example():
     plt.switch_backend('agg')
     example.main(samples=10, max_infidelity=0.3)

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 
 def pytest_configure(config):
     # Ignore deprecation warnings in python code generated from our protobuf definitions.
@@ -35,3 +37,11 @@ def pytest_addoption(parser):
         default=False,
         help="run Rigetti integration tests",
     )
+
+
+@pytest.fixture
+def closefigures():
+    import matplotlib.pyplot as plt
+
+    yield
+    plt.close('all')

--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -91,6 +91,7 @@ def test_example_runs_phase_estimator():
     examples.phase_estimator.main(qnums=(2,), repetitions=2)
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_example_heatmaps():
     pytest.importorskip("cirq_google")
     plt.switch_backend('agg')
@@ -114,6 +115,7 @@ def test_example_runs_hhl():
     examples.hhl.main()
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_example_runs_qubit_characterizations():
     examples.qubit_characterizations_example.main(
         minimum_cliffords=2, maximum_cliffords=6, cliffords_step=2
@@ -124,6 +126,7 @@ def test_example_swap_networks():
     examples.swap_networks.main()
 
 
+@pytest.mark.usefixtures('closefigures')
 def test_example_cross_entropy_benchmarking():
     examples.cross_entropy_benchmarking_example.main(
         repetitions=10, num_circuits=2, cycles=[2, 3, 4]


### PR DESCRIPTION
Add test fixture that cleans up any open matplotlib figures and
plug it in the tests that open new figures.
Fix RuntimeWarning: More than 20 figures have been opened.
