### PR TITLE
Add _apply_channel_ optimizations for reset and confusion

### DIFF
--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -177,13 +177,13 @@ class _SliceConfig:
 
 
 @dataclasses.dataclass
-class _CutMoveRescaleSlicesArgs:
+class _BuildFromSlicesArgs:
     slices: Tuple[_SliceConfig, ...]
     scale: complex
 
 
-def _cut_move_rescale_slices(
-    args: Sequence[_CutMoveRescaleSlicesArgs], source: np.ndarray, out: np.ndarray
+def _build_from_slices(
+    args: Sequence[_BuildFromSlicesArgs], source: np.ndarray, out: np.ndarray
 ) -> np.ndarray:
     d = len(source.shape)
     out[...] = 0

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -185,6 +185,52 @@ class _BuildFromSlicesArgs:
 def _build_from_slices(
     args: Sequence[_BuildFromSlicesArgs], source: np.ndarray, out: np.ndarray
 ) -> np.ndarray:
+    """Populates `out` from the desired slices of `source`.
+
+    This function is useful for optimizing multiplying a state by one or more one-hot matrices,
+    as is common when working with Kraus components. It is more efficient than using an einsum.
+
+    For instance in 3*3*3 3D space, one could take a cube array, take all the horizontal slices,
+    and add them up into the top slice leaving everything else zero. If the vertical axis was 1,
+    and the top was index=2, then this would be written as follows:
+
+        _build_from_slices(
+            [
+                _BuildFromSlicesArgs((_SliceConfig(axis=1, source_index=0, target_index=2),), 1),
+                _BuildFromSlicesArgs((_SliceConfig(axis=1, source_index=1, target_index=2),), 1),
+                _BuildFromSlicesArgs((_SliceConfig(axis=1, source_index=2, target_index=2),), 1),
+            ],
+            source,
+            out,
+        )
+
+    When multiple slices are included in the _BuildFromSlicesArgs, this means to take the
+    intersection of the source space and move it to the intersection of the target space. For
+    example, the following takes the bottom-left edge and moves it to the top-right, leaving all
+    other cells zero. Assume the lateral axis is 2 and right-most index thereof is 2:
+
+        _build_from_slices(
+            [
+                _BuildFromSlicesArgs(
+                    (
+                        _SliceConfig(axis=1, source_index=0, target_index=2),  # top
+                        _SliceConfig(axis=2, source_index=0, target_index=2),  # right
+                    ),
+                    scale=1,
+                ),
+            ],
+            source,
+            out,
+        )
+
+    Args:
+        args: The list of slice configurations to sum up into the output.
+        source: The source tensor for the slice data.
+        out: An output tensor that is the same shape as the source.
+
+    Returns:
+        The output tensor.
+    """
     d = len(source.shape)
     out[...] = 0
     for arg in args:

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -187,8 +187,7 @@ def _build_from_slices(
 ) -> np.ndarray:
     """Populates `out` from the desired slices of `source`.
 
-    This function is useful for optimizing multiplying a state by one or more one-hot matrices,
-    as is common when working with Kraus components. It is more efficient than using an einsum.
+    This function is best described by example.
 
     For instance in 3*3*3 3D space, one could take a cube array, take all the horizontal slices,
     and add them up into the top slice leaving everything else zero. If the vertical axis was 1,
@@ -222,6 +221,9 @@ def _build_from_slices(
             source,
             out,
         )
+
+    This function is useful for optimizing multiplying a state by one or more one-hot matrices,
+    as is common when working with Kraus components. It is more efficient than using an einsum.
 
     Args:
         args: The list of slice configurations to sum up into the output.

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -183,9 +183,7 @@ class _OneHotArgs:
 
 
 def _multiply_by_onehots(
-    onehots: Sequence[_OneHotArgs],
-    source: np.ndarray,
-    out: np.ndarray,
+    onehots: Sequence[_OneHotArgs], source: np.ndarray, out: np.ndarray
 ) -> np.ndarray:
     if out is source:
         raise ValueError('out is target')

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -14,8 +14,8 @@
 
 """Utility methods for transforming matrices or vectors."""
 
-from typing import Any, Tuple, Optional, Sequence, List, Union
 import dataclasses
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -193,9 +193,9 @@ def _multiply_by_onehots(
         for sleis in onehot.slices:
             source_slice[sleis.axis] = sleis.source_index
             target_slice[sleis.axis] = sleis.dest_index
-        source_data = source[tuple(source_slice)].copy()
+        source_data = source[tuple(source_slice)]
         if onehot.scale != 1:
-            source_data *= onehot.scale
+            source_data = source_data * onehot.scale
         out[tuple(target_slice)] += source_data
     return out
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -173,7 +173,7 @@ def targeted_left_multiply(
 class _SliceConfig:
     axis: int
     source_index: int
-    dest_index: int
+    target_index: int
 
 
 @dataclasses.dataclass
@@ -240,11 +240,8 @@ def _build_from_slices(
         target_slice: List[Any] = [slice(None)] * d
         for sleis in arg.slices:
             source_slice[sleis.axis] = sleis.source_index
-            target_slice[sleis.axis] = sleis.dest_index
-        source_data = source[tuple(source_slice)]
-        if arg.scale != 1:
-            source_data = source_data * arg.scale
-        out[tuple(target_slice)] += source_data
+            target_slice[sleis.axis] = sleis.target_index
+        out[tuple(target_slice)] += arg.scale * source[tuple(source_slice)]
     return out
 
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -170,32 +170,32 @@ def targeted_left_multiply(
 
 
 @dataclasses.dataclass
-class _OneHotSlice:
+class _SliceConfig:
     axis: int
     source_index: int
     dest_index: int
 
 
 @dataclasses.dataclass
-class _OneHotArgs:
-    slices: Tuple[_OneHotSlice, ...]
-    scale: np.complex
+class _CutMoveRescaleSlicesArgs:
+    slices: Tuple[_SliceConfig, ...]
+    scale: complex
 
 
-def _multiply_by_onehots(
-    onehots: Sequence[_OneHotArgs], source: np.ndarray, out: np.ndarray
+def _cut_move_rescale_slices(
+    args: Sequence[_CutMoveRescaleSlicesArgs], source: np.ndarray, out: np.ndarray
 ) -> np.ndarray:
     d = len(source.shape)
     out[...] = 0
-    for onehot in onehots:
+    for arg in args:
         source_slice: List[Any] = [slice(None)] * d
         target_slice: List[Any] = [slice(None)] * d
-        for sleis in onehot.slices:
+        for sleis in arg.slices:
             source_slice[sleis.axis] = sleis.source_index
             target_slice[sleis.axis] = sleis.dest_index
         source_data = source[tuple(source_slice)]
-        if onehot.scale != 1:
-            source_data = source_data * onehot.scale
+        if arg.scale != 1:
+            source_data = source_data * arg.scale
         out[tuple(target_slice)] += source_data
     return out
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -198,10 +198,10 @@ def _multiply_by_onehots(
         for sleis in onehot.slices:
             source_slice[sleis.axis] = sleis.source_index
             target_slice[sleis.axis] = sleis.dest_index
-        source_data = source[source_slice].copy()
+        source_data = source[tuple(source_slice)].copy()
         if onehot.scale != 1:
             source_data *= onehot.scale
-        out[target_slice] += source_data
+        out[tuple(target_slice)] += source_data
     return out
 
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -185,9 +185,6 @@ class _OneHotArgs:
 def _multiply_by_onehots(
     onehots: Sequence[_OneHotArgs], source: np.ndarray, out: np.ndarray
 ) -> np.ndarray:
-    if out is source:
-        raise ValueError('out is target')
-
     d = len(source.shape)
     out[...] = 0
     for onehot in onehots:

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -734,6 +734,17 @@ class ResetChannel(raw_types.Gate):
         channel[:, 0, :] = np.eye(self._dimension)
         return channel
 
+    def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
+        import cirq.linalg.transformations as tr
+        onehots = []
+        for i in range(self._dimension):
+            s1 = tr._OneHotSlice(axis=args.left_axes[0], source_index=i, dest_index=0)
+            s2 = tr._OneHotSlice(axis=args.right_axes[0], source_index=i, dest_index=0)
+            onehots.append(tr._OneHotArgs(slices=(s1, s2), scale=1))
+        tr._multiply_by_onehots(onehots, args.target_tensor, out=args.auxiliary_buffer0)
+        np.copyto(dst=args.target_tensor, src=args.auxiliary_buffer0)
+        return args.target_tensor
+
     def _has_kraus_(self) -> bool:
         return True
 

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -831,17 +831,6 @@ class PhaseDampingChannel(raw_types.Gate):
             np.array([[0.0, 0.0], [0.0, np.sqrt(self._gamma)]]),
         )
 
-    def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
-        if self._gamma != 1:
-            return NotImplemented
-        configs = []
-        for i in range(2):
-            s1 = transformations._SliceConfig(axis=args.left_axes[0], source_index=i, dest_index=i)
-            s2 = transformations._SliceConfig(axis=args.right_axes[0], source_index=i, dest_index=i)
-            configs.append(transformations._BuildFromSlicesArgs(slices=(s1, s2), scale=1))
-        transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
-        return args.out_buffer
-
     def _has_kraus_(self) -> bool:
         return True
 

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -20,8 +20,8 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, 
 import numpy as np
 
 from cirq import protocols, value
+from cirq.linalg import transformations
 from cirq.ops import raw_types, common_gates, pauli_gates, identity
-
 
 if TYPE_CHECKING:
     import cirq
@@ -735,14 +735,12 @@ class ResetChannel(raw_types.Gate):
         return channel
 
     def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
-        import cirq.linalg.transformations as tr
-
-        onehots = []
+        configs = []
         for i in range(self._dimension):
-            s1 = tr._OneHotSlice(axis=args.left_axes[0], source_index=i, dest_index=0)
-            s2 = tr._OneHotSlice(axis=args.right_axes[0], source_index=i, dest_index=0)
-            onehots.append(tr._OneHotArgs(slices=(s1, s2), scale=1))
-        tr._multiply_by_onehots(onehots, args.target_tensor, out=args.out_buffer)
+            s1 = transformations._SliceConfig(axis=args.left_axes[0], source_index=i, dest_index=0)
+            s2 = transformations._SliceConfig(axis=args.right_axes[0], source_index=i, dest_index=0)
+            configs.append(transformations._CutMoveRescaleSlicesArgs(slices=(s1, s2), scale=1))
+        transformations._cut_move_rescale_slices(configs, args.target_tensor, out=args.out_buffer)
         return args.out_buffer
 
     def _has_kraus_(self) -> bool:

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -739,8 +739,8 @@ class ResetChannel(raw_types.Gate):
         for i in range(self._dimension):
             s1 = transformations._SliceConfig(axis=args.left_axes[0], source_index=i, dest_index=0)
             s2 = transformations._SliceConfig(axis=args.right_axes[0], source_index=i, dest_index=0)
-            configs.append(transformations._CutMoveRescaleSlicesArgs(slices=(s1, s2), scale=1))
-        transformations._cut_move_rescale_slices(configs, args.target_tensor, out=args.out_buffer)
+            configs.append(transformations._BuildFromSlicesArgs(slices=(s1, s2), scale=1))
+        transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
         return args.out_buffer
 
     def _has_kraus_(self) -> bool:
@@ -830,6 +830,17 @@ class PhaseDampingChannel(raw_types.Gate):
             np.array([[1.0, 0.0], [0.0, np.sqrt(1.0 - self._gamma)]]),
             np.array([[0.0, 0.0], [0.0, np.sqrt(self._gamma)]]),
         )
+
+    def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
+        if self._gamma != 1:
+            return NotImplemented
+        configs = []
+        for i in range(2):
+            s1 = transformations._SliceConfig(axis=args.left_axes[0], source_index=i, dest_index=i)
+            s2 = transformations._SliceConfig(axis=args.right_axes[0], source_index=i, dest_index=i)
+            configs.append(transformations._BuildFromSlicesArgs(slices=(s1, s2), scale=1))
+        transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
+        return args.out_buffer
 
     def _has_kraus_(self) -> bool:
         return True

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -736,6 +736,7 @@ class ResetChannel(raw_types.Gate):
 
     def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
         import cirq.linalg.transformations as tr
+
         onehots = []
         for i in range(self._dimension):
             s1 = tr._OneHotSlice(axis=args.left_axes[0], source_index=i, dest_index=0)

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -741,9 +741,8 @@ class ResetChannel(raw_types.Gate):
             s1 = tr._OneHotSlice(axis=args.left_axes[0], source_index=i, dest_index=0)
             s2 = tr._OneHotSlice(axis=args.right_axes[0], source_index=i, dest_index=0)
             onehots.append(tr._OneHotArgs(slices=(s1, s2), scale=1))
-        tr._multiply_by_onehots(onehots, args.target_tensor, out=args.auxiliary_buffer0)
-        np.copyto(dst=args.target_tensor, src=args.auxiliary_buffer0)
-        return args.target_tensor
+        tr._multiply_by_onehots(onehots, args.target_tensor, out=args.out_buffer)
+        return args.out_buffer
 
     def _has_kraus_(self) -> bool:
         return True

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -737,8 +737,12 @@ class ResetChannel(raw_types.Gate):
     def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
         configs = []
         for i in range(self._dimension):
-            s1 = transformations._SliceConfig(axis=args.left_axes[0], source_index=i, dest_index=0)
-            s2 = transformations._SliceConfig(axis=args.right_axes[0], source_index=i, dest_index=0)
+            s1 = transformations._SliceConfig(
+                axis=args.left_axes[0], source_index=i, target_index=0
+            )
+            s2 = transformations._SliceConfig(
+                axis=args.right_axes[0], source_index=i, target_index=0
+            )
             configs.append(transformations._BuildFromSlicesArgs(slices=(s1, s2), scale=1))
         transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
         return args.out_buffer
@@ -832,8 +836,12 @@ class PhaseDampingChannel(raw_types.Gate):
             return NotImplemented
         configs = []
         for i in range(2):
-            s1 = transformations._SliceConfig(axis=args.left_axes[0], source_index=i, dest_index=i)
-            s2 = transformations._SliceConfig(axis=args.right_axes[0], source_index=i, dest_index=i)
+            s1 = transformations._SliceConfig(
+                axis=args.left_axes[0], source_index=i, target_index=i
+            )
+            s2 = transformations._SliceConfig(
+                axis=args.right_axes[0], source_index=i, target_index=i
+            )
             configs.append(transformations._BuildFromSlicesArgs(slices=(s1, s2), scale=1))
         transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
         return args.out_buffer

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -529,6 +529,13 @@ def test_reset_each():
             assert op.qubits == (qubits[i],)
 
 
+def test_reset_consistency():
+    two_d_chan = cirq.ResetChannel()
+    cirq.testing.assert_has_consistent_apply_channel(two_d_chan)
+    three_d_chan = cirq.ResetChannel(dimension=3)
+    cirq.testing.assert_has_consistent_apply_channel(three_d_chan)
+
+
 def test_phase_damping_channel():
     d = cirq.phase_damp(0.3)
     np.testing.assert_almost_equal(
@@ -583,6 +590,15 @@ def test_phase_damping_channel_text_diagram():
     assert cirq.circuit_diagram_info(pd, args=no_precision) == cirq.CircuitDiagramInfo(
         wire_symbols=('PD(0.1000009)',)
     )
+
+
+def test_phase_damp_consistency():
+    full_damp = cirq.PhaseDampingChannel(gamma=1)
+    cirq.testing.assert_has_consistent_apply_channel(full_damp)
+    partial_damp = cirq.PhaseDampingChannel(gamma=0.5)
+    cirq.testing.assert_has_consistent_apply_channel(partial_damp)
+    no_damp = cirq.PhaseDampingChannel(gamma=0)
+    cirq.testing.assert_has_consistent_apply_channel(no_damp)
 
 
 def test_phase_flip_channel():

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -211,6 +211,14 @@ class GateOperation(raw_types.Operation):
             return getter()
         return NotImplemented
 
+    def _apply_channel_(
+        self, args: 'protocols.ApplyChannelArgs'
+    ) -> Union[np.ndarray, None, NotImplementedType]:
+        getter = getattr(self.gate, '_apply_channel_', None)
+        if getter is not None:
+            return getter(args)
+        return NotImplemented
+
     def _has_kraus_(self) -> bool:
         getter = getattr(self.gate, '_has_kraus_', None)
         if getter is not None:

--- a/cirq-core/cirq/ops/gate_operation_test.py
+++ b/cirq-core/cirq/ops/gate_operation_test.py
@@ -494,6 +494,7 @@ def test_gate_to_operation_to_gate_round_trips():
         cirq.Pauli,
         # Private gates.
         cirq.transformers.analytical_decompositions.two_qubit_to_fsim._BGate,
+        cirq.transformers.measurement_transformers._ConfusionChannel,
         cirq.transformers.measurement_transformers._ModAdd,
         cirq.transformers.routing.visualize_routed_circuit._SwapPrintGate,
         cirq.ops.raw_types._InverseCompositeGate,

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -17,6 +17,7 @@
 from cirq.testing.circuit_compare import (
     assert_circuits_with_terminal_measurements_are_equivalent,
     assert_circuits_have_same_unitary_given_final_permutation,
+    assert_has_consistent_apply_channel,
     assert_has_consistent_apply_unitary,
     assert_has_consistent_apply_unitary_for_various_exponents,
     assert_has_diagram,

--- a/cirq-core/cirq/testing/circuit_compare.py
+++ b/cirq-core/cirq/testing/circuit_compare.py
@@ -333,6 +333,50 @@ def assert_has_consistent_apply_unitary(val: Any, *, atol: float = 1e-8) -> None
         np.testing.assert_allclose(actual.reshape(n, n), expected, atol=atol)
 
 
+def assert_has_consistent_apply_channel(val: Any, *, atol: float = 1e-8) -> None:
+    """Tests whether a value's _apply_channel_ is correct.
+
+    Contrasts the effects of the value's `_apply_channel_` with the superoperator calculated from
+    the Kraus components returned by the value's `_kraus_` method.
+
+    Args:
+        val: The value under test. Should have a `__pow__` method.
+        atol: Absolute error tolerance.
+    """
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
+    # pylint: enable=unused-variable
+
+    kraus = protocols.kraus(val, default=None)
+    expected = qis.kraus_to_superoperator(kraus) if kraus is not None else None
+
+    qid_shape = protocols.qid_shape(val)
+
+    eye = qis.eye_tensor(qid_shape * 2, dtype=np.complex128)
+    actual = protocols.apply_channel(
+        val=val,
+        args=protocols.ApplyChannelArgs(
+            target_tensor=eye,
+            out_buffer=np.ones_like(eye) * float('nan'),
+            auxiliary_buffer0=np.ones_like(eye) * float('nan'),
+            auxiliary_buffer1=np.ones_like(eye) * float('nan'),
+            left_axes=list(range(len(qid_shape))),
+            right_axes=list(range(len(qid_shape), len(qid_shape) * 2)),
+        ),
+        default=None,
+    )
+
+    # If you don't have a Kraus, you shouldn't be able to apply a channel.
+    if expected is None:
+        assert actual is None
+
+    # If you applied a channel, it should match the superoperator you say you have.
+    if actual is not None:
+        assert expected is not None
+        n = np.product(qid_shape) ** 2
+        np.testing.assert_allclose(actual.reshape((n, n)), expected, atol=atol)
+
+
 def _assert_apply_unitary_works_when_axes_transposed(val: Any, *, atol: float = 1e-8) -> None:
     """Tests whether a value's _apply_unitary_ handles out-of-order axes.
 

--- a/cirq-core/cirq/testing/circuit_compare_test.py
+++ b/cirq-core/cirq/testing/circuit_compare_test.py
@@ -262,6 +262,72 @@ Highlighted differences:
     assert expected_error in ex_info.value.args[0]
 
 
+def test_assert_has_consistent_apply_channel():
+    class Correct:
+        def _apply_channel_(self, args: cirq.ApplyChannelArgs):
+            args.target_tensor[...] = 0
+            return args.target_tensor
+
+        def _kraus_(self):
+            return [np.array([[0, 0], [0, 0]])]
+
+        def _num_qubits_(self):
+            return 1
+
+    cirq.testing.assert_has_consistent_apply_channel(Correct())
+
+    class Wrong:
+        def _apply_channel_(self, args: cirq.ApplyChannelArgs):
+            args.target_tensor[...] = 0
+            return args.target_tensor
+
+        def _kraus_(self):
+            return [np.array([[1, 0], [0, 0]])]
+
+        def _num_qubits_(self):
+            return 1
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_has_consistent_apply_channel(Wrong())
+
+    class NoNothing:
+        def _apply_channel_(self, args: cirq.ApplyChannelArgs):
+            return NotImplemented
+
+        def _kraus_(self):
+            return NotImplemented
+
+        def _num_qubits_(self):
+            return 1
+
+    cirq.testing.assert_has_consistent_apply_channel(NoNothing())
+
+    class NoKraus:
+        def _apply_channel_(self, args: cirq.ApplyChannelArgs):
+            return args.target_tensor
+
+        def _kraus_(self):
+            return NotImplemented
+
+        def _num_qubits_(self):
+            return 1
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_has_consistent_apply_channel(NoKraus())
+
+    class NoApply:
+        def _apply_channel_(self, args: cirq.ApplyChannelArgs):
+            return NotImplemented
+
+        def _kraus_(self):
+            return [np.array([[0, 0], [0, 0]])]
+
+        def _num_qubits_(self):
+            return 1
+
+    cirq.testing.assert_has_consistent_apply_channel(NoApply())
+
+
 def test_assert_has_consistent_apply_unitary():
     class IdentityReturningUnalteredWorkspace:
         def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> np.ndarray:

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -362,10 +362,14 @@ class _ConfusionChannel(ops.Gate):
             axis_count = len(args.left_axes)
             for j in range(axis_count):
                 s1 = transformations._SliceConfig(
-                    axis=args.left_axes[j], source_index=index[j], dest_index=index[j + axis_count]
+                    axis=args.left_axes[j],
+                    source_index=index[j],
+                    target_index=index[j + axis_count],
                 )
                 s2 = transformations._SliceConfig(
-                    axis=args.right_axes[j], source_index=index[j], dest_index=index[j + axis_count]
+                    axis=args.right_axes[j],
+                    source_index=index[j],
+                    target_index=index[j + axis_count],
                 )
                 slices.extend([s1, s2])
             configs.append(transformations._BuildFromSlicesArgs(slices=tuple(slices), scale=scale))

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -352,15 +352,20 @@ class _ConfusionChannel(ops.Gate):
 
     def _apply_channel_(self, args: 'cirq.ApplyChannelArgs'):
         import cirq.linalg.transformations as tr
+
         onehots = []
         p = np.prod(self._shape)
-        for component in range(p ** 2):
+        for component in range(p**2):
             index = np.unravel_index(component, self._shape * 2)
             slices = []
             k = len(args.left_axes)
             for i in range(k):
-                s1 = tr._OneHotSlice(axis=args.left_axes[i], source_index=index[i], dest_index=index[i + k])
-                s2 = tr._OneHotSlice(axis=args.right_axes[i], source_index=index[i], dest_index=index[i + k])
+                s1 = tr._OneHotSlice(
+                    axis=args.left_axes[i], source_index=index[i], dest_index=index[i + k]
+                )
+                s2 = tr._OneHotSlice(
+                    axis=args.right_axes[i], source_index=index[i], dest_index=index[i + k]
+                )
                 slices.extend([s1, s2])
             onehot = tr._OneHotArgs(slices=tuple(slices), scale=self._confusion_map.flat[component])
             onehots.append(onehot)

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -369,9 +369,9 @@ class _ConfusionChannel(ops.Gate):
                 )
                 slices.extend([s1, s2])
             configs.append(
-                transformations._CutMoveRescaleSlicesArgs(slices=tuple(slices), scale=scale)
+                transformations._BuildFromSlicesArgs(slices=tuple(slices), scale=scale)
             )
-        transformations._cut_move_rescale_slices(configs, args.target_tensor, out=args.out_buffer)
+        transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
         return args.out_buffer
 
 

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -364,9 +364,8 @@ class _ConfusionChannel(ops.Gate):
                 slices.extend([s1, s2])
             onehot = tr._OneHotArgs(slices=tuple(slices), scale=self._confusion_map.flat[component])
             onehots.append(onehot)
-        tr._multiply_by_onehots(onehots, args.target_tensor, out=args.auxiliary_buffer0)
-        np.copyto(dst=args.target_tensor, src=args.auxiliary_buffer0)
-        return args.target_tensor
+        tr._multiply_by_onehots(onehots, args.target_tensor, out=args.out_buffer)
+        return args.out_buffer
 
 
 @value.value_equality

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -368,9 +368,7 @@ class _ConfusionChannel(ops.Gate):
                     axis=args.right_axes[j], source_index=index[j], dest_index=index[j + axis_count]
                 )
                 slices.extend([s1, s2])
-            configs.append(
-                transformations._BuildFromSlicesArgs(slices=tuple(slices), scale=scale)
-            )
+            configs.append(transformations._BuildFromSlicesArgs(slices=tuple(slices), scale=scale))
         transformations._build_from_slices(configs, args.target_tensor, out=args.out_buffer)
         return args.out_buffer
 

--- a/cirq-core/cirq/transformers/measurement_transformers_test.py
+++ b/cirq-core/cirq/transformers/measurement_transformers_test.py
@@ -17,7 +17,7 @@ import pytest
 import sympy
 
 import cirq
-from cirq.transformers.measurement_transformers import _mod_add, _MeasurementQid
+from cirq.transformers.measurement_transformers import _ConfusionChannel, _MeasurementQid, _mod_add
 
 
 def assert_equivalent_to_deferred(circuit: cirq.Circuit):
@@ -575,3 +575,17 @@ def test_drop_terminal_nonterminal_error():
 
     with pytest.raises(ValueError, match='Context has `deep=False`'):
         _ = cirq.drop_terminal_measurements(circuit, context=None)
+
+
+def test_confusion_channel_consistency():
+    two_d_chan = _ConfusionChannel(np.array([[0.5, 0.5], [0.4, 0.6]]), shape=(2,))
+    cirq.testing.assert_has_consistent_apply_channel(two_d_chan)
+    three_d_chan = _ConfusionChannel(
+        np.array([[0.5, 0.3, 0.2], [0.4, 0.5, 0.1], [0, 0, 1]]), shape=(3,)
+    )
+    cirq.testing.assert_has_consistent_apply_channel(three_d_chan)
+    two_q_chan = _ConfusionChannel(
+        np.array([[0.5, 0.3, 0.1, 0.1], [0.4, 0.5, 0.1, 0], [0, 0, 1, 0], [0, 0, 0.5, 0.5]]),
+        shape=(2, 2),
+    )
+    cirq.testing.assert_has_consistent_apply_channel(two_q_chan)


### PR DESCRIPTION
Confusion matrix and reset channels both can be viewed as starting with a zero DM tensor and then copying (adding) in scaled slices from the original DM tensor. Thus we make a helper function that does this and add `_apply_channel_` optimizations to those gates.

Fixes #5901.

Starts #5900 though I haven't looked at all gates.

Also starts #4579 but there's likely more to do there as well. I didn't add the new test function to the primary test suite because creating superoperators is likely computationally expensive (granted most if not all gates that use this would be three or fewer qubits, which is still cheap), and the test not relevant for most gates.