### PR TITLE
Add support for deep=True to `cirq.drop_empty_moments` transformer

### DIFF
--- a/cirq-core/cirq/transformers/drop_empty_moments.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments.py
@@ -34,4 +34,11 @@ def drop_empty_moments(
     Returns:
           Copy of the transformed input circuit.
     """
-    return transformer_primitives.map_moments(circuit.unfreeze(False), lambda m, _: m if m else [])
+    if context is None:
+        context = transformer_api.TransformerContext()
+    return transformer_primitives.map_moments(
+        circuit.unfreeze(False),
+        lambda m, _: m if m else [],
+        deep=context.deep,
+        tags_to_ignore=context.tags_to_ignore,
+    )

--- a/cirq-core/cirq/transformers/drop_empty_moments_test.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments_test.py
@@ -29,3 +29,30 @@ def test_drop():
         ),
         cirq.Circuit(cirq.Moment([cirq.CNOT(q1, q2)])),
     )
+
+
+def test_drop_empty_moments():
+    q1, q2 = cirq.LineQubit.range(2)
+    c_nested = cirq.FrozenCircuit(
+        cirq.Moment(),
+        cirq.Moment(),
+        cirq.Moment([cirq.CNOT(q1, q2)]),
+        cirq.Moment(),
+    )
+    c_nested_dropped = cirq.FrozenCircuit(cirq.CNOT(q1, q2))
+    c_orig = cirq.Circuit(
+        c_nested,
+        cirq.CircuitOperation(c_nested).repeat(6).with_tags("nocompile"),
+        c_nested,
+        cirq.CircuitOperation(c_nested).repeat(5).with_tags("preserve_tag"),
+        c_nested,
+    )
+    c_expected = cirq.Circuit(
+        c_nested_dropped,
+        cirq.CircuitOperation(c_nested).repeat(6).with_tags("nocompile"),
+        c_nested_dropped,
+        cirq.CircuitOperation(c_nested_dropped).repeat(5).with_tags("preserve_tag"),
+        c_nested_dropped,
+    )
+    context = cirq.TransformerContext(tags_to_ignore=("nocompile",), deep=True)
+    cirq.testing.assert_same_circuits(cirq.drop_empty_moments(c_orig, context=context), c_expected)


### PR DESCRIPTION
- Adds support to recursively run `cirq.drop_empty_moments` transformer on circuits wrapped inside a circuit operation by setting deep=True in transformer context.
- Part of https://github.com/quantumlib/Cirq/issues/5039