### PR TITLE
Make `BaseDensePauliString` an iterable class.

### DIFF
--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -19,6 +19,7 @@ from typing import (
     cast,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Sequence,
@@ -199,6 +200,10 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
             return type(self)(coefficient=1, pauli_mask=self.pauli_mask[item])
 
         raise TypeError(f'indices must be integers or slices, not {type(item)}')
+
+    def __iter__(self) -> Iterator['cirq.Gate']:
+        for i in range(len(self)):
+            yield self[i]
 
     def __len__(self):
         return len(self.pauli_mask)

--- a/cirq-core/cirq/ops/dense_pauli_string_test.py
+++ b/cirq-core/cirq/ops/dense_pauli_string_test.py
@@ -46,6 +46,7 @@ def test_init():
 
     # Mixed types.
     assert cirq.DensePauliString([1, 'X', cirq.X]) == cirq.DensePauliString('XXX')
+    assert list(cirq.DensePauliString('XXX')) == [cirq.X, cirq.X, cirq.X]
     with pytest.raises(TypeError, match='Expected a cirq.PAULI_GATE_LIKE'):
         _ = cirq.DensePauliString([object()])
 


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/4837