### PR TITLE
Update error message when invalid sympy arg is serialized

### DIFF
--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -190,7 +190,11 @@ def _arg_func_to_proto(
         for arg in value.args:
             arg_to_proto(arg, arg_function_language=arg_function_language, out=msg.func.args.add())
     else:
-        raise ValueError(f'Unrecognized arg type: {type(value)}')
+        raise ValueError(
+            f"Unrecognized Sympy expression type: {type(value)}."
+            " Only the following types are recognized: 'sympy.Symbol', 'sympy.Add', 'sympy.Mul',"
+            " 'sympy.Pow'."
+        )
 
 
 def float_arg_from_proto(


### PR DESCRIPTION
Fixes #2384

Clarifies what sympy expressions are allowed when a user tries to serialize a circuit which contains unrecognized Sympy expressions.

@dstrain115 