### PR TITLE
Missing cirq_google import in command line QCS example

### DIFF
--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -512,6 +512,7 @@
    ],
    "source": [
     "import cirq\n",
+    "import cirq_google as cg\n",
     "\n",
     "def example():\n",
     "    \"\"\"Hello qubit example run against a quantum processor.\"\"\"\n",


### PR DESCRIPTION
Adds missing import.