### PR TITLE
Upgrade to API v0.3

### DIFF
--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -169,6 +169,7 @@ class _IonQClient:
 
         Args:
             job_id: The UUID of the job (returned when the job was created).
+            aggregation: The aggregation method for symmetrized jobs
 
         Returns:
             The json body of the response as a dict.
@@ -184,7 +185,9 @@ class _IonQClient:
             params["aggregation"] = aggregation
 
         def request():
-            return requests.get(f'{self.url}/jobs/{job_id}/results', params=params, headers=self.headers)
+            return requests.get(
+                f'{self.url}/jobs/{job_id}/results', params=params, headers=self.headers
+            )
 
         return self._make_request(request, {}).json()
 

--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -42,14 +42,14 @@ class _IonQClient:
     """
 
     SUPPORTED_TARGETS = {'qpu', 'simulator'}
-    SUPPORTED_VERSIONS = {'v0.1'}
+    SUPPORTED_VERSIONS = {'v0.3'}
 
     def __init__(
         self,
         remote_host: str,
         api_key: str,
         default_target: Optional[str] = None,
-        api_version: str = 'v0.1',
+        api_version: str = 'v0.3',
         max_retry_seconds: int = 3600,  # 1 hour
         verbose: bool = False,
     ):
@@ -67,7 +67,7 @@ class _IonQClient:
             api_key: The key used for authenticating against the IonQ API.
             default_target: The default target to run against. Supports one of 'qpu' and
                 'simulator'. Can be overridden by calls with target in their signature.
-            api_version: Which version fo the api to use. As of Dec, 2020, accepts 'v0.1' only,
+            api_version: Which version fo the api to use. As of Feb, 2023, accepts 'v0.3' only,
                 which is the default.
             max_retry_seconds: The time to continue retriable responses. Defaults to 3600.
             verbose: Whether to print to stderr and stdio any retriable errors that are encountered.
@@ -79,7 +79,7 @@ class _IonQClient:
         )
         assert (
             api_version in self.SUPPORTED_VERSIONS
-        ), f'Only api v0.1 is accepted but was {api_version}'
+        ), f'Only api v0.3 is accepted but was {api_version}'
         assert (
             default_target is None or default_target in self.SUPPORTED_TARGETS
         ), f'Target can only be one of {self.SUPPORTED_TARGETS} but was {default_target}.'
@@ -134,6 +134,9 @@ class _IonQClient:
         # API does not return number of shots so pass this through as metadata.
         json['metadata']['shots'] = str(repetitions)
 
+        if serialized_program.error_mitigation:
+            json['error_mitigation'] = serialized_program.error_mitigation
+
         def request():
             return requests.post(f'{self.url}/jobs', json=json, headers=self.headers)
 
@@ -155,6 +158,30 @@ class _IonQClient:
 
         def request():
             return requests.get(f'{self.url}/jobs/{job_id}', headers=self.headers)
+
+        return self._make_request(request, {}).json()
+
+    def get_results(self, job_id: str, aggregation: Optional[str] = None):
+        """Get job results from IonQ API.
+
+        Args:
+            job_id: The UUID of the job (returned when the job was created).
+
+        Returns:
+            The json body of the response as a dict.
+
+        Raises:
+            IonQNotFoundException: If job or results don't exist.
+            IonQException: For other API call failures.
+        """
+
+        params = {}
+
+        if aggregation:
+            params["aggregation"] = aggregation
+
+        def request():
+            return requests.get(f'{self.url}/jobs/{job_id}/results', params=params, headers=self.headers)
 
         return self._make_request(request, {}).json()
 
@@ -185,7 +212,7 @@ class _IonQClient:
         Args:
             job_id: The UUID of the job (returned when the job was created).
 
-        Note that the IonQ API v0.1 can cancel a completed job, which updates its status to
+        Note that the IonQ API v0.3 can cancel a completed job, which updates its status to
         canceled.
 
         Returns:

--- a/cirq-ionq/cirq_ionq/ionq_client_test.py
+++ b/cirq-ionq/cirq_ionq/ionq_client_test.py
@@ -78,7 +78,7 @@ def test_ionq_client_attributes():
         max_retry_seconds=10,
         verbose=True,
     )
-    assert client.url == 'http://example.com/v0.1'
+    assert client.url == 'http://example.com/v0.3'
     assert client.headers == {
         'Authorization': 'apiKey to_my_heart',
         'Content-Type': 'application/json',
@@ -110,7 +110,7 @@ def test_ionq_client_create_job(mock_post):
     }
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_post.assert_called_with(
-        'http://example.com/v0.1/jobs', json=expected_json, headers=expected_headers
+        'http://example.com/v0.3/jobs', json=expected_json, headers=expected_headers
     )
 
 
@@ -255,7 +255,7 @@ def test_ionq_client_get_job(mock_get):
     assert response == {'foo': 'bar'}
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
-    mock_get.assert_called_with('http://example.com/v0.1/jobs/job_id', headers=expected_headers)
+    mock_get.assert_called_with('http://example.com/v0.3/jobs/job_id', headers=expected_headers)
 
 
 @mock.patch('requests.get')
@@ -319,7 +319,7 @@ def test_ionq_client_list_jobs(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/jobs', headers=expected_headers, json={'limit': 1000}, params={}
+        'http://example.com/v0.3/jobs', headers=expected_headers, json={'limit': 1000}, params={}
     )
 
 
@@ -333,7 +333,7 @@ def test_ionq_client_list_jobs_status(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/jobs',
+        'http://example.com/v0.3/jobs',
         headers=expected_headers,
         json={'limit': 1000},
         params={'status': 'canceled'},
@@ -350,7 +350,7 @@ def test_ionq_client_list_jobs_limit(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/jobs', headers=expected_headers, json={'limit': 1000}, params={}
+        'http://example.com/v0.3/jobs', headers=expected_headers, json={'limit': 1000}, params={}
     )
 
 
@@ -367,7 +367,7 @@ def test_ionq_client_list_jobs_batches(mock_get):
     assert response == [{'id': '1'}, {'id': '2'}, {'id': '3'}]
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
-    url = 'http://example.com/v0.1/jobs'
+    url = 'http://example.com/v0.3/jobs'
     mock_get.assert_has_calls(
         [
             mock.call(url, headers=expected_headers, json={'limit': 1}, params={}),
@@ -392,7 +392,7 @@ def test_ionq_client_list_jobs_batches_does_not_divide_total(mock_get):
     assert response == [{'id': '1'}, {'id': '2'}, {'id': '3'}]
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
-    url = 'http://example.com/v0.1/jobs'
+    url = 'http://example.com/v0.3/jobs'
     mock_get.assert_has_calls(
         [
             mock.call(url, headers=expected_headers, json={'limit': 2}, params={}),
@@ -446,7 +446,7 @@ def test_ionq_client_cancel_job(mock_put):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_put.assert_called_with(
-        'http://example.com/v0.1/jobs/job_id/status/cancel', headers=expected_headers
+        'http://example.com/v0.3/jobs/job_id/status/cancel', headers=expected_headers
     )
 
 
@@ -510,7 +510,7 @@ def test_ionq_client_delete_job(mock_delete):
     assert response == {'foo': 'bar'}
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
-    mock_delete.assert_called_with('http://example.com/v0.1/jobs/job_id', headers=expected_headers)
+    mock_delete.assert_called_with('http://example.com/v0.3/jobs/job_id', headers=expected_headers)
 
 
 @mock.patch('requests.delete')
@@ -574,7 +574,7 @@ def test_ionq_client_get_current_calibrations(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/calibrations/current', headers=expected_headers
+        'http://example.com/v0.3/calibrations/current', headers=expected_headers
     )
 
 
@@ -631,7 +631,7 @@ def test_ionq_client_list_calibrations(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/calibrations',
+        'http://example.com/v0.3/calibrations',
         headers=expected_headers,
         json={'limit': 1000},
         params={},
@@ -651,7 +651,7 @@ def test_ionq_client_list_calibrations_dates(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/calibrations',
+        'http://example.com/v0.3/calibrations',
         headers=expected_headers,
         json={'limit': 1000},
         params={'start': 1284286794000, 'end': 1284286795000},
@@ -670,7 +670,7 @@ def test_ionq_client_list_calibrations_limit(mock_get):
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
     mock_get.assert_called_with(
-        'http://example.com/v0.1/calibrations',
+        'http://example.com/v0.3/calibrations',
         headers=expected_headers,
         json={'limit': 1000},
         params={},
@@ -690,7 +690,7 @@ def test_ionq_client_list_calibrations_batches(mock_get):
     assert response == [{'id': '1'}, {'id': '2'}, {'id': '3'}]
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
-    url = 'http://example.com/v0.1/calibrations'
+    url = 'http://example.com/v0.3/calibrations'
     mock_get.assert_has_calls(
         [
             mock.call(url, headers=expected_headers, json={'limit': 1}, params={}),
@@ -715,7 +715,7 @@ def test_ionq_client_list_calibrations_batches_does_not_divide_total(mock_get):
     assert response == [{'id': '1'}, {'id': '2'}, {'id': '3'}]
 
     expected_headers = {'Authorization': 'apiKey to_my_heart', 'Content-Type': 'application/json'}
-    url = 'http://example.com/v0.1/calibrations'
+    url = 'http://example.com/v0.3/calibrations'
     mock_get.assert_has_calls(
         [
             mock.call(url, headers=expected_headers, json={'limit': 2}, params={}),

--- a/cirq-ionq/cirq_ionq/job.py
+++ b/cirq-ionq/cirq_ionq/job.py
@@ -173,7 +173,10 @@ class Job:
         return measurement_dict
 
     def results(
-        self, timeout_seconds: int = 7200, polling_seconds: int = 1, aggregation: Optional[str] = None
+        self,
+        timeout_seconds: int = 7200,
+        polling_seconds: int = 1,
+        aggregation: Optional[str] = None
     ) -> Union[results.QPUResult, results.SimulatorResult]:
         """Polls the IonQ api for results.
 

--- a/cirq-ionq/cirq_ionq/job_test.py
+++ b/cirq-ionq/cirq_ionq/job_test.py
@@ -58,16 +58,17 @@ def test_job_str():
 
 
 def test_job_results_qpu():
+    mock_client = mock.MagicMock()
+    mock_client.get_results.return_value = {'0': '0.6', '2': '0.4'}
     job_dict = {
         'id': 'my_id',
         'status': 'completed',
         'qubits': '2',
         'target': 'qpu',
         'metadata': {'shots': 1000, 'measurement0': f'a{chr(31)}0,1'},
-        'data': {'histogram': {'0': '0.6', '2': '0.4'}},
         'warning': {'messages': ['foo', 'bar']},
     }
-    job = ionq.Job(None, job_dict)
+    job = ionq.Job(mock_client, job_dict)
     with warnings.catch_warnings(record=True) as w:
         results = job.results()
         assert len(w) == 2
@@ -78,16 +79,17 @@ def test_job_results_qpu():
 
 
 def test_job_results_rounding_qpu():
+    mock_client = mock.MagicMock()
+    mock_client.get_results.return_value = {'0': '0.0006', '2': '0.9994'}
     job_dict = {
         'id': 'my_id',
         'status': 'completed',
         'qubits': '2',
         'target': 'qpu',
         'metadata': {'shots': 5000, 'measurement0': f'a{chr(31)}0,1'},
-        'data': {'histogram': {'0': '0.0006', '2': '0.9994'}},
     }
     # 5000*0.0006 ~ 2.9999 but should be interpreted as 3
-    job = ionq.Job(None, job_dict)
+    job = ionq.Job(mock_client, job_dict)
     expected = ionq.QPUResult({0: 3, 1: 4997}, 2, {'a': [0, 1]})
     results = job.results()
     assert results == expected
@@ -110,20 +112,23 @@ def test_job_results_failed_no_error_message():
 
 
 def test_job_results_qpu_endianness():
+    mock_client = mock.MagicMock()
+    mock_client.get_results.return_value = {'0': '0.6', '1': '0.4'}
     job_dict = {
         'id': 'my_id',
         'status': 'completed',
         'qubits': '2',
         'target': 'qpu',
         'metadata': {'shots': 1000},
-        'data': {'histogram': {'0': '0.6', '1': '0.4'}},
     }
-    job = ionq.Job(None, job_dict)
+    job = ionq.Job(mock_client, job_dict)
     results = job.results()
     assert results == ionq.QPUResult({0: 600, 2: 400}, 2, measurement_dict={})
 
 
 def test_job_results_qpu_target_endianness():
+    mock_client = mock.MagicMock()
+    mock_client.get_results.return_value = {'0': '0.6', '1': '0.4'}
     job_dict = {
         'id': 'my_id',
         'status': 'completed',
@@ -132,7 +137,7 @@ def test_job_results_qpu_target_endianness():
         'metadata': {'shots': 1000},
         'data': {'histogram': {'0': '0.6', '1': '0.4'}},
     }
-    job = ionq.Job(None, job_dict)
+    job = ionq.Job(mock_client, job_dict)
     results = job.results()
     assert results == ionq.QPUResult({0: 600, 2: 400}, 2, measurement_dict={})
 
@@ -146,10 +151,10 @@ def test_job_results_poll(mock_sleep):
         'qubits': '1',
         'target': 'qpu',
         'metadata': {'shots': 1000},
-        'data': {'histogram': {'0': '0.6', '1': '0.4'}},
     }
     mock_client = mock.MagicMock()
     mock_client.get_job.side_effect = [ready_job, completed_job]
+    mock_client.get_results.return_value = {'0': '0.6', '1': '0.4'}
     job = ionq.Job(mock_client, ready_job)
     results = job.results(polling_seconds=0)
     assert results == ionq.QPUResult({0: 600, 1: 400}, 1, measurement_dict={})
@@ -179,29 +184,31 @@ def test_job_results_poll_timeout_with_error_message(mock_sleep):
 
 
 def test_job_results_simulator():
+    mock_client = mock.MagicMock()
+    mock_client.get_results.return_value = {'0': '0.6', '1': '0.4'}
     job_dict = {
         'id': 'my_id',
         'status': 'completed',
         'qubits': '1',
         'target': 'simulator',
-        'data': {'histogram': {'0': '0.6', '1': '0.4'}},
         'metadata': {'shots': '100'},
     }
-    job = ionq.Job(None, job_dict)
+    job = ionq.Job(mock_client, job_dict)
     results = job.results()
     assert results == ionq.SimulatorResult({0: 0.6, 1: 0.4}, 1, {}, 100)
 
 
 def test_job_results_simulator_endianness():
+    mock_client = mock.MagicMock()
+    mock_client.get_results.return_value = {'0': '0.6', '1': '0.4'}
     job_dict = {
         'id': 'my_id',
         'status': 'completed',
         'qubits': '2',
         'target': 'simulator',
-        'data': {'histogram': {'0': '0.6', '1': '0.4'}},
         'metadata': {'shots': '100'},
     }
-    job = ionq.Job(None, job_dict)
+    job = ionq.Job(mock_client, job_dict)
     results = job.results()
     assert results == ionq.SimulatorResult({0: 0.6, 2: 0.4}, 2, {}, 100)
 

--- a/cirq-ionq/cirq_ionq/sampler_test.py
+++ b/cirq-ionq/cirq_ionq/sampler_test.py
@@ -91,10 +91,7 @@ def test_sampler_multiple_jobs():
     job0 = ionq.Job(client=mock_service, job_dict=job_dict0)
     job1 = ionq.Job(client=mock_service, job_dict=job_dict1)
     mock_service.create_job.side_effect = [job0, job1]
-    mock_service.get_results.side_effect = [
-        {'0': '0.25', '1': '0.75'},
-        {'0': '0.5', '1': '0.5'}
-    ]
+    mock_service.get_results.side_effect = [{'0': '0.25', '1': '0.75'}, {'0': '0.5', '1': '0.5'}]
 
     sampler = ionq.Sampler(service=mock_service, timeout_seconds=10, target='qpu')
     q0 = cirq.LineQubit(0)

--- a/cirq-ionq/cirq_ionq/sampler_test.py
+++ b/cirq-ionq/cirq_ionq/sampler_test.py
@@ -29,11 +29,11 @@ def test_sampler_qpu():
         'qubits': '1',
         'target': 'qpu',
         'metadata': {'shots': 4, 'measurement0': f'a{chr(31)}0'},
-        'data': {'histogram': {'0': '0.25', '1': '0.75'}},
     }
 
     job = ionq.Job(client=mock_service, job_dict=job_dict)
     mock_service.create_job.return_value = job
+    mock_service.get_results.return_value = {'0': '0.25', '1': '0.75'}
 
     sampler = ionq.Sampler(service=mock_service, target='qpu')
     q0 = cirq.LineQubit(0)
@@ -53,11 +53,11 @@ def test_sampler_simulator():
         'qubits': '1',
         'target': 'simulator',
         'metadata': {'shots': 4, 'measurement0': f'a{chr(31)}0'},
-        'data': {'histogram': {'0': '0.25', '1': '0.75'}},
     }
 
     job = ionq.Job(client=mock_service, job_dict=job_dict)
     mock_service.create_job.return_value = job
+    mock_service.get_results.return_value = {'0': '0.25', '1': '0.75'}
 
     sampler = ionq.Sampler(service=mock_service, target='simulator', seed=10)
     q0 = cirq.LineQubit(0)
@@ -79,7 +79,6 @@ def test_sampler_multiple_jobs():
         'qubits': '1',
         'target': 'qpu',
         'metadata': {'shots': 4, 'measurement0': f'a{chr(31)}0'},
-        'data': {'histogram': {'0': '0.25', '1': '0.75'}},
     }
     job_dict1 = {
         'id': '1',
@@ -87,12 +86,15 @@ def test_sampler_multiple_jobs():
         'qubits': '1',
         'target': 'qpu',
         'metadata': {'shots': 4, 'measurement0': f'a{chr(31)}0'},
-        'data': {'histogram': {'0': '0.5', '1': '0.5'}},
     }
 
     job0 = ionq.Job(client=mock_service, job_dict=job_dict0)
     job1 = ionq.Job(client=mock_service, job_dict=job_dict1)
     mock_service.create_job.side_effect = [job0, job1]
+    mock_service.get_results.side_effect = [
+        {'0': '0.25', '1': '0.75'},
+        {'0': '0.5', '1': '0.5'}
+    ]
 
     sampler = ionq.Sampler(service=mock_service, timeout_seconds=10, target='qpu')
     q0 = cirq.LineQubit(0)

--- a/cirq-ionq/cirq_ionq/serializer.py
+++ b/cirq-ionq/cirq_ionq/serializer.py
@@ -40,6 +40,7 @@ class SerializedProgram:
 
     body: dict
     metadata: dict
+    error_mitigation: Optional[dict] = None
 
 
 class Serializer:
@@ -75,7 +76,7 @@ class Serializer:
             MSGate: self._serialize_ms_gate,
         }
 
-    def serialize(self, circuit: cirq.AbstractCircuit) -> SerializedProgram:
+    def serialize(self, circuit: cirq.AbstractCircuit, error_mitigation: Optional[dict] = None) -> SerializedProgram:
         """Serialize the given circuit.
 
         Raises:
@@ -97,7 +98,7 @@ class Serializer:
         }
         metadata = self._serialize_measurements(op for op in serialized_ops if op['gate'] == 'meas')
 
-        return SerializedProgram(body=body, metadata=metadata)
+        return SerializedProgram(body=body, metadata=metadata, error_mitigation=error_mitigation)
 
     def _validate_circuit(self, circuit: cirq.AbstractCircuit):
         if len(circuit) == 0:

--- a/cirq-ionq/cirq_ionq/serializer.py
+++ b/cirq-ionq/cirq_ionq/serializer.py
@@ -76,7 +76,9 @@ class Serializer:
             MSGate: self._serialize_ms_gate,
         }
 
-    def serialize(self, circuit: cirq.AbstractCircuit, error_mitigation: Optional[dict] = None) -> SerializedProgram:
+    def serialize(
+        self, circuit: cirq.AbstractCircuit, error_mitigation: Optional[dict] = None
+    ) -> SerializedProgram:
         """Serialize the given circuit.
 
         Raises:

--- a/cirq-ionq/cirq_ionq/service.py
+++ b/cirq-ionq/cirq_ionq/service.py
@@ -107,7 +107,9 @@ class Service:
             A `cirq.Result` for running the circuit.
         """
         resolved_circuit = cirq.resolve_parameters(circuit, param_resolver)
-        result = self.create_job(resolved_circuit, repetitions, name, target, error_mitigation).results()
+        result = self.create_job(
+            resolved_circuit, repetitions, name, target, error_mitigation
+        ).results()
         if isinstance(result, results.QPUResult):
             return result.to_cirq_result(params=cirq.ParamResolver(param_resolver))
         # pylint: disable=unexpected-keyword-arg

--- a/cirq-ionq/cirq_ionq/service_test.py
+++ b/cirq-ionq/cirq_ionq/service_test.py
@@ -39,9 +39,9 @@ def test_service_run(target, expected_results):
         'target': target,
         'metadata': {'shots': '4', 'measurement0': f'a{chr(31)}0'},
         'qubits': '1',
-        'data': {'histogram': {'0': '0.25', '1': '0.75'}},
         'status': 'completed',
     }
+    mock_client.get_results.return_value = {'0': '0.25', '1': '0.75'}
     service._client = mock_client
 
     a = sympy.Symbol('a')
@@ -72,10 +72,10 @@ def test_sampler():
         'qubits': '1',
         'target': 'qpu',
         'metadata': {'shots': 4, 'measurement0': f'a{chr(31)}0'},
-        'data': {'histogram': {'0': '0.25', '1': '0.75'}},
     }
     mock_client.create_job.return_value = job_dict
     mock_client.get_job.return_value = job_dict
+    mock_client.get_results.return_value = {'0': '0.25', '1': '0.75'}
 
     sampler = service.sampler(target='qpu', seed=10)
 
@@ -179,4 +179,4 @@ def test_service_no_param_or_env_variable():
 
 def test_service_no_url_default():
     service = ionq.Service(api_key='tomyheart')
-    assert service.remote_host == 'https://api.ionq.co/v0.1'
+    assert service.remote_host == 'https://api.ionq.co/v0.3'


### PR DESCRIPTION
This new version of the API separates job status and metadata from actual results into two different endpoints.

v0.3 also includes support for error_mitigation settings like symmetrization as described in https://arxiv.org/pdf/2301.07233.pdf

This includes:
- add a new error_mitigation parameter on job submission so users can configure it
- add a new aggregation parameter on results that would allow getting results aggregated under the two different methods described in the paper. Averaging and Plurality voting