### PR TITLE
Add `{Frozen}Circuit.from_moments` to construct circuit by moments.

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -157,6 +157,10 @@ class AbstractCircuit(abc.ABC):
     def _from_moments(cls: Type[CIRCUIT_TYPE], moments: Iterable['cirq.Moment']) -> CIRCUIT_TYPE:
         """Create a circuit from moments.
 
+        This must be implemented by subclasses. It provides a more efficient way
+        to construct a circuit instance since we already have the moments and so
+        can skip the analysis required to implement various insert strategies.
+
         Args:
             moments: Moments of the circuit.
         """

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -150,7 +150,9 @@ class AbstractCircuit(abc.ABC):
         Args:
             *moments: Op tree for each moment.
         """
-        return cls._from_moments(Moment(moment) for moment in moments)
+        return cls._from_moments(
+            moment if isinstance(moment, Moment) else Moment(moment) for moment in moments
+        )
 
     @classmethod
     @abc.abstractmethod
@@ -970,9 +972,7 @@ class AbstractCircuit(abc.ABC):
         )
 
     def _with_key_path_(self, path: Tuple[str, ...]):
-        return self._from_moments(
-            protocols.with_key_path(moment, path) for moment in self.moments
-        )
+        return self._from_moments(protocols.with_key_path(moment, path) for moment in self.moments)
 
     def _with_key_path_prefix_(self, prefix: Tuple[str, ...]):
         return self._from_moments(
@@ -1568,9 +1568,7 @@ class AbstractCircuit(abc.ABC):
         # the qubits from one factor belong to a specific independent qubit set.
         # This makes it possible to create independent circuits based on these
         # moments.
-        return (
-            self._from_moments(m[qubits] for m in self.moments) for qubits in qubit_factors
-        )
+        return (self._from_moments(m[qubits] for m in self.moments) for qubits in qubit_factors)
 
     def _control_keys_(self) -> FrozenSet['cirq.MeasurementKey']:
         controls = frozenset(k for op in self.all_operations() for k in protocols.control_keys(op))

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1731,7 +1731,7 @@ class Circuit(AbstractCircuit):
         Args:
             *moments: Op tree for each moment.
         """
-        return cls(Moment(moment) for moment in moments)
+        return cls(*(Moment(moment) for moment in moments))
 
     def _load_contents_with_earliest_strategy(self, contents: 'cirq.OP_TREE'):
         """Optimized algorithm to load contents quickly.

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1731,7 +1731,9 @@ class Circuit(AbstractCircuit):
         Args:
             *moments: Op tree for each moment.
         """
-        return cls(*(Moment(moment) for moment in moments))
+        new_circuit = Circuit()
+        new_circuit._moments = list(Moment(moment) for moment in moments)
+        return new_circuit
 
     def _load_contents_with_earliest_strategy(self, contents: 'cirq.OP_TREE'):
         """Optimized algorithm to load contents quickly.

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1733,11 +1733,6 @@ class Circuit(AbstractCircuit):
 
     @classmethod
     def _from_moments(cls, moments: Iterable['cirq.Moment']) -> 'Circuit':
-        """Create a circuit from moments.
-
-        Args:
-            *moments: Op tree for each moment.
-        """
         new_circuit = Circuit()
         new_circuit._moments[:] = moments
         return new_circuit

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -70,6 +70,21 @@ class _MomentAndOpTypeValidatingDeviceType(cirq.Device):
 moment_and_op_type_validating_device = _MomentAndOpTypeValidatingDeviceType()
 
 
+def test_from_moments():
+    a, b, c, d = cirq.LineQubit.range(4)
+    assert cirq.Circuit.from_moments(
+        [cirq.X(a), cirq.Y(b)],
+        [cirq.X(c)],
+        [],
+        cirq.Z(d),
+    ) == cirq.Circuit(
+        cirq.Moment(cirq.X(a), cirq.Y(b)),
+        cirq.Moment(cirq.X(c)),
+        cirq.Moment(),
+        cirq.Moment(cirq.Z(d)),
+    )
+
+
 def test_alignment():
     assert repr(cirq.Alignment.LEFT) == 'cirq.Alignment.LEFT'
     assert repr(cirq.Alignment.RIGHT) == 'cirq.Alignment.RIGHT'

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -77,11 +77,13 @@ def test_from_moments():
         [cirq.X(c)],
         [],
         cirq.Z(d),
+        [cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')],
     ) == cirq.Circuit(
         cirq.Moment(cirq.X(a), cirq.Y(b)),
         cirq.Moment(cirq.X(c)),
         cirq.Moment(),
         cirq.Moment(cirq.Z(d)),
+        cirq.Moment(cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')),
     )
 
 

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -286,6 +286,16 @@ def test_append_control_key_subcircuit():
     assert len(c) == 1
 
 
+def test_measurement_key_paths():
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.measure(a, key='A'))
+    assert cirq.measurement_key_names(circuit1) == {'A'}
+    circuit2 = cirq.with_key_path(circuit1, ('B',))
+    assert cirq.measurement_key_names(circuit2) == {'B:A'}
+    circuit3 = cirq.with_key_path_prefix(circuit2, ('C',))
+    assert cirq.measurement_key_names(circuit3) == {'C:B:A'}
+
+
 def test_append_moments():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')

--- a/cirq-core/cirq/circuits/frozen_circuit.py
+++ b/cirq-core/cirq/circuits/frozen_circuit.py
@@ -64,7 +64,7 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
         Args:
             *moments: Op tree for each moment.
         """
-        return Circuit.from_moments(*moments).freeze()
+        return cls(*(Moment(moment) for moment in moments))
 
     @property
     def moments(self) -> Sequence['cirq.Moment']:

--- a/cirq-core/cirq/circuits/frozen_circuit.py
+++ b/cirq-core/cirq/circuits/frozen_circuit.py
@@ -55,7 +55,7 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
             moments = cast(Sequence[Moment], contents)
         else:
             moments = Circuit(*contents, strategy=strategy).moments
-        self._moments: Tuple[Moment] = tuple(moments)
+        self._moments: Tuple[Moment, ...] = tuple(moments)
 
     @classmethod
     def from_moments(cls, *moments: 'cirq.OP_TREE') -> 'FrozenCircuit':
@@ -64,7 +64,9 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
         Args:
             *moments: Op tree for each moment.
         """
-        return cls(*(Moment(moment) for moment in moments))
+        new_circuit = FrozenCircuit()
+        new_circuit._moments = tuple(Moment(moment) for moment in moments)
+        return new_circuit
 
     @property
     def moments(self) -> Sequence['cirq.Moment']:

--- a/cirq-core/cirq/circuits/frozen_circuit_test.py
+++ b/cirq-core/cirq/circuits/frozen_circuit_test.py
@@ -28,11 +28,13 @@ def test_from_moments():
         [cirq.X(c)],
         [],
         cirq.Z(d),
+        [cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')],
     ) == cirq.FrozenCircuit(
         cirq.Moment(cirq.X(a), cirq.Y(b)),
         cirq.Moment(cirq.X(c)),
         cirq.Moment(),
         cirq.Moment(cirq.Z(d)),
+        cirq.Moment(cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')),
     )
 
 

--- a/cirq-core/cirq/circuits/frozen_circuit_test.py
+++ b/cirq-core/cirq/circuits/frozen_circuit_test.py
@@ -21,6 +21,21 @@ import pytest
 import cirq
 
 
+def test_from_moments():
+    a, b, c, d = cirq.LineQubit.range(4)
+    assert cirq.FrozenCircuit.from_moments(
+        [cirq.X(a), cirq.Y(b)],
+        [cirq.X(c)],
+        [],
+        cirq.Z(d),
+    ) == cirq.FrozenCircuit(
+        cirq.Moment(cirq.X(a), cirq.Y(b)),
+        cirq.Moment(cirq.X(c)),
+        cirq.Moment(),
+        cirq.Moment(cirq.Z(d)),
+    )
+
+
 def test_freeze_and_unfreeze():
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.X(a), cirq.H(b))


### PR DESCRIPTION
In our internal code almost all circuits are constructed with explicit moments rather than using an insertion strategy because we want to control the alignment of ops. Here we add a `from_moments` classmethod on `Circuit` and `FrozenCircuit` which takes any number of `OP_TREE` args and converts each one to a `Moment` in the resulting circuit. This gives a convenient way to construct circuits without cluttering the code with multiple calls to `Moment`.

Also adds special cases in both the `Circuit` and `FrozenCircuit` constructors to handle constructing from a single circuit or a sequence of moments.