### PR TITLE
Add benchmarks for transformer primitives and json serialization

### DIFF
--- a/benchmarks/serialization.py
+++ b/benchmarks/serialization.py
@@ -15,9 +15,13 @@
 import cirq
 
 
-def _human_size(num_bytes: int, units=(' bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB')):
+def _human_size(num_bytes: int, mod: int = 0, units=(' bytes', 'KB', 'MB', 'GB', 'TB', 'PB')):
     """Returns a human readable string representation of bytes"""
-    return f'{num_bytes}{units[0]}' if num_bytes < 1024 else _human_size(num_bytes >> 10, units[1:])
+    return (
+        f'{num_bytes}.{mod}{units[0]}'
+        if num_bytes < 1024
+        else _human_size(num_bytes >> 10, num_bytes % 1024, units[1:])
+    )
 
 
 class SerializeLargeExpandedCircuits:

--- a/benchmarks/serialization.py
+++ b/benchmarks/serialization.py
@@ -1,0 +1,49 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+
+
+def _human_size(num_bytes: int, units=(' bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB')):
+    """Returns a human readable string representation of bytes"""
+    return f'{num_bytes}{units[0]}' if num_bytes < 1024 else _human_size(num_bytes >> 10, units[1:])
+
+
+class SerializeLargeExpandedCircuits:
+    param_names = ["num_qubits", "num_moments"]
+    params = ([100, 500, 1000], [100, 1000, 4000])
+    timeout = 600  # Change timeout to 2 minutes instead of default 60 seconds.
+
+    def setup(self, num_qubits: int, num_moments: int):
+        qubits = cirq.LineQubit.range(num_qubits)
+        one_q_x_moment = cirq.Moment(cirq.X(q) for q in qubits[::2])
+        one_q_y_moment = cirq.Moment(cirq.Y(q) for q in qubits[1::2])
+        two_q_cx_moment = cirq.Moment(
+            cirq.CNOT(q1, q2) for q1, q2 in zip(qubits[::4], qubits[1::4])
+        )
+        two_q_cz_moment = cirq.Moment(cirq.CZ(q1, q2) for q1, q2 in zip(qubits[::4], qubits[1::4]))
+        measurement_moment = cirq.Moment(cirq.measure_each(*qubits))
+        self.circuit = cirq.Circuit(
+            [one_q_x_moment, two_q_cx_moment, one_q_y_moment, two_q_cz_moment, measurement_moment]
+            * (num_moments // 5)
+        )
+
+    def time_json_serialization(self, *_):
+        _ = cirq.to_json(self.circuit)
+
+    def time_json_serialization_gzip(self, *_):
+        _ = cirq.to_json_gzip(self.circuit)
+
+    def track_json_serialization_gzip_size(self, *_):
+        return _human_size(len(cirq.to_json_gzip(self.circuit)))

--- a/benchmarks/transformers/transformer_primitives.py
+++ b/benchmarks/transformers/transformer_primitives.py
@@ -1,0 +1,65 @@
+# Copyright 2022 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+
+
+class MapLargeExpandedCircuit:
+    param_names = ["num_qubits", "num_moments"]
+    params = ([100, 500, 1000], [100, 1000, 4000])
+    timeout = 600  # Change timeout to 2 minutes instead of default 60 seconds.
+
+    def setup(self, num_qubits: int, num_moments: int):
+        qubits = cirq.LineQubit.range(num_qubits)
+        one_q_x_moment = cirq.Moment(cirq.X(q) for q in qubits[::2])
+        one_q_y_moment = cirq.Moment(cirq.Y(q) for q in qubits[1::2])
+        two_q_cx_moment = cirq.Moment(
+            cirq.CNOT(q1, q2) for q1, q2 in zip(qubits[::4], qubits[1::4])
+        )
+        two_q_cz_moment = cirq.Moment(cirq.CZ(q1, q2) for q1, q2 in zip(qubits[::4], qubits[1::4]))
+        self.circuit = cirq.Circuit(
+            [one_q_x_moment, two_q_cx_moment, one_q_y_moment, two_q_cz_moment] * (num_moments // 4)
+        )
+
+    def time_map_moments(self, num_qubits: int, _):
+        all_qubits = cirq.LineQubit.range(num_qubits)
+
+        def map_func(m: cirq.Moment, _) -> cirq.Moment:
+            new_ops = [op.with_tags("old op") for op in m.operations]
+            new_ops += [
+                cirq.Z(q).with_tags("new op")
+                for q in all_qubits
+                if not m.operates_on_single_qubit(q)
+            ]
+            return cirq.Moment(new_ops)
+
+        _ = cirq.map_moments(circuit=self.circuit, map_func=map_func)
+
+    def time_map_operations_apply_tag(self, *_):
+        def map_func(op: cirq.Operation, _) -> cirq.Operation:
+            return op.with_tags("old op")
+
+        _ = cirq.map_operations(circuit=self.circuit, map_func=map_func)
+
+    def time_map_operations_to_optree(self, *_):
+        def map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
+            return [op, op]
+
+        _ = cirq.map_operations(circuit=self.circuit, map_func=map_func)
+
+    def time_map_operations_to_optree_and_unroll(self, *_):
+        def map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
+            return [op, op]
+
+        _ = cirq.map_operations_and_unroll(circuit=self.circuit, map_func=map_func)


### PR DESCRIPTION
This PR adds representative benchmarks for transformer primitives and circuit serialization, both of which are important use cases as we start dealing with larger circuits. 

@kjsatz Can you please take a look at the benchmarks and see if it captures our discussion? Would be also good to get your perspective on what should be the target timings these benchmarks should ideally run in? (cc @maffoo as well)

Tl;Dr is that the performance right now is too slow and we'd have to make sure we address the performance bottlenecks here so that these benchmarks can run significantly faster.

```text
$> asv run -b serialization.SerializeLargeExpandedCircuits -b transformers.transformer_primitives*
· Creating environments
· Discovering benchmarks
· Running 7 total benchmarks (1 commits * 1 environments * 7 benchmarks)
[  0.00%] · For Cirq commit 8ea41a8a <master>:
[  0.00%] ·· Benchmarking virtualenv-py3.8
[  7.14%] ··· Running (serialization.SerializeLargeExpandedCircuits.time_json_serialization--).
[ 14.29%] ··· Running (serialization.SerializeLargeExpandedCircuits.time_json_serialization_gzip--)
[ 28.57%] ··· Running (transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_moments--).
[ 35.71%] ··· Running (transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_operations_apply_tag--).
[ 42.86%] ··· Running (transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_operations_to_optree--).
[ 50.00%] ··· Running (transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_operations_to_optree_and_unroll--).
[ 57.14%] ··· serialization.SerializeLargeExpandedCircuits.time_json_serialization                                                                                                                        ok
[ 57.14%] ··· ============ ============ ============ ============
              --                        num_moments
              ------------ --------------------------------------
               num_qubits      100          1000         4000
              ============ ============ ============ ============
                  100        403±70ms    3.66±0.3s    14.1±0.2s
                  500       1.82±0.06s   18.6±0.3s    1.22±0.01m
                  1000      3.50±0.08s   36.2±0.06s   2.61±0.04m
              ============ ============ ============ ============

[ 64.29%] ··· serialization.SerializeLargeExpandedCircuits.time_json_serialization_gzip                                                                                                                   ok
[ 64.29%] ··· ============ =========== =========== ============
              --                       num_moments
              ------------ ------------------------------------
               num_qubits      100         1000        4000
              ============ =========== =========== ============
                  100        420±30ms   4.12±0.1s    18.8±1s
                  500       2.09±0.3s    22.4±1s    1.54±0.07m
                  1000      4.34±0.6s    45.5±2s    3.49±0.4m
              ============ =========== =========== ============

[ 71.43%] ··· serialization.SerializeLargeExpandedCircuits.track_json_serialization_gzip_size                                                                                                             ok
[ 71.43%] ··· ============ ========= ========= ========
              --                   num_moments
              ------------ ----------------------------
               num_qubits     100       1000     4000
              ============ ========= ========= ========
                  100        "31KB"   "309KB"   "1MB"
                  500       "144KB"    "1MB"    "5MB"
                  1000      "278KB"    "2MB"    "10MB"
              ============ ========= ========= ========

[ 78.57%] ··· transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_moments                                                                                                                ok
[ 78.57%] ··· ============ =========== =========== ===========
              --                       num_moments
              ------------ -----------------------------------
               num_qubits      100         1000        4000
              ============ =========== =========== ===========
                  100        147±40ms   1.15±0.7s    4.49±1s
                  500       797±300ms    8.78±1s     33.6±6s
                  1000      1.46±0.4s    16.2±3s    1.15±0.2m
              ============ =========== =========== ===========

[ 85.71%] ··· transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_operations_apply_tag                                                                                                   ok
[ 85.71%] ··· ============ =========== =========== ===========
              --                       num_moments
              ------------ -----------------------------------
               num_qubits      100         1000        4000
              ============ =========== =========== ===========
                  100        274±40ms   1.77±0.6s   9.47±0.2s
                  500       1.18±0.2s    15.6±2s     45.6±3s
                  1000      1.98±0.4s    24.4±2s    1.65±0.2m
              ============ =========== =========== ===========

[ 92.86%] ··· transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_operations_to_optree                                                                                                   ok
[ 92.86%] ··· ============ =========== =========== ===========
              --                       num_moments
              ------------ -----------------------------------
               num_qubits      100         1000        4000
              ============ =========== =========== ===========
                  100        426±60ms   3.15±0.7s    22.9±4s
                  500       1.66±0.5s    23.1±2s    1.65±0.2m
                  1000      4.32±0.3s    44.2±5s    3.17±0.3m
              ============ =========== =========== ===========

[100.00%] ··· transformers.transformer_primitives.MapLargeExpandedCircuit.time_map_operations_to_optree_and_unroll
                                                                                2/9 failed
[100.00%] ··· ============ =========== ============ ===========
              --                       num_moments
              ------------ ------------------------------------
               num_qubits      100         1000         4000
              ============ =========== ============ ===========
                  100       1.43±0.3s    11.6±1s     1.10±0.2m
                  500       4.37±0.4s    56.4±4s       failed
                  1000      11.9±0.4s   1.80±0.06m     failed
              ============ =========== ============ ===========
```