### PR TITLE
Implement run_batch for IonQ Sampler

### DIFF
--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 """A `cirq.Sampler` implementation for the IonQ API."""
 
-from typing import List, Optional, Sequence, Union, TYPE_CHECKING
+from typing import List, Optional, Sequence, Union
 
-from cirq_ionq import results
+from cirq_ionq import results, Job
 import cirq
-import cirq_ionq
 
 
 class Sampler(cirq.Sampler):
@@ -121,7 +120,7 @@ class Sampler(cirq.Sampler):
         program: cirq.AbstractCircuit,
         resolvers: Sequence[cirq.ParamResolver],
         repetitions: int = 1,
-    ) -> Sequence[cirq_ionq.Job]:
+    ) -> Sequence[Job]:
         jobs = [
             self._service.create_job(
                 circuit=cirq.resolve_parameters(program, resolver),
@@ -134,7 +133,7 @@ class Sampler(cirq.Sampler):
 
     def _resolve_sweep(
         self,
-        jobs: Sequence[cirq_ionq.Job],
+        jobs: Sequence[Job],
         resolvers: Sequence[cirq.ParamResolver],
     ):
         kwargs = {}

--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -89,10 +89,13 @@ class Sampler(cirq.Sampler):
         resolvers = [r for r in cirq.to_resolvers(params_list)]
 
         sweeps = [
-            self._start_sweep(program, params, repetitions)
+            self._start_sweep(program, [params], repetitions)
             for program, params, repetitions in zip(programs, resolvers, repetitions)
         ]
-        return [self._resolve_sweep(jobs, params) for jobs, params in zip(sweeps, resolvers)]
+        return [
+            self._resolve_sweep(jobs, [params] * len(jobs))
+            for jobs, params in zip(sweeps, resolvers)
+        ]
 
     def run_sweep(
         self,

--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -90,7 +90,7 @@ class Sampler(cirq.Sampler):
 
         sweeps = [
             self._start_sweep(program, params, repetitions)
-            for circuit, params, repetitions in zip(programs, resolvers, repetitions)
+            for program, params, repetitions in zip(programs, resolvers, repetitions)
         ]
         return [self._resolve_sweep(jobs, params) for jobs, params in zip(sweeps, resolvers)]
 

--- a/cirq-ionq/cirq_ionq/sampler.py
+++ b/cirq-ionq/cirq_ionq/sampler.py
@@ -15,7 +15,6 @@
 
 from typing import List, Optional, Sequence, Union
 
-from cirq_ionq import results, Job
 import cirq
 
 
@@ -39,7 +38,7 @@ class Sampler(cirq.Sampler):
 
     def __init__(
         self,
-        service: 'cirq_ionq.Service',
+        service: Service,
         target: Optional[str],
         timeout_seconds: Optional[int] = None,
         seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,

--- a/cirq-ionq/cirq_ionq/service.py
+++ b/cirq-ionq/cirq_ionq/service.py
@@ -114,7 +114,12 @@ class Service:
             return sim_result.to_cirq_result(params=cirq.ParamResolver(param_resolver), seed=seed)
             # pylint: enable=unexpected-keyword-arg
 
-    def sampler(self, target: Optional[str] = None, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None):
+    def sampler(
+        self,
+        target: Optional[str] = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
+        timeout_seconds: Optional[int] = None,
+    ):
         """Returns a `cirq.Sampler` object for accessing the sampler interface.
 
         Args:
@@ -124,10 +129,13 @@ class Service:
             seed: If the target is `simulation` the seed for generating results. If None, this
                 will be `np.random`, if an int, will be `np.random.RandomState(int)`, otherwise
                 must be a modulate similar to `np.random`.
+            timeout_seconds: Length of time to wait for results. Default is specified in the job.
         Returns:
             A `cirq.Sampler` for the IonQ API.
         """
-        return sampler.Sampler(service=self, target=target, seed=seed)
+        return sampler.Sampler(
+            service=self, target=target, seed=seed, timeout_seconds=timeout_seconds
+        )
 
     def create_job(
         self,


### PR DESCRIPTION
Also add timeout_seconds to sampler method def

This allows for running a large configurable batch of jobs in parallel.
Along with https://github.com/tensorflow/quantum/commit/5ddde161a422a0f8d8da17512614fc29622d9e94
this should allow TensorFlow Quantum to parallelize more of its operation when used with
Cirq's IonQ package.