### PR TITLE
Remove ids from notebooks

### DIFF
--- a/docs/gatezoo.ipynb
+++ b/docs/gatezoo.ipynb
@@ -194,22 +194,9 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/docs/gatezoo.ipynb
+++ b/docs/gatezoo.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e694355-6c8f-43c5-b1ae-4e86af9fc9eb",
    "metadata": {
     "cellView": "form",
     "id": "KQa9t_gadIuR"
@@ -26,7 +25,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42a837dc-73a7-4a4e-a79b-563786f1bfc6",
    "metadata": {
     "id": "xwec7FrkdFmi"
    },
@@ -36,7 +34,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ffc5e6a-50af-495e-b713-ad7c626a6181",
    "metadata": {
     "id": "5KZia7jmdJ3V"
    },
@@ -59,7 +56,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb448db9-c75a-44e1-900c-532101085565",
    "metadata": {
     "id": "541571c2edcd"
    },
@@ -71,7 +67,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b650764-128c-46fe-8b19-ee54762a77ef",
    "metadata": {
     "id": "bd9529db1c0b"
    },
@@ -100,7 +95,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5731f798-b633-4039-a138-8c70b4d8fac4",
    "metadata": {
     "id": "1cd004cc2f3a"
    },
@@ -118,7 +112,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cb68f8a-4285-42ba-9a0f-b73bf13cd4f1",
    "metadata": {
     "id": "0c3a029e2155"
    },
@@ -129,7 +122,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d65a3acf-4446-4d7b-9077-39cd0b1095b6",
    "metadata": {
     "id": "10c855370f45"
    },
@@ -142,7 +134,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5d38c50-1774-4acf-b22c-47cd103c8a8d",
    "metadata": {
     "id": "e96e1c459258"
    },
@@ -153,7 +144,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a7fec58-bbe6-4ec7-8158-5afe735ea7e2",
    "metadata": {
     "id": "4bfc17ef80bb"
    },
@@ -166,7 +156,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e478b06c-3a62-4b6c-a614-12dc25182304",
    "metadata": {
     "id": "0e2ea8a0a0ae"
    },
@@ -177,7 +166,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "110838d7-5a53-4b53-aeea-4496549e8e1f",
    "metadata": {
     "id": "6631a361ac42"
    },
@@ -190,7 +178,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a560cfb-6d7b-4837-85d1-6aa96accc264",
    "metadata": {
     "id": "b5ffeefa3c76"
    },
@@ -207,9 +194,22 @@
   },
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
These appear to have come from a jupyter nbformat versioning issue.  "id" was added in the 4.5 schema.  Somehow these got saved into a 4.0 schema notebook.  

This breaks our nightly docs build right now.