### PR TITLE
docfixit: interop format

### DIFF
--- a/docs/interop.ipynb
+++ b/docs/interop.ipynb
@@ -176,10 +176,10 @@
    "source": [
     "### Advanced: Adding JSON compatibility for custom objects in cirq\n",
     "\n",
-    "Most cirq objects come with serialization functionality added already.  If you are adding a custom object (such as a custom gate), you can still serialize the object, but you will need to add the magic functions `_json_dict_` and `_from_json_dict` to your object to do so.\n",
+    "Most cirq objects come with serialization functionality added already.  If you are adding a custom object (such as a custom gate), you can still serialize the object, but you will need to add the magic functions `_json_dict_` and `_from_json_dict_` to your object to do so.\n",
     "\n",
     "When de-serializing, in order to instantiate the correct object, you will also have to pass in a custom resolver.  This is a function that will take as input the serialized `cirq_type` string and output a constructable class.  See \n",
-    "`cirq.protocols.json_serialization` for more details."
+    "[`cirq.protocols.json_serialization`](https://github.com/quantumlib/Cirq/blob/master/cirq-core/cirq/protocols/json_serialization.py) for more details."
    ]
   },
   {
@@ -285,7 +285,7 @@
    "source": [
     "#### Gate conversion rules \n",
     "\n",
-    "Note: The standard Quantum Experience standard gates are defined in ([qelib.inc](https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/qasm/libs/qelib1.inc)) \n",
+    "Note: The standard Quantum Experience standard gates (defined in [qelib.inc](https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/qasm/libs/qelib1.inc)) are \n",
     "based on the `U` and `CX` built-in instructions, and we could generate them dynamically. Instead, we chose to map them to native Cirq gates explicitly, which results in a more user-friendly circuit. \n",
     "\n",
     "| QE gates| Cirq translation| Notes|\n",

--- a/docs/interop.ipynb
+++ b/docs/interop.ipynb
@@ -285,7 +285,7 @@
    "source": [
     "#### Gate conversion rules \n",
     "\n",
-    "Note: The standard Quantum Experience standard gates (defined in [qelib.inc](https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/qasm/libs/qelib1.inc)) are \n",
+    "Note: The standard Quantum Experience gates (defined in [qelib.inc](https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/qasm/libs/qelib1.inc)) are \n",
     "based on the `U` and `CX` built-in instructions, and we could generate them dynamically. Instead, we chose to map them to native Cirq gates explicitly, which results in a more user-friendly circuit. \n",
     "\n",
     "| QE gates| Cirq translation| Notes|\n",


### PR DESCRIPTION
Minor patches to the interop doc.

Not super familiar with our QASM integration, but last I checked we hadn't changed it and don't intend to migrate to OpenQASM3.0 unless external contributors jump in on it.