### PR TITLE
Add ZGateFamily to validate virtual/physical Z gates.

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -95,6 +95,7 @@ from cirq_google.ops import (
     PhysicalZTag,
     SycamoreGate,
     SYC,
+    ZGateFamily,
 )
 
 from cirq_google.optimizers import (

--- a/cirq-google/cirq_google/json_resolver_cache.py
+++ b/cirq-google/cirq_google/json_resolver_cache.py
@@ -34,6 +34,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'GateTabulation': cirq_google.GateTabulation,
         'PhysicalZTag': cirq_google.PhysicalZTag,
         'FSimGateFamily': cirq_google.FSimGateFamily,
+        'ZGateFamily': cirq_google.ZGateFamily,
         'FloquetPhasedFSimCalibrationOptions': cirq_google.FloquetPhasedFSimCalibrationOptions,
         'FloquetPhasedFSimCalibrationRequest': cirq_google.FloquetPhasedFSimCalibrationRequest,
         'PhasedFSimCalibrationResult': cirq_google.PhasedFSimCalibrationResult,

--- a/cirq-google/cirq_google/json_test_data/ZGateFamily.json
+++ b/cirq-google/cirq_google/json_test_data/ZGateFamily.json
@@ -1,0 +1,10 @@
+[
+    {
+        "cirq_type": "ZGateFamily",
+        "physical_z": false
+    },
+    {
+        "cirq_type": "ZGateFamily",
+        "physical_z": true
+    }
+]

--- a/cirq-google/cirq_google/json_test_data/ZGateFamily.repr
+++ b/cirq-google/cirq_google/json_test_data/ZGateFamily.repr
@@ -1,0 +1,4 @@
+[
+    cirq_google.ZGateFamily(physical_z=False),
+    cirq_google.ZGateFamily(physical_z=True),
+]

--- a/cirq-google/cirq_google/ops/__init__.py
+++ b/cirq-google/cirq_google/ops/__init__.py
@@ -28,3 +28,7 @@ from cirq_google.ops.sycamore_gate import (
     SycamoreGate,
     SYC,
 )
+
+from cirq_google.ops.z_gate_family import (
+    ZGateFamily,
+)

--- a/cirq-google/cirq_google/ops/z_gate_family.py
+++ b/cirq-google/cirq_google/ops/z_gate_family.py
@@ -1,0 +1,68 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Union
+
+import cirq
+from cirq.ops import raw_types
+from cirq_google.ops.physical_z_tag import PhysicalZTag
+
+
+_PHYSICAL_Z_TAG = PhysicalZTag()
+
+
+class ZGateFamily(cirq.GateFamily):
+    """A GateFamily which accepts either virtual or physical Z gates from Google devices.
+
+    If `physical_z` is true, accepts physical Z gates, i.e. `TaggedOperations` containing a Z gate
+    and a `cirq_google.PhysicalZTag`.
+    Otherwise, Accepts virtual Z gates, i.e. Z gates without a `cirq_google.PhysicalZTag`.
+    """
+
+    def __init__(self, physical_z=False) -> None:
+        self._physical_z = physical_z
+        super().__init__(cirq.Z, ignore_global_phase=True)
+
+    def __contains__(self, item: Union[raw_types.Gate, raw_types.Operation]) -> bool:
+        if (
+            isinstance(item, cirq.TaggedOperation)
+            and item.gate is not None
+            and super().__contains__(item.gate)
+        ):
+            return self._physical_z == (_PHYSICAL_Z_TAG in item.tags)
+
+        if not self._physical_z:
+            return super().__contains__(item)
+
+        return False
+
+    def _default_name(self) -> str:
+        return f"ZGateFamily({'Physical' if self._physical_z else 'Virtual'})"
+
+    def _default_description(self) -> str:
+        if self._physical_z:
+            return 'Accepts TaggedOperations containing a Z gate and a cirq_google.PhysicalZTag'
+        return 'Accepts a virtual Z gate, i.e. a Z gate without cirq_google.PhysicalZTag'
+
+    def __repr__(self) -> str:
+        return 'cirq_google.ZGateFamily(' f'physical_z={self._physical_z})'
+
+    def _json_dict_(self):
+        return {
+            'physical_z': self._physical_z,
+        }
+
+    @classmethod
+    def _from_json_dict_(cls, physical_z, **kwargs):
+        return cls(physical_z)

--- a/cirq-google/cirq_google/ops/z_gate_family_test.py
+++ b/cirq-google/cirq_google/ops/z_gate_family_test.py
@@ -1,0 +1,56 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import cirq
+from cirq_google.ops.physical_z_tag import PhysicalZTag
+from cirq_google.ops.z_gate_family import ZGateFamily
+
+
+q = cirq.LineQubit(0)
+
+
+@pytest.mark.parametrize(
+    'physical_z, gate, accepted',
+    [
+        (True, cirq.Z(q).with_tags(PhysicalZTag()), True),
+        (True, cirq.Z(q).with_tags('some_tag'), False),
+        (True, cirq.Z(q).with_tags(), False),
+        (True, cirq.Z(q), False),
+        (True, cirq.Z, False),
+        (True, (cirq.Z ** 0.5)(q), False),
+        (True, cirq.Z ** 0.5, False),
+        (False, cirq.Z(q).with_tags(PhysicalZTag()), False),
+        (False, cirq.Z(q).with_tags('some_tag'), True),
+        (False, cirq.Z(q).with_tags(), True),
+        (False, cirq.Z(q), True),
+        (False, cirq.Z, True),
+        (False, (cirq.Z ** 0.5)(q), False),
+        (False, cirq.Z ** 0.5, False),
+    ],
+)
+def test_z_gate_family_accept(gate, physical_z, accepted):
+    assert (gate in ZGateFamily(physical_z)) == accepted
+
+
+def test_virtual_z_gate_family_repr():
+    gate_family = ZGateFamily(physical_z=False)
+    cirq.testing.assert_equivalent_repr(gate_family, setup_code='import cirq\nimport cirq_google')
+    assert 'ZGateFamily(Virtual)' in str(gate_family)
+
+
+def test_physical_z_gate_family_repr():
+    gate_family = ZGateFamily(physical_z=True)
+    cirq.testing.assert_equivalent_repr(gate_family, setup_code='import cirq\nimport cirq_google')
+    assert 'ZGateFamily(Physical)' in str(gate_family)


### PR DESCRIPTION
* Both `ZGateFamily(physical_z=True)` and `ZGateFamily(physical_z=False)` will be included in most Google gatesets.
  * Having distinct GateFamily instances allows different gate durations to be specified.
* Correspond to `VirtualZ` and `PhysicalZ` gate types in `DeviceSpecification` proto.
* Devices can disable physical Z support by removing `PhysicalZ` from `DeviceSpecification`, which translates to excluding `ZGateFamily(physical_z=True)` from the gateset.

@dstrain115 @tanujkhattar