### PR TITLE
Update getting started notebook

### DIFF
--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -371,7 +371,9 @@
     "id": "bJ7ePCCNrh82"
    },
    "source": [
-    "Note that the qubit that we used for the simulation above, `(0, 0)`, does not exist on the hardware. Since the grid may change over time, we'll programatically select a valid qubit by inspecting `device.qubits`. We then use the `optimized_for_sycamore()` function to remap the circuit description for our device; this function will also substitute gates to comply with the device's gate set."
+    "Note that the qubit that we used for the simulation above, `(0, 0)`, does not exist on the hardware. Since the grid of available qubits may change over time, we'll programatically select a valid qubit by inspecting `device.qubits`. We then use the `transform_qubits()` method to remap the circuit onto that qubit.\n",
+    "\n",
+    "In order to run on hardware, we must also ensure that the circuit only contains gates that the hardware supports. The basic gates used here are always available, so this circuit can be run without any further changes, but in general you may need to apply additional transformations before running arbitrary circuits. See the [best practices](../../google/best_practices.md) guide for more information about running circuits on hardware."
    ]
   },
   {

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -214,8 +214,6 @@
    "source": [
     "import cirq\n",
     "import cirq_google as cg\n",
-    "import random\n",
-    "import string\n",
     "\n",
     "# Define a qubit at an arbitrary grid location.\n",
     "qubit = cirq.GridQubit(0, 0)\n",
@@ -362,8 +360,8 @@
    "source": [
     "processor = engine.get_processor(processor_id)\n",
     "\n",
-    "# Print the device showing qubit connectivity for the Sycamore gateset.\n",
-    "device = processor.get_device([cg.SYC_GATESET])\n",
+    "# Print the device showing qubit connectivity.\n",
+    "device = processor.get_device()\n",
     "print(device)"
    ]
   },
@@ -394,13 +392,10 @@
    "source": [
     "valid_qubit = device.qubits[0]\n",
     "\n",
-    "# Re-map qubits and gates for Sycamore hardware.\n",
-    "syc_circuit = cg.optimized_for_sycamore(\n",
-    "    circuit,\n",
-    "    new_device=device,\n",
-    "    qubit_map=lambda q: valid_qubit) # Constant fn since there's only one qubit.\n",
+    "# Transform circuit to use an available hardware qubit.\n",
+    "hw_circuit = circuit.transform_qubits(lambda q: valid_qubit)\n",
     "\n",
-    "print(syc_circuit)"
+    "print(hw_circuit)"
    ]
   },
   {
@@ -441,18 +436,18 @@
     "\n",
     "# Upload the program and submit jobs to run in one call.\n",
     "job = engine.run_sweep(\n",
-    "    program=syc_circuit,\n",
+    "    program=hw_circuit,\n",
     "    repetitions=10000,\n",
-    "    processor_ids=[processor.processor_id],\n",
-    "    gate_set=cg.SYC_GATESET)\n",
+    "    processor_ids=[processor.processor_id])\n",
     "\n",
     "print(\"Scheduled. View the job at: https://console.cloud.google.com/quantum/\"\n",
     "      \"programs/{}?&project={}\".format(job.program_id, project_id))\n",
     "\n",
     "# Print out the results. This blocks until the results are returned.\n",
-    "results = [str(int(b)) for b in job.results()[0].measurements['result'][:, 0]]\n",
-    "print(\"Measurement results:\\n\")\n",
-    "print(''.join(results))"
+    "results = job.results()\n",
+    "print(\"\\nMeasurement results:\")\n",
+    "for result in results:\n",
+    "    print(result)"
    ]
   },
   {
@@ -537,17 +532,17 @@
     "    job = engine.run_sweep(\n",
     "        program=circuit,\n",
     "        repetitions=1000,\n",
-    "        processor_ids=[processor.processor_id],\n",
-    "        gate_set=cg.SYC_GATESET)\n",
+    "        processor_ids=[processor.processor_id])\n",
     "\n",
     "    print(\"Scheduled. View the job at: https://console.cloud.google.com/quantum/\"\n",
     "          f\"programs/{job.program_id}/jobs/{job.job_id}\"\n",
     "          f\"/overview?project={project_id}\")\n",
     "\n",
     "    # Print out the results. This blocks until the results are returned.\n",
-    "    results = [str(int(b)) for b in job.results()[0].measurements['result'][:, 0]]\n",
+    "    results = job.results()\n",
     "    print(\"\\nMeasurement results:\")\n",
-    "    print(''.join(results))\n",
+    "    for result in results:\n",
+    "        print(result)\n",
     "\n",
     "\n",
     "if __name__ == '__main__':\n",


### PR DESCRIPTION
- Use Circuit.transform_qubits instead of cg.optimize_for_sycamore, since all we need to do is change qubits.
- Don't specify a gate_set, which will use CircuitSerializer by default.
- Use standard string representation of cirq.Result.
- Remove unused imports.