### PR TITLE
Change ValueError to assertion in clifford_optimize

### DIFF
--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
@@ -92,14 +92,12 @@ def clifford_optimized_circuit(circuit: circuits.Circuit, atol: float = 1e-8) ->
 
             qubit, pauli = next(iter(merge_op.pauli_string.items()))
             quarter_turns = round(merge_op.exponent_relative * 2)
-            if merge_op.pauli_string.coefficient not in [1, -1]:
-                # TODO: Add support for more general phases.
-                # Github issue: https://github.com/quantumlib/Cirq/issues/2962
-                # Legacy coverage ignore, we need test code that hits this.
-                # coverage: ignore
-                raise NotImplementedError(
-                    'Only +1/-1 pauli string coefficients currently supported'
-                )
+            # The coefficient is initialized as 1 above, and only modified by pass_operations_over,
+            # which can only negate it.
+            assert merge_op.pauli_string.coefficient in [
+                1,
+                -1,
+            ], 'PauliString coefficient not in {1, -1}'
             quarter_turns *= int(merge_op.pauli_string.coefficient.real)
             quarter_turns %= 4
             part_cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(pauli, quarter_turns)

--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
@@ -92,12 +92,6 @@ def clifford_optimized_circuit(circuit: circuits.Circuit, atol: float = 1e-8) ->
 
             qubit, pauli = next(iter(merge_op.pauli_string.items()))
             quarter_turns = round(merge_op.exponent_relative * 2)
-            # The coefficient is initialized as 1 above, and only modified by pass_operations_over,
-            # which can only negate it.
-            assert merge_op.pauli_string.coefficient in [
-                1,
-                -1,
-            ], 'PauliString coefficient not in {1, -1}'
             quarter_turns *= int(merge_op.pauli_string.coefficient.real)
             quarter_turns %= 4
             part_cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(pauli, quarter_turns)


### PR DESCRIPTION
Fixes #2962

@dabacon hunch was correct. The coefficient is initialized at 1, and can only be negated. Changed the error to an assertion accordingly,

https://github.com/quantumlib/Cirq/blob/9cefed8c384dc8a6751e4fe114873bf349160721/cirq-core/cirq/ops/pauli_string.py#L946

Update: Removed the assertion entirely since that assertion already exists in `PauliStringPhasor.__init__`