### PR TITLE
Fix sympy error

### DIFF
--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -59,7 +59,6 @@ class ParamResolver:
 
     Raises:
         TypeError if formulas are passed as keys.
-        ValueError if the resulting value cannot be interpreted.
     """
 
     def __new__(cls, param_dict: 'cirq.ParamResolverOrSimilarType' = None):
@@ -113,6 +112,7 @@ class ParamResolver:
         Raises:
             RecursionError: If the ParamResolver detects a loop in recursive
                 resolution.
+            ValueError: If the resulting value cannot be interpreted.
         """
 
         # Input is a pass through type, no resolution needed: return early

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -14,6 +14,7 @@
 
 """Resolves ParameterValues to assigned values."""
 import numbers
+import warnings
 from typing import Any, cast, Dict, Iterator, Mapping, Optional, TYPE_CHECKING, Union
 
 import numpy as np
@@ -179,7 +180,11 @@ class ParamResolver:
         if not recursive:
             # Resolves one step at a time. For example:
             # a.subs({a: b, b: c}) == b
-            v = value.subs(self.param_dict, simultaneous=True)
+            try:
+                v = value.subs(self.param_dict, simultaneous=True)
+            except sympy.SympifyError:
+                warnings.warn(f'Could not resolve parameter {value}')
+                return value
             if v.free_symbols:
                 return v
             elif sympy.im(v):

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -112,7 +112,7 @@ class ParamResolver:
         Raises:
             RecursionError: If the ParamResolver detects a loop in recursive
                 resolution.
-            ValueError: If the resulting value cannot be interpreted.
+            sympy.SympifyError: If the resulting value cannot be interpreted.
         """
 
         # Input is a pass through type, no resolution needed: return early

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -182,10 +182,11 @@ class ParamResolver:
             # a.subs({a: b, b: c}) == b
             try:
                 v = value.subs(self.param_dict, simultaneous=True)
-            except sympy.SympifyError:  # coverage: ignore
+            except sympy.SympifyError as e:  # coverage: ignore
                 # Lines will be covered in sympy 1.12+
-                warnings.warn(f'Could not resolve parameter {value}')  # coverage: ignore
-                return value  # coverage: ignore
+                raise ValueError(
+                    f'Could not resolve parameter {value}, underlying error {e}'
+                )  # coverage: ignore
             if v.free_symbols:
                 return v
             elif sympy.im(v):

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -182,7 +182,7 @@ class ParamResolver:
             # a.subs({a: b, b: c}) == b
             try:
                 v = value.subs(self.param_dict, simultaneous=True)
-            except sympy.SympifyError:
+            except sympy.SympifyError:  # coverage: ignore
                 # Lines will be covered in sympy 1.12+
                 warnings.warn(f'Could not resolve parameter {value}')  # coverage: ignore
                 return value  # coverage: ignore

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -14,7 +14,6 @@
 
 """Resolves ParameterValues to assigned values."""
 import numbers
-import warnings
 from typing import Any, cast, Dict, Iterator, Mapping, Optional, TYPE_CHECKING, Union
 
 import numpy as np
@@ -60,6 +59,7 @@ class ParamResolver:
 
     Raises:
         TypeError if formulas are passed as keys.
+        ValueError if the resulting value cannot be interpreted.
     """
 
     def __new__(cls, param_dict: 'cirq.ParamResolverOrSimilarType' = None):

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -180,13 +180,12 @@ class ParamResolver:
         if not recursive:
             # Resolves one step at a time. For example:
             # a.subs({a: b, b: c}) == b
-            try:
-                v = value.subs(self.param_dict, simultaneous=True)
-            except sympy.SympifyError as e:  # coverage: ignore
-                # Lines will be covered in sympy 1.12+
-                raise ValueError(
-                    f'Could not resolve parameter {value}, underlying error {e}'
-                )  # coverage: ignore
+            #
+            # Note that a sympy.SympifyError here likely means
+            # that one of the expressions was not parsable by sympy
+            # (such as a function returning NotImplemented)
+            v = value.subs(self.param_dict, simultaneous=True)
+
             if v.free_symbols:
                 return v
             elif sympy.im(v):

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -183,8 +183,9 @@ class ParamResolver:
             try:
                 v = value.subs(self.param_dict, simultaneous=True)
             except sympy.SympifyError:
-                warnings.warn(f'Could not resolve parameter {value}')
-                return value
+                # Lines will be covered in sympy 1.12+
+                warnings.warn(f'Could not resolve parameter {value}')  # coverage: ignore
+                return value  # coverage: ignore
             if v.free_symbols:
                 return v
             elif sympy.im(v):

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -244,8 +244,10 @@ def test_custom_resolved_value():
     c = sympy.Symbol('c')
     r = cirq.ParamResolver({a: foo, b: bar, c: baz})
     assert r.value_of(a) is foo
-    assert r.value_of(b) is b
     assert r.value_of(c) == 'Baz'
+
+    with pytest.raises(ValueError, match='Could not resolve parameter b'):
+        _ = r.value_of(b)
 
 
 def test_compose():

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -227,26 +227,30 @@ def test_custom_resolved_value():
         def _resolved_value_(self):
             return self
 
-    class Bar:
-        def _resolved_value_(self):
-            return NotImplemented
-
     class Baz:
         def _resolved_value_(self):
             return 'Baz'
 
     foo = Foo()
-    bar = Bar()
     baz = Baz()
 
     a = sympy.Symbol('a')
-    b = sympy.Symbol('b')
-    c = sympy.Symbol('c')
-    r = cirq.ParamResolver({a: foo, b: bar, c: baz})
+    b = sympy.Symbol('c')
+    r = cirq.ParamResolver({a: foo, b: baz})
     assert r.value_of(a) is foo
-    assert r.value_of(c) == 'Baz'
+    assert r.value_of(b) == 'Baz'
 
-    with pytest.raises(ValueError, match='Could not resolve parameter b'):
+
+@pytest.mark.xfail(reason='this test requires sympy 1.12', strict=True)
+def test_custom_value_not_implemented():
+    class Bar:
+        def _resolved_value_(self):
+            return NotImplemented
+
+    b = sympy.Symbol('b')
+    bar = Bar()
+    r = cirq.ParamResolver({b: bar})
+    with pytest.raises(sympy.SympifyError):
         _ = r.value_of(b)
 
 


### PR DESCRIPTION
- Sympy will soon error out if an expression is not parsable by sympy.  It used to just ignore this.
- We have one test that exercises this (resolver_test.py:247). Modify code to handle this and print out a warning.
- This is breaking some internal google code and preventing sympy upgrade.