### PR TITLE
Revert "Pin python-rapidjson in cirq-rigetti."

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -9,8 +9,6 @@ pydantic~=1.8.2
 pyjwt~=1.7.1
 pyquil~=2.28.2; python_version < "3.7"
 pyquil~=3.0.0; python_version >= "3.7"
-# Remove once https://github.com/python-rapidjson/python-rapidjson/issues/166 is resolved.
-python-rapidjson<=1.6
 python-dateutil~=2.8.1
 qcs-api-client~=0.8.0
 retrying~=1.3.3


### PR DESCRIPTION
Reverts quantumlib/Cirq#5666 now that https://github.com/python-rapidjson/python-rapidjson/issues/166 has been fixed.