### PR TITLE
Import `transformers/analytical_decompositions/*` methods in `optimizers/*`

### DIFF
--- a/cirq-core/cirq/optimizers/__init__.py
+++ b/cirq-core/cirq/optimizers/__init__.py
@@ -68,6 +68,27 @@ from cirq.optimizers.synchronize_terminal_measurements import (
     SynchronizeTerminalMeasurements,
 )
 
+from cirq.transformers.analytical_decompositions import (
+    compute_cphase_exponents_for_fsim_decomposition,
+    decompose_cphase_into_two_fsim,
+    decompose_clifford_tableau_to_operations,
+    decompose_multi_controlled_x,
+    decompose_multi_controlled_rotation,
+    decompose_two_qubit_interaction_into_four_fsim_gates,
+    is_negligible_turn,
+    prepare_two_qubit_state_using_cz,
+    prepare_two_qubit_state_using_sqrt_iswap,
+    single_qubit_matrix_to_gates,
+    single_qubit_matrix_to_pauli_rotations,
+    single_qubit_matrix_to_phased_x_z,
+    single_qubit_matrix_to_phxz,
+    single_qubit_op_to_framed_phase_form,
+    three_qubit_matrix_to_operations,
+    two_qubit_matrix_to_diagonal_and_operations,
+    two_qubit_matrix_to_operations,
+    two_qubit_matrix_to_sqrt_iswap_operations,
+)
+
 from cirq import _compat
 
 _compat.deprecated_submodule(


### PR DESCRIPTION
After the recent migration of decompositions from `optimizers/*` to `transformers/analytical_decompositions/*`, the following user code breaks despite deprecating the moved submodules. 

```python
from cirq import optimizers
from cirq.optimizers import two_qubit_decompositions
_ = two_qubit_decompositions.two_qubit_matrix_to_operations(mat) # This is deprecated correctly and will emit a deprecation warning but work as expected.
_ = optimizers.two_qubit_matrix_to_operations(mat) # This would currently break since the optimizers module is neither deprecated nor has these top-level objects available
```

This PR adds a fix to temporarily unbreak the above user code by importing top-level objects from `transformers/analytical_decompositions/*` to `optimizers/*`. Once all files from `optimizers/*` have been moved to `transformers/`, we will deprecate the `optimizers/` module, and then this hack can be reverted and the correct deprecation warnings will be emitted when using `optimizers.two_qubit_matrix_to_operations` (and other top-level objects). 

Part of #4722 