### PR TITLE
Deprecate SupportsPhase

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -643,7 +643,6 @@ from cirq.protocols import (
     SupportsMixture,
     SupportsParameterization,
     SupportsPauliExpansion,
-    SupportsPhase,
     SupportsQasm,
     SupportsQasmWithArgs,
     SupportsQasmWithArgsAndQubits,

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -914,7 +914,7 @@ class CZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j ** (2 * self._exponent * self._global_shift)
-        z_phase = 1j ** self._exponent
+        z_phase = 1j**self._exponent
         c = -1j * z_phase * np.sin(np.pi * self._exponent / 2) / 2
         return value.LinearDict(
             {
@@ -1096,7 +1096,7 @@ class CXPowGate(eigen_gate.EigenGate):
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j ** (2 * self._exponent * self._global_shift)
-        cnot_phase = 1j ** self._exponent
+        cnot_phase = 1j**self._exponent
         c = -1j * cnot_phase * np.sin(np.pi * self._exponent / 2) / 2
         return value.LinearDict(
             {

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -42,7 +42,7 @@ import sympy
 
 import cirq
 from cirq import protocols, value
-from cirq._compat import proper_repr
+from cirq._compat import deprecated, proper_repr
 from cirq._doc import document
 from cirq.ops import controlled_gate, eigen_gate, gate_features, raw_types
 
@@ -221,8 +221,11 @@ class XPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
     def phase_exponent(self):
         return 0.0
 
+    @deprecated(
+        fix='Create a new PhasedXPowGate with axis_phase_exponent=phase_turns * 2.',
+        deadline='v1.0',
+    )
     def _phase_by_(self, phase_turns, qubit_index):
-        """See `cirq.SupportsPhase`."""
         return cirq.ops.phased_x_gate.PhasedXPowGate(
             exponent=self._exponent, phase_exponent=phase_turns * 2
         )
@@ -396,8 +399,11 @@ class YPowGate(eigen_gate.EigenGate, gate_features.SingleQubitGate):
     def phase_exponent(self):
         return 0.5
 
+    @deprecated(
+        fix='Create a new PhasedXPowGate with phase_exponent=0.5+phase_turns * 2.',
+        deadline='v1.0',
+    )
     def _phase_by_(self, phase_turns, qubit_index):
-        """See `cirq.SupportsPhase`."""
         return cirq.ops.phased_x_gate.PhasedXPowGate(
             exponent=self._exponent, phase_exponent=0.5 + phase_turns * 2
         )
@@ -908,7 +914,7 @@ class CZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j ** (2 * self._exponent * self._global_shift)
-        z_phase = 1j**self._exponent
+        z_phase = 1j ** self._exponent
         c = -1j * z_phase * np.sin(np.pi * self._exponent / 2) / 2
         return value.LinearDict(
             {
@@ -1090,7 +1096,7 @@ class CXPowGate(eigen_gate.EigenGate):
         if protocols.is_parameterized(self):
             return NotImplemented
         global_phase = 1j ** (2 * self._exponent * self._global_shift)
-        cnot_phase = 1j**self._exponent
+        cnot_phase = 1j ** self._exponent
         c = -1j * cnot_phase * np.sin(np.pi * self._exponent / 2) / 2
         return value.LinearDict(
             {

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -53,7 +53,7 @@ def test_phase_sensitive_eigen_gates_consistent_protocols(eigen_gate_type):
 def test_cz_init():
     assert cirq.CZPowGate(exponent=0.5).exponent == 0.5
     assert cirq.CZPowGate(exponent=5).exponent == 5
-    assert (cirq.CZ**0.5).exponent == 0.5
+    assert (cirq.CZ ** 0.5).exponent == 0.5
 
 
 @pytest.mark.parametrize('theta,pi', [(0.4, np.pi), (sympy.Symbol("theta"), sympy.pi)])
@@ -80,14 +80,14 @@ def test_transformations(theta, pi):
 
 def test_cz_str():
     assert str(cirq.CZ) == 'CZ'
-    assert str(cirq.CZ**0.5) == 'CZ**0.5'
-    assert str(cirq.CZ**-0.25) == 'CZ**-0.25'
+    assert str(cirq.CZ ** 0.5) == 'CZ**0.5'
+    assert str(cirq.CZ ** -0.25) == 'CZ**-0.25'
 
 
 def test_cz_repr():
     assert repr(cirq.CZ) == 'cirq.CZ'
-    assert repr(cirq.CZ**0.5) == '(cirq.CZ**0.5)'
-    assert repr(cirq.CZ**-0.25) == '(cirq.CZ**-0.25)'
+    assert repr(cirq.CZ ** 0.5) == '(cirq.CZ**0.5)'
+    assert repr(cirq.CZ ** -0.25) == '(cirq.CZ**-0.25)'
 
 
 def test_cz_unitary():
@@ -96,17 +96,17 @@ def test_cz_unitary():
     )
 
     assert np.allclose(
-        cirq.unitary(cirq.CZ**0.5),
+        cirq.unitary(cirq.CZ ** 0.5),
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1j]]),
     )
 
     assert np.allclose(
-        cirq.unitary(cirq.CZ**0),
+        cirq.unitary(cirq.CZ ** 0),
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]),
     )
 
     assert np.allclose(
-        cirq.unitary(cirq.CZ**-0.5),
+        cirq.unitary(cirq.CZ ** -0.5),
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1j]]),
     )
 
@@ -116,9 +116,9 @@ def test_z_init():
     assert z.exponent == 5
 
     # Canonicalizes exponent for equality, but keeps the inner details.
-    assert cirq.Z**0.5 != cirq.Z**-0.5
-    assert (cirq.Z**-1) ** 0.5 == cirq.Z**-0.5
-    assert cirq.Z**-1 == cirq.Z
+    assert cirq.Z ** 0.5 != cirq.Z ** -0.5
+    assert (cirq.Z ** -1) ** 0.5 == cirq.Z ** -0.5
+    assert cirq.Z ** -1 == cirq.Z
 
 
 @pytest.mark.parametrize(
@@ -222,11 +222,11 @@ def test_global_phase_controlled_gate(gate, matrix):
 def test_rot_gates_eq():
     eq = cirq.testing.EqualsTester()
     gates = [
-        lambda p: cirq.CZ**p,
-        lambda p: cirq.X**p,
-        lambda p: cirq.Y**p,
-        lambda p: cirq.Z**p,
-        lambda p: cirq.CNOT**p,
+        lambda p: cirq.CZ ** p,
+        lambda p: cirq.X ** p,
+        lambda p: cirq.Y ** p,
+        lambda p: cirq.Z ** p,
+        lambda p: cirq.CNOT ** p,
     ]
     for gate in gates:
         eq.add_equality_group(gate(3.5), gate(-0.5))
@@ -250,22 +250,22 @@ def test_rot_gates_eq():
 
 def test_z_unitary():
     assert np.allclose(cirq.unitary(cirq.Z), np.array([[1, 0], [0, -1]]))
-    assert np.allclose(cirq.unitary(cirq.Z**0.5), np.array([[1, 0], [0, 1j]]))
-    assert np.allclose(cirq.unitary(cirq.Z**0), np.array([[1, 0], [0, 1]]))
-    assert np.allclose(cirq.unitary(cirq.Z**-0.5), np.array([[1, 0], [0, -1j]]))
+    assert np.allclose(cirq.unitary(cirq.Z ** 0.5), np.array([[1, 0], [0, 1j]]))
+    assert np.allclose(cirq.unitary(cirq.Z ** 0), np.array([[1, 0], [0, 1]]))
+    assert np.allclose(cirq.unitary(cirq.Z ** -0.5), np.array([[1, 0], [0, -1j]]))
 
 
 def test_y_unitary():
     assert np.allclose(cirq.unitary(cirq.Y), np.array([[0, -1j], [1j, 0]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.Y**0.5), np.array([[1 + 1j, -1 - 1j], [1 + 1j, 1 + 1j]]) / 2
+        cirq.unitary(cirq.Y ** 0.5), np.array([[1 + 1j, -1 - 1j], [1 + 1j, 1 + 1j]]) / 2
     )
 
-    assert np.allclose(cirq.unitary(cirq.Y**0), np.array([[1, 0], [0, 1]]))
+    assert np.allclose(cirq.unitary(cirq.Y ** 0), np.array([[1, 0], [0, 1]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.Y**-0.5), np.array([[1 - 1j, 1 - 1j], [-1 + 1j, 1 - 1j]]) / 2
+        cirq.unitary(cirq.Y ** -0.5), np.array([[1 - 1j, 1 - 1j], [-1 + 1j, 1 - 1j]]) / 2
     )
 
 
@@ -273,18 +273,18 @@ def test_x_unitary():
     assert np.allclose(cirq.unitary(cirq.X), np.array([[0, 1], [1, 0]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.X**0.5), np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]]) / 2
+        cirq.unitary(cirq.X ** 0.5), np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]]) / 2
     )
 
-    assert np.allclose(cirq.unitary(cirq.X**0), np.array([[1, 0], [0, 1]]))
+    assert np.allclose(cirq.unitary(cirq.X ** 0), np.array([[1, 0], [0, 1]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.X**-0.5), np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]]) / 2
+        cirq.unitary(cirq.X ** -0.5), np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]]) / 2
     )
 
 
 def test_h_unitary():
-    sqrt = cirq.unitary(cirq.H**0.5)
+    sqrt = cirq.unitary(cirq.H ** 0.5)
     m = np.dot(sqrt, sqrt)
     assert np.allclose(m, cirq.unitary(cirq.H), atol=1e-8)
 
@@ -296,7 +296,7 @@ def test_h_init():
 
 def test_h_str():
     assert str(cirq.H) == 'H'
-    assert str(cirq.H**0.5) == 'H**0.5'
+    assert str(cirq.H ** 0.5) == 'H**0.5'
 
 
 def test_x_act_on_tableau():
@@ -311,8 +311,8 @@ def test_x_act_on_tableau():
         prng=np.random.RandomState(),
     )
 
-    cirq.act_on(cirq.X**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.X**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
@@ -320,18 +320,18 @@ def test_x_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.X**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.X**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.X**2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.X**foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.X ** foo, args, [cirq.LineQubit(1)])
 
 
 class iZGate(cirq.SingleQubitGate):
@@ -360,8 +360,8 @@ def test_y_act_on_tableau():
         prng=np.random.RandomState(),
     )
 
-    cirq.act_on(cirq.Y**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Y**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(iZGate(), args, [cirq.LineQubit(1)])
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
@@ -371,19 +371,19 @@ def test_y_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.Y**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Y**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(iZGate(), args, [cirq.LineQubit(1)])
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.Y**2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.Y**foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.Y ** foo, args, [cirq.LineQubit(1)])
 
 
 def test_z_h_act_on_tableau():
@@ -401,8 +401,8 @@ def test_z_h_act_on_tableau():
     )
 
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
@@ -414,29 +414,29 @@ def test_z_h_act_on_tableau():
     assert args.tableau == original_tableau
 
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.Z**2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.H**2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.H ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.Z**foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.Z ** foo, args, [cirq.LineQubit(1)])
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.H**foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.H ** foo, args, [cirq.LineQubit(1)])
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.H**1.5, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.H ** 1.5, args, [cirq.LineQubit(1)])
 
 
 def test_cx_act_on_tableau():
@@ -471,16 +471,16 @@ def test_cx_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.CX**4, args, cirq.LineQubit.range(2), allow_decompose=False)
+    cirq.act_on(cirq.CX ** 4, args, cirq.LineQubit.range(2), allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CX**foo, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CX ** foo, args, cirq.LineQubit.range(2))
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CX**1.5, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CX ** 1.5, args, cirq.LineQubit.range(2))
 
 
 def test_cz_act_on_tableau():
@@ -515,16 +515,16 @@ def test_cz_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.CZ**4, args, cirq.LineQubit.range(2), allow_decompose=False)
+    cirq.act_on(cirq.CZ ** 4, args, cirq.LineQubit.range(2), allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CZ**foo, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CZ ** foo, args, cirq.LineQubit.range(2))
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CZ**1.5, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CZ ** 1.5, args, cirq.LineQubit.range(2))
 
 
 def test_cz_act_on_equivalent_to_h_cx_h_tableau():
@@ -557,33 +557,33 @@ foo = sympy.Symbol('foo')
 @pytest.mark.parametrize(
     'input_gate_sequence, outcome',
     [
-        ([cirq.X**foo], 'Error'),
-        ([cirq.X**0.25], 'Error'),
-        ([cirq.X**4], 'Original'),
-        ([cirq.X**0.5, cirq.X**0.5], 'Flipped'),
+        ([cirq.X ** foo], 'Error'),
+        ([cirq.X ** 0.25], 'Error'),
+        ([cirq.X ** 4], 'Original'),
+        ([cirq.X ** 0.5, cirq.X ** 0.5], 'Flipped'),
         ([cirq.X], 'Flipped'),
-        ([cirq.X**3.5, cirq.X**3.5], 'Flipped'),
-        ([cirq.Y**foo], 'Error'),
-        ([cirq.Y**0.25], 'Error'),
-        ([cirq.Y**4], 'Original'),
-        ([cirq.Y**0.5, cirq.Y**0.5, iZGate()], 'Flipped'),
+        ([cirq.X ** 3.5, cirq.X ** 3.5], 'Flipped'),
+        ([cirq.Y ** foo], 'Error'),
+        ([cirq.Y ** 0.25], 'Error'),
+        ([cirq.Y ** 4], 'Original'),
+        ([cirq.Y ** 0.5, cirq.Y ** 0.5, iZGate()], 'Flipped'),
         ([cirq.Y, iZGate()], 'Flipped'),
-        ([cirq.Y**3.5, cirq.Y**3.5, iZGate()], 'Flipped'),
-        ([cirq.Z**foo], 'Error'),
-        ([cirq.H**foo], 'Error'),
-        ([cirq.H**1.5], 'Error'),
-        ([cirq.Z**4], 'Original'),
-        ([cirq.H**4], 'Original'),
+        ([cirq.Y ** 3.5, cirq.Y ** 3.5, iZGate()], 'Flipped'),
+        ([cirq.Z ** foo], 'Error'),
+        ([cirq.H ** foo], 'Error'),
+        ([cirq.H ** 1.5], 'Error'),
+        ([cirq.Z ** 4], 'Original'),
+        ([cirq.H ** 4], 'Original'),
         ([cirq.H, cirq.S, cirq.S, cirq.H], 'Flipped'),
         ([cirq.H, cirq.Z, cirq.H], 'Flipped'),
-        ([cirq.H, cirq.Z**3.5, cirq.Z**3.5, cirq.H], 'Flipped'),
-        ([cirq.CX**foo], 'Error'),
-        ([cirq.CX**1.5], 'Error'),
-        ([cirq.CX**4], 'Original'),
+        ([cirq.H, cirq.Z ** 3.5, cirq.Z ** 3.5, cirq.H], 'Flipped'),
+        ([cirq.CX ** foo], 'Error'),
+        ([cirq.CX ** 1.5], 'Error'),
+        ([cirq.CX ** 4], 'Original'),
         ([cirq.CX], 'Flipped'),
-        ([cirq.CZ**foo], 'Error'),
-        ([cirq.CZ**1.5], 'Error'),
-        ([cirq.CZ**4], 'Original'),
+        ([cirq.CZ ** foo], 'Error'),
+        ([cirq.CZ ** 1.5], 'Error'),
+        ([cirq.CZ ** 4], 'Original'),
         ([cirq.CZ, MinusOnePhaseGate()], 'Original'),
     ],
 )
@@ -625,28 +625,28 @@ def test_act_on_ch_form(input_gate_sequence, outcome):
         (cirq.X, True),
         (cirq.Y, True),
         (cirq.Z, True),
-        (cirq.X**0.5, True),
-        (cirq.Y**0.5, True),
-        (cirq.Z**0.5, True),
-        (cirq.X**3.5, True),
-        (cirq.Y**3.5, True),
-        (cirq.Z**3.5, True),
-        (cirq.X**4, True),
-        (cirq.Y**4, True),
-        (cirq.Z**4, True),
+        (cirq.X ** 0.5, True),
+        (cirq.Y ** 0.5, True),
+        (cirq.Z ** 0.5, True),
+        (cirq.X ** 3.5, True),
+        (cirq.Y ** 3.5, True),
+        (cirq.Z ** 3.5, True),
+        (cirq.X ** 4, True),
+        (cirq.Y ** 4, True),
+        (cirq.Z ** 4, True),
         (cirq.H, True),
         (cirq.CX, True),
         (cirq.CZ, True),
-        (cirq.H**4, True),
-        (cirq.CX**4, True),
-        (cirq.CZ**4, True),
+        (cirq.H ** 4, True),
+        (cirq.CX ** 4, True),
+        (cirq.CZ ** 4, True),
         # Unsupported gates should not fail too.
-        (cirq.X**0.25, False),
-        (cirq.Y**0.25, False),
-        (cirq.Z**0.25, False),
-        (cirq.H**0.5, False),
-        (cirq.CX**0.5, False),
-        (cirq.CZ**0.5, False),
+        (cirq.X ** 0.25, False),
+        (cirq.Y ** 0.25, False),
+        (cirq.Z ** 0.25, False),
+        (cirq.H ** 0.5, False),
+        (cirq.CX ** 0.5, False),
+        (cirq.CZ ** 0.5, False),
     ],
 )
 def test_act_on_consistency(input_gate, assert_implemented):
@@ -742,7 +742,7 @@ b: -----------------------------@---X---@---X^0.5---@-------------------I---@^t-
 
 def test_cnot_unitary():
     np.testing.assert_almost_equal(
-        cirq.unitary(cirq.CNOT**0.5),
+        cirq.unitary(cirq.CNOT ** 0.5),
         np.array(
             [
                 [1, 0, 0, 0],
@@ -803,23 +803,23 @@ def test_cnot_decompose():
 
 def test_repr():
     assert repr(cirq.X) == 'cirq.X'
-    assert repr(cirq.X**0.5) == '(cirq.X**0.5)'
+    assert repr(cirq.X ** 0.5) == '(cirq.X**0.5)'
 
     assert repr(cirq.Z) == 'cirq.Z'
-    assert repr(cirq.Z**0.5) == 'cirq.S'
-    assert repr(cirq.Z**0.25) == 'cirq.T'
-    assert repr(cirq.Z**0.125) == '(cirq.Z**0.125)'
+    assert repr(cirq.Z ** 0.5) == 'cirq.S'
+    assert repr(cirq.Z ** 0.25) == 'cirq.T'
+    assert repr(cirq.Z ** 0.125) == '(cirq.Z**0.125)'
 
     assert repr(cirq.S) == 'cirq.S'
-    assert repr(cirq.S**-1) == '(cirq.S**-1)'
+    assert repr(cirq.S ** -1) == '(cirq.S**-1)'
     assert repr(cirq.T) == 'cirq.T'
-    assert repr(cirq.T**-1) == '(cirq.T**-1)'
+    assert repr(cirq.T ** -1) == '(cirq.T**-1)'
 
     assert repr(cirq.Y) == 'cirq.Y'
-    assert repr(cirq.Y**0.5) == '(cirq.Y**0.5)'
+    assert repr(cirq.Y ** 0.5) == '(cirq.Y**0.5)'
 
     assert repr(cirq.CNOT) == 'cirq.CNOT'
-    assert repr(cirq.CNOT**0.5) == '(cirq.CNOT**0.5)'
+    assert repr(cirq.CNOT ** 0.5) == '(cirq.CNOT**0.5)'
 
     cirq.testing.assert_equivalent_repr(
         cirq.X ** (sympy.Symbol('a') / 2 - sympy.Symbol('c') * 3 + 5)
@@ -832,30 +832,30 @@ def test_repr():
     # should be using the "shortest decimal value closer to X than any other
     # floating point value" strategy, as opposed to the "exactly value in
     # decimal" strategy.
-    assert repr(cirq.CZ**0.2) == '(cirq.CZ**0.2)'
+    assert repr(cirq.CZ ** 0.2) == '(cirq.CZ**0.2)'
 
 
 def test_str():
     assert str(cirq.X) == 'X'
-    assert str(cirq.X**0.5) == 'X**0.5'
+    assert str(cirq.X ** 0.5) == 'X**0.5'
     assert str(cirq.rx(np.pi)) == 'Rx(π)'
     assert str(cirq.rx(0.5 * np.pi)) == 'Rx(0.5π)'
     assert str(cirq.XPowGate(global_shift=-0.25)) == 'XPowGate(exponent=1.0, global_shift=-0.25)'
 
     assert str(cirq.Z) == 'Z'
-    assert str(cirq.Z**0.5) == 'S'
-    assert str(cirq.Z**0.125) == 'Z**0.125'
+    assert str(cirq.Z ** 0.5) == 'S'
+    assert str(cirq.Z ** 0.125) == 'Z**0.125'
     assert str(cirq.rz(np.pi)) == 'Rz(π)'
     assert str(cirq.rz(1.4 * np.pi)) == 'Rz(1.4π)'
     assert str(cirq.ZPowGate(global_shift=0.25)) == 'ZPowGate(exponent=1.0, global_shift=0.25)'
 
     assert str(cirq.S) == 'S'
-    assert str(cirq.S**-1) == 'S**-1'
+    assert str(cirq.S ** -1) == 'S**-1'
     assert str(cirq.T) == 'T'
-    assert str(cirq.T**-1) == 'T**-1'
+    assert str(cirq.T ** -1) == 'T**-1'
 
     assert str(cirq.Y) == 'Y'
-    assert str(cirq.Y**0.5) == 'Y**0.5'
+    assert str(cirq.Y ** 0.5) == 'Y**0.5'
     assert str(cirq.ry(np.pi)) == 'Ry(π)'
     assert str(cirq.ry(3.14 * np.pi)) == 'Ry(3.14π)'
     assert (
@@ -864,9 +864,9 @@ def test_str():
     )
 
     assert str(cirq.CX) == 'CNOT'
-    assert str(cirq.CNOT**0.5) == 'CNOT**0.5'
+    assert str(cirq.CNOT ** 0.5) == 'CNOT**0.5'
     assert str(cirq.CZ) == 'CZ'
-    assert str(cirq.CZ**0.5) == 'CZ**0.5'
+    assert str(cirq.CZ ** 0.5) == 'CZ**0.5'
     assert str(cirq.cphase(np.pi)) == 'CZ'
     assert str(cirq.cphase(np.pi / 2)) == 'CZ**0.5'
 
@@ -938,49 +938,51 @@ def test_cphase_unitary(angle_rads, expected_unitary):
 
 def test_parameterized_cphase():
     assert cirq.cphase(sympy.pi) == cirq.CZ
-    assert cirq.cphase(sympy.pi / 2) == cirq.CZ**0.5
+    assert cirq.cphase(sympy.pi / 2) == cirq.CZ ** 0.5
 
 
 @pytest.mark.parametrize('gate', [cirq.X, cirq.Y, cirq.Z])
 def test_x_y_z_stabilizer(gate):
     assert cirq.has_stabilizer_effect(gate)
-    assert cirq.has_stabilizer_effect(gate**0.5)
-    assert cirq.has_stabilizer_effect(gate**0)
-    assert cirq.has_stabilizer_effect(gate**-0.5)
-    assert cirq.has_stabilizer_effect(gate**4)
-    assert not cirq.has_stabilizer_effect(gate**1.2)
+    assert cirq.has_stabilizer_effect(gate ** 0.5)
+    assert cirq.has_stabilizer_effect(gate ** 0)
+    assert cirq.has_stabilizer_effect(gate ** -0.5)
+    assert cirq.has_stabilizer_effect(gate ** 4)
+    assert not cirq.has_stabilizer_effect(gate ** 1.2)
     foo = sympy.Symbol('foo')
-    assert not cirq.has_stabilizer_effect(gate**foo)
+    assert not cirq.has_stabilizer_effect(gate ** foo)
 
 
 def test_h_stabilizer():
     gate = cirq.H
     assert cirq.has_stabilizer_effect(gate)
-    assert not cirq.has_stabilizer_effect(gate**0.5)
-    assert cirq.has_stabilizer_effect(gate**0)
-    assert not cirq.has_stabilizer_effect(gate**-0.5)
-    assert cirq.has_stabilizer_effect(gate**4)
-    assert not cirq.has_stabilizer_effect(gate**1.2)
+    assert not cirq.has_stabilizer_effect(gate ** 0.5)
+    assert cirq.has_stabilizer_effect(gate ** 0)
+    assert not cirq.has_stabilizer_effect(gate ** -0.5)
+    assert cirq.has_stabilizer_effect(gate ** 4)
+    assert not cirq.has_stabilizer_effect(gate ** 1.2)
     foo = sympy.Symbol('foo')
-    assert not cirq.has_stabilizer_effect(gate**foo)
+    assert not cirq.has_stabilizer_effect(gate ** foo)
 
 
 @pytest.mark.parametrize('gate', [cirq.CX, cirq.CZ])
 def test_cx_cz_stabilizer(gate):
     assert cirq.has_stabilizer_effect(gate)
-    assert not cirq.has_stabilizer_effect(gate**0.5)
-    assert cirq.has_stabilizer_effect(gate**0)
-    assert not cirq.has_stabilizer_effect(gate**-0.5)
-    assert cirq.has_stabilizer_effect(gate**4)
-    assert not cirq.has_stabilizer_effect(gate**1.2)
+    assert not cirq.has_stabilizer_effect(gate ** 0.5)
+    assert cirq.has_stabilizer_effect(gate ** 0)
+    assert not cirq.has_stabilizer_effect(gate ** -0.5)
+    assert cirq.has_stabilizer_effect(gate ** 4)
+    assert not cirq.has_stabilizer_effect(gate ** 1.2)
     foo = sympy.Symbol('foo')
-    assert not cirq.has_stabilizer_effect(gate**foo)
+    assert not cirq.has_stabilizer_effect(gate ** foo)
 
 
 def test_phase_by_xy():
-    assert cirq.phase_by(cirq.X, 0.25, 0) == cirq.Y
-    assert cirq.phase_by(cirq.X**0.5, 0.25, 0) == cirq.Y**0.5
-    assert cirq.phase_by(cirq.X**-0.5, 0.25, 0) == cirq.Y**-0.5
+    with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=8):
+        assert cirq.phase_by(cirq.X, 0.25, 0) == cirq.Y
+        assert cirq.phase_by(cirq.Y, 0.75, 0) == cirq.X
+        assert cirq.phase_by(cirq.X ** 0.5, 0.25, 0) == cirq.Y ** 0.5
+        assert cirq.phase_by(cirq.X ** -0.5, 0.25, 0) == cirq.Y ** -0.5
 
 
 def test_ixyz_circuit_diagram():
@@ -1108,12 +1110,12 @@ q: ───Rz(π)───Rz(-π)───Rz(-π)───Rz(0.5π)───Rz(
 
 def test_trace_distance():
     foo = sympy.Symbol('foo')
-    sx = cirq.X**foo
-    sy = cirq.Y**foo
-    sz = cirq.Z**foo
-    sh = cirq.H**foo
-    scx = cirq.CX**foo
-    scz = cirq.CZ**foo
+    sx = cirq.X ** foo
+    sy = cirq.Y ** foo
+    sz = cirq.Z ** foo
+    sh = cirq.H ** foo
+    scx = cirq.CX ** foo
+    scz = cirq.CZ ** foo
     # These values should have 1.0 or 0.0 directly returned
     assert cirq.trace_distance_bound(sx) == 1.0
     assert cirq.trace_distance_bound(sy) == 1.0
@@ -1124,23 +1126,23 @@ def test_trace_distance():
     assert cirq.trace_distance_bound(cirq.I) == 0.0
     # These values are calculated, so we use approx_eq
     assert cirq.approx_eq(cirq.trace_distance_bound(cirq.X), 1.0)
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Y**-1), 1.0)
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Z**0.5), np.sin(np.pi / 4))
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.H**0.25), np.sin(np.pi / 8))
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.CX**2), 0.0)
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Y ** -1), 1.0)
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Z ** 0.5), np.sin(np.pi / 4))
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.H ** 0.25), np.sin(np.pi / 8))
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.CX ** 2), 0.0)
     assert cirq.approx_eq(cirq.trace_distance_bound(cirq.CZ ** (1 / 9)), np.sin(np.pi / 18))
 
 
 def test_commutes():
     assert cirq.commutes(cirq.ZPowGate(exponent=sympy.Symbol('t')), cirq.Z)
     assert cirq.commutes(cirq.Z, cirq.Z(cirq.LineQubit(0)), default=None) is None
-    assert cirq.commutes(cirq.Z**0.1, cirq.XPowGate(exponent=0))
+    assert cirq.commutes(cirq.Z ** 0.1, cirq.XPowGate(exponent=0))
 
 
 def test_approx_eq():
-    assert cirq.approx_eq(cirq.Z**0.1, cirq.Z**0.2, atol=0.3)
-    assert not cirq.approx_eq(cirq.Z**0.1, cirq.Z**0.2, atol=0.05)
-    assert cirq.approx_eq(cirq.Y**0.1, cirq.Y**0.2, atol=0.3)
-    assert not cirq.approx_eq(cirq.Y**0.1, cirq.Y**0.2, atol=0.05)
-    assert cirq.approx_eq(cirq.X**0.1, cirq.X**0.2, atol=0.3)
-    assert not cirq.approx_eq(cirq.X**0.1, cirq.X**0.2, atol=0.05)
+    assert cirq.approx_eq(cirq.Z ** 0.1, cirq.Z ** 0.2, atol=0.3)
+    assert not cirq.approx_eq(cirq.Z ** 0.1, cirq.Z ** 0.2, atol=0.05)
+    assert cirq.approx_eq(cirq.Y ** 0.1, cirq.Y ** 0.2, atol=0.3)
+    assert not cirq.approx_eq(cirq.Y ** 0.1, cirq.Y ** 0.2, atol=0.05)
+    assert cirq.approx_eq(cirq.X ** 0.1, cirq.X ** 0.2, atol=0.3)
+    assert not cirq.approx_eq(cirq.X ** 0.1, cirq.X ** 0.2, atol=0.05)

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -53,7 +53,7 @@ def test_phase_sensitive_eigen_gates_consistent_protocols(eigen_gate_type):
 def test_cz_init():
     assert cirq.CZPowGate(exponent=0.5).exponent == 0.5
     assert cirq.CZPowGate(exponent=5).exponent == 5
-    assert (cirq.CZ ** 0.5).exponent == 0.5
+    assert (cirq.CZ**0.5).exponent == 0.5
 
 
 @pytest.mark.parametrize('theta,pi', [(0.4, np.pi), (sympy.Symbol("theta"), sympy.pi)])
@@ -80,14 +80,14 @@ def test_transformations(theta, pi):
 
 def test_cz_str():
     assert str(cirq.CZ) == 'CZ'
-    assert str(cirq.CZ ** 0.5) == 'CZ**0.5'
-    assert str(cirq.CZ ** -0.25) == 'CZ**-0.25'
+    assert str(cirq.CZ**0.5) == 'CZ**0.5'
+    assert str(cirq.CZ**-0.25) == 'CZ**-0.25'
 
 
 def test_cz_repr():
     assert repr(cirq.CZ) == 'cirq.CZ'
-    assert repr(cirq.CZ ** 0.5) == '(cirq.CZ**0.5)'
-    assert repr(cirq.CZ ** -0.25) == '(cirq.CZ**-0.25)'
+    assert repr(cirq.CZ**0.5) == '(cirq.CZ**0.5)'
+    assert repr(cirq.CZ**-0.25) == '(cirq.CZ**-0.25)'
 
 
 def test_cz_unitary():
@@ -96,17 +96,17 @@ def test_cz_unitary():
     )
 
     assert np.allclose(
-        cirq.unitary(cirq.CZ ** 0.5),
+        cirq.unitary(cirq.CZ**0.5),
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1j]]),
     )
 
     assert np.allclose(
-        cirq.unitary(cirq.CZ ** 0),
+        cirq.unitary(cirq.CZ**0),
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]),
     )
 
     assert np.allclose(
-        cirq.unitary(cirq.CZ ** -0.5),
+        cirq.unitary(cirq.CZ**-0.5),
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1j]]),
     )
 
@@ -116,9 +116,9 @@ def test_z_init():
     assert z.exponent == 5
 
     # Canonicalizes exponent for equality, but keeps the inner details.
-    assert cirq.Z ** 0.5 != cirq.Z ** -0.5
-    assert (cirq.Z ** -1) ** 0.5 == cirq.Z ** -0.5
-    assert cirq.Z ** -1 == cirq.Z
+    assert cirq.Z**0.5 != cirq.Z**-0.5
+    assert (cirq.Z**-1) ** 0.5 == cirq.Z**-0.5
+    assert cirq.Z**-1 == cirq.Z
 
 
 @pytest.mark.parametrize(
@@ -222,11 +222,11 @@ def test_global_phase_controlled_gate(gate, matrix):
 def test_rot_gates_eq():
     eq = cirq.testing.EqualsTester()
     gates = [
-        lambda p: cirq.CZ ** p,
-        lambda p: cirq.X ** p,
-        lambda p: cirq.Y ** p,
-        lambda p: cirq.Z ** p,
-        lambda p: cirq.CNOT ** p,
+        lambda p: cirq.CZ**p,
+        lambda p: cirq.X**p,
+        lambda p: cirq.Y**p,
+        lambda p: cirq.Z**p,
+        lambda p: cirq.CNOT**p,
     ]
     for gate in gates:
         eq.add_equality_group(gate(3.5), gate(-0.5))
@@ -250,22 +250,22 @@ def test_rot_gates_eq():
 
 def test_z_unitary():
     assert np.allclose(cirq.unitary(cirq.Z), np.array([[1, 0], [0, -1]]))
-    assert np.allclose(cirq.unitary(cirq.Z ** 0.5), np.array([[1, 0], [0, 1j]]))
-    assert np.allclose(cirq.unitary(cirq.Z ** 0), np.array([[1, 0], [0, 1]]))
-    assert np.allclose(cirq.unitary(cirq.Z ** -0.5), np.array([[1, 0], [0, -1j]]))
+    assert np.allclose(cirq.unitary(cirq.Z**0.5), np.array([[1, 0], [0, 1j]]))
+    assert np.allclose(cirq.unitary(cirq.Z**0), np.array([[1, 0], [0, 1]]))
+    assert np.allclose(cirq.unitary(cirq.Z**-0.5), np.array([[1, 0], [0, -1j]]))
 
 
 def test_y_unitary():
     assert np.allclose(cirq.unitary(cirq.Y), np.array([[0, -1j], [1j, 0]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.Y ** 0.5), np.array([[1 + 1j, -1 - 1j], [1 + 1j, 1 + 1j]]) / 2
+        cirq.unitary(cirq.Y**0.5), np.array([[1 + 1j, -1 - 1j], [1 + 1j, 1 + 1j]]) / 2
     )
 
-    assert np.allclose(cirq.unitary(cirq.Y ** 0), np.array([[1, 0], [0, 1]]))
+    assert np.allclose(cirq.unitary(cirq.Y**0), np.array([[1, 0], [0, 1]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.Y ** -0.5), np.array([[1 - 1j, 1 - 1j], [-1 + 1j, 1 - 1j]]) / 2
+        cirq.unitary(cirq.Y**-0.5), np.array([[1 - 1j, 1 - 1j], [-1 + 1j, 1 - 1j]]) / 2
     )
 
 
@@ -273,18 +273,18 @@ def test_x_unitary():
     assert np.allclose(cirq.unitary(cirq.X), np.array([[0, 1], [1, 0]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.X ** 0.5), np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]]) / 2
+        cirq.unitary(cirq.X**0.5), np.array([[1 + 1j, 1 - 1j], [1 - 1j, 1 + 1j]]) / 2
     )
 
-    assert np.allclose(cirq.unitary(cirq.X ** 0), np.array([[1, 0], [0, 1]]))
+    assert np.allclose(cirq.unitary(cirq.X**0), np.array([[1, 0], [0, 1]]))
 
     assert np.allclose(
-        cirq.unitary(cirq.X ** -0.5), np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]]) / 2
+        cirq.unitary(cirq.X**-0.5), np.array([[1 - 1j, 1 + 1j], [1 + 1j, 1 - 1j]]) / 2
     )
 
 
 def test_h_unitary():
-    sqrt = cirq.unitary(cirq.H ** 0.5)
+    sqrt = cirq.unitary(cirq.H**0.5)
     m = np.dot(sqrt, sqrt)
     assert np.allclose(m, cirq.unitary(cirq.H), atol=1e-8)
 
@@ -296,7 +296,7 @@ def test_h_init():
 
 def test_h_str():
     assert str(cirq.H) == 'H'
-    assert str(cirq.H ** 0.5) == 'H**0.5'
+    assert str(cirq.H**0.5) == 'H**0.5'
 
 
 def test_x_act_on_tableau():
@@ -311,8 +311,8 @@ def test_x_act_on_tableau():
         prng=np.random.RandomState(),
     )
 
-    cirq.act_on(cirq.X ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.X ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
@@ -320,18 +320,18 @@ def test_x_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.X ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.X ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.X ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.X**2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.X ** foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.X**foo, args, [cirq.LineQubit(1)])
 
 
 class iZGate(cirq.SingleQubitGate):
@@ -360,8 +360,8 @@ def test_y_act_on_tableau():
         prng=np.random.RandomState(),
     )
 
-    cirq.act_on(cirq.Y ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Y ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(iZGate(), args, [cirq.LineQubit(1)])
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
@@ -371,19 +371,19 @@ def test_y_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.Y ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Y ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(iZGate(), args, [cirq.LineQubit(1)])
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.Y ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Y**2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.Y ** foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.Y**foo, args, [cirq.LineQubit(1)])
 
 
 def test_z_h_act_on_tableau():
@@ -401,8 +401,8 @@ def test_z_h_act_on_tableau():
     )
 
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z ** 0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z**0.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
@@ -414,29 +414,29 @@ def test_z_h_act_on_tableau():
     assert args.tableau == original_tableau
 
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
-    cirq.act_on(cirq.Z ** 3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z**3.5, args, [cirq.LineQubit(1)], allow_decompose=False)
     cirq.act_on(cirq.H, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.Z ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.Z**2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
-    cirq.act_on(cirq.H ** 2, args, [cirq.LineQubit(1)], allow_decompose=False)
+    cirq.act_on(cirq.H**2, args, [cirq.LineQubit(1)], allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == flipped_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.Z ** foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.Z**foo, args, [cirq.LineQubit(1)])
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.H ** foo, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.H**foo, args, [cirq.LineQubit(1)])
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.H ** 1.5, args, [cirq.LineQubit(1)])
+        cirq.act_on(cirq.H**1.5, args, [cirq.LineQubit(1)])
 
 
 def test_cx_act_on_tableau():
@@ -471,16 +471,16 @@ def test_cx_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.CX ** 4, args, cirq.LineQubit.range(2), allow_decompose=False)
+    cirq.act_on(cirq.CX**4, args, cirq.LineQubit.range(2), allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CX ** foo, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CX**foo, args, cirq.LineQubit.range(2))
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CX ** 1.5, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CX**1.5, args, cirq.LineQubit.range(2))
 
 
 def test_cz_act_on_tableau():
@@ -515,16 +515,16 @@ def test_cz_act_on_tableau():
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
-    cirq.act_on(cirq.CZ ** 4, args, cirq.LineQubit.range(2), allow_decompose=False)
+    cirq.act_on(cirq.CZ**4, args, cirq.LineQubit.range(2), allow_decompose=False)
     assert args.log_of_measurement_results == {}
     assert args.tableau == original_tableau
 
     foo = sympy.Symbol('foo')
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CZ ** foo, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CZ**foo, args, cirq.LineQubit.range(2))
 
     with pytest.raises(TypeError, match="Failed to act action on state"):
-        cirq.act_on(cirq.CZ ** 1.5, args, cirq.LineQubit.range(2))
+        cirq.act_on(cirq.CZ**1.5, args, cirq.LineQubit.range(2))
 
 
 def test_cz_act_on_equivalent_to_h_cx_h_tableau():
@@ -557,33 +557,33 @@ foo = sympy.Symbol('foo')
 @pytest.mark.parametrize(
     'input_gate_sequence, outcome',
     [
-        ([cirq.X ** foo], 'Error'),
-        ([cirq.X ** 0.25], 'Error'),
-        ([cirq.X ** 4], 'Original'),
-        ([cirq.X ** 0.5, cirq.X ** 0.5], 'Flipped'),
+        ([cirq.X**foo], 'Error'),
+        ([cirq.X**0.25], 'Error'),
+        ([cirq.X**4], 'Original'),
+        ([cirq.X**0.5, cirq.X**0.5], 'Flipped'),
         ([cirq.X], 'Flipped'),
-        ([cirq.X ** 3.5, cirq.X ** 3.5], 'Flipped'),
-        ([cirq.Y ** foo], 'Error'),
-        ([cirq.Y ** 0.25], 'Error'),
-        ([cirq.Y ** 4], 'Original'),
-        ([cirq.Y ** 0.5, cirq.Y ** 0.5, iZGate()], 'Flipped'),
+        ([cirq.X**3.5, cirq.X**3.5], 'Flipped'),
+        ([cirq.Y**foo], 'Error'),
+        ([cirq.Y**0.25], 'Error'),
+        ([cirq.Y**4], 'Original'),
+        ([cirq.Y**0.5, cirq.Y**0.5, iZGate()], 'Flipped'),
         ([cirq.Y, iZGate()], 'Flipped'),
-        ([cirq.Y ** 3.5, cirq.Y ** 3.5, iZGate()], 'Flipped'),
-        ([cirq.Z ** foo], 'Error'),
-        ([cirq.H ** foo], 'Error'),
-        ([cirq.H ** 1.5], 'Error'),
-        ([cirq.Z ** 4], 'Original'),
-        ([cirq.H ** 4], 'Original'),
+        ([cirq.Y**3.5, cirq.Y**3.5, iZGate()], 'Flipped'),
+        ([cirq.Z**foo], 'Error'),
+        ([cirq.H**foo], 'Error'),
+        ([cirq.H**1.5], 'Error'),
+        ([cirq.Z**4], 'Original'),
+        ([cirq.H**4], 'Original'),
         ([cirq.H, cirq.S, cirq.S, cirq.H], 'Flipped'),
         ([cirq.H, cirq.Z, cirq.H], 'Flipped'),
-        ([cirq.H, cirq.Z ** 3.5, cirq.Z ** 3.5, cirq.H], 'Flipped'),
-        ([cirq.CX ** foo], 'Error'),
-        ([cirq.CX ** 1.5], 'Error'),
-        ([cirq.CX ** 4], 'Original'),
+        ([cirq.H, cirq.Z**3.5, cirq.Z**3.5, cirq.H], 'Flipped'),
+        ([cirq.CX**foo], 'Error'),
+        ([cirq.CX**1.5], 'Error'),
+        ([cirq.CX**4], 'Original'),
         ([cirq.CX], 'Flipped'),
-        ([cirq.CZ ** foo], 'Error'),
-        ([cirq.CZ ** 1.5], 'Error'),
-        ([cirq.CZ ** 4], 'Original'),
+        ([cirq.CZ**foo], 'Error'),
+        ([cirq.CZ**1.5], 'Error'),
+        ([cirq.CZ**4], 'Original'),
         ([cirq.CZ, MinusOnePhaseGate()], 'Original'),
     ],
 )
@@ -625,28 +625,28 @@ def test_act_on_ch_form(input_gate_sequence, outcome):
         (cirq.X, True),
         (cirq.Y, True),
         (cirq.Z, True),
-        (cirq.X ** 0.5, True),
-        (cirq.Y ** 0.5, True),
-        (cirq.Z ** 0.5, True),
-        (cirq.X ** 3.5, True),
-        (cirq.Y ** 3.5, True),
-        (cirq.Z ** 3.5, True),
-        (cirq.X ** 4, True),
-        (cirq.Y ** 4, True),
-        (cirq.Z ** 4, True),
+        (cirq.X**0.5, True),
+        (cirq.Y**0.5, True),
+        (cirq.Z**0.5, True),
+        (cirq.X**3.5, True),
+        (cirq.Y**3.5, True),
+        (cirq.Z**3.5, True),
+        (cirq.X**4, True),
+        (cirq.Y**4, True),
+        (cirq.Z**4, True),
         (cirq.H, True),
         (cirq.CX, True),
         (cirq.CZ, True),
-        (cirq.H ** 4, True),
-        (cirq.CX ** 4, True),
-        (cirq.CZ ** 4, True),
+        (cirq.H**4, True),
+        (cirq.CX**4, True),
+        (cirq.CZ**4, True),
         # Unsupported gates should not fail too.
-        (cirq.X ** 0.25, False),
-        (cirq.Y ** 0.25, False),
-        (cirq.Z ** 0.25, False),
-        (cirq.H ** 0.5, False),
-        (cirq.CX ** 0.5, False),
-        (cirq.CZ ** 0.5, False),
+        (cirq.X**0.25, False),
+        (cirq.Y**0.25, False),
+        (cirq.Z**0.25, False),
+        (cirq.H**0.5, False),
+        (cirq.CX**0.5, False),
+        (cirq.CZ**0.5, False),
     ],
 )
 def test_act_on_consistency(input_gate, assert_implemented):
@@ -742,7 +742,7 @@ b: -----------------------------@---X---@---X^0.5---@-------------------I---@^t-
 
 def test_cnot_unitary():
     np.testing.assert_almost_equal(
-        cirq.unitary(cirq.CNOT ** 0.5),
+        cirq.unitary(cirq.CNOT**0.5),
         np.array(
             [
                 [1, 0, 0, 0],
@@ -803,23 +803,23 @@ def test_cnot_decompose():
 
 def test_repr():
     assert repr(cirq.X) == 'cirq.X'
-    assert repr(cirq.X ** 0.5) == '(cirq.X**0.5)'
+    assert repr(cirq.X**0.5) == '(cirq.X**0.5)'
 
     assert repr(cirq.Z) == 'cirq.Z'
-    assert repr(cirq.Z ** 0.5) == 'cirq.S'
-    assert repr(cirq.Z ** 0.25) == 'cirq.T'
-    assert repr(cirq.Z ** 0.125) == '(cirq.Z**0.125)'
+    assert repr(cirq.Z**0.5) == 'cirq.S'
+    assert repr(cirq.Z**0.25) == 'cirq.T'
+    assert repr(cirq.Z**0.125) == '(cirq.Z**0.125)'
 
     assert repr(cirq.S) == 'cirq.S'
-    assert repr(cirq.S ** -1) == '(cirq.S**-1)'
+    assert repr(cirq.S**-1) == '(cirq.S**-1)'
     assert repr(cirq.T) == 'cirq.T'
-    assert repr(cirq.T ** -1) == '(cirq.T**-1)'
+    assert repr(cirq.T**-1) == '(cirq.T**-1)'
 
     assert repr(cirq.Y) == 'cirq.Y'
-    assert repr(cirq.Y ** 0.5) == '(cirq.Y**0.5)'
+    assert repr(cirq.Y**0.5) == '(cirq.Y**0.5)'
 
     assert repr(cirq.CNOT) == 'cirq.CNOT'
-    assert repr(cirq.CNOT ** 0.5) == '(cirq.CNOT**0.5)'
+    assert repr(cirq.CNOT**0.5) == '(cirq.CNOT**0.5)'
 
     cirq.testing.assert_equivalent_repr(
         cirq.X ** (sympy.Symbol('a') / 2 - sympy.Symbol('c') * 3 + 5)
@@ -832,30 +832,30 @@ def test_repr():
     # should be using the "shortest decimal value closer to X than any other
     # floating point value" strategy, as opposed to the "exactly value in
     # decimal" strategy.
-    assert repr(cirq.CZ ** 0.2) == '(cirq.CZ**0.2)'
+    assert repr(cirq.CZ**0.2) == '(cirq.CZ**0.2)'
 
 
 def test_str():
     assert str(cirq.X) == 'X'
-    assert str(cirq.X ** 0.5) == 'X**0.5'
+    assert str(cirq.X**0.5) == 'X**0.5'
     assert str(cirq.rx(np.pi)) == 'Rx(π)'
     assert str(cirq.rx(0.5 * np.pi)) == 'Rx(0.5π)'
     assert str(cirq.XPowGate(global_shift=-0.25)) == 'XPowGate(exponent=1.0, global_shift=-0.25)'
 
     assert str(cirq.Z) == 'Z'
-    assert str(cirq.Z ** 0.5) == 'S'
-    assert str(cirq.Z ** 0.125) == 'Z**0.125'
+    assert str(cirq.Z**0.5) == 'S'
+    assert str(cirq.Z**0.125) == 'Z**0.125'
     assert str(cirq.rz(np.pi)) == 'Rz(π)'
     assert str(cirq.rz(1.4 * np.pi)) == 'Rz(1.4π)'
     assert str(cirq.ZPowGate(global_shift=0.25)) == 'ZPowGate(exponent=1.0, global_shift=0.25)'
 
     assert str(cirq.S) == 'S'
-    assert str(cirq.S ** -1) == 'S**-1'
+    assert str(cirq.S**-1) == 'S**-1'
     assert str(cirq.T) == 'T'
-    assert str(cirq.T ** -1) == 'T**-1'
+    assert str(cirq.T**-1) == 'T**-1'
 
     assert str(cirq.Y) == 'Y'
-    assert str(cirq.Y ** 0.5) == 'Y**0.5'
+    assert str(cirq.Y**0.5) == 'Y**0.5'
     assert str(cirq.ry(np.pi)) == 'Ry(π)'
     assert str(cirq.ry(3.14 * np.pi)) == 'Ry(3.14π)'
     assert (
@@ -864,9 +864,9 @@ def test_str():
     )
 
     assert str(cirq.CX) == 'CNOT'
-    assert str(cirq.CNOT ** 0.5) == 'CNOT**0.5'
+    assert str(cirq.CNOT**0.5) == 'CNOT**0.5'
     assert str(cirq.CZ) == 'CZ'
-    assert str(cirq.CZ ** 0.5) == 'CZ**0.5'
+    assert str(cirq.CZ**0.5) == 'CZ**0.5'
     assert str(cirq.cphase(np.pi)) == 'CZ'
     assert str(cirq.cphase(np.pi / 2)) == 'CZ**0.5'
 
@@ -938,51 +938,51 @@ def test_cphase_unitary(angle_rads, expected_unitary):
 
 def test_parameterized_cphase():
     assert cirq.cphase(sympy.pi) == cirq.CZ
-    assert cirq.cphase(sympy.pi / 2) == cirq.CZ ** 0.5
+    assert cirq.cphase(sympy.pi / 2) == cirq.CZ**0.5
 
 
 @pytest.mark.parametrize('gate', [cirq.X, cirq.Y, cirq.Z])
 def test_x_y_z_stabilizer(gate):
     assert cirq.has_stabilizer_effect(gate)
-    assert cirq.has_stabilizer_effect(gate ** 0.5)
-    assert cirq.has_stabilizer_effect(gate ** 0)
-    assert cirq.has_stabilizer_effect(gate ** -0.5)
-    assert cirq.has_stabilizer_effect(gate ** 4)
-    assert not cirq.has_stabilizer_effect(gate ** 1.2)
+    assert cirq.has_stabilizer_effect(gate**0.5)
+    assert cirq.has_stabilizer_effect(gate**0)
+    assert cirq.has_stabilizer_effect(gate**-0.5)
+    assert cirq.has_stabilizer_effect(gate**4)
+    assert not cirq.has_stabilizer_effect(gate**1.2)
     foo = sympy.Symbol('foo')
-    assert not cirq.has_stabilizer_effect(gate ** foo)
+    assert not cirq.has_stabilizer_effect(gate**foo)
 
 
 def test_h_stabilizer():
     gate = cirq.H
     assert cirq.has_stabilizer_effect(gate)
-    assert not cirq.has_stabilizer_effect(gate ** 0.5)
-    assert cirq.has_stabilizer_effect(gate ** 0)
-    assert not cirq.has_stabilizer_effect(gate ** -0.5)
-    assert cirq.has_stabilizer_effect(gate ** 4)
-    assert not cirq.has_stabilizer_effect(gate ** 1.2)
+    assert not cirq.has_stabilizer_effect(gate**0.5)
+    assert cirq.has_stabilizer_effect(gate**0)
+    assert not cirq.has_stabilizer_effect(gate**-0.5)
+    assert cirq.has_stabilizer_effect(gate**4)
+    assert not cirq.has_stabilizer_effect(gate**1.2)
     foo = sympy.Symbol('foo')
-    assert not cirq.has_stabilizer_effect(gate ** foo)
+    assert not cirq.has_stabilizer_effect(gate**foo)
 
 
 @pytest.mark.parametrize('gate', [cirq.CX, cirq.CZ])
 def test_cx_cz_stabilizer(gate):
     assert cirq.has_stabilizer_effect(gate)
-    assert not cirq.has_stabilizer_effect(gate ** 0.5)
-    assert cirq.has_stabilizer_effect(gate ** 0)
-    assert not cirq.has_stabilizer_effect(gate ** -0.5)
-    assert cirq.has_stabilizer_effect(gate ** 4)
-    assert not cirq.has_stabilizer_effect(gate ** 1.2)
+    assert not cirq.has_stabilizer_effect(gate**0.5)
+    assert cirq.has_stabilizer_effect(gate**0)
+    assert not cirq.has_stabilizer_effect(gate**-0.5)
+    assert cirq.has_stabilizer_effect(gate**4)
+    assert not cirq.has_stabilizer_effect(gate**1.2)
     foo = sympy.Symbol('foo')
-    assert not cirq.has_stabilizer_effect(gate ** foo)
+    assert not cirq.has_stabilizer_effect(gate**foo)
 
 
 def test_phase_by_xy():
     with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=8):
         assert cirq.phase_by(cirq.X, 0.25, 0) == cirq.Y
         assert cirq.phase_by(cirq.Y, 0.75, 0) == cirq.X
-        assert cirq.phase_by(cirq.X ** 0.5, 0.25, 0) == cirq.Y ** 0.5
-        assert cirq.phase_by(cirq.X ** -0.5, 0.25, 0) == cirq.Y ** -0.5
+        assert cirq.phase_by(cirq.X**0.5, 0.25, 0) == cirq.Y**0.5
+        assert cirq.phase_by(cirq.X**-0.5, 0.25, 0) == cirq.Y**-0.5
 
 
 def test_ixyz_circuit_diagram():
@@ -1110,12 +1110,12 @@ q: ───Rz(π)───Rz(-π)───Rz(-π)───Rz(0.5π)───Rz(
 
 def test_trace_distance():
     foo = sympy.Symbol('foo')
-    sx = cirq.X ** foo
-    sy = cirq.Y ** foo
-    sz = cirq.Z ** foo
-    sh = cirq.H ** foo
-    scx = cirq.CX ** foo
-    scz = cirq.CZ ** foo
+    sx = cirq.X**foo
+    sy = cirq.Y**foo
+    sz = cirq.Z**foo
+    sh = cirq.H**foo
+    scx = cirq.CX**foo
+    scz = cirq.CZ**foo
     # These values should have 1.0 or 0.0 directly returned
     assert cirq.trace_distance_bound(sx) == 1.0
     assert cirq.trace_distance_bound(sy) == 1.0
@@ -1126,23 +1126,23 @@ def test_trace_distance():
     assert cirq.trace_distance_bound(cirq.I) == 0.0
     # These values are calculated, so we use approx_eq
     assert cirq.approx_eq(cirq.trace_distance_bound(cirq.X), 1.0)
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Y ** -1), 1.0)
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Z ** 0.5), np.sin(np.pi / 4))
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.H ** 0.25), np.sin(np.pi / 8))
-    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.CX ** 2), 0.0)
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Y**-1), 1.0)
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.Z**0.5), np.sin(np.pi / 4))
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.H**0.25), np.sin(np.pi / 8))
+    assert cirq.approx_eq(cirq.trace_distance_bound(cirq.CX**2), 0.0)
     assert cirq.approx_eq(cirq.trace_distance_bound(cirq.CZ ** (1 / 9)), np.sin(np.pi / 18))
 
 
 def test_commutes():
     assert cirq.commutes(cirq.ZPowGate(exponent=sympy.Symbol('t')), cirq.Z)
     assert cirq.commutes(cirq.Z, cirq.Z(cirq.LineQubit(0)), default=None) is None
-    assert cirq.commutes(cirq.Z ** 0.1, cirq.XPowGate(exponent=0))
+    assert cirq.commutes(cirq.Z**0.1, cirq.XPowGate(exponent=0))
 
 
 def test_approx_eq():
-    assert cirq.approx_eq(cirq.Z ** 0.1, cirq.Z ** 0.2, atol=0.3)
-    assert not cirq.approx_eq(cirq.Z ** 0.1, cirq.Z ** 0.2, atol=0.05)
-    assert cirq.approx_eq(cirq.Y ** 0.1, cirq.Y ** 0.2, atol=0.3)
-    assert not cirq.approx_eq(cirq.Y ** 0.1, cirq.Y ** 0.2, atol=0.05)
-    assert cirq.approx_eq(cirq.X ** 0.1, cirq.X ** 0.2, atol=0.3)
-    assert not cirq.approx_eq(cirq.X ** 0.1, cirq.X ** 0.2, atol=0.05)
+    assert cirq.approx_eq(cirq.Z**0.1, cirq.Z**0.2, atol=0.3)
+    assert not cirq.approx_eq(cirq.Z**0.1, cirq.Z**0.2, atol=0.05)
+    assert cirq.approx_eq(cirq.Y**0.1, cirq.Y**0.2, atol=0.3)
+    assert not cirq.approx_eq(cirq.Y**0.1, cirq.Y**0.2, atol=0.05)
+    assert cirq.approx_eq(cirq.X**0.1, cirq.X**0.2, atol=0.3)
+    assert not cirq.approx_eq(cirq.X**0.1, cirq.X**0.2, atol=0.05)

--- a/cirq-core/cirq/ops/matrix_gates.py
+++ b/cirq-core/cirq/ops/matrix_gates.py
@@ -71,7 +71,7 @@ class MatrixGate(raw_types.Gate):
 
         if qid_shape is None:
             n = int(np.round(np.log2(matrix.shape[0] or 1)))
-            if 2 ** n != matrix.shape[0]:
+            if 2**n != matrix.shape[0]:
                 raise ValueError(
                     f'Matrix width ({matrix.shape[0]}) is not a power of 2 and '
                     f'qid_shape is not specified.'
@@ -109,7 +109,7 @@ class MatrixGate(raw_types.Gate):
         if not isinstance(exponent, (int, float)):
             return NotImplemented
         e = cast(float, exponent)
-        new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b ** e)
+        new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b**e)
         return MatrixGate(new_mat, qid_shape=self._qid_shape)
 
     def _phase_by_(self, phase_turns: float, qubit_index: int) -> 'MatrixGate':

--- a/cirq-core/cirq/ops/matrix_gates.py
+++ b/cirq-core/cirq/ops/matrix_gates.py
@@ -71,7 +71,7 @@ class MatrixGate(raw_types.Gate):
 
         if qid_shape is None:
             n = int(np.round(np.log2(matrix.shape[0] or 1)))
-            if 2**n != matrix.shape[0]:
+            if 2 ** n != matrix.shape[0]:
                 raise ValueError(
                     f'Matrix width ({matrix.shape[0]}) is not a power of 2 and '
                     f'qid_shape is not specified.'
@@ -109,7 +109,7 @@ class MatrixGate(raw_types.Gate):
         if not isinstance(exponent, (int, float)):
             return NotImplemented
         e = cast(float, exponent)
-        new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b**e)
+        new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b ** e)
         return MatrixGate(new_mat, qid_shape=self._qid_shape)
 
     def _phase_by_(self, phase_turns: float, qubit_index: int) -> 'MatrixGate':
@@ -125,6 +125,9 @@ class MatrixGate(raw_types.Gate):
         result[linalg.slice_for_qubits_equal_to([i], 1)] *= p
         result[linalg.slice_for_qubits_equal_to([j], 1)] *= np.conj(p)
         return MatrixGate(matrix=result.reshape(self._matrix.shape), qid_shape=self._qid_shape)
+
+    def phase_by(self, phase_turns: float, qubit_index: int) -> 'MatrixGate':
+        return self._phase_by_(phase_turns, qubit_index)
 
     def _decompose_(self, qubits: Tuple['cirq.Qid', ...]) -> 'cirq.OP_TREE':
         if self._qid_shape == (2,):

--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -80,16 +80,16 @@ def test_single_qubit_extrapolate():
     assert cirq.has_unitary(x2)
     x2i = cirq.MatrixGate(np.conj(cirq.unitary(x2).T))
 
-    assert cirq.approx_eq(x ** 0, i, atol=1e-9)
-    assert cirq.approx_eq(x2 ** 0, i, atol=1e-9)
-    assert cirq.approx_eq(x2 ** 2, x, atol=1e-9)
-    assert cirq.approx_eq(x2 ** -1, x2i, atol=1e-9)
-    assert cirq.approx_eq(x2 ** 3, x2i, atol=1e-9)
-    assert cirq.approx_eq(x ** -1, x, atol=1e-9)
+    assert cirq.approx_eq(x**0, i, atol=1e-9)
+    assert cirq.approx_eq(x2**0, i, atol=1e-9)
+    assert cirq.approx_eq(x2**2, x, atol=1e-9)
+    assert cirq.approx_eq(x2**-1, x2i, atol=1e-9)
+    assert cirq.approx_eq(x2**3, x2i, atol=1e-9)
+    assert cirq.approx_eq(x**-1, x, atol=1e-9)
 
     z2 = cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))
     z4 = cirq.MatrixGate(np.array([[1, 0], [0, (1 + 1j) * np.sqrt(0.5)]]))
-    assert cirq.approx_eq(z2 ** 0.5, z4, atol=1e-9)
+    assert cirq.approx_eq(z2**0.5, z4, atol=1e-9)
     with pytest.raises(TypeError):
         _ = x ** sympy.Symbol('a')
 
@@ -125,9 +125,9 @@ def test_two_qubit_extrapolate():
     cz4 = cirq.MatrixGate(np.diag([1, 1, 1, (1 + 1j) * np.sqrt(0.5)]))
     i = cirq.MatrixGate(np.eye(4))
 
-    assert cirq.approx_eq(cz2 ** 0, i, atol=1e-9)
-    assert cirq.approx_eq(cz4 ** 0, i, atol=1e-9)
-    assert cirq.approx_eq(cz2 ** 0.5, cz4, atol=1e-9)
+    assert cirq.approx_eq(cz2**0, i, atol=1e-9)
+    assert cirq.approx_eq(cz4**0, i, atol=1e-9)
+    assert cirq.approx_eq(cz2**0.5, cz4, atol=1e-9)
     with pytest.raises(TypeError):
         _ = cz2 ** sympy.Symbol('a')
 
@@ -278,7 +278,7 @@ def test_str_executes():
 
 @pytest.mark.parametrize('n', [1, 2, 3, 4, 5])
 def test_implements_consistent_protocols(n):
-    u = cirq.testing.random_unitary(2 ** n)
+    u = cirq.testing.random_unitary(2**n)
     g1 = cirq.MatrixGate(u)
     cirq.testing.assert_implements_consistent_protocols(g1, ignoring_global_phase=True)
     cirq.testing.assert_decompose_ends_at_default_gateset(g1)
@@ -323,7 +323,7 @@ def test_matrix_gate_pow():
     assert cirq.pow(cirq.MatrixGate(1j * np.eye(1)), 2) == cirq.MatrixGate(-np.eye(1))
 
     m = cirq.MatrixGate(np.diag([1, 1j, -1]), qid_shape=(3,))
-    assert m ** 3 == cirq.MatrixGate(np.diag([1, -1j, -1]), qid_shape=(3,))
+    assert m**3 == cirq.MatrixGate(np.diag([1, -1j, -1]), qid_shape=(3,))
 
 
 def test_phase_by():

--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -80,16 +80,16 @@ def test_single_qubit_extrapolate():
     assert cirq.has_unitary(x2)
     x2i = cirq.MatrixGate(np.conj(cirq.unitary(x2).T))
 
-    assert cirq.approx_eq(x**0, i, atol=1e-9)
-    assert cirq.approx_eq(x2**0, i, atol=1e-9)
-    assert cirq.approx_eq(x2**2, x, atol=1e-9)
-    assert cirq.approx_eq(x2**-1, x2i, atol=1e-9)
-    assert cirq.approx_eq(x2**3, x2i, atol=1e-9)
-    assert cirq.approx_eq(x**-1, x, atol=1e-9)
+    assert cirq.approx_eq(x ** 0, i, atol=1e-9)
+    assert cirq.approx_eq(x2 ** 0, i, atol=1e-9)
+    assert cirq.approx_eq(x2 ** 2, x, atol=1e-9)
+    assert cirq.approx_eq(x2 ** -1, x2i, atol=1e-9)
+    assert cirq.approx_eq(x2 ** 3, x2i, atol=1e-9)
+    assert cirq.approx_eq(x ** -1, x, atol=1e-9)
 
     z2 = cirq.MatrixGate(np.array([[1, 0], [0, 1j]]))
     z4 = cirq.MatrixGate(np.array([[1, 0], [0, (1 + 1j) * np.sqrt(0.5)]]))
-    assert cirq.approx_eq(z2**0.5, z4, atol=1e-9)
+    assert cirq.approx_eq(z2 ** 0.5, z4, atol=1e-9)
     with pytest.raises(TypeError):
         _ = x ** sympy.Symbol('a')
 
@@ -125,9 +125,9 @@ def test_two_qubit_extrapolate():
     cz4 = cirq.MatrixGate(np.diag([1, 1, 1, (1 + 1j) * np.sqrt(0.5)]))
     i = cirq.MatrixGate(np.eye(4))
 
-    assert cirq.approx_eq(cz2**0, i, atol=1e-9)
-    assert cirq.approx_eq(cz4**0, i, atol=1e-9)
-    assert cirq.approx_eq(cz2**0.5, cz4, atol=1e-9)
+    assert cirq.approx_eq(cz2 ** 0, i, atol=1e-9)
+    assert cirq.approx_eq(cz4 ** 0, i, atol=1e-9)
+    assert cirq.approx_eq(cz2 ** 0.5, cz4, atol=1e-9)
     with pytest.raises(TypeError):
         _ = cz2 ** sympy.Symbol('a')
 
@@ -278,7 +278,7 @@ def test_str_executes():
 
 @pytest.mark.parametrize('n', [1, 2, 3, 4, 5])
 def test_implements_consistent_protocols(n):
-    u = cirq.testing.random_unitary(2**n)
+    u = cirq.testing.random_unitary(2 ** n)
     g1 = cirq.MatrixGate(u)
     cirq.testing.assert_implements_consistent_protocols(g1, ignoring_global_phase=True)
     cirq.testing.assert_decompose_ends_at_default_gateset(g1)
@@ -323,31 +323,39 @@ def test_matrix_gate_pow():
     assert cirq.pow(cirq.MatrixGate(1j * np.eye(1)), 2) == cirq.MatrixGate(-np.eye(1))
 
     m = cirq.MatrixGate(np.diag([1, 1j, -1]), qid_shape=(3,))
-    assert m**3 == cirq.MatrixGate(np.diag([1, -1j, -1]), qid_shape=(3,))
+    assert m ** 3 == cirq.MatrixGate(np.diag([1, -1j, -1]), qid_shape=(3,))
 
 
 def test_phase_by():
-    # Single qubit case.
-    x = cirq.MatrixGate(cirq.unitary(cirq.X))
-    y = cirq.phase_by(x, 0.25, 0)
-    cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(y), cirq.unitary(cirq.Y), atol=1e-8
-    )
+    with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=4):
+        # Single qubit case.
+        x = cirq.MatrixGate(cirq.unitary(cirq.X))
+        y = cirq.phase_by(x, 0.25, 0)
+        cirq.testing.assert_allclose_up_to_global_phase(
+            cirq.unitary(y), cirq.unitary(cirq.Y), atol=1e-8
+        )
 
-    # Two qubit case. Commutes with control.
-    cx = cirq.MatrixGate(cirq.unitary(cirq.X.controlled(1)))
-    cx2 = cirq.phase_by(cx, 0.25, 0)
-    cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(cx2), cirq.unitary(cx), atol=1e-8)
+        y2 = x.phase_by(0.25, 0)
+        cirq.testing.assert_allclose_up_to_global_phase(
+            cirq.unitary(y2), cirq.unitary(cirq.Y), atol=1e-8
+        )
 
-    # Two qubit case. Doesn't commute with target.
-    cy = cirq.phase_by(cx, 0.25, 1)
-    cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(cy), cirq.unitary(cirq.Y.controlled(1)), atol=1e-8
-    )
+        # Two qubit case. Commutes with control.
+        cx = cirq.MatrixGate(cirq.unitary(cirq.X.controlled(1)))
+        cx2 = cirq.phase_by(cx, 0.25, 0)
+        cirq.testing.assert_allclose_up_to_global_phase(
+            cirq.unitary(cx2), cirq.unitary(cx), atol=1e-8
+        )
 
-    m = cirq.MatrixGate(np.eye(3), qid_shape=[3])
-    with pytest.raises(TypeError, match='returned NotImplemented'):
-        _ = cirq.phase_by(m, 0.25, 0)
+        # Two qubit case. Doesn't commute with target.
+        cy = cirq.phase_by(cx, 0.25, 1)
+        cirq.testing.assert_allclose_up_to_global_phase(
+            cirq.unitary(cy), cirq.unitary(cirq.Y.controlled(1)), atol=1e-8
+        )
+
+        m = cirq.MatrixGate(np.eye(3), qid_shape=[3])
+        with pytest.raises(TypeError, match='returned NotImplemented'):
+            _ = cirq.phase_by(m, 0.25, 0)
 
 
 def test_protocols_and_repr():

--- a/cirq-core/cirq/ops/phased_x_gate.py
+++ b/cirq-core/cirq/ops/phased_x_gate.py
@@ -56,7 +56,7 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
 
         e = cast(float, value.canonicalize_half_turns(self._exponent))
         p = cast(float, self.phase_exponent)
-        epsilon = 10 ** -args.precision
+        epsilon = 10**-args.precision
 
         if abs(e + 0.5) <= epsilon:
             return args.format(
@@ -81,7 +81,7 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         q = qubits[0]
         z = cirq.Z(q) ** self._phase_exponent
         x = cirq.XPowGate(exponent=self._exponent, global_shift=self.global_shift).on(q)
-        return z ** -1, x, z
+        return z**-1, x, z
 
     @property
     def exponent(self) -> Union[float, sympy.Symbol]:
@@ -119,8 +119,8 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         """See `cirq.SupportsUnitary`."""
         if self._is_parameterized_():
             return None
-        z = protocols.unitary(cirq.Z ** self._phase_exponent)
-        x = protocols.unitary(cirq.X ** self._exponent)
+        z = protocols.unitary(cirq.Z**self._phase_exponent)
+        x = protocols.unitary(cirq.X**self._exponent)
         p = np.exp(1j * np.pi * self._global_shift * self._exponent)
         return np.dot(np.dot(z, x), np.conj(z)) * p
 

--- a/cirq-core/cirq/ops/phased_x_gate.py
+++ b/cirq-core/cirq/ops/phased_x_gate.py
@@ -20,7 +20,7 @@ import sympy
 
 import cirq
 from cirq import value, protocols
-from cirq._compat import proper_repr
+from cirq._compat import deprecated, proper_repr
 from cirq.ops import gate_features, common_gates
 from cirq.type_workarounds import NotImplementedType
 
@@ -56,7 +56,7 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
 
         e = cast(float, value.canonicalize_half_turns(self._exponent))
         p = cast(float, self.phase_exponent)
-        epsilon = 10**-args.precision
+        epsilon = 10 ** -args.precision
 
         if abs(e + 0.5) <= epsilon:
             return args.format(
@@ -81,7 +81,7 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         q = qubits[0]
         z = cirq.Z(q) ** self._phase_exponent
         x = cirq.XPowGate(exponent=self._exponent, global_shift=self.global_shift).on(q)
-        return z**-1, x, z
+        return z ** -1, x, z
 
     @property
     def exponent(self) -> Union[float, sympy.Symbol]:
@@ -119,8 +119,8 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
         """See `cirq.SupportsUnitary`."""
         if self._is_parameterized_():
             return None
-        z = protocols.unitary(cirq.Z**self._phase_exponent)
-        x = protocols.unitary(cirq.X**self._exponent)
+        z = protocols.unitary(cirq.Z ** self._phase_exponent)
+        x = protocols.unitary(cirq.X ** self._exponent)
         p = np.exp(1j * np.pi * self._global_shift * self._exponent)
         return np.dot(np.dot(z, x), np.conj(z)) * p
 
@@ -160,8 +160,11 @@ class PhasedXPowGate(gate_features.SingleQubitGate):
             global_shift=self._global_shift,
         )
 
+    @deprecated(
+        fix='Create a new PhasedXPowGate with phase_exponent+=phase_turns * 2.',
+        deadline='v1.0',
+    )
     def _phase_by_(self, phase_turns, qubit_index):
-        """See `cirq.SupportsPhase`."""
         assert qubit_index == 0
         return PhasedXPowGate(
             exponent=self._exponent,

--- a/cirq-core/cirq/ops/phased_x_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_gate_test.py
@@ -75,16 +75,16 @@ def test_no_symbolic_qasm_but_fails_gracefully(sym):
 
 def test_extrapolate():
     g = cirq.PhasedXPowGate(phase_exponent=0.25)
-    assert g ** 0.25 == (g ** 0.5) ** 0.5
+    assert g**0.25 == (g**0.5) ** 0.5
 
     # The gate is self-inverse, but there are hidden variables tracking the
     # exponent's sign and scale.
-    assert g ** -1 == g
+    assert g**-1 == g
     assert g.exponent == 1
-    assert (g ** -1).exponent == -1
-    assert g ** -0.5 == (g ** -1) ** 0.5 != g ** 0.5
-    assert g == g ** 3
-    assert g ** 0.5 != (g ** 3) ** 0.5 == g ** -0.5
+    assert (g**-1).exponent == -1
+    assert g**-0.5 == (g**-1) ** 0.5 != g**0.5
+    assert g == g**3
+    assert g**0.5 != (g**3) ** 0.5 == g**-0.5
 
 
 def test_eq():
@@ -104,7 +104,7 @@ def test_eq():
         cirq.PhasedXPowGate(phase_exponent=2.5, exponent=3),
         cirq.Y,
     )
-    eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=0.5, exponent=0.25), cirq.Y ** 0.25)
+    eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=0.5, exponent=0.25), cirq.Y**0.25)
 
     eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=0.25, exponent=0.25, global_shift=0.1))
     eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=2.25, exponent=0.25, global_shift=0.2))

--- a/cirq-core/cirq/ops/phased_x_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_gate_test.py
@@ -75,16 +75,16 @@ def test_no_symbolic_qasm_but_fails_gracefully(sym):
 
 def test_extrapolate():
     g = cirq.PhasedXPowGate(phase_exponent=0.25)
-    assert g**0.25 == (g**0.5) ** 0.5
+    assert g ** 0.25 == (g ** 0.5) ** 0.5
 
     # The gate is self-inverse, but there are hidden variables tracking the
     # exponent's sign and scale.
-    assert g**-1 == g
+    assert g ** -1 == g
     assert g.exponent == 1
-    assert (g**-1).exponent == -1
-    assert g**-0.5 == (g**-1) ** 0.5 != g**0.5
-    assert g == g**3
-    assert g**0.5 != (g**3) ** 0.5 == g**-0.5
+    assert (g ** -1).exponent == -1
+    assert g ** -0.5 == (g ** -1) ** 0.5 != g ** 0.5
+    assert g == g ** 3
+    assert g ** 0.5 != (g ** 3) ** 0.5 == g ** -0.5
 
 
 def test_eq():
@@ -104,7 +104,7 @@ def test_eq():
         cirq.PhasedXPowGate(phase_exponent=2.5, exponent=3),
         cirq.Y,
     )
-    eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=0.5, exponent=0.25), cirq.Y**0.25)
+    eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=0.5, exponent=0.25), cirq.Y ** 0.25)
 
     eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=0.25, exponent=0.25, global_shift=0.1))
     eq.add_equality_group(cirq.PhasedXPowGate(phase_exponent=2.25, exponent=0.25, global_shift=0.2))
@@ -234,21 +234,22 @@ q: ───PhX(a)^b───PhX(2*a)^(b + 1)───PhX(0.25)───PhX(1)�
 
 
 def test_phase_by():
-    g = cirq.PhasedXPowGate(phase_exponent=0.25)
-    g2 = cirq.phase_by(g, 0.25, 0)
-    assert g2 == cirq.PhasedXPowGate(phase_exponent=0.75)
+    with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=8):
+        g = cirq.PhasedXPowGate(phase_exponent=0.25)
+        g2 = cirq.phase_by(g, 0.25, 0)
+        assert g2 == cirq.PhasedXPowGate(phase_exponent=0.75)
 
-    g = cirq.PhasedXPowGate(phase_exponent=0)
-    g2 = cirq.phase_by(g, 0.125, 0)
-    assert g2 == cirq.PhasedXPowGate(phase_exponent=0.25)
+        g = cirq.PhasedXPowGate(phase_exponent=0)
+        g2 = cirq.phase_by(g, 0.125, 0)
+        assert g2 == cirq.PhasedXPowGate(phase_exponent=0.25)
 
-    g = cirq.PhasedXPowGate(phase_exponent=0.5)
-    g2 = cirq.phase_by(g, 0.125, 0)
-    assert g2 == cirq.PhasedXPowGate(phase_exponent=0.75)
+        g = cirq.PhasedXPowGate(phase_exponent=0.5)
+        g2 = cirq.phase_by(g, 0.125, 0)
+        assert g2 == cirq.PhasedXPowGate(phase_exponent=0.75)
 
-    g = cirq.PhasedXPowGate(phase_exponent=0.5)
-    g2 = cirq.phase_by(g, sympy.Symbol('b') + 1, 0)
-    assert g2 == cirq.PhasedXPowGate(phase_exponent=2 * sympy.Symbol('b') + 2.5)
+        g = cirq.PhasedXPowGate(phase_exponent=0.5)
+        g2 = cirq.phase_by(g, sympy.Symbol('b') + 1, 0)
+        assert g2 == cirq.PhasedXPowGate(phase_exponent=2 * sympy.Symbol('b') + 2.5)
 
 
 @pytest.mark.parametrize(

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -145,8 +145,8 @@ class PhasedXZGate(gate_features.SingleQubitGate):
         """See `cirq.SupportsUnitary`."""
         if self._is_parameterized_():
             return None
-        z_pre = protocols.unitary(ops.Z ** -self._axis_phase_exponent)
-        x = protocols.unitary(ops.X ** self._x_exponent)
+        z_pre = protocols.unitary(ops.Z**-self._axis_phase_exponent)
+        x = protocols.unitary(ops.X**self._x_exponent)
         z_post = protocols.unitary(ops.Z ** (self._axis_phase_exponent + self._z_exponent))
         return z_post @ x @ z_pre
 

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -7,7 +7,7 @@ import sympy
 
 from cirq import value, ops, protocols, linalg
 from cirq.ops import gate_features
-from cirq._compat import proper_repr
+from cirq._compat import proper_repr, deprecated
 
 if TYPE_CHECKING:
     import cirq
@@ -145,8 +145,8 @@ class PhasedXZGate(gate_features.SingleQubitGate):
         """See `cirq.SupportsUnitary`."""
         if self._is_parameterized_():
             return None
-        z_pre = protocols.unitary(ops.Z**-self._axis_phase_exponent)
-        x = protocols.unitary(ops.X**self._x_exponent)
+        z_pre = protocols.unitary(ops.Z ** -self._axis_phase_exponent)
+        x = protocols.unitary(ops.X ** self._x_exponent)
         z_post = protocols.unitary(ops.Z ** (self._axis_phase_exponent + self._z_exponent))
         return z_post @ x @ z_pre
 
@@ -193,8 +193,11 @@ class PhasedXZGate(gate_features.SingleQubitGate):
             axis_phase_exponent=resolver.value_of(self._axis_phase_exponent, recursive),
         )
 
+    @deprecated(
+        fix='Create a new PhasedXZGate with axis_phase_exponent+=phase_turns * 2.',
+        deadline='v1.0',
+    )
     def _phase_by_(self, phase_turns, qubit_index) -> 'cirq.PhasedXZGate':
-        """See `cirq.SupportsPhase`."""
         assert qubit_index == 0
         return PhasedXZGate(
             x_exponent=self._x_exponent,

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -231,6 +231,11 @@ def test_protocols():
     g = cirq.PhasedXZGate(x_exponent=a, z_exponent=b, axis_phase_exponent=t)
     cirq.testing.assert_implements_consistent_protocols(g)
 
+    with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=2):
+      gate = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=0)
+      expected = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=1.0)
+      assert cirq.phase_by(gate, 0.5, 0) == expected
+
 
 def test_inverse():
     a = random.random()

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -124,32 +124,32 @@ def test_canonicalization():
 def test_from_matrix():
     # Axis rotations.
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X**0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X ** 0.1)),
         cirq.PhasedXZGate(x_exponent=0.1, z_exponent=0, axis_phase_exponent=0),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X**-0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X ** -0.1)),
         cirq.PhasedXZGate(x_exponent=-0.1, z_exponent=0, axis_phase_exponent=0),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y**0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y ** 0.1)),
         cirq.PhasedXZGate(x_exponent=0.1, z_exponent=0, axis_phase_exponent=0.5),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y**-0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y ** -0.1)),
         cirq.PhasedXZGate(x_exponent=-0.1, z_exponent=0, axis_phase_exponent=0.5),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z**-0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z ** -0.1)),
         cirq.PhasedXZGate(x_exponent=0, z_exponent=-0.1, axis_phase_exponent=0),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z**0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z ** 0.1)),
         cirq.PhasedXZGate(x_exponent=0, z_exponent=0.1, axis_phase_exponent=0),
         atol=1e-8,
     )
@@ -232,9 +232,9 @@ def test_protocols():
     cirq.testing.assert_implements_consistent_protocols(g)
 
     with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=2):
-      gate = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=0)
-      expected = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=1.0)
-      assert cirq.phase_by(gate, 0.5, 0) == expected
+        gate = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=0)
+        expected = cirq.PhasedXZGate(x_exponent=0, z_exponent=0, axis_phase_exponent=1.0)
+        assert cirq.phase_by(gate, 0.5, 0) == expected
 
 
 def test_inverse():
@@ -245,7 +245,7 @@ def test_inverse():
     g = cirq.PhasedXZGate(x_exponent=a, z_exponent=b, axis_phase_exponent=c).on(q)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(g**-1), np.transpose(np.conjugate(cirq.unitary(g))), atol=1e-8
+        cirq.unitary(g ** -1), np.transpose(np.conjugate(cirq.unitary(g))), atol=1e-8
     )
 
 

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -124,32 +124,32 @@ def test_canonicalization():
 def test_from_matrix():
     # Axis rotations.
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X ** 0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X**0.1)),
         cirq.PhasedXZGate(x_exponent=0.1, z_exponent=0, axis_phase_exponent=0),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X ** -0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.X**-0.1)),
         cirq.PhasedXZGate(x_exponent=-0.1, z_exponent=0, axis_phase_exponent=0),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y ** 0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y**0.1)),
         cirq.PhasedXZGate(x_exponent=0.1, z_exponent=0, axis_phase_exponent=0.5),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y ** -0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Y**-0.1)),
         cirq.PhasedXZGate(x_exponent=-0.1, z_exponent=0, axis_phase_exponent=0.5),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z ** -0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z**-0.1)),
         cirq.PhasedXZGate(x_exponent=0, z_exponent=-0.1, axis_phase_exponent=0),
         atol=1e-8,
     )
     assert cirq.approx_eq(
-        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z ** 0.1)),
+        cirq.PhasedXZGate.from_matrix(cirq.unitary(cirq.Z**0.1)),
         cirq.PhasedXZGate(x_exponent=0, z_exponent=0.1, axis_phase_exponent=0),
         atol=1e-8,
     )
@@ -245,7 +245,7 @@ def test_inverse():
     g = cirq.PhasedXZGate(x_exponent=a, z_exponent=b, axis_phase_exponent=c).on(q)
 
     cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(g ** -1), np.transpose(np.conjugate(cirq.unitary(g))), atol=1e-8
+        cirq.unitary(g**-1), np.transpose(np.conjugate(cirq.unitary(g))), atol=1e-8
     )
 
 

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -171,9 +171,9 @@ def test_default_validation_and_inverse():
         TestGate().on(a)
 
     t = TestGate().on(a, b)
-    i = t ** -1
-    assert i ** -1 == t
-    assert t ** -1 == i
+    i = t**-1
+    assert i**-1 == t
+    assert t**-1 == i
     assert cirq.decompose(i) == [cirq.X(a), cirq.S(b) ** -1, cirq.Z(a)]
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(i), cirq.unitary(t).conj().T, atol=1e-8
@@ -188,7 +188,7 @@ def test_default_inverse():
             return 3
 
         def _decompose_(self, qubits):
-            return (cirq.X ** 0.1).on_each(*qubits)
+            return (cirq.X**0.1).on_each(*qubits)
 
     assert cirq.inverse(TestGate(), None) is not None
     cirq.testing.assert_has_consistent_qid_shape(cirq.inverse(TestGate()))
@@ -214,7 +214,7 @@ def test_default_qudit_inverse():
             return (1, 2, 3)
 
         def _decompose_(self, qubits):
-            return (cirq.X ** 0.1).on(qubits[1])
+            return (cirq.X**0.1).on(qubits[1])
 
     assert cirq.qid_shape(cirq.inverse(TestGate(), None)) == (1, 2, 3)
     cirq.testing.assert_has_consistent_qid_shape(cirq.inverse(TestGate()))
@@ -616,7 +616,7 @@ def test_tagged_operation_forwards_protocols():
 
     y = cirq.Y(q1)
     tagged_y = cirq.Y(q1).with_tags(tag)
-    assert tagged_y ** 0.5 == cirq.YPowGate(exponent=0.5)(q1)
+    assert tagged_y**0.5 == cirq.YPowGate(exponent=0.5)(q1)
     assert tagged_y * 2 == (y * 2)
     assert 3 * tagged_y == (3 * y)
     controlled_y = tagged_y.controlled_by(q2)
@@ -634,8 +634,8 @@ def test_tagged_operation_forwards_protocols():
     assert cirq.commutes(clifford_x, tagged_x)
     assert cirq.commutes(tagged_x, tagged_x)
 
-    assert cirq.trace_distance_bound(y ** 0.001) == cirq.trace_distance_bound(
-        (y ** 0.001).with_tags(tag)
+    assert cirq.trace_distance_bound(y**0.001) == cirq.trace_distance_bound(
+        (y**0.001).with_tags(tag)
     )
 
     flip = cirq.bit_flip(0.5)(q1)

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -171,9 +171,9 @@ def test_default_validation_and_inverse():
         TestGate().on(a)
 
     t = TestGate().on(a, b)
-    i = t**-1
-    assert i**-1 == t
-    assert t**-1 == i
+    i = t ** -1
+    assert i ** -1 == t
+    assert t ** -1 == i
     assert cirq.decompose(i) == [cirq.X(a), cirq.S(b) ** -1, cirq.Z(a)]
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(i), cirq.unitary(t).conj().T, atol=1e-8
@@ -188,7 +188,7 @@ def test_default_inverse():
             return 3
 
         def _decompose_(self, qubits):
-            return (cirq.X**0.1).on_each(*qubits)
+            return (cirq.X ** 0.1).on_each(*qubits)
 
     assert cirq.inverse(TestGate(), None) is not None
     cirq.testing.assert_has_consistent_qid_shape(cirq.inverse(TestGate()))
@@ -214,7 +214,7 @@ def test_default_qudit_inverse():
             return (1, 2, 3)
 
         def _decompose_(self, qubits):
-            return (cirq.X**0.1).on(qubits[1])
+            return (cirq.X ** 0.1).on(qubits[1])
 
     assert cirq.qid_shape(cirq.inverse(TestGate(), None)) == (1, 2, 3)
     cirq.testing.assert_has_consistent_qid_shape(cirq.inverse(TestGate()))
@@ -616,10 +616,9 @@ def test_tagged_operation_forwards_protocols():
 
     y = cirq.Y(q1)
     tagged_y = cirq.Y(q1).with_tags(tag)
-    assert tagged_y**0.5 == cirq.YPowGate(exponent=0.5)(q1)
+    assert tagged_y ** 0.5 == cirq.YPowGate(exponent=0.5)(q1)
     assert tagged_y * 2 == (y * 2)
     assert 3 * tagged_y == (3 * y)
-    assert cirq.phase_by(y, 0.125, 0) == cirq.phase_by(tagged_y, 0.125, 0)
     controlled_y = tagged_y.controlled_by(q2)
     assert controlled_y.qubits == (
         q2,
@@ -635,8 +634,8 @@ def test_tagged_operation_forwards_protocols():
     assert cirq.commutes(clifford_x, tagged_x)
     assert cirq.commutes(tagged_x, tagged_x)
 
-    assert cirq.trace_distance_bound(y**0.001) == cirq.trace_distance_bound(
-        (y**0.001).with_tags(tag)
+    assert cirq.trace_distance_bound(y ** 0.001) == cirq.trace_distance_bound(
+        (y ** 0.001).with_tags(tag)
     )
 
     flip = cirq.bit_flip(0.5)(q1)

--- a/cirq-core/cirq/protocols/__init__.py
+++ b/cirq-core/cirq/protocols/__init__.py
@@ -154,7 +154,6 @@ from cirq.protocols.resolve_parameters import (
 )
 from cirq.protocols.phase_protocol import (
     phase_by,
-    SupportsPhase,
 )
 from cirq.protocols.qid_shape_protocol import (
     num_qubits,

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -154,7 +154,6 @@ TestSpec = ModuleJsonTestSpec(
         'SupportsMixture',
         'SupportsParameterization',
         'SupportsPauliExpansion',
-        'SupportsPhase',
         'SupportsQasm',
         'SupportsQasmWithArgs',
         'SupportsQasmWithArgsAndQubits',

--- a/cirq-core/cirq/protocols/phase_protocol.py
+++ b/cirq-core/cirq/protocols/phase_protocol.py
@@ -14,39 +14,20 @@
 
 from typing import Any, TypeVar
 
-from typing_extensions import Protocol
-
 # This is a special value to indicate that a type error should be returned.
 # This is used within phase_by to raise an error if no underlying
 # implementation of _phase_by_ exists.
-from cirq._doc import doc_private
+from cirq._compat import deprecated
 
 RaiseTypeErrorIfNotProvided: Any = ([],)
 
 TDefault = TypeVar('TDefault')
 
 
-class SupportsPhase(Protocol):
-    """An effect that can be phased around the Z axis of target qubits."""
-
-    @doc_private
-    def _phase_by_(self: Any, phase_turns: float, qubit_index: int):
-        """Returns a phased version of the effect.
-
-        Specifically, returns an object with matrix P U P^-1 (up to global
-        phase) where U is the given object's matrix and
-        P = Z(qubit_index)**(2 * phase_turns). For example, an X gate phased
-        by 90 degrees would be a Y gate.
-
-        Args:
-            phase_turns: The amount to phase the gate, in fractions of a whole
-                turn. Multiply by 2π to get radians.
-            qubit_index: The index of the target qubit the phasing applies to.
-        Returns:
-            The phased gate or operation.
-        """
-
-
+@deprecated(
+    fix='Create a new gate and add phase_turns * 2 to the relevant exponent.',
+    deadline='v1.0',
+)
 def phase_by(
     val: Any, phase_turns: float, qubit_index: int, default: TDefault = RaiseTypeErrorIfNotProvided
 ):

--- a/cirq-core/cirq/protocols/phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/phase_protocol_test.py
@@ -40,23 +40,23 @@ def test_phase_by():
     rin = ReturnsNotImplemented()
 
     # Without default
+    with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=8):
+        with pytest.raises(TypeError, match='no _phase_by_ method'):
+            _ = cirq.phase_by(n, 1, 0)
+        with pytest.raises(TypeError, match='returned NotImplemented'):
+            _ = cirq.phase_by(rin, 1, 0)
 
-    with pytest.raises(TypeError, match='no _phase_by_ method'):
-        _ = cirq.phase_by(n, 1, 0)
-    with pytest.raises(TypeError, match='returned NotImplemented'):
-        _ = cirq.phase_by(rin, 1, 0)
+        # With default
+        assert cirq.phase_by(n, 1, 0, default=None) is None
+        assert cirq.phase_by(rin, 1, 0, default=None) is None
 
-    # With default
-    assert cirq.phase_by(n, 1, 0, default=None) is None
-    assert cirq.phase_by(rin, 1, 0, default=None) is None
-
-    test = PhaseIsAddition(3)
-    assert test.phase == [0, 0, 0]
-    test = cirq.phase_by(test, 0.25, 0)
-    assert test.phase == [0.25, 0, 0]
-    test = cirq.phase_by(test, 0.25, 0)
-    assert test.phase == [0.50, 0, 0]
-    test = cirq.phase_by(test, 0.40, 1)
-    assert test.phase == [0.50, 0.40, 0]
-    test = cirq.phase_by(test, 0.40, 4)
-    assert test.phase == [0.50, 0.40, 0]
+        test = PhaseIsAddition(3)
+        assert test.phase == [0, 0, 0]
+        test = cirq.phase_by(test, 0.25, 0)
+        assert test.phase == [0.25, 0, 0]
+        test = cirq.phase_by(test, 0.25, 0)
+        assert test.phase == [0.50, 0, 0]
+        test = cirq.phase_by(test, 0.40, 1)
+        assert test.phase == [0.50, 0.40, 0]
+        test = cirq.phase_by(test, 0.40, 4)
+        assert test.phase == [0.50, 0.40, 0]

--- a/cirq-core/cirq/testing/consistent_phase_by.py
+++ b/cirq-core/cirq/testing/consistent_phase_by.py
@@ -18,9 +18,11 @@ import numpy as np
 import sympy
 
 from cirq import protocols, linalg
+from cirq._compat import deprecated
 from cirq.testing import lin_alg_utils
 
 
+@deprecated(fix='phase_by no longer needs to be tested', deadline='v1.0')
 def assert_phase_by_is_consistent_with_unitary(val: Any):
     """Uses `val._unitary_` to check `val._phase_by_`'s behavior."""
 

--- a/cirq-core/cirq/testing/consistent_phase_by_test.py
+++ b/cirq-core/cirq/testing/consistent_phase_by_test.py
@@ -24,7 +24,7 @@ class GoodPhaser:
         self.e = e
 
     def _unitary_(self):
-        return np.array([[0, 1j ** -self.e], [1j ** self.e, 0]])
+        return np.array([[0, 1j**-self.e], [1j**self.e, 0]])
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return GoodPhaser(self.e + phase_turns * 4)
@@ -43,8 +43,8 @@ class GoodQuditPhaser:
     def _unitary_(self):
         return np.array(
             [
-                [0, 1j ** -self.e, 0],
-                [0, 0, 1j ** self.e],
+                [0, 1j**-self.e, 0],
+                [0, 0, 1j**self.e],
                 [1, 0, 0],
             ]
         )
@@ -61,7 +61,7 @@ class BadPhaser:
         self.e = e
 
     def _unitary_(self):
-        return np.array([[0, 1j ** -(self.e * 2)], [1j ** self.e, 0]])
+        return np.array([[0, 1j ** -(self.e * 2)], [1j**self.e, 0]])
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return BadPhaser(self.e + phase_turns * 4)

--- a/cirq-core/cirq/testing/consistent_phase_by_test.py
+++ b/cirq-core/cirq/testing/consistent_phase_by_test.py
@@ -24,7 +24,7 @@ class GoodPhaser:
         self.e = e
 
     def _unitary_(self):
-        return np.array([[0, 1j**-self.e], [1j**self.e, 0]])
+        return np.array([[0, 1j ** -self.e], [1j ** self.e, 0]])
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return GoodPhaser(self.e + phase_turns * 4)
@@ -43,8 +43,8 @@ class GoodQuditPhaser:
     def _unitary_(self):
         return np.array(
             [
-                [0, 1j**-self.e, 0],
-                [0, 0, 1j**self.e],
+                [0, 1j ** -self.e, 0],
+                [0, 0, 1j ** self.e],
                 [1, 0, 0],
             ]
         )
@@ -61,7 +61,7 @@ class BadPhaser:
         self.e = e
 
     def _unitary_(self):
-        return np.array([[0, 1j ** -(self.e * 2)], [1j**self.e, 0]])
+        return np.array([[0, 1j ** -(self.e * 2)], [1j ** self.e, 0]])
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return BadPhaser(self.e + phase_turns * 4)
@@ -97,15 +97,16 @@ class SemiBadPhaser:
 
 
 def test_assert_phase_by_is_consistent_with_unitary():
-    cirq.testing.assert_phase_by_is_consistent_with_unitary(GoodPhaser(0.5))
+    with cirq.testing.assert_deprecated('phase_by', deadline='v1.0', count=23):
+        cirq.testing.assert_phase_by_is_consistent_with_unitary(GoodPhaser(0.5))
 
-    cirq.testing.assert_phase_by_is_consistent_with_unitary(GoodQuditPhaser(0.5))
+        cirq.testing.assert_phase_by_is_consistent_with_unitary(GoodQuditPhaser(0.5))
 
-    with pytest.raises(AssertionError, match='Phased unitary was incorrect for index #0'):
-        cirq.testing.assert_phase_by_is_consistent_with_unitary(BadPhaser(0.5))
+        with pytest.raises(AssertionError, match='Phased unitary was incorrect for index #0'):
+            cirq.testing.assert_phase_by_is_consistent_with_unitary(BadPhaser(0.5))
 
-    with pytest.raises(AssertionError, match='Phased unitary was incorrect for index #1'):
-        cirq.testing.assert_phase_by_is_consistent_with_unitary(SemiBadPhaser([0.5, 0.25]))
+        with pytest.raises(AssertionError, match='Phased unitary was incorrect for index #1'):
+            cirq.testing.assert_phase_by_is_consistent_with_unitary(SemiBadPhaser([0.5, 0.25]))
 
-    # Vacuous success.
-    cirq.testing.assert_phase_by_is_consistent_with_unitary(NotPhaser())
+        # Vacuous success.
+        cirq.testing.assert_phase_by_is_consistent_with_unitary(NotPhaser())

--- a/cirq-core/cirq/testing/consistent_protocols.py
+++ b/cirq-core/cirq/testing/consistent_protocols.py
@@ -28,9 +28,6 @@ from cirq.testing.consistent_decomposition import (
     assert_decompose_is_consistent_with_unitary,
     assert_decompose_ends_at_default_gateset,
 )
-from cirq.testing.consistent_phase_by import (
-    assert_phase_by_is_consistent_with_unitary,
-)
 from cirq.testing.consistent_qasm import (
     assert_qasm_is_consistent_with_unitary,
 )
@@ -75,7 +72,7 @@ def assert_implements_consistent_protocols(
         p = protocols.pow(val, exponent, None)
         if p is not None:
             _assert_meets_standards_helper(
-                val**exponent,
+                val ** exponent,
                 ignoring_global_phase=ignoring_global_phase,
                 setup_code=setup_code,
                 global_vals=global_vals,
@@ -163,7 +160,6 @@ def _assert_meets_standards_helper(
     assert_decompose_is_consistent_with_unitary(val, ignoring_global_phase=ignoring_global_phase)
     if not ignore_decompose_to_default_gateset:
         assert_decompose_ends_at_default_gateset(val)
-    assert_phase_by_is_consistent_with_unitary(val)
     assert_pauli_expansion_is_consistent_with_unitary(val)
     assert_equivalent_repr(
         val, setup_code=setup_code, global_vals=global_vals, local_vals=local_vals

--- a/cirq-core/cirq/testing/consistent_protocols.py
+++ b/cirq-core/cirq/testing/consistent_protocols.py
@@ -72,7 +72,7 @@ def assert_implements_consistent_protocols(
         p = protocols.pow(val, exponent, None)
         if p is not None:
             _assert_meets_standards_helper(
-                val ** exponent,
+                val**exponent,
                 ignoring_global_phase=ignoring_global_phase,
                 setup_code=setup_code,
                 global_vals=global_vals,

--- a/cirq-core/cirq/transformers/eject_z.py
+++ b/cirq-core/cirq/transformers/eject_z.py
@@ -146,7 +146,7 @@ def eject_z(
             if eject_parameterized or not protocols.is_parameterized(gate.z_exponent):
                 qubit = phased_op.qubits[0]
                 qubit_phase[qubit] += gate.z_exponent / 2
-                gate = gate.with_z_exponent(0)
+                gate = phased_op.gate.with_z_exponent(0)
                 phased_op = gate.on(qubit)
                 phased_xz_replacements[moment_index, phased_op] = gate
                 last_phased_xz_op[qubit] = (moment_index, phased_op)

--- a/cirq-core/cirq/transformers/eject_z.py
+++ b/cirq-core/cirq/transformers/eject_z.py
@@ -137,16 +137,17 @@ def eject_z(
             return op
 
         if isinstance(gate, ops.PhasedXZGate):
-            phased_op = ops.PhasedXZGate(
+            phased_gate = ops.PhasedXZGate(
                 x_exponent=gate.x_exponent,
                 z_exponent=gate.z_exponent,
                 axis_phase_exponent=gate.axis_phase_exponent - qubit_phase[op.qubits[0]] * 2,
-            )(op.qubits[0])
+            )
+            phased_op = phased_gate(op.qubits[0])
 
             if eject_parameterized or not protocols.is_parameterized(gate.z_exponent):
                 qubit = phased_op.qubits[0]
                 qubit_phase[qubit] += gate.z_exponent / 2
-                gate = phased_op.gate.with_z_exponent(0)
+                gate = phased_gate.with_z_exponent(0)
                 phased_op = gate.on(qubit)
                 phased_xz_replacements[moment_index, phased_op] = gate
                 last_phased_xz_op[qubit] = (moment_index, phased_op)


### PR DESCRIPTION
- Removes Protocol and deprecates _phase_by_ functions.
- Updates eject_z to phase gates rather than the protocol, which
is the only use within cirq itself.

Fixes: #1850