### PR TITLE
untangle entangled tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/isolated-base.env.txt
       - name: Test each module in isolation
-        # TODO(#5870) - remove --randomly-dont-reorganize after fixing order-related test failures
-        run: pytest --randomly-dont-reorganize -n auto -m slow dev_tools/packaging/isolated_packages_test.py
+        run: pytest -n auto -m slow dev_tools/packaging/isolated_packages_test.py
   pytest:
     name: Pytest Ubuntu
     strategy:

--- a/check/pytest
+++ b/check/pytest
@@ -16,8 +16,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 cd "$(git rev-parse --show-toplevel)"
 
 PYTEST_ARGS=()
-# TODO(#5870) - remove this after fixing order-related test failures
-PYTEST_ARGS+=("--randomly-dont-reorganize")
 
 PARALLEL=""
 for arg in "$@"; do

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -28,7 +28,7 @@ from cirq_google.engine.engine import EngineContext
 from cirq_google.engine.test_utils import uses_async_mock
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def mock_grpc_client():
     with mock.patch(
         'cirq_google.engine.engine_client.quantum.QuantumEngineServiceClient'

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -207,7 +207,7 @@ _CALIBRATION_RESULTS_V2 = util.pack_any(
 )
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def mock_grpc_client():
     with mock.patch(
         'cirq_google.engine.engine_client.quantum.QuantumEngineServiceClient'

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -479,7 +479,7 @@ def test_get_batch_size(get_program_async):
         _ = program.batch_size()
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def mock_grpc_client():
     with mock.patch(
         'cirq_google.engine.engine_client.quantum.QuantumEngineServiceClient'

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -276,7 +276,7 @@ def test_make_random_id():
     assert random_id != random_id2
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='module', autouse=True)
 def mock_grpc_client_async():
     with mock.patch(
         'cirq_google.engine.engine_client.quantum.QuantumEngineServiceAsyncClient', autospec=True

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -48,9 +48,8 @@ def test_isolated_packages(cloned_env, module):
     )
     assert result.returncode == 0, f"Failed to install {module.name}:\n{result.stderr}"
 
-    # TODO(#5870) - remove --randomly-dont-reorganize after fixing order-related test failures
     result = shell_tools.run(
-        f"{env}/bin/pytest --randomly-dont-reorganize ./{module.root} --ignore ./cirq-core/cirq/contrib".split(),
+        f"{env}/bin/pytest ./{module.root} --ignore ./cirq-core/cirq/contrib".split(),
         capture_output=True,
         check=False,
     )


### PR DESCRIPTION
- Avoid clashing test mocks of QuantumEngineServiceClient by limiting
  mocking to the relevant test module.
- Enable test reordering by pytest-randomly.

Fixes #5870.
