### PR TITLE
Fix Default InsertStrategy in Circuits Notebook

### DIFF
--- a/docs/build/circuits.ipynb
+++ b/docs/build/circuits.ipynb
@@ -292,7 +292,7 @@
     "id": "OQX8FTMyAwCw"
    },
    "source": [
-    "This has again created two `Moment` objects. How did `Circuit` know how to do this? The `Circuit.append` method (and its cousin, `Circuit.insert`) both take an argument called `strategy` of type `cirq.InsertStrategy`. By default, `InsertStrategy` is `InsertStrategy.NEW_THEN_INLINE`."
+    "This has again created two `Moment` objects. How did `Circuit` know how to do this? The `Circuit.append` method (and its cousin, `Circuit.insert`) both take an argument called `strategy` of type `cirq.InsertStrategy`. By default, `InsertStrategy` is `InsertStrategy.EARLIEST`."
    ]
   },
   {


### PR DESCRIPTION
Minor fix in Circuits notebook.

According to both the [reference docs](https://quantumai.google/reference/python/cirq/Circuit#append) and [source](https://github.com/quantumlib/Cirq/blob/v1.1.0/cirq-core/cirq/circuits/circuit.py#L2368-L2381), the default InsertStrategy is EARLIEST.