### PR TITLE
Fix very trivial grammar issues & typos in docs/start/basics

### DIFF
--- a/docs/start/basics.ipynb
+++ b/docs/start/basics.ipynb
@@ -111,12 +111,12 @@
    "source": [
     "## Qubits\n",
     "\n",
-    "The first part of creating a quantum circuit is to define a set of qubits (also known as a quantum registers) to act on.\n",
+    "The first part of creating a quantum circuit is to define a set of qubits (also known as a quantum register) to act on.\n",
     "\n",
     "Cirq has three main ways of defining qubits:\n",
     "\n",
-    "*   `cirq.NamedQubit`: used to label qubits by an abstract name\n",
-    "*   `cirq.LineQubit`: qubits labelled by number in a linear array \n",
+    "*   `cirq.NamedQubit`: used to label qubits by an abstract name.\n",
+    "*   `cirq.LineQubit`: qubits labelled by number in a linear array.\n",
     "*   `cirq.GridQubit`: qubits labelled by two numbers in a rectangular lattice.\n",
     "\n",
     "Here are some examples of defining each type of qubit."
@@ -233,7 +233,7 @@
     "\n",
     "You are now ready to construct a quantum circuit.  A `Circuit` is a collection of `Moment`s. A `Moment` is a collection of `Operation`s that all act during the same abstract time slice.  Each `Operation` must be applied to a disjoint set of qubits compared to each of the other `Operation`s in the `Moment`.  A `Moment` can be thought of as a vertical slice of a quantum circuit diagram.\n",
     "\n",
-    "Circuits can be constructed in several different ways.  By default, cirq will attempt to slide your operation into the earliest possible `Moment` when you insert it. You can use the append function in two ways: \n",
+    "Circuits can be constructed in several different ways.  By default, Cirq will attempt to slide your operation into the earliest possible `Moment` when you insert it. You can use the append function in two ways: \n",
     "\n",
     "By appending each operation one-by-one: "
    ]
@@ -330,7 +330,7 @@
     "id": "3FC9bdlXmShh"
    },
    "source": [
-    "Sometimes, you may not want cirq to automatically shift operations all the way to the left.  To construct a circuit without doing this, you can create the circuit moment-by-moment or use a different `InsertStrategy`, explained more in the [Circuit documentation](/cirq/build/circuits.ipynb)."
+    "Sometimes, you may not want Cirq to automatically shift operations all the way to the left.  To construct a circuit without doing this, you can create the circuit moment-by-moment or use a different `InsertStrategy`, explained more in the [Circuit documentation](/cirq/build/circuits.ipynb)."
    ]
   },
   {
@@ -507,11 +507,11 @@
     "\n",
     "Cirq circuits allow for gates to have symbols as free parameters within the circuit.  This is especially useful for variational algorithms, which vary parameters within the circuit in order to optimize a cost function, but it can be useful in a variety of circumstances.\n",
     "\n",
-    "For parameters, cirq uses the library `sympy` to add `sympy.Symbol` as parameters to gates and operations.  \n",
+    "For parameters, Cirq uses the library `sympy` to add `sympy.Symbol` as parameters to gates and operations.  \n",
     "\n",
     "Once the circuit is complete, you can fill in the possible values of each of these parameters with a `Sweep`.  There are several possibilities that can be used as a sweep:\n",
     "\n",
-    "*   `cirq.Points`: A list of manually specified values for one specific symbol as a sequence of floats\n",
+    "*   `cirq.Points`: A list of manually specified values for one specific symbol as a sequence of floats.\n",
     "*   `cirq.Linspace`: A linear sweep from a starting value to an ending value.\n",
     "*   `cirq.ListSweep`: A list of manually specified values for several different symbols, specified as a list of dictionaries.\n",
     "*   `cirq.Zip` and `cirq.Product`: Sweeps can be combined list-wise by zipping them together or through their Cartesian product.\n",
@@ -643,7 +643,7 @@
    "source": [
     "### Transformers\n",
     "\n",
-    "The last concept in this tutorial is the transformer.  An transformer can take a circuit and modify it.  Usually, this will entail combining or modifying operations to make it more efficient and shorter, though an transformer can, in theory, do any sort of circuit manipulation.\n",
+    "The last concept in this tutorial is the transformer.  A transformer can take a circuit and modify it.  Usually, this will entail combining or modifying operations to make it more efficient and shorter, though a transformer can, in theory, do any sort of circuit manipulation.\n",
     "\n",
     "For example, the `cirq.merge_single_qubit_gates_to_phxz` transformer will take consecutive single-qubit operations and merge them into a single `PhasedXZ` operation."
    ]
@@ -684,12 +684,12 @@
     "\n",
     "There is much more to learn and try out for those who are interested:\n",
     "\n",
-    "* Learn about the variety of [Gates](/cirq/build/gates) available in cirq and more about the different ways to construct [Circuits](/cirq/build/circuits)\n",
+    "* Learn about the variety of [Gates](/cirq/build/gates) available in cirq and more about the different ways to construct [Circuits](/cirq/build/circuits).\n",
     "* Learn more about [Simulations](/cirq/simulate/simulation) and how it works.\n",
-    "* Learn about [Noise](/cirq/noise) and how to utilize multi-level systems using [Qudits](/cirq/build/qudits)\n",
+    "* Learn about [Noise](/cirq/noise) and how to utilize multi-level systems using [Qudits](/cirq/build/qudits).\n",
     "* Dive into some [Experiments](/cirq/experiments) and some in-depth tutorials of how to use cirq.\n",
     "\n",
-    "Also, join our [cirq-announce mailing list](https://groups.google.com/forum/#!forum/cirq-announce) to hear about changes and releases or go to the [cirq github](https://github.com/quantumlib/Cirq/) to file issues."
+    "Also, join our [cirq-announce mailing list](https://groups.google.com/forum/#!forum/cirq-announce) to hear about changes and releases or go to the [Cirq GitHub repository](https://github.com/quantumlib/Cirq/) to file issues."
    ]
   }
  ],


### PR DESCRIPTION
This is such a trivial PR, but I spotted them and figured I may as well offer to fix them very quickly.

This fixes a couple of very tiny grammar bugs, plus a few cases of cirq -> Cirq capitalization, and some missing periods at the ends of list items (to make all lists on the page follow the same convention).