### PR TITLE
Add `drop_empty_moments` and `drop_negligible_operations` transformers.

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -358,6 +358,8 @@ from cirq.transformers import (
     decompose_multi_controlled_x,
     decompose_multi_controlled_rotation,
     decompose_two_qubit_interaction_into_four_fsim_gates,
+    drop_empty_moments,
+    drop_negligible_operations,
     is_negligible_turn,
     map_moments,
     map_operations,

--- a/cirq-core/cirq/contrib/paulistring/convert_gate_set.py
+++ b/cirq-core/cirq/contrib/paulistring/convert_gate_set.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cirq import circuits, optimizers
+from cirq import circuits, optimizers, transformers
 
 from cirq.contrib.paulistring.convert_to_pauli_string_phasors import ConvertToPauliStringPhasors
 
@@ -34,5 +34,4 @@ def converted_gate_set(
         keep_clifford=not no_clifford_gates,
         atol=atol,
     ).optimize_circuit(conv_circuit)
-    optimizers.DropEmptyMoments().optimize_circuit(conv_circuit)
-    return conv_circuit
+    return transformers.drop_empty_moments(conv_circuit)

--- a/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
@@ -12,7 +12,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")\n",
     "\n",
     "try:\n",
@@ -78,7 +78,7 @@
    "source": [
     "qubits = cirq.LineQubit.range(3)\n",
     "circuit = cirq.testing.random_circuit(qubits, n_moments=10, op_density=0.8, random_state=52)\n",
-    "cirq.DropEmptyMoments().optimize_circuit(circuit)\n",
+    "circuit = cirq.drop_empty_moments(circuit)\n",
     "SVGCircuit(circuit)"
    ]
   },
@@ -87,7 +87,9 @@
    "metadata": {},
    "source": [
     "### Circuit to Tensors\n",
-    "The circuit defines a tensor network representation. By default, the initial state is the `|0...0>` state (represented by the \"zero qubit\" operations labeled \"Q0\" in the legend. \"Q1\" are single qubit operations and \"Q2\" are two qubit operations. The open legs are the indices into the state vector and are of the form \"i{m}_q{n}\" where `m` is the time index (given by the returned `qubit_frontier` dictionary) and \"n\" is the qubit string."
+    "The circuit defines a tensor network representation. By default, the initial state is the `|0...0>` state (represented by the \"zero qubit\" operations labeled \"Q0\" in the legend. \"Q1\" are single qubit operations and \"Q2\" are two qubit operations. The open legs are the indices into the state vector and are of the form \"i{m}_q{n}\" where `m` is the time index (given by the returned `qubit_frontier` dictionary) and \"n\" is the qubit string.\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {
@@ -285,7 +287,7 @@
     "    circuit = cirq.testing.random_circuit(qubits, n_moments=n_moments, op_density=0.8)\n",
     "    noise_model = cirq.ConstantQubitNoiseModel(cirq.DepolarizingChannel(p=1e-3))\n",
     "    circuit = cirq.Circuit(noise_model.noisy_moments(circuit.moments, qubits))\n",
-    "    cirq.DropEmptyMoments().optimize_circuit(circuit)\n",
+    "    circuit = cirq.drop_empty_moments(circuit)\n",
     "    n_moments = len(circuit)\n",
     "    variables = {'circuit': circuit, 'qubits': qubits}\n",
     "\n",

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -207,8 +207,8 @@
     "ccq.MergeNQubitGates(n_qubits=2).optimize_circuit(compressed_c)\n",
     "ccq.MergeNQubitGates(n_qubits=1).optimize_circuit(compressed_c)\n",
     "\n",
-    "cirq.DropNegligible(tolerance=1e-6).optimize_circuit(compressed_c)\n",
-    "cirq.DropEmptyMoments().optimize_circuit(compressed_c)\n",
+    "compressed_c = cirq.drop_negligible_operations(compressed_c, atol=1e-6)\n",
+    "compressed_c = cirq.drop_empty_moments(compressed_c)\n",
     "print(len(list(compressed_c.all_operations())), len(compressed_c.all_qubits()))\n",
     "SVGCircuit(compressed_c)"
    ]

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -12,7 +12,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")\n",
     "\n",
     "try:\n",
@@ -28,7 +28,9 @@
    "metadata": {},
    "source": [
     "# Contract a Grid Circuit\n",
-    "Shallow circuits on a planar grid with low-weight observables permit easy contraction."
+    "Shallow circuits on a planar grid with low-weight observables permit easy contraction.\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {

--- a/cirq-core/cirq/contrib/quimb/density_matrix_test.py
+++ b/cirq-core/cirq/contrib/quimb/density_matrix_test.py
@@ -58,7 +58,7 @@ def test_tensor_density_matrix_3():
 def test_tensor_density_matrix_4():
     qubits = cirq.LineQubit.range(4)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=100, op_density=0.8)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
+    circuit = cirq.drop_empty_moments(circuit)
     noise_model = cirq.ConstantQubitNoiseModel(cirq.DepolarizingChannel(p=1e-3))
     circuit = cirq.Circuit(noise_model.noisy_moments(circuit.moments, qubits))
     rho1 = cirq.final_density_matrix(circuit, dtype=np.complex128)
@@ -69,7 +69,7 @@ def test_tensor_density_matrix_4():
 def test_tensor_density_matrix_gridqubit():
     qubits = cirq.GridQubit.rect(2, 2)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=10, op_density=0.8)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
+    circuit = cirq.drop_empty_moments(circuit)
     noise_model = cirq.ConstantQubitNoiseModel(cirq.DepolarizingChannel(p=1e-3))
     circuit = cirq.Circuit(noise_model.noisy_moments(circuit.moments, qubits))
     rho1 = cirq.final_density_matrix(circuit, dtype=np.complex128)

--- a/cirq-core/cirq/contrib/quimb/grid_circuits.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits.py
@@ -137,10 +137,9 @@ def simplify_expectation_value_circuit(circuit_sand: cirq.Circuit):
     n_op = sum(1 for _ in circuit_sand.all_operations())
     while True:
         MergeNQubitGates(n_qubits=1).optimize_circuit(circuit_sand)
-        cirq.DropNegligible(tolerance=1e-6).optimize_circuit(circuit_sand)
+        circuit_sand = cirq.drop_negligible_operations(circuit_sand, atol=1e-6)
         MergeNQubitGates(n_qubits=2).optimize_circuit(circuit_sand)
-        cirq.DropNegligible(tolerance=1e-6)
-        cirq.DropEmptyMoments().optimize_circuit(circuit_sand)
+        circuit_sand = cirq.drop_empty_moments(circuit_sand)
         new_n_op = sum(1 for _ in circuit_sand.all_operations())
 
         if new_n_op < n_op:

--- a/cirq-core/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor_test.py
@@ -250,8 +250,8 @@ def test_drop_negligible():
         cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Z})) ** 0.25,
         cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Z})) ** sym,
     )
-    cirq.DropNegligible().optimize_circuit(circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
+    circuit = cirq.drop_negligible_operations(circuit)
+    circuit = cirq.drop_empty_moments(circuit)
     assert circuit == expected
 
 

--- a/cirq-core/cirq/optimizers/drop_empty_moments.py
+++ b/cirq-core/cirq/optimizers/drop_empty_moments.py
@@ -16,8 +16,10 @@
 
 from cirq.circuits.circuit import Circuit
 from cirq.circuits import circuit as _circuit
+from cirq._compat import deprecated_class
 
 
+@deprecated_class(deadline='v1.0', fix='Use cirq.drop_empty_moments instead.')
 class DropEmptyMoments:
     """Removes empty moments from a circuit."""
 

--- a/cirq-core/cirq/optimizers/drop_negligible.py
+++ b/cirq-core/cirq/optimizers/drop_negligible.py
@@ -18,11 +18,13 @@ from typing import List, Tuple, TYPE_CHECKING
 
 from cirq import protocols
 from cirq.circuits import circuit as _circuit
+from cirq._compat import deprecated_class
 
 if TYPE_CHECKING:
     from cirq import ops
 
 
+@deprecated_class(deadline='v1.0', fix='Use cirq.drop_negligible_operations instead.')
 class DropNegligible:
     """An optimization pass that removes operations with tiny effects."""
 

--- a/cirq-core/cirq/optimizers/eject_z_test.py
+++ b/cirq-core/cirq/optimizers/eject_z_test.py
@@ -374,7 +374,7 @@ def test_swap():
     optimized = original.copy()
 
     cirq.EjectZ().optimize_circuit(optimized)
-    cirq.DropEmptyMoments().optimize_circuit(optimized)
+    optimized = cirq.drop_empty_moments(optimized)
 
     assert optimized[0].operations == (cirq.SWAP(a, b),)
     # Note: EjectZ drops `global_phase` from Rz turning it into a Z
@@ -397,7 +397,7 @@ def test_swap_fsim(theta):
     optimized = original.copy()
 
     cirq.EjectZ().optimize_circuit(optimized)
-    cirq.DropEmptyMoments().optimize_circuit(optimized)
+    optimized = cirq.drop_empty_moments(optimized)
 
     assert optimized[0].operations == (cirq.FSimGate(theta=theta, phi=0.123).on(a, b),)
     # Note: EjectZ drops `global_phase` from Rz turning it into a Z
@@ -420,7 +420,7 @@ def test_swap_iswap(exponent):
     optimized = original.copy()
 
     cirq.EjectZ().optimize_circuit(optimized)
-    cirq.DropEmptyMoments().optimize_circuit(optimized)
+    optimized = cirq.drop_empty_moments(optimized)
 
     assert optimized[0].operations == (cirq.ISWAP(a, b) ** exponent,)
     # Note: EjectZ drops `global_phase` from Rz turning it into a Z

--- a/cirq-core/cirq/optimizers/expand_composite_test.py
+++ b/cirq-core/cirq/optimizers/expand_composite_test.py
@@ -17,9 +17,7 @@ import cirq
 
 
 def assert_equal_mod_empty(expected, actual):
-    drop_empty = cirq.DropEmptyMoments()
-    drop_empty.optimize_circuit(actual)
-
+    actual = cirq.drop_empty_moments(actual)
     assert expected == actual, f'EXPECTED {expected} : ACTUAL {actual}'
 
 

--- a/cirq-core/cirq/optimizers/merge_interactions_test.py
+++ b/cirq-core/cirq/optimizers/merge_interactions_test.py
@@ -35,13 +35,13 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit):
         post(actual)
         post(expected)
 
-    followup_optimizations_new: List[cirq.TRANSFORMER] = [
+    followup_transformers: List[cirq.TRANSFORMER] = [
         cirq.drop_negligible_operations,
         cirq.drop_empty_moments,
     ]
-    for post_new in followup_optimizations_new:
-        actual = post_new(actual).unfreeze(copy=False)
-        expected = post_new(expected).unfreeze(copy=False)
+    for transform in followup_transformers:
+        actual = transform(actual).unfreeze(copy=False)
+        expected = transform(expected).unfreeze(copy=False)
 
     assert actual == expected, f'ACTUAL {actual} : EXPECTED {expected}'
 

--- a/cirq-core/cirq/optimizers/merge_interactions_test.py
+++ b/cirq-core/cirq/optimizers/merge_interactions_test.py
@@ -30,12 +30,18 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit):
         cirq.merge_single_qubit_gates_into_phased_x_z,
         cirq.EjectPhasedPaulis().optimize_circuit,
         cirq.EjectZ().optimize_circuit,
-        cirq.DropNegligible().optimize_circuit,
-        cirq.DropEmptyMoments().optimize_circuit,
     ]
     for post in followup_optimizations:
         post(actual)
         post(expected)
+
+    followup_optimizations_new: List[cirq.TRANSFORMER] = [
+        cirq.drop_negligible_operations,
+        cirq.drop_empty_moments,
+    ]
+    for post_new in followup_optimizations_new:
+        actual = post_new(actual).unfreeze(copy=False)
+        expected = post_new(expected).unfreeze(copy=False)
 
     assert actual == expected, f'ACTUAL {actual} : EXPECTED {expected}'
 
@@ -249,7 +255,7 @@ def test_post_clean_up():
 
     optimizer = cirq.MergeInteractions(allow_partial_czs=False, post_clean_up=clean_up)
     optimizer.optimize_circuit(circuit)
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
+    circuit = cirq.drop_empty_moments(circuit)
 
     assert isinstance(circuit[0].operations[0].gate, Marker)
     assert isinstance(circuit[-1].operations[0].gate, Marker)

--- a/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap_test.py
+++ b/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap_test.py
@@ -41,12 +41,18 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit, **kwargs):
         cirq.merge_single_qubit_gates_into_phased_x_z,
         cirq.EjectPhasedPaulis().optimize_circuit,
         cirq.EjectZ().optimize_circuit,
-        cirq.DropNegligible().optimize_circuit,
-        cirq.DropEmptyMoments().optimize_circuit,
     ]
     for post in followup_optimizations:
         post(actual)
         post(expected)
+
+    followup_optimizations_new: List[cirq.TRANSFORMER] = [
+        cirq.drop_negligible_operations,
+        cirq.drop_empty_moments,
+    ]
+    for post_new in followup_optimizations_new:
+        actual = post_new(actual).unfreeze(copy=False)
+        expected = post_new(expected).unfreeze(copy=False)
 
     assert actual == expected, f'ACTUAL {actual} : EXPECTED {expected}'
 

--- a/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap_test.py
+++ b/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap_test.py
@@ -46,13 +46,13 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit, **kwargs):
         post(actual)
         post(expected)
 
-    followup_optimizations_new: List[cirq.TRANSFORMER] = [
+    followup_transformers: List[cirq.TRANSFORMER] = [
         cirq.drop_negligible_operations,
         cirq.drop_empty_moments,
     ]
-    for post_new in followup_optimizations_new:
-        actual = post_new(actual).unfreeze(copy=False)
-        expected = post_new(expected).unfreeze(copy=False)
+    for transform in followup_transformers:
+        actual = transform(actual).unfreeze(copy=False)
+        expected = transform(expected).unfreeze(copy=False)
 
     assert actual == expected, f'ACTUAL {actual} : EXPECTED {expected}'
 

--- a/cirq-core/cirq/optimizers/merge_single_qubit_gates_test.py
+++ b/cirq-core/cirq/optimizers/merge_single_qubit_gates_test.py
@@ -29,10 +29,10 @@ def assert_optimizes(
     optimizer(before)
 
     # Ignore differences that would be caught by follow-up optimizations.
-    followup_optimizations = [cirq.DropNegligible(), cirq.DropEmptyMoments()]
+    followup_optimizations = [cirq.drop_negligible_operations, cirq.drop_empty_moments]
     for post in followup_optimizations:
-        post(before)  # type: ignore #  error: "object" not callable
-        post(expected)  # type: ignore #  error: "object" not callable
+        before = post(before)  # type: ignore #  error: "object" not callable
+        expected = post(expected)  # type: ignore #  error: "object" not callable
 
     assert before == expected, f'BEFORE:\n{before}\nEXPECTED:\n{expected}'
 
@@ -150,7 +150,7 @@ def test_rewrite():
     cirq.MergeSingleQubitGates(rewriter=lambda ops: cirq.H(ops[0].qubits[0])).optimize_circuit(
         circuit
     )
-    cirq.DropEmptyMoments().optimize_circuit(circuit)
+    circuit = cirq.drop_empty_moments(circuit)
 
     cirq.testing.assert_same_circuits(
         circuit,

--- a/cirq-core/cirq/optimizers/merge_single_qubit_gates_test.py
+++ b/cirq-core/cirq/optimizers/merge_single_qubit_gates_test.py
@@ -29,10 +29,10 @@ def assert_optimizes(
     optimizer(before)
 
     # Ignore differences that would be caught by follow-up optimizations.
-    followup_optimizations = [cirq.drop_negligible_operations, cirq.drop_empty_moments]
-    for post in followup_optimizations:
-        before = post(before)  # type: ignore #  error: "object" not callable
-        expected = post(expected)  # type: ignore #  error: "object" not callable
+    followup_transformers = [cirq.drop_negligible_operations, cirq.drop_empty_moments]
+    for transform in followup_transformers:
+        before = transform(before)  # type: ignore #  error: "object" not callable
+        expected = transform(expected)  # type: ignore #  error: "object" not callable
 
     assert before == expected, f'BEFORE:\n{before}\nEXPECTED:\n{expected}'
 

--- a/cirq-core/cirq/transformers/__init__.py
+++ b/cirq-core/cirq/transformers/__init__.py
@@ -43,6 +43,10 @@ from cirq.transformers.heuristic_decompositions import (
 
 from cirq.transformers.align import align_left, align_right
 
+from cirq.transformers.drop_empty_moments import drop_empty_moments
+
+from cirq.transformers.drop_negligible_operations import drop_negligible_operations
+
 from cirq.transformers.transformer_api import (
     LogLevel,
     TRANSFORMER,

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
@@ -211,7 +211,7 @@ def _optimize_multiplexed_angles_circuit(operations: Sequence[ops.Operation]):
         the optimized operations
     """
     circuit = cirq.Circuit(operations)
-    cirq.optimizers.DropNegligible().optimize_circuit(circuit)
+    circuit = cirq.transformers.drop_negligible_operations(circuit)
     if np.allclose(circuit.unitary(), np.eye(8), atol=1e-14):
         return cirq.Circuit([])
 

--- a/cirq-core/cirq/transformers/drop_empty_moments.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments.py
@@ -1,0 +1,37 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transformer pass that removes empty moments from a circuit."""
+
+from typing import Optional, TYPE_CHECKING
+from cirq.transformers import transformer_api, transformer_primitives
+
+if TYPE_CHECKING:
+    import cirq
+
+
+@transformer_api.transformer
+def drop_empty_moments(
+    circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
+) -> 'cirq.Circuit':
+    """Removes empty moments from a circuit.
+
+    Args:
+          circuit: Input circuit to transform.
+          context: `cirq.TransformerContext` storing common configurable options for transformers.
+
+    Returns:
+          Copy of the transformed input circuit.
+    """
+    return transformer_primitives.map_moments(circuit.unfreeze(False), lambda m, _: m if m else [])

--- a/cirq-core/cirq/transformers/drop_empty_moments_test.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments_test.py
@@ -21,17 +21,11 @@ def test_drop():
     cirq.testing.assert_same_circuits(
         cirq.drop_empty_moments(
             cirq.Circuit(
-                [
-                    cirq.Moment(),
-                    cirq.Moment(),
-                    cirq.Moment([cirq.CNOT(q1, q2)]),
-                    cirq.Moment(),
-                ]
+                cirq.Moment(),
+                cirq.Moment(),
+                cirq.Moment([cirq.CNOT(q1, q2)]),
+                cirq.Moment(),
             )
         ),
-        cirq.Circuit(
-            [
-                cirq.Moment([cirq.CNOT(q1, q2)]),
-            ]
-        ),
+        cirq.Circuit(cirq.Moment([cirq.CNOT(q1, q2)])),
     )

--- a/cirq-core/cirq/transformers/drop_empty_moments_test.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Cirq Developers
+# Copyright 2022 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,26 +15,21 @@
 import cirq
 
 
-def assert_optimizes(before, after):
-    with cirq.testing.assert_deprecated("Use cirq.drop_empty_moments", deadline='v1.0'):
-        opt = cirq.DropEmptyMoments()
-        opt.optimize_circuit(before)
-        assert before == after
-
-
 def test_drop():
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
-    assert_optimizes(
-        before=cirq.Circuit(
-            [
-                cirq.Moment(),
-                cirq.Moment(),
-                cirq.Moment([cirq.CNOT(q1, q2)]),
-                cirq.Moment(),
-            ]
+    cirq.testing.assert_same_circuits(
+        cirq.drop_empty_moments(
+            cirq.Circuit(
+                [
+                    cirq.Moment(),
+                    cirq.Moment(),
+                    cirq.Moment([cirq.CNOT(q1, q2)]),
+                    cirq.Moment(),
+                ]
+            )
         ),
-        after=cirq.Circuit(
+        cirq.Circuit(
             [
                 cirq.Moment([cirq.CNOT(q1, q2)]),
             ]

--- a/cirq-core/cirq/transformers/drop_negligible_operations.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations.py
@@ -1,0 +1,54 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transformer pass that removes operations with tiny effects."""
+
+from typing import Optional, TYPE_CHECKING
+from cirq import protocols
+from cirq.transformers import transformer_api, transformer_primitives
+
+if TYPE_CHECKING:
+    import cirq
+
+
+@transformer_api.transformer
+def drop_negligible_operations(
+    circuit: 'cirq.AbstractCircuit',
+    *,
+    context: Optional['cirq.TransformerContext'] = None,
+    atol: float = 1e-8,
+) -> 'cirq.Circuit':
+    """Removes operations with tiny effects.
+
+    An operation `op` is considered to have a tiny effect if
+    `cirq.trace_distance_bound(op) <= atol`.
+
+    Args:
+          circuit: Input circuit to transform.
+          context: `cirq.TransformerContext` storing common configurable options for transformers.
+          atol: Absolute tolerance to determine if an operation `op` is negligible --
+                i.e. if `cirq.trace_distance_bound(op) <= atol`.
+
+    Returns:
+          Copy of the transformed input circuit.
+    """
+
+    def map_func(op: 'cirq.Operation', _: int) -> 'cirq.OP_TREE':
+        if protocols.is_measurement(op) or (
+            context and not set(op.tags).isdisjoint(context.ignore_tags)
+        ):
+            return op
+        return [] if protocols.trace_distance_bound(op) <= atol else op
+
+    return transformer_primitives.map_operations(circuit, map_func).unfreeze(copy=False)

--- a/cirq-core/cirq/transformers/drop_negligible_operations_test.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Cirq Developers
+# Copyright 2022 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,21 +19,21 @@ NO_COMPILE_TAG = "no_compile_tag"
 
 def test_leaves_big():
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit([cirq.Moment([cirq.Z(a) ** 0.1])])
+    circuit = cirq.Circuit(cirq.Moment(cirq.Z(a) ** 0.1))
     cirq.testing.assert_same_circuits(cirq.drop_negligible_operations(circuit, atol=0.001), circuit)
 
 
 def test_clears_small():
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit([cirq.Moment([cirq.Z(a) ** 0.000001])])
+    circuit = cirq.Circuit(cirq.Moment(cirq.Z(a) ** 0.000001))
     cirq.testing.assert_same_circuits(
-        cirq.drop_negligible_operations(circuit, atol=0.001), cirq.Circuit([cirq.Moment()])
+        cirq.drop_negligible_operations(circuit, atol=0.001), cirq.Circuit(cirq.Moment())
     )
 
 
 def test_does_not_clear_small_no_compile():
     a = cirq.NamedQubit('a')
-    circuit = cirq.Circuit([cirq.Moment([(cirq.Z(a) ** 0.000001).with_tags(NO_COMPILE_TAG)])])
+    circuit = cirq.Circuit(cirq.Moment((cirq.Z(a) ** 0.000001).with_tags(NO_COMPILE_TAG)))
     cirq.testing.assert_same_circuits(
         cirq.drop_negligible_operations(
             circuit, context=cirq.TransformerContext(ignore_tags=(NO_COMPILE_TAG,)), atol=0.001
@@ -53,11 +53,9 @@ def test_clears_known_empties_even_at_zero_tolerance():
     cirq.testing.assert_same_circuits(
         cirq.drop_negligible_operations(circuit, atol=0),
         cirq.Circuit(
-            [
-                cirq.Moment(),
-                cirq.Moment([cirq.Y(a) ** 0.0000001]),
-                cirq.Moment([cirq.X(a) ** -0.0000001]),
-                cirq.Moment(),
-            ]
+            cirq.Moment(),
+            cirq.Moment(cirq.Y(a) ** 0.0000001),
+            cirq.Moment(cirq.X(a) ** -0.0000001),
+            cirq.Moment(),
         ),
     )

--- a/cirq-core/cirq/transformers/drop_negligible_operations_test.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations_test.py
@@ -14,27 +14,32 @@
 
 import cirq
 
-
-def assert_optimizes(atol: float, initial_circuit: cirq.Circuit, expected_circuit: cirq.Circuit):
-    with cirq.testing.assert_deprecated("Use cirq.drop_negligible_operations", deadline='v1.0'):
-        optimizer = cirq.DropNegligible(atol)
-        circuit = cirq.Circuit(initial_circuit)
-        optimizer.optimize_circuit(circuit)
-        assert circuit == expected_circuit
+NO_COMPILE_TAG = "no_compile_tag"
 
 
 def test_leaves_big():
     a = cirq.NamedQubit('a')
     circuit = cirq.Circuit([cirq.Moment([cirq.Z(a) ** 0.1])])
-
-    assert_optimizes(0.001, initial_circuit=circuit, expected_circuit=circuit)
+    cirq.testing.assert_same_circuits(cirq.drop_negligible_operations(circuit, atol=0.001), circuit)
 
 
 def test_clears_small():
     a = cirq.NamedQubit('a')
     circuit = cirq.Circuit([cirq.Moment([cirq.Z(a) ** 0.000001])])
+    cirq.testing.assert_same_circuits(
+        cirq.drop_negligible_operations(circuit, atol=0.001), cirq.Circuit([cirq.Moment()])
+    )
 
-    assert_optimizes(0.001, initial_circuit=circuit, expected_circuit=cirq.Circuit([cirq.Moment()]))
+
+def test_does_not_clear_small_no_compile():
+    a = cirq.NamedQubit('a')
+    circuit = cirq.Circuit([cirq.Moment([(cirq.Z(a) ** 0.000001).with_tags(NO_COMPILE_TAG)])])
+    cirq.testing.assert_same_circuits(
+        cirq.drop_negligible_operations(
+            circuit, context=cirq.TransformerContext(ignore_tags=(NO_COMPILE_TAG,)), atol=0.001
+        ),
+        circuit,
+    )
 
 
 def test_clears_known_empties_even_at_zero_tolerance():
@@ -42,15 +47,12 @@ def test_clears_known_empties_even_at_zero_tolerance():
     circuit = cirq.Circuit(
         cirq.Z(a) ** 0, cirq.Y(a) ** 0.0000001, cirq.X(a) ** -0.0000001, cirq.CZ(a, b) ** 0
     )
-    assert_optimizes(
-        0.001,
-        initial_circuit=circuit,
-        expected_circuit=cirq.Circuit([cirq.Moment()] * 4),
+    cirq.testing.assert_same_circuits(
+        cirq.drop_negligible_operations(circuit, atol=0.001), cirq.Circuit([cirq.Moment()] * 4)
     )
-    assert_optimizes(
-        0,
-        initial_circuit=circuit,
-        expected_circuit=cirq.Circuit(
+    cirq.testing.assert_same_circuits(
+        cirq.drop_negligible_operations(circuit, atol=0),
+        cirq.Circuit(
             [
                 cirq.Moment(),
                 cirq.Moment([cirq.Y(a) ** 0.0000001]),

--- a/cirq-google/cirq_google/optimizers/optimize_for_sycamore.py
+++ b/cirq-google/cirq_google/optimizers/optimize_for_sycamore.py
@@ -33,7 +33,6 @@ def _get_common_cleanup_optimizers(tolerance: float) -> List[Callable[[cirq.Circ
     return [
         cirq.EjectPhasedPaulis(tolerance=tolerance).optimize_circuit,
         cirq.EjectZ(tolerance=tolerance).optimize_circuit,
-        cirq.DropNegligible(tolerance=tolerance).optimize_circuit,
     ]
 
 
@@ -166,6 +165,8 @@ def optimized_for_sycamore(
     opts = _OPTIMIZER_TYPES[optimizer_type](tolerance=tolerance, tabulation=tabulation)
     for optimizer in opts:
         optimizer(copy)
+
+    copy = cirq.drop_negligible_operations(copy, atol=tolerance)
 
     ret = cirq.Circuit(
         (op.transform_qubits(qubit_map) for op in copy.all_operations()),

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -52,6 +52,8 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
     'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
     'docs/tutorials/google/xeb_calibration_example.ipynb',
     'docs/named_topologies.ipynb',
+    # New Transformers.
+    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -54,6 +54,7 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
     'docs/named_topologies.ipynb',
     # New Transformers.
     'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
+    'cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb',
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule

--- a/docs/tutorials/google/spin_echoes.ipynb
+++ b/docs/tutorials/google/spin_echoes.ipynb
@@ -232,8 +232,8 @@
     "        cirq.MergeInteractionsToSqrtIswap().optimize_circuit(circuit)\n",
     "        cirq.EjectPhasedPaulis().optimize_circuit(circuit)\n",
     "        cirq.EjectZ().optimize_circuit(circuit)\n",
-    "        cirq.DropNegligible().optimize_circuit(circuit)\n",
-    "        cirq.DropEmptyMoments().optimize_circuit(circuit)\n",
+    "        circuit = cirq.drop_negligible_operations(circuit)\n",
+    "        circuit = cirq.drop_empty_moments(circuit)\n",
     "\n",
     "    # Insert spin echoes. Note: It's important to do this after optimization, as\n",
     "    # optimization will remove spin echoes.\n",
@@ -250,7 +250,7 @@
     "    # Alignment.\n",
     "    if with_alignment:\n",
     "        circuit = cirq.align_right(circuit)\n",
-    "        cirq.SynchronizeTerminalMeasurements().optimize_circuit(circuit)\n",
+    "        circuit = synchronize_terminal_measurements(circuit)\n",
     "\n",
     "    return circuit\n",
     "\n",
@@ -819,7 +819,7 @@
     "id": "J537zBXPHny4"
    },
    "source": [
-    "Note: Optimizers can cause terminal measurements to become misaligned, but this can be fixed with `cirq.SynchronizeTerminalMeasurements` as discussed below."
+    "Note: Optimizers can cause terminal measurements to become misaligned, but this can be fixed with `cirq.synchronize_terminal_measurements` as discussed below."
    ]
   },
   {
@@ -1045,8 +1045,8 @@
     }
    ],
    "source": [
-    "cirq.DropNegligible().optimize_circuit(circuit)\n",
-    "cirq.DropEmptyMoments().optimize_circuit(circuit)\n",
+    "circuit = cirq.drop_negligible_operations(circuit)\n",
+    "circuit = cirq.drop_empty_moments(circuit)\n",
     "circuit"
    ]
   },
@@ -1065,7 +1065,7 @@
     "id": "q0J0zRqjKKhP"
    },
    "source": [
-    "You can use the `cirq.SynchronizeTerminalMeasurements` to move all measurements to the final moment if it can accommodate them (without overlapping with other operations)."
+    "You can use the `cirq.synchronize_terminal_measurements` to move all measurements to the final moment if it can accommodate them (without overlapping with other operations)."
    ]
   },
   {
@@ -1114,7 +1114,7 @@
     }
    ],
    "source": [
-    "cirq.SynchronizeTerminalMeasurements().optimize_circuit(circuit)\n",
+    "circuit = cirq.synchronize_terminal_measurements(circuit)\n",
     "circuit"
    ]
   },


### PR DESCRIPTION
- Replaces `DropEmptyMoments` and `DropNegligible` optimizers.
- Part of Organization (and deprecation) of cirq-core/optimizers in cirq-core/transformers #4722
- Follows the new Transformer API Compiling: Circuit Transformers API #4483
- Supports no compile tags NoCompile Tag for optimizers NoCompile Tag for optimizers #4253
