### PR TITLE
GateFamily: tag validation

### DIFF
--- a/cirq-core/cirq/protocols/json_test_data/GateFamily.json
+++ b/cirq-core/cirq/protocols/json_test_data/GateFamily.json
@@ -4,7 +4,9 @@
     "gate": "XPowGate",
     "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-    "ignore_global_phase": true
+    "ignore_global_phase": true,
+    "tags_to_accept": [],
+    "tags_to_ignore": []
   },
   {
     "cirq_type": "GateFamily",
@@ -15,6 +17,30 @@
     },
     "name": "XFamily",
     "description": "Just the X gate.",
-    "ignore_global_phase": false
+    "ignore_global_phase": false,
+    "tags_to_accept": [],
+    "tags_to_ignore": []
+  },
+  {
+    "cirq_type": "GateFamily",
+    "gate": "ZPowGate",
+    "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
+    "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
+    "ignore_global_phase": true,
+    "tags_to_accept": [
+      "physical_z"
+    ],
+    "tags_to_ignore": []
+  },
+  {
+    "cirq_type": "GateFamily",
+    "gate": "ZPowGate",
+    "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
+    "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
+    "ignore_global_phase": true,
+    "tags_to_accept": [],
+    "tags_to_ignore": [
+      "physical_z"
+    ]
   }
 ]

--- a/cirq-core/cirq/protocols/json_test_data/GateFamily.repr
+++ b/cirq-core/cirq/protocols/json_test_data/GateFamily.repr
@@ -1,4 +1,6 @@
 [
-    cirq.GateFamily(gate=cirq.ops.common_gates.XPowGate, ignore_global_phase=True),
-    cirq.GateFamily(gate=cirq.X, name="XFamily", description="Just the X gate.", ignore_global_phase=False)
+    cirq.GateFamily(gate=cirq.ops.common_gates.XPowGate, ignore_global_phase=True, tags_to_accept=frozenset(), tags_to_ignore=frozenset()),
+    cirq.GateFamily(gate=cirq.X, name="XFamily", description="Just the X gate.", ignore_global_phase=False, tags_to_accept=frozenset(), tags_to_ignore=frozenset()),
+    cirq.GateFamily(gate=cirq.ops.common_gates.ZPowGate, ignore_global_phase=True, tags_to_accept=frozenset({'physical_z'}), tags_to_ignore=frozenset()),
+    cirq.GateFamily(gate=cirq.ops.common_gates.ZPowGate, ignore_global_phase=True, tags_to_accept=frozenset(), tags_to_ignore=frozenset({'physical_z'})),
 ]

--- a/cirq-core/cirq/protocols/json_test_data/Gateset.json
+++ b/cirq-core/cirq/protocols/json_test_data/Gateset.json
@@ -7,7 +7,9 @@
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "AnyUnitaryGateFamily",
@@ -22,7 +24,9 @@
         },
         "name": "Instance GateFamily: X",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       }
     ],
     "name": null,
@@ -40,14 +44,18 @@
         },
         "name": "Instance GateFamily: X",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "GateFamily",
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "AnyUnitaryGateFamily",

--- a/cirq-core/cirq/protocols/json_test_data/GridDeviceMetadata.json
+++ b/cirq-core/cirq/protocols/json_test_data/GridDeviceMetadata.json
@@ -94,21 +94,27 @@
         "gate": "XPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "GateFamily",
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "GateFamily",
         "gate": "ZPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       }
     ],
     "name": null,
@@ -121,7 +127,9 @@
         "gate": "XPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "Duration",
@@ -134,7 +142,9 @@
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "Duration",
@@ -147,7 +157,9 @@
         "gate": "ZPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-        "ignore_global_phase": true
+        "ignore_global_phase": true,
+        "tags_to_accept": [],
+        "tags_to_ignore": []
       },
       {
         "cirq_type": "Duration",


### PR DESCRIPTION
Adding general validation of gate tags to GateFamily, as described in https://github.com/quantumlib/Cirq/pull/5063#discussion_r826415632

Replaces https://github.com/quantumlib/Cirq/pull/5063

@tanujkhattar 