### PR TITLE
Remove Rigetti from local checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Run Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Coverage check
-        run: check/pytest-and-incremental-coverage -n auto
+        run: check/pytest-and-incremental-coverage -n auto --rigetti-integration
       - name: Stop Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
   windows:

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -72,7 +72,6 @@ source dev_tools/pypath
 
 # Run tests while producing coverage files.
 check/pytest --actually-quiet \
-             --rigetti-integration \
              --cov \
              --cov-config=dev_tools/conf/.coveragerc \
              "${PYTEST_ARGS[@]}"

--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -347,7 +347,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -374,7 +374,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -393,7 +393,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -412,7 +412,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -431,7 +431,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -462,7 +462,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -481,7 +481,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout == (
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'
@@ -507,7 +507,7 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.returncode == 0
     assert result.stdout.startswith(
         'INTERCEPTED check/pytest '
-        '--actually-quiet --rigetti-integration --cov '
+        '--actually-quiet --cov '
         '--cov-config=dev_tools/conf/.coveragerc\n'
         'The annotate command will be removed in a future version.\n'
         'Get in touch if you still use it: ned@nedbatchelder.com\n'


### PR DESCRIPTION
This remove the rigetti integration tests from the default of `pytest-and-incremental-coverage` and hence of `all`.  It keeps these tests in the CI workflow.  

The alternative to this would be to add the docker up and down to these scripts, but I'm hesitant to do this as these download external docker images.

Fixes #4660