### PR TITLE
Add support for arbitrary angles to IonQ native MS Gate

### DIFF
--- a/cirq-ionq/cirq_ionq/ionq_native_gates.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_gates.py
@@ -179,35 +179,38 @@ document(
 class MSGate(cirq.Gate):
     r"""The Mølmer–Sørensen (MS) gate is a two qubit gate native to trapped ions.
 
-    The unitary matrix of this gate for parameters $\phi_0$ and $\phi_1$ is
+    The unitary matrix of this gate for parameters $\phi_0$, $\phi_1$ and $\theta is
 
     $$
-    \frac{1}{\sqrt{2}}
     \begin{bmatrix}
-        1 & 0 &  0 & -ie^{-i2\pi(\phi_0+\phi_1)} \\
-        0 & 1 & -ie^{-i2\pi(\phi_0-\phi_1)} & 0 \\
-        0 & -ie^{i2\pi(\phi_0-\phi_1)} & 1 & 0 \\
-        -ie^{i2\pi(\phi_0+\phi_1)} & 0 & 0 & 1 \\
+        cos{\theta} & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin{\theta} \\
+        0 & cos{\theta} & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin{\theta} & 0 \\
+        0 & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin(\theta) & cos{\theta} & 0 \\
+        -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin{\theta} & 0 & 0 & cos{\theta}
     \end{bmatrix}
     $$
 
     See [IonQ best practices](https://ionq.com/docs/getting-started-with-native-gates){:external}.
     """
 
-    def __init__(self, *, phi0, phi1):
+    def __init__(self, *, phi0, phi1, theta=0.25):
         self.phi0 = phi0
         self.phi1 = phi1
+        self.theta = theta
 
     def _unitary_(self) -> np.ndarray:
-        diag = 1 / math.sqrt(2)
+        theta = self.theta
         phi0 = self.phi0
         phi1 = self.phi1
+        diag = np.cos(2 * math.pi * theta)
+        sin = np.sin(2 * math.pi * theta)
+
         return np.array(
             [
-                [diag, 0, 0, diag * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 + phi1))],
-                [0, diag, diag * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 - phi1)), 0],
-                [0, diag * -1j * cmath.exp(1j * 2 * math.pi * (phi0 - phi1)), diag, 0],
-                [diag * -1j * cmath.exp(1j * 2 * math.pi * (phi0 + phi1)), 0, 0, diag],
+                [diag, 0, 0, sin * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 + phi1))],
+                [0, diag, sin * -1j * cmath.exp(-1j * 2 * math.pi * (phi0 - phi1)), 0],
+                [0, sin * -1j * cmath.exp(1j * 2 * math.pi * (phi0 - phi1)), diag, 0],
+                [sin * -1j * cmath.exp(1j * 2 * math.pi * (phi0 + phi1)), 0, 0, diag],
             ]
         )
 
@@ -232,7 +235,7 @@ class MSGate(cirq.Gate):
         return f'cirq_ionq.MSGate(phi0={self.phi0!r}, phi1={self.phi1!r})'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return cirq.obj_to_dict_helper(self, ['phi0', 'phi1'])
+        return cirq.obj_to_dict_helper(self, ['phi0', 'phi1', 'theta'])
 
     def _value_equality_values_(self) -> Any:
         return (self.phi0, self.phi1)

--- a/cirq-ionq/cirq_ionq/ionq_native_gates.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_gates.py
@@ -183,10 +183,10 @@ class MSGate(cirq.Gate):
 
     $$
     \begin{bmatrix}
-        cos{\theta} & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin{\theta} \\
-        0 & cos{\theta} & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin{\theta} & 0 \\
-        0 & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin(\theta) & cos{\theta} & 0 \\
-        -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin{\theta} & 0 & 0 & cos{\theta}
+        cos{\theta/2} & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin{\theta/2} \\
+        0 & cos{\theta/2} & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin{\theta/2} & 0 \\
+        0 & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin(\theta/2) & cos{\theta/2} & 0 \\
+        -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin{\theta/2} & 0 & 0 & cos{\theta/2}
     \end{bmatrix}
     $$
 
@@ -202,8 +202,8 @@ class MSGate(cirq.Gate):
         theta = self.theta
         phi0 = self.phi0
         phi1 = self.phi1
-        diag = np.cos(2 * math.pi * theta)
-        sin = np.sin(2 * math.pi * theta)
+        diag = np.cos(math.pi * theta)
+        sin = np.sin(math.pi * theta)
 
         return np.array(
             [

--- a/cirq-ionq/cirq_ionq/json_test_data/MSGate.json
+++ b/cirq-ionq/cirq_ionq/json_test_data/MSGate.json
@@ -1,5 +1,6 @@
 {
   "cirq_type": "MSGate",
   "phi0": 0.1, 
-  "phi1": 0.55
+  "phi1": 0.55,
+  "theta": 0.25
 }

--- a/cirq-ionq/cirq_ionq/serializer.py
+++ b/cirq-ionq/cirq_ionq/serializer.py
@@ -205,7 +205,7 @@ class Serializer:
         return {'gate': 'gpi2', 'target': targets[0], 'phase': gate.phase}
 
     def _serialize_ms_gate(self, gate: MSGate, targets: Sequence[int]) -> Optional[dict]:
-        return {'gate': 'ms', 'targets': targets, 'phases': gate.phases}
+        return {'gate': 'ms', 'targets': targets, 'phases': gate.phases, 'angle': gate.theta}
 
     def _serialize_cnot_pow_gate(
         self, gate: cirq.CNotPowGate, targets: Sequence[int]

--- a/cirq-ionq/cirq_ionq/serializer_test.py
+++ b/cirq-ionq/cirq_ionq/serializer_test.py
@@ -267,7 +267,7 @@ def test_serialize_native_gates():
             'circuit': [
                 {'gate': 'gpi', 'target': 0, 'phase': 0.1},
                 {'gate': 'gpi2', 'target': 1, 'phase': 0.2},
-                {'gate': 'ms', 'targets': [1, 2], 'phases': [0.3, 0.4]},
+                {'gate': 'ms', 'targets': [1, 2], 'phases': [0.3, 0.4], 'angle': 0.25},
             ],
         },
         metadata={},


### PR DESCRIPTION
ionq's native MSGate now supports an additional parameter for an arbitrary theta angle.

This angle defaults to 0.25, equivalent to a PI/2 rotation, which matches previous definition. The value is specified in fractions of 2PI, same as in phases.