### PR TITLE
GridDevice serialization refactor

### DIFF
--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -502,7 +502,7 @@ class GridDevice(cirq.Device):
         return out
 
     @classmethod
-    def from_device_information(
+    def _from_device_information(
         cls,
         *,
         qubit_pairs: Collection[Tuple[cirq.GridQubit, cirq.GridQubit]],
@@ -510,6 +510,8 @@ class GridDevice(cirq.Device):
         gate_durations: Optional[Mapping['cirq.GateFamily', 'cirq.Duration']] = None,
     ) -> 'GridDevice':
         """Constructs a GridDevice using the device information provided.
+
+        EXPERIMENTAL: this method may have changes which are not backward compatible in the future.
 
         This is a convenience method for constructing a GridDevice given partial gateset and
         gate_duration information: for every distinct gate, only one representation needs to be in

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -231,8 +231,8 @@ def _serialize_gateset_and_gate_durations(
         }
         if len(gate_durations_picos) > 1:
             raise ValueError(
-                'Multiple gate families in the following list exist in the gate duration dict,'
-                f' and they are expected to have the same duration value: {gate_rep.serializable_forms}'
+                'Multiple gate families in the following list exist in the gate duration dict, and '
+                f'they are expected to have the same duration value: {gate_rep.serializable_forms}'
             )
         elif len(gate_durations_picos) == 1:
             gate_spec.gate_duration_picos = gate_durations_picos.pop()

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -426,7 +426,7 @@ class GridDevice(cirq.Device):
         """Creates a GridDevice object.
 
         This constructor should not be used directly outside the class implementation. Use
-        `from_proto()` or `from_device_information()` instead.
+        `from_proto()` instead.
         """
         self._metadata = metadata
 

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -134,7 +134,12 @@ _GATES: List[_GateRepresentations] = [
 
 
 def _in_or_equals(g: GateOrFamily, gate_family: cirq.GateFamily):
-    return (isinstance(g, cirq.GateFamily) and g == gate_family) or g in gate_family
+    if isinstance(g, cirq.GateFamily):
+        return g == gate_family
+    elif isinstance(g, cirq.Gate):
+        return g in gate_family
+    else:  # Gate type
+        return cirq.GateFamily(g) == gate_family
 
 
 def _validate_device_specification(proto: v2.device_pb2.DeviceSpecification) -> None:
@@ -469,8 +474,10 @@ class GridDevice(cirq.Device):
             DeviceSpecification.
         """
         qubits = self._metadata.qubit_set
-        pairs: List[Tuple[cirq.GridQubit, cirq.GridQubit]] = [
-            tuple(sorted(pair)) for pair in self._metadata.qubit_pairs
+        unordered_pairs = [tuple(pair_set) for pair_set in self._metadata.qubit_pairs]
+        pairs = [
+            (pair[0], pair[1]) if pair[0] <= pair[1] else (pair[1], pair[0])
+            for pair in unordered_pairs
         ]
         gateset = self._metadata.gateset
         gate_durations = self._metadata.gate_durations

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -148,15 +148,6 @@ _GATES: List[_GateRepresentations] = [
 ]
 
 
-def _in_or_equals(g: GateOrFamily, gate_family: cirq.GateFamily):
-    if isinstance(g, cirq.GateFamily):
-        return g == gate_family
-    elif isinstance(g, cirq.Gate):
-        return g in gate_family
-    else:  # Gate type
-        return cirq.GateFamily(g) == gate_family
-
-
 def _validate_device_specification(proto: v2.device_pb2.DeviceSpecification) -> None:
     """Raises a ValueError if the `DeviceSpecification` proto is invalid."""
 
@@ -213,8 +204,7 @@ def _serialize_gateset_and_gate_durations(
     for gate_family in gateset.gates:
         gate_spec = v2.device_pb2.GateSpecification()
         gate_rep = next(
-            (gr for gr in _GATES for gf in gr.serializable_forms if _in_or_equals(gate_family, gf)),
-            None,
+            (gr for gr in _GATES for gf in gr.serializable_forms if gf == gate_family), None
         )
         if gate_rep is None:
             raise ValueError(f'Unrecognized gate: {gate_family}.')

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -17,7 +17,6 @@ from typing import Dict, List, Tuple
 
 import unittest.mock as mock
 import pytest
-from google.protobuf import text_format
 
 import cirq
 import cirq_google
@@ -440,6 +439,107 @@ def test_grid_device_repr_pretty(cycle, func):
     printer.text.assert_called_once_with(func(device))
 
 
+def test_device_from_device_information_equals_device_from_proto():
+    device_info, spec = _create_device_spec_with_horizontal_couplings()
+
+    # The set of gates in gate_durations are consistent with what's generated in
+    # _create_device_spec_with_horizontal_couplings()
+    base_duration = cirq.Duration(picos=1_000)
+    gate_durations = {
+        cirq.GateFamily(cirq_google.SYC): base_duration * 0,
+        cirq.GateFamily(cirq.SQRT_ISWAP): base_duration * 1,
+        cirq.GateFamily(cirq.SQRT_ISWAP_INV): base_duration * 2,
+        cirq.GateFamily(cirq.CZ): base_duration * 3,
+        cirq.GateFamily(cirq.ops.phased_x_z_gate.PhasedXZGate): base_duration * 4,
+        cirq.GateFamily(
+            cirq.ops.common_gates.ZPowGate, tags_to_ignore=[cirq_google.PhysicalZTag()]
+        ): base_duration
+        * 5,
+        cirq.GateFamily(
+            cirq.ops.common_gates.ZPowGate, tags_to_accept=[cirq_google.PhysicalZTag()]
+        ): base_duration
+        * 6,
+        cirq.GateFamily(cirq_google.experimental.ops.coupler_pulse.CouplerPulse): base_duration * 7,
+        cirq.GateFamily(cirq.ops.measurement_gate.MeasurementGate): base_duration * 8,
+        cirq.GateFamily(cirq.ops.wait_gate.WaitGate): base_duration * 9,
+    }
+
+    device_from_information = cirq_google.GridDevice.from_device_information(
+        qubit_pairs=device_info.qubit_pairs,
+        gateset=cirq.Gateset(*gate_durations.keys()),
+        gate_durations=gate_durations,
+    )
+
+    assert device_from_information == cirq_google.GridDevice.from_proto(spec)
+
+
+@pytest.mark.parametrize(
+    'error_match, qubit_pairs, gateset, gate_durations',
+    [
+        (
+            'Self loop encountered in qubit',
+            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 0))],
+            cirq.Gateset(),
+            None,
+        ),
+        (
+            'Unrecognized gate',
+            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
+            cirq.Gateset(cirq.H),
+            None,
+        ),
+        (
+            'Some gate_durations keys are not found in gateset',
+            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
+            cirq.Gateset(cirq.CZ),
+            {cirq.GateFamily(cirq.SQRT_ISWAP): cirq.Duration(picos=1_000)},
+        ),
+        (
+            'Multiple gate families .* expected to have the same duration value',
+            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
+            cirq.Gateset(cirq.PhasedXZGate, cirq.XPowGate),
+            {
+                cirq.GateFamily(cirq.PhasedXZGate): cirq.Duration(picos=1_000),
+                cirq.GateFamily(cirq.XPowGate): cirq.Duration(picos=2_000),
+            },
+        ),
+    ],
+)
+def test_from_device_information_invalid_input(error_match, qubit_pairs, gateset, gate_durations):
+    with pytest.raises(ValueError, match=error_match):
+        grid_device.GridDevice.from_device_information(
+            qubit_pairs=qubit_pairs, gateset=gateset, gate_durations=gate_durations
+        )
+
+
+def test_from_device_information_fsim_gate_family():
+    """Verifies that FSimGateFamilies are recognized correctly."""
+
+    gateset = cirq.Gateset(
+        cirq_google.FSimGateFamily(gates_to_accept=[cirq_google.SYC]),
+        cirq_google.FSimGateFamily(gates_to_accept=[cirq.SQRT_ISWAP]),
+        cirq_google.FSimGateFamily(gates_to_accept=[cirq.SQRT_ISWAP_INV]),
+        cirq_google.FSimGateFamily(gates_to_accept=[cirq.CZ]),
+    )
+
+    device = grid_device.GridDevice.from_device_information(
+        qubit_pairs=[(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))], gateset=gateset
+    )
+
+    assert gateset.gates.issubset(device.metadata.gateset.gates)
+
+
+def test_from_device_information_empty():
+    device = grid_device.GridDevice.from_device_information(
+        qubit_pairs=[], gateset=cirq.Gateset(), gate_durations=None
+    )
+
+    assert len(device.metadata.qubit_set) == 0
+    assert len(device.metadata.qubit_pairs) == 0
+    assert device.metadata.gateset == cirq.Gateset()
+    assert device.metadata.gate_durations is None
+
+
 def test_to_proto():
     device_info, expected_spec = _create_device_spec_with_horizontal_couplings()
 
@@ -465,82 +565,12 @@ def test_to_proto():
         cirq.GateFamily(cirq.ops.wait_gate.WaitGate): base_duration * 9,
     }
 
-    spec = grid_device._create_device_specification_proto(
-        qubits=device_info.grid_qubits,
-        pairs=device_info.qubit_pairs,
+    spec = cirq_google.GridDevice.from_device_information(
+        qubit_pairs=device_info.qubit_pairs,
         gateset=cirq.Gateset(*gate_durations.keys()),
         gate_durations=gate_durations,
+    ).to_proto()
+
+    assert cirq_google.GridDevice.from_proto(spec) == cirq_google.GridDevice.from_proto(
+        expected_spec
     )
-
-    assert text_format.MessageToString(spec) == text_format.MessageToString(expected_spec)
-
-
-@pytest.mark.parametrize(
-    'error_match, qubits, qubit_pairs, gateset, gate_durations',
-    [
-        (
-            'Gate durations contain keys which are not part of the gateset',
-            [cirq.GridQubit(0, 0)],
-            [],
-            cirq.Gateset(cirq.CZ),
-            {cirq.GateFamily(cirq.SQRT_ISWAP): 1_000},
-        ),
-        ('not in the GridQubit form', [cirq.NamedQubit('q0_0')], [], cirq.Gateset(), None),
-        (
-            'valid_targets contain .* which is not in valid_qubits',
-            [cirq.GridQubit(0, 0)],
-            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
-            cirq.Gateset(),
-            None,
-        ),
-        (
-            'has a target which contains repeated qubits',
-            [cirq.GridQubit(0, 0)],
-            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 0))],
-            cirq.Gateset(),
-            None,
-        ),
-        ('Unrecognized gate', [cirq.GridQubit(0, 0)], [], cirq.Gateset(cirq.H), None),
-    ],
-)
-def test_to_proto_invalid_input(error_match, qubits, qubit_pairs, gateset, gate_durations):
-    with pytest.raises(ValueError, match=error_match):
-        grid_device._create_device_specification_proto(
-            qubits=qubits, pairs=qubit_pairs, gateset=gateset, gate_durations=gate_durations
-        )
-
-
-def test_to_proto_empty():
-    spec = grid_device._create_device_specification_proto(
-        # Qubits are always expected to be set
-        qubits=[cirq.GridQubit(0, i) for i in range(5)],
-        pairs=[],
-        gateset=cirq.Gateset(),
-        gate_durations=None,
-    )
-    device = cirq_google.GridDevice.from_proto(spec)
-
-    assert len(device.metadata.qubit_set) == 5
-    assert len(device.metadata.qubit_pairs) == 0
-    assert device.metadata.gateset == cirq.Gateset()
-    assert device.metadata.gate_durations is None
-
-
-def test_to_proto_fsim_gate_family():
-    """Verifies that FSimGateFamilies are serialized correctly."""
-
-    gateset = cirq.Gateset(
-        cirq_google.FSimGateFamily(gates_to_accept=[cirq_google.SYC]),
-        cirq_google.FSimGateFamily(gates_to_accept=[cirq.SQRT_ISWAP]),
-        cirq_google.FSimGateFamily(gates_to_accept=[cirq.SQRT_ISWAP_INV]),
-        cirq_google.FSimGateFamily(gates_to_accept=[cirq.CZ]),
-    )
-
-    spec = grid_device._create_device_specification_proto(
-        qubits=[cirq.GridQubit(0, 0)], pairs=(), gateset=gateset
-    )
-
-    assert any(gate_spec.HasField('syc') for gate_spec in spec.valid_gates)
-    assert any(gate_spec.HasField('sqrt_iswap') for gate_spec in spec.valid_gates)
-    assert any(gate_spec.HasField('sqrt_iswap_inv') for gate_spec in spec.valid_gates)
-    assert any(gate_spec.HasField('cz') for gate_spec in spec.valid_gates)

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -442,8 +442,25 @@ def test_grid_device_repr_pretty(cycle, func):
 def test_device_from_device_information_equals_device_from_proto():
     device_info, spec = _create_device_spec_with_horizontal_couplings()
 
-    # The set of gates in gate_durations are consistent with what's generated in
+    # The set of gates in gateset and gate durations are consistent with what's generated in
     # _create_device_spec_with_horizontal_couplings()
+    gateset = cirq.Gateset(
+        cirq_google.SYC,
+        cirq.SQRT_ISWAP,
+        cirq.SQRT_ISWAP_INV,
+        cirq.CZ,
+        cirq.ops.phased_x_z_gate.PhasedXZGate,
+        cirq.GateFamily(
+            cirq.ops.common_gates.ZPowGate, tags_to_ignore=[cirq_google.PhysicalZTag()]
+        ),
+        cirq.GateFamily(
+            cirq.ops.common_gates.ZPowGate, tags_to_accept=[cirq_google.PhysicalZTag()]
+        ),
+        cirq_google.experimental.ops.coupler_pulse.CouplerPulse,
+        cirq.ops.measurement_gate.MeasurementGate,
+        cirq.ops.wait_gate.WaitGate,
+    )
+
     base_duration = cirq.Duration(picos=1_000)
     gate_durations = {
         cirq.GateFamily(cirq_google.SYC): base_duration * 0,
@@ -465,9 +482,7 @@ def test_device_from_device_information_equals_device_from_proto():
     }
 
     device_from_information = cirq_google.GridDevice.from_device_information(
-        qubit_pairs=device_info.qubit_pairs,
-        gateset=cirq.Gateset(*gate_durations.keys()),
-        gate_durations=gate_durations,
+        qubit_pairs=device_info.qubit_pairs, gateset=gateset, gate_durations=gate_durations
     )
 
     assert device_from_information == cirq_google.GridDevice.from_proto(spec)

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -481,7 +481,7 @@ def test_device_from_device_information_equals_device_from_proto():
         cirq.GateFamily(cirq.ops.wait_gate.WaitGate): base_duration * 9,
     }
 
-    device_from_information = cirq_google.GridDevice.from_device_information(
+    device_from_information = cirq_google.GridDevice._from_device_information(
         qubit_pairs=device_info.qubit_pairs, gateset=gateset, gate_durations=gate_durations
     )
 
@@ -522,7 +522,7 @@ def test_device_from_device_information_equals_device_from_proto():
 )
 def test_from_device_information_invalid_input(error_match, qubit_pairs, gateset, gate_durations):
     with pytest.raises(ValueError, match=error_match):
-        grid_device.GridDevice.from_device_information(
+        grid_device.GridDevice._from_device_information(
             qubit_pairs=qubit_pairs, gateset=gateset, gate_durations=gate_durations
         )
 
@@ -537,7 +537,7 @@ def test_from_device_information_fsim_gate_family():
         cirq_google.FSimGateFamily(gates_to_accept=[cirq.CZ]),
     )
 
-    device = grid_device.GridDevice.from_device_information(
+    device = grid_device.GridDevice._from_device_information(
         qubit_pairs=[(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))], gateset=gateset
     )
 
@@ -545,7 +545,7 @@ def test_from_device_information_fsim_gate_family():
 
 
 def test_from_device_information_empty():
-    device = grid_device.GridDevice.from_device_information(
+    device = grid_device.GridDevice._from_device_information(
         qubit_pairs=[], gateset=cirq.Gateset(), gate_durations=None
     )
 
@@ -580,7 +580,7 @@ def test_to_proto():
         cirq.GateFamily(cirq.ops.wait_gate.WaitGate): base_duration * 9,
     }
 
-    spec = cirq_google.GridDevice.from_device_information(
+    spec = cirq_google.GridDevice._from_device_information(
         qubit_pairs=device_info.qubit_pairs,
         gateset=cirq.Gateset(*gate_durations.keys()),
         gate_durations=gate_durations,

--- a/cirq-google/cirq_google/devices/known_devices.py
+++ b/cirq-google/cirq_google/devices/known_devices.py
@@ -79,7 +79,7 @@ def _create_grid_device_from_diagram(
             if neighbor > qubit and neighbor in qubit_set:
                 pairs.append((qubit, cast(cirq.GridQubit, neighbor)))
 
-    return grid_device.GridDevice.from_device_information(
+    return grid_device.GridDevice._from_device_information(
         qubit_pairs=pairs, gateset=gateset, gate_durations=gate_durations
     )
 

--- a/cirq-google/cirq_google/devices/known_devices.py
+++ b/cirq-google/cirq_google/devices/known_devices.py
@@ -57,7 +57,6 @@ def _create_grid_device_from_diagram(
     ascii_grid: str,
     gateset: cirq.Gateset,
     gate_durations: Optional[Dict['cirq.GateFamily', 'cirq.Duration']] = None,
-    out: Optional[device_pb2.DeviceSpecification] = None,
 ) -> grid_device.GridDevice:
     """Parse ASCIIart device layout into a GridDevice instance.
 
@@ -80,10 +79,9 @@ def _create_grid_device_from_diagram(
             if neighbor > qubit and neighbor in qubit_set:
                 pairs.append((qubit, cast(cirq.GridQubit, neighbor)))
 
-    device_specification = grid_device._create_device_specification_proto(
-        qubits=qubits, pairs=pairs, gateset=gateset, gate_durations=gate_durations, out=out
+    return grid_device.GridDevice.from_device_information(
+        qubit_pairs=pairs, gateset=gateset, gate_durations=gate_durations
     )
-    return grid_device.GridDevice.from_proto(device_specification)
 
 
 def populate_qubits_in_device_proto(


### PR DESCRIPTION
This refactor adds the `to_proto()` method to serialize `GridDevice` into `DeviceSpecification`. The convenience method to create a `DeviceSpecification` from partial gateset information, `_create_device_specification_proto()`, is also reimplemented as `GridDevice.from_device_information()` and returns a `GridDevice` instead. These features makes using server-side GridDevice viable - Server-side and client-side GridDevice instances should now be identical.

In addition, gateset serialization and deserialization mappings are reorganized into a shared data structure.

cc @maffoo @pavoljuhas 