### PR TITLE
Make sure the closefigures fixture is defined

### DIFF
--- a/cirq-core/cirq/conftest.py
+++ b/cirq-core/cirq/conftest.py
@@ -14,7 +14,9 @@
 
 import inspect
 import os
+
 import matplotlib.pyplot as plt
+import pytest
 
 
 def pytest_configure(config):
@@ -30,3 +32,9 @@ def pytest_pyfunc_call(pyfuncitem):
             f'{pyfuncitem._obj.__name__} is a bare async function. '
             f'It should be decorated with "@duet.sync".'
         )
+
+
+@pytest.fixture
+def closefigures():
+    yield
+    plt.close('all')

--- a/cirq-google/cirq_google/engine/calibration_test.py
+++ b/cirq-google/cirq_google/engine/calibration_test.py
@@ -16,6 +16,7 @@ import datetime
 import pytest
 
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 from google.protobuf.text_format import Merge
 
 import cirq
@@ -194,7 +195,7 @@ def test_calibration_heatmap():
 @pytest.mark.usefixtures('closefigures')
 def test_calibration_plot_histograms():
     calibration = cg.Calibration(_CALIBRATION_DATA)
-    _, ax = mpl.pyplot.subplots(1, 1)
+    _, ax = plt.pyplot.subplots(1, 1)
     calibration.plot_histograms(['t1', 'two_qubit_xeb'], ax, labels=['T1', 'XEB'])
     assert len(ax.get_lines()) == 4
 

--- a/cirq-google/cirq_google/engine/calibration_test.py
+++ b/cirq-google/cirq_google/engine/calibration_test.py
@@ -195,7 +195,7 @@ def test_calibration_heatmap():
 @pytest.mark.usefixtures('closefigures')
 def test_calibration_plot_histograms():
     calibration = cg.Calibration(_CALIBRATION_DATA)
-    _, ax = plt.pyplot.subplots(1, 1)
+    _, ax = plt.subplots(1, 1)
     calibration.plot_histograms(['t1', 'two_qubit_xeb'], ax, labels=['T1', 'XEB'])
     assert len(ax.get_lines()) == 4
 

--- a/conftest.py
+++ b/conftest.py
@@ -37,11 +37,3 @@ def pytest_addoption(parser):
         default=False,
         help="run Rigetti integration tests",
     )
-
-
-@pytest.fixture
-def closefigures():
-    import matplotlib.pyplot as plt
-
-    yield
-    plt.close('all')

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Cirq Developers
+# Copyright 2022 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+
 import matplotlib.pyplot as plt
 import pytest
-
-
-def pytest_configure(config):
-    os.environ['CIRQ_TESTING'] = "true"
 
 
 @pytest.fixture


### PR DESCRIPTION
Problem: closefigures fixture is defined in the global conftest.py,
which is not included in cirq packages.  Package archives thus
contain tests with undefined fixture.

Solution: move closefigures definition to package conftest.py files.

Also add missing import of pyplot for `test_calibration_plot_histograms`.
