### PR TITLE
Disable broken symbols.

### DIFF
--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -95,6 +95,11 @@ def generate_cirq():
         site_path=FLAGS.site_path,
         callbacks=[public_api.local_definitions_filter, filter_unwanted_inherited_methods],
         extra_docs=_doc.RECORDED_CONST_DOCS,
+        private_map={
+            # Opt to not build docs for these paths for now since they error.
+            "cirq.experiments": ["CrossEntropyResultDict", "GridInteractionLayer"],
+            "cirq.experiments.random_quantum_circuit_generation": ["GridInteractionLayer"],
+        },
     )
     doc_controls.decorate_all_class_attributes(
         doc_controls.do_not_doc_inheritable, networkx.DiGraph, skip=[]


### PR DESCRIPTION
API Docs builds appear to be broken on some select symbols in Cirq-core. This disables them to allow builds to resume. Opened #5166 