### PR TITLE
Make `PauliMeasurementGate` respect sign of the pauli observable.

### DIFF
--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -43,7 +43,7 @@ def test_init(observable, key):
     assert g.num_qubits() == len(observable)
     assert g.key == 'a'
     assert g.mkey == cirq.MeasurementKey('a')
-    assert g._observable == tuple(observable)
+    assert g._observable == cirq.DensePauliString(observable)
     assert cirq.qid_shape(g) == (2,) * len(observable)
 
 
@@ -162,6 +162,9 @@ def test_bad_observable_raises():
     with pytest.raises(ValueError, match=r'Pauli observable .* must be Iterable\[`cirq.Pauli`\]'):
         _ = cirq.PauliMeasurementGate(cirq.DensePauliString('XYZI'))
 
+    with pytest.raises(ValueError, match=r'must have coefficient \+1/-1.'):
+        _ = cirq.PauliMeasurementGate(cirq.DensePauliString('XYZ', coefficient=1j))
+
 
 def test_with_observable():
     o1 = [cirq.Z, cirq.Y, cirq.X]
@@ -170,3 +173,20 @@ def test_with_observable():
     g2 = cirq.PauliMeasurementGate(o2, key='a')
     assert g1.with_observable(o2) == g2
     assert g1.with_observable(o1) is g1
+
+
+@pytest.mark.parametrize(
+    'rot, obs, out',
+    [
+        (cirq.I, cirq.DensePauliString("Z", coefficient=+1), 0),
+        (cirq.I, cirq.DensePauliString("Z", coefficient=-1), 1),
+        (cirq.Y ** 0.5, cirq.DensePauliString("X", coefficient=+1), 0),
+        (cirq.Y ** 0.5, cirq.DensePauliString("X", coefficient=-1), 1),
+        (cirq.X ** -0.5, cirq.DensePauliString("Y", coefficient=+1), 0),
+        (cirq.X ** -0.5, cirq.DensePauliString("Y", coefficient=-1), 1),
+    ],
+)
+def test_pauli_measurement_gate_samples(rot, obs, out):
+    q = cirq.NamedQubit("q")
+    c = cirq.Circuit(rot(q), cirq.PauliMeasurementGate(obs, key='out').on(q))
+    assert cirq.Simulator().sample(c)['out'][0] == out

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.json
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.json
@@ -1,42 +1,53 @@
-[{
-  "cirq_type": "PauliMeasurementGate",
-  "observable": [
-    {
-      "cirq_type": "_PauliX",
-      "exponent": 1.0,
-      "global_shift": 0.0
+[
+  {
+    "cirq_type": "PauliMeasurementGate",
+    "observable": {
+      "cirq_type": "DensePauliString",
+      "pauli_mask": [
+        1,
+        2,
+        3
+      ],
+      "coefficient": {
+        "cirq_type": "complex",
+        "real": 1.0,
+        "imag": 0.0
+      }
     },
-    {
-      "cirq_type": "_PauliY",
-      "exponent": 1.0,
-      "global_shift": 0.0
+    "key": "key"
+  },
+  {
+    "cirq_type": "PauliMeasurementGate",
+    "observable": {
+      "cirq_type": "DensePauliString",
+      "pauli_mask": [
+        1,
+        2,
+        3
+      ],
+      "coefficient": {
+        "cirq_type": "complex",
+        "real": 1.0,
+        "imag": 0.0
+      }
     },
-    {
-      "cirq_type": "_PauliZ",
-      "exponent": 1.0,
-      "global_shift": 0.0
-    }
-  ],
-  "key": "key"
-},
-{
-  "cirq_type": "PauliMeasurementGate",
-  "observable": [
-    {
-      "cirq_type": "_PauliX",
-      "exponent": 1.0,
-      "global_shift": 0.0
+    "key": "p:q:key"
+  },
+  {
+    "cirq_type": "PauliMeasurementGate",
+    "observable": {
+      "cirq_type": "DensePauliString",
+      "pauli_mask": [
+        1,
+        2,
+        3
+      ],
+      "coefficient": {
+        "cirq_type": "complex",
+        "real": -1.0,
+        "imag": 0.0
+      }
     },
-    {
-      "cirq_type": "_PauliY",
-      "exponent": 1.0,
-      "global_shift": 0.0
-    },
-    {
-      "cirq_type": "_PauliZ",
-      "exponent": 1.0,
-      "global_shift": 0.0
-    }
-  ],
-  "key": "p:q:key"
-}]
+    "key": "key"
+  }
+]

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.json_inward
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.json_inward
@@ -1,0 +1,42 @@
+[{
+  "cirq_type": "PauliMeasurementGate",
+  "observable": [
+    {
+      "cirq_type": "_PauliX",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    },
+    {
+      "cirq_type": "_PauliY",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    },
+    {
+      "cirq_type": "_PauliZ",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    }
+  ],
+  "key": "key"
+},
+{
+  "cirq_type": "PauliMeasurementGate",
+  "observable": [
+    {
+      "cirq_type": "_PauliX",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    },
+    {
+      "cirq_type": "_PauliY",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    },
+    {
+      "cirq_type": "_PauliZ",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    }
+  ],
+  "key": "p:q:key"
+}]

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr
@@ -1,5 +1,6 @@
 [
     cirq.PauliMeasurementGate((cirq.X, cirq.Y, cirq.Z), cirq.MeasurementKey(name='key')),
-    cirq.PauliMeasurementGate((cirq.X, cirq.Y, cirq.Z), cirq.MeasurementKey(path=('p', 'q'), name='key')),
+    cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ"), cirq.MeasurementKey(path=('p', 'q'), name='key')),
+    cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ", coefficient=-1), cirq.MeasurementKey(name='key')),
 ]
 

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr_inward
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr_inward
@@ -1,0 +1,5 @@
+[
+    cirq.PauliMeasurementGate((cirq.X, cirq.Y, cirq.Z), cirq.MeasurementKey(name='key')),
+    cirq.PauliMeasurementGate((cirq.X, cirq.Y, cirq.Z), cirq.MeasurementKey(path=('p', 'q'), name='key')),
+]
+


### PR DESCRIPTION
Fixes #4814 

Note that this is a breaking change because:
- Serialization of the `PauliMeasurementGate` is now different -- the serialized observable is `DensePauliString` instead of a tuple of Pauli's.
-  A DensePauliString with coefficient != +1/-1 will now raise a `ValueError` whereas earlier the coefficient was simply ignored.  