### PR TITLE
Ignore operations on more than 10 qubits in drop_negligible_operations transformer

### DIFF
--- a/cirq-core/cirq/transformers/drop_negligible_operations.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations.py
@@ -48,7 +48,11 @@ def drop_negligible_operations(
 
     def map_func(op: 'cirq.Operation', _: int) -> 'cirq.OP_TREE':
         return (
-            op if protocols.is_measurement(op) or protocols.trace_distance_bound(op) > atol else []
+            op
+            if protocols.num_qubits(op) > 10
+            or protocols.is_measurement(op)
+            or protocols.trace_distance_bound(op) > atol
+            else []
         )
 
     return transformer_primitives.map_operations(

--- a/cirq-core/cirq/transformers/drop_negligible_operations_test.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations_test.py
@@ -103,4 +103,7 @@ def test_ignores_large_ops():
     circuit = cirq.Circuit(
         cirq.CircuitOperation(subcircuit).repeat(10), cirq.measure(*qubits, key='out')
     )
-    assert cirq.drop_negligible_operations(circuit, context=cirq.TransformerContext(deep=True))
+    cirq.testing.assert_same_circuits(
+        circuit,
+        cirq.drop_negligible_operations(circuit, context=cirq.TransformerContext(deep=True)),
+    )

--- a/cirq-core/cirq/transformers/drop_negligible_operations_test.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations_test.py
@@ -94,3 +94,13 @@ def test_recursively_runs_inside_circuit_ops_deep():
     cirq.testing.assert_same_circuits(
         cirq.drop_negligible_operations(c_orig, context=context, atol=0.001), c_expected
     )
+
+
+def test_ignores_large_ops():
+    qnum = 20
+    qubits = cirq.LineQubit.range(qnum)
+    subcircuit = cirq.FrozenCircuit(cirq.X.on_each(*qubits))
+    circuit = cirq.Circuit(
+        cirq.CircuitOperation(subcircuit).repeat(10), cirq.measure(*qubits, key='out')
+    )
+    assert cirq.drop_negligible_operations(circuit, context=cirq.TransformerContext(deep=True))


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/5302