### PR TITLE
Add return type annotation on MeasurementGate.full_invert_mask

### DIFF
--- a/cirq-core/cirq/ops/measurement_gate.py
+++ b/cirq-core/cirq/ops/measurement_gate.py
@@ -153,7 +153,7 @@ class MeasurementGate(raw_types.Gate):
             self.num_qubits(), key=self.key, invert_mask=tuple(new_mask), qid_shape=self._qid_shape
         )
 
-    def full_invert_mask(self) -> Sequence[bool]:
+    def full_invert_mask(self) -> Tuple[bool, ...]:
         """Returns the invert mask for all qubits.
 
         If the user supplies a partial invert_mask, this returns that mask

--- a/cirq-core/cirq/ops/measurement_gate.py
+++ b/cirq-core/cirq/ops/measurement_gate.py
@@ -153,7 +153,7 @@ class MeasurementGate(raw_types.Gate):
             self.num_qubits(), key=self.key, invert_mask=tuple(new_mask), qid_shape=self._qid_shape
         )
 
-    def full_invert_mask(self):
+    def full_invert_mask(self) -> Sequence[bool]:
         """Returns the invert mask for all qubits.
 
         If the user supplies a partial invert_mask, this returns that mask


### PR DESCRIPTION
Add a return type annotation on `MeasurementGate.full_invert_mask`, which returns a tuple of the same length as the number of qubits. This is in contrast to the invert mask itself, which can be specified as a partial mask for just some of the qubits.