### PR TITLE
Allow simulator quantum state representations to be used in qis

### DIFF
--- a/cirq-core/cirq/contrib/quimb/mps_simulator.py
+++ b/cirq-core/cirq/contrib/quimb/mps_simulator.py
@@ -231,7 +231,7 @@ class _MPSHandler(qis.QuantumStateRepresentation):
             estimated_gate_error_list: The error estimations.
             simulation_options: Numerical options for the simulation.
         """
-        self._qid_shape = qid_shape
+        super().__init__(qid_shape)
         self._grouping = grouping
         self._M = M
         self._format_i = format_i

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -663,4 +663,5 @@ class CliffordTableau(StabilizerState):
         return [self._measure(axis, seed) for axis in axes]
 
     def state_vector(self):
+        # This function should exist.
         raise NotImplementedError()

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -14,9 +14,11 @@
 
 import abc
 from typing import Any, Dict, List, Sequence, Tuple, TYPE_CHECKING, TypeVar
+
 import numpy as np
 
 from cirq import protocols, value
+from cirq.qis import states
 from cirq.value import big_endian_int_to_digits, linear_dict
 
 if TYPE_CHECKING:
@@ -25,7 +27,7 @@ if TYPE_CHECKING:
 TSelf = TypeVar('TSelf', bound='QuantumStateRepresentation')
 
 
-class QuantumStateRepresentation(metaclass=abc.ABCMeta):
+class QuantumStateRepresentation(states.QuantumState, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def copy(self: TSelf, deep_copy_buffers: bool = True) -> TSelf:
         """Creates a copy of the object.
@@ -95,11 +97,6 @@ class QuantumStateRepresentation(metaclass=abc.ABCMeta):
     @property
     def supports_factor(self) -> bool:
         """Subclasses that allow factorization should override this."""
-        return False
-
-    @property
-    def can_represent_mixed_states(self) -> bool:
-        """Subclasses that can represent mixed states should override this."""
         return False
 
 
@@ -214,13 +211,14 @@ class CliffordTableau(StabilizerState):
     an eigenoperator of the state vector with eigenvalue one: P|psi> = |psi>.
     """
 
-    def __init__(self, num_qubits, initial_state: int = 0):
+    def __init__(self, num_qubits: int, initial_state: int = 0):
         """Initializes CliffordTableau
         Args:
             num_qubits: The number of qubits in the system.
             initial_state: The computational basis representation of the
                 state as a big endian int.
         """
+        super().__init__((2,) * num_qubits)
         self.n = num_qubits
 
         # The last row (`2n+1`-th row) is the scratch row used in _measurement
@@ -663,3 +661,6 @@ class CliffordTableau(StabilizerState):
         self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
     ) -> List[int]:
         return [self._measure(axis, seed) for axis in axes]
+
+    def state_vector(self):
+        raise NotImplementedError()

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 TSelf = TypeVar('TSelf', bound='QuantumStateRepresentation')
 
 
-class QuantumStateRepresentation(states.QuantumState, metaclass=abc.ABCMeta):
+class QuantumStateRepresentation(states.HasQuantumState, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def copy(self: TSelf, deep_copy_buffers: bool = True) -> TSelf:
         """Creates a copy of the object.

--- a/cirq-core/cirq/qis/measures.py
+++ b/cirq-core/cirq/qis/measures.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from cirq import protocols, value, _import
 from cirq.qis.states import (
-    QuantumState,
+    HasQuantumState,
     infer_qid_shape,
     quantum_state,
     validate_density_matrix,
@@ -274,7 +274,7 @@ def von_neumann_entropy(
     Raises:
         ValueError: Invalid quantum state.
     """
-    if isinstance(state, QuantumState) and state.can_represent_mixed_states:
+    if isinstance(state, HasQuantumState) and state.can_represent_mixed_states:
         state = state.density_matrix()
     if isinstance(state, np.ndarray) and state.ndim == 2 and state.shape[0] == state.shape[1]:
         if validate:

--- a/cirq-core/cirq/qis/measures.py
+++ b/cirq-core/cirq/qis/measures.py
@@ -274,8 +274,8 @@ def von_neumann_entropy(
     Raises:
         ValueError: Invalid quantum state.
     """
-    if isinstance(state, QuantumState) and state._is_density_matrix():
-        state = state.data
+    if isinstance(state, QuantumState) and state.can_represent_mixed_states:
+        state = state.density_matrix()
     if isinstance(state, np.ndarray) and state.ndim == 2 and state.shape[0] == state.shape[1]:
         if validate:
             if qid_shape is None:

--- a/cirq-core/cirq/qis/measures_test.py
+++ b/cirq-core/cirq/qis/measures_test.py
@@ -185,9 +185,9 @@ def test_fidelity_different_simulator_outputs_compatible():
         for _ in range(2)
     ]
 
-    def final_state(sim: cirq.Simulator):
+    def final_state(sim: cirq.SimulatorBase):
         return [
-            sim.simulate(c)._final_step_result._sim_state.create_merged_state()._state
+            sim.simulate(c)._final_step_result_typed._sim_state.create_merged_state()._state
             for c in circuits
         ]
 

--- a/cirq-core/cirq/qis/measures_test.py
+++ b/cirq-core/cirq/qis/measures_test.py
@@ -167,6 +167,7 @@ def test_fidelity_product_states():
 def test_fidelity_symmetric_sim_types():
     from cirq.sim.act_on_state_vector_args import _BufferedStateVector
     from cirq.sim.act_on_density_matrix_args import _BufferedDensityMatrix
+
     sv1 = _BufferedStateVector.create(initial_state=VEC1)
     sv2 = _BufferedStateVector.create(initial_state=VEC2)
     dm1 = _BufferedDensityMatrix.create(initial_state=MAT1)

--- a/cirq-core/cirq/qis/measures_test.py
+++ b/cirq-core/cirq/qis/measures_test.py
@@ -164,6 +164,21 @@ def test_fidelity_product_states():
         )
 
 
+def test_fidelity_symmetric_sim_types():
+    from cirq.sim.act_on_state_vector_args import _BufferedStateVector
+    from cirq.sim.act_on_density_matrix_args import _BufferedDensityMatrix
+    sv1 = _BufferedStateVector.create(initial_state=VEC1)
+    sv2 = _BufferedStateVector.create(initial_state=VEC2)
+    dm1 = _BufferedDensityMatrix.create(initial_state=MAT1)
+    dm2 = _BufferedDensityMatrix.create(initial_state=MAT2)
+    np.testing.assert_allclose(cirq.fidelity(sv1, sv2), cirq.fidelity(sv2, sv1))
+    np.testing.assert_allclose(cirq.fidelity(sv1, dm1), cirq.fidelity(dm1, sv1))
+    np.testing.assert_allclose(
+        cirq.fidelity(cirq.density_matrix(dm1.density_matrix()), dm2),
+        cirq.fidelity(cirq.density_matrix(dm2.density_matrix()), dm1),
+    )
+
+
 def test_fidelity_fail_inference():
     state_vector = cirq.one_hot(shape=(4,), dtype=np.complex128)
     state_tensor = np.reshape(state_vector, (2, 2))

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -115,7 +115,7 @@ def quantum_state_array(
     *,  # Force keyword arguments
     copy: bool = False,
     dtype: Optional['DTypeLike'] = None,
-) -> np.ndarray:
+) -> Tuple[np.ndarray, Tuple[int, ...]]:
     """Create a QuantumState object from a state-like object.
 
     Args:
@@ -188,7 +188,7 @@ def quantum_state_array(
                 data = data.astype(dtype, casting='unsafe', copy=True)
             else:
                 data = data.copy()
-    return data
+    return data, qid_shape
 
 
 class _StateVector(QuantumState):
@@ -246,7 +246,9 @@ def quantum_state(
     dtype: Optional['DTypeLike'] = None,
     atol: float = 1e-7,
 ) -> QuantumState:
-    data = quantum_state_array(state, qid_shape, copy=copy, dtype=dtype)
+    if isinstance(state, QuantumState):
+        return state
+    data, qid_shape = quantum_state_array(state, qid_shape, copy=copy, dtype=dtype)
     dim = np.prod(qid_shape, dtype=np.int64).item()
     if data.shape == (dim, dim):
         return _DensityMatrix(data)

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -446,8 +446,6 @@ def _potential_qid_shapes(state: _NON_INT_STATE_LIKE) -> '_QidShapeSet':
     """Return a set of qid shapes compatible with a given state."""
     if isinstance(state, HasQuantumState):
         return _QidShapeSet(explicit_qid_shapes={state.qid_shape})
-    if isinstance(state, value.ProductState):
-        return _QidShapeSet(explicit_qid_shapes={(2,) * len(state)})
 
     if isinstance(state, Sequence):
         state = np.array(state)

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -124,6 +124,7 @@ class QuantumState(HasQuantumState):
         atol: float = 1e-7,
     ) -> None:
         """Initialize a quantum state object.
+
         Args:
             data: The data representing the quantum state.
             qid_shape: The qid shape.
@@ -131,6 +132,7 @@ class QuantumState(HasQuantumState):
                 represent a valid quantum state with the given dtype.
             dtype: The expected data type of the quantum state.
             atol: Absolute numerical tolerance to use for validation.
+
         Raises:
             ValueError: The qid shape was not specified and could not be
                 inferred.
@@ -164,17 +166,6 @@ class QuantumState(HasQuantumState):
             return None
         return np.reshape(self.data, (self._dim,))
 
-    def state_tensor(self) -> Optional[np.ndarray]:
-        """Return the state tensor of this state.
-
-        A state tensor stores the amplitudes of a pure state as an array with
-        shape equal to the qid shape of the state.
-        If the state is a density matrix, this method returns None.
-        """
-        if self._is_density_matrix():
-            return None
-        return np.reshape(self.data, self.qid_shape)
-
     def density_matrix(self) -> np.ndarray:
         """Return the density matrix of this state.
 
@@ -182,9 +173,7 @@ class QuantumState(HasQuantumState):
         (a two-dimensional array).
         """
         if not self._is_density_matrix():
-            state_vector = self.state_vector()
-            assert state_vector is not None, 'only None if _is_density_matrix'
-            return np.outer(state_vector, np.conj(state_vector))
+            return super().density_matrix()
         return self.data
 
     def _is_density_matrix(self) -> bool:
@@ -306,6 +295,8 @@ def quantum_state(
             dtype = DEFAULT_COMPLEX_DTYPE
         data = one_hot(index=state, shape=(dim,), dtype=dtype)
     else:
+        if isinstance(state, HasQuantumState):
+            state = state.state_vector_or_density_matrix()
         data = np.array(state, copy=False)
         if qid_shape is None:
             qid_shape = infer_qid_shape(state)

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -155,6 +155,7 @@ class QuantumState(HasQuantumState):
 
     def state_vector(self) -> Optional[np.ndarray]:
         """Return the state vector of this state.
+
         A state vector stores the amplitudes of a pure state as a
         one-dimensional array.
         If the state is a density matrix, this method returns None.
@@ -165,6 +166,7 @@ class QuantumState(HasQuantumState):
 
     def state_tensor(self) -> Optional[np.ndarray]:
         """Return the state tensor of this state.
+
         A state tensor stores the amplitudes of a pure state as an array with
         shape equal to the qid shape of the state.
         If the state is a density matrix, this method returns None.
@@ -175,6 +177,7 @@ class QuantumState(HasQuantumState):
 
     def density_matrix(self) -> np.ndarray:
         """Return the density matrix of this state.
+
         A density matrix stores the entries of a density matrix as a matrix
         (a two-dimensional array).
         """
@@ -192,9 +195,11 @@ class QuantumState(HasQuantumState):
         self, *, dtype: Optional['DTypeLike'] = None, atol=1e-7  # Force keyword arguments
     ) -> None:
         """Check if this quantum state is valid.
+
         Args:
             dtype: The expected data type of the quantum state.
             atol: Absolute numerical tolerance to use for validation.
+
         Raises:
             ValueError: Invalid quantum state.
         """
@@ -233,6 +238,7 @@ def quantum_state(
     atol: float = 1e-7,
 ) -> QuantumState:
     """Create a QuantumState object from a state-like object.
+
     Args:
         state: The state-like object.
         qid_shape: The qid shape.
@@ -241,6 +247,7 @@ def quantum_state(
             represent a valid quantum state with the given dtype.
         dtype: The desired data type.
         atol: Absolute numerical tolerance to use for validation.
+
     Raises:
         ValueError: Invalid quantum state.
         ValueError: The qid shape was not specified and could not be inferred.

--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -88,7 +88,8 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
                 density_matrix = initial_state
             if np.may_share_memory(density_matrix, initial_state):
                 density_matrix = density_matrix.copy()
-        density_matrix = density_matrix.astype(dtype, copy=False)
+        if dtype:
+            density_matrix = density_matrix.astype(dtype, copy=False)
         return cls(density_matrix, buffer)
 
     def copy(self, deep_copy_buffers: bool = True) -> '_BufferedDensityMatrix':

--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -49,7 +49,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         self._buffer = buffer
         if len(density_matrix.shape) % 2 != 0:
             raise ValueError('The dimension of target_tensor is not divisible by 2.')
-        self._qid_shape = density_matrix.shape[: len(density_matrix.shape) // 2]
+        super().__init__(density_matrix.shape[: len(density_matrix.shape) // 2])
 
     @classmethod
     def create(
@@ -234,6 +234,9 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
     @property
     def can_represent_mixed_states(self) -> bool:
         return True
+
+    def density_matrix(self) -> np.ndarray:
+        return self._density_matrix
 
 
 class ActOnDensityMatrixArgs(ActOnArgs[_BufferedDensityMatrix]):

--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -237,7 +237,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         return True
 
     def density_matrix(self) -> np.ndarray:
-        return self._density_matrix
+        return self._density_matrix.reshape((self._dim, self._dim))
 
 
 class ActOnDensityMatrixArgs(ActOnArgs[_BufferedDensityMatrix]):

--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -45,7 +45,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         if buffer is None:
             buffer = np.empty_like(state_vector)
         self._buffer = buffer
-        self._qid_shape = state_vector.shape
+        super().__init__(state_vector.shape)
 
     @classmethod
     def create(
@@ -306,6 +306,9 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
     @property
     def supports_factor(self) -> bool:
         return True
+
+    def state_vector(self) -> np.ndarray:
+        return self._state_vector
 
 
 class ActOnStateVectorArgs(ActOnArgs[_BufferedStateVector]):

--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -83,7 +83,8 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
                 state_vector = initial_state
             if np.may_share_memory(state_vector, initial_state):
                 state_vector = state_vector.copy()
-        state_vector = state_vector.astype(dtype, copy=False)
+        if dtype:
+            state_vector = state_vector.astype(dtype, copy=False)
         return cls(state_vector, buffer)
 
     def copy(self, deep_copy_buffers: bool = True) -> '_BufferedStateVector':

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -38,6 +38,7 @@ class StabilizerStateChForm(qis.StabilizerState):
             initial_state: The computational basis representation of the
                 state as a big endian int.
         """
+        super().__init__((2,) * num_qubits)
         self.n = num_qubits
 
         # The state is represented by a set of binary matrices and vectors.

--- a/cirq-core/cirq/value/product_state.py
+++ b/cirq-core/cirq/value/product_state.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from cirq import protocols
 from cirq._doc import document
+from cirq.qis.states import HasQuantumState
 
 if TYPE_CHECKING:
     import cirq
@@ -48,7 +49,7 @@ class _NamedOneQubitState(metaclass=abc.ABCMeta):
 
 
 @dataclass(frozen=True)
-class ProductState:
+class ProductState(HasQuantumState):
     """A quantum state that is a tensor product of one qubit states.
 
     For example, the |00⟩ state is `cirq.KET_ZERO(q0) * cirq.KET_ZERO(q1)`.
@@ -63,6 +64,9 @@ class ProductState:
             # coverage: ignore
             states = dict()
 
+        n = len(states)
+        object.__setattr__(self, '_qid_shape', (2,) * n)
+        object.__setattr__(self, '_dim', 2 ** n)
         object.__setattr__(self, 'states', states)
 
     @property

--- a/cirq-core/cirq/value/product_state.py
+++ b/cirq-core/cirq/value/product_state.py
@@ -66,7 +66,7 @@ class ProductState(HasQuantumState):
 
         n = len(states)
         object.__setattr__(self, '_qid_shape', (2,) * n)
-        object.__setattr__(self, '_dim', 2 ** n)
+        object.__setattr__(self, '_dim', 2**n)
         object.__setattr__(self, 'states', states)
 
     @property


### PR DESCRIPTION
This PR unifies the quantum state types between `sim` and `qis` modules.

We create a `HasQuantumState` interface, from which both `QuantumState` and `ProductState` (used in qis), and `QuantumStateRepresentation` (the base class of quantum states used in simulators, including CliffordTableau, MPS, CHForm, SV/DM) inherit.

We then update the relevant `qis` method parameters to use `HasQuantumState` instead of `QuantumState`. This allows a broader range of quantum state representations to be analyzed in our `qis` utilities.

xref #4582