### PR TITLE
Update notebooks that depend on unreleased features

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -40,24 +40,7 @@ from dev_tools.notebooks import list_all_notebooks, filter_notebooks, rewrite_no
 # note that these notebooks are still tested in dev_tools/notebook_test.py
 # Please, always indicate in comments the feature used for easier bookkeeping.
 
-NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
-    # Hardcoded qubit placement
-    'docs/google/qubit-placement.ipynb',
-    # get_qcs_objects_for_notebook
-    'docs/noise/calibration_api.ipynb',
-    'docs/tutorials/google/colab.ipynb',
-    'docs/tutorials/google/identifying_hardware_changes.ipynb',
-    'docs/tutorials/google/echoes.ipynb',
-    'docs/noise/floquet_calibration_example.ipynb',
-    'docs/tutorials/google/spin_echoes.ipynb',
-    'docs/tutorials/google/start.ipynb',
-    'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
-    'docs/noise/qcvv/xeb_calibration_example.ipynb',
-    'docs/named_topologies.ipynb',
-    'docs/start/intro.ipynb',
-    # Circuit routing
-    'docs/transform/routing_transformer.ipynb',
-]
+NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = []
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule
 # please always add a reason for skipping.

--- a/docs/google/qubit-placement.ipynb
+++ b/docs/google/qubit-placement.ipynb
@@ -39,8 +39,7 @@
    "source": [
     "# Qubit Placement\n",
     "\n",
-    "This notebooks walks through qubit placement runtime features exposed through the `cirq_google.workflow` tools.",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "This notebooks walks through qubit placement runtime features exposed through the `cirq_google.workflow` tools."
    ]
   },
   {
@@ -77,8 +76,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    # This depends on unreleased (as of 1.14) qubit placement functions.\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq"
    ]

--- a/docs/named_topologies.ipynb
+++ b/docs/named_topologies.ipynb
@@ -65,15 +65,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ea381f53cf89"
-   },
-   "source": [
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -85,7 +76,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    \n",
     "import cirq"

--- a/docs/noise/calibration_api.ipynb
+++ b/docs/noise/calibration_api.ipynb
@@ -79,8 +79,7 @@
     "id": "BRfLi9YSMg4v"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -103,7 +102,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "print(\"Using cirq version\", cirq.__version__)"

--- a/docs/noise/floquet_calibration_example.ipynb
+++ b/docs/noise/floquet_calibration_example.ipynb
@@ -79,8 +79,7 @@
     "id": "pigDhoDrO7vr"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -106,7 +105,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "print(\"Using cirq version\", cirq.__version__)"

--- a/docs/noise/qcvv/xeb_calibration_example.ipynb
+++ b/docs/noise/qcvv/xeb_calibration_example.ipynb
@@ -88,9 +88,7 @@
     "id": "q8VcUax18RtL"
    },
    "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -116,7 +114,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install --quiet cirq --pre"
+    "    !pip install --quiet cirq"
    ]
   },
   {

--- a/docs/start/intro.ipynb
+++ b/docs/start/intro.ipynb
@@ -82,10 +82,7 @@
    "source": [
     "To use Cirq one first needs to install Cirq.  Installation instructions are available at [https://quantumai.google/cirq/start/install](https://quantumai.google/cirq/start/install).  For the purpose of this tutorial, we run `pip install cirq` as shown in the following code cell to install the latest release of Cirq. \n",
     "\n",
-    "> Different notebook execution systems exist, but for most part they have \"run\" button on a cell which you can click, or \"shift + enter\" is often the shortcut to run the cell. \n",
-    "\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`.\n"
+    "> Different notebook execution systems exist, but for most part they have \"run\" button on a cell which you can click, or \"shift + enter\" is often the shortcut to run the cell."
    ]
   },
   {
@@ -100,7 +97,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "\n",

--- a/docs/transform/routing_transformer.ipynb
+++ b/docs/transform/routing_transformer.ipynb
@@ -69,8 +69,7 @@
     "id": "RrRN9ilV0Ltg"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -85,7 +84,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    import cirq\n",
     "\n",
     "    print(\"installed cirq.\")"

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -68,8 +68,7 @@
     "id": "fe7e28f44667"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -85,7 +84,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq-google --pre\n",
+    "    !pip install --quiet cirq-google\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google"

--- a/docs/tutorials/google/echoes.ipynb
+++ b/docs/tutorials/google/echoes.ipynb
@@ -99,9 +99,7 @@
     "id": "bpBUR4JblClA"
    },
    "source": [
-    "We first install Cirq then import packages we will use.\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "We first install Cirq then import packages we will use."
    ]
   },
   {
@@ -115,7 +113,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install --quiet cirq --pre"
+    "    !pip install --quiet cirq"
    ]
   },
   {

--- a/docs/tutorials/google/identifying_hardware_changes.ipynb
+++ b/docs/tutorials/google/identifying_hardware_changes.ipynb
@@ -137,9 +137,7 @@
    "source": [
     "### Setup\n",
     "\n",
-    "First, install Cirq and import the necessary packages.\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "First, install Cirq and import the necessary packages."
    ]
   },
   {
@@ -188,7 +186,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install --quiet cirq --pre"
+    "    !pip install --quiet cirq"
    ]
   },
   {

--- a/docs/tutorials/google/spin_echoes.ipynb
+++ b/docs/tutorials/google/spin_echoes.ipynb
@@ -93,8 +93,7 @@
     "id": "BRfLi9YSMg4v"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -109,7 +108,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -68,8 +68,7 @@
     "id": "fe7e28f44667"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq-google --pre`."
+    "## Setup"
    ]
   },
   {
@@ -85,7 +84,7 @@
     "    import cirq_google as cg\n",
     "except ImportError:\n",
     "    print(\"installing cirq-google...\")\n",
-    "    !pip install --quiet cirq-google --pre\n",
+    "    !pip install --quiet cirq-google\n",
     "    print(\"installed cirq-google.\")\n",
     "    import cirq\n",
     "    import cirq_google as cg"

--- a/docs/tutorials/google/visualizing_calibration_metrics.ipynb
+++ b/docs/tutorials/google/visualizing_calibration_metrics.ipynb
@@ -70,8 +70,7 @@
     "id": "fe7e28f44667"
    },
    "source": [
-    "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "## Setup"
    ]
   },
   {
@@ -88,7 +87,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "import cirq\n",
     "import cirq_google\n",


### PR DESCRIPTION
Cirq 1.1.0 was recently released. This PR updates all notebooks depending on unreleased features to use the latest released Cirq instead. 