### PR TITLE
[cirqflow] Auto-Batching in execution loop

### DIFF
--- a/cirq-google/cirq_google/workflow/quantum_runtime_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime_test.py
@@ -207,6 +207,20 @@ def test_execute(tmpdir, rt_config):
     assert manual_exegroup_result == exegroup_result
     assert helper_loaded_result == exegroup_result
 
-    exe_result = returned_exegroup_result.executable_results[0]
+
+def test_execute_2(tmpdir):
+    rt_config = cg.QuantumRuntimeConfiguration(
+        processor_record=cg.SimulatedProcessorWithLocalDeviceRecord('rainbow'),
+        run_id='my_run_id',
+        qubit_placer=cg.NaiveQubitPlacer(),
+    )
+    executable_group = cg.QuantumExecutableGroup(_get_quantum_executables())
+    cg.execute(rt_config=rt_config, executable_group=executable_group, base_data_dir=tmpdir)
+
+    results = cg.ExecutableGroupResultFilesystemRecord.from_json(
+        run_id='my_run_id', base_data_dir=tmpdir
+    ).load(base_data_dir=tmpdir)
+
+    exe_result = results.executable_results[0]
     assert 'placement' in exe_result.runtime_info.timings_s
     assert 'run' in exe_result.runtime_info.timings_s


### PR DESCRIPTION
This modifies the `cirq_google.workflow.execute()` execution loop to support custom job submission logic via the `JobSubmitter` interface.

In particular, I've implemented a batching job submitter which will accumulate job requests until a threshhold is reached, at which point it will send a batched job. It will "un batch" the results and stream them back to the main thread.

The threading queue system is designed to keep as much code synchronous and easy to reason about as possible. As such, circuit preparation (qubit placement, compilation, ...) is still in a recognizable `for` loop, and result consumption (saving data, logging, ...) is still in a `for` loop.

![Auto Batcher](https://user-images.githubusercontent.com/4967059/155632592-74083fbf-33b9-4029-a895-b23b904e4fb5.png)

This is a prototype and I haven't quite settled on the user-facing API. I think the user will provide an implementer of the `JobSubmitter` class as part of the `QuantumRuntimeConfiguration` (which can encapsulate arguments like `batch_size`) The `_JobSubmitterRequest` and `_JobSubmitterResponse` dataclasses should remain completely internal and will likely gain (or possible lose) attributes as more advanced submission behavior is codified 

@maffoo @dstrain115 @wcourtney I'd love to get your initial impression on this prototype, as I'm sure you all have thought about these things before.
