### PR TITLE
Remove unnecessary casts and type: ignores

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_test.py
@@ -24,7 +24,7 @@ import sympy.utilities.matchpy_connector
 
 def aqt_device(chain_length: int, use_timedelta=False) -> cad.AQTDevice:
     ms = 1000 * cirq.Duration(nanos=1) if not use_timedelta else timedelta(microseconds=1)
-    return cad.AQTDevice(  # type: ignore
+    return cad.AQTDevice(
         measurement_duration=100 * ms,  # type: ignore
         twoq_gates_duration=200 * ms,  # type: ignore
         oneq_gates_duration=10 * ms,  # type: ignore

--- a/cirq-core/cirq/_compat_test.py
+++ b/cirq-core/cirq/_compat_test.py
@@ -367,7 +367,7 @@ def test_deprecated_class():
 
 
 def _from_parent_import_deprecated():
-    from cirq.testing._compat_test_data import fake_a  # type: ignore
+    from cirq.testing._compat_test_data import fake_a
 
     assert fake_a.MODULE_A_ATTRIBUTE == 'module_a'
 
@@ -379,7 +379,7 @@ def _import_deprecated_assert_sub():
 
 
 def _from_deprecated_import_sub():
-    from cirq.testing._compat_test_data.fake_a import module_b  # type: ignore
+    from cirq.testing._compat_test_data.fake_a import module_b
 
     assert module_b.MODULE_B_ATTRIBUTE == 'module_b'
 
@@ -450,7 +450,7 @@ def _import_multiple_deprecated():
     from cirq.testing._compat_test_data.module_a.module_b import module_c
 
     assert module_c.MODULE_C_ATTRIBUTE == 'module_c'
-    from cirq.testing._compat_test_data.fake_a.module_b import module_c  # type: ignore
+    from cirq.testing._compat_test_data.fake_a.module_b import module_c
 
     assert module_c.MODULE_C_ATTRIBUTE == 'module_c'
     from cirq.testing._compat_test_data.fake_b import module_c  # type: ignore
@@ -531,7 +531,7 @@ def _repeated_import_path():
 
     # pylint: disable=line-too-long
     from cirq.testing._compat_test_data.repeated_child.cirq.testing._compat_test_data.repeated_child import (  # type: ignore
-        child,  # type: ignore
+        child,
     )
 
     assert child.CHILD_ATTRIBUTE == 'child'
@@ -798,7 +798,7 @@ def _test_broken_module_2_inner():
             match="missing_module cannot be imported. The typical reasons",
         ):
             # note that this passes
-            from cirq.testing._compat_test_data import broken_ref  # type: ignore
+            from cirq.testing._compat_test_data import broken_ref
 
             # but when you try to use it
             broken_ref.something()

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2073,7 +2073,7 @@ class Circuit(AbstractCircuit):
                 self._moments.insert(k, moment_or_op)
                 k += 1
             else:
-                op = cast(ops.Operation, moment_or_op)
+                op = moment_or_op
                 p = self._pick_or_create_inserted_op_moment_index(k, op, strategy)
                 while p >= len(self._moments):
                     self._moments.append(Moment())

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_diagram_info.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_diagram_info.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast, Optional, Tuple
+from typing import Optional, Tuple
 
 from cirq import ops, protocols
 
@@ -59,7 +59,7 @@ def hardcoded_qcircuit_diagram_info(op: ops.Operation) -> Optional[protocols.Cir
         if isinstance(op.gate, ops.MeasurementGate)
         else ()
     )
-    return protocols.CircuitDiagramInfo(cast(Tuple[str, ...], symbols)) if symbols else None
+    return protocols.CircuitDiagramInfo(symbols) if symbols else None
 
 
 def convert_text_diagram_info_to_qcircuit_diagram_info(

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -4,7 +4,7 @@ https://arxiv.org/abs/1811.12926.
 """
 
 from dataclasses import dataclass
-from typing import Optional, List, cast, Callable, Dict, Tuple, Set, Any
+from typing import Optional, List, Callable, Dict, Tuple, Set, Any
 
 import networkx as nx
 import numpy as np
@@ -75,7 +75,7 @@ def compute_heavy_set(circuit: cirq.Circuit) -> List[int]:
     # Classically compute the probabilities of each output bit-string through
     # simulation.
     simulator = cirq.Simulator()
-    results = cast(cirq.StateVectorTrialResult, simulator.simulate(program=circuit))
+    results = simulator.simulate(program=circuit)
 
     # Compute the median probability of the output bit-strings. Note that heavy
     # output is defined in terms of probabilities, where our wave function is in

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -216,7 +216,6 @@ def tdd_to_svg(
         t += f'<line x1="{x}" x2="{x}" y1="{y1}" y2="{y2}" stroke="black" stroke-width="3" />'
 
     for (xi, yi), v in tdd.entries.items():
-        xi = cast(int, xi)
         yi = yi_map[yi]
 
         x = col_starts[xi] + col_widths[xi] / 2

--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -24,7 +24,7 @@ from cirq import _compat, ops, protocols
 if TYPE_CHECKING:
     import cirq
 
-TSelf = TypeVar('TSelf', bound='_BaseGridQid')  # type: ignore
+TSelf = TypeVar('TSelf', bound='_BaseGridQid')
 
 
 @functools.total_ordering  # type: ignore

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -22,7 +22,7 @@ from cirq import ops, protocols
 if TYPE_CHECKING:
     import cirq
 
-TSelf = TypeVar('TSelf', bound='_BaseLineQid')  # type: ignore
+TSelf = TypeVar('TSelf', bound='_BaseLineQid')
 
 
 @functools.total_ordering  # type: ignore

--- a/cirq-core/cirq/devices/noise_model.py
+++ b/cirq-core/cirq/devices/noise_model.py
@@ -283,7 +283,7 @@ document(
 
 NOISE_MODEL_LIKE = Union[None, 'cirq.NoiseModel', 'cirq.Gate']
 document(
-    NOISE_MODEL_LIKE,  # type: ignore
+    NOISE_MODEL_LIKE,
     """A `cirq.NoiseModel` or a value that can be trivially converted into one.
 
     `None` is a `NOISE_MODEL_LIKE`. It will be replaced by the `cirq.NO_NOISE`

--- a/cirq-core/cirq/interop/quirk/cells/parse.py
+++ b/cirq-core/cirq/interop/quirk/cells/parse.py
@@ -154,7 +154,7 @@ def _parse_formula_using_token_map(
         a = vals.pop()
         # Note: vals seems to be _HangingToken
         # func operates on _ResolvedTokens. Ignoring type issues for now.
-        vals.append(cast(_HangingNode, op).func(a, b))  # type: ignore[arg-type]
+        vals.append(op.func(a, b))  # type: ignore[arg-type]
 
     def close_paren() -> None:
         while True:
@@ -176,10 +176,7 @@ def _parse_formula_using_token_map(
         # Implied multiplication?
         mul = cast(_CustomQuirkOperationToken, token_map["*"])
         if could_be_binary and token != ")":
-            if (
-                not isinstance(token, _CustomQuirkOperationToken)
-                or cast(_CustomQuirkOperationToken, token).binary_action is None
-            ):
+            if not isinstance(token, _CustomQuirkOperationToken) or token.binary_action is None:
                 burn_ops(mul.priority)
                 ops.append(
                     _HangingNode(

--- a/cirq-core/cirq/interop/quirk/url_to_circuit.py
+++ b/cirq-core/cirq/interop/quirk/url_to_circuit.py
@@ -235,7 +235,7 @@ def quirk_json_to_circuit(
 
     # Remap qubits if requested.
     if qubits is not None:
-        qs = cast(Sequence['cirq.Qid'], qubits)
+        qs = qubits
 
         def map_qubit(qubit: 'cirq.Qid') -> 'cirq.Qid':
             q = cast(devices.LineQubit, qubit)

--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -232,13 +232,13 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         # pylint: disable=line-too-long
         'XEBPhasedFSimCharacterizationOptions': cirq.experiments.XEBPhasedFSimCharacterizationOptions,
         # pylint: enable=line-too-long
-        '_XEigenState': cirq.value.product_state._XEigenState,  # type: ignore
+        '_XEigenState': cirq.value.product_state._XEigenState,
         'XPowGate': cirq.XPowGate,
         'XXPowGate': cirq.XXPowGate,
-        '_YEigenState': cirq.value.product_state._YEigenState,  # type: ignore
+        '_YEigenState': cirq.value.product_state._YEigenState,
         'YPowGate': cirq.YPowGate,
         'YYPowGate': cirq.YYPowGate,
-        '_ZEigenState': cirq.value.product_state._ZEigenState,  # type: ignore
+        '_ZEigenState': cirq.value.product_state._ZEigenState,
         'Zip': cirq.Zip,
         'ZPowGate': cirq.ZPowGate,
         'ZZPowGate': cirq.ZZPowGate,

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -15,7 +15,6 @@ from typing import (
     AbstractSet,
     Any,
     Mapping,
-    cast,
     Dict,
     FrozenSet,
     List,
@@ -85,7 +84,7 @@ class ClassicallyControlledOperation(raw_types.Operation):
                 c = value.KeyCondition(c)
             if isinstance(c, sympy.Basic):
                 c = value.SympyCondition(c)
-            conds.append(cast('cirq.Condition', c))
+            conds.append(c)
         self._conditions: Tuple['cirq.Condition', ...] = tuple(conds)
         self._sub_operation: 'cirq.Operation' = sub_operation
 

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, cast, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 
 import numpy as np
@@ -90,7 +90,7 @@ def _validate_map_input(
 ) -> Dict[Pauli, Tuple[Pauli, bool]]:
     if pauli_map_to is None:
         xyz_to = {pauli_gates.X: x_to, pauli_gates.Y: y_to, pauli_gates.Z: z_to}
-        pauli_map_to = {cast(Pauli, p): trans for p, trans in xyz_to.items() if trans is not None}
+        pauli_map_to = {p: trans for p, trans in xyz_to.items() if trans is not None}
     elif x_to is not None or y_to is not None or z_to is not None:
         raise ValueError(
             '{} can take either pauli_map_to or a combination'
@@ -531,9 +531,7 @@ class SingleQubitCliffordGate(CliffordGate):
             trans_to2 = trans_from
             flip2 = not flip
         rotation_map[trans_from2] = (trans_to2, flip2)
-        return SingleQubitCliffordGate.from_double_map(
-            cast(Dict[Pauli, Tuple[Pauli, bool]], rotation_map)
-        )
+        return SingleQubitCliffordGate.from_double_map(rotation_map)
 
     @staticmethod
     def from_double_map(

--- a/cirq-core/cirq/ops/common_gate_families.py
+++ b/cirq-core/cirq/ops/common_gate_families.py
@@ -148,7 +148,7 @@ class ParallelGateFamily(gateset.GateFamily):
         if isinstance(gate, parallel_gate.ParallelGate):
             if not max_parallel_allowed:
                 max_parallel_allowed = protocols.num_qubits(gate)
-            gate = cast(parallel_gate.ParallelGate, gate).sub_gate
+            gate = gate.sub_gate
         self._max_parallel_allowed = max_parallel_allowed
         super().__init__(gate, name=name, description=description)
 

--- a/cirq-core/cirq/ops/control_values.py
+++ b/cirq-core/cirq/ops/control_values.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-from typing import Union, Tuple, List, TYPE_CHECKING, Any, Dict, Generator, cast, Iterator, Optional
+from typing import Union, Tuple, List, TYPE_CHECKING, Any, Dict, Generator, Iterator, Optional
 from dataclasses import dataclass
 
 import itertools
@@ -121,7 +121,6 @@ class ProductOfSums(AbstractControlValues):
 
     def _expand(self) -> Iterator[Tuple[int, ...]]:
         """Returns the combinations tracked by the object."""
-        self = cast('ProductOfSums', self)
         return itertools.product(*self._internal_representation)
 
     def __repr__(self) -> str:
@@ -231,7 +230,6 @@ class SumOfProducts(AbstractControlValues):
 
     def _expand(self) -> Iterator[Tuple[int, ...]]:
         """Returns the combinations tracked by the object."""
-        self = cast('SumOfProducts', self)
         return iter(self._internal_representation)
 
     def __repr__(self) -> str:

--- a/cirq-core/cirq/ops/controlled_gate.py
+++ b/cirq-core/cirq/ops/controlled_gate.py
@@ -112,7 +112,7 @@ class ControlledGate(raw_types.Gate):
 
         # Flatten nested ControlledGates.
         if isinstance(sub_gate, ControlledGate):
-            self._sub_gate = sub_gate.sub_gate  # type: ignore
+            self._sub_gate = sub_gate.sub_gate
             self._control_values = self._control_values & sub_gate.control_values
             self._control_qid_shape += sub_gate.control_qid_shape
         else:

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -50,7 +50,7 @@ PauliSumLike = Union[
     int, float, complex, PauliString, 'PauliSum', pauli_string.SingleQubitPauliStringGateOperation
 ]
 document(
-    PauliSumLike,  # type: ignore
+    PauliSumLike,
     """Any value that can be easily translated into a sum of Pauli products.
     """,
 )

--- a/cirq-core/cirq/ops/matrix_gates.py
+++ b/cirq-core/cirq/ops/matrix_gates.py
@@ -14,7 +14,7 @@
 
 """Quantum gates defined by a matrix."""
 
-from typing import Any, cast, Dict, Iterable, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, Iterable, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 
@@ -115,8 +115,7 @@ class MatrixGate(raw_types.Gate):
     def __pow__(self, exponent: Any) -> 'MatrixGate':
         if not isinstance(exponent, (int, float)):
             return NotImplemented
-        e = cast(float, exponent)
-        new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b**e)
+        new_mat = linalg.map_eigenvalues(self._matrix, lambda b: b**exponent)
         return MatrixGate(new_mat, qid_shape=self._qid_shape)
 
     def _phase_by_(self, phase_turns: float, qubit_index: int) -> 'MatrixGate':

--- a/cirq-core/cirq/ops/named_qubit.py
+++ b/cirq-core/cirq/ops/named_qubit.py
@@ -21,7 +21,7 @@ from cirq.ops import raw_types
 if TYPE_CHECKING:
     import cirq
 
-TSelf = TypeVar('TSelf', bound='_BaseNamedQid')  # type: ignore
+TSelf = TypeVar('TSelf', bound='_BaseNamedQid')
 
 
 @functools.total_ordering  # type: ignore

--- a/cirq-core/cirq/ops/op_tree.py
+++ b/cirq-core/cirq/ops/op_tree.py
@@ -55,7 +55,7 @@ class OpTree(Protocol):
 
 OP_TREE = Union[Operation, OpTree]
 document(
-    OP_TREE,  # type: ignore
+    OP_TREE,
     """An operation or nested collections of operations.
 
     Here are some examples of things that can be given to a method that takes a

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -78,7 +78,7 @@ PAULI_STRING_LIKE = Union[
     Iterable,  # of PAULI_STRING_LIKE, but mypy doesn't do recursive types yet.
 ]
 document(
-    PAULI_STRING_LIKE,  # type: ignore
+    PAULI_STRING_LIKE,
     """A `cirq.PauliString` or a value that can easily be converted into one.
 
     Complex numbers turn into the coefficient of an empty Pauli string.
@@ -94,7 +94,7 @@ document(
 
 PAULI_GATE_LIKE = Union['cirq.Pauli', 'cirq.IdentityGate', str, int,]
 document(
-    PAULI_GATE_LIKE,  # type: ignore
+    PAULI_GATE_LIKE,
     """An object that can be interpreted as a Pauli gate.
 
     Allowed values are:
@@ -1715,4 +1715,4 @@ def _pauli_like_to_pauli_int(key: Any, pauli_gate_like: PAULI_GATE_LIKE):
             f"But the value isn't in "
             f"{set(PAULI_GATE_LIKE_TO_INDEX_MAP.keys())!r}"
         )
-    return cast(int, pauli_int)
+    return pauli_int

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -14,7 +14,7 @@
 
 import itertools
 import math
-from typing import List, cast
+from typing import List
 
 import numpy as np
 import pytest
@@ -656,10 +656,7 @@ def _assert_pass_over(ops: List[cirq.Operation], before: cirq.PauliString, after
 @pytest.mark.parametrize('shift,sign', itertools.product(range(3), (-1, +1)))
 def test_pass_operations_over_single(shift: int, sign: int):
     q0, q1 = _make_qubits(2)
-    X, Y, Z = (
-        cirq.Pauli.by_relative_index(cast(cirq.Pauli, pauli), shift)
-        for pauli in (cirq.X, cirq.Y, cirq.Z)
-    )
+    X, Y, Z = (cirq.Pauli.by_relative_index(pauli, shift) for pauli in (cirq.X, cirq.Y, cirq.Z))
 
     op0 = cirq.SingleQubitCliffordGate.from_pauli(Y)(q1)
     ps_before: cirq.PauliString[cirq.Qid] = cirq.PauliString({q0: X}, sign)
@@ -698,10 +695,7 @@ def test_pass_operations_over_single(shift: int, sign: int):
 def test_pass_operations_over_double(shift: int, t_or_f1: bool, t_or_f2: bool, neg: bool):
     sign = -1 if neg else +1
     q0, q1, q2 = _make_qubits(3)
-    X, Y, Z = (
-        cirq.Pauli.by_relative_index(cast(cirq.Pauli, pauli), shift)
-        for pauli in (cirq.X, cirq.Y, cirq.Z)
-    )
+    X, Y, Z = (cirq.Pauli.by_relative_index(pauli, shift) for pauli in (cirq.X, cirq.Y, cirq.Z))
 
     op0 = cirq.PauliInteractionGate(Z, t_or_f1, X, t_or_f2)(q0, q1)
     ps_before = cirq.PauliString(qubit_pauli_map={q0: Z, q2: Y}, coefficient=sign)

--- a/cirq-core/cirq/ops/qubit_order_or_list.py
+++ b/cirq-core/cirq/ops/qubit_order_or_list.py
@@ -25,7 +25,7 @@ from cirq.ops import qubit_order, raw_types
 
 QubitOrderOrList = Union[qubit_order.QubitOrder, Iterable[raw_types.Qid]]
 document(
-    QubitOrderOrList,  # type: ignore
+    QubitOrderOrList,
     """Specifies a qubit ordering.
 
     The ordering can either be specified by an iterable (such as a list) with

--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -729,7 +729,7 @@ def to_json_gzip(
             actually_a_file.write(json_str)
             return None
 
-    gzip_data = gzip.compress(bytes(json_str, encoding='utf-8'))  # type: ignore
+    gzip_data = gzip.compress(bytes(json_str, encoding='utf-8'))
     if file_or_fn is None:
         return gzip_data
 

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -79,7 +79,7 @@ MODULE_TEST_SPECS = _get_testspecs_for_modules()
 def test_deprecated_cirq_type_in_json_dict():
     class HasOldJsonDict:
         # Required for testing serialization of non-cirq objects.
-        __module__ = 'test.noncirq.namespace'  # type: ignore
+        __module__ = 'test.noncirq.namespace'
 
         def __eq__(self, other):
             return isinstance(other, HasOldJsonDict)

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -38,7 +38,7 @@ STATE_VECTOR_LIKE = Union[
     # Product state object
     'cirq.ProductState',
 ]
-document(STATE_VECTOR_LIKE, """An object representing a state vector.""")  # type: ignore
+document(STATE_VECTOR_LIKE, """An object representing a state vector.""")
 
 QUANTUM_STATE_LIKE = Union[
     # state vector
@@ -48,7 +48,7 @@ QUANTUM_STATE_LIKE = Union[
     # quantum state object
     'cirq.QuantumState',
 ]
-document(QUANTUM_STATE_LIKE, """An object representing a quantum state.""")  # type: ignore
+document(QUANTUM_STATE_LIKE, """An object representing a quantum state.""")
 
 
 class QuantumState:

--- a/cirq-core/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator.py
@@ -247,9 +247,7 @@ class CliffordState:
         try:
             act_on(op, ch_form_args)
         except TypeError:
-            raise ValueError(
-                f'{str(op.gate)} cannot be run with Clifford simulator.'
-            )  # type: ignore
+            raise ValueError(f'{op.gate} cannot be run with Clifford simulator.')
         return
 
     def apply_measurement(

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
@@ -72,7 +72,7 @@ class StabilizerSimulationState(
             strats.append(self._strat_decompose)
             strats.append(self._strat_act_from_single_qubit_decompose)
         for strat in strats:
-            result = strat(action, qubits)  # type: ignore
+            result = strat(action, qubits)
             if result is True:
                 return True
             assert result is NotImplemented, str(result)

--- a/cirq-core/cirq/sim/density_matrix_simulator.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator.py
@@ -303,7 +303,7 @@ class DensityMatrixStepResult(simulator_base.StepResultBase['cirq.DensityMatrixS
         # Dtype doesn't have a good repr, so we work around by invoking __name__.
         return (
             f'cirq.DensityMatrixStepResult(sim_state={self._sim_state!r},'
-            f' dtype=np.{self._dtype.__name__})'  # type: ignore
+            f' dtype=np.{self._dtype.__name__})'
         )
 
 

--- a/cirq-core/cirq/sim/mux.py
+++ b/cirq-core/cirq/sim/mux.py
@@ -17,7 +17,7 @@
 Filename is a reference to multiplexing.
 """
 
-from typing import cast, List, Optional, Sequence, Type, TYPE_CHECKING, Union
+from typing import List, Optional, Sequence, Type, TYPE_CHECKING, Union
 
 import numpy as np
 
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 CIRCUIT_LIKE = Union[circuits.Circuit, ops.Gate, ops.OP_TREE]
 document(
-    CIRCUIT_LIKE,  # type: ignore
+    CIRCUIT_LIKE,
     """A `circuits.Circuit` or a value that can be trivially converted into it:
         a gate, an operation, and a list or tree of operations.
     """,
@@ -92,7 +92,6 @@ def sample(
 
 
 def _to_circuit(program: 'cirq.CIRCUIT_LIKE') -> 'cirq.Circuit':
-    result = None
     if isinstance(program, circuits.Circuit):
         # No change needed.
         result = program
@@ -101,7 +100,7 @@ def _to_circuit(program: 'cirq.CIRCUIT_LIKE') -> 'cirq.Circuit':
     else:
         # It should be an OP_TREE.
         result = circuits.Circuit(program)
-    return cast('cirq.Circuit', result)
+    return result
 
 
 def final_state_vector(
@@ -274,7 +273,7 @@ def final_density_matrix(
     if not protocols.has_unitary(circuit_like):
         can_do_unitary_simulation = False
     if isinstance(circuit_like, circuits.Circuit):
-        if cast(circuits.Circuit, circuit_like).has_measurements():
+        if circuit_like.has_measurements():
             # Including terminal measurements.
             can_do_unitary_simulation = False
     if noise_model != devices.NO_NOISE:

--- a/cirq-core/cirq/sim/sparse_simulator.py
+++ b/cirq-core/cirq/sim/sparse_simulator.py
@@ -282,5 +282,5 @@ class SparseSimulatorStep(
         # Dtype doesn't have a good repr, so we work around by invoking __name__.
         return (
             f'cirq.SparseSimulatorStep(sim_state={self._sim_state!r},'
-            f' dtype=np.{self._dtype.__name__})'  # type: ignore
+            f' dtype=np.{self._dtype.__name__})'
         )

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -41,8 +41,7 @@ class StateVectorMixin:
             *args: Passed on to the class that this is mixed in with.
             **kwargs: Passed on to the class that this is mixed in with.
         """
-        # Reason for 'type: ignore': https://github.com/python/mypy/issues/5887
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)
         self._qubit_map = qubit_map or {}
         qid_shape = simulator._qubit_map_to_shape(self._qubit_map)
         self._qid_shape = None if qubit_map is None else qid_shape

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -364,7 +364,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
             _strat_act_on_state_vector_from_channel,
         ]
         if allow_decompose:
-            strats.append(strat_act_on_from_apply_decompose)  # type: ignore
+            strats.append(strat_act_on_from_apply_decompose)
 
         # Try each strategy, stopping if one works.
         for strat in strats:

--- a/cirq-core/cirq/study/flatten_expressions.py
+++ b/cirq-core/cirq/study/flatten_expressions.py
@@ -225,7 +225,7 @@ class _ParamFlattener(resolver.ParamResolver):
         # TODO: Support complex values for typing below.
         symbol_params: resolver.ParamDictType = {
             _ensure_not_str(param): _ensure_not_str(val)  # type: ignore[misc]
-            for param, val in params.items()  # type: ignore[misc]
+            for param, val in params.items()
         }
         super().__init__(symbol_params)
         if get_param_name is None:

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -28,13 +28,12 @@ if TYPE_CHECKING:
 
 ParamDictType = Dict['cirq.TParamKey', 'cirq.TParamValComplex']
 ParamMappingType = Mapping['cirq.TParamKey', 'cirq.TParamValComplex']
-document(ParamDictType, """Dictionary from symbols to values.""")  # type: ignore
-document(ParamMappingType, """Immutable map from symbols to values.""")  # type: ignore
+document(ParamDictType, """Dictionary from symbols to values.""")
+document(ParamMappingType, """Immutable map from symbols to values.""")
 
 ParamResolverOrSimilarType = Union['cirq.ParamResolver', ParamMappingType, None]
 document(
-    ParamResolverOrSimilarType,  # type: ignore
-    """Something that can be used to turn parameters into values.""",
+    ParamResolverOrSimilarType, """Something that can be used to turn parameters into values."""
 )
 
 # Used to mark values that are being resolved recursively to detect loops.
@@ -186,7 +185,7 @@ class ParamResolver:
             elif sympy.im(v):
                 # Technically, this should not return complex, but changing
                 # type signature to complex would cause many cascading issues
-                return complex(v)  # type: ignore[return-value]
+                return complex(v)
             else:
                 return float(v)
 
@@ -216,7 +215,7 @@ class ParamResolver:
         new_dict.update({k: self.value_of(k, recursive) for k in self})  # type: ignore[misc]
         new_dict.update(
             {k: resolver.value_of(v, recursive) for k, v in new_dict.items()}  # type: ignore[misc]
-        )  # type: ignore[misc]
+        )
         if recursive and self.param_dict:
             new_resolver = ParamResolver(cast(ParamDictType, new_dict))
             # Resolve down to single-step mappings.

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -32,8 +32,8 @@ import cirq
         np.int32(45),
         np.float64(6.3),
         np.int32(2),
-        np.complex64(1j),  # type: ignore[arg-type]
-        np.complex128(2j),  # type: ignore[arg-type]
+        np.complex64(1j),
+        np.complex128(2j),
         complex(1j),
         fractions.Fraction(3, 2),
     ],

--- a/cirq-core/cirq/study/result.py
+++ b/cirq-core/cirq/study/result.py
@@ -151,8 +151,7 @@ class Result(abc.ABC):
         # Get the length quickly from one of the keyed results.
         return len(next(iter(self.records.values())))
 
-    # Reason for 'type: ignore': https://github.com/python/mypy/issues/5273
-    def multi_measurement_histogram(  # type: ignore
+    def multi_measurement_histogram(
         self,
         *,  # Forces keyword args.
         keys: Iterable[TMeasurementKey],
@@ -211,8 +210,7 @@ class Result(abc.ABC):
             c[fold_func(sample)] += 1
         return c
 
-    # Reason for 'type: ignore': https://github.com/python/mypy/issues/5273
-    def histogram(  # type: ignore
+    def histogram(
         self,
         *,  # Forces keyword args.
         key: TMeasurementKey,

--- a/cirq-core/cirq/study/sweepable.py
+++ b/cirq-core/cirq/study/sweepable.py
@@ -62,7 +62,7 @@ def to_sweeps(sweepable: Sweepable) -> List[Sweep]:
                 DeprecationWarning,
                 stacklevel=2,
             )
-        product_sweep = dict_to_product_sweep(sweepable)  # type: ignore[arg-type]
+        product_sweep = dict_to_product_sweep(sweepable)
         return [_resolver_to_sweep(resolver) for resolver in product_sweep]
     if isinstance(sweepable, Iterable) and not isinstance(sweepable, str):
         return [sweep for item in sweepable for sweep in to_sweeps(item)]  # type: ignore[arg-type]

--- a/cirq-core/cirq/testing/consistent_qasm.py
+++ b/cirq-core/cirq/testing/consistent_qasm.py
@@ -113,7 +113,7 @@ def assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, unitary):
     try:
         # We don't want to require qiskit as a dependency but
         # if Qiskit is installed, test QASM output against it.
-        import qiskit  # type: ignore
+        import qiskit
     except ImportError:
         return
 

--- a/cirq-core/cirq/testing/consistent_resolve_parameters.py
+++ b/cirq-core/cirq/testing/consistent_resolve_parameters.py
@@ -45,6 +45,6 @@ def assert_consistent_resolve_parameters(val: Any):
             name: sympy.Symbol(name + '_CONSISTENCY_TEST') for name in names
         }
         param_dict.update({sympy.Symbol(name + '_CONSISTENCY_TEST'): 0 for name in names})
-        resolver = cirq.ParamResolver(param_dict)  # type:ignore
+        resolver = cirq.ParamResolver(param_dict)
         resolved = cirq.resolve_parameters_once(val, resolver)
         assert cirq.parameter_names(resolved) == set(name + '_CONSISTENCY_TEST' for name in names)

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz.py
@@ -217,8 +217,7 @@ def _parity_interaction(
 
     h = rads * -2 / np.pi
     if gate is not None:
-        g = cast(ops.Gate, gate)
-        yield g.on(q0), g.on(q1)
+        yield gate.on(q0), gate.on(q1)
 
     # If rads is ±pi/4 radians within tolerance, single full-CZ suffices.
     if _is_trivial_angle(rads, atol):

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms.py
@@ -88,8 +88,7 @@ def _parity_interaction(
         return
 
     if gate is not None:
-        g = cast(ops.Gate, gate)
-        yield g.on(q0), g.on(q1)
+        yield gate.on(q0), gate.on(q1)
 
     yield ops.ms(-1 * rads).on(q0, q1)
 

--- a/cirq-core/cirq/transformers/eject_phased_paulis.py
+++ b/cirq-core/cirq/transformers/eject_phased_paulis.py
@@ -287,7 +287,7 @@ def _double_cross_over_cz(
     """
     t = cast(value.TParamVal, _try_get_known_cz_half_turns(op))
     for q in op.qubits:
-        held_w_phases[q] = cast(value.TParamVal, held_w_phases[q]) + t / 2
+        held_w_phases[q] += t / 2
     return op
 
 

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
@@ -68,11 +68,7 @@ def create_transformer_with_kwargs(transformer: 'cirq.TRANSFORMER', **kwargs) ->
     def transformer_with_kwargs(
         circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
     ) -> 'cirq.AbstractCircuit':
-        # Need to ignore mypy type because `cirq.TRANSFORMER` is a callable protocol which only
-        # accepts circuit and context; and doesn't expect additional keyword arguments. Note
-        # that transformers with additional keyword arguments with a default value do satisfy the
-        # `cirq.TRANSFORMER` API.
-        return transformer(circuit, context=context, **kwargs)  # type: ignore
+        return transformer(circuit, context=context, **kwargs)
 
     return transformer_with_kwargs
 

--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -669,7 +669,7 @@ def unroll_circuit_op_greedy_frontier(
                 continue
             if any(frontier[q] > idx for q in op.qubits):
                 continue
-            op_untagged = cast(circuits.CircuitOperation, op.untagged)
+            op_untagged = op.untagged
             if deep:
                 op_untagged = op_untagged.replace(
                     circuit=unroll_circuit_op_greedy_frontier(

--- a/cirq-core/cirq/value/duration.py
+++ b/cirq-core/cirq/value/duration.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 DURATION_LIKE = Union[None, datetime.timedelta, 'cirq.Duration']
 document(
-    DURATION_LIKE,  # type: ignore
+    DURATION_LIKE,
     """A `cirq.Duration` or value that can trivially converted to one.
 
     A `datetime.timedelta` is a `cirq.DURATION_LIKE`. It is converted while

--- a/cirq-core/cirq/value/type_alias.py
+++ b/cirq-core/cirq/value/type_alias.py
@@ -23,15 +23,10 @@ from cirq.value import linear_dict
 """
 
 TParamKey = Union[str, sympy.Expr]
-document(TParamKey, """A parameter that a parameter resolver may map to a value.""")  # type: ignore
+document(TParamKey, """A parameter that a parameter resolver may map to a value.""")
 
 TParamVal = Union[float, sympy.Expr]
-document(
-    TParamVal, """A value that a parameter resolver may return for a parameter."""  # type: ignore
-)
+document(TParamVal, """A value that a parameter resolver may return for a parameter.""")
 
 TParamValComplex = Union[linear_dict.Scalar, sympy.Expr]
-document(
-    TParamValComplex,
-    """A complex value that parameter resolvers may use for parameters.""",  # type: ignore
-)
+document(TParamValComplex, """A complex value that parameter resolvers may use for parameters.""")

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/async_client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/async_client.py
@@ -23,7 +23,7 @@ from google.api_core.client_options import ClientOptions
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials   # type: ignore
+from google.auth import credentials as ga_credentials
 from google.oauth2 import service_account              # type: ignore
 
 try:
@@ -34,9 +34,9 @@ except AttributeError:  # pragma: NO COVER
 from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service import pagers
 from cirq_google.cloud.quantum_v1alpha1.types import engine
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
-from google.protobuf import any_pb2  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import timestamp_pb2  # type: ignore
+from google.protobuf import any_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import timestamp_pb2
 from .transports.base import QuantumEngineServiceTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import QuantumEngineServiceGrpcAsyncIOTransport
 from .client import QuantumEngineServiceClient
@@ -134,7 +134,7 @@ class QuantumEngineServiceAsyncClient:
         Raises:
             google.auth.exceptions.MutualTLSChannelError: If any errors happen.
         """
-        return QuantumEngineServiceClient.get_mtls_endpoint_and_cert_source(client_options)  # type: ignore
+        return QuantumEngineServiceClient.get_mtls_endpoint_and_cert_source(client_options)
 
     @property
     def transport(self) -> QuantumEngineServiceTransport:

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
@@ -23,10 +23,10 @@ from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials             # type: ignore
-from google.auth.transport import mtls                            # type: ignore
-from google.auth.transport.grpc import SslCredentials             # type: ignore
-from google.auth.exceptions import MutualTLSChannelError          # type: ignore
+from google.auth import credentials as ga_credentials
+from google.auth.transport import mtls
+from google.auth.transport.grpc import SslCredentials
+from google.auth.exceptions import MutualTLSChannelError
 from google.oauth2 import service_account                         # type: ignore
 
 try:
@@ -37,9 +37,9 @@ except AttributeError:  # pragma: NO COVER
 from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service import pagers
 from cirq_google.cloud.quantum_v1alpha1.types import engine
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
-from google.protobuf import any_pb2  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import timestamp_pb2  # type: ignore
+from google.protobuf import any_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import timestamp_pb2
 from .transports.base import QuantumEngineServiceTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import QuantumEngineServiceGrpcTransport
 from .transports.grpc_asyncio import QuantumEngineServiceGrpcAsyncIOTransport
@@ -390,7 +390,7 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
                 )
             self._transport = transport
         else:
-            import google.auth._default  # type: ignore
+            import google.auth._default
 
             if api_key_value and hasattr(google.auth._default, "get_api_key_credentials"):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/base.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/base.py
@@ -17,17 +17,17 @@ import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import pkg_resources
 
-import google.auth  # type: ignore
+import google.auth
 import google.api_core
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials  # type: ignore
+from google.auth import credentials as ga_credentials
 from google.oauth2 import service_account # type: ignore
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
-from google.protobuf import empty_pb2  # type: ignore
+from google.protobuf import empty_pb2
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc.py
@@ -18,15 +18,15 @@ from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import grpc_helpers
 from google.api_core import gapic_v1
-import google.auth                         # type: ignore
-from google.auth import credentials as ga_credentials  # type: ignore
-from google.auth.transport.grpc import SslCredentials  # type: ignore
+import google.auth
+from google.auth import credentials as ga_credentials
+from google.auth.transport.grpc import SslCredentials
 
 import grpc  # type: ignore
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
-from google.protobuf import empty_pb2  # type: ignore
+from google.protobuf import empty_pb2
 from .base import QuantumEngineServiceTransport, DEFAULT_CLIENT_INFO
 
 

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc_asyncio.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc_asyncio.py
@@ -18,15 +18,15 @@ from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import gapic_v1
 from google.api_core import grpc_helpers_async
-from google.auth import credentials as ga_credentials   # type: ignore
-from google.auth.transport.grpc import SslCredentials  # type: ignore
+from google.auth import credentials as ga_credentials
+from google.auth.transport.grpc import SslCredentials
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
-from google.protobuf import empty_pb2  # type: ignore
+from google.protobuf import empty_pb2
 from .base import QuantumEngineServiceTransport, DEFAULT_CLIENT_INFO
 from .grpc import QuantumEngineServiceGrpcTransport
 

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/engine.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/engine.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import proto  # type: ignore
+import proto
 
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import field_mask_pb2  # type: ignore
+from google.protobuf import duration_pb2
+from google.protobuf import field_mask_pb2
 
 
 __protobuf__ = proto.module(

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/quantum.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/quantum.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import proto  # type: ignore
+import proto
 
-from google.protobuf import any_pb2  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import field_mask_pb2  # type: ignore
-from google.protobuf import timestamp_pb2  # type: ignore
+from google.protobuf import any_pb2
+from google.protobuf import duration_pb2
+from google.protobuf import field_mask_pb2
+from google.protobuf import timestamp_pb2
 
 
 __protobuf__ = proto.module(

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -722,7 +722,7 @@ def _allow_deprecated_freezegun(func):
                 # mypy can't resolve that orig_exist ensures that orig_value
                 # of type Optional[str] can't be None
                 # coverage: ignore
-                os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value  # type: ignore
+                os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value
             else:
                 del os.environ[ALLOW_DEPRECATION_IN_TEST]
 

--- a/cirq-google/cirq_google/ops/fsim_gate_family.py
+++ b/cirq-google/cirq_google/ops/fsim_gate_family.py
@@ -245,7 +245,7 @@ class FSimGateFamily(cirq.GateFamily):
     def _get_value_equality_values(self, g: POSSIBLE_FSIM_GATES) -> Any:
         # TODO: Remove condition once https://github.com/quantumlib/Cirq/issues/4585 is fixed.
         if type(g) == cirq.PhasedISwapPowGate:
-            return (g.phase_exponent, *g._iswap._value_equality_values_())  # type: ignore
+            return (g.phase_exponent, *g._iswap._value_equality_values_())
         return g._value_equality_values_()
 
     def _get_value_equality_values_cls(self, g: POSSIBLE_FSIM_GATES) -> Any:

--- a/cirq-ionq/cirq_ionq/service.py
+++ b/cirq-ionq/cirq_ionq/service.py
@@ -15,7 +15,7 @@
 
 import datetime
 import os
-from typing import cast, Optional, Sequence
+from typing import Optional, Sequence
 
 import cirq
 from cirq_ionq import calibration, ionq_client, job, results, sampler, serializer
@@ -108,11 +108,9 @@ class Service:
         result = self.create_job(resolved_circuit, repetitions, name, target).results()
         if isinstance(result, results.QPUResult):
             return result.to_cirq_result(params=cirq.ParamResolver(param_resolver))
-        else:
-            sim_result = cast(results.SimulatorResult, result)
-            # pylint: disable=unexpected-keyword-arg
-            return sim_result.to_cirq_result(params=cirq.ParamResolver(param_resolver), seed=seed)
-            # pylint: enable=unexpected-keyword-arg
+        # pylint: disable=unexpected-keyword-arg
+        return result.to_cirq_result(params=cirq.ParamResolver(param_resolver), seed=seed)
+        # pylint: enable=unexpected-keyword-arg
 
     def sampler(self, target: Optional[str] = None, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None):
         """Returns a `cirq.Sampler` object for accessing the sampler interface.

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -315,7 +315,6 @@ class OctagonalQubit(cirq.ops.Qid):
         """
         if type(other) != OctagonalQubit:
             raise TypeError("can only measure distance from other Octagonal qubits")
-        other = cast(OctagonalQubit, other)
         return sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2 + (self.z - other.z) ** 2)
 
     @property
@@ -427,7 +426,6 @@ class AspenQubit(OctagonalQubit):
         """
         if type(other) != AspenQubit:
             raise TypeError("can only measure distance from other Aspen qubits")
-        other = cast(AspenQubit, other)
         return sqrt((self.x - other.x) ** 2 + (self.y - other.y) ** 2 + (self.z - other.z) ** 2)
 
     def to_grid_qubit(self) -> cirq.GridQubit:

--- a/cirq-rigetti/cirq_rigetti/circuit_sweep_executors_test.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_sweep_executors_test.py
@@ -167,9 +167,7 @@ def test_invalid_pyquil_region_measurement(
     ) -> Tuple[Program, Dict[str, str]]:
         return program, {cirq_key: f'{cirq_key}-doesnt-exist' for cirq_key in measurement_id_map}
 
-    transformer = circuit_transformers.build(
-        post_transformation_hooks=[broken_hook]  # type: ignore
-    )
+    transformer = circuit_transformers.build(post_transformation_hooks=[broken_hook])
 
     with pytest.raises(ValueError):
         _ = executors.with_quilc_compilation_and_cirq_parameter_resolution(

--- a/cirq-rigetti/cirq_rigetti/conftest.py
+++ b/cirq-rigetti/cirq_rigetti/conftest.py
@@ -16,16 +16,10 @@ from typing import Tuple, Optional, List, Union, Generic, TypeVar, Dict
 
 from unittest.mock import create_autospec, Mock
 import pytest
-from pyquil import Program  # type: ignore
-from pyquil.quantum_processor import AbstractQuantumProcessor, NxQuantumProcessor  # type: ignore
-from pyquil.api import (
-    QAM,
-    QuantumComputer,
-    QuantumExecutable,
-    QAMExecutionResult,
-    EncryptedProgram,
-)  # type: ignore
-from pyquil.api._abstract_compiler import AbstractCompiler  # type: ignore
+from pyquil import Program
+from pyquil.quantum_processor import AbstractQuantumProcessor, NxQuantumProcessor
+from pyquil.api import QAM, QuantumComputer, QuantumExecutable, QAMExecutionResult, EncryptedProgram
+from pyquil.api._abstract_compiler import AbstractCompiler
 from qcs_api_client.client._configuration.settings import QCSClientConfigurationSettings
 from qcs_api_client.client._configuration import (
     QCSClientConfiguration,
@@ -196,9 +190,7 @@ class MockQPUImplementer:
                 executable=program, readout_data=qam._mock_results  # type: ignore
             )
 
-        quantum_computer.qam.run = Mock(  # type: ignore
-            quantum_computer.qam.run, side_effect=run  # type: ignore
-        )
+        quantum_computer.qam.run = Mock(quantum_computer.qam.run, side_effect=run)  # type: ignore
         return quantum_computer
 
 

--- a/dev_tools/check.py
+++ b/dev_tools/check.py
@@ -123,10 +123,9 @@ class Check(metaclass=abc.ABCMeta):
             A CheckResult instance.
         """
         env.report_status_to_github('pending', 'Running...', self.context())
-        chosen_env = cast(env_tools.PreparedEnv, env)
-        os.chdir(cast(str, chosen_env.destination_directory))
+        os.chdir(cast(str, env.destination_directory))
 
-        result = self.run(chosen_env, verbose, previous_failures)
+        result = self.run(env, verbose, previous_failures)
 
         if result.unexpected_error is not None:
             env.report_status_to_github('error', 'Unexpected error.', self.context())

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -2,6 +2,8 @@
 exclude = dev_tools/modules_test_data/.*/setup\.py
 show_error_codes = true
 plugins = duet.typing
+warn_unused_ignores = true
+warn_redundant_casts = true
 
 [mypy-__main__]
 follow_imports = silent

--- a/dev_tools/import_test.py
+++ b/dev_tools/import_test.py
@@ -175,7 +175,7 @@ def verify_import_tree(depth: int = 1, track_others: bool = False, timeit: bool 
     project_dir = os.path.dirname(os.path.dirname(__file__))
     cirq_dir = os.path.join(project_dir, 'cirq')
     sys.path.append(cirq_dir)  # Put cirq/_import.py in the path.
-    from cirq._import import wrap_module_executions  # type: ignore
+    from cirq._import import wrap_module_executions
 
     sys.path[:] = orig_path  # Restore the path.
 

--- a/examples/direct_fidelity_estimation.py
+++ b/examples/direct_fidelity_estimation.py
@@ -248,9 +248,7 @@ def _estimate_pauli_traces_general(
 
     dense_simulator = cirq.DensityMatrixSimulator()
     # rho in https://arxiv.org/abs/1104.3835
-    clean_density_matrix = cast(
-        cirq.DensityMatrixTrialResult, dense_simulator.simulate(circuit)
-    ).final_density_matrix
+    clean_density_matrix = dense_simulator.simulate(circuit).final_density_matrix
 
     all_operators = itertools.product([cirq.I, cirq.X, cirq.Y, cirq.Z], repeat=n_qubits)
     if n_measured_operators is not None:
@@ -407,10 +405,7 @@ def direct_fidelity_estimation(
             raise TypeError(
                 'sampler is not a cirq.DensityMatrixSimulator but samples_per_term is zero.'
             )
-        noisy_simulator = cast(cirq.DensityMatrixSimulator, sampler)
-        noisy_density_matrix = cast(
-            cirq.DensityMatrixTrialResult, noisy_simulator.simulate(circuit)
-        ).final_density_matrix
+        noisy_density_matrix = sampler.simulate(circuit).final_density_matrix
 
     if clifford_circuit and n_measured_operators is None:
         # In case the circuit is Clifford and we compute an exhaustive list of

--- a/examples/swap_networks.py
+++ b/examples/swap_networks.py
@@ -20,7 +20,7 @@ implied graph is not a subgraph of the hardware adjacency graph.
 
 import itertools
 import random
-from typing import cast, Dict, List, Sequence, Tuple, TypeVar, Union
+from typing import Dict, List, Sequence, Tuple, TypeVar, Union
 
 import cirq
 import cirq.contrib.acquaintance as cca
@@ -34,9 +34,7 @@ LogicalMapping = Dict[LogicalMappingKey, LogicalIndex]
 
 def get_random_graph(n_vertices: int, edge_prob: float = 0.5) -> List[Tuple[int, int]]:
     return [
-        cast(Tuple[int, int], ij)
-        for ij in itertools.combinations(range(n_vertices), 2)
-        if random.random() <= edge_prob
+        ij for ij in itertools.combinations(range(n_vertices), 2) if random.random() <= edge_prob
     ]
 
 


### PR DESCRIPTION
Update mypy configuration to fail if there are unnecessary `cast` calls or `type: ignore` comments, so that we clean these up rather than accumulating cruft.