### PR TITLE
Wrap private fields for DensePauliString

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -30,6 +30,8 @@ import pandas as pd
 import sympy
 import sympy.printing.repr
 
+ALLOW_DEPRECATION_IN_TEST = 'ALLOW_DEPRECATION_IN_TEST'
+
 
 try:
     from functools import cached_property  # pylint: disable=unused-import
@@ -144,8 +146,6 @@ def proper_eq(a: Any, b: Any) -> bool:
 
 
 def _warn_or_error(msg):
-    from cirq.testing.deprecation import ALLOW_DEPRECATION_IN_TEST
-
     deprecation_allowed = ALLOW_DEPRECATION_IN_TEST in os.environ
     if _called_from_test() and not deprecation_allowed:
         for filename, line_number, function_name, text in reversed(traceback.extract_stack()):

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -308,7 +308,7 @@ class SingleQubitCliffordGate(gate_features.SingleQubitGate):
             to = z_to
         else:
             to = x_to * z_to  # Y = iXZ
-            to.coefficient *= 1j
+            to._coefficient *= 1j
         # pauli_mask returns a value between 0 and 4 for [I, X, Y, Z].
         to_gate = Pauli._XYZ[to.pauli_mask[0] - 1]
         return PauliTransform(to=to_gate, flip=bool(to.coefficient != 1.0))

--- a/cirq-core/cirq/ops/dense_pauli_string_test.py
+++ b/cirq-core/cirq/ops/dense_pauli_string_test.py
@@ -658,3 +658,14 @@ def test_symbolic():
     assert p == cirq.MutableDensePauliString('XYZ', coefficient=t * r)
     p /= r
     assert p == cirq.MutableDensePauliString('XYZ', coefficient=t)
+
+
+def test_setters_deprecated():
+    gate = cirq.DensePauliString('X')
+    mask = np.array([0, 3, 1, 2], dtype=np.uint8)
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        gate.pauli_mask = mask
+    assert gate.pauli_mask is mask
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        gate.coefficient = -1
+    assert gate.coefficient == -1

--- a/cirq-core/cirq/testing/deprecation.py
+++ b/cirq-core/cirq/testing/deprecation.py
@@ -16,7 +16,7 @@ import logging
 import os
 from typing import Iterator, Optional
 
-ALLOW_DEPRECATION_IN_TEST = 'ALLOW_DEPRECATION_IN_TEST'
+from cirq._compat import ALLOW_DEPRECATION_IN_TEST
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
https://github.com/quantumlib/Cirq/issues/4851 for `DensePauliString`. This was *slightly* less straightforward than others.

* Required moving `ALLOW_DEPRECATION_IN_TEST` or else a circular dependency was created.
* One place externally where setting the field still was necessary. (A factory method in `CliffordGate`).
* One member is of type `ndarray`, which is mutable, so we set `flags.writeable = False`