### PR TITLE
Allow server-side warnings from IonQ

### DIFF
--- a/cirq-ionq/cirq_ionq/job.py
+++ b/cirq-ionq/cirq_ionq/job.py
@@ -14,6 +14,7 @@
 """Represents a job created via the IonQ API."""
 
 import time
+import warnings
 from typing import Dict, Sequence, Union, TYPE_CHECKING
 
 from cirq_ionq import ionq_exceptions, results
@@ -196,6 +197,10 @@ class Job:
                 break
             time.sleep(polling_seconds)
             time_waited_seconds += polling_seconds
+        if 'warning' in self._job and 'messages' in self._job['warning']:
+            for warning in self._job['warning']['messages']:
+                warnings.warn(warning)
+
         if self.status() != 'completed':
             if 'failure' in self._job and 'error' in self._job['failure']:
                 error = self._job['failure']['error']

--- a/cirq-ionq/cirq_ionq/job_test.py
+++ b/cirq-ionq/cirq_ionq/job_test.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 import pytest
+import warnings
 
 import cirq_ionq as ionq
 
@@ -64,9 +65,14 @@ def test_job_results_qpu():
         'target': 'qpu',
         'metadata': {'shots': 1000, 'measurement0': f'a{chr(31)}0,1'},
         'data': {'histogram': {'0': '0.6', '2': '0.4'}},
+        'warning': { 'messages': ['foo', 'bar'], },
     }
     job = ionq.Job(None, job_dict)
-    results = job.results()
+    with warnings.catch_warnings(record=True) as w:
+      results = job.results()
+      assert len(w) == 2
+      assert "foo" in str(w[0].message)
+      assert "bar" in str(w[1].message)
     expected = ionq.QPUResult({0: 600, 1: 400}, 2, {'a': [0, 1]})
     assert results == expected
 

--- a/cirq-ionq/cirq_ionq/job_test.py
+++ b/cirq-ionq/cirq_ionq/job_test.py
@@ -14,8 +14,8 @@
 
 from unittest import mock
 
-import pytest
 import warnings
+import pytest
 
 import cirq_ionq as ionq
 

--- a/cirq-ionq/cirq_ionq/job_test.py
+++ b/cirq-ionq/cirq_ionq/job_test.py
@@ -65,14 +65,16 @@ def test_job_results_qpu():
         'target': 'qpu',
         'metadata': {'shots': 1000, 'measurement0': f'a{chr(31)}0,1'},
         'data': {'histogram': {'0': '0.6', '2': '0.4'}},
-        'warning': { 'messages': ['foo', 'bar'], },
+        'warning': {
+            'messages': ['foo', 'bar'],
+        },
     }
     job = ionq.Job(None, job_dict)
     with warnings.catch_warnings(record=True) as w:
-      results = job.results()
-      assert len(w) == 2
-      assert "foo" in str(w[0].message)
-      assert "bar" in str(w[1].message)
+        results = job.results()
+        assert len(w) == 2
+        assert "foo" in str(w[0].message)
+        assert "bar" in str(w[1].message)
     expected = ionq.QPUResult({0: 600, 1: 400}, 2, {'a': [0, 1]})
     assert results == expected
 


### PR DESCRIPTION
This will be used to notify users about deprecations and changes to the API without needing to update Cirq independently.