### PR TITLE
Minor style changes to qvm builder code notebook

### DIFF
--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -41,6 +41,7 @@ SKIP_NOTEBOOKS = [
     'docs/noise/qcvv/xeb_calibration_example.ipynb',
     'docs/noise/calibration_api.ipynb',
     'docs/noise/floquet_calibration_example.ipynb',
+    # shouldn't have outputs generated for style reasons
     'docs/simulate/qvm_builder_code.ipynb',
 ]
 

--- a/docs/simulate/qvm_builder_code.ipynb
+++ b/docs/simulate/qvm_builder_code.ipynb
@@ -127,6 +127,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "cellView": "form",
     "id": "pbHCUPLpq5WE"
    },
    "outputs": [],
@@ -174,7 +175,9 @@
    "outputs": [],
    "source": [
     "# create your device ready circuit here!\n",
-    "your_circuit_name = cirq.Circuit(cirq.measure(cirq.GridQubit(4, 3)))"
+    "q0 = cirq.GridQubit(4, 1)\n",
+    "your_circuit = cirq.Circuit([(cirq.X**0.5)(q0), cirq.measure(q0)])\n",
+    "print(your_circuit)"
    ]
   },
   {
@@ -190,12 +193,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "cellView": "form",
     "id": "bFjnNSqRZsFu"
    },
    "outputs": [],
    "source": [
     "# @title Enter the name of your device ready circuit and execute it on the Quantum Virtual Machine\n",
-    "circuit = your_circuit_name  # @param\n",
+    "circuit = your_circuit  # @param\n",
     "\n",
     "reps = 3000\n",
     "start = time.time()\n",


### PR DESCRIPTION
Hide some of the code behind a button in the builder notebook, use the same example shown in QSS, add an explanatory comment in notebook_test