### PR TITLE
IonQ: Handle 409 errors that are injected by Cloudflare

### DIFF
--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -40,6 +40,7 @@ RETRIABLE_STATUS_CODES = {
     *list(range(520, 530)),
 }
 
+
 def _is_retriable(code, method):
     return code in RETRIABLE_STATUS_CODES or (method == "GET" and code in RETRIABLE_FOR_GETS)
 

--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -25,17 +25,23 @@ import requests
 import cirq_ionq
 from cirq_ionq import ionq_exceptions
 
+# https://support.cloudflare.com/hc/en-us/articles/115003014512-4xx-Client-Error
+# "Cloudflare will generate and serve a 409 response for a Error 1001: DNS Resolution Error."
+# We may want to condition on the body as well, to allow for some GET requests to return 409 in
+# the future.
+RETRIABLE_FOR_GETS = {requests.codes.conflict}
+# Retriable regardless of the source
+# Handle 52x responses from cloudflare.
+# See https://support.cloudflare.com/hc/en-us/articles/115003011431/
 RETRIABLE_STATUS_CODES = {
     requests.codes.internal_server_error,
     requests.codes.bad_gateway,
     requests.codes.service_unavailable,
+    *list(range(520, 530)),
 }
 
-
-def _is_retriable(code):
-    # Handle 52x responses from cloudflare.
-    # See https://support.cloudflare.com/hc/en-us/articles/115003011431/
-    return code in RETRIABLE_STATUS_CODES or (code >= 520 and code <= 530)
+def _is_retriable(code, method):
+    return code in RETRIABLE_STATUS_CODES or (method == "GET" and code in RETRIABLE_FOR_GETS)
 
 
 class _IonQClient:
@@ -304,7 +310,7 @@ class _IonQClient:
                     raise ionq_exceptions.IonQNotFoundException(
                         'IonQ could not find requested resource.'
                     )
-                if not _is_retriable(response.status_code):
+                if not _is_retriable(response.status_code, response.request.method):
                     error = {}
                     try:
                         error = response.json()

--- a/cirq-ionq/cirq_ionq/ionq_client_test.py
+++ b/cirq-ionq/cirq_ionq/ionq_client_test.py
@@ -253,6 +253,9 @@ def test_ionq_client_get_job_retry_409(mock_get):
     mock_get.side_effect = [response1, response2]
     response1.ok = False
     response1.status_code = requests.codes.conflict
+    response1.request.method = "GET"
+    response2.ok = True
+    response2.json.return_value = {'foo': 'bar'}
 
     client = ionq.ionq_client._IonQClient(remote_host='http://example.com', api_key='to_my_heart')
     response = client.get_job(job_id='job_id')

--- a/cirq-ionq/cirq_ionq/ionq_client_test.py
+++ b/cirq-ionq/cirq_ionq/ionq_client_test.py
@@ -252,7 +252,7 @@ def test_ionq_client_get_job_retry_409(mock_get):
     response2 = mock.MagicMock()
     mock_get.side_effect = [response1, response2]
     response1.ok = False
-    response1.status_code = requests.codes.aborted
+    response1.status_code = requests.codes.conflict
 
     client = ionq.ionq_client._IonQClient(remote_host='http://example.com', api_key='to_my_heart')
     response = client.get_job(job_id='job_id')


### PR DESCRIPTION
When these occur on GETs, they can be retried.