### PR TITLE
Engine validator: rename validate_gate_set to validate_program

### DIFF
--- a/cirq-google/cirq_google/engine/engine_validator.py
+++ b/cirq-google/cirq_google/engine/engine_validator.py
@@ -23,7 +23,7 @@ MAX_MESSAGE_SIZE = 10_000_000
 MAX_MOMENTS = 10000
 MAX_TOTAL_REPETITIONS = 5_000_000
 
-GATE_SET_VALIDATOR_TYPE = Callable[
+PROGRAM_VALIDATOR_TYPE = Callable[
     [Sequence[cirq.AbstractCircuit], Sequence[cirq.Sweepable], int, 'Serializer'], None,
 ]
 
@@ -65,14 +65,14 @@ def _verify_measurements(circuits):
             raise RuntimeError('Code must measure at least one qubit.')
 
 
-def validate_gate_set(
+def validate_program(
     circuits: Sequence[cirq.AbstractCircuit],
     sweeps: Sequence[cirq.Sweepable],
     repetitions: int,
-    gate_set: Serializer,
+    serializer: Serializer,
     max_size: int = MAX_MESSAGE_SIZE,
 ) -> None:
-    """Validate that the message size is below the maximum size limit.
+    """Validate that the Program message size is below the maximum size limit.
 
     Args:
         circuits:  A sequence of  `cirq.Circuit` objects to validate.  For
@@ -81,7 +81,7 @@ def validate_gate_set(
         sweeps:  Parameters to run with each circuit.  The length of the
           sweeps sequence should be the same as the circuits argument.
         repetitions:  Number of repetitions to run with each sweep.
-        gate_set:  Serializer to use to serialize the circuits and sweeps.
+        serializer:  Serializer to use to serialize the circuits and sweeps.
         max_size:  proto size limit to check against.
 
     Raises:
@@ -90,19 +90,19 @@ def validate_gate_set(
     batch = v2.batch_pb2.BatchProgram()
     packed = any_pb2.Any()
     for circuit in circuits:
-        gate_set.serialize(circuit, msg=batch.programs.add())
+        serializer.serialize(circuit, msg=batch.programs.add())
     packed.Pack(batch)
     message_size = len(packed.SerializeToString())
     if message_size > max_size:
         raise RuntimeError("INVALID_PROGRAM: Program too long.")
 
 
-def create_gate_set_validator(max_size: int = MAX_MESSAGE_SIZE) -> GATE_SET_VALIDATOR_TYPE:
-    """Creates a Callable gate set validator with a set message size.
+def create_program_validator(max_size: int = MAX_MESSAGE_SIZE) -> PROGRAM_VALIDATOR_TYPE:
+    """Creates a Callable program validator with a set message size.
 
     This validator can be used for a validator in `cg.ValidatingSampler`
     and can also be useful in generating 'engine emulators' by using
-    `cg.SimulatedLocalProcessor` with this callable as a gate_set_validator.
+    `cg.SimulatedLocalProcessor` with this callable as a program_validator.
 
     Args:
         max_size:  proto size limit to check against.
@@ -114,9 +114,9 @@ def create_gate_set_validator(max_size: int = MAX_MESSAGE_SIZE) -> GATE_SET_VALI
         circuits: Sequence[cirq.AbstractCircuit],
         sweeps: Sequence[cirq.Sweepable],
         repetitions: int,
-        gate_set: Serializer,
+        serializer: Serializer,
     ):
-        return validate_gate_set(circuits, sweeps, repetitions, gate_set, max_size)
+        return validate_program(circuits, sweeps, repetitions, serializer, max_size)
 
     return _validator
 

--- a/cirq-google/cirq_google/engine/engine_validator_test.py
+++ b/cirq-google/cirq_google/engine/engine_validator_test.py
@@ -41,17 +41,17 @@ def test_validate_gate_set():
     with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=None):
         circuit = _big_circuit(4)
 
-        engine_validator.validate_gate_set(
+        engine_validator.validate_program(
             [circuit] * 5, [{}] * 5, 1000, cg.FSIM_GATESET, max_size=100000
         )
 
         with pytest.raises(RuntimeError, match='Program too long'):
-            engine_validator.validate_gate_set(
+            engine_validator.validate_program(
                 [circuit] * 10, [{}] * 10, 1000, cg.FSIM_GATESET, max_size=100000
             )
 
         with pytest.raises(RuntimeError, match='Program too long'):
-            engine_validator.validate_gate_set(
+            engine_validator.validate_program(
                 [circuit] * 5, [{}] * 5, 1000, cg.FSIM_GATESET, max_size=10000
             )
 
@@ -60,11 +60,11 @@ def test_create_gate_set_validator():
     with cirq.testing.assert_deprecated('SerializableGateSet', deadline='v0.16', count=None):
         circuit = _big_circuit(4)
 
-        smaller_size_validator = engine_validator.create_gate_set_validator(max_size=30000)
+        smaller_size_validator = engine_validator.create_program_validator(max_size=30000)
         smaller_size_validator([circuit] * 2, [{}] * 2, 1000, cg.FSIM_GATESET)
         with pytest.raises(RuntimeError, match='Program too long'):
             smaller_size_validator([circuit] * 5, [{}] * 5, 1000, cg.FSIM_GATESET)
-        larger_size_validator = engine_validator.create_gate_set_validator(max_size=500000)
+        larger_size_validator = engine_validator.create_program_validator(max_size=500000)
         larger_size_validator([circuit] * 10, [{}] * 10, 1000, cg.FSIM_GATESET)
 
 

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -37,7 +37,7 @@ VALID_LANGUAGES = [
     'type.googleapis.com/cirq.google.api.v2.BatchProgram',
 ]
 
-GATE_SET_VALIDATOR_TYPE = Callable[
+PROGRAM_VALIDATOR_TYPE = Callable[
     [Sequence[cirq.AbstractCircuit], Sequence[cirq.Sweepable], int, 'Serializer'], None,
 ]
 
@@ -97,7 +97,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
         sampler: cirq.Sampler = cirq.Simulator(),
         device: cirq.Device = cirq.UNCONSTRAINED_DEVICE,
         validator: validating_sampler.VALIDATOR_TYPE = None,
-        gate_set_validator: GATE_SET_VALIDATOR_TYPE = None,
+        program_validator: PROGRAM_VALIDATOR_TYPE = None,
         simulation_type: LocalSimulationType = LocalSimulationType.SYNCHRONOUS,
         calibrations: Optional[Dict[int, calibration.Calibration]] = None,
         **kwargs,
@@ -106,7 +106,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
         self._calibrations = calibrations or {}
         self._device = device
         self._simulation_type = simulation_type
-        self._gate_set_validator = gate_set_validator or (lambda a, b, c, d: None)
+        self._program_validator = program_validator or (lambda a, b, c, d: None)
         self._validator = validator
         self._sampler = validating_sampler.ValidatingSampler(
             device=self._device, validator=self._validator, sampler=sampler
@@ -217,7 +217,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             program_id = self._create_id(id_type='program')
         if job_id is None:
             job_id = self._create_id(id_type='job')
-        self._gate_set_validator(programs, params_list or [{}], repetitions, CIRCUIT_SERIALIZER)
+        self._program_validator(programs, params_list or [{}], repetitions, CIRCUIT_SERIALIZER)
         self._programs[program_id] = SimulatedLocalProgram(
             program_id=program_id,
             simulation_type=self._simulation_type,
@@ -300,7 +300,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             program_id = self._create_id(id_type='program')
         if job_id is None:
             job_id = self._create_id(id_type='job')
-        self._gate_set_validator([program], [params], repetitions, CIRCUIT_SERIALIZER)
+        self._program_validator([program], [params], repetitions, CIRCUIT_SERIALIZER)
         self._programs[program_id] = SimulatedLocalProgram(
             program_id=program_id,
             simulation_type=self._simulation_type,

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import datetime
 
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, TYPE_CHECKING, Union
+from typing import Dict, Iterable, List, Optional, Sequence, TYPE_CHECKING, Union
 
 import cirq
 

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -27,6 +27,7 @@ from cirq_google.engine.simulated_local_job import SimulatedLocalJob
 from cirq_google.engine.simulated_local_program import SimulatedLocalProgram
 from cirq_google.serialization.circuit_serializer import CIRCUIT_SERIALIZER
 from cirq_google.engine.processor_sampler import ProcessorSampler
+from cirq_google.engine import engine_validator
 
 if TYPE_CHECKING:
     import cirq_google as cg
@@ -35,10 +36,6 @@ if TYPE_CHECKING:
 VALID_LANGUAGES = [
     'type.googleapis.com/cirq.google.api.v2.Program',
     'type.googleapis.com/cirq.google.api.v2.BatchProgram',
-]
-
-PROGRAM_VALIDATOR_TYPE = Callable[
-    [Sequence[cirq.AbstractCircuit], Sequence[cirq.Sweepable], int, 'Serializer'], None,
 ]
 
 
@@ -97,7 +94,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
         sampler: cirq.Sampler = cirq.Simulator(),
         device: cirq.Device = cirq.UNCONSTRAINED_DEVICE,
         validator: validating_sampler.VALIDATOR_TYPE = None,
-        program_validator: PROGRAM_VALIDATOR_TYPE = None,
+        program_validator: engine_validator.PROGRAM_VALIDATOR_TYPE = None,
         simulation_type: LocalSimulationType = LocalSimulationType.SYNCHRONOUS,
         calibrations: Optional[Dict[int, calibration.Calibration]] = None,
         **kwargs,

--- a/cirq-google/cirq_google/engine/virtual_engine_factory.py
+++ b/cirq-google/cirq_google/engine/virtual_engine_factory.py
@@ -180,7 +180,7 @@ def _create_virtual_processor_from_device(
         processor_id=processor_id,
         device=device,
         validator=engine_validator.create_engine_validator(),
-        gate_set_validator=engine_validator.create_gate_set_validator(),
+        program_validator=engine_validator.create_program_validator(),
         calibrations={calibration.timestamp // 1000: calibration},
     )
 


### PR DESCRIPTION
Removing the notion of gate sets in engine validator.

@dstrain115 
cc @maffoo 