### PR TITLE
Update Neutral Atoms to Transformers

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -668,6 +668,7 @@ from cirq.protocols import (
 
 from cirq.ion import ConvertToIonGates, IonDevice, ms, two_qubit_matrix_to_ion_operations
 from cirq.neutral_atoms import (
+    convert_to_neutral_atom_gates,
     ConvertToNeutralAtomGates,
     is_native_neutral_atom_gate,
     is_native_neutral_atom_op,

--- a/cirq-core/cirq/neutral_atoms/__init__.py
+++ b/cirq-core/cirq/neutral_atoms/__init__.py
@@ -17,6 +17,7 @@
 from cirq.neutral_atoms.neutral_atom_devices import NeutralAtomDevice
 
 from cirq.neutral_atoms.convert_to_neutral_atom_gates import (
+    convert_to_neutral_atom_gates,
     ConvertToNeutralAtomGates,
     is_native_neutral_atom_gate,
     is_native_neutral_atom_op,

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
@@ -13,15 +13,25 @@
 # limitations under the License.
 from typing import List, Optional, TYPE_CHECKING
 
-from cirq import ops, protocols
+from cirq import ops, protocols, transformers
+from cirq._compat import deprecated_class
 from cirq.circuits.optimization_pass import PointOptimizationSummary, PointOptimizer
-from cirq.neutral_atoms import neutral_atom_devices
-from cirq import transformers
+from cirq.neutral_atoms import neutral_atom_gateset
 
 if TYPE_CHECKING:
     import cirq
 
 
+@transformers.transformer
+def convert_to_neutral_atom_gates(
+    circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
+) -> 'cirq.Circuit':
+    return transformers.optimize_for_target_gateset(
+        circuit, gateset=neutral_atom_gateset.NeutralAtomGateset()
+    )
+
+
+@deprecated_class(deadline='v0.16', fix='Use cirq.convert_to_neutral_atom_gates instead.')
 class ConvertToNeutralAtomGates(PointOptimizer):
     """Attempts to convert gates into native Atom gates.
 
@@ -48,7 +58,7 @@ class ConvertToNeutralAtomGates(PointOptimizer):
         """
         super().__init__()
         self.ignore_failures = ignore_failures
-        self.gateset = neutral_atom_devices.neutral_atom_gateset()
+        self.gateset = neutral_atom_gateset.neutral_atom_gateset()
 
     def _convert_one(self, op: ops.Operation) -> ops.OP_TREE:
         # Known matrix?
@@ -91,8 +101,8 @@ class ConvertToNeutralAtomGates(PointOptimizer):
 
 
 def is_native_neutral_atom_op(operation: ops.Operation) -> bool:
-    return operation in neutral_atom_devices.neutral_atom_gateset()
+    return operation in neutral_atom_gateset.neutral_atom_gateset()
 
 
 def is_native_neutral_atom_gate(gate: ops.Gate) -> bool:
-    return gate in neutral_atom_devices.neutral_atom_gateset()
+    return gate in neutral_atom_gateset.neutral_atom_gateset()

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
@@ -16,37 +16,56 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq import ops
+
+
+Q = cirq.LineQubit.range(3)
+
+
+@pytest.mark.parametrize(
+    'expected',
+    (
+        cirq.Circuit(cirq.X.on(Q[0])),
+        cirq.Circuit(cirq.Y.on(Q[0])),
+        cirq.Circuit(cirq.ParallelGate(cirq.X, 3).on(*Q)),
+        cirq.Circuit(cirq.CNOT.on(Q[0], Q[1])),
+    ),
+)
+def test_gates_preserved(expected: cirq.Circuit):
+    actual = cirq.convert_to_neutral_atom_gates(expected)
+    assert actual == expected
 
 
 def test_coverage():
-    q = cirq.LineQubit.range(3)
-    g = cirq.testing.ThreeQubitGate()
+    with cirq.testing.assert_deprecated(
+        "Use cirq.convert_to_neutral_atom_gates", deadline='v0.16', count=5
+    ):
+        q = cirq.LineQubit.range(3)
+        g = cirq.testing.ThreeQubitGate()
 
-    class FakeOperation(ops.Operation):
-        def __init__(self, gate, qubits):
-            self._gate = gate
-            self._qubits = qubits
+        class FakeOperation(cirq.Operation):
+            def __init__(self, gate, qubits):
+                self._gate = gate
+                self._qubits = qubits
 
-        @property
-        def qubits(self):
-            return self._qubits
+            @property
+            def qubits(self):
+                return self._qubits
 
-        def with_qubits(self, *new_qubits):
-            return FakeOperation(self._gate, new_qubits)
+            def with_qubits(self, *new_qubits):
+                return FakeOperation(self._gate, new_qubits)
 
-    op = FakeOperation(g, q).with_qubits(*q)
-    circuit_ops = [cirq.Y(q[0]), cirq.ParallelGate(cirq.X, 3).on(*q)]
-    c = cirq.Circuit(circuit_ops)
-    cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
-    assert c == cirq.Circuit(circuit_ops)
-    assert cirq.neutral_atoms.ConvertToNeutralAtomGates().convert(cirq.X.on(q[0])) == [
-        cirq.X.on(q[0])
-    ]
-    with pytest.raises(TypeError, match="Don't know how to work with"):
-        cirq.neutral_atoms.ConvertToNeutralAtomGates().convert(op)
-    assert not cirq.neutral_atoms.is_native_neutral_atom_op(op)
-    assert not cirq.neutral_atoms.is_native_neutral_atom_gate(g)
+        op = FakeOperation(g, q).with_qubits(*q)
+        circuit_ops = [cirq.Y(q[0]), cirq.ParallelGate(cirq.X, 3).on(*q)]
+        c = cirq.Circuit(circuit_ops)
+        cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
+        assert c == cirq.Circuit(circuit_ops)
+        assert cirq.neutral_atoms.ConvertToNeutralAtomGates().convert(cirq.X.on(q[0])) == [
+            cirq.X.on(q[0])
+        ]
+        with pytest.raises(TypeError, match="Don't know how to work with"):
+            cirq.neutral_atoms.ConvertToNeutralAtomGates().convert(op)
+        assert not cirq.neutral_atoms.is_native_neutral_atom_op(op)
+        assert not cirq.neutral_atoms.is_native_neutral_atom_gate(g)
 
 
 def test_avoids_decompose_fallback_when_matrix_available_single_qubit():
@@ -60,8 +79,13 @@ def test_avoids_decompose_fallback_when_matrix_available_single_qubit():
 
     q = cirq.GridQubit(0, 0)
     c = cirq.Circuit(OtherX().on(q), OtherOtherX().on(q))
-    cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
-    cirq.testing.assert_has_diagram(c, '(0, 0): ───PhX(1)───PhX(1)───')
+    converted = cirq.convert_to_neutral_atom_gates(c)
+    cirq.testing.assert_has_diagram(converted, '(0, 0): ───PhX(1)───PhX(1)───')
+    with cirq.testing.assert_deprecated(
+        "Use cirq.convert_to_neutral_atom_gates", deadline='v0.16', count=2
+    ):
+        cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
+        cirq.testing.assert_has_diagram(c, '(0, 0): ───PhX(1)───PhX(1)───')
 
 
 def test_avoids_decompose_fallback_when_matrix_available_two_qubit():
@@ -76,12 +100,15 @@ def test_avoids_decompose_fallback_when_matrix_available_two_qubit():
     q00 = cirq.GridQubit(0, 0)
     q01 = cirq.GridQubit(0, 1)
     c = cirq.Circuit(OtherCZ().on(q00, q01), OtherOtherCZ().on(q00, q01))
-    cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
-    cirq.testing.assert_has_diagram(
-        c,
-        """
+    expected_diagram = """
 (0, 0): ───@───@───
            │   │
 (0, 1): ───@───@───
-""",
-    )
+"""
+    converted = cirq.convert_to_neutral_atom_gates(c)
+    cirq.testing.assert_has_diagram(converted, expected_diagram)
+    with cirq.testing.assert_deprecated(
+        "Use cirq.convert_to_neutral_atom_gates", deadline='v0.16', count=2
+    ):
+        cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
+        cirq.testing.assert_has_diagram(c, expected_diagram)

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -20,7 +20,8 @@ from cirq import _compat, devices, ops, circuits, value
 from cirq.devices.grid_qubit import GridQubit
 from cirq.ops import raw_types
 from cirq.value import Duration
-from cirq.neutral_atoms import convert_to_neutral_atom_gates
+from cirq.neutral_atoms.convert_to_neutral_atom_gates import ConvertToNeutralAtomGates
+from cirq.neutral_atoms import neutral_atom_gateset
 
 if TYPE_CHECKING:
     import cirq
@@ -29,22 +30,6 @@ if TYPE_CHECKING:
 def _subgate_if_parallel_gate(gate: 'cirq.Gate') -> 'cirq.Gate':
     """Returns gate.sub_gate if gate is a ParallelGate, else returns gate"""
     return gate.sub_gate if isinstance(gate, ops.ParallelGate) else gate
-
-
-def neutral_atom_gateset(max_parallel_z=None, max_parallel_xy=None):
-    return ops.Gateset(
-        ops.AnyIntegerPowerGateFamily(ops.CNotPowGate),
-        ops.AnyIntegerPowerGateFamily(ops.CCNotPowGate),
-        ops.AnyIntegerPowerGateFamily(ops.CZPowGate),
-        ops.AnyIntegerPowerGateFamily(ops.CCZPowGate),
-        ops.ParallelGateFamily(ops.ZPowGate, max_parallel_allowed=max_parallel_z),
-        ops.ParallelGateFamily(ops.XPowGate, max_parallel_allowed=max_parallel_xy),
-        ops.ParallelGateFamily(ops.YPowGate, max_parallel_allowed=max_parallel_xy),
-        ops.ParallelGateFamily(ops.PhasedXPowGate, max_parallel_allowed=max_parallel_xy),
-        ops.MeasurementGate,
-        ops.IdentityGate,
-        unroll_circuit_op=False,
-    )
 
 
 @value.value_equality
@@ -107,7 +92,7 @@ class NeutralAtomDevice(devices.Device):
             ops.AnyIntegerPowerGateFamily(ops.CCZPowGate),
             unroll_circuit_op=False,
         )
-        self.gateset = neutral_atom_gateset(max_parallel_z, max_parallel_xy)
+        self.gateset = neutral_atom_gateset.neutral_atom_gateset(max_parallel_z, max_parallel_xy)
         for q in qubits:
             if not isinstance(q, GridQubit):
                 raise ValueError(f'Unsupported qubit type: {q!r}')
@@ -133,7 +118,7 @@ class NeutralAtomDevice(devices.Device):
         deadline='v0.15',
     )
     def decompose_operation(self, operation: ops.Operation) -> ops.OP_TREE:
-        return convert_to_neutral_atom_gates.ConvertToNeutralAtomGates().convert(operation)
+        return ConvertToNeutralAtomGates().convert(operation)
 
     def duration_of(self, operation: ops.Operation):
         """Provides the duration of the given operation on this device.

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices_test.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices_test.py
@@ -114,7 +114,7 @@ def test_init_errors():
 
 def test_decompose_error_deprecated():
     d = square_device(2, 2, holes=[cirq.GridQubit(1, 1)])
-    with cirq.testing.assert_deprecated('ConvertToNeutralAtomGates', deadline='v0.15'):
+    with cirq.testing.assert_deprecated('ConvertToNeutralAtomGates', deadline='v0.15', count=2):
         for op in d.decompose_operation((cirq.CCZ**1.5).on(*(d.qubit_list()))):
             d.validate_operation(op)
 


### PR DESCRIPTION
Create function convert_to_neutral_atom_gateset() to
replace PointOptimizer ConvertToNeutralAtomGateset.

Create NeutralAtomGateset that works as a compilation target
gateset.