### PR TITLE
Removing unnecessary return statement in cirq-core/cirq/circuits/moment.py

### DIFF
--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -148,6 +148,7 @@ class Moment:
         """
         if self.operates_on([qubit]):
             return self.__getitem__(qubit)
+        return None
 
     def with_operation(self, operation: 'cirq.Operation') -> 'cirq.Moment':
         """Returns an equal moment, but with the given op added.

--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -148,8 +148,6 @@ class Moment:
         """
         if self.operates_on([qubit]):
             return self.__getitem__(qubit)
-        else:
-            return None
 
     def with_operation(self, operation: 'cirq.Operation') -> 'cirq.Moment':
         """Returns an equal moment, but with the given op added.


### PR DESCRIPTION
The 
```
else:
  return None
```
was not needed as python will do this anyway.