### PR TITLE
Allow specifying timeout_seconds when constructing an ionq Sampler

### DIFF
--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -91,7 +91,7 @@ class Sampler(cirq.Sampler):
         ]
         kwargs = {}
         if self._timeout_seconds is not None:
-            kwargs = { timeout_seconds: self._timeout_seconds }
+            kwargs = {timeout_seconds: self._timeout_seconds}
         job_results = [job.results(**kwargs) for job in jobs]
         cirq_results = []
         for result, params in zip(job_results, resolvers):

--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -44,6 +44,7 @@ class Sampler(cirq.Sampler):
         self,
         service: 'cirq_ionq.Service',
         target: Optional[str],
+        timeout_seconds: Optional[int] = None,
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ):
         """Construct the sampler.
@@ -57,10 +58,12 @@ class Sampler(cirq.Sampler):
             seed: If the target is `simulation` the seed for generating results. If None, this
                 will be `np.random`, if an int, will be `np.random.RandomState(int)`, otherwise
                 must be a modulate similar to `np.random`.
+            timeout_seconds: Length of time to wait for results. Default is specified in the job.
         """
         self._service = service
         self._target = target
         self._seed = seed
+        self._timeout_seconds = timeout_seconds
 
     def run_sweep(
         self,
@@ -86,7 +89,10 @@ class Sampler(cirq.Sampler):
             )
             for resolver in resolvers
         ]
-        job_results = [job.results() for job in jobs]
+        kwargs = {}
+        if self._timeout_seconds is not None:
+            kwargs = { timeout_seconds: self._timeout_seconds }
+        job_results = [job.results(**kwargs) for job in jobs]
         cirq_results = []
         for result, params in zip(job_results, resolvers):
             if isinstance(result, results.QPUResult):

--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -91,7 +91,7 @@ class Sampler(cirq.Sampler):
         ]
         kwargs = {}
         if self._timeout_seconds is not None:
-            kwargs = {timeout_seconds: self._timeout_seconds}
+            kwargs = {"timeout_seconds": self._timeout_seconds}
         job_results = [job.results(**kwargs) for job in jobs]
         cirq_results = []
         for result, params in zip(job_results, resolvers):

--- a/cirq-ionq/cirq_ionq/sampler_test.py
+++ b/cirq-ionq/cirq_ionq/sampler_test.py
@@ -94,7 +94,7 @@ def test_sampler_multiple_jobs():
     job1 = ionq.Job(client=mock_service, job_dict=job_dict1)
     mock_service.create_job.side_effect = [job0, job1]
 
-    sampler = ionq.Sampler(service=mock_service, target='qpu')
+    sampler = ionq.Sampler(service=mock_service, timeout_seconds=10, target='qpu')
     q0 = cirq.LineQubit(0)
     x = sp.Symbol('x')
     circuit = cirq.Circuit(cirq.X(q0) ** x, cirq.measure(q0, key='a'))


### PR DESCRIPTION
This allows users of tensorflow quantum to use a high timeout and https://github.com/tensorflow/quantum/blob/f10d36b64761a003fd542392767fa079d57df0aa/tensorflow_quantum/python/quantum_context.py\#L82-L101 to run highly parallel workloads that may take very long times per-job without flakiness.