### PR TITLE
Adds default decompositions for `cirq.MatrixGate` into X/Y/Z/CZ target gateset.

### DIFF
--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -276,16 +276,19 @@ def test_str_executes():
     assert '0' in str(cirq.MatrixGate(np.eye(4)))
 
 
-def test_one_qubit_consistent():
-    u = cirq.testing.random_unitary(2)
-    g = cirq.MatrixGate(u)
-    cirq.testing.assert_implements_consistent_protocols(g)
+@pytest.mark.parametrize('n', [1, 2, 3, 4, 5])
+def test_implements_consistent_protocols(n):
+    u = cirq.testing.random_unitary(2 ** n)
+    g1 = cirq.MatrixGate(u)
+    cirq.testing.assert_implements_consistent_protocols(g1, ignoring_global_phase=True)
+    cirq.testing.assert_decompose_ends_at_default_gateset(g1)
 
+    if n == 1:
+        return
 
-def test_two_qubit_consistent():
-    u = cirq.testing.random_unitary(4)
-    g = cirq.MatrixGate(u)
-    cirq.testing.assert_implements_consistent_protocols(g)
+    g2 = cirq.MatrixGate(u, qid_shape=(4,) + (2,) * (n - 2))
+    cirq.testing.assert_implements_consistent_protocols(g2, ignoring_global_phase=True)
+    cirq.testing.assert_decompose_ends_at_default_gateset(g2)
 
 
 def test_repr():

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -51,6 +51,8 @@ def assert_decompose_is_consistent_with_unitary(val: Any, ignoring_global_phase:
 
 def _known_gate_with_no_decomposition(val: Any):
     """Checks whether `val` is a known gate with no default decomposition to default gateset."""
+    if isinstance(val, ops.MatrixGate):
+        return protocols.qid_shape(val) not in [(2,), (2,) * 2, (2,) * 3]
     return False
 
 


### PR DESCRIPTION
- Uses known analytical decompositions for matrix gates on 1/2/3 qubits. 
- Adds `cirq.MatrixGate` acting on > 3 qubits or on a qudit to set of known gates with no analytical decomposition in the `cirq.testing.assert_decompose_ends_at_default_gateset` test suite. 
- Part of https://github.com/quantumlib/Cirq/issues/4858