### PR TITLE
__init__ for calibrations package

### DIFF
--- a/cirq-google/cirq_google/devices/calibrations/__init__.py
+++ b/cirq-google/cirq_google/devices/calibrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Lack of an `__init__.py` file prevented discovery of these files in `setup.py`.