### PR TITLE
Delete the target_tensor parameter that was deprecated in 0.15

### DIFF
--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -245,16 +245,9 @@ class ActOnDensityMatrixArgs(ActOnArgs):
         parameter_desc='log_of_measurement_results',
         match=lambda args, kwargs: 'log_of_measurement_results' in kwargs or len(args) > 5,
     )
-    @_compat.deprecated_parameter(
-        deadline='v0.15',
-        fix='Use initial_state instead.',
-        parameter_desc='target_tensor',
-        match=lambda args, kwargs: 'target_tensor' in kwargs,
-    )
     def __init__(
         self,
         *,
-        target_tensor: Optional[np.ndarray] = None,
         available_buffer: Optional[List[np.ndarray]] = None,
         qid_shape: Optional[Tuple[int, ...]] = None,
         prng: Optional[np.random.RandomState] = None,
@@ -267,9 +260,6 @@ class ActOnDensityMatrixArgs(ActOnArgs):
         """Inits ActOnDensityMatrixArgs.
 
         Args:
-            target_tensor: The state vector to act on, stored as a numpy array
-                with one dimension for each qubit in the system. Operations are
-                expected to perform inplace edits of this object.
             available_buffer: A workspace with the same shape and dtype as
                 `target_tensor`. Used by operations that cannot be applied to
                 `target_tensor` inline, in order to avoid unnecessary
@@ -295,7 +285,7 @@ class ActOnDensityMatrixArgs(ActOnArgs):
                 and `qid_shape` is not provided.
         """
         state = _BufferedDensityMatrix.create(
-            initial_state=target_tensor if target_tensor is not None else initial_state,
+            initial_state=initial_state,
             qid_shape=tuple(q.dimension for q in qubits) if qubits is not None else None,
             dtype=dtype,
             buffer=available_buffer,
@@ -338,8 +328,7 @@ class ActOnDensityMatrixArgs(ActOnArgs):
     def __repr__(self) -> str:
         return (
             'cirq.ActOnDensityMatrixArgs('
-            f'target_tensor={proper_repr(self.target_tensor)},'
-            f' available_buffer={proper_repr(self.available_buffer)},'
+            f'initial_state={proper_repr(self.target_tensor)},'
             f' qid_shape={self.qid_shape!r},'
             f' qubits={self.qubits!r},'
             f' log_of_measurement_results={proper_repr(self.log_of_measurement_results)})'

--- a/cirq-core/cirq/sim/act_on_density_matrix_args_test.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args_test.py
@@ -44,13 +44,6 @@ def test_shallow_copy_buffers():
     assert copy.available_buffer is args.available_buffer
 
 
-def test_deprecated_warning_and_default_parameter_error():
-    tensor = np.ndarray(shape=(2,))
-    with cirq.testing.assert_deprecated('Use initial_state instead', deadline='v0.15'):
-        with pytest.raises(ValueError, match='dimension of target_tensor is not divisible by 2'):
-            cirq.ActOnDensityMatrixArgs(target_tensor=tensor)
-
-
 def test_decomposed_fallback():
     class Composite(cirq.Gate):
         def num_qubits(self) -> int:

--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -343,16 +343,9 @@ class ActOnStateVectorArgs(ActOnArgs):
         parameter_desc='log_of_measurement_results',
         match=lambda args, kwargs: 'log_of_measurement_results' in kwargs or len(args) > 4,
     )
-    @_compat.deprecated_parameter(
-        deadline='v0.15',
-        fix='Use initial_state instead.',
-        parameter_desc='target_tensor',
-        match=lambda args, kwargs: 'target_tensor' in kwargs,
-    )
     def __init__(
         self,
         *,
-        target_tensor: Optional[np.ndarray] = None,
         available_buffer: Optional[np.ndarray] = None,
         prng: Optional[np.random.RandomState] = None,
         log_of_measurement_results: Optional[Dict[str, List[int]]] = None,
@@ -364,9 +357,6 @@ class ActOnStateVectorArgs(ActOnArgs):
         """Inits ActOnStateVectorArgs.
 
         Args:
-            target_tensor: The state vector to act on, stored as a numpy array
-                with one dimension for each qubit in the system. Operations are
-                expected to perform inplace edits of this object.
             available_buffer: A workspace with the same shape and dtype as
                 `target_tensor`. Used by operations that cannot be applied to
                 `target_tensor` inline, in order to avoid unnecessary
@@ -388,7 +378,7 @@ class ActOnStateVectorArgs(ActOnArgs):
                 simulation.
         """
         state = _BufferedStateVector.create(
-            initial_state=target_tensor if target_tensor is not None else initial_state,
+            initial_state=initial_state,
             qid_shape=tuple(q.dimension for q in qubits) if qubits is not None else None,
             dtype=dtype,
             buffer=available_buffer,
@@ -506,8 +496,7 @@ class ActOnStateVectorArgs(ActOnArgs):
     def __repr__(self) -> str:
         return (
             'cirq.ActOnStateVectorArgs('
-            f'target_tensor={proper_repr(self.target_tensor)},'
-            f' available_buffer={proper_repr(self.available_buffer)},'
+            f'initial_state={proper_repr(self.target_tensor)},'
             f' qubits={self.qubits!r},'
             f' log_of_measurement_results={proper_repr(self.log_of_measurement_results)})'
         )

--- a/cirq-core/cirq/sim/act_on_state_vector_args_test.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args_test.py
@@ -39,11 +39,6 @@ def test_default_parameter():
     assert args.available_buffer.dtype == tensor.dtype
 
 
-def test_deprecated_target_tensor():
-    with cirq.testing.assert_deprecated('Use initial_state instead', deadline='v0.15'):
-        cirq.ActOnStateVectorArgs(target_tensor=np.array([1.0, 0.0, 0.0, 0.0], dtype=np.complex64))
-
-
 def test_infer_target_tensor():
     dtype = np.complex64
     args = cirq.ActOnStateVectorArgs(

--- a/cirq-core/cirq/sim/clifford/act_on_stabilizer_ch_form_args.py
+++ b/cirq-core/cirq/sim/clifford/act_on_stabilizer_ch_form_args.py
@@ -33,18 +33,11 @@ class ActOnStabilizerCHFormArgs(
         deadline='v0.15',
         fix='Use classical_data.',
         parameter_desc='log_of_measurement_results',
-        match=lambda args, kwargs: 'log_of_measurement_results' in kwargs or len(args) > 3,
-    )
-    @_compat.deprecated_parameter(
-        deadline='v0.15',
-        fix='Use initial_state instead of state.',
-        parameter_desc='state',
-        match=lambda args, kwargs: 'state' in kwargs,
+        match=lambda args, kwargs: 'log_of_measurement_results' in kwargs,
     )
     def __init__(
         self,
         *,
-        state: Optional['cirq.StabilizerStateChForm'] = None,
         prng: Optional[np.random.RandomState] = None,
         log_of_measurement_results: Optional[Dict[str, List[int]]] = None,
         qubits: Optional[Sequence['cirq.Qid']] = None,
@@ -75,7 +68,6 @@ class ActOnStabilizerCHFormArgs(
             ValueError: If initial state is an integer but qubits are not
                 provided.
         """
-        initial_state = state or initial_state
         if isinstance(initial_state, int):
             if qubits is None:
                 raise ValueError('Must specify qubits if initial state is integer')

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -1075,15 +1075,14 @@ def test_density_matrix_trial_result_repr():
         "measurements={'m': np.array([[1]], dtype=np.int32)}, "
         "final_step_result=cirq.DensityMatrixStepResult("
         "sim_state=cirq.ActOnDensityMatrixArgs("
-        "target_tensor=np.array([[(0.5+0j), (0.5+0j)], [(0.5+0j), (0.5+0j)]], dtype=np.complex64), "
-        "available_buffer=[], "
+        "initial_state=np.array([[(0.5+0j), (0.5+0j)], [(0.5+0j), (0.5+0j)]], dtype=np.complex64), "
         "qid_shape=(2,), "
         "qubits=(cirq.LineQubit(0),), "
         "log_of_measurement_results={}), "
         "dtype=np.complex64))"
     )
     assert repr(trial_result) == expected_repr
-    with cirq.testing.assert_deprecated('Use initial_state instead', deadline='v0.15', count=2):
+    with cirq.testing.assert_deprecated('log_of_measurement_results', deadline='v0.15'):
         assert eval(expected_repr) == trial_result
 
 

--- a/cirq-core/cirq/sim/state_vector_simulator_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulator_test.py
@@ -41,14 +41,13 @@ def test_state_vector_trial_result_repr():
         "measurements={'m': np.array([[1]], dtype=np.int32)}, "
         "final_step_result=cirq.SparseSimulatorStep("
         "sim_state=cirq.ActOnStateVectorArgs("
-        "target_tensor=np.array([0j, (1+0j)], dtype=np.complex64), "
-        "available_buffer=np.array([0j, (1+0j)], dtype=np.complex64), "
+        "initial_state=np.array([0j, (1+0j)], dtype=np.complex64), "
         "qubits=(cirq.NamedQubit('a'),), "
         "log_of_measurement_results={}), "
         "dtype=np.complex64))"
     )
     assert repr(trial_result) == expected_repr
-    with cirq.testing.assert_deprecated('Use initial_state instead', deadline='v0.15', count=2):
+    with cirq.testing.assert_deprecated('log_of_measurement_results', deadline='v0.15'):
         assert eval(expected_repr) == trial_result
 
 


### PR DESCRIPTION
A few simulators used either initial_state or target_tensor to initialize their ActOnArgs. We deprecated the latter in 0.15. This PR deletes those. Note that one follow-on change included here is that the repr functions needed to be changed to emit the field as `initial_state` too. (I wish I'd just called it `quantum_state` now, but oh well). @95-martin-orion

I also went ahead and removed the buffer from the repr, since it is just noise. 