### PR TITLE
Add show_error_codes option to mypy config

### DIFF
--- a/dev_tools/conf/mypy-next.ini
+++ b/dev_tools/conf/mypy-next.ini
@@ -1,4 +1,5 @@
 [mypy]
+show_error_codes = true
 
 [mypy-__main__]
 follow_imports = silent

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+show_error_codes = true
 
 [mypy-__main__]
 follow_imports = silent


### PR DESCRIPTION
This causes mypy to show error codes in its output, which can be used to ignore specific type errors rather than blanket ignores. For example, given an error like:
```
cirq-core/cirq/_compat.py:37: error: Name 'cached_property' already defined (possibly by an import)  [no-redef]
```
we can then do:
```python
from backports.cached_property import cached_property  # type: ignore[no-redef]
```