### PR TITLE
Re-introduce less idiomatic code for `_group_interchangeable_qubits` implementation

### DIFF
--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -149,9 +149,7 @@ class GateOperation(raw_types.Operation):
         groups: Dict[int, List['cirq.Qid']] = {}
         for i, q in enumerate(self.qubits):
             k = self.gate.qubit_index_to_equivalence_group_key(i)
-            if k not in groups:
-                groups[k] = []
-            groups[k].append(q)
+            groups.setdefault(k, []).append(q)
         return tuple(sorted((k, frozenset(v)) for k, v in groups.items()))
 
     def _value_equality_values_(self):

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -14,7 +14,6 @@
 
 """Basic types defining qubits, gates, and operations."""
 
-import itertools
 import re
 from typing import (
     AbstractSet,
@@ -29,6 +28,7 @@ from typing import (
     TypeVar,
     TYPE_CHECKING,
     Union,
+    List,
 )
 
 import numpy as np
@@ -146,17 +146,13 @@ class GateOperation(raw_types.Operation):
     ) -> Tuple[Union['cirq.Qid', Tuple[int, FrozenSet['cirq.Qid']]], ...]:
         if not isinstance(self.gate, gate_features.InterchangeableQubitsGate):
             return self.qubits
-        else:
-
-            def make_key(i_q: Tuple[int, 'cirq.Qid']) -> int:
-                return cast(
-                    gate_features.InterchangeableQubitsGate, self.gate
-                ).qubit_index_to_equivalence_group_key(i_q[0])
-
-            return tuple(
-                (k, frozenset(g for _, g in kg))
-                for k, kg in itertools.groupby(enumerate(self.qubits), make_key)
-            )
+        groups: Dict[int, List['cirq.Qid']] = {}
+        for i, q in enumerate(self.qubits):
+            k = self.gate.qubit_index_to_equivalence_group_key(i)
+            if k not in groups:
+                groups[k] = []
+            groups[k].append(q)
+        return tuple(sorted((k, frozenset(v)) for k, v in groups.items()))
 
     def _value_equality_values_(self):
         return self.gate, self._group_interchangeable_qubits()

--- a/cirq-core/cirq/ops/gate_operation_test.py
+++ b/cirq-core/cirq/ops/gate_operation_test.py
@@ -444,3 +444,24 @@ def test_is_parameterized():
     assert not cirq.is_parameterized(No1().on(q))
     assert not cirq.is_parameterized(No2().on(q))
     assert cirq.is_parameterized(Yes().on(q))
+
+
+def test_group_interchangeable_qubits_creates_tuples_with_unique_keys():
+    class MyGate(cirq.Gate, cirq.InterchangeableQubitsGate):
+        def __init__(self, num_qubits) -> None:
+            self._num_qubits = num_qubits
+
+        def num_qubits(self) -> int:
+            return self._num_qubits
+
+        def qubit_index_to_equivalence_group_key(self, index: int) -> int:
+            if index % 2 == 0:
+                return index
+            return 0
+
+    qubits = cirq.LineQubit.range(4)
+    gate = MyGate(len(qubits))
+
+    assert gate(qubits[0], qubits[1], qubits[2], qubits[3]) == gate(
+        qubits[3], qubits[1], qubits[2], qubits[0]
+    )


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/5148
Reverts: https://github.com/quantumlib/Cirq/pull/4941

I'm willing to hear about making this code idiomatic while not breaking the newly added test.