### PR TITLE
Fix link to noise models

### DIFF
--- a/docs/start/basics.ipynb
+++ b/docs/start/basics.ipynb
@@ -447,7 +447,7 @@
     "\n",
     "Cirq also provides the [Quantum Virtual Machine](/cirq/simulate/quantum_virtual_machine), which is a simulated virtual version of quantum hardware devices. It consists of two primary components: \n",
     "1. A [virtual Engine interface](/cirq/simulate/virtual_engine_interface) that enables you to verify and run circuits with the same interface that quantum hardware would have.\n",
-    "2. A set of [noise models](cirq/noise/representing_noise) that try to realistically replicate the noise present in actual Google quantum hardware devices.\n",
+    "2. A set of [noise models](/cirq/noise/representing_noise) that try to realistically replicate the noise present in actual Google quantum hardware devices.\n",
     "\n",
     "The QVM is intended to serve as a replacement for the Google quantum hardware, in two cases: \n",
     "1. Running your circuit on a QVM can give an approximation of how your circuit runs under the influence of hardware-like noise. This can be useful to help you reconfigure or change your circuit to be less impacted by noise when run on actual quantum hardware.\n",


### PR DESCRIPTION
Fixes the following broken link on [basics page](https://quantumai.google/cirq/start/basics#virtual_machine_simulation):

> A set of [noise models](https://quantumai.google/cirq/start/cirq/noise/representing_noise) that try...