### PR TITLE
Ensure compatible version of numpy in isolated_notebook_test.py

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -104,6 +104,8 @@ PACKAGES = [
     # https://github.com/networkx/networkx/issues/4718 pinned networkx 2.5.1 to 4.4.2
     # however, jupyter brings in 5.0.6
     'decorator<5',
+    # TODO(#5967): allow numpy-1.24 when it is supported in Cirq and numba
+    'numpy>=1.16,<1.24',
 ]
 
 


### PR DESCRIPTION
Keep numpy version in the isolated Python environment at 1.23 as
numpy-1.24 is incompatible with cirq and numba.

Fixes stuck notebook tests which import numba.

Related to #5967
