### PR TITLE
un-hash param resolver

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -433,7 +433,6 @@ class CircuitOperation(ops.Operation):
                         self.repetitions,
                         frozenset(self.qubit_map.items()),
                         frozenset(self.measurement_key_map.items()),
-                        self.param_resolver,
                         self.parent_path,
                         tuple([] if self.repetition_ids is None else self.repetition_ids),
                         self.use_repetition_ids,


### PR DESCRIPTION
Fixes #4327.

This is a minimal attempt at disabling hashing of `ParamResolver`. Noted weirdness:
- `CircuitOperation`s which only differ in `ParamResolver` will have the same hash - I couldn't find a quick way to also disable `CircuitOperation` hashing without breaking tests. Potentially bad if e.g. we're using sets to dedupe `CircuitOperation`s somewhere.
- It's still a bad idea to mutate `ParamResolver.param_dict`, since it's used to build the fast-evaluation cache.