### PR TITLE
Fix numpy annotations np.array -> np.ndarray

### DIFF
--- a/cirq-core/cirq/circuits/qasm_output.py
+++ b/cirq-core/cirq/circuits/qasm_output.py
@@ -43,7 +43,7 @@ class QasmUGate(ops.SingleQubitGate):
         self.phi = phi % 2
 
     @staticmethod
-    def from_matrix(mat: np.array) -> 'QasmUGate':
+    def from_matrix(mat: np.ndarray) -> 'QasmUGate':
         pre_phase, rotation, post_phase = linalg.deconstruct_single_qubit_matrix_into_angles(mat)
         return QasmUGate(
             rotation / np.pi,
@@ -115,7 +115,7 @@ class QasmTwoQubitGate(ops.Gate):
         return self.kak
 
     @staticmethod
-    def from_matrix(mat: np.array, atol=1e-8) -> 'QasmTwoQubitGate':
+    def from_matrix(mat: np.ndarray, atol=1e-8) -> 'QasmTwoQubitGate':
         """Creates a QasmTwoQubitGate from the given matrix.
 
         Args:

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
@@ -305,7 +305,7 @@ class CircuitLibraryCombination:
     """
 
     layer: Optional[Any]
-    combinations: np.array
+    combinations: np.ndarray
     pairs: List[QidPairT]
 
 

--- a/cirq-core/cirq/ion/ion_decomposition_test.py
+++ b/cirq-core/cirq/ion/ion_decomposition_test.py
@@ -117,7 +117,7 @@ def assert_ms_depth_below(operations, threshold):
     (2, _random_double_MS_effect()) for _ in range(10)
 ])
 # yapf: enable
-def test_two_to_ops(max_ms_depth: int, effect: np.array):
+def test_two_to_ops(max_ms_depth: int, effect: np.ndarray):
     q0 = cirq.NamedQubit('q0')
     q1 = cirq.NamedQubit('q1')
 

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -240,33 +240,33 @@ class CliffordTableau(StabilizerState):
             self._zs[self.n + i, i] = True
 
     @property
-    def xs(self) -> np.array:
+    def xs(self) -> np.ndarray:
         return self._xs[:-1, :]
 
     @xs.setter
-    def xs(self, new_xs: np.array) -> None:
+    def xs(self, new_xs: np.ndarray) -> None:
         assert np.shape(new_xs) == (2 * self.n, self.n)
         self._xs[:-1, :] = np.array(new_xs).astype(bool)
 
     @property
-    def zs(self) -> np.array:
+    def zs(self) -> np.ndarray:
         return self._zs[:-1, :]
 
     @zs.setter
-    def zs(self, new_zs: np.array) -> None:
+    def zs(self, new_zs: np.ndarray) -> None:
         assert np.shape(new_zs) == (2 * self.n, self.n)
         self._zs[:-1, :] = np.array(new_zs).astype(bool)
 
     @property
-    def rs(self) -> np.array:
+    def rs(self) -> np.ndarray:
         return self._rs[:-1]
 
     @rs.setter
-    def rs(self, new_rs: np.array) -> None:
+    def rs(self, new_rs: np.ndarray) -> None:
         assert np.shape(new_rs) == (2 * self.n,)
         self._rs[:-1] = np.array(new_rs).astype(bool)
 
-    def matrix(self) -> np.array:
+    def matrix(self) -> np.ndarray:
         """Returns the 2n * 2n matrix representation of the Clifford tableau."""
         return np.concatenate([self.xs, self.zs], axis=1)
 

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -222,7 +222,7 @@ def _probs(
 
 
 def _validate_density_matrix_qid_shape(
-    density_matrix: np.array, qid_shape: Tuple[int, ...]
+    density_matrix: np.ndarray, qid_shape: Tuple[int, ...]
 ) -> Tuple[int, ...]:
     """Validates that a tensor's shape is a valid shape for qids and returns the
     qid shape.

--- a/cirq-google/cirq_google/calibration/engine_simulator.py
+++ b/cirq-google/cirq_google/calibration/engine_simulator.py
@@ -373,7 +373,7 @@ class PhasedFSimEngineSimulator(cirq.SimulatesIntermediateStateVector[cirq.Spars
             ideal_when_missing_parameter=ideal_when_missing_parameter,
         )
 
-    def final_state_vector(self, program: cirq.Circuit) -> np.array:
+    def final_state_vector(self, program: cirq.Circuit) -> np.ndarray:
         result = self.simulate(program)
         return result.state_vector()
 

--- a/cirq-google/cirq_google/calibration/phased_fsim.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim.py
@@ -1033,7 +1033,7 @@ class PhaseCalibratedFSimGate:
             (cirq.rz(0.5 * gamma - beta).on(a), cirq.rz(0.5 * gamma + beta).on(b)),
         )
 
-    def _unitary_(self) -> np.array:
+    def _unitary_(self) -> np.ndarray:
         """Implements Cirq's `unitary` protocol for this object."""
         p = np.exp(-np.pi * 1j * self.phase_exponent)
         return (

--- a/examples/stabilizer_code.py
+++ b/examples/stabilizer_code.py
@@ -114,8 +114,8 @@ def _gaussian_elimination(
 
 
 def _transfer_to_standard_form(
-    M: np.array, n: int, k: int
-) -> Tuple[np.array, np.array, np.array, int]:
+    M: np.ndarray, n: int, k: int
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, int]:
     """Puts the stabilizer matrix in its standardized form, as in section 4.1 of the thesis.
 
     Args:


### PR DESCRIPTION
`np.array` is not a valid type, but rather a factory function for creating arrays. The actual type is `np.ndarray`. This change reduces the number of `check/mypy --next` errors by >60% from 244 to 96 on my machine.