### PR TITLE
Install recent version of ply in interop.ipynb

### DIFF
--- a/docs/build/interop.ipynb
+++ b/docs/build/interop.ipynb
@@ -206,7 +206,7 @@
    "outputs": [],
    "source": [
     "!pip install --quiet cirq\n",
-    "!pip install --quiet ply==3.4"
+    "!pip install --quiet ply"
    ]
   },
   {


### PR DESCRIPTION
Keep users safe from downgrading their ply package installed with cirq.

Related to #6032
