### PR TITLE
Potential fix for unclickable sidebar heading

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -198,7 +198,7 @@ upper_tabs:
       contents:
       - title: "Overview"
         path: /cirq/experiments
-      - heading: "Algorithms in Cirq"
+      - heading: "Algorithms in base Cirq"
       - title: "Textbook Algorithms Workshop"
         path: /cirq/experiments/textbook_algorithms
       - title: "Shor's Algorithm"
@@ -211,9 +211,6 @@ upper_tabs:
         path: /cirq/experiments/fourier_checking
       - title: "Hidden Linear Function problem"
         path: /cirq/experiments/hidden_linear_function
-      - heading: "Algorithms in ReCirq"
-      - title: "Overview"
-        path: /cirq/experiments#recirq-experiments
       - include: /cirq/experiments/_toc.yaml
 
     - name: "Contribute"

--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -212,6 +212,8 @@ upper_tabs:
       - title: "Hidden Linear Function problem"
         path: /cirq/experiments/hidden_linear_function
       - heading: "Algorithms in ReCirq"
+      - title: "Overview"
+        path: /cirq/experiments#recirq-experiments
       - include: /cirq/experiments/_toc.yaml
 
     - name: "Contribute"

--- a/docs/experiments/_index.yaml
+++ b/docs/experiments/_index.yaml
@@ -5,13 +5,13 @@ landing_page:
   nav: left
   rows:
     - heading: Experiments using quantum circuits
-      description: This is a collection of algorithms and experiments written in and using Cirq. Some are hosted in the Cirq Github repository, and some are hosted in ReCirq, a repository for research performed with Cirq.
+      description: This is a collection of algorithms and experiments written in and using Cirq. A couple of them use only base Cirq, but the rest use additional code stored in ReCirq, a Github repository for research code that uses and builds upon Cirq.
     - buttons:
       - label: Cirq Github
         path: https://github.com/quantumlib/Cirq
       - label: ReCirq Github
         path: https://github.com/quantumlib/ReCirq
-    - heading: Algorithms in Cirq
+    - heading: Algorithms in base Cirq
       description: Algorithms and experiments executable using only default Cirq code.
       options:
         - cards


### PR DESCRIPTION
Minor addition to fix unclickable "Algorithms in ReCirq" heading in the "Experiments" tab sidebar. 

b/244171974

@wcourtney 