### PR TITLE
Update repr of pauli strings

### DIFF
--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -138,12 +138,12 @@ def test_op_repr():
     ps = cirq.X(a) * cirq.Y(b) * cirq.Z(c)
     assert (
         repr(cirq.measure_single_paulistring(ps))
-        == 'cirq.measure_single_paulistring((cirq.X(cirq.LineQubit(0))'
+        == 'cirq.measure_single_paulistring(((1+0j)*cirq.X(cirq.LineQubit(0))'
         '*cirq.Y(cirq.LineQubit(1))*cirq.Z(cirq.LineQubit(2))))'
     )
     assert (
         repr(cirq.measure_single_paulistring(ps, key='out'))
-        == "cirq.measure_single_paulistring((cirq.X(cirq.LineQubit(0))"
+        == "cirq.measure_single_paulistring(((1+0j)*cirq.X(cirq.LineQubit(0))"
         "*cirq.Y(cirq.LineQubit(1))*cirq.Z(cirq.LineQubit(2))), "
         "key=cirq.MeasurementKey(name='out'))"
     )

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -397,7 +397,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         factors = []
         if self._coefficient == -1:
             prefix = '-'
-        elif self._coefficient != 1:
+        else:
             factors.append(repr(self._coefficient))
 
         if not ordered_qubits:

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -310,6 +310,12 @@ def test_repr():
     cirq.testing.assert_equivalent_repr(cirq.PauliString())
 
 
+def test_repr_coefficient_of_one():
+    pauli_string = cirq.Z(cirq.LineQubit(0)) * 1
+    assert type(pauli_string) == type(eval(repr(pauli_string)))
+    cirq.testing.assert_equivalent_repr(pauli_string)
+
+
 def test_str():
     q0, q1, q2 = _make_qubits(3)
     pauli_string = cirq.PauliString({q2: cirq.X, q1: cirq.Y, q0: cirq.Z})


### PR DESCRIPTION
- The repr of pauli strings with coefficient of one
used to truncate the one.
- The old way is prettier but does not actually repr to the same thing,
ie.  type(eval('cirq.Z.on(cirq.LineQubit(0))')
!=   type(eval('1*cirq.Z.on(cirq.LineQubit(0))')

Fixes: #2771