### PR TITLE
Add support for deep=True to `cirq.align_left` and `cirq.align_right` transformers

### DIFF
--- a/cirq-core/cirq/transformers/align.py
+++ b/cirq-core/cirq/transformers/align.py
@@ -14,6 +14,7 @@
 
 """Transformer passes which align operations to the left or right of the circuit."""
 
+import dataclasses
 from typing import Optional, TYPE_CHECKING
 from cirq import circuits, ops
 from cirq.transformers import transformer_api
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-@transformer_api.transformer
+@transformer_api.transformer(add_deep_support=True)
 def align_left(
     circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
 ) -> 'cirq.Circuit':
@@ -54,7 +55,7 @@ def align_left(
     return ret
 
 
-@transformer_api.transformer
+@transformer_api.transformer(add_deep_support=True)
 def align_right(
     circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
 ) -> 'cirq.Circuit':
@@ -70,4 +71,6 @@ def align_right(
     Returns:
           Copy of the transformed input circuit.
     """
+    if context is not None and context.deep is True:
+        context = dataclasses.replace(context, deep=False)
     return align_left(circuit[::-1], context=context)[::-1]

--- a/cirq-core/cirq/transformers/align_test.py
+++ b/cirq-core/cirq/transformers/align_test.py
@@ -71,6 +71,41 @@ def test_align_left_no_compile_context():
     )
 
 
+def test_align_left_deep():
+    q1, q2 = cirq.LineQubit.range(2)
+    c_nested = cirq.FrozenCircuit(
+        [
+            cirq.Moment([cirq.X(q1)]),
+            cirq.Moment([cirq.Y(q2)]),
+            cirq.Moment([cirq.Z(q1), cirq.Y(q2).with_tags("nocompile")]),
+            cirq.Moment([cirq.Y(q1)]),
+            cirq.measure(q2, key='a'),
+            cirq.Z(q1).with_classical_controls('a'),
+        ]
+    )
+    c_nested_aligned = cirq.FrozenCircuit(
+        cirq.Moment(cirq.X(q1), cirq.Y(q2)),
+        cirq.Moment(cirq.Z(q1)),
+        cirq.Moment([cirq.Y(q1), cirq.Y(q2).with_tags("nocompile")]),
+        cirq.measure(q2, key='a'),
+        cirq.Z(q1).with_classical_controls('a'),
+    )
+    c_orig = cirq.Circuit(
+        c_nested,
+        cirq.CircuitOperation(c_nested).repeat(6).with_tags("nocompile"),
+        c_nested,
+        cirq.CircuitOperation(c_nested).repeat(5).with_tags("preserve_tag"),
+    )
+    c_expected = cirq.Circuit(
+        c_nested_aligned,
+        cirq.CircuitOperation(c_nested).repeat(6).with_tags("nocompile"),
+        c_nested_aligned,
+        cirq.CircuitOperation(c_nested_aligned).repeat(5).with_tags("preserve_tag"),
+    )
+    context = cirq.TransformerContext(tags_to_ignore=["nocompile"], deep=True)
+    cirq.testing.assert_same_circuits(cirq.align_left(c_orig, context=context), c_expected)
+
+
 def test_align_left_subset_of_operations():
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
@@ -131,6 +166,39 @@ def test_align_right_no_compile_context():
             ]
         ),
     )
+
+
+def test_align_right_deep():
+    q1, q2 = cirq.LineQubit.range(2)
+    c_nested = cirq.FrozenCircuit(
+        cirq.Moment([cirq.X(q1)]),
+        cirq.Moment([cirq.Y(q1), cirq.X(q2).with_tags("nocompile")]),
+        cirq.Moment([cirq.X(q2)]),
+        cirq.Moment([cirq.Y(q1)]),
+        cirq.measure(q1, key='a'),
+        cirq.Z(q2).with_classical_controls('a'),
+    )
+    c_nested_aligned = cirq.FrozenCircuit(
+        cirq.Moment([cirq.X(q1), cirq.X(q2).with_tags("nocompile")]),
+        [cirq.Y(q1), cirq.Y(q1)],
+        cirq.Moment(cirq.measure(q1, key='a'), cirq.X(q2)),
+        cirq.Z(q2).with_classical_controls('a'),
+    )
+    c_orig = cirq.Circuit(
+        c_nested,
+        cirq.CircuitOperation(c_nested).repeat(6).with_tags("nocompile"),
+        c_nested,
+        cirq.CircuitOperation(c_nested).repeat(5).with_tags("preserve_tag"),
+    )
+    c_expected = cirq.Circuit(
+        c_nested_aligned,
+        cirq.CircuitOperation(c_nested).repeat(6).with_tags("nocompile"),
+        cirq.Moment(),
+        c_nested_aligned,
+        cirq.CircuitOperation(c_nested_aligned).repeat(5).with_tags("preserve_tag"),
+    )
+    context = cirq.TransformerContext(tags_to_ignore=["nocompile"], deep=True)
+    cirq.testing.assert_same_circuits(cirq.align_right(c_orig, context=context), c_expected)
 
 
 def test_classical_control():


### PR DESCRIPTION
- Adds support to recursively run `cirq.align_left` and `cirq.align_right` transformers on circuits wrapped inside a circuit operation by setting `deep=True` in transformer context.
- Part of https://github.com/quantumlib/Cirq/issues/5039