### PR TITLE
Escape both `<>` characters in SVG test labels

### DIFF
--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -16,13 +16,9 @@ def fixup_text(text: str):
         # https://github.com/quantumlib/Cirq/issues/4499
         # TODO: Visualize Custom MatrixGate
         return '?'
-    if '[<virtual>]' in text:
-        # https://github.com/quantumlib/Cirq/issues/2905
-        # TODO: escape angle brackets when you actually want to display tags
-        return text.replace('[<virtual>]', '')  # coverage: ignore
-    if '[cirq.VirtualTag()]' in text:
-        # https://github.com/quantumlib/Cirq/issues/2905
-        return text.replace('[cirq.VirtualTag()]', '')
+    # https://github.com/quantumlib/Cirq/issues/2905
+    text = text.replace('[<virtual>]', '')
+    text = text.replace('[cirq.VirtualTag()]', '')
     text = text.replace('<', '&lt;').replace('>', '&gt;')
     return text
 

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -23,10 +23,7 @@ def fixup_text(text: str):
     if '[cirq.VirtualTag()]' in text:
         # https://github.com/quantumlib/Cirq/issues/2905
         return text.replace('[cirq.VirtualTag()]', '')
-    if '<' in text:
-        return text.replace('<', '&lt;')
-    if '>' in text:
-        return text.replace('>', '&gt;')
+    text = text.replace('<', '&lt;').replace('>', '&gt;')
     return text
 
 

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -1,5 +1,5 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-import IPython.display
+import IPython.display  # type: ignore
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -63,7 +63,14 @@ def test_empty_moments():
 
 @pytest.mark.parametrize(
     'symbol,svg_symbol',
-    [('<a', '&lt;a'), ('<=b', '&lt;=b'), ('>c', '&gt;c'), ('>=d', '&gt;=d'), ('>e<', '&gt;e&lt;')],
+    [
+        ('<a', '&lt;a'),
+        ('<=b', '&lt;=b'),
+        ('>c', '&gt;c'),
+        ('>=d', '&gt;=d'),
+        ('>e<', '&gt;e&lt;'),
+        ('A[<virtual>]B[cirq.VirtualTag()]C>D<E', 'ABC&gt;D&lt;E'),
+    ],
 )
 def test_gate_with_less_greater_str(symbol, svg_symbol):
     class CustomGate(cirq.Gate):

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -21,6 +21,7 @@ def test_svg():
             cirq.MatrixGate(np.eye(2)).on(a),
         )
     )
+    assert '?' in svg_text
     assert '<svg' in svg_text
     assert '</svg>' in svg_text
 

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -1,6 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-import pytest
+import IPython.display
 import numpy as np
+import pytest
 
 import cirq
 from cirq.contrib.svg import circuit_to_svg
@@ -59,20 +60,20 @@ def test_empty_moments():
     assert '</svg>' in svg_2
 
 
-def test_gate_with_less_greater_str():
+@pytest.mark.parametrize(
+    'symbol,svg_symbol',
+    [('<a', '&lt;a'), ('<=b', '&lt;=b'), ('>c', '&gt;c'), ('>=d', '&gt;=d'), ('>e<', '&gt;e&lt;')],
+)
+def test_gate_with_less_greater_str(symbol, svg_symbol):
     class CustomGate(cirq.Gate):
         def _num_qubits_(self) -> int:
-            return 4
+            return 1
 
         def _circuit_diagram_info_(self, _) -> cirq.CircuitDiagramInfo:
-            return cirq.CircuitDiagramInfo(wire_symbols=['<a', '<=b', '>c', '>=d'])
+            return cirq.CircuitDiagramInfo(wire_symbols=[symbol])
 
-    circuit = cirq.Circuit(CustomGate().on(*cirq.LineQubit.range(4)))
+    circuit = cirq.Circuit(CustomGate().on(cirq.LineQubit(0)))
     svg = circuit_to_svg(circuit)
-    import IPython.display  # type: ignore
 
     _ = IPython.display.SVG(svg)
-    assert '&lt;a' in svg
-    assert '&lt;=b' in svg
-    assert '&gt;c' in svg
-    assert '&gt;=d' in svg
+    assert svg_symbol in svg


### PR DESCRIPTION
Also parametrize `test_gate_with_less_greater_str` so it is easier to
add checks for more wire symbols later.

