### PR TITLE
Change switch_to_new condition in `TwoQubitCompilationTargetGateset` to switch only when it's optimal in terms of 2q gate counts

### DIFF
--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset_test.py
@@ -199,3 +199,23 @@ m: ═════════════════════════�
 m: ═════════════════════════════════════════════════════@═══^═══
 ''',
     )
+
+
+def test_two_qubit_compilation_replaces_only_if_2q_gate_count_is_less():
+    class DummyTargetGateset(cirq.TwoQubitCompilationTargetGateset):
+        def __init__(self):
+            super().__init__(cirq.X, cirq.CNOT)
+
+        def _decompose_two_qubit_operation(self, op: 'cirq.Operation', _) -> DecomposeResult:
+            q0, q1 = op.qubits
+            return [cirq.X.on_each(q0, q1), cirq.CNOT(q0, q1)] * 10
+
+        def _decompose_single_qubit_operation(self, op: 'cirq.Operation', _) -> DecomposeResult:
+            return cirq.X(*op.qubits) if op.gate == cirq.Y else NotImplemented
+
+    q = cirq.LineQubit.range(2)
+    ops = [cirq.Y.on_each(*q), cirq.CNOT(*q), cirq.Z.on_each(*q)]
+    c_orig = cirq.Circuit(ops)
+    c_expected = cirq.Circuit(cirq.X.on_each(*q), ops[-2:])
+    c_new = cirq.optimize_for_target_gateset(c_orig, gateset=DummyTargetGateset())
+    cirq.testing.assert_same_circuits(c_new, c_expected)


### PR DESCRIPTION
`cirq.TwoQubitCompilationTargetGateset` currently implements a logic to compare the analytical decomposition of a merged 2q connected component (`new_optree`) with the one which already exists in the circuit (`old_optree`) and switch iff:
- *Any* gate in in `old_optree` is not part of the target gateset
- Number of 2q gates in `new_optree` is less than those in `old_optree`

This PR changes the switch condition to:
- *Any 2q* gate in in `old_optree` is not part of the target gateset  # This changes from *Any* to *Any 2q*
- Number of 2q gates in `new_optree` is less than those in `old_optree`

This is useful because if the old merged connected component (i.e. `old_optree`) is optimal in terms of 2q gates but contains single qubit gates outside of the target gateset; we should only replace the single qubit gates and not the entire decomposition with a more in-efficient decomposition. 

See the newly added test for a dummy example. 

cc @verult ; Part of https://github.com/quantumlib/Cirq/issues/5254
