### PR TITLE
Add support for decompositions of parameterized `cirq.CCZPowGate`

### DIFF
--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -95,9 +95,6 @@ class CCZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
 
         where p = T**self._exponent
         """
-        if protocols.is_parameterized(self):
-            return NotImplemented
-
         a, b, c = qubits
 
         # Hacky magic: avoid the non-adjacent edge.

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -192,6 +192,7 @@ def test_identity_multiplication():
         (cirq.CCZ(*cirq.LineQubit.range(3)), 8),
         (cirq.CCX(*cirq.LineQubit.range(3)), 8),
         (cirq.CCZ(cirq.LineQubit(0), cirq.LineQubit(2), cirq.LineQubit(1)), 8),
+        (cirq.CCZ(cirq.LineQubit(0), cirq.LineQubit(2), cirq.LineQubit(1)) ** sympy.Symbol("s"), 8),
         (cirq.CSWAP(*cirq.LineQubit.range(3)), 9),
         (cirq.CSWAP(*reversed(cirq.LineQubit.range(3))), 9),
         (cirq.CSWAP(cirq.LineQubit(1), cirq.LineQubit(0), cirq.LineQubit(2)), 12),


### PR DESCRIPTION
- The decomposition of cirq.CCZPowGate is generic enough already to support parameterized gates.
- This PR removes an unnecessary if condition to not decompose parameterized gates.
- Part of https://github.com/quantumlib/Cirq/issues/4858