### PR TITLE
[cirq-rigetti]: Unpin requirements (#4798)

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,4 +1,5 @@
 httpx>=0.15.5
 pyquil~=2.28.2; python_version < "3.7"
 pyquil~=3.0; python_version >= "3.7"
+pytest-httpx
 qcs-api-client>=0.8.0

--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,5 +1,5 @@
 httpx>=0.15.5
 pyquil~=2.28.2; python_version < "3.7"
-pyquil~=3.0; python_version >= "3.7"
+pyquil~=3.0.0; python_version >= "3.7"
 pytest-httpx
 qcs-api-client>=0.8.0

--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,19 +1,4 @@
-attrs~=20.3.0
-certifi~=2021.5.30
-h11~=0.9.0
-httpcore~=0.11.1
-httpx~=0.15.5
-idna~=2.10
-iso8601~=0.1.14
-pydantic~=1.8.2
-pyjwt~=1.7.1
+httpx>=0.15.5
 pyquil~=2.28.2; python_version < "3.7"
-pyquil~=3.0.0; python_version >= "3.7"
-python-dateutil~=2.8.1
-qcs-api-client~=0.8.0
-retrying~=1.3.3
-rfc3339~=6.2
-rfc3986~=1.5.0
-six~=1.16.0
-sniffio~=1.2.0
-toml~=0.10.2
+pyquil~=3.0; python_version >= "3.7"
+qcs-api-client>=0.8.0

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -6,7 +6,7 @@ follow_imports = silent
 ignore_missing_imports = true
 
 # 3rd-party libs for which we don't have stubs
-[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,oauth2client.*,pandas.*,proto.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.auth.*,google.oauth2.*,google.protobuf.text_format.*,quimb.*,pyquil.*,google.cloud.*,filelock.*,codeowners.*,tqdm.*,importlib_metadata.*,google.colab.*,IPython.*,astroid.*,pylint.*]
+[mypy-apiclient.*,freezegun.*,matplotlib.*,mpl_toolkits,multiprocessing.dummy,oauth2client.*,pandas.*,proto.*,pytest.*,scipy.*,sortedcontainers.*,setuptools.*,pylatex.*,networkx.*,qiskit.*,pypandoc.*,ply.*,_pytest.*,google.api.*,google.api_core.*,grpc.*,google.auth.*,google.oauth2.*,google.protobuf.text_format.*,quimb.*,pyquil.*,google.cloud.*,filelock.*,codeowners.*,tqdm.*,importlib_metadata.*,google.colab.*,IPython.*,astroid.*,pylint.*,pytest_httpx.*]
 follow_imports = silent
 ignore_missing_imports = true
 

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -6,6 +6,9 @@ pytest-cov
 # Notebook >=6.4.8 + coverage > 6.2 hangs CI: https://github.com/quantumlib/Cirq/issues/4897
 coverage<=6.2
 
+# for testing cirq-rigetti
+pytest-httpx
+
 # for parallel testing notebooks
 pytest-xdist~=2.2.0
 filelock~=3.0.12

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -6,9 +6,6 @@ pytest-cov
 # Notebook >=6.4.8 + coverage > 6.2 hangs CI: https://github.com/quantumlib/Cirq/issues/4897
 coverage<=6.2
 
-# for testing cirq-rigetti
-pytest-httpx
-
 # for parallel testing notebooks
 pytest-xdist~=2.2.0
 filelock~=3.0.12


### PR DESCRIPTION
Closes #4798.

Converts basic cirq-rigetti test to use pytest-httpx instead of raw httpcore patching.
Removes sub-dependencies that are not explicitly used in cirq-rigetti.


* tests (cirq-rigetti): use pytest-httpx
* requirements (cirq-rigetti): remove unused requirements
