### PR TITLE
Add metadata to sweeps

### DIFF
--- a/cirq-core/cirq/protocols/json_test_data/Linspace.json
+++ b/cirq-core/cirq/protocols/json_test_data/Linspace.json
@@ -1,7 +1,20 @@
-{
-  "cirq_type": "Linspace",
-  "key": "a",
-  "start": 0,
-  "stop": 1,
-  "length": 4
-}
+[
+    {
+      "cirq_type": "Linspace",
+      "key": "a",
+      "start": 0,
+      "stop": 1,
+      "length": 4
+    },
+    {
+      "cirq_type": "Linspace",
+      "key": "b",
+      "start": 1,
+      "stop": 2,
+      "length": 3,
+      "metadata": {
+              "cirq_type": "NamedQubit",
+              "name": "b"
+      }
+    }
+]

--- a/cirq-core/cirq/protocols/json_test_data/Linspace.repr
+++ b/cirq-core/cirq/protocols/json_test_data/Linspace.repr
@@ -1,1 +1,4 @@
-cirq.Linspace("a", start=0, stop=1, length=4)
+[
+    cirq.Linspace("a", start=0, stop=1, length=4),
+    cirq.Linspace("b", start=1, stop=2, length=3, metadata=cirq.NamedQubit("b"))
+]

--- a/cirq-core/cirq/protocols/json_test_data/Points.json
+++ b/cirq-core/cirq/protocols/json_test_data/Points.json
@@ -1,8 +1,19 @@
-{
-  "cirq_type": "Points",
-  "key": "a",
-  "points": [
-    0,
-    0.4
-  ]
-}
+[
+    {
+      "cirq_type": "Points",
+      "key": "a",
+      "points": [
+        0,
+        0.4
+      ]
+    },
+    {
+      "cirq_type": "Points",
+      "key": "amp",
+      "points": [
+        0,
+        1
+      ],
+      "metadata": "used to turn amp on or off"
+    }
+]

--- a/cirq-core/cirq/protocols/json_test_data/Points.repr
+++ b/cirq-core/cirq/protocols/json_test_data/Points.repr
@@ -1,1 +1,4 @@
-cirq.Points('a', [0, 0.4])
+[
+    cirq.Points('a', [0, 0.4]),
+    cirq.Points('amp', [0, 1], metadata='used to turn amp on or off'),
+]

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -511,7 +511,7 @@ class Linspace(SingleSweep):
         )
 
     def _json_dict_(self) -> Dict[str, Any]:
-        if self.metadata:
+        if self.metadata is not None:
             return protocols.obj_to_dict_helper(
                 self, ["key", "start", "stop", "length", "metadata"]
             )

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -454,7 +454,7 @@ class Points(SingleSweep):
         return f'cirq.Points({self.key!r}, {self.points!r}{metadata_repr})'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        if self.metadata:
+        if self.metadata is not None:
             return protocols.obj_to_dict_helper(self, ["key", "points", "metadata"])
         return protocols.obj_to_dict_helper(self, ["key", "points"])
 

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -436,7 +436,7 @@ class Points(SingleSweep):
                 annotate the sweep or its variable.
 
         """
-        super(Points, self).__init__(key)
+        super().__init__(key)
         self.points = points
         self.metadata = metadata
 

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -483,7 +483,7 @@ class Linspace(SingleSweep):
             metadata: Optional metadata to attach to the sweep to
                 annotate the sweep or its variable.
         """
-        super(Linspace, self).__init__(key)
+        super().__init__(key)
         self.start = start
         self.stop = stop
         self.length = length

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -504,7 +504,7 @@ class Linspace(SingleSweep):
                 yield self.start * (1 - p) + self.stop * p
 
     def __repr__(self) -> str:
-        metadata_repr = f', metadata={self.metadata!r}' if self.metadata else ""
+        metadata_repr = f', metadata={self.metadata!r}' if self.metadata is not None else ""
         return (
             f'cirq.Linspace({self.key!r}, start={self.start!r}, '
             f'stop={self.stop!r}, length={self.length!r}{metadata_repr})'

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -450,7 +450,7 @@ class Points(SingleSweep):
         return iter(self.points)
 
     def __repr__(self) -> str:
-        metadata_repr = f', metadata={self.metadata!r}' if self.metadata else ""
+        metadata_repr = f', metadata={self.metadata!r}' if self.metadata is not None else ""
         return f'cirq.Points({self.key!r}, {self.points!r}{metadata_repr})'
 
     def _json_dict_(self) -> Dict[str, Any]:

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -273,6 +273,12 @@ def test_repr():
     )
     cirq.testing.assert_equivalent_repr(cirq.Points('zero&pi', [0, 3.14159]))
     cirq.testing.assert_equivalent_repr(cirq.Linspace('I/10', 0, 1, 10))
+    cirq.testing.assert_equivalent_repr(
+        cirq.Points('zero&pi', [0, 3.14159], metadata='example str')
+    )
+    cirq.testing.assert_equivalent_repr(
+        cirq.Linspace('for_q0', 0, 1, 10, metadata=cirq.LineQubit(0))
+    )
 
 
 def test_zip_product_str():


### PR DESCRIPTION
- Adds optional metadata attribute to Linspace and Points.
- This will be used to adjust device parameters via sweep.

See https://tinyurl.com/cirq-sweep-metadata-public for RFC.