### PR TITLE
Small housekeeping in check/pytest

### DIFF
--- a/check/pytest
+++ b/check/pytest
@@ -30,10 +30,6 @@ if [ -z "${PARALLEL}" ]; then
 fi
 
 source dev_tools/pypath
-PYTHON_VERSION=$(python -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-if [ "$PYTHON_VERSION" -lt "37" ]; then
-  PYTEST_ARGS+=("--ignore=cirq-rigetti")
-fi
 
 pytest "${PYTEST_ARGS[@]}"
 RESULT=$?

--- a/check/pytest
+++ b/check/pytest
@@ -15,19 +15,9 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 cd "$(git rev-parse --show-toplevel)"
 
-PYTEST_ARGS=()
-
-PARALLEL=""
-for arg in "$@"; do
-    if [[ "${arg}" == "-n" ]]; then
-	PARALLEL=1
-    fi
-    PYTEST_ARGS+=("${arg}")
-done
-
-if [ -z "${PARALLEL}" ]; then
-    PYTEST_ARGS+=("-n=auto")
-fi
+# Run in parallel by default.  Pass the `-n0` option for a single-process run.
+# (the last `-n` option wins)
+PYTEST_ARGS=( "-n=auto" "$@" )
 
 source dev_tools/pypath
 


### PR DESCRIPTION
- Clean up special-casing for Python 3.6 as we require Python 3.7.

- Simplify handling of the parallel job count `-n COUNT` option in check/pytest.
  Obey the `-n0` option on the command line in addition to `-n 0` to
  request non-parallel testing.
