### PR TITLE
QCS Getting Started Guide - setup cleanup 

### DIFF
--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -163,14 +163,24 @@
     }
    ],
    "source": [
+    "import os\n",
+    "\n",
     "# The Google Cloud Project id to use.\n",
     "project_id = \"\" #@param {type:\"string\"}\n",
-    "processor_id = \"pacific\" #@param {type:\"string\"}\n",
+    "processor_id = \"\" #@param {type:\"string\"}\n",
+    "\n",
+    "os.environ['GOOGLE_CLOUD_PROJECT'] = project_id\n",
     "\n",
     "from cirq_google.engine.qcs_notebook import get_qcs_objects_for_notebook\n",
     "device_sampler = get_qcs_objects_for_notebook(project_id, processor_id)\n",
     "\n",
-    "if not device_sampler.signed_in:\n",
+    "if device_sampler.signed_in:\n",
+    "  # Defaults to a processor if no processor_id is specified.\n",
+    "  if processor_id == '':\n",
+    "    processors = cg.get_engine(project_id).list_processors()\n",
+    "    if len(processors) > 0:\n",
+    "      processor_id = processors[0].processor_id\n",
+    "else:\n",
     "    raise Exception(\"Please setup project_id in this cell or set the `GOOGLE_CLOUD_PROJECT` env var to your project id.\")"
    ]
   },


### PR DESCRIPTION
* remove default processor id
* set project env var

Note: `get_qcs_objects_for_notebook()` already selects a default processor id for device and sampler generation using the same logic, but the ID of the newly selected processor is not returned.

Alternatively, `get_qcs_objects_for_notebook()` can be modified to return a processor instead of a device and sampler, and retrieve the selected processor via `processor_id`. I don't have a preference between the two options.

There are 3 other spots where the processor id is hard-coded. If this approach looks good, I'll go ahead and update the other places, too.

cc @dstrain115 @wcourtney 