### PR TITLE
Silence warning on complex-to-float conversion

### DIFF
--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -745,7 +745,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         while any(result.shape):
             result = np.trace(result, axis1=0, axis2=len(result.shape) // 2)
 
-        return float(result * self.coefficient)
+        return float(np.real(result * self.coefficient))
 
     def zip_items(
         self, other: 'cirq.PauliString[TKey]'


### PR DESCRIPTION
Make it clear we want to use the real part.
