### PR TITLE
Make sure cirq gates and operations decompose to XPow/YPow/ZPow/CZPow + Measurement

### DIFF
--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -93,11 +93,17 @@ class ControlledOperation(raw_types.Operation):
         )
 
     def _decompose_(self):
+        result = protocols.decompose_once_with_qubits(self.gate, self.qubits, NotImplemented)
+        if result is not NotImplemented:
+            return result
+
         result = protocols.decompose_once(self.sub_operation, NotImplemented)
         if result is NotImplemented:
             return NotImplemented
 
-        return [ControlledOperation(self.controls, op, self.control_values) for op in result]
+        return [
+            op.controlled_by(*self.controls, control_values=self.control_values) for op in result
+        ]
 
     def _value_equality_values_(self):
         return (frozenset(zip(self.controls, self.control_values)), self.sub_operation)

--- a/cirq-core/cirq/ops/matrix_gates.py
+++ b/cirq-core/cirq/ops/matrix_gates.py
@@ -18,12 +18,22 @@ from typing import Any, cast, Dict, Iterable, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 
-from cirq import linalg, protocols
+from cirq import linalg, protocols, _import
 from cirq._compat import proper_repr
 from cirq.ops import raw_types
 
 if TYPE_CHECKING:
     import cirq
+
+single_qubit_decompositions = _import.LazyLoader(
+    'single_qubit_decompositions', globals(), 'cirq.transformers.analytical_decompositions'
+)
+two_qubit_to_cz = _import.LazyLoader(
+    'two_qubit_to_cz', globals(), 'cirq.transformers.analytical_decompositions'
+)
+three_qubit_decomposition = _import.LazyLoader(
+    'three_qubit_decomposition', globals(), 'cirq.transformers.analytical_decompositions'
+)
 
 
 class MatrixGate(raw_types.Gate):
@@ -115,6 +125,20 @@ class MatrixGate(raw_types.Gate):
         result[linalg.slice_for_qubits_equal_to([i], 1)] *= p
         result[linalg.slice_for_qubits_equal_to([j], 1)] *= np.conj(p)
         return MatrixGate(matrix=result.reshape(self._matrix.shape), qid_shape=self._qid_shape)
+
+    def _decompose_(self, qubits: Tuple['cirq.Qid', ...]):
+        if self._qid_shape == (2,):
+            return [
+                g.on(qubits[0])
+                for g in single_qubit_decompositions.single_qubit_matrix_to_gates(self._matrix)
+            ]
+        if self._qid_shape == (2,) * 2:
+            return two_qubit_to_cz.two_qubit_matrix_to_operations(
+                *qubits, self._matrix, allow_partial_czs=True
+            )
+        if self._qid_shape == (2,) * 3:
+            return three_qubit_decomposition.three_qubit_matrix_to_operations(*qubits, self._matrix)
+        return NotImplemented
 
     def _has_unitary_(self) -> bool:
         return True

--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -279,13 +279,19 @@ def test_str_executes():
 def test_one_qubit_consistent():
     u = cirq.testing.random_unitary(2)
     g = cirq.MatrixGate(u)
-    cirq.testing.assert_implements_consistent_protocols(g)
+    cirq.testing.assert_implements_consistent_protocols(g, ignoring_global_phase=True)
 
 
 def test_two_qubit_consistent():
     u = cirq.testing.random_unitary(4)
     g = cirq.MatrixGate(u)
-    cirq.testing.assert_implements_consistent_protocols(g)
+    cirq.testing.assert_implements_consistent_protocols(g, ignoring_global_phase=True)
+
+
+def test_three_qubit_consistent():
+    u = cirq.testing.random_unitary(8)
+    g = cirq.MatrixGate(u)
+    cirq.testing.assert_implements_consistent_protocols(g, ignoring_global_phase=True)
 
 
 def test_repr():

--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -47,6 +47,15 @@ RaiseTypeErrorIfNotProvided: Any = ([],)
 DecomposeResult = Union[None, NotImplementedType, 'cirq.OP_TREE']
 OpDecomposer = Callable[['cirq.Operation'], DecomposeResult]
 
+DECOMPOSE_TARGET_GATESET = ops.Gateset(
+    ops.XPowGate,
+    ops.YPowGate,
+    ops.ZPowGate,
+    ops.CZPowGate,
+    ops.MeasurementGate,
+    ops.GlobalPhaseGate,
+)
+
 
 def _value_error_describing_bad_operation(op: 'cirq.Operation') -> ValueError:
     return ValueError(f"Operation doesn't satisfy the given `keep` but can't be decomposed: {op!r}")

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -33,6 +33,7 @@ from cirq.testing.consistent_controlled_gate_op import (
 )
 
 from cirq.testing.consistent_decomposition import (
+    assert_decompose_ends_at_default_gateset,
     assert_decompose_is_consistent_with_unitary,
 )
 

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -47,3 +47,20 @@ def assert_decompose_is_consistent_with_unitary(val: Any, ignoring_global_phase:
     else:
         # coverage: ignore
         np.testing.assert_allclose(actual, expected, atol=1e-8)
+
+
+def assert_decompose_ends_at_default_gateset(val: Any):
+    """Ensures that all cirq gate decompositions end at the default cirq gateset."""
+
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
+    # pylint: enable=unused-variable
+    if protocols.is_parameterized(val):
+        return
+    args = () if isinstance(val, ops.Operation) else (tuple(devices.LineQid.for_gate(val)),)
+    dec_once = protocols.decompose_once(val, None, *args)
+    if dec_once is None:
+        # _decompose_ is NotImplemented, so silently return.
+        return
+    dec = [*ops.flatten_to_ops(protocols.decompose(d) for d in dec_once)]
+    assert all(op in protocols.decompose_protocol.DECOMPOSE_TARGET_GATESET for op in dec)

--- a/cirq-core/cirq/testing/consistent_decomposition_test.py
+++ b/cirq-core/cirq/testing/consistent_decomposition_test.py
@@ -49,3 +49,63 @@ def test_assert_decompose_is_consistent_with_unitary():
         cirq.testing.assert_decompose_is_consistent_with_unitary(
             BadGateDecompose().on(cirq.NamedQubit('q'))
         )
+
+
+class GateDecomposesToDefaultGateset(cirq.Gate):
+    def _num_qubits_(self):
+        return 2
+
+    def _decompose_(self, qubits):
+        return [GoodGateDecompose().on(qubits[0]), BadGateDecompose().on(qubits[1])]
+
+
+class GateDecomposeDoesNotEndInDefaultGateset(cirq.Gate):
+    def _num_qubits_(self):
+        return 4
+
+    def _decompose_(self, qubits):
+        return cirq.MatrixGate(cirq.testing.random_unitary(16)).on(*qubits)
+
+
+class GateDecomposeNotImplemented(cirq.SingleQubitGate):
+    def _decompose_(self, qubits):
+        return NotImplemented
+
+
+class ParameterizedGate(cirq.SingleQubitGate):
+    def _is_parameterized_(self):
+        return True
+
+    def _num_qubits_(self):
+        return 4
+
+    def _decompose_(self, qubits):
+        assert False, "Decompose should not be called for parameterized gates."
+
+
+def test_assert_decompose_ends_at_default_gateset():
+
+    cirq.testing.assert_decompose_ends_at_default_gateset(GateDecomposesToDefaultGateset())
+    cirq.testing.assert_decompose_ends_at_default_gateset(
+        GateDecomposesToDefaultGateset().on(*cirq.LineQubit.range(2))
+    )
+
+    cirq.testing.assert_decompose_ends_at_default_gateset(GateDecomposeNotImplemented())
+    cirq.testing.assert_decompose_ends_at_default_gateset(
+        GateDecomposeNotImplemented().on(cirq.NamedQubit('q'))
+    )
+
+    cirq.testing.assert_decompose_ends_at_default_gateset(ParameterizedGate())
+    cirq.testing.assert_decompose_ends_at_default_gateset(
+        ParameterizedGate().on(*cirq.LineQubit.range(4))
+    )
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_decompose_ends_at_default_gateset(
+            GateDecomposeDoesNotEndInDefaultGateset()
+        )
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_decompose_ends_at_default_gateset(
+            GateDecomposeDoesNotEndInDefaultGateset().on(*cirq.LineQubit.range(4))
+        )

--- a/cirq-core/cirq/testing/consistent_protocols.py
+++ b/cirq-core/cirq/testing/consistent_protocols.py
@@ -26,6 +26,7 @@ from cirq.testing.circuit_compare import (
 )
 from cirq.testing.consistent_decomposition import (
     assert_decompose_is_consistent_with_unitary,
+    assert_decompose_ends_at_default_gateset,
 )
 from cirq.testing.consistent_phase_by import (
     assert_phase_by_is_consistent_with_unitary,
@@ -55,6 +56,7 @@ def assert_implements_consistent_protocols(
     setup_code: str = 'import cirq\nimport numpy as np\nimport sympy',
     global_vals: Optional[Dict[str, Any]] = None,
     local_vals: Optional[Dict[str, Any]] = None,
+    ignore_decompose_to_default_gateset: bool = False,
 ) -> None:
     """Checks that a value is internally consistent and has a good __repr__."""
     global_vals = global_vals or {}
@@ -66,6 +68,7 @@ def assert_implements_consistent_protocols(
         setup_code=setup_code,
         global_vals=global_vals,
         local_vals=local_vals,
+        ignore_decompose_to_default_gateset=ignore_decompose_to_default_gateset,
     )
 
     for exponent in exponents:
@@ -77,6 +80,7 @@ def assert_implements_consistent_protocols(
                 setup_code=setup_code,
                 global_vals=global_vals,
                 local_vals=local_vals,
+                ignore_decompose_to_default_gateset=ignore_decompose_to_default_gateset,
             )
 
 
@@ -90,11 +94,12 @@ def assert_eigengate_implements_consistent_protocols(
     setup_code: str = 'import cirq\nimport numpy as np\nimport sympy',
     global_vals: Optional[Dict[str, Any]] = None,
     local_vals: Optional[Dict[str, Any]] = None,
+    ignore_decompose_to_default_gateset: bool = False,
 ) -> None:
     """Checks that an EigenGate subclass is internally consistent and has a
     good __repr__."""
     # pylint: disable=unused-variable
-    __tracebackhide__ = True
+    # __tracebackhide__ = True
     # pylint: enable=unused-variable
 
     for exponent in exponents:
@@ -105,6 +110,7 @@ def assert_eigengate_implements_consistent_protocols(
                 setup_code=setup_code,
                 global_vals=global_vals,
                 local_vals=local_vals,
+                ignore_decompose_to_default_gateset=ignore_decompose_to_default_gateset,
             )
 
 
@@ -143,8 +149,9 @@ def _assert_meets_standards_helper(
     setup_code: str,
     global_vals: Optional[Dict[str, Any]],
     local_vals: Optional[Dict[str, Any]],
+    ignore_decompose_to_default_gateset: bool,
 ) -> None:
-    __tracebackhide__ = True  # pylint: disable=unused-variable
+    # __tracebackhide__ = True  # pylint: disable=unused-variable
 
     assert_consistent_resolve_parameters(val)
     assert_specifies_has_unitary_if_unitary(val)
@@ -154,6 +161,8 @@ def _assert_meets_standards_helper(
     assert_qasm_is_consistent_with_unitary(val)
     assert_has_consistent_trace_distance_bound(val)
     assert_decompose_is_consistent_with_unitary(val, ignoring_global_phase=ignoring_global_phase)
+    if not ignore_decompose_to_default_gateset:
+        assert_decompose_ends_at_default_gateset(val)
     assert_phase_by_is_consistent_with_unitary(val)
     assert_pauli_expansion_is_consistent_with_unitary(val)
     assert_equivalent_repr(


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/4858

This PR makes sure that most cirq gates and operations decompose to a default cirq gateset, which is defined to be XPow/YPow/ZPow/CZPow/Measurement and GlobalPhaseGate. 

`cirq.testing.assert_implements_consistent_protocols` is extended to also check that if an object (gate / operation) has a `_decompose_` method defined, then it should always end up decomposing to the cirq default gateset. 

Note that some gates, like MatrixGates on more than 3 qubits, Controlled gates acting on qudits / multi-qubit matrix gates etc.  can still not be decomposed into the default gateset always. 

