### PR TITLE
Autoformat all of engine_client_test.py

### DIFF
--- a/cirq-google/cirq_google/engine/engine_client_test.py
+++ b/cirq-google/cirq_google/engine/engine_client_test.py
@@ -113,61 +113,52 @@ def test_list_program(client_constructor):
     }
 
 
-# yapf: disable
 @pytest.mark.parametrize(
     'expected_filter, created_after, created_before, labels',
     [
-        ('',
+        ('', None, None, None),
+        ('create_time >= 2020-09-01', datetime.date(2020, 9, 1), None, None),
+        (
+            'create_time >= 1598918400',
+            datetime.datetime(2020, 9, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
             None,
             None,
-            None),
-        ('create_time >= 2020-09-01',
-            datetime.date(2020, 9, 1),
-            None,
-            None),
-        ('create_time >= 1598918400',
-            datetime.datetime(2020, 9, 1, 0, 0, 0,
-                              tzinfo=datetime.timezone.utc),
-            None,
-            None),
-        ('create_time <= 2020-10-01',
-            None,
-            datetime.date(2020, 10, 1),
-            None),
-        ('create_time >= 2020-09-01 AND create_time <= 1598918410',
-            datetime.date(2020, 9, 1),
-            datetime.datetime(2020, 9, 1, 0, 0, 10,
-                            tzinfo=datetime.timezone.utc),
-            None),
-        ('labels.color:red AND labels.shape:*',
-            None,
-            None,
-            {
-            'color': 'red',
-            'shape': '*'
-            },
         ),
-        ('create_time >= 2020-08-01 AND '
-         'create_time <= 1598918400 AND '
-         'labels.color:red AND labels.shape:*',
+        ('create_time <= 2020-10-01', None, datetime.date(2020, 10, 1), None),
+        (
+            'create_time >= 2020-09-01 AND create_time <= 1598918410',
+            datetime.date(2020, 9, 1),
+            datetime.datetime(2020, 9, 1, 0, 0, 10, tzinfo=datetime.timezone.utc),
+            None,
+        ),
+        (
+            'labels.color:red AND labels.shape:*',
+            None,
+            None,
+            {'color': 'red', 'shape': '*'},
+        ),
+        (
+            'create_time >= 2020-08-01 AND '
+            'create_time <= 1598918400 AND '
+            'labels.color:red AND labels.shape:*',
             datetime.date(2020, 8, 1),
             datetime.datetime(2020, 9, 1, tzinfo=datetime.timezone.utc),
-            {
-            'color': 'red',
-            'shape': '*'
-            },
+            {'color': 'red', 'shape': '*'},
         ),
-    ])
-# yapf: enable
+    ],
+)
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
-def test_list_program_filters(client_constructor, expected_filter,
-                              created_before, created_after, labels):
+def test_list_program_filters(
+    client_constructor, expected_filter, created_before, created_after, labels
+):
     grpc_client = setup_mock_(client_constructor)
     client = EngineClient()
-    client.list_programs(project_id='proj',
-                         created_before=created_before,
-                         created_after=created_after,
-                         has_labels=labels)
+    client.list_programs(
+        project_id='proj',
+        created_before=created_before,
+        created_after=created_after,
+        has_labels=labels,
+    )
     assert grpc_client.list_quantum_programs.call_args[1] == {
         'filter_': expected_filter,
     }
@@ -176,8 +167,7 @@ def test_list_program_filters(client_constructor, expected_filter,
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_list_program_filters_invalid_type(client_constructor):
     with pytest.raises(ValueError, match=""):
-        EngineClient().list_programs(project_id='proj',
-                                     created_before="Unsupported date/time")
+        EngineClient().list_programs(project_id='proj', created_before="Unsupported date/time")
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -191,15 +181,16 @@ def test_set_program_description(client_constructor):
     assert client.set_program_description('proj', 'prog', 'A program') == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              description='A program'),
-        qtypes.field_mask_pb2.FieldMask(paths=['description']))
+        qtypes.QuantumProgram(name='projects/proj/programs/prog', description='A program'),
+        qtypes.field_mask_pb2.FieldMask(paths=['description']),
+    )
 
     assert client.set_program_description('proj', 'prog', '') == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumProgram(name='projects/proj/programs/prog'),
-        qtypes.field_mask_pb2.FieldMask(paths=['description']))
+        qtypes.field_mask_pb2.FieldMask(paths=['description']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -207,12 +198,8 @@ def test_set_program_labels(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
     grpc_client.get_quantum_program.return_value = qtypes.QuantumProgram(
-        labels={
-            'color': 'red',
-            'weather': 'sun',
-            'run': '1'
-        },
-        label_fingerprint='hash')
+        labels={'color': 'red', 'weather': 'sun', 'run': '1'}, label_fingerprint='hash'
+    )
     result = qtypes.QuantumProgram(name='projects/proj/programs/prog')
     grpc_client.update_quantum_program.return_value = result
 
@@ -221,79 +208,65 @@ def test_set_program_labels(client_constructor):
     assert client.set_program_labels('proj', 'prog', labels) == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              labels=labels,
-                              label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumProgram(
+            name='projects/proj/programs/prog', labels=labels, label_fingerprint='hash'
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
     assert client.set_program_labels('proj', 'prog', {}) == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumProgram(name='projects/proj/programs/prog', label_fingerprint='hash'),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_add_program_labels(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    existing = qtypes.QuantumProgram(labels={
-        'color': 'red',
-        'weather': 'sun',
-        'run': '1'
-    },
-                                     label_fingerprint='hash')
+    existing = qtypes.QuantumProgram(
+        labels={'color': 'red', 'weather': 'sun', 'run': '1'}, label_fingerprint='hash'
+    )
     grpc_client.get_quantum_program.return_value = existing
     result = qtypes.QuantumProgram(name='projects/proj/programs/prog')
     grpc_client.update_quantum_program.return_value = result
 
     client = EngineClient()
-    assert client.add_program_labels('proj', 'prog',
-                                     {'color': 'red'}) == existing
+    assert client.add_program_labels('proj', 'prog', {'color': 'red'}) == existing
     assert grpc_client.update_quantum_program.call_count == 0
 
-    assert client.add_program_labels('proj', 'prog',
-                                     {'hello': 'world'}) == result
+    assert client.add_program_labels('proj', 'prog', {'hello': 'world'}) == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              labels={
-                                  'color': 'red',
-                                  'weather': 'sun',
-                                  'run': '1',
-                                  'hello': 'world'
-                              },
-                              label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumProgram(
+            name='projects/proj/programs/prog',
+            labels={'color': 'red', 'weather': 'sun', 'run': '1', 'hello': 'world'},
+            label_fingerprint='hash',
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
-    assert client.add_program_labels('proj', 'prog', {
-        'hello': 'world',
-        'color': 'blue'
-    }) == result
+    assert client.add_program_labels('proj', 'prog', {'hello': 'world', 'color': 'blue'}) == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              labels={
-                                  'color': 'blue',
-                                  'weather': 'sun',
-                                  'run': '1',
-                                  'hello': 'world'
-                              },
-                              label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumProgram(
+            name='projects/proj/programs/prog',
+            labels={'color': 'blue', 'weather': 'sun', 'run': '1', 'hello': 'world'},
+            label_fingerprint='hash',
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_remove_program_labels(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    existing = qtypes.QuantumProgram(labels={
-        'color': 'red',
-        'weather': 'sun',
-        'run': '1'
-    },
-                                     label_fingerprint='hash')
+    existing = qtypes.QuantumProgram(
+        labels={'color': 'red', 'weather': 'sun', 'run': '1'}, label_fingerprint='hash'
+    )
     grpc_client.get_quantum_program.return_value = existing
     result = qtypes.QuantumProgram(name='projects/proj/programs/prog')
     grpc_client.update_quantum_program.return_value = result
@@ -302,25 +275,26 @@ def test_remove_program_labels(client_constructor):
     assert client.remove_program_labels('proj', 'prog', ['other']) == existing
     assert grpc_client.update_quantum_program.call_count == 0
 
-    assert client.remove_program_labels('proj', 'prog',
-                                        ['hello', 'weather']) == result
+    assert client.remove_program_labels('proj', 'prog', ['hello', 'weather']) == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              labels={
-                                  'color': 'red',
-                                  'run': '1',
-                              },
-                              label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumProgram(
+            name='projects/proj/programs/prog',
+            labels={
+                'color': 'red',
+                'run': '1',
+            },
+            label_fingerprint='hash',
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
-    assert client.remove_program_labels('proj', 'prog',
-                                        ['color', 'weather', 'run']) == result
+    assert client.remove_program_labels('proj', 'prog', ['color', 'weather', 'run']) == result
     assert grpc_client.update_quantum_program.call_args[0] == (
         'projects/proj/programs/prog',
-        qtypes.QuantumProgram(name='projects/proj/programs/prog',
-                              label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumProgram(name='projects/proj/programs/prog', label_fingerprint='hash'),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -329,12 +303,10 @@ def test_delete_program(client_constructor):
 
     client = EngineClient()
     assert not client.delete_program('proj', 'prog')
-    assert grpc_client.delete_quantum_program.call_args[0] == (
-        'projects/proj/programs/prog', False)
+    assert grpc_client.delete_quantum_program.call_args[0] == ('projects/proj/programs/prog', False)
 
     assert not client.delete_program('proj', 'prog', delete_jobs=True)
-    assert grpc_client.delete_quantum_program.call_args[0] == (
-        'projects/proj/programs/prog', True)
+    assert grpc_client.delete_quantum_program.call_args[0] == ('projects/proj/programs/prog', True)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -347,9 +319,9 @@ def test_create_job(client_constructor):
     run_context = qtypes.any_pb2.Any()
     labels = {'hello': 'world'}
     client = EngineClient()
-    assert client.create_job('proj', 'prog', 'job0', ['processor0'],
-                             run_context, 10, 'A job',
-                             labels) == ('job0', result)
+    assert client.create_job(
+        'proj', 'prog', 'job0', ['processor0'], run_context, 10, 'A job', labels
+    ) == ('job0', result)
     assert grpc_client.create_quantum_job.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumJob(
@@ -358,9 +330,14 @@ def test_create_job(client_constructor):
             scheduling_config=qtypes.SchedulingConfig(
                 priority=10,
                 processor_selector=qtypes.SchedulingConfig.ProcessorSelector(
-                    processor_names=['projects/proj/processors/processor0'])),
+                    processor_names=['projects/proj/processors/processor0']
+                ),
+            ),
             description='A job',
-            labels=labels), False)
+            labels=labels,
+        ),
+        False,
+    )
 
     assert client.create_job(
         'proj',
@@ -379,15 +356,17 @@ def test_create_job(client_constructor):
             scheduling_config=qtypes.SchedulingConfig(
                 priority=10,
                 processor_selector=qtypes.SchedulingConfig.ProcessorSelector(
-                    processor_names=['projects/proj/processors/processor0'])),
-            description='A job'), False)
+                    processor_names=['projects/proj/processors/processor0']
+                ),
+            ),
+            description='A job',
+        ),
+        False,
+    )
 
-    assert client.create_job('proj',
-                             'prog',
-                             'job0', ['processor0'],
-                             run_context,
-                             10,
-                             labels=labels) == ('job0', result)
+    assert client.create_job(
+        'proj', 'prog', 'job0', ['processor0'], run_context, 10, labels=labels
+    ) == ('job0', result)
     assert grpc_client.create_quantum_job.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumJob(
@@ -396,11 +375,18 @@ def test_create_job(client_constructor):
             scheduling_config=qtypes.SchedulingConfig(
                 priority=10,
                 processor_selector=qtypes.SchedulingConfig.ProcessorSelector(
-                    processor_names=['projects/proj/processors/processor0'])),
-            labels=labels), False)
+                    processor_names=['projects/proj/processors/processor0']
+                ),
+            ),
+            labels=labels,
+        ),
+        False,
+    )
 
-    assert client.create_job('proj', 'prog', 'job0', ['processor0'],
-                             run_context, 10) == ('job0', result)
+    assert client.create_job('proj', 'prog', 'job0', ['processor0'], run_context, 10) == (
+        'job0',
+        result,
+    )
     assert grpc_client.create_quantum_job.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumJob(
@@ -409,15 +395,21 @@ def test_create_job(client_constructor):
             scheduling_config=qtypes.SchedulingConfig(
                 priority=10,
                 processor_selector=qtypes.SchedulingConfig.ProcessorSelector(
-                    processor_names=['projects/proj/processors/processor0'])),
-        ), False)
+                    processor_names=['projects/proj/processors/processor0']
+                ),
+            ),
+        ),
+        False,
+    )
 
-    assert client.create_job('proj',
-                             'prog',
-                             job_id=None,
-                             processor_ids=['processor0'],
-                             run_context=run_context,
-                             priority=10) == ('job0', result)
+    assert client.create_job(
+        'proj',
+        'prog',
+        job_id=None,
+        processor_ids=['processor0'],
+        run_context=run_context,
+        priority=10,
+    ) == ('job0', result)
     assert grpc_client.create_quantum_job.call_args[0] == (
         'projects/proj/programs/prog',
         qtypes.QuantumJob(
@@ -425,16 +417,22 @@ def test_create_job(client_constructor):
             scheduling_config=qtypes.SchedulingConfig(
                 priority=10,
                 processor_selector=qtypes.SchedulingConfig.ProcessorSelector(
-                    processor_names=['projects/proj/processors/processor0'])),
-        ), False)
+                    processor_names=['projects/proj/processors/processor0']
+                ),
+            ),
+        ),
+        False,
+    )
 
     with pytest.raises(ValueError, match='priority must be between 0 and 1000'):
-        client.create_job('proj',
-                          'prog',
-                          job_id=None,
-                          processor_ids=['processor0'],
-                          run_context=run_context,
-                          priority=5000)
+        client.create_job(
+            'proj',
+            'prog',
+            job_id=None,
+            processor_ids=['processor0'],
+            run_context=run_context,
+            priority=5000,
+        )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -447,11 +445,15 @@ def test_get_job(client_constructor):
     client = EngineClient()
     assert client.get_job('proj', 'prog', 'job0', False) == result
     assert grpc_client.get_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0', False)
+        'projects/proj/programs/prog/jobs/job0',
+        False,
+    )
 
     assert client.get_job('proj', 'prog', 'job0', True) == result
     assert grpc_client.get_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0', True)
+        'projects/proj/programs/prog/jobs/job0',
+        True,
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -465,15 +467,16 @@ def test_set_job_description(client_constructor):
     assert client.set_job_description('proj', 'prog', 'job0', 'A job') == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          description='A job'),
-        qtypes.field_mask_pb2.FieldMask(paths=['description']))
+        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0', description='A job'),
+        qtypes.field_mask_pb2.FieldMask(paths=['description']),
+    )
 
     assert client.set_job_description('proj', 'prog', 'job0', '') == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
         qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0'),
-        qtypes.field_mask_pb2.FieldMask(paths=['description']))
+        qtypes.field_mask_pb2.FieldMask(paths=['description']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -481,12 +484,8 @@ def test_set_job_labels(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
     grpc_client.get_quantum_job.return_value = qtypes.QuantumJob(
-        labels={
-            'color': 'red',
-            'weather': 'sun',
-            'run': '1'
-        },
-        label_fingerprint='hash')
+        labels={'color': 'red', 'weather': 'sun', 'run': '1'}, label_fingerprint='hash'
+    )
     result = qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
     grpc_client.update_quantum_job.return_value = result
 
@@ -495,107 +494,95 @@ def test_set_job_labels(client_constructor):
     assert client.set_job_labels('proj', 'prog', 'job0', labels) == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          labels=labels,
-                          label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumJob(
+            name='projects/proj/programs/prog/jobs/job0', labels=labels, label_fingerprint='hash'
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
     assert client.set_job_labels('proj', 'prog', 'job0', {}) == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0', label_fingerprint='hash'),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_add_job_labels(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    existing = qtypes.QuantumJob(labels={
-        'color': 'red',
-        'weather': 'sun',
-        'run': '1'
-    },
-                                 label_fingerprint='hash')
+    existing = qtypes.QuantumJob(
+        labels={'color': 'red', 'weather': 'sun', 'run': '1'}, label_fingerprint='hash'
+    )
     grpc_client.get_quantum_job.return_value = existing
     result = qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
     grpc_client.update_quantum_job.return_value = result
 
     client = EngineClient()
-    assert client.add_job_labels('proj', 'prog', 'job0',
-                                 {'color': 'red'}) == existing
+    assert client.add_job_labels('proj', 'prog', 'job0', {'color': 'red'}) == existing
     assert grpc_client.update_quantum_job.call_count == 0
 
-    assert client.add_job_labels('proj', 'prog', 'job0',
-                                 {'hello': 'world'}) == result
+    assert client.add_job_labels('proj', 'prog', 'job0', {'hello': 'world'}) == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          labels={
-                              'color': 'red',
-                              'weather': 'sun',
-                              'run': '1',
-                              'hello': 'world'
-                          },
-                          label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumJob(
+            name='projects/proj/programs/prog/jobs/job0',
+            labels={'color': 'red', 'weather': 'sun', 'run': '1', 'hello': 'world'},
+            label_fingerprint='hash',
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
-    assert client.add_job_labels('proj', 'prog', 'job0', {
-        'hello': 'world',
-        'color': 'blue'
-    }) == result
+    assert (
+        client.add_job_labels('proj', 'prog', 'job0', {'hello': 'world', 'color': 'blue'}) == result
+    )
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          labels={
-                              'color': 'blue',
-                              'weather': 'sun',
-                              'run': '1',
-                              'hello': 'world'
-                          },
-                          label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumJob(
+            name='projects/proj/programs/prog/jobs/job0',
+            labels={'color': 'blue', 'weather': 'sun', 'run': '1', 'hello': 'world'},
+            label_fingerprint='hash',
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_remove_job_labels(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    existing = qtypes.QuantumJob(labels={
-        'color': 'red',
-        'weather': 'sun',
-        'run': '1'
-    },
-                                 label_fingerprint='hash')
+    existing = qtypes.QuantumJob(
+        labels={'color': 'red', 'weather': 'sun', 'run': '1'}, label_fingerprint='hash'
+    )
     grpc_client.get_quantum_job.return_value = existing
     result = qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
     grpc_client.update_quantum_job.return_value = result
 
     client = EngineClient()
-    assert client.remove_job_labels('proj', 'prog', 'job0',
-                                    ['other']) == existing
+    assert client.remove_job_labels('proj', 'prog', 'job0', ['other']) == existing
     assert grpc_client.update_quantum_program.call_count == 0
 
-    assert client.remove_job_labels('proj', 'prog', 'job0',
-                                    ['hello', 'weather']) == result
+    assert client.remove_job_labels('proj', 'prog', 'job0', ['hello', 'weather']) == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          labels={
-                              'color': 'red',
-                              'run': '1',
-                          },
-                          label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumJob(
+            name='projects/proj/programs/prog/jobs/job0',
+            labels={
+                'color': 'red',
+                'run': '1',
+            },
+            label_fingerprint='hash',
+        ),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
-    assert client.remove_job_labels('proj', 'prog', 'job0',
-                                    ['color', 'weather', 'run']) == result
+    assert client.remove_job_labels('proj', 'prog', 'job0', ['color', 'weather', 'run']) == result
     assert grpc_client.update_quantum_job.call_args[0] == (
         'projects/proj/programs/prog/jobs/job0',
-        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0',
-                          label_fingerprint='hash'),
-        qtypes.field_mask_pb2.FieldMask(paths=['labels']))
+        qtypes.QuantumJob(name='projects/proj/programs/prog/jobs/job0', label_fingerprint='hash'),
+        qtypes.field_mask_pb2.FieldMask(paths=['labels']),
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -604,8 +591,7 @@ def test_delete_job(client_constructor):
 
     client = EngineClient()
     assert not client.delete_job('proj', 'prog', 'job0')
-    assert grpc_client.delete_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0',)
+    assert grpc_client.delete_quantum_job.call_args[0] == ('projects/proj/programs/prog/jobs/job0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -614,22 +600,19 @@ def test_cancel_job(client_constructor):
 
     client = EngineClient()
     assert not client.cancel_job('proj', 'prog', 'job0')
-    assert grpc_client.cancel_quantum_job.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0',)
+    assert grpc_client.cancel_quantum_job.call_args[0] == ('projects/proj/programs/prog/jobs/job0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_job_results(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    result = qtypes.QuantumResult(
-        parent='projects/proj/programs/prog/jobs/job0')
+    result = qtypes.QuantumResult(parent='projects/proj/programs/prog/jobs/job0')
     grpc_client.get_quantum_result.return_value = result
 
     client = EngineClient()
     assert client.get_job_results('proj', 'prog', 'job0') == result
-    assert grpc_client.get_quantum_result.call_args[0] == (
-        'projects/proj/programs/prog/jobs/job0',)
+    assert grpc_client.get_quantum_result.call_args[0] == ('projects/proj/programs/prog/jobs/job0',)
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -638,149 +621,134 @@ def test_list_jobs(client_constructor):
 
     results = [
         qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job1'),
-        qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job2')
+        qtypes.QuantumJob(name='projects/proj/programs/prog1/jobs/job2'),
     ]
     grpc_client.list_quantum_jobs.return_value = results
 
     client = EngineClient()
     assert client.list_jobs(project_id='proj', program_id='prog1') == results
-    assert grpc_client.list_quantum_jobs.call_args[0] == (
-        'projects/proj/programs/prog1',)
+    assert grpc_client.list_quantum_jobs.call_args[0] == ('projects/proj/programs/prog1',)
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': '',
     }
 
     assert client.list_jobs(project_id='proj') == results
-    assert grpc_client.list_quantum_jobs.call_args[0] == (
-        'projects/proj/programs/-',)
+    assert grpc_client.list_quantum_jobs.call_args[0] == ('projects/proj/programs/-',)
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': '',
     }
 
 
-# yapf: disable
 @pytest.mark.parametrize(
     'expected_filter, '
-        'created_after, '
-        'created_before, '
-        'labels, '
-        'execution_states, '
-        'executed_processor_ids, '
-        'scheduled_processor_ids, ',
+    'created_after, '
+    'created_before, '
+    'labels, '
+    'execution_states, '
+    'executed_processor_ids, '
+    'scheduled_processor_ids, ',
     [
-        ('',
+        ('', None, None, None, None, None, None),
+        ('create_time >= 2020-09-01', datetime.date(2020, 9, 1), None, None, None, None, None),
+        (
+            'create_time >= 1598918400',
+            datetime.datetime(2020, 9, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
             None,
             None,
             None,
             None,
             None,
-            None),
-        ('create_time >= 2020-09-01',
+        ),
+        ('create_time <= 2020-10-01', None, datetime.date(2020, 10, 1), None, None, None, None),
+        (
+            'create_time >= 2020-09-01 AND create_time <= 1598918410',
             datetime.date(2020, 9, 1),
+            datetime.datetime(2020, 9, 1, 0, 0, 10, tzinfo=datetime.timezone.utc),
             None,
             None,
             None,
             None,
-            None),
-        ('create_time >= 1598918400',
-            datetime.datetime(2020, 9, 1, 0, 0, 0,
-                              tzinfo=datetime.timezone.utc),
+        ),
+        (
+            'labels.color:red AND labels.shape:*',
+            None,
+            None,
+            {'color': 'red', 'shape': '*'},
             None,
             None,
             None,
-            None,
-            None),
-        ('create_time <= 2020-10-01',
-            None,
-            datetime.date(2020, 10, 1),
+        ),
+        (
+            '(execution_status.state = FAILURE OR ' 'execution_status.state = CANCELLED)',
             None,
             None,
             None,
-            None),
-        ('create_time >= 2020-09-01 AND create_time <= 1598918410',
-            datetime.date(2020, 9, 1),
-            datetime.datetime(2020, 9, 1, 0, 0, 10,
-                            tzinfo=datetime.timezone.utc),
+            [
+                quantum.enums.ExecutionStatus.State.FAILURE,
+                quantum.enums.ExecutionStatus.State.CANCELLED,
+            ],
             None,
             None,
-            None,
-            None),
-        ('labels.color:red AND labels.shape:*',
-            None,
-            None,
-            {
-            'color': 'red',
-            'shape': '*'
-            },
-            None,
-            None,
-            None),
-        ('(execution_status.state = FAILURE OR '
-         'execution_status.state = CANCELLED)',
-            None,
-            None,
-            None,
-            [quantum.enums.ExecutionStatus.State.FAILURE,
-             quantum.enums.ExecutionStatus.State.CANCELLED,],
-            None,
-            None),
-        ('create_time >= 2020-08-01 AND '
-         'create_time <= 1598918400 AND '
-         'labels.color:red AND labels.shape:* AND '
-         '(execution_status.state = SUCCESS)',
+        ),
+        (
+            'create_time >= 2020-08-01 AND '
+            'create_time <= 1598918400 AND '
+            'labels.color:red AND labels.shape:* AND '
+            '(execution_status.state = SUCCESS)',
             datetime.date(2020, 8, 1),
             datetime.datetime(2020, 9, 1, tzinfo=datetime.timezone.utc),
-            {
-            'color': 'red',
-            'shape': '*'
-            },
-            [quantum.enums.ExecutionStatus.State.SUCCESS,],
-            None,
-            None),
-        ('(executed_processor_id = proc1)',
+            {'color': 'red', 'shape': '*'},
+            [
+                quantum.enums.ExecutionStatus.State.SUCCESS,
+            ],
             None,
             None,
-            None,
-            None,
-            ['proc1'],
-            None),
-        ('(executed_processor_id = proc1 OR executed_processor_id = proc2)',
+        ),
+        ('(executed_processor_id = proc1)', None, None, None, None, ['proc1'], None),
+        (
+            '(executed_processor_id = proc1 OR executed_processor_id = proc2)',
             None,
             None,
             None,
             None,
             ['proc1', 'proc2'],
-            None),
-        ('(scheduled_processor_ids: proc1)',
+            None,
+        ),
+        ('(scheduled_processor_ids: proc1)', None, None, None, None, None, ['proc1']),
+        (
+            '(scheduled_processor_ids: proc1 OR scheduled_processor_ids: proc2)',
             None,
             None,
             None,
             None,
             None,
-            ['proc1']),
-        ('(scheduled_processor_ids: proc1 OR scheduled_processor_ids: proc2)',
-            None,
-            None,
-            None,
-            None,
-            None,
-            ['proc1', 'proc2']),
-    ])
-# yapf: enable
+            ['proc1', 'proc2'],
+        ),
+    ],
+)
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
-def test_list_jobs_filters(client_constructor, expected_filter, created_before,
-                           created_after, labels, execution_states,
-                           executed_processor_ids, scheduled_processor_ids):
+def test_list_jobs_filters(
+    client_constructor,
+    expected_filter,
+    created_before,
+    created_after,
+    labels,
+    execution_states,
+    executed_processor_ids,
+    scheduled_processor_ids,
+):
     grpc_client = setup_mock_(client_constructor)
     client = EngineClient()
-    client.list_jobs(project_id='proj',
-                     program_id='prog',
-                     created_before=created_before,
-                     created_after=created_after,
-                     has_labels=labels,
-                     execution_states=execution_states,
-                     executed_processor_ids=executed_processor_ids,
-                     scheduled_processor_ids=scheduled_processor_ids)
+    client.list_jobs(
+        project_id='proj',
+        program_id='prog',
+        created_before=created_before,
+        created_after=created_after,
+        has_labels=labels,
+        execution_states=execution_states,
+        executed_processor_ids=executed_processor_ids,
+        scheduled_processor_ids=scheduled_processor_ids,
+    )
     assert grpc_client.list_quantum_jobs.call_args[1] == {
         'filter_': expected_filter,
     }
@@ -792,14 +760,13 @@ def test_list_processors(client_constructor):
 
     results = [
         qtypes.QuantumProcessor(name='projects/proj/processor/processor0'),
-        qtypes.QuantumProcessor(name='projects/proj/processor/processor1')
+        qtypes.QuantumProcessor(name='projects/proj/processor/processor1'),
     ]
     grpc_client.list_quantum_processors.return_value = results
 
     client = EngineClient()
     assert client.list_processors('proj') == results
-    assert grpc_client.list_quantum_processors.call_args[0] == (
-        'projects/proj',)
+    assert grpc_client.list_quantum_processors.call_args[0] == ('projects/proj',)
     assert grpc_client.list_quantum_processors.call_args[1] == {
         'filter_': '',
     }
@@ -815,7 +782,8 @@ def test_get_processor(client_constructor):
     client = EngineClient()
     assert client.get_processor('proj', 'processor0') == result
     assert grpc_client.get_quantum_processor.call_args[0] == (
-        'projects/proj/processors/processor0',)
+        'projects/proj/processors/processor0',
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -823,17 +791,16 @@ def test_list_calibrations(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
     results = [
-        qtypes.QuantumCalibration(
-            name='projects/proj/processor/processor0/calibrations/123456'),
-        qtypes.QuantumCalibration(
-            name='projects/proj/processor/processor1/calibrations/224466')
+        qtypes.QuantumCalibration(name='projects/proj/processor/processor0/calibrations/123456'),
+        qtypes.QuantumCalibration(name='projects/proj/processor/processor1/calibrations/224466'),
     ]
     grpc_client.list_quantum_calibrations.return_value = results
 
     client = EngineClient()
     assert client.list_calibrations('proj', 'processor0') == results
     assert grpc_client.list_quantum_calibrations.call_args[0] == (
-        'projects/proj/processors/processor0',)
+        'projects/proj/processors/processor0',
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -841,13 +808,15 @@ def test_get_calibration(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
     result = qtypes.QuantumCalibration(
-        name='projects/proj/processors/processor0/calibrations/123456')
+        name='projects/proj/processors/processor0/calibrations/123456'
+    )
     grpc_client.get_quantum_calibration.return_value = result
 
     client = EngineClient()
     assert client.get_calibration('proj', 'processor0', 123456) == result
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/123456',)
+        'projects/proj/processors/processor0/calibrations/123456',
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -855,34 +824,35 @@ def test_get_current_calibration(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
     result = qtypes.QuantumCalibration(
-        name='projects/proj/processors/processor0/calibrations/123456')
+        name='projects/proj/processors/processor0/calibrations/123456'
+    )
     grpc_client.get_quantum_calibration.return_value = result
 
     client = EngineClient()
     assert client.get_current_calibration('proj', 'processor0') == result
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/current',)
+        'projects/proj/processors/processor0/calibrations/current',
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_get_current_calibration_does_not_exist(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    grpc_client.get_quantum_calibration.side_effect = exceptions.NotFound(
-        'not found')
+    grpc_client.get_quantum_calibration.side_effect = exceptions.NotFound('not found')
 
     client = EngineClient()
     assert client.get_current_calibration('proj', 'processor0') is None
     assert grpc_client.get_quantum_calibration.call_args[0] == (
-        'projects/proj/processors/processor0/calibrations/current',)
+        'projects/proj/processors/processor0/calibrations/current',
+    )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_get_current_calibration_error(client_constructor):
     grpc_client = setup_mock_(client_constructor)
 
-    grpc_client.get_quantum_calibration.side_effect = exceptions.BadRequest(
-        'boom')
+    grpc_client.get_quantum_calibration.side_effect = exceptions.BadRequest('boom')
 
     client = EngineClient()
     with pytest.raises(EngineException, match='boom'):
@@ -892,8 +862,7 @@ def test_get_current_calibration_error(client_constructor):
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_api_doesnt_retry_not_found_errors(client_constructor):
     grpc_client = setup_mock_(client_constructor)
-    grpc_client.get_quantum_program.side_effect = exceptions.NotFound(
-        'not found')
+    grpc_client.get_quantum_program.side_effect = exceptions.NotFound('not found')
 
     client = EngineClient()
     with pytest.raises(EngineException, match='not found'):
@@ -904,12 +873,10 @@ def test_api_doesnt_retry_not_found_errors(client_constructor):
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_api_retry_5xx_errors(client_constructor):
     grpc_client = setup_mock_(client_constructor)
-    grpc_client.get_quantum_program.side_effect = exceptions.ServiceUnavailable(
-        'internal error')
+    grpc_client.get_quantum_program.side_effect = exceptions.ServiceUnavailable('internal error')
 
     client = EngineClient(max_retry_delay_seconds=0.3)
-    with pytest.raises(TimeoutError,
-                       match='Reached max retry attempts.*internal error'):
+    with pytest.raises(TimeoutError, match='Reached max retry attempts.*internal error'):
         client.get_program('proj', 'prog', False)
     assert grpc_client.get_quantum_program.call_count == 3
 
@@ -944,15 +911,14 @@ def test_create_reservation(client_constructor):
     grpc_client.create_quantum_reservation.return_value = result
 
     client = EngineClient()
-    assert client.create_reservation('proj', 'processor0', start, end,
-                                     users) == result
+    assert client.create_reservation('proj', 'processor0', start, end, users) == result
     assert grpc_client.create_quantum_reservation.call_count == 1
     kwargs = grpc_client.create_quantum_reservation.call_args[1]
     # The outgoing argument will not have the resource name
     result.name = ''
     assert kwargs == {
         'parent': 'projects/proj/processors/processor0',
-        'quantum_reservation': result
+        'quantum_reservation': result,
     }
 
 
@@ -969,8 +935,7 @@ def test_cancel_reservation(client_constructor):
     grpc_client.cancel_quantum_reservation.return_value = result
 
     client = EngineClient()
-    assert (client.cancel_reservation('proj', 'processor0',
-                                      'papar-party-44') == result)
+    assert client.cancel_reservation('proj', 'processor0', 'papar-party-44') == result
     kwargs = grpc_client.cancel_quantum_reservation.call_args[1]
     assert kwargs == {
         'name': name,
@@ -990,8 +955,7 @@ def test_delete_reservation(client_constructor):
     grpc_client.delete_quantum_reservation.return_value = result
 
     client = EngineClient()
-    assert (client.delete_reservation('proj', 'processor0',
-                                      'papar-party-44') == result)
+    assert client.delete_reservation('proj', 'processor0', 'papar-party-44') == result
     kwargs = grpc_client.delete_quantum_reservation.call_args[1]
     assert kwargs == {
         'name': name,
@@ -1011,8 +975,7 @@ def test_get_reservation(client_constructor):
     grpc_client.get_quantum_reservation.return_value = result
 
     client = EngineClient()
-    assert (client.get_reservation('proj', 'processor0',
-                                   'papar-party-44') == result)
+    assert client.get_reservation('proj', 'processor0', 'papar-party-44') == result
     kwargs = grpc_client.get_quantum_reservation.call_args[1]
     assert kwargs == {
         'name': name,
@@ -1023,12 +986,10 @@ def test_get_reservation(client_constructor):
 def test_get_reservation_not_found(client_constructor):
     grpc_client = setup_mock_(client_constructor)
     name = 'projects/proj/processors/processor0/reservations/papar-party-44'
-    grpc_client.get_quantum_reservation.side_effect = exceptions.NotFound(
-        'not found')
+    grpc_client.get_quantum_reservation.side_effect = exceptions.NotFound('not found')
 
     client = EngineClient()
-    assert (client.get_reservation('proj', 'processor0',
-                                   'papar-party-44') is None)
+    assert client.get_reservation('proj', 'processor0', 'papar-party-44') is None
     kwargs = grpc_client.get_quantum_reservation.call_args[1]
     assert kwargs == {
         'name': name,
@@ -1038,8 +999,7 @@ def test_get_reservation_not_found(client_constructor):
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
 def test_get_reservation_exception(client_constructor):
     grpc_client = setup_mock_(client_constructor)
-    grpc_client.get_quantum_reservation.side_effect = exceptions.BadRequest(
-        'boom')
+    grpc_client.get_quantum_reservation.side_effect = exceptions.BadRequest('boom')
 
     client = EngineClient()
     with pytest.raises(EngineException, match='boom'):
@@ -1067,7 +1027,7 @@ def test_list_reservation(client_constructor):
     grpc_client.list_quantum_reservations.return_value = results
 
     client = EngineClient()
-    assert (client.list_reservations('proj', 'processor0') == results)
+    assert client.list_reservations('proj', 'processor0') == results
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceClient', autospec=True)
@@ -1083,22 +1043,22 @@ def test_update_reservation(client_constructor):
     grpc_client.update_quantum_reservation.return_value = result
 
     client = EngineClient()
-    assert (client.update_reservation(
-        'proj',
-        'processor0',
-        'papar-party-44',
-        start=datetime.datetime.fromtimestamp(1000001000),
-        end=datetime.datetime.fromtimestamp(1000002000),
-        whitelisted_users=['jeff@google.com'],
-    ) == result)
+    assert (
+        client.update_reservation(
+            'proj',
+            'processor0',
+            'papar-party-44',
+            start=datetime.datetime.fromtimestamp(1000001000),
+            end=datetime.datetime.fromtimestamp(1000002000),
+            whitelisted_users=['jeff@google.com'],
+        )
+        == result
+    )
     kwargs = grpc_client.update_quantum_reservation.call_args[1]
     assert kwargs == {
-        'name':
-        name,
-        'quantum_reservation':
-        result,
-        'update_mask':
-        FieldMask(paths=['start_time', 'end_time', 'whitelisted_users'])
+        'name': name,
+        'quantum_reservation': result,
+        'update_mask': FieldMask(paths=['start_time', 'end_time', 'whitelisted_users']),
     }
 
 
@@ -1113,17 +1073,20 @@ def test_update_reservation_remove_all_users(client_constructor):
     grpc_client.update_quantum_reservation.return_value = result
 
     client = EngineClient()
-    assert (client.update_reservation(
-        'proj',
-        'processor0',
-        'papar-party-44',
-        whitelisted_users=[],
-    ) == result)
+    assert (
+        client.update_reservation(
+            'proj',
+            'processor0',
+            'papar-party-44',
+            whitelisted_users=[],
+        )
+        == result
+    )
     kwargs = grpc_client.update_quantum_reservation.call_args[1]
     assert kwargs == {
         'name': name,
         'quantum_reservation': result,
-        'update_mask': FieldMask(paths=['whitelisted_users'])
+        'update_mask': FieldMask(paths=['whitelisted_users']),
     }
 
 
@@ -1147,10 +1110,11 @@ def test_list_time_slots(client_constructor):
             end_time=Timestamp(seconds=1000020000),
             slot_type=qenums.QuantumTimeSlot.TimeSlotType.RESERVATION,
             reservation_config=qtypes.QuantumTimeSlot.ReservationConfig(
-                project_id='super_secret_quantum'),
-        )
+                project_id='super_secret_quantum'
+            ),
+        ),
     ]
     grpc_client.list_quantum_time_slots.return_value = results
 
     client = EngineClient()
-    assert (client.list_time_slots('proj', 'processor0') == results)
+    assert client.list_time_slots('proj', 'processor0') == results


### PR DESCRIPTION
Previously we had `yapf: disable`/`yapf: enable` directives to exclude some large pytest parametrize expressions which the beta version of black had trouble with. These are handled fine by the new version, so we remove the directives and format the entire file.