### PR TITLE
Fix `_value_equality_values_cls_` handling in `_value_equality_approx_eq`

### DIFF
--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -92,15 +92,13 @@ def _value_equality_hash(self: _SupportsValueEquality) -> int:
 def _value_equality_approx_eq(
     self: _SupportsValueEquality, other: _SupportsValueEquality, atol: float
 ) -> bool:
-
-    # Preserve regular equality type-comparison logic.
     cls_self = self._value_equality_values_cls_()
-    if not isinstance(other, cls_self):
+    get_cls_other = getattr(other, '_value_equality_values_cls_', None)
+    if get_cls_other is None:
         return NotImplemented
     cls_other = other._value_equality_values_cls_()
     if cls_self != cls_other:
         return False
-
     # Delegate to cirq.approx_eq for approximate equality comparison.
     return protocols.approx_eq(
         self._value_equality_approximate_values_(),

--- a/cirq-core/cirq/value/value_equality_attr_test.py
+++ b/cirq-core/cirq/value/value_equality_attr_test.py
@@ -75,6 +75,8 @@ def test_value_equality_manual():
     eq.add_equality_group(MasqueradePositiveD(4), MasqueradePositiveD(4), BasicD(4))
     eq.add_equality_group(MasqueradePositiveD(-1), MasqueradePositiveD(-1))
     eq.add_equality_group(BasicD(-1))
+    assert cirq.approx_eq(MasqueradePositiveD(3), BasicD(3))
+    assert cirq.approx_eq(MasqueradePositiveD(4), MasqueradePositiveD(4))
 
 
 @cirq.value_equality(unhashable=True)


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/4834