### PR TITLE
Speed up circuit construction when contents are a list of moments

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1743,7 +1743,7 @@ class Circuit(AbstractCircuit):
         self._moments: List['cirq.Moment'] = []
         flattened_contents = tuple(ops.flatten_to_ops_or_moments(contents))
         if all(isinstance(c, Moment) for c in flattened_contents):
-            self._moments[:] = flattened_contents
+            self._moments[:] = cast(Iterable[Moment], flattened_contents)
             return
         with _compat.block_overlapping_deprecation('.*'):
             if strategy == InsertStrategy.EARLIEST:

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1741,11 +1741,15 @@ class Circuit(AbstractCircuit):
                 circuit.
         """
         self._moments: List['cirq.Moment'] = []
+        flattened_contents = tuple(ops.flatten_to_ops_or_moments(contents))
+        if all(isinstance(c, Moment) for c in flattened_contents):
+            self._moments[:] = flattened_contents
+            return
         with _compat.block_overlapping_deprecation('.*'):
             if strategy == InsertStrategy.EARLIEST:
-                self._load_contents_with_earliest_strategy(contents)
+                self._load_contents_with_earliest_strategy(flattened_contents)
             else:
-                self.append(contents, strategy=strategy)
+                self.append(flattened_contents, strategy=strategy)
 
     @classmethod
     def _from_moments(cls, moments: Iterable['cirq.Moment']) -> 'Circuit':


### PR DESCRIPTION
When the input is a list of moment, we can just assign that list to `self._moments` instead of using either `append` or `_load_contents_with_earliest_strategy`.  

* `Circuit.append`: This is already essentially `O(D)` if the the input is a list of moments because of the special case `isinstance` check: https://github.com/quantumlib/Cirq/blob/ff81f807bd00b8d0654466b0fdcb3224a687f877/cirq-core/cirq/circuits/circuit.py#L2102
* `Circuit._load_contents_with_earliest_strategy`: has complexity `O(D * Q)` instead of `O(D)`, even if input is all `Moment`s because it iterates on all the qubits that the moment acts on, for each moment; to keep track of the latest used index in case it encounters an operation which is not part of a moment and needs to be inserted using the earliest strategy. See 
https://github.com/quantumlib/Cirq/blob/ff81f807bd00b8d0654466b0fdcb3224a687f877/cirq-core/cirq/circuits/circuit.py#L1825

The fact that introducing `_load_contents_with_earliest_strategy` slowed down moment-by-moment circuit construction to `O(D * Q)` instead of `O(D)` is also visible from the regressions in circuit construction asv benchmarks:


![image](https://user-images.githubusercontent.com/7863287/192909409-6e7d87c6-9a8e-4388-b1de-0efbf1033f0b.png)


After this change, the moment-by-moment circuit construction time for a distance 25 surface code is again ~30ms instead of > 3 seconds. The output for `asv run` on a local copy is as follows:

```
$ asv run --python=same --bench SurfaceCodeRotatedMemoryZ.time_circuit_construction_moment_by_moment --cpu-affinity 10 
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_usr_local_google_home_tanujkhattar_anaconda3_envs_cirq_bin_python
[ 50.00%] ··· Running (circuit_construction.SurfaceCodeRotatedMemoryZ.time_circuit_construction_moment_by_moment--).
[100.00%] ··· circuit_construction.SurfaceCodeRotatedMemoryZ.time_circuit_construction_moment_by_moment                                                                                                                                                                                 ok
[100.00%] ··· ========== =============
               distance               
              ---------- -------------
                  3         497±10μs  
                  5       1.39±0.08ms 
                  7        2.70±0.1ms 
                  9        4.23±0.2ms 
                  11       6.64±0.1ms 
                  13       9.17±0.4ms 
                  15       11.5±0.2ms 
                  17       15.7±0.6ms 
                  19       19.7±0.7ms 
                  21        24.9±1ms  
                  23       27.6±0.6ms 
                  25       32.8±0.4ms 
              ========== =============
```

compared to the current master version:

```
$ asv run  --bench SurfaceCodeRotatedMemoryZ.time_circuit_construction_moment_by_moment --cpu-affinity 8
· Creating environments
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] · For Cirq commit ff81f807 <master>:
[  0.00%] ·· Benchmarking virtualenv-py3.8
[ 50.00%] ··· Running (circuit_construction.SurfaceCodeRotatedMemoryZ.time_circuit_construction_moment_by_moment--).
[100.00%] ··· circuit_construction.SurfaceCodeRotatedMemoryZ.time_circuit_construction_moment_by_moment                                                                                                                                                                                 ok
[100.00%] ··· ========== ============
               distance              
              ---------- ------------
                  3       2.03±0.1ms 
                  5       8.02±0.2ms 
                  7        26.2±3ms  
                  9        69.1±4ms  
                  11       137±8ms   
                  13       246±9ms   
                  15       455±7ms   
                  17       774±20ms  
                  19      1.14±0.01s 
                  21      1.67±0.04s 
                  23      2.50±0.08s 
                  25      3.57±0.04s 
              ========== ============
```


cc @dabacon @dstrain115 @maffoo @dkothari11
