### PR TITLE
Mark to_json arguments as optional

### DIFF
--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -584,8 +584,8 @@ def to_json(
     obj: Any,
     file_or_fn: Union[None, IO, pathlib.Path, str] = None,
     *,
-    indent: int = 2,
-    separators: Tuple[str, str] = None,
+    indent: Optional[int] = 2,
+    separators: Optional[Tuple[str, str]] = None,
     cls: Type[json.JSONEncoder] = CirqEncoder,
 ) -> Optional[str]:
     """Write a JSON file containing a representation of obj.


### PR DESCRIPTION
since they are for `json.dumps`, see https://docs.python.org/3/library/json.html#basic-usage