### PR TITLE
Move `two_qubit_matrix_to_ion_operations` to cirq/transformers/analytical_decompositions

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -402,6 +402,7 @@ from cirq.transformers import (
     transformer,
     two_qubit_matrix_to_cz_operations,
     two_qubit_matrix_to_diagonal_and_cz_operations,
+    two_qubit_matrix_to_ion_operations,
     two_qubit_matrix_to_sqrt_iswap_operations,
     two_qubit_gate_product_tabulation,
     TwoQubitCompilationTargetGateset,
@@ -668,7 +669,7 @@ from cirq.protocols import (
     with_rescoped_keys,
 )
 
-from cirq.ion import ConvertToIonGates, IonDevice, two_qubit_matrix_to_ion_operations
+from cirq.ion import ConvertToIonGates, IonDevice
 from cirq.neutral_atoms import (
     ConvertToNeutralAtomGates,
     is_native_neutral_atom_gate,

--- a/cirq-core/cirq/ion/__init__.py
+++ b/cirq-core/cirq/ion/__init__.py
@@ -16,13 +16,7 @@
 
 from cirq.ops import ms
 
-from cirq.ion.ion_decomposition import two_qubit_matrix_to_ion_operations
-
-from cirq.ion.ion_device import IonDevice
-
-from cirq.ion.convert_to_ion_gates import ConvertToIonGates
-
-from cirq.ion.ion_decomposition import two_qubit_matrix_to_ion_operations
+from cirq.transformers import two_qubit_matrix_to_ion_operations
 
 from cirq.ion.ion_device import IonDevice
 

--- a/cirq-core/cirq/transformers/__init__.py
+++ b/cirq-core/cirq/transformers/__init__.py
@@ -33,6 +33,7 @@ from cirq.transformers.analytical_decompositions import (
     three_qubit_matrix_to_operations,
     two_qubit_matrix_to_cz_operations,
     two_qubit_matrix_to_diagonal_and_cz_operations,
+    two_qubit_matrix_to_ion_operations,
     two_qubit_matrix_to_sqrt_iswap_operations,
 )
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/__init__.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/__init__.py
@@ -50,6 +50,10 @@ from cirq.transformers.analytical_decompositions.two_qubit_to_fsim import (
     decompose_two_qubit_interaction_into_four_fsim_gates,
 )
 
+from cirq.transformers.analytical_decompositions.two_qubit_to_ms import (
+    two_qubit_matrix_to_ion_operations,
+)
+
 from cirq.transformers.analytical_decompositions.two_qubit_to_sqrt_iswap import (
     parameterized_2q_op_to_sqrt_iswap_operations,
     two_qubit_matrix_to_sqrt_iswap_operations,

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms_test.py
@@ -1,4 +1,17 @@
-# pylint: disable=wrong-or-nonexistent-copyright-notice
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import random
 
 import numpy as np


### PR DESCRIPTION
Part of https://github.com/quantumlib/Cirq/issues/2793