### PR TITLE
Add median calibrations to package

### DIFF
--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -72,6 +72,7 @@ setup(
         'cirq_google': ['py.typed'],
         'cirq_google.api.v2': ['*'],
         'cirq_google.api.v1': ['*'],
+        'cirq_google.devices.calibrations': ['*'],
         'cirq_google.devices.specifications': ['*'],
         'cirq_google.json_test_data': ['*'],
     },


### PR DESCRIPTION
#5338 added median calibration data to the Cirq repository, but failed to expose it in the pypi package.

This change should ensure that `.../cirq_google/devices/calibrations/` is populated when the user pip-installs Cirq (or currently, the pre-release of Cirq).