### PR TITLE
Restrict numpy version to 1.23

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -6,7 +6,7 @@ backports.cached_property~=1.0.1; python_version < '3.8'
 duet~=0.2.7
 matplotlib~=3.0
 networkx~=2.4
-numpy~=1.16
+numpy>=1.16,<=1.23
 pandas
 sortedcontainers~=2.0
 scipy

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -6,7 +6,7 @@ backports.cached_property~=1.0.1; python_version < '3.8'
 duet~=0.2.7
 matplotlib~=3.0
 networkx~=2.4
-numpy>=1.16,<=1.23
+numpy>=1.16,<1.24
 pandas
 sortedcontainers~=2.0
 scipy


### PR DESCRIPTION
Part of fixing https://github.com/quantumlib/Cirq/issues/5967