### PR TITLE
Replace shell_tools.run_shell --> shell_tools.run

### DIFF
--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import subprocess
 from typing import TYPE_CHECKING, Iterable
 
 from dev_tools import shell_tools
@@ -29,7 +30,7 @@ def run(
     arg: str = '',
     setup: str = '',
     additional_intercepts: Iterable[str] = (),
-) -> shell_tools.CommandOutput:
+) -> subprocess.CompletedProcess:
     """Invokes the given script within a temporary test environment."""
 
     with open(script_file) as f:
@@ -71,12 +72,8 @@ chmod +x ./test-script.sh
 """.format(
         dir_path, setup, arg
     )
-    return shell_tools.run_shell(
-        cmd=cmd,
-        log_run_to_stderr=False,
-        raise_on_fail=False,
-        out=shell_tools.TeeCapture(),
-        err=shell_tools.TeeCapture(),
+    return shell_tools.run(
+        cmd, log_run_to_stderr=False, shell=True, check=False, capture_output=True
     )
 
 
@@ -89,10 +86,10 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         arg='HEAD~1',
         setup='touch file.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\nFound 0 test files associated with changes.\n"
         ).split()
@@ -104,10 +101,10 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         arg='HEAD~1',
         setup='touch file_test.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == 'INTERCEPTED pytest file_test.py\n'
+    assert result.returncode == 0
+    assert result.stdout == 'INTERCEPTED pytest file_test.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\nFound 1 test files associated with changes.\n"
         ).split()
@@ -121,10 +118,10 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         'git add -A\n'
         'git commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == 'INTERCEPTED pytest file_test.py\n'
+    assert result.returncode == 0
+    assert result.stdout == 'INTERCEPTED pytest file_test.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\nFound 1 test files associated with changes.\n"
         ).split()
@@ -139,10 +136,10 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         'git commit -m test --quiet --no-gpg-sign\n'
         'echo x > file_test.py\n',
     )
-    assert result.exit_code == 0
-    assert result.out == 'INTERCEPTED pytest file_test.py\n'
+    assert result.returncode == 0
+    assert result.stdout == 'INTERCEPTED pytest file_test.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD'.\nFound 1 test files associated with changes.\n"
         ).split()
@@ -157,10 +154,10 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         'git commit -m test --quiet --no-gpg-sign\n'
         'echo x > file.py\n',
     )
-    assert result.exit_code == 0
-    assert result.out == 'INTERCEPTED pytest file_test.py\n'
+    assert result.returncode == 0
+    assert result.stdout == 'INTERCEPTED pytest file_test.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD'.\nFound 1 test files associated with changes.\n"
         ).split()
@@ -175,12 +172,12 @@ def test_pytest_changed_files_file_selection(tmpdir_factory):
         'git commit -m test --quiet --no-gpg-sign\n'
         'echo x > __init__.py\n',
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED pytest cirq-core/cirq/protocols/json_serialization_test.py\n'
     )
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD'.\nFound 1 test files associated with changes.\n"
         ).split()
@@ -193,10 +190,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     result = run(
         script_file='check/pytest-changed-files', tmpdir_factory=tmpdir_factory, arg='HEAD'
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD'.\nFound 0 test files associated with changes.\n"
         ).split()
@@ -205,15 +202,15 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
     result = run(
         script_file='check/pytest-changed-files', tmpdir_factory=tmpdir_factory, arg='HEAD~999999'
     )
-    assert result.exit_code == 1
-    assert result.out == ''
-    assert "No revision 'HEAD~999999'." in result.err
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert "No revision 'HEAD~999999'." in result.stderr
 
     result = run(script_file='check/pytest-changed-files', tmpdir_factory=tmpdir_factory)
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'master'.\nFound 0 test files associated with changes.\n"
         ).split()
@@ -224,10 +221,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         tmpdir_factory=tmpdir_factory,
         setup='git branch origin/master',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'origin/master'.\n"
             "Found 0 test files associated with changes.\n"
@@ -239,10 +236,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         tmpdir_factory=tmpdir_factory,
         setup='git branch upstream/master',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'upstream/master'.\n"
             "Found 0 test files associated with changes.\n"
@@ -254,10 +251,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         tmpdir_factory=tmpdir_factory,
         setup='git branch upstream/master; git branch origin/master',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'upstream/master'.\n"
             "Found 0 test files associated with changes.\n"
@@ -270,9 +267,9 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         arg='file',
         setup='git checkout -b other --quiet\ngit branch -D master --quiet\n',
     )
-    assert result.exit_code == 1
-    assert result.out == ''
-    assert "No revision 'file'." in result.err
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert "No revision 'file'." in result.stderr
 
     # Fails on file.
     result = run(
@@ -281,9 +278,9 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         arg='file',
         setup='touch file\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 1
-    assert result.out == ''
-    assert "No revision 'file'." in result.err
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert "No revision 'file'." in result.stderr
 
     # Works when ambiguous between revision and file.
     result = run(
@@ -292,10 +289,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         arg='HEAD',
         setup='touch HEAD\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD'.\nFound 0 test files associated with changes.\n"
         ).split()
@@ -306,10 +303,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         tmpdir_factory=tmpdir_factory,
         setup='touch master\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'master'.\nFound 0 test files associated with changes.\n"
         ).split()
@@ -329,10 +326,10 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory):
         'git remote add origin alt\n'
         'git fetch origin master --quiet 2> /dev/null\n',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'origin/master'.\n"
             "Found 0 test files associated with changes.\n"
@@ -348,8 +345,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         arg='HEAD',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -359,24 +356,24 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py HEAD\n'
     )
-    assert result.err == "Comparing against revision 'HEAD'.\n"
+    assert result.stderr == "Comparing against revision 'HEAD'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
         tmpdir_factory=tmpdir_factory,
         arg='HEAD~999999',
     )
-    assert result.exit_code == 1
-    assert result.out == ''
-    assert "No revision 'HEAD~999999'." in result.err
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert "No revision 'HEAD~999999'." in result.stderr
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
         tmpdir_factory=tmpdir_factory,
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -386,7 +383,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py master\n'
     )
-    assert result.err == "Comparing against revision 'master'.\n"
+    assert result.stderr == "Comparing against revision 'master'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
@@ -394,8 +391,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         setup='git branch origin/master',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -405,7 +402,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py origin/master\n'
     )
-    assert result.err == "Comparing against revision 'origin/master'.\n"
+    assert result.stderr == "Comparing against revision 'origin/master'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
@@ -413,8 +410,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         setup='git branch upstream/master',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -424,7 +421,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py upstream/master\n'
     )
-    assert result.err == "Comparing against revision 'upstream/master'.\n"
+    assert result.stderr == "Comparing against revision 'upstream/master'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
@@ -432,8 +429,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         setup='git branch upstream/master; git branch origin/master',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -443,7 +440,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py upstream/master\n'
     )
-    assert result.err == "Comparing against revision 'upstream/master'.\n"
+    assert result.stderr == "Comparing against revision 'upstream/master'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
@@ -451,9 +448,9 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         setup='git checkout -b other --quiet\ngit branch -D master --quiet\n',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 1
-    assert result.out == ''
-    assert 'No default revision found to compare against' in result.err
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert 'No default revision found to compare against' in result.stderr
 
     # Works when ambiguous between revision and file.
     result = run(
@@ -463,8 +460,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         setup='touch HEAD\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -474,7 +471,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py HEAD\n'
     )
-    assert result.err == "Comparing against revision 'HEAD'.\n"
+    assert result.stderr == "Comparing against revision 'HEAD'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
@@ -482,8 +479,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         setup='touch master\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out == (
+    assert result.returncode == 0
+    assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -493,7 +490,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py master\n'
     )
-    assert result.err == "Comparing against revision 'master'.\n"
+    assert result.stderr == "Comparing against revision 'master'.\n"
 
     result = run(
         script_file='check/pytest-and-incremental-coverage',
@@ -508,8 +505,8 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'git checkout -q alt\n',
         additional_intercepts=['check/pytest'],
     )
-    assert result.exit_code == 0
-    assert result.out.startswith(
+    assert result.returncode == 0
+    assert result.stdout.startswith(
         'INTERCEPTED check/pytest '
         '--actually-quiet --rigetti-integration --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
@@ -519,64 +516,64 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py '
     )
-    assert result.err.startswith("Comparing against revision 'master' (merge base ")
+    assert result.stderr.startswith("Comparing against revision 'master' (merge base ")
 
 
 @only_on_posix
 def test_incremental_format_branch_selection(tmpdir_factory):
     result = run(script_file='check/format-incremental', tmpdir_factory=tmpdir_factory, arg='HEAD')
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'HEAD'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'HEAD'." in result.stderr
 
     result = run(
         script_file='check/format-incremental', tmpdir_factory=tmpdir_factory, arg='HEAD~9999'
     )
-    assert result.exit_code == 1
-    assert result.out == ''
-    assert "No revision 'HEAD~9999'." in result.err
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert "No revision 'HEAD~9999'." in result.stderr
 
     result = run(script_file='check/format-incremental', tmpdir_factory=tmpdir_factory)
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'master'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'master'." in result.stderr
 
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
         setup='git branch origin/master',
     )
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'origin/master'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'origin/master'." in result.stderr
 
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
         setup='git branch upstream/master',
     )
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'upstream/master'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'upstream/master'." in result.stderr
 
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
         setup='git branch upstream/master; git branch origin/master',
     )
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'upstream/master'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'upstream/master'." in result.stderr
 
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
         setup='git checkout -b other --quiet\ngit branch -D master --quiet\n',
     )
-    assert result.exit_code == 1
-    assert result.out == ''
+    assert result.returncode == 1
+    assert result.stdout == ''
 
-    assert 'No default revision found to compare against' in result.err
+    assert 'No default revision found to compare against' in result.stderr
 
     # Works when ambiguous between revision and file.
     result = run(
@@ -585,18 +582,18 @@ def test_incremental_format_branch_selection(tmpdir_factory):
         arg='HEAD',
         setup='touch HEAD.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'HEAD'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'HEAD'." in result.stderr
 
     result = run(
         script_file='check/format-incremental',
         tmpdir_factory=tmpdir_factory,
         setup='touch master.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert "No files to format" in result.out
-    assert "Comparing against revision 'master'." in result.err
+    assert result.returncode == 0
+    assert "No files to format" in result.stdout
+    assert "Comparing against revision 'master'." in result.stderr
 
     result = run(
         script_file='check/format-incremental',
@@ -613,9 +610,9 @@ def test_incremental_format_branch_selection(tmpdir_factory):
         'git add -A\n'
         'git commit -q -m test3 --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert 'INTERCEPTED black --color --check --diff alt.py' in result.out
-    assert result.err.startswith("Comparing against revision 'master' (merge base ")
+    assert result.returncode == 0
+    assert 'INTERCEPTED black --color --check --diff alt.py' in result.stdout
+    assert result.stderr.startswith("Comparing against revision 'master' (merge base ")
 
 
 @only_on_posix
@@ -627,10 +624,10 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         arg='HEAD~1',
         setup='touch file.py\ngit add -A\ngit commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == ''
+    assert result.returncode == 0
+    assert result.stdout == ''
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\n"
             "Found 0 lintable files associated with changes.\n"
@@ -650,10 +647,10 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         'git add -A\n'
         'git commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == intercepted_prefix + 'cirq/file.py\n'
+    assert result.returncode == 0
+    assert result.stdout == intercepted_prefix + 'cirq/file.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\n"
             "Found 1 lintable files associated with changes.\n"
@@ -669,10 +666,10 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         'git add -A\n'
         'git commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == intercepted_prefix + 'cirq/file.py\n'
+    assert result.returncode == 0
+    assert result.stdout == intercepted_prefix + 'cirq/file.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\n"
             "Found 1 lintable files associated with changes.\n"
@@ -689,10 +686,10 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         'git commit -m test --quiet --no-gpg-sign\n'
         'echo x > cirq/file.py',
     )
-    assert result.exit_code == 0
-    assert result.out == intercepted_prefix + 'cirq/file.py\n'
+    assert result.returncode == 0
+    assert result.stdout == intercepted_prefix + 'cirq/file.py\n'
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD'.\n"
             "Found 1 lintable files associated with changes.\n"
@@ -709,10 +706,12 @@ def test_pylint_changed_files_file_selection(tmpdir_factory):
         'git add -A\n'
         'git commit -m test --quiet --no-gpg-sign\n',
     )
-    assert result.exit_code == 0
-    assert result.out == intercepted_prefix + ('cirq/file.py dev_tools/file.py examples/file.py\n')
+    assert result.returncode == 0
+    assert result.stdout == intercepted_prefix + (
+        'cirq/file.py dev_tools/file.py examples/file.py\n'
+    )
     assert (
-        result.err.split()
+        result.stderr.split()
         == (
             "Comparing against revision 'HEAD~1'.\n"
             "Found 3 lintable files associated with changes.\n"

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -181,20 +181,20 @@ cd {notebook_env}
 . ./bin/activate
 pip list
 papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
-    stdout, stderr, status = shell_tools.run_shell(
-        cmd=cmd,
+    result = shell_tools.run(
+        cmd,
         log_run_to_stderr=False,
-        raise_on_fail=False,
-        out=shell_tools.TeeCapture(),
-        err=shell_tools.TeeCapture(),
+        shell=True,
+        check=False,
+        capture_output=True,
         # important to get rid of PYTHONPATH specifically, which contains
         # the Cirq repo path due to check/pytest
         env={},
     )
 
-    if status != 0:
-        print(stdout)
-        print(stderr)
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr)
         pytest.fail(
             f"Notebook failure: {notebook_file}, please see {out_path} for the output "
             f"notebook (in Github Actions, you can download it from the workflow artifact"

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -63,16 +63,12 @@ def test_notebooks_against_released_cirq(notebook_path):
     cmd = f"""mkdir -p out/{notebook_rel_dir}
 papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
 
-    _, stderr, status = shell_tools.run_shell(
-        cmd=cmd,
-        log_run_to_stderr=False,
-        raise_on_fail=False,
-        out=shell_tools.TeeCapture(),
-        err=shell_tools.TeeCapture(),
+    result = shell_tools.run(
+        cmd, log_run_to_stderr=False, shell=True, check=False, capture_output=True
     )
 
-    if status != 0:
-        print(stderr)
+    if result.returncode != 0:
+        print(result.stderr)
         pytest.fail(
             f"Notebook failure: {notebook_file}, please see {out_path} for the output "
             f"notebook (in Github Actions, you can download it from the workflow artifact"


### PR DESCRIPTION
Stop using shell_tools.run_shell which is slated for removal.

Partially implements https://github.com/quantumlib/Cirq/issues/4394