### PR TITLE
Properly use links in docs for external urls

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -11,18 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# pylint: disable=line-too-long
 """Current device parameters for the AQT/UIBK ion trap device
 
 The device is based on a linear calcium ion string with
 arbitrary connectivity. For more information see:
 
-https://quantumoptics.at/en/publications/journal-articles.html
+[https://quantumoptics.at/en/publications/journal-articles.html](https://quantumoptics.at/en/publications/journal-articles.html){:.external}
 
-https://iopscience.iop.org/article/10.1088/1367-2630/15/12/123012/meta
+[https://iopscience.iop.org/article/10.1088/1367-2630/15/12/123012/meta](https://iopscience.iop.org/article/10.1088/1367-2630/15/12/123012/meta){:.external}
 
 The native gate set consists of the local gates: X,Y, and XX entangling gates
 
 """
+# pylint: enable=line-too-long
+
 import json
 from typing import Any, cast, Dict, Optional, Sequence, List, Tuple, Union
 import numpy as np

--- a/cirq-aqt/cirq_aqt/aqt_sampler.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler.py
@@ -14,11 +14,11 @@
 """Samplers to access the AQT ion trap devices via the provided API. For
 more information on these devices see the AQT homepage:
 
-https://www.aqt.eu
+[https://www.aqt.eu](https://www.aqt.eu){:.external}
 
 API keys for classical simulators and quantum devices can be obtained at:
 
-https://gateway-portal.aqt.eu/
+[https://gateway-portal.aqt.eu/](https://gateway-portal.aqt.eu/){:.external}
 
 """
 

--- a/cirq-google/cirq_google/engine/runtime_estimator.py
+++ b/cirq-google/cirq_google/engine/runtime_estimator.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# pylint: disable=line-too-long
 """Utility functions to estimate runtime using Engine to execute circuits.
 
 Users can call estimate_run_time, estimate_run_sweep_time, or
@@ -25,12 +25,13 @@ Your experience may vary based on many factors not captured here.
 Parameters were calculated using a variety of width/depth/sweeps from
 the rep rate calculator, see:
 
-https://github.com/quantumlib/ReCirq/blob/master/recirq/benchmarks/rep_rate/
+[https://github.com/quantumlib/ReCirq/blob/master/recirq/benchmarks/rep_rate/](https://github.com/quantumlib/ReCirq/blob/master/recirq/benchmarks/rep_rate/){:.external}
 
 Model was then fitted by hand, correcting for anomalies and outliers
 when possible.
-
 """
+# pylint: enable=line-too-long
+
 from typing import List, Optional, Sequence
 import cirq
 


### PR DESCRIPTION
Follows https://www.tensorflow.org/community/contribute/docs_style

This gets rid of warnings that appear when pushing docs to devsite.