### PR TITLE
Add iterator support for AbstractJob

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -181,7 +181,7 @@ class AbstractJob(abc.ABC):
         """
 
     def __iter__(self) -> Iterator[cirq.Result]:
-        return iter(self.results())
+        yield from self.results()
 
     # pylint: disable=function-redefined
     @overload


### PR DESCRIPTION
- Add support for next() in AbstractJob
- Changes __iter__ to return a generator, which
will have support for iteration in for loops, as well as
next().
- Also improve the iteration tests to be more thorough and accurate.

Fixes: #5120