### PR TITLE
Fix issues reported by shellcheck

### DIFF
--- a/check/all
+++ b/check/all
@@ -31,8 +31,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 # Parse arguments.
 apply_arg=""

--- a/check/all
+++ b/check/all
@@ -45,7 +45,7 @@ for arg in "$@"; do
     elif [[ "${arg}" == "--apply-format-changes" ]]; then
         apply_arg="--apply"
     elif [ -z "${rev}" ]; then
-        if [ "$(git cat-file -t ${arg} 2> /dev/null)" != "commit" ]; then
+        if [ "$(git cat-file -t "${arg}" 2> /dev/null)" != "commit" ]; then
             echo -e "\033[31mNo revision '${arg}'.\033[0m" >&2
             exit 1
         fi

--- a/check/asv_run
+++ b/check/asv_run
@@ -8,7 +8,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 asv run "$@"

--- a/check/build-changed-protos
+++ b/check/build-changed-protos
@@ -31,7 +31,7 @@ topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
 cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
-if [ ! -z "$1" ] && [[ $1 != -* ]]; then
+if [ -n "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
@@ -64,7 +64,7 @@ dev_tools/build-protos.sh
 # but the error logic will still work.
 uncommitted=$(git status --porcelain 2>/dev/null | grep -E "^?? cirq-google" | cut -d " " -f 3)
 
-if [[ ! -z "$uncommitted" ]]; then
+if [[ -n "$uncommitted" ]]; then
     echo -e "\033[31mERROR: Uncommitted generated files found! Please generate and commit these files using dev_tools/build-protos.sh:\033[0m"
     for generated in $uncommitted
     do

--- a/check/build-changed-protos
+++ b/check/build-changed-protos
@@ -26,8 +26,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
 if [ ! -z "$1" ] && [[ $1 != -* ]]; then

--- a/check/build-changed-protos
+++ b/check/build-changed-protos
@@ -32,7 +32,7 @@ cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
 if [ -n "$1" ] && [[ $1 != -* ]]; then
-    if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
+    if [ "$(git cat-file -t "$1" 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi

--- a/check/doctest
+++ b/check/doctest
@@ -14,8 +14,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 source dev_tools/pypath
 

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -32,8 +32,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 
 # Parse arguments.

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -47,7 +47,7 @@ for arg in "$@"; do
     elif [[ "${arg}" == "--all" ]]; then
         only_changed=0
     elif [ -z "${rev}" ]; then
-        if [ "$(git cat-file -t ${arg} 2> /dev/null)" != "commit" ]; then
+        if [ "$(git cat-file -t "${arg}" 2> /dev/null)" != "commit" ]; then
             echo -e "\033[31mNo revision '${arg}'.\033[0m" >&2
             exit 1
         fi
@@ -83,7 +83,7 @@ if (( only_changed == 1 )); then
 
     # Get the modified, added and moved python files.
     IFS=$'\n' read -r -d '' -a format_files < \
-        <(git diff --name-only --diff-filter=MAR ${rev} -- '*.py' ':(exclude)cirq-google/cirq_google/cloud/*' ':(exclude)*_pb2.py')
+        <(git diff --name-only --diff-filter=MAR "${rev}" -- '*.py' ':(exclude)cirq-google/cirq_google/cloud/*' ':(exclude)*_pb2.py')
 else
     echo -e "Formatting all python files." >&2
     IFS=$'\n' read -r -d '' -a format_files < \

--- a/check/misc
+++ b/check/misc
@@ -8,8 +8,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 # Check for non-contrib references to contrib.
 results=$(grep -Rl "\bcirq\.contrib\b" cirq-core | grep -v "cirq/contrib" | grep -v "__")

--- a/check/mypy
+++ b/check/mypy
@@ -8,8 +8,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 CONFIG_FILE='mypy.ini'
 

--- a/check/mypy
+++ b/check/mypy
@@ -14,10 +14,11 @@ cd "${topdir}" || exit $?
 
 CONFIG_FILE='mypy.ini'
 
-CIRQ_PACKAGES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
+read -r -a CIRQ_PACKAGES < \
+    <(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
 
 echo -e -n "\033[31m"
-mypy --config-file=dev_tools/conf/$CONFIG_FILE "$@" $CIRQ_PACKAGES dev_tools examples
+mypy --config-file=dev_tools/conf/$CONFIG_FILE "$@" "${CIRQ_PACKAGES[@]}" dev_tools examples
 result=$?
 echo -e -n "\033[0m"
 

--- a/check/nbformat
+++ b/check/nbformat
@@ -25,8 +25,9 @@ for arg in "$@"; do
 done
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 pip show tensorflow-docs > /dev/null || exit 1
 

--- a/check/nbformat
+++ b/check/nbformat
@@ -36,7 +36,7 @@ FORMAT_CMD="python3 -m tensorflow_docs.tools.nbfmt --indent=1"
 # Test the notebooks
 unformatted=$($FORMAT_CMD --test docs 2>&1 | grep "\- docs" || true)
 needed_changes=0
-if [ ! -z "${unformatted}" ]; then
+if [ -n "${unformatted}" ]; then
     needed_changes=1
     if (( only_print == 0 )); then
         $FORMAT_CMD docs

--- a/check/npm
+++ b/check/npm
@@ -23,7 +23,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 npm --prefix 'cirq-web/cirq_ts' "$@"

--- a/check/npx
+++ b/check/npx
@@ -22,8 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
 
-cd 'cirq-web/cirq_ts'
+cd "${topdir}/cirq-web/cirq_ts" || exit $?
 npx "$@"

--- a/check/pylint
+++ b/check/pylint
@@ -8,8 +8,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 CIRQ_MODULES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
 

--- a/check/pylint
+++ b/check/pylint
@@ -12,7 +12,8 @@ thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
 topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
 cd "${topdir}" || exit $?
 
-CIRQ_MODULES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
+read -r -a CIRQ_MODULES < \
+    <(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
 
 # Add dev_tools to $PYTHONPATH so that pylint can find custom checkers
-env PYTHONPATH=dev_tools pylint --jobs=0 --rcfile=dev_tools/conf/.pylintrc "$@" $CIRQ_MODULES dev_tools examples
+env PYTHONPATH=dev_tools pylint --jobs=0 --rcfile=dev_tools/conf/.pylintrc "$@" "${CIRQ_MODULES[@]}" dev_tools examples

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -25,8 +25,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
 if [ ! -z "$1" ] && [[ $1 != -* ]]; then

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -30,7 +30,7 @@ topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
 cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
-if [ ! -z "$1" ] && [[ $1 != -* ]]; then
+if [ -n "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -31,7 +31,7 @@ cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
 if [ -n "$1" ] && [[ $1 != -* ]]; then
-    if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
+    if [ "$(git cat-file -t "$1" 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi
@@ -56,7 +56,7 @@ fi
 
 typeset -a changed
 IFS=$'\n' read -r -d '' -a changed < \
-    <(git diff --name-only ${rev} -- '*.py' ':(exclude)cirq-google/cirq_google/cloud/*' ':(exclude)*_pb2.py' \
+    <(git diff --name-only "${rev}" -- '*.py' ':(exclude)cirq-google/cirq_google/cloud/*' ':(exclude)*_pb2.py' \
     | grep -E "^(cirq|dev_tools|examples).*.py$"
 )
 

--- a/check/pytest
+++ b/check/pytest
@@ -12,8 +12,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 PYTEST_ARGS=()
 

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -79,7 +79,7 @@ pytest_result=$?
 
 # assume successful cover_result in case coverage is not run
 cover_result=0
-if (( $ANALYZE_COV )); then
+if (( ANALYZE_COV )); then
     # Convert to .py,cover files.
     coverage annotate
 
@@ -92,7 +92,7 @@ if (( $ANALYZE_COV )); then
 fi
 
 # Report result.
-if (( ${pytest_result} || ${cover_result} )); then
+if (( pytest_result || cover_result )); then
     exit 1
 fi
 exit 0

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -28,8 +28,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 # Figure out which branch to compare against.
 rest=$@

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -34,7 +34,7 @@ cd "${topdir}" || exit $?
 
 # Figure out which branch to compare against.
 rest=$@
-if [ ! -z "$1" ] && [[ $1 != -* ]]; then
+if [ -n "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -35,7 +35,7 @@ cd "${topdir}" || exit $?
 # Figure out which branch to compare against.
 rest=$@
 if [ -n "$1" ] && [[ $1 != -* ]]; then
-    if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
+    if [ "$(git cat-file -t "$1" 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -33,14 +33,14 @@ topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
 cd "${topdir}" || exit $?
 
 # Figure out which branch to compare against.
-rest=$@
+rest=( "$@" )
 if [ -n "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t "$1" 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi
     rev=$1
-    rest=${@:2}
+    rest=( "${@:2}" )
 elif [ "$(git cat-file -t upstream/master 2> /dev/null)" == "commit" ]; then
     rev=upstream/master
 elif [ "$(git cat-file -t origin/master 2> /dev/null)" == "commit" ]; then
@@ -78,4 +78,4 @@ fi
 
 source dev_tools/pypath
 
-pytest ${rest} "${changed[@]}"
+pytest "${rest[@]}" "${changed[@]}"

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -34,7 +34,7 @@ cd "$(git rev-parse --show-toplevel)" || exit 1
 
 # Figure out which revision to compare against.
 if [ -n "$1" ] && [[ $1 != -* ]]; then
-    if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
+    if [ "$(git cat-file -t "$1" 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1
     fi

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -33,7 +33,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
 # Figure out which revision to compare against.
-if [ ! -z "$1" ] && [[ $1 != -* ]]; then
+if [ -n "$1" ] && [[ $1 != -* ]]; then
     if [ "$(git cat-file -t $1 2> /dev/null)" != "commit" ]; then
         echo -e "\033[31mNo revision '$1'.\033[0m" >&2
         exit 1

--- a/check/ts-build
+++ b/check/ts-build
@@ -22,7 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 check/npx webpack --mode production "$@"

--- a/check/ts-build-current
+++ b/check/ts-build-current
@@ -26,7 +26,7 @@ check/ts-build
 # Find the changed bundle.js files, if any
 untracked=$(git status --porcelain 2>/dev/null | grep "cirq-web/cirq_ts/dist/" | cut -d " " -f 3)
 
-if [[ ! -z "$untracked" ]]; then
+if [[ -n "$untracked" ]]; then
     echo -e "\033[31mERROR: Uncommitted changes to bundle file(s) found! Please commit these files:\033[0m"
     for generated in $untracked
     do

--- a/check/ts-coverage
+++ b/check/ts-coverage
@@ -22,7 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 check/npm run coverage "$@"

--- a/check/ts-lint
+++ b/check/ts-lint
@@ -22,7 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 check/npm run lint "$@"

--- a/check/ts-lint-and-format
+++ b/check/ts-lint-and-format
@@ -22,7 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 check/npm run fix "$@"

--- a/check/ts-test
+++ b/check/ts-test
@@ -24,7 +24,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 check/npm run test "$@"

--- a/check/ts-test-e2e
+++ b/check/ts-test-e2e
@@ -24,7 +24,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
 
 check/npm run test-e2e "$@"

--- a/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
+++ b/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -20,10 +20,10 @@ set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd "$(git rev-parse --show-toplevel)"
 
-REQS="-r dev_tools/requirements/pytest-minimal.env.txt"
+reqs=( -r dev_tools/requirements/pytest-minimal.env.txt )
 
 # Install contrib requirements only if needed.
 changed=$(git diff --name-only origin/master | grep "cirq/contrib" || true)
-[ "${changed}" = "" ] || REQS="$REQS -r cirq-core/cirq/contrib/requirements.txt"
+[ "${changed}" = "" ] || reqs+=( -r cirq-core/cirq/contrib/requirements.txt )
 
-pip install $REQS
+pip install "${reqs[@]}"

--- a/dev_tools/docs/build-rtd-docs.sh
+++ b/dev_tools/docs/build-rtd-docs.sh
@@ -33,7 +33,7 @@
 set -e
 trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
-[[ $1 == 'fast' ]] && CPUS='-j auto' || CPUS=''
+[[ $1 == 'fast' ]] && cpus=( -j auto ) || cpus=( )
 
 # Get the working directory to the repo root.
 cd "$(git rev-parse --show-toplevel)"/rtd_docs
@@ -48,7 +48,7 @@ rm -rf "${docs_conf_dir}/generated"
 rm -rf "${out_dir}"
 
 # Regenerate docs.
-sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W --keep-going $CPUS
+sphinx-build -M html "${docs_conf_dir}" "${out_dir}" -W --keep-going "${cpus[@]}"
 
 # Cleanup newly generated temporary files.
 rm -rf "${docs_conf_dir}/generated"

--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -42,7 +42,7 @@ cd "${repo_dir}"
 PROJECT_NAME=cirq-core/cirq
 
 ACTUAL_VERSION_LINE=$(tail -n 1 "${PROJECT_NAME}/_version.py")
-ACTUAL_VERSION=$(echo $ACTUAL_VERSION_LINE | cut -d'"' -f 2)
+ACTUAL_VERSION=$(echo "$ACTUAL_VERSION_LINE" | cut -d'"' -f 2)
 
 if [[ ${ACTUAL_VERSION} == *"dev" ]]; then
   echo "${ACTUAL_VERSION}$(date "+%Y%m%d%H%M%S")"

--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -41,7 +41,7 @@ cd "${repo_dir}"
 
 PROJECT_NAME=cirq-core/cirq
 
-ACTUAL_VERSION_LINE=$(cat "${PROJECT_NAME}/_version.py" | tail -n 1)
+ACTUAL_VERSION_LINE=$(tail -n 1 "${PROJECT_NAME}/_version.py")
 ACTUAL_VERSION=`echo $ACTUAL_VERSION_LINE | cut -d'"' -f 2`
 
 if [[ ${ACTUAL_VERSION} == *"dev" ]]; then

--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -42,7 +42,7 @@ cd "${repo_dir}"
 PROJECT_NAME=cirq-core/cirq
 
 ACTUAL_VERSION_LINE=$(tail -n 1 "${PROJECT_NAME}/_version.py")
-ACTUAL_VERSION=`echo $ACTUAL_VERSION_LINE | cut -d'"' -f 2`
+ACTUAL_VERSION=$(echo $ACTUAL_VERSION_LINE | cut -d'"' -f 2)
 
 if [[ ${ACTUAL_VERSION} == *"dev" ]]; then
   echo "${ACTUAL_VERSION}$(date "+%Y%m%d%H%M%S")"

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -24,7 +24,7 @@ set -e
 
 # Temporary workspace.
 tmp_dir=$(mktemp -d)
-trap "{ rm -rf ${tmp_dir}; }" EXIT
+trap '{ rm -rf "${tmp_dir}"; }' EXIT
 
 # New virtual environment
 echo "Working in a fresh virtualenv at ${tmp_dir}/env"

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -32,10 +32,10 @@ virtualenv --quiet "--python=/usr/bin/python3" "${tmp_dir}/env"
 
 export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 out_dir=${tmp_dir}/dist
-dev_tools/packaging/produce-package.sh ${out_dir} $CIRQ_PRE_RELEASE_VERSION
+dev_tools/packaging/produce-package.sh "${out_dir}" "$CIRQ_PRE_RELEASE_VERSION"
 
 # test installation
-"${tmp_dir}/env/bin/python" -m pip install ${out_dir}/*
+"${tmp_dir}/env/bin/python" -m pip install "${out_dir}"/*
 
 echo ===========================
 echo Testing that code executes
@@ -51,7 +51,7 @@ echo =======================================
 
 CIRQ_PACKAGES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package)
 for p in $CIRQ_PACKAGES; do
-  echo --- Testing $p -----
+  echo "--- Testing $p -----"
   python_test="import $p; print($p); assert '${tmp_dir}' in $p.__file__, 'Package path seems invalid.'"
   env PYTHONPATH='' "${tmp_dir}/env/bin/python" -c "$python_test" && echo -e "\033[32mPASS\033[0m"  || echo -e "\033[31mFAIL\033[0m"
 done

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -30,7 +30,8 @@ trap '{ rm -rf "${tmp_dir}"; }' EXIT
 echo "Working in a fresh virtualenv at ${tmp_dir}/env"
 virtualenv --quiet "--python=/usr/bin/python3" "${tmp_dir}/env"
 
-export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
+export CIRQ_PRE_RELEASE_VERSION
+CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 out_dir=${tmp_dir}/dist
 dev_tools/packaging/produce-package.sh "${out_dir}" "$CIRQ_PRE_RELEASE_VERSION"
 

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -65,7 +65,7 @@ CIRQ_MODULES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode folder -
 
 for m in $CIRQ_MODULES; do
   echo "processing $m/setup.py..."
-  cd $m
+  cd "$m"
   python3 setup.py -q bdist_wheel -d "${out_dir}"
   cd ..
 done

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -46,7 +46,7 @@ if [ -n "$(git status --short)" ]; then
     echo -e "\033[31mWARNING: You have uncommitted changes. They won't be included in the package.\033[0m"
 fi
 tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
-trap "{ rm -rf ${tmp_git_dir}; }" EXIT
+trap '{ rm -rf "${tmp_git_dir}"; }' EXIT
 cd "${tmp_git_dir}"
 git init --quiet
 git fetch "${repo_dir}" HEAD --quiet --depth=1

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -42,7 +42,7 @@ repo_dir=$(git rev-parse --show-toplevel)
 cd "${repo_dir}"
 
 # Make a clean copy of HEAD, without files ignored by git (but potentially kept by setup.py).
-if [ ! -z "$(git status --short)" ]; then
+if [ -n "$(git status --short)" ]; then
     echo -e "\033[31mWARNING: You have uncommitted changes. They won't be included in the package.\033[0m"
 fi
 tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
@@ -51,7 +51,7 @@ cd "${tmp_git_dir}"
 git init --quiet
 git fetch "${repo_dir}" HEAD --quiet --depth=1
 git checkout FETCH_HEAD -b work --quiet
-if [ ! -z "${SPECIFIED_VERSION}" ]; then
+if [ -n "${SPECIFIED_VERSION}" ]; then
     CIRQ_PACKAGES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
     for PROJECT_NAME in $CIRQ_PACKAGES; do
       echo '__version__ = "'"${SPECIFIED_VERSION}"'"' > "${tmp_git_dir}/${PROJECT_NAME}/_version.py"

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -109,7 +109,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # Temporary workspace.
 tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
-trap "{ rm -rf ${tmp_package_dir}; }" EXIT
+trap '{ rm -rf "${tmp_package_dir}"; }' EXIT
 
 # Configure to push to a pre-release package of cirq.
 export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -62,7 +62,7 @@ if [[ "${EXPECTED_VERSION}" != *dev* ]]; then
   echo -e "\033[31mExpected version must include 'dev'.\033[0m"
   exit 1
 fi
-ACTUAL_VERSION_LINE=$(cat "${PROJECT_NAME}/_version.py" | tail -n 1)
+ACTUAL_VERSION_LINE=$(tail -n 1 "${PROJECT_NAME}/_version.py")
 if [ "${ACTUAL_VERSION_LINE}" != '__version__ = "'"${EXPECTED_VERSION}"'"' ]; then
   echo -e "\033[31mExpected version (${EXPECTED_VERSION}) didn't match the one in ${PROJECT_NAME}/_version.py (${ACTUAL_VERSION_LINE}).\033[0m"
   exit 1

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -69,7 +69,7 @@ if [ "${ACTUAL_VERSION_LINE}" != '__version__ = "'"${EXPECTED_VERSION}"'"' ]; th
 fi
 
 if [ -z "${PROD_SWITCH}" ] || [ "${PROD_SWITCH}" = "--test" ]; then
-    PYPI_REPOSITORY_FLAG="--repository-url=https://test.pypi.org/legacy/"
+    PYPI_REPOSITORY_FLAG=( "--repository-url=https://test.pypi.org/legacy/" )
     PYPI_REPO_NAME="TEST"
     USERNAME="${TEST_TWINE_USERNAME}"
     PASSWORD="${TEST_TWINE_PASSWORD}"
@@ -82,7 +82,7 @@ if [ -z "${PROD_SWITCH}" ] || [ "${PROD_SWITCH}" = "--test" ]; then
       exit 1
     fi
 elif [ "${PROD_SWITCH}" = "--prod" ]; then
-    PYPI_REPOSITORY_FLAG=''
+    PYPI_REPOSITORY_FLAG=( )
     PYPI_REPO_NAME="PROD"
     USERNAME="${PROD_TWINE_USERNAME}"
     PASSWORD="${PROD_TWINE_PASSWORD}"
@@ -116,6 +116,6 @@ export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"
-twine upload --username="${USERNAME}" --password="${PASSWORD}" ${PYPI_REPOSITORY_FLAG} "${tmp_package_dir}/*"
+twine upload --username="${USERNAME}" --password="${PASSWORD}" "${PYPI_REPOSITORY_FLAG[@]}" "${tmp_package_dir}/*"
 
 echo -e "\033[32mUploaded package with version ${UPLOAD_VERSION} to ${PYPI_REPO_NAME} pypi repository\033[0m"

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -112,7 +112,8 @@ tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")
 trap '{ rm -rf "${tmp_package_dir}"; }' EXIT
 
 # Configure to push to a pre-release package of cirq.
-export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
+export CIRQ_PRE_RELEASE_VERSION
+CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 
 # Produce packages.
 dev_tools/packaging/produce-package.sh "${tmp_package_dir}" "${UPLOAD_VERSION}"

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -88,7 +88,7 @@ for PYTHON_VERSION in python3; do
     "${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import cirq; print(cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))))"
 
     # Install pytest + dev deps.
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install -r ${DEV_DEPS_FILE}
+    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install -r "${DEV_DEPS_FILE}"
 
     # Run tests.
     PY_VER=$(ls "${tmp_dir}/${PYTHON_VERSION}/lib")

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -69,39 +69,39 @@ tmp_dir=$(mktemp -d "/tmp/verify-published-package.XXXXXXXXXXXXXXXX")
 cd "${tmp_dir}"
 trap '{ rm -rf "${tmp_dir}"; }' EXIT
 
-# Test python 3 versions.
-for PYTHON_VERSION in python3; do
-    # Prepare.
-    CONTRIB_DEPS_FILE="${REPO_ROOT}/cirq-core/cirq/contrib/requirements.txt"
-    DEV_DEPS_FILE="${REPO_ROOT}/dev_tools/requirements/deps/dev-tools.txt"
+# Test installation from published package
+PYTHON_VERSION=python3
 
-    echo -e "\n\033[32m${PYTHON_VERSION}\033[0m"
-    echo "Working in a fresh virtualenv at ${tmp_dir}/${PYTHON_VERSION}"
-    virtualenv --quiet "--python=/usr/bin/${PYTHON_VERSION}" "${tmp_dir}/${PYTHON_VERSION}"
+# Prepare.
+CONTRIB_DEPS_FILE="${REPO_ROOT}/cirq-core/cirq/contrib/requirements.txt"
+DEV_DEPS_FILE="${REPO_ROOT}/dev_tools/requirements/deps/dev-tools.txt"
 
-    echo Installing "${PYPI_PROJECT_NAME}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi"
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet ${PIP_FLAGS} "${PYPI_PROJECT_NAME}==${PROJECT_VERSION}" --extra-index-url https://pypi.python.org/simple
+echo -e "\n\033[32m${PYTHON_VERSION}\033[0m"
+echo "Working in a fresh virtualenv at ${tmp_dir}/${PYTHON_VERSION}"
+virtualenv --quiet "--python=/usr/bin/${PYTHON_VERSION}" "${tmp_dir}/${PYTHON_VERSION}"
 
-    # Check that code runs without dev deps.
-    echo Checking that code executes
-    "${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import cirq_google; print(cirq_google.Sycamore)"
-    "${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import cirq; print(cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))))"
+echo Installing "${PYPI_PROJECT_NAME}==${PROJECT_VERSION} from ${PYPI_REPO_NAME} pypi"
+"${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet ${PIP_FLAGS} "${PYPI_PROJECT_NAME}==${PROJECT_VERSION}" --extra-index-url https://pypi.python.org/simple
 
-    # Install pytest + dev deps.
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install -r "${DEV_DEPS_FILE}"
+# Check that code runs without dev deps.
+echo Checking that code executes
+"${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import cirq_google; print(cirq_google.Sycamore)"
+"${tmp_dir}/${PYTHON_VERSION}/bin/python" -c "import cirq; print(cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2))))"
 
-    # Run tests.
-    PY_VER=$(ls "${tmp_dir}/${PYTHON_VERSION}/lib")
-    echo Running cirq tests
-    cirq_dir="${tmp_dir}/${PYTHON_VERSION}/lib/${PY_VER}/site-packages/${PROJECT_NAME}"
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pytest" --quiet --disable-pytest-warnings --ignore="${cirq_dir}/contrib" "${cirq_dir}"
+# Install pytest + dev deps.
+"${tmp_dir}/${PYTHON_VERSION}/bin/pip" install -r "${DEV_DEPS_FILE}"
 
-    echo "Installing contrib dependencies"
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${CONTRIB_DEPS_FILE}"
+# Run tests.
+PY_VER=$(ls "${tmp_dir}/${PYTHON_VERSION}/lib")
+echo Running cirq tests
+cirq_dir="${tmp_dir}/${PYTHON_VERSION}/lib/${PY_VER}/site-packages/${PROJECT_NAME}"
+"${tmp_dir}/${PYTHON_VERSION}/bin/pytest" --quiet --disable-pytest-warnings --ignore="${cirq_dir}/contrib" "${cirq_dir}"
 
-    echo "Running contrib tests"
-    "${tmp_dir}/${PYTHON_VERSION}/bin/pytest" --quiet --disable-pytest-warnings "${cirq_dir}/contrib"
-done
+echo "Installing contrib dependencies"
+"${tmp_dir}/${PYTHON_VERSION}/bin/pip" install --quiet -r "${CONTRIB_DEPS_FILE}"
+
+echo "Running contrib tests"
+"${tmp_dir}/${PYTHON_VERSION}/bin/pytest" --quiet --disable-pytest-warnings "${cirq_dir}/contrib"
 
 echo
 echo -e '\033[32mVERIFIED\033[0m'

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -67,7 +67,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Temporary workspace.
 tmp_dir=$(mktemp -d "/tmp/verify-published-package.XXXXXXXXXXXXXXXX")
 cd "${tmp_dir}"
-trap "{ rm -rf ${tmp_dir}; }" EXIT
+trap '{ rm -rf "${tmp_dir}"; }' EXIT
 
 # Test python 3 versions.
 for PYTHON_VERSION in python3; do

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -72,8 +72,6 @@ trap "{ rm -rf ${tmp_dir}; }" EXIT
 # Test python 3 versions.
 for PYTHON_VERSION in python3; do
     # Prepare.
-    CORE_DEPS_FILE="${REPO_ROOT}/cirq-core/requirements.txt"
-    GOOGLE_DEPS_FILE="${REPO_ROOT}/cirq-google/requirements.txt"
     CONTRIB_DEPS_FILE="${REPO_ROOT}/cirq-core/cirq/contrib/requirements.txt"
     DEV_DEPS_FILE="${REPO_ROOT}/dev_tools/requirements/deps/dev-tools.txt"
 

--- a/dev_tools/pr_monitor.sh
+++ b/dev_tools/pr_monitor.sh
@@ -48,9 +48,9 @@
 
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-repo_dir=$(git rev-parse --show-toplevel)
-cd "${repo_dir}"
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+repo_dir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${repo_dir}" || exit $?
 
 # Do the thing.
 export PYTHONPATH=${repo_dir}

--- a/dev_tools/pr_monitor.sh
+++ b/dev_tools/pr_monitor.sh
@@ -54,4 +54,4 @@ cd "${repo_dir}" || exit $?
 
 # Do the thing.
 export PYTHONPATH=${repo_dir}
-python3 ${repo_dir}/dev_tools/pr_monitor.py "$@"
+python3 "${repo_dir}/dev_tools/pr_monitor.py" "$@"

--- a/dev_tools/pypath
+++ b/dev_tools/pypath
@@ -21,6 +21,7 @@
 
 
 if [ -n "${ZSH_VERSION}" ]; then
+    # shellcheck disable=2296,2298
     _PYPATH_BASE_DIR="${${(%):-%x}:a:h:h}"
 else
     _PYPATH_BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
- exit on cd failure, SC2164
- needless double negative, SC2236
- fix useless use of cat, SC2002
- replace legacy backticks, SC2006
- clean unused variables, SC2034
- avoid globing/splitting on variable expansion, SC2086
- expand variables at trap execution, SC2064
- remove redundant loop over single value, SC2043
- export variable separately from value assignment, SC2155
- ${name} is not needed in arithmetic expressions, SC2004
- do not assign array to string, SC2124
- disable shellcheck for zsh block
