### PR TITLE
Union[None, X] is Optional[X]

### DIFF
--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -135,7 +135,7 @@ def decompose(
     fallback_decomposer: Optional[OpDecomposer] = None,
     keep: Optional[Callable[['cirq.Operation'], bool]] = None,
     on_stuck_raise: Union[
-        None, Exception, Callable[['cirq.Operation'], Union[None, Exception]]
+        None, Exception, Callable[['cirq.Operation'], Optional[Exception]]
     ] = _value_error_describing_bad_operation,
     preserve_structure: bool = False,
 ) -> List['cirq.Operation']:
@@ -394,7 +394,7 @@ def _decompose_preserving_structure(
     fallback_decomposer: Optional[OpDecomposer] = None,
     keep: Optional[Callable[['cirq.Operation'], bool]] = None,
     on_stuck_raise: Union[
-        None, Exception, Callable[['cirq.Operation'], Union[None, Exception]]
+        None, Exception, Callable[['cirq.Operation'], Optional[Exception]]
     ] = _value_error_describing_bad_operation,
 ) -> List['cirq.Operation']:
     """Preserves structure (e.g. subcircuits) while decomposing ops.

--- a/cirq-core/cirq/protocols/pow_protocol.py
+++ b/cirq-core/cirq/protocols/pow_protocol.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, cast, overload, TYPE_CHECKING, TypeVar, Union, Callable
+from typing import Any, Callable, cast, Optional, overload, TypeVar, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import cirq
@@ -81,7 +81,7 @@ def pow(val: Any, exponent: Any, default: Any = RaiseTypeErrorIfNotProvided) -> 
         TypeError: `val` doesn't have a __pow__ method (or that method returned
             NotImplemented) and no `default` value was specified.
     """
-    raiser = cast(Union[None, Callable], getattr(val, '__pow__', None))
+    raiser = cast(Optional[Callable], getattr(val, '__pow__', None))
     result = NotImplemented if raiser is None else raiser(exponent)
     if result is not NotImplemented:
         return result

--- a/cirq-core/cirq/protocols/pow_protocol.py
+++ b/cirq-core/cirq/protocols/pow_protocol.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, cast, Optional, overload, TypeVar, TYPE_CHECKING, Union
+from typing import Any, Callable, Optional, overload, TypeVar, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     import cirq
@@ -57,6 +57,9 @@ def pow(val: Any, exponent: Any, default: TDefault) -> Any:
     pass
 
 
+# pylint: enable=function-redefined
+
+
 def pow(val: Any, exponent: Any, default: Any = RaiseTypeErrorIfNotProvided) -> Any:
     """Returns `val**factor` of the given value, if defined.
 
@@ -81,7 +84,7 @@ def pow(val: Any, exponent: Any, default: Any = RaiseTypeErrorIfNotProvided) -> 
         TypeError: `val` doesn't have a __pow__ method (or that method returned
             NotImplemented) and no `default` value was specified.
     """
-    raiser = cast(Optional[Callable], getattr(val, '__pow__', None))
+    raiser: Optional[Callable] = getattr(val, '__pow__', None)
     result = NotImplemented if raiser is None else raiser(exponent)
     if result is not NotImplemented:
         return result
@@ -96,4 +99,4 @@ def pow(val: Any, exponent: Any, default: Any = RaiseTypeErrorIfNotProvided) -> 
     )
 
 
-# pylint: enable=function-redefined, redefined-builtin
+# pylint: enable=redefined-builtin

--- a/cirq-core/cirq/work/observable_settings.py
+++ b/cirq-core/cirq/work/observable_settings.py
@@ -14,7 +14,7 @@
 
 import dataclasses
 import numbers
-from typing import Union, Iterable, Dict, TYPE_CHECKING, ItemsView, Tuple, FrozenSet
+from typing import Union, Iterable, Dict, Optional, TYPE_CHECKING, ItemsView, Tuple, FrozenSet
 
 import sympy
 
@@ -62,7 +62,7 @@ class InitObsSetting:
         return protocols.dataclass_json_dict(self)
 
 
-def _max_weight_observable(observables: Iterable[ops.PauliString]) -> Union[None, ops.PauliString]:
+def _max_weight_observable(observables: Iterable[ops.PauliString]) -> Optional[ops.PauliString]:
     """Create a new observable that is compatible with all input observables
     and has the maximum non-identity elements.
 
@@ -89,7 +89,7 @@ def _max_weight_observable(observables: Iterable[ops.PauliString]) -> Union[None
     return ops.PauliString(qubit_pauli_map)
 
 
-def _max_weight_state(states: Iterable[value.ProductState]) -> Union[None, value.ProductState]:
+def _max_weight_state(states: Iterable[value.ProductState]) -> Optional[value.ProductState]:
     """Create a new state that is compatible with all input states
     and has the maximum weight.
 


### PR DESCRIPTION
Also tightens some pylint exceptions, and uses a type annotation and not a cast to clean things in pow protocol a bit.