### PR TITLE
Bump tensorflow-docs version

### DIFF
--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -95,11 +95,6 @@ def generate_cirq():
         site_path=FLAGS.site_path,
         callbacks=[public_api.local_definitions_filter, filter_unwanted_inherited_methods],
         extra_docs=_doc.RECORDED_CONST_DOCS,
-        private_map={
-            # Opt to not build docs for these paths for now since they error.
-            "cirq.experiments": ["CrossEntropyResultDict", "GridInteractionLayer"],
-            "cirq.experiments.random_quantum_circuit_generation": ["GridInteractionLayer"],
-        },
     )
     doc_controls.decorate_all_class_attributes(
         doc_controls.do_not_doc_inheritable, networkx.DiGraph, skip=[]

--- a/dev_tools/requirements/deps/tensorflow-docs.txt
+++ b/dev_tools/requirements/deps/tensorflow-docs.txt
@@ -1,2 +1,1 @@
-# don't upgrade this just yet, anything later will require protobuf>=3.14
-tensorflow-docs@git+https://github.com/tensorflow/docs@a90bcd30eb550f8d4ee335ff3daf18de5ca84b70
+tensorflow-docs@git+https://github.com/tensorflow/docs@3a6a7a3322de8620f0031ae3a0a4b62e40d1d7f2


### PR DESCRIPTION
Fixes #5166. My understanding is that previously we had some conflict with protobuf versions due to gapic generated code, but that was updated in #5139.