### PR TITLE
`AbstractCircuit.freeze` should not reallocate moments

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1820,7 +1820,11 @@ class Circuit(AbstractCircuit):
         # each index.
         for i in range(length):
             if i in moments_by_index:
-                self._moments.append(moments_by_index[i].with_operations(op_lists_by_index[i]))
+                if op_lists_by_index[i]:
+                    self._moments.append(moments_by_index[i].with_operations(op_lists_by_index[i]))
+                else:
+                    self._moments.append(moments_by_index[i])
+
             else:
                 self._moments.append(Moment(op_lists_by_index[i]))
 

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4486,6 +4486,13 @@ def test_concat_ragged_alignment():
     )
 
 
+def test_freeze_not_relocate_moments():
+    q = cirq.q(0)
+    c = cirq.Circuit(cirq.X(q), cirq.measure(q))
+    f = c.freeze()
+    assert [mc is fc for mc, fc in zip(c, f)] == [True, True]
+
+
 def test_factorize_one_factor():
     circuit = cirq.Circuit()
     q0, q1, q2 = cirq.LineQubit.range(3)


### PR DESCRIPTION
Fixes: https://github.com/quantumlib/Cirq/issues/5816