### PR TITLE
Improve typing in commutes and apply_unitary protocols

### DIFF
--- a/cirq-core/cirq/contrib/paulistring/pauli_string_dag.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_dag.py
@@ -21,7 +21,7 @@ from cirq.contrib import circuitdag
 def pauli_string_reorder_pred(op1: ops.Operation, op2: ops.Operation) -> bool:
     ps1 = cast(ops.PauliStringGateOperation, op1).pauli_string
     ps2 = cast(ops.PauliStringGateOperation, op2).pauli_string
-    return protocols.commutes(ps1, ps2)
+    return bool(protocols.commutes(ps1, ps2))
 
 
 def pauli_string_dag_from_circuit(circuit: circuits.Circuit) -> circuitdag.CircuitDag:


### PR DESCRIPTION
- In `commutes_protocol` use local marker-only type for raising
  TypeError.  Require the `default` argument to be either that,
  bool or None for indeterminate result.  Take out np.ndarray
  from that typing enchilada.

- Simplify typing in protocols `apply_unitary`, `apply_unitaries`
  Require `default` argument to be only of np.ndarray type,
  do not let it be None.
