### PR TITLE
Add `__cirq_debug__` flag and conditionally disable qid validations in gates and operations

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -9,6 +9,7 @@
     "environment_type": "virtualenv",
     "show_commit_url": "https://github.com/quantumlib/Cirq/commit/",
     "pythons": ["3.8"],
+    "matrix": {"env_nobuild": {"PYTHONOPTIMIZE": ["-O", ""]}},
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -16,6 +16,8 @@
 
 from cirq import _import
 
+from cirq._compat import __cirq_debug__
+
 # A module can only depend on modules imported earlier in this list of modules
 # at import time.  Pytest will fail otherwise (enforced by
 # dev_tools/import_test.py).

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -16,7 +16,7 @@
 
 from cirq import _import
 
-from cirq._compat import __cirq_debug__
+from cirq._compat import __cirq_debug__, with_debug
 
 # A module can only depend on modules imported earlier in this list of modules
 # at import time.  Pytest will fail otherwise (enforced by

--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -15,6 +15,8 @@
 """Workarounds for compatibility issues between versions and libraries."""
 import contextlib
 import dataclasses
+
+import contextvars
 import functools
 import importlib
 import inspect
@@ -31,8 +33,17 @@ import pandas as pd
 import sympy
 import sympy.printing.repr
 
+from cirq._doc import document
+
 ALLOW_DEPRECATION_IN_TEST = 'ALLOW_DEPRECATION_IN_TEST'
 
+__cirq_debug__ = contextvars.ContextVar('__cirq_debug__', default=__debug__)
+document(
+    __cirq_debug__,
+    "A cirq specific flag which can be used to conditionally turn off all validations across Cirq "
+    "to boost performance in production mode. Defaults to python's built-in constant __debug__. "
+    "The flag is implemented as a `ContextVar` and is thread safe.",
+)
 
 try:
     from functools import cached_property  # pylint: disable=unused-import

--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -26,7 +26,7 @@ import sys
 import traceback
 import warnings
 from types import ModuleType
-from typing import Any, Callable, Dict, Optional, overload, Set, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Iterator, Optional, overload, Set, Tuple, Type, TypeVar
 
 import numpy as np
 import pandas as pd
@@ -44,6 +44,23 @@ document(
     "to boost performance in production mode. Defaults to python's built-in constant __debug__. "
     "The flag is implemented as a `ContextVar` and is thread safe.",
 )
+
+
+@contextlib.contextmanager
+def with_debug(value: bool) -> Iterator[None]:
+    """Sets the value of global constant `cirq.__cirq_debug__` within the context.
+
+    If `__cirq_debug__` is set to False, all validations in Cirq are disabled to optimize
+    performance. Users should use the `cirq.with_debug` context manager instead of manually
+    mutating the value of `__cirq_debug__` flag. On exit, the context manager resets the
+    value of `__cirq_debug__` flag to what it was before entering the context manager.
+    """
+    token = __cirq_debug__.set(value)
+    try:
+        yield
+    finally:
+        __cirq_debug__.reset(token)
+
 
 try:
     from functools import cached_property  # pylint: disable=unused-import

--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -14,9 +14,8 @@
 
 """Workarounds for compatibility issues between versions and libraries."""
 import contextlib
-import dataclasses
-
 import contextvars
+import dataclasses
 import functools
 import importlib
 import inspect

--- a/cirq-core/cirq/_compat_test.py
+++ b/cirq-core/cirq/_compat_test.py
@@ -51,6 +51,16 @@ from cirq._compat import (
 )
 
 
+def test_with_debug():
+    assert cirq.__cirq_debug__.get()
+    with cirq.with_debug(False):
+        assert not cirq.__cirq_debug__.get()
+        with cirq.with_debug(True):
+            assert cirq.__cirq_debug__.get()
+        assert not cirq.__cirq_debug__.get()
+    assert cirq.__cirq_debug__.get()
+
+
 def test_proper_repr():
     v = sympy.Symbol('t') * 3
     v2 = eval(proper_repr(v))

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -273,7 +273,7 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
                 operations = [self.on(*target) for target in iterator]
             return operations
 
-        if __cirq_debug__.get() is False:
+        if not __cirq_debug__.get():
             return [
                 op
                 for q in targets

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -280,7 +280,7 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
                 for op in (
                     self.on_each(*q)
                     if isinstance(q, Iterable) and not isinstance(q, str)
-                    else [self.on(cast(cirq.Qid, q))]
+                    else [self.on(cast('cirq.Qid', q))]
                 )
             ]
 

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -17,6 +17,7 @@
 import abc
 import functools
 from typing import (
+    cast,
     AbstractSet,
     Any,
     Callable,
@@ -274,10 +275,13 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
 
         if __cirq_debug__.get() is False:
             return [
-                self.on_each(*q)
-                if isinstance(q, Iterable) and not isinstance(q, str)
-                else self.on(q)
+                op
                 for q in targets
+                for op in (
+                    self.on_each(*q)
+                    if isinstance(q, Iterable) and not isinstance(q, str)
+                    else [self.on(cast(cirq.Qid, q))]
+                )
             ]
 
         for target in targets:

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -162,13 +162,12 @@ def test_disable_op_validation():
         h_op.validate_args([q0, q1])
 
     # Passes, skipping validation.
-    cirq.__cirq_debug__.set(False)
-    op = cirq.H(q0, q1)
-    assert op.qubits == (q0, q1)
-    h_op.validate_args([q0, q1])
+    with cirq.with_debug(False):
+        op = cirq.H(q0, q1)
+        assert op.qubits == (q0, q1)
+        h_op.validate_args([q0, q1])
 
     # Fails again when validation is re-enabled.
-    cirq.__cirq_debug__.set(True)
     with pytest.raises(ValueError, match='Wrong number'):
         _ = cirq.H(q0, q1)
     with pytest.raises(ValueError, match='Wrong number'):
@@ -812,10 +811,9 @@ def test_single_qubit_gate_validates_on_each():
     with pytest.raises(ValueError):
         _ = g.on_each(*test_non_qubits)
 
-    cirq.__cirq_debug__.set(False)
-    assert g.on_each(*test_non_qubits)[0].qubits == ('0',)
+    with cirq.with_debug(False):
+        assert g.on_each(*test_non_qubits)[0].qubits == ('0',)
 
-    cirq.__cirq_debug__.set(True)
     with pytest.raises(ValueError):
         _ = g.on_each(*test_non_qubits)
 
@@ -883,9 +881,8 @@ def test_on_each_two_qubits():
     with pytest.raises(ValueError, match='Expected 2 qubits'):
         g.on_each([(a, b, a)])
 
-    cirq.__cirq_debug__.set(False)
-    assert g.on_each([(a, b, a)])[0].qubits == (a, b, a)
-    cirq.__cirq_debug__.set(True)
+    with cirq.with_debug(False):
+        assert g.on_each([(a, b, a)])[0].qubits == (a, b, a)
 
     with pytest.raises(ValueError, match='Expected 2 qubits'):
         g.on_each(zip([a, a]))

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -3,6 +3,7 @@
 # functools.cached_property was introduced in python 3.8
 backports.cached_property~=1.0.1; python_version < '3.8'
 
+contextvars
 duet~=0.2.7
 matplotlib~=3.0
 networkx~=2.4

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -3,7 +3,6 @@
 # functools.cached_property was introduced in python 3.8
 backports.cached_property~=1.0.1; python_version < '3.8'
 
-contextvars
 duet~=0.2.7
 matplotlib~=3.0
 networkx~=2.4


### PR DESCRIPTION
This is the first PR in a series of PRs to provide cirq users to conditionally disable validations in cirq to boost runtime performance. The proposal for adding a `__cirq_debug__` flag is presented in https://github.com/quantumlib/Cirq/issues/5988

This PR adds:
1) A `cirq.__debug__` flag, which is thread safe and implemented using contextvars. The default value is set to `__debug__` global constant in python. 
2) Conditions the qid shape validations in `Gate.validate_args()`, `Operation.validate_args` and `Gate.on_each` on the value of `cirq.__debug__` flag. 

Benchmarks on my laptop show improvement of about ~20%.

```bash
$> asv run --python=same --bench XOnAllQubitsCircuit
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 2 environments * 1 benchmarks)
[  0.00%] ·· Benchmarking existing-py_Users_tanujkhattar_opt_anaconda3_envs_cirq_bin_python-PYTHONOPTIMIZE-O
[ 25.00%] ··· Running (circuit_construction.XOnAllQubitsCircuit.time_circuit_construction--).
[ 50.00%] ··· circuit_construction.XOnAllQubitsCircuit.time_circuit_construction                                                                                                                          ok
[ 50.00%] ··· ===================== ============ ============= ============= ============
              --                                           Depth(D)
              --------------------- -----------------------------------------------------
               Number of Qubits(N)       1             10           100          1000
              ===================== ============ ============= ============= ============
                        1             23.6±3μs      151±3μs     1.39±0.07ms   14.4±0.3ms
                        10            89.4±3μs      790±50μs     7.68±0.2ms   77.7±0.9ms
                       100            722±20μs    7.14±0.09ms    70.8±0.7ms    731±5ms
                       1000          7.05±0.1ms     71.2±1ms      748±10ms    7.69±0.2s
              ===================== ============ ============= ============= ============

[ 50.00%] ·· Benchmarking existing-py_Users_tanujkhattar_opt_anaconda3_envs_cirq_bin_python-PYTHONOPTIMIZE
[ 75.00%] ··· Running (circuit_construction.XOnAllQubitsCircuit.time_circuit_construction--).
[100.00%] ··· circuit_construction.XOnAllQubitsCircuit.time_circuit_construction                                                                                                                          ok
[100.00%] ··· ===================== ============ ============= ============= ============
              --                                           Depth(D)
              --------------------- -----------------------------------------------------
               Number of Qubits(N)       1             10           100          1000
              ===================== ============ ============= ============= ============
                        1             25.5±2μs      223±60μs    1.75±0.03ms   16.2±0.4ms
                        10            109±4μs       978±20μs     9.80±0.2ms   99.7±0.5ms
                       100            939±30μs    8.95±0.09ms     91.1±1ms     954±20ms
                       1000          9.42±0.2ms     89.9±1ms      949±10ms    9.63±0.03s
              ===================== ============ ============= ============= ============
```

This should also make the [cirq.contrib.hacks.disable_validation](https://github.com/quantumlib/Cirq/blob/master/cirq-core/cirq/contrib/hacks/disable_validation.py) obsolete.


cc @maffoo @zchen088 @dabacon @dstrain115 