### PR TITLE
Fix mypy error on master

### DIFF
--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import datetime
-import enum
 import sys
 import threading
 from typing import (

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import datetime
+import enum
 import sys
 import threading
 from typing import (
@@ -170,7 +171,9 @@ class EngineClient:
                 message = err.message
                 # Raise RuntimeError for exceptions that are not retryable.
                 # Otherwise, pass through to retry.
-                if err.code.value not in RETRYABLE_ERROR_CODES:
+                err_code: Union[None, int, enum.Enum] = err.code
+                err_code_int = err_code.value if isinstance(err_code, enum.Enum) else err_code
+                if err_code_int not in RETRYABLE_ERROR_CODES:
                     raise EngineException(message) from err
 
             if current_delay > self.max_retry_delay_seconds:

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -171,9 +171,7 @@ class EngineClient:
                 message = err.message
                 # Raise RuntimeError for exceptions that are not retryable.
                 # Otherwise, pass through to retry.
-                err_code: Union[None, int, enum.Enum] = err.code
-                err_code_int = err_code.value if isinstance(err_code, enum.Enum) else err_code
-                if err_code_int not in RETRYABLE_ERROR_CODES:
+                if err.code not in RETRYABLE_ERROR_CODES:
                     raise EngineException(message) from err
 
             if current_delay > self.max_retry_delay_seconds:


### PR DESCRIPTION
mypy tests on master are currently failing. See https://github.com/quantumlib/Cirq/runs/8237862866?check_suite_focus=true

This PR fixes the failing test.

google/api_core/exceptions defines `code: Union[None, int]`. See 
https://github.com/googleapis/python-api-core/blob/fe617c205918a3e4dfddeb06123e70540898032e/google/api_core/exceptions.py#L119

However, the derived classes can assign an enum to `code`. See 
https://github.com/googleapis/python-api-core/blob/fe617c205918a3e4dfddeb06123e70540898032e/google/api_core/exceptions.py#L222

This PR assumes that `code` can be `Union[None, int, enum.Enum]` and handles the 3 cases appropriately, thus getting rid of the mypy error. 