### PR TITLE
Pin Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           node-version: '14.16.1'
+      - name: Check node version
+        run: node -v
       - name: Install npm
         run: check/npm ci
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.16.1'
       - name: Check node version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.16.1'
       - name: Install npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14.16.1'
-      - name: Check node version
-        run: node -v
       - name: Install npm
         run: check/npm ci
       - name: Lint
@@ -361,6 +359,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.16.1'
       - name: Install npm dependencies
@@ -374,6 +373,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '14.16.1'
       - name: Install npm dependencies


### PR DESCRIPTION
The previous Typescript checks were automatically picking the latest version of Node.

Fixes: https://github.com/quantumlib/Cirq/pull/5292#issuecomment-1439113744