### PR TITLE
All single-qubit Cliffords

### DIFF
--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -265,7 +265,6 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
 
 
 class CommonCliffordGates(metaclass=CommonCliffordGateMetaClass):
-
     @classmethod
     def from_clifford_tableau(cls, tableau: qis.CliffordTableau) -> 'CliffordGate':
         """Create the CliffordGate instance from Clifford Tableau.

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from cirq import _compat, protocols, value, linalg, qis
 from cirq._import import LazyLoader
-from cirq.ops import common_gates, identity, named_qubit, raw_types, pauli_gates, phased_x_z_gate
+from cirq.ops import common_gates, named_qubit, raw_types, pauli_gates, phased_x_z_gate
 from cirq.ops.pauli_gates import Pauli
 from cirq.type_workarounds import NotImplementedType
 

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -239,7 +239,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
             t = qis.CliffordTableau(num_qubits=2)
             t.xs = [[1, 1], [0, 1], [0, 0], [0, 0]]
             t.zs = [[0, 0], [0, 0], [1, 0], [1, 1]]
-            cls._CNOT = cls.from_clifford_tableau(t)
+            cls._CNOT = CliffordGate.from_clifford_tableau(t)
         return cls._CNOT
 
     @property
@@ -248,7 +248,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
             t = qis.CliffordTableau(num_qubits=2)
             t.xs = [[1, 0], [0, 1], [0, 0], [0, 0]]
             t.zs = [[0, 1], [1, 0], [1, 0], [0, 1]]
-            cls._CZ = cls.from_clifford_tableau(t)
+            cls._CZ = CliffordGate.from_clifford_tableau(t)
         return cls._CZ
 
     @property
@@ -257,7 +257,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
             t = qis.CliffordTableau(num_qubits=2)
             t.xs = [[0, 1], [1, 0], [0, 0], [0, 0]]
             t.zs = [[0, 0], [0, 0], [0, 1], [1, 0]]
-            cls._SWAP = cls.from_clifford_tableau(t)
+            cls._SWAP = CliffordGate.from_clifford_tableau(t)
         return cls._SWAP
 
     @property

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -154,6 +154,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
             mY = (pauli_gates.Y, True)
             pZ = (pauli_gates.Z, False)
             mZ = (pauli_gates.Z, True)
+            # Order in is relied on in properties that retrieve a specific Clifford below.
             cls._all_single_qubit_cliffords = (
                 # 0: Identity
                 cls.from_clifford_tableau(_to_clifford_tableau(x_to=pX, z_to=pZ)),  # I

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -145,7 +145,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
     """A metaclass used to lazy initialize several common Clifford Gate as class attributes."""
 
     @property
-    def all_single_qubit_cliffords(cls) - Sequence['cirq.SingleQubitCliffordGate']:
+    def all_single_qubit_cliffords(cls) -> Sequence['cirq.SingleQubitCliffordGate']:
         """All 24 single-qubit Clifford gates."""
         if getattr(cls, '_all_single_qubit_cliffords', None) is None:
             pX = (pauli_gates.X, False)

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -145,140 +145,126 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
     """A metaclass used to lazy initialize several common Clifford Gate as class attributes."""
 
     @property
+    def all_single_qubit_cliffords(cls):
+        """All 24 single-qubit Clifford gates."""
+        if getattr(cls, '_all_single_qubit_cliffords', None) is None:
+            pX = (pauli_gates.X, False)
+            mX = (pauli_gates.X, True)
+            pY = (pauli_gates.Y, False)
+            mY = (pauli_gates.Y, True)
+            pZ = (pauli_gates.Z, False)
+            mZ = (pauli_gates.Z, True)
+            cls._all_single_qubit_cliffords = tuple([
+                # 0: Identity
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pX, z_to=pZ)),  # I
+                # 1..3: Paulis
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pX, z_to=mZ)),  # X
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mX, z_to=mZ)),  # Y
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mX, z_to=pZ)),  # Z
+                # 4..6: Square roots of Paulis
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pX, z_to=mY)),  # I-iX
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mZ, z_to=pX)),  # I-iY
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pY, z_to=pZ)),  # I-iZ aka S
+                # 7..9: Negative square roots of Paulis
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pX, z_to=pY)),  # I+iX
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pZ, z_to=mX)),  # I+iY
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mY, z_to=pZ)),  # I+iZ
+                # 10..15: Hadamards
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pZ, z_to=pX)),  # Z+X aka H
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pY, z_to=mZ)),  # X+Y
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mX, z_to=pY)),  # Y+Z
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mZ, z_to=mX)),  # Z-X
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mY, z_to=mZ)),  # X-Y
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mX, z_to=mY)),  # Y-Z
+                # 16..23: Order-3 Cliffords
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pY, z_to=pX)),  # I-i(+X+Y+Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mZ, z_to=mY)),  # I-i(+X+Y-Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pZ, z_to=mY)),  # I-i(+X-Y+Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mY, z_to=mX)),  # I-i(+X-Y-Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mZ, z_to=pY)),  # I-i(-X+Y+Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=mY, z_to=pX)),  # I-i(-X+Y-Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pY, z_to=mX)),  # I-i(-X-Y+Z)
+                cls.from_clifford_tableau(_to_clifford_tableau(x_to=pZ, z_to=pY)),  # I-i(-X-Y-Z)
+            ])
+        return cls._all_single_qubit_cliffords
+
+    @property
     def I(cls):
-        if getattr(cls, '_I', None) is None:
-            cls._I = cls._generate_clifford_from_known_gate(1, identity.I)
-        return cls._I
+        return cls.all_single_qubit_cliffords[0]
 
     @property
     def X(cls):
-        if getattr(cls, '_X', None) is None:
-            cls._X = cls._generate_clifford_from_known_gate(1, pauli_gates.X)
-        return cls._X
+        return cls.all_single_qubit_cliffords[1]
 
     @property
     def Y(cls):
-        if getattr(cls, '_Y', None) is None:
-            cls._Y = cls._generate_clifford_from_known_gate(1, pauli_gates.Y)
-        return cls._Y
+        return cls.all_single_qubit_cliffords[2]
 
     @property
     def Z(cls):
-        if getattr(cls, '_Z', None) is None:
-            cls._Z = cls._generate_clifford_from_known_gate(1, pauli_gates.Z)
-        return cls._Z
+        return cls.all_single_qubit_cliffords[3]
 
     @property
     def H(cls):
-        if getattr(cls, '_H', None) is None:
-            cls._H = cls._generate_clifford_from_known_gate(1, common_gates.H)
-        return cls._H
+        return cls.all_single_qubit_cliffords[10]
 
     @property
     def S(cls):
-        if getattr(cls, '_S', None) is None:
-            cls._S = cls._generate_clifford_from_known_gate(1, common_gates.S)
-        return cls._S
+        return cls.all_single_qubit_cliffords[6]
 
     @property
     def CNOT(cls):
         if getattr(cls, '_CNOT', None) is None:
-            cls._CNOT = cls._generate_clifford_from_known_gate(2, common_gates.CNOT)
+            t = qis.CliffordTableau(num_qubits=2)
+            t.xs = [[1, 1], [0, 1], [0, 0], [0, 0]]
+            t.zs = [[0, 0], [0, 0], [1, 0], [1, 1]]
+            cls._CNOT = cls.from_clifford_tableau(t)
         return cls._CNOT
 
     @property
     def CZ(cls):
         if getattr(cls, '_CZ', None) is None:
-            cls._CZ = cls._generate_clifford_from_known_gate(2, common_gates.CZ)
+            t = qis.CliffordTableau(num_qubits=2)
+            t.xs = [[1, 0], [0, 1], [0, 0], [0, 0]]
+            t.zs = [[0, 1], [1, 0], [1, 0], [0, 1]]
+            cls._CZ = cls.from_clifford_tableau(t)
         return cls._CZ
 
     @property
     def SWAP(cls):
         if getattr(cls, '_SWAP', None) is None:
-            cls._SWAP = cls._generate_clifford_from_known_gate(2, common_gates.SWAP)
+            t = qis.CliffordTableau(num_qubits=2)
+            t.xs = [[0, 1], [1, 0], [0, 0], [0, 0]]
+            t.zs = [[0, 0], [0, 0], [0, 1], [1, 0]]
+            cls._SWAP = cls.from_clifford_tableau(t)
         return cls._SWAP
 
     @property
     def X_sqrt(cls):
-        if getattr(cls, '_X_sqrt', None) is None:
-            # Unfortunately, due the code style, the matrix should be viewed transposed.
-            # Note xs, zs, and rs are column vector.
-            # Transformation: X -> X, Z -> -Y
-            _clifford_tableau = qis.CliffordTableau._from_json_dict_(
-                n=1, rs=[0, 1], xs=[[1], [1]], zs=[[0], [1]]
-            )
-            cls._X_sqrt = cls.from_clifford_tableau(_clifford_tableau)
-        return cls._X_sqrt
+        return cls.all_single_qubit_cliffords[4]
 
     @property
     def X_nsqrt(cls):
-        if getattr(cls, '_X_nsqrt', None) is None:
-            # Transformation: X->X, Z->Y
-            _clifford_tableau = qis.CliffordTableau._from_json_dict_(
-                n=1, rs=[0, 0], xs=[[1], [1]], zs=[[0], [1]]
-            )
-            cls._X_nsqrt = cls.from_clifford_tableau(_clifford_tableau)
-        return cls._X_nsqrt
+        return cls.all_single_qubit_cliffords[7]
 
     @property
     def Y_sqrt(cls):
-        if getattr(cls, '_Y_sqrt', None) is None:
-            # Transformation: X -> -Z,  Z -> X
-            _clifford_tableau = qis.CliffordTableau._from_json_dict_(
-                n=1, rs=[1, 0], xs=[[0], [1]], zs=[[1], [0]]
-            )
-            cls._Y_sqrt = cls.from_clifford_tableau(_clifford_tableau)
-        return cls._Y_sqrt
+        return cls.all_single_qubit_cliffords[5]
 
     @property
     def Y_nsqrt(cls):
-        if getattr(cls, '_Y_nsqrt', None) is None:
-            # Transformation: X -> Z, Z -> -X
-            _clifford_tableau = qis.CliffordTableau._from_json_dict_(
-                n=1, rs=[0, 1], xs=[[0], [1]], zs=[[1], [0]]
-            )
-            cls._Y_nsqrt = cls.from_clifford_tableau(_clifford_tableau)
-        return cls._Y_nsqrt
+        return cls.all_single_qubit_cliffords[8]
 
     @property
     def Z_sqrt(cls):
-        if getattr(cls, '_Z_sqrt', None) is None:
-            # Transformation: X -> Y, Z -> Z
-            _clifford_tableau = qis.CliffordTableau._from_json_dict_(
-                n=1, rs=[0, 0], xs=[[1], [0]], zs=[[1], [1]]
-            )
-            cls._Z_sqrt = cls.from_clifford_tableau(_clifford_tableau)
-        return cls._Z_sqrt
+        return cls.all_single_qubit_cliffords[6]
 
     @property
     def Z_nsqrt(cls):
-        if getattr(cls, '_Z_nsqrt', None) is None:
-            # Transformation: X -> -Y,  Z -> Z
-            _clifford_tableau = qis.CliffordTableau._from_json_dict_(
-                n=1, rs=[1, 0], xs=[[1], [0]], zs=[[1], [1]]
-            )
-            cls._Z_nsqrt = cls.from_clifford_tableau(_clifford_tableau)
-        return cls._Z_nsqrt
+        return cls.all_single_qubit_cliffords[9]
 
 
 class CommonCliffordGates(metaclass=CommonCliffordGateMetaClass):
-
-    # We need to use the lazy initialization of these common gates since they need to use
-    # cirq.sim, which can not be imported when
-    @classmethod
-    def _generate_clifford_from_known_gate(
-        cls, num_qubits: int, gate: raw_types.Gate
-    ) -> Union['SingleQubitCliffordGate', 'CliffordGate']:
-        qubits = devices.LineQubit.range(num_qubits)
-        t = qis.CliffordTableau(num_qubits=num_qubits)
-        args = sim.CliffordTableauSimulationState(
-            tableau=t, qubits=qubits, prng=np.random.RandomState()
-        )
-
-        protocols.act_on(gate, args, qubits, allow_decompose=False)
-        if num_qubits == 1:
-            return SingleQubitCliffordGate.from_clifford_tableau(args.tableau)
-        return CliffordGate.from_clifford_tableau(args.tableau)
 
     @classmethod
     def from_clifford_tableau(cls, tableau: qis.CliffordTableau) -> 'CliffordGate':

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -145,7 +145,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
     """A metaclass used to lazy initialize several common Clifford Gate as class attributes."""
 
     @property
-    def all_single_qubit_cliffords(cls):
+    def all_single_qubit_cliffords(cls) - Sequence['cirq.SingleQubitCliffordGate']:
         """All 24 single-qubit Clifford gates."""
         if getattr(cls, '_all_single_qubit_cliffords', None) is None:
             pX = (pauli_gates.X, False)
@@ -154,7 +154,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
             mY = (pauli_gates.Y, True)
             pZ = (pauli_gates.Z, False)
             mZ = (pauli_gates.Z, True)
-            cls._all_single_qubit_cliffords = tuple([
+            cls._all_single_qubit_cliffords = (
                 # 0: Identity
                 cls.from_clifford_tableau(_to_clifford_tableau(x_to=pX, z_to=pZ)),  # I
                 # 1..3: Paulis
@@ -185,35 +185,35 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
                 cls.from_clifford_tableau(_to_clifford_tableau(x_to=mY, z_to=pX)),  # I-i(-X+Y-Z)
                 cls.from_clifford_tableau(_to_clifford_tableau(x_to=pY, z_to=mX)),  # I-i(-X-Y+Z)
                 cls.from_clifford_tableau(_to_clifford_tableau(x_to=pZ, z_to=pY)),  # I-i(-X-Y-Z)
-            ])
+            )
         return cls._all_single_qubit_cliffords
 
     @property
-    def I(cls):
+    def I(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[0]
 
     @property
-    def X(cls):
+    def X(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[1]
 
     @property
-    def Y(cls):
+    def Y(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[2]
 
     @property
-    def Z(cls):
+    def Z(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[3]
 
     @property
-    def H(cls):
+    def H(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[10]
 
     @property
-    def S(cls):
+    def S(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[6]
 
     @property
-    def CNOT(cls):
+    def CNOT(cls) -> 'cirq.CliffordGate':
         if getattr(cls, '_CNOT', None) is None:
             t = qis.CliffordTableau(num_qubits=2)
             t.xs = [[1, 1], [0, 1], [0, 0], [0, 0]]
@@ -222,7 +222,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
         return cls._CNOT
 
     @property
-    def CZ(cls):
+    def CZ(cls) -> 'cirq.CliffordGate':
         if getattr(cls, '_CZ', None) is None:
             t = qis.CliffordTableau(num_qubits=2)
             t.xs = [[1, 0], [0, 1], [0, 0], [0, 0]]
@@ -231,7 +231,7 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
         return cls._CZ
 
     @property
-    def SWAP(cls):
+    def SWAP(cls) -> 'cirq.CliffordGate':
         if getattr(cls, '_SWAP', None) is None:
             t = qis.CliffordTableau(num_qubits=2)
             t.xs = [[0, 1], [1, 0], [0, 0], [0, 0]]
@@ -240,27 +240,27 @@ class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
         return cls._SWAP
 
     @property
-    def X_sqrt(cls):
+    def X_sqrt(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[4]
 
     @property
-    def X_nsqrt(cls):
+    def X_nsqrt(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[7]
 
     @property
-    def Y_sqrt(cls):
+    def Y_sqrt(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[5]
 
     @property
-    def Y_nsqrt(cls):
+    def Y_nsqrt(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[8]
 
     @property
-    def Z_sqrt(cls):
+    def Z_sqrt(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[6]
 
     @property
-    def Z_nsqrt(cls):
+    def Z_nsqrt(cls) -> 'cirq.SingleQubitCliffordGate':
         return cls.all_single_qubit_cliffords[9]
 
 

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -509,22 +509,7 @@ def test_text_diagram_info(gate, sym, exp):
     )
 
 
-@pytest.mark.parametrize(
-    "clifford_gate",
-    (
-        cirq.SingleQubitCliffordGate.I,
-        cirq.SingleQubitCliffordGate.H,
-        cirq.SingleQubitCliffordGate.X,
-        cirq.SingleQubitCliffordGate.Y,
-        cirq.SingleQubitCliffordGate.Z,
-        cirq.SingleQubitCliffordGate.X_sqrt,
-        cirq.SingleQubitCliffordGate.Y_sqrt,
-        cirq.SingleQubitCliffordGate.Z_sqrt,
-        cirq.SingleQubitCliffordGate.X_nsqrt,
-        cirq.SingleQubitCliffordGate.Y_nsqrt,
-        cirq.SingleQubitCliffordGate.Z_nsqrt,
-    ),
-)
+@pytest.mark.parametrize("clifford_gate", cirq.SingleQubitCliffordGate.all_single_qubit_cliffords)
 def test_from_unitary(clifford_gate):
     u = cirq.unitary(clifford_gate)
     result_gate = cirq.SingleQubitCliffordGate.from_unitary(u)
@@ -563,22 +548,7 @@ def test_from_unitary_not_clifford():
     assert cirq.SingleQubitCliffordGate.from_unitary_with_global_phase(u) is None
 
 
-@pytest.mark.parametrize(
-    "clifford_gate",
-    (
-        cirq.SingleQubitCliffordGate.I,
-        cirq.SingleQubitCliffordGate.H,
-        cirq.SingleQubitCliffordGate.X,
-        cirq.SingleQubitCliffordGate.Y,
-        cirq.SingleQubitCliffordGate.Z,
-        cirq.SingleQubitCliffordGate.X_sqrt,
-        cirq.SingleQubitCliffordGate.Y_sqrt,
-        cirq.SingleQubitCliffordGate.Z_sqrt,
-        cirq.SingleQubitCliffordGate.X_nsqrt,
-        cirq.SingleQubitCliffordGate.Y_nsqrt,
-        cirq.SingleQubitCliffordGate.Z_nsqrt,
-    ),
-)
+@pytest.mark.parametrize("clifford_gate", cirq.SingleQubitCliffordGate.all_single_qubit_cliffords)
 def test_decompose_gate(clifford_gate):
     gates = clifford_gate.decompose_gate()
     u = functools.reduce(np.dot, [np.eye(2), *(cirq.unitary(gate) for gate in reversed(gates))])
@@ -633,12 +603,12 @@ def test_common_clifford_gate(clifford_gate, standard_gate):
     cirq.testing.assert_allclose_up_to_global_phase(u_c, u_s, atol=1e-8)
 
 
-@pytest.mark.parametrize('clifford_gate_name', ("I", "X", "Y", "Z", "H", "S", "CNOT", "CZ", "SWAP"))
-def test_common_clifford_gate_caching(clifford_gate_name):
-    cache_name = f"_{clifford_gate_name}"
+@pytest.mark.parametrize('property_name', ("all_single_qubit_cliffords", "CNOT", "CZ", "SWAP"))
+def test_common_clifford_gate_caching(property_name):
+    cache_name = f"_{property_name}"
     delattr(cirq.CliffordGate, cache_name)
     assert not hasattr(cirq.CliffordGate, cache_name)
-    _ = getattr(cirq.CliffordGate, clifford_gate_name)
+    _ = getattr(cirq.CliffordGate, property_name)
     assert hasattr(cirq.CliffordGate, cache_name)
 
 
@@ -886,3 +856,43 @@ def test_clifford_gate_act_on_ch_form():
 def test_clifford_gate_act_on_fail():
     with pytest.raises(TypeError, match="Failed to act"):
         cirq.act_on(cirq.CliffordGate.X, DummySimulationState(), qubits=())
+
+
+def test_all_single_qubit_clifford_unitaries():
+    i = np.eye(2)
+    x = np.array([[0, 1], [1, 0]])
+    y = np.array([[0, -1j], [1j, 0]])
+    z = np.diag([1, -1])
+
+    cs = [cirq.unitary(c) for c in cirq.CliffordGate.all_single_qubit_cliffords]
+
+    # Identity
+    assert cirq.equal_up_to_global_phase(cs[0], i)
+    # Paulis
+    assert cirq.equal_up_to_global_phase(cs[1], x)
+    assert cirq.equal_up_to_global_phase(cs[2], y)
+    assert cirq.equal_up_to_global_phase(cs[3], z)
+    # Square roots of Paulis
+    assert cirq.equal_up_to_global_phase(cs[4], (i - 1j * x) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[5], (i - 1j * y) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[6], (i - 1j * z) / np.sqrt(2))
+    # Negative square roots of Paulis
+    assert cirq.equal_up_to_global_phase(cs[7], (i + 1j * x) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[8], (i + 1j * y) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[9], (i + 1j * z) / np.sqrt(2))
+    # Hadamards
+    assert cirq.equal_up_to_global_phase(cs[10], (z + x) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[11], (x + y) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[12], (y + z) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[13], (z - x) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[14], (x - y) / np.sqrt(2))
+    assert cirq.equal_up_to_global_phase(cs[15], (y - z) / np.sqrt(2))
+    # Order-3 Cliffords
+    assert cirq.equal_up_to_global_phase(cs[16], (i - 1j * (x + y + z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[17], (i - 1j * (x + y - z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[18], (i - 1j * (x - y + z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[19], (i - 1j * (x - y - z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[20], (i - 1j * (-x + y + z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[21], (i - 1j * (-x + y - z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[22], (i - 1j * (-x - y + z)) / 2)
+    assert cirq.equal_up_to_global_phase(cs[23], (i - 1j * (-x - y - z)) / 2)


### PR DESCRIPTION
This makes it easier to use any single-qubit Clifford gate in tests, including currently neglected order-3 Cliffords. See [context](https://github.com/quantumlib/Cirq/pull/5568#discussion_r904050802).

The PR also simplifies the construction of the gates. In particular, we don't need a simulator to get a gate's tableau.