### PR TITLE
Update IonQ to use CompilationTargetGateset

### DIFF
--- a/cirq-ionq/cirq_ionq/__init__.py
+++ b/cirq-ionq/cirq_ionq/__init__.py
@@ -16,7 +16,7 @@ from cirq_ionq._version import __version__
 
 from cirq_ionq.calibration import Calibration
 
-from cirq_ionq.ionq_devices import IonQAPIDevice, decompose_to_device
+from cirq_ionq.ionq_devices import IonQCompilationTargetGateset, decompose_to_device
 
 from cirq_ionq.ionq_exceptions import (
     IonQException,

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -22,22 +22,22 @@ from cirq.transformers.target_gatesets import compilation_target_gateset
 
 @cirq.transformer
 def merge_to_phased_x_and_z(
-    c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None
-) -> cirq.Circuit:
+    c: cirq.AbstractCircuit, *, context: Optional['cirq.TransformerContext'] = None
+) -> cirq.AbstractCircuit:
     return cirq.merge_single_qubit_gates_to_phased_x_and_z(c)
 
 
 @cirq.transformer
 def decompose_phased_x_pow(
-    c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None
-) -> cirq.Circuit:
+    c: cirq.AbstractCircuit, *, context: Optional['cirq.TransformerContext'] = None
+) -> cirq.AbstractCircuit:
     return cirq.map_operations_and_unroll(
         c, lambda op, _: cirq.decompose_once(op) if type(op.gate) == cirq.PhasedXPowGate else op
     )
 
 
 def decompose_to_device(operation: cirq.Operation, atol: float = 1e-8) -> cirq.OP_TREE:
-    """Decompose operation to ionq native operations.
+    """Decompose operation to IonQ QIS operations.
 
 
     Merges single qubit operations and decomposes two qubit operations

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -28,7 +28,9 @@ def merge_to_phased_x_and_z(
 
 
 @cirq.transformer
-def decompose_phased_x_pow(c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None) -> cirq.Circuit:
+def decompose_phased_x_pow(
+    c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None
+) -> cirq.Circuit:
     return cirq.map_operations_and_unroll(
         c, lambda op, _: cirq.decompose_once(op) if type(op.gate) == cirq.PhasedXPowGate else op
     )

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -20,15 +20,15 @@ from cirq.transformers import transformer_api, drop_empty_moments, drop_negligib
 from cirq.transformers.target_gatesets import compilation_target_gateset
 
 
-@transformer_api.transformer
+@cirq.transformer
 def merge_to_phased_x_and_z(
     c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None
-):
+) -> cirq.Circuit:
     return cirq.merge_single_qubit_gates_to_phased_x_and_z(c)
 
 
-@transformer_api.transformer
-def decompose_phased_x_pow(c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None):
+@cirq.transformer
+def decompose_phased_x_pow(c: cirq.Circuit, *, context: Optional['cirq.TransformerContext'] = None) -> cirq.Circuit:
     return cirq.map_operations_and_unroll(
         c, lambda op, _: cirq.decompose_once(op) if type(op.gate) == cirq.PhasedXPowGate else op
     )

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -16,7 +16,7 @@
 from typing import Any, Dict, List, Optional
 import cirq
 from cirq import protocols
-from cirq.transformers import transformer_api, drop_empty_moments, drop_negligible_operations
+from cirq.transformers import drop_empty_moments, drop_negligible_operations
 from cirq.transformers.target_gatesets import compilation_target_gateset
 
 
@@ -149,7 +149,7 @@ class IonQCompilationTargetGateset(compilation_target_gateset.TwoQubitCompilatio
         return self.atol
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return {'atol': self.atol}
+        return cirq.obj_to_dict_helper(self, ['atol'])
 
     @classmethod
     def _from_json_dict_(cls, atol, **kwargs):

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -13,88 +13,11 @@
 # limitations under the License.
 """Devices for IonQ hardware."""
 
-from typing import AbstractSet, Sequence, Union
-
+from typing import Any, Dict, List
 import cirq
-from cirq import _compat
-
-
-_VALID_GATES = cirq.Gateset(
-    cirq.H,
-    cirq.CNOT,
-    cirq.SWAP,
-    cirq.XPowGate,
-    cirq.YPowGate,
-    cirq.ZPowGate,
-    cirq.XXPowGate,
-    cirq.YYPowGate,
-    cirq.ZZPowGate,
-    cirq.MeasurementGate,
-    unroll_circuit_op=False,
-)
-
-
-class IonQAPIDevice(cirq.Device):
-    """A device that uses the QIS gates exposed by the IonQ API.
-
-    When using this device in constructing a circuit, it will convert one and two qubit gates
-    that are not supported by the API into those supported by the API if they have a unitary
-    matrix (support the unitary protocol).
-
-    Note that this device does not do any compression of the resulting circuit, i.e. it may
-    result in a series of single qubit gates that could be executed using far fewer elements.
-
-    The gates supported by the API are
-        * `cirq.XPowGate`, `cirq.YPowGate`, `cirq.ZPowGate`
-        * `cirq.XXPowGate`, `cirq.YYPowGate`, `cirq.ZZPowGate`
-        * `cirq.CNOT`, `cirq.H`, `cirq.SWAP`
-        * `cirq.MeasurementGate`
-    """
-
-    def __init__(self, qubits: Union[Sequence[cirq.LineQubit], int], atol=1e-8):
-        """Construct the device.
-
-        Args:
-            qubits: The qubits upon which this device acts or the number of qubits. If the number
-                of qubits, then the qubits will be `cirq.LineQubit`s from 0 to this number minus
-                one.
-            atol: The absolute tolerance used for gate calculations and decompositions.
-        """
-        if isinstance(qubits, int):
-            self.qubits = frozenset(cirq.LineQubit.range(qubits))
-        else:
-            self.qubits = frozenset(qubits)
-        self.atol = atol
-        self._metadata = cirq.DeviceMetadata(
-            self.qubits, [(a, b) for a in self.qubits for b in self.qubits if a != b]
-        )
-
-    @property
-    def metadata(self) -> cirq.DeviceMetadata:
-        return self._metadata
-
-    @_compat.deprecated(fix='Use metadata.qubit_set if applicable.', deadline='v0.15')
-    def qubit_set(self) -> AbstractSet['cirq.Qid']:
-        return self.qubits
-
-    def validate_operation(self, operation: cirq.Operation):
-        if operation.gate is None:
-            raise ValueError(
-                f'IonQAPIDevice does not support operations with no gates {operation}.'
-            )
-        if not self.is_api_gate(operation):
-            raise ValueError(f'IonQAPIDevice has unsupported gate {operation.gate}.')
-        if not set(operation.qubits).intersection(self.metadata.qubit_set):
-            raise ValueError(f'Operation with qubits not on the device. Qubits: {operation.qubits}')
-
-    def is_api_gate(self, operation: cirq.Operation) -> bool:
-        return operation in _VALID_GATES
-
-    @_compat.deprecated(
-        fix='Use cirq_ionq.decompose_to_device operation instead.', deadline='v0.15'
-    )
-    def decompose_operation(self, operation: cirq.Operation) -> cirq.OP_TREE:
-        return decompose_to_device(operation)
+from cirq import protocols
+from cirq.transformers import drop_empty_moments, drop_negligible_operations
+from cirq.transformers.target_gatesets import compilation_target_gateset
 
 
 def decompose_to_device(operation: cirq.Operation, atol: float = 1e-8) -> cirq.OP_TREE:
@@ -117,40 +40,116 @@ def decompose_to_device(operation: cirq.Operation, atol: float = 1e-8) -> cirq.O
             for the ionq device.
 
     """
-    if operation in _VALID_GATES:
+    gateset = IonQCompilationTargetGateset(atol)
+    if operation in gateset:
         return operation
+
     assert cirq.has_unitary(operation), (
         f'Operation {operation} is not available on the IonQ API nor does it have a '
         'unitary matrix to use to decompose it to the API.'
     )
     num_qubits = len(operation.qubits)
-    if num_qubits == 1:
-        return _decompose_single_qubit(operation, atol)
-    if num_qubits == 2:
-        return _decompose_two_qubit(operation)
+    if num_qubits <= 2:
+        return list(
+            cirq.optimize_for_target_gateset(
+                cirq.Circuit(operation), gateset=IonQCompilationTargetGateset(atol)
+            ).all_operations()
+        )
     raise ValueError(f'Operation {operation} not supported by IonQ API.')
 
 
-def _decompose_single_qubit(operation: cirq.Operation, atol: float) -> cirq.OP_TREE:
-    qubit = operation.qubits[0]
-    mat = cirq.unitary(operation)
-    for gate in cirq.single_qubit_matrix_to_gates(mat, atol):
-        yield gate(qubit)
+class IonQCompilationTargetGateset(compilation_target_gateset.TwoQubitCompilationTargetGateset):
+    """A two-qubit target gateset for gates exposed by the IonQ API.
 
+    When using this in constructing a circuit, it will convert one and two qubit gates
+    that are not supported by the API into those supported by the API if they have a unitary
+    matrix (support the unitary protocol).
 
-def _decompose_two_qubit(operation: cirq.Operation) -> cirq.OP_TREE:
-    """Decomposes a two qubit unitary operation into ZPOW, XPOW, and CNOT."""
-    mat = cirq.unitary(operation)
-    q0, q1 = operation.qubits
-    naive = cirq.two_qubit_matrix_to_cz_operations(q0, q1, mat, allow_partial_czs=False)
-    temp = cirq.map_operations_and_unroll(
-        cirq.Circuit(naive),
-        lambda op, _: [cirq.H(op.qubits[1]), cirq.CNOT(*op.qubits), cirq.H(op.qubits[1])]
-        if type(op.gate) == cirq.CZPowGate
-        else op,
-    )
-    temp = cirq.merge_single_qubit_gates_to_phased_x_and_z(temp)
-    # A final pass breaks up PhasedXPow into Rz, Rx.
-    yield cirq.map_operations_and_unroll(
-        temp, lambda op, _: cirq.decompose_once(op) if type(op.gate) == cirq.PhasedXPowGate else op
-    ).all_operations()
+    Note that this device does not do any compression of the resulting circuit, i.e. it may
+    result in a series of single qubit gates that could be executed using far fewer elements.
+
+    The gates supported by the API are
+        * `cirq.XPowGate`, `cirq.YPowGate`, `cirq.ZPowGate`
+        * `cirq.XXPowGate`, `cirq.YYPowGate`, `cirq.ZZPowGate`
+        * `cirq.CNOT`, `cirq.H`, `cirq.SWAP`
+        * `cirq.MeasurementGate`
+    """
+
+    def __init__(self, atol=1e-8):
+        """Construct the gateset
+
+        Args:
+            atol: The absolute tolerance used for gate calculations and decompositions.
+        """
+        super().__init__(
+            cirq.H,
+            cirq.CNOT,
+            cirq.SWAP,
+            cirq.XPowGate,
+            cirq.YPowGate,
+            cirq.ZPowGate,
+            cirq.XXPowGate,
+            cirq.YYPowGate,
+            cirq.ZZPowGate,
+            cirq.MeasurementGate,
+            name='IonQCompilationTargetGateset',
+        )
+        self.atol = atol
+
+    def __repr__(self) -> str:
+        return f'cirq_ionq.IonQCompilationTargetGateset(atol={self.atol})'
+
+    def is_api_gate(self, operation: cirq.Operation) -> bool:
+        return operation in self
+
+    def _decompose_single_qubit_operation(self, operation: cirq.Operation, _) -> 'cirq.OP_TREE':
+        if self.is_api_gate(operation):
+            return operation
+        if not protocols.has_unitary(operation):
+            raise ValueError(f'Operation {operation} not supported by IonQ API.')
+        qubit = operation.qubits[0]
+        mat = cirq.unitary(operation)
+        return [gate(qubit) for gate in cirq.single_qubit_matrix_to_gates(mat, self.atol)]
+
+    def _decompose_two_qubit_operation(self, operation: cirq.Operation, _) -> 'cirq.OP_TREE':
+        """Decomposes a two qubit unitary operation into ZPOW, XPOW, and CNOT."""
+        if self.is_api_gate(operation):
+            return operation
+        if not protocols.has_unitary(operation):
+            raise ValueError(f'Operation {operation} not supported by IonQ API.')
+        mat = cirq.unitary(operation)
+        q0, q1 = operation.qubits
+        naive = cirq.two_qubit_matrix_to_cz_operations(
+            q0, q1, mat, allow_partial_czs=False, atol=self.atol
+        )
+        return cirq.map_operations_and_unroll(
+            cirq.Circuit(naive),
+            lambda op, _: [cirq.H(op.qubits[1]), cirq.CNOT(*op.qubits), cirq.H(op.qubits[1])]
+            if type(op.gate) == cirq.CZPowGate
+            else op,
+        )
+
+    def _value_equality_values_(self) -> Any:
+        return self.atol
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {'atol': self.atol}
+
+    @classmethod
+    def _from_json_dict_(cls, atol, **kwargs):
+        return cls(atol=atol)
+
+    @property
+    def postprocess_transformers(self) -> List['cirq.TRANSFORMER']:
+        """List of transformers which should be run after decomposing individual operations."""
+        return [
+            lambda c, context: cirq.merge_single_qubit_gates_to_phased_x_and_z(c),
+            lambda c, context: cirq.map_operations_and_unroll(
+                c,
+                lambda op, _: cirq.decompose_once(op)
+                if type(op.gate) == cirq.PhasedXPowGate
+                else op,
+            ),
+            drop_negligible_operations,
+            drop_empty_moments,
+        ]

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -16,18 +16,18 @@
 from typing import Any, Dict, List, Optional
 import cirq
 from cirq import protocols
-from cirq.transformers import drop_empty_moments, drop_negligible_operations
+from cirq.transformers import transformer_api, drop_empty_moments, drop_negligible_operations
 from cirq.transformers.target_gatesets import compilation_target_gateset
 
 
-@cirq.transformer
+@transformer_api.transformer
 def merge_to_phased_x_and_z(
     c: cirq.AbstractCircuit, *, context: Optional['cirq.TransformerContext'] = None
 ) -> cirq.AbstractCircuit:
     return cirq.merge_single_qubit_gates_to_phased_x_and_z(c)
 
 
-@cirq.transformer
+@transformer_api.transformer
 def decompose_phased_x_pow(
     c: cirq.AbstractCircuit, *, context: Optional['cirq.TransformerContext'] = None
 ) -> cirq.AbstractCircuit:

--- a/cirq-ionq/cirq_ionq/ionq_devices_test.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices_test.py
@@ -48,85 +48,7 @@ VALID_GATES = (
 )
 
 
-@pytest.mark.parametrize('gate', VALID_GATES)
-def test_validate_operation_valid(gate):
-    qubits = cirq.LineQubit.range(gate.num_qubits())
-    device = ionq.IonQAPIDevice(qubits=qubits)
-    operation = gate(*qubits)
-    device.validate_operation(operation)
-
-
 INVALID_GATES = (cirq.CNOT**0.5, cirq.SWAP**0.5, cirq.CCX, cirq.CCZ, cirq.CZ)
-
-
-@pytest.mark.parametrize('gate', INVALID_GATES)
-def test_validate_operation_invalid(gate):
-    qubits = cirq.LineQubit.range(gate.num_qubits())
-    device = ionq.IonQAPIDevice(qubits=qubits)
-    operation = gate(*qubits)
-    with pytest.raises(ValueError, match='unsupported gate'):
-        device.validate_operation(operation)
-
-
-def test_metadata():
-    device = ionq.IonQAPIDevice(qubits=[cirq.LineQubit(0)])
-    assert device.metadata.qubit_set == {cirq.LineQubit(0)}
-
-
-def test_validate_operation_no_gate():
-    device = ionq.IonQAPIDevice(qubits=[])
-    with pytest.raises(ValueError, match='no gates'):
-        device.validate_operation(cirq.CircuitOperation(cirq.FrozenCircuit()))
-
-
-def test_validate_operation_qubit_not_on_device():
-    device = ionq.IonQAPIDevice(qubits=[cirq.LineQubit(0)])
-    with pytest.raises(ValueError, match='not on the device'):
-        device.validate_operation(cirq.H(cirq.LineQubit(1)))
-
-
-def test_validate_moment_valid():
-    moment = cirq.Moment()
-    q = 0
-    all_qubits = []
-    for gate in VALID_GATES:
-        qubits = cirq.LineQubit.range(q, q + gate.num_qubits())
-        all_qubits.extend(qubits)
-        moment += [gate(*qubits)]
-        q += gate.num_qubits()
-    device = ionq.IonQAPIDevice(len(all_qubits))
-    device.validate_moment(moment)
-
-
-@pytest.mark.parametrize('gate', INVALID_GATES)
-def test_validate_moment_invalid(gate):
-    qubits = cirq.LineQubit.range(gate.num_qubits())
-    moment = cirq.Moment([gate(*qubits)])
-    device = ionq.IonQAPIDevice(qubits=qubits)
-    with pytest.raises(ValueError, match='unsupported gate'):
-        device.validate_moment(moment)
-
-
-def test_validate_circuit_valid():
-    qubits = cirq.LineQubit.range(10)
-    device = ionq.IonQAPIDevice(qubits)
-    for _ in range(100):
-        circuit = cirq.testing.random_circuit(
-            qubits=qubits,
-            n_moments=3,
-            op_density=0.5,
-            gate_domain={gate: gate.num_qubits() for gate in VALID_GATES},
-        )
-        device.validate_circuit(circuit)
-
-
-@pytest.mark.parametrize('gate', VALID_GATES)
-def test_decompose_leaves_supported_alone_deprecated(gate):
-    qubits = cirq.LineQubit.range(gate.num_qubits())
-    device = ionq.IonQAPIDevice(qubits=qubits)
-    operation = gate(*qubits)
-    with cirq.testing.assert_deprecated('decompose_to_device', deadline='v0.15'):
-        assert device.decompose_operation(operation) == operation
 
 
 @pytest.mark.parametrize('gate', VALID_GATES)
@@ -136,21 +58,19 @@ def test_decompose_leaves_supported_alone(gate):
     assert ionq.decompose_to_device(operation) == operation
 
 
-VALID_DECOMPOSED_GATES = cirq.Gateset(cirq.XPowGate, cirq.ZPowGate, cirq.CNOT)
+VALID_DECOMPOSED_GATES = cirq.Gateset(cirq.XPowGate, cirq.ZPowGate, cirq.CNOT, cirq.MeasurementGate)
 
 
-def test_decompose_single_qubit_matrix_gate_deprecated():
+def test_decompose_single_qubit_matrix_gateset():
     q = cirq.LineQubit(0)
-    device = ionq.IonQAPIDevice(qubits=[q])
+    device = ionq.IonQCompilationTargetGateset()
     for _ in range(100):
         gate = cirq.MatrixGate(cirq.testing.random_unitary(2))
         circuit = cirq.Circuit(gate(q))
-        with cirq.testing.assert_deprecated('decompose_to_device', deadline='v0.15'):
-            decomposed_circuit = cirq.Circuit(*device.decompose_operation(gate(q)))
+        decomposed_circuit = cirq.optimize_for_target_gateset(circuit, gateset=device)
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
             circuit, decomposed_circuit, atol=1e-8
         )
-        assert VALID_DECOMPOSED_GATES.validate(decomposed_circuit)
 
 
 def test_decompose_single_qubit_matrix_gate():
@@ -165,14 +85,13 @@ def test_decompose_single_qubit_matrix_gate():
         assert VALID_DECOMPOSED_GATES.validate(decomposed_circuit)
 
 
-def test_decompose_two_qubit_matrix_gate_deprecated():
+def test_decompose_two_qubit_matrix_gateset():
     q0, q1 = cirq.LineQubit.range(2)
-    device = ionq.IonQAPIDevice(qubits=[q0, q1])
+    device = ionq.IonQCompilationTargetGateset()
     for _ in range(10):
         gate = cirq.MatrixGate(cirq.testing.random_unitary(4))
         circuit = cirq.Circuit(gate(q0, q1))
-        with cirq.testing.assert_deprecated('decompose_to_device', deadline='v0.15'):
-            decomposed_circuit = cirq.Circuit(*device.decompose_operation(gate(q0, q1)))
+        decomposed_circuit = cirq.optimize_for_target_gateset(circuit, gateset=device)
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
             circuit, decomposed_circuit, atol=1e-8
         )
@@ -191,13 +110,16 @@ def test_decompose_two_qubit_matrix_gate():
         assert VALID_DECOMPOSED_GATES.validate(decomposed_circuit)
 
 
-def test_decompose_unsupported_gate_deprecated():
-    q0, q1, q2 = cirq.LineQubit.range(3)
-    device = ionq.IonQAPIDevice(qubits=[q0, q1, q2])
-    op = cirq.CCZ(q0, q1, q2)
-    with pytest.raises(ValueError, match='not supported'):
-        with cirq.testing.assert_deprecated('decompose_to_device', deadline='v0.15'):
-            _ = device.decompose_operation(op)
+def test_decompose_two_qubit_matrix_gate():
+    q0, q1 = cirq.LineQubit.range(2)
+    for _ in range(10):
+        gate = cirq.MatrixGate(cirq.testing.random_unitary(4))
+        circuit = cirq.Circuit(gate(q0, q1))
+        decomposed_circuit = cirq.Circuit(*ionq.decompose_to_device(gate(q0, q1)))
+        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+            circuit, decomposed_circuit, atol=1e-8
+        )
+        assert VALID_DECOMPOSED_GATES.validate(decomposed_circuit)
 
 
 def test_decompose_unsupported_gate():

--- a/cirq-ionq/cirq_ionq/ionq_devices_test.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices_test.py
@@ -110,18 +110,6 @@ def test_decompose_two_qubit_matrix_gate():
         assert VALID_DECOMPOSED_GATES.validate(decomposed_circuit)
 
 
-def test_decompose_two_qubit_matrix_gate():
-    q0, q1 = cirq.LineQubit.range(2)
-    for _ in range(10):
-        gate = cirq.MatrixGate(cirq.testing.random_unitary(4))
-        circuit = cirq.Circuit(gate(q0, q1))
-        decomposed_circuit = cirq.Circuit(*ionq.decompose_to_device(gate(q0, q1)))
-        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-            circuit, decomposed_circuit, atol=1e-8
-        )
-        assert VALID_DECOMPOSED_GATES.validate(decomposed_circuit)
-
-
 def test_decompose_unsupported_gate():
     q0, q1, q2 = cirq.LineQubit.range(3)
     op = cirq.CCZ(q0, q1, q2)

--- a/cirq-ionq/cirq_ionq/json_resolver_cache.py
+++ b/cirq-ionq/cirq_ionq/json_resolver_cache.py
@@ -25,4 +25,5 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # coverage: ignor
         "GPIGate": cirq_ionq.GPIGate,
         "GPI2Gate": cirq_ionq.GPI2Gate,
         "MSGate": cirq_ionq.MSGate,
+        "IonQCompilationTargetGateset": cirq_ionq.IonQCompilationTargetGateset,
     }


### PR DESCRIPTION
https://github.com/quantumlib/Cirq/issues/4901

Deletes IonQAPIDevice
Introduces IonQCompilationTargetGateset with roughly equivalent functionality (but not restricted to only 2 qubit operations)
Migrates decompose_to_device to IonQCompilationTargetGateset