### PR TITLE
Links and titles

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -54,7 +54,6 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
     'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
     'docs/noise/qcvv/xeb_calibration_example.ipynb',
     'docs/named_topologies.ipynb',
-    'docs/representing_noise.ipynb',
     'docs/start/intro.ipynb',
 ]
 

--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -170,6 +170,8 @@ upper_tabs:
       contents:
       - title: "Overview"
         path: /cirq/noise
+      - title: "Representing Noise"
+        path: /cirq/noise/representing_noise
       ####  CHARACTERIZATION AND COMPENSATION  ####
       - heading: "Characterization and compensation"
       - title: "Calibration FAQ"

--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -65,6 +65,8 @@ upper_tabs:
       - heading: "Advanced"
       - title: "Operators"
         path: /cirq/build/operators
+      - title: "Observables and PauliStrings"
+        path: /cirq/build/pauli_observables
       - title: "Qudits"
         path: /cirq/build/qudits
       - title: "Protocols"
@@ -84,8 +86,6 @@ upper_tabs:
         path: /cirq/simulate/params
       - title: "State Histograms"
         path: /cirq/simulate/state_histograms
-      - title: "Observables and PauliStrings"
-        path: /cirq/simulate/pauli_observables
 
       - heading: "Quantum Virtual Machine"
       - title: "Quantum Virtual Machine"

--- a/docs/build/_index.yaml
+++ b/docs/build/_index.yaml
@@ -35,6 +35,9 @@ landing_page:
       - heading: Operators
         description: Unitary operators, measurements and noise channels.
         path: /cirq/build/operators
+      - heading: Observables and PauliStrings
+        description: Build and measure observables from sums and products of Pauli operators.
+        path: /cirq/build/pauli_observables
       - heading: Qudits
         description: Qutrits and higher dimensional quantum systems.
         path: /cirq/build/qudits

--- a/docs/build/pauli_observables.ipynb
+++ b/docs/build/pauli_observables.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "[Observables](https://en.wikipedia.org/wiki/Observable){:.external} are, in general, some sort of measurable property of a circuit. At its very simplest, this could be whether a qubit measures to be $|0\\rangle$ or $|1\\rangle$ in the standard computational basis. In the Pauli basis, this corresponds to the `Z` observable. In general, this is roughly a way to measure qubit state in a basis other than the computational one, by applying basis-changing operations before measurement. \n",
     "\n",
-    "In Cirq, compositions, linear combinations, and tensor products of Pauli operators are represented with `cirq.PauliString` and `cirq.PauliSum`, which this tutorial will demonstrate next. Fundamentally, these objects are still [Operations](/cirq/bild/operators), and can be added to circuits like any other operation. The second half of this tutorial will cover the second use of `PauliString`s, as observables in measurement. "
+    "In Cirq, compositions, linear combinations, and tensor products of Pauli operators are represented with `cirq.PauliString` and `cirq.PauliSum`, which this tutorial will demonstrate next. Fundamentally, these objects are still [Operations](/cirq/build/operators), and can be added to circuits like any other operation. The second half of this tutorial will cover the second use of `PauliString`s, as observables in measurement. "
    ]
   },
   {

--- a/docs/hardware/qubit_picking.ipynb
+++ b/docs/hardware/qubit_picking.ipynb
@@ -222,7 +222,7 @@
    "source": [
     "### Two qubit gate FSim error\n",
     "\n",
-    "FSim error represents [coherent](cirq/representing_noise#channels) two-qubit error that cannot be represented by Pauli channels (that is, it results from entanglement). Instead, it is represented as an additional `cirq.PhasedFSimGate` with small parameters that would be applied to a given qubit pair after any two-qubit gate's execution.\n",
+    "FSim error represents [coherent](/cirq/representing_noise#channels) two-qubit error that cannot be represented by Pauli channels (that is, it results from entanglement). Instead, it is represented as an additional `cirq.PhasedFSimGate` with small parameters that would be applied to a given qubit pair after any two-qubit gate's execution.\n",
     "\n",
     "The following example takes the norm of a couple of the parameters, as a rough approximate representation of the goodness of qubit pairs relative to one another. "
    ]

--- a/docs/hardware/qubit_picking.ipynb
+++ b/docs/hardware/qubit_picking.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "### One qubit gate Pauli error data\n",
     "\n",
-    "Pauli error defines decoherence of a single qubit in one of the Pauli [channels](/cirq/representing_noise) X, Y, or Z. If the errors are distributed in the uniform distribution over all three axes, the probability of applying an erroneous Pauli gate X, Y, or Z will be the Pauli error divided by three. See page 11 of [this Supplementary Information document](https://arxiv.org/abs/1910.11333){:.external} for more on Pauli error. \n",
+    "Pauli error defines decoherence of a single qubit in one of the Pauli [channels](/cirq/noise/representing_noise) X, Y, or Z. If the errors are distributed in the uniform distribution over all three axes, the probability of applying an erroneous Pauli gate X, Y, or Z will be the Pauli error divided by three. See page 11 of [this Supplementary Information document](https://arxiv.org/abs/1910.11333){:.external} for more on Pauli error. \n",
     "\n",
     "Below is the single qubit Pauli error for the `cirq.PhasedXZGate` supported by the Rainbow processor, pulled from the `gate_pauli_errors` attribute of the noise properties object. You can inspect the error for the other supported one-qubit gates by replacing the `gate` variable below. However, as of July 19th, 2022, the error estimation process results in identical Pauli error for all one-qubit gates."
    ]
@@ -222,7 +222,7 @@
    "source": [
     "### Two qubit gate FSim error\n",
     "\n",
-    "FSim error represents [coherent](/cirq/representing_noise#channels) two-qubit error that cannot be represented by Pauli channels (that is, it results from entanglement). Instead, it is represented as an additional `cirq.PhasedFSimGate` with small parameters that would be applied to a given qubit pair after any two-qubit gate's execution.\n",
+    "FSim error represents [coherent](/cirq/noise/representing_noise#channels) two-qubit error that cannot be represented by Pauli channels (that is, it results from entanglement). Instead, it is represented as an additional `cirq.PhasedFSimGate` with small parameters that would be applied to a given qubit pair after any two-qubit gate's execution.\n",
     "\n",
     "The following example takes the norm of a couple of the parameters, as a rough approximate representation of the goodness of qubit pairs relative to one another. "
    ]

--- a/docs/noise/_index.yaml
+++ b/docs/noise/_index.yaml
@@ -6,6 +6,12 @@ landing_page:
   rows:
     - heading: Manage noise when running circuits
       description: Running circuits on quantum hardware devices means dealing with the noise those devices introduce to the computation. Cirq provides the following ways of managing that noise, to improve the quality of the measured results.
+    options:
+      - cards
+    items:
+      - heading: Representing Noise
+        description: Noise models and channels and what types of error they replicate.
+        path: /cirq/noise/representing_noise
     - heading: Characterization and compensation
       description: Characterize the error a device is exhibiting, then compensate for that error by changing the circuit or reinterpreting the results.
       options:

--- a/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb
+++ b/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb
@@ -34,6 +34,15 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "b5cbe21a91f4"
+   },
+   "source": [
+    "# Coherent vs Incoherent Error with XEB"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "zC1qlUJoSXhm"
    },
    "source": [
@@ -74,7 +83,7 @@
     "id": "57flCRpJpup3"
    },
    "source": [
-    "# Noisy Sampler Setup"
+    "## Setup"
    ]
   },
   {
@@ -355,8 +364,8 @@
     "id": "423f56a942f6"
    },
    "source": [
-    "# Fidelity Data Collection\n",
-    "## Sample Circuits\n",
+    "## Fidelity Data Collection\n",
+    "### Sample Circuits\n",
     "\n",
     "The following call will zip together the `circuit_library` circuits according to `combs_by_layer` into larger circuits that evaluate multiple qubit pairs in parallel, before sampling them. Remember that `samplers` contains coherent and incoherent noise samplers, an errorless sampler, and a fused sampler. Mapping `sample_2q_xeb_circuits` to the list of samplers produces sampled data, generated with identical parameters except for the difference in noise model. "
    ]
@@ -442,9 +451,9 @@
     "id": "QDPtNQlPz3BL"
    },
    "source": [
-    "# Visualizing Fidelity by Noise Model\n",
+    "## Visualizing Fidelity by Noise Model\n",
     "\n",
-    "## Qubit Pair Heatmaps\n",
+    "### Qubit Pair Heatmaps\n",
     "The following cell visualizes the by-cycle fidelity error in qubit pair heatmaps."
    ]
   },
@@ -495,7 +504,7 @@
     "id": "c47ti1_uKnLs"
    },
    "source": [
-    "## Circuit Fidelity by Cycle\n",
+    "### Circuit Fidelity by Cycle\n",
     "The qubit pair heatmaps are good, but summarize the fidelity data too much to reveal meaningful patterns. To rectify this, graph the circuit fidelity by cycle, alongside an exponential decay curve from the by-cycle fidelity estimation. For reference, an exponential decay associated with the original depolarization chance of `5e-3` is included. \n",
     "\n",
     "First some graphing utilities:\n"
@@ -656,7 +665,7 @@
     "id": "6025a292d19b"
    },
    "source": [
-    "# Characterize Gate Parameters\n",
+    "## Characterize Gate Parameters\n",
     "\n",
     "A classical optimizer can be used to approximate the two-qubit gate parameters that were actually used from the fidelity data. Here, the parameter of interest is the `phi` parameter, which is the one used to perturb `SQRT_ISWAP`. To characterize `phi`, flag it in the `SqrtISwapXEBOptions` object. Don't characterize the others parameters, for runtime reasons. This object, once passed into the optimizer wrapper `characterize_phased_fsim_parameters_with_xeb_by_pair`, denotes that the optimizer expects the two-qubit entangling gate used to be a `SQRT_ISWAP`, and that it will look for parameters to that gate (or the PhasedFSim version of it) which most closely replicate the observed fidelity data. \n",
     "\n",
@@ -780,7 +789,7 @@
     "id": "qvXyscaYfpUv"
    },
    "source": [
-    "# Visualizing Refitted Fidelities by Noise Model\n",
+    "## Visualizing Refitted Fidelities by Noise Model\n",
     "\n",
     "Finally, plot the original and refit circuit fidelities by cycle, with exponential decay curves, for each of the available datasets. "
    ]
@@ -866,7 +875,7 @@
     "id": "E8BdVyNGLGnm"
    },
    "source": [
-    "# Conclusion\n",
+    "## Conclusion\n",
     "\n",
     "Cross Entropy Benchmarking and optimizer refitting has been shown here to effectively characterize patterns of coherent error, to find the (parameters of the) true unitary operation used on individual qubit pairs. Importantly, this is effective even in the case where incoherent error is also acting on the system, but with noticeably reduced accuracy. In a real hardware system, with many interacting sources of error, XEB can still be useful to identify consistent coherent error, but it's important to remember that other error can confound these results. "
    ]
@@ -877,7 +886,7 @@
     "id": "wxvZ2plRMB-l"
    },
    "source": [
-    "# What's Next?\n",
+    "## What's Next?\n",
     "\n",
     "Now that you've identified coherent error, what can you do about it? \n",
     "- Depending on the parameter(s) identified to be out of tune, you may be able to change the circuits you want to run to compensate for that change. Read [Calibration API](../tutorials/google/calibration_api.ipynb) for further information.\n",

--- a/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb
+++ b/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb
@@ -48,16 +48,16 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/qcvv/coherent_vs_incoherent_xeb>\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/noise/qcvv/coherent_vs_incoherent_xeb>\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/qcvv/coherent_vs_incoherent_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/qcvv/coherent_vs_incoherent_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/qcvv/coherent_vs_incoherent_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/noise/qcvv/coherent_vs_incoherent_xeb.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -70,11 +70,11 @@
    "source": [
     "This notebook demonstrates how to use Cross Entropy Benchmarking (XEB) end-to-end to compare coherent gate parameter error and incoherent depolarization error. It will mimic a small device graph of `cirq.GridQubit` pairs and simulate two-qubit XEB benchmarking circuits on them with noise models that introduce coherent and incoherent error before visualizing and comparing the results.\n",
     "\n",
-    "For more information on types of error, see [Average, Pauli and Incoherent Error](../google/calibration.md#average-pauli-and-incoherent_error). \n",
+    "For more information on types of error, see [Average, Pauli and Incoherent Error](/cirq/noise/calibration.md#average-pauli-and-incoherent_error). \n",
     "\n",
-    "For more information on noise and noise models, see [Noise](../noise.ipynb).\n",
+    "For more information on noise and noise models, see [Noise](/cirq/noise).\n",
     "\n",
-    "For more information on how XEB works in detail, see [XEB Theory](./xeb_theory.ipynb) notebook."
+    "For more information on how XEB works in detail, see [XEB Theory](/cirq/noise/qcvv/xeb_theory) notebook."
    ]
   },
   {
@@ -144,7 +144,7 @@
    "source": [
     "## Prepare Noise Models\n",
     "\n",
-    "To compare coherent and incoherent error, use two different noise models, which introduce coherent and incoherent error respectively. Also included are a noiseless model and a \"fused\" model that combines both coherent and incoherent error, for comparison. See [Noise](../noise.ipynb) for the difference between coherent and incoherent error. \n",
+    "To compare coherent and incoherent error, use two different noise models, which introduce coherent and incoherent error respectively. Also included are a noiseless model and a \"fused\" model that combines both coherent and incoherent error, for comparison. See [Noise](/cirq/noise) for the difference between coherent and incoherent error. \n",
     "\n",
     "The coherent noise model is represented by a perturbed `SQRT_ISWAP` gate, which implements a slightly different unitary than a true `SQRT_ISWAP`. Perturbed gates are caused by hardware losing its calibrated tuning, which typically occurres naturally over time between device calibrations. \n",
     "\n",
@@ -822,7 +822,7 @@
     "id": "E4xIRDi9gBnu"
    },
    "source": [
-    "In the coherent error case, the optimization was able to refit the fidelities very well. The new curves of the refit data almost perfectly match the horizontal line at `1.0` fidelity. The success of this refit means that the estimated parameters for this case are very likely to represent the actual parameters of the gate operation used, which was seen in the fact that the optimization re-discovered the `phi` value that was originally used to perturb `SQRT_ISWAP`. In the real hardware case, identifying these parameters means identifying what unitary the gate control hardware actually implemented. If this unitary is far from the intended one, hardware re-calibration or [compensation](../tutorials/google/calibration_api.ipynb) must be performed in order to improve circuit fidelity. \n",
+    "In the coherent error case, the optimization was able to refit the fidelities very well. The new curves of the refit data almost perfectly match the horizontal line at `1.0` fidelity. The success of this refit means that the estimated parameters for this case are very likely to represent the actual parameters of the gate operation used, which was seen in the fact that the optimization re-discovered the `phi` value that was originally used to perturb `SQRT_ISWAP`. In the real hardware case, identifying these parameters means identifying what unitary the gate control hardware actually implemented. If this unitary is far from the intended one, hardware re-calibration or [compensation](/cirq/noise/calibration_api) must be performed in order to improve circuit fidelity. \n",
     "\n",
     "In constrast, the optimizer was completely unable to refit the circuit fidelities in the incoherent error case. The refit fidelities find no meaningful fidelity improvement, instead following the same, expected `5e-3` exponential decay as the original fidelities. Unsurprisingly, the optimizer was unable to find any coherent error in the incoherent-only fidelity data. \n",
     "\n",
@@ -889,7 +889,7 @@
     "## What's Next?\n",
     "\n",
     "Now that you've identified coherent error, what can you do about it? \n",
-    "- Depending on the parameter(s) identified to be out of tune, you may be able to change the circuits you want to run to compensate for that change. Read [Calibration API](../tutorials/google/calibration_api.ipynb) for further information.\n",
+    "- Depending on the parameter(s) identified to be out of tune, you may be able to change the circuits you want to run to compensate for that change. Read [Calibration API](/cirq/noise/calibration_api) for further information.\n",
     "- In the real hardware case, the device may need to be re-calibrated in order to fix the tuning of particular gate operations on particular qubits. Reach out to your google contact to let us know!"
    ]
   }

--- a/docs/noise/representing_noise.ipynb
+++ b/docs/noise/representing_noise.ipynb
@@ -39,16 +39,16 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/representing_noise\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/noise/representing_noise\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/representing_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/noise/representing_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/representing_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/noise/representing_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/representing_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/noise/representing_noise.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]

--- a/docs/noise/representing_noise.ipynb
+++ b/docs/noise/representing_noise.ipynb
@@ -65,18 +65,9 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ea381f53cf89"
-   },
-   "source": [
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
    ]
   },
   {

--- a/docs/simulate/_index.yaml
+++ b/docs/simulate/_index.yaml
@@ -21,9 +21,6 @@ landing_page:
       - heading: State Histograms
         description: Visualize the results of simulation as a histogram over basis states.
         path: /cirq/simulate/state_histograms
-      - heading: Observables and PauliStrings
-        description: Build and measure observables from sums and products of Pauli operators.
-        path: /cirq/simulate/pauli_observables
 
     - heading: Quantum Virtual Machine
       description: Run circuits on a virtual version of quantum hardware, complete with an identical interface and noisy simulation that mimics hardware devices.

--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -145,7 +145,7 @@
    "source": [
     "### Build a noisy simulator with a hardware noise model\n",
     "\n",
-    "- Load median device noise data for the processor you have chosen. Learn more about device noise data [here](/cirq/representing_noise)\n",
+    "- Load median device noise data for the processor you have chosen. Learn more about device noise data [here](/cirq/noise/representing_noise)\n",
     "- Transform the median device noise data to a Cirq noise properties object\n",
     "- Create a noise model using your noise properties\n",
     "- Set up a qsim sampler which runs noisy simulations using your noise model. Learn more about noisy simulation with qsim here in the [Noisy simulation with qsim page](/qsim/tutorials/noisy_qsimcirq)."

--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -148,7 +148,7 @@
     "- Load median device noise data for the processor you have chosen. Learn more about device noise data [here](/cirq/representing_noise)\n",
     "- Transform the median device noise data to a Cirq noise properties object\n",
     "- Create a noise model using your noise properties\n",
-    "- Set up a qsim sampler which runs noisy simulations using your noise model. Learn more about noisy simulation with qsim here in the [Noisy simulation with qsim page](qsim/tutorials/noisy_qsimcirq)."
+    "- Set up a qsim sampler which runs noisy simulations using your noise model. Learn more about noisy simulation with qsim here in the [Noisy simulation with qsim page](/qsim/tutorials/noisy_qsimcirq)."
    ]
   },
   {

--- a/docs/simulate/qvm_basic_example.ipynb
+++ b/docs/simulate/qvm_basic_example.ipynb
@@ -123,7 +123,7 @@
     "## Create a **Quantum Virtual Machine**\n",
     "\n",
     "The following cell builds a Quantum Virtual Machine that mimics a particular Google quantum hardware device (currently Rainbow or Weber) using the following customizable steps: \n",
-    "- Constructing a `cirq.NoiseModel` object from device calibration data saved in Cirq. See [Representing Noise](/cirq/representing_noise) for more on noise models. \n",
+    "- Constructing a `cirq.NoiseModel` object from device calibration data saved in Cirq. See [Representing Noise](/cirq/noise/representing_noise) for more on noise models. \n",
     "- Building a `qsimcirq.QsimSimulator` that uses this noise model. See [Noisy Simulation](/cirq/simulate/noisy_simulation) and [Noise simulation with qsim](/qsim/tutorials/noisy_qsimcirq) for more. \n",
     "- Creating a `cirq.Device` that imposes the same constraints on circuits that the original device would. See [Devices](/cirq/hardware/devices) for more on these constraint objects. \n",
     "- Packaging the simulator and device into an object that implements the `cirq.Engine` interface that the hardware device would use. \n",

--- a/docs/simulate/qvm_stabilizer_example.ipynb
+++ b/docs/simulate/qvm_stabilizer_example.ipynb
@@ -51,13 +51,13 @@
     "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/simulate/qvm_stabilizer_example\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/simulate/qvm_stabilizer_code.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/simulate/qvm_stabilizer_example.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/simulate/qvm_stabilizer_code.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/simulate/qvm_stabilizer_example.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/simulate/qvm_stabilizer_code.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/simulate/qvm_stabilizer_example.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]

--- a/docs/simulate/virtual_engine_interface.ipynb
+++ b/docs/simulate/virtual_engine_interface.ipynb
@@ -48,16 +48,16 @@
    "source": [
     "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/qvm/qve\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
+    "    <a target=\"_blank\" href=\"https://quantumai.google/cirq/simulate/virtual_engine_interface\"><img src=\"https://quantumai.google/site-assets/images/buttons/quantumai_logo_1x.png\" />View on QuantumAI</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/qvm/qve.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/quantumlib/Cirq/blob/master/docs/simulate/virtual_engine_interface.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/colab_logo_1x.png\" />Run in Google Colab</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/qvm/qve.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/quantumlib/Cirq/blob/master/docs/simulate/virtual_engine_interface.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/github_logo_1x.png\" />View source on GitHub</a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/qvm/qve.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
+    "    <a href=\"https://storage.googleapis.com/tensorflow_docs/Cirq/docs/simulate/virtual_engine_interface.ipynb\"><img src=\"https://quantumai.google/site-assets/images/buttons/download_icon_1x.png\" />Download notebook</a>\n",
     "  </td>\n",
     "</table>"
    ]
@@ -234,7 +234,7 @@
     "id": "FtCpP5evY2Ss"
    },
    "source": [
-    "You can also run [Parameter Sweeps](/cirq/simulate/parameter_sweeps) with the `run_sweep` function, which returns a `cirq.Job`-type object instead of a `Result`. This way, jobs can be prepared and run asynchronously. When running a parameter sweep over many parameter options, or with particularly large circuits, it can be useful to set the job running and return for the results later, with the ability to check job execution status in between. "
+    "You can also run [Parameter Sweeps](/cirq/simulate/params) with the `run_sweep` function, which returns a `cirq.Job`-type object instead of a `Result`. This way, jobs can be prepared and run asynchronously. When running a parameter sweep over many parameter options, or with particularly large circuits, it can be useful to set the job running and return for the results later, with the ability to check job execution status in between. "
    ]
   },
   {

--- a/docs/start/basics.ipynb
+++ b/docs/start/basics.ipynb
@@ -447,7 +447,7 @@
     "\n",
     "Cirq also provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine), which is a simulated virtual version of quantum hardware devices. It consists of two primary components: \n",
     "1. A [virtual Engine interface](/cirq/simulate/virtual_engine_interface) that enables you to verify and run circuits with the same interface that quantum hardware would have.\n",
-    "2. A set of [noise models](cirq/simulate/representing_noise) that try to realistically replicate the noise present in actual Google quantum hardware devices.\n",
+    "2. A set of [noise models](cirq/representing_noise) that try to realistically replicate the noise present in actual Google quantum hardware devices.\n",
     "\n",
     "The QVM is intended to serve as a replacement for the Google quantum hardware, in two cases: \n",
     "1. Running your circuit on a QVM can give an approximation of how your circuit runs under the influence of hardware-like noise. This can be useful to help you reconfigure or change your circuit to be less impacted by noise when run on actual quantum hardware.\n",

--- a/docs/start/basics.ipynb
+++ b/docs/start/basics.ipynb
@@ -447,7 +447,7 @@
     "\n",
     "Cirq also provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine), which is a simulated virtual version of quantum hardware devices. It consists of two primary components: \n",
     "1. A [virtual Engine interface](/cirq/simulate/virtual_engine_interface) that enables you to verify and run circuits with the same interface that quantum hardware would have.\n",
-    "2. A set of [noise models](cirq/representing_noise) that try to realistically replicate the noise present in actual Google quantum hardware devices.\n",
+    "2. A set of [noise models](cirq/noise/representing_noise) that try to realistically replicate the noise present in actual Google quantum hardware devices.\n",
     "\n",
     "The QVM is intended to serve as a replacement for the Google quantum hardware, in two cases: \n",
     "1. Running your circuit on a QVM can give an approximation of how your circuit runs under the influence of hardware-like noise. This can be useful to help you reconfigure or change your circuit to be less impacted by noise when run on actual quantum hardware.\n",

--- a/docs/start/intro.ipynb
+++ b/docs/start/intro.ipynb
@@ -2607,7 +2607,7 @@
    "source": [
     "# Quantum Virtual Machine\n",
     "\n",
-    "Cirq provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) as a way to run circuits using the same interface that quantum hardware uses and get results that approximate those the hardware would produce. It combines [Devices](/cirq/hardware/devices), [Noisy Simulation](/cirq/simulate/noisy_simulation), realistic [Noise Models](/cirq/simulate/representing_noise) and a [Virtual Engine Interface](/cirq/simulate/virtual_engine_interface) to produce a `cirq.SimulatedLocalEngine` that you can treat almost interchangeably with hardware devices. See the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) page to learn more about how it works, or jump to the [QVM Creation Template](/cirq/simulate/qvm_builder_code) notebook to just start using it. "
+    "Cirq provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) as a way to run circuits using the same interface that quantum hardware uses and get results that approximate those the hardware would produce. It combines [Devices](/cirq/hardware/devices), [Noisy Simulation](/cirq/simulate/noisy_simulation), realistic [Noise Models](/cirq/representing_noise) and a [Virtual Engine Interface](/cirq/simulate/virtual_engine_interface) to produce a `cirq.SimulatedLocalEngine` that you can treat almost interchangeably with hardware devices. See the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) page to learn more about how it works, or jump to the [QVM Creation Template](/cirq/simulate/qvm_builder_code) notebook to just start using it. "
    ]
   },
   {

--- a/docs/start/intro.ipynb
+++ b/docs/start/intro.ipynb
@@ -2607,7 +2607,7 @@
    "source": [
     "# Quantum Virtual Machine\n",
     "\n",
-    "Cirq provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) as a way to run circuits using the same interface that quantum hardware uses and get results that approximate those the hardware would produce. It combines [Devices](/cirq/hardware/devices), [Noisy Simulation](/cirq/simulate/noisy_simulation), realistic [Noise Models](/cirq/representing_noise) and a [Virtual Engine Interface](/cirq/simulate/virtual_engine_interface) to produce a `cirq.SimulatedLocalEngine` that you can treat almost interchangeably with hardware devices. See the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) page to learn more about how it works, or jump to the [QVM Creation Template](/cirq/simulate/qvm_builder_code) notebook to just start using it. "
+    "Cirq provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) as a way to run circuits using the same interface that quantum hardware uses and get results that approximate those the hardware would produce. It combines [Devices](/cirq/hardware/devices), [Noisy Simulation](/cirq/simulate/noisy_simulation), realistic [Noise Models](/cirq/noise/representing_noise) and a [Virtual Engine Interface](/cirq/simulate/virtual_engine_interface) to produce a `cirq.SimulatedLocalEngine` that you can treat almost interchangeably with hardware devices. See the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine) page to learn more about how it works, or jump to the [QVM Creation Template](/cirq/simulate/qvm_builder_code) notebook to just start using it. "
    ]
   },
   {


### PR DESCRIPTION
Fix title sizing for XEB page
Fix links in other pages
Move Pauli observables to build, where it was intended to be in the first place. 
Move Representing Noise to noise.