### PR TITLE
Move NA gateset out to `target_gatesets`

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -382,6 +382,7 @@ from cirq.transformers import (
     merge_single_qubit_gates_to_phased_x_and_z,
     merge_single_qubit_gates_to_phxz,
     merge_single_qubit_moments_to_phxz,
+    NeutralAtomGateset,
     optimize_for_target_gateset,
     parameterized_2q_op_to_sqrt_iswap_operations,
     prepare_two_qubit_state_using_cz,

--- a/cirq-core/cirq/neutral_atoms/__init__.py
+++ b/cirq-core/cirq/neutral_atoms/__init__.py
@@ -21,5 +21,3 @@ from cirq.neutral_atoms.convert_to_neutral_atom_gates import (
     is_native_neutral_atom_gate,
     is_native_neutral_atom_op,
 )
-
-from cirq.neutral_atoms.neutral_atom_gateset import NeutralAtomGateset

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates.py
@@ -16,7 +16,7 @@ from typing import List, Optional, TYPE_CHECKING
 from cirq import ops, protocols, transformers
 from cirq._compat import deprecated_class
 from cirq.circuits.optimization_pass import PointOptimizationSummary, PointOptimizer
-from cirq.neutral_atoms.neutral_atom_gateset import NeutralAtomGateset
+from cirq.transformers.target_gatesets.neutral_atom_gateset import NeutralAtomGateset
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
@@ -31,9 +31,7 @@ Q = cirq.LineQubit.range(3)
     ),
 )
 def test_gates_preserved(expected: cirq.Circuit):
-    actual = cirq.optimize_for_target_gateset(
-        expected, gateset=cirq.neutral_atoms.NeutralAtomGateset()
-    )
+    actual = cirq.optimize_for_target_gateset(expected, gateset=cirq.NeutralAtomGateset())
     assert actual == expected
 
 
@@ -59,15 +57,13 @@ def test_coverage():
         op = FakeOperation(g, q).with_qubits(*q)
         circuit_ops = [cirq.Y(q[0]), cirq.ParallelGate(cirq.X, 3).on(*q)]
         c = cirq.Circuit(circuit_ops)
-        cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
+        cirq.ConvertToNeutralAtomGates().optimize_circuit(c)
         assert c == cirq.Circuit(circuit_ops)
-        assert cirq.neutral_atoms.ConvertToNeutralAtomGates().convert(cirq.X.on(q[0])) == [
-            cirq.X.on(q[0])
-        ]
+        assert cirq.ConvertToNeutralAtomGates().convert(cirq.X.on(q[0])) == [cirq.X.on(q[0])]
         with pytest.raises(TypeError, match="Don't know how to work with"):
-            cirq.neutral_atoms.ConvertToNeutralAtomGates().convert(op)
-        assert not cirq.neutral_atoms.is_native_neutral_atom_op(op)
-        assert not cirq.neutral_atoms.is_native_neutral_atom_gate(g)
+            cirq.ConvertToNeutralAtomGates().convert(op)
+        assert not cirq.is_native_neutral_atom_op(op)
+        assert not cirq.is_native_neutral_atom_gate(g)
 
 
 def test_avoids_decompose_fallback_when_matrix_available_single_qubit():
@@ -81,12 +77,12 @@ def test_avoids_decompose_fallback_when_matrix_available_single_qubit():
 
     q = cirq.GridQubit(0, 0)
     c = cirq.Circuit(OtherX().on(q), OtherOtherX().on(q))
-    converted = cirq.optimize_for_target_gateset(c, gateset=cirq.neutral_atoms.NeutralAtomGateset())
+    converted = cirq.optimize_for_target_gateset(c, gateset=cirq.NeutralAtomGateset())
     cirq.testing.assert_has_diagram(converted, '(0, 0): ───PhX(1)───PhX(1)───')
     with cirq.testing.assert_deprecated(
         "Use cirq.optimize_for_target_gateset", deadline='v0.16', count=2
     ):
-        cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
+        cirq.ConvertToNeutralAtomGates().optimize_circuit(c)
         cirq.testing.assert_has_diagram(c, '(0, 0): ───PhX(1)───PhX(1)───')
 
 
@@ -107,10 +103,10 @@ def test_avoids_decompose_fallback_when_matrix_available_two_qubit():
            │   │
 (0, 1): ───@───@───
 """
-    converted = cirq.optimize_for_target_gateset(c, gateset=cirq.neutral_atoms.NeutralAtomGateset())
+    converted = cirq.optimize_for_target_gateset(c, gateset=cirq.NeutralAtomGateset())
     cirq.testing.assert_has_diagram(converted, expected_diagram)
     with cirq.testing.assert_deprecated(
         "Use cirq.optimize_for_target_gateset", deadline='v0.16', count=2
     ):
-        cirq.neutral_atoms.ConvertToNeutralAtomGates().optimize_circuit(c)
+        cirq.ConvertToNeutralAtomGates().optimize_circuit(c)
         cirq.testing.assert_has_diagram(c, expected_diagram)

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -20,7 +20,7 @@ from cirq import devices, ops, circuits, value
 from cirq.devices.grid_qubit import GridQubit
 from cirq.ops import raw_types
 from cirq.value import Duration
-from cirq.neutral_atoms.neutral_atom_gateset import NeutralAtomGateset
+from cirq.transformers.target_gatesets.neutral_atom_gateset import NeutralAtomGateset
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -45,6 +45,7 @@ TestSpec = ModuleJsonTestSpec(
         'Linspace',
         'ListSweep',
         'NeutralAtomDevice',
+        'NeutralAtomGateset',
         'PauliSumCollector',
         'PauliSumExponential',
         'PauliTransform',

--- a/cirq-core/cirq/transformers/__init__.py
+++ b/cirq-core/cirq/transformers/__init__.py
@@ -45,6 +45,7 @@ from cirq.transformers.heuristic_decompositions import (
 from cirq.transformers.target_gatesets import (
     CompilationTargetGateset,
     CZTargetGateset,
+    NeutralAtomGateset,
     SqrtIswapTargetGateset,
     TwoQubitCompilationTargetGateset,
 )

--- a/cirq-core/cirq/transformers/target_gatesets/__init__.py
+++ b/cirq-core/cirq/transformers/target_gatesets/__init__.py
@@ -22,3 +22,5 @@ from cirq.transformers.target_gatesets.compilation_target_gateset import (
 from cirq.transformers.target_gatesets.cz_gateset import CZTargetGateset
 
 from cirq.transformers.target_gatesets.sqrt_iswap_gateset import SqrtIswapTargetGateset
+
+from cirq.transformers.target_gatesets.neutral_atom_gateset import NeutralAtomGateset

--- a/cirq-core/cirq/transformers/target_gatesets/neutral_atom_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/neutral_atom_gateset.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 from typing import List, Optional, TYPE_CHECKING
 
-from cirq import ops, protocols, transformers
+from cirq import ops, protocols
 from cirq.protocols.decompose_protocol import DecomposeResult
-
+from cirq.transformers.target_gatesets import compilation_target_gateset
+from cirq.transformers.analytical_decompositions import single_qubit_decompositions
+from cirq.transformers.analytical_decompositions import two_qubit_to_cz
 
 if TYPE_CHECKING:
     import cirq
 
 
-class NeutralAtomGateset(transformers.CompilationTargetGateset):
+class NeutralAtomGateset(compilation_target_gateset.CompilationTargetGateset):
     """A Compilation target intended for neutral atom devices.
 
     This gateset supports CNOT, CCNOT (TOFFOLI) gates, CZ,
@@ -71,10 +73,10 @@ class NeutralAtomGateset(transformers.CompilationTargetGateset):
         # Known matrix?
         mat = protocols.unitary(op, None) if len(op.qubits) <= 2 else None
         if mat is not None and len(op.qubits) == 1:
-            gates = transformers.single_qubit_matrix_to_phased_x_z(mat)
+            gates = single_qubit_decompositions.single_qubit_matrix_to_phased_x_z(mat)
             return [g.on(op.qubits[0]) for g in gates]
         if mat is not None and len(op.qubits) == 2:
-            return transformers.two_qubit_matrix_to_cz_operations(
+            return two_qubit_to_cz.two_qubit_matrix_to_cz_operations(
                 op.qubits[0], op.qubits[1], mat, allow_partial_czs=False, clean_operations=True
             )
 

--- a/cirq-core/cirq/transformers/target_gatesets/neutral_atom_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/neutral_atom_gateset_test.py
@@ -14,7 +14,7 @@
 import pytest
 
 import cirq
-import cirq.neutral_atoms.neutral_atom_gateset as nag
+import cirq.transformers.target_gatesets.neutral_atom_gateset as nag
 
 Q = cirq.LineQubit.range(10)
 

--- a/cirq-pasqal/cirq_pasqal/pasqal_gateset.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_gateset.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 import cirq
 
 
-class PasqalGateset(cirq.neutral_atoms.NeutralAtomGateset):
+class PasqalGateset(cirq.NeutralAtomGateset):
     """A Compilation target intended for Pasqal neutral atom devices.
     This gateset supports single qubit gates that can be used
     in a parallel fashion as well as CZ.
@@ -51,9 +51,7 @@ class PasqalGateset(cirq.neutral_atoms.NeutralAtomGateset):
         # Call cirq.Gateset __init__ which is our grand-father inherited class
         # pylint doesn't like this so disable checks on this.
         # pylint: disable=bad-super-call
-        super(cirq.neutral_atoms.NeutralAtomGateset, self).__init__(
-            *gate_families, unroll_circuit_op=False
-        )
+        super(cirq.NeutralAtomGateset, self).__init__(*gate_families, unroll_circuit_op=False)
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Thinking a little bit more on https://github.com/quantumlib/Cirq/issues/2793 I'm wondering if we can't just move the `NeutralAtomGateset` into `compilation_targets` (plan is still to outright get rid of the neutral_atom device). It would save us an extra deprecation and still accomplish the goal of emptying out the `neutral_atom` directory. What do people think ?