### PR TITLE
Add `Moment.from_ops` to more efficiently construct moments

### DIFF
--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -124,7 +124,7 @@ class Moment:
         results in better performance in cases where the contents of the moment
         are already in the form of a sequence of operations rather than an
         arbitrary OP_TREE.
-        
+
         Args:
             *ops: Operations to include in the Moment.
         """

--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -118,6 +118,16 @@ class Moment:
 
     @classmethod
     def from_ops(cls, *ops: 'cirq.Operation') -> 'cirq.Moment':
+        """Construct a Moment from the given operations.
+
+        This avoids calling `flatten_to_ops` in the moment constructor, which
+        results in better performance in cases where the contents of the moment
+        are already in the form of a sequence of operations rather than an
+        arbitrary OP_TREE.
+        
+        Args:
+            *ops: Operations to include in the Moment.
+        """
         return cls(*ops, _flatten_contents=False)
 
     @property
@@ -178,7 +188,7 @@ class Moment:
             raise ValueError(f'Overlapping operations: {operation}')
 
         # Use private variables to facilitate a quick copy.
-        m = Moment()
+        m = Moment(_flatten_contents=False)
         m._operations = self._operations + (operation,)
         m._sorted_operations = None
         m._qubits = self._qubits.union(operation.qubits)
@@ -208,7 +218,7 @@ class Moment:
         if not flattened_contents:
             return self
 
-        m = Moment()
+        m = Moment(_flatten_contents=False)
         # Use private variables to facilitate a quick copy.
         m._qubit_to_op = self._qubit_to_op.copy()
         qubits = set(self._qubits)
@@ -497,7 +507,7 @@ class Moment:
 
     @classmethod
     def _from_json_dict_(cls, operations, **kwargs):
-        return Moment(operations)
+        return cls.from_ops(*operations)
 
     def __add__(self, other: 'cirq.OP_TREE') -> 'cirq.Moment':
 

--- a/cirq-core/cirq/circuits/moment_test.py
+++ b/cirq-core/cirq/circuits/moment_test.py
@@ -170,6 +170,13 @@ def test_operation_at():
     assert cirq.Moment([cirq.CZ(a, b), cirq.X(c)]).operation_at(a) == cirq.CZ(a, b)
 
 
+def test_from_ops():
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+
+    assert cirq.Moment.from_ops(cirq.X(a), cirq.Y(b)) == cirq.Moment(cirq.X(a), cirq.Y(b))
+
+
 def test_with_operation():
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')


### PR DESCRIPTION
This adds a new classmethod `cirq.Moment.from_ops` for constructing a moment from operations without calling `flatten_to_ops`. This can save a significant amount of time in workloads that construct a lot of circuits. For example, in one internal benchmark we spend almost 3% of the total runtime in the `cirq.Moment` construct (20s out of 676s total).

This also adds functions `cirq.m` and `cirq.c` as shorthands for `cirq.Moment.from_ops` and `cirq.FrozenCircuit.from_moments`, repsectively. These are similar to the `cirq.q` helper for constructing qubit types (https://github.com/quantumlib/Cirq/pull/5181) while trying to guide users to use cirq in the most performant way: avoiding the `OP_TREE` overhead associated with the default moment and circuit constructors, and preferring `FrozenCircuit` which is immutable and so can cache computed properties of the circuit. These single-letter aliases may be more controversial, but I thought I'd at least propose them. They could also be split out from this PR because I think `cirq.Moment.from_ops` is useful even without the helper functions.