### PR TITLE
pr_monitor: post empty string as commit message if PR body is empty

### DIFF
--- a/dev_tools/pr_monitor.py
+++ b/dev_tools/pr_monitor.py
@@ -772,7 +772,7 @@ def attempt_squash_merge(pr: PullRequestDetails) -> Union[bool, CannotAutomergeE
     )
     data = {
         'commit_title': f'{pr.title} (#{pr.pull_id})',
-        'commit_message': pr.body if pr.body is not None else '',
+        'commit_message': pr.body or '',
         'sha': pr.branch_sha,
         'merge_method': 'squash',
     }

--- a/dev_tools/pr_monitor.py
+++ b/dev_tools/pr_monitor.py
@@ -772,7 +772,7 @@ def attempt_squash_merge(pr: PullRequestDetails) -> Union[bool, CannotAutomergeE
     )
     data = {
         'commit_title': f'{pr.title} (#{pr.pull_id})',
-        'commit_message': pr.body,
+        'commit_message': pr.body if pr.body is not None else '',
         'sha': pr.branch_sha,
         'merge_method': 'squash',
     }


### PR DESCRIPTION
Fixes #4412

Verified in my personal fork via curling the API directly.

@MichaelBroughton
cc @dabacon 