### PR TITLE
Fix phase in factor

### DIFF
--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -589,12 +589,12 @@ def factor_state_vector(
     slices1 = (slice(None),) * n_axes + pivot[n_axes:]
     slices2 = pivot[:n_axes] + (slice(None),) * (t1.ndim - n_axes)
     extracted = t1[slices1]
-    extracted = extracted / np.sum(abs(extracted) ** 2) ** 0.5
+    extracted = extracted / np.linalg.norm(extracted)
     remainder = t1[slices2]
-    remainder = remainder / np.sum(abs(remainder) ** 2) ** 0.5
+    remainder = remainder / (np.linalg.norm(remainder) * t1[pivot] / abs(t1[pivot]))
     if validate:
         t2 = state_vector_kronecker_product(extracted, remainder)
-        if not predicates.allclose_up_to_global_phase(t2, t1, atol=atol):
+        if not np.allclose(t2, t1, atol=atol):
             if not np.isclose(np.linalg.norm(t1), 1):
                 raise ValueError('Input state must be normalized.')
             raise EntangledStateError('The tensor cannot be factored by the requested axes')

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -1434,3 +1434,22 @@ def test_unseparated_states_str():
 qubits: (cirq.LineQubit(0), cirq.LineQubit(1))
 output vector: 0.707j|00⟩ + 0.707j|10⟩"""
     )
+
+
+@pytest.mark.parametrize('split', [True, False])
+def test_measurement_preserves_phase(split: bool):
+    c1, c2, t = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(
+        cirq.H(t),
+        cirq.measure(t, key="t"),
+        cirq.CZ(c1, c2).with_classical_controls("t"),
+        cirq.reset(t),
+    )
+    simulator = cirq.Simulator(split_untangled_states=split)
+    # Run enough times that both options of |110> - |111> are likely measured.
+    for _ in range(20):
+        for step in simulator.simulate_moment_steps(
+            circuit, initial_state=(1, 1, 1), qubit_order=(c1, c2, t)
+        ):
+            pass
+        assert step.dirac_notation() == "|110⟩"


### PR DESCRIPTION
Fixes #5834

Phase in input tensor was being allocated to both output tensors. This PR readjusts to remove the phase from the remainder tensor (a nice thing about this is that if the remainder _is_ nothing but a global phase, then it's `1`). 

The validation is updated to check `np.all_close` rather than `allclose_up_to_global_phase`, and a unit test for #5834 is added.