### PR TITLE
Fix state vector factorization validation

### DIFF
--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -594,9 +594,7 @@ def factor_state_vector(
     remainder = remainder / np.sum(abs(remainder) ** 2) ** 0.5
     if validate:
         t2 = state_vector_kronecker_product(extracted, remainder)
-        axes2 = list(axes) + [i for i in range(t1.ndim) if i not in axes]
-        t3 = transpose_state_vector_to_axis_order(t2, axes2)
-        if not np.allclose(t3, t, atol=atol):
+        if not predicates.allclose_up_to_global_phase(t2, t1, atol=atol):
             raise ValueError('The tensor cannot be factored by the requested axes')
     return extracted, remainder
 

--- a/cirq-core/cirq/sim/state_vector_test.py
+++ b/cirq-core/cirq/sim/state_vector_test.py
@@ -379,10 +379,10 @@ def test_step_result_bloch_vector():
 
 def test_factor_validation():
     args = cirq.Simulator()._create_act_on_args(0, qubits=cirq.LineQubit.range(2))
-    args.apply_operation(cirq.H(cirq.LineQubit(0)))
+    args.apply_operation(cirq.H(cirq.LineQubit(0)) ** 0.7)
     t = args.create_merged_state().target_tensor
     cirq.linalg.transformations.factor_state_vector(t, [0])
-    cirq.linalg.transformations.factor_state_vector(t, [1], atol=1e-2)
+    cirq.linalg.transformations.factor_state_vector(t, [1])
     args.apply_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
     t = args.create_merged_state().target_tensor
     with pytest.raises(ValueError, match='factor'):


### PR DESCRIPTION
The `validate` block here did not account for the possibility of a phase shift. It was just luck that `H(q0), I(q1)` factorization in the test did not cause one. Also there's no need to transpose the axes here, just compare `t1` and `t2` directly.