### PR TITLE
Fix docstring typos in cirq.devices submodule

### DIFF
--- a/cirq-core/cirq/devices/grid_device_metadata.py
+++ b/cirq-core/cirq/devices/grid_device_metadata.py
@@ -71,7 +71,7 @@ class GridDeviceMetadata(device.DeviceMetadata):
             if a == b:
                 raise ValueError(f"Self loop encountered in qubit {a}")
 
-        # Keep lexigraphically smaller tuples for undirected edges.
+        # Keep lexicographically smaller tuples for undirected edges.
         edge_set = set()
         node_set = set()
         for a, b in sorted_pairs:
@@ -133,7 +133,7 @@ class GridDeviceMetadata(device.DeviceMetadata):
 
     @property
     def isolated_qubits(self) -> FrozenSet['cirq.GridQubit']:
-        """Returns the set of all isolated qubits on the device (if appliable)."""
+        """Returns the set of all isolated qubits on the device (if applicable)."""
         return self._isolated_qubits
 
     @property

--- a/cirq-core/cirq/devices/insertion_noise_model.py
+++ b/cirq-core/cirq/devices/insertion_noise_model.py
@@ -35,7 +35,7 @@ class InsertionNoiseModel(devices.NoiseModel):
             operations that should be added. If two gate types provided apply
             to a target gate, the most specific type will match; if neither
             type is more specific (e.g. A is a subtype of B, but B defines
-            qubits and A does not) then the first one appering in this dict
+            qubits and A does not) then the first one appearing in this dict
             will match.
         prepend: If True, put noise before affected gates. Default: False.
         require_physical_tag: whether to only apply noise to operations tagged

--- a/cirq-core/cirq/devices/noise_model.py
+++ b/cirq-core/cirq/devices/noise_model.py
@@ -42,7 +42,7 @@ class NoiseModel(metaclass=value.ABCMetaImplementAnyOneOf):
 
     @classmethod
     def from_noise_model_like(cls, noise: 'cirq.NOISE_MODEL_LIKE') -> 'cirq.NoiseModel':
-        """Transforms an object into a noise model if umambiguously possible.
+        """Transforms an object into a noise model if unambiguously possible.
 
         Args:
             noise: `None`, a `cirq.NoiseModel`, or a single qubit operation.

--- a/cirq-core/cirq/devices/thermal_noise_model.py
+++ b/cirq-core/cirq/devices/thermal_noise_model.py
@@ -188,17 +188,17 @@ class ThermalNoiseModel(devices.NoiseModel):
             heat_rate_GHz: single number (units GHz) specifying heating rate,
                 either per qubit, or global value for all.
                 Given a rate gh, the Lindblad op will be sqrt(gh)*a^dag
-                (where a is annihilation), so that the heating Lindbldian is
+                (where a is annihilation), so that the heating Lindbladian is
                 gh(a^dag • a - 0.5{a*a^dag, •}).
             cool_rate_GHz: single number (units GHz) specifying cooling rate,
                 either per qubit, or global value for all.
                 Given a rate gc, the Lindblad op will be sqrt(gc)*a
-                so that the cooling Lindbldian is gc(a • a^dag - 0.5{n, •})
+                so that the cooling Lindbladian is gc(a • a^dag - 0.5{n, •})
                 This number is equivalent to 1/T1.
             dephase_rate_GHz: single number (units GHz) specifying dephasing
                 rate, either per qubit, or global value for all.
                 Given a rate gd, Lindblad op will be sqrt(2*gd)*n where
-                n = a^dag * a, so that the dephasing Lindbldian is
+                n = a^dag * a, so that the dephasing Lindbladian is
                 2 * gd * (n • n - 0.5{n^2, •}).
                 This number is equivalent to 1/Tphi.
             require_physical_tag: whether to only apply noise to operations


### PR DESCRIPTION
No change in code function.
