### PR TITLE
json serialize SharedRuntimeInfo.device

### DIFF
--- a/cirq-google/cirq_google/json_test_data/cirq.google.ExecutableGroupResult.json
+++ b/cirq-google/cirq_google/json_test_data/cirq.google.ExecutableGroupResult.json
@@ -21,6 +21,7 @@
   "shared_runtime_info": {
     "cirq_type": "cirq.google.SharedRuntimeInfo",
     "run_id": "my run",
+    "device": null,
     "run_start_time": {
       "cirq_type": "datetime.datetime",
       "timestamp": 1651091275.571572

--- a/cirq-google/cirq_google/json_test_data/cirq.google.SharedRuntimeInfo.json
+++ b/cirq-google/cirq_google/json_test_data/cirq.google.SharedRuntimeInfo.json
@@ -1,6 +1,7 @@
 {
   "cirq_type": "cirq.google.SharedRuntimeInfo",
   "run_id": "my run",
+  "device": null,
   "run_start_time": {
     "cirq_type": "datetime.datetime",
     "timestamp": 1651091275.571572

--- a/cirq-google/cirq_google/workflow/quantum_runtime.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime.py
@@ -59,10 +59,7 @@ class SharedRuntimeInfo:
         return 'cirq.google'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        d = dataclass_json_dict(self)
-        # TODO (gh-4699): serialize `device` as well once SerializableDevice is serializable.
-        del d['device']
-        return d
+        return dataclass_json_dict(self)
 
     def __repr__(self) -> str:
         return _compat.dataclass_repr(self, namespace='cirq_google')

--- a/cirq-google/cirq_google/workflow/quantum_runtime_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime_test.py
@@ -201,9 +201,7 @@ def test_execute(tmpdir, rt_config):
         run_id=run_id, base_data_dir=tmpdir
     ).load(base_data_dir=tmpdir)
 
-    # TODO(gh-4699): Don't null-out device once it's serializable.
     assert isinstance(returned_exegroup_result.shared_runtime_info.device, cirq.Device)
-    returned_exegroup_result.shared_runtime_info.device = None
 
     assert returned_exegroup_result == exegroup_result
     assert manual_exegroup_result == exegroup_result


### PR DESCRIPTION
Include the SharedRuntimeInfo.device field in the JSON dump and
update the affected test data files.
