### PR TITLE
Fix an error in qvm_stabilizer_example.ipynb

### DIFF
--- a/docs/simulate/qvm_stabilizer_example.ipynb
+++ b/docs/simulate/qvm_stabilizer_example.ipynb
@@ -370,7 +370,7 @@
    "source": [
     "# A labeling function.\n",
     "def fold_func(bits) -> str:\n",
-    "    suffix = \"\".join(map(str, [bits[i][0] for i in range(4)]))\n",
+    "    suffix = \"\".join(map(str, [bits[i][0] for i in range(1,5)]))\n",
     "    return f\"{bits[0][0]}_{suffix}\"\n",
     "\n",
     "\n",


### PR DESCRIPTION
The indexes for keys 'abcd' should be 1~4. The index 0 is for 'meas' key (line 377).