### PR TITLE
Add .gitignore rules for Emacs backup and checkpoint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ docs/api_docs
 # Ignore Bazel files
 /bazel-*
 
+# Ignore Emacs backup & checkpoint files
+*~
+.\#*
+\#*#
+
 # Default pycharm virtual env
 .venv/
 


### PR DESCRIPTION
These additions to `.gitignore` make git ignore the normal backup files and checkpoint files created by most flavors of the Emacs editor.

Note: I will completely understand if people prefer to reject this PR. I'm submitting it as a concrete suggestion, but I'm aware there's a balance between adding `.gitignore` rules that enough people find useful versus adding every rule under the sun. There are other ways to handle this specific matter (of ignoring these Emacs files), so it will not be a burden for me if this doesn't get accepted. Adding it to the Cirq repo would be a convenience to me and other Emacs users out there (if there are any!), but it is far from the most important thing to worry about.