### PR TITLE
Creates fake grid device for testing qubit connectivity in routing

### DIFF
--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -98,6 +98,10 @@ from cirq.testing.repr_pretty_tester import (
     FakePrinter,
 )
 
-from cirq.testing.routing_devices import construct_grid_device, RoutingTestingDevice
+from cirq.testing.routing_devices import (
+    construct_square_device,
+    construct_ring_device,
+    RoutingTestingDevice,
+)
 
 from cirq.testing.sample_circuits import nonoptimal_toffoli_circuit

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -99,7 +99,7 @@ from cirq.testing.repr_pretty_tester import (
 )
 
 from cirq.testing.routing_devices import (
-    construct_square_device,
+    construct_grid_device,
     construct_ring_device,
     RoutingTestingDevice,
 )

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -98,4 +98,6 @@ from cirq.testing.repr_pretty_tester import (
     FakePrinter,
 )
 
+from cirq.testing.routing_devices import construct_grid_device, RoutingTestingDevice
+
 from cirq.testing.sample_circuits import nonoptimal_toffoli_circuit

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -1,0 +1,65 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provides test devices that can validate circuits during a routing procedure."""
+
+from typing import Optional, TYPE_CHECKING
+import networkx as nx
+
+from cirq import devices
+
+if TYPE_CHECKING:
+    import cirq
+
+
+class RoutingTestingDevice(devices.Device):
+    """Testing device to be used only for testing qubit connectivity in routing procedures."""
+
+    def __init__(self, metadata: devices.DeviceMetadata) -> None:
+        self._metadata = metadata
+
+    @property
+    def metadata(self) -> Optional[devices.DeviceMetadata]:
+        return self._metadata
+
+    def validate_operation(self, operation: 'cirq.Operation') -> None:
+        for q in operation.qubits:
+            if q not in self._metadata.qubit_set:
+                raise ValueError(f'Qubit not on device: {q!r}.')
+
+        if (
+            len(operation.qubits) == 2
+            and operation.qubits[0] not in self._metadata.nx_graph[operation.qubits[1]]
+        ):
+            raise ValueError(f'Qubit pair is not valid on device: {operation.qubits!r}.')
+
+
+def construct_grid_device(d: int) -> RoutingTestingDevice:
+    qubits = devices.GridQubit.square(d)
+
+    nx_graph = nx.Graph()
+    row_edges = [
+        (devices.GridQubit(i, j), devices.GridQubit(i, j + 1))
+        for i in range(d)
+        for j in range(d - 1)
+    ]
+    col_edges = [
+        (devices.GridQubit(i, j), devices.GridQubit(i + 1, j))
+        for j in range(d)
+        for i in range(d - 1)
+    ]
+    nx_graph.add_edges_from(row_edges)
+    nx_graph.add_edges_from(col_edges)
+
+    metadata = devices.DeviceMetadata(qubits, nx_graph)
+    return RoutingTestingDevice(metadata)

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -37,14 +37,11 @@ class RoutingTestingDevice(devices.Device):
             if q not in self._metadata.qubit_set:
                 raise ValueError(f'Qubit not on device: {q!r}.')
 
-        if (
-            len(operation.qubits) == 2
-            and operation.qubits[0] not in self._metadata.nx_graph[operation.qubits[1]]
-        ):
+        if len(operation.qubits) == 2 and operation.qubits not in self._metadata.nx_graph.edges:
             raise ValueError(f'Qubit pair is not valid on device: {operation.qubits!r}.')
 
 
-def construct_grid_device(d: int) -> RoutingTestingDevice:
+def construct_square_device(d: int) -> RoutingTestingDevice:
     qubits = devices.GridQubit.square(d)
 
     nx_graph = nx.Graph()
@@ -60,6 +57,19 @@ def construct_grid_device(d: int) -> RoutingTestingDevice:
     ]
     nx_graph.add_edges_from(row_edges)
     nx_graph.add_edges_from(col_edges)
+
+    metadata = devices.DeviceMetadata(qubits, nx_graph)
+    return RoutingTestingDevice(metadata)
+
+
+def construct_ring_device(d: int, directed: bool = False) -> RoutingTestingDevice:
+    qubits = devices.LineQubit.range(d)
+    if directed:
+        nx_graph = nx.DiGraph()
+    else:
+        nx_graph = nx.Graph()
+    edges = [(qubits[i % d], qubits[(i + 1) % d]) for i in range(d)]
+    nx_graph.add_edges_from(edges)
 
     metadata = devices.DeviceMetadata(qubits, nx_graph)
     return RoutingTestingDevice(metadata)

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -18,7 +18,7 @@ from typing import Optional, TYPE_CHECKING
 from importlib_metadata import metadata
 import networkx as nx
 
-from cirq import devices
+from cirq import devices, ops
 
 if TYPE_CHECKING:
     import cirq
@@ -33,7 +33,7 @@ class RoutingTestingDevice(devices.Device):
         elif qubit_type == 'LineQubit':
             relabeling_map = {old: devices.LineQubit(old) for old in nx_graph}
         else:
-            relabeling_map = {old: devices.NamedQubit(old) for old in nx_graph}
+            relabeling_map = {old: ops.NamedQubit(str(old)) for old in nx_graph}
 
         # Relabel nodes in-place.
         nx.relabel_nodes(nx_graph, relabeling_map, copy=False)
@@ -63,4 +63,5 @@ def construct_ring_device(l: int, directed: bool = False) -> RoutingTestingDevic
         nx_graph = nx.cycle_graph(l, create_using=nx.DiGraph)
     else:
         nx_graph = nx.cycle_graph(l)
+
     return RoutingTestingDevice(nx_graph, qubit_type="LineQubit")

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Provides test devices that can validate circuits during a routing procedure."""
 
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import networkx as nx
 

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Provides test devices that can validate circuits during a routing procedure."""
 
-from typing import Hashable, Optional, Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 
 import networkx as nx
 
@@ -24,44 +24,39 @@ if TYPE_CHECKING:
 
 
 class RoutingTestingDevice(devices.Device):
-    """Testing device to be used only for testing qubit connectivity in routing procedures."""
+    """Testing device to be used for testing qubit connectivity in routing procedures."""
 
-    def __init__(self, nx_graph: nx.Graph, qubit_type: str = 'NamedQubit') -> None:
-        relabeling_map: Dict[Hashable, 'cirq.Qid'] = {}
-        if qubit_type == 'GridQubit':
-            relabeling_map = {old: devices.GridQubit(*old) for old in nx_graph}
-        elif qubit_type == 'LineQubit':
-            relabeling_map = {old: devices.LineQubit(old) for old in nx_graph}
-        else:
-            relabeling_map = {old: ops.NamedQubit(str(old)) for old in nx_graph}
-
+    def __init__(self, nx_graph: nx.Graph) -> None:
+        relabeling_map = {
+            old: ops.q(old) if isinstance(old, (int, str)) else ops.q(*old) for old in nx_graph
+        }
         # Relabel nodes in-place.
         nx.relabel_nodes(nx_graph, relabeling_map, copy=False)
 
         self._metadata = devices.DeviceMetadata(relabeling_map.values(), nx_graph)
 
     @property
-    def metadata(self) -> Optional[devices.DeviceMetadata]:
+    def metadata(self) -> devices.DeviceMetadata:
         return self._metadata
 
     def validate_operation(self, operation: 'cirq.Operation') -> None:
-        for q in operation.qubits:
-            if q not in self._metadata.qubit_set:
-                raise ValueError(f'Qubit not on device: {q!r}.')
+        if not self._metadata.qubit_set.issuperset(operation.qubits):
+            raise ValueError(f'Qubits not on device: {operation.qubits!r}.')
 
-        if len(operation.qubits) == 2 and operation.qubits not in self._metadata.nx_graph.edges:
-            raise ValueError(f'Qubit pair is not valid on device: {operation.qubits!r}.')
+        if len(operation.qubits) > 1:
+            if len(operation.qubits) == 2:
+                if operation.qubits not in self._metadata.nx_graph.edges:
+                    raise ValueError(f'Qubit pair is not valid on device: {operation.qubits!r}.')
+                return
+
+            if operation not in ops.GateFamily(ops.MeasurementGate):
+                raise ValueError(f'Gate {operation.gate!r} is not supported on more than 2 qubits.')
 
 
 def construct_grid_device(m: int, n: int) -> RoutingTestingDevice:
-    return RoutingTestingDevice(nx.grid_2d_graph(m, n), qubit_type="GridQubit")
+    return RoutingTestingDevice(nx.grid_2d_graph(m, n))
 
 
 def construct_ring_device(l: int, directed: bool = False) -> RoutingTestingDevice:
-    if directed:
-        # If create_using is directed, the direction is in increasing order.
-        nx_graph = nx.cycle_graph(l, create_using=nx.DiGraph)
-    else:
-        nx_graph = nx.cycle_graph(l)
-
-    return RoutingTestingDevice(nx_graph, qubit_type="LineQubit")
+    nx_graph = nx.cycle_graph(l, create_using=nx.DiGraph if directed else nx.Graph)
+    return RoutingTestingDevice(nx_graph)

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 """Provides test devices that can validate circuits during a routing procedure."""
 
-from typing import Optional, TYPE_CHECKING
+from typing import Hashable, Optional, Dict, TYPE_CHECKING
 
-from importlib_metadata import metadata
 import networkx as nx
 
 from cirq import devices, ops
@@ -28,6 +27,7 @@ class RoutingTestingDevice(devices.Device):
     """Testing device to be used only for testing qubit connectivity in routing procedures."""
 
     def __init__(self, nx_graph: nx.Graph, qubit_type: str = 'NamedQubit') -> None:
+        relabeling_map: Dict[Hashable, 'cirq.Qid'] = {}
         if qubit_type == 'GridQubit':
             relabeling_map = {old: devices.GridQubit(*old) for old in nx_graph}
         elif qubit_type == 'LineQubit':

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -46,11 +46,16 @@ class RoutingTestingDevice(devices.Device):
         if len(operation.qubits) > 1:
             if len(operation.qubits) == 2:
                 if operation.qubits not in self._metadata.nx_graph.edges:
-                    raise ValueError(f'Qubit pair is not valid on device: {operation.qubits!r}.')
+                    raise ValueError(
+                        f'Qubit pair is not a valid edge on device: {operation.qubits!r}.'
+                    )
                 return
 
-            if operation not in ops.GateFamily(ops.MeasurementGate):
-                raise ValueError(f'Gate {operation.gate!r} is not supported on more than 2 qubits.')
+            if not isinstance(operation.gate, ops.MeasurementGate):
+                raise ValueError(
+                    f'Unsupported operation: {operation}. '
+                    f'Routing device only supports 1 / 2 qubit operations.'
+                )
 
 
 def construct_grid_device(m: int, n: int) -> RoutingTestingDevice:

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -17,15 +17,19 @@ import cirq
 
 
 def test_grid_device():
-    square_device = cirq.testing.construct_grid_device(5, 5)
-    square_device_graph = square_device.metadata.nx_graph
-    assert all(q in square_device_graph.nodes for q in cirq.GridQubit.square(5))
-    assert nx.is_isomorphic(nx.grid_2d_graph(5, 5), square_device_graph)
-
     rect_device = cirq.testing.construct_grid_device(5, 7)
     rect_device_graph = rect_device.metadata.nx_graph
+    isomorphism_class = nx.Graph()
+    row_edges = [
+        (cirq.GridQubit(i, j), cirq.GridQubit(i, j + 1)) for i in range(5) for j in range(6)
+    ]
+    col_edges = [
+        (cirq.GridQubit(i, j), cirq.GridQubit(i + 1, j)) for j in range(7) for i in range(4)
+    ]
+    isomorphism_class.add_edges_from(row_edges)
+    isomorphism_class.add_edges_from(col_edges)
     assert all(q in rect_device_graph.nodes for q in cirq.GridQubit.rect(5, 7))
-    assert nx.is_isomorphic(nx.grid_2d_graph(5, 7), rect_device_graph)
+    assert nx.is_isomorphic(isomorphism_class, rect_device_graph)
 
 
 def test_grid_op_validation():
@@ -53,12 +57,18 @@ def test_ring_device():
     undirected_device = cirq.testing.construct_ring_device(5)
     undirected_device_graph = undirected_device.metadata.nx_graph
     assert all(q in undirected_device_graph.nodes for q in cirq.LineQubit.range(5))
-    assert nx.is_isomorphic(nx.cycle_graph(5), undirected_device_graph)
+    isomorphism_class = nx.Graph()
+    edges = [(cirq.LineQubit(i % 5), cirq.LineQubit((i + 1) % 5)) for i in range(5)]
+    isomorphism_class.add_edges_from(edges)
+    assert nx.is_isomorphic(isomorphism_class, undirected_device_graph)
 
     directed_device = cirq.testing.construct_ring_device(5, directed=True)
     directed_device_graph = directed_device.metadata.nx_graph
     assert all(q in directed_device_graph.nodes for q in cirq.LineQubit.range(5))
-    assert nx.is_isomorphic(nx.cycle_graph(5, create_using=nx.DiGraph), directed_device_graph)
+    isomorphism_class = nx.DiGraph()
+    edges = [(cirq.LineQubit(i % 5), cirq.LineQubit((i + 1) % 5)) for i in range(5)]
+    isomorphism_class.add_edges_from(edges)
+    assert nx.is_isomorphic(isomorphism_class, directed_device_graph)
 
 
 def test_ring_op_validation():
@@ -78,3 +88,12 @@ def test_ring_op_validation():
     undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
     undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(1), cirq.LineQubit(0)))
     directed_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
+
+
+def test_namedqubit_device():
+    nx_graph = nx.star_graph(10)
+    device = cirq.testing.RoutingTestingDevice(nx_graph)
+    relabeled_graph = device.metadata.nx_graph
+    qubit_set = {cirq.NamedQubit(str(n)) for n in range(11)}
+    assert set(relabeled_graph.nodes) == qubit_set
+    assert nx.is_isomorphic(nx_graph, relabeled_graph)

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -1,0 +1,46 @@
+
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import cirq
+import networkx as nx
+
+from cirq.testing.routing_devices import construct_grid_device
+
+
+def test_grid_device():
+    device = construct_grid_device(5)
+    device_graph = device.metadata.nx_graph
+
+    assert all(q in device_graph.nodes for q in cirq.GridQubit.square(5))
+    assert nx.is_isomorphic(nx.grid_2d_graph(5, 5), device_graph)
+
+
+def test_op_validation():
+    device = construct_grid_device(5)
+
+    with pytest.raises(ValueError, match="Qubit not on device"):
+        device.validate_operation(cirq.X(cirq.NamedQubit("a")))
+    with pytest.raises(ValueError, match="Qubit not on device"):
+        device.validate_operation(cirq.CNOT(cirq.NamedQubit("a"), cirq.GridQubit(0, 0)))
+    with pytest.raises(ValueError, match="Qubit not on device"):
+        device.validate_operation(cirq.CNOT(cirq.GridQubit(5, 4), cirq.GridQubit(4, 4)))
+
+    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+        device.validate_operation(cirq.CNOT(cirq.GridQubit(0, 0), cirq.GridQubit(0, 2)))
+    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+        device.validate_operation(cirq.CNOT(cirq.GridQubit(2, 0), cirq.GridQubit(0, 0)))
+
+    device.validate_operation(cirq.CNOT(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)))
+    device.validate_operation(cirq.CNOT(cirq.GridQubit(1, 0), cirq.GridQubit(0, 0)))

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -1,4 +1,3 @@
-
 # Copyright 2021 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -12,22 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-import cirq
 import networkx as nx
+import cirq
 
-from cirq.testing.routing_devices import construct_grid_device
 
-
-def test_grid_device():
-    device = construct_grid_device(5)
+def test_square_device():
+    device = cirq.testing.construct_square_device(5)
     device_graph = device.metadata.nx_graph
 
     assert all(q in device_graph.nodes for q in cirq.GridQubit.square(5))
     assert nx.is_isomorphic(nx.grid_2d_graph(5, 5), device_graph)
 
 
-def test_op_validation():
-    device = construct_grid_device(5)
+def test_square_op_validation():
+    device = cirq.testing.construct_square_device(5)
 
     with pytest.raises(ValueError, match="Qubit not on device"):
         device.validate_operation(cirq.X(cirq.NamedQubit("a")))
@@ -43,3 +41,30 @@ def test_op_validation():
 
     device.validate_operation(cirq.CNOT(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)))
     device.validate_operation(cirq.CNOT(cirq.GridQubit(1, 0), cirq.GridQubit(0, 0)))
+
+
+def test_ring_device():
+    device = cirq.testing.construct_ring_device(5)
+    device_graph = device.metadata.nx_graph
+
+    assert all(q in device_graph.nodes for q in cirq.LineQubit.range(5))
+    assert nx.is_isomorphic(nx.cycle_graph(5), device_graph)
+
+
+def test_ring_op_validation():
+    directed_device = cirq.testing.construct_ring_device(5, directed=True)
+    undirected_device = cirq.testing.construct_ring_device(5, directed=False)
+
+    with pytest.raises(ValueError, match="Qubit not on device"):
+        directed_device.validate_operation(cirq.X(cirq.LineQubit(5)))
+    with pytest.raises(ValueError, match="Qubit not on device"):
+        undirected_device.validate_operation(cirq.X(cirq.LineQubit(5)))
+
+    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+        undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(2)))
+    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+        directed_device.validate_operation(cirq.CNOT(cirq.LineQubit(1), cirq.LineQubit(0)))
+
+    undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
+    undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(1), cirq.LineQubit(0)))
+    directed_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -44,9 +44,9 @@ def test_grid_op_validation():
     with pytest.raises(ValueError, match="Qubits not on device"):
         device.validate_operation(cirq.CNOT(cirq.GridQubit(4, 7), cirq.GridQubit(4, 6)))
 
-    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+    with pytest.raises(ValueError, match="Qubit pair is not a valid edge on device"):
         device.validate_operation(cirq.CNOT(cirq.GridQubit(0, 0), cirq.GridQubit(0, 2)))
-    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+    with pytest.raises(ValueError, match="Qubit pair is not a valid edge on device"):
         device.validate_operation(cirq.CNOT(cirq.GridQubit(2, 0), cirq.GridQubit(0, 0)))
 
     device.validate_operation(cirq.CNOT(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1)))
@@ -82,9 +82,9 @@ def test_ring_op_validation():
     with pytest.raises(ValueError, match="Qubits not on device"):
         undirected_device.validate_operation(cirq.X(cirq.LineQubit(5)))
 
-    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+    with pytest.raises(ValueError, match="Qubit pair is not a valid edge on device"):
         undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(2)))
-    with pytest.raises(ValueError, match="Qubit pair is not valid on device"):
+    with pytest.raises(ValueError, match="Qubit pair is not a valid edge on device"):
         directed_device.validate_operation(cirq.CNOT(cirq.LineQubit(1), cirq.LineQubit(0)))
 
     undirected_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
@@ -95,13 +95,11 @@ def test_ring_op_validation():
 def test_allowed_multi_qubit_gates():
     device = cirq.testing.construct_ring_device(5)
 
-    device.validate_operation(cirq.measure(cirq.LineQubit(0)))
-    device.validate_operation(cirq.measure(cirq.LineQubit.range(2)))
-    device.validate_operation(cirq.measure(cirq.LineQubit.range(3)))
+    device.validate_operation(cirq.MeasurementGate(1).on(cirq.LineQubit(0)))
+    device.validate_operation(cirq.MeasurementGate(2).on(*cirq.LineQubit.range(2)))
+    device.validate_operation(cirq.MeasurementGate(3).on(*cirq.LineQubit.range(3)))
 
-    with pytest.raises(
-        ValueError, match=f"Gate {cirq.CCNOT!r} is not supported on more than 2 qubits."
-    ):
+    with pytest.raises(ValueError, match=f"Unsupported operation"):
         device.validate_operation(cirq.CCNOT(*cirq.LineQubit.range(3)))
 
     device.validate_operation(cirq.CNOT(*cirq.LineQubit.range(2)))


### PR DESCRIPTION
This PR is creates a fake device to be used only for testing qubit connectivity in routing procedures. It only creates grid (square) devices for now in the cirq-core/testing directory. Other device architectures like ring devices will be added in the future. 

For more context see,  http://tinyurl.com/cirq-qubit-routing