### PR TITLE
Added GateDurationTable to simplify duration lookup of equivalent gates.

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -83,6 +83,7 @@ from cirq.devices import (
     ConstantQubitNoiseModel,
     Device,
     DeviceMetadata,
+    GateDurationTable,
     GridDeviceMetadata,
     GridQid,
     GridQubit,

--- a/cirq-core/cirq/devices/__init__.py
+++ b/cirq-core/cirq/devices/__init__.py
@@ -16,7 +16,7 @@
 
 from cirq.devices.device import Device, DeviceMetadata
 
-from cirq.devices.grid_device_metadata import GridDeviceMetadata
+from cirq.devices.grid_device_metadata import GateDurationTable, GridDeviceMetadata
 
 from cirq.devices.grid_qubit import GridQid, GridQubit
 


### PR DESCRIPTION
Per @tanujkhattar 's [suggestion](https://github.com/quantumlib/Cirq/pull/5315#discussion_r878592157), it would be useful to have the most general GateFamily for a particular gate instance as the key of `GridDeviceMetadata.gate_durations` (i.e. `cg.FSimGateFamily(gates_to_accept=[cg.SYC])` instead of `cirq.GateFamily(cg.SYC)`). However, constructing the GateFamily to look up a particular gate duration is additional overhead for the user.

Here I propose a `GateDurationTable` data structure which is initialized using the most general GateFamilies for each device gate, while allowing users to look up duration using specific gate instances. For example:

```python
>>> gdt = GateDurationTable({ cg.FSimGateFamily(gates_to_accept=[cg.SYC]): cirq.Duration(nanos=1) })

>>> gdt[cg.SYC]
cirq.Duration(nanos=1)

>>> gdt[cirq.FSimGate(math.pi/2, math.pi/6)]
cirq.Duration(nanos=1)
```

Users can still see the full durations list via `print(gdt)`.

How does this look conceptually?

We may not want to overcomplicate gate duration logic since it's mostly informational and values are approximate, but I think this is a low hanging fruit where we can make the experience better.

@MichaelBroughton @tanujkhattar 