### PR TITLE
Add support for deep=True to merge_single_qubit_gates* transformers

### DIFF
--- a/cirq-core/cirq/transformers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates.py
@@ -129,4 +129,9 @@ def merge_single_qubit_moments_to_phxz(
                 ret_ops.append(gate(q))
         return circuits.Moment(ret_ops)
 
-    return transformer_primitives.merge_moments(circuit, merge_func).unfreeze(copy=False)
+    return transformer_primitives.merge_moments(
+        circuit,
+        merge_func,
+        deep=context.deep if context else False,
+        tags_to_ignore=tuple(tags_to_ignore),
+    ).unfreeze(copy=False)


### PR DESCRIPTION
- Adds support to recursively run `cirq.merge_single_qubit_moments_to_phxz` transformer on circuits wrapped inside a circuit operation by setting deep=True in transformer context.
- Also adds tests for `cirq.merge_single_qubit_gates_to_phxz` and `cirq.merge_single_qubit_gates_to_phased_x_and_z`, both of which automatically support deep=True flag after https://github.com/quantumlib/Cirq/pull/5122
- Part of https://github.com/quantumlib/Cirq/issues/5039
