### PR TITLE
Order of keys shouldn't matter when comparing cirq.google.KeyValueExecutableSpec

### DIFF
--- a/cirq-google/cirq_google/workflow/quantum_executable.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable.py
@@ -79,6 +79,12 @@ class KeyValueExecutableSpec(ExecutableSpec):
     def __repr__(self) -> str:
         return cirq._compat.dataclass_repr(self, namespace='cirq_google')
 
+    def __eq__(self, other):
+        # The conversion to a dict object is required so that the order of the keys doesn't matter.
+        return (self.executable_family == other.executable_family) and (
+            dict(self.key_value_pairs) == dict(other.key_value_pairs)
+        )
+
 
 @dataclass(frozen=True)
 class BitstringsMeasurement:

--- a/cirq-google/cirq_google/workflow/quantum_executable.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable.py
@@ -47,7 +47,8 @@ class KeyValueExecutableSpec(ExecutableSpec):
     Args:
         executable_family: A unique name to group executables.
         key_value_pairs: A tuple of key-value pairs. The keys should be strings but the values
-            can be any immutable object.
+            can be any immutable object. Note that the order of the key-value pairs does NOT matter
+            when comparing two objects.
     """
 
     executable_family: str

--- a/cirq-google/cirq_google/workflow/quantum_executable_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable_test.py
@@ -187,3 +187,12 @@ def test_quantum_executable_group_serialization(tmpdir):
     cirq.to_json(eg, f'{tmpdir}/eg.json')
     eg_reconstructed = cirq.read_json(f'{tmpdir}/eg.json')
     assert eg == eg_reconstructed
+
+
+def test_equality():
+    d1 = dict.fromkeys(['a', 'b'])
+    d2 = dict.fromkeys(['b', 'a'])
+    assert d1 == d2
+    k1 = KeyValueExecutableSpec.from_dict(d1, executable_family='test')
+    k2 = KeyValueExecutableSpec.from_dict(d2, executable_family='test')
+    assert k1 == k2

--- a/cirq-google/cirq_google/workflow/quantum_executable_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable_test.py
@@ -190,8 +190,8 @@ def test_quantum_executable_group_serialization(tmpdir):
 
 
 def test_equality():
-    d1 = dict.fromkeys(['a', 'b'])
-    d2 = dict.fromkeys(['b', 'a'])
+    d1 = {'a': 1, 'b': 2}
+    d2 = {'b': 2, 'a': 1}
     assert d1 == d2
     k1 = KeyValueExecutableSpec.from_dict(d1, executable_family='test')
     k2 = KeyValueExecutableSpec.from_dict(d2, executable_family='test')

--- a/cirq-google/cirq_google/workflow/quantum_executable_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable_test.py
@@ -190,6 +190,24 @@ def test_quantum_executable_group_serialization(tmpdir):
 
 
 def test_equality():
+    k1 = KeyValueExecutableSpec(
+        executable_family='test',
+        key_value_pairs=(
+            ('a', 1),
+            ('b', 2),
+        ),
+    )
+    k2 = KeyValueExecutableSpec(
+        executable_family='test',
+        key_value_pairs=(
+            ('b', 2),
+            ('a', 1),
+        ),
+    )
+    assert k1 == k2
+
+
+def test_equality_from_dictionaries():
     d1 = {'a': 1, 'b': 2}
     d2 = {'b': 2, 'a': 1}
     assert d1 == d2


### PR DESCRIPTION
For issue #4734. It was discussed there that the order of the keys should not matter.