### PR TITLE
Fix typos and nits in docs/transform.ipynb

### DIFF
--- a/docs/transform.ipynb
+++ b/docs/transform.ipynb
@@ -108,16 +108,16 @@
     "Transformers that come with cirq can be found in the `cirq.transformers` package.\n",
     "\n",
     "A few notable examples are:\n",
-    "*   **cirq.align_left / cirq.align_right**: Align gates to the left/right of the circuit.\n",
-    "*   **cirq.defer_measurements**:  Moves all (non-terminal) measurements in a circuit to the end of circuit by implementing the deferred measurement principle.\n",
-    "*   **cirq.drop_empty_moments** / **cirq.drop_negligible_operations**:  Removes moments that are empty or operations that have very small effects, respectively.\n",
-    "*   **cirq.eject_phased_paulis**: Pushes X, Y, and PhasedX gates towards the end of the circuit, potentially absorbing Z gates and modifying gates along the way.\n",
-    "*   **cirq.eject_z**:  Pushes Z gates towards the end of the circuit, potentially adjusting phases of gates that they pass through.\n",
-    "*   **cirq.expand_composite**:  Uses `cirq.decompose` to expand composite gates.\n",
-    "*   **cirq.merge_k_qubit_unitaries**: Replaces connected components of unitary operations, acting on <= k qubits, with op-tree given by `rewriter(circuit_op)`.\n",
-    "*   **cirq.optimize_for_target_gateset**: Attempts to convert a circuit into and equivalent circuit using only gates from a given target gateset.\n",
-    "*   **cirq.stratified_circuit**: Repacks the circuit to ensure that moments only contain operations from the same category.\n",
-    "*   **cirq.synchronize_terminal_measurements**:  Moves all terminal measurements in a circuit to the final moment, if possible.\n",
+    "*   **`cirq.align_left` / `cirq.align_right`**: Align gates to the left/right of the circuit.\n",
+    "*   **`cirq.defer_measurements`**:  Moves all (non-terminal) measurements in a circuit to the end of circuit by implementing the deferred measurement principle.\n",
+    "*   **`cirq.drop_empty_moments`** / **`cirq.drop_negligible_operations`**:  Removes moments that are empty or operations that have very small effects, respectively.\n",
+    "*   **`cirq.eject_phased_paulis`**: Pushes X, Y, and PhasedX gates towards the end of the circuit, potentially absorbing Z gates and modifying gates along the way.\n",
+    "*   **`cirq.eject_z`**:  Pushes Z gates towards the end of the circuit, potentially adjusting phases of gates that they pass through.\n",
+    "*   **`cirq.expand_composite`**:  Uses `cirq.decompose` to expand composite gates.\n",
+    "*   **`cirq.merge_k_qubit_unitaries`**: Replaces connected components of unitary operations, acting on <= k qubits, with op-tree given by `rewriter(circuit_op)`.\n",
+    "*   **`cirq.optimize_for_target_gateset`**: Attempts to convert a circuit into an equivalent circuit using only gates from a given target gateset.\n",
+    "*   **`cirq.stratified_circuit`**: Repacks the circuit to ensure that moments only contain operations from the same category.\n",
+    "*   **`cirq.synchronize_terminal_measurements`**:  Moves all terminal measurements in a circuit to the final moment, if possible.\n",
     "\n",
     "\n",
     "Below you can see how to implement a transformer pipeline called `optimize_circuit`."
@@ -171,7 +171,7 @@
     "\n",
     "Every transformer in Cirq accepts a `cirq.TransformerContext` instance, which stores common configurable options useful for all transformers. \n",
     "\n",
-    "One of the members of transformer context dataclass is `cirq.TransformerLogger` instance. When a logger instance is specified, every cirq transformer logs it's action on the input circuit using the given logger instance. The logs can then be inspected to understand the action of each individual transformer on the circuit. \n",
+    "One of the members of transformer context dataclass is `cirq.TransformerLogger` instance. When a logger instance is specified, every cirq transformer logs its action on the input circuit using the given logger instance. The logs can then be inspected to understand the action of each individual transformer on the circuit.\n",
     "\n",
     "Below, you can inspect the action of each transformer in the `optimize_circuit` method defined above. "
    ]
@@ -195,7 +195,7 @@
     "id": "kLm-5LHr0YAd"
    },
    "source": [
-    "## Support for no-compile tags. \n",
+    "## Support for no-compile tags\n",
     "\n",
     "Cirq also supports tagging operations with no-compile tags such that these tagged operations are ignored when applying transformations on the circuit. This allows users to gain more fine-grained conrol over the compilation process. \n",
     "\n",
@@ -239,7 +239,7 @@
     "id": "3f3c7851a571"
    },
    "source": [
-    "## Support for recursively transforming sub-circuits.\n",
+    "## Support for recursively transforming sub-circuits\n",
     "\n",
     "By default, an operation `op` of type `cirq.CircuitOperation` is considered as a single top-level operation by cirq transformers. As a result, the sub-circuits wrapped inside circuit operations will often be left as it is and a transformer will only modify the top-level circuit. \n",
     "\n",
@@ -281,7 +281,7 @@
    },
    "source": [
     "## Compiling to NISQ targets: `cirq.CompilationTargetGateset`\n",
-    "Cirq's philosophy on compiling circuits for execution on a NISQ target device or simulator is that it would often require running only a handful of individual compilation passes on the input circuit, one after the other. \n",
+    "Cirqs philosophy on compiling circuits for execution on a NISQ target device or simulator is that it would often require running only a handful of individual compilation passes on the input circuit, one after the other.\n",
     "\n",
     "**`cirq.CompilationTargetGateset`** is an abstraction in Cirq to represent such compilation targets as well as the bundles of transformer passes which should be executed to compile a circuit to this target. Cirq has implementations for common target gatesets like `cirq.CZTargetGateset`, `cirq.SqrtIswapTargetGateset` etc.\n",
     "\n",
@@ -320,6 +320,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "b963809fa20b"
+   },
+   "source": [
+    "`cirq.optimize_for_target_gateset` also supports all the features discussed above, using `cirq.TransformerContext`. For example, you can compile the circuit for sqrt-iswap target gateset and inspect action of individual transformers using `cirq.TransformerLogger`, as shown below."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -327,8 +336,6 @@
    },
    "outputs": [],
    "source": [
-    "# `cirq.optimize_for_target_gateset` also supports all the features discussed above, using `cirq.TransformerContext`.\n",
-    "# For example, you can compile the circuit for Sqrt-Iswap Target Gateset and inspect action of individual transformers.\n",
     "context = cirq.TransformerContext(logger=cirq.TransformerLogger())\n",
     "gateset = cirq.SqrtIswapTargetGateset()\n",
     "sqrt_iswap_circuit = cirq.optimize_for_target_gateset(circuit, gateset = gateset, context=context)\n",
@@ -342,7 +349,7 @@
     "id": "jyNdxrkI4CYX"
    },
    "source": [
-    "# Building custom Transformers"
+    "# Building custom transformers"
    ]
   },
   {
@@ -351,7 +358,7 @@
     "id": "6da0Ra7bz2St"
    },
    "source": [
-    "## `cirq.TRANSFORMER` API and `@cirq.transformer` decorator.\n",
+    "## `cirq.TRANSFORMER` API and `@cirq.transformer` decorator\n",
     "\n",
     "Any callable that satisfies the `cirq.TRANSFORMER` contract, i.e. takes a `cirq.AbstractCircuit` and `cirq.TransformerContext` and returns a transformed `cirq.AbstractCircuit`, is a valid transformer in Cirq. \n",
     "\n",
@@ -401,10 +408,10 @@
     "id": "OLJrXdyTCGev"
    },
    "source": [
-    "## `cirq.TransformerContext` to store common configurable options. \n",
+    "## `cirq.TransformerContext` to store common configurable options\n",
     "`cirq.TransformerContext` is a dataclass that stores common configurable options for all transformers. All cirq transformers should accept the transformer context as an optional keyword argument. \n",
     "\n",
-    "The `@cirq.transformer` decorator inspects the `cirq.TransformerContext` argument and automatically appends useful functionality like support for automated logging and recursively running the transformer on nested sub-circuits. \n"
+    "The `@cirq.transformer` decorator can inspect the `cirq.TransformerContext` argument and automatically append useful functionality, like support for automated logging and recursively running the transformer on nested sub-circuits.\n"
    ]
   },
   {
@@ -413,7 +420,7 @@
     "id": "5OuMLlNAFPcW"
    },
    "source": [
-    "### `cirq.TransformerLogger` and support for automated logging.\n",
+    "### `cirq.TransformerLogger` and support for automated logging\n",
     "The `cirq.TransformerLogger` class is used to log the actions of a transformer on an input circuit. `@cirq.transformer` decorator automatically adds support for logging the initial and final circuits for each transfomer step. "
    ]
   },
@@ -437,7 +444,7 @@
     "id": "UvFdvxQ6MZD9"
    },
    "source": [
-    "### Support for `deep=True`.\n",
+    "### Support for `deep=True`\n",
     "You can call `@cirq.transformer(add_deep_support=True)` to automatically add the functionality of recursively running the custom transformer on circuits wrapped inside `cirq.CircuitOperation`. The recursive execution behavior of the transformer can then be controlled by setting `deep=True` in the transformer context. "
    ]
   },
@@ -488,8 +495,8 @@
     "\n",
     "- **`cirq.map_operations`**: Applies local transformations on operations, by calling `map_func(op)` for each `op`.\n",
     "- **`cirq.map_moments`**: Applies local transformation on moments, by calling `map_func(m)` for each moment `m`.\n",
-    "- **`cirq.merge_operations`**: Merges connected component of operations by calling `merge_func(op1, op2)` on iteratively for every mergeable operation `op1` and `op2`.\n",
-    "- **`cirq.merge_moments`**: Merges adjacent moments, from left to right, by calling `merge_func(m1, m2)`.\n",
+    "- **`cirq.merge_operations`**: Merges connected component of operations by iteratively calling `merge_func(op1, op2)`  for every pair of mergeable operations `op1` and `op2`.\n",
+    "- **`cirq.merge_moments`**: Merges adjacent moments, from left to right, by iteratively calling `merge_func(m1, m2)` for adjacent moments `m1` and `m2`.\n",
     "\n",
     "\n",
     "An important property of these primitives is that they have support for common configurable options present in `cirq.TransformerContext`, such as `tags_to_ignore` and `deep`. See the example below for a better understanding."

--- a/docs/transform.ipynb
+++ b/docs/transform.ipynb
@@ -281,7 +281,7 @@
    },
    "source": [
     "## Compiling to NISQ targets: `cirq.CompilationTargetGateset`\n",
-    "Cirqs philosophy on compiling circuits for execution on a NISQ target device or simulator is that it would often require running only a handful of individual compilation passes on the input circuit, one after the other.\n",
+    "Cirq's philosophy on compiling circuits for execution on a NISQ target device or simulator is that it would often require running only a handful of individual compilation passes on the input circuit, one after the other.\n",
     "\n",
     "**`cirq.CompilationTargetGateset`** is an abstraction in Cirq to represent such compilation targets as well as the bundles of transformer passes which should be executed to compile a circuit to this target. Cirq has implementations for common target gatesets like `cirq.CZTargetGateset`, `cirq.SqrtIswapTargetGateset` etc.\n",
     "\n",


### PR DESCRIPTION
Part of docs cleanup for Cirq 1.0