### PR TITLE
Add performance benchmarks for CQC circuit routing

### DIFF
--- a/benchmarks/transformers/routing.py
+++ b/benchmarks/transformers/routing.py
@@ -1,0 +1,39 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+
+
+class RouteCQC:
+    params = [[10, 50, 100], [10, 100, 1000], [0.5], [10]]
+    param_names = ["qubits", "depth", "op_density", "grid_device_size"]
+    timeout = 300  # Increase timeout to 5 minutes instead of default 60 seconds.
+
+    def setup(self, qubits: int, depth: int, op_density: float, grid_device_size: int):
+        gate_domain = {cirq.CNOT: 2, cirq.X: 1}
+        self.circuit = cirq.testing.random_circuit(
+            qubits, depth, op_density, gate_domain=gate_domain, random_state=12345
+        )
+        self.device = cirq.testing.construct_grid_device(grid_device_size, grid_device_size)
+        self.router = cirq.RouteCQC(self.device.metadata.nx_graph)
+
+    def time_circuit_routing(self, *_):
+        self.routed_circuit = self.router(self.circuit)
+
+    def track_routed_circuit_depth_ratio(self, *_) -> float:
+        self.routed_circuit = self.router(self.circuit)
+        return len(self.routed_circuit) / len(self.circuit)
+
+    def teardown(self, *_):
+        self.device.validate_circuit(self.routed_circuit)

--- a/benchmarks/transformers/routing.py
+++ b/benchmarks/transformers/routing.py
@@ -18,7 +18,7 @@ import cirq
 class RouteCQC:
     params = [[10, 25, 50, 75, 100], [10, 50, 100, 250, 500, 1000], [0.5], [10]]
     param_names = ["qubits", "depth", "op_density", "grid_device_size"]
-    timeout = 180  # Increase timeout to 3 minutes instead of default 60 seconds.
+    timeout = 300  # Increase timeout to 5 minutes instead of default 60 seconds.
 
     def setup(self, qubits: int, depth: int, op_density: float, grid_device_size: int):
         gate_domain = {cirq.CNOT: 2, cirq.X: 1}

--- a/benchmarks/transformers/routing.py
+++ b/benchmarks/transformers/routing.py
@@ -16,9 +16,9 @@ import cirq
 
 
 class RouteCQC:
-    params = [[10, 50, 100], [10, 100, 1000], [0.5], [10]]
+    params = [[10, 25, 50, 75, 100], [10, 50, 100, 250, 500, 1000], [0.5], [10]]
     param_names = ["qubits", "depth", "op_density", "grid_device_size"]
-    timeout = 300  # Increase timeout to 5 minutes instead of default 60 seconds.
+    timeout = 120  # Increase timeout to 2 minutes instead of default 60 seconds.
 
     def setup(self, qubits: int, depth: int, op_density: float, grid_device_size: int):
         gate_domain = {cirq.CNOT: 2, cirq.X: 1}

--- a/benchmarks/transformers/routing.py
+++ b/benchmarks/transformers/routing.py
@@ -18,7 +18,7 @@ import cirq
 class RouteCQC:
     params = [[10, 25, 50, 75, 100], [10, 50, 100, 250, 500, 1000], [0.5], [10]]
     param_names = ["qubits", "depth", "op_density", "grid_device_size"]
-    timeout = 120  # Increase timeout to 2 minutes instead of default 60 seconds.
+    timeout = 180  # Increase timeout to 3 minutes instead of default 60 seconds.
 
     def setup(self, qubits: int, depth: int, op_density: float, grid_device_size: int):
         gate_domain = {cirq.CNOT: 2, cirq.X: 1}


### PR DESCRIPTION
Part of https://github.com/quantumlib/Cirq/issues/3840

Would be useful to track the improvements in runtime after https://github.com/quantumlib/Cirq/issues/5860 is fixed. 

Testing via `asv run --quick` locally gives the following output:

```
[ 25.00%] ··· transformers.routing.RouteCQC.time_circuit_routing                                                                                                                                                                                                                        ok
[ 25.00%] ··· ======== =============== =============== ================ ================ ================ =================
              --                                      depth / op_density / grid_device_size                                
              -------- ----------------------------------------------------------------------------------------------------
               qubits   10 / 0.5 / 10   50 / 0.5 / 10   100 / 0.5 / 10   250 / 0.5 / 10   500 / 0.5 / 10   1000 / 0.5 / 10 
              ======== =============== =============== ================ ================ ================ =================
                 10        33.2±0ms        50.0±0ms        66.5±0ms         114±0ms          213±0ms           395±0ms     
                 25        56.9±0ms        160±0ms         291±0ms          664±0ms          1.31±0s           2.56±0s     
                 50        248±0ms         960±0ms         1.84±0s          4.60±0s          9.01±0s           18.4±0s     
                 75        621±0ms         3.18±0s         6.50±0s          17.9±0s          33.2±0s           1.11±0m     
                100        2.11±0s         8.42±0s         18.9±0s          43.5±0s          1.43±0m           2.98±0m     
              ======== =============== =============== ================ ================ ================ =================

[ 50.00%] ··· transformers.routing.RouteCQC.track_routed_circuit_depth_ratio                                                                                                                                                                                                            ok
[ 50.00%] ··· ======== =============== =============== ================ ================ ================ =================
              --                                      depth / op_density / grid_device_size                                
              -------- ----------------------------------------------------------------------------------------------------
               qubits   10 / 0.5 / 10   50 / 0.5 / 10   100 / 0.5 / 10   250 / 0.5 / 10   500 / 0.5 / 10   1000 / 0.5 / 10 
              ======== =============== =============== ================ ================ ================ =================
                 10          2.0             2.4             2.16            2.064            2.218             2.167      
                 25          3.4             4.0             4.15            4.068             4.09             4.003      
                 50          6.2             6.56            6.73            6.648            6.758             6.763      
                 75          6.0             8.92            9.04             9.3              9.43             9.303      
                100          10.5           11.94           12.22            11.776           11.878            11.799     
              ======== =============== =============== ================ ================ ================ =================

```


cc @ammareltigani 