### PR TITLE
Cleanup docs/noise.ipynb in preparation for Cirq 1.0 launch

### DIFF
--- a/docs/noise.ipynb
+++ b/docs/noise.ipynb
@@ -116,7 +116,7 @@
     "id": "708b5b720a74"
    },
    "source": [
-    "Cirq defines many commonly used quantum channels in [`ops/common_channels.py`](https://github.com/quantumlib/Cirq/blob/master/cirq/ops/common_channels.py). For example, the single-qubit bit-flip channel\n",
+    "Cirq defines many commonly used quantum channels in [`ops/common_channels.py`](https://github.com/quantumlib/Cirq/blob/master/cirq-core/cirq/ops/common_channels.py). For example, the single-qubit bit-flip channel\n",
     "\n",
     "$$\n",
     "\\rho \\rightarrow (1 - p) \\rho + p X \\rho X\n",
@@ -145,7 +145,7 @@
     "id": "f1f501177e53"
    },
    "source": [
-    "To see the Kraus operators of a channel, the `cirq.channel` protocol can be used. (See the [protocols guide](./protocols.ipynb).)"
+    "To see the Kraus operators of a channel, the `cirq.kraus` protocol can be used. (See the [protocols guide](./protocols.ipynb).)"
    ]
   },
   {
@@ -282,7 +282,7 @@
     "id": "ddbc622c98da"
    },
    "source": [
-    "## The `channel` and `mixture` protocols"
+    "## The `kraus` and `mixture` protocols"
    ]
   },
   {
@@ -291,7 +291,7 @@
     "id": "2dee355d2ae8"
    },
    "source": [
-    "We have seen the `cirq.channel` protocol which returns the Kraus operators of a channel. Some channels have the interpretation of randomly applying a single unitary Kraus operator $U_k$ with probability $p_k$, namely\n",
+    "We have seen the `cirq.kraus` protocol which returns the Kraus operators of a channel. Some channels have the interpretation of randomly applying a single unitary Kraus operator $U_k$ with probability $p_k$, namely\n",
     "\n",
     "$$\n",
     "\\rho \\rightarrow \\sum_k p_k U_k \\rho U_k^\\dagger {\\rm ~where~} \\sum_k p_k =1 {\\rm ~and~ U_k U_k^\\dagger= I}.\n",
@@ -361,9 +361,9 @@
    "source": [
     "To summarize:\n",
     "\n",
-    "* Every `Gate` in Cirq supports the `cirq.channel` protocol.\n",
-    "  - If magic method `_kraus_` is not defined, `cirq.channel` looks for `_mixture_` then for `_unitary_`.\n",
-    "* A subset of channels which support `cirq.channel` also support the `cirq.mixture` protocol.\n",
+    "* Every `Gate` in Cirq supports the `cirq.kraus` protocol.\n",
+    "  - If magic method `_kraus_` is not defined, `cirq.kraus` looks for `_mixture_` then for `_unitary_`.\n",
+    "* A subset of channels which support `cirq.kraus` also support the `cirq.mixture` protocol.\n",
     "  - If magic method `_mixture_` is not defined, `cirq.mixture` looks for `_unitary_`.\n",
     "* A subset of channels which support `cirq.mixture` also support the `cirq.unitary` protocol."
    ]
@@ -377,11 +377,11 @@
     "For concrete examples, consider `cirq.X`, `cirq.BitFlipChannel`, and `cirq.AmplitudeDampingChannel` which are all subclasses of `cirq.Gate`.\n",
     "\n",
     "* `cirq.X` defines the `_unitary_` method. \n",
-    "  - As a result, it supports the `cirq.unitary` protocol, the `cirq.mixture` protocol, and the `cirq.channel` protocol.\n",
+    "  - As a result, it supports the `cirq.unitary` protocol, the `cirq.mixture` protocol, and the `cirq.kraus` protocol.\n",
     "* `cirq.BitFlipChannel` defines the `_mixture_` method but not the `_unitary_` method.\n",
-    "  - As a result, it only supports the `cirq.mixture` protocol and the `cirq.channel` protocol.\n",
+    "  - As a result, it only supports the `cirq.mixture` protocol and the `cirq.kraus` protocol.\n",
     "* `cirq.AmplitudeDampingChannel` defines the `_kraus_` method, but not the `_mixture_` method or the `_unitary_` method.\n",
-    "  - As a result, it only supports the `cirq.channel` protocol."
+    "  - As a result, it only supports the `cirq.kraus` protocol."
    ]
   },
   {
@@ -425,7 +425,7 @@
     "    (0.9, np.array([[1, 0], [0, 1]], dtype=np.complex64)),\n",
     "    (0.1, np.array([[0, 1], [1, 0]], dtype=np.complex64)),\n",
     "]\n",
-    "bit_flip = cirq.MixedUnitaryChannel(mix)\n",
+    "bit_flip_mix = cirq.MixedUnitaryChannel(mix)\n",
     "\n",
     "# This is equivalent to an X-basis measurement.\n",
     "ops = [\n",
@@ -436,7 +436,7 @@
     "\n",
     "# These circuits have the same behavior.\n",
     "circuit = cirq.Circuit(\n",
-    "    bit_flip.on(q0),\n",
+    "    bit_flip_mix.on(q0),\n",
     "    cirq.H(q0),\n",
     "    x_meas.on(q0),\n",
     ")\n",
@@ -531,7 +531,7 @@
     "id": "72486a155131"
    },
    "source": [
-    "Note: Since `_mixture_` is defined, the `cirq.channel` protocol can also be used."
+    "Note: Since `_mixture_` is defined, the `cirq.kraus` protocol can also be used."
    ]
   },
   {
@@ -890,7 +890,7 @@
     "id": "11b18c640767"
    },
    "source": [
-    "Another technique is to pass a noise channel to the density matrix simulator as shown below."
+    "Another technique is to directly pass a `cirq.NoiseModel`, or a value that can be trivially converted into one, to the density matrix simulator as shown below."
    ]
   },
   {
@@ -901,7 +901,8 @@
    },
    "outputs": [],
    "source": [
-    "\"\"\"Define a density matrix simulator with a noise model.\"\"\"\n",
+    "\"\"\"Define a density matrix simulator with a `cirq.NOISE_MODEL_LIKE` object.\"\"\"\n",
+    "\n",
     "noisy_dsim = cirq.DensityMatrixSimulator(\n",
     "    noise=cirq.generalized_amplitude_damp(p=0.1, gamma=0.5)\n",
     ")"


### PR DESCRIPTION
- Part of docs cleanup effort in preparation of Cirq 1.0 launch. 
- Maybe @95-martin-orion can add more details about `NoiseProperties` and realistic device noise once the work is done. 