### PR TITLE
Add SymbolFunc to precompile sympy expressions for faster resolution

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -510,6 +510,7 @@ from cirq.study import (
     Product,
     Sweep,
     Sweepable,
+    SymbolFunc,
     to_resolvers,
     to_sweep,
     to_sweeps,

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -202,9 +202,11 @@ class PhasedXZGate(gate_features.SingleQubitGate):
     ) -> 'cirq.PhasedXZGate':
         """See `cirq.SupportsParameterization`."""
         return PhasedXZGate(
-            z_exponent=resolver.value_of(self._z_exponent_compiled, recursive),
-            x_exponent=resolver.value_of(self._x_exponent_compiled, recursive),
-            axis_phase_exponent=resolver.value_of(self._axis_phase_exponent_compiled, recursive),
+            z_exponent=protocols.resolve_parameters(self._z_exponent_compiled, resolver, recursive),
+            x_exponent=protocols.resolve_parameters(self._x_exponent_compiled, resolver, recursive),
+            axis_phase_exponent=protocols.resolve_parameters(
+                self._axis_phase_exponent_compiled, resolver, recursive
+            ),
         )
 
     def _phase_by_(self, phase_turns, qubit_index) -> 'cirq.PhasedXZGate':

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -6,7 +6,9 @@ import numpy as np
 import sympy
 
 from cirq import value, ops, protocols, linalg
+from cirq._compat import cached_property
 from cirq.ops import gate_features
+from cirq.study import SymbolFunc
 from cirq._compat import proper_repr
 
 if TYPE_CHECKING:
@@ -183,14 +185,26 @@ class PhasedXZGate(gate_features.SingleQubitGate):
             | protocols.parameter_names(self._axis_phase_exponent)
         )
 
+    @cached_property
+    def _x_exponent_compiled(self) -> Union[numbers.Real, SymbolFunc]:
+        return SymbolFunc.compile_expr(self._x_exponent)
+
+    @cached_property
+    def _z_exponent_compiled(self) -> Union[numbers.Real, SymbolFunc]:
+        return SymbolFunc.compile_expr(self._z_exponent)
+
+    @cached_property
+    def _axis_phase_exponent_compiled(self) -> Union[numbers.Real, SymbolFunc]:
+        return SymbolFunc.compile_expr(self._axis_phase_exponent)
+
     def _resolve_parameters_(
         self, resolver: 'cirq.ParamResolver', recursive: bool
     ) -> 'cirq.PhasedXZGate':
         """See `cirq.SupportsParameterization`."""
         return PhasedXZGate(
-            z_exponent=resolver.value_of(self._z_exponent, recursive),
-            x_exponent=resolver.value_of(self._x_exponent, recursive),
-            axis_phase_exponent=resolver.value_of(self._axis_phase_exponent, recursive),
+            z_exponent=resolver.value_of(self._z_exponent_compiled, recursive),
+            x_exponent=resolver.value_of(self._x_exponent_compiled, recursive),
+            axis_phase_exponent=resolver.value_of(self._axis_phase_exponent_compiled, recursive),
         )
 
     def _phase_by_(self, phase_turns, qubit_index) -> 'cirq.PhasedXZGate':

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -160,6 +160,7 @@ TestSpec = ModuleJsonTestSpec(
         'SupportsQasmWithArgsAndQubits',
         'SupportsTraceDistanceBound',
         'SupportsUnitary',
+        'SymbolFunc',
         # mypy types:
         'CIRCUIT_LIKE',
         'DURATION_LIKE',

--- a/cirq-core/cirq/study/__init__.py
+++ b/cirq-core/cirq/study/__init__.py
@@ -27,6 +27,11 @@ from cirq.study.resolver import (
     ParamResolverOrSimilarType,
 )
 
+from cirq.study.result import (
+    ResultDict,
+    Result,
+)
+
 from cirq.study.sweepable import (
     Sweepable,
     to_resolvers,
@@ -46,7 +51,4 @@ from cirq.study.sweeps import (
     dict_to_zip_sweep,
 )
 
-from cirq.study.result import (
-    ResultDict,
-    Result,
-)
+from cirq.study.symbol_func import SymbolFunc

--- a/cirq-core/cirq/study/symbol_func.py
+++ b/cirq-core/cirq/study/symbol_func.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
+
 class SymbolFunc:
     """A "lambdified" symbolic expression that is faster for parameter resolution."""
 

--- a/cirq-core/cirq/study/symbol_func.py
+++ b/cirq-core/cirq/study/symbol_func.py
@@ -1,8 +1,23 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import AbstractSet, TYPE_CHECKING, TypeVar, Union
 
 import sympy
 
-from cirq import protocols
+import cirq._compat as _compat
+import cirq.protocols as protocols
 
 if TYPE_CHECKING:
     import cirq
@@ -29,7 +44,7 @@ class SymbolFunc:
         self.func = sympy.lambdify(self.params, expr)
 
     def __repr__(self) -> str:
-        return f'SymbolFunc({self.expr!r})'
+        return f'cirq.SymbolFunc({_compat.proper_repr(self.expr)})'
 
     def _is_parameterized_(self) -> bool:
         return True

--- a/cirq-core/cirq/study/symbol_func.py
+++ b/cirq-core/cirq/study/symbol_func.py
@@ -41,7 +41,9 @@ class SymbolFunc:
         self.expr = expr
         self.param_set = protocols.parameter_names(expr)
         self.params = sorted(self.param_set)
-        self.func = sympy.lambdify(self.params, expr)
+        func_args = [f'_{i}' for i in range(len(self.params))]
+        self.func_expr = expr.subs({param: arg for param, arg in zip(self.params, func_args)})
+        self.func = sympy.lambdify(func_args, self.func_expr)
 
     def __repr__(self) -> str:
         return f'cirq.SymbolFunc({_compat.proper_repr(self.expr)})'

--- a/cirq-core/cirq/study/symbol_func.py
+++ b/cirq-core/cirq/study/symbol_func.py
@@ -1,0 +1,41 @@
+from typing import AbstractSet, TYPE_CHECKING, TypeVar, Union
+
+import sympy
+
+from cirq import protocols
+
+if TYPE_CHECKING:
+    import cirq
+
+
+T = TypeVar('T')
+
+class SymbolFunc:
+    """A "lambdified" symbolic expression that is faster for parameter resolution."""
+
+    @classmethod
+    def compile_expr(cls, expr: Union[T, sympy.Basic]) -> Union[T, sympy.Symbol, 'SymbolFunc']:
+        if isinstance(expr, sympy.Symbol):
+            return expr
+        if isinstance(expr, sympy.Basic):
+            return cls(expr)
+        return expr
+
+    def __init__(self, expr: sympy.Basic) -> None:
+        self.expr = expr
+        self.param_set = protocols.parameter_names(expr)
+        self.params = sorted(self.param_set)
+        self.func = sympy.lambdify(self.params, expr)
+
+    def __repr__(self) -> str:
+        return f'SymbolFunc({self.expr!r})'
+
+    def _is_parameterized_(self) -> bool:
+        return True
+
+    def _parameter_names_(self) -> AbstractSet[str]:
+        return self.param_set
+
+    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> float:
+        args = [resolver.value_of(param, recursive=recursive) for param in self.params]
+        return self.func(*args)

--- a/cirq-core/cirq/study/symbol_func_test.py
+++ b/cirq-core/cirq/study/symbol_func_test.py
@@ -1,0 +1,44 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sympy
+
+import cirq
+
+
+def test_compile_expr():
+    assert cirq.SymbolFunc.compile_expr(123) == 123
+    assert cirq.SymbolFunc.compile_expr(sympy.Symbol('abc')) == sympy.Symbol('abc')
+
+    expr = sympy.Symbol('abc') + 1
+    compiled = cirq.SymbolFunc.compile_expr(expr)
+    assert isinstance(compiled, cirq.SymbolFunc)
+    assert compiled.expr == expr
+
+
+def test_symbol_func_repr():
+    assert repr(cirq.SymbolFunc(sympy.Symbol('a'))) == "cirq.SymbolFunc(sympy.Symbol('a'))"
+
+
+def test_resolve_parameters():
+    func = cirq.SymbolFunc(sympy.Symbol('a') + sympy.Symbol('b'))
+    assert cirq.is_parameterized(func)
+    assert cirq.parameter_names(func) == {'a', 'b'}
+    assert cirq.resolve_parameters(func, {'a': 1, 'b': 10}) == 11
+
+    expr2 = cirq.resolve_parameters(func, {'a': 1})
+    assert isinstance(expr2, sympy.Basic)
+    assert cirq.is_parameterized(expr2)
+    assert cirq.parameter_names(expr2) == {'b'}
+    assert cirq.resolve_parameters(expr2, {'b': 10}) == 11

--- a/cirq-core/cirq/study/symbol_func_test.py
+++ b/cirq-core/cirq/study/symbol_func_test.py
@@ -27,6 +27,14 @@ def test_compile_expr():
     assert compiled.expr == expr
 
 
+def test_symbol_func_internal_symbols():
+    expr = sympy.Symbol('weird symbol') * sympy.Symbol('weird, also!') + 1
+    compiled = cirq.SymbolFunc(expr)
+    assert compiled.expr == expr
+    assert compiled.func_expr == sympy.Symbol('_0') * sympy.Symbol('_1') + 1
+    assert cirq.resolve_parameters(compiled, {'weird symbol': 3, 'weird, also!': 5}) == 16
+
+
 def test_symbol_func_repr():
     assert repr(cirq.SymbolFunc(sympy.Symbol('a'))) == "cirq.SymbolFunc(sympy.Symbol('a'))"
 


### PR DESCRIPTION
This significantly speeds up parameter resolution with symbolic expressions, which is particularly helpful if evaluating the same expressions repeatedly, for example in a sweep over parameters. Here is an example comparing repeated evaluation of a symbolic expression vs the pre-compiled `SymbolFunc`, where the latter is about 30x faster (4.802s -> 0.155s):
```python
In [1]: import sympy; import cirq

In [2]: expr = sympy.Symbol('a') - 1.0

In [3]: func = cirq.SymbolFunc(expr)

In [4]: def resolve(obj, reps=1000):
   ...:     for i in range(reps):
   ...:         cirq.resolve_parameters(obj, {'a': i / 10})
   ...: 

In [5]: %prun -s cumtime resolve(expr, 10000)
         9946944 function calls (9766944 primitive calls) in 4.802 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    4.802    4.802 {built-in method builtins.exec}
        1    0.000    0.000    4.802    4.802 <string>:1(<module>)
        1    0.014    0.014    4.802    4.802 <ipython-input-4-21f33806cd36>:1(resolve)
    10000    0.019    0.000    4.788    0.000 resolve_parameters.py:135(resolve_parameters)
40000/10000    0.150    0.000    4.742    0.000 resolver.py:73(value_of)
    10000    0.179    0.000    3.898    0.000 basic.py:764(subs)
80001/40001    0.099    0.000    2.819    0.000 cache.py:69(wrapper)
    10000    0.009    0.000    2.452    0.000 decorators.py:254(_func)
    10000    0.007    0.000    2.439    0.000 decorators.py:129(binary_op_wrapper)
    10000    0.008    0.000    2.430    0.000 expr.py:222(__mul__)
    10000    0.089    0.000    2.311    0.000 operations.py:46(__new__)
    10000    0.180    0.000    2.038    0.000 mul.py:178(flatten)
100000/60000    0.181    0.000    1.467    0.000 assumptions.py:452(getit)
60000/10000    0.248    0.000    1.440    0.000 assumptions.py:464(_ask)
    60000    0.307    0.000    0.901    0.000 random.py:293(shuffle)
    10000    0.016    0.000    0.595    0.000 expr.py:845(_eval_is_positive)
    10000    0.019    0.000    0.593    0.000 expr.py:855(_eval_is_negative)
  1070000    0.407    0.000    0.587    0.000 random.py:250(_randbelow_with_getrandbits)
   140000    0.071    0.000    0.498    0.000 sympify.py:92(sympify)
   120000    0.060    0.000    0.367    0.000 sympify.py:486(_sympify)
    20000    0.093    0.000    0.362    0.000 numbers.py:1031(__new__)
    50000    0.077    0.000    0.361    0.000 numbers.py:1383(__eq__)
    20000    0.124    0.000    0.281    0.000 basic.py:1867(_aresame)
    20000    0.038    0.000    0.266    0.000 symbol.py:399(__new__)
    10000    0.010    0.000    0.257    0.000 basic.py:957(_subs)
    50000    0.058    0.000    0.241    0.000 resolver.py:245(_resolve_value)
    20000    0.044    0.000    0.231    0.000 compatibility.py:498(ordered)
  1089998    0.182    0.000    0.219    0.000 {built-in method builtins.isinstance}
    10000    0.017    0.000    0.212    0.000 basic.py:906(<listcomp>)
    20000    0.083    0.000    0.198    0.000 mul.py:455(_gather)
    20000    0.046    0.000    0.189    0.000 symbol.py:274(__new_stage2__)
    10000    0.004    0.000    0.172    0.000 basic.py:925(<lambda>)
    10000    0.038    0.000    0.167    0.000 compatibility.py:476(_nodes)
    10000    0.005    0.000    0.152    0.000 mul.py:29(_mulsort)
    10000    0.013    0.000    0.148    0.000 {method 'sort' of 'list' objects}
...

In [6]: %prun -s cumtime resolve(func, 10000)
         420016 function calls (420006 primitive calls) in 0.155 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.155    0.155 {built-in method builtins.exec}
        1    0.000    0.000    0.155    0.155 <string>:1(<module>)
        1    0.006    0.006    0.155    0.155 <ipython-input-4-21f33806cd36>:1(resolve)
    10000    0.016    0.000    0.149    0.000 resolve_parameters.py:135(resolve_parameters)
    10000    0.008    0.000    0.113    0.000 symbol_func.py:37(_resolve_parameters_)
    10000    0.004    0.000    0.104    0.000 symbol_func.py:38(<listcomp>)
    10000    0.006    0.000    0.100    0.000 resolver.py:73(value_of)
    20000    0.014    0.000    0.094    0.000 resolver.py:245(_resolve_value)
    10000    0.006    0.000    0.059    0.000 numbers.py:3389(__eq__)
    10000    0.004    0.000    0.053    0.000 sympify.py:486(_sympify)
    10000    0.026    0.000    0.049    0.000 sympify.py:92(sympify)
   100000    0.017    0.000    0.026    0.000 {built-in method builtins.isinstance}
    10000    0.005    0.000    0.014    0.000 sympify.py:58(_is_numpy_instance)
    10000    0.005    0.000    0.009    0.000 {built-in method builtins.any}
    20000    0.004    0.000    0.009    0.000 abc.py:96(__instancecheck__)
    10000    0.006    0.000    0.008    0.000 resolver.py:65(__init__)
    10000    0.005    0.000    0.008    0.000 resolver.py:60(__new__)
    50000    0.006    0.000    0.006    0.000 {built-in method builtins.getattr}
    20000    0.005    0.000    0.005    0.000 {built-in method _abc._abc_instancecheck}
    30000    0.004    0.000    0.004    0.000 sympify.py:64(<genexpr>)
    10000    0.002    0.000    0.002    0.000 sympify.py:14(__init__)
    10000    0.002    0.000    0.002    0.000 {built-in method __new__ of type object at 0x7f49d7809340}
    10000    0.001    0.000    0.001    0.000 inspect.py:487(getmro)
    10000    0.001    0.000    0.001    0.000 <lambdifygenerated-1>:1(_lambdifygenerated)
    10000    0.001    0.000    0.001    0.000 {built-in method builtins.hasattr}
    10000    0.001    0.000    0.001    0.000 typing.py:1149(cast)
    10000    0.001    0.000    0.001    0.000 {method 'get' of 'dict' objects}
      6/1    0.000    0.000    0.000    0.000 abc.py:100(__subclasscheck__)
      6/1    0.000    0.000    0.000    0.000 {built-in method _abc._abc_subclasscheck}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```
We have also updated the `PhasedXZGate` to precompile symbolic parameters if needed before parameter resolution. This provides an even bigger ~66x speedup when compiling a parameterized example gate (3.585s -> 0.054s):

Master:
```python
In [1]: import sympy; import cirq

In [2]: gate = cirq.PhasedXZGate(x_exponent=sympy.Symbol('x') - 1.0, z_exponent=sympy.Symbol('z') - 2.0, axis_phase_ex
   ...: ponent=sympy.Symbol('a') - 3.0)

In [3]: def resolve(obj, reps=1000):
   ...:     for i in range(reps):
   ...:         cirq.resolve_parameters(obj, {'x': i / 2, 'z': i / 5, 'a': i / 10})
   ...: 

In [4]: %prun -s cumtime resolve(gate, 1000)
         7942201 function calls (7786201 primitive calls) in 3.585 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    3.585    3.585 {built-in method builtins.exec}
        1    0.000    0.000    3.585    3.585 <string>:1(<module>)
        1    0.002    0.002    3.585    3.585 <ipython-input-3-8914482a37fe>:1(resolve)
     1000    0.003    0.000    3.582    0.004 resolve_parameters.py:135(resolve_parameters)
     1000    0.003    0.000    3.577    0.004 phased_x_z_gate.py:186(_resolve_parameters_)
12000/3000    0.047    0.000    3.573    0.001 resolver.py:73(value_of)
     3000    0.091    0.000    3.321    0.001 basic.py:764(subs)
75009/39009    0.080    0.000    2.268    0.000 cache.py:69(wrapper)
     9000    0.007    0.000    1.983    0.000 decorators.py:254(_func)
     9000    0.006    0.000    1.972    0.000 decorators.py:129(binary_op_wrapper)
     9000    0.007    0.000    1.964    0.000 expr.py:222(__mul__)
     9000    0.077    0.000    1.880    0.000 operations.py:46(__new__)
     9000    0.159    0.000    1.645    0.000 mul.py:178(flatten)
90000/54000    0.044    0.000    1.151    0.000 assumptions.py:452(getit)
54000/9000    0.205    0.000    1.128    0.000 assumptions.py:464(_ask)
    54000    0.268    0.000    0.795    0.000 random.py:293(shuffle)
   963000    0.363    0.000    0.521    0.000 random.py:250(_randbelow_with_getrandbits)
24000/12000    0.058    0.000    0.435    0.000 compatibility.py:498(ordered)
     9000    0.010    0.000    0.393    0.000 expr.py:845(_eval_is_positive)
     9000    0.010    0.000    0.388    0.000 expr.py:855(_eval_is_negative)
    87000    0.044    0.000    0.292    0.000 sympify.py:92(sympify)
    69000    0.161    0.000    0.287    0.000 sympify.py:486(_sympify)
     9000    0.003    0.000    0.259    0.000 basic.py:925(<lambda>)
     9000    0.030    0.000    0.256    0.000 compatibility.py:476(_nodes)
    18000    0.110    0.000    0.245    0.000 basic.py:1867(_aresame)
     9000    0.009    0.000    0.230    0.000 basic.py:957(_subs)
     9000    0.012    0.000    0.213    0.000 basic.py:1518(count)
    12000    0.053    0.000    0.208    0.000 numbers.py:1031(__new__)
     9000    0.014    0.000    0.186    0.000 basic.py:906(<listcomp>)
    18000    0.073    0.000    0.169    0.000 mul.py:455(_gather)
    12000    0.024    0.000    0.169    0.000 symbol.py:399(__new__)
     9000    0.011    0.000    0.156    0.000 basic.py:2052(_make_find_query)
     9000    0.004    0.000    0.132    0.000 mul.py:29(_mulsort)
     9000    0.011    0.000    0.128    0.000 {method 'sort' of 'list' objects}
    18000    0.027    0.000    0.121    0.000 numbers.py:1383(__eq__)
    12000    0.028    0.000    0.119    0.000 symbol.py:274(__new_stage2__)
     9000    0.032    0.000    0.117    0.000 basic.py:189(compare)
   638982    0.104    0.000    0.116    0.000 {built-in method builtins.isinstance}
```

This branch:
```python
In [1]: import sympy; import cirq

In [2]: gate = cirq.PhasedXZGate(x_exponent=sympy.Symbol('x') - 1.0, z_exponent=sympy.Symbol('z') - 2.0, axis_phase_ex
   ...: ponent=sympy.Symbol('a') - 3.0)

In [3]: def resolve(obj, reps=1000):
   ...:     for i in range(reps):
   ...:         cirq.resolve_parameters(obj, {'x': i / 2, 'z': i / 5, 'a': i / 10})
   ...: 

In [4]: %prun -s cumtime resolve(gate, 1000)
         117004 function calls in 0.054 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.054    0.054 {built-in method builtins.exec}
        1    0.000    0.000    0.054    0.054 <string>:1(<module>)
        1    0.001    0.001    0.054    0.054 <ipython-input-3-8914482a37fe>:1(resolve)
     1000    0.002    0.000    0.053    0.000 resolve_parameters.py:135(resolve_parameters)
     1000    0.002    0.000    0.049    0.000 phased_x_z_gate.py:200(_resolve_parameters_)
     3000    0.004    0.000    0.047    0.000 resolver.py:73(value_of)
     3000    0.004    0.000    0.039    0.000 resolver.py:245(_resolve_value)
     3000    0.002    0.000    0.032    0.000 numbers.py:3389(__eq__)
     3000    0.001    0.000    0.030    0.000 sympify.py:486(_sympify)
     3000    0.016    0.000    0.028    0.000 sympify.py:92(sympify)
     6000    0.003    0.000    0.009    0.000 sympify.py:58(_is_numpy_instance)
    36000    0.007    0.000    0.008    0.000 {built-in method builtins.isinstance}
     6000    0.003    0.000    0.006    0.000 {built-in method builtins.any}
    18000    0.003    0.000    0.003    0.000 sympify.py:64(<genexpr>)
    13000    0.002    0.000    0.002    0.000 {built-in method builtins.getattr}
     3000    0.001    0.000    0.002    0.000 abc.py:96(__instancecheck__)
     1000    0.001    0.000    0.001    0.000 resolver.py:65(__init__)
     1000    0.001    0.000    0.001    0.000 resolver.py:60(__new__)
     3000    0.001    0.000    0.001    0.000 {built-in method _abc._abc_instancecheck}
     3000    0.001    0.000    0.001    0.000 sympify.py:14(__init__)
     3000    0.000    0.000    0.000    0.000 inspect.py:487(getmro)
     1000    0.000    0.000    0.000    0.000 phased_x_z_gate.py:32(__init__)
     3000    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
     1000    0.000    0.000    0.000    0.000 {built-in method __new__ of type object at 0x7f62d01c6340}
     1000    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
     1000    0.000    0.000    0.000    0.000 typing.py:1149(cast)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```
