### PR TITLE
Remove stale TODO and fix #5546

### DIFF
--- a/cirq-core/cirq/contrib/paulistring/optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/optimize_test.py
@@ -50,7 +50,6 @@ def test_optimize():
 
     cirq.testing.assert_allclose_up_to_global_phase(c_orig.unitary(), c_opt.unitary(), atol=1e-7)
 
-    # TODO(#5546) Fix '[Z]^1' (should be 'Z')
     cirq.testing.assert_has_diagram(
         c_opt,
         """


### PR DESCRIPTION
https://github.com/quantumlib/Cirq/issues/5546 was raised because the test diagram had to be changed from `─Z─` to  `─[Z]^1─`

This was caused because of precision issues caused by changing `np.complex128` to `np.complex64`. 

A recent PR (https://github.com/quantumlib/Cirq/commit/f904a09031b102a3ad5d7b55eff2c8efe565197f) rolled back the change and increased the precision back to `np.complex128`; thereby reverting the diagram to it's original form  `─Z─`.

We can remove the stale TODO and close the issue. 

Fixes https://github.com/quantumlib/Cirq/issues/5546