### PR TITLE
Simplify dev_tools.notebooks.utils.rewrite_notebook

### DIFF
--- a/dev_tools/notebooks/__init__.py
+++ b/dev_tools/notebooks/__init__.py
@@ -12,4 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import filter_notebooks, list_all_notebooks, rewrite_notebook
+from dev_tools.notebooks.utils import (
+    filter_notebooks,
+    list_all_notebooks,
+    remove_if_temporary_notebook,
+    rewrite_notebook,
+)

--- a/dev_tools/notebooks/__init__.py
+++ b/dev_tools/notebooks/__init__.py
@@ -12,9 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dev_tools.notebooks.utils import (
-    filter_notebooks,
-    list_all_notebooks,
-    remove_if_temporary_notebook,
-    rewrite_notebook,
-)
+from dev_tools.notebooks.utils import filter_notebooks, list_all_notebooks, rewrite_notebook

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -33,7 +33,12 @@ from typing import Set, List
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import list_all_notebooks, filter_notebooks, rewrite_notebook
+from dev_tools.notebooks import (
+    list_all_notebooks,
+    filter_notebooks,
+    rewrite_notebook,
+    remove_if_temporary_notebook,
+)
 
 # these notebooks rely on features that are not released yet
 # after every release we should raise a PR and empty out this list
@@ -208,6 +213,7 @@ papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
             f"instead of `pip install cirq` to this notebook, and exclude it from "
             f"dev_tools/notebooks/isolated_notebook_test.py."
         )
+    remove_if_temporary_notebook(rewritten_notebook_path)
 
 
 @pytest.mark.parametrize("notebook_path", NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES)

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -177,7 +177,7 @@ def test_notebooks_against_released_cirq(partition, notebook_path, cloned_env):
 
     notebook_file = os.path.basename(notebook_path)
 
-    rewritten_notebook_descriptor, rewritten_notebook_path = rewrite_notebook(notebook_path)
+    rewritten_notebook_path = rewrite_notebook(notebook_path)
 
     cmd = f"""
 mkdir -p out/{notebook_rel_dir}
@@ -208,9 +208,6 @@ papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
             f"instead of `pip install cirq` to this notebook, and exclude it from "
             f"dev_tools/notebooks/isolated_notebook_test.py."
         )
-
-    if rewritten_notebook_descriptor:
-        os.close(rewritten_notebook_descriptor)
 
 
 @pytest.mark.parametrize("notebook_path", NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES)

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -33,12 +33,7 @@ from typing import Set, List
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import (
-    list_all_notebooks,
-    filter_notebooks,
-    rewrite_notebook,
-    remove_if_temporary_notebook,
-)
+from dev_tools.notebooks import list_all_notebooks, filter_notebooks, rewrite_notebook
 
 # these notebooks rely on features that are not released yet
 # after every release we should raise a PR and empty out this list
@@ -213,7 +208,7 @@ papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
             f"instead of `pip install cirq` to this notebook, and exclude it from "
             f"dev_tools/notebooks/isolated_notebook_test.py."
         )
-    remove_if_temporary_notebook(rewritten_notebook_path)
+    os.remove(rewritten_notebook_path)
 
 
 @pytest.mark.parametrize("notebook_path", NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -67,7 +67,7 @@ def test_notebooks_against_released_cirq(notebook_path):
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))
     out_path = f"out/{notebook_rel_dir}/{notebook_file[:-6]}.out.ipynb"
-    rewritten_notebook_descriptor, rewritten_notebook_path = rewrite_notebook(notebook_path)
+    rewritten_notebook_path = rewrite_notebook(notebook_path)
     papermill_flags = "--no-request-save-on-cell-execute --autosave-cell-every 0"
     cmd = f"""mkdir -p out/{notebook_rel_dir}
 papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
@@ -83,6 +83,3 @@ papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
             f"notebook (in Github Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs')"
         )
-
-    if rewritten_notebook_descriptor:
-        os.close(rewritten_notebook_descriptor)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,12 +24,7 @@ import os
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import (
-    filter_notebooks,
-    list_all_notebooks,
-    rewrite_notebook,
-    remove_if_temporary_notebook,
-)
+from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_notebook
 
 SKIP_NOTEBOOKS = [
     # skipping vendor notebooks as we don't have auth sorted out
@@ -88,4 +83,4 @@ papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
             f"notebook (in Github Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs')"
         )
-    remove_if_temporary_notebook(rewritten_notebook_path)
+    os.remove(rewritten_notebook_path)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,7 +24,12 @@ import os
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_notebook
+from dev_tools.notebooks import (
+    filter_notebooks,
+    list_all_notebooks,
+    rewrite_notebook,
+    remove_if_temporary_notebook,
+)
 
 SKIP_NOTEBOOKS = [
     # skipping vendor notebooks as we don't have auth sorted out
@@ -83,3 +88,4 @@ papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
             f"notebook (in Github Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs')"
         )
+    remove_if_temporary_notebook(rewritten_notebook_path)

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -105,23 +105,24 @@ def rewrite_notebook(notebook_path):
 
     used_patterns = set()
     with open(notebook_path, 'r') as original_file:
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.ipynb', delete=False) as new_file:
-            new_file_path = new_file.name
-            for line in original_file:
-                new_line = line
-                for pattern, replacement in patterns:
-                    new_line = pattern.sub(replacement, new_line)
-                    if new_line != line:
-                        used_patterns.add(pattern)
-                        break
-                new_file.write(new_line)
+        lines = original_file.readlines()
+    for i, line in enumerate(lines):
+        for pattern, replacement in patterns:
+            new_line = pattern.sub(replacement, line)
+            if new_line != line:
+                lines[i] = new_line
+                used_patterns.add(pattern)
+                break
 
     assert len(patterns) == len(used_patterns), (
         'Not all patterns where used. Patterns not used: '
         f'{set(x for x, _ in patterns) - used_patterns}'
     )
 
-    return new_file_path
+    with tempfile.NamedTemporaryFile(mode='w', suffix='-rewrite.ipynb', delete=False) as new_file:
+        new_file.writelines(lines)
+
+    return new_file.name
 
 
 def remove_if_temporary_notebook(notebook_path: str):

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -120,19 +120,3 @@ def rewrite_notebook(notebook_path):
         new_file.writelines(lines)
 
     return new_file.name
-
-
-def remove_if_temporary_notebook(notebook_path: str):
-    """Delete temporary notebook if written by `rewrite_notebook`.
-
-    Do nothing if the specified notebook is not in the temporary directory
-    or if its filename does not end in '-rewrite.ipynb'
-
-    Use this to safely clean up notebooks created by `rewrite_notebook`.
-    """
-    if (
-        notebook_path.endswith('-rewrite.ipynb')
-        and os.path.isfile(notebook_path)
-        and os.path.dirname(notebook_path) == tempfile.gettempdir()
-    ):
-        os.remove(notebook_path)

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -122,3 +122,19 @@ def rewrite_notebook(notebook_path):
     )
 
     return new_file_path
+
+
+def remove_if_temporary_notebook(notebook_path: str):
+    """Delete temporary notebook if written by `rewrite_notebook`.
+
+    Do nothing if the specified notebook is not in the temporary directory
+    or if its filename does not end in '-rewrite.ipynb'
+
+    Use this to safely clean up notebooks created by `rewrite_notebook`.
+    """
+    if (
+        notebook_path.endswith('-rewrite.ipynb')
+        and os.path.isfile(notebook_path)
+        and os.path.dirname(notebook_path) == tempfile.gettempdir()
+    ):
+        os.remove(notebook_path)

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -82,23 +82,20 @@ def rewrite_notebook(notebook_path):
     It is the responsibility of the caller of this method to delete the new file.
 
     Returns:
-        The file path for the rewritten file.  If no `.tst` file was found,
-        return the input `notebook_path` as the notebook was not changed.
-        Otherwise return a new path created in the temporary directory.
+        The absolute path to the rewritten file in temporary directory.
+        If no `.tst` file exists the new file is a copy of the input notebook.
 
     Raises:
         AssertionError: If there are multiple `->` per line, or not all of the replacements
             are used.
     """
-    notebook_test_path = os.path.splitext(notebook_path)[0] + '.tst'
-    if not os.path.exists(notebook_test_path):
-        return notebook_path
-
     # Get the rewrite rules.
     patterns = []
-    with open(notebook_test_path, 'r') as f:
-        for line in f:
-            if '->' in line:
+    notebook_test_path = os.path.splitext(notebook_path)[0] + '.tst'
+    if os.path.exists(notebook_test_path):
+        with open(notebook_test_path, 'r') as f:
+            pattern_lines = (line for line in f if '->' in line)
+            for line in pattern_lines:
                 parts = line.rstrip().split('->')
                 assert len(parts) == 2, f'Replacement lines may only contain one -> but was {line}'
                 patterns.append((re.compile(parts[0]), parts[1]))

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -37,40 +37,37 @@ def write_test_data(ipynb_txt, tst_txt):
 def test_rewrite_notebook():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3')
 
-    descriptor, path = dt.rewrite_notebook(ipynb_path)
+    path = dt.rewrite_notebook(ipynb_path)
 
     assert path != ipynb_path
     with open(path, 'r') as f:
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 4'
 
-    os.close(descriptor)
     shutil.rmtree(directory)
 
 
 def test_rewrite_notebook_multiple():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\nd = 4->d = 1')
 
-    descriptor, path = dt.rewrite_notebook(ipynb_path)
+    path = dt.rewrite_notebook(ipynb_path)
 
     with open(path, 'r') as f:
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 1'
 
-    os.close(descriptor)
     shutil.rmtree(directory)
 
 
 def test_rewrite_notebook_ignore_non_seperator_lines():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\n# comment')
 
-    descriptor, path = dt.rewrite_notebook(ipynb_path)
+    path = dt.rewrite_notebook(ipynb_path)
 
     with open(path, 'r') as f:
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 4'
 
-    os.close(descriptor)
     shutil.rmtree(directory)
 
 
@@ -80,9 +77,8 @@ def test_rewrite_notebook_no_tst_file():
     with open(ipynb_path, 'w') as f:
         f.write('d = 5\nd = 4')
 
-    descriptor, path = dt.rewrite_notebook(ipynb_path)
+    path = dt.rewrite_notebook(ipynb_path)
 
-    assert descriptor is None
     assert path == ipynb_path
 
     shutil.rmtree(directory)

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -45,8 +45,7 @@ def test_rewrite_notebook():
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 4'
 
-    dt.remove_if_temporary_notebook(path)
-    assert not os.path.exists(path)
+    os.remove(path)
     shutil.rmtree(directory)
 
 
@@ -59,8 +58,7 @@ def test_rewrite_notebook_multiple():
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 1'
 
-    dt.remove_if_temporary_notebook(path)
-    assert not os.path.exists(path)
+    os.remove(path)
     shutil.rmtree(directory)
 
 
@@ -73,8 +71,7 @@ def test_rewrite_notebook_ignore_non_seperator_lines():
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 4'
 
-    dt.remove_if_temporary_notebook(path)
-    assert not os.path.exists(path)
+    os.remove(path)
     shutil.rmtree(directory)
 
 
@@ -88,8 +85,7 @@ def test_rewrite_notebook_no_tst_file():
     assert path != ipynb_path
     assert filecmp.cmp(path, ipynb_path)
 
-    dt.remove_if_temporary_notebook(path)
-
+    os.remove(path)
     shutil.rmtree(directory)
 
 

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -34,7 +34,6 @@ def write_test_data(ipynb_txt, tst_txt):
     return directory, ipynb_path
 
 
-@pytest.mark.xfail(reason='notebook files not cleaned', strict=True)
 def test_rewrite_notebook():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3')
 
@@ -46,10 +45,10 @@ def test_rewrite_notebook():
         assert rewritten == 'd = 3\nd = 4'
 
     shutil.rmtree(directory)
+    dt.remove_if_temporary_notebook(path)
     assert not os.path.exists(path)
 
 
-@pytest.mark.xfail(reason='notebook files not cleaned', strict=True)
 def test_rewrite_notebook_multiple():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\nd = 4->d = 1')
 
@@ -60,10 +59,10 @@ def test_rewrite_notebook_multiple():
         assert rewritten == 'd = 3\nd = 1'
 
     shutil.rmtree(directory)
+    dt.remove_if_temporary_notebook(path)
     assert not os.path.exists(path)
 
 
-@pytest.mark.xfail(reason='notebook files not cleaned', strict=True)
 def test_rewrite_notebook_ignore_non_seperator_lines():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\n# comment')
 
@@ -74,6 +73,7 @@ def test_rewrite_notebook_ignore_non_seperator_lines():
         assert rewritten == 'd = 3\nd = 4'
 
     shutil.rmtree(directory)
+    dt.remove_if_temporary_notebook(path)
     assert not os.path.exists(path)
 
 
@@ -85,9 +85,10 @@ def test_rewrite_notebook_no_tst_file():
 
     path = dt.rewrite_notebook(ipynb_path)
 
+    # verify clean up is skipped when files are not rewritten
     assert path == ipynb_path
-
-    assert os.path.exists(ipynb_path)
+    dt.remove_if_temporary_notebook(path)
+    assert os.path.exists(path)
     shutil.rmtree(directory)
 
 

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import filecmp
 import os
 import shutil
 import tempfile
@@ -84,11 +85,10 @@ def test_rewrite_notebook_no_tst_file():
         f.write('d = 5\nd = 4')
 
     path = dt.rewrite_notebook(ipynb_path)
+    assert path != ipynb_path
+    assert filecmp.cmp(path, ipynb_path)
 
-    # verify clean up is skipped when files are not rewritten
-    assert path == ipynb_path
     dt.remove_if_temporary_notebook(path)
-    assert os.path.exists(path)
 
     shutil.rmtree(directory)
 

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -44,9 +44,9 @@ def test_rewrite_notebook():
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 4'
 
-    shutil.rmtree(directory)
     dt.remove_if_temporary_notebook(path)
     assert not os.path.exists(path)
+    shutil.rmtree(directory)
 
 
 def test_rewrite_notebook_multiple():
@@ -58,9 +58,9 @@ def test_rewrite_notebook_multiple():
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 1'
 
-    shutil.rmtree(directory)
     dt.remove_if_temporary_notebook(path)
     assert not os.path.exists(path)
+    shutil.rmtree(directory)
 
 
 def test_rewrite_notebook_ignore_non_seperator_lines():
@@ -72,9 +72,9 @@ def test_rewrite_notebook_ignore_non_seperator_lines():
         rewritten = f.read()
         assert rewritten == 'd = 3\nd = 4'
 
-    shutil.rmtree(directory)
     dt.remove_if_temporary_notebook(path)
     assert not os.path.exists(path)
+    shutil.rmtree(directory)
 
 
 def test_rewrite_notebook_no_tst_file():
@@ -89,6 +89,7 @@ def test_rewrite_notebook_no_tst_file():
     assert path == ipynb_path
     dt.remove_if_temporary_notebook(path)
     assert os.path.exists(path)
+
     shutil.rmtree(directory)
 
 

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -34,6 +34,7 @@ def write_test_data(ipynb_txt, tst_txt):
     return directory, ipynb_path
 
 
+@pytest.mark.xfail(reason='notebook files not cleaned', strict=True)
 def test_rewrite_notebook():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3')
 
@@ -45,8 +46,10 @@ def test_rewrite_notebook():
         assert rewritten == 'd = 3\nd = 4'
 
     shutil.rmtree(directory)
+    assert not os.path.exists(path)
 
 
+@pytest.mark.xfail(reason='notebook files not cleaned', strict=True)
 def test_rewrite_notebook_multiple():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\nd = 4->d = 1')
 
@@ -57,8 +60,10 @@ def test_rewrite_notebook_multiple():
         assert rewritten == 'd = 3\nd = 1'
 
     shutil.rmtree(directory)
+    assert not os.path.exists(path)
 
 
+@pytest.mark.xfail(reason='notebook files not cleaned', strict=True)
 def test_rewrite_notebook_ignore_non_seperator_lines():
     directory, ipynb_path = write_test_data('d = 5\nd = 4', 'd = 5->d = 3\n# comment')
 
@@ -69,6 +74,7 @@ def test_rewrite_notebook_ignore_non_seperator_lines():
         assert rewritten == 'd = 3\nd = 4'
 
     shutil.rmtree(directory)
+    assert not os.path.exists(path)
 
 
 def test_rewrite_notebook_no_tst_file():
@@ -81,6 +87,7 @@ def test_rewrite_notebook_no_tst_file():
 
     assert path == ipynb_path
 
+    assert os.path.exists(ipynb_path)
     shutil.rmtree(directory)
 
 


### PR DESCRIPTION
Do not return the OS file descriptor as it was only used for
closing that file in `rewrite_notebook` callers.
Return only the filename of the rewritten notebook.
