### PR TITLE
Move Engine interfaces to GridDevice

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -285,6 +285,7 @@ class AbstractProcessor(abc.ABC):
         """
 
     @abc.abstractmethod
+    @util.deprecated_get_device_gate_sets_parameter()
     def get_device(self, gate_sets: Iterable['serializer.Serializer'] = ()) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -872,6 +872,7 @@ def get_engine(project_id: Optional[str] = None) -> Engine:
     return Engine(project_id=project_id, service_args=service_args)
 
 
+@util.deprecated_get_device_gate_sets_parameter(param_name='gatesets')
 def get_engine_device(
     processor_id: str,
     project_id: Optional[str] = None,
@@ -880,11 +881,9 @@ def get_engine_device(
     """Returns a `Device` object for a given processor.
 
     This is a short-cut for creating an engine object, getting the
-    processor object, and retrieving the device.  Note that the
-    gateset is required in order to match the serialized specification
-    back into cirq objects.
+    processor object, and retrieving the device.
     """
-    return get_engine(project_id).get_processor(processor_id).get_device(gatesets)
+    return get_engine(project_id).get_processor(processor_id).get_device()
 
 
 def get_engine_calibration(

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -334,6 +334,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         else:
             return None
 
+    @util.deprecated_get_device_gate_sets_parameter()
     def get_device(self, gate_sets: Iterable[serializer.Serializer] = ()) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -18,9 +18,10 @@ from typing import cast, Dict, Iterable, List, Optional, Sequence, TYPE_CHECKING
 from google.protobuf import any_pb2
 
 import cirq
+from cirq import _compat
 from cirq_google.cloud import quantum
 from cirq_google.api import v2
-from cirq_google.devices import serializable_device
+from cirq_google.devices import grid_device
 from cirq_google.engine import (
     abstract_processor,
     calibration,
@@ -28,8 +29,7 @@ from cirq_google.engine import (
     processor_sampler,
     util,
 )
-from cirq_google.serialization import serializable_gate_set, serializer
-from cirq_google.serialization import gate_sets as gs
+from cirq_google.serialization import serializer
 
 if TYPE_CHECKING:
     import cirq_google as cg
@@ -338,23 +338,13 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         """Returns a `Device` created from the processor's device specification.
 
         This method queries the processor to retrieve the device specification,
-        which is then use to create a `serializable_gate_set.SerializableDevice` that will validate
-        that operations are supported and use the correct qubits.
+        which is then use to create a `cirq_google.GridDevice` that will
+        validate that operations are supported and use the correct qubits.
         """
         spec = self.get_device_specification()
         if not spec:
             raise ValueError('Processor does not have a device specification')
-        if not gate_sets:
-            # Default is to use all named gatesets in the device spec
-            gate_sets = []
-            for valid_gate_set in spec.valid_gate_sets:
-                if valid_gate_set.name in gs.NAMED_GATESETS:
-                    gate_sets.append(gs.NAMED_GATESETS[valid_gate_set.name])
-        if not all(isinstance(gs, serializable_gate_set.SerializableGateSet) for gs in gate_sets):
-            raise ValueError('All gate_sets must be SerializableGateSet currently.')
-        return serializable_device.SerializableDevice.from_proto(
-            spec, cast(Iterable[serializable_gate_set.SerializableGateSet], gate_sets)
-        )
+        return grid_device.GridDevice.from_proto(spec)
 
     @cirq._compat.deprecated_parameter(
         deadline='v1.0',

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 import datetime
 
-from typing import cast, Dict, Iterable, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Dict, Iterable, List, Optional, Sequence, TYPE_CHECKING, Union
 
 from google.protobuf import any_pb2
 
 import cirq
-from cirq import _compat
 from cirq_google.cloud import quantum
 from cirq_google.api import v2
 from cirq_google.devices import grid_device

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -75,23 +75,26 @@ _CALIBRATION = quantum.QuantumCalibration(
 _DEVICE_SPEC = util.pack_any(
     Merge(
         """
-valid_gate_sets: [{
-    name: 'test_set',
-    valid_gates: [{
-        id: 'x',
-        number_of_qubits: 1,
-        gate_duration_picos: 1000,
-        valid_targets: ['1q_targets']
-    }]
-}],
-valid_qubits: ['0_0', '1_1'],
-valid_targets: [{
-    name: '1q_targets',
-    target_ordering: SYMMETRIC,
-    targets: [{
-        ids: ['0_0']
-    }]
-}]
+valid_qubits: "0_0"
+valid_qubits: "1_1"
+valid_qubits: "2_2"
+valid_targets {
+  name: "2_qubit_targets"
+  target_ordering: SYMMETRIC
+  targets {
+    ids: "0_0"
+    ids: "1_1"
+  }
+}
+valid_gates {
+  gate_duration_picos: 1000
+  cz {
+  }
+}
+valid_gates {
+  phased_xz {
+  }
+}
 """,
         v2.device_pb2.DeviceSpecification(),
     )
@@ -294,19 +297,17 @@ def test_get_device_specification():
 
     # Construct expected device proto based on example
     expected = v2.device_pb2.DeviceSpecification()
-    gs = expected.valid_gate_sets.add()
-    gs.name = 'test_set'
-    gates = gs.valid_gates.add()
-    gates.id = 'x'
-    gates.number_of_qubits = 1
-    gates.gate_duration_picos = 1000
-    gates.valid_targets.extend(['1q_targets'])
-    expected.valid_qubits.extend(['0_0', '1_1'])
+    expected.valid_qubits.extend(['0_0', '1_1', '2_2'])
     target = expected.valid_targets.add()
-    target.name = '1q_targets'
+    target.name = '2_qubit_targets'
     target.target_ordering = v2.device_pb2.TargetSet.SYMMETRIC
     new_target = target.targets.add()
-    new_target.ids.extend(['0_0'])
+    new_target.ids.extend(['0_0', '1_1'])
+    gate = expected.valid_gates.add()
+    gate.cz.SetInParent()
+    gate.gate_duration_picos = 1000
+    gate = expected.valid_gates.add()
+    gate.phased_xz.SetInParent()
 
     processor = cg.EngineProcessor(
         'a', 'p', EngineContext(), _processor=quantum.QuantumProcessor(device_spec=_DEVICE_SPEC)
@@ -318,39 +319,16 @@ def test_get_device():
     processor = cg.EngineProcessor(
         'a', 'p', EngineContext(), _processor=quantum.QuantumProcessor(device_spec=_DEVICE_SPEC)
     )
-    device = processor.get_device(gate_sets=[_GATE_SET])
-    assert device.qubits == [cirq.GridQubit(0, 0), cirq.GridQubit(1, 1)]
-    device.validate_operation(cirq.X(cirq.GridQubit(0, 0)))
+    device = processor.get_device()
+    assert device.metadata.qubit_set == frozenset(
+        [cirq.GridQubit(0, 0), cirq.GridQubit(1, 1), cirq.GridQubit(2, 2)]
+    )
+    device.validate_operation(cirq.X(cirq.GridQubit(2, 2)))
+    device.validate_operation(cirq.CZ(cirq.GridQubit(0, 0), cirq.GridQubit(1, 1)))
     with pytest.raises(ValueError):
         device.validate_operation(cirq.X(cirq.GridQubit(1, 2)))
     with pytest.raises(ValueError):
-        device.validate_operation(cirq.Y(cirq.GridQubit(0, 0)))
-    with pytest.raises(ValueError, match='must be SerializableGateSet'):
-        processor.get_device(gate_sets=[cg.serialization.circuit_serializer.CIRCUIT_SERIALIZER])
-
-
-def test_default_gate_sets():
-    with cirq.testing.assert_deprecated('no longer be available', deadline='v0.16', count=1):
-        # Sycamore should have valid gate sets with default
-        sycamore_proto = known_devices.create_device_proto_from_diagram(
-            known_devices._SYCAMORE_GRID,
-            [cg.SQRT_ISWAP_GATESET, cg.SYC_GATESET],
-            known_devices._SYCAMORE_DURATIONS_PICOS,
-        )
-        processor = cg.EngineProcessor(
-            'a',
-            'p',
-            EngineContext(),
-            _processor=quantum.QuantumProcessor(device_spec=util.pack_any(sycamore_proto)),
-        )
-        device = processor.get_device()
-        device.validate_operation(cirq.X(cirq.GridQubit(5, 4)))
-        # Test that a device with no standard gatesets doesn't blow up
-        processor = cg.EngineProcessor(
-            'a', 'p', EngineContext(), _processor=quantum.QuantumProcessor(device_spec=_DEVICE_SPEC)
-        )
-        device = processor.get_device()
-        assert device.qubits == [cirq.GridQubit(0, 0), cirq.GridQubit(1, 1)]
+        device.validate_operation(cirq.H(cirq.GridQubit(0, 0)))
 
 
 def test_get_missing_device():

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -24,7 +24,6 @@ from google.protobuf.text_format import Merge
 from google.protobuf.timestamp_pb2 import Timestamp
 import cirq
 import cirq_google as cg
-import cirq_google.devices.known_devices as known_devices
 from cirq_google.api import v2
 from cirq_google.engine import util
 from cirq_google.engine.engine import EngineContext

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -329,12 +329,14 @@ def test_get_device():
         device.validate_operation(cirq.X(cirq.GridQubit(1, 2)))
     with pytest.raises(ValueError):
         device.validate_operation(cirq.H(cirq.GridQubit(0, 0)))
+    with pytest.raises(ValueError):
+        device.validate_operation(cirq.CZ(cirq.GridQubit(1, 1), cirq.GridQubit(2, 2)))
 
 
 def test_get_missing_device():
     processor = cg.EngineProcessor('a', 'p', EngineContext(), _processor=quantum.QuantumProcessor())
     with pytest.raises(ValueError, match='device specification'):
-        _ = processor.get_device(gate_sets=[_GATE_SET])
+        _ = processor.get_device()
 
 
 @uses_async_mock

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -129,7 +129,8 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
     def get_current_calibration(self) -> Optional[calibration.Calibration]:
         return self.get_latest_calibration(int(datetime.datetime.now().timestamp()))
 
-    def get_device(self, gate_sets: Optional[Iterable['Serializer']] = None) -> cirq.Device:
+    @util.deprecated_get_device_gate_sets_parameter()
+    def get_device(self, gate_sets: Iterable['Serializer'] = ()) -> cirq.Device:
         """Returns a `Device` created from the processor's device specification.
 
         This method queries the processor to retrieve the device specification,

--- a/cirq-google/cirq_google/engine/util.py
+++ b/cirq-google/cirq_google/engine/util.py
@@ -61,3 +61,25 @@ def deprecated_gate_set_parameter(func):
         or (gate_set_param.kind != inspect.Parameter.KEYWORD_ONLY and len(args) > idx),
     )
     return decorator(func)
+
+
+def deprecated_get_device_gate_sets_parameter(param_name='gate_sets'):
+    """Decorates variations of get_device functions, which take a deprecated 'gate_sets' parameter."""
+
+    def decorator(func):
+        signature = inspect.signature(func)
+        gate_sets_param = signature.parameters[param_name]
+        assert gate_sets_param.default == ()
+        idx = list(signature.parameters).index(param_name)
+
+        deprecation_decorator = cirq._compat.deprecated_parameter(
+            deadline='v0.16',
+            fix='Specifying gate_sets is no longer necessary to get a device.'
+            ' Remove the gate_sets parameter.',
+            parameter_desc=param_name,
+            match=lambda args, kwargs: param_name in kwargs
+            or (gate_sets_param.kind != inspect.Parameter.KEYWORD_ONLY and len(args) > idx),
+        )
+        return deprecation_decorator(func)
+
+    return decorator

--- a/cirq-google/cirq_google/engine/util.py
+++ b/cirq-google/cirq_google/engine/util.py
@@ -64,7 +64,7 @@ def deprecated_gate_set_parameter(func):
 
 
 def deprecated_get_device_gate_sets_parameter(param_name='gate_sets'):
-    """Decorates variations of get_device functions, which take a deprecated 'gate_sets' parameter."""
+    """Decorates get device functions, which take a deprecated 'gate_sets' parameter."""
 
     def decorator(func):
         signature = inspect.signature(func)


### PR DESCRIPTION
* Migrate the different `processor.get_device()` methods and `Engine.get_engine_device()` to GridDevice
* Deprecate the `gate_sets` parameter in various `get_device()` methods, and remove `gate_sets` usages.

A dedicated deprecation decorator was added in order to handle `gate_sets` parameter being passed in as a positional argument.

Originally I had planned to do this after the 0.15 release, but because library code is not allowed to rely on deprecated code within tests, this is blocking SerializableDevice deprecation (https://github.com/quantumlib/Cirq/pull/5522).

@dstrain115 @MichaelBroughton 