### PR TITLE
Re-add in pylint plugin

### DIFF
--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -45,8 +45,7 @@ enable=
     syntax-error,
     too-many-function-args,
     trailing-whitespace,
-    # Disabling until https://github.com/PyCQA/pylint/issues/3791 is fixed
-    # undefined-variable,
+    undefined-variable,
     unexpected-keyword-arg,
     unhashable-dict-key,
     unnecessary-pass,


### PR DESCRIPTION
The `undefined-variable` pylint plugin can now be re-added in, as it was removed until [an underlying issue](https://github.com/PyCQA/pylint/issues/3791) had been fixed.