### PR TITLE
Keep up with quimb-1.5.0

### DIFF
--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -177,6 +177,8 @@ def tensor_expectation_value(
     if ram_gb > max_ram_gb:
         raise MemoryError(f"We estimate that this contraction will take too much RAM! {ram_gb} GB")
     e_val = tn.contract(inplace=True)
+    if isinstance(e_val, qtn.TensorNetwork):
+        e_val = e_val.item()
     assert e_val.imag < tol
     assert cast(complex, pauli_string.coefficient).imag < tol
     return e_val.real * pauli_string.coefficient

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -62,6 +62,9 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
 # By default all notebooks should be tested, however, this list contains exceptions to the rule
 # please always add a reason for skipping.
 SKIP_NOTEBOOKS = [
+    # TODO(#6088) - enable notebooks below
+    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
+    # End of TODO(#6088)
     # skipping vendor notebooks as we don't have auth sorted out
     "**/aqt/*.ipynb",
     "**/azure-quantum/*.ipynb",

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -29,6 +29,9 @@ from dev_tools import shell_tools
 from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_notebook
 
 SKIP_NOTEBOOKS = [
+    # TODO(#6088) - enable notebooks below
+    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
+    # End of TODO(#6088)
     # skipping vendor notebooks as we don't have auth sorted out
     '**/aqt/*.ipynb',
     '**/azure-quantum/*.ipynb',

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -84,7 +84,7 @@ def env_with_temporary_pip_target():
 
 @pytest.mark.slow
 @pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
-def test_notebooks_against_released_cirq(
+def test_notebooks_against_cirq_head(
     notebook_path, require_packages_not_changed, env_with_temporary_pip_target
 ):
     """Test that jupyter notebooks execute.

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -73,8 +73,11 @@ def require_packages_not_changed():
 def env_with_temporary_pip_target():
     """Setup system environment that tells pip to install packages to a temporary directory."""
     with tempfile.TemporaryDirectory(suffix='-notebook-site-packages') as tmpdirname:
+        # Note: We need to append the PYTHONPATH here so that development Cirq,
+        # if configured by dev_tools/pypath, would remain the active Cirq even
+        # if some notebook executes `!pip install cirq`
         pythonpath = (
-            f'{tmpdirname}{os.pathsep}{os.environ["PYTHONPATH"]}'
+            f'{os.environ["PYTHONPATH"]}{os.pathsep}{tmpdirname}'
             if 'PYTHONPATH' in os.environ
             else tmpdirname
         )

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -73,9 +73,10 @@ def require_packages_not_changed():
 def env_with_temporary_pip_target():
     """Setup system environment that tells pip to install packages to a temporary directory."""
     with tempfile.TemporaryDirectory(suffix='-notebook-site-packages') as tmpdirname:
-        # Note: We need to append the PYTHONPATH here so that development Cirq,
-        # if configured by dev_tools/pypath, would remain the active Cirq even
-        # if some notebook executes `!pip install cirq`
+        # Note: We need to append tmpdirname to the PYTHONPATH, because PYTHONPATH may
+        # already point to the development sources of Cirq (as happens with check/pytest).
+        # Should some notebook pip-install a stable version of Cirq to tmpdirname,
+        # it would appear in PYTHONPATH after the development Cirq.
         pythonpath = (
             f'{os.environ["PYTHONPATH"]}{os.pathsep}{tmpdirname}'
             if 'PYTHONPATH' in os.environ

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -29,9 +29,6 @@ from dev_tools import shell_tools
 from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_notebook
 
 SKIP_NOTEBOOKS = [
-    # TODO(#6088) - enable notebooks below
-    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
-    # End of TODO(#6088)
     # skipping vendor notebooks as we don't have auth sorted out
     '**/aqt/*.ipynb',
     '**/azure-quantum/*.ipynb',


### PR DESCRIPTION
As of quimb-1.5.0 `TensorNetwork.contract(inplace=True)` returns
TensorNetwork instead of scalar.  Convert to scalar if needed.
