### PR TITLE
Make gate_sets actually optional

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -28,7 +28,6 @@ import cirq
 from cirq_google.api import v2
 from cirq_google.engine import calibration
 from cirq_google.engine.client import quantum
-from cirq_google.serialization import circuit_serializer
 
 if TYPE_CHECKING:
     import cirq_google
@@ -239,7 +238,7 @@ class AbstractProcessor(abc.ABC):
 
     @abc.abstractmethod
     def get_sampler(
-        self, gate_set: Optional['serializer.Serializer'] = circuit_serializer.CIRCUIT_SERIALIZER
+        self, gate_set: Optional['serializer.Serializer'] = None,
     ) -> cirq.Sampler:
         """Returns a sampler backed by the processor.
 
@@ -284,7 +283,7 @@ class AbstractProcessor(abc.ABC):
     @abc.abstractmethod
     def get_device(
         self,
-        gate_sets: Iterable['serializer.Serializer'] = (circuit_serializer.CIRCUIT_SERIALIZER,),
+        gate_sets: Iterable['serializer.Serializer'] = (),
     ) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -28,6 +28,7 @@ import cirq
 from cirq_google.api import v2
 from cirq_google.engine import calibration
 from cirq_google.engine.client import quantum
+from cirq_google.serialization import circuit_serializer
 
 if TYPE_CHECKING:
     import cirq_google
@@ -237,7 +238,9 @@ class AbstractProcessor(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_sampler(self, gate_set: Optional['serializer.Serializer']) -> cirq.Sampler:
+    def get_sampler(
+        self, gate_set: Optional['serializer.Serializer'] = circuit_serializer.CIRCUIT_SERIALIZER
+    ) -> cirq.Sampler:
         """Returns a sampler backed by the processor.
 
         Args:
@@ -279,7 +282,10 @@ class AbstractProcessor(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_device(self, gate_sets: Iterable['serializer.Serializer']) -> cirq.Device:
+    def get_device(
+        self,
+        gate_sets: Iterable['serializer.Serializer'] = (circuit_serializer.CIRCUIT_SERIALIZER,),
+    ) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 
         This method queries the processor to retrieve the device specification,

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -238,7 +238,8 @@ class AbstractProcessor(abc.ABC):
 
     @abc.abstractmethod
     def get_sampler(
-        self, gate_set: Optional['serializer.Serializer'] = None,
+        self,
+        gate_set: Optional['serializer.Serializer'] = None,
     ) -> cirq.Sampler:
         """Returns a sampler backed by the processor.
 

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -95,7 +95,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         return engine_base.Engine(self.project_id, context=self.context)
 
     def get_sampler(
-        self, gate_set: Optional[serializer.Serializer]
+        self, gate_set: Optional[serializer.Serializer] = circuit_serializer.CIRCUIT_SERIALIZER
     ) -> engine_sampler.QuantumEngineSampler:
         """Returns a sampler backed by the engine.
 
@@ -335,7 +335,9 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         else:
             return None
 
-    def get_device(self, gate_sets: Iterable[serializer.Serializer]) -> cirq.Device:
+    def get_device(
+        self, gate_sets: Iterable[serializer.Serializer] = (circuit_serializer.CIRCUIT_SERIALIZER,)
+    ) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 
         This method queries the processor to retrieve the device specification,

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -28,6 +28,7 @@ from cirq_google.engine import (
     engine_sampler,
 )
 from cirq_google.serialization import circuit_serializer, serializable_gate_set, serializer
+from cirq_google.serialization import gate_sets as gs
 
 if TYPE_CHECKING:
     import cirq_google.engine.engine as engine_base
@@ -95,7 +96,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         return engine_base.Engine(self.project_id, context=self.context)
 
     def get_sampler(
-        self, gate_set: Optional[serializer.Serializer] = None,
+        self,
+        gate_set: Optional[serializer.Serializer] = None,
     ) -> engine_sampler.QuantumEngineSampler:
         """Returns a sampler backed by the engine.
 
@@ -336,7 +338,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             return None
 
     def get_device(
-        self, gate_sets: Iterable[serializer.Serializer] = (),
+        self,
+        gate_sets: Iterable[serializer.Serializer] = (),
     ) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 
@@ -344,8 +347,6 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         which is then use to create a `serializable_gate_set.SerializableDevice` that will validate
         that operations are supported and use the correct qubits.
         """
-        if not gate_sets:
-          gate_sets = (circuit_serializer.CIRCUIT_SERIALIZER,)
         spec = self.get_device_specification()
         if not spec:
             raise ValueError('Processor does not have a device specification')

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -350,6 +350,12 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         spec = self.get_device_specification()
         if not spec:
             raise ValueError('Processor does not have a device specification')
+        if not gate_sets:
+            # Default is to use all named gatesets in the device spec
+            gate_sets = []
+            for valid_gate_set in spec.valid_gate_sets:
+                if valid_gate_set.name in gs.NAMED_GATESETS:
+                    gate_sets.append(gs.NAMED_GATESETS[valid_gate_set.name])
         if not all(isinstance(gs, serializable_gate_set.SerializableGateSet) for gs in gate_sets):
             raise ValueError('All gate_sets must be SerializableGateSet currently.')
         return serializable_device.SerializableDevice.from_proto(

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -95,13 +95,13 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         return engine_base.Engine(self.project_id, context=self.context)
 
     def get_sampler(
-        self, gate_set: Optional[serializer.Serializer] = circuit_serializer.CIRCUIT_SERIALIZER
+        self, gate_set: Optional[serializer.Serializer] = None,
     ) -> engine_sampler.QuantumEngineSampler:
         """Returns a sampler backed by the engine.
 
         Args:
             gate_set: A `Serializer` that determines how to serialize circuits
-            when requesting samples.
+            when requesting samples. If not specified, uses proto v2.5 serialization.
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.QuantumEngineSampler`
@@ -336,7 +336,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             return None
 
     def get_device(
-        self, gate_sets: Iterable[serializer.Serializer] = (circuit_serializer.CIRCUIT_SERIALIZER,)
+        self, gate_sets: Iterable[serializer.Serializer] = (),
     ) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 
@@ -344,6 +344,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         which is then use to create a `serializable_gate_set.SerializableDevice` that will validate
         that operations are supported and use the correct qubits.
         """
+        if not gate_sets:
+          gate_sets = (circuit_serializer.CIRCUIT_SERIALIZER,)
         spec = self.get_device_specification()
         if not spec:
             raise ValueError('Processor does not have a device specification')

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -24,6 +24,7 @@ from google.protobuf.text_format import Merge
 from google.protobuf.timestamp_pb2 import Timestamp
 import cirq
 import cirq_google as cg
+import cirq_google.devices.known_devices as known_devices
 from cirq_google.api import v2
 from cirq_google.engine.engine import EngineContext
 from cirq_google.engine.client.quantum_v1alpha1 import enums as qenums
@@ -335,11 +336,22 @@ def test_get_device():
 
 
 def test_default_gate_sets():
+    # Sycamore should have valid gate sets with default
+    processor = cg.EngineProcessor(
+        'a',
+        'p',
+        EngineContext(),
+        _processor=qtypes.QuantumProcessor(device_spec=_to_any(known_devices.SYCAMORE_PROTO)),
+    )
+    device = processor.get_device()
+    device.validate_operation(cirq.X(cirq.GridQubit(5, 4)))
+    # Test that a device with no standard gatesets doesn't blow up
     processor = cg.EngineProcessor(
         'a', 'p', EngineContext(), _processor=qtypes.QuantumProcessor(device_spec=_DEVICE_SPEC)
     )
     device = processor.get_device()
     assert device.qubits == [cirq.GridQubit(0, 0), cirq.GridQubit(1, 1)]
+
 
 def test_get_missing_device():
     processor = cg.EngineProcessor('a', 'p', EngineContext(), _processor=qtypes.QuantumProcessor())

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -334,6 +334,13 @@ def test_get_device():
         processor.get_device(gate_sets=[cg.serialization.circuit_serializer.CIRCUIT_SERIALIZER])
 
 
+def test_default_gate_sets():
+    processor = cg.EngineProcessor(
+        'a', 'p', EngineContext(), _processor=qtypes.QuantumProcessor(device_spec=_DEVICE_SPEC)
+    )
+    device = processor.get_device()
+    assert device.qubits == [cirq.GridQubit(0, 0), cirq.GridQubit(1, 1)]
+
 def test_get_missing_device():
     processor = cg.EngineProcessor('a', 'p', EngineContext(), _processor=qtypes.QuantumProcessor())
     with pytest.raises(ValueError, match='device specification'):

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -77,6 +77,15 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             based on the given serializer.
         calibrations: A dictionary of calibration metrics keyed by epoch seconds
             that can be returned by the processor.
+        processor_id: Unique string id of the processor.
+        engine: The parent `AbstractEngine` object, if available.
+        expected_down_time: Optional datetime of the next expected downtime.
+            For informational purpose only.
+        expected_recovery_time: Optional datetime when the processor is
+            expected to be available again.  For informational purpose only.
+        schedule:  List of time slots that the scheduling/reservation should
+            use.  All time slots must be non-overlapping.
+        project_name: A project_name for resource naming.
     """
 
     def __init__(


### PR DESCRIPTION
- mypy and pycharm need a default value in the abstract interface
in order to be truly optional.
- Also, add a copy of the inherited arguments in
SimulatedLocalProcessor.