### PR TITLE
Optimize apply_matrix_to_slices when sparse

### DIFF
--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -299,7 +299,7 @@ def apply_matrix_to_slices(
         for j, s_j in enumerate(slices):
             if i != j:
                 if matrix[i, j] == 1:
-                    out[s_i] += target[s_j]
+                    out[s_i] += target[s_j]  # type: ignore[index]
                 elif matrix[i, j] != 0:
                     out[s_i] += target[s_j] * matrix[i, j]  # type: ignore[index]
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -292,10 +292,16 @@ def apply_matrix_to_slices(
 
     # Apply operation.
     for i, s_i in enumerate(slices):
-        out[s_i] *= matrix[i, i]  # type: ignore[index]
+        if matrix[i, i] == 0:
+            out[s_i] = 0
+        elif matrix[i, i] != 1:
+            out[s_i] *= matrix[i, i]  # type: ignore[index]
         for j, s_j in enumerate(slices):
             if i != j:
-                out[s_i] += target[s_j] * matrix[i, j]  # type: ignore[index]
+                if matrix[i, j] == 1:
+                    out[s_i] += target[s_j]
+                elif matrix[i, j] != 0:
+                    out[s_i] += target[s_j] * matrix[i, j]  # type: ignore[index]
 
     return out
 


### PR DESCRIPTION
Improves the perf of `apply_matrix_to_slices` when the operator matrix has ones and zeroes. For example for `ResetChannel` on a large density matrix, this results in about a 3x speedup.

```python
cirq.DensityMatrixSimulator(split_untangled_states=False).simulate(
    cirq.Circuit([cirq.reset(cirq.LineQubit(0))] * 100), qubit_order=cirq.LineQubit.range(11)
)
```