### PR TITLE
Add link to dev environment page in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ the appropriate branches.
 you can perform these locally, and then push the new commit following
 the same process as above.
 
+## Development Environment Setup
+
+Please refer to our [development page](docs/dev/development.md) for instructions
+on setting up your local development environment.
+
 ## Code Testing Standards
 
 When a pull request is created or updated, various automatic checks will 


### PR DESCRIPTION
Might be helpful to add a section in CONTRIBUTING.md to describe dev environment setup as it could be one of the first docs contributors look at. WDYT?

edit: Just found links to development.md elsewhere in the doc. Do you think it makes sense to have a dedicated section, to make it obvious where to look for dev environment setup?