### PR TITLE
Update cirq.contrib.svg to escape < and > characters

### DIFF
--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -23,6 +23,10 @@ def fixup_text(text: str):
     if '[cirq.VirtualTag()]' in text:
         # https://github.com/quantumlib/Cirq/issues/2905
         return text.replace('[cirq.VirtualTag()]', '')
+    if '<' in text:
+        return text.replace('<', '&lt;')
+    if '>' in text:
+        return text.replace('>', '&gt;')
     return text
 
 

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -69,7 +69,7 @@ def test_gate_with_less_greater_str():
 
     circuit = cirq.Circuit(CustomGate().on(*cirq.LineQubit.range(4)))
     svg = circuit_to_svg(circuit)
-    import IPython.display
+    import IPython.display  # type: ignore
 
     _ = IPython.display.SVG(svg)
     assert '&lt;a' in svg

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -57,3 +57,22 @@ def test_empty_moments():
     svg_2 = circuit_to_svg(cirq.Circuit(cirq.Moment()))
     assert '<svg' in svg_2
     assert '</svg>' in svg_2
+
+
+def test_gate_with_less_greater_str():
+    class CustomGate(cirq.Gate):
+        def _num_qubits_(self) -> int:
+            return 4
+
+        def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
+            return cirq.CircuitDiagramInfo(wire_symbols=['<a', '<=b', '>c', '>=d'])
+
+    circuit = cirq.Circuit(CustomGate().on(*cirq.LineQubit.range(4)))
+    svg = circuit_to_svg(circuit)
+    import IPython.display
+
+    _ = IPython.display.SVG(svg)
+    assert '&lt;a' in svg
+    assert '&lt;=b' in svg
+    assert '&gt;c' in svg
+    assert '&gt;=d' in svg


### PR DESCRIPTION
If we use the symbols `<` or `>` in the circuit diagram of any gate right now, `circuit_to_svg` would result in a string that leads to a parsing error because the less than / greater than symbols are not escaped correctly. 

This PR updates the svg generation logic to correctly escape the `<` and `>` characters. 