### PR TITLE
Remove unused method SimulationState.with_qubits

### DIFF
--- a/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
@@ -73,20 +73,6 @@ def test_cannot_act():
         cirq.act_on(NoDetails(), args, qubits=())
 
 
-def test_with_qubits():
-    original = cirq.DensityMatrixSimulationState(
-        qubits=cirq.LineQubit.range(1), initial_state=1, dtype=np.complex64
-    )
-    extened = original.with_qubits(cirq.LineQubit.range(1, 2))
-    np.testing.assert_almost_equal(
-        extened.target_tensor,
-        cirq.density_matrix_kronecker_product(
-            np.array([[0, 0], [0, 1]], dtype=np.complex64),
-            np.array([[1, 0], [0, 0]], dtype=np.complex64),
-        ),
-    )
-
-
 def test_qid_shape_error():
     with pytest.raises(ValueError, match="qid_shape must be provided"):
         cirq.sim.density_matrix_simulation_state._BufferedDensityMatrix.create(initial_state=0)

--- a/cirq-core/cirq/sim/simulation_state.py
+++ b/cirq-core/cirq/sim/simulation_state.py
@@ -173,27 +173,6 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         args._set_qubits(self.qubits + other.qubits)
         return args
 
-    def with_qubits(self: TSelf, qubits) -> TSelf:
-        """Extend current state space with added qubits.
-
-        The state of the added qubits is the default value set in the
-        subclasses. A new state space is created as the Kronecker product of
-        the original one and the added one.
-
-        Args:
-            qubits: The qubits to be added to the state space.
-
-        Returns:
-            A new subclass object containing the extended state space.
-        """
-        # TODO(#5721): Fix inconsistent usage of the `state` argument in the
-        # SimulationState base (required) and in its derived classes (unknown
-        # in StateVectorSimulationState), then remove the pylint filter below.
-        # pylint: disable=missing-kwoa
-        new_space = type(self)(qubits=qubits)  # type: ignore
-        # pylint: enable=missing-kwoa
-        return self.kronecker_product(new_space)
-
     def factor(
         self: TSelf, qubits: Sequence['cirq.Qid'], *, validate=True, atol=1e-07, inplace=False
     ) -> Tuple[TSelf, TSelf]:

--- a/cirq-core/cirq/sim/state_vector_simulation_state_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state_test.py
@@ -269,20 +269,6 @@ def test_measured_mixture():
     assert results.histogram(key='flip') == results.histogram(key='m')
 
 
-def test_with_qubits():
-    original = cirq.StateVectorSimulationState(
-        qubits=cirq.LineQubit.range(2), initial_state=1, dtype=np.complex64
-    )
-    extened = original.with_qubits(cirq.LineQubit.range(2, 4))
-    np.testing.assert_almost_equal(
-        extened.target_tensor,
-        cirq.state_vector_kronecker_product(
-            np.array([[0.0 + 0.0j, 1.0 + 0.0j], [0.0 + 0.0j, 0.0 + 0.0j]], dtype=np.complex64),
-            np.array([[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 0.0 + 0.0j]], dtype=np.complex64),
-        ),
-    )
-
-
 def test_qid_shape_error():
     with pytest.raises(ValueError, match="qid_shape must be provided"):
         cirq.sim.state_vector_simulation_state._BufferedStateVector.create(initial_state=0)


### PR DESCRIPTION
Avoid contradictory use of the constructor `state` argument,
which is required for the SimulationState base class,
but unknown to its derived classes.

Closes #5721
