### PR TITLE
Fix coverage CI break.

### DIFF
--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -1,6 +1,7 @@
 -r ipython.txt
 
-notebook>=6.4.1
+# Notebook >=6.4.8 + coverage > 6.2 hangs CI: https://github.com/quantumlib/Cirq/issues/4897
+notebook>=6.4.1,<=6.4.7
 
 # https://github.com/nteract/papermill/issues/519
 ipykernel==5.3.4

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -3,6 +3,8 @@
 pytest
 pytest-asyncio
 pytest-cov
+# Notebook >=6.4.8 + coverage > 6.2 hangs CI: https://github.com/quantumlib/Cirq/issues/4897
+coverage<=6.2
 
 # for parallel testing notebooks
 pytest-xdist~=2.2.0


### PR DESCRIPTION
It looks like there is some weird interactions involving `coverage==6.2` -> 6.3 and `notebook==6.4.7` -> 6.4.8. This pins them back.

Opened: https://github.com/quantumlib/Cirq/issues/4897