### PR TITLE
In QCS getting started, only install cirq-google

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -24,6 +24,7 @@
 # tests is possible, via setting the NOTEBOOK_PARTITIONS env var to e.g. 5, and then passing to
 # pytest the `-k partition-0` or `-k partition-1`, etc. argument to limit to the given partition.
 import os
+import re
 import subprocess
 import sys
 import warnings
@@ -77,7 +78,8 @@ SKIP_NOTEBOOKS = [
     "examples/*stabilizer_code*",
     # Until openfermion is upgraded, this version of Cirq throws an error
     "docs/tutorials/educators/chemistry.ipynb",
-] + NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES
+    *NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES,
+]
 
 # The Rigetti integration requires Python >= 3.7.
 if sys.version_info < (3, 7):
@@ -215,15 +217,15 @@ def test_ensure_unreleased_notebooks_install_cirq_pre(notebook_path):
     # utf-8 is important for Windows testing, otherwise characters like ┌──┐ fail on cp1252
     with open(notebook_path, encoding="utf-8") as notebook:
         content = notebook.read()
-        mandatory_lines = [
-            "!pip install --quiet cirq --pre",
-            "Note: this notebook relies on unreleased Cirq features. "
-            "If you want to try these features, make sure you install cirq via "
-            "`pip install cirq --pre`.",
+        mandatory_matches = [
+            r"!pip install --quiet cirq(-google)? --pre",
+            r"Note: this notebook relies on unreleased Cirq features\. "
+            r"If you want to try these features, make sure you install cirq(-google)? via "
+            r"`pip install cirq(-google)? --pre`\.",
         ]
 
-        for m in mandatory_lines:
-            assert m in content, (
+        for m in mandatory_matches:
+            assert re.search(m, content), (
                 f"{notebook_path} is marked as NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES, "
-                f"however it is missing the mandatory line:\n{m}"
+                f"however it contains no line matching:\n{m}"
             )

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -77,7 +77,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq-google --pre`."
    ]
   },
   {
@@ -99,9 +99,9 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
-    "    print(\"installed cirq.\")"
+    "    print(\"installing cirq-google...\")\n",
+    "    !pip install --quiet cirq-google --pre\n",
+    "    print(\"installed cirq-google.\")"
    ]
   },
   {


### PR DESCRIPTION
This significantly speeds up the startup experience because we don't have to install all the other packages in the cirq metapackage. In testing just now installing `cirq-google` took about 7 seconds in colab, whereas installing `cirq` took about 30 seconds.