### PR TITLE
Support complex params in `work` module

### DIFF
--- a/cirq-core/cirq/work/observable_measurement.py
+++ b/cirq-core/cirq/work/observable_measurement.py
@@ -20,7 +20,6 @@ import tempfile
 import warnings
 from typing import (
     Any,
-    cast,
     Dict,
     Iterable,
     List,
@@ -35,6 +34,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import sympy
+
 from cirq import circuits, study, ops, value, protocols
 from cirq._doc import document
 from cirq.work.observable_grouping import group_settings_greedy, GROUPER_T

--- a/cirq-core/cirq/work/observable_measurement.py
+++ b/cirq-core/cirq/work/observable_measurement.py
@@ -18,18 +18,7 @@ import itertools
 import os
 import tempfile
 import warnings
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TYPE_CHECKING,
-    Union,
-)
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import pandas as pd

--- a/cirq-core/cirq/work/observable_measurement.py
+++ b/cirq-core/cirq/work/observable_measurement.py
@@ -542,7 +542,7 @@ def measure_grouped_settings(
     for max_setting, param_resolver in itertools.product(
         grouped_settings.keys(), study.to_resolvers(circuit_sweep)
     ):
-        circuit_params = cast(Dict[str, float], param_resolver.param_dict)
+        circuit_params = param_resolver.param_dict
         meas_spec = _MeasurementSpec(max_setting=max_setting, circuit_params=circuit_params)
         accumulator = BitstringAccumulator(
             meas_spec=meas_spec,

--- a/cirq-core/cirq/work/observable_measurement_data.py
+++ b/cirq-core/cirq/work/observable_measurement_data.py
@@ -17,7 +17,7 @@ import datetime
 from typing import Dict, List, Tuple, TYPE_CHECKING, Iterable, Any
 
 import numpy as np
-from cirq import ops, protocols
+from cirq import ops, protocols, value
 from cirq._compat import proper_repr
 from cirq.work.observable_settings import (
     InitObsSetting,
@@ -105,7 +105,7 @@ class ObservableMeasuredResult:
     mean: float
     variance: float
     repetitions: int
-    circuit_params: Dict[str, float]
+    circuit_params: Dict[str, value.Scalar]
 
     def __repr__(self):
         # I wish we could use the default dataclass __repr__ but

--- a/cirq-core/cirq/work/observable_settings.py
+++ b/cirq-core/cirq/work/observable_settings.py
@@ -125,21 +125,22 @@ def observables_to_settings(
         yield InitObsSetting(init_state=zeros_state(qubits), observable=observable)
 
 
-def _fix_precision(val: float, precision) -> int:
-    """Convert floating point numbers to (implicitly) fixed point integers.
+def _fix_precision(val: value.Scalar, precision) -> int:
+    """Convert floating point or complex numbers to (implicitly) fixed point
+    integers. Complex numbers will use the real part only.
 
     Circuit parameters can be floats but we also need to use them as
     dictionary keys. We secretly use these fixed-precision integers.
     """
-    return int(val * precision)
+    return int((val if isinstance(val, float) else val.real) * precision)
 
 
 def _hashable_param(
-    param_tuples: ItemsView[str, float], precision=1e7
+    param_tuples: ItemsView[str, value.Scalar], precision=1e7
 ) -> FrozenSet[Tuple[str, float]]:
     """Hash circuit parameters using fixed precision.
 
-    Circuit parameters can be floats but we also need to use them as
+    Circuit parameters can be complex but we also need to use them as
     dictionary keys. We secretly use these fixed-precision integers.
     """
     return frozenset((k, _fix_precision(v, precision)) for k, v in param_tuples)
@@ -156,7 +157,7 @@ class _MeasurementSpec:
     """
 
     max_setting: InitObsSetting
-    circuit_params: Dict[str, float]
+    circuit_params: Dict[str, value.Scalar]
 
     def __hash__(self):
         return hash((self.max_setting, _hashable_param(self.circuit_params.items())))

--- a/cirq-core/cirq/work/observable_settings.py
+++ b/cirq-core/cirq/work/observable_settings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import dataclasses
+import numbers
 from typing import Union, Iterable, Dict, TYPE_CHECKING, ItemsView, Tuple, FrozenSet
 
 from cirq import ops, value, protocols
@@ -125,19 +126,21 @@ def observables_to_settings(
         yield InitObsSetting(init_state=zeros_state(qubits), observable=observable)
 
 
-def _fix_precision(val: value.Scalar, precision) -> int:
+def _fix_precision(val: value.Scalar, precision) -> Union[int, Tuple[int, int]]:
     """Convert floating point or complex numbers to (implicitly) fixed point
-    integers. Complex numbers will use the real part only.
+    integers. Complex numbers will return fixed-point (real, imag) tuples.
 
-    Circuit parameters can be floats but we also need to use them as
+    Circuit parameters can be complex but we also need to use them as
     dictionary keys. We secretly use these fixed-precision integers.
     """
-    return int((val if isinstance(val, float) else val.real) * precision)
+    if isinstance(val, (complex, numbers.Complex)):
+        return int(val.real * precision), int(val.imag * precision)
+    return int(val * precision)
 
 
 def _hashable_param(
     param_tuples: ItemsView[str, value.Scalar], precision=1e7
-) -> FrozenSet[Tuple[str, float]]:
+) -> FrozenSet[Tuple[str, Union[int, Tuple[int, int]]]]:
     """Hash circuit parameters using fixed precision.
 
     Circuit parameters can be complex but we also need to use them as

--- a/cirq-core/cirq/work/observable_settings_test.py
+++ b/cirq-core/cirq/work/observable_settings_test.py
@@ -65,12 +65,18 @@ def test_param_hash():
     params1 = [('beta', 1.23), ('gamma', 4.56)]
     params2 = [('beta', 1.23), ('gamma', 4.56)]
     params3 = [('beta', 1.24), ('gamma', 4.57)]
+    params4 = [('beta', 1.23 + 0.01j), ('gamma', 4.56 + 0.01j)]
+    params5 = [('beta', 1.23 + 0.01j), ('gamma', 4.56 + 0.01j)]
     assert _hashable_param(params1) == _hashable_param(params1)
     assert hash(_hashable_param(params1)) == hash(_hashable_param(params1))
     assert _hashable_param(params1) == _hashable_param(params2)
     assert hash(_hashable_param(params1)) == hash(_hashable_param(params2))
     assert _hashable_param(params1) != _hashable_param(params3)
-    assert hash(_hashable_param(params1)) != _hashable_param(params3)
+    assert hash(_hashable_param(params1)) != hash(_hashable_param(params3))
+    assert _hashable_param(params1) != _hashable_param(params4)
+    assert hash(_hashable_param(params1)) != hash(_hashable_param(params4))
+    assert _hashable_param(params4) == _hashable_param(params5)
+    assert hash(_hashable_param(params4)) == hash(_hashable_param(params5))
 
 
 def test_measurement_spec():

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -15,11 +15,11 @@
 
 import abc
 import collections
-from typing import cast, Dict, FrozenSet, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import pandas as pd
 
-from cirq import ops, protocols, study
+from cirq import ops, protocols, study, value
 from cirq.work.observable_measurement import (
     measure_observables,
     RepetitionsStoppingCriteria,
@@ -329,8 +329,8 @@ class Sampler(metaclass=abc.ABCMeta):
 
         # Flatten Circuit Sweep into one big list of Params.
         # Keep track of their indices so we can map back.
-        flat_params = [cast(Dict[str, float], pr.param_dict) for pr in study.to_resolvers(params)]
-        circuit_param_to_sweep_i: Dict[FrozenSet[Tuple[str, float]], int] = {
+        flat_params = [pr.param_dict for pr in study.to_resolvers(params)]
+        circuit_param_to_sweep_i: Dict[FrozenSet[Tuple[str, value.Scalar]], int] = {
             _hashable_param(param.items()): i for i, param in enumerate(flat_params)
         }
 

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -19,7 +19,7 @@ from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple, TYPE_CHECKI
 
 import pandas as pd
 
-from cirq import ops, protocols, study, value
+from cirq import ops, protocols, study
 from cirq.work.observable_measurement import (
     measure_observables,
     RepetitionsStoppingCriteria,
@@ -330,7 +330,7 @@ class Sampler(metaclass=abc.ABCMeta):
         # Flatten Circuit Sweep into one big list of Params.
         # Keep track of their indices so we can map back.
         flat_params = [pr.param_dict for pr in study.to_resolvers(params)]
-        circuit_param_to_sweep_i: Dict[FrozenSet[Tuple[str, value.Scalar]], int] = {
+        circuit_param_to_sweep_i: Dict[FrozenSet[Tuple[str, Union[int, Tuple[int, int]]]], int] = {
             _hashable_param(param.items()): i for i, param in enumerate(flat_params)
         }
 

--- a/cirq-core/cirq/work/sampler_test.py
+++ b/cirq-core/cirq/work/sampler_test.py
@@ -258,6 +258,19 @@ def test_sampler_sample_expectation_values_multi_param():
     assert np.allclose(results, [[1], [-1], [1]])
 
 
+def test_sampler_sample_expectation_values_complex_param():
+    a = cirq.LineQubit(0)
+    t = sympy.Symbol('t')
+    sampler = cirq.Simulator(seed=1)
+    circuit = cirq.Circuit(cirq.global_phase_operation(t))
+    obs = cirq.Z(a)
+    results = sampler.sample_expectation_values(
+        circuit, [obs], num_samples=5, params=cirq.Points('t', [1, 1j, (1 + 1j) / np.sqrt(2)])
+    )
+
+    assert np.allclose(results, [[1], [1], [1]])
+
+
 def test_sampler_sample_expectation_values_multi_qubit():
     q = cirq.LineQubit.range(3)
     sampler = cirq.Simulator(seed=1)


### PR DESCRIPTION
Update all "circuit_params" members to allow complex scalar values. Update the hashing function also to handle these values by returning fixed-point `(real, imag)` tuples for complex numbers. Add a couple sanity checks that things still work.

Closes #5282

@tanujkhattar 