### PR TITLE
Fix protobuf version specifiers in cirq-google/requirements.txt

### DIFF
--- a/cirq-google/requirements.txt
+++ b/cirq-google/requirements.txt
@@ -1,3 +1,3 @@
 google-api-core[grpc] >= 1.14.0, < 2.0.0dev
-proto-plus>=1.20.0
-protobuf>=3.13.0<4
+proto-plus >= 1.20.0
+protobuf >= 3.13.0, < 4


### PR DESCRIPTION
I encountered an error in CI where pip was installing protobuf 4 (https://github.com/quantumlib/Cirq/runs/6606535751?check_suite_focus=true) and I think it was because the multiple version specifiers are supposed to be separated by a comma. Cleaned up the requirements file to add the comma as well as some whitespace for clarity (and consistency with the first line).