### PR TITLE
Add `expand_composite` transformer to replace `ExpandComposite` optimizer

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -362,6 +362,7 @@ from cirq.transformers import (
     decompose_two_qubit_interaction_into_four_fsim_gates,
     drop_empty_moments,
     drop_negligible_operations,
+    expand_composite,
     is_negligible_turn,
     map_moments,
     map_operations,

--- a/cirq-core/cirq/contrib/acquaintance/bipartite_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/bipartite_test.py
@@ -278,8 +278,7 @@ def test_circuit_diagrams(part_size, subgraph):
     no_decomp = lambda op: isinstance(
         op.gate, (cca.AcquaintanceOpportunityGate, cca.SwapPermutationGate)
     )
-    expander = cirq.ExpandComposite(no_decomp=no_decomp)
-    expander(circuit)
+    circuit = cirq.expand_composite(circuit, no_decomp=no_decomp)
     diagram = circuit_diagrams['decomposed', subgraph, part_size]
     cirq.testing.assert_has_diagram(circuit, diagram)
 

--- a/cirq-core/cirq/contrib/acquaintance/gates_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/gates_test.py
@@ -78,8 +78,7 @@ f: ───×(2,1)───
     ct.assert_has_diagram(swap_network, expected_text_diagram)
 
     no_decomp = lambda op: isinstance(op.gate, (cca.CircularShiftGate, cca.LinearPermutationGate))
-    expander = cirq.ExpandComposite(no_decomp=no_decomp)
-    expander(swap_network)
+    swap_network = cirq.expand_composite(swap_network, no_decomp=no_decomp)
     expected_text_diagram = """
 a: ───█───────╲0╱───█─────────────────█───────────╲0╱───█───────0↦1───
       │       │     │                 │           │     │       │
@@ -95,9 +94,6 @@ f: ─────────────────█───────�
     """.strip()
     ct.assert_has_diagram(swap_network, expected_text_diagram)
 
-    no_decomp = lambda op: isinstance(op.gate, cca.CircularShiftGate)
-    expander = cirq.ExpandComposite(no_decomp=no_decomp)
-
     acquaintance_size = 3
     n_parts = 6
     part_lens = (1,) * n_parts
@@ -106,8 +102,8 @@ f: ─────────────────█───────�
         *qubits[:n_qubits]
     )
     swap_network = cirq.Circuit(swap_network_op)
-
-    expander(swap_network)
+    no_decomp = lambda op: isinstance(op.gate, cca.CircularShiftGate)
+    swap_network = cirq.expand_composite(swap_network, no_decomp=no_decomp)
     expected_text_diagram = """
 a: ───╲0╱─────────╲0╱─────────╲0╱─────────
       │           │           │

--- a/cirq-core/cirq/contrib/acquaintance/mutation_utils.py
+++ b/cirq-core/cirq/contrib/acquaintance/mutation_utils.py
@@ -16,7 +16,7 @@ import collections
 
 from typing import cast, Dict, List, Optional, Sequence, Union, TYPE_CHECKING
 
-from cirq import circuits, ops, optimizers
+from cirq import ops, transformers
 
 from cirq.contrib.acquaintance.gates import SwapNetworkGate, AcquaintanceOpportunityGate
 from cirq.contrib.acquaintance.devices import get_acquaintance_size
@@ -98,14 +98,19 @@ def replace_acquaintance_with_swap_network(
     return reflected
 
 
-class ExposeAcquaintanceGates(optimizers.ExpandComposite):
+class ExposeAcquaintanceGates:
     """Decomposes permutation gates that provide acquaintance opportunities."""
 
     def __init__(self):
-        circuits.PointOptimizer.__init__(self)
         self.no_decomp = lambda op: (
             not get_acquaintance_size(op) or isinstance(op.gate, AcquaintanceOpportunityGate)
         )
+
+    def optimize_circuit(self, circuit: 'cirq.Circuit') -> None:
+        circuit._moments = [*transformers.expand_composite(circuit, no_decomp=self.no_decomp)]
+
+    def __call__(self, circuit: 'cirq.Circuit') -> None:
+        self.optimize_circuit(circuit)
 
 
 expose_acquaintance_gates = ExposeAcquaintanceGates()

--- a/cirq-core/cirq/contrib/acquaintance/mutation_utils_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/mutation_utils_test.py
@@ -43,11 +43,6 @@ d: ───█───
     assert actual_text_diagram == expected_text_diagram
     assert cca.get_acquaintance_size(trivial_strategy) == 1
 
-    is_shift_or_lin_perm = lambda op: isinstance(
-        op.gate, (cca.CircularShiftGate, cca.LinearPermutationGate)
-    )
-    expand = cirq.ExpandComposite(no_decomp=is_shift_or_lin_perm)
-
     quadratic_strategy = cca.complete_acquaintance_strategy(qubits[:8], 2)
     actual_text_diagram = quadratic_strategy.to_text_diagram().strip()
     expected_text_diagram = """
@@ -69,8 +64,10 @@ h: ───×(7,0)───
     """.strip()
     assert actual_text_diagram == expected_text_diagram
     assert cca.get_acquaintance_size(quadratic_strategy) == 2
-
-    expand(quadratic_strategy)
+    is_shift_or_lin_perm = lambda op: isinstance(
+        op.gate, (cca.CircularShiftGate, cca.LinearPermutationGate)
+    )
+    quadratic_strategy = cirq.expand_composite(quadratic_strategy, no_decomp=is_shift_or_lin_perm)
     actual_text_diagram = quadratic_strategy.to_text_diagram(transpose=True).strip()
     expected_text_diagram = '\n'.join(
         (

--- a/cirq-core/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/optimizers_test.py
@@ -29,7 +29,6 @@ def test_remove_redundant_acquaintance_opportunities():
     """
     ct.assert_has_diagram(strategy, diagram_before)
     cca.remove_redundant_acquaintance_opportunities(strategy)
-    cca.remove_redundant_acquaintance_opportunities(strategy)
     diagram_after = """
 0: ───█───────
       │

--- a/cirq-core/cirq/contrib/acquaintance/permutation_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/permutation_test.py
@@ -24,17 +24,15 @@ import cirq.contrib.acquaintance as cca
 def test_swap_permutation_gate():
     no_decomp = lambda op: (isinstance(op, cirq.GateOperation) and op.gate == cirq.SWAP)
     a, b = cirq.NamedQubit('a'), cirq.NamedQubit('b')
-    expander = cirq.ExpandComposite(no_decomp=no_decomp)
     gate = cca.SwapPermutationGate()
     assert gate.num_qubits() == 2
     circuit = cirq.Circuit(gate(a, b))
-    expander(circuit)
+    circuit = cirq.expand_composite(circuit, no_decomp=no_decomp)
     assert tuple(circuit.all_operations()) == (cirq.SWAP(a, b),)
 
     no_decomp = lambda op: (isinstance(op, cirq.GateOperation) and op.gate == cirq.CZ)
-    expander = cirq.ExpandComposite(no_decomp=no_decomp)
     circuit = cirq.Circuit(cca.SwapPermutationGate(cirq.CZ)(a, b))
-    expander(circuit)
+    circuit = cirq.expand_composite(circuit, no_decomp=no_decomp)
     assert tuple(circuit.all_operations()) == (cirq.CZ(a, b),)
 
     assert cirq.commutes(gate, cirq.ZZ)

--- a/cirq-core/cirq/contrib/acquaintance/shift_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/shift_test.py
@@ -49,19 +49,14 @@ def test_circular_shift_gate_repr():
 def test_circular_shift_gate_decomposition():
     qubits = [cirq.NamedQubit(q) for q in 'abcdef']
 
-    expander = cirq.ExpandComposite()
     circular_shift = cca.CircularShiftGate(2, 1, cirq.CZ)(*qubits[:2])
-    circuit = cirq.Circuit(circular_shift)
-    expander.optimize_circuit(circuit)
+    circuit = cirq.expand_composite(cirq.Circuit(circular_shift))
     expected_circuit = cirq.Circuit((cirq.Moment((cirq.CZ(*qubits[:2]),)),))
     assert circuit == expected_circuit
 
     no_decomp = lambda op: (isinstance(op, cirq.GateOperation) and op.gate == cirq.SWAP)
-    expander = cirq.ExpandComposite(no_decomp=no_decomp)
-
     circular_shift = cca.CircularShiftGate(6, 3)(*qubits)
-    circuit = cirq.Circuit(circular_shift)
-    expander.optimize_circuit(circuit)
+    circuit = cirq.expand_composite(cirq.Circuit(circular_shift), no_decomp=no_decomp)
     actual_text_diagram = circuit.to_text_diagram().strip()
     expected_text_diagram = """
 a: ───────────×───────────
@@ -79,8 +74,7 @@ f: ───────────×───────────
     assert actual_text_diagram == expected_text_diagram
 
     circular_shift = cca.CircularShiftGate(6, 2)(*qubits)
-    circuit = cirq.Circuit(circular_shift)
-    expander.optimize_circuit(circuit)
+    circuit = cirq.expand_composite(cirq.Circuit(circular_shift), no_decomp=no_decomp)
     actual_text_diagram = circuit.to_text_diagram().strip()
     expected_text_diagram = """
 a: ───────×───────────────

--- a/cirq-core/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor_test.py
@@ -341,13 +341,13 @@ def test_decompose_with_symbol():
     ps = cirq.PauliString({q0: cirq.Y})
     op = cirq.PauliStringPhasor(ps, exponent_neg=sympy.Symbol('a'))
     circuit = cirq.Circuit(op)
-    cirq.ExpandComposite().optimize_circuit(circuit)
+    circuit = cirq.expand_composite(circuit)
     cirq.testing.assert_has_diagram(circuit, "q0: ───X^0.5───Z^a───X^-0.5───")
 
     ps = cirq.PauliString({q0: cirq.Y}, -1)
     op = cirq.PauliStringPhasor(ps, exponent_neg=sympy.Symbol('a'))
     circuit = cirq.Circuit(op)
-    cirq.ExpandComposite().optimize_circuit(circuit)
+    circuit = cirq.expand_composite(circuit)
     cirq.testing.assert_has_diagram(circuit, "q0: ───X^0.5───X───Z^a───X───X^-0.5───")
 
 

--- a/cirq-core/cirq/optimizers/expand_composite.py
+++ b/cirq-core/cirq/optimizers/expand_composite.py
@@ -21,11 +21,13 @@ from cirq.circuits.optimization_pass import (
     PointOptimizer,
     PointOptimizationSummary,
 )
+from cirq._compat import deprecated_class
 
 if TYPE_CHECKING:
     import cirq
 
 
+@deprecated_class(deadline='v1.0', fix='Use cirq.expand_composite instead.')
 class ExpandComposite(PointOptimizer):
     """An optimizer that expands composite operations via `cirq.decompose`.
 

--- a/cirq-core/cirq/transformers/__init__.py
+++ b/cirq-core/cirq/transformers/__init__.py
@@ -43,6 +43,8 @@ from cirq.transformers.heuristic_decompositions import (
 
 from cirq.transformers.align import align_left, align_right
 
+from cirq.transformers.expand_composite import expand_composite
+
 from cirq.transformers.drop_empty_moments import drop_empty_moments
 
 from cirq.transformers.drop_negligible_operations import drop_negligible_operations

--- a/cirq-core/cirq/transformers/expand_composite.py
+++ b/cirq-core/cirq/transformers/expand_composite.py
@@ -1,0 +1,56 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transformer pass that expands composite operations via `cirq.decompose`."""
+
+from typing import Callable, Optional, TYPE_CHECKING
+
+from cirq import ops, protocols
+from cirq.transformers import transformer_api, transformer_primitives
+
+if TYPE_CHECKING:
+    import cirq
+
+
+@transformer_api.transformer
+def expand_composite(
+    circuit: 'cirq.AbstractCircuit',
+    *,
+    context: Optional['cirq.TransformerContext'] = None,
+    no_decomp: Callable[[ops.Operation], bool] = (lambda _: False),
+):
+    """A transformer that expands composite operations via `cirq.decompose`.
+
+    For each operation in the circuit, this pass examines if the operation can
+    be decomposed. If it can be, the operation is cleared out and and replaced
+    with its decomposition using a fixed insertion strategy.
+
+    Transformation is applied using `cirq.map_operations_and_unroll`, which preserves the
+    moment structure of the input circuit.
+
+    Args:
+          circuit: Input circuit to transform.
+          context: `cirq.TransformerContext` storing common configurable options for transformers.
+          no_decomp: A predicate that determines whether an operation should
+                be decomposed or not. Defaults to decomposing everything.
+    Returns:
+          Copy of the transformed input circuit.
+    """
+
+    def map_func(op: 'cirq.Operation', _) -> 'cirq.OP_TREE':
+        return protocols.decompose(op, keep=no_decomp, on_stuck_raise=None)
+
+    return transformer_primitives.map_operations_and_unroll(
+        circuit, map_func, tags_to_ignore=context.tags_to_ignore if context else ()
+    ).unfreeze(copy=False)


### PR DESCRIPTION
- Part of https://github.com/quantumlib/Cirq/issues/4722
- Follows the new Transformer API https://github.com/quantumlib/Cirq/issues/4483
- Supports no compile tags NoCompile Tag for optimizers https://github.com/quantumlib/Cirq/issues/4253