### PR TITLE
Add AQTDeviceMetadata and clean up AQTDevice

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -292,12 +292,7 @@ class AQTDevice(cirq.Device):
         return q if q in self.qubits else None
 
     def _value_equality_values_(self) -> Any:
-        return (
-            self.metadata.measurement_duration,
-            self.metadata.twoq_gates_duration,
-            self.metadata.oneq_gates_duration,
-            self.qubits,
-        )
+        return (self.metadata, self.qubits)
 
     def __str__(self) -> str:
         diagram = cirq.TextDiagramDrawer()

--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Current device parameters for the AQT/UIBK ion trap device
 
 The device is based on a linear calcium ion string with
@@ -30,7 +31,7 @@ import networkx as nx
 import numpy as np
 
 import cirq
-from cirq_aqt import aqt_target_gateset
+from cirq_aqt import aqt_device_metadata
 
 gate_dict = {'X': cirq.X, 'Y': cirq.Y, 'Z': cirq.Z, 'MS': cirq.XX, 'R': cirq.PhasedXPowGate}
 
@@ -245,41 +246,28 @@ class AQTDevice(cirq.Device):
         Raises:
             TypeError: If not all the qubits supplied are `cirq.LineQubit`s.
         """
-        self._measurement_duration = cirq.Duration(measurement_duration)
-        self._twoq_gates_duration = cirq.Duration(twoq_gates_duration)
-        self._oneq_gates_duration = cirq.Duration(oneq_gates_duration)
         if not all(isinstance(qubit, cirq.LineQubit) for qubit in qubits):
             raise TypeError(
                 "All qubits were not of type cirq.LineQubit, instead were "
                 f"{set(type(qubit) for qubit in qubits)}"
             )
         self.qubits = frozenset(qubits)
-        self.gateset = aqt_target_gateset.AQTTargetGateset()
 
         graph = nx.Graph()
         graph.add_edges_from([(a, b) for a in qubits for b in qubits if a != b], directed=False)
-        self._metadata = cirq.DeviceMetadata(self.qubits, graph)
+        self._metadata = aqt_device_metadata.AQTDeviceMetadata(
+            qubits=self.qubits,
+            measurement_duration=measurement_duration,
+            twoq_gates_duration=twoq_gates_duration,
+            oneq_gates_duration=oneq_gates_duration,
+        )
 
     @property
     def metadata(self) -> cirq.DeviceMetadata:
         return self._metadata
 
-    def decompose_circuit(self, circuit: cirq.Circuit) -> cirq.Circuit:
-        return cirq.optimize_for_target_gateset(circuit, gateset=self.gateset)
-
-    def duration_of(self, operation):
-        if isinstance(operation.gate, cirq.XXPowGate):
-            return self._twoq_gates_duration
-        if isinstance(
-            operation.gate, (cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.PhasedXPowGate)
-        ):
-            return self._oneq_gates_duration
-        if isinstance(operation.gate, cirq.MeasurementGate):
-            return self._measurement_duration
-        raise ValueError(f'Unsupported gate type: {operation!r}')
-
     def validate_gate(self, gate: cirq.Gate):
-        if gate not in self.gateset:
+        if gate not in self.metadata.gateset:
             raise ValueError(f'Unsupported gate type: {gate!r}')
 
     def validate_operation(self, operation):
@@ -305,9 +293,9 @@ class AQTDevice(cirq.Device):
 
     def _value_equality_values_(self) -> Any:
         return (
-            self._measurement_duration,
-            self._twoq_gates_duration,
-            self._oneq_gates_duration,
+            self.metadata.measurement_duration,
+            self.metadata.twoq_gates_duration,
+            self.metadata.oneq_gates_duration,
             self.qubits,
         )
 
@@ -324,9 +312,9 @@ class AQTDevice(cirq.Device):
     def __repr__(self) -> str:
         return (
             f'cirq_aqt.aqt_device.AQTDevice('
-            f'measurement_duration={self._measurement_duration!r}, '
-            f'twoq_gates_duration={self._twoq_gates_duration!r}, '
-            f'oneq_gates_duration={self._oneq_gates_duration!r}, '
+            f'measurement_duration={self.metadata.measurement_duration!r}, '
+            f'twoq_gates_duration={self.metadata.twoq_gates_duration!r}, '
+            f'oneq_gates_duration={self.metadata.oneq_gates_duration!r}, '
             f'qubits={sorted(self.qubits)!r}'
             f')'
         )

--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -263,7 +263,7 @@ class AQTDevice(cirq.Device):
         )
 
     @property
-    def metadata(self) -> cirq.DeviceMetadata:
+    def metadata(self) -> aqt_device_metadata.AQTDeviceMetadata:
         return self._metadata
 
     def validate_gate(self, gate: cirq.Gate):

--- a/cirq-aqt/cirq_aqt/aqt_device_metadata.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata.py
@@ -16,7 +16,7 @@
 """DeviceMetadata for ion trap device with mutually linked qubits placed on a line.
 """
 
-from typing import Iterable
+from typing import Any, Iterable, Mapping
 
 import networkx as nx
 
@@ -27,26 +27,98 @@ from cirq_aqt import aqt_target_gateset
 class AQTDeviceMetadata(cirq.DeviceMetadata):
     """Hardware metadata for ion trap device with all-connected qubits placed on a line."""
 
-    def __init__(self, qubits: Iterable['cirq.LineQubit']):
+    def __init__(
+        self,
+        qubits: Iterable['cirq.LineQubit'],
+        measurement_duration: 'cirq.DURATION_LIKE',
+        twoq_gates_duration: 'cirq.DURATION_LIKE',
+        oneq_gates_duration: 'cirq.DURATION_LIKE',
+    ):
         """Create metadata object for AQTDevice.
 
         Args:
-            qubits: Iterable of `cirq.Qid`s that exist on the device.
+            qubits: Iterable of `cirq.LineQubit`s that exist on the device.
+            measurement_duration: The maximum duration of a measurement.
+            twoq_gates_duration: The maximum duration of a two qubit operation.
+            oneq_gates_duration: The maximum duration of a single qubit operation.
         """
 
         graph = nx.Graph()
         graph.add_edges_from([(a, b) for a in qubits for b in qubits if a != b], directed=False)
         super().__init__(qubits, graph)
         self._gateset = aqt_target_gateset.AQTTargetGateset()
+        self._measurement_duration = measurement_duration
+        self._twoq_gates_duration = twoq_gates_duration
+        self._oneq_gates_duration = oneq_gates_duration
+        self._gate_durations = {
+            cirq.GateFamily(cirq.MeasurementGate): measurement_duration,
+            cirq.GateFamily(cirq.XXPowGate): twoq_gates_duration,
+            cirq.GateFamily(cirq.XPowGate): oneq_gates_duration,
+            cirq.GateFamily(cirq.YPowGate): oneq_gates_duration,
+            cirq.GateFamily(cirq.ZPowGate): oneq_gates_duration,
+            cirq.GateFamily(cirq.PhasedXPowGate): oneq_gates_duration,
+        }
+        assert not self._gateset.gates.symmetric_difference(self._gate_durations.keys()), (
+            "AQTDeviceMetadata.gate_durations must have the same Gates " "as AQTTargetGateset."
+        )
 
     @property
     def gateset(self) -> 'cirq.Gateset':
         """Returns the `cirq.Gateset` of supported gates on this device."""
         return self._gateset
 
+    @property
+    def gate_durations(self) -> Mapping['cirq.GateFamily', 'cirq.Duration']:
+        """Get a dictionary of supported gate families and their gate operation durations.
+
+        Use `duration_of` to obtain duration of a specific `cirq.GateOperation` instance.
+        """
+        return self._gate_durations
+
+    @property
+    def measurement_duration(self) -> 'cirq.DURATION_LIKE':
+        """Return the maximum duration of the measurement operation."""
+        return self._measurement_duration
+
+    @property
+    def oneq_gates_duration(self) -> 'cirq.DURATION_LIKE':
+        """Return the maximum duration of an operation on one-qubit gates."""
+        return self._oneq_gates_duration
+
+    @property
+    def twoq_gates_duration(self) -> 'cirq.DURATION_LIKE':
+        """Return the maximum duration of an operation on two-qubit gates."""
+        return self._twoq_gates_duration
+
+    def duration_of(self, operation: 'cirq.Operation') -> 'cirq.DURATION_LIKE':
+        """Return the maximum duration of the specifed gate operation.
+
+        Args:
+            operation: The `cirq.Operation` for which to determine its duration.
+
+        Raises:
+            ValueError: if the operation has an unsupported gate type.
+        """
+        for gate_family, duration in self.gate_durations.items():
+            if operation in gate_family:
+                return duration
+        else:
+            raise ValueError(f'Unsupported gate type: {operation!r}')
+
+    def _value_equality_values_(self) -> Any:
+        return (
+            self._measurement_duration,
+            self._twoq_gates_duration,
+            self._oneq_gates_duration,
+            self.qubit_set,
+        )
+
     def __repr__(self) -> str:
         return (
             f'cirq_aqt.aqt_device_metadata.AQTDeviceMetadata('
-            f'qubits={sorted(self.qubit_set)!r}'
+            f'qubits={sorted(self.qubit_set)!r}, '
+            f'measurement_duration={self.measurement_duration!r}, '
+            f'twoq_gates_duration={self.twoq_gates_duration!r}, '
+            f'oneq_gates_duration={self.oneq_gates_duration!r}'
             f')'
         )

--- a/cirq-aqt/cirq_aqt/aqt_device_metadata.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata.py
@@ -1,0 +1,52 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""DeviceMetadata for ion trap device with mutually linked qubits placed on a line.
+"""
+
+from typing import Iterable
+
+import networkx as nx
+
+import cirq
+from cirq_aqt import aqt_target_gateset
+
+
+class AQTDeviceMetadata(cirq.DeviceMetadata):
+    """Hardware metadata for ion trap device with all-connected qubits placed on a line."""
+
+    def __init__(self, qubits: Iterable['cirq.LineQubit']):
+        """Create metadata object for AQTDevice.
+
+        Args:
+            qubits: Iterable of `cirq.Qid`s that exist on the device.
+        """
+
+        graph = nx.Graph()
+        graph.add_edges_from([(a, b) for a in qubits for b in qubits if a != b], directed=False)
+        super().__init__(qubits, graph)
+        self._gateset = aqt_target_gateset.AQTTargetGateset()
+
+    @property
+    def gateset(self) -> 'cirq.Gateset':
+        """Returns the `cirq.Gateset` of supported gates on this device."""
+        return self._gateset
+
+    def __repr__(self) -> str:
+        return (
+            f'cirq_aqt.aqt_device_metadata.AQTDeviceMetadata('
+            f'qubits={sorted(self.qubit_set)!r}'
+            f')'
+        )

--- a/cirq-aqt/cirq_aqt/aqt_device_metadata.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata.py
@@ -47,16 +47,16 @@ class AQTDeviceMetadata(cirq.DeviceMetadata):
         graph.add_edges_from([(a, b) for a in qubits for b in qubits if a != b], directed=False)
         super().__init__(qubits, graph)
         self._gateset = aqt_target_gateset.AQTTargetGateset()
-        self._measurement_duration = measurement_duration
-        self._twoq_gates_duration = twoq_gates_duration
-        self._oneq_gates_duration = oneq_gates_duration
+        self._measurement_duration = cirq.Duration(measurement_duration)
+        self._twoq_gates_duration = cirq.Duration(twoq_gates_duration)
+        self._oneq_gates_duration = cirq.Duration(oneq_gates_duration)
         self._gate_durations = {
-            cirq.GateFamily(cirq.MeasurementGate): measurement_duration,
-            cirq.GateFamily(cirq.XXPowGate): twoq_gates_duration,
-            cirq.GateFamily(cirq.XPowGate): oneq_gates_duration,
-            cirq.GateFamily(cirq.YPowGate): oneq_gates_duration,
-            cirq.GateFamily(cirq.ZPowGate): oneq_gates_duration,
-            cirq.GateFamily(cirq.PhasedXPowGate): oneq_gates_duration,
+            cirq.GateFamily(cirq.MeasurementGate): self._measurement_duration,
+            cirq.GateFamily(cirq.XXPowGate): self._twoq_gates_duration,
+            cirq.GateFamily(cirq.XPowGate): self._oneq_gates_duration,
+            cirq.GateFamily(cirq.YPowGate): self._oneq_gates_duration,
+            cirq.GateFamily(cirq.ZPowGate): self._oneq_gates_duration,
+            cirq.GateFamily(cirq.PhasedXPowGate): self._oneq_gates_duration,
         }
         assert not self._gateset.gates.symmetric_difference(self._gate_durations.keys()), (
             "AQTDeviceMetadata.gate_durations must have the same Gates " "as AQTTargetGateset."

--- a/cirq-aqt/cirq_aqt/aqt_device_metadata_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata_test.py
@@ -1,0 +1,36 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for AQTDeviceMetadata."""
+
+import cirq
+from cirq_aqt.aqt_device_metadata import AQTDeviceMetadata
+from cirq_aqt.aqt_target_gateset import AQTTargetGateset
+
+
+def test_aqtdevice_metadata():
+    qubits = cirq.LineQubit.range(5)
+    metadata = AQTDeviceMetadata(qubits)
+    assert metadata.qubit_set == frozenset(qubits)
+    assert set(qubits) == set(metadata.nx_graph.nodes())
+    edges = metadata.nx_graph.edges()
+    assert len(edges) == 10
+    assert all(q0 != q1 for q0, q1 in edges)
+    assert AQTTargetGateset() == metadata.gateset
+
+
+def test_repr():
+    qubits = cirq.LineQubit.range(3)
+    metadata = AQTDeviceMetadata(qubits)
+    cirq.testing.assert_equivalent_repr(metadata, setup_code='import cirq\nimport cirq_aqt\n')

--- a/cirq-aqt/cirq_aqt/aqt_device_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_test.py
@@ -13,21 +13,27 @@
 # limitations under the License.
 
 from datetime import timedelta
+from typing import List
 
 import pytest
 
 import cirq
-import cirq_aqt
-import cirq_aqt.aqt_device as cad
+from cirq_aqt import aqt_device, aqt_device_metadata
 
 
-def aqt_device(chain_length: int, use_timedelta=False) -> cad.AQTDevice:
-    ms = 1000 * cirq.Duration(nanos=1) if not use_timedelta else timedelta(microseconds=1)
-    return cad.AQTDevice(
-        measurement_duration=100 * ms,  # type: ignore
-        twoq_gates_duration=200 * ms,  # type: ignore
-        oneq_gates_duration=10 * ms,  # type: ignore
-        qubits=cirq.LineQubit.range(chain_length),
+@pytest.fixture
+def qubits() -> List[cirq.LineQubit]:
+    return cirq.LineQubit.range(3)
+
+
+@pytest.fixture
+def device(qubits) -> aqt_device.AQTDevice:
+    ms = cirq.Duration(millis=1)
+    return aqt_device.AQTDevice(
+        measurement_duration=100 * ms,
+        twoq_gates_duration=200 * ms,
+        oneq_gates_duration=10 * ms,
+        qubits=qubits,
     )
 
 
@@ -40,136 +46,112 @@ class NotImplementedOperation(cirq.Operation):
         raise NotImplementedError()
 
 
-def test_init():
-    d = aqt_device(3)
-    ms = 1000 * cirq.Duration(nanos=1)
-    q0 = cirq.LineQubit(0)
-    q1 = cirq.LineQubit(1)
-    q2 = cirq.LineQubit(2)
-
-    assert d.qubits == {q0, q1, q2}
-    assert d.metadata.twoq_gates_duration == 200 * ms
-    assert d.metadata.oneq_gates_duration == 10 * ms
-    assert d.metadata.measurement_duration == 100 * ms
-
+def test_init_qubits(device, qubits):
+    ms = cirq.Duration(millis=1)
+    assert device.qubits == frozenset(qubits)
     with pytest.raises(TypeError, match="NamedQubit"):
-        cad.AQTDevice(
-            measurement_duration=ms,
-            twoq_gates_duration=ms,
-            oneq_gates_duration=ms,
+        aqt_device.AQTDevice(
+            measurement_duration=100 * ms,
+            twoq_gates_duration=200 * ms,
+            oneq_gates_duration=10 * ms,
             qubits=[cirq.LineQubit(0), cirq.NamedQubit("a")],
         )
 
 
-def test_metadata():
-    d = aqt_device(3)
-    assert d.metadata.qubit_set == frozenset(
-        {cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2)}
+@pytest.mark.parametrize('ms', [cirq.Duration(millis=1), timedelta(milliseconds=1)])
+def test_init_durations(ms, qubits):
+    dev = aqt_device.AQTDevice(
+        qubits=qubits,
+        measurement_duration=100 * ms,
+        twoq_gates_duration=200 * ms,
+        oneq_gates_duration=10 * ms,
     )
-    assert len(d.metadata.nx_graph.edges()) == 3
+    assert dev.metadata.twoq_gates_duration == cirq.Duration(millis=200)
+    assert dev.metadata.oneq_gates_duration == cirq.Duration(millis=10)
+    assert dev.metadata.measurement_duration == cirq.Duration(millis=100)
 
 
-def test_init_timedelta():
-    d = aqt_device(3, use_timedelta=True)
-    ms = 1000 * cirq.Duration(nanos=1)
-    q0 = cirq.LineQubit(0)
-    q1 = cirq.LineQubit(1)
-    q2 = cirq.LineQubit(2)
-
-    assert d.qubits == {q0, q1, q2}
-    assert d.metadata.twoq_gates_duration == 200 * ms
-    assert d.metadata.oneq_gates_duration == 10 * ms
-    assert d.metadata.measurement_duration == 100 * ms
+def test_metadata(device, qubits):
+    assert isinstance(device.metadata, aqt_device_metadata.AQTDeviceMetadata)
+    assert device.metadata.qubit_set == frozenset(qubits)
 
 
-def test_repr():
-    d = aqt_device(3)
-    assert repr(d) == (
+def test_repr(device):
+    assert repr(device) == (
         "cirq_aqt.aqt_device.AQTDevice("
-        "measurement_duration=cirq.Duration(micros=100), "
-        "twoq_gates_duration=cirq.Duration(micros=200), "
-        "oneq_gates_duration=cirq.Duration(micros=10), "
+        "measurement_duration=cirq.Duration(millis=100), "
+        "twoq_gates_duration=cirq.Duration(millis=200), "
+        "oneq_gates_duration=cirq.Duration(millis=10), "
         "qubits=[cirq.LineQubit(0), cirq.LineQubit(1), "
         "cirq.LineQubit(2)])"
     )
-    device = cirq_aqt.aqt_device.get_aqt_device(5)
     cirq.testing.assert_equivalent_repr(device, setup_code='import cirq\nimport cirq_aqt\n')
 
 
-def test_validate_measurement_non_adjacent_qubits_ok():
-    d = aqt_device(3)
-
-    d.validate_operation(
+def test_validate_measurement_non_adjacent_qubits_ok(device):
+    device.validate_operation(
         cirq.GateOperation(cirq.MeasurementGate(2, 'key'), (cirq.LineQubit(0), cirq.LineQubit(1)))
     )
 
 
-def test_validate_operation_existing_qubits():
-    d = aqt_device(3)
-
-    d.validate_operation(cirq.GateOperation(cirq.XX, (cirq.LineQubit(0), cirq.LineQubit(1))))
-    d.validate_operation(cirq.Z(cirq.LineQubit(0)))
-    d.validate_operation(
+def test_validate_operation_existing_qubits(device):
+    device.validate_operation(cirq.GateOperation(cirq.XX, (cirq.LineQubit(0), cirq.LineQubit(1))))
+    device.validate_operation(cirq.Z(cirq.LineQubit(0)))
+    device.validate_operation(
         cirq.PhasedXPowGate(phase_exponent=0.75, exponent=0.25, global_shift=0.1).on(
             cirq.LineQubit(1)
         )
     )
 
     with pytest.raises(ValueError):
-        d.validate_operation(cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(-1)))
+        device.validate_operation(cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(-1)))
     with pytest.raises(ValueError):
-        d.validate_operation(cirq.Z(cirq.LineQubit(-1)))
+        device.validate_operation(cirq.Z(cirq.LineQubit(-1)))
     with pytest.raises(ValueError):
-        d.validate_operation(cirq.CZ(cirq.LineQubit(1), cirq.LineQubit(1)))
+        device.validate_operation(cirq.CZ(cirq.LineQubit(1), cirq.LineQubit(1)))
     with pytest.raises(ValueError):
-        d.validate_operation(cirq.X(cirq.NamedQubit("q1")))
+        device.validate_operation(cirq.X(cirq.NamedQubit("q1")))
 
 
-def test_validate_operation_supported_gate():
-    d = aqt_device(3)
-
+def test_validate_operation_supported_gate(device):
     class MyGate(cirq.Gate):
         def num_qubits(self):
             return 1
 
-    d.validate_operation(cirq.GateOperation(cirq.Z, [cirq.LineQubit(0)]))
+    device.validate_operation(cirq.GateOperation(cirq.Z, [cirq.LineQubit(0)]))
 
     assert MyGate().num_qubits() == 1
     with pytest.raises(ValueError):
-        d.validate_operation(cirq.GateOperation(MyGate(), [cirq.LineQubit(0)]))
+        device.validate_operation(cirq.GateOperation(MyGate(), [cirq.LineQubit(0)]))
     with pytest.raises(ValueError):
-        d.validate_operation(NotImplementedOperation())
+        device.validate_operation(NotImplementedOperation())
 
 
-def test_aqt_device_eq():
+def test_aqt_device_eq(device):
     eq = cirq.testing.EqualsTester()
-    eq.make_equality_group(lambda: aqt_device(3))
-    eq.make_equality_group(lambda: aqt_device(4))
+    eq.make_equality_group(lambda: device)
 
 
-def test_validate_circuit_repeat_measurement_keys():
-    d = aqt_device(3)
-
+def test_validate_circuit_repeat_measurement_keys(device):
     circuit = cirq.Circuit()
     circuit.append(
         [cirq.measure(cirq.LineQubit(0), key='a'), cirq.measure(cirq.LineQubit(1), key='a')]
     )
 
     with pytest.raises(ValueError, match='Measurement key a repeated'):
-        d.validate_circuit(circuit)
+        device.validate_circuit(circuit)
 
 
-def test_aqt_device_str():
-    assert str(aqt_device(3)) == "q(0)───q(1)───q(2)"
+def test_aqt_device_str(device):
+    assert str(device) == "q(0)───q(1)───q(2)"
 
 
-def test_aqt_device_pretty_repr():
-    cirq.testing.assert_repr_pretty(aqt_device(3), "q(0)───q(1)───q(2)")
-    cirq.testing.assert_repr_pretty(aqt_device(3), "AQTDevice(...)", cycle=True)
+def test_aqt_device_pretty_repr(device):
+    cirq.testing.assert_repr_pretty(device, "q(0)───q(1)───q(2)")
+    cirq.testing.assert_repr_pretty(device, "AQTDevice(...)", cycle=True)
 
 
-def test_at():
-    d = aqt_device(3)
-    assert d.at(-1) is None
-    assert d.at(0) == cirq.LineQubit(0)
-    assert d.at(2) == cirq.LineQubit(2)
+def test_at(device):
+    assert device.at(-1) is None
+    assert device.at(0) == cirq.LineQubit(0)
+    assert device.at(2) == cirq.LineQubit(2)


### PR DESCRIPTION
Move AQTDevice specifications to a new dedicated AQTDeviceMetadata class.
Move `AQTDevice.gateset` and the `duration_of()` method to AQTDeviceMetadata.
Remove method `AQTDevice.decompose_circuit()`.
Pytestify tests for AQTDevice.

Fixes #5726
