### PR TITLE
Fix docs/circuits.ipynb as part of docs cleanup for Cirq 1.0

### DIFF
--- a/docs/circuits.ipynb
+++ b/docs/circuits.ipynb
@@ -1,15 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "DkA0Fobtb9dM"
-   },
-   "source": [
-    "##### Copyright 2020 The Cirq Developers"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -18,7 +9,8 @@
    },
    "outputs": [],
    "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "#@title Copyright 2020 The Cirq Developers\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "# you may not use this file except in compliance with the License.\n",
     "# You may obtain a copy of the License at\n",
     "#\n",
@@ -75,6 +67,7 @@
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq\n",
+    "    import cirq\n",
     "    print(\"installed cirq.\")"
    ]
   },
@@ -106,7 +99,7 @@
    "source": [
     "Let's unpack this.\n",
     "\n",
-    "At the base of this construction is the notion of a qubit. In Cirq, qubits and other quantum objects are identified by instances of subclasses of the Qid base class. Different subclasses of Qid can be used for different purposes. For example, the qubits that Google’s Xmon devices use are often arranged on the vertices of a square grid. For this, the class GridQubit subclasses Qid. For example, we can create a 3 by 3 grid of qubits using"
+    "At the base of this construction is the notion of a qubit. In Cirq, qubits and other quantum objects are identified by instances of subclasses of the `cirq.Qid` base class. Different subclasses of Qid can be used for different purposes. For example, the qubits that Google’s devices use are often arranged on the vertices of a square grid. For this, the class `cirq.GridQubit` subclasses `cirq.Qid`. For example, we can create a 3 by 3 grid of qubits using"
    ]
   },
   {
@@ -115,17 +108,8 @@
    "metadata": {
     "id": "G30Zl1VwAwCU"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import cirq\n",
     "qubits = [cirq.GridQubit(x, y) for x in range(3) for y in range(3)]\n",
     "\n",
     "print(qubits[0])"
@@ -137,7 +121,7 @@
     "id": "gpi9rwuiAwCZ"
    },
    "source": [
-    "The next level up is the notion of a `Gate`. A `Gate` represents a physical process that occurs on a `Qubit`. The important property of a `Gate` is that it can be applied to one or more qubits. This can be done via the `Gate.on` method itself or via `()`, and doing this turns the `Gate` into a `GateOperation`."
+    "The next level up is the notion of `cirq.Gate`. A `cirq.Gate` represents a physical process that occurs on a qubit. The important property of a gate is that it can be applied to one or more qubits. This can be done via the `gate.on(*qubits)` method itself or via `gate(*qubits)`, and doing this turns a `cirq.Gate` into a `cirq.Operation`."
    ]
   },
   {
@@ -146,15 +130,7 @@
    "metadata": {
     "id": "-X_LL4_nAwCa"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X((0, 0))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This is an Pauli X gate. It is an object instance.\n",
     "x_gate = cirq.X\n",
@@ -171,7 +147,7 @@
     "id": "0N7X3nmFAwCd"
    },
    "source": [
-    "A `Moment` is simply a collection of operations, each of which operates on a different set of qubits, and which conceptually represents these operations as occurring during this abstract time slice. The `Moment` structure itself is not required to be related to the actual scheduling of the operations on a quantum computer, or via a simulator, though it can be. For example, here is a `Moment` in which **Pauli** `X` and a `CZ` gate operate on three qubits:"
+    "A `cirq.Moment` is simply a collection of operations, each of which operates on a different set of qubits, and which conceptually represents these operations as occurring during this abstract time slice. The `Moment` structure itself is not required to be related to the actual scheduling of the operations on a quantum computer, or via a simulator, though it can be. For example, here is a `Moment` in which **Pauli** `X` and a `CZ` gate operate on three qubits:"
    ]
   },
   {
@@ -180,19 +156,11 @@
    "metadata": {
     "id": "naO0-nS0AwCe"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "X((0, 2)) and CZ((0, 0), (0, 1))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cz = cirq.CZ(qubits[0], qubits[1])\n",
     "x = cirq.X(qubits[2])\n",
-    "moment = cirq.Moment([x, cz])\n",
+    "moment = cirq.Moment(x, cz)\n",
     "\n",
     "print(moment)"
    ]
@@ -205,7 +173,7 @@
    "source": [
     "The above is not the only way one can construct moments, nor even the typical method, but illustrates that a `Moment` is just a collection of operations on disjoint sets of qubits.\n",
     "\n",
-    "Finally, at the top level a `Circuit` is an ordered series of `Moment` objects. The first `Moment` in this series contains the first `Operations` that will be applied. Here, for example, is a simple circuit made up of two moments:"
+    "Finally, at the top level a `cirq.Circuit` is an ordered series of `cirq.Moment` objects. The first `Moment` in this series contains the first `Operations` that will be applied. Here, for example, is a simple circuit made up of two moments:"
    ]
   },
   {
@@ -214,19 +182,7 @@
    "metadata": {
     "id": "W7ToOyp9AwCi"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───────\n",
-      "           │\n",
-      "(0, 1): ───@───@───\n",
-      "               │\n",
-      "(0, 2): ───X───@───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cz01 = cirq.CZ(qubits[0], qubits[1])\n",
     "x2 = cirq.X(qubits[2])\n",
@@ -266,19 +222,7 @@
    "metadata": {
     "id": "7xtjmYzKAwCn"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───\n",
-      "           │\n",
-      "(1, 0): ───@───\n",
-      "\n",
-      "(2, 0): ───H───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from cirq.ops import CZ, H\n",
     "q0, q1, q2 = [cirq.GridQubit(i, 0) for i in range(3)]\n",
@@ -303,19 +247,7 @@
    "metadata": {
     "id": "HO8WYyU9AwCq"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───H───\n",
-      "           │\n",
-      "(1, 0): ───@───@───\n",
-      "               │\n",
-      "(2, 0): ───H───@───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit.append([H(q0), CZ(q1, q2)])\n",
     "\n",
@@ -337,19 +269,7 @@
    "metadata": {
     "id": "Q3qzMlQmAwCt"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───H───\n",
-      "           │\n",
-      "(1, 0): ───@───@───\n",
-      "               │\n",
-      "(2, 0): ───H───@───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit()\n",
     "circuit.append([CZ(q0, q1), H(q2), H(q0), CZ(q1, q2)])\n",
@@ -363,7 +283,7 @@
     "id": "OQX8FTMyAwCw"
    },
    "source": [
-    "We see that here we have again created two `Moment` objects. How did `Circuit` know how to do this? `Circuit`'s `Circuit.append` method (and its cousin, `Circuit.insert`) both take an argument called the `InsertStrategy`. By default, `InsertStrategy` is `InsertStrategy.NEW_THEN_INLINE`."
+    "We see that here we have again created two `Moment` objects. How did `Circuit` know how to do this? `Circuit`'s `Circuit.append` method (and its cousin, `Circuit.insert`) both take an argument called `strategy` of type `cirq.InsertStrategy`. By default, `InsertStrategy` is `InsertStrategy.NEW_THEN_INLINE`."
    ]
   },
   {
@@ -374,7 +294,7 @@
    "source": [
     "### InsertStrategies\n",
     "\n",
-    "`InsertStrategy` defines how `Operations` are placed in a `Circuit` when requested to be inserted at a given location. Here, a location is identified by the index of the `Moment` (in the `Circuit`) where the insertion is requested to be placed at (in the case of `Circuit.append`, this means inserting at the `Moment`, at an index one greater than the maximum moment index in the `Circuit`). \n",
+    "`cirq.InsertStrategy` defines how `Operations` are placed in a `Circuit` when requested to be inserted at a given location. Here, a location is identified by the index of the `Moment` (in the `Circuit`) where the insertion is requested to be placed at (in the case of `Circuit.append`, this means inserting at the `Moment`, at an index one greater than the maximum moment index in the `Circuit`). \n",
     "\n",
     "There are four such strategies: `InsertStrategy.EARLIEST`, `InsertStrategy.NEW`, `InsertStrategy.INLINE` and `InsertStrategy.NEW_THEN_INLINE`.\n",
     "\n",
@@ -391,19 +311,7 @@
    "metadata": {
     "id": "Hd5IGmQrAwCx"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───H───\n",
-      "           │\n",
-      "(1, 0): ───@───────\n",
-      "\n",
-      "(2, 0): ───H───────\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from cirq.circuits import InsertStrategy\n",
     "\n",
@@ -433,19 +341,7 @@
    "metadata": {
     "id": "Yupv8gQOAwC0"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───H───────────\n",
-      "\n",
-      "(1, 0): ───────H───────\n",
-      "\n",
-      "(2, 0): ───────────H───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit()\n",
     "circuit.append([H(q0), H(q1), H(q2)], strategy=InsertStrategy.NEW)\n",
@@ -486,19 +382,7 @@
    "metadata": {
     "id": "J3LTjH9-AwC5"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───────H───────\n",
-      "\n",
-      "(1, 0): ───@───@───H───\n",
-      "           │   │\n",
-      "(2, 0): ───@───@───H───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit()\n",
     "circuit.append([CZ(q1, q2)])\n",
@@ -514,7 +398,7 @@
     "id": "7iDg6j4fAwC7"
    },
    "source": [
-    "After two initial `CZ` between the second and third qubit, we try to insert three `H` `Operations`. We see that the `H` on the first qubit is inserted into the previous `Moment`, but the `H` on the second and third qubits cannot be inserted into the previous `Moment`, so a new `Moment` is created.\n",
+    "After two initial `CZ` between the second and third qubit, we try to insert three `H` operations. We see that the `H` on the first qubit is inserted into the previous `Moment`, but the `H` on the second and third qubits cannot be inserted into the previous `Moment`, so a new `Moment` is created.\n",
     "\n",
     "Finally, we turn to a useful strategy to start a new moment and then start\n",
     "inserting from that point, `InsertStrategy.NEW_THEN_INLINE`"
@@ -535,19 +419,7 @@
    "metadata": {
     "id": "LmT3IKEEAwC9"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───H───H───\n",
-      "\n",
-      "(1, 0): ───────@───\n",
-      "               │\n",
-      "(2, 0): ───────@───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit()\n",
     "circuit.append([H(q0)])\n",
@@ -593,18 +465,7 @@
    "metadata": {
     "id": "kmt8hAfZAwDA"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CZ((0, 0), (1, 0))\n",
-      "[cirq.H.on(cirq.GridQubit(0, 0)), cirq.H.on(cirq.GridQubit(1, 0)), cirq.H.on(cirq.GridQubit(2, 0))]\n",
-      "[cirq.CZ.on(cirq.GridQubit(1, 0), cirq.GridQubit(2, 0))]\n",
-      "[cirq.H.on(cirq.GridQubit(0, 0)), [cirq.CZ.on(cirq.GridQubit(1, 0), cirq.GridQubit(2, 0))]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def my_layer():\n",
     "    yield CZ(q0, q1)\n",
@@ -625,19 +486,7 @@
    "metadata": {
     "id": "LXs7ffVWAwDC"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───H───H───────\n",
-      "           │\n",
-      "(1, 0): ───@───H───@───@───\n",
-      "                   │   │\n",
-      "(2, 0): ───H───────@───@───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(circuit)"
    ]
@@ -657,7 +506,7 @@
     "\n",
     "When we pass an iterator to the `append` method, `Circuit` is able to flatten all of these and pass them as one giant list to `Circuit.append` (this also works for `Circuit.insert`).\n",
     "\n",
-    "The above idea uses the concept of `OP_TREE`. An `OP_TREE` is not a class, but a *contract*. The basic idea is that, if the input can be iteratively flattened into a list of operations, then the input is an `OP_TREE`.\n",
+    "The above idea uses the concept of `cirq.OP_TREE`. An `OP_TREE` is not a class, but a *contract*. The basic idea is that, if the input can be iteratively flattened into a list of operations, then the input is an `OP_TREE`.\n",
     "\n",
     "A very nice pattern emerges from this structure: define generators for sub-circuits, which can vary by size or `Operation` parameters.\n",
     "\n",
@@ -670,17 +519,7 @@
    "metadata": {
     "id": "dC6iBIqrAwDF"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───H───\n",
-      "\n",
-      "(1, 0): ───H───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit(H(q0), H(q1))\n",
     "print(circuit)"
@@ -703,16 +542,7 @@
    "metadata": {
     "id": "z2csEbbyAwDI"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "H((0, 0))\n",
-      "CZ((0, 0), (1, 0))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit(H(q0), CZ(q0, q1))\n",
     "for moment in circuit:\n",
@@ -734,17 +564,7 @@
    "metadata": {
     "id": "hxczWjkMAwDL"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(0, 0): ───@───────\n",
-      "           │\n",
-      "(1, 0): ───@───H───\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "circuit = cirq.Circuit(H(q0), CZ(q0, q1), H(q1), CZ(q0, q1))\n",
     "print(circuit[1:3])"
@@ -769,7 +589,6 @@
     "\n",
     "\n",
     "- [Transform circuits](transform.ipynb) - features related to circuit optimization and compilation\n",
-    "- [Devices](devices.ipynb) - validate circuits against device constraints\n",
     "- [Import/export circuits](interop.ipynb) - features to serialize/deserialize circuits into/from different formats"
    ]
   }


### PR DESCRIPTION
- Remove output
- Move import to top
- Minor changes to content (add `cirq.` prefix to many quoted words)
- Remove broken link to devices.ipynb