### PR TITLE
Fix default QuantumStateRepresentation sampler for qudits

### DIFF
--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -70,7 +70,7 @@ class QuantumStateRepresentation(metaclass=abc.ABCMeta):
         for _ in range(repetitions):
             state = self.copy()
             measurements.append(state.measure(axes, prng))
-        return np.array(measurements, dtype=bool)
+        return np.array(measurements, dtype=np.uint8)
 
     def kron(self: TSelf, other: TSelf) -> TSelf:
         """Joins two state spaces together."""

--- a/cirq-core/cirq/sim/simulator_base_test.py
+++ b/cirq-core/cirq/sim/simulator_base_test.py
@@ -95,17 +95,6 @@ class SplittableCountingActOnArgs(CountingActOnArgs):
 
 
 class CountingStepResult(cirq.StepResultBase[CountingActOnArgs, CountingActOnArgs]):
-    def sample(
-        self,
-        qubits: List[cirq.Qid],
-        repetitions: int = 1,
-        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
-    ) -> np.ndarray:
-        measurements: List[List[int]] = []
-        for _ in range(repetitions):
-            measurements.append(self._merged_sim_state._perform_measurement(qubits))
-        return np.array(measurements, dtype=int)
-
     def _simulator_state(self) -> CountingActOnArgs:
         return self._merged_sim_state
 


### PR DESCRIPTION
I'd updated a test to use the default sample method, (which didn't exist when the test was originally written). The sampler array was being created as dtype bool and failed a couple tests. Changed that to uint8, and updated a test to use the default sampler.