### PR TITLE
GateFamily: do not serialize gates_to_accept and gates_to_ignore when empty

### DIFF
--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -269,14 +269,17 @@ class GateFamily:
         )
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return {
+        d: Dict[str, Any] = {
             'gate': self._gate_json(),
             'name': self.name,
             'description': self.description,
             'ignore_global_phase': self._ignore_global_phase,
-            'tags_to_accept': list(self._tags_to_accept),
-            'tags_to_ignore': list(self._tags_to_ignore),
         }
+        if self._tags_to_accept:
+            d['tags_to_accept'] = list(self._tags_to_accept)
+        if self._tags_to_ignore:
+            d['tags_to_ignore'] = list(self._tags_to_ignore)
+        return d
 
     @classmethod
     def _from_json_dict_(

--- a/cirq-core/cirq/protocols/json_test_data/CZTargetGateset.json
+++ b/cirq-core/cirq/protocols/json_test_data/CZTargetGateset.json
@@ -23,27 +23,21 @@
         },
         "name": "Instance GateFamily: ISWAP**0.5",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == ISWAP**0.5`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "XPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "ZPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       }
     ]
   }

--- a/cirq-core/cirq/protocols/json_test_data/GateFamily.json
+++ b/cirq-core/cirq/protocols/json_test_data/GateFamily.json
@@ -4,9 +4,7 @@
     "gate": "XPowGate",
     "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-    "ignore_global_phase": true,
-    "tags_to_accept": [],
-    "tags_to_ignore": []
+    "ignore_global_phase": true
   },
   {
     "cirq_type": "GateFamily",
@@ -17,9 +15,7 @@
     },
     "name": "XFamily",
     "description": "Just the X gate.",
-    "ignore_global_phase": false,
-    "tags_to_accept": [],
-    "tags_to_ignore": []
+    "ignore_global_phase": false
   },
   {
     "cirq_type": "GateFamily",
@@ -29,8 +25,7 @@
     "ignore_global_phase": true,
     "tags_to_accept": [
       "physical_z"
-    ],
-    "tags_to_ignore": []
+    ]
   },
   {
     "cirq_type": "GateFamily",
@@ -38,7 +33,6 @@
     "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`\nIgnored tags: ['physical_z']",
     "ignore_global_phase": true,
-    "tags_to_accept": [],
     "tags_to_ignore": [
       "physical_z"
     ]

--- a/cirq-core/cirq/protocols/json_test_data/Gateset.json
+++ b/cirq-core/cirq/protocols/json_test_data/Gateset.json
@@ -7,9 +7,7 @@
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "AnyUnitaryGateFamily",
@@ -24,9 +22,7 @@
         },
         "name": "Instance GateFamily: X",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       }
     ],
     "name": null,
@@ -44,18 +40,14 @@
         },
         "name": "Instance GateFamily: X",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == X`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "AnyUnitaryGateFamily",

--- a/cirq-core/cirq/protocols/json_test_data/GridDeviceMetadata.json
+++ b/cirq-core/cirq/protocols/json_test_data/GridDeviceMetadata.json
@@ -94,27 +94,21 @@
         "gate": "XPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "ZPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
@@ -125,9 +119,7 @@
         },
         "name": "Instance GateFamily: CZ",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == CZ`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
@@ -138,9 +130,7 @@
         },
         "name": "Instance GateFamily: ISWAP**0.5",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == ISWAP**0.5`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       }
     ],
     "name": null,
@@ -157,9 +147,7 @@
         },
         "name": "Instance GateFamily: ISWAP**0.5",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == ISWAP**0.5`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "Duration",
@@ -176,9 +164,7 @@
         },
         "name": "Instance GateFamily: CZ",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == CZ`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "Duration",
@@ -191,9 +177,7 @@
         "gate": "XPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "Duration",
@@ -206,9 +190,7 @@
         "gate": "YPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "Duration",
@@ -221,9 +203,7 @@
         "gate": "ZPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "Duration",

--- a/cirq-core/cirq/protocols/json_test_data/SqrtIswapTargetGateset.json
+++ b/cirq-core/cirq/protocols/json_test_data/SqrtIswapTargetGateset.json
@@ -32,27 +32,21 @@
         },
         "name": "Instance GateFamily: CZ",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `g == CZ`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "XPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       },
       {
         "cirq_type": "GateFamily",
         "gate": "ZPowGate",
         "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
         "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-        "ignore_global_phase": true,
-        "tags_to_accept": [],
-        "tags_to_ignore": []
+        "ignore_global_phase": true
       }
     ]
   }

--- a/cirq-google/cirq_google/json_test_data/cirq.google.GridDevice.json
+++ b/cirq-google/cirq_google/json_test_data/cirq.google.GridDevice.json
@@ -96,27 +96,21 @@
                     "gate": "XPowGate",
                     "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "GateFamily",
                     "gate": "YPowGate",
                     "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "GateFamily",
                     "gate": "ZPowGate",
                     "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "GateFamily",
@@ -127,9 +121,7 @@
                     },
                     "name": "Instance GateFamily: CZ",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `g == CZ`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "GateFamily",
@@ -140,9 +132,7 @@
                     },
                     "name": "Instance GateFamily: ISWAP**0.5",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `g == ISWAP**0.5`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 }
             ],
             "name": null,
@@ -159,9 +149,7 @@
                     },
                     "name": "Instance GateFamily: ISWAP**0.5",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `g == ISWAP**0.5`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "Duration",
@@ -178,9 +166,7 @@
                     },
                     "name": "Instance GateFamily: CZ",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `g == CZ`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "Duration",
@@ -193,9 +179,7 @@
                     "gate": "XPowGate",
                     "name": "Type GateFamily: cirq.ops.common_gates.XPowGate",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.XPowGate)`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "Duration",
@@ -208,9 +192,7 @@
                     "gate": "YPowGate",
                     "name": "Type GateFamily: cirq.ops.common_gates.YPowGate",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.YPowGate)`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "Duration",
@@ -223,9 +205,7 @@
                     "gate": "ZPowGate",
                     "name": "Type GateFamily: cirq.ops.common_gates.ZPowGate",
                     "description": "Accepts `cirq.Gate` instances `g` s.t. `isinstance(g, cirq.ops.common_gates.ZPowGate)`",
-                    "ignore_global_phase": true,
-                    "tags_to_accept": [],
-                    "tags_to_ignore": []
+                    "ignore_global_phase": true
                 },
                 {
                     "cirq_type": "Duration",


### PR DESCRIPTION
GateFamily has existed prior to the last release, while GateFamily tag support has not gone into a release yet. Removing empty lists in serialized JSON before the next release as recommended to ensure backward compatibility.

@95-martin-orion 