### PR TITLE
Fix tests that break python-repeat

### DIFF
--- a/cirq-core/cirq/contrib/acquaintance/topological_sort_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/topological_sort_test.py
@@ -21,7 +21,7 @@ import cirq.contrib.acquaintance as cca
 @pytest.mark.parametrize(
     'circuit_dag,sorted_nodes',
     [
-        (dag, cca.random_topological_sort(dag))
+        (dag, tuple(cca.random_topological_sort(dag)))
         for dag in [
             cirq.CircuitDag.from_circuit(cirq.testing.random_circuit(10, 10, 0.5)) for _ in range(5)
         ]

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -134,16 +134,18 @@ def test_access_sweep():
     assert sixth_elem == cirq.ParamResolver({'a': 2, 'b': 5})
 
 
+# We use factories since some of these produce generators and we want to
+# test for passing in a generator to initializer.
 @pytest.mark.parametrize(
-    'r_list',
+    'r_list_factory',
     [
-        [{'a': a, 'b': a + 1} for a in (0, 0.5, 1, -10)],
-        ({'a': a, 'b': a + 1} for a in (0, 0.5, 1, -10)),
-        ({sympy.Symbol('a'): a, 'b': a + 1} for a in (0, 0.5, 1, -10)),
+        lambda: [{'a': a, 'b': a + 1} for a in (0, 0.5, 1, -10)],
+        lambda: ({'a': a, 'b': a + 1} for a in (0, 0.5, 1, -10)),
+        lambda: ({sympy.Symbol('a'): a, 'b': a + 1} for a in (0, 0.5, 1, -10)),
     ],
 )
-def test_list_sweep(r_list):
-    sweep = cirq.ListSweep(r_list)
+def test_list_sweep(r_list_factory):
+    sweep = cirq.ListSweep(r_list_factory())
     assert sweep.keys == ['a', 'b']
     assert len(sweep) == 4
     assert len(list(sweep)) == 4

--- a/cirq-core/cirq/testing/circuit_compare_test.py
+++ b/cirq-core/cirq/testing/circuit_compare_test.py
@@ -133,9 +133,10 @@ def test_random_same_matrix(circuit):
 
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(circuit, same)
 
-    circuit.append(cirq.measure(a))
+    mutable_circuit = circuit.copy()
+    mutable_circuit.append(cirq.measure(a))
     same.append(cirq.measure(a))
-    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(circuit, same)
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(mutable_circuit, same)
 
 
 def test_correct_qubit_ordering():


### PR DESCRIPTION
I use python-repeat to check for flaky tests.  It allows you to pass in `--count XXX` to repeat a test multiple times.  Interestingly, for parameterized tests the decorator that creates the parameterized tests is run once globally, and then the tests are repeated.  This means that these tests can catch places where the parameterized values are mutated in some way during a test.  

This fixes the cases found from `check/pytest --count 100`.  In general mutating parameters called to functions without being very explicit about it is something we should try to avoid. 