### PR TITLE
Serializers deprecation

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -165,7 +165,8 @@ _compat.deprecate_attributes(
     {
         'XMON': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'
@@ -174,7 +175,8 @@ _compat.deprecate_attributes(
         ),
         'FSIM_GATESET': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'
@@ -183,7 +185,8 @@ _compat.deprecate_attributes(
         ),
         'SQRT_ISWAP_GATESET': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'
@@ -192,7 +195,8 @@ _compat.deprecate_attributes(
         ),
         'SYC_GATESET': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'
@@ -201,7 +205,8 @@ _compat.deprecate_attributes(
         ),
         'NAMED_GATESETS': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'

--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -160,58 +160,25 @@ from cirq_google.json_resolver_cache import _class_resolver_dictionary
 
 _register_resolver(_class_resolver_dictionary)
 
+
+_SERIALIZABLE_GATESET_DEPRECATION_MESSAGE = (
+    'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+    ' SerializingArgs, DeserializingArgs) will no longer be supported.'
+    ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of a device'
+    ' is represented as a cirq.Gateset and is available as'
+    ' GridDevice.metadata.gateset.'
+    ' Engine methods no longer require gate sets to be passed in.'
+    ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.'
+)
+
+
 _compat.deprecate_attributes(
     __name__,
     {
-        'XMON': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
-        'FSIM_GATESET': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
-        'SQRT_ISWAP_GATESET': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
-        'SYC_GATESET': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
-        'NAMED_GATESETS': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
+        'XMON': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
+        'FSIM_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
+        'SQRT_ISWAP_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
+        'SYC_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
+        'NAMED_GATESETS': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
     },
 )

--- a/cirq-google/cirq_google/devices/known_devices.py
+++ b/cirq-google/cirq_google/devices/known_devices.py
@@ -175,7 +175,7 @@ def create_device_proto_for_qubits(
                 gate = gs_proto.valid_gates.add()
                 gate.id = gate_id
 
-                if not isinstance(serializer, op_serializer.GateOpSerializer):
+                if not isinstance(serializer, op_serializer._GateOpSerializer):
                     # This implies that 'serializer' handles non-gate ops,
                     # such as CircuitOperations. No other properties apply.
                     continue

--- a/cirq-google/cirq_google/devices/serializable_device_test.py
+++ b/cirq-google/cirq_google/devices/serializable_device_test.py
@@ -27,7 +27,11 @@ import cirq_google.serialization.common_serializers as cgc
 
 
 def _just_cz():
-    with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=None):
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer, and
+    # cirq_google.GateOpDeserializer
+    with cirq.testing.assert_deprecated(
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=None
+    ):
         return cg.SerializableGateSet(
             gate_set_name='cz_gate_set',
             serializers=[
@@ -42,7 +46,11 @@ def _just_cz():
 
 
 def _just_meas():
-    with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=None):
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer, and
+    # cirq_google.GateOpDeserializer
+    with cirq.testing.assert_deprecated(
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=None
+    ):
         return cg.SerializableGateSet(
             gate_set_name='meas_gate_set',
             serializers=[

--- a/cirq-google/cirq_google/serialization/common_serializers.py
+++ b/cirq-google/cirq_google/serialization/common_serializers.py
@@ -75,7 +75,7 @@ def _convert_physical_z(op: cirq.Operation, proto: v2.program_pb2.Operation):
 # Single qubit serializers for arbitrary rotations
 #
 SINGLE_QUBIT_SERIALIZERS = [
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy',
         args=[
@@ -87,7 +87,7 @@ SINGLE_QUBIT_SERIALIZERS = [
             ),
         ],
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.XPowGate,
         serialized_gate_id='xy',
         args=[
@@ -99,7 +99,7 @@ SINGLE_QUBIT_SERIALIZERS = [
             ),
         ],
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.YPowGate,
         serialized_gate_id='xy',
         args=[
@@ -111,7 +111,7 @@ SINGLE_QUBIT_SERIALIZERS = [
             ),
         ],
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.ZPowGate,
         serialized_gate_id='z',
         args=[
@@ -125,7 +125,7 @@ SINGLE_QUBIT_SERIALIZERS = [
             ),
         ],
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.PhasedXZGate,
         serialized_gate_id='xyz',
         args=[
@@ -148,7 +148,7 @@ SINGLE_QUBIT_SERIALIZERS = [
 # Single qubit deserializers for arbitrary rotations
 #
 SINGLE_QUBIT_DESERIALIZERS = [
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='xy',
         gate_constructor=cirq.PhasedXPowGate,
         args=[
@@ -162,7 +162,7 @@ SINGLE_QUBIT_DESERIALIZERS = [
             ),
         ],
     ),
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='z',
         gate_constructor=cirq.ZPowGate,
         args=[
@@ -172,7 +172,7 @@ SINGLE_QUBIT_DESERIALIZERS = [
         ],
         op_wrapper=lambda op, proto: _convert_physical_z(op, proto),
     ),
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='xyz',
         gate_constructor=cirq.PhasedXZGate,
         args=[
@@ -195,7 +195,7 @@ SINGLE_QUBIT_DESERIALIZERS = [
 #
 # Measurement Serializer and Deserializer
 #
-MEASUREMENT_SERIALIZER = op_serializer.GateOpSerializer(
+MEASUREMENT_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.MeasurementGate,
     serialized_gate_id='meas',
     args=[
@@ -207,7 +207,7 @@ MEASUREMENT_SERIALIZER = op_serializer.GateOpSerializer(
         ),
     ],
 )
-MEASUREMENT_DESERIALIZER = op_deserializer.GateOpDeserializer(
+MEASUREMENT_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='meas',
     gate_constructor=cirq.MeasurementGate,
     args=[
@@ -226,7 +226,7 @@ MEASUREMENT_DESERIALIZER = op_deserializer.GateOpDeserializer(
 # Serializers for single qubit rotations confined to half-pi increments
 #
 SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy_pi',
         args=[
@@ -238,7 +238,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
             cast(cirq.PhasedXPowGate, op.gate).exponent, 1
         ),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.XPowGate,
         serialized_gate_id='xy_pi',
         args=[
@@ -250,7 +250,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.XPowGate, op.gate).exponent, 1),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.YPowGate,
         serialized_gate_id='xy_pi',
         args=[
@@ -262,7 +262,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.YPowGate, op.gate).exponent, 1),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.XPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
@@ -274,7 +274,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.XPowGate, op.gate).exponent, 0.5),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.YPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
@@ -286,7 +286,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.YPowGate, op.gate).exponent, 0.5),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
@@ -304,7 +304,7 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
 # Deserializers for single qubit rotations confined to half-pi increments
 #
 SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='xy_pi',
         gate_constructor=cirq.PhasedXPowGate,
         args=[
@@ -318,7 +318,7 @@ SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
             ),
         ],
     ),
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='xy_half_pi',
         gate_constructor=cirq.PhasedXPowGate,
         args=[
@@ -360,7 +360,7 @@ def _add_phase_match(op: cirq.Operation, proto: v2.program_pb2.Operation):
 #
 
 # Only CZ
-CZ_SERIALIZER = op_serializer.GateOpSerializer(
+CZ_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.CZPowGate,
     serialized_gate_id='cz',
     args=[
@@ -373,7 +373,7 @@ CZ_SERIALIZER = op_serializer.GateOpSerializer(
 )
 
 # CZ to any power
-CZ_POW_SERIALIZER = op_serializer.GateOpSerializer(
+CZ_POW_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.CZPowGate,
     serialized_gate_id='cz',
     args=[
@@ -384,7 +384,7 @@ CZ_POW_SERIALIZER = op_serializer.GateOpSerializer(
     ],
 )
 
-CZ_POW_DESERIALIZER = op_deserializer.GateOpDeserializer(
+CZ_POW_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='cz',
     gate_constructor=cirq.CZPowGate,
     args=[
@@ -398,7 +398,7 @@ CZ_POW_DESERIALIZER = op_deserializer.GateOpDeserializer(
 #
 # Sycamore Gate Serializer and deserializer
 #
-SYC_SERIALIZER = op_serializer.GateOpSerializer(
+SYC_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.FSimGate,
     serialized_gate_id='syc',
     args=[_phase_match_arg],
@@ -408,7 +408,7 @@ SYC_SERIALIZER = op_serializer.GateOpSerializer(
     ),
 )
 
-SYC_DESERIALIZER = op_deserializer.GateOpDeserializer(
+SYC_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='syc',
     gate_constructor=lambda: cirq.FSimGate(theta=np.pi / 2, phi=np.pi / 6),
     args=[],
@@ -420,7 +420,7 @@ SYC_DESERIALIZER = op_deserializer.GateOpDeserializer(
 # (e.g. ISWAP ** 0.5)
 #
 SQRT_ISWAP_SERIALIZERS = [
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.FSimGate,
         serialized_gate_id='fsim_pi_4',
         args=[_phase_match_arg],
@@ -429,7 +429,7 @@ SQRT_ISWAP_SERIALIZERS = [
             and _near_mod_2pi(cast(cirq.FSimGate, op.gate).phi, 0)
         ),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.ISwapPowGate,
         serialized_gate_id='fsim_pi_4',
         args=[_phase_match_arg],
@@ -437,7 +437,7 @@ SQRT_ISWAP_SERIALIZERS = [
             lambda op: _near_mod_n(cast(cirq.ISwapPowGate, op.gate).exponent, -0.5, 4)
         ),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.FSimGate,
         serialized_gate_id='inv_fsim_pi_4',
         args=[_phase_match_arg],
@@ -446,7 +446,7 @@ SQRT_ISWAP_SERIALIZERS = [
             and _near_mod_2pi(cast(cirq.FSimGate, op.gate).phi, 0)
         ),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.ISwapPowGate,
         serialized_gate_id='inv_fsim_pi_4',
         args=[_phase_match_arg],
@@ -457,13 +457,13 @@ SQRT_ISWAP_SERIALIZERS = [
 ]
 
 SQRT_ISWAP_DESERIALIZERS = [
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='fsim_pi_4',
         gate_constructor=lambda: cirq.FSimGate(theta=np.pi / 4, phi=0),
         args=[],
         op_wrapper=lambda op, proto: _add_phase_match(op, proto),
     ),
-    op_deserializer.GateOpDeserializer(
+    op_deserializer._GateOpDeserializer(
         serialized_gate_id='inv_fsim_pi_4',
         gate_constructor=lambda: cirq.FSimGate(theta=-np.pi / 4, phi=0),
         args=[],
@@ -496,7 +496,7 @@ _LIMITED_ISWAP_GATE_FAMILY = fsim_gate_family.FSimGateFamily(
     allow_symbols=True,
 )
 LIMITED_FSIM_SERIALIZERS = [
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.FSimGate,
         serialized_gate_id='fsim',
         args=[
@@ -510,7 +510,7 @@ LIMITED_FSIM_SERIALIZERS = [
         ],
         can_serialize_predicate=(lambda op: op in _LIMITED_FSIM_GATE_FAMILY),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.ISwapPowGate,
         serialized_gate_id='fsim',
         args=[
@@ -527,7 +527,7 @@ LIMITED_FSIM_SERIALIZERS = [
         ],
         can_serialize_predicate=(lambda op: op in _LIMITED_ISWAP_GATE_FAMILY),
     ),
-    op_serializer.GateOpSerializer(
+    op_serializer._GateOpSerializer(
         gate_type=cirq.CZPowGate,
         serialized_gate_id='fsim',
         args=[
@@ -544,7 +544,7 @@ LIMITED_FSIM_SERIALIZERS = [
 ]
 
 
-LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(
+LIMITED_FSIM_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='fsim',
     gate_constructor=cirq.FSimGate,
     args=[
@@ -568,7 +568,7 @@ LIMITED_FSIM_DESERIALIZER = op_deserializer.GateOpDeserializer(
 # Coupler Pulse serializer and deserializer
 #
 
-COUPLER_PULSE_SERIALIZER = op_serializer.GateOpSerializer(
+COUPLER_PULSE_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=CouplerPulse,
     serialized_gate_id='coupler_pulse',
     args=[
@@ -592,7 +592,7 @@ COUPLER_PULSE_SERIALIZER = op_serializer.GateOpSerializer(
         ),
     ],
 )
-COUPLER_PULSE_DESERIALIZER = op_deserializer.GateOpDeserializer(
+COUPLER_PULSE_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='coupler_pulse',
     gate_constructor=CouplerPulse,
     args=[
@@ -626,7 +626,7 @@ COUPLER_PULSE_DESERIALIZER = op_deserializer.GateOpDeserializer(
 #
 # WaitGate serializer and deserializer
 #
-WAIT_GATE_SERIALIZER = op_serializer.GateOpSerializer(
+WAIT_GATE_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.WaitGate,
     serialized_gate_id='wait',
     args=[
@@ -637,7 +637,7 @@ WAIT_GATE_SERIALIZER = op_serializer.GateOpSerializer(
         )
     ],
 )
-WAIT_GATE_DESERIALIZER = op_deserializer.GateOpDeserializer(
+WAIT_GATE_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='wait',
     gate_constructor=cirq.WaitGate,
     args=[

--- a/cirq-google/cirq_google/serialization/common_serializers.py
+++ b/cirq-google/cirq_google/serialization/common_serializers.py
@@ -79,11 +79,19 @@ SINGLE_QUBIT_SERIALIZERS = [
         gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns', serialized_type=float, op_getter='phase_exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter='phase_exponent',
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+                ),
             ),
         ],
     ),
@@ -91,11 +99,19 @@ SINGLE_QUBIT_SERIALIZERS = [
         gate_type=cirq.XPowGate,
         serialized_gate_id='xy',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns', serialized_type=float, op_getter=lambda op: 0.0
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter=lambda op: 0.0,
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+                ),
             ),
         ],
     ),
@@ -103,11 +119,19 @@ SINGLE_QUBIT_SERIALIZERS = [
         gate_type=cirq.YPowGate,
         serialized_gate_id='xy',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns', serialized_type=float, op_getter=lambda op: 0.5
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter=lambda op: 0.5,
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+                ),
             ),
         ],
     ),
@@ -115,13 +139,19 @@ SINGLE_QUBIT_SERIALIZERS = [
         gate_type=cirq.ZPowGate,
         serialized_gate_id='z',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='type',
-                serialized_type=str,
-                op_getter=lambda op: PHYSICAL_Z if PhysicalZTag() in op.tags else VIRTUAL_Z,
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='type',
+                    serialized_type=str,
+                    op_getter=lambda op: PHYSICAL_Z if PhysicalZTag() in op.tags else VIRTUAL_Z,
+                ),
             ),
         ],
     ),
@@ -129,16 +159,25 @@ SINGLE_QUBIT_SERIALIZERS = [
         gate_type=cirq.PhasedXZGate,
         serialized_gate_id='xyz',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='x_exponent', serialized_type=float, op_getter='x_exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='x_exponent', serialized_type=float, op_getter='x_exponent'
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='z_exponent', serialized_type=float, op_getter='z_exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='z_exponent', serialized_type=float, op_getter='z_exponent'
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='axis_phase_exponent',
-                serialized_type=float,
-                op_getter='axis_phase_exponent',
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_phase_exponent',
+                    serialized_type=float,
+                    op_getter='axis_phase_exponent',
+                ),
             ),
         ],
     ),
@@ -152,13 +191,19 @@ SINGLE_QUBIT_DESERIALIZERS = [
         serialized_gate_id='xy',
         gate_constructor=cirq.PhasedXPowGate,
         args=[
-            op_deserializer.DeserializingArg(
-                serialized_name='axis_half_turns',
-                constructor_arg_name='phase_exponent',
-                default=0.0,
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='axis_half_turns',
+                    constructor_arg_name='phase_exponent',
+                    default=0.0,
+                ),
             ),
-            op_deserializer.DeserializingArg(
-                serialized_name='half_turns', constructor_arg_name='exponent', default=1.0
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='half_turns', constructor_arg_name='exponent', default=1.0
+                ),
             ),
         ],
     ),
@@ -166,8 +211,11 @@ SINGLE_QUBIT_DESERIALIZERS = [
         serialized_gate_id='z',
         gate_constructor=cirq.ZPowGate,
         args=[
-            op_deserializer.DeserializingArg(
-                serialized_name='half_turns', constructor_arg_name='exponent', default=1.0
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='half_turns', constructor_arg_name='exponent', default=1.0
+                ),
             )
         ],
         op_wrapper=lambda op, proto: _convert_physical_z(op, proto),
@@ -176,16 +224,25 @@ SINGLE_QUBIT_DESERIALIZERS = [
         serialized_gate_id='xyz',
         gate_constructor=cirq.PhasedXZGate,
         args=[
-            op_deserializer.DeserializingArg(
-                serialized_name='x_exponent', constructor_arg_name='x_exponent', default=0.0
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='x_exponent', constructor_arg_name='x_exponent', default=0.0
+                ),
             ),
-            op_deserializer.DeserializingArg(
-                serialized_name='z_exponent', constructor_arg_name='z_exponent', default=0.0
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='z_exponent', constructor_arg_name='z_exponent', default=0.0
+                ),
             ),
-            op_deserializer.DeserializingArg(
-                serialized_name='axis_phase_exponent',
-                constructor_arg_name='axis_phase_exponent',
-                default=0.0,
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='axis_phase_exponent',
+                    constructor_arg_name='axis_phase_exponent',
+                    default=0.0,
+                ),
             ),
         ],
     ),
@@ -199,11 +256,17 @@ MEASUREMENT_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.MeasurementGate,
     serialized_gate_id='meas',
     args=[
-        op_serializer.SerializingArg(
-            serialized_name='key', serialized_type=str, op_getter=cirq.measurement_key_name
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='key', serialized_type=str, op_getter=cirq.measurement_key_name
+            ),
         ),
-        op_serializer.SerializingArg(
-            serialized_name='invert_mask', serialized_type=List[bool], op_getter='invert_mask'
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='invert_mask', serialized_type=List[bool], op_getter='invert_mask'
+            ),
         ),
     ],
 )
@@ -211,11 +274,17 @@ MEASUREMENT_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='meas',
     gate_constructor=cirq.MeasurementGate,
     args=[
-        op_deserializer.DeserializingArg(serialized_name='key', constructor_arg_name='key'),
-        op_deserializer.DeserializingArg(
-            serialized_name='invert_mask',
-            constructor_arg_name='invert_mask',
-            value_func=lambda x: tuple(cast(list, x)),
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(serialized_name='key', constructor_arg_name='key'),
+        ),
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='invert_mask',
+                constructor_arg_name='invert_mask',
+                value_func=lambda x: tuple(cast(list, x)),
+            ),
         ),
     ],
     num_qubits_param='num_qubits',
@@ -230,8 +299,13 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy_pi',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns', serialized_type=float, op_getter='phase_exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter='phase_exponent',
+                ),
             )
         ],
         can_serialize_predicate=lambda op: _near_mod_2(
@@ -242,10 +316,13 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         gate_type=cirq.XPowGate,
         serialized_gate_id='xy_pi',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns',
-                serialized_type=float,
-                op_getter=lambda op: (cast(cirq.XPowGate, op.gate).exponent - 1) / 2,
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter=lambda op: (cast(cirq.XPowGate, op.gate).exponent - 1) / 2,
+                ),
             )
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.XPowGate, op.gate).exponent, 1),
@@ -254,10 +331,13 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         gate_type=cirq.YPowGate,
         serialized_gate_id='xy_pi',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns',
-                serialized_type=float,
-                op_getter=lambda op: cast(cirq.YPowGate, op.gate).exponent / 2,
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter=lambda op: cast(cirq.YPowGate, op.gate).exponent / 2,
+                ),
             )
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.YPowGate, op.gate).exponent, 1),
@@ -266,10 +346,13 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         gate_type=cirq.XPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns',
-                serialized_type=float,
-                op_getter=lambda op: cast(cirq.XPowGate, op.gate).exponent - 0.5,
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter=lambda op: cast(cirq.XPowGate, op.gate).exponent - 0.5,
+                ),
             )
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.XPowGate, op.gate).exponent, 0.5),
@@ -278,10 +361,13 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         gate_type=cirq.YPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns',
-                serialized_type=float,
-                op_getter=lambda op: cast(cirq.YPowGate, op.gate).exponent,
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter=lambda op: cast(cirq.YPowGate, op.gate).exponent,
+                ),
             )
         ],
         can_serialize_predicate=lambda op: _near_mod_2(cast(cirq.YPowGate, op.gate).exponent, 0.5),
@@ -290,8 +376,13 @@ SINGLE_QUBIT_HALF_PI_SERIALIZERS = [
         gate_type=cirq.PhasedXPowGate,
         serialized_gate_id='xy_half_pi',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='axis_half_turns', serialized_type=float, op_getter='phase_exponent'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='axis_half_turns',
+                    serialized_type=float,
+                    op_getter='phase_exponent',
+                ),
             )
         ],
         can_serialize_predicate=lambda op: _near_mod_2(
@@ -308,13 +399,19 @@ SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
         serialized_gate_id='xy_pi',
         gate_constructor=cirq.PhasedXPowGate,
         args=[
-            op_deserializer.DeserializingArg(
-                serialized_name='axis_half_turns', constructor_arg_name='phase_exponent'
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='axis_half_turns', constructor_arg_name='phase_exponent'
+                ),
             ),
-            op_deserializer.DeserializingArg(
-                serialized_name='axis_half_turns',
-                constructor_arg_name='exponent',
-                value_func=lambda _: 1,
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='axis_half_turns',
+                    constructor_arg_name='exponent',
+                    value_func=lambda _: 1,
+                ),
             ),
         ],
     ),
@@ -322,13 +419,19 @@ SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
         serialized_gate_id='xy_half_pi',
         gate_constructor=cirq.PhasedXPowGate,
         args=[
-            op_deserializer.DeserializingArg(
-                serialized_name='axis_half_turns', constructor_arg_name='phase_exponent'
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='axis_half_turns', constructor_arg_name='phase_exponent'
+                ),
             ),
-            op_deserializer.DeserializingArg(
-                serialized_name='axis_half_turns',
-                constructor_arg_name='exponent',
-                value_func=lambda _: 0.5,
+            cast(
+                op_deserializer.DeserializingArg,
+                op_deserializer._DeserializingArg(
+                    serialized_name='axis_half_turns',
+                    constructor_arg_name='exponent',
+                    value_func=lambda _: 0.5,
+                ),
             ),
         ],
     ),
@@ -340,11 +443,14 @@ SINGLE_QUBIT_HALF_PI_DESERIALIZERS = [
 #
 #############################################
 
-_phase_match_arg = op_serializer.SerializingArg(
-    serialized_name='phase_match',
-    serialized_type=str,
-    op_getter=lambda op: PHASE_MATCH_PHYS_Z if PhysicalZTag() in op.tags else None,
-    required=False,
+_phase_match_arg = cast(
+    op_serializer.SerializingArg,
+    op_serializer._SerializingArg(
+        serialized_name='phase_match',
+        serialized_type=str,
+        op_getter=lambda op: PHASE_MATCH_PHYS_Z if PhysicalZTag() in op.tags else None,
+        required=False,
+    ),
 )
 
 
@@ -364,8 +470,11 @@ CZ_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.CZPowGate,
     serialized_gate_id='cz',
     args=[
-        op_serializer.SerializingArg(
-            serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+            ),
         ),
         _phase_match_arg,
     ],
@@ -377,8 +486,11 @@ CZ_POW_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.CZPowGate,
     serialized_gate_id='cz',
     args=[
-        op_serializer.SerializingArg(
-            serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+            ),
         ),
         _phase_match_arg,
     ],
@@ -388,8 +500,11 @@ CZ_POW_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='cz',
     gate_constructor=cirq.CZPowGate,
     args=[
-        op_deserializer.DeserializingArg(
-            serialized_name='half_turns', constructor_arg_name='exponent', default=1.0
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='half_turns', constructor_arg_name='exponent', default=1.0
+            ),
         )
     ],
     op_wrapper=lambda op, proto: _add_phase_match(op, proto),
@@ -500,11 +615,17 @@ LIMITED_FSIM_SERIALIZERS = [
         gate_type=cirq.FSimGate,
         serialized_gate_id='fsim',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='theta', serialized_type=float, op_getter='theta'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='theta', serialized_type=float, op_getter='theta'
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='phi', serialized_type=float, op_getter='phi'
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='phi', serialized_type=float, op_getter='phi'
+                ),
             ),
             _phase_match_arg,
         ],
@@ -514,14 +635,20 @@ LIMITED_FSIM_SERIALIZERS = [
         gate_type=cirq.ISwapPowGate,
         serialized_gate_id='fsim',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='theta',
-                serialized_type=float,
-                # Note that ISWAP ** 0.5 is Fsim(-pi/4,0)
-                op_getter=(lambda op: cast(cirq.ISwapPowGate, op.gate).exponent * -np.pi / 2),
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='theta',
+                    serialized_type=float,
+                    # Note that ISWAP ** 0.5 is Fsim(-pi/4,0)
+                    op_getter=(lambda op: cast(cirq.ISwapPowGate, op.gate).exponent * -np.pi / 2),
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='phi', serialized_type=float, op_getter=lambda e: 0
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='phi', serialized_type=float, op_getter=lambda e: 0
+                ),
             ),
             _phase_match_arg,
         ],
@@ -531,11 +658,17 @@ LIMITED_FSIM_SERIALIZERS = [
         gate_type=cirq.CZPowGate,
         serialized_gate_id='fsim',
         args=[
-            op_serializer.SerializingArg(
-                serialized_name='theta', serialized_type=float, op_getter=lambda e: 0
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='theta', serialized_type=float, op_getter=lambda e: 0
+                ),
             ),
-            op_serializer.SerializingArg(
-                serialized_name='phi', serialized_type=float, op_getter=lambda e: np.pi
+            cast(
+                op_serializer.SerializingArg,
+                op_serializer._SerializingArg(
+                    serialized_name='phi', serialized_type=float, op_getter=lambda e: np.pi
+                ),
             ),
             _phase_match_arg,
         ],
@@ -548,11 +681,17 @@ LIMITED_FSIM_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='fsim',
     gate_constructor=cirq.FSimGate,
     args=[
-        op_deserializer.DeserializingArg(
-            serialized_name='theta', constructor_arg_name='theta', default=0.0
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='theta', constructor_arg_name='theta', default=0.0
+            ),
         ),
-        op_deserializer.DeserializingArg(
-            serialized_name='phi', constructor_arg_name='phi', default=0.0
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='phi', constructor_arg_name='phi', default=0.0
+            ),
         ),
     ],
     op_wrapper=lambda op, proto: _add_phase_match(op, proto),
@@ -572,23 +711,35 @@ COUPLER_PULSE_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=CouplerPulse,
     serialized_gate_id='coupler_pulse',
     args=[
-        op_serializer.SerializingArg(
-            serialized_name='coupling_mhz', serialized_type=float, op_getter='coupling_mhz'
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='coupling_mhz', serialized_type=float, op_getter='coupling_mhz'
+            ),
         ),
-        op_serializer.SerializingArg(
-            serialized_name='hold_time_ns',
-            serialized_type=float,
-            op_getter=lambda op: cast(CouplerPulse, op.gate).hold_time.total_nanos(),
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='hold_time_ns',
+                serialized_type=float,
+                op_getter=lambda op: cast(CouplerPulse, op.gate).hold_time.total_nanos(),
+            ),
         ),
-        op_serializer.SerializingArg(
-            serialized_name='rise_time_ns',
-            serialized_type=float,
-            op_getter=lambda op: cast(CouplerPulse, op.gate).rise_time.total_nanos(),
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='rise_time_ns',
+                serialized_type=float,
+                op_getter=lambda op: cast(CouplerPulse, op.gate).rise_time.total_nanos(),
+            ),
         ),
-        op_serializer.SerializingArg(
-            serialized_name='padding_time_ns',
-            serialized_type=float,
-            op_getter=lambda op: cast(CouplerPulse, op.gate).padding_time.total_nanos(),
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='padding_time_ns',
+                serialized_type=float,
+                op_getter=lambda op: cast(CouplerPulse, op.gate).padding_time.total_nanos(),
+            ),
         ),
     ],
 )
@@ -596,28 +747,40 @@ COUPLER_PULSE_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='coupler_pulse',
     gate_constructor=CouplerPulse,
     args=[
-        op_deserializer.DeserializingArg(
-            serialized_name='coupling_mhz', constructor_arg_name='coupling_mhz'
-        ),
-        op_deserializer.DeserializingArg(
-            serialized_name='hold_time_ns',
-            constructor_arg_name='hold_time',
-            value_func=lambda nanos: cirq.Duration(
-                nanos=cast(Union[int, float, sympy.Expr], nanos)
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='coupling_mhz', constructor_arg_name='coupling_mhz'
             ),
         ),
-        op_deserializer.DeserializingArg(
-            serialized_name='rise_time_ns',
-            constructor_arg_name='rise_time',
-            value_func=lambda nanos: cirq.Duration(
-                nanos=cast(Union[int, float, sympy.Expr], nanos)
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='hold_time_ns',
+                constructor_arg_name='hold_time',
+                value_func=lambda nanos: cirq.Duration(
+                    nanos=cast(Union[int, float, sympy.Expr], nanos)
+                ),
             ),
         ),
-        op_deserializer.DeserializingArg(
-            serialized_name='padding_time_ns',
-            constructor_arg_name='padding_time',
-            value_func=lambda nanos: cirq.Duration(
-                nanos=cast(Union[int, float, sympy.Expr], nanos)
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='rise_time_ns',
+                constructor_arg_name='rise_time',
+                value_func=lambda nanos: cirq.Duration(
+                    nanos=cast(Union[int, float, sympy.Expr], nanos)
+                ),
+            ),
+        ),
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='padding_time_ns',
+                constructor_arg_name='padding_time',
+                value_func=lambda nanos: cirq.Duration(
+                    nanos=cast(Union[int, float, sympy.Expr], nanos)
+                ),
             ),
         ),
     ],
@@ -630,10 +793,13 @@ WAIT_GATE_SERIALIZER = op_serializer._GateOpSerializer(
     gate_type=cirq.WaitGate,
     serialized_gate_id='wait',
     args=[
-        op_serializer.SerializingArg(
-            serialized_name='nanos',
-            serialized_type=float,
-            op_getter=lambda op: cast(cirq.WaitGate, op.gate).duration.total_nanos(),
+        cast(
+            op_serializer.SerializingArg,
+            op_serializer._SerializingArg(
+                serialized_name='nanos',
+                serialized_type=float,
+                op_getter=lambda op: cast(cirq.WaitGate, op.gate).duration.total_nanos(),
+            ),
         )
     ],
 )
@@ -641,11 +807,14 @@ WAIT_GATE_DESERIALIZER = op_deserializer._GateOpDeserializer(
     serialized_gate_id='wait',
     gate_constructor=cirq.WaitGate,
     args=[
-        op_deserializer.DeserializingArg(
-            serialized_name='nanos',
-            constructor_arg_name='duration',
-            value_func=lambda nanos: cirq.Duration(
-                nanos=cast(Union[int, float, sympy.Expr], nanos)
+        cast(
+            op_deserializer.DeserializingArg,
+            op_deserializer._DeserializingArg(
+                serialized_name='nanos',
+                constructor_arg_name='duration',
+                value_func=lambda nanos: cirq.Duration(
+                    nanos=cast(Union[int, float, sympy.Expr], nanos)
+                ),
             ),
         )
     ],

--- a/cirq-google/cirq_google/serialization/gate_sets.py
+++ b/cirq-google/cirq_google/serialization/gate_sets.py
@@ -168,28 +168,21 @@ GOOGLE_GATESETS = [SYC_GATESET, SQRT_ISWAP_GATESET, FSIM_GATESET, XMON]
 document(GOOGLE_GATESETS, """All Google gatesets""")
 
 
+_SERIALIZABLE_GATESET_DEPRECATION_MESSAGE = (
+    'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+    ' SerializingArgs, DeserializingArgs) will no longer be supported.'
+    ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of a device'
+    ' is represented as a cirq.Gateset and is available as'
+    ' GridDevice.metadata.gateset.'
+    ' Engine methods no longer require gate sets to be passed in.'
+    ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.'
+)
+
+
 _compat.deprecate_attributes(
     __name__,
     {
-        'EXPERIMENTAL_PULSE_GATESET': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
-        'GOOGLE_GATESETS': (
-            'v0.16',
-            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-            ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
-            ' a device is represented as a cirq.Gateset and is available as'
-            ' GridDevice.metadata.gateset.'
-            ' Engine methods no longer require gate sets to be passed in.'
-            ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.',
-        ),
+        'EXPERIMENTAL_PULSE_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
+        'GOOGLE_GATESETS': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
     },
 )

--- a/cirq-google/cirq_google/serialization/gate_sets.py
+++ b/cirq-google/cirq_google/serialization/gate_sets.py
@@ -173,7 +173,8 @@ _compat.deprecate_attributes(
     {
         'EXPERIMENTAL_PULSE_GATESET': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'
@@ -182,7 +183,8 @@ _compat.deprecate_attributes(
         ),
         'GOOGLE_GATESETS': (
             'v0.16',
-            'SerializableGateSet will no longer be supported.'
+            'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
+            ' SerializingArgs, DeserializingArgs) will no longer be supported.'
             ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of '
             ' a device is represented as a cirq.Gateset and is available as'
             ' GridDevice.metadata.gateset.'

--- a/cirq-google/cirq_google/serialization/op_deserializer.py
+++ b/cirq-google/cirq_google/serialization/op_deserializer.py
@@ -66,7 +66,27 @@ class OpDeserializer(abc.ABC):
 
 
 @dataclass(frozen=True)
-class DeserializingArg:
+class _DeserializingArg:
+    """HACK: non-deprecated version of DeserializingArg.
+
+    This is used by global gatesets to bypass the behavior that deprecation warnings thrown
+    during module loading fail unit tests.
+    """
+
+    serialized_name: str
+    constructor_arg_name: str
+    value_func: Optional[Callable[[arg_func_langs.ARG_LIKE], Any]] = None
+    required: bool = True
+    default: Any = None
+
+
+@cirq._compat.deprecated_class(
+    deadline='v0.16',
+    fix='Will no longer be used because GateOpDeserializer is deprecated.'
+    ' CircuitSerializer will be the only supported circuit serializer going forward.',
+)
+@dataclass(frozen=True)
+class DeserializingArg(_DeserializingArg):
     """Specification of the arguments to deserialize an argument to a gate.
 
     Args:
@@ -83,12 +103,6 @@ class DeserializingArg:
         default: default value to set if the value is not present in the
             arg.  If set, required is ignored.
     """
-
-    serialized_name: str
-    constructor_arg_name: str
-    value_func: Optional[Callable[[arg_func_langs.ARG_LIKE], Any]] = None
-    required: bool = True
-    default: Any = None
 
 
 class _GateOpDeserializer(OpDeserializer):

--- a/cirq-google/cirq_google/serialization/op_deserializer.py
+++ b/cirq-google/cirq_google/serialization/op_deserializer.py
@@ -91,11 +91,11 @@ class DeserializingArg:
     default: Any = None
 
 
-class GateOpDeserializer(OpDeserializer):
-    """Describes how to deserialize a proto to a given Gate type.
+class _GateOpDeserializer(OpDeserializer):
+    """HACK: non-deprecated version of GateOpDeserializer.
 
-    Attributes:
-        serialized_gate_id: The id used when serializing the gate.
+    This is used by global gatesets to bypass the behavior that deprecation warnings thrown
+    during module loading fail unit tests.
     """
 
     def __init__(
@@ -109,25 +109,6 @@ class GateOpDeserializer(OpDeserializer):
         ] = lambda x, y: x,
         deserialize_tokens: Optional[bool] = True,
     ):
-        """Constructs a deserializer.
-
-        Args:
-            serialized_gate_id: The serialized id of the gate that is being
-                deserialized.
-            gate_constructor: A function that produces the deserialized gate
-                given arguments from args.
-            args: A list of the arguments to be read from the serialized
-                gate and the information required to use this to construct
-                the gate using the gate_constructor above.
-            num_qubits_param: Some gate constructors require that the number
-                of qubits be passed to their constructor. This is the name
-                of the parameter in the constructor for this value. If None,
-                no number of qubits is passed to the constructor.
-            op_wrapper: An optional Callable to modify the resulting
-                GateOperation, for instance, to add tags
-            deserialize_tokens: Whether to convert tokens to
-                CalibrationTags. Defaults to True.
-        """
         self._serialized_gate_id = serialized_gate_id
         self._gate_constructor = gate_constructor
         self._args = args
@@ -147,23 +128,6 @@ class GateOpDeserializer(OpDeserializer):
         constants: List[v2.program_pb2.Constant] = None,
         deserialized_constants: List[Any] = None,  # unused
     ) -> cirq.Operation:
-        """Turns a cirq_google.api.v2.Operation proto into a GateOperation.
-
-        Args:
-            proto: The proto object to be deserialized.
-            arg_function_language: The `arg_function_language` field from
-                `Program.Language`.
-            constants: The list of Constant protos referenced by constant
-                table indices in `proto`.
-            deserialized_constants: Unused in this method.
-
-        Returns:
-            The deserialized GateOperation represented by `proto`.
-
-        Raises:
-            ValueError: If the proto references a missing constants table, or a required arg is
-                missing.
-        """
         qubits = [v2.qubit_from_proto_id(q.id) for q in proto.qubits]
         args = self._args_from_proto(proto, arg_function_language=arg_function_language)
         if self._num_qubits_param is not None:
@@ -213,6 +177,90 @@ class GateOpDeserializer(OpDeserializer):
             if value is not None:
                 return_args[arg.constructor_arg_name] = value
         return return_args
+
+
+@cirq._compat.deprecated_class(
+    deadline='v0.16',
+    fix='Will no longer be supported.'
+    ' CircuitSerializer will be the only supported circuit serializer going forward.',
+)
+class GateOpDeserializer(_GateOpDeserializer):
+    """Describes how to deserialize a proto to a given Gate type.
+
+    Attributes:
+        serialized_gate_id: The id used when serializing the gate.
+    """
+
+    def __init__(
+        self,
+        serialized_gate_id: str,
+        gate_constructor: Callable,
+        args: Sequence[DeserializingArg],
+        num_qubits_param: Optional[str] = None,
+        op_wrapper: Callable[
+            [cirq.Operation, v2.program_pb2.Operation], cirq.Operation
+        ] = lambda x, y: x,
+        deserialize_tokens: Optional[bool] = True,
+    ):
+        """Constructs a deserializer.
+
+        Args:
+            serialized_gate_id: The serialized id of the gate that is being
+                deserialized.
+            gate_constructor: A function that produces the deserialized gate
+                given arguments from args.
+            args: A list of the arguments to be read from the serialized
+                gate and the information required to use this to construct
+                the gate using the gate_constructor above.
+            num_qubits_param: Some gate constructors require that the number
+                of qubits be passed to their constructor. This is the name
+                of the parameter in the constructor for this value. If None,
+                no number of qubits is passed to the constructor.
+            op_wrapper: An optional Callable to modify the resulting
+                GateOperation, for instance, to add tags
+            deserialize_tokens: Whether to convert tokens to
+                CalibrationTags. Defaults to True.
+        """
+        super().__init__(
+            serialized_gate_id,
+            gate_constructor,
+            args,
+            num_qubits_param,
+            op_wrapper,
+            deserialize_tokens,
+        )
+
+    def from_proto(
+        self,
+        proto: v2.program_pb2.Operation,
+        *,
+        arg_function_language: str = '',
+        constants: List[v2.program_pb2.Constant] = None,
+        deserialized_constants: List[Any] = None,  # unused
+    ) -> cirq.Operation:
+        """Turns a cirq_google.api.v2.Operation proto into a GateOperation.
+
+        Args:
+            proto: The proto object to be deserialized.
+            arg_function_language: The `arg_function_language` field from
+                `Program.Language`.
+            constants: The list of Constant protos referenced by constant
+                table indices in `proto`.
+            deserialized_constants: Unused in this method.
+
+        Returns:
+            The deserialized GateOperation represented by `proto`.
+
+        Raises:
+            ValueError: If the proto references a missing constants table, or a required arg is
+                missing.
+        """
+        return super().from_proto(
+            proto,
+            arg_function_language=arg_function_language,
+            constants=constants,
+            deserialized_constants=deserialized_constants,
+        )
 
 
 class CircuitOpDeserializer(OpDeserializer):

--- a/cirq-google/cirq_google/serialization/op_deserializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_deserializer_test.py
@@ -43,7 +43,8 @@ class GateWithAttribute(cirq.testing.SingleQubitGate):
 
 
 def base_deserializer():
-    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
+    # Deprecated: cirq_google.GateOpDeserializer and cirq_google.DeserializingArg.
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=2):
         return cg.GateOpDeserializer(
             serialized_gate_id='my_gate',
             gate_constructor=GateWithAttribute,
@@ -55,6 +56,19 @@ def _create_gate_op_deserializer(*, serialized_gate_id, gate_constructor, args):
     with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
         return cg.GateOpDeserializer(
             serialized_gate_id=serialized_gate_id, gate_constructor=gate_constructor, args=args
+        )
+
+
+def _create_deserializing_arg(
+    *, serialized_name, constructor_arg_name, value_func=None, required=True, default=None
+):
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
+        return cg.DeserializingArg(
+            serialized_name=serialized_name,
+            constructor_arg_name=constructor_arg_name,
+            value_func=value_func,
+            required=required,
+            default=default,
         )
 
 
@@ -160,7 +174,7 @@ def test_from_proto_value_func():
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
-            cg.DeserializingArg(
+            _create_deserializing_arg(
                 serialized_name='my_val', constructor_arg_name='val', value_func=lambda x: x + 1
             )
         ],
@@ -182,8 +196,8 @@ def test_from_proto_not_required_ok():
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
-            cg.DeserializingArg(serialized_name='my_val', constructor_arg_name='val'),
-            cg.DeserializingArg(
+            _create_deserializing_arg(serialized_name='my_val', constructor_arg_name='val'),
+            _create_deserializing_arg(
                 serialized_name='not_req', constructor_arg_name='not_req', required=False
             ),
         ],
@@ -205,8 +219,8 @@ def test_from_proto_missing_required_arg():
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
-            cg.DeserializingArg(serialized_name='my_val', constructor_arg_name='val'),
-            cg.DeserializingArg(
+            _create_deserializing_arg(serialized_name='my_val', constructor_arg_name='val'),
+            _create_deserializing_arg(
                 serialized_name='not_req', constructor_arg_name='not_req', required=False
             ),
         ],
@@ -227,8 +241,8 @@ def test_from_proto_required_arg_not_assigned():
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
-            cg.DeserializingArg(serialized_name='my_val', constructor_arg_name='val'),
-            cg.DeserializingArg(
+            _create_deserializing_arg(serialized_name='my_val', constructor_arg_name='val'),
+            _create_deserializing_arg(
                 serialized_name='not_req', constructor_arg_name='not_req', required=False
             ),
         ],
@@ -245,10 +259,10 @@ def test_defaults():
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
-            cg.DeserializingArg(
+            _create_deserializing_arg(
                 serialized_name='my_val', constructor_arg_name='val', default=1.0
             ),
-            cg.DeserializingArg(
+            _create_deserializing_arg(
                 serialized_name='not_req',
                 constructor_arg_name='not_req',
                 default='hello',

--- a/cirq-google/cirq_google/serialization/op_deserializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_deserializer_test.py
@@ -43,11 +43,19 @@ class GateWithAttribute(cirq.testing.SingleQubitGate):
 
 
 def base_deserializer():
-    return cg.GateOpDeserializer(
-        serialized_gate_id='my_gate',
-        gate_constructor=GateWithAttribute,
-        args=[cg.DeserializingArg(serialized_name='my_val', constructor_arg_name='val')],
-    )
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
+        return cg.GateOpDeserializer(
+            serialized_gate_id='my_gate',
+            gate_constructor=GateWithAttribute,
+            args=[cg.DeserializingArg(serialized_name='my_val', constructor_arg_name='val')],
+        )
+
+
+def _create_gate_op_deserializer(*, serialized_gate_id, gate_constructor, args):
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
+        return cg.GateOpDeserializer(
+            serialized_gate_id=serialized_gate_id, gate_constructor=gate_constructor, args=args
+        )
 
 
 TEST_CASES = [
@@ -148,7 +156,7 @@ def test_from_proto_function_argument_not_set():
 
 
 def test_from_proto_value_func():
-    deserializer = cg.GateOpDeserializer(
+    deserializer = _create_gate_op_deserializer(
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
@@ -170,7 +178,7 @@ def test_from_proto_value_func():
 
 
 def test_from_proto_not_required_ok():
-    deserializer = cg.GateOpDeserializer(
+    deserializer = _create_gate_op_deserializer(
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
@@ -193,7 +201,7 @@ def test_from_proto_not_required_ok():
 
 
 def test_from_proto_missing_required_arg():
-    deserializer = cg.GateOpDeserializer(
+    deserializer = _create_gate_op_deserializer(
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
@@ -215,7 +223,7 @@ def test_from_proto_missing_required_arg():
 
 
 def test_from_proto_required_arg_not_assigned():
-    deserializer = cg.GateOpDeserializer(
+    deserializer = _create_gate_op_deserializer(
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
@@ -233,11 +241,13 @@ def test_from_proto_required_arg_not_assigned():
 
 
 def test_defaults():
-    deserializer = cg.GateOpDeserializer(
+    deserializer = _create_gate_op_deserializer(
         serialized_gate_id='my_gate',
         gate_constructor=GateWithAttribute,
         args=[
-            cg.DeserializingArg(serialized_name='my_val', constructor_arg_name='val', default=1.0),
+            cg.DeserializingArg(
+                serialized_name='my_val', constructor_arg_name='val', default=1.0
+            ),
             cg.DeserializingArg(
                 serialized_name='not_req',
                 constructor_arg_name='not_req',

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -99,7 +99,27 @@ class OpSerializer(abc.ABC):
 
 
 @dataclass(frozen=True)
-class SerializingArg:
+class _SerializingArg:
+    """HACK: non-deprecated version of SerializingArg.
+
+    This is used by global gatesets to bypass the behavior that deprecation warnings thrown
+    during module loading fail unit tests.
+    """
+
+    serialized_name: str
+    serialized_type: Type[ARG_LIKE]
+    op_getter: Union[str, Callable[[cirq.Operation], Optional[ARG_LIKE]]]
+    required: bool = True
+    default: Any = None
+
+
+@cirq._compat.deprecated_class(
+    deadline='v0.16',
+    fix='Will no longer be used because GateOpSerializer is deprecated.'
+    ' CircuitSerializer will be the only supported circuit serializer going forward.',
+)
+@dataclass(frozen=True)
+class SerializingArg(_SerializingArg):
     """Specification of the arguments for a Gate and its serialization.
 
     Args:
@@ -115,12 +135,6 @@ class SerializingArg:
         default: default value.  avoid serializing if this is the value.
             Note that the DeserializingArg must also have this as default.
     """
-
-    serialized_name: str
-    serialized_type: Type[ARG_LIKE]
-    op_getter: Union[str, Callable[[cirq.Operation], Optional[ARG_LIKE]]]
-    required: bool = True
-    default: Any = None
 
 
 class _GateOpSerializer(OpSerializer):

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -123,14 +123,11 @@ class SerializingArg:
     default: Any = None
 
 
-class GateOpSerializer(OpSerializer):
-    """Describes how to serialize a GateOperation for a given Gate type.
+class _GateOpSerializer(OpSerializer):
+    """HACK: non-deprecated version of GateOpSerializer.
 
-    Attributes:
-        gate_type: The type of the gate that can be serialized.
-        serialized_gate_id: The id used when serializing the gate.
-        serialize_tokens: Whether to convert CalibrationTags into tokens
-            on the Operation proto.  Defaults to True.
+    This is used by global gatesets to bypass the behavior that deprecation warnings thrown
+    during module loading fail unit tests.
     """
 
     def __init__(
@@ -142,22 +139,6 @@ class GateOpSerializer(OpSerializer):
         can_serialize_predicate: Callable[[cirq.Operation], bool] = lambda x: True,
         serialize_tokens: Optional[bool] = True,
     ):
-        """Construct the serializer.
-
-        Args:
-            gate_type: The type of the gate that is being serialized.
-            serialized_gate_id: The string id of the gate when serialized.
-            args: A list of specification of the arguments to the gate when
-                serializing, including how to get this information from the
-                gate of the given gate type.
-            can_serialize_predicate: Sometimes an Operation can only be
-                serialized for particular parameters. This predicate will be
-                checked before attempting to serialize the Operation. If the
-                predicate is False, serialization will result in a None value.
-                Default value is a lambda that always returns True.
-            serialize_tokens: Whether to convert calibration tags into tokens
-                on the Operation proto.
-        """
         self._gate_type = gate_type
         self._serialized_gate_id = serialized_gate_id
         self._args = args
@@ -181,12 +162,6 @@ class GateOpSerializer(OpSerializer):
         return self._can_serialize_predicate
 
     def can_serialize_operation(self, op: cirq.Operation) -> bool:
-        """Whether the given operation can be serialized by this serializer.
-
-        This checks that the gate is a subclass of the gate type for this
-        serializer, and that the gate returns true for
-        `can_serializer_predicate` called on the gate.
-        """
         supported_gate_type = self._gate_type in type(op.gate).mro()
         return supported_gate_type and super().can_serialize_operation(op)
 
@@ -199,11 +174,6 @@ class GateOpSerializer(OpSerializer):
         constants: List[v2.program_pb2.Constant] = None,
         raw_constants: Dict[Any, int] = None,
     ) -> Optional[v2.program_pb2.Operation]:
-        """Returns the cirq_google.api.v2.Operation message as a proto dict.
-
-        Note that this function may modify the constant list if it adds
-        tokens to the circuit's constant table.
-        """
 
         gate = op.gate
         if not isinstance(gate, self.internal_type):
@@ -287,6 +257,86 @@ class GateOpSerializer(OpSerializer):
                     arg.serialized_name, arg.serialized_type, type(value)
                 )
             )
+
+
+@cirq._compat.deprecated_class(
+    deadline='v0.16',
+    fix='Will no longer be supported.'
+    ' CircuitSerializer will be the only supported circuit serializer going forward.',
+)
+class GateOpSerializer(_GateOpSerializer):
+    """Describes how to serialize a GateOperation for a given Gate type.
+
+    Attributes:
+        gate_type: The type of the gate that can be serialized.
+        serialized_gate_id: The id used when serializing the gate.
+        serialize_tokens: Whether to convert CalibrationTags into tokens
+            on the Operation proto.  Defaults to True.
+    """
+
+    def __init__(
+        self,
+        *,
+        gate_type: Type[Gate],
+        serialized_gate_id: str,
+        args: List[SerializingArg],
+        can_serialize_predicate: Callable[[cirq.Operation], bool] = lambda x: True,
+        serialize_tokens: Optional[bool] = True,
+    ):
+        """Construct the serializer.
+
+        Args:
+            gate_type: The type of the gate that is being serialized.
+            serialized_gate_id: The string id of the gate when serialized.
+            args: A list of specification of the arguments to the gate when
+                serializing, including how to get this information from the
+                gate of the given gate type.
+            can_serialize_predicate: Sometimes an Operation can only be
+                serialized for particular parameters. This predicate will be
+                checked before attempting to serialize the Operation. If the
+                predicate is False, serialization will result in a None value.
+                Default value is a lambda that always returns True.
+            serialize_tokens: Whether to convert calibration tags into tokens
+                on the Operation proto.
+        """
+        super().__init__(
+            gate_type=gate_type,
+            serialized_gate_id=serialized_gate_id,
+            args=args,
+            can_serialize_predicate=can_serialize_predicate,
+            serialize_tokens=serialize_tokens,
+        )
+
+    def can_serialize_operation(self, op: cirq.Operation) -> bool:
+        """Whether the given operation can be serialized by this serializer.
+
+        This checks that the gate is a subclass of the gate type for this
+        serializer, and that the gate returns true for
+        `can_serializer_predicate` called on the gate.
+        """
+        return super().can_serialize_operation(op)
+
+    def to_proto(
+        self,
+        op: cirq.Operation,
+        msg: Optional[v2.program_pb2.Operation] = None,
+        *,
+        arg_function_language: Optional[str] = '',
+        constants: List[v2.program_pb2.Constant] = None,
+        raw_constants: Dict[Any, int] = None,
+    ) -> Optional[v2.program_pb2.Operation]:
+        """Returns the cirq_google.api.v2.Operation message as a proto dict.
+
+        Note that this function may modify the constant list if it adds
+        tokens to the circuit's constant table.
+        """
+        return super().to_proto(
+            op,
+            msg,
+            arg_function_language=arg_function_language,
+            constants=constants,
+            raw_constants=raw_constants,
+        )
 
 
 class CircuitOpSerializer(OpSerializer):

--- a/cirq-google/cirq_google/serialization/op_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_serializer_test.py
@@ -140,7 +140,9 @@ def test_to_proto_attribute(val_type, val, arg_value):
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[
-            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=val_type, op_getter='val'
+            )
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -157,7 +159,9 @@ def test_to_proto_property(val_type, val, arg_value):
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=val_type, op_getter='val'
+            )
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -174,7 +178,9 @@ def test_to_proto_callable(val_type, val, arg_value):
         gate_type=GateWithMethod,
         serialized_gate_id='my_gate',
         args=[
-            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter=get_val)
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=val_type, op_getter=get_val
+            )
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -189,7 +195,11 @@ def test_to_proto_gate_predicate():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
         can_serialize_predicate=lambda x: x.gate.val == 1,
     )
     q = cirq.GridQubit(1, 2)
@@ -203,7 +213,11 @@ def test_to_proto_gate_mismatch():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
     )
     q = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='GateWithAttribute.*GateWithProperty'):
@@ -214,7 +228,11 @@ def test_to_proto_unsupported_type():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=bytes, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=bytes, op_getter='val'
+            )
+        ],
     )
     q = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='bytes'):
@@ -225,7 +243,11 @@ def test_to_proto_named_qubit_supported():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
     )
     q = cirq.NamedQubit('a')
     arg_value = 1.0
@@ -245,7 +267,11 @@ def test_to_proto_line_qubit_supported():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
     )
     q = cirq.LineQubit('10')
     arg_value = 1.0
@@ -280,7 +306,11 @@ def test_to_proto_no_getattr():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='nope')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='nope'
+            )
+        ],
     )
     q = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='does not have'):
@@ -292,7 +322,9 @@ def test_to_proto_not_required_ok():
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            _create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val'),
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            ),
             _create_serializing_arg(
                 serialized_name='not_req',
                 serialized_type=float,
@@ -329,7 +361,9 @@ def test_to_proto_type_mismatch(val_type, val):
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=val_type, op_getter='val'
+            )
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -341,7 +375,11 @@ def test_can_serialize_operation_subclass():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
         can_serialize_predicate=lambda x: x.gate.val == 1,
     )
     q = cirq.GridQubit(1, 1)
@@ -376,7 +414,11 @@ def test_token_serialization():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
     )
     q = cirq.GridQubit(1, 2)
     tag = cg.CalibrationTag('my_token')
@@ -406,7 +448,11 @@ def test_token_serialization_with_constant_reference(constants, expected_index, 
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[
+            _create_serializing_arg(
+                serialized_name='my_val', serialized_type=float, op_getter='val'
+            )
+        ],
     )
     # Make a local copy since we are modifying the array in-place.
     constants = copy.copy(constants)

--- a/cirq-google/cirq_google/serialization/op_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_serializer_test.py
@@ -47,6 +47,19 @@ def _create_gate_op_serializer(
         )
 
 
+def _create_serializing_arg(
+    *, serialized_name, serialized_type, op_getter, required=True, default=None
+):
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
+        return cg.SerializingArg(
+            serialized_name=serialized_name,
+            serialized_type=serialized_type,
+            op_getter=op_getter,
+            required=required,
+            default=default,
+        )
+
+
 def op_proto(json: Dict) -> v2.program_pb2.Operation:
     op = v2.program_pb2.Operation()
     json_format.ParseDict(json, op)
@@ -127,7 +140,7 @@ def test_to_proto_attribute(val_type, val, arg_value):
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
+            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -144,7 +157,7 @@ def test_to_proto_property(val_type, val, arg_value):
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
+            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -161,7 +174,7 @@ def test_to_proto_callable(val_type, val, arg_value):
         gate_type=GateWithMethod,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(serialized_name='my_val', serialized_type=val_type, op_getter=get_val)
+            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter=get_val)
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -176,7 +189,7 @@ def test_to_proto_gate_predicate():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
         can_serialize_predicate=lambda x: x.gate.val == 1,
     )
     q = cirq.GridQubit(1, 2)
@@ -190,7 +203,7 @@ def test_to_proto_gate_mismatch():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
     )
     q = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='GateWithAttribute.*GateWithProperty'):
@@ -201,7 +214,7 @@ def test_to_proto_unsupported_type():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=bytes, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=bytes, op_getter='val')],
     )
     q = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='bytes'):
@@ -212,7 +225,7 @@ def test_to_proto_named_qubit_supported():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
     )
     q = cirq.NamedQubit('a')
     arg_value = 1.0
@@ -232,7 +245,7 @@ def test_to_proto_line_qubit_supported():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
     )
     q = cirq.LineQubit('10')
     arg_value = 1.0
@@ -253,7 +266,7 @@ def test_to_proto_required_but_not_present():
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(
+            _create_serializing_arg(
                 serialized_name='my_val', serialized_type=float, op_getter=lambda x: None
             )
         ],
@@ -267,7 +280,7 @@ def test_to_proto_no_getattr():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='nope')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='nope')],
     )
     q = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='does not have'):
@@ -279,8 +292,8 @@ def test_to_proto_not_required_ok():
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val'),
-            cg.SerializingArg(
+            _create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val'),
+            _create_serializing_arg(
                 serialized_name='not_req',
                 serialized_type=float,
                 op_getter='not_req',
@@ -316,7 +329,7 @@ def test_to_proto_type_mismatch(val_type, val):
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
+            _create_serializing_arg(serialized_name='my_val', serialized_type=val_type, op_getter='val')
         ],
     )
     q = cirq.GridQubit(1, 2)
@@ -328,7 +341,7 @@ def test_can_serialize_operation_subclass():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
         can_serialize_predicate=lambda x: x.gate.val == 1,
     )
     q = cirq.GridQubit(1, 1)
@@ -341,7 +354,7 @@ def test_defaults_not_serialized():
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[
-            cg.SerializingArg(
+            _create_serializing_arg(
                 serialized_name='my_val', serialized_type=float, default=1.0, op_getter='val'
             )
         ],
@@ -363,7 +376,7 @@ def test_token_serialization():
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
     )
     q = cirq.GridQubit(1, 2)
     tag = cg.CalibrationTag('my_token')
@@ -393,7 +406,7 @@ def test_token_serialization_with_constant_reference(constants, expected_index, 
     serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
-        args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
+        args=[_create_serializing_arg(serialized_name='my_val', serialized_type=float, op_getter='val')],
     )
     # Make a local copy since we are modifying the array in-place.
     constants = copy.copy(constants)

--- a/cirq-google/cirq_google/serialization/op_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/op_serializer_test.py
@@ -29,6 +29,24 @@ from cirq_google.api import v2
 DEFAULT_TOKEN = 'test_tag'
 
 
+def _create_gate_op_serializer(
+    *,
+    gate_type,
+    serialized_gate_id,
+    args,
+    can_serialize_predicate=lambda x: True,
+    serialize_tokens=True,
+):
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=1):
+        return cg.GateOpSerializer(
+            gate_type=gate_type,
+            serialized_gate_id=serialized_gate_id,
+            args=args,
+            can_serialize_predicate=can_serialize_predicate,
+            serialize_tokens=serialize_tokens,
+        )
+
+
 def op_proto(json: Dict) -> v2.program_pb2.Operation:
     op = v2.program_pb2.Operation()
     json_format.ParseDict(json, op)
@@ -105,7 +123,7 @@ TEST_CASES = (
 
 @pytest.mark.parametrize(('val_type', 'val', 'arg_value'), TEST_CASES)
 def test_to_proto_attribute(val_type, val, arg_value):
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[
@@ -122,7 +140,7 @@ def test_to_proto_attribute(val_type, val, arg_value):
 
 @pytest.mark.parametrize(('val_type', 'val', 'arg_value'), TEST_CASES)
 def test_to_proto_property(val_type, val, arg_value):
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
@@ -139,7 +157,7 @@ def test_to_proto_property(val_type, val, arg_value):
 
 @pytest.mark.parametrize(('val_type', 'val', 'arg_value'), TEST_CASES)
 def test_to_proto_callable(val_type, val, arg_value):
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithMethod,
         serialized_gate_id='my_gate',
         args=[
@@ -155,7 +173,7 @@ def test_to_proto_callable(val_type, val, arg_value):
 
 
 def test_to_proto_gate_predicate():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
@@ -169,7 +187,7 @@ def test_to_proto_gate_predicate():
 
 
 def test_to_proto_gate_mismatch():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
@@ -180,7 +198,7 @@ def test_to_proto_gate_mismatch():
 
 
 def test_to_proto_unsupported_type():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=bytes, op_getter='val')],
@@ -191,7 +209,7 @@ def test_to_proto_unsupported_type():
 
 
 def test_to_proto_named_qubit_supported():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
@@ -211,7 +229,7 @@ def test_to_proto_named_qubit_supported():
 
 
 def test_to_proto_line_qubit_supported():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
@@ -231,7 +249,7 @@ def test_to_proto_line_qubit_supported():
 
 
 def test_to_proto_required_but_not_present():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
@@ -246,7 +264,7 @@ def test_to_proto_required_but_not_present():
 
 
 def test_to_proto_no_getattr():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='nope')],
@@ -257,7 +275,7 @@ def test_to_proto_no_getattr():
 
 
 def test_to_proto_not_required_ok():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
@@ -294,7 +312,7 @@ def test_to_proto_not_required_ok():
     ),
 )
 def test_to_proto_type_mismatch(val_type, val):
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithProperty,
         serialized_gate_id='my_gate',
         args=[
@@ -307,7 +325,7 @@ def test_to_proto_type_mismatch(val_type, val):
 
 
 def test_can_serialize_operation_subclass():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
@@ -319,7 +337,7 @@ def test_can_serialize_operation_subclass():
 
 
 def test_defaults_not_serialized():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[
@@ -342,7 +360,7 @@ def test_defaults_not_serialized():
 
 
 def test_token_serialization():
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],
@@ -372,7 +390,7 @@ TWO_CONSTANTS = [
     (([], 0, ONE_CONSTANT), (ONE_CONSTANT, 0, ONE_CONSTANT), (TWO_CONSTANTS, 1, TWO_CONSTANTS)),
 )
 def test_token_serialization_with_constant_reference(constants, expected_index, expected_constants):
-    serializer = cg.GateOpSerializer(
+    serializer = _create_gate_op_serializer(
         gate_type=GateWithAttribute,
         serialized_gate_id='my_gate',
         args=[cg.SerializingArg(serialized_name='my_val', serialized_type=float, op_getter='val')],

--- a/cirq-google/cirq_google/serialization/serializable_gate_set_test.py
+++ b/cirq-google/cirq_google/serialization/serializable_gate_set_test.py
@@ -142,9 +142,10 @@ def test_is_supported_circuit_operation():
 
 def test_is_supported_operation_can_serialize_predicate():
     x_deserializer = _x_deserializer()
-    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer, and
+    # cirq_google.SerializingArg
     with cirq.testing.assert_deprecated(
-        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=2
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=3
     ):
         q = cirq.GridQubit(1, 2)
         serializer = cg.GateOpSerializer(
@@ -545,9 +546,10 @@ def test_serialize_deserialize_circuit_op():
 
 
 def test_multiple_serializers():
-    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer, and
+    # cirq_google.SerializingArg
     with cirq.testing.assert_deprecated(
-        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=3
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=5
     ):
         serializer1 = cg.GateOpSerializer(
             gate_type=cirq.XPowGate,

--- a/cirq-google/cirq_google/serialization/serializable_gate_set_test.py
+++ b/cirq-google/cirq_google/serialization/serializable_gate_set_test.py
@@ -21,44 +21,67 @@ import cirq
 import cirq_google as cg
 from cirq_google.api import v2
 
-X_SERIALIZER = cg.GateOpSerializer(
-    gate_type=cirq.XPowGate,
-    serialized_gate_id='x_pow',
-    args=[
-        cg.SerializingArg(serialized_name='half_turns', serialized_type=float, op_getter='exponent')
-    ],
-)
 
-X_DESERIALIZER = cg.GateOpDeserializer(
-    serialized_gate_id='x_pow',
-    gate_constructor=cirq.XPowGate,
-    args=[cg.DeserializingArg(serialized_name='half_turns', constructor_arg_name='exponent')],
-)
+def _x_serializer():
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=None):
+        return cg.GateOpSerializer(
+            gate_type=cirq.XPowGate,
+            serialized_gate_id='x_pow',
+            args=[
+                cg.SerializingArg(
+                    serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+                )
+            ],
+        )
 
-Y_SERIALIZER = cg.GateOpSerializer(
-    gate_type=cirq.YPowGate,
-    serialized_gate_id='y_pow',
-    args=[
-        cg.SerializingArg(serialized_name='half_turns', serialized_type=float, op_getter='exponent')
-    ],
-)
 
-Y_DESERIALIZER = cg.GateOpDeserializer(
-    serialized_gate_id='y_pow',
-    gate_constructor=cirq.YPowGate,
-    args=[cg.DeserializingArg(serialized_name='half_turns', constructor_arg_name='exponent')],
-)
+def _x_deserializer():
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=None):
+        return cg.GateOpDeserializer(
+            serialized_gate_id='x_pow',
+            gate_constructor=cirq.XPowGate,
+            args=[
+                cg.DeserializingArg(serialized_name='half_turns', constructor_arg_name='exponent')
+            ],
+        )
+
+
+def _y_serializer():
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=None):
+        return cg.GateOpSerializer(
+            gate_type=cirq.YPowGate,
+            serialized_gate_id='y_pow',
+            args=[
+                cg.SerializingArg(
+                    serialized_name='half_turns', serialized_type=float, op_getter='exponent'
+                )
+            ],
+        )
+
+
+def _y_deserializer():
+    with cirq.testing.assert_deprecated('CircuitSerializer', deadline='v0.16', count=None):
+        return cg.GateOpDeserializer(
+            serialized_gate_id='y_pow',
+            gate_constructor=cirq.YPowGate,
+            args=[
+                cg.DeserializingArg(serialized_name='half_turns', constructor_arg_name='exponent')
+            ],
+        )
+
 
 CIRCUIT_OP_SERIALIZER = cg.CircuitOpSerializer()
 CIRCUIT_OP_DESERIALIZER = cg.CircuitOpDeserializer()
 
 
 def _my_gate_set():
+    x_serializer = _x_serializer()
+    x_deserializer = _x_deserializer()
     with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=1):
         return cg.SerializableGateSet(
             gate_set_name='my_gate_set',
-            serializers=[X_SERIALIZER, CIRCUIT_OP_SERIALIZER],
-            deserializers=[X_DESERIALIZER, CIRCUIT_OP_DESERIALIZER],
+            serializers=[x_serializer, CIRCUIT_OP_SERIALIZER],
+            deserializers=[x_deserializer, CIRCUIT_OP_DESERIALIZER],
         )
 
 
@@ -118,7 +141,11 @@ def test_is_supported_circuit_operation():
 
 
 def test_is_supported_operation_can_serialize_predicate():
-    with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=1):
+    x_deserializer = _x_deserializer()
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer
+    with cirq.testing.assert_deprecated(
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=2
+    ):
         q = cirq.GridQubit(1, 2)
         serializer = cg.GateOpSerializer(
             gate_type=cirq.XPowGate,
@@ -131,7 +158,7 @@ def test_is_supported_operation_can_serialize_predicate():
             can_serialize_predicate=lambda x: x.gate.exponent == 1.0,
         )
         gate_set = cg.SerializableGateSet(
-            gate_set_name='my_gate_set', serializers=[serializer], deserializers=[X_DESERIALIZER]
+            gate_set_name='my_gate_set', serializers=[serializer], deserializers=[x_deserializer]
         )
         assert gate_set.is_supported_operation(cirq.XPowGate()(q))
         assert not gate_set.is_supported_operation(cirq.XPowGate()(q) ** 0.5)
@@ -149,11 +176,11 @@ def test_serialize_deserialize_circuit():
             moments=[
                 v2.program_pb2.Moment(
                     operations=[
-                        X_SERIALIZER.to_proto(cirq.X(q0)),
-                        X_SERIALIZER.to_proto(cirq.X(q1)),
+                        _x_serializer().to_proto(cirq.X(q0)),
+                        _x_serializer().to_proto(cirq.X(q1)),
                     ]
                 ),
-                v2.program_pb2.Moment(operations=[X_SERIALIZER.to_proto(cirq.X(q0))]),
+                v2.program_pb2.Moment(operations=[_x_serializer().to_proto(cirq.X(q0))]),
             ],
         ),
     )
@@ -187,7 +214,7 @@ def test_serialize_deserialize_circuit_with_tokens():
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[
                 v2.program_pb2.Moment(operations=[op1, op2]),
-                v2.program_pb2.Moment(operations=[X_SERIALIZER.to_proto(cirq.X(q0))]),
+                v2.program_pb2.Moment(operations=[_x_serializer().to_proto(cirq.X(q0))]),
             ],
         ),
         constants=[
@@ -237,7 +264,7 @@ def test_serialize_deserialize_circuit_with_subcircuit():
             moments=[
                 v2.program_pb2.Moment(operations=[op1], circuit_operations=[c_op1]),
                 v2.program_pb2.Moment(
-                    operations=[X_SERIALIZER.to_proto(cirq.X(q0))], circuit_operations=[c_op2]
+                    operations=[_x_serializer().to_proto(cirq.X(q0))], circuit_operations=[c_op2]
                 ),
             ],
         ),
@@ -246,7 +273,9 @@ def test_serialize_deserialize_circuit_with_subcircuit():
             v2.program_pb2.Constant(
                 circuit_value=v2.program_pb2.Circuit(
                     scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
-                    moments=[v2.program_pb2.Moment(operations=[X_SERIALIZER.to_proto(cirq.X(q0))])],
+                    moments=[
+                        v2.program_pb2.Moment(operations=[_x_serializer().to_proto(cirq.X(q0))])
+                    ],
                 )
             ),
         ],
@@ -441,11 +470,13 @@ def test_serialize_circuit_op_errors():
     with pytest.raises(ValueError, match='CircuitOp serialization requires a constants list'):
         _my_gate_set().serialize_op(op, raw_constants=raw_constants)
 
+    x_serializer = _x_serializer()
+    x_deserializer = _x_deserializer()
     with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=1):
         NO_CIRCUIT_OP_GATE_SET = cg.SerializableGateSet(
             gate_set_name='no_circuit_op_gateset',
-            serializers=[X_SERIALIZER],
-            deserializers=[X_DESERIALIZER],
+            serializers=[x_serializer],
+            deserializers=[x_deserializer],
         )
         with pytest.raises(ValueError, match='Cannot serialize CircuitOperation'):
             NO_CIRCUIT_OP_GATE_SET.serialize_op(
@@ -454,7 +485,13 @@ def test_serialize_circuit_op_errors():
 
 
 def test_deserialize_circuit_op_errors():
-    with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=2):
+    x_serializer = _x_serializer()
+    x_deserializer = _x_deserializer()
+
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer
+    with cirq.testing.assert_deprecated(
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=3
+    ):
         constants = [default_circuit_proto()]
         deserialized_constants = [default_circuit()]
 
@@ -464,8 +501,8 @@ def test_deserialize_circuit_op_errors():
 
         NO_CIRCUIT_OP_GATE_SET = cg.SerializableGateSet(
             gate_set_name='no_circuit_op_gateset',
-            serializers=[X_SERIALIZER],
-            deserializers=[X_DESERIALIZER],
+            serializers=[x_serializer],
+            deserializers=[x_deserializer],
         )
         with pytest.raises(ValueError, match='Unsupported deserialized of a CircuitOperation'):
             NO_CIRCUIT_OP_GATE_SET.deserialize_op(
@@ -508,7 +545,10 @@ def test_serialize_deserialize_circuit_op():
 
 
 def test_multiple_serializers():
-    with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=1):
+    # Deprecations: cirq_google.SerializableGateSet, cirq_google.GateOpSerializer
+    with cirq.testing.assert_deprecated(
+        'SerializableGateSet', 'CircuitSerializer', deadline='v0.16', count=3
+    ):
         serializer1 = cg.GateOpSerializer(
             gate_type=cirq.XPowGate,
             serialized_gate_id='x_pow',
@@ -538,13 +578,17 @@ def test_multiple_serializers():
 
 
 def test_gateset_with_added_types():
+    x_serializer = _x_serializer()
+    x_deserializer = _x_deserializer()
+    y_serializer = _y_serializer()
+    y_deserializer = _y_deserializer()
     with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=2):
         q = cirq.GridQubit(1, 1)
         x_gateset = cg.SerializableGateSet(
-            gate_set_name='x', serializers=[X_SERIALIZER], deserializers=[X_DESERIALIZER]
+            gate_set_name='x', serializers=[x_serializer], deserializers=[x_deserializer]
         )
         xy_gateset = x_gateset.with_added_types(
-            gate_set_name='xy', serializers=[Y_SERIALIZER], deserializers=[Y_DESERIALIZER]
+            gate_set_name='xy', serializers=[y_serializer], deserializers=[y_deserializer]
         )
         assert x_gateset.name == 'x'
         assert x_gateset.is_supported_operation(cirq.X(q))
@@ -568,14 +612,16 @@ def test_gateset_with_added_types():
 
 
 def test_gateset_with_added_types_again():
+    x_serializer = _x_serializer()
+    x_deserializer = _x_deserializer()
     """Verify that adding a serializer twice doesn't mess anything up."""
     with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=2):
         q = cirq.GridQubit(2, 2)
         x_gateset = cg.SerializableGateSet(
-            gate_set_name='x', serializers=[X_SERIALIZER], deserializers=[X_DESERIALIZER]
+            gate_set_name='x', serializers=[x_serializer], deserializers=[x_deserializer]
         )
         xx_gateset = x_gateset.with_added_types(
-            gate_set_name='xx', serializers=[X_SERIALIZER], deserializers=[X_DESERIALIZER]
+            gate_set_name='xx', serializers=[x_serializer], deserializers=[x_deserializer]
         )
 
         assert xx_gateset.name == 'xx'


### PR DESCRIPTION
This PR deprecates all serializers we plan to deprecate
* Deprecated GateOpSerializer, GateOpDeserializer, DeserializingArg, and SerializingArg using the class wrapper technique. 
* CircuitSerializer and serializer classes it depends on (`CircuitOp[De]Serializer`, `Serializer`) are left in place.
* Skipping deprecation of common serializers in `common_serializers.py` for now and remove them directly after the 0.15 release as it's very unlikely for users to access them directly. Most users interact with them via global gatesets, e.g.

https://github.com/quantumlib/Cirq/blob/abfc619bfe31e93573993c76cecfddc5689dea9b/cirq-google/cirq_google/serialization/gate_sets.py#L43-L64

But if time allows, I'll try to deprecate common serializers as well.

* Added mentions of serializer deprecations in global gateset deprecation warnings.

@dstrain115 