### PR TITLE
Make the quantum state generic

### DIFF
--- a/cirq-core/cirq/contrib/quimb/mps_simulator.py
+++ b/cirq-core/cirq/contrib/quimb/mps_simulator.py
@@ -573,7 +573,7 @@ class _MPSHandler(qis.QuantumStateRepresentation):
 
 
 @value.value_equality
-class MPSState(ActOnArgs):
+class MPSState(ActOnArgs[_MPSHandler]):
     """A state of the MPS simulation."""
 
     def __init__(
@@ -621,7 +621,6 @@ class MPSState(ActOnArgs):
             log_of_measurement_results=log_of_measurement_results,
             classical_data=classical_data,
         )
-        self._state: _MPSHandler = state
 
     def i_str(self, i: int) -> str:
         # Returns the index name for the i'th qid.

--- a/cirq-core/cirq/sim/act_on_args.py
+++ b/cirq-core/cirq/sim/act_on_args.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Objects and methods for acting efficiently on a state tensor."""
+import abc
 import copy
 from typing import (
     Any,
     cast,
     Dict,
+    Generic,
     Iterator,
     List,
     Mapping,
@@ -35,12 +37,13 @@ from cirq.protocols.decompose_protocol import _try_decompose_into_operations_and
 from cirq.sim.operation_target import OperationTarget
 
 TSelf = TypeVar('TSelf', bound='ActOnArgs')
+TState = TypeVar('TState', bound='cirq.QuantumStateRepresentation')
 
 if TYPE_CHECKING:
     import cirq
 
 
-class ActOnArgs(OperationTarget[TSelf]):
+class ActOnArgs(OperationTarget, Generic[TState], metaclass=abc.ABCMeta):
     """State and context for an operation acting on a state tensor."""
 
     def __init__(
@@ -77,7 +80,7 @@ class ActOnArgs(OperationTarget[TSelf]):
                 for k, v in (log_of_measurement_results or {}).items()
             }
         )
-        self._state = state
+        self._state = cast(TState, state)
         if state is None:
             _warn_or_error('This function will require a valid `state` input in cirq v0.16.')
 

--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -236,7 +236,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         return True
 
 
-class ActOnDensityMatrixArgs(ActOnArgs):
+class ActOnDensityMatrixArgs(ActOnArgs[_BufferedDensityMatrix]):
     """State and context for an operation acting on a density matrix.
 
     To act on this object, directly edit the `target_tensor` property, which is
@@ -301,7 +301,6 @@ class ActOnDensityMatrixArgs(ActOnArgs):
             log_of_measurement_results=log_of_measurement_results,
             classical_data=classical_data,
         )
-        self._state: _BufferedDensityMatrix = state
 
     def _act_on_fallback_(
         self,

--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -326,7 +326,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         return True
 
 
-class ActOnStateVectorArgs(ActOnArgs):
+class ActOnStateVectorArgs(ActOnArgs[_BufferedStateVector]):
     """State and context for an operation acting on a state vector.
 
     There are two common ways to act on this object:
@@ -390,7 +390,6 @@ class ActOnStateVectorArgs(ActOnArgs):
             log_of_measurement_results=log_of_measurement_results,
             classical_data=classical_data,
         )
-        self._state: _BufferedStateVector = state
 
     @_compat.deprecated(
         deadline='v0.16',

--- a/cirq-core/cirq/sim/clifford/act_on_stabilizer_args.py
+++ b/cirq-core/cirq/sim/clifford/act_on_stabilizer_args.py
@@ -31,7 +31,9 @@ if TYPE_CHECKING:
 TStabilizerState = TypeVar('TStabilizerState', bound='cirq.StabilizerState')
 
 
-class ActOnStabilizerArgs(ActOnArgs, Generic[TStabilizerState], metaclass=abc.ABCMeta):
+class ActOnStabilizerArgs(
+    ActOnArgs[TStabilizerState], Generic[TStabilizerState], metaclass=abc.ABCMeta
+):
     """Abstract wrapper around a stabilizer state for the act_on protocol."""
 
     def __init__(
@@ -64,7 +66,6 @@ class ActOnStabilizerArgs(ActOnArgs, Generic[TStabilizerState], metaclass=abc.AB
             log_of_measurement_results=log_of_measurement_results,
             classical_data=classical_data,
         )
-        self._state: TStabilizerState = state
 
     @property
     def state(self) -> TStabilizerState:

--- a/cirq-core/cirq/sim/simulator_base_test.py
+++ b/cirq-core/cirq/sim/simulator_base_test.py
@@ -56,7 +56,7 @@ class CountingState(cirq.qis.QuantumStateRepresentation):
         )
 
 
-class CountingActOnArgs(cirq.ActOnArgs):
+class CountingActOnArgs(cirq.ActOnArgs[CountingState]):
     def __init__(self, state, qubits, classical_data):
         state_obj = CountingState(state)
         super().__init__(
@@ -64,7 +64,6 @@ class CountingActOnArgs(cirq.ActOnArgs):
             qubits=qubits,
             classical_data=classical_data,
         )
-        self._state: CountingState = state_obj
 
     def _act_on_fallback_(
         self,


### PR DESCRIPTION
Makes the ActOnArgs generic on which quantum state type it contains. This allows us to delete the annoying `self._state: <State> = state` typehints. @95-martin-orion 