### PR TITLE
Retry bad_gateway in cirq-ionq

### DIFF
--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -26,7 +26,7 @@ import cirq_ionq
 from cirq_ionq import ionq_exceptions
 
 
-RETRIABLE_STATUS_CODES = {requests.codes.internal_server_error, requests.codes.service_unavailable}
+RETRIABLE_STATUS_CODES = {requests.codes.internal_server_error, requests.codes.bad_gateway, requests.codes.service_unavailable}
 
 
 def _is_retriable(code):

--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -25,8 +25,11 @@ import requests
 import cirq_ionq
 from cirq_ionq import ionq_exceptions
 
-
-RETRIABLE_STATUS_CODES = {requests.codes.internal_server_error, requests.codes.bad_gateway, requests.codes.service_unavailable}
+RETRIABLE_STATUS_CODES = {
+    requests.codes.internal_server_error,
+    requests.codes.bad_gateway,
+    requests.codes.service_unavailable,
+}
 
 
 def _is_retriable(code):


### PR DESCRIPTION
This error occurred due to a cloudflare outage, and should be retried to avoid disrupting automated usage of the libs.