### PR TITLE
Add default decomposition for cirq.QubitPermutationGate in terms of adjacent swaps

### DIFF
--- a/cirq-core/cirq/ops/permutation_gate.py
+++ b/cirq-core/cirq/ops/permutation_gate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Sequence, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Iterable, Sequence, Tuple, TYPE_CHECKING
 
 from cirq import protocols, value
 from cirq._compat import deprecated
@@ -79,7 +79,7 @@ class QubitPermutationGate(raw_types.Gate):
         qubit_ids = [*range(n)]
         is_sorted = False
 
-        def _swap_if_out_of_order(idx: int) -> bool:
+        def _swap_if_out_of_order(idx: int) -> Iterable['cirq.Operation']:
             nonlocal is_sorted
             if self._permutation[qubit_ids[idx]] > self._permutation[qubit_ids[idx + 1]]:
                 yield swap_gates.SWAP(qubits[idx], qubits[idx + 1])

--- a/cirq-core/cirq/ops/permutation_gate_test.py
+++ b/cirq-core/cirq/ops/permutation_gate_test.py
@@ -15,6 +15,7 @@
 import pytest
 
 import cirq
+import numpy as np
 from cirq.ops import QubitPermutationGate
 
 
@@ -30,8 +31,12 @@ def test_permutation_gate_repr():
     cirq.testing.assert_equivalent_repr(QubitPermutationGate([0, 1]))
 
 
-def test_permutation_gate_consistent_protocols():
-    gate = QubitPermutationGate([1, 0, 2, 3])
+rs = np.random.RandomState(seed=1234)
+
+
+@pytest.mark.parametrize('permutation', [rs.permutation(i) for i in range(3, 7)])
+def test_permutation_gate_consistent_protocols(permutation):
+    gate = QubitPermutationGate(list(permutation))
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
@@ -97,6 +102,8 @@ def test_permutation_gate_maps(maps, permutation):
     qs = cirq.LineQubit.range(len(permutation))
     permutationOp = cirq.QubitPermutationGate(permutation).on(*qs)
     circuit = cirq.Circuit(permutationOp)
+    cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)
+    circuit = cirq.Circuit(cirq.I.on_each(*qs), cirq.decompose(permutationOp))
     cirq.testing.assert_equivalent_computational_basis_map(maps, circuit)
 
 


### PR DESCRIPTION
- Adds decomposition to `cirq.QubitPermutationGate` in terms of minimum number of adjacent swap operations on qubits. 
- Part of https://github.com/quantumlib/Cirq/issues/4858

Closes https://github.com/quantumlib/Cirq/issues/5090