### PR TITLE
Remove qubit pair ordering requirement in SerializableDevice

### DIFF
--- a/cirq-google/cirq_google/devices/serializable_device.py
+++ b/cirq-google/cirq_google/devices/serializable_device.py
@@ -108,7 +108,7 @@ class SerializableDevice(cirq.Device):
                 for gate_def in gate_defs
                 if gate_def.number_of_qubits == 2
                 for pair in gate_def.target_set
-                if len(pair) == 2 and pair[0] < pair[1]
+                if len(pair) == 2
             ],
             gateset=cirq.Gateset(
                 *(g for g in gate_definitions.keys() if issubclass(g, cirq.Gate)),

--- a/cirq-google/cirq_google/devices/serializable_device_test.py
+++ b/cirq-google/cirq_google/devices/serializable_device_test.py
@@ -121,7 +121,7 @@ def test_metadata_correct():
         pairs = [
             (qubits[0], qubits[1]),
             (qubits[0], qubits[3]),
-            (qubits[1], qubits[4]),
+            (qubits[4], qubits[1]),
             (qubits[4], qubits[5]),
         ]
         device_proto = cgdk.create_device_proto_for_qubits(


### PR DESCRIPTION
This call site was missed after https://github.com/quantumlib/Cirq/issues/5169 was fixed.

If `gate_definitions` contain a pair of the same qubit, GridDeviceMetadata will throw a ValueError.

@mpharrigan 