### PR TITLE
Treat default gate families with tags_to_ignore or tags_to_accept as custom gate families in Gatesets

### DIFF
--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -198,6 +198,14 @@ class GateFamily:
     def description(self) -> str:
         return self._description
 
+    @property
+    def tags_to_accept(self) -> FrozenSet[Hashable]:
+        return self._tags_to_accept
+
+    @property
+    def tags_to_ignore(self) -> FrozenSet[Hashable]:
+        return self._tags_to_ignore
+
     def _predicate(self, gate: raw_types.Gate) -> bool:
         """Checks whether `cirq.Gate` instance `gate` belongs to this GateFamily.
 
@@ -370,7 +378,7 @@ class Gateset:
                 )
 
         for g in unique_gate_list:
-            if type(g) == GateFamily:
+            if type(g) == GateFamily and not (g.tags_to_ignore or g.tags_to_accept):
                 if isinstance(g.gate, raw_types.Gate):
                     self._instance_gate_families[g.gate] = g
                 else:

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -378,7 +378,7 @@ class Gateset:
                 )
 
         for g in unique_gate_list:
-            if type(g) == GateFamily and not (g.tags_to_ignore or g.tags_to_accept):
+            if type(g) is GateFamily and not (g.tags_to_ignore or g.tags_to_accept):
                 if isinstance(g.gate, raw_types.Gate):
                     self._instance_gate_families[g.gate] = g
                 else:

--- a/cirq-core/cirq/ops/gateset_test.py
+++ b/cirq-core/cirq/ops/gateset_test.py
@@ -418,10 +418,21 @@ def test_gateset_eq():
     )
 
 
-def test_gateset_contains_with_tags_to_ignore():
-    gs = cirq.Gateset(
-        cirq.GateFamily(cirq.ZPowGate, tags_to_accept=["PhysicalZTag"]),
-        cirq.GateFamily(cirq.ZPowGate, tags_to_ignore=["PhysicalZTag"]),
-    )
-    op = cirq.Z(q).with_tags("PhysicalZTag")
-    assert op in gs
+def test_gateset_contains_with_tags():
+    tag = "PhysicalZTag"
+    gf_accept = cirq.GateFamily(cirq.ZPowGate, tags_to_accept=[tag])
+    gf_ignore = cirq.GateFamily(cirq.ZPowGate, tags_to_ignore=[tag])
+    op = cirq.Z(q)
+    op_with_tag = cirq.Z(q).with_tags(tag)
+
+    # Only tags to ignore.
+    assert op in cirq.Gateset(gf_ignore)
+    assert op_with_tag not in cirq.Gateset(gf_ignore)
+
+    # Only tags to accept
+    assert op not in cirq.Gateset(gf_accept)
+    assert op_with_tag in cirq.Gateset(gf_accept)
+
+    # Both tags to accept and tags to ignore
+    assert op in cirq.Gateset(gf_accept, gf_ignore)
+    assert op_with_tag in cirq.Gateset(gf_accept, gf_ignore)

--- a/cirq-core/cirq/ops/gateset_test.py
+++ b/cirq-core/cirq/ops/gateset_test.py
@@ -416,3 +416,12 @@ def test_gateset_eq():
             )
         )
     )
+
+
+def test_gateset_contains_with_tags_to_ignore():
+    gs = cirq.Gateset(
+        cirq.GateFamily(cirq.ZPowGate, tags_to_accept=["PhysicalZTag"]),
+        cirq.GateFamily(cirq.ZPowGate, tags_to_ignore=["PhysicalZTag"]),
+    )
+    op = cirq.Z(q).with_tags("PhysicalZTag")
+    assert op in gs

--- a/cirq-google/cirq_google/devices/known_devices_test.py
+++ b/cirq-google/cirq_google/devices/known_devices_test.py
@@ -506,10 +506,8 @@ def test_sycamore_devices(device, qubit_size, layout_str):
         cirq.SQRT_ISWAP_INV,
         cirq.X,
         cirq.Y,
-        # Broken due to issue #5543.
-        # TODO(#5543) Uncomment
-        # cirq.Z,
-        # cirq.Z(q0).with_tags(cirq_google.PhysicalZTag()),
+        cirq.Z,
+        cirq.Z(q0).with_tags(cirq_google.PhysicalZTag()),
         coupler_pulse.CouplerPulse(hold_time=cirq.Duration(nanos=10), coupling_mhz=25.0),
         cirq.measure(q0),
         cirq.WaitGate(cirq.Duration(millis=5)),


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/5543