### PR TITLE
Remove deprecated argument of pyplot.stem

### DIFF
--- a/docs/experiments/fourier_checking.ipynb
+++ b/docs/experiments/fourier_checking.ipynb
@@ -615,8 +615,8 @@
     "print(f\"gs: {list(gs)}\")\n",
     "print(f'Correlation: {correlation} Forrelation: {forrelation}')\n",
     "plt.figure(figsize=(15, 5))\n",
-    "plt.stem(fs, use_line_collection=True)\n",
-    "plt.stem(gs, linefmt='--r', markerfmt='ro', use_line_collection=True)\n",
+    "plt.stem(fs)\n",
+    "plt.stem(gs, linefmt='--r', markerfmt='ro')\n",
     "plt.title(f\"Two distributions from F set\")\n",
     "\n",
     "print('')\n",
@@ -627,8 +627,8 @@
     "print(f'Correlation: {correlation} Forrelation: {forrelation}')\n",
     "\n",
     "plt.figure(figsize=(15, 5))\n",
-    "plt.stem(fs, use_line_collection=True)\n",
-    "plt.stem(gs, linefmt='--r', markerfmt='ro', use_line_collection=True)\n",
+    "plt.stem(fs)\n",
+    "plt.stem(gs, linefmt='--r', markerfmt='ro')\n",
     "_ = plt.title(f\"Two distributions from U set\")\n"
    ]
   },


### PR DESCRIPTION
`use_line_collection` is deprecated and defaults to `True` anyway.
Prevent deprecation messages from showing up at
https://quantumai.google/cirq/experiments/fourier_checking
