### PR TITLE
TESTING `numpy~=1.21`

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -6,7 +6,7 @@ backports.cached_property~=1.0.1; python_version < '3.8'
 duet~=0.2.7
 matplotlib~=3.0
 networkx~=2.4
-numpy~=1.16
+numpy~=1.21
 pandas
 sortedcontainers~=2.0
 scipy


### PR DESCRIPTION
https://numpy.org/neps/nep-0029-deprecation_policy.html recommends we get rid of `numpy~1.20`  support by `Jan 31, 2023 `