### PR TITLE
Restore weekly cadence for the CI-weekly workflow

### DIFF
--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -3,9 +3,7 @@ name: Continuous Integration - Weekly
 on:
   schedule:
     # Checks out master by default.
-    # TODO (#6037) - replace with weekly cadence after verification
-    - cron: '0 0 * * *'
-    # - cron: '0 0 * * 0'
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: ${{ github.workflow }}

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -228,9 +228,6 @@ def test_all_notebooks_against_released_cirq(partition, notebook_path, cloned_en
     See `test_changed_notebooks_against_released_cirq` for more details on
     notebooks execution.
     """
-    # TODO(#6037,pavoljuhas) - remove after confirming we get error reports from the CI
-    if notebook_path.endswith('/circuits.ipynb'):
-        assert False, 'intentional failure to simulate CI-weekly run with failed test'
     _rewrite_and_run_notebook(notebook_path, cloned_env)
 
 


### PR DESCRIPTION
Also remove the intentional test failure as
it was correctly reported by the CI.

Finalizes #6037
Reverts #6060
