### PR TITLE
Fix typo in docs/tutorials/state_histograms.ipynb

### DIFF
--- a/docs/tutorials/state_histograms.ipynb
+++ b/docs/tutorials/state_histograms.ipynb
@@ -195,7 +195,7 @@
    },
    "source": [
     "### Modifying plot properties\n",
-    "You can pass additional arguments to the `cirs.plot_state_histogram` method to modify plot properties like `title`, `xlabel`, `ylabel` and `tick_labels`. For example:"
+    "You can pass additional arguments to the `cirq.plot_state_histogram` method to modify plot properties like `title`, `xlabel`, `ylabel` and `tick_labels`. For example:"
    ]
   },
   {

--- a/docs/tutorials/state_histograms.ipynb
+++ b/docs/tutorials/state_histograms.ipynb
@@ -195,7 +195,7 @@
    },
    "source": [
     "### Modifying plot properties\n",
-    "You can pass additional arguments to the `cirq.plot_state_histogram` method to modify plot properties like `title`, `xlabel`, `ylabel` and `tick_labels`. For example:"
+    "You can pass additional arguments to the `cirq.plot_state_histogram` method to modify plot properties like `title`, `xlabel`, `ylabel` and `tick_label`. For example:"
    ]
   },
   {


### PR DESCRIPTION
Part of docs cleanup for Cirq 1.0