### PR TITLE
Add binary literal example to methods of SimulatesAmplitudes class

### DIFF
--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -157,8 +157,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
                 significant qubit, i.e. in big-endian ordering.
-                Binary literals should be input with the prefix 0b or 0B. 
-	        For example, 0010 should be input as 0b0010 or 0B0010.
+                If inputting a binary literal add the prefix 0b or 0B.
+            For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
 
             param_resolver: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
@@ -218,8 +218,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
                 significant qubit, i.e. in big-endian ordering.
-                Binary literals should be input with the prefix 0b or 0B. 
-	        For example, 0010 should be input as 0b0010 or 0B0010.
+                If inputting a binary literal add the prefix 0b or 0B.
+          For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
             params: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
                 is often used in specifying the initial state, i.e. the

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -156,7 +156,7 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
             bitstrings: The bitstrings whose amplitudes are desired, input
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
-                significant qubit, i.e. in big-endian ordering. If inputting 
+                significant qubit, i.e. in big-endian ordering. If inputting
                 a binary literal add the prefix 0b or 0B.
                 For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
             param_resolver: Parameters to run with the program.

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -156,10 +156,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
             bitstrings: The bitstrings whose amplitudes are desired, input
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
-                significant qubit, i.e. in big-endian ordering.
-                If inputting a binary literal add the prefix 0b or 0B.
-            For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
-
+                significant qubit, i.e. in big-endian ordering. If inputting a binary literal add the prefix 0b or 0B.
+                For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
             param_resolver: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
                 is often used in specifying the initial state, i.e. the
@@ -217,9 +215,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
             bitstrings: The bitstrings whose amplitudes are desired, input
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
-                significant qubit, i.e. in big-endian ordering.
-                If inputting a binary literal add the prefix 0b or 0B.
-          For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
+                significant qubit, i.e. in big-endian ordering. If inputting a binary literal add the prefix 0b or 0B.
+                For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
             params: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
                 is often used in specifying the initial state, i.e. the

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -156,7 +156,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
             bitstrings: The bitstrings whose amplitudes are desired, input
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
-                significant qubit, i.e. in big-endian ordering. If inputting a binary literal add the prefix 0b or 0B.
+                significant qubit, i.e. in big-endian ordering. If inputting 
+                a binary literal add the prefix 0b or 0B.
                 For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
             param_resolver: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
@@ -215,7 +216,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
             bitstrings: The bitstrings whose amplitudes are desired, input
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
-                significant qubit, i.e. in big-endian ordering. If inputting a binary literal add the prefix 0b or 0B.
+                significant qubit, i.e. in big-endian ordering. If inputting
+                a binary literal add the prefix 0b or 0B.
                 For example: 0010 can be input as 0b0010, 0B0010, 2, 0x2, etc.
             params: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -157,6 +157,9 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
                 significant qubit, i.e. in big-endian ordering.
+                Binary literals should be input with the prefix 0b or 0B. 
+	        For example, 0010 should be input as 0b0010 or 0B0010.
+
             param_resolver: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
                 is often used in specifying the initial state, i.e. the
@@ -215,6 +218,8 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
                 as an integer array where each integer is formed from measured
                 qubit values according to `qubit_order` from most to least
                 significant qubit, i.e. in big-endian ordering.
+                Binary literals should be input with the prefix 0b or 0B. 
+	        For example, 0010 should be input as 0b0010 or 0B0010.
             params: Parameters to run with the program.
             qubit_order: Determines the canonical ordering of the qubits. This
                 is often used in specifying the initial state, i.e. the


### PR DESCRIPTION
Resolves #2603 