### PR TITLE
Improve dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8-slim AS cirq_base
 
 # Install dependencies.
 # rm -rf /var/lib/apt/lists/* cleans up apt cache. See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y \
      python3-pip \
      locales \
      && rm -rf /var/lib/apt/lists/*
@@ -10,17 +10,17 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
 
 # Configure UTF-8 encoding.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8 
+ENV LANG en_US.UTF-8 
+ENV LANGUAGE en_US:en 
+ENV LC_ALL en_US.UTF-8
 
 # Make python3 default
 RUN rm -f /usr/bin/python \
      && ln -s /usr/bin/python3 /usr/bin/python
 #cirq stable image
 FROM cirq_base AS cirq_stable
-RUN pip3 install cirq
+RUN pip3 install --no-cache-dir cirq
 
 ##cirq pre_release image
 FROM cirq_base AS cirq_pre_release
-RUN pip3 install cirq --pre
+RUN pip3 install --no-cache-dir cirq --pre


### PR DESCRIPTION
Hi there,

  Thanks for maintaining cirq. I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of Changes:
* Added the `--no-cache-dir` flag to pip install commands in the Dockerfile
* Added the `--no-install-recommends` flag to apt-get install commands in the Dockerfile


Impact on the image size:
* Image size before repair: 1.04 GB
* Image size after repair: 665.56 MB
* Difference: 403.57 MB (37.75%)

The `--no-cache-dir` flag disables the package cache for pip install, ensuring that the latest version of a package and its dependencies are installed. The `--no-install-recommends` flag saves layer space, improves build times, and reduces the size and attack surface of the final image. It also prevents hidden dependencies from being installed.

I hope that you will find these changes useful to you. :smile: Let me know if you have any questions or concerns.

Thanks,