### PR TITLE
Fix docstring indentation of cirq.PauliString

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -134,14 +134,12 @@ class GridQid(_BaseGridQid):
     New GridQid can be constructed by adding or subtracting tuples or numpy
     arrays
 
-        >>> cirq.GridQid(2, 3, dimension=2) + (3, 1)
-        cirq.GridQid(5, 4, dimension=2)
-
-        >>> cirq.GridQid(2, 3, dimension=2) - (1, 2)
-        cirq.GridQid(1, 1, dimension=2)
-
-        >>> cirq.GridQid(2, 3, dimension=2) + np.array([3, 1], dtype=int)
-        cirq.GridQid(5, 4, dimension=2)
+    >>> cirq.GridQid(2, 3, dimension=2) + (3, 1)
+    cirq.GridQid(5, 4, dimension=2)
+    >>> cirq.GridQid(2, 3, dimension=2) - (1, 2)
+    cirq.GridQid(1, 1, dimension=2)
+    >>> cirq.GridQid(2, 3, dimension=2) + np.array([3, 1], dtype=int)
+    cirq.GridQid(5, 4, dimension=2)
     """
 
     def __init__(self, row: int, col: int, *, dimension: int) -> None:
@@ -284,14 +282,12 @@ class GridQubit(_BaseGridQid):
 
     New GridQubits can be constructed by adding or subtracting tuples
 
-        >>> cirq.GridQubit(2, 3) + (3, 1)
-        cirq.GridQubit(5, 4)
-
-        >>> cirq.GridQubit(2, 3) - (1, 2)
-        cirq.GridQubit(1, 1)
-
-        >>> cirq.GridQubit(2, 3,) + np.array([3, 1], dtype=int)
-        cirq.GridQubit(5, 4)
+    >>> cirq.GridQubit(2, 3) + (3, 1)
+    cirq.GridQubit(5, 4)
+    >>> cirq.GridQubit(2, 3) - (1, 2)
+    cirq.GridQubit(1, 1)
+    >>> cirq.GridQubit(2, 3,) + np.array([3, 1], dtype=int)
+    cirq.GridQubit(5, 4)
     """
 
     def __getstate__(self):

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -140,26 +140,19 @@ class PauliString(raw_types.Operation, Generic[TKey]):
     PauliStrings can be constructed via various different ways, some examples are
     given as follows:
 
-        >>> a, b, c = cirq.LineQubit.range(3)
-
-        >>> print(cirq.PauliString([cirq.X(a), cirq.X(a)]))
-        I
-
-        >>> print(cirq.PauliString(-1, cirq.X(a), cirq.Y(b), cirq.Z(c)))
-        -X(q(0))*Y(q(1))*Z(q(2))
-
-        >>> print(-1 * cirq.X(a) * cirq.Y(b) * cirq.Z(c))
-        -X(q(0))*Y(q(1))*Z(q(2))
-
-        >>> print(cirq.PauliString({a: cirq.X}, [-2, 3, cirq.Y(a)]))
-        -6j*Z(q(0))
-
-        >>> print(cirq.PauliString({a: cirq.I, b: cirq.X}))
-        X(q(1))
-
-        >>> print(cirq.PauliString({a: cirq.Y},
-        ...                        qubit_pauli_map={a: cirq.X}))
-        1j*Z(q(0))
+    >>> a, b, c = cirq.LineQubit.range(3)
+    >>> print(cirq.PauliString([cirq.X(a), cirq.X(a)]))
+    I
+    >>> print(cirq.PauliString(-1, cirq.X(a), cirq.Y(b), cirq.Z(c)))
+    -X(q(0))*Y(q(1))*Z(q(2))
+    >>> print(-1 * cirq.X(a) * cirq.Y(b) * cirq.Z(c))
+    -X(q(0))*Y(q(1))*Z(q(2))
+    >>> print(cirq.PauliString({a: cirq.X}, [-2, 3, cirq.Y(a)]))
+    -6j*Z(q(0))
+    >>> print(cirq.PauliString({a: cirq.I, b: cirq.X}))
+    X(q(1))
+    >>> print(cirq.PauliString({a: cirq.Y}, qubit_pauli_map={a: cirq.X}))
+    1j*Z(q(0))
 
     Note that `cirq.PauliString`s are immutable objects. If you need a mutable version
     of pauli strings, see `cirq.MutablePauliString`.

--- a/cirq-core/cirq/study/flatten_expressions.py
+++ b/cirq-core/cirq/study/flatten_expressions.py
@@ -55,53 +55,54 @@ def flatten(val: Any) -> Tuple[Any, 'ExpressionMap']:
         are described above.
 
     Examples:
-        >>> qubit = cirq.LineQubit(0)
-        >>> a = sympy.Symbol('a')
-        >>> circuit = cirq.Circuit(
-        ...     cirq.X(qubit) ** (a/4),
-        ...     cirq.Y(qubit) ** (1-a/2),
-        ... )
-        >>> print(circuit)
-        0: ───X^(a/4)───Y^(1 - a/2)───
 
-        >>> sweep = cirq.Linspace(a, start=0, stop=3, length=4)
-        >>> print(cirq.ListSweep(sweep))
-        Sweep:
-        {'a': 0.0}
-        {'a': 1.0}
-        {'a': 2.0}
-        {'a': 3.0}
+    >>> qubit = cirq.LineQubit(0)
+    >>> a = sympy.Symbol('a')
+    >>> circuit = cirq.Circuit(
+    ...     cirq.X(qubit) ** (a/4),
+    ...     cirq.Y(qubit) ** (1-a/2),
+    ... )
+    >>> print(circuit)
+    0: ───X^(a/4)───Y^(1 - a/2)───
 
-        >>> c_flat, expr_map = cirq.flatten(circuit)
-        >>> print(c_flat)
-        0: ───X^(<a/4>)───Y^(<1 - a/2>)───
-        >>> expr_map
-        cirq.ExpressionMap({a/4: <a/4>, 1 - a/2: <1 - a/2>})
+    >>> sweep = cirq.Linspace(a, start=0, stop=3, length=4)
+    >>> print(cirq.ListSweep(sweep))
+    Sweep:
+    {'a': 0.0}
+    {'a': 1.0}
+    {'a': 2.0}
+    {'a': 3.0}
 
-        >>> new_sweep = expr_map.transform_sweep(sweep)
-        >>> print(new_sweep)
-        Sweep:
-        {'<a/4>': 0.0, '<1 - a/2>': 1.0}
-        {'<a/4>': 0.25, '<1 - a/2>': 0.5}
-        {'<a/4>': 0.5, '<1 - a/2>': 0.0}
-        {'<a/4>': 0.75, '<1 - a/2>': -0.5}
+    >>> c_flat, expr_map = cirq.flatten(circuit)
+    >>> print(c_flat)
+    0: ───X^(<a/4>)───Y^(<1 - a/2>)───
+    >>> expr_map
+    cirq.ExpressionMap({a/4: <a/4>, 1 - a/2: <1 - a/2>})
 
-        >>> for params in sweep:  # Original
-        ...     print(circuit,
-        ...           '=>',
-        ...           cirq.resolve_parameters(circuit, params))
-        0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0───Y───
-        0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0.25───Y^0.5───
-        0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0.5───Y^0───
-        0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0.75───Y^-0.5───
+    >>> new_sweep = expr_map.transform_sweep(sweep)
+    >>> print(new_sweep)
+    Sweep:
+    {'<a/4>': 0.0, '<1 - a/2>': 1.0}
+    {'<a/4>': 0.25, '<1 - a/2>': 0.5}
+    {'<a/4>': 0.5, '<1 - a/2>': 0.0}
+    {'<a/4>': 0.75, '<1 - a/2>': -0.5}
 
-        >>> for params in new_sweep:  # Flattened
-        ...     print(c_flat, '=>', end=' ')
-        ...     print(cirq.resolve_parameters(c_flat, params))
-        0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0───Y───
-        0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0.25───Y^0.5───
-        0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0.5───Y^0───
-        0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0.75───Y^-0.5───
+    >>> for params in sweep:  # Original
+    ...     print(circuit,
+    ...           '=>',
+    ...           cirq.resolve_parameters(circuit, params))
+    0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0───Y───
+    0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0.25───Y^0.5───
+    0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0.5───Y^0───
+    0: ───X^(a/4)───Y^(1 - a/2)─── => 0: ───X^0.75───Y^-0.5───
+
+    >>> for params in new_sweep:  # Flattened
+    ...     print(c_flat, '=>', end=' ')
+    ...     print(cirq.resolve_parameters(c_flat, params))
+    0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0───Y───
+    0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0.25───Y^0.5───
+    0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0.5───Y^0───
+    0: ───X^(<a/4>)───Y^(<1 - a/2>)─── => 0: ───X^0.75───Y^-0.5───
     """
     flattener = _ParamFlattener()
     val_flat = flattener.flatten(val)


### PR DESCRIPTION
Code block of cirq.PauliString is rendered incorrectly due to indentation. See https://quantumai.google/reference/python/cirq/PauliString#used-in-the-notebooks 

This PR changes the indentation to match the previous code block that gets rendered correctly. 