### PR TITLE
Check that control and target qubits disjoint in ControlledOperations

### DIFF
--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -54,6 +54,12 @@ class ControlledOperation(raw_types.Operation):
             control_values = ((1,),) * len(controls)
         if len(control_values) != len(controls):
             raise ValueError('len(control_values) != len(controls)')
+        # Verify qubits don't overlap
+        op_qids = set(sub_operation.qubits)
+        if not op_qids.isdisjoint(controls):
+            raise ValueError(
+                f'Sub-operation and controls share qubits ({op_qids.intersection(controls)}).'
+            )
         # Convert to sorted tuples
         self._control_values = cast(
             Tuple[Tuple[int, ...], ...],

--- a/cirq-core/cirq/ops/controlled_operation_test.py
+++ b/cirq-core/cirq/ops/controlled_operation_test.py
@@ -105,6 +105,8 @@ def test_controlled_operation_init():
         _ = cirq.ControlledOperation([cb], v, control_values=[2])
     with pytest.raises(ValueError, match='Control values .*outside of range'):
         _ = cirq.ControlledOperation([cb], v, control_values=[(1, -1)])
+    with pytest.raises(ValueError, match='share qubits'):
+        _ = cirq.ControlledOperation([cb], cirq.X(cb))
 
 
 def test_controlled_operation_eq():
@@ -140,8 +142,9 @@ def test_str():
     assert str(cirq.ControlledOperation([c1], cirq.CZ(c2, q2))) == "CCZ(c1, c2, q2)"
 
     class SingleQubitOp(cirq.Operation):
+        @property
         def qubits(self) -> Tuple[cirq.Qid, ...]:
-            pass
+            return ()
 
         def with_qubits(self, *new_qubits: cirq.Qid):
             pass


### PR DESCRIPTION
Adds check that control and target qubits are disjoint, plus a test.

xref #4007