### PR TITLE
Upgrade black to stable version with format stability guarantees

### DIFF
--- a/dev_tools/requirements/deps/format.txt
+++ b/dev_tools/requirements/deps/format.txt
@@ -1,3 +1,2 @@
 -r flynt.txt
-black==21.12b0
-click<=8.0.4
+black==22.3.0


### PR DESCRIPTION
Version [22.1.0](https://black.readthedocs.io/en/latest/change_log.html#id1) is the first non-beta version of black and has a new [stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy). The last time we bumped the black version in https://github.com/quantumlib/Cirq/pull/4753 we did not actually reformat any code, so we could do that here and just rely on incremental formatting going forward, or we could do a global reformat to bring things up to date as we did when we originally switched to black in https://github.com/quantumlib/Cirq/pull/3516. I think the changes this time would be much less drastic than in the original switch. The main thing we've seen internally is tighter binding of the power operator, e.g. new black does `a**b + c**d` instead of `a ** b + c ** d`, which is a definite improvement.