### PR TITLE
Fix type check of SerializableDevice gate_definitions

### DIFF
--- a/cirq-google/cirq_google/devices/serializable_device.py
+++ b/cirq-google/cirq_google/devices/serializable_device.py
@@ -107,7 +107,7 @@ class SerializableDevice(cirq.Device):
                 *[
                     g
                     for g in gate_definitions.keys()
-                    if isinstance(g, (cirq.Gate, type(cirq.Gate)))
+                    if isinstance(g, cirq.Gate) or issubclass(g, cirq.Gate)
                 ],
                 cirq.GlobalPhaseGate,
             ),


### PR DESCRIPTION
The type(cirq.Gate) is cirq.ABCMetaImplementAnyOneOf which could
match unrelated instances.  Use subclass check instead.
