### PR TITLE
IonQ: Handle loss of precision in floats

### DIFF
--- a/cirq-ionq/cirq_ionq/job.py
+++ b/cirq-ionq/cirq_ionq/job.py
@@ -214,7 +214,7 @@ class Job:
         if self.target().startswith('qpu'):
             repetitions = self.repetitions()
             counts = {
-                _little_endian_to_big(int(k), self.num_qubits()): int(repetitions * float(v))
+                _little_endian_to_big(int(k), self.num_qubits()): round(repetitions * float(v))
                 for k, v in self._job['data']['histogram'].items()
             }
             return results.QPUResult(

--- a/cirq-ionq/cirq_ionq/job_test.py
+++ b/cirq-ionq/cirq_ionq/job_test.py
@@ -86,7 +86,7 @@ def test_job_results_rounding_qpu():
         'metadata': {'shots': 5000, 'measurement0': f'a{chr(31)}0,1'},
         'data': {'histogram': {'0': '0.0006', '2': '0.9994'}},
     }
-    # 5000*0.0004 ~ 2.9999 but should be interpreted as 3
+    # 5000*0.0006 ~ 2.9999 but should be interpreted as 3
     job = ionq.Job(None, job_dict)
     expected = ionq.QPUResult({0: 3, 1: 4997}, 2, {'a': [0, 1]})
     results = job.results()

--- a/cirq-ionq/cirq_ionq/job_test.py
+++ b/cirq-ionq/cirq_ionq/job_test.py
@@ -77,6 +77,22 @@ def test_job_results_qpu():
     assert results == expected
 
 
+def test_job_results_rounding_qpu():
+    job_dict = {
+        'id': 'my_id',
+        'status': 'completed',
+        'qubits': '2',
+        'target': 'qpu',
+        'metadata': {'shots': 5000, 'measurement0': f'a{chr(31)}0,1'},
+        'data': {'histogram': {'0': '0.0006', '2': '0.9994'}},
+    }
+    # 5000*0.0004 ~ 2.9999 but should be interpreted as 3
+    job = ionq.Job(None, job_dict)
+    expected = ionq.QPUResult({0: 3, 1: 4997}, 2, {'a': [0, 1]})
+    results = job.results()
+    assert results == expected
+
+
 def test_job_results_failed():
     job_dict = {'id': 'my_id', 'status': 'failed', 'failure': {'error': 'too many qubits'}}
     job = ionq.Job(None, job_dict)


### PR DESCRIPTION
We can't guarantee that shot * prob cleanly returns an integer, for example 0.0006*5000 does not return 3 due to an inability to represent 0.0006 perfectly. See https://docs.python.org/3/tutorial/floatingpoint.html