### PR TITLE
Add transformer primitives as methods on TransformerContext

### DIFF
--- a/cirq-core/cirq/contrib/acquaintance/executor.py
+++ b/cirq-core/cirq/contrib/acquaintance/executor.py
@@ -112,16 +112,11 @@ class StrategyExecutorTransformer:
             A copy of the modified circuit after executing an acquaintance
               strategy on all instances of AcquaintanceOpportunityGate
         """
-
+        context = context or transformers.TransformerContext(deep=False)
         circuit = transformers.expand_composite(
             circuit, no_decomp=expose_acquaintance_gates.no_decomp
         )
-        return transformers.map_operations_and_unroll(
-            circuit=circuit,
-            map_func=self._map_func,
-            deep=context.deep if context else False,
-            tags_to_ignore=context.tags_to_ignore if context else (),
-        ).unfreeze(copy=False)
+        return context.map_operations_and_unroll(circuit, self._map_func).unfreeze(copy=False)
 
     @property
     def mapping(self) -> LogicalMapping:

--- a/cirq-core/cirq/transformers/drop_empty_moments.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments.py
@@ -15,7 +15,7 @@
 """Transformer pass that removes empty moments from a circuit."""
 
 from typing import Optional, TYPE_CHECKING
-from cirq.transformers import transformer_api, transformer_primitives
+from cirq.transformers import transformer_api
 
 if TYPE_CHECKING:
     import cirq
@@ -36,9 +36,4 @@ def drop_empty_moments(
     """
     if context is None:
         context = transformer_api.TransformerContext()
-    return transformer_primitives.map_moments(
-        circuit.unfreeze(False),
-        lambda m, _: m if m else [],
-        deep=context.deep,
-        tags_to_ignore=context.tags_to_ignore,
-    )
+    return context.map_moments(circuit.unfreeze(False), lambda m, _: m if m else [])

--- a/cirq-core/cirq/transformers/drop_negligible_operations.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations.py
@@ -16,7 +16,7 @@
 
 from typing import Optional, TYPE_CHECKING
 from cirq import protocols
-from cirq.transformers import transformer_api, transformer_primitives
+from cirq.transformers import transformer_api
 
 if TYPE_CHECKING:
     import cirq
@@ -43,8 +43,7 @@ def drop_negligible_operations(
     Returns:
           Copy of the transformed input circuit.
     """
-    if context is None:
-        context = transformer_api.TransformerContext()
+    context = context or transformer_api.TransformerContext()
 
     def map_func(op: 'cirq.Operation', _: int) -> 'cirq.OP_TREE':
         return (
@@ -55,6 +54,4 @@ def drop_negligible_operations(
             else []
         )
 
-    return transformer_primitives.map_operations(
-        circuit, map_func, tags_to_ignore=context.tags_to_ignore, deep=context.deep
-    ).unfreeze(copy=False)
+    return context.map_operations(circuit, map_func).unfreeze(copy=False)

--- a/cirq-core/cirq/transformers/eject_phased_paulis.py
+++ b/cirq-core/cirq/transformers/eject_phased_paulis.py
@@ -19,7 +19,7 @@ import sympy
 import numpy as np
 
 from cirq import circuits, ops, value, protocols
-from cirq.transformers import transformer_api, transformer_primitives
+from cirq.transformers import transformer_api
 from cirq.transformers.analytical_decompositions import single_qubit_decompositions
 
 if TYPE_CHECKING:
@@ -56,8 +56,9 @@ def eject_phased_paulis(
     Returns:
           Copy of the transformed input circuit.
     """
+    context = context or transformer_api.TransformerContext()
     held_w_phases: Dict[ops.Qid, value.TParamVal] = {}
-    tags_to_ignore = set(context.tags_to_ignore) if context else set()
+    tags_to_ignore = set(context.tags_to_ignore)
 
     def map_func(op: 'cirq.Operation', _: int) -> 'cirq.OP_TREE':
         # Dump if `op` marked with a no compile tag.
@@ -99,7 +100,7 @@ def eject_phased_paulis(
 
     # Map operations and put anything that's still held at the end of the circuit.
     return circuits.Circuit(
-        transformer_primitives.map_operations_and_unroll(circuit, map_func),
+        context.reset().map_operations_and_unroll(circuit, map_func),
         _dump_held(held_w_phases.keys(), held_w_phases),
     )
 

--- a/cirq-core/cirq/transformers/expand_composite.py
+++ b/cirq-core/cirq/transformers/expand_composite.py
@@ -17,7 +17,7 @@
 from typing import Callable, Optional, TYPE_CHECKING
 
 from cirq import circuits, ops, protocols
-from cirq.transformers import transformer_api, transformer_primitives
+from cirq.transformers import transformer_api
 
 if TYPE_CHECKING:
     import cirq
@@ -47,15 +47,12 @@ def expand_composite(
     Returns:
           Copy of the transformed input circuit.
     """
+    context = context or transformer_api.TransformerContext()
+    deep = context.deep
 
     def map_func(op: 'cirq.Operation', _) -> 'cirq.OP_TREE':
-        if context and context.deep and isinstance(op.untagged, circuits.CircuitOperation):
+        if deep and isinstance(op.untagged, circuits.CircuitOperation):
             return op
         return protocols.decompose(op, keep=no_decomp, on_stuck_raise=None)
 
-    return transformer_primitives.map_operations_and_unroll(
-        circuit,
-        map_func,
-        tags_to_ignore=context.tags_to_ignore if context else (),
-        deep=context.deep if context else False,
-    ).unfreeze(copy=False)
+    return context.map_operations_and_unroll(circuit, map_func).unfreeze(copy=False)

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -18,7 +18,7 @@ from typing import Optional, Callable, Hashable, Sequence, TYPE_CHECKING
 
 from cirq import circuits
 from cirq.protocols import decompose_protocol as dp
-from cirq.transformers import transformer_api, transformer_primitives
+from cirq.transformers import transformer_api
 
 if TYPE_CHECKING:
     import cirq
@@ -87,12 +87,8 @@ def _decompose_operations_to_target_gateset(
             ),
         )
 
-    return transformer_primitives.map_operations_and_unroll(
-        circuit,
-        map_func,
-        tags_to_ignore=context.tags_to_ignore if context else (),
-        deep=context.deep if context else False,
-    ).unfreeze(copy=False)
+    context = context or transformer_api.TransformerContext()
+    return context.map_operations_and_unroll(circuit, map_func).unfreeze(copy=False)
 
 
 @transformer_api.transformer

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -18,7 +18,7 @@ import itertools
 from typing import TYPE_CHECKING, Type, Callable, Optional, Union, Iterable, Sequence, List, Tuple
 
 from cirq import ops, circuits, _import
-from cirq.transformers import transformer_api, transformer_primitives
+from cirq.transformers import transformer_api
 
 drop_empty_moments = _import.LazyLoader('drop_empty_moments', globals(), 'cirq.transformers')
 
@@ -130,7 +130,7 @@ def _stratify_circuit(
                     break
         return [circuits.Moment(op_list) for op_list in stratified_ops]
 
-    stratified_circuit = transformer_primitives.map_moments(circuit, map_func).unfreeze(copy=False)
+    stratified_circuit = context.reset().map_moments(circuit, map_func).unfreeze(copy=False)
     assert len(stratified_circuit) == len(circuit) * num_categories
 
     # Try to move operations to the left to reduce circuit depth, preserving stratification.


### PR DESCRIPTION
This is a proposal to make `transformer_primitives` functions available as methods on `TransformerContext`. Then they can be invoked without passing extra parameters which are already stored on the context, such as the `deep` flag and `tags_to_ignore`. I think this would be simplified somewhat if we changed transformer primitives to take `TransformerContext` instead of `Optional[TransformerContext]`, with a default value specified as appropriate, but we can't change that due to backwards compatibility so there are a bunch of places where we would have to do things like `context = context or transformers.TransformerContext(...)` to instantiate a default context if needed. Still I think this simplifies existing transformers quite a bit and could prevent bugs in the future from forgetting to pass args from the context manually. I also added a function `TransformerContext.replace` that allows creating a new context with some parameters changed, to allow overriding some parameters before calling a primitive. I've updated a few existing callsites to use the new style, but for now just want to put this up to get feedback before changing more.