### PR TITLE
Fix push event to fallback to run_id in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - master
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: Continuous Integration
 
-on: [ pull_request ]
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 concurrency: 
   group: ${{ github.head_ref }}


### PR DESCRIPTION
On closer examination, it appears that `github.head_ref` does not exist in the `push` action event context: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

This _should_ fix this.