### PR TITLE
Update to pylint 2.13

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1359,7 +1359,7 @@ class AbstractCircuit(abc.ABC):
         same moment index.
 
         Args:
-            circuits: The circuits to merge together.
+            *circuits: The circuits to merge together.
             align: The alignment for the zip, see `cirq.Alignment`.
 
         Returns:
@@ -1441,7 +1441,7 @@ class AbstractCircuit(abc.ABC):
             False
 
         Args:
-            circuits: The circuits to concatenate.
+            *circuits: The circuits to concatenate.
             align: When to stop when sliding the circuits together.
                 'left': Stop when the starts of the circuits align.
                 'right': Stop when the ends of the circuits align.

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -616,7 +616,7 @@ class CircuitOperation(ops.Operation):
         """Returns a copy of this operation with an updated qubit mapping.
 
         Args:
-            new_qubits: A list of qubits to target. Qubits in this list are
+            *new_qubits: A list of qubits to target. Qubits in this list are
                 matched to qubits in the circuit following default qubit order,
                 ignoring any existing qubit map.
 

--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -177,7 +177,7 @@ class Moment:
         """Returns a new moment with the given contents added.
 
         Args:
-            contents: New operations to add to this moment.
+            *contents: New operations to add to this moment.
 
         Returns:
             The new moment.

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -75,7 +75,7 @@ def draw_gridlike(
         ax: Optional matplotlib axis to use for drawing.
         tilted: If True, directly position as (row, column); otherwise,
             rotate 45 degrees to accommodate google-style diagonal grids.
-        kwargs: Additional arguments to pass to `nx.draw_networkx`.
+        **kwargs: Additional arguments to pass to `nx.draw_networkx`.
 
     Returns:
         A positions dictionary mapping nodes to (x, y) coordinates suitable for future calls
@@ -126,7 +126,7 @@ class LineTopology(NamedTopology):
         Args:
             ax: Optional matplotlib axis to use for drawing.
             tilted: If True, draw as a horizontal line. Otherwise, draw on a diagonal.
-            kwargs: Additional arguments to pass to `nx.draw_networkx`.
+            **kwargs: Additional arguments to pass to `nx.draw_networkx`.
         """
         g2 = nx.relabel_nodes(self.graph, {n: (n, 1) for n in self.graph.nodes})
         return draw_gridlike(g2, ax=ax, tilted=tilted, **kwargs)
@@ -217,7 +217,7 @@ class TiltedSquareLattice(NamedTopology):
             ax: Optional matplotlib axis to use for drawing.
             tilted: If True, directly position as (row, column); otherwise,
                 rotate 45 degrees to accommodate the diagonal nature of this topology.
-            kwargs: Additional arguments to pass to `nx.draw_networkx`.
+            **kwargs: Additional arguments to pass to `nx.draw_networkx`.
         """
         return draw_gridlike(self.graph, ax=ax, tilted=tilted, **kwargs)
 

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -171,7 +171,7 @@ class TomographyResult:
             axes: A list of 2 `plt.Axes` instances. Note that they must be in
                 3d projections. If not given, a new figure is created with 2
                 axes and the plotted figure is shown.
-            plot_kwargs: The optional kwargs passed to bar3d.
+            **plot_kwargs: The optional kwargs passed to bar3d.
 
         Returns:
             the list of `plt.Axes` being plotted on.

--- a/cirq-core/cirq/linalg/decompositions.py
+++ b/cirq-core/cirq/linalg/decompositions.py
@@ -592,7 +592,7 @@ def scatter_plot_normalized_kak_interaction_coefficients(
             wireframe. Defaults to `True`.
         ax: A matplotlib 3d axes object to plot into. If not specified, a new
             figure is created, plotted, and shown.
-        kwargs: Arguments forwarded into the call to `scatter` that plots the
+        **kwargs: Arguments forwarded into the call to `scatter` that plots the
             points. Working arguments include color `c='blue'`, scale `s=2`,
             labelling `label="theta=pi/4"`, etc. For reference see the
             `matplotlib.pyplot.scatter` documentation:

--- a/cirq-core/cirq/ops/arithmetic_operation.py
+++ b/cirq-core/cirq/ops/arithmetic_operation.py
@@ -107,7 +107,7 @@ class ArithmeticOperation(Operation, metaclass=abc.ABCMeta):
         """Returns the same operation targeting different registers.
 
         Args:
-            new_registers: The new values that should be returned by the
+            *new_registers: The new values that should be returned by the
                 `registers` method.
 
         Returns:

--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -198,7 +198,7 @@ def qft(
     equivalently `cirq.inverse(cirq.qft(*qubits))`.
 
     Args:
-        qubits: The qubits to apply the qft to.
+        *qubits: The qubits to apply the qft to.
         without_reverse: When set, swap gates at the end of the qft are omitted.
             This reverses the qubit order relative to the standard qft effect,
             but makes the gate cheaper to apply.

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -1311,7 +1311,7 @@ def test_pauli_string_expectation_from_density_matrix_pure_state_with_coef():
     z0z2 = cirq.Z(qs[0]) * cirq.Z(qs[2]) * -1
     z1x2 = -cirq.Z(qs[1]) * cirq.X(qs[2])
 
-    for state in [rho, rho.reshape(2, 2, 2, 2, 2, 2, 2, 2)]:
+    for state in [rho, rho.reshape((2, 2, 2, 2, 2, 2, 2, 2))]:
         np.testing.assert_allclose(z0z1.expectation_from_density_matrix(state, q_map), -0.123)
         np.testing.assert_allclose(z0z2.expectation_from_density_matrix(state, q_map), 0)
         np.testing.assert_allclose(z1x2.expectation_from_density_matrix(state, q_map), 1)

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -458,7 +458,7 @@ class Operation(metaclass=abc.ABCMeta):
         """Returns the same operation, but applied to different qubits.
 
         Args:
-            new_qubits: The new qubits to apply the operation to. The order must
+            *new_qubits: The new qubits to apply the operation to. The order must
                 exactly match the order of qubits returned from the operation's
                 `qubits` property.
         """
@@ -489,7 +489,7 @@ class Operation(metaclass=abc.ABCMeta):
         also restrict the operation to be JSON serializable.
 
         Args:
-            new_tags: The tags to wrap this operation in.
+            *new_tags: The tags to wrap this operation in.
         """
         if not new_tags:
             return self
@@ -529,7 +529,7 @@ class Operation(metaclass=abc.ABCMeta):
            are specified, returns self.
 
         Args:
-            control_qubits: Qubits to control the operation by. Required.
+            *control_qubits: Qubits to control the operation by. Required.
             control_values: For which control qubit values to apply the
                 operation.  A sequence of the same length as `control_qubits`
                 where each entry is an integer (or set of integers)
@@ -627,7 +627,7 @@ class Operation(metaclass=abc.ABCMeta):
         since tags are considered a local attribute.
 
         Args:
-            conditions: A list of measurement keys, strings that can be parsed
+            *conditions: A list of measurement keys, strings that can be parsed
                 into measurement keys, or sympy expressions where the free
                 symbols are measurement key strings.
 

--- a/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap_test.py
+++ b/cirq-core/cirq/optimizers/merge_interactions_to_sqrt_iswap_test.py
@@ -29,7 +29,7 @@ def assert_optimizes(before: cirq.Circuit, expected: cirq.Circuit, **kwargs):
     Args:
         before: The input circuit to optimize.
         expected: The expected result of optimization to compare against.
-        kwargs: Any extra arguments to pass to the
+        **kwargs: Any extra arguments to pass to the
             ``MergeInteractionsToSqrtIswap`` constructor.
     """
     actual = before.copy()

--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -279,10 +279,10 @@ def decompose_once(val: Any, default=RaiseTypeErrorIfNotProvided, *args, **kwarg
             `_decompose_` method or that method returns `NotImplemented` or
             `None`. If not specified, non-decomposable values cause a
             `TypeError`.
-        args: Positional arguments to forward into the `_decompose_` method of
+        *args: Positional arguments to forward into the `_decompose_` method of
             `val`.  For example, this is used to tell gates what qubits they are
             being applied to.
-        kwargs: Keyword arguments to forward into the `_decompose_` method of
+        **kwargs: Keyword arguments to forward into the `_decompose_` method of
             `val`.
 
     Returns:

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -375,7 +375,7 @@ def infer_qid_shape(*states: 'cirq.QUANTUM_STATE_LIKE') -> Tuple[int, ...]:
     an error is raised.
 
     Args:
-        states: The states for which to infer the qid shape.
+        *states: The states for which to infer the qid shape.
 
     Returns:
         The inferred qid shape.

--- a/cirq-core/cirq/testing/deprecation.py
+++ b/cirq-core/cirq/testing/deprecation.py
@@ -28,7 +28,7 @@ def assert_deprecated(*msgs: str, deadline: str, count: Optional[int] = 1) -> It
     >>>     # do something deprecated
 
     Args:
-        msgs: messages that should match the warnings captured
+        *msgs: messages that should match the warnings captured
         deadline: the expected deadline the feature will be deprecated by. Has to follow the format
             vX.Y (minor versions only)
         count: if None count of messages is not asserted, otherwise the number of deprecation

--- a/cirq-core/cirq/testing/equals_tester.py
+++ b/cirq-core/cirq/testing/equals_tester.py
@@ -123,7 +123,7 @@ class EqualsTester:
         Adds the objects as a group.
 
         Args:
-            factories: Methods for producing independent copies of an item.
+            *factories: Methods for producing independent copies of an item.
 
         Raises:
             AssertionError: The factories produce items not equal to the others,

--- a/cirq-core/cirq/testing/logs.py
+++ b/cirq-core/cirq/testing/logs.py
@@ -40,7 +40,7 @@ def assert_logs(
     can be done beyond these simple asserts.
 
     Args:
-        matches: Each of these is checked to see if they match, as a substring,
+        *matches: Each of these is checked to see if they match, as a substring,
             any of the captures log messages.
         count: The expected number of messages in logs. Defaults to 1. If None is passed in counts
             are not checked.

--- a/cirq-core/cirq/testing/order_tester.py
+++ b/cirq-core/cirq/testing/order_tester.py
@@ -106,7 +106,7 @@ class OrderTester:
         Adds the objects as a group.
 
         Args:
-            group_items: items making the equivalence group
+            *group_items: items making the equivalence group
 
         Raises:
             AssertionError: The group elements aren't equal to each other,

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -19,7 +19,7 @@ import cirq
 
 def test_empty_init():
     with pytest.raises(TypeError, match='required positional argument'):
-        _ = cirq.MeasurementKey()
+        _ = cirq.MeasurementKey()  # pylint: disable=no-value-for-parameter
     with pytest.raises(ValueError, match='valid string'):
         _ = cirq.MeasurementKey(None)
     with pytest.raises(ValueError, match='valid string'):

--- a/cirq-core/cirq/vis/heatmap.py
+++ b/cirq-core/cirq/vis/heatmap.py
@@ -295,7 +295,7 @@ class Heatmap:
         Args:
             ax: the Axes to plot on. If not given, a new figure is created,
                 plotted on, and shown.
-            kwargs: The optional keyword arguments are used to temporarily
+            **kwargs: The optional keyword arguments are used to temporarily
                 override the values present in the heatmap config. See
                 __init__ for more details on the allowed arguments.
         Returns:
@@ -384,7 +384,7 @@ class TwoQubitInteractionHeatmap(Heatmap):
         Args:
             ax: the Axes to plot on. If not given, a new figure is created,
                 plotted on, and shown.
-            kwargs: The optional keyword arguments are used to temporarily
+            **kwargs: The optional keyword arguments are used to temporarily
                 override the values present in the heatmap config. See
                 __init__ for more details on the allowed arguments.
         Returns:

--- a/cirq-google/cirq_google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
+++ b/cirq-google/cirq_google/engine/client/quantum_v1alpha1/gapic/transports/quantum_engine_service_grpc_transport.py
@@ -84,7 +84,7 @@ class QuantumEngineServiceGrpcTransport(object):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
-            kwargs (dict): Keyword arguments, which are passed to the
+            **kwargs (dict): Keyword arguments, which are passed to the
                 channel creation.
 
         Returns:

--- a/cirq-ionq/cirq_ionq/service.py
+++ b/cirq-ionq/cirq_ionq/service.py
@@ -110,7 +110,9 @@ class Service:
             return result.to_cirq_result(params=cirq.ParamResolver(param_resolver))
         else:
             sim_result = cast(results.SimulatorResult, result)
+            # pylint: disable=unexpected-keyword-arg
             return sim_result.to_cirq_result(params=cirq.ParamResolver(param_resolver), seed=seed)
+            # pylint: enable=unexpected-keyword-arg
 
     def sampler(self, target: Optional[str] = None, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None):
         """Returns a `cirq.Sampler` object for accessing the sampler interface.

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -30,7 +30,6 @@ enable=
     missing-raises-doc,
     mixed-indentation,
     mixed-line-endings,
-    not-callable,
     no-value-for-parameter,
     nonexistent-operator,
     not-in-loop,

--- a/dev_tools/pylint_copyright_checker_test.py
+++ b/dev_tools/pylint_copyright_checker_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from astroid import parse
-from pylint.testutils import CheckerTestCase, Message
+from pylint.testutils import CheckerTestCase, MessageTest
 
 from dev_tools.pylint_copyright_checker import CopyrightChecker
 
@@ -27,42 +27,49 @@ class TestCopyrightChecker(CheckerTestCase):
         r"""Report message when no copyright notice at the beginning of a file."""
         node = parse("import os")
         with self.assertAddsMessages(
-            Message(
+            MessageTest(
                 msg_id='wrong-or-nonexistent-copyright-notice',
                 line=1,
+                col_offset=0,
             ),
         ):
             self.checker.process_module(node)
 
     def test_wrong_copyright(self) -> None:
         r"""Report message when the copyright notice is incorrect."""
-        node = parse("# Copyright 2021 Someone else")
+        comment = "# Copyright 2021 Someone else"
+        node = parse(comment)
         with self.assertAddsMessages(
-            Message(
+            MessageTest(
                 msg_id='wrong-or-nonexistent-copyright-notice',
                 line=1,
+                col_offset=comment.index("Someone"),
             ),
         ):
             self.checker.process_module(node)
 
     def test_shorter_copyright(self) -> None:
         r"""Report message when the copyright notice is incorrect."""
-        node = parse("# Copyright 2021 The")
+        comment = "# Copyright 2021 The"
+        node = parse(comment)
         with self.assertAddsMessages(
-            Message(
+            MessageTest(
                 msg_id='wrong-or-nonexistent-copyright-notice',
                 line=1,
+                col_offset=len(comment),
             ),
         ):
             self.checker.process_module(node)
 
     def test_longer_copyright(self) -> None:
         r"""Report message when the copyright notice is incorrect."""
-        node = parse("# Copyright 2021 The Cirq Developers and extra")
+        comment = "# Copyright 2021 The Cirq Developers and extra"
+        node = parse(comment)
         with self.assertAddsMessages(
-            Message(
+            MessageTest(
                 msg_id='wrong-or-nonexistent-copyright-notice',
                 line=1,
+                col_offset=comment.index(" and extra"),
             ),
         ):
             self.checker.process_module(node)

--- a/dev_tools/requirements/deps/pylint.txt
+++ b/dev_tools/requirements/deps/pylint.txt
@@ -1,3 +1,3 @@
 # for linting
 
-pylint~=2.6.0
+pylint~=2.13.0

--- a/dev_tools/shell_tools.py
+++ b/dev_tools/shell_tools.py
@@ -148,7 +148,7 @@ def run_cmd(
     """Invokes a subprocess and waits for it to finish.
 
     Args:
-        cmd: Components of the command to execute, e.g. ["echo", "dog"].
+        *cmd: Components of the command to execute, e.g. ["echo", "dog"].
         out: Where to write the process' stdout. Defaults to sys.stdout. Can be
             anything accepted by print's 'file' parameter, or None if the
             output should be dropped, or a TeeCapture instance. If a TeeCapture
@@ -168,7 +168,6 @@ def run_cmd(
         abbreviate_non_option_arguments: When logging to stderr, this cuts off
             the potentially-huge tail of the command listing off e.g. hundreds
             of file paths. No effect if log_run_to_stderr is not set.
-
         **kwargs: Extra arguments for asyncio.create_subprocess_shell, such as
             a cwd (current working directory) argument.
 
@@ -261,7 +260,7 @@ def output_of(*cmd: Optional[str], **kwargs) -> str:
     """Invokes a subprocess and returns its output as a string.
 
     Args:
-        cmd: Components of the command to execute, e.g. ["echo", "dog"].
+        *cmd: Components of the command to execute, e.g. ["echo", "dog"].
         **kwargs: Extra arguments for asyncio.create_subprocess_shell, such as
             a cwd (current working directory) argument.
 

--- a/examples/hhl.py
+++ b/examples/hhl.py
@@ -142,7 +142,7 @@ class PhaseKickback(cirq.Gate):
         qubits = list(qubits)
         memory = qubits.pop()
         for i, qubit in enumerate(qubits):
-            yield cirq.ControlledGate(self.U ** (2 ** i))(qubit, memory)
+            yield cirq.ControlledGate(self.U ** (2**i))(qubit, memory)
 
 
 class EigenRotation(cirq.Gate):
@@ -286,7 +286,7 @@ def main():
 
     # Set C to be the smallest eigenvalue that can be represented by the
     # circuit.
-    C = 2 * math.pi / (2 ** register_size * t)
+    C = 2 * math.pi / (2**register_size * t)
 
     # Simulate circuit.
     print("Expected observable outputs:")

--- a/examples/hhl.py
+++ b/examples/hhl.py
@@ -200,7 +200,7 @@ def hhl_circuit(A, C, t, register_size, *input_prep_gates):
         C: Algorithm parameter, see above.
         t: Algorithm parameter, see above.
         register_size: The size of the eigenvalue register.
-        input_prep_gates: A list of gates to be applied to |0> to generate the desired input
+        *input_prep_gates: A list of gates to be applied to |0> to generate the desired input
             state |b>.
 
     Returns:


### PR DESCRIPTION
The new version of pylint support `--ignore-paths` (added in [pylint 2.9](https://pylint.pycqa.org/en/latest/whatsnew/2.9.html)) that allows specifying directories to ignore, which will make it easier to integrate generated code that we don't want to lint (see https://github.com/quantumlib/Cirq/pull/5139). Just a few minor changes were needed to get lint checks to pass with this new version, in particular the new version checks that `*args` and `**kwargs` include the `*` or `**` in the docstring.