### PR TITLE
Allow symbol for coupling_mhz in CouplerPulse gate

### DIFF
--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
@@ -55,7 +55,7 @@ class CouplerPulse(cirq.ops.Gate):
     def __init__(
         self,
         hold_time: cirq.Duration,
-        coupling_mhz: float,
+        coupling_mhz: cirq.TParamVal,
         rise_time: Optional[cirq.Duration] = cirq.Duration(nanos=8),
         padding_time: Optional[cirq.Duration] = cirq.Duration(nanos=2.5),
     ):

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
@@ -17,6 +17,7 @@ from typing import AbstractSet, Any, Optional, Tuple
 import numpy as np
 
 import cirq
+from cirq._compat import proper_repr
 
 
 @cirq.value_equality(approximate=True)
@@ -78,10 +79,10 @@ class CouplerPulse(cirq.ops.Gate):
     def __repr__(self) -> str:
         return (
             'cirq_google.experimental.ops.coupler_pulse.'
-            + f'CouplerPulse(hold_time={self.hold_time!r}, '
-            + f'coupling_mhz={self.coupling_mhz}, '
-            + f'rise_time={self.rise_time!r}, '
-            + f'padding_time={self.padding_time!r})'
+            + f'CouplerPulse(hold_time={proper_repr(self.hold_time)}, '
+            + f'coupling_mhz={proper_repr(self.coupling_mhz)}, '
+            + f'rise_time={proper_repr(self.rise_time)}, '
+            + f'padding_time={proper_repr(self.padding_time)})'
         )
 
     def __str__(self) -> str:
@@ -95,9 +96,9 @@ class CouplerPulse(cirq.ops.Gate):
     def _is_parameterized_(self) -> bool:
         return (
             cirq.is_parameterized(self.hold_time)
+            or cirq.is_parameterized(self.coupling_mhz)
             or cirq.is_parameterized(self.rise_time)
             or cirq.is_parameterized(self.padding_time)
-            or cirq.is_parameterized(self.coupling_mhz)
         )
 
     def _parameter_names_(self: Any) -> AbstractSet[str]:

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Tuple
+from typing import AbstractSet, Any, Optional, Tuple
 
 import numpy as np
 
@@ -90,6 +90,32 @@ class CouplerPulse(cirq.ops.Gate):
             + f'coupling_mhz={self.coupling_mhz}, '
             + f'rise_time={self.rise_time}, '
             + f'padding_time={self.padding_time})'
+        )
+
+    def _is_parameterized_(self) -> bool:
+        return (
+            cirq.is_parameterized(self.hold_time)
+            or cirq.is_parameterized(self.rise_time)
+            or cirq.is_parameterized(self.padding_time)
+            or cirq.is_parameterized(self.coupling_mhz)
+        )
+
+    def _parameter_names_(self: Any) -> AbstractSet[str]:
+        return (
+            cirq.parameter_names(self.hold_time)
+            | cirq.parameter_names(self.coupling_mhz)
+            | cirq.parameter_names(self.rise_time)
+            | cirq.parameter_names(self.padding_time)
+        )
+
+    def _resolve_parameters_(
+        self, resolver: cirq.ParamResolverOrSimilarType, recursive: bool
+    ) -> 'CouplerPulse':
+        return CouplerPulse(
+            hold_time=cirq.resolve_parameters(self.hold_time, resolver, recursive=recursive),
+            coupling_mhz=cirq.resolve_parameters(self.coupling_mhz, resolver, recursive=recursive),
+            rise_time=cirq.resolve_parameters(self.rise_time, resolver, recursive=recursive),
+            padding_time=cirq.resolve_parameters(self.padding_time, resolver, recursive=recursive),
         )
 
     def _value_equality_values_(self) -> Any:

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
+import sympy
 
 import cirq
 import cirq_google.experimental.ops.coupler_pulse as coupler_pulse
@@ -112,3 +114,86 @@ def test_coupler_pulse_circuit_diagram():
 1: ───/‾‾(10 ns@25.0MHz)‾‾\───
 """,
     )
+
+
+@pytest.mark.parametrize(
+    'gate, resolver, expected',
+    [
+        (
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
+            ),
+            {'t_ns': 50},
+            coupler_pulse.CouplerPulse(hold_time=cirq.Duration(nanos=50), coupling_mhz=10),
+        ),
+        (
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
+            ),
+            {'g': 10},
+            coupler_pulse.CouplerPulse(hold_time=cirq.Duration(nanos=50), coupling_mhz=10),
+        ),
+    ],
+)
+def test_coupler_pulse_resolution(gate, resolver, expected):
+    assert cirq.resolve_parameters(gate, resolver) == expected
+
+
+@pytest.mark.parametrize(
+    'gate, param_names',
+    [
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
+                ),
+                {'t_ns'},
+        ),
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
+                ),
+                {'g'},
+        ),
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=sympy.Symbol('g')
+                ),
+                {'g', 't_ns'},
+        ),
+    ],
+)
+def test_coupler_pulse_parameter_names(gate, param_names):
+    assert cirq.parameter_names(gate) == param_names
+
+
+@pytest.mark.parametrize(
+    'gate, is_parameterized',
+    [
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=50), coupling_mhz=10
+                ),
+                False,
+        ),
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
+                ),
+                True,
+        ),
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
+                ),
+                True,
+        ),
+        (
+                coupler_pulse.CouplerPulse(
+                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=sympy.Symbol('g')
+                ),
+                True,
+        ),
+    ],
+)
+def test_coupler_pulse_is_parameterized(gate, is_parameterized):
+    assert cirq.is_parameterized(gate) == is_parameterized

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
@@ -143,22 +143,22 @@ def test_coupler_pulse_resolution(gate, resolver, expected):
     'gate, param_names',
     [
         (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
-                ),
-                {'t_ns'},
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
+            ),
+            {'t_ns'},
         ),
         (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
-                ),
-                {'g'},
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
+            ),
+            {'g'},
         ),
         (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=sympy.Symbol('g')
-                ),
-                {'g', 't_ns'},
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=sympy.Symbol('g')
+            ),
+            {'g', 't_ns'},
         ),
     ],
 )
@@ -169,29 +169,24 @@ def test_coupler_pulse_parameter_names(gate, param_names):
 @pytest.mark.parametrize(
     'gate, is_parameterized',
     [
+        (coupler_pulse.CouplerPulse(hold_time=cirq.Duration(nanos=50), coupling_mhz=10), False),
         (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=50), coupling_mhz=10
-                ),
-                False,
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
+            ),
+            True,
         ),
         (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=10
-                ),
-                True,
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
+            ),
+            True,
         ),
         (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=50), coupling_mhz=sympy.Symbol('g')
-                ),
-                True,
-        ),
-        (
-                coupler_pulse.CouplerPulse(
-                    hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=sympy.Symbol('g')
-                ),
-                True,
+            coupler_pulse.CouplerPulse(
+                hold_time=cirq.Duration(nanos=sympy.Symbol('t_ns')), coupling_mhz=sympy.Symbol('g')
+            ),
+            True,
         ),
     ],
 )


### PR DESCRIPTION
This is something we use on our internal version of this gate.