### PR TITLE
Add json serialization for PauliSum

### DIFF
--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -146,6 +146,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'PauliString': cirq.PauliString,
         'PauliStringPhasor': cirq.PauliStringPhasor,
         'PauliStringPhasorGate': cirq.PauliStringPhasorGate,
+        'PauliSum': cirq.PauliSum,
         '_PauliX': cirq.ops.pauli_gates._PauliX,
         '_PauliY': cirq.ops.pauli_gates._PauliY,
         '_PauliZ': cirq.ops.pauli_gates._PauliZ,

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -499,19 +499,15 @@ class PauliSum:
         raise ValueError(f'{self} is not unitary')
 
     def _json_dict_(self):
-        def key_json(k):
-            # k is a frozenset, each element of frozen set is a tuple.
-            return [[x for x in e] for e in sorted(list(k))]
+        def key_json(k: UnitPauliStringT):
+            return [list(e) for e in sorted(k)]
 
-        return {
-            'keys': [key_json(k) for k in self._linear_dict.keys()],
-            'values': list(self._linear_dict.values()),
-        }
+        return {'items': list((key_json(k), v) for k, v in self._linear_dict.items())}
 
     @classmethod
-    def _from_json_dict_(cls, keys, values, **kwargs):
+    def _from_json_dict_(cls, items, **kwargs):
         mapping = dict()
-        for k, v in zip(keys, values):
+        for k, v in items:
             mapping[frozenset(tuple(x) for x in k)] = v
         return cls(linear_dict=value.LinearDict(mapping))
 

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -506,9 +506,10 @@ class PauliSum:
 
     @classmethod
     def _from_json_dict_(cls, items, **kwargs):
-        mapping = dict()
-        for k, v in items:
-            mapping[frozenset(tuple(x) for x in k)] = v
+        mapping = {
+            frozenset(tuple(qid_pauli) for qid_pauli in unit_pauli_string): val
+            for unit_pauli_string, val in items
+        }
         return cls(linear_dict=value.LinearDict(mapping))
 
     def expectation_from_state_vector(

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -498,6 +498,23 @@ class PauliSum:
             return m
         raise ValueError(f'{self} is not unitary')
 
+    def _json_dict_(self):
+        def key_json(k):
+            # k is a frozenset, each element of frozen set is a tuple.
+            return [[x for x in e] for e in sorted(list(k))]
+
+        return {
+            'keys': [key_json(k) for k in self._linear_dict.keys()],
+            'values': list(self._linear_dict.values()),
+        }
+
+    @classmethod
+    def _from_json_dict_(cls, keys, values, **kwargs):
+        mapping = dict()
+        for k, v in zip(keys, values):
+            mapping[frozenset(tuple(x) for x in k)] = v
+        return cls(linear_dict=value.LinearDict(mapping))
+
     def expectation_from_state_vector(
         self,
         state_vector: np.ndarray,

--- a/cirq-core/cirq/protocols/json_test_data/PauliSum.json
+++ b/cirq-core/cirq/protocols/json_test_data/PauliSum.json
@@ -1,0 +1,65 @@
+{
+  "cirq_type": "PauliSum",
+  "keys": [
+    [
+      [
+        {
+          "cirq_type": "LineQubit",
+          "x": 0
+        },
+        {
+          "cirq_type": "_PauliX",
+          "exponent": 1.0,
+          "global_shift": 0.0
+        }
+      ],
+      [
+        {
+          "cirq_type": "LineQubit",
+          "x": 1
+        },
+        {
+          "cirq_type": "_PauliX",
+          "exponent": 1.0,
+          "global_shift": 0.0
+        }
+      ]
+    ],
+    [
+      [
+        {
+          "cirq_type": "LineQubit",
+          "x": 0
+        },
+        {
+          "cirq_type": "_PauliY",
+          "exponent": 1.0,
+          "global_shift": 0.0
+        }
+      ],
+      [
+        {
+          "cirq_type": "LineQubit",
+          "x": 1
+        },
+        {
+          "cirq_type": "_PauliY",
+          "exponent": 1.0,
+          "global_shift": 0.0
+        }
+      ]
+    ]
+  ],
+  "values": [
+    {
+      "cirq_type": "complex",
+      "real": 1.0,
+      "imag": 0.0
+    },
+    {
+      "cirq_type": "complex",
+      "real": 0.0,
+      "imag": 1.0
+    }
+  ]
+}

--- a/cirq-core/cirq/protocols/json_test_data/PauliSum.json
+++ b/cirq-core/cirq/protocols/json_test_data/PauliSum.json
@@ -1,65 +1,67 @@
 {
   "cirq_type": "PauliSum",
-  "keys": [
+  "items": [
     [
       [
-        {
-          "cirq_type": "LineQubit",
-          "x": 0
-        },
-        {
-          "cirq_type": "_PauliX",
-          "exponent": 1.0,
-          "global_shift": 0.0
-        }
+        [
+          {
+            "cirq_type": "LineQubit",
+            "x": 0
+          },
+          {
+            "cirq_type": "_PauliX",
+            "exponent": 1.0,
+            "global_shift": 0.0
+          }
+        ],
+        [
+          {
+            "cirq_type": "LineQubit",
+            "x": 1
+          },
+          {
+            "cirq_type": "_PauliX",
+            "exponent": 1.0,
+            "global_shift": 0.0
+          }
+        ]
       ],
-      [
-        {
-          "cirq_type": "LineQubit",
-          "x": 1
-        },
-        {
-          "cirq_type": "_PauliX",
-          "exponent": 1.0,
-          "global_shift": 0.0
-        }
-      ]
+      {
+        "cirq_type": "complex",
+        "real": 1.0,
+        "imag": 0.0
+      }
     ],
     [
       [
-        {
-          "cirq_type": "LineQubit",
-          "x": 0
-        },
-        {
-          "cirq_type": "_PauliY",
-          "exponent": 1.0,
-          "global_shift": 0.0
-        }
+        [
+          {
+            "cirq_type": "LineQubit",
+            "x": 0
+          },
+          {
+            "cirq_type": "_PauliY",
+            "exponent": 1.0,
+            "global_shift": 0.0
+          }
+        ],
+        [
+          {
+            "cirq_type": "LineQubit",
+            "x": 1
+          },
+          {
+            "cirq_type": "_PauliY",
+            "exponent": 1.0,
+            "global_shift": 0.0
+          }
+        ]
       ],
-      [
-        {
-          "cirq_type": "LineQubit",
-          "x": 1
-        },
-        {
-          "cirq_type": "_PauliY",
-          "exponent": 1.0,
-          "global_shift": 0.0
-        }
-      ]
+      {
+        "cirq_type": "complex",
+        "real": 0.0,
+        "imag": 1.0
+      }
     ]
-  ],
-  "values": [
-    {
-      "cirq_type": "complex",
-      "real": 1.0,
-      "imag": 0.0
-    },
-    {
-      "cirq_type": "complex",
-      "real": 0.0,
-      "imag": 1.0
-    }
   ]
 }

--- a/cirq-core/cirq/protocols/json_test_data/PauliSum.repr
+++ b/cirq-core/cirq/protocols/json_test_data/PauliSum.repr
@@ -1,0 +1,1 @@
+cirq.PauliSum(cirq.LinearDict({frozenset({(cirq.LineQubit(1), cirq.X), (cirq.LineQubit(0), cirq.X)}): (1+0j), frozenset({(cirq.LineQubit(1), cirq.Y), (cirq.LineQubit(0), cirq.Y)}): (1j)}))

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -47,7 +47,6 @@ TestSpec = ModuleJsonTestSpec(
         'DiagonalGate',
         'NeutralAtomDevice',
         'PauliInteractionGate',
-        'PauliSum',
         'PauliSumCollector',
         'PauliSumExponential',
         'PauliTransform',


### PR DESCRIPTION
Fixes #3071 

One approach to this would have been to serialize frozenset and tuple in Cirq, but this instead takes the approach of not relying on this but appropriately serializing and deserializing these.