### PR TITLE
Fix failing CI after Pandas 2.0 update

### DIFF
--- a/cirq-core/cirq/experiments/xeb_simulation_test.py
+++ b/cirq-core/cirq/experiments/xeb_simulation_test.py
@@ -59,7 +59,7 @@ def test_simulate_circuit_length_validation():
         )
         for _ in range(2)
     ]
-    cycle_depths = np.arange(3, 50, 9)
+    cycle_depths = np.arange(3, 50, 9, dtype=np.int64)
     with pytest.raises(ValueError, match='.*not long enough.*'):
         _ = simulate_2q_xeb_circuits(circuits=circuits, cycle_depths=cycle_depths)
 
@@ -127,7 +127,7 @@ def test_incremental_simulate(multiprocess):
         )
         for _ in range(20)
     ]
-    cycle_depths = np.arange(3, 100, 9)
+    cycle_depths = np.arange(3, 100, 9, dtype=np.int64)
 
     if multiprocess:
         pool = multiprocessing.Pool()


### PR DESCRIPTION
CI is failing on master because pytest on Windows are failing. Upon some digging, it looks like a new release of Pandas 2.0 today broke us. See https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#other-api-changes

My rough guess is that the culprit is "_pandas.testing.assert_index_equal() with parameter exact="equiv" now considers two indexes equal when both are either a RangeIndex or Index with an int64 dtype. Previously it meant either a RangeIndex or a Int64Index (GH51098)_"

I'm not fully sure why it's failing only on Windows but the change is small enough that I feel comfortable unblocking the open PRs without spending more time in investigating the root cause. 
