### PR TITLE
Google gateset class prototype

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -92,6 +92,7 @@ from cirq_google.line import (
 from cirq_google.ops import (
     CalibrationTag,
     FSimGateFamily,
+    Gateset,
     PhysicalZTag,
     SycamoreGate,
     SYC,

--- a/cirq-google/cirq_google/ops/__init__.py
+++ b/cirq-google/cirq_google/ops/__init__.py
@@ -20,6 +20,10 @@ from cirq_google.ops.fsim_gate_family import (
     FSimGateFamily,
 )
 
+from cirq_google.ops.gateset import (
+    Gateset,
+)
+
 from cirq_google.ops.physical_z_tag import (
     PhysicalZTag,
 )

--- a/cirq-google/cirq_google/ops/fsim_gate_family.py
+++ b/cirq-google/cirq_google/ops/fsim_gate_family.py
@@ -38,6 +38,14 @@ T = TypeVar(
     cirq.CZPowGate,
     cirq.IdentityGate,
 )
+POSSIBLE_FSIM_GATE_TYPES = (
+    cirq.FSimGate,
+    cirq.PhasedFSimGate,
+    cirq.ISwapPowGate,
+    cirq.PhasedISwapPowGate,
+    cirq.CZPowGate,
+    cirq.IdentityGate,
+)
 
 
 def _exp(theta: Union[complex, sympy.Basic]):

--- a/cirq-google/cirq_google/ops/gateset.py
+++ b/cirq-google/cirq_google/ops/gateset.py
@@ -1,0 +1,112 @@
+from typing import cast, Optional, Union, Type, List, Sequence
+
+import cirq
+from cirq_google.ops import fsim_gate_family, sycamore_gate
+from cirq.protocols.decompose_protocol import DecomposeResult
+import cirq_google.transformers.target_gatesets as cg_target_gatesets
+
+
+def _build_equivalence_gate_families(device_gateset: cirq.Gateset) -> List[cirq.GateFamily]:
+    fsim_gates = [
+        cast(fsim_gate_family.POSSIBLE_FSIM_GATES, g)
+        for g in device_gateset.gates
+        if isinstance(g, tuple(fsim_gate_family.POSSIBLE_FSIM_GATE_TYPES))
+    ]
+    return [fsim_gate_family.FSimGateFamily(gates_to_accept=fsim_gates)]
+
+    # TODO(verult) PhasedXZGateFamily
+
+
+class Gateset(cirq.CompilationTargetGateset):
+    """Represents the gateset of a Google device.
+
+    This gateset accept circuits that use any Cirq gate representation of valid device gates.
+
+    It can also be used as an argument in cirq.optimize_for_target_gateset() to transform your
+    circuit into one that consists of valid gates for the target device. In cases where multiple
+    `CompilationTargetGateset`s are possible for a given gateset, a pre-determined default will be
+    applied, but all available `CompilationTargetGateset`s can be accessed via the `target_gatesets`
+    property.
+
+    Users typically interact with this class by accessing its instantiations via
+    `GoogleDevice.metadata.gateset`.
+
+    Examples:
+
+    ```
+    # View what gates and `CompilationTargetGatesets` are supported by the device.
+    print(gateset)
+
+    # Checks whether a gate is valid for the device.
+    cirq.X in gateset
+
+    # Checks whether the circuit only contains valid gates for the device.
+    gateset.validate(circuit)
+
+    # Transform the circuit into one that can be executed on the device.
+    cirq.optimize_for_target_gateset(circuit, gateset=gateset)
+
+    # Choose your own target gateset, if the device supports multiple.
+    cirq.optimize_for_target_gateset(circuit, gateset=gateset.target_gatesets[1])
+    """
+
+    def __init__(
+        self,
+        device_name,
+        *device_gates: Union[Type[cirq.Gate], cirq.Gate, cirq.GateFamily],
+    ) -> None:
+        self._device_name = device_name
+        self._device_gateset = cirq.Gateset(*device_gates)
+        equivalence_gate_families = _build_equivalence_gate_families(self._device_gateset)
+        super().__init__(*(tuple(self._device_gateset.gates) + tuple(equivalence_gate_families)))
+        self._build_target_gatesets()
+
+    def _build_target_gatesets(self):
+        self._target_gatesets: List[cirq.CompilationTargetGateset] = []
+
+        if cirq.CZ in self._device_gateset:
+            self._target_gatesets.append(cirq.CZTargetGateset())
+        if cirq.SQRT_ISWAP in self._device_gateset and cirq.SQRT_ISWAP_INV in self._device_gateset:
+            self._target_gatesets.append(cirq.SqrtIswapTargetGateset())
+        if sycamore_gate.SYC in self._device_gateset:
+            # TODO(verult) add tabulation
+            self._target_gatesets.append(cg_target_gatesets.SycamoreTargetGateset())
+
+    @property
+    def num_qubits(self) -> int:
+        if self.default_target_gateset is None:
+            return 0
+        return self.default_target_gateset.num_qubits
+
+    def decompose_to_target_gateset(self, op: 'cirq.Operation', moment_idx: int) -> DecomposeResult:
+        if self.default_target_gateset is None:
+            return None
+        return self.default_target_gateset.decompose_to_target_gateset(op, moment_idx)
+
+    @property
+    def target_gatesets(self) -> Sequence[cirq.CompilationTargetGateset]:
+        return self._target_gatesets
+
+    @property
+    def default_target_gateset(self) -> Optional[cirq.CompilationTargetGateset]:
+        return self._target_gatesets[0] if self._target_gatesets else None
+
+    def __str__(self) -> str:
+        header = f"Gateset for Google device '{self._device_name}':"
+        header_line = '-' * len(header)
+        target_gatesets = "None"
+        if len(self._target_gatesets) > 0:
+            target_gatesets = '\n\n'.join(
+                ['#####\n' + str(gs) + '\n#####' for gs in self._target_gatesets]
+            )
+        return (
+            f'{header}\n'
+            + f'{header_line}\n\n'
+            + 'Device Gates:\n\n'
+            + '#####\n'
+            + str(self._device_gateset)
+            + '\n#####\n\nTarget Gatesets:\n\n'
+            + target_gatesets
+            + '\n'
+        )
+        # TODO(verult) consider including equivalence gatefamily information

--- a/cirq-google/cirq_google/ops/gateset_test.py
+++ b/cirq-google/cirq_google/ops/gateset_test.py
@@ -1,0 +1,27 @@
+import cirq
+import cirq_google
+
+
+def test_basic():
+    gs = cirq_google.Gateset(
+        'mock_device',
+        cirq.CZ,
+        cirq_google.SYC,
+        cirq.PhasedXZGate,
+    )
+    g = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=0)
+    assert g in gs
+
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(g(q))
+    assert gs.validate(circuit)
+
+    assert gs.num_qubits == 2
+
+    assert gs.default_target_gateset is not None
+    assert len(gs.target_gatesets) == 2
+
+    q0, q1 = cirq.LineQubit(0), cirq.LineQubit(1)
+    circuit = cirq.Circuit(cirq.ISWAP(q0, q1))
+    cirq.optimize_for_target_gateset(circuit, gateset=gs)
+    cirq.optimize_for_target_gateset(circuit, gateset=gs.target_gatesets[1])


### PR DESCRIPTION
This is a prototype for a Google Gateset class which
* is used to instantiate all Google device gatesets, and designed to be surfaced via the `device.metadata.gateset` property.
* is a subclass of `CompilationTargetGateset`, so it can be used as an argument to `cirq.optimize_for_target_gateset` to transform a user circuit into one which can be executed on the device.
* supports the possibility of multiple `CompilationTargetGatesets` (e.g. having both `SycamoreTargetGateset` and `SqrtIswapTargetGateset` available for the same device). One target gateset is used as default when someone uses the overall Gateset as a `cirq.optimize_for_target_gateset` argument, but users have access to all available target gatesets for the device (the `target_gatesets` property).
* The device gateset, eventually provided by the newest `DeviceSpecification` proto, is scanned to detect known target gatesets and equivalence GateFamilies.
* The underlying gateset in existing `CompilationTargetGateset` implementations (e.g. `(CZPowGate, MeasurementGate, AnyUnitaryGateFamily)` for `CZTargetGateset` is ignored. The constructed gateset (device gates from `DeviceSpecification` + equivalence GateFamilies) is used for validation instead (including for [signaling termination of decompositions](https://github.com/quantumlib/Cirq/blob/701f62c33d7285519dfd68a2a71ee48d376c6739/cirq-core/cirq/transformers/optimize_for_target_gateset.py#L71)). @tanujkhattar FYI
* Allows the validation gateset to be a superset of a target gateset. Use cases:
  * Reuse the same target gateset when `PhysicalZ` or `CouplerPulse` is disabled.
  * Allows multiple `CompilationTargetGateset`s as mentioned above.
* `__str__()` outputs the list of device gates and target gatesets in a readable format. Equivalence GateFamilies might be implementation detail, but we could consider exposing them, too.

**Context**: Previously we decided to allow a `CompilationTargetGateset` to be optionally surfaced through the `cirq.Device` interface in addition to a `cirq.Gateset`. The simplest solution of returning one `CompilationTargetGateset` for a Google device is not sufficient because some gatesets could have multiple targets (e.g. a gateset containing both SYC and SQRT_ISWAP gates).

**Alternative**: Always return one `CompilationTargetGateset` when multiple are available. Don't provide the choice.

Would love to hear your thoughts, and let me know if the design makes sense or if you have other ideas. Thanks!
@95-martin-orion @dstrain115 @MichaelBroughton @tanujkhattar 