### PR TITLE
Add support for repeated keys in result protos

### DIFF
--- a/cirq-google/cirq_google/api/v2/result.proto
+++ b/cirq-google/cirq_google/api/v2/result.proto
@@ -46,6 +46,9 @@ message MeasurementResult {
   // The measurement key for the measurement.
   string key = 1;
 
+  // Number of instances of this key in each circuit repetition.
+  int32 instances = 3;
+
   // For each qubit that is measured, these are the measurement results.
   repeated QubitMeasurementResult qubit_measurement_results = 2;
 }
@@ -55,14 +58,15 @@ message QubitMeasurementResult {
   // Which qubit was measured.
   Qubit qubit = 1;
 
-  // These are the results of a measurement on a qubit. Measurement results are
-  // repetitions number of bits, where the repetitions are define in the
-  // sweep result message.
+  // These are the results of a measurement on a qubit. The number of bits
+  // measured is equal to repetitions * instances, where repetitions is defined
+  // in the SweepResult message, and instances is defined in the MeasurementResult
+  // message.
   //
   // The bytes in this field are constructed as follows:
   //
   // 1. The results of the measurements produce a list of bits ordered by
-  //    the round of repetition.
+  //    the round of repetition and instance within a round.
   //
   // 2. This list is broken up into blocks of 8 bits, with the final block
   //    potentially not being a full 8 bits.

--- a/cirq-google/cirq_google/api/v2/result_pb2.py
+++ b/cirq-google/cirq_google/api/v2/result_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'\n\035com.google.cirq.google.api.v2B\013ResultProtoP\001',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x1f\x63irq_google/api/v2/result.proto\x12\x12\x63irq.google.api.v2\x1a cirq_google/api/v2/program.proto\"@\n\x06Result\x12\x36\n\rsweep_results\x18\x01 \x03(\x0b\x32\x1f.cirq.google.api.v2.SweepResult\"j\n\x0bSweepResult\x12\x13\n\x0brepetitions\x18\x01 \x01(\x05\x12\x46\n\x15parameterized_results\x18\x02 \x03(\x0b\x32\'.cirq.google.api.v2.ParameterizedResult\"\x8c\x01\n\x13ParameterizedResult\x12\x31\n\x06params\x18\x01 \x01(\x0b\x32!.cirq.google.api.v2.ParameterDict\x12\x42\n\x13measurement_results\x18\x02 \x03(\x0b\x32%.cirq.google.api.v2.MeasurementResult\"o\n\x11MeasurementResult\x12\x0b\n\x03key\x18\x01 \x01(\t\x12M\n\x19qubit_measurement_results\x18\x02 \x03(\x0b\x32*.cirq.google.api.v2.QubitMeasurementResult\"S\n\x16QubitMeasurementResult\x12(\n\x05qubit\x18\x01 \x01(\x0b\x32\x19.cirq.google.api.v2.Qubit\x12\x0f\n\x07results\x18\x02 \x01(\x0c\"\x8c\x01\n\rParameterDict\x12G\n\x0b\x61ssignments\x18\x01 \x03(\x0b\x32\x32.cirq.google.api.v2.ParameterDict.AssignmentsEntry\x1a\x32\n\x10\x41ssignmentsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02:\x02\x38\x01\x42.\n\x1d\x63om.google.cirq.google.api.v2B\x0bResultProtoP\x01\x62\x06proto3'
+  serialized_pb=b'\n\x1f\x63irq_google/api/v2/result.proto\x12\x12\x63irq.google.api.v2\x1a cirq_google/api/v2/program.proto\"@\n\x06Result\x12\x36\n\rsweep_results\x18\x01 \x03(\x0b\x32\x1f.cirq.google.api.v2.SweepResult\"j\n\x0bSweepResult\x12\x13\n\x0brepetitions\x18\x01 \x01(\x05\x12\x46\n\x15parameterized_results\x18\x02 \x03(\x0b\x32\'.cirq.google.api.v2.ParameterizedResult\"\x8c\x01\n\x13ParameterizedResult\x12\x31\n\x06params\x18\x01 \x01(\x0b\x32!.cirq.google.api.v2.ParameterDict\x12\x42\n\x13measurement_results\x18\x02 \x03(\x0b\x32%.cirq.google.api.v2.MeasurementResult\"\x82\x01\n\x11MeasurementResult\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\tinstances\x18\x03 \x01(\x05\x12M\n\x19qubit_measurement_results\x18\x02 \x03(\x0b\x32*.cirq.google.api.v2.QubitMeasurementResult\"S\n\x16QubitMeasurementResult\x12(\n\x05qubit\x18\x01 \x01(\x0b\x32\x19.cirq.google.api.v2.Qubit\x12\x0f\n\x07results\x18\x02 \x01(\x0c\"\x8c\x01\n\rParameterDict\x12G\n\x0b\x61ssignments\x18\x01 \x03(\x0b\x32\x32.cirq.google.api.v2.ParameterDict.AssignmentsEntry\x1a\x32\n\x10\x41ssignmentsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02:\x02\x38\x01\x42.\n\x1d\x63om.google.cirq.google.api.v2B\x0bResultProtoP\x01\x62\x06proto3'
   ,
   dependencies=[cirq__google_dot_api_dot_v2_dot_program__pb2.DESCRIPTOR,])
 
@@ -153,7 +153,14 @@ _MEASUREMENTRESULT = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='qubit_measurement_results', full_name='cirq.google.api.v2.MeasurementResult.qubit_measurement_results', index=1,
+      name='instances', full_name='cirq.google.api.v2.MeasurementResult.instances', index=1,
+      number=3, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='qubit_measurement_results', full_name='cirq.google.api.v2.MeasurementResult.qubit_measurement_results', index=2,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -171,8 +178,8 @@ _MEASUREMENTRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=406,
-  serialized_end=517,
+  serialized_start=407,
+  serialized_end=537,
 )
 
 
@@ -210,8 +217,8 @@ _QUBITMEASUREMENTRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=519,
-  serialized_end=602,
+  serialized_start=539,
+  serialized_end=622,
 )
 
 
@@ -249,8 +256,8 @@ _PARAMETERDICT_ASSIGNMENTSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=695,
-  serialized_end=745,
+  serialized_start=715,
+  serialized_end=765,
 )
 
 _PARAMETERDICT = _descriptor.Descriptor(
@@ -280,8 +287,8 @@ _PARAMETERDICT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=605,
-  serialized_end=745,
+  serialized_start=625,
+  serialized_end=765,
 )
 
 _RESULT.fields_by_name['sweep_results'].message_type = _SWEEPRESULT

--- a/cirq-google/cirq_google/api/v2/result_pb2.pyi
+++ b/cirq-google/cirq_google/api/v2/result_pb2.pyi
@@ -86,12 +86,14 @@ class ParameterizedResult(google___protobuf___message___Message):
 
 class MeasurementResult(google___protobuf___message___Message):
     key = ... # type: typing___Text
+    instances = ... # type: int
 
     @property
     def qubit_measurement_results(self) -> google___protobuf___internal___containers___RepeatedCompositeFieldContainer[QubitMeasurementResult]: ...
 
     def __init__(self,
         key : typing___Optional[typing___Text] = None,
+        instances : typing___Optional[int] = None,
         qubit_measurement_results : typing___Optional[typing___Iterable[QubitMeasurementResult]] = None,
         ) -> None: ...
     @classmethod
@@ -99,9 +101,9 @@ class MeasurementResult(google___protobuf___message___Message):
     def MergeFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     def CopyFrom(self, other_msg: google___protobuf___message___Message) -> None: ...
     if sys.version_info >= (3,):
-        def ClearField(self, field_name: typing_extensions___Literal[u"key",u"qubit_measurement_results"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[u"instances",u"key",u"qubit_measurement_results"]) -> None: ...
     else:
-        def ClearField(self, field_name: typing_extensions___Literal[b"key",b"qubit_measurement_results"]) -> None: ...
+        def ClearField(self, field_name: typing_extensions___Literal[b"instances",b"key",b"qubit_measurement_results"]) -> None: ...
 
 class QubitMeasurementResult(google___protobuf___message___Message):
     results = ... # type: bytes

--- a/cirq-google/cirq_google/api/v2/results.py
+++ b/cirq-google/cirq_google/api/v2/results.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import cast, Dict, Hashable, Iterable, List, Optional, Sequence
-from collections import Counter, OrderedDict
+from collections import OrderedDict
 import dataclasses
 import numpy as np
 

--- a/cirq-google/cirq_google/api/v2/results.py
+++ b/cirq-google/cirq_google/api/v2/results.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import cast, Dict, Hashable, Iterable, Iterator, List, Optional, Sequence, Set
+from typing import cast, Dict, Hashable, Iterable, List, Optional, Sequence
 from collections import Counter, OrderedDict
 import dataclasses
 import numpy as np
@@ -204,8 +204,6 @@ def _trial_sweep_from_proto(
             shape = (msg.repetitions, instances, len(qubit_results))
             records[mr.key] = np.array(ordered_results).transpose().reshape(shape)
         trial_sweep.append(
-            cirq.ResultDict(
-                params=cirq.ParamResolver(dict(pr.params.assignments)), records=records
-            )
+            cirq.ResultDict(params=cirq.ParamResolver(dict(pr.params.assignments)), records=records)
         )
     return trial_sweep

--- a/cirq-google/cirq_google/api/v2/results.py
+++ b/cirq-google/cirq_google/api/v2/results.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import cast, Dict, Hashable, Iterable, Iterator, List, Optional, Sequence, Set
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 import dataclasses
 import numpy as np
 
@@ -28,18 +28,14 @@ class MeasureInfo:
     Attributes:
         key: String identifying this measurement.
         qubits: List of measured qubits, in order.
-        slot: The location of this measurement within the program. For circuits,
-            this is just the moment index; for schedules it is the start time
-            of the measurement. This is used internally when scheduling on
-            hardware so that we can combine measurements that occupy the same
-            slot.
+        instances: The number of times a given key occurs in a circuit.
         invert_mask: a list of booleans describing whether the results should
             be flipped for each of the qubits in the qubits field.
     """
 
     key: str
     qubits: List[cirq.GridQubit]
-    slot: int
+    instances: int
     invert_mask: List[bool]
     tags: List[Hashable]
 
@@ -54,34 +50,31 @@ def find_measurements(program: cirq.AbstractCircuit) -> List[MeasureInfo]:
         NotImplementedError: If the program is of a type that is not recognized.
         ValueError: If there is a duplicate measurement key.
     """
-    measurements: List[MeasureInfo] = []
-    keys: Set[str] = set()
-
-    if isinstance(program, cirq.AbstractCircuit):
-        measure_iter = _circuit_measurements(program)
-    else:
+    if not isinstance(program, cirq.AbstractCircuit):
         raise NotImplementedError(f'Unrecognized program type: {type(program)}')
 
-    for m in measure_iter:
-        if m.key in keys:
-            raise ValueError(f'Duplicate measurement key: {m.key}')
-        keys.add(m.key)
-        measurements.append(m)
-
-    return measurements
-
-
-def _circuit_measurements(circuit: cirq.AbstractCircuit) -> Iterator[MeasureInfo]:
-    for i, moment in enumerate(circuit):
+    measurements: Dict[str, MeasureInfo] = {}
+    instances: Dict[str, int] = Counter()
+    for moment in program:
         for op in moment:
             if isinstance(op.gate, cirq.MeasurementGate):
-                yield MeasureInfo(
+                m = MeasureInfo(
                     key=op.gate.key,
                     qubits=_grid_qubits(op),
-                    slot=i,
+                    instances=1,
                     invert_mask=list(op.gate.full_invert_mask()),
                     tags=list(op.tags),
                 )
+                prev_m = measurements.get(m.key)
+                if prev_m is None:
+                    measurements[m.key] = m
+                elif m != prev_m:
+                    raise ValueError(f"Incompatible repeated keys: {m} != {prev_m}")
+                instances[m.key] += 1
+    # Update instance counts for each measurement.
+    for k, m in measurements.items():
+        m.instances = instances[k]
+    return list(measurements.values())
 
 
 def _grid_qubits(op: cirq.Operation) -> List[cirq.GridQubit]:
@@ -137,16 +130,18 @@ def results_to_proto(
                 sweep_result.repetitions = trial_result.repetitions
             elif trial_result.repetitions != sweep_result.repetitions:
                 raise ValueError('Different numbers of repetitions in one sweep.')
+            reps = sweep_result.repetitions
             pr = sweep_result.parameterized_results.add()
             pr.params.assignments.update(trial_result.params.param_dict)
             for m in measurements:
                 mr = pr.measurement_results.add()
                 mr.key = m.key
-                m_data = trial_result.measurements[m.key]
+                mr.instances = m.instances
+                m_data = trial_result.records[m.key]
                 for i, qubit in enumerate(m.qubits):
                     qmr = mr.qubit_measurement_results.add()
                     qmr.qubit.id = v2.qubit_to_proto_id(qubit)
-                    qmr.results = pack_bits(m_data[:, i])
+                    qmr.results = pack_bits(m_data[:, :, i].reshape(reps * m.instances))
     return out
 
 
@@ -193,22 +188,24 @@ def _trial_sweep_from_proto(
 
     trial_sweep: List[cirq.Result] = []
     for pr in msg.parameterized_results:
-        m_data: Dict[str, np.ndarray] = {}
+        records: Dict[str, np.ndarray] = {}
         for mr in pr.measurement_results:
+            instances = max(mr.instances, 1)
             qubit_results: OrderedDict[cirq.GridQubit, np.ndarray] = OrderedDict()
             for qmr in mr.qubit_measurement_results:
                 qubit = v2.grid_qubit_from_proto_id(qmr.qubit.id)
                 if qubit in qubit_results:
                     raise ValueError(f'Qubit already exists: {qubit}.')
-                qubit_results[qubit] = unpack_bits(qmr.results, msg.repetitions)
+                qubit_results[qubit] = unpack_bits(qmr.results, msg.repetitions * instances)
             if measure_map:
                 ordered_results = [qubit_results[qubit] for qubit in measure_map[mr.key].qubits]
             else:
                 ordered_results = list(qubit_results.values())
-            m_data[mr.key] = np.array(ordered_results).transpose()
+            shape = (msg.repetitions, instances, len(qubit_results))
+            records[mr.key] = np.array(ordered_results).transpose().reshape(shape)
         trial_sweep.append(
             cirq.ResultDict(
-                params=cirq.ParamResolver(dict(pr.params.assignments)), measurements=m_data
+                params=cirq.ParamResolver(dict(pr.params.assignments)), records=records
             )
         )
     return trial_sweep

--- a/cirq-google/cirq_google/api/v2/results_test.py
+++ b/cirq-google/cirq_google/api/v2/results_test.py
@@ -180,8 +180,7 @@ def test_results_to_proto_sweep_repetitions():
     trial_results = [
         [
             cirq.ResultDict(
-                params=cirq.ParamResolver({'i': 0}),
-                records={'foo': np.array([[[0]]], dtype=bool)},
+                params=cirq.ParamResolver({'i': 0}), records={'foo': np.array([[[0]]], dtype=bool)}
             ),
             cirq.ResultDict(
                 params=cirq.ParamResolver({'i': 1}),
@@ -196,7 +195,11 @@ def test_results_to_proto_sweep_repetitions():
 def test_results_from_proto_qubit_ordering():
     measurements = [
         v2.MeasureInfo(
-            'foo', [q(0, 0), q(0, 1), q(1, 1)], instances=1, invert_mask=[False, False, False], tags=[]
+            'foo',
+            [q(0, 0), q(0, 1), q(1, 1)],
+            instances=1,
+            invert_mask=[False, False, False],
+            tags=[],
         )
     ]
     proto = v2.result_pb2.Result()
@@ -236,7 +239,11 @@ def test_results_from_proto_qubit_ordering():
 def test_results_from_proto_duplicate_qubit():
     measurements = [
         v2.MeasureInfo(
-            'foo', [q(0, 0), q(0, 1), q(1, 1)], instances=1, invert_mask=[False, False, False], tags=[]
+            'foo',
+            [q(0, 0), q(0, 1), q(1, 1)],
+            instances=1,
+            invert_mask=[False, False, False],
+            tags=[],
         )
     ]
     proto = v2.result_pb2.Result()

--- a/cirq-google/cirq_google/api/v2/results_test.py
+++ b/cirq-google/cirq_google/api/v2/results_test.py
@@ -88,7 +88,20 @@ def test_find_measurements_fill_mask():
     _check_measurement(m, 'k', [q(0, 0), q(0, 1), q(0, 2)], 1, [False, True, False])
 
 
-def test_find_measurements_duplicate_keys():
+def test_find_measurements_repeated_keys():
+    circuit = cirq.Circuit(
+        cirq.measure(q(0, 0), q(0, 1), key='k'),
+        cirq.measure(q(0, 1), q(0, 2), key='j'),
+        cirq.measure(q(0, 0), q(0, 1), key='k'),
+    )
+    measurements = v2.find_measurements(circuit)
+
+    assert len(measurements) == 2
+    _check_measurement(measurements[0], 'k', [q(0, 0), q(0, 1)], 2)
+    _check_measurement(measurements[1], 'j', [q(0, 1), q(0, 2)], 1)
+
+
+def test_find_measurements_incompatible_repeated_keys():
     circuit = cirq.Circuit()
     circuit.append(cirq.measure(q(0, 0), q(0, 1), key='k'))
     circuit.append(cirq.measure(q(0, 1), q(0, 2), key='k'))
@@ -173,6 +186,61 @@ def test_results_to_proto():
             np.testing.assert_array_equal(
                 trial_result.measurements['foo'], expected_trial_result.measurements['foo']
             )
+
+
+def test_results_to_proto_repeated_keys():
+    measurements = [
+        v2.MeasureInfo('foo', [q(0, 0)], instances=2, invert_mask=[False], tags=[]),
+        v2.MeasureInfo('bar', [q(0, 0)], instances=1, invert_mask=[False], tags=[]),
+    ]
+    trial_results = [
+        [
+            cirq.ResultDict(
+                params=cirq.ParamResolver({'i': 0}),
+                records={
+                    'foo': np.array([[[0], [0]], [[0], [1]], [[0], [0]], [[0], [1]]], dtype=bool),
+                    'bar': np.array([[[0]], [[1]], [[1]], [[0]]], dtype=bool),
+                },
+            ),
+            cirq.ResultDict(
+                params=cirq.ParamResolver({'i': 1}),
+                records={
+                    'foo': np.array([[[0], [0]], [[0], [1]], [[0], [1]], [[0], [0]]], dtype=bool),
+                    'bar': np.array([[[0]], [[1]], [[1]], [[0]]], dtype=bool),
+                },
+            ),
+        ],
+        [
+            cirq.ResultDict(
+                params=cirq.ParamResolver({'i': 0}),
+                records={
+                    'foo': np.array([[[0], [0]], [[0], [1]], [[0], [0]], [[0], [1]]], dtype=bool),
+                    'bar': np.array([[[0]], [[1]], [[1]], [[0]]], dtype=bool),
+                },
+            ),
+            cirq.ResultDict(
+                params=cirq.ParamResolver({'i': 1}),
+                records={
+                    'foo': np.array([[[0], [0]], [[0], [1]], [[0], [1]], [[0], [0]]], dtype=bool),
+                    'bar': np.array([[[0]], [[1]], [[1]], [[0]]], dtype=bool),
+                },
+            ),
+        ],
+    ]
+    proto = v2.results_to_proto(trial_results, measurements)
+    assert isinstance(proto, v2.result_pb2.Result)
+    assert len(proto.sweep_results) == 2
+    deserialized = v2.results_from_proto(proto, measurements)
+    assert len(deserialized) == 2
+    for sweep_results, expected in zip(deserialized, trial_results):
+        assert len(sweep_results) == len(expected)
+        for trial_result, expected_trial_result in zip(sweep_results, expected):
+            assert trial_result.params == expected_trial_result.params
+            assert trial_result.repetitions == expected_trial_result.repetitions
+            for key in ['foo', 'bar']:
+                np.testing.assert_array_equal(
+                    trial_result.records[key], expected_trial_result.records[key]
+                )
 
 
 def test_results_to_proto_sweep_repetitions():


### PR DESCRIPTION
This is a first step toward supporting repeated keys in circuits run through quantum engine. I need to expand the tests to cover cases where instances > 1, but the main logic is ready for review.