### PR TITLE
Remove public fields from subop gates and ops

### DIFF
--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -19,6 +19,7 @@ import sympy
 
 import cirq
 from cirq import value, _compat
+from cirq._compat import deprecated
 from cirq.ops import raw_types
 
 
@@ -93,7 +94,19 @@ class PhaseGradientGate(raw_types.Gate):
 
     def __init__(self, *, num_qubits: int, exponent: Union[float, sympy.Basic]):
         self._num_qubits = num_qubits
-        self.exponent = exponent
+        self._exponent = exponent
+
+    @property
+    def exponent(self) -> Union[float, sympy.Basic]:
+        return self._exponent
+
+    @exponent.setter  # type: ignore
+    @deprecated(
+        deadline="v0.15",
+        fix="The mutators of this class are deprecated, instantiate a new object instead.",
+    )
+    def exponent(self, exponent: Union[float, sympy.Basic]):
+        self._exponent = exponent
 
     def _json_dict_(self) -> Dict[str, Any]:
         return {

--- a/cirq-core/cirq/ops/fourier_transform_test.py
+++ b/cirq-core/cirq/ops/fourier_transform_test.py
@@ -170,3 +170,11 @@ def test_circuit_diagram():
 3: ───#4────#4───────
         """,
     )
+
+
+def test_setters_deprecated():
+    gate = cirq.PhaseGradientGate(num_qubits=1, exponent=0.1)
+    assert gate.exponent == 0.1
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        gate.exponent = 0.2
+        assert gate.exponent == 0.2

--- a/cirq-core/cirq/ops/permutation_gate.py
+++ b/cirq-core/cirq/ops/permutation_gate.py
@@ -15,6 +15,7 @@
 from typing import Any, Dict, Sequence, Tuple, TYPE_CHECKING
 
 from cirq import protocols, value
+from cirq._compat import deprecated
 from cirq.ops import raw_types
 
 if TYPE_CHECKING:
@@ -50,7 +51,19 @@ class QubitPermutationGate(raw_types.Gate):
                 f"Invalid indices: {invalid_indices}"
             )
 
-        self.permutation = tuple(permutation)
+        self._permutation = tuple(permutation)
+
+    @property
+    def permutation(self) -> Tuple[int, ...]:
+        return self._permutation
+
+    @permutation.setter  # type: ignore
+    @deprecated(
+        deadline="v0.15",
+        fix="The mutators of this class are deprecated, instantiate a new object instead.",
+    )
+    def permutation(self, permutation: Tuple[int, ...]):
+        self._permutation = permutation
 
     def _value_equality_values_(self):
         return self.permutation

--- a/cirq-core/cirq/ops/permutation_gate_test.py
+++ b/cirq-core/cirq/ops/permutation_gate_test.py
@@ -98,3 +98,11 @@ def test_permutation_gate_maps(maps, permutation):
     permutationOp = cirq.QubitPermutationGate(permutation).on(*qs)
     circuit = cirq.Circuit(permutationOp)
     cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)
+
+
+def test_setters_deprecated():
+    gate = cirq.QubitPermutationGate((1, 2, 0))
+    assert gate.permutation == (1, 2, 0)
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        gate.permutation = (2, 1, 0)
+        assert gate.permutation == (2, 1, 0)

--- a/cirq-core/cirq/ops/random_gate_channel.py
+++ b/cirq-core/cirq/ops/random_gate_channel.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from cirq import protocols, value
 from cirq.ops import raw_types
-from cirq._compat import proper_repr
+from cirq._compat import deprecated, proper_repr
 
 if TYPE_CHECKING:
     import cirq
@@ -38,20 +38,44 @@ if TYPE_CHECKING:
 class RandomGateChannel(raw_types.Gate):
     """Applies a sub gate with some probability."""
 
-    def __init__(self, *, sub_gate: 'cirq.Gate', probability: value.TParamVal):
+    def __init__(self, *, sub_gate: 'cirq.Gate', probability: 'cirq.TParamVal'):
         if (
             isinstance(probability, numbers.Number)
             and not 0 <= float(cast(SupportsFloat, probability)) <= 1
         ):
             raise ValueError("not 0 <= probability <= 1")
 
-        self.sub_gate = sub_gate
-        self.probability = probability
+        self._sub_gate = sub_gate
+        self._probability = probability
 
         # Auto flatten.
         if isinstance(self.sub_gate, RandomGateChannel):
-            self.probability *= self.sub_gate.probability
-            self.sub_gate = self.sub_gate.sub_gate
+            self._probability *= self.sub_gate.probability
+            self._sub_gate = self.sub_gate.sub_gate
+
+    @property
+    def sub_gate(self) -> 'cirq.Gate':
+        return self._sub_gate
+
+    @sub_gate.setter  # type: ignore
+    @deprecated(
+        deadline="v0.15",
+        fix="The mutators of this class are deprecated, instantiate a new object instead.",
+    )
+    def sub_gate(self, sub_gate: 'cirq.Gate'):
+        self._sub_gate = sub_gate
+
+    @property
+    def probability(self) -> 'cirq.TParamVal':
+        return self._probability
+
+    @probability.setter  # type: ignore
+    @deprecated(
+        deadline="v0.15",
+        fix="The mutators of this class are deprecated, instantiate a new object instead.",
+    )
+    def probability(self, probability: 'cirq.TParamVal'):
+        self._probability = probability
 
     def _qid_shape_(self) -> Tuple[int, ...]:
         return protocols.qid_shape(self.sub_gate)

--- a/cirq-core/cirq/ops/random_gate_channel_test.py
+++ b/cirq-core/cirq/ops/random_gate_channel_test.py
@@ -258,3 +258,13 @@ def test_unsupported_stabilizer_safety():
     c = cirq.Circuit((cirq.X(q) ** 0.25).with_probability(0.5), cirq.measure(q, key='m'))
     with pytest.raises(TypeError, match='Failed to act'):
         cirq.StabilizerSampler().sample(c, repetitions=100)
+
+
+def test_setters_deprecated():
+    gate = cirq.RandomGateChannel(sub_gate=cirq.X, probability=0.1)
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        gate.sub_gate = cirq.Y
+        assert gate.sub_gate == cirq.Y
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        gate.probability = 0.2
+        assert gate.probability == 0.2

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -38,6 +38,7 @@ import numpy as np
 import sympy
 
 from cirq import protocols, value
+from cirq._compat import deprecated
 from cirq._import import LazyLoader
 from cirq.type_workarounds import NotImplementedType
 
@@ -675,8 +676,20 @@ class TaggedOperation(Operation):
     """
 
     def __init__(self, sub_operation: 'cirq.Operation', *tags: Hashable):
-        self.sub_operation = sub_operation
+        self._sub_operation = sub_operation
         self._tags = tuple(tags)
+
+    @property
+    def sub_operation(self) -> 'cirq.Operation':
+        return self._sub_operation
+
+    @sub_operation.setter  # type: ignore
+    @deprecated(
+        deadline="v0.15",
+        fix="The mutators of this class are deprecated, instantiate a new object instead.",
+    )
+    def sub_operation(self, sub_operation: 'cirq.Operation'):
+        self._sub_operation = sub_operation
 
     @property
     def qubits(self) -> Tuple['cirq.Qid', ...]:

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -932,3 +932,14 @@ def test_on_each_iterable_qid():
             raise NotImplementedError()
 
     assert cirq.H.on_each(QidIter())[0] == cirq.H.on(QidIter())
+
+
+def test_setters_deprecated():
+    q = cirq.LineQubit(0)
+    subop = cirq.X(q)
+    op = cirq.TaggedOperation(subop, 'tag')
+    assert op.sub_operation == subop
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        new_subop = cirq.Y(q)
+        op.sub_operation = new_subop
+        assert op.sub_operation == new_subop

--- a/cirq-core/cirq/ops/wait_gate.py
+++ b/cirq-core/cirq/ops/wait_gate.py
@@ -16,6 +16,7 @@ from typing import AbstractSet, Any, Dict, Optional, Tuple, TYPE_CHECKING, Union
 import sympy
 
 from cirq import value, protocols
+from cirq._compat import deprecated
 from cirq.ops import raw_types
 
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ class WaitGate(raw_types.Gate):
             ValueError: If the `qid_shape` provided is empty or `num_qubits` contradicts
                 `qid_shape`.
         """
-        self.duration = value.Duration(duration)
+        self._duration = value.Duration(duration)
         if not protocols.is_parameterized(self.duration) and self.duration < 0:
             raise ValueError('duration < 0')
         if qid_shape is None:
@@ -66,6 +67,18 @@ class WaitGate(raw_types.Gate):
         if num_qubits != len(qid_shape):
             raise ValueError('len(qid_shape) != num_qubits')
         self._qid_shape = qid_shape
+
+    @property
+    def duration(self) -> 'cirq.Duration':
+        return self._duration
+
+    @duration.setter  # type: ignore
+    @deprecated(
+        deadline="v0.15",
+        fix="The mutators of this class are deprecated, instantiate a new object instead.",
+    )
+    def duration(self, duration: 'cirq.Duration'):
+        self._duration = duration
 
     def _is_parameterized_(self) -> bool:
         return protocols.is_parameterized(self.duration)

--- a/cirq-core/cirq/ops/wait_gate_test.py
+++ b/cirq-core/cirq/ops/wait_gate_test.py
@@ -87,3 +87,13 @@ def test_json():
 
 def test_str():
     assert str(cirq.WaitGate(cirq.Duration(nanos=5))) == 'WaitGate(5 ns)'
+
+
+def test_setters_deprecated():
+    duration = cirq.Duration(millis=1)
+    gate = cirq.WaitGate(duration)
+    assert gate.duration == duration
+    with cirq.testing.assert_deprecated('mutators', deadline='v0.15'):
+        new_duration = cirq.Duration(millis=2)
+        gate.duration = new_duration
+        assert gate.duration == new_duration


### PR DESCRIPTION
Change public fields to private, and encapsulate with getters and deprecated setters.

xref #4851