### PR TITLE
Import cirq after installation in calibration tutorials

### DIFF
--- a/docs/noise/calibration_api.ipynb
+++ b/docs/noise/calibration_api.ipynb
@@ -105,7 +105,8 @@
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")\n",
-    "print(cirq.__version__)"
+    "    import cirq\n",
+    "print(\"Using cirq version\", cirq.__version__)"
    ]
   },
   {

--- a/docs/noise/floquet_calibration_example.ipynb
+++ b/docs/noise/floquet_calibration_example.ipynb
@@ -108,7 +108,8 @@
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")\n",
-    "(cirq.__version__)"
+    "    import cirq\n",
+    "print(\"Using cirq version\", cirq.__version__)"
    ]
   },
   {


### PR DESCRIPTION
Avoid NameError in the initial run of the colab which installs cirq.
No need to scare first-time users with error traceback.
