### PR TITLE
Add assert_decompose_ends_at_default_gateset consistency test

### DIFF
--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -47,6 +47,15 @@ RaiseTypeErrorIfNotProvided: Any = ([],)
 DecomposeResult = Union[None, NotImplementedType, 'cirq.OP_TREE']
 OpDecomposer = Callable[['cirq.Operation'], DecomposeResult]
 
+DECOMPOSE_TARGET_GATESET = ops.Gateset(
+    ops.XPowGate,
+    ops.YPowGate,
+    ops.ZPowGate,
+    ops.CZPowGate,
+    ops.MeasurementGate,
+    ops.GlobalPhaseGate,
+)
+
 
 def _value_error_describing_bad_operation(op: 'cirq.Operation') -> ValueError:
     return ValueError(f"Operation doesn't satisfy the given `keep` but can't be decomposed: {op!r}")

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -33,6 +33,7 @@ from cirq.testing.consistent_controlled_gate_op import (
 )
 
 from cirq.testing.consistent_decomposition import (
+    assert_decompose_ends_at_default_gateset,
     assert_decompose_is_consistent_with_unitary,
 )
 

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -47,3 +47,20 @@ def assert_decompose_is_consistent_with_unitary(val: Any, ignoring_global_phase:
     else:
         # coverage: ignore
         np.testing.assert_allclose(actual, expected, atol=1e-8)
+
+
+def assert_decompose_ends_at_default_gateset(val: Any):
+    """Ensures that all cirq gate decompositions end at the default cirq gateset."""
+
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
+    # pylint: enable=unused-variable
+    if protocols.is_parameterized(val):
+        return
+    args = () if isinstance(val, ops.Operation) else (tuple(devices.LineQid.for_gate(val)),)
+    dec_once = protocols.decompose_once(val, None, *args)
+    if dec_once is None:
+        # _decompose_ is NotImplemented, so silently return.
+        return
+    dec = [*ops.flatten_to_ops(protocols.decompose(d) for d in dec_once)]
+    assert all(op in protocols.decompose_protocol.DECOMPOSE_TARGET_GATESET for op in dec)

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -49,7 +49,7 @@ def assert_decompose_is_consistent_with_unitary(val: Any, ignoring_global_phase:
         np.testing.assert_allclose(actual, expected, atol=1e-8)
 
 
-def _known_gate_with_no_decomposition(val: 'cirq.Gate'):
+def _known_gate_with_no_decomposition(val: Any):
     """Checks whether `val` is a known gate with no default decomposition to default gateset."""
     return False
 

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -57,7 +57,7 @@ def _known_gate_with_no_decomposition(val: Any):
 def assert_decompose_ends_at_default_gateset(val: Any):
     """Asserts that cirq.decompose(val) ends at default cirq gateset or a known gate."""
     if _known_gate_with_no_decomposition(val):
-        return
+        return  # coverage: ignore
     args = () if isinstance(val, ops.Operation) else (tuple(devices.LineQid.for_gate(val)),)
     dec_once = protocols.decompose_once(val, [val(*args[0]) if args else val], *args)
     for op in [*ops.flatten_to_ops(protocols.decompose(d) for d in dec_once)]:

--- a/cirq-core/cirq/testing/consistent_decomposition_test.py
+++ b/cirq-core/cirq/testing/consistent_decomposition_test.py
@@ -74,9 +74,6 @@ class GateDecomposeNotImplemented(cirq.SingleQubitGate):
 
 
 class ParameterizedGate(cirq.SingleQubitGate):
-    def _is_parameterized_(self):
-        return True
-
     def _num_qubits_(self):
         return 2
 

--- a/cirq-core/cirq/testing/consistent_decomposition_test.py
+++ b/cirq-core/cirq/testing/consistent_decomposition_test.py
@@ -49,3 +49,63 @@ def test_assert_decompose_is_consistent_with_unitary():
         cirq.testing.assert_decompose_is_consistent_with_unitary(
             BadGateDecompose().on(cirq.NamedQubit('q'))
         )
+
+
+class GateDecomposesToDefaultGateset(cirq.Gate):
+    def _num_qubits_(self):
+        return 2
+
+    def _decompose_(self, qubits):
+        return [GoodGateDecompose().on(qubits[0]), BadGateDecompose().on(qubits[1])]
+
+
+class GateDecomposeDoesNotEndInDefaultGateset(cirq.Gate):
+    def _num_qubits_(self):
+        return 4
+
+    def _decompose_(self, qubits):
+        return cirq.MatrixGate(cirq.testing.random_unitary(16)).on(*qubits)
+
+
+class GateDecomposeNotImplemented(cirq.SingleQubitGate):
+    def _decompose_(self, qubits):
+        return NotImplemented
+
+
+class ParameterizedGate(cirq.SingleQubitGate):
+    def _is_parameterized_(self):
+        return True
+
+    def _num_qubits_(self):
+        return 4
+
+    def _decompose_(self, qubits):
+        assert False, "Decompose should not be called for parameterized gates."
+
+
+def test_assert_decompose_ends_at_default_gateset():
+
+    cirq.testing.assert_decompose_ends_at_default_gateset(GateDecomposesToDefaultGateset())
+    cirq.testing.assert_decompose_ends_at_default_gateset(
+        GateDecomposesToDefaultGateset().on(*cirq.LineQubit.range(2))
+    )
+
+    cirq.testing.assert_decompose_ends_at_default_gateset(GateDecomposeNotImplemented())
+    cirq.testing.assert_decompose_ends_at_default_gateset(
+        GateDecomposeNotImplemented().on(cirq.NamedQubit('q'))
+    )
+
+    cirq.testing.assert_decompose_ends_at_default_gateset(ParameterizedGate())
+    cirq.testing.assert_decompose_ends_at_default_gateset(
+        ParameterizedGate().on(*cirq.LineQubit.range(4))
+    )
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_decompose_ends_at_default_gateset(
+            GateDecomposeDoesNotEndInDefaultGateset()
+        )
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_decompose_ends_at_default_gateset(
+            GateDecomposeDoesNotEndInDefaultGateset().on(*cirq.LineQubit.range(4))
+        )


### PR DESCRIPTION
- Part-1 of https://github.com/quantumlib/Cirq/pull/5057
- The PR adds ` cirq.testing.assert_decompose_ends_at_default_gateset` which checks that if the given object (gate / operation) has a _decompose_ method defined, then it should always end up decomposing to the cirq default gateset.
- In subsequent PRs, this method will also be added to `cirq.testing.assert_implements_consistent_protocols` to extend the coverage of this test across all cirq objects. 


cc @MichaelBroughton 