### PR TITLE
Pass through None during param resolution

### DIFF
--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -261,6 +261,8 @@ class ParamResolver:
 
 
 def _resolve_value(val: Any) -> Any:
+    if val is None:
+        return val
     if isinstance(val, numbers.Number) and not isinstance(val, sympy.Basic):
         return val
     if isinstance(val, sympy_numbers.IntegerConstant):

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -25,6 +25,7 @@ import cirq
 @pytest.mark.parametrize(
     'val',
     [
+        None,
         3.2,
         np.float32(3.2),
         int(1),


### PR DESCRIPTION
- pass through None as a parameter if set.

Technically a breaking change, since this used to silently drop parameters that were set as None. 

Fixes: #4029