### PR TITLE
Prevent implicit package search from top level setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,5 +70,5 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
-    packages = [],
+    packages=[],
 )

--- a/setup.py
+++ b/setup.py
@@ -70,4 +70,5 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    packages = [],
 )


### PR DESCRIPTION
The top level setup.py is virtual and only declares cirq-core,
cirq-google, and others as its dependencies.
Make sure it does not search for packages,
which would raise setuptools error.

Resolves https://github.com/quantumlib/Cirq/issues/5291