### PR TITLE
Allow repetitions to be parameterized

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -154,7 +154,10 @@ class CircuitOperation(ops.Operation):
                     f'Expected repetition_ids to be a list of length {loop_size}, '
                     f'got: {self.repetition_ids}'
                 )
-        elif not isinstance(self.repetitions, sympy.Basic):
+        elif isinstance(self.repetitions, sympy.Basic):
+            if self.repetition_ids is not None:
+                raise ValueError('Cannot use repetition ids with parameterized repetitions')
+        else:
             raise TypeError('Only integer or sympy repetitions are allowed.')
 
         # Disallow mapping to keys containing the `MEASUREMENT_KEY_SEPARATOR`

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -234,7 +234,7 @@ class CircuitOperation(ops.Operation):
 
     def _ensure_deterministic_loop_count(self):
         if self.repeat_until or isinstance(self.repetitions, sympy.Basic):
-            raise ValueError(f'Cannot unroll circuit due to nondeterministic repetitions')
+            raise ValueError('Cannot unroll circuit due to nondeterministic repetitions')
 
     def _measurement_key_objs_(self) -> AbstractSet['cirq.MeasurementKey']:
         if self._cached_measurement_key_objs is None:

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -465,7 +465,7 @@ class CircuitOperation(ops.Operation):
 
         # If `self.repetition_ids` is None, this will just return `repetition_ids`.
         repetition_ids = _full_join_string_lists(repetition_ids, self.repetition_ids)
-        final_repetitions = self.repetitions * repetitions
+        final_repetitions = protocols.mul(self.repetitions, repetitions)
         return self.replace(repetitions=final_repetitions, repetition_ids=repetition_ids)
 
     def __pow__(self, power: IntParam) -> 'cirq.CircuitOperation':
@@ -509,8 +509,6 @@ class CircuitOperation(ops.Operation):
         Args:
             qubit_map: A mapping of old qubits to new qubits. This map will be
                 composed with any existing qubit mapping.
-            transform: A function mapping old qubits to new qubits. This
-                function will be composed with any existing qubit mapping.
 
         Returns:
             A copy of this operation targeting qubits as indicated by qubit_map.

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -284,9 +284,7 @@ class CircuitOperation(ops.Operation):
         return frozenset(self._parameter_names_generator())
 
     def _parameter_names_generator(self) -> Iterator[str]:
-        rep_name = protocols.parameter_names(self.repetitions)
-        if rep_name:
-            yield from rep_name
+        yield from protocols.parameter_names(self.repetitions)
         for symbol in protocols.parameter_symbols(self.circuit):
             for name in protocols.parameter_names(
                 protocols.resolve_parameters(symbol, self.param_resolver, recursive=False)

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -136,7 +136,7 @@ class CircuitOperation(ops.Operation):
 
         # Ensure that the circuit is invertible if the repetitions are negative.
         if isinstance(self.repetitions, float):
-            if abs(self.repetitions - round(self.repetitions)) < 0.001:
+            if math.isclose(self.repetitions, round(self.repetitions)):
                 object.__setattr__(self, 'repetitions', round(self.repetitions))
         if isinstance(self.repetitions, (int, np.integer)):
             if self.repetitions < 0:

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -160,7 +160,10 @@ class CircuitOperation(ops.Operation):
             if self.repetition_ids is not None:
                 raise ValueError('Cannot use repetition ids with parameterized repetitions')
         else:
-            raise TypeError('Only integer or sympy repetitions are allowed.')
+            raise TypeError(
+                f'Only integer or sympy repetitions are allowed.\n'
+                f'User provided: {self.repetitions}'
+            )
 
         # Disallow mapping to keys containing the `MEASUREMENT_KEY_SEPARATOR`
         for mapped_key in self.measurement_key_map.values():
@@ -521,7 +524,6 @@ class CircuitOperation(ops.Operation):
                 return self
 
             expected_repetition_id_length = abs(repetitions)
-            # The eventual number of repetitions of the returned CircuitOperation.
 
             if repetition_ids is None:
                 repetition_ids = default_repetition_ids(expected_repetition_id_length)
@@ -531,8 +533,10 @@ class CircuitOperation(ops.Operation):
                     f'{expected_repetition_id_length}'
                 )
 
-        # If `self.repetition_ids` is None, this will just return `repetition_ids`.
+        # If either self.repetition_ids or repetitions is None, it returns the other unchanged.
         repetition_ids = _full_join_string_lists(repetition_ids, self.repetition_ids)
+
+        # The eventual number of repetitions of the returned CircuitOperation.
         final_repetitions = protocols.mul(self.repetitions, repetitions)
         return self.replace(repetitions=final_repetitions, repetition_ids=repetition_ids)
 

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -521,9 +521,6 @@ class CircuitOperation(ops.Operation):
                     f'Expected repetition_ids={repetition_ids} length to be '
                     f'{expected_repetition_id_length}'
                 )
-        else:
-            if repetition_ids is not None:
-                raise ValueError('Cannot use repetition ids with parameterized repetitions')
 
         # If `self.repetition_ids` is None, this will just return `repetition_ids`.
         repetition_ids = _full_join_string_lists(repetition_ids, self.repetition_ids)

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -228,14 +228,12 @@ class CircuitOperation(ops.Operation):
         return self.circuit._is_measurement_()
 
     def _has_unitary_(self):
-        if self._parameter_names_():
+        if self._parameter_names_() or self.repeat_until:
             return False
         return NotImplemented
 
     def _ensure_deterministic_loop_count(self):
-        if self.use_repetition_ids and (
-            self.repeat_until or isinstance(self.repetitions, sympy.Basic)
-        ):
+        if self.repeat_until or isinstance(self.repetitions, sympy.Basic):
             raise ValueError(f'Cannot unroll circuit due to nondeterministic repetitions')
 
     def _measurement_key_objs_(self) -> AbstractSet['cirq.MeasurementKey']:

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -400,6 +400,8 @@ def test_parameterized_repeat():
         cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1.5, 'b': 1})
     with pytest.raises(ValueError, match='Circuit contains ops whose symbols were not specified'):
         cirq.Simulator().simulate(cirq.Circuit(op))
+    with pytest.raises(ValueError, match='repetition ids with parameterized repetitions'):
+        op.repeat(sympy.Symbol('c'), repetition_ids=['x', 'y'])
 
 
 def test_qid_shape():

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -442,24 +442,24 @@ def test_parameterized_repeat_side_effects():
     with pytest.raises(
         ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
     ):
+        cirq.measurement_key_names(op)
+    with pytest.raises(
+        ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
+    ):
         op.mapped_circuit()
     with pytest.raises(
         ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
     ):
         cirq.decompose(op)
 
-    # Cannot use repetition ids
+    # Not compatible with repetition ids
     with pytest.raises(ValueError, match='repetition ids with parameterized repetitions'):
         op.with_repetition_ids(['x', 'y'])
     with pytest.raises(ValueError, match='repetition ids with parameterized repetitions'):
         op.repeat(repetition_ids=['x', 'y'])
 
-    # TODO(daxfohl): The next two should work, but requires some changes to
-    # _measurement_key_names_ such that it does not depend on _measurement_key_objs_.
-    with pytest.raises(
-        ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
-    ):
-        cirq.measurement_key_names(op)
+    # TODO(daxfohl): This should work, but likely requires a new protocol that returns *just* the
+    # name of the measurement keys. (measurement_key_names returns the full serialized string).
     with pytest.raises(
         ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
     ):
@@ -482,6 +482,32 @@ def test_parameterized_repeat_side_effects():
             cirq.measure(q, key=cirq.MeasurementKey.parse_serialized('1:m')),
         )
     )
+
+
+def test_parameterized_repeat_side_effects_when_not_using_rep_ids():
+    q = cirq.LineQubit(0)
+    op = cirq.CircuitOperation(
+        cirq.FrozenCircuit(cirq.X(q).with_classical_controls('c'), cirq.measure(q, key='m')),
+        repetitions=sympy.Symbol('a'),
+        use_repetition_ids=False,
+    )
+    assert cirq.control_keys(op) == {cirq.MeasurementKey('c')}
+    assert cirq.parameter_names(op.with_params({'a': 1})) == {'a'}
+    assert set(map(str, cirq.measurement_key_objs(op))) == {'m'}
+    assert cirq.measurement_key_names(op) == {'m'}
+    assert cirq.measurement_key_names(cirq.with_measurement_key_mapping(op, {'m': 'm2'})) == {'m2'}
+    with pytest.raises(
+        ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
+    ):
+        op.mapped_circuit()
+    with pytest.raises(
+        ValueError, match='Cannot unroll circuit due to nondeterministic repetitions'
+    ):
+        cirq.decompose(op)
+    with pytest.raises(ValueError, match='repetition ids with parameterized repetitions'):
+        op.with_repetition_ids(['x', 'y'])
+    with pytest.raises(ValueError, match='repetition ids with parameterized repetitions'):
+        op.repeat(repetition_ids=['x', 'y'])
 
 
 def test_qid_shape():

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -337,7 +337,7 @@ def test_repeat(add_measurements, use_default_ids_for_initial_rep):
     ):
         _ = op_base.repeat()
 
-    with pytest.raises(TypeError, match='Only integer repetitions are allowed'):
+    with pytest.raises(TypeError, match='Only integer or sympy repetitions are allowed'):
         _ = op_base.repeat(1.3)
 
 
@@ -357,6 +357,21 @@ def test_repeat_zero_times(add_measurements, use_repetition_ids, initial_reps):
     assert np.allclose(result.state_vector(), [0, 1] if initial_reps % 2 else [1, 0])
     result = cirq.Simulator().simulate(cirq.Circuit(op ** 0))
     assert np.allclose(result.state_vector(), [1, 0])
+
+
+def test_parameterized_repeat():
+    q = cirq.LineQubit(0)
+    op = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q))) ** sympy.Symbol('a')
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 0})
+    assert np.allclose(result.state_vector(), [1, 0])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1})
+    assert np.allclose(result.state_vector(), [0, 1])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 2})
+    assert np.allclose(result.state_vector(), [1, 0])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': -1})
+    assert np.allclose(result.state_vector(), [0, 1])
+    with pytest.raises(TypeError, match='Only integer or sympy repetitions are allowed'):
+        cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1.5})
 
 
 def test_qid_shape():

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -362,6 +362,7 @@ def test_repeat_zero_times(add_measurements, use_repetition_ids, initial_reps):
 def test_parameterized_repeat():
     q = cirq.LineQubit(0)
     op = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q))) ** sympy.Symbol('a')
+    assert cirq.parameter_names(op) == {'a'}
     result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 0})
     assert np.allclose(result.state_vector(), [1, 0])
     result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1})
@@ -372,6 +373,33 @@ def test_parameterized_repeat():
     assert np.allclose(result.state_vector(), [0, 1])
     with pytest.raises(TypeError, match='Only integer or sympy repetitions are allowed'):
         cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1.5})
+    with pytest.raises(ValueError, match='Circuit contains ops whose symbols were not specified'):
+        cirq.Simulator().simulate(cirq.Circuit(op))
+    op = op ** -1
+    assert cirq.parameter_names(op) == {'a'}
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 0})
+    assert np.allclose(result.state_vector(), [1, 0])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1})
+    assert np.allclose(result.state_vector(), [0, 1])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 2})
+    assert np.allclose(result.state_vector(), [1, 0])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': -1})
+    assert np.allclose(result.state_vector(), [0, 1])
+    with pytest.raises(TypeError, match='Only integer or sympy repetitions are allowed'):
+        cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1.5})
+    with pytest.raises(ValueError, match='Circuit contains ops whose symbols were not specified'):
+        cirq.Simulator().simulate(cirq.Circuit(op))
+    op = op ** sympy.Symbol('b')
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1, 'b': 1})
+    assert np.allclose(result.state_vector(), [0, 1])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 2, 'b': 1})
+    assert np.allclose(result.state_vector(), [1, 0])
+    result = cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1, 'b': 2})
+    assert np.allclose(result.state_vector(), [1, 0])
+    with pytest.raises(TypeError, match='Only integer or sympy repetitions are allowed'):
+        cirq.Simulator().simulate(cirq.Circuit(op), param_resolver={'a': 1.5, 'b': 1})
+    with pytest.raises(ValueError, match='Circuit contains ops whose symbols were not specified'):
+        cirq.Simulator().simulate(cirq.Circuit(op))
 
 
 def test_qid_shape():

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -339,7 +339,8 @@ def test_repeat(add_measurements, use_default_ids_for_initial_rep):
 
     with pytest.raises(TypeError, match='Only integer or sympy repetitions are allowed'):
         _ = op_base.repeat(1.3)
-    assert op_base.repeat(3.0001).repetitions == 3
+    assert op_base.repeat(3.00000000001).repetitions == 3
+    assert op_base.repeat(2.99999999999).repetitions == 3
 
 
 @pytest.mark.parametrize('add_measurements', [True, False])

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -533,9 +533,7 @@ def test_simulate_ignore_measurements(split: bool):
 @pytest.mark.parametrize('split', [True, False])
 def test_simulate_ignore_measurements_subcircuits(split: bool):
     q0 = cirq.LineQubit(0)
-    with cirq.testing.assert_deprecated(
-        'ignore_measurement_results', deadline='v0.15', count=7 if split else 5
-    ):
+    with cirq.testing.assert_deprecated('ignore_measurement_results', deadline='v0.15', count=None):
         simulator = cirq.DensityMatrixSimulator(
             split_untangled_states=split, ignore_measurement_results=True
         )

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -534,7 +534,7 @@ def test_simulate_ignore_measurements(split: bool):
 def test_simulate_ignore_measurements_subcircuits(split: bool):
     q0 = cirq.LineQubit(0)
     with cirq.testing.assert_deprecated(
-        'ignore_measurement_results', deadline='v0.15', count=6 if split else 4
+        'ignore_measurement_results', deadline='v0.15', count=7 if split else 5
     ):
         simulator = cirq.DensityMatrixSimulator(
             split_untangled_states=split, ignore_measurement_results=True

--- a/cirq-core/cirq/transformers/measurement_transformers_test.py
+++ b/cirq-core/cirq/transformers/measurement_transformers_test.py
@@ -39,7 +39,7 @@ def assert_equivalent_to_deferred(circuit: cirq.Circuit):
 
 def assert_equivalent_to_dephased(circuit: cirq.Circuit):
     qubits = list(circuit.all_qubits())
-    with cirq.testing.assert_deprecated('ignore_measurement_results', deadline='v0.15', count=14):
+    with cirq.testing.assert_deprecated('ignore_measurement_results', deadline='v0.15', count=16):
         sim = cirq.DensityMatrixSimulator(ignore_measurement_results=True)
         num_qubits = len(qubits)
         backwards = list(circuit.all_operations())[::-1]

--- a/cirq-core/cirq/transformers/measurement_transformers_test.py
+++ b/cirq-core/cirq/transformers/measurement_transformers_test.py
@@ -39,7 +39,7 @@ def assert_equivalent_to_deferred(circuit: cirq.Circuit):
 
 def assert_equivalent_to_dephased(circuit: cirq.Circuit):
     qubits = list(circuit.all_qubits())
-    with cirq.testing.assert_deprecated('ignore_measurement_results', deadline='v0.15', count=16):
+    with cirq.testing.assert_deprecated('ignore_measurement_results', deadline='v0.15', count=None):
         sim = cirq.DensityMatrixSimulator(ignore_measurement_results=True)
         num_qubits = len(qubits)
         backwards = list(circuit.all_operations())[::-1]

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -344,6 +344,7 @@ class CircuitOpSerializer(OpSerializer):
         elif isinstance(op.repetitions, (int, np.integer)):
             msg.repetition_specification.repetition_count = int(op.repetitions)
         else:
+            # TODO: Parameterized repetitions should be serializable.
             raise ValueError(f'Cannot serialize repetitions of type {type(op.repetitions)}')
 
         for q1, q2 in op.qubit_map.items():

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -341,8 +341,8 @@ class CircuitOpSerializer(OpSerializer):
         ):
             for rep_id in op.repetition_ids:
                 msg.repetition_specification.repetition_ids.ids.append(rep_id)
-        elif isinstance(op.repetitions, int):
-            msg.repetition_specification.repetition_count = op.repetitions
+        elif isinstance(op.repetitions, (int, np.integer)):
+            msg.repetition_specification.repetition_count = int(op.repetitions)
         else:
             raise ValueError(f'Cannot serialize repetitions of type {type(op.repetitions)}')
 

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -341,8 +341,10 @@ class CircuitOpSerializer(OpSerializer):
         ):
             for rep_id in op.repetition_ids:
                 msg.repetition_specification.repetition_ids.ids.append(rep_id)
-        else:
+        elif isinstance(op.repetitions, int):
             msg.repetition_specification.repetition_count = op.repetitions
+        else:
+            raise ValueError(f'Cannot serialize repetitions of type {type(op.repetitions)}')
 
         for q1, q2 in op.qubit_map.items():
             entry = msg.qubit_map.entries.add()

--- a/cirq-google/cirq_google/serialization/op_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_serializer_test.py
@@ -470,6 +470,11 @@ def test_circuit_op_to_proto_errors():
     with pytest.raises(ValueError, match='Encountered a circuit not in the constants table'):
         serializer.to_proto(to_serialize, constants=constants, raw_constants=bad_raw_constants)
 
+    with pytest.raises(ValueError, match='Cannot serialize repetitions of type'):
+        serializer.to_proto(
+            to_serialize ** sympy.Symbol('a'), constants=constants, raw_constants=raw_constants
+        )
+
 
 @pytest.mark.parametrize('repetitions', [1, 5, ['a', 'b', 'c']])
 def test_circuit_op_to_proto(repetitions):


### PR DESCRIPTION
Since recursive parameter resolution is now working (#5033) we can do this now.

The biggest caveat with this code is that params are floats, and repetitions must be an integer. I added a new type IntParam for the `repetitions` field itself, but it's still possible for the resolver to put a float value there. I added a runtime check for that. It may make sense to allow floats if they're really close to an integer, but I didn't do that here yet.

Closes #3266