### PR TITLE
Add an icon for Heatmaps in Noise overview

### DIFF
--- a/docs/noise/_index.yaml
+++ b/docs/noise/_index.yaml
@@ -30,3 +30,5 @@ landing_page:
         - heading: Heatmaps
           description: Functions to plot noise characteristics across a device.
           path: /cirq/tutorials/heatmaps
+          icon:
+            name: menu_book


### PR DESCRIPTION
Tiny PR for missed icon on Noise overview page. 