### PR TITLE
Pin sympy version to <1.10

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -13,6 +13,7 @@ numpy~=1.16
 pandas
 sortedcontainers~=2.0
 scipy
-sympy==1.9
+# TODO: unpin once #5058 is resolved
+sympy<1.10
 typing_extensions
 tqdm

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -13,6 +13,6 @@ numpy~=1.16
 pandas
 sortedcontainers~=2.0
 scipy
-sympy
+sympy==1.9
 typing_extensions
 tqdm


### PR DESCRIPTION
Part of #5058. The latest sympy release (v1.10) appears to have broken our mypy tests: #4936, #4964, #5030

Pinning until we can bring ourselves up to date (assuming that's what we want to do here)