### PR TITLE
Clean up redundant use of `_deprecate_attributes`

### DIFF
--- a/cirq-core/cirq/sim/__init__.py
+++ b/cirq-core/cirq/sim/__init__.py
@@ -98,13 +98,3 @@ from cirq.sim.clifford import (
     CliffordTrialResult,
     CliffordSimulatorStepResult,
 )
-
-# pylint: disable=wrong-import-order
-import sys as _sys
-from cirq._compat import deprecate_attributes as _deprecate_attributes
-
-deprecated_constants: Dict[str, Tuple[str, str]] = {
-    # currently none, you can use this to deprecate constants, for example like this:
-    # 'STATE_VECTOR_LIKE': ('v0.9', 'Use cirq.STATE_VECTOR_LIKE instead'),
-}
-_sys.modules[__name__] = _deprecate_attributes(_sys.modules[__name__], deprecated_constants)


### PR DESCRIPTION
`deprecate_attributes` replaces standard Python module with a wrapper
that modifies attribute access.  Avoid unless truly needed.