### PR TITLE
BugFix in `cirq.merge_moments` to correctly handle new empty moments.

### DIFF
--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -392,7 +392,7 @@ def merge_moments(
     merged_moments: List[circuits.Moment] = [circuit[0]]
     for current_moment in circuit[1:]:
         merged_moment = merge_func(merged_moments[-1], current_moment)
-        if not merged_moment:
+        if merged_moment is None:
             merged_moments.append(current_moment)
         else:
             merged_moments[-1] = merged_moment

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -362,6 +362,20 @@ def test_merge_moments():
     )
 
 
+def test_merge_moments_empty_moment_as_intermediate_step():
+    q = cirq.NamedQubit("q")
+    c_orig = cirq.Circuit([cirq.X(q), cirq.Y(q), cirq.Z(q)] * 2, cirq.X(q) ** 0.5)
+
+    def merge_func(m1: cirq.Moment, m2: cirq.Moment):
+        gate = cirq.single_qubit_matrix_to_phxz(cirq.unitary(cirq.Circuit(m1, m2)), atol=1e-8)
+        return cirq.Moment(gate.on(q) if gate else [])
+
+    c_new = cirq.merge_moments(c_orig, merge_func)
+    assert len(c_new) == 1
+    assert isinstance(c_new[0][q].gate, cirq.PhasedXZGate)
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(c_orig, c_new, atol=1e-8)
+
+
 def test_merge_moments_empty_circuit():
     def fail_if_called_func(*_):
         assert False


### PR DESCRIPTION
Fixes a bug where `cirq.merge_moments` would treat a newly merged empty `cirq.Moment()` as the case where we return `None` to indicate that two moments cannot be merged. 