### PR TITLE
[WIP] support qubit managers in cirq.decompose

### DIFF
--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -42,6 +42,8 @@ from cirq.type_workarounds import NotImplementedType
 if TYPE_CHECKING:
     import cirq
 
+TQubitManager = TypeVar('TQubitManager')
+
 
 @value.value_equality(approximate=True)
 class GateOperation(raw_types.Operation):
@@ -161,6 +163,11 @@ class GateOperation(raw_types.Operation):
 
     def _decompose_(self) -> 'cirq.OP_TREE':
         return protocols.decompose_once_with_qubits(self.gate, self.qubits, NotImplemented)
+
+    def _decompose_with_qubit_manager_(self, qubit_manager: TQubitManager) -> 'cirq.OP_TREE':
+        return protocols.decompose_once_with_qubits(
+            self.gate, self.qubits, NotImplemented, qubit_manager=qubit_manager
+        )
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
         getter = getattr(self.gate, '_pauli_expansion_', None)

--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -42,6 +42,8 @@ TDefault = TypeVar('TDefault')
 
 TError = TypeVar('TError', bound=Exception)
 
+TQubitManager = TypeVar('TQubitManager')
+
 RaiseTypeErrorIfNotProvided: Any = ([],)
 
 DecomposeResult = Union[None, NotImplementedType, 'cirq.OP_TREE']
@@ -138,7 +140,7 @@ def decompose(
         None, Exception, Callable[['cirq.Operation'], Optional[Exception]]
     ] = _value_error_describing_bad_operation,
     preserve_structure: bool = False,
-    qubit_manager: Optional['cirq.QubitManager'] = None,
+    qubit_manager: Optional[TQubitManager] = None,
 ) -> List['cirq.Operation']:
     """Recursively decomposes a value into `cirq.Operation`s meeting a criteria.
 
@@ -273,7 +275,7 @@ def decompose_once(
     val: Any,
     default=RaiseTypeErrorIfNotProvided,
     *args,
-    qubit_manager: Optional['cirq.QubitManager'] = None,
+    qubit_manager: Optional[TQubitManager] = None,
     **kwargs,
 ):
     """Decomposes a value into operations, if possible.
@@ -344,7 +346,7 @@ def decompose_once_with_qubits(
     val: Any,
     qubits: Iterable['cirq.Qid'],
     default=RaiseTypeErrorIfNotProvided,
-    qubit_manager: Optional['cirq.QubitManager'] = None,
+    qubit_manager: Optional[TQubitManager] = None,
 ):
     """Decomposes a value into operations on the given qubits.
 
@@ -417,7 +419,7 @@ def _decompose_preserving_structure(
     on_stuck_raise: Union[
         None, Exception, Callable[['cirq.Operation'], Optional[Exception]]
     ] = _value_error_describing_bad_operation,
-    qubit_manager: Optional['cirq.QubitManager'] = None,
+    qubit_manager: Optional[TQubitManager] = None,
 ) -> List['cirq.Operation']:
     """Preserves structure (e.g. subcircuits) while decomposing ops.
 

--- a/cirq-core/cirq/protocols/decompose_protocol_test.py
+++ b/cirq-core/cirq/protocols/decompose_protocol_test.py
@@ -308,3 +308,23 @@ def test_decompose_tagged_operation():
         'tag',
     )
     assert cirq.decompose_once(op) == cirq.decompose_once(op.untagged)
+
+
+class GateThatSupportsQubitManager(cirq.Gate):
+    def _num_qubits_(self):
+        ...
+
+    def _qid_shape_(self):
+        return (2,)
+
+    def num_qubit(self):
+        ...
+
+    def _decompose_with_qubit_manager_(self, qubits, qubit_manager):
+        return [cirq.X(qubits[0])]
+
+
+def test_decompose_with_qubit_manager():
+    q = cirq.NamedQubit('used_with_qm')
+    op = GateThatSupportsQubitManager().on(q)
+    assert cirq.decompose(op) == [cirq.X(q)]


### PR DESCRIPTION
This PR adds support for using a qubit manager in `cirq.decompose` through a new class method `_decompose_with_qubit_manager_`.  


Related to #6040 and  #6081