### PR TITLE
Fix CI failure due to incompatible qiskit packages

### DIFF
--- a/dev_tools/requirements/deps/dev-tools.txt
+++ b/dev_tools/requirements/deps/dev-tools.txt
@@ -11,7 +11,7 @@
 asv
 
 # For verifying behavior of qasm output.
-qiskit-aer~=0.9.1
+qiskit-aer~=0.10.4
 
 # For verifying rst
 rstcheck~=3.3.1


### PR DESCRIPTION
Both qiskit-aer and its dependency qiskit-terra attempt to write
`qiskit/providers/__init__.py`.  If the version from qiskit-aer 0.9.1
wins it causes broken import of qiskit.providers.aer.
Here we update qiskit-aer to its latest version 0.10.4.

This fixes failing CI checks for Python 3.8 such as
https://github.com/quantumlib/Cirq/runs/7139878042.
