### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
     name: Pytest Ubuntu
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -163,9 +163,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - name: Force old pip (3.6 only)
-        if: matrix.python-version == '3.6'
-        run: pip install pip==20.2
       - uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -8,7 +8,7 @@
     "dvcs": "git",
     "environment_type": "virtualenv",
     "show_commit_url": "https://github.com/quantumlib/Cirq/commit/",
-    "pythons": ["3.6", "3.7", "3.8"],
+    "pythons": ["3.7", "3.8"],
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",

--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -60,7 +60,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -541,7 +541,6 @@ from cirq.value import (
     Condition,
     Duration,
     DURATION_LIKE,
-    GenericMetaImplementAnyOneOf,
     KeyCondition,
     LinearDict,
     MEASUREMENT_KEY_SEPARATOR,

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 """Define version number here, read it from setup.py automatically,
-and warn users that the latest version of cirq uses python 3.6+"""
+and warn users that the latest version of cirq uses python 3.7+"""
 
 import sys
 
-if sys.version_info < (3, 6, 0):
+if sys.version_info < (3, 7, 0):
     # coverage: ignore
     raise SystemError(
-        "You installed the latest version of cirq but aren't on python 3.6+.\n"
+        "You installed the latest version of cirq but aren't on python 3.7+.\n"
         'To fix this error, you need to either:\n'
         '\n'
-        'A) Update to python 3.6 or later.\n'
+        'A) Update to python 3.7 or later.\n'
         '- OR -\n'
         'B) Explicitly install an older deprecated-but-compatible version '
         'of cirq (e.g. "python -m pip install cirq==0.5.*")'

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -130,7 +130,6 @@ TestSpec = ModuleJsonTestSpec(
         'Pauli',
         'SingleQubitGate',
         'ABCMetaImplementAnyOneOf',
-        'GenericMetaImplementAnyOneOf',
         'SimulatesAmplitudes',
         'SimulatesExpectationValues',
         'SimulatesFinalState',

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -452,7 +452,7 @@ class SimulatesExpectationValues(metaclass=value.ABCMetaImplementAnyOneOf):
 
 
 class SimulatesFinalState(
-    Generic[TSimulationTrialResult], metaclass=value.GenericMetaImplementAnyOneOf
+    Generic[TSimulationTrialResult], metaclass=value.ABCMetaImplementAnyOneOf
 ):
     """Simulator that allows access to the simulator's final state.
 

--- a/cirq-core/cirq/value/__init__.py
+++ b/cirq-core/cirq/value/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Value conversion utilities and classes for time and quantum states."""
-from cirq.value.abc_alt import ABCMetaImplementAnyOneOf, alternative, GenericMetaImplementAnyOneOf
+from cirq.value.abc_alt import ABCMetaImplementAnyOneOf, alternative
 
 from cirq.value.angle import (
     canonicalize_half_turns,

--- a/cirq-core/cirq/value/abc_alt.py
+++ b/cirq-core/cirq/value/abc_alt.py
@@ -17,15 +17,6 @@ import abc
 import functools
 from typing import cast, Callable, Set, TypeVar
 
-# Required due to PEP 560
-try:
-    # python 3.6 class for generic metaclasses
-    from typing import GenericMeta  # type: ignore
-except ImportError:
-    # In python 3.7, GenericMeta doesn't exist but we don't need it
-    class GenericMeta(type):  # type: ignore
-        pass
-
 
 T = TypeVar('T')
 
@@ -154,14 +145,3 @@ class ABCMetaImplementAnyOneOf(abc.ABCMeta):
         cls.__abstractmethods__ |= abstracts  # Add to the set made by ABCMeta
         cls._implemented_by_ = implemented_by
         return cls
-
-
-class GenericMetaImplementAnyOneOf(GenericMeta, ABCMetaImplementAnyOneOf):
-    """Generic version of ABCMetaImplementAnyOneOf.
-
-    Classes which inherit from Generic[T] must use this type instead of
-    ABCMetaImplementAnyOneOf due to https://github.com/python/typing/issues/449.
-
-    This issue is specific to python3.6; this class can be removed when Cirq
-    python3.6 support is turned down.
-    """

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -1,8 +1,5 @@
 # Runtime requirements for the python 3 version of cirq.
 
-# for python 3.6 and below dataclasses needs to be installed
-dataclasses; python_version < '3.7'
-
 # functools.cached_property was introduced in python 3.8
 backports.cached_property~=1.0.1; python_version < '3.8'
 

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -63,7 +63,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     extras_require={'contrib': contrib_requirements},
     license='Apache 2',

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 """Define version number here, read it from setup.py automatically,
-and warn users that the latest version of cirq uses python 3.6+"""
+and warn users that the latest version of cirq uses python 3.7+"""
 
 import sys
 
-if sys.version_info < (3, 6, 0):
+if sys.version_info < (3, 7, 0):
     # coverage: ignore
     raise SystemError(
-        "You installed the latest version of cirq but aren't on python 3.6+.\n"
+        "You installed the latest version of cirq but aren't on python 3.7+.\n"
         'To fix this error, you need to either:\n'
         '\n'
-        'A) Update to python 3.6 or later.\n'
+        'A) Update to python 3.7 or later.\n'
         '- OR -\n'
         'B) Explicitly install an older deprecated-but-compatible version '
         'of cirq (e.g. "python -m pip install cirq==0.5.*")'

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -62,7 +62,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -59,7 +59,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -58,7 +58,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -62,7 +62,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/dev_tools/modules_test.py
+++ b/dev_tools/modules_test.py
@@ -37,7 +37,7 @@ def test_modules():
             'url': 'http://github.com/quantumlib/cirq',
             'author': 'The Cirq Developers',
             'author_email': 'cirq-dev@googlegroups.com',
-            'python_requires': '>=3.6.0',
+            'python_requires': '>=3.7.0',
             'install_requires': ['req1', 'req2'],
             'license': 'Apache 2',
             'packages': ['pack1', 'pack1.sub'],

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -22,7 +22,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.6.0'),
+    python_requires=('>=3.7.0'),
     install_requires=requirements,
     license='Apache 2',
     packages=pack1_packages,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
 line-length = 100
-target_version = ['py36', 'py37', 'py38']
+target_version = ['py37', 'py38', 'py39']
 skip-string-normalization = true
 skip-magic-trailing-comma = true

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     install_requires=requirements,
     extras_require={'dev_env': dev_requirements},
     license='Apache 2',


### PR DESCRIPTION
This is a step toward following the numpy python support schedule (https://github.com/quantumlib/Cirq/issues/3347). Note that according to the schedule we should be at 3.8+, but we cannot yet drop support for 3.7 since colab is still at 3.7.13.