### PR TITLE
Streaming client prototype: EngineClient interface and stream handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,4 @@ filterwarnings = [
     "error:`np.long` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
     "error:`np.unicode` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
 ]
+log_cli = true


### PR DESCRIPTION
A prototype of `EngineClient.create_job_and_get_result()` covering the happy path only; it doesn't handle stream disconnects, so it never makes a GetResult call over the stream.

The prototype contains:
* A long running stream handler to receive stream responses
  * Runs in the asyncio context.
  * Handler restart logic (including making a GetResult request for every outstanding job in Response Listener) is missing
* Response listener
* `EngineClient.create_job_and_get_result()` implementation to send requests to the request stream directly and receive responses from the Response Listener.
  * The request stream data structure is not yet thread-safe.

cc @maffoo @wcourtney 