### PR TITLE
Preparations to remove the proto field Program.language.gate_set

### DIFF
--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -14,6 +14,7 @@
 
 import datetime
 from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
+from cirq_google.serialization import circuit_serializer
 
 import duet
 from google.protobuf import any_pb2
@@ -24,18 +25,9 @@ from cirq_google.cloud import quantum
 from cirq_google.engine.result_type import ResultType
 from cirq_google.api import v2
 from cirq_google.engine import engine_job
-from cirq_google.serialization import gate_sets
 
 if TYPE_CHECKING:
     import cirq_google.engine.engine as engine_base
-
-
-_GOOGLE_GATESETS = [
-    gate_sets.SYC_GATESET,
-    gate_sets.SQRT_ISWAP_GATESET,
-    gate_sets.FSIM_GATESET,
-    gate_sets.XMON,
-]
 
 
 class EngineProgram(abstract_program.AbstractProgram):
@@ -563,13 +555,6 @@ def _deserialize_program(code: any_pb2.Any, program_num: Optional[int] = None) -
 
         program = batch.programs[program_num]
     if program is not None:
-        # TODO(#5050) Move to CircuitSerializer
-        gate_set_map = {g.name: g for g in _GOOGLE_GATESETS}
-        if program.language.gate_set not in gate_set_map:
-            raise ValueError(
-                f'Unknown gateset {program.language.gate_set}. '
-                f'Supported gatesets: {list(gate_set_map.keys())}.'
-            )
-        return gate_set_map[program.language.gate_set].deserialize(program)
+        return circuit_serializer.CIRCUIT_SERIALIZER.deserialize(program)
 
     raise ValueError(f'unsupported program type: {code_type}')

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -32,18 +32,11 @@ class CircuitSerializer(serializer.Serializer):
     to the `serialize()` method of the class, which will produce a
     `Program` proto.  Likewise, the `deserialize` method will produce
     a `cirq.Circuit` object from a `Program` proto.
-
-    This class is more performant than the previous `SerializableGateSet`
-    at the cost of some extendability.
     """
 
-    def __init__(self, gate_set_name: str):
-        """Construct the circuit serializer object.
-
-        Args:
-            gate_set_name: The name used to identify the gate set.
-        """
-        super().__init__(gate_set_name)
+    def __init__(self):
+        """Construct the circuit serializer object."""
+        super().__init__(gate_set_name='v2_5')
 
     def serialize(
         self,
@@ -608,4 +601,4 @@ class CircuitSerializer(serializer.Serializer):
         )
 
 
-CIRCUIT_SERIALIZER = CircuitSerializer('v2_5')
+CIRCUIT_SERIALIZER = CircuitSerializer()

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -69,7 +69,6 @@ class CircuitSerializer(serializer.Serializer):
         raw_constants: Dict[Any, int] = {}
         if msg is None:
             msg = v2.program_pb2.Program()
-        msg.language.gate_set = self.name
         msg.language.arg_function_language = (
             arg_function_language or arg_func_langs.MOST_PERMISSIVE_LANGUAGE
         )
@@ -314,19 +313,9 @@ class CircuitSerializer(serializer.Serializer):
             The deserialized Circuit
 
         Raises:
-            ValueError: If the given proto has no language or the langauge gate set mismatches
-                that specified in as the name of this serialized gate set. Also if deserializing
-                a schedule is attempted.
+            ValueError: If deserializing a schedule is attempted.
             NotImplementedError: If the program proto does not contain a circuit or schedule.
         """
-        if not proto.HasField('language') or not proto.language.gate_set:
-            raise ValueError('Missing gate set specification.')
-        if proto.language.gate_set != self.name:
-            raise ValueError(
-                'Gate set in proto was {} but expected {}'.format(
-                    proto.language.gate_set, self.name
-                )
-            )
         which = proto.WhichOneof('program')
         arg_func_language = (
             proto.language.arg_function_language or arg_func_langs.MOST_PERMISSIVE_LANGUAGE

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -38,7 +38,7 @@ def op_proto(json: Dict) -> v2.program_pb2.Operation:
 def circuit_proto(json: Dict, qubits: List[str]):
     constants = [v2.program_pb2.Constant(qubit=v2.program_pb2.Qubit(id=q)) for q in qubits]
     return v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[v2.program_pb2.Moment(operations=[op_proto(json)])],
@@ -260,7 +260,7 @@ def test_serialize_deserialize_ops(op, op_proto):
     # Serialize / Deserializer circuit with single operation
     circuit = cirq.Circuit(op)
     circuit_proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[v2.program_pb2.Moment(operations=[op_proto])],
@@ -278,7 +278,7 @@ def test_serialize_deserialize_circuit():
     circuit = cirq.Circuit(cirq.X(q0), cirq.X(q1), cirq.X(q0))
 
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[
@@ -347,7 +347,7 @@ def test_serialize_deserialize_circuit_with_tokens():
     op_q0_tag2.token_constant_index = 3
 
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[
@@ -371,7 +371,7 @@ def test_deserialize_circuit_with_token_strings():
     """Supporting token strings for backwards compatibility."""
     serializer = cg.CircuitSerializer('my_gate_set')
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[
@@ -433,7 +433,7 @@ def test_serialize_deserialize_circuit_with_subcircuit():
     qmap.value.id = '2_5'
 
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[
@@ -462,7 +462,7 @@ def test_serialize_deserialize_empty_circuit():
     circuit = cirq.Circuit()
 
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='exp', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT, moments=[]
         ),
@@ -476,7 +476,7 @@ def test_deserialize_empty_moment():
     circuit = cirq.Circuit([cirq.Moment()])
 
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language=''),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[v2.program_pb2.Moment()],
@@ -544,7 +544,7 @@ def test_deserialize_unsupported_gate_type():
         }
     )
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(arg_function_language='', gate_set='my_gate_set'),
+        language=v2.program_pb2.Language(arg_function_language=''),
         circuit=v2.program_pb2.Circuit(
             scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
             moments=[v2.program_pb2.Moment(operations=[operation_proto])],
@@ -578,34 +578,9 @@ def test_serialize_op_bad_operation():
         serializer.serialize(cirq.Circuit(null_op))
 
 
-def test_deserialize_invalid_gate_set():
-    serializer = cg.CircuitSerializer('my_gate_set')
-    proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(gate_set='not_my_gate_set'),
-        circuit=v2.program_pb2.Circuit(
-            scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT, moments=[]
-        ),
-    )
-    with pytest.raises(ValueError, match='not_my_gate_set'):
-        serializer.deserialize(proto)
-
-    proto.language.gate_set = ''
-    with pytest.raises(ValueError, match='Missing gate set'):
-        serializer.deserialize(proto)
-
-    proto = v2.program_pb2.Program(
-        circuit=v2.program_pb2.Circuit(
-            scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT, moments=[]
-        )
-    )
-    with pytest.raises(ValueError, match='Missing gate set'):
-        serializer.deserialize(proto)
-
-
 def test_deserialize_schedule_not_supported():
     serializer = cg.CircuitSerializer('my_gate_set')
     proto = v2.program_pb2.Program(
-        language=v2.program_pb2.Language(gate_set='my_gate_set'),
         schedule=v2.program_pb2.Schedule(
             scheduled_operations=[v2.program_pb2.ScheduledOperation(start_time_picos=0)]
         ),

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -251,7 +251,7 @@ OPERATIONS = [
 
 @pytest.mark.parametrize(('op', 'op_proto'), OPERATIONS)
 def test_serialize_deserialize_ops(op, op_proto):
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
 
     constants = []
 
@@ -272,7 +272,7 @@ def test_serialize_deserialize_ops(op, op_proto):
 
 
 def test_serialize_deserialize_circuit():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     q0 = cirq.GridQubit(1, 1)
     q1 = cirq.GridQubit(1, 2)
     circuit = cirq.Circuit(cirq.X(q0), cirq.X(q1), cirq.X(q0))
@@ -320,7 +320,7 @@ def test_serialize_deserialize_circuit():
 
 
 def test_serialize_deserialize_circuit_with_tokens():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     tag1 = cg.CalibrationTag('abc123')
     tag2 = cg.CalibrationTag('def456')
     circuit = cirq.Circuit(
@@ -369,7 +369,7 @@ def test_serialize_deserialize_circuit_with_tokens():
 
 def test_deserialize_circuit_with_token_strings():
     """Supporting token strings for backwards compatibility."""
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     proto = v2.program_pb2.Program(
         language=v2.program_pb2.Language(arg_function_language='exp'),
         circuit=v2.program_pb2.Circuit(
@@ -396,7 +396,7 @@ def test_deserialize_circuit_with_token_strings():
 
 
 def test_serialize_deserialize_circuit_with_subcircuit():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     tag1 = cg.CalibrationTag('abc123')
     fcircuit = cirq.FrozenCircuit(cirq.XPowGate(exponent=2 * sympy.Symbol('t'))(Q0))
     circuit = cirq.Circuit(
@@ -458,7 +458,7 @@ def test_serialize_deserialize_circuit_with_subcircuit():
 
 
 def test_serialize_deserialize_empty_circuit():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     circuit = cirq.Circuit()
 
     proto = v2.program_pb2.Program(
@@ -472,7 +472,7 @@ def test_serialize_deserialize_empty_circuit():
 
 
 def test_deserialize_empty_moment():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     circuit = cirq.Circuit([cirq.Moment()])
 
     proto = v2.program_pb2.Program(
@@ -486,15 +486,15 @@ def test_deserialize_empty_moment():
 
 
 def test_circuit_serializer_name():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     assert serializer.name == 'my_gate_set'
-    serializer = cg.CircuitSerializer('serial_box')
+    serializer = cg.CircuitSerializer()
     assert serializer.name == 'serial_box'
     assert cg.serialization.circuit_serializer.CIRCUIT_SERIALIZER.name == 'v2_5'
 
 
 def test_serialize_unrecognized():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     with pytest.raises(NotImplementedError, match='program type'):
         serializer.serialize("not quite right")
 
@@ -519,7 +519,7 @@ def default_circuit():
 
 
 def test_serialize_circuit_op_errors():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     constants = [default_circuit_proto()]
     raw_constants = {default_circuit(): 0}
 
@@ -535,7 +535,7 @@ def test_serialize_circuit_op_errors():
 
 
 def test_deserialize_unsupported_gate_type():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     operation_proto = op_proto(
         {
             'gate': {'id': 'no_pow'},
@@ -555,7 +555,7 @@ def test_deserialize_unsupported_gate_type():
 
 
 def test_serialize_op_unsupported_type():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     q0 = cirq.GridQubit(1, 1)
     q1 = cirq.GridQubit(1, 2)
     with pytest.raises(ValueError, match='CNOT'):
@@ -563,7 +563,7 @@ def test_serialize_op_unsupported_type():
 
 
 def test_serialize_op_bad_operation():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
 
     class NullOperation(cirq.Operation):
         @property
@@ -579,18 +579,18 @@ def test_serialize_op_bad_operation():
 
 
 def test_deserialize_schedule_not_supported():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     proto = v2.program_pb2.Program(
         schedule=v2.program_pb2.Schedule(
             scheduled_operations=[v2.program_pb2.ScheduledOperation(start_time_picos=0)]
-        ),
+        )
     )
     with pytest.raises(ValueError, match='no longer supported'):
         serializer.deserialize(proto)
 
 
 def test_deserialize_fsim_missing_parameters():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     proto = circuit_proto(
         {'fsimgate': {'theta': {'float_value': 3.0}}, 'qubit_constant_index': [0, 1]},
         ['1_1', '1_2'],
@@ -600,7 +600,7 @@ def test_deserialize_fsim_missing_parameters():
 
 
 def test_deserialize_wrong_types():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     proto = circuit_proto(
         {
             'measurementgate': {
@@ -616,7 +616,7 @@ def test_deserialize_wrong_types():
 
 
 def test_no_constants_table():
-    serializer = cg.CircuitSerializer('my_gate_set')
+    serializer = cg.CircuitSerializer()
     op = op_proto(
         {
             'xpowgate': {'exponent': {'float_value': 1.0}},


### PR DESCRIPTION
* Make CircuitSerializer the only 'gateset'
* Remove gate_set_name from CircuitSerializer constructor. This is a breaking change, but server side never references the class directly. Instead, it uses the CIRCUIT_SERIALIZER singleton.

@dstrain115 