### PR TITLE
Use GitHub tarball for tensorflow-docs dependency

### DIFF
--- a/dev_tools/requirements/deps/tensorflow-docs.txt
+++ b/dev_tools/requirements/deps/tensorflow-docs.txt
@@ -1,1 +1,1 @@
-tensorflow-docs@git+https://github.com/tensorflow/docs@3a6a7a3322de8620f0031ae3a0a4b62e40d1d7f2
+tensorflow-docs@https://github.com/tensorflow/docs/tarball/3a6a7a3322de8620f0031ae3a0a4b62e40d1d7f2


### PR DESCRIPTION
Avoid traffic throttling on GitHub due to too much cloning.

Fix https://github.com/quantumlib/Cirq/issues/5880
