### PR TITLE
added P gate to list of available gates that can be parsed from QASM

### DIFF
--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -83,8 +83,7 @@ class QasmGateStatement:
         if len(args) != self.num_args:
             raise QasmException(
                 "{} only takes {} arg(s) (qubits and/or registers), "
-                "got: {}, at line {}".format(
-                    self.qasm_gate, self.num_args, len(args), lineno)
+                "got: {}, at line {}".format(self.qasm_gate, self.num_args, len(args), lineno)
             )
 
     def _validate_params(self, params: List[float], lineno: int):
@@ -110,8 +109,7 @@ class QasmGateStatement:
         # the actual gate we'll apply the arguments to might be a parameterized
         # or non-parameterized gate
         final_gate: ops.Gate = (
-            self.cirq_gate if isinstance(
-                self.cirq_gate, ops.Gate) else self.cirq_gate(params)
+            self.cirq_gate if isinstance(self.cirq_gate, ops.Gate) else self.cirq_gate(params)
         )
         # OpenQASM gates can be applied on single qubits and qubit registers.
         # We represent single qubits as registers of size 1.
@@ -122,16 +120,14 @@ class QasmGateStatement:
         # through each qubit of the registers 0 to n-1 and use the same one
         # qubit from the "single-qubit registers" for each operation.
         op_qubits = functools.reduce(
-            cast(Callable[[List['cirq.Qid'], List['cirq.Qid']],
-                 List['cirq.Qid']], np.broadcast),
+            cast(Callable[[List['cirq.Qid'], List['cirq.Qid']], List['cirq.Qid']], np.broadcast),
             args,
         )
         for qubits in op_qubits:
             if isinstance(qubits, ops.Qid):
                 yield final_gate.on(qubits)
             elif len(np.unique(qubits)) < len(qubits):
-                raise QasmException(
-                    f"Overlapping qubits in arguments at line {lineno}")
+                raise QasmException(f"Overlapping qubits in arguments at line {lineno}")
             else:
                 yield final_gate.on(*qubits)
 
@@ -219,8 +215,7 @@ class QasmParser:
         ),
         'u2': QasmGateStatement(
             qasm_gate='u2',
-            cirq_gate=(lambda params: QasmUGate(
-                0.5, params[0] / np.pi, params[1] / np.pi)),
+            cirq_gate=(lambda params: QasmUGate(0.5, params[0] / np.pi, params[1] / np.pi)),
             num_params=2,
             num_args=1,
         ),
@@ -236,8 +231,7 @@ class QasmParser:
             num_args=1,
             cirq_gate=(
                 lambda params: QasmUGate(
-                    params[0] / np.pi, (params[1] / np.pi) -
-                    0.5, (-params[1] / np.pi) + 0.5
+                    params[0] / np.pi, (params[1] / np.pi) - 0.5, (-params[1] / np.pi) + 0.5
                 )
             ),
         ),
@@ -278,8 +272,7 @@ class QasmParser:
     def p_qasm_format_only(self, p):
         """qasm : format"""
         self.supported_format = True
-        p[0] = Qasm(self.supported_format, self.qelibinc,
-                    self.qregs, self.cregs, self.circuit)
+        p[0] = Qasm(self.supported_format, self.qelibinc, self.qregs, self.cregs, self.circuit)
 
     def p_qasm_no_format_specified_error(self, p):
         """qasm : QELIBINC
@@ -290,13 +283,11 @@ class QasmParser:
     def p_qasm_include(self, p):
         """qasm : qasm QELIBINC"""
         self.qelibinc = True
-        p[0] = Qasm(self.supported_format, self.qelibinc,
-                    self.qregs, self.cregs, self.circuit)
+        p[0] = Qasm(self.supported_format, self.qelibinc, self.qregs, self.cregs, self.circuit)
 
     def p_qasm_circuit(self, p):
         """qasm : qasm circuit"""
-        p[0] = Qasm(self.supported_format, self.qelibinc,
-                    self.qregs, self.cregs, p[2])
+        p[0] = Qasm(self.supported_format, self.qelibinc, self.qregs, self.cregs, p[2])
 
     def p_format(self, p):
         """format : FORMAT_SPEC"""
@@ -334,11 +325,9 @@ class QasmParser:
         | CREG ID '[' NATURAL_NUMBER ']' ';'"""
         name, length = p[2], p[4]
         if name in self.qregs.keys() or name in self.cregs.keys():
-            raise QasmException(
-                f"{name} is already defined at line {p.lineno(2)}")
+            raise QasmException(f"{name} is already defined at line {p.lineno(2)}")
         if length == 0:
-            raise QasmException(
-                f"Illegal, zero-length register '{name}' at line {p.lineno(4)}")
+            raise QasmException(f"Illegal, zero-length register '{name}' at line {p.lineno(4)}")
         if p[1] == "qreg":
             self.qregs[name] = length
         else:
@@ -399,8 +388,7 @@ class QasmParser:
         """expr : ID '(' expr ')'"""
         func = p[1]
         if func not in self.functions.keys():
-            raise QasmException(
-                f"Function not recognized: '{func}' at line {p.lineno(1)}")
+            raise QasmException(f"Function not recognized: '{func}' at line {p.lineno(1)}")
         p[0] = self.functions[func](p[3])
 
     def p_expr_unary(self, p):
@@ -445,8 +433,7 @@ class QasmParser:
         """qarg : ID"""
         reg = p[1]
         if reg not in self.qregs.keys():
-            raise QasmException(
-                f'Undefined quantum register "{reg}" at line {p.lineno(1)}')
+            raise QasmException(f'Undefined quantum register "{reg}" at line {p.lineno(1)}')
         qubits = []
         for idx in range(self.qregs[reg]):
             arg_name = self.make_name(idx, reg)
@@ -462,8 +449,7 @@ class QasmParser:
         """carg : ID"""
         reg = p[1]
         if reg not in self.cregs.keys():
-            raise QasmException(
-                f'Undefined classical register "{reg}" at line {p.lineno(1)}')
+            raise QasmException(f'Undefined classical register "{reg}" at line {p.lineno(1)}')
 
         p[0] = [self.make_name(idx, reg) for idx in range(self.cregs[reg])]
 
@@ -476,8 +462,7 @@ class QasmParser:
         idx = p[3]
         arg_name = self.make_name(idx, reg)
         if reg not in self.qregs.keys():
-            raise QasmException(
-                f'Undefined quantum register "{reg}" at line {p.lineno(1)}')
+            raise QasmException(f'Undefined quantum register "{reg}" at line {p.lineno(1)}')
         size = self.qregs[reg]
         if idx >= size:
             raise QasmException(
@@ -495,8 +480,7 @@ class QasmParser:
         idx = p[3]
         arg_name = self.make_name(idx, reg)
         if reg not in self.cregs.keys():
-            raise QasmException(
-                f'Undefined classical register "{reg}" at line {p.lineno(1)}')
+            raise QasmException(f'Undefined classical register "{reg}" at line {p.lineno(1)}')
 
         size = self.cregs[reg]
         if idx >= size:
@@ -537,8 +521,7 @@ class QasmParser:
             v = (p[5] >> i) & 1
             conditions.append(sympy.Eq(sympy.Symbol(key), v))
         p[0] = [
-            ops.ClassicallyControlledOperation(
-                conditions=conditions, sub_operation=tuple(p[7])[0])
+            ops.ClassicallyControlledOperation(conditions=conditions, sub_operation=tuple(p[7])[0])
         ]
 
     def p_error(self, p):
@@ -567,8 +550,7 @@ at line {p.lineno}, column {self.find_column(p)}"""
 
     def debug_context(self, p):
         debug_start = max(self.qasm.rfind('\n', 0, p.lexpos) + 1, p.lexpos - 5)
-        debug_end = min(self.qasm.find(
-            '\n', p.lexpos, p.lexpos + 5), p.lexpos + 5)
+        debug_end = min(self.qasm.find('\n', p.lexpos, p.lexpos + 5), p.lexpos + 5)
 
         return (
             "..."


### PR DESCRIPTION
### Summary
P gate was previously unable to be parsed from QASM to Cirq circuit. Added ability for `p(params[0])` gates to be parsed as `QasmUGate(0, 0, params[0] / np.pi)`.

### Details & Comments
- Previously not able to parse P gate using `circuit_from_qasm(qasm)` method under `cirq.contrib.qasm_import` module.
- Added P gate into `qelib_gates` dictionary under `_parser.py`.