### PR TITLE
pytest - keep "slow" tests deselected after `-k EXPRESSION`

### DIFF
--- a/dev_tools/conftest.py
+++ b/dev_tools/conftest.py
@@ -31,9 +31,8 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    keywordexpr = config.option.keyword
     markexpr = config.option.markexpr
-    if keywordexpr or markexpr:
+    if markexpr:
         return  # let pytest handle this
 
     skip_slow_marker = pytest.mark.skip(reason='slow marker not selected')


### PR DESCRIPTION
Problem: `pytest -k 'not docker'`  runs notebook tests marked as "slow"

Solution: Check only the mark expression when deciding whether to
run the `slow` tests.
