### PR TITLE
Pin Jinja2 version for build_docs CI.

### DIFF
--- a/rtd_docs/requirements.txt
+++ b/rtd_docs/requirements.txt
@@ -3,3 +3,4 @@ myst-parser
 Sphinx~=3.2.0
 sphinx_rtd_theme
 sphinx-notfound-page
+Jinja2<=3.0.3


### PR DESCRIPTION
See CI failure here: #5134 