### PR TITLE
Add Duration to TParamVal Union

### DIFF
--- a/cirq-core/cirq/value/type_alias.py
+++ b/cirq-core/cirq/value/type_alias.py
@@ -15,6 +15,7 @@
 from typing import Union
 import sympy
 
+from cirq import Duration
 from cirq._doc import document
 
 """Supply aliases for commonly used types.
@@ -23,7 +24,7 @@ from cirq._doc import document
 TParamKey = Union[str, sympy.Basic]
 document(TParamKey, """A parameter that a parameter resolver may map to a value.""")  # type: ignore
 
-TParamVal = Union[float, sympy.Basic]
+TParamVal = Union[float, sympy.Basic, Duration]
 document(
     TParamVal, """A value that a parameter resolver may return for a parameter."""  # type: ignore
 )


### PR DESCRIPTION
Add `Duration` to `TParamVal` to allow resolving parameters that are `Durations`

Some gates, like `cirq_google.experimental.ops.coupler_pulse.CouplerPulse`, have parameters like `hold_time` that are `Duration`s rather than floats. I'm currently trying to implement parameter resolving for gates like this.

`ParamResolver.value_of` returns type `TParamVal = Union[float, sympy.Basic]`, which doesn't include `Duration`. This PR includes it, so we can resolve and sweep over those parameters.

There's obviously possible problems with breaking the assumption that param resolvers return floats exclusively when fully resolved. An alternative solution would be just mandating that gates like the above accept floats, and advertise the time unit they expect. 
