### PR TITLE
fixed XPowGate matrix description

### DIFF
--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -72,10 +72,10 @@ class XPowGate(eigen_gate.EigenGate):
 
     The unitary matrix of `cirq.XPowGate(exponent=t, global_shift=s)` is:
     $$
-    e^{i \pi s t}
+    e^{i \pi t (s + 1/2)}
     \begin{bmatrix}
-      e^{i \pi t /2} \cos(\pi t /2) & -i e^{i \pi t /2} \sin(\pi t /2) \\
-      -i e^{i \pi t /2} \sin(\pi t /2) & e^{i \pi t /2} \cos(\pi t /2)
+      \cos(\pi t /2) & -i \sin(\pi t /2) \\
+      -i \sin(\pi t /2) & \cos(\pi t /2)
     \end{bmatrix}
     $$
 

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -74,8 +74,8 @@ class XPowGate(eigen_gate.EigenGate):
     $$
     e^{i \pi s t}
     \begin{bmatrix}
-      e^{i \pi t /2} \cos(\pi t) & -i e^{i \pi t /2} \sin(\pi t) \\
-      -i e^{i \pi t /2} \sin(\pi t) & e^{i \pi t /2} \cos(\pi t)
+      e^{i \pi t /2} \cos(\pi t /2) & -i e^{i \pi t /2} \sin(\pi t /2) \\
+      -i e^{i \pi t /2} \sin(\pi t /2) & e^{i \pi t /2} \cos(\pi t /2)
     \end{bmatrix}
     $$
 


### PR DESCRIPTION
Let t = 1.
Then the XPowGate matrix should be a phase factor times the Pauli X-matrix, 
which means that the first coefficient should equal 0. 
As written, the first coefficient is equal to a phase factor times \cos(\pi t), 
which does not equal 0.