### PR TITLE
Add support for decompositions of parameterized cirq.CCZPowGate

### DIFF
--- a/cirq-core/cirq/circuits/quil_output_test.py
+++ b/cirq-core/cirq/circuits/quil_output_test.py
@@ -434,14 +434,15 @@ CPHASE10(pi/2) 0 1
 CPHASE(pi/2) 0 1
 """
 
-QUIL_DIAGONAL_DEFGATE_PROGRAM = """
-DEFGATE USERGATE1:
-    1.0, 0.0, 0.0, 0.0
-    0.0, 1.0, 0.0, 0.0
-    0.0, 0.0, 1.0, 0.0
-    0.0, 0.0, 0.0, 1.0
-
-USERGATE1 0 1
+QUIL_DIAGONAL_DECOMPOSE_PROGRAM = """
+RZ(0) 0
+RZ(0) 1
+CPHASE(0) 0 1
+X 0
+X 1
+CPHASE(0) 0 1
+X 0
+X 1
 """
 
 
@@ -463,13 +464,14 @@ def test_two_qubit_diagonal_gate_quil_output():
     # Qubit ordering differs between pyQuil and Cirq.
     cirq_unitary = cirq.Circuit(cirq.SWAP(q0, q1), operations, cirq.SWAP(q0, q1)).unitary()
     assert np.allclose(pyquil_unitary, cirq_unitary)
-    # Also test non-CPHASE case.
+    # Also test non-CPHASE case, which decomposes into X/RZ/CPhase
     operations = [
         cirq.TwoQubitDiagonalGate([0, 0, 0, 0])(q0, q1),
     ]
     output = cirq.QuilOutput(operations, (q0, q1))
     program = pyquil.Program(str(output))
-    assert f"\n{program.out()}" == QUIL_DIAGONAL_DEFGATE_PROGRAM
+    print(program.out())
+    assert f"\n{program.out()}" == QUIL_DIAGONAL_DECOMPOSE_PROGRAM
 
 
 def test_parseable_defgate_output():

--- a/cirq-core/cirq/circuits/quil_output_test.py
+++ b/cirq-core/cirq/circuits/quil_output_test.py
@@ -470,7 +470,6 @@ def test_two_qubit_diagonal_gate_quil_output():
     ]
     output = cirq.QuilOutput(operations, (q0, q1))
     program = pyquil.Program(str(output))
-    print(program.out())
     assert f"\n{program.out()}" == QUIL_DIAGONAL_DECOMPOSE_PROGRAM
 
 

--- a/cirq-core/cirq/ops/two_qubit_diagonal_gate_test.py
+++ b/cirq-core/cirq/ops/two_qubit_diagonal_gate_test.py
@@ -34,6 +34,22 @@ def test_consistent_protocols(gate):
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
+def test_parameterized_decompose():
+    angles = sympy.symbols('x0, x1, x2, x3')
+    parameterized_op = cirq.TwoQubitDiagonalGate(angles).on(*cirq.LineQubit.range(2))
+    decomposed_circuit = cirq.Circuit(cirq.decompose(parameterized_op))
+    for resolver in (
+        cirq.Linspace('x0', -2, 2, 6)
+        * cirq.Linspace('x1', -2, 2, 6)
+        * cirq.Linspace('x2', -2, 2, 6)
+        * cirq.Linspace('x3', -2, 2, 6)
+    ):
+        np.testing.assert_allclose(
+            cirq.unitary(cirq.resolve_parameters(parameterized_op, resolver)),
+            cirq.unitary(cirq.resolve_parameters(decomposed_circuit, resolver)),
+        )
+
+
 def test_unitary():
     diagonal_angles = [2, 3, 5, 7]
     assert cirq.has_unitary(cirq.TwoQubitDiagonalGate(diagonal_angles))


### PR DESCRIPTION
- The decomposition of `cirq.CCZPowGate` is generic enough already to support parameterized gates. 
- This PR removes an unnecessary if condition to not decompose parameterized gates. 
- Part of #4858 