### PR TITLE
Tell git to ignore build directories from distutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__
 
 # packaging
 *.egg-info/
+build/
 
 # Sphinx
 _build

--- a/cirq-web/.gitignore
+++ b/cirq-web/.gitignore
@@ -6,7 +6,3 @@ node_modules/
 
 # Coverage testing information
 .nyc_output/
-
-# Extras
-build/
-


### PR DESCRIPTION
It is sufficient to have the pattern once in the top .gitignore.
