### PR TITLE
Fix test failure on differing precision of float in proto string

### DIFF
--- a/cirq-google/cirq_google/calibration/phased_fsim_test.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import re
 
 from typing import cast
 from unittest import mock
@@ -223,12 +222,14 @@ def test_floquet_to_calibration_layer_with_measure_qubits():
 
 def test_xeb_to_calibration_layer():
     q_00, q_01, q_02, q_03 = [cirq.GridQubit(0, index) for index in range(4)]
-    gate = cirq.FSimGate(theta=np.pi / 4, phi=0.0)
+    gate = cirq.FSimGate(theta=0.75, phi=0.0)
     request = XEBPhasedFSimCalibrationRequest(
         gate=gate,
         pairs=((q_00, q_01), (q_02, q_03)),
         options=XEBPhasedFSimCalibrationOptions(
             n_library_circuits=22,
+            fatol=0.0078125,
+            xatol=0.0078125,
             fsim_options=XEBPhasedFSimCharacterizationOptions(
                 characterize_theta=True,
                 characterize_zeta=True,
@@ -246,8 +247,8 @@ def test_xeb_to_calibration_layer():
             'n_library_circuits': 22,
             'n_combinations': 10,
             'cycle_depths': '5_25_50_100_200_300',
-            'fatol': 5e-3,
-            'xatol': 5e-3,
+            'fatol': 0.0078125,
+            'xatol': 0.0078125,
             'characterize_theta': True,
             'characterize_zeta': True,
             'characterize_chi': False,
@@ -267,9 +268,6 @@ def test_xeb_to_calibration_layer():
         desired_textproto = f.read()
 
     layer_str = str(new_layer)
-    # Fix precision issues
-    layer_str = re.sub(r'0.004999\d+', '0.005', layer_str)
-    layer_str = re.sub(r'\b0.78539818\d*', '0.7853982', layer_str)
     assert layer_str == desired_textproto
 
 

--- a/cirq-google/cirq_google/calibration/phased_fsim_test.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim_test.py
@@ -269,6 +269,7 @@ def test_xeb_to_calibration_layer():
     layer_str = str(new_layer)
     # Fix precision issues
     layer_str = re.sub(r'0.004999\d+', '0.005', layer_str)
+    layer_str = re.sub(r'\b0.78539818\d*', '0.7853982', layer_str)
     assert layer_str == desired_textproto
 
 

--- a/cirq-google/cirq_google/calibration/test_data/xeb_calibration_layer.textproto
+++ b/cirq-google/cirq_google/calibration/test_data/xeb_calibration_layer.textproto
@@ -12,7 +12,7 @@ layer {
         qubit_constant_index: 1
         fsimgate {
           theta {
-            float_value: 0.7853981852531433
+            float_value: 0.7853982
           }
           phi {
             float_value: 0.0
@@ -24,7 +24,7 @@ layer {
         qubit_constant_index: 3
         fsimgate {
           theta {
-            float_value: 0.7853981852531433
+            float_value: 0.7853982
           }
           phi {
             float_value: 0.0

--- a/cirq-google/cirq_google/calibration/test_data/xeb_calibration_layer.textproto
+++ b/cirq-google/cirq_google/calibration/test_data/xeb_calibration_layer.textproto
@@ -12,7 +12,7 @@ layer {
         qubit_constant_index: 1
         fsimgate {
           theta {
-            float_value: 0.7853982
+            float_value: 0.75
           }
           phi {
             float_value: 0.0
@@ -24,7 +24,7 @@ layer {
         qubit_constant_index: 3
         fsimgate {
           theta {
-            float_value: 0.7853982
+            float_value: 0.75
           }
           phi {
             float_value: 0.0
@@ -106,7 +106,7 @@ args {
   key: "fatol"
   value {
     arg_value {
-      float_value: 0.005
+      float_value: 0.0078125
     }
   }
 }
@@ -130,7 +130,7 @@ args {
   key: "xatol"
   value {
     arg_value {
-      float_value: 0.005
+      float_value: 0.0078125
     }
   }
 }


### PR DESCRIPTION
Problem: CI Pytest MacOS (3.10) fails because float value is output with
a lower precision than in the expected textproto,
https://github.com/quantumlib/Cirq/actions/runs/3192951160/jobs/5211002538.

Solution: Test with parameters that have exact decimal representation,
theta = 0.75,  fatol = xatol = 2**-7 = 0.0078125.