### PR TITLE
Support adding qubits and deleting operations in `cirq.map_operations`.

### DIFF
--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -195,6 +195,21 @@ def test_map_operations_raises_qubits_not_subset():
         )
 
 
+def test_map_operations_can_add_qubits_if_flag_false():
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.H(q[0]))
+    c_mapped = cirq.map_operations(c, lambda *_: cirq.CNOT(q[0], q[1]), raise_if_add_qubits=False)
+    cirq.testing.assert_same_circuits(c_mapped, cirq.Circuit(cirq.CNOT(q[0], q[1])))
+
+
+def test_map_operations_can_drop_operations():
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.X(q[0]), cirq.Y(q[1]), cirq.X(q[1]), cirq.Y(q[0]))
+    c_mapped = cirq.map_operations(c, lambda op, _: op if op.gate == cirq.X else [])
+    c_expected = cirq.Circuit(cirq.Moment(cirq.X(q[0])), cirq.Moment(cirq.X(q[1])))
+    cirq.testing.assert_same_circuits(c_mapped, c_expected)
+
+
 def test_map_moments_drop_empty_moments():
     op = cirq.X(cirq.NamedQubit("x"))
     c = cirq.Circuit(cirq.Moment(op), cirq.Moment(), cirq.Moment(op))


### PR DESCRIPTION
- Add support for deleting an operation 
- Add support for adding operations which act on qubits outside of `op.qubits` -- This requires passing an explicit flag for use cases like https://github.com/quantumlib/Cirq/pull/4849
- Fixes type annotation for `map_moments` to accept a single modified moment or a sequence of moments. 