### PR TITLE
Make SimulationState classes private.

### DIFF
--- a/cirq-core/cirq/contrib/custom_simulators/custom_state_simulator_test.py
+++ b/cirq-core/cirq/contrib/custom_simulators/custom_state_simulator_test.py
@@ -19,6 +19,7 @@ import sympy
 
 import cirq
 from cirq.contrib.custom_simulators.custom_state_simulator import CustomStateSimulator
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
 class ComputationalBasisState(cirq.qis.QuantumStateRepresentation):
@@ -45,7 +46,6 @@ class ComputationalBasisSimState(cirq.SimulationState[ComputationalBasisState]):
             i = self.qubit_map[qubits[0]]
             self._state.basis[i] = int(gate.exponent + self._state.basis[i]) % qubits[0].dimension
             return True
-        pass
 
 
 def create_test_circuit():
@@ -73,7 +73,7 @@ def test_basis_state_simulator():
 
 def test_built_in_states():
     # Verify this works for the built-in states too, you just lose the custom step/trial results.
-    sim = CustomStateSimulator(cirq.StateVectorSimulationState)
+    sim = CustomStateSimulator(_StateVectorSimulationState)
     circuit = create_test_circuit()
     r = sim.simulate(circuit)
     assert r.measurements == {'a': np.array([1]), 'b': np.array([2])}
@@ -83,7 +83,7 @@ def test_built_in_states():
 
 
 def test_product_state_mode_built_in_state():
-    sim = CustomStateSimulator(cirq.StateVectorSimulationState, split_untangled_states=True)
+    sim = CustomStateSimulator(_StateVectorSimulationState, split_untangled_states=True)
     circuit = create_test_circuit()
     r = sim.simulate(circuit)
     assert r.measurements == {'a': np.array([1]), 'b': np.array([2])}
@@ -177,7 +177,6 @@ class ComputationalBasisSimProductState(cirq.SimulationState[ComputationalBasisP
             i = self.qubit_map[qubits[0]]
             self._state.basis[i] = int(gate.exponent + self._state.basis[i]) % qubits[0].dimension
             return True
-        pass
 
 
 def test_product_state_mode():

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -19,7 +19,9 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq.protocols.act_on_protocol_test import DummySimulationState
+from cirq.protocols.act_on_protocol_test import _DummySimulationState
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 from cirq.testing import EqualsTester, assert_allclose_up_to_global_phase
 
 _bools = (False, True)
@@ -819,10 +821,10 @@ def test_clifford_gate_act_on_small_case():
     # Note this is also covered by the `from_op_list` one, etc.
 
     qubits = cirq.LineQubit.range(5)
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=5), qubits=qubits, prng=np.random.RandomState()
     )
-    expected_args = cirq.CliffordTableauSimulationState(
+    expected_args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=5), qubits=qubits, prng=np.random.RandomState()
     )
     cirq.act_on(cirq.H, expected_args, qubits=[qubits[0]], allow_decompose=False)
@@ -854,8 +856,8 @@ def test_clifford_gate_act_on_large_case():
         t1 = cirq.CliffordTableau(num_qubits=n)
         t2 = cirq.CliffordTableau(num_qubits=n)
         qubits = cirq.LineQubit.range(n)
-        args1 = cirq.CliffordTableauSimulationState(tableau=t1, qubits=qubits, prng=prng)
-        args2 = cirq.CliffordTableauSimulationState(tableau=t2, qubits=qubits, prng=prng)
+        args1 = _CliffordTableauSimulationState(tableau=t1, qubits=qubits, prng=prng)
+        args2 = _CliffordTableauSimulationState(tableau=t2, qubits=qubits, prng=prng)
         ops = []
         for _ in range(num_ops):
             g = prng.randint(len(gate_candidate))
@@ -874,7 +876,7 @@ def test_clifford_gate_act_on_ch_form():
     # Although we don't support CH_form from the _act_on_, it will fall back
     # to the decomposititon method and apply it through decomposed ops.
     # Here we run it for the coverage only.
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         initial_state=cirq.StabilizerStateChForm(num_qubits=2, initial_state=1),
         qubits=cirq.LineQubit.range(2),
         prng=np.random.RandomState(),
@@ -885,4 +887,4 @@ def test_clifford_gate_act_on_ch_form():
 
 def test_clifford_gate_act_on_fail():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.CliffordGate.X, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.CliffordGate.X, _DummySimulationState(), qubits=())

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -18,7 +18,8 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq.protocols.act_on_protocol_test import DummySimulationState
+from cirq.protocols.act_on_protocol_test import _DummySimulationState
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 X = np.array([[0, 1], [1, 0]])
 Y = np.array([[0, -1j], [1j, 0]])
@@ -492,9 +493,9 @@ def test_reset_channel_text_diagram():
 
 def test_reset_act_on():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.ResetChannel(), DummySimulationState(), qubits=())
+        cirq.act_on(cirq.ResetChannel(), _DummySimulationState(), qubits=())
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(2, 2, 2, 2, 2), dtype=np.complex64),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -719,7 +720,7 @@ def test_bit_flip_channel_text_diagram():
 def test_stabilizer_supports_depolarize():
     with pytest.raises(TypeError, match="act_on"):
         for _ in range(100):
-            cirq.act_on(cirq.depolarize(3 / 4), DummySimulationState(), qubits=())
+            cirq.act_on(cirq.depolarize(3 / 4), _DummySimulationState(), qubits=())
 
     q = cirq.LineQubit(0)
     c = cirq.Circuit(cirq.depolarize(3 / 4).on(q), cirq.measure(q, key='m'))

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -17,7 +17,9 @@ import pytest
 import sympy
 
 import cirq
-from cirq.protocols.act_on_protocol_test import DummySimulationState
+from cirq.protocols.act_on_protocol_test import _DummySimulationState
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 H = np.array([[1, 1], [1, -1]]) * np.sqrt(0.5)
 HH = cirq.kron(H, H)
@@ -287,11 +289,11 @@ def test_h_str():
 
 def test_x_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.X, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.X, _DummySimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
     flipped_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=23)
 
-    state = cirq.CliffordTableauSimulationState(
+    state = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -336,11 +338,11 @@ class MinusOnePhaseGate(cirq.testing.SingleQubitGate):
 
 def test_y_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.Y, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.Y, _DummySimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
     flipped_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=23)
 
-    state = cirq.CliffordTableauSimulationState(
+    state = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -374,13 +376,13 @@ def test_y_act_on_tableau():
 
 def test_z_h_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.Z, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.Z, _DummySimulationState(), qubits=())
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.H, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.H, _DummySimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
     flipped_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=23)
 
-    state = cirq.CliffordTableauSimulationState(
+    state = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -427,10 +429,10 @@ def test_z_h_act_on_tableau():
 
 def test_cx_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.CX, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.CX, _DummySimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
 
-    state = cirq.CliffordTableauSimulationState(
+    state = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -471,10 +473,10 @@ def test_cx_act_on_tableau():
 
 def test_cz_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.CZ, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.CZ, _DummySimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
 
-    state = cirq.CliffordTableauSimulationState(
+    state = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -514,12 +516,12 @@ def test_cz_act_on_tableau():
 
 
 def test_cz_act_on_equivalent_to_h_cx_h_tableau():
-    state1 = cirq.CliffordTableauSimulationState(
+    state1 = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=2),
         qubits=cirq.LineQubit.range(2),
         prng=np.random.RandomState(),
     )
-    state2 = cirq.CliffordTableauSimulationState(
+    state2 = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=2),
         qubits=cirq.LineQubit.range(2),
         prng=np.random.RandomState(),
@@ -581,7 +583,7 @@ def test_act_on_ch_form(input_gate_sequence, outcome):
     else:
         assert num_qubits == 2
         qubits = cirq.LineQubit.range(2)
-    state = cirq.StabilizerChFormSimulationState(
+    state = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(2),
         prng=np.random.RandomState(),
         initial_state=original_state.copy(),

--- a/cirq-core/cirq/ops/global_phase_op_test.py
+++ b/cirq-core/cirq/ops/global_phase_op_test.py
@@ -17,6 +17,8 @@ import pytest
 import sympy
 
 import cirq
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 
 def test_init():
@@ -44,7 +46,7 @@ def test_protocols():
 @pytest.mark.parametrize('phase', [1, 1j, -1])
 def test_act_on_tableau(phase):
     original_tableau = cirq.CliffordTableau(0)
-    args = cirq.CliffordTableauSimulationState(original_tableau.copy(), np.random.RandomState())
+    args = _CliffordTableauSimulationState(original_tableau.copy(), np.random.RandomState())
     cirq.act_on(cirq.global_phase_operation(phase), args, allow_decompose=False)
     assert args.tableau == original_tableau
 
@@ -52,7 +54,7 @@ def test_act_on_tableau(phase):
 @pytest.mark.parametrize('phase', [1, 1j, -1])
 def test_act_on_ch_form(phase):
     state = cirq.StabilizerStateChForm(0)
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=[], prng=np.random.RandomState(), initial_state=state
     )
     cirq.act_on(cirq.global_phase_operation(phase), args, allow_decompose=False)
@@ -241,7 +243,7 @@ def test_gate_protocols():
 @pytest.mark.parametrize('phase', [1, 1j, -1])
 def test_gate_act_on_tableau(phase):
     original_tableau = cirq.CliffordTableau(0)
-    args = cirq.CliffordTableauSimulationState(original_tableau.copy(), np.random.RandomState())
+    args = _CliffordTableauSimulationState(original_tableau.copy(), np.random.RandomState())
     cirq.act_on(cirq.GlobalPhaseGate(phase), args, qubits=(), allow_decompose=False)
     assert args.tableau == original_tableau
 
@@ -249,7 +251,7 @@ def test_gate_act_on_tableau(phase):
 @pytest.mark.parametrize('phase', [1, 1j, -1])
 def test_gate_act_on_ch_form(phase):
     state = cirq.StabilizerStateChForm(0)
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=[], prng=np.random.RandomState(), initial_state=state
     )
     cirq.act_on(cirq.GlobalPhaseGate(phase), args, qubits=(), allow_decompose=False)

--- a/cirq-core/cirq/ops/measurement_gate_test.py
+++ b/cirq-core/cirq/ops/measurement_gate_test.py
@@ -17,6 +17,9 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 from cirq.type_workarounds import NotImplementedType
 
 
@@ -370,7 +373,7 @@ def test_act_on_state_vector():
         a, b, key='out', invert_mask=(True,), confusion_map={(1,): np.array([[0, 1], [1, 0]])}
     )
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(2, 2, 2, 2, 2)),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -380,7 +383,7 @@ def test_act_on_state_vector():
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [1, 1]}
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(2, 2, 2, 2, 2)),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -392,7 +395,7 @@ def test_act_on_state_vector():
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [1, 0]}
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(2, 2, 2, 2, 2)),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -419,7 +422,7 @@ def test_act_on_clifford_tableau():
     # The below assertion does not fail since it ignores non-unitary operations
     cirq.testing.assert_all_implemented_act_on_effects_match_unitary(m)
 
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=5, initial_state=0),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -427,7 +430,7 @@ def test_act_on_clifford_tableau():
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [1, 1]}
 
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=5, initial_state=8),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -436,7 +439,7 @@ def test_act_on_clifford_tableau():
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [1, 0]}
 
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=5, initial_state=10),
         qubits=cirq.LineQubit.range(5),
         prng=np.random.RandomState(),
@@ -459,20 +462,20 @@ def test_act_on_stabilizer_ch_form():
     # The below assertion does not fail since it ignores non-unitary operations
     cirq.testing.assert_all_implemented_act_on_effects_match_unitary(m)
 
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(5), prng=np.random.RandomState(), initial_state=0
     )
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [1, 1]}
 
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(5), prng=np.random.RandomState(), initial_state=8
     )
 
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [1, 0]}
 
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(5), prng=np.random.RandomState(), initial_state=10
     )
     cirq.act_on(m, args)
@@ -495,7 +498,7 @@ def test_act_on_qutrit():
         confusion_map={(1,): np.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]])},
     )
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(3, 3, 3, 3, 3)),
         qubits=cirq.LineQid.range(5, dimension=3),
         prng=np.random.RandomState(),
@@ -507,7 +510,7 @@ def test_act_on_qutrit():
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [2, 0]}
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(3, 3, 3, 3, 3)),
         qubits=cirq.LineQid.range(5, dimension=3),
         prng=np.random.RandomState(),
@@ -519,7 +522,7 @@ def test_act_on_qutrit():
     cirq.act_on(m, args)
     assert args.log_of_measurement_results == {'out': [2, 2]}
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(shape=(3, 3, 3, 3, 3)),
         qubits=cirq.LineQid.range(5, dimension=3),
         prng=np.random.RandomState(),
@@ -533,7 +536,7 @@ def test_act_on_qutrit():
 
 
 def test_act_on_no_confusion_map_deprecated():
-    class OldSimState(cirq.StateVectorSimulationState):
+    class OldSimState(_StateVectorSimulationState):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.measured = False
@@ -559,7 +562,7 @@ def test_act_on_no_confusion_map_deprecated():
 def test_act_on_no_confusion_map_scope_limited():
     error_msg = "error from deeper in measure"
 
-    class ErrorProneSimState(cirq.StateVectorSimulationState):
+    class ErrorProneSimState(_StateVectorSimulationState):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.measured = False

--- a/cirq-core/cirq/ops/random_gate_channel_test.py
+++ b/cirq-core/cirq/ops/random_gate_channel_test.py
@@ -219,13 +219,13 @@ def test_stabilizer_supports_probability():
 
 
 def test_unsupported_stabilizer_safety():
-    from cirq.protocols.act_on_protocol_test import DummySimulationState
+    from cirq.protocols.act_on_protocol_test import _DummySimulationState
 
     with pytest.raises(TypeError, match="act_on"):
         for _ in range(100):
-            cirq.act_on(cirq.X.with_probability(0.5), DummySimulationState(), qubits=())
+            cirq.act_on(cirq.X.with_probability(0.5), _DummySimulationState(), qubits=())
     with pytest.raises(TypeError, match="act_on"):
-        cirq.act_on(cirq.X.with_probability(sympy.Symbol('x')), DummySimulationState(), qubits=())
+        cirq.act_on(cirq.X.with_probability(sympy.Symbol('x')), _DummySimulationState(), qubits=())
 
     q = cirq.LineQubit(0)
     c = cirq.Circuit((cirq.X(q) ** 0.25).with_probability(0.5), cirq.measure(q, key='m'))

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -761,9 +761,9 @@ def test_tagged_act_on():
             pass
 
     q = cirq.LineQubit(1)
-    from cirq.protocols.act_on_protocol_test import DummySimulationState
+    from cirq.protocols.act_on_protocol_test import _DummySimulationState
 
-    args = DummySimulationState()
+    args = _DummySimulationState()
     cirq.act_on(YesActOn()(q).with_tags("test"), args)
     with pytest.raises(TypeError, match="Failed to act"):
         cirq.act_on(NoActOn()(q).with_tags("test"), args)

--- a/cirq-core/cirq/protocols/act_on_protocol.py
+++ b/cirq-core/cirq/protocols/act_on_protocol.py
@@ -32,7 +32,7 @@ class SupportsActOn(Protocol):
         """Applies an action to the given argument, if it is a supported type.
 
         For example, unitary operations can implement an `_act_on_` method that
-        checks if `isinstance(sim_state, cirq.StateVectorSimulationState)` and,
+        checks if `isinstance(sim_state, _StateVectorSimulationState)` and,
         if so, apply their unitary effect to the state vector.
 
         The global `cirq.act_on` method looks for whether or not the given
@@ -64,7 +64,7 @@ class SupportsActOnQubits(Protocol):
         """Applies an action to the given argument, if it is a supported type.
 
         For example, unitary operations can implement an `_act_on_` method that
-        checks if `isinstance(sim_state, cirq.StateVectorSimulationState)` and,
+        checks if `isinstance(sim_state, _StateVectorSimulationState)` and,
         if so, apply their unitary effect to the state vector.
 
         The global `cirq.act_on` method looks for whether or not the given
@@ -110,7 +110,7 @@ def act_on(
 
     For example, the action may be a `cirq.Operation` and the state argument may
     represent the internal state of a state vector simulator (a
-    `cirq.StateVectorSimulationState`).
+    `_StateVectorSimulationState`).
 
     For non-operations, the `qubits` argument must be explicitly supplied.
 

--- a/cirq-core/cirq/protocols/act_on_protocol_test.py
+++ b/cirq-core/cirq/protocols/act_on_protocol_test.py
@@ -28,7 +28,7 @@ class DummyQuantumState(cirq.QuantumStateRepresentation):
         pass
 
 
-class DummySimulationState(cirq.SimulationState):
+class _DummySimulationState(cirq.SimulationState):
     def __init__(self, fallback_result: Any = NotImplemented):
         super().__init__(prng=np.random.RandomState(), state=DummyQuantumState())
         self.fallback_result = fallback_result
@@ -43,18 +43,18 @@ op = cirq.X(cirq.LineQubit(0))
 
 
 def test_act_on_fallback_succeeds():
-    state = DummySimulationState(fallback_result=True)
+    state = _DummySimulationState(fallback_result=True)
     cirq.act_on(op, state)
 
 
 def test_act_on_fallback_fails():
-    state = DummySimulationState(fallback_result=NotImplemented)
+    state = _DummySimulationState(fallback_result=NotImplemented)
     with pytest.raises(TypeError, match='Failed to act'):
         cirq.act_on(op, state)
 
 
 def test_act_on_fallback_errors():
-    state = DummySimulationState(fallback_result=False)
+    state = _DummySimulationState(fallback_result=False)
     with pytest.raises(ValueError, match='_act_on_fallback_ must return True or NotImplemented'):
         cirq.act_on(op, state)
 
@@ -71,7 +71,7 @@ def test_act_on_errors():
         def _act_on_(self, sim_state):
             return False
 
-    state = DummySimulationState(fallback_result=True)
+    state = _DummySimulationState(fallback_result=True)
     with pytest.raises(ValueError, match='_act_on_ must return True or NotImplemented'):
         cirq.act_on(Op(), state)
 
@@ -85,7 +85,7 @@ def test_qubits_not_allowed_for_operations():
         def with_qubits(self: TSelf, *new_qubits: 'cirq.Qid') -> TSelf:
             pass
 
-    state = DummySimulationState()
+    state = _DummySimulationState()
     with pytest.raises(
         ValueError, match='Calls to act_on should not supply qubits if the action is an Operation'
     ):
@@ -93,12 +93,12 @@ def test_qubits_not_allowed_for_operations():
 
 
 def test_qubits_should_be_defined_for_operations():
-    state = DummySimulationState()
+    state = _DummySimulationState()
     with pytest.raises(ValueError, match='Calls to act_on should'):
         cirq.act_on(cirq.KrausChannel([np.array([[1, 0], [0, 0]])]), state, qubits=None)
 
 
 def test_args_deprecated():
-    args = DummySimulationState(fallback_result=True)
+    args = _DummySimulationState(fallback_result=True)
     with cirq.testing.assert_deprecated(deadline='v0.16'):
         cirq.act_on(action=op, args=args)  # pylint: disable=no-value-for-parameter

--- a/cirq-core/cirq/sim/act_on_density_matrix_args.py
+++ b/cirq-core/cirq/sim/act_on_density_matrix_args.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from cirq import _compat
-from cirq.sim.density_matrix_simulation_state import DensityMatrixSimulationState
+from cirq.sim.density_matrix_simulation_state import _DensityMatrixSimulationState
 
 
-@_compat.deprecated_class(deadline='v0.16', fix='Use cirq.DensityMatrixSimulationState instead.')
-class ActOnDensityMatrixArgs(DensityMatrixSimulationState):
+@_compat.deprecated_class(deadline='v0.16', fix='Use _DensityMatrixSimulationState instead.')
+class ActOnDensityMatrixArgs(_DensityMatrixSimulationState):
     pass

--- a/cirq-core/cirq/sim/act_on_state_vector_args.py
+++ b/cirq-core/cirq/sim/act_on_state_vector_args.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from cirq import _compat
-from cirq.sim.state_vector_simulation_state import StateVectorSimulationState
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
-@_compat.deprecated_class(deadline='v0.16', fix='Use cirq.StateVectorSimulationState instead.')
-class ActOnStateVectorArgs(StateVectorSimulationState):
+@_compat.deprecated_class(deadline='v0.16', fix='Use _StateVectorSimulationState instead.')
+class ActOnStateVectorArgs(_StateVectorSimulationState):
     pass

--- a/cirq-core/cirq/sim/clifford/act_on_clifford_tableau_args.py
+++ b/cirq-core/cirq/sim/clifford/act_on_clifford_tableau_args.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from cirq import _compat
-from cirq.sim.clifford.clifford_tableau_simulation_state import CliffordTableauSimulationState
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 
 
-@_compat.deprecated_class(deadline='v0.16', fix='Use cirq.CliffordTableauSimulationState instead.')
-class ActOnCliffordTableauArgs(CliffordTableauSimulationState):
+@_compat.deprecated_class(deadline='v0.16', fix='Use _CliffordTableauSimulationState instead.')
+class ActOnCliffordTableauArgs(_CliffordTableauSimulationState):
     pass

--- a/cirq-core/cirq/sim/clifford/act_on_stabilizer_args.py
+++ b/cirq-core/cirq/sim/clifford/act_on_stabilizer_args.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from cirq import _compat
-from cirq.sim.clifford.stabilizer_simulation_state import StabilizerSimulationState
+from cirq.sim.clifford.stabilizer_simulation_state import _StabilizerSimulationState
 
 
-@_compat.deprecated_class(deadline='v0.16', fix='Use cirq.StabilizerSimulationState instead.')
-class ActOnStabilizerArgs(StabilizerSimulationState):
+@_compat.deprecated_class(deadline='v0.16', fix='Use _StabilizerSimulationState instead.')
+class ActOnStabilizerArgs(_StabilizerSimulationState):
     pass

--- a/cirq-core/cirq/sim/clifford/act_on_stabilizer_ch_form_args.py
+++ b/cirq-core/cirq/sim/clifford/act_on_stabilizer_ch_form_args.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from cirq import _compat
-from cirq.sim.clifford.stabilizer_ch_form_simulation_state import StabilizerChFormSimulationState
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 
-@_compat.deprecated_class(deadline='v0.16', fix='Use cirq.StabilizerChFormSimulationState instead.')
-class ActOnStabilizerCHFormArgs(StabilizerChFormSimulationState):
+@_compat.deprecated_class(deadline='v0.16', fix='Use _StabilizerChFormSimulationState instead.')
+class ActOnStabilizerCHFormArgs(_StabilizerChFormSimulationState):
     pass

--- a/cirq-core/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator.py
@@ -37,13 +37,14 @@ import cirq
 from cirq import protocols, value
 from cirq.protocols import act_on
 from cirq.sim import clifford, simulator, simulator_base
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 
 class CliffordSimulator(
     simulator_base.SimulatorBase[
         'cirq.CliffordSimulatorStepResult',
         'cirq.CliffordTrialResult',
-        'cirq.StabilizerChFormSimulationState',
+        '_StabilizerChFormSimulationState',
     ]
 ):
     """An efficient simulator for Clifford circuits."""
@@ -69,10 +70,10 @@ class CliffordSimulator(
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union[int, 'cirq.StabilizerChFormSimulationState'],
+        initial_state: Union[int, '_StabilizerChFormSimulationState'],
         qubits: Sequence['cirq.Qid'],
         classical_data: 'cirq.ClassicalDataStore',
-    ) -> 'cirq.StabilizerChFormSimulationState':
+    ) -> '_StabilizerChFormSimulationState':
         """Creates the ActOnStabilizerChFormArgs for a circuit.
 
         Args:
@@ -88,10 +89,10 @@ class CliffordSimulator(
         Returns:
             ActOnStabilizerChFormArgs for the circuit.
         """
-        if isinstance(initial_state, clifford.StabilizerChFormSimulationState):
+        if isinstance(initial_state, _StabilizerChFormSimulationState):
             return initial_state
 
-        return clifford.StabilizerChFormSimulationState(
+        return _StabilizerChFormSimulationState(
             prng=self._prng,
             classical_data=classical_data,
             qubits=qubits,
@@ -99,7 +100,7 @@ class CliffordSimulator(
         )
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[clifford.StabilizerChFormSimulationState]'
+        self, sim_state: 'cirq.SimulationStateBase[_StabilizerChFormSimulationState]'
     ):
         return CliffordSimulatorStepResult(sim_state=sim_state)
 
@@ -107,7 +108,7 @@ class CliffordSimulator(
         self,
         params: 'cirq.ParamResolver',
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StabilizerChFormSimulationState]',
+        final_simulator_state: 'cirq.SimulationStateBase[_StabilizerChFormSimulationState]',
     ):
 
         return CliffordTrialResult(
@@ -116,14 +117,14 @@ class CliffordSimulator(
 
 
 class CliffordTrialResult(
-    simulator_base.SimulationTrialResultBase['clifford.StabilizerChFormSimulationState']
+    simulator_base.SimulationTrialResultBase['_StabilizerChFormSimulationState']
 ):
     @simulator._deprecated_step_result_parameter(old_position=3)
     def __init__(
         self,
         params: 'cirq.ParamResolver',
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StabilizerChFormSimulationState]',
+        final_simulator_state: 'cirq.SimulationStateBase[_StabilizerChFormSimulationState]',
     ) -> None:
         super().__init__(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
@@ -147,13 +148,11 @@ class CliffordTrialResult(
 
 
 class CliffordSimulatorStepResult(
-    simulator_base.StepResultBase['cirq.StabilizerChFormSimulationState']
+    simulator_base.StepResultBase['_StabilizerChFormSimulationState']
 ):
     """A `StepResult` that includes `StateVectorMixin` methods."""
 
-    def __init__(
-        self, sim_state: 'cirq.SimulationStateBase[clifford.StabilizerChFormSimulationState]'
-    ):
+    def __init__(self, sim_state: 'cirq.SimulationStateBase[_StabilizerChFormSimulationState]'):
         """Results of a step of the simulator.
         Attributes:
             sim_state: The qubit:SimulationState lookup for this step.
@@ -242,7 +241,7 @@ class CliffordState:
         return self.ch_form.state_vector()
 
     def apply_unitary(self, op: 'cirq.Operation'):
-        ch_form_args = clifford.StabilizerChFormSimulationState(
+        ch_form_args = _StabilizerChFormSimulationState(
             prng=np.random.RandomState(), qubits=self.qubit_map.keys(), initial_state=self.ch_form
         )
         try:
@@ -272,7 +271,7 @@ class CliffordState:
             state = self.copy()
 
         classical_data = value.ClassicalDataDictionaryStore()
-        ch_form_args = clifford.StabilizerChFormSimulationState(
+        ch_form_args = _StabilizerChFormSimulationState(
             prng=prng,
             classical_data=classical_data,
             qubits=self.qubit_map.keys(),

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -7,6 +7,7 @@ import sympy
 
 import cirq
 import cirq.testing
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 
 def test_simulate_no_circuit():
@@ -211,7 +212,7 @@ def test_clifford_state_initial_state():
 
 def test_clifford_trial_result_repr():
     q0 = cirq.LineQubit(0)
-    final_simulator_state = cirq.StabilizerChFormSimulationState(qubits=[q0])
+    final_simulator_state = _StabilizerChFormSimulationState(qubits=[q0])
     assert (
         repr(
             cirq.CliffordTrialResult(
@@ -222,7 +223,8 @@ def test_clifford_trial_result_repr():
         )
         == "cirq.SimulationTrialResult(params=cirq.ParamResolver({}), "
         "measurements={'m': array([[1]])}, "
-        "final_simulator_state=cirq.StabilizerChFormSimulationState("
+        "final_simulator_state=cirq.sim.clifford.stabilizer_ch_form_simulation_state"
+        "._StabilizerChFormSimulationState("
         "initial_state=StabilizerStateChForm(num_qubits=1), "
         "qubits=(cirq.LineQubit(0),), "
         "classical_data=cirq.ClassicalDataDictionaryStore()))"
@@ -231,7 +233,7 @@ def test_clifford_trial_result_repr():
 
 def test_clifford_trial_result_str():
     q0 = cirq.LineQubit(0)
-    final_simulator_state = cirq.StabilizerChFormSimulationState(qubits=[q0])
+    final_simulator_state = _StabilizerChFormSimulationState(qubits=[q0])
     assert (
         str(
             cirq.CliffordTrialResult(
@@ -247,7 +249,7 @@ def test_clifford_trial_result_str():
 
 def test_clifford_trial_result_repr_pretty():
     q0 = cirq.LineQubit(0)
-    final_simulator_state = cirq.StabilizerChFormSimulationState(qubits=[q0])
+    final_simulator_state = _StabilizerChFormSimulationState(qubits=[q0])
     result = cirq.CliffordTrialResult(
         params=cirq.ParamResolver({}),
         measurements={'m': np.array([[1]])},

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
@@ -18,14 +18,15 @@ from typing import Optional, Sequence, TYPE_CHECKING
 
 import numpy as np
 
+from cirq import _compat
 from cirq.qis import clifford_tableau
-from cirq.sim.clifford.stabilizer_simulation_state import StabilizerSimulationState
+from cirq.sim.clifford.stabilizer_simulation_state import _StabilizerSimulationState
 
 if TYPE_CHECKING:
     import cirq
 
 
-class CliffordTableauSimulationState(StabilizerSimulationState[clifford_tableau.CliffordTableau]):
+class _CliffordTableauSimulationState(_StabilizerSimulationState[clifford_tableau.CliffordTableau]):
     """State and context for an operation acting on a clifford tableau."""
 
     def __init__(
@@ -35,7 +36,7 @@ class CliffordTableauSimulationState(StabilizerSimulationState[clifford_tableau.
         qubits: Optional[Sequence['cirq.Qid']] = None,
         classical_data: Optional['cirq.ClassicalDataStore'] = None,
     ):
-        """Inits CliffordTableauSimulationState.
+        """Inits _CliffordTableauSimulationState.
 
         Args:
             tableau: The CliffordTableau to act on. Operations are expected to
@@ -53,3 +54,14 @@ class CliffordTableauSimulationState(StabilizerSimulationState[clifford_tableau.
     @property
     def tableau(self) -> 'cirq.CliffordTableau':
         return self.state
+
+
+@_compat.deprecated_class(
+    deadline='v0.16',
+    fix=(
+        'This class is now private. If you must use it, replace it with '
+        'cirq.sim.clifford.clifford_tableau_simulation_state._CliffordTableauSimulationState.'
+    ),
+)
+class CliffordTableauSimulationState(_CliffordTableauSimulationState):
+    pass

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state_test.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 
 
 def test_unitary_fallback():
@@ -33,7 +34,7 @@ def test_unitary_fallback():
             return np.array([[0, -1j], [1j, 0]])
 
     original_tableau = cirq.CliffordTableau(num_qubits=3)
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
@@ -42,13 +43,13 @@ def test_unitary_fallback():
     cirq.act_on(UnitaryXGate(), args, [cirq.LineQubit(1)])
     assert args.tableau == cirq.CliffordTableau(num_qubits=3, initial_state=2)
 
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
     )
     cirq.act_on(UnitaryYGate(), args, [cirq.LineQubit(1)])
-    expected_args = cirq.CliffordTableauSimulationState(
+    expected_args = _CliffordTableauSimulationState(
         tableau=original_tableau.copy(),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
@@ -64,7 +65,7 @@ def test_cannot_act():
     class NoDetailsSingleQubitGate(cirq.testing.SingleQubitGate):
         pass
 
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=3),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
@@ -78,13 +79,13 @@ def test_cannot_act():
 
 
 def test_copy():
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=3),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
     )
     args1 = args.copy()
-    assert isinstance(args1, cirq.CliffordTableauSimulationState)
+    assert isinstance(args1, _CliffordTableauSimulationState)
     assert args is not args1
     assert args.tableau is not args1.tableau
     assert args.tableau == args1.tableau

--- a/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state.py
@@ -16,16 +16,16 @@ from typing import Optional, Sequence, TYPE_CHECKING, Union
 
 import numpy as np
 
-from cirq._compat import proper_repr
+from cirq import _compat
 from cirq.sim.clifford import stabilizer_state_ch_form
-from cirq.sim.clifford.stabilizer_simulation_state import StabilizerSimulationState
+from cirq.sim.clifford.stabilizer_simulation_state import _StabilizerSimulationState
 
 if TYPE_CHECKING:
     import cirq
 
 
-class StabilizerChFormSimulationState(
-    StabilizerSimulationState[stabilizer_state_ch_form.StabilizerStateChForm]
+class _StabilizerChFormSimulationState(
+    _StabilizerSimulationState[stabilizer_state_ch_form.StabilizerStateChForm]
 ):
     """Wrapper around a stabilizer state in CH form for the act_on protocol."""
 
@@ -69,8 +69,20 @@ class StabilizerChFormSimulationState(
 
     def __repr__(self) -> str:
         return (
-            'cirq.StabilizerChFormSimulationState('
-            f'initial_state={proper_repr(self.state)},'
+            'cirq.sim.clifford.stabilizer_ch_form_simulation_state'
+            '._StabilizerChFormSimulationState('
+            f'initial_state={_compat.proper_repr(self.state)},'
             f' qubits={self.qubits!r},'
             f' classical_data={self.classical_data!r})'
         )
+
+
+@_compat.deprecated_class(
+    deadline='v0.16',
+    fix=(
+        'This class is now private. If you must use it, replace it with '
+        'cirq.sim.clifford.stabilizer_ch_form_simulation_state._StabilizerChFormSimulationState.'
+    ),
+)
+class StabilizerChFormSimulationState(_StabilizerChFormSimulationState):
+    pass

--- a/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state_test.py
@@ -16,20 +16,21 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 
 def test_init_state():
-    args = cirq.StabilizerChFormSimulationState(qubits=cirq.LineQubit.range(1), initial_state=1)
+    args = _StabilizerChFormSimulationState(qubits=cirq.LineQubit.range(1), initial_state=1)
     np.testing.assert_allclose(args.state.state_vector(), [0, 1])
     with pytest.raises(ValueError, match='Must specify qubits'):
-        _ = cirq.StabilizerChFormSimulationState(initial_state=1)
+        _ = _StabilizerChFormSimulationState(initial_state=1)
 
 
 def test_cannot_act():
     class NoDetails(cirq.testing.SingleQubitGate):
         pass
 
-    args = cirq.StabilizerChFormSimulationState(qubits=[], prng=np.random.RandomState())
+    args = _StabilizerChFormSimulationState(qubits=[], prng=np.random.RandomState())
 
     with pytest.raises(TypeError, match="Failed to act"):
         cirq.act_on(NoDetails(), args, qubits=())
@@ -38,13 +39,13 @@ def test_cannot_act():
 def test_gate_with_act_on():
     class CustomGate(cirq.testing.SingleQubitGate):
         def _act_on_(self, sim_state, qubits):
-            if isinstance(sim_state, cirq.StabilizerChFormSimulationState):
+            if isinstance(sim_state, _StabilizerChFormSimulationState):
                 qubit = sim_state.qubit_map[qubits[0]]
                 sim_state.state.gamma[qubit] += 1
                 return True
 
     state = cirq.StabilizerStateChForm(num_qubits=3)
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState(), initial_state=state
     )
 
@@ -61,11 +62,11 @@ def test_unitary_fallback_y():
         def _unitary_(self):
             return np.array([[0, -1j], [1j, 0]])
 
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState()
     )
     cirq.act_on(UnitaryYGate(), args, [cirq.LineQubit(1)])
-    expected_args = cirq.StabilizerChFormSimulationState(
+    expected_args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState()
     )
     cirq.act_on(cirq.Y, expected_args, [cirq.LineQubit(1)])
@@ -80,11 +81,11 @@ def test_unitary_fallback_h():
         def _unitary_(self):
             return np.array([[1, 1], [1, -1]]) / (2**0.5)
 
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState()
     )
     cirq.act_on(UnitaryHGate(), args, [cirq.LineQubit(1)])
-    expected_args = cirq.StabilizerChFormSimulationState(
+    expected_args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState()
     )
     cirq.act_on(cirq.H, expected_args, [cirq.LineQubit(1)])
@@ -92,11 +93,11 @@ def test_unitary_fallback_h():
 
 
 def test_copy():
-    args = cirq.StabilizerChFormSimulationState(
+    args = _StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState()
     )
     args1 = args.copy()
-    assert isinstance(args1, cirq.StabilizerChFormSimulationState)
+    assert isinstance(args1, _StabilizerChFormSimulationState)
     assert args is not args1
     assert args.state is not args1.state
     np.testing.assert_equal(args.state.state_vector(), args1.state.state_vector())

--- a/cirq-core/cirq/sim/clifford/stabilizer_sampler.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_sampler.py
@@ -19,7 +19,7 @@ import numpy as np
 import cirq
 from cirq import protocols, value
 from cirq.qis.clifford_tableau import CliffordTableau
-from cirq.sim.clifford.clifford_tableau_simulation_state import CliffordTableauSimulationState
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 from cirq.work import sampler
 
 
@@ -53,7 +53,7 @@ class StabilizerSampler(sampler.Sampler):
         qubits = circuit.all_qubits()
 
         for _ in range(repetitions):
-            state = CliffordTableauSimulationState(
+            state = _CliffordTableauSimulationState(
                 CliffordTableau(num_qubits=len(qubits)), qubits=list(qubits), prng=self._prng
             )
             for op in circuit.all_operations():

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
@@ -18,8 +18,7 @@ from typing import Any, cast, Dict, Generic, List, Optional, Sequence, TYPE_CHEC
 import numpy as np
 import sympy
 
-from cirq import linalg, ops, protocols
-from cirq._compat import deprecated_parameter
+from cirq import _compat, linalg, ops, protocols
 from cirq.ops import common_gates, global_phase_op, matrix_gates, swap_gates
 from cirq.ops.clifford_gate import SingleQubitCliffordGate
 from cirq.protocols import has_unitary, num_qubits, unitary
@@ -33,18 +32,18 @@ if TYPE_CHECKING:
 TStabilizerState = TypeVar('TStabilizerState', bound='cirq.StabilizerState')
 
 
-class StabilizerSimulationState(
+class _StabilizerSimulationState(
     SimulationState[TStabilizerState], Generic[TStabilizerState], metaclass=abc.ABCMeta
 ):
     """Abstract wrapper around a stabilizer state for the act_on protocol."""
 
-    @deprecated_parameter(
+    @_compat.deprecated_parameter(
         deadline='v0.16',
         fix='Use kwargs instead of positional args',
         parameter_desc='args',
         match=lambda args, kwargs: len(args) > 1,
     )
-    @deprecated_parameter(
+    @_compat.deprecated_parameter(
         deadline='v0.16',
         fix='Replace log_of_measurement_results with'
         ' classical_data=cirq.ClassicalDataDictionaryStore(_records=logs).',
@@ -59,7 +58,7 @@ class StabilizerSimulationState(
         qubits: Optional[Sequence['cirq.Qid']] = None,
         classical_data: Optional['cirq.ClassicalDataStore'] = None,
     ):
-        """Initializes the StabilizerSimulationState.
+        """Initializes the _StabilizerSimulationState.
 
         Args:
             state: The quantum stabilizer state to use in the simulation or
@@ -181,3 +180,14 @@ class StabilizerSimulationState(
         for op in operations:
             protocols.act_on(op, self)
         return True
+
+
+@_compat.deprecated_class(
+    deadline='v0.16',
+    fix=(
+        'This class is now private. If you must use it, replace it with '
+        'cirq.sim.clifford.stabilizer_simulation_state._StabilizerSimulationState.'
+    ),
+)
+class StabilizerSimulationState(_StabilizerSimulationState):
+    pass

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
@@ -18,12 +18,13 @@ import numpy as np
 import sympy
 
 import cirq
+from cirq.sim.clifford.stabilizer_simulation_state import _StabilizerSimulationState
 
 
 def test_apply_gate():
     q0, q1 = cirq.LineQubit.range(2)
     state = Mock()
-    args = cirq.StabilizerSimulationState(state=state, qubits=[q0, q1])
+    args = _StabilizerSimulationState(state=state, qubits=[q0, q1])
 
     assert args._strat_apply_gate(cirq.X, [q0]) is True
     state.apply_x.assert_called_with(0, 1.0, 0.0)
@@ -92,7 +93,7 @@ def test_apply_gate():
 def test_apply_mixture():
     q0 = cirq.LineQubit(0)
     state = Mock()
-    args = cirq.StabilizerSimulationState(state=state, qubits=[q0])
+    args = _StabilizerSimulationState(state=state, qubits=[q0])
 
     for _ in range(100):
         assert args._strat_apply_mixture(cirq.BitFlipChannel(0.5), [q0]) is True
@@ -103,7 +104,7 @@ def test_apply_mixture():
 def test_act_from_single_qubit_decompose():
     q0 = cirq.LineQubit(0)
     state = Mock()
-    args = cirq.StabilizerSimulationState(state=state, qubits=[q0])
+    args = _StabilizerSimulationState(state=state, qubits=[q0])
     assert (
         args._strat_act_from_single_qubit_decompose(
             cirq.MatrixGate(np.array([[0, 1], [1, 0]])), [q0]
@@ -123,13 +124,13 @@ def test_decompose():
 
     q0 = cirq.LineQubit(0)
     state = Mock()
-    args = cirq.StabilizerSimulationState(state=state, qubits=[q0])
+    args = _StabilizerSimulationState(state=state, qubits=[q0])
     assert args._strat_decompose(XContainer(), [q0]) is True
     state.apply_x.assert_called_with(0, 1.0, 0.0)
 
 
 def test_deprecated():
     with cirq.testing.assert_deprecated('log_of_measurement_results', deadline='v0.16', count=2):
-        _ = cirq.StabilizerSimulationState(state=0, log_of_measurement_results={})
+        _ = _StabilizerSimulationState(state=0, log_of_measurement_results={})
     with cirq.testing.assert_deprecated('positional', deadline='v0.16'):
-        _ = cirq.StabilizerSimulationState(0)
+        _ = _StabilizerSimulationState(0)

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form_test.py
@@ -17,6 +17,7 @@ import pytest
 
 import cirq
 import cirq.testing
+from cirq.sim.clifford.stabilizer_ch_form_simulation_state import _StabilizerChFormSimulationState
 
 # TODO: This and clifford tableau need tests.
 # Github issue: https://github.com/quantumlib/Cirq/issues/3021
@@ -66,7 +67,7 @@ def test_run():
         state = cirq.StabilizerStateChForm(num_qubits=3)
         classical_data = cirq.ClassicalDataDictionaryStore()
         for op in circuit.all_operations():
-            args = cirq.StabilizerChFormSimulationState(
+            args = _StabilizerChFormSimulationState(
                 qubits=list(circuit.all_qubits()),
                 prng=np.random.RandomState(),
                 classical_data=classical_data,

--- a/cirq-core/cirq/sim/density_matrix_simulation_state.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state.py
@@ -17,8 +17,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
 
-from cirq import protocols, qis, sim
-from cirq._compat import proper_repr
+from cirq import _compat, protocols, qis, sim
 from cirq.linalg import transformations
 from cirq.sim.simulation_state import SimulationState, strat_act_on_from_apply_decompose
 
@@ -237,7 +236,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         return True
 
 
-class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
+class _DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
     """State and context for an operation acting on a density matrix.
 
     To act on this object, directly edit the `target_tensor` property, which is
@@ -255,7 +254,7 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
         dtype: Type[np.number] = np.complex64,
         classical_data: Optional['cirq.ClassicalDataStore'] = None,
     ):
-        """Inits DensityMatrixSimulationState.
+        """Inits _DensityMatrixSimulationState.
 
         Args:
             available_buffer: A workspace with the same shape and dtype as
@@ -313,8 +312,8 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
 
     def __repr__(self) -> str:
         return (
-            'cirq.DensityMatrixSimulationState('
-            f'initial_state={proper_repr(self.target_tensor)},'
+            'cirq.sim.density_matrix_simulation_state._DensityMatrixSimulationState('
+            f'initial_state={_compat.proper_repr(self.target_tensor)},'
             f' qid_shape={self.qid_shape!r},'
             f' qubits={self.qubits!r},'
             f' classical_data={self.classical_data!r})'
@@ -333,8 +332,19 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
         return self._state._qid_shape
 
 
+@_compat.deprecated_class(
+    deadline='v0.16',
+    fix=(
+        'This class is now private. If you must use it, replace it with '
+        'cirq.sim.density_matrix_simulation_state._DensityMatrixSimulationState.'
+    ),
+)
+class DensityMatrixSimulationState(_DensityMatrixSimulationState):
+    pass
+
+
 def _strat_apply_channel_to_state(
-    action: Any, args: 'cirq.DensityMatrixSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: '_DensityMatrixSimulationState', qubits: Sequence['cirq.Qid']
 ) -> bool:
     """Apply channel to state."""
     return True if args._state.apply_channel(action, args.get_axes(qubits)) else NotImplemented

--- a/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq.sim.density_matrix_simulation_state import _DensityMatrixSimulationState
 
 
 def test_default_parameter():
@@ -23,7 +24,7 @@ def test_default_parameter():
     tensor = cirq.to_valid_density_matrix(
         0, len(qid_shape), qid_shape=qid_shape, dtype=np.complex64
     )
-    args = cirq.DensityMatrixSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
+    args = _DensityMatrixSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
     np.testing.assert_almost_equal(args.target_tensor, tensor)
     assert len(args.available_buffer) == 3
     for buffer in args.available_buffer:
@@ -33,7 +34,7 @@ def test_default_parameter():
 
 
 def test_shallow_copy_buffers():
-    args = cirq.DensityMatrixSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
+    args = _DensityMatrixSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
     copy = args.copy(deep_copy_buffers=False)
     assert copy.available_buffer is args.available_buffer
 
@@ -46,7 +47,7 @@ def test_decomposed_fallback():
         def _decompose_(self, qubits):
             yield cirq.X(*qubits)
 
-    args = cirq.DensityMatrixSimulationState(
+    args = _DensityMatrixSimulationState(
         qubits=cirq.LineQubit.range(1),
         prng=np.random.RandomState(),
         initial_state=0,
@@ -63,7 +64,7 @@ def test_cannot_act():
     class NoDetails:
         pass
 
-    args = cirq.DensityMatrixSimulationState(
+    args = _DensityMatrixSimulationState(
         qubits=cirq.LineQubit.range(1),
         prng=np.random.RandomState(),
         initial_state=0,
@@ -74,7 +75,7 @@ def test_cannot_act():
 
 
 def test_with_qubits():
-    original = cirq.DensityMatrixSimulationState(
+    original = _DensityMatrixSimulationState(
         qubits=cirq.LineQubit.range(1), initial_state=1, dtype=np.complex64
     )
     extened = original.with_qubits(cirq.LineQubit.range(1, 2))
@@ -94,12 +95,12 @@ def test_qid_shape_error():
 
 def test_initial_state_vector():
     qubits = cirq.LineQubit.range(3)
-    args = cirq.DensityMatrixSimulationState(
+    args = _DensityMatrixSimulationState(
         qubits=qubits, initial_state=np.full((8,), 1 / np.sqrt(8)), dtype=np.complex64
     )
     assert args.target_tensor.shape == (2, 2, 2, 2, 2, 2)
 
-    args2 = cirq.DensityMatrixSimulationState(
+    args2 = _DensityMatrixSimulationState(
         qubits=qubits, initial_state=np.full((2, 2, 2), 1 / np.sqrt(8)), dtype=np.complex64
     )
     assert args2.target_tensor.shape == (2, 2, 2, 2, 2, 2)
@@ -107,12 +108,12 @@ def test_initial_state_vector():
 
 def test_initial_state_matrix():
     qubits = cirq.LineQubit.range(3)
-    args = cirq.DensityMatrixSimulationState(
+    args = _DensityMatrixSimulationState(
         qubits=qubits, initial_state=np.full((8, 8), 1 / 8), dtype=np.complex64
     )
     assert args.target_tensor.shape == (2, 2, 2, 2, 2, 2)
 
-    args2 = cirq.DensityMatrixSimulationState(
+    args2 = _DensityMatrixSimulationState(
         qubits=qubits, initial_state=np.full((2, 2, 2, 2, 2, 2), 1 / 8), dtype=np.complex64
     )
     assert args2.target_tensor.shape == (2, 2, 2, 2, 2, 2)
@@ -121,19 +122,19 @@ def test_initial_state_matrix():
 def test_initial_state_bad_shape():
     qubits = cirq.LineQubit.range(3)
     with pytest.raises(ValueError, match="Invalid quantum state"):
-        cirq.DensityMatrixSimulationState(
+        _DensityMatrixSimulationState(
             qubits=qubits, initial_state=np.full((4,), 1 / 2), dtype=np.complex64
         )
     with pytest.raises(ValueError, match="Invalid quantum state"):
-        cirq.DensityMatrixSimulationState(
+        _DensityMatrixSimulationState(
             qubits=qubits, initial_state=np.full((2, 2), 1 / 2), dtype=np.complex64
         )
 
     with pytest.raises(ValueError, match="Invalid quantum state"):
-        cirq.DensityMatrixSimulationState(
+        _DensityMatrixSimulationState(
             qubits=qubits, initial_state=np.full((4, 4), 1 / 4), dtype=np.complex64
         )
     with pytest.raises(ValueError, match="Invalid quantum state"):
-        cirq.DensityMatrixSimulationState(
+        _DensityMatrixSimulationState(
             qubits=qubits, initial_state=np.full((2, 2, 2, 2), 1 / 4), dtype=np.complex64
         )

--- a/cirq-core/cirq/sim/density_matrix_simulator.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator.py
@@ -23,13 +23,14 @@ from cirq.sim import simulator, density_matrix_simulation_state, simulator_base
 if TYPE_CHECKING:
     import cirq
     from numpy.typing import DTypeLike
+    from cirq.sim.density_matrix_simulation_state import _DensityMatrixSimulationState
 
 
 class DensityMatrixSimulator(
     simulator_base.SimulatorBase[
         'cirq.DensityMatrixStepResult',
         'cirq.DensityMatrixTrialResult',
-        'cirq.DensityMatrixSimulationState',
+        '_DensityMatrixSimulationState',
     ],
     simulator.SimulatesExpectationValues,
 ):
@@ -148,13 +149,11 @@ class DensityMatrixSimulator(
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union[
-            np.ndarray, 'cirq.STATE_VECTOR_LIKE', 'cirq.DensityMatrixSimulationState'
-        ],
+        initial_state: Union[np.ndarray, 'cirq.STATE_VECTOR_LIKE', '_DensityMatrixSimulationState'],
         qubits: Sequence['cirq.Qid'],
         classical_data: 'cirq.ClassicalDataStore',
-    ) -> 'cirq.DensityMatrixSimulationState':
-        """Creates the DensityMatrixSimulationState for a circuit.
+    ) -> '_DensityMatrixSimulationState':
+        """Creates the _DensityMatrixSimulationState for a circuit.
 
         Args:
             initial_state: The initial state for the simulation in the
@@ -166,12 +165,12 @@ class DensityMatrixSimulator(
                 simulation.
 
         Returns:
-            DensityMatrixSimulationState for the circuit.
+            _DensityMatrixSimulationState for the circuit.
         """
-        if isinstance(initial_state, density_matrix_simulation_state.DensityMatrixSimulationState):
+        if isinstance(initial_state, density_matrix_simulation_state._DensityMatrixSimulationState):
             return initial_state
 
-        return density_matrix_simulation_state.DensityMatrixSimulationState(
+        return density_matrix_simulation_state._DensityMatrixSimulationState(
             qubits=qubits,
             prng=self._prng,
             classical_data=classical_data,
@@ -183,7 +182,7 @@ class DensityMatrixSimulator(
         return not protocols.measurement_keys_touched(val)
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]'
+        self, sim_state: 'cirq.SimulationStateBase[_DensityMatrixSimulationState]'
     ):
         return DensityMatrixStepResult(sim_state=sim_state, dtype=self._dtype)
 
@@ -191,7 +190,7 @@ class DensityMatrixSimulator(
         self,
         params: 'cirq.ParamResolver',
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]',
+        final_simulator_state: 'cirq.SimulationStateBase[_DensityMatrixSimulationState]',
     ) -> 'cirq.DensityMatrixTrialResult':
         return DensityMatrixTrialResult(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
@@ -232,7 +231,7 @@ class DensityMatrixSimulator(
         return swept_evs
 
 
-class DensityMatrixStepResult(simulator_base.StepResultBase['cirq.DensityMatrixSimulationState']):
+class DensityMatrixStepResult(simulator_base.StepResultBase['_DensityMatrixSimulationState']):
     """A single step in the simulation of the DensityMatrixSimulator.
 
     Attributes:
@@ -248,7 +247,7 @@ class DensityMatrixStepResult(simulator_base.StepResultBase['cirq.DensityMatrixS
     )
     def __init__(
         self,
-        sim_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]',
+        sim_state: 'cirq.SimulationStateBase[_DensityMatrixSimulationState]',
         simulator: 'cirq.DensityMatrixSimulator' = None,
         dtype: 'DTypeLike' = np.complex64,
     ):
@@ -349,7 +348,7 @@ class DensityMatrixSimulatorState:
 @value.value_equality(unhashable=True)
 class DensityMatrixTrialResult(
     simulator_base.SimulationTrialResultBase[
-        density_matrix_simulation_state.DensityMatrixSimulationState
+        density_matrix_simulation_state._DensityMatrixSimulationState
     ]
 ):
     """A `SimulationTrialResult` for `DensityMatrixSimulator` runs.
@@ -394,7 +393,7 @@ class DensityMatrixTrialResult(
         self,
         params: 'cirq.ParamResolver',
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]',
+        final_simulator_state: 'cirq.SimulationStateBase[_DensityMatrixSimulationState]',
     ) -> None:
         super().__init__(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -22,6 +22,7 @@ import sympy
 
 import cirq
 import cirq.testing
+from cirq.sim.density_matrix_simulation_state import _DensityMatrixSimulationState
 
 
 class _TestMixture(cirq.Gate):
@@ -994,12 +995,13 @@ def test_density_matrix_step_result_repr():
     assert (
         repr(
             cirq.DensityMatrixStepResult(
-                sim_state=cirq.DensityMatrixSimulationState(
+                sim_state=_DensityMatrixSimulationState(
                     initial_state=np.ones((2, 2)) * 0.5, qubits=[q0]
                 )
             )
         )
-        == "cirq.DensityMatrixStepResult(sim_state=cirq.DensityMatrixSimulationState("
+        == "cirq.DensityMatrixStepResult(sim_state="
+        "cirq.sim.density_matrix_simulation_state._DensityMatrixSimulationState("
         "initial_state=np.array([[(0.5+0j), (0.5+0j)], [(0.5+0j), (0.5+0j)]], dtype=np.complex64), "
         "qid_shape=(2,), qubits=(cirq.LineQubit(0),), "
         "classical_data=cirq.ClassicalDataDictionaryStore()), dtype=np.complex64)"
@@ -1008,7 +1010,7 @@ def test_density_matrix_step_result_repr():
 
 def test_density_matrix_trial_result_eq():
     q0 = cirq.LineQubit(0)
-    final_simulator_state = cirq.DensityMatrixSimulationState(
+    final_simulator_state = _DensityMatrixSimulationState(
         initial_state=np.ones((2, 2)) * 0.5, qubits=[q0]
     )
     eq = cirq.testing.EqualsTester()
@@ -1042,7 +1044,7 @@ def test_density_matrix_trial_result_eq():
 
 def test_density_matrix_trial_result_qid_shape():
     q0, q1 = cirq.LineQubit.range(2)
-    final_simulator_state = cirq.DensityMatrixSimulationState(
+    final_simulator_state = _DensityMatrixSimulationState(
         initial_state=np.ones((4, 4)) / 4, qubits=[q0, q1]
     )
     assert cirq.qid_shape(
@@ -1053,7 +1055,7 @@ def test_density_matrix_trial_result_qid_shape():
         )
     ) == (2, 2)
     q0, q1 = cirq.LineQid.for_qid_shape((3, 4))
-    final_simulator_state = cirq.DensityMatrixSimulationState(
+    final_simulator_state = _DensityMatrixSimulationState(
         initial_state=np.ones((12, 12)) / 12, qubits=[q0, q1]
     )
     assert cirq.qid_shape(
@@ -1068,7 +1070,7 @@ def test_density_matrix_trial_result_qid_shape():
 def test_density_matrix_trial_result_repr():
     q0 = cirq.LineQubit(0)
     dtype = np.complex64
-    final_simulator_state = cirq.DensityMatrixSimulationState(
+    final_simulator_state = _DensityMatrixSimulationState(
         available_buffer=[],
         qid_shape=(2,),
         prng=np.random.RandomState(0),
@@ -1085,7 +1087,8 @@ def test_density_matrix_trial_result_repr():
         "cirq.DensityMatrixTrialResult("
         "params=cirq.ParamResolver({'s': 1}), "
         "measurements={'m': np.array([[1]], dtype=np.int32)}, "
-        "final_simulator_state=cirq.DensityMatrixSimulationState("
+        "final_simulator_state=cirq.sim.density_matrix_simulation_state"
+        "._DensityMatrixSimulationState("
         "initial_state=np.array([[(0.5+0j), (0.5+0j)], [(0.5+0j), (0.5+0j)]], dtype=np.complex64), "
         "qid_shape=(2,), "
         "qubits=(cirq.LineQubit(0),), "
@@ -1156,7 +1159,7 @@ def test_works_on_pauli_string():
 def test_density_matrix_trial_result_str():
     q0 = cirq.LineQubit(0)
     dtype = np.complex64
-    final_simulator_state = cirq.DensityMatrixSimulationState(
+    final_simulator_state = _DensityMatrixSimulationState(
         available_buffer=[],
         qid_shape=(2,),
         prng=np.random.RandomState(0),
@@ -1181,7 +1184,7 @@ def test_density_matrix_trial_result_str():
 def test_density_matrix_trial_result_repr_pretty():
     q0 = cirq.LineQubit(0)
     dtype = np.complex64
-    final_simulator_state = cirq.DensityMatrixSimulationState(
+    final_simulator_state = _DensityMatrixSimulationState(
         available_buffer=[],
         qid_shape=(2,),
         prng=np.random.RandomState(0),

--- a/cirq-core/cirq/sim/simulation_state_test.py
+++ b/cirq-core/cirq/sim/simulation_state_test.py
@@ -32,7 +32,7 @@ class DummyQuantumState(cirq.QuantumStateRepresentation):
         return self
 
 
-class DummySimulationState(cirq.SimulationState):
+class _DummySimulationState(cirq.SimulationState):
     def __init__(self):
         super().__init__(state=DummyQuantumState(), qubits=cirq.LineQubit.range(2))
 
@@ -43,7 +43,7 @@ class DummySimulationState(cirq.SimulationState):
 
 
 def test_measurements():
-    args = DummySimulationState()
+    args = _DummySimulationState()
     args.measure([cirq.LineQubit(0)], "test", [False], {})
     assert args.log_of_measurement_results["test"] == [5]
 
@@ -56,14 +56,14 @@ def test_decompose():
         def _decompose_(self, qubits):
             yield cirq.X(*qubits)
 
-    args = DummySimulationState()
+    args = _DummySimulationState()
     assert simulation_state.strat_act_on_from_apply_decompose(
         Composite(), args, [cirq.LineQubit(0)]
     )
 
 
 def test_mapping():
-    args = DummySimulationState()
+    args = _DummySimulationState()
     assert list(iter(args)) == cirq.LineQubit.range(2)
     r1 = args[cirq.LineQubit(0)]
     assert args is r1
@@ -74,7 +74,7 @@ def test_mapping():
 def test_swap_bad_dimensions():
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQid(1, 3)
-    args = DummySimulationState()
+    args = _DummySimulationState()
     with pytest.raises(ValueError, match='Cannot swap different dimensions'):
         args.swap(q0, q1)
 
@@ -82,14 +82,14 @@ def test_swap_bad_dimensions():
 def test_rename_bad_dimensions():
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQid(1, 3)
-    args = DummySimulationState()
+    args = _DummySimulationState()
     with pytest.raises(ValueError, match='Cannot rename to different dimensions'):
         args.rename(q0, q1)
 
 
 def test_transpose_qubits():
     q0, q1, q2 = cirq.LineQubit.range(3)
-    args = DummySimulationState()
+    args = _DummySimulationState()
     assert args.transpose_to_qubit_order((q1, q0)).qubits == (q1, q0)
     with pytest.raises(ValueError, match='Qubits do not match'):
         args.transpose_to_qubit_order((q0, q2))
@@ -98,7 +98,7 @@ def test_transpose_qubits():
 
 
 def test_field_getters():
-    args = DummySimulationState()
+    args = _DummySimulationState()
     assert args.prng is np.random
     assert args.qubit_map == {q: i for i, q in enumerate(cirq.LineQubit.range(2))}
     with cirq.testing.assert_deprecated('always returns False', deadline='v0.16'):

--- a/cirq-core/cirq/sim/simulator_base.py
+++ b/cirq-core/cirq/sim/simulator_base.py
@@ -472,7 +472,7 @@ class SimulationTrialResultBase(
         super().__init__(params, measurements, final_simulator_state=final_simulator_state)
         self._merged_sim_state_cache: Optional[TSimulationState] = None
 
-    def get_state_containing_qubit(self, qubit: 'cirq.Qid') -> TSimulationState:
+    def _get_state_containing_qubit(self, qubit: 'cirq.Qid') -> TSimulationState:
         """Returns the independent state space containing the qubit.
 
         Args:
@@ -482,12 +482,23 @@ class SimulationTrialResultBase(
             The state space containing the qubit."""
         return self._final_simulator_state[qubit]
 
+    @_compat.deprecated(deadline='v0.16', fix='This method is now private.')
+    def get_state_containing_qubit(self, qubit: 'cirq.Qid') -> TSimulationState:
+        """Returns the independent state space containing the qubit.
+
+        Args:
+            qubit: The qubit whose state space is required.
+
+        Returns:
+            The state space containing the qubit."""
+        return self._get_state_containing_qubit(qubit)
+
     def _get_substates(self) -> Sequence[TSimulationState]:
         state = self._final_simulator_state
         if isinstance(state, SimulationProductState):
             substates: Dict[TSimulationState, int] = {}
             for q in state.qubits:
-                substates[self.get_state_containing_qubit(q)] = 0
+                substates[self._get_state_containing_qubit(q)] = 0
             substates[state[None]] = 0
             return tuple(substates.keys())
         return [state.create_merged_state()]

--- a/cirq-core/cirq/sim/sparse_simulator.py
+++ b/cirq-core/cirq/sim/sparse_simulator.py
@@ -25,6 +25,7 @@ from cirq.sim import simulator, state_vector, state_vector_simulator, state_vect
 if TYPE_CHECKING:
     import cirq
     from numpy.typing import DTypeLike
+    from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
 class Simulator(
@@ -154,11 +155,11 @@ class Simulator(
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union['cirq.STATE_VECTOR_LIKE', 'cirq.StateVectorSimulationState'],
+        initial_state: Union['cirq.STATE_VECTOR_LIKE', '_StateVectorSimulationState'],
         qubits: Sequence['cirq.Qid'],
         classical_data: 'cirq.ClassicalDataStore',
     ):
-        """Creates the StateVectorSimulationState for a circuit.
+        """Creates the _StateVectorSimulationState for a circuit.
 
         Args:
             initial_state: The initial state for the simulation in the
@@ -170,12 +171,12 @@ class Simulator(
                 simulation.
 
         Returns:
-            StateVectorSimulationState for the circuit.
+            _StateVectorSimulationState for the circuit.
         """
-        if isinstance(initial_state, state_vector_simulation_state.StateVectorSimulationState):
+        if isinstance(initial_state, state_vector_simulation_state._StateVectorSimulationState):
             return initial_state
 
-        return state_vector_simulation_state.StateVectorSimulationState(
+        return state_vector_simulation_state._StateVectorSimulationState(
             qubits=qubits,
             prng=self._prng,
             classical_data=classical_data,
@@ -184,7 +185,7 @@ class Simulator(
         )
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]'
+        self, sim_state: 'cirq.SimulationStateBase[_StateVectorSimulationState]'
     ):
         return SparseSimulatorStep(sim_state=sim_state, dtype=self._dtype)
 
@@ -229,7 +230,7 @@ class SparseSimulatorStep(
     )
     def __init__(
         self,
-        sim_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]',
+        sim_state: 'cirq.SimulationStateBase[_StateVectorSimulationState]',
         simulator: 'cirq.Simulator' = None,
         dtype: 'DTypeLike' = np.complex64,
     ):

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -20,6 +20,7 @@ import pytest
 import sympy
 
 import cirq
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
 def test_invalid_dtype():
@@ -752,7 +753,7 @@ def test_does_not_modify_initial_state():
 
 def test_simulator_step_state_mixin():
     qubits = cirq.LineQubit.range(2)
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.array([0, 1, 0, 0]).reshape((2, 2)),
         prng=cirq.value.parse_random_state(0),
         qubits=qubits,
@@ -770,7 +771,7 @@ def test_simulator_step_state_mixin():
 
 def test_sparse_simulator_repr():
     qubits = cirq.LineQubit.range(2)
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.array([0, 1, 0, 0]).reshape((2, 2)),
         prng=cirq.value.parse_random_state(0),
         qubits=qubits,
@@ -780,7 +781,8 @@ def test_sparse_simulator_repr():
     step = cirq.SparseSimulatorStep(sim_state=args, dtype=np.complex64)
     # No equality so cannot use cirq.testing.assert_equivalent_repr
     assert (
-        repr(step) == "cirq.SparseSimulatorStep(sim_state=cirq.StateVectorSimulationState("
+        repr(step) == "cirq.SparseSimulatorStep(sim_state="
+        "cirq.sim.state_vector_simulation_state._StateVectorSimulationState("
         "initial_state=np.array([[0j, (1+0j)], [0j, 0j]], dtype=np.complex64), "
         "qubits=(cirq.LineQubit(0), cirq.LineQubit(1)), "
         "classical_data=cirq.ClassicalDataDictionaryStore()), dtype=np.complex64)"

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -293,7 +293,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         """Gives a new state vector for the system.
 
         Typically, the new state vector should be `args.available_buffer` where
-        `args` is this `cirq.StateVectorSimulationState` instance.
+        `args` is this `_StateVectorSimulationState` instance.
 
         Args:
             new_target_tensor: The new system state. Must have the same shape
@@ -308,7 +308,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         return True
 
 
-class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
+class _StateVectorSimulationState(SimulationState[_BufferedStateVector]):
     """State and context for an operation acting on a state vector.
 
     There are two common ways to act on this object:
@@ -329,7 +329,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         dtype: Type[np.number] = np.complex64,
         classical_data: Optional['cirq.ClassicalDataStore'] = None,
     ):
-        """Inits StateVectorSimulationState.
+        """Inits _StateVectorSimulationState.
 
         Args:
             available_buffer: A workspace with the same shape and dtype as
@@ -365,7 +365,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         """Gives a new state vector for the system.
 
         Typically, the new state vector should be `args.available_buffer` where
-        `args` is this `cirq.StateVectorSimulationState` instance.
+        `args` is this `_StateVectorSimulationState` instance.
 
         Args:
             new_target_tensor: The new system state. Must have the same shape
@@ -456,7 +456,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
 
     def __repr__(self) -> str:
         return (
-            'cirq.StateVectorSimulationState('
+            'cirq.sim.state_vector_simulation_state._StateVectorSimulationState('
             f'initial_state={proper_repr(self.target_tensor)},'
             f' qubits={self.qubits!r},'
             f' classical_data={self.classical_data!r})'
@@ -471,14 +471,25 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         return self._state._buffer
 
 
+@_compat.deprecated_class(
+    deadline='v0.16',
+    fix=(
+        'This class is now private. If you must use it, replace it with '
+        'cirq.sim.state_vector_simulation_state._StateVectorSimulationState.'
+    ),
+)
+class StateVectorSimulationState(_StateVectorSimulationState):
+    pass
+
+
 def _strat_act_on_state_vector_from_apply_unitary(
-    action: Any, args: 'cirq.StateVectorSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: '_StateVectorSimulationState', qubits: Sequence['cirq.Qid']
 ) -> bool:
     return True if args._state.apply_unitary(action, args.get_axes(qubits)) else NotImplemented
 
 
 def _strat_act_on_state_vector_from_mixture(
-    action: Any, args: 'cirq.StateVectorSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: '_StateVectorSimulationState', qubits: Sequence['cirq.Qid']
 ) -> bool:
     index = args._state.apply_mixture(action, args.get_axes(qubits), args.prng)
     if index is None:
@@ -490,7 +501,7 @@ def _strat_act_on_state_vector_from_mixture(
 
 
 def _strat_act_on_state_vector_from_channel(
-    action: Any, args: 'cirq.StateVectorSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: '_StateVectorSimulationState', qubits: Sequence['cirq.Qid']
 ) -> bool:
     index = args._state.apply_channel(action, args.get_axes(qubits), args.prng)
     if index is None:

--- a/cirq-core/cirq/sim/state_vector_simulation_state_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state_test.py
@@ -18,13 +18,14 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
 def test_default_parameter():
     dtype = np.complex64
     tensor = cirq.one_hot(shape=(2, 2, 2), dtype=np.complex64)
     qubits = cirq.LineQubit.range(3)
-    args = cirq.StateVectorSimulationState(qubits=qubits, initial_state=tensor, dtype=dtype)
+    args = _StateVectorSimulationState(qubits=qubits, initial_state=tensor, dtype=dtype)
     qid_shape = cirq.protocols.qid_shape(qubits)
     tensor = np.reshape(tensor, qid_shape)
     np.testing.assert_almost_equal(args.target_tensor, tensor)
@@ -34,7 +35,7 @@ def test_default_parameter():
 
 def test_infer_target_tensor():
     dtype = np.complex64
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         qubits=cirq.LineQubit.range(2),
         initial_state=np.array([1.0, 0.0, 0.0, 0.0], dtype=dtype),
         dtype=dtype,
@@ -44,9 +45,7 @@ def test_infer_target_tensor():
         np.array([[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 0.0 + 0.0j]], dtype=dtype),
     )
 
-    args = cirq.StateVectorSimulationState(
-        qubits=cirq.LineQubit.range(2), initial_state=0, dtype=dtype
-    )
+    args = _StateVectorSimulationState(qubits=cirq.LineQubit.range(2), initial_state=0, dtype=dtype)
     np.testing.assert_almost_equal(
         args.target_tensor,
         np.array([[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 0.0 + 0.0j]], dtype=dtype),
@@ -54,7 +53,7 @@ def test_infer_target_tensor():
 
 
 def test_shallow_copy_buffers():
-    args = cirq.StateVectorSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
+    args = _StateVectorSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
     copy = args.copy(deep_copy_buffers=False)
     assert copy.available_buffer is args.available_buffer
 
@@ -67,7 +66,7 @@ def test_decomposed_fallback():
         def _decompose_(self, qubits):
             yield cirq.X(*qubits)
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty((2, 2, 2), dtype=np.complex64),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
@@ -85,7 +84,7 @@ def test_cannot_act():
     class NoDetails:
         pass
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty((2, 2, 2), dtype=np.complex64),
         qubits=cirq.LineQubit.range(3),
         prng=np.random.RandomState(),
@@ -109,7 +108,7 @@ def test_act_using_probabilistic_single_qubit_channel():
     mock_prng = mock.Mock()
 
     mock_prng.random.return_value = 1 / 3 + 1e-6
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty_like(initial_state),
         qubits=cirq.LineQubit.range(4),
         prng=mock_prng,
@@ -128,7 +127,7 @@ def test_act_using_probabilistic_single_qubit_channel():
     )
 
     mock_prng.random.return_value = 1 / 3 - 1e-6
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty_like(initial_state),
         qubits=cirq.LineQubit.range(4),
         prng=mock_prng,
@@ -165,7 +164,7 @@ def test_act_using_adaptive_two_qubit_channel():
 
     def get_result(state: np.ndarray, sample: float):
         mock_prng.random.return_value = sample
-        args = cirq.StateVectorSimulationState(
+        args = _StateVectorSimulationState(
             available_buffer=np.empty_like(state),
             qubits=cirq.LineQubit.range(4),
             prng=mock_prng,
@@ -220,7 +219,7 @@ def test_probability_comes_up_short_results_in_fallback():
     mock_prng = mock.Mock()
     mock_prng.random.return_value = 0.9999
 
-    args = cirq.StateVectorSimulationState(
+    args = _StateVectorSimulationState(
         available_buffer=np.empty(2, dtype=np.complex64),
         qubits=cirq.LineQubit.range(1),
         prng=mock_prng,
@@ -269,7 +268,7 @@ def test_measured_mixture():
 
 
 def test_with_qubits():
-    original = cirq.StateVectorSimulationState(
+    original = _StateVectorSimulationState(
         qubits=cirq.LineQubit.range(2), initial_state=1, dtype=np.complex64
     )
     extened = original.with_qubits(cirq.LineQubit.range(2, 4))
@@ -288,7 +287,7 @@ def test_qid_shape_error():
 
 
 def test_deprecated_methods():
-    args = cirq.StateVectorSimulationState(qubits=[cirq.LineQubit(0)])
+    args = _StateVectorSimulationState(qubits=[cirq.LineQubit(0)])
     with cirq.testing.assert_deprecated('unintentionally made public', deadline='v0.16'):
         args.subspace_index([0], 0)
     with cirq.testing.assert_deprecated('unintentionally made public', deadline='v0.16'):

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -35,6 +35,7 @@ from cirq.sim import simulator, state_vector, simulator_base
 
 if TYPE_CHECKING:
     import cirq
+    from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
 TStateVectorStepResult = TypeVar('TStateVectorStepResult', bound='StateVectorStepResult')
@@ -43,7 +44,7 @@ TStateVectorStepResult = TypeVar('TStateVectorStepResult', bound='StateVectorSte
 class SimulatesIntermediateStateVector(
     Generic[TStateVectorStepResult],
     simulator_base.SimulatorBase[
-        TStateVectorStepResult, 'cirq.StateVectorTrialResult', 'cirq.StateVectorSimulationState',
+        TStateVectorStepResult, 'cirq.StateVectorTrialResult', '_StateVectorSimulationState',
     ],
     simulator.SimulatesAmplitudes,
     metaclass=abc.ABCMeta,
@@ -69,7 +70,7 @@ class SimulatesIntermediateStateVector(
         self,
         params: 'cirq.ParamResolver',
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]',
+        final_simulator_state: 'cirq.SimulationStateBase[_StateVectorSimulationState]',
     ) -> 'cirq.StateVectorTrialResult':
         return StateVectorTrialResult(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
@@ -102,7 +103,7 @@ class SimulatesIntermediateStateVector(
 
 
 class StateVectorStepResult(
-    simulator_base.StepResultBase['cirq.StateVectorSimulationState'], metaclass=abc.ABCMeta
+    simulator_base.StepResultBase['_StateVectorSimulationState'], metaclass=abc.ABCMeta
 ):
     pass
 
@@ -137,7 +138,7 @@ class StateVectorSimulatorState:
 @value.value_equality(unhashable=True)
 class StateVectorTrialResult(
     state_vector.StateVectorMixin,
-    simulator_base.SimulationTrialResultBase['cirq.StateVectorSimulationState'],
+    simulator_base.SimulationTrialResultBase['_StateVectorSimulationState'],
 ):
     """A `SimulationTrialResult` that includes the `StateVectorMixin` methods.
 
@@ -149,7 +150,7 @@ class StateVectorTrialResult(
         self,
         params: 'cirq.ParamResolver',
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]',
+        final_simulator_state: 'cirq.SimulationStateBase[_StateVectorSimulationState]',
     ) -> None:
         super().__init__(
             params=params,

--- a/cirq-core/cirq/sim/state_vector_simulator_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulator_test.py
@@ -16,11 +16,12 @@ import numpy as np
 
 import cirq
 import cirq.testing
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 
 
 def test_state_vector_trial_result_repr():
     q0 = cirq.NamedQubit('a')
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         available_buffer=np.array([0, 1], dtype=np.complex64),
         prng=np.random.RandomState(0),
         qubits=[q0],
@@ -36,7 +37,7 @@ def test_state_vector_trial_result_repr():
         "cirq.StateVectorTrialResult("
         "params=cirq.ParamResolver({'s': 1}), "
         "measurements={'m': np.array([[1]], dtype=np.int32)}, "
-        "final_simulator_state=cirq.StateVectorSimulationState("
+        "final_simulator_state=cirq.sim.state_vector_simulation_state._StateVectorSimulationState("
         "initial_state=np.array([0j, (1+0j)], dtype=np.complex64), "
         "qubits=(cirq.NamedQubit('a'),), "
         "classical_data=cirq.ClassicalDataDictionaryStore()))"
@@ -55,7 +56,7 @@ def test_state_vector_simulator_state_repr():
 
 def test_state_vector_trial_result_equality():
     eq = cirq.testing.EqualsTester()
-    final_simulator_state = cirq.StateVectorSimulationState(initial_state=np.array([]))
+    final_simulator_state = _StateVectorSimulationState(initial_state=np.array([]))
     eq.add_equality_group(
         cirq.StateVectorTrialResult(
             params=cirq.ParamResolver({}),
@@ -82,7 +83,7 @@ def test_state_vector_trial_result_equality():
             final_simulator_state=final_simulator_state,
         )
     )
-    final_simulator_state = cirq.StateVectorSimulationState(initial_state=np.array([1]))
+    final_simulator_state = _StateVectorSimulationState(initial_state=np.array([1]))
     eq.add_equality_group(
         cirq.StateVectorTrialResult(
             params=cirq.ParamResolver({'s': 1}),
@@ -94,7 +95,7 @@ def test_state_vector_trial_result_equality():
 
 def test_state_vector_trial_result_state_mixin():
     qubits = cirq.LineQubit.range(2)
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         qubits=qubits, initial_state=np.array([0, 1, 0, 0])
     )
     result = cirq.StateVectorTrialResult(
@@ -110,7 +111,7 @@ def test_state_vector_trial_result_state_mixin():
 
 
 def test_state_vector_trial_result_qid_shape():
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         qubits=[cirq.NamedQubit('a')], initial_state=np.array([0, 1])
     )
     trial_result = cirq.StateVectorTrialResult(
@@ -120,7 +121,7 @@ def test_state_vector_trial_result_qid_shape():
     )
     assert cirq.qid_shape(trial_result) == (2,)
 
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         qubits=cirq.LineQid.for_qid_shape((3, 2)), initial_state=np.array([0, 0, 0, 0, 1, 0])
     )
     trial_result = cirq.StateVectorTrialResult(
@@ -134,7 +135,7 @@ def test_state_vector_trial_result_qid_shape():
 def test_state_vector_trial_state_vector_is_copy():
     final_state_vector = np.array([0, 1], dtype=np.complex64)
     qubit_map = {cirq.NamedQubit('a'): 0}
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         qubits=list(qubit_map), initial_state=final_state_vector
     )
     trial_result = cirq.StateVectorTrialResult(
@@ -146,7 +147,7 @@ def test_state_vector_trial_state_vector_is_copy():
 def test_implicit_copy_deprecated():
     final_state_vector = np.array([0, 1], dtype=np.complex64)
     qubit_map = {cirq.NamedQubit('a'): 0}
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         qubits=list(qubit_map), initial_state=final_state_vector
     )
     trial_result = cirq.StateVectorTrialResult(
@@ -161,7 +162,7 @@ def test_implicit_copy_deprecated():
 
 def test_str_big():
     qs = cirq.LineQubit.range(10)
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         prng=np.random.RandomState(0),
         qubits=qs,
         initial_state=np.array([1] * 2**10, dtype=np.complex64) * 0.03125,
@@ -172,7 +173,7 @@ def test_str_big():
 
 
 def test_pretty_print():
-    final_simulator_state = cirq.StateVectorSimulationState(
+    final_simulator_state = _StateVectorSimulationState(
         available_buffer=np.array([1]),
         prng=np.random.RandomState(0),
         qubits=[],

--- a/cirq-core/cirq/testing/consistent_act_on.py
+++ b/cirq-core/cirq/testing/consistent_act_on.py
@@ -46,7 +46,7 @@ def state_vector_has_stabilizer(state_vector: np.ndarray, stabilizer: DensePauli
     """
 
     qubits = LineQubit.range(protocols.num_qubits(stabilizer))
-    args = state_vector_simulation_state.StateVectorSimulationState(
+    args = state_vector_simulation_state._StateVectorSimulationState(
         available_buffer=np.empty_like(state_vector),
         qubits=qubits,
         prng=np.random.RandomState(),
@@ -71,7 +71,7 @@ def assert_all_implemented_act_on_effects_match_unitary(
     Args:
         val: A gate or operation that may be an input to protocols.act_on.
         assert_tableau_implemented: asserts that protocols.act_on() works with
-          val and CliffordTableauSimulationState inputs.
+          val and _CliffordTableauSimulationState inputs.
         assert_ch_form_implemented: asserts that protocols.act_on() works with
           val and ActOnStabilizerStateChFormArgs inputs.
     """
@@ -159,7 +159,7 @@ def _final_clifford_tableau(
         the tableau otherwise."""
 
     tableau = clifford_tableau.CliffordTableau(len(qubit_map))
-    args = clifford_tableau_simulation_state.CliffordTableauSimulationState(
+    args = clifford_tableau_simulation_state._CliffordTableauSimulationState(
         tableau=tableau, qubits=list(qubit_map.keys()), prng=np.random.RandomState()
     )
     for op in circuit.all_operations():
@@ -187,7 +187,7 @@ def _final_stabilizer_state_ch_form(
         returns the StabilizerStateChForm otherwise."""
 
     stabilizer_ch_form = stabilizer_state_ch_form.StabilizerStateChForm(len(qubit_map))
-    args = stabilizer_ch_form_simulation_state.StabilizerChFormSimulationState(
+    args = stabilizer_ch_form_simulation_state._StabilizerChFormSimulationState(
         qubits=list(qubit_map.keys()),
         prng=np.random.RandomState(),
         initial_state=stabilizer_ch_form,

--- a/cirq-core/cirq/testing/consistent_act_on_test.py
+++ b/cirq-core/cirq/testing/consistent_act_on_test.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 import cirq
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 
 
 class GoodGate(cirq.testing.SingleQubitGate):
@@ -25,7 +26,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
         return np.array([[0, 1], [1, 0]])
 
     def _act_on_(self, sim_state: 'cirq.SimulationStateBase', qubits: Sequence['cirq.Qid']):
-        if isinstance(sim_state, cirq.CliffordTableauSimulationState):
+        if isinstance(sim_state, _CliffordTableauSimulationState):
             tableau = sim_state.tableau
             q = sim_state.qubit_map[qubits[0]]
             tableau.rs[:] ^= tableau.zs[:, q]
@@ -38,7 +39,7 @@ class BadGate(cirq.testing.SingleQubitGate):
         return np.array([[0, 1j], [1, 0]])
 
     def _act_on_(self, sim_state: 'cirq.SimulationStateBase', qubits: Sequence['cirq.Qid']):
-        if isinstance(sim_state, cirq.CliffordTableauSimulationState):
+        if isinstance(sim_state, _CliffordTableauSimulationState):
             tableau = sim_state.tableau
             q = sim_state.qubit_map[qubits[0]]
             tableau.rs[:] ^= tableau.zs[:, q]

--- a/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition.py
@@ -18,7 +18,8 @@ from typing import List, TYPE_CHECKING
 import functools
 
 import numpy as np
-from cirq import ops, protocols, qis, sim
+from cirq import ops, protocols, qis
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 
 if TYPE_CHECKING:
     import cirq
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
 
 def _X(
     q: int,
-    args: sim.CliffordTableauSimulationState,
+    args: _CliffordTableauSimulationState,
     operations: List[ops.Operation],
     qubits: List['cirq.Qid'],
 ):
@@ -36,7 +37,7 @@ def _X(
 
 def _Z(
     q: int,
-    args: sim.CliffordTableauSimulationState,
+    args: _CliffordTableauSimulationState,
     operations: List[ops.Operation],
     qubits: List['cirq.Qid'],
 ):
@@ -46,7 +47,7 @@ def _Z(
 
 def _Sdg(
     q: int,
-    args: sim.CliffordTableauSimulationState,
+    args: _CliffordTableauSimulationState,
     operations: List[ops.Operation],
     qubits: List['cirq.Qid'],
 ):
@@ -57,7 +58,7 @@ def _Sdg(
 
 def _H(
     q: int,
-    args: sim.CliffordTableauSimulationState,
+    args: _CliffordTableauSimulationState,
     operations: List[ops.Operation],
     qubits: List['cirq.Qid'],
 ):
@@ -68,7 +69,7 @@ def _H(
 def _CNOT(
     q1: int,
     q2: int,
-    args: sim.CliffordTableauSimulationState,
+    args: _CliffordTableauSimulationState,
     operations: List[ops.Operation],
     qubits: List['cirq.Qid'],
 ):
@@ -79,7 +80,7 @@ def _CNOT(
 def _SWAP(
     q1: int,
     q2: int,
-    args: sim.CliffordTableauSimulationState,
+    args: _CliffordTableauSimulationState,
     operations: List[ops.Operation],
     qubits: List['cirq.Qid'],
 ):
@@ -114,9 +115,7 @@ def decompose_clifford_tableau_to_operations(
 
     t: qis.CliffordTableau = clifford_tableau.copy()
     operations: List[ops.Operation] = []
-    args = sim.CliffordTableauSimulationState(
-        tableau=t, qubits=qubits, prng=np.random.RandomState()
-    )
+    args = _CliffordTableauSimulationState(tableau=t, qubits=qubits, prng=np.random.RandomState())
 
     _X_with_ops = functools.partial(_X, args=args, operations=operations, qubits=qubits)
     _Z_with_ops = functools.partial(_Z, args=args, operations=operations, qubits=qubits)

--- a/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition_test.py
@@ -16,6 +16,7 @@ import pytest
 import numpy as np
 
 import cirq
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 from cirq.testing import assert_allclose_up_to_global_phase
 
 ALLOW_DEPRECATION_IN_TEST = 'ALLOW_DEPRECATION_IN_TEST'
@@ -39,7 +40,7 @@ def test_misaligned_qubits():
 def test_clifford_decompose_one_qubit():
     """Two random instance for one qubit decomposition."""
     qubits = cirq.LineQubit.range(1)
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=1), qubits=qubits, prng=np.random.RandomState()
     )
     cirq.act_on(cirq.X, args, qubits=[qubits[0]], allow_decompose=False)
@@ -51,7 +52,7 @@ def test_clifford_decompose_one_qubit():
     assert_allclose_up_to_global_phase(cirq.unitary(expect_circ), cirq.unitary(circ), atol=1e-7)
 
     qubits = cirq.LineQubit.range(1)
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=1), qubits=qubits, prng=np.random.RandomState()
     )
     cirq.act_on(cirq.Z, args, qubits=[qubits[0]], allow_decompose=False)
@@ -74,7 +75,7 @@ def test_clifford_decompose_one_qubit():
 def test_clifford_decompose_two_qubits():
     """Two random instance for two qubits decomposition."""
     qubits = cirq.LineQubit.range(2)
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=2), qubits=qubits, prng=np.random.RandomState()
     )
     cirq.act_on(cirq.H, args, qubits=[qubits[0]], allow_decompose=False)
@@ -85,7 +86,7 @@ def test_clifford_decompose_two_qubits():
     assert_allclose_up_to_global_phase(cirq.unitary(expect_circ), cirq.unitary(circ), atol=1e-7)
 
     qubits = cirq.LineQubit.range(2)
-    args = cirq.CliffordTableauSimulationState(
+    args = _CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=2), qubits=qubits, prng=np.random.RandomState()
     )
     cirq.act_on(cirq.H, args, qubits=[qubits[0]], allow_decompose=False)
@@ -118,7 +119,7 @@ def test_clifford_decompose_by_unitary():
         t = cirq.CliffordTableau(num_qubits=n)
         qubits = cirq.LineQubit.range(n)
         expect_circ = cirq.Circuit()
-        args = cirq.CliffordTableauSimulationState(tableau=t, qubits=qubits, prng=prng)
+        args = _CliffordTableauSimulationState(tableau=t, qubits=qubits, prng=prng)
         for _ in range(num_ops):
             g = prng.randint(len(gate_candidate))
             indices = (prng.randint(n),) if g < 5 else prng.choice(n, 2, replace=False)
@@ -145,7 +146,7 @@ def test_clifford_decompose_by_reconstruction():
         t = cirq.CliffordTableau(num_qubits=n)
         qubits = cirq.LineQubit.range(n)
         expect_circ = cirq.Circuit()
-        args = cirq.CliffordTableauSimulationState(tableau=t, qubits=qubits, prng=prng)
+        args = _CliffordTableauSimulationState(tableau=t, qubits=qubits, prng=prng)
         for _ in range(num_ops):
             g = prng.randint(len(gate_candidate))
             indices = (prng.randint(n),) if g < 5 else prng.choice(n, 2, replace=False)
@@ -156,7 +157,7 @@ def test_clifford_decompose_by_reconstruction():
         ops = cirq.decompose_clifford_tableau_to_operations(qubits, args.tableau)
 
         reconstruct_t = cirq.CliffordTableau(num_qubits=n)
-        reconstruct_args = cirq.CliffordTableauSimulationState(
+        reconstruct_args = _CliffordTableauSimulationState(
             tableau=reconstruct_t, qubits=qubits, prng=prng
         )
         for op in ops:

--- a/cirq-google/cirq_google/calibration/engine_simulator.py
+++ b/cirq-google/cirq_google/calibration/engine_simulator.py
@@ -29,6 +29,7 @@ import numpy as np
 
 import cirq
 from cirq import value
+from cirq.sim.state_vector_simulation_state import _StateVectorSimulationState
 from cirq_google.calibration.phased_fsim import (
     FloquetPhasedFSimCalibrationRequest,
     PhaseCalibratedFSimGate,
@@ -466,10 +467,10 @@ class PhasedFSimEngineSimulator(cirq.SimulatesIntermediateStateVector[cirq.Spars
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union[int, cirq.StateVectorSimulationState],
+        initial_state: Union[int, _StateVectorSimulationState],
         qubits: Sequence[cirq.Qid],
         classical_data: cirq.ClassicalDataStore,
-    ) -> cirq.StateVectorSimulationState:
+    ) -> _StateVectorSimulationState:
         # Needs an implementation since it's abstract but will never actually be called.
         raise NotImplementedError()
 

--- a/examples/direct_fidelity_estimation.py
+++ b/examples/direct_fidelity_estimation.py
@@ -29,7 +29,7 @@ from typing import cast, List, Optional, Tuple
 import cirq
 import duet
 import numpy as np
-from cirq.sim import clifford
+from cirq.sim.clifford.clifford_tableau_simulation_state import _CliffordTableauSimulationState
 
 
 def build_circuit() -> Tuple[cirq.Circuit, List[cirq.Qid]]:
@@ -369,9 +369,7 @@ def direct_fidelity_estimation(
     clifford_tableau = cirq.CliffordTableau(n_qubits)
     try:
         for gate in circuit.all_operations():
-            tableau_args = clifford.CliffordTableauSimulationState(
-                tableau=clifford_tableau, qubits=qubits
-            )
+            tableau_args = _CliffordTableauSimulationState(tableau=clifford_tableau, qubits=qubits)
             cirq.act_on(gate, tableau_args)
     except TypeError:
         clifford_circuit = False


### PR DESCRIPTION
Fixes #5401.

Prepends an underscore in front of all `SimulationState` subclass names, then handles the fallout of that change.