### PR TITLE
Add json serialization to SycamoreTargetGateset.

### DIFF
--- a/cirq-google/cirq_google/json_resolver_cache.py
+++ b/cirq-google/cirq_google/json_resolver_cache.py
@@ -39,6 +39,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'FloquetPhasedFSimCalibrationRequest': cirq_google.FloquetPhasedFSimCalibrationRequest,
         'PhasedFSimCalibrationResult': cirq_google.PhasedFSimCalibrationResult,
         'PhasedFSimCharacterization': cirq_google.PhasedFSimCharacterization,
+        'SycamoreTargetGateset': cirq_google.SycamoreTargetGateset,
         'XEBPhasedFSimCalibrationOptions': cirq_google.XEBPhasedFSimCalibrationOptions,
         'XEBPhasedFSimCalibrationRequest': cirq_google.XEBPhasedFSimCalibrationRequest,
         'LocalXEBPhasedFSimCalibrationOptions': cirq_google.LocalXEBPhasedFSimCalibrationOptions,

--- a/cirq-google/cirq_google/json_test_data/SycamoreTargetGateset.json
+++ b/cirq-google/cirq_google/json_test_data/SycamoreTargetGateset.json
@@ -1,0 +1,5 @@
+{
+    "cirq_type": "SycamoreTargetGateset",
+    "atol": 1e-08,
+    "tabulation": null
+}

--- a/cirq-google/cirq_google/json_test_data/SycamoreTargetGateset.repr
+++ b/cirq-google/cirq_google/json_test_data/SycamoreTargetGateset.repr
@@ -1,0 +1,1 @@
+cirq_google.SycamoreTargetGateset(atol=1e-08, tabulation=None)

--- a/cirq-google/cirq_google/json_test_data/spec.py
+++ b/cirq-google/cirq_google/json_test_data/spec.py
@@ -22,7 +22,6 @@ TestSpec = ModuleJsonTestSpec(
         'WITHOUT_CHI_FLOQUET_PHASED_FSIM_CHARACTERIZATION',
         'XmonDevice',
         'XMON',
-        'SycamoreTargetGateset',
     ],
     should_not_be_serialized=[
         'AnnealSequenceSearchStrategy',

--- a/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset.py
+++ b/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset.py
@@ -15,7 +15,7 @@
 """Target gateset used for compiling circuits to Sycamore + 1-q rotations + measurement gates."""
 
 import itertools
-from typing import cast, List, Optional, Sequence
+from typing import cast, Any, Dict, List, Optional, Sequence
 
 import cirq
 from cirq.protocols.decompose_protocol import DecomposeResult
@@ -165,6 +165,12 @@ class SycamoreTargetGateset(cirq.TwoQubitCompilationTargetGateset):
         return (
             f'cirq_google.SycamoreTargetGateset('
             f'atol={self.atol}, '
-            f'tabulation={self.tabulation}, '
-            f')'
+            f'tabulation={self.tabulation})'
         )
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return {'atol': self.atol, 'tabulation': self.tabulation}
+
+    @classmethod
+    def _from_json_dict_(cls, atol, tabulation, **kwargs):
+        return cls(atol=atol, tabulation=tabulation)

--- a/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
+++ b/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
@@ -387,3 +387,19 @@ def test_supported_operation(op):
     )
     multi_qubit_ops = [e for e in converted_circuit.all_operations() if len(e.qubits) > 1]
     assert all(isinstance(e.gate, cirq_google.SycamoreGate) for e in multi_qubit_ops)
+
+
+@pytest.mark.parametrize(
+    'gateset',
+    [
+        cirq_google.SycamoreTargetGateset(),
+        cirq_google.SycamoreTargetGateset(
+            tabulation=cirq.two_qubit_gate_product_tabulation(
+                cirq.unitary(cirq_google.SYC), 0.1, random_state=cirq.value.parse_random_state(11)
+            )
+        ),
+    ],
+)
+def test_repr_json(gateset):
+    assert eval(repr(gateset)) == gateset
+    assert cirq.read_json(json_text=cirq.to_json(gateset)) == gateset


### PR DESCRIPTION
This makes it possible to fully serialize `GridDeviceMetadata`.

A repr/json with tabulation set is omitted because the repr of cirq.two_qubit_gate_product_tabulation() is very long.

@tanujkhattar 