### PR TITLE
Add numpy support for Google serialization

### DIFF
--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -37,7 +37,16 @@ FLOAT_ARG_LIKE = Union[float, sympy.Expr]
 
 # Types for comparing floats
 # Includes sympy types.  Needed for arg parsing.
-FLOAT_TYPES = (float, int, sympy.Integer, sympy.Float, sympy.Rational, sympy.NumberSymbol)
+FLOAT_TYPES = (
+    float,
+    int,
+    np.integer,
+    np.floating,
+    sympy.Integer,
+    sympy.Float,
+    sympy.Rational,
+    sympy.NumberSymbol,
+)
 
 # Supported function languages in order from least to most flexible.
 # Clients should use the least flexible language they can, to make it easier

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -14,6 +14,8 @@
 
 from typing import Dict, List
 import pytest
+
+import numpy as np
 import sympy
 from google.protobuf import json_format
 
@@ -65,6 +67,14 @@ OPERATIONS = [
     (
         cirq.XPowGate(exponent=0.125)(Q1),
         op_proto({'xpowgate': {'exponent': {'float_value': 0.125}}, 'qubit_constant_index': [0]}),
+    ),
+    (
+        cirq.XPowGate(exponent=np.double(0.125))(Q1),
+        op_proto({'xpowgate': {'exponent': {'float_value': 0.125}}, 'qubit_constant_index': [0]}),
+    ),
+    (
+        cirq.XPowGate(exponent=np.short(1))(Q1),
+        op_proto({'xpowgate': {'exponent': {'float_value': 1.0}}, 'qubit_constant_index': [0]}),
     ),
     (
         cirq.XPowGate(exponent=sympy.Symbol('a'))(Q1),

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -274,7 +274,7 @@ class GateOpSerializer(OpSerializer):
 
     def _check_type(self, value: ARG_LIKE, arg: SerializingArg) -> None:
         if arg.serialized_type == float:
-            if not isinstance(value, (float, int)):
+            if not isinstance(value, (float, int, np.integer, np.floating)):
                 raise ValueError(f'Expected type convertible to float but was {type(value)}')
         elif arg.serialized_type == List[bool]:
             if not isinstance(value, (list, tuple, np.ndarray)) or not all(

--- a/cirq-google/cirq_google/serialization/op_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_serializer_test.py
@@ -69,6 +69,8 @@ def get_val(op):
 
 TEST_CASES = (
     (float, 1.0, {'arg_value': {'float_value': 1.0}}),
+    (float, np.short(1), {'arg_value': {'float_value': 1.0}}),
+    (float, np.double(1.0), {'arg_value': {'float_value': 1.0}}),
     (str, 'abc', {'arg_value': {'string_value': 'abc'}}),
     (float, 1, {'arg_value': {'float_value': 1.0}}),
     (List[bool], [True, False], {'arg_value': {'bool_values': {'values': [True, False]}}}),


### PR DESCRIPTION
- Adds support for numpy types for CircuitSerializer and
deprecated GateOpSerializer.
- Also add checks for numpy floats and ints.

Fixes: #4010 