### PR TITLE
Add support for allocating qubits in decompose to cirq.unitary

### DIFF
--- a/cirq-core/cirq/protocols/apply_unitary_protocol.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol.py
@@ -13,7 +13,18 @@
 # limitations under the License.
 """A protocol for implementing high performance unitary left-multiplies."""
 import warnings
-from typing import Any, cast, Iterable, Optional, Sequence, Tuple, TYPE_CHECKING, TypeVar, Union
+from typing import (
+    Any,
+    cast,
+    Iterable,
+    Optional,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+    Callable,
+)
 
 import numpy as np
 from typing_extensions import Protocol
@@ -363,6 +374,7 @@ def apply_unitary(
     with warnings.catch_warnings():
         warnings.filterwarnings(action="error", category=np.ComplexWarning)
         for strat in strats:
+            strat = cast(Callable[[Any, ApplyUnitaryArgs], Optional[np.ndarray]], strat)
             result = strat(unitary_value, args)
             if result is None:
                 break

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -17,6 +17,7 @@ import pytest
 
 import cirq
 from cirq.protocols.apply_unitary_protocol import _incorporate_result_into_target
+from cirq import testing
 
 
 def test_apply_unitary_presence_absence():
@@ -719,26 +720,6 @@ def test_cast_to_complex():
         cirq.apply_unitary(y0, args)
 
 
-class NotDecomposableGate(cirq.Gate):
-    def num_qubits(self):
-        return 1
-
-
-class DecomposableGate(cirq.Gate):
-    def __init__(self, sub_gate: cirq.Gate, allocate_ancilla: bool) -> None:
-        super().__init__()
-        self._sub_gate = sub_gate
-        self._allocate_ancilla = allocate_ancilla
-
-    def num_qubits(self):
-        return 1
-
-    def _decompose_(self, qubits):
-        if self._allocate_ancilla:
-            yield cirq.Z(cirq.LineQubit(1))
-        yield self._sub_gate(qubits[0])
-
-
 def test_strat_apply_unitary_from_decompose():
     state = np.eye(2, dtype=np.complex128)
     args = cirq.ApplyUnitaryArgs(
@@ -746,14 +727,14 @@ def test_strat_apply_unitary_from_decompose():
     )
     np.testing.assert_allclose(
         cirq.apply_unitaries(
-            [DecomposableGate(cirq.X, False)(cirq.LineQubit(0))], [cirq.LineQubit(0)], args
+            [testing.DecomposableGate(cirq.X, False)(cirq.LineQubit(0))], [cirq.LineQubit(0)], args
         ),
         [[0, 1], [1, 0]],
     )
 
     with pytest.raises(TypeError):
         _ = cirq.apply_unitaries(
-            [DecomposableGate(NotDecomposableGate(), True)(cirq.LineQubit(0))],
+            [testing.DecomposableGate(testing.NotDecomposableGate(), True)(cirq.LineQubit(0))],
             [cirq.LineQubit(0)],
             args,
         )

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -717,3 +717,43 @@ def test_cast_to_complex():
         np.ComplexWarning, match='Casting complex values to real discards the imaginary part'
     ):
         cirq.apply_unitary(y0, args)
+
+
+class NotDecomposableGate(cirq.Gate):
+    def num_qubits(self):
+        return 1
+
+
+class DecomposableGate(cirq.Gate):
+    def __init__(self, sub_gate: cirq.Gate, allocate_ancilla: bool) -> None:
+        super().__init__()
+        self._sub_gate = sub_gate
+        self._allocate_ancilla = allocate_ancilla
+
+    def num_qubits(self):
+        return 1
+
+    def _decompose_(self, qubits):
+        if self._allocate_ancilla:
+            yield cirq.Z(cirq.LineQubit(1))
+        yield self._sub_gate(qubits[0])
+
+
+def test_strat_apply_unitary_from_decompose():
+    state = np.eye(2, dtype=np.complex128)
+    args = cirq.ApplyUnitaryArgs(
+        target_tensor=state, available_buffer=np.zeros_like(state), axes=(0,)
+    )
+    np.testing.assert_allclose(
+        cirq.apply_unitaries(
+            [DecomposableGate(cirq.X, False)(cirq.LineQubit(0))], [cirq.LineQubit(0)], args
+        ),
+        [[0, 1], [1, 0]],
+    )
+
+    with pytest.raises(TypeError):
+        _ = cirq.apply_unitaries(
+            [DecomposableGate(NotDecomposableGate(), True)(cirq.LineQubit(0))],
+            [cirq.LineQubit(0)],
+            args,
+        )

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -757,3 +757,13 @@ def test_strat_apply_unitary_from_decompose():
             [cirq.LineQubit(0)],
             args,
         )
+
+
+def test_unitary_construction():
+    with pytest.raises(TypeError):
+        _ = cirq.ApplyUnitaryArgs.for_unitary()
+
+    np.testing.assert_allclose(
+        cirq.ApplyUnitaryArgs.for_unitary(num_qubits=3).target_tensor,
+        cirq.eye_tensor((2,) * 3, dtype=np.complex128),
+    )

--- a/cirq-core/cirq/protocols/unitary_protocol.py
+++ b/cirq-core/cirq/protocols/unitary_protocol.py
@@ -17,7 +17,6 @@ from typing import Any, TypeVar, Union, Optional
 import numpy as np
 from typing_extensions import Protocol
 
-from cirq import qis
 from cirq._doc import doc_private
 from cirq.protocols import qid_shape_protocol
 from cirq.protocols.apply_unitary_protocol import ApplyUnitaryArgs, apply_unitaries
@@ -162,9 +161,7 @@ def _strat_unitary_from_apply_unitary(val: Any) -> Optional[np.ndarray]:
         return NotImplemented
 
     # Apply unitary effect to an identity matrix.
-    state = qis.eye_tensor(val_qid_shape, dtype=np.complex128)
-    buffer = np.empty_like(state)
-    result = method(ApplyUnitaryArgs(state, buffer, range(len(val_qid_shape))))
+    result = method(ApplyUnitaryArgs.for_unitary(val_qid_shape))
 
     if result is NotImplemented or result is None:
         return result
@@ -187,10 +184,8 @@ def _strat_unitary_from_decompose(val: Any) -> Optional[np.ndarray]:
     val_qid_shape = qid_shape_protocol.qid_shape(ancillas) + val_qid_shape
 
     # Apply sub-operations' unitary effects to an identity matrix.
-    state = qis.eye_tensor(val_qid_shape, dtype=np.complex128)
-    buffer = np.empty_like(state)
     result = apply_unitaries(
-        operations, ordered_qubits, ApplyUnitaryArgs(state, buffer, range(len(val_qid_shape))), None
+        operations, ordered_qubits, ApplyUnitaryArgs.for_unitary(val_qid_shape), None
     )
 
     # Package result.

--- a/cirq-core/cirq/protocols/unitary_protocol.py
+++ b/cirq-core/cirq/protocols/unitary_protocol.py
@@ -161,7 +161,7 @@ def _strat_unitary_from_apply_unitary(val: Any) -> Optional[np.ndarray]:
         return NotImplemented
 
     # Apply unitary effect to an identity matrix.
-    result = method(ApplyUnitaryArgs.for_unitary(val_qid_shape))
+    result = method(ApplyUnitaryArgs.for_unitary(qid_shape=val_qid_shape))
 
     if result is NotImplemented or result is None:
         return result
@@ -185,7 +185,7 @@ def _strat_unitary_from_decompose(val: Any) -> Optional[np.ndarray]:
 
     # Apply sub-operations' unitary effects to an identity matrix.
     result = apply_unitaries(
-        operations, ordered_qubits, ApplyUnitaryArgs.for_unitary(val_qid_shape), None
+        operations, ordered_qubits, ApplyUnitaryArgs.for_unitary(qid_shape=val_qid_shape), None
     )
 
     # Package result.

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import cast, Optional
+from typing import Optional
 
 import numpy as np
 import pytest

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -107,3 +107,11 @@ from cirq.testing.routing_devices import (
 )
 
 from cirq.testing.sample_circuits import nonoptimal_toffoli_circuit
+
+from cirq.testing.sample_gates import (
+    DecomposableGate,
+    NotDecomposableGate,
+    GateThatAllocatesAQubit,
+    GateThatAllocatesTwoQubits,
+    GateThatDecomposesIntoNGates,
+)

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -109,8 +109,6 @@ from cirq.testing.routing_devices import (
 from cirq.testing.sample_circuits import nonoptimal_toffoli_circuit
 
 from cirq.testing.sample_gates import (
-    DecomposableGate,
-    NotDecomposableGate,
     GateThatAllocatesAQubit,
     GateThatAllocatesTwoQubits,
     GateThatDecomposesIntoNGates,

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -108,8 +108,4 @@ from cirq.testing.routing_devices import (
 
 from cirq.testing.sample_circuits import nonoptimal_toffoli_circuit
 
-from cirq.testing.sample_gates import (
-    GateThatAllocatesAQubit,
-    GateThatAllocatesTwoQubits,
-    GateThatDecomposesIntoNGates,
-)
+from cirq.testing.sample_gates import PhaseUsingCleanAncilla, PhaseUsingDirtyAncilla

--- a/cirq-core/cirq/testing/sample_gates.py
+++ b/cirq-core/cirq/testing/sample_gates.py
@@ -17,6 +17,8 @@ from cirq import ops
 
 
 class GateThatAllocatesAQubit(ops.Gate):
+    r"""A gate that applies $Z^\theta$ indirectly through a clean ancilla."""
+
     def __init__(self, theta: float) -> None:
         super().__init__()
         self._theta = theta
@@ -35,6 +37,8 @@ class GateThatAllocatesAQubit(ops.Gate):
 
 
 class GateThatAllocatesTwoQubits(ops.Gate):
+    r"""A gate that applies $-j Z \otimes Z$ indirectly through two ancillas."""
+
     def _num_qubits_(self):
         return 2
 
@@ -53,16 +57,18 @@ class GateThatAllocatesTwoQubits(ops.Gate):
 
     @classmethod
     def target_unitary(cls) -> np.ndarray:
-        # Unitary = (-j I_2) \otimes Z
+        # Unitary = -j Z \otimes Z
         return np.array([[-1j, 0, 0, 0], [0, 1j, 0, 0], [0, 0, 1j, 0], [0, 0, 0, -1j]])
 
 
 class GateThatDecomposesIntoNGates(ops.Gate):
-    def __init__(self, n: int, sub_gate: ops.Gate, theta: float) -> None:
+    r"""Applies $(Z^\theta)^{\otimes_n}$ on work qubits and `subgate` on $n$ borrowable ancillas."""
+
+    def __init__(self, n: int, subgate: ops.Gate, theta: float) -> None:
         super().__init__()
         self._n = n
-        self._subgate = sub_gate
-        self._name = str(sub_gate)
+        self._subgate = subgate
+        self._name = str(subgate)
         self._theta = theta
 
     def _num_qubits_(self) -> int:

--- a/cirq-core/cirq/testing/sample_gates.py
+++ b/cirq-core/cirq/testing/sample_gates.py
@@ -16,26 +16,6 @@ import numpy as np
 from cirq import ops
 
 
-class NotDecomposableGate(ops.Gate):
-    def num_qubits(self):
-        return 1
-
-
-class DecomposableGate(ops.Gate):
-    def __init__(self, sub_gate: ops.Gate, allocate_ancilla: bool) -> None:
-        super().__init__()
-        self._sub_gate = sub_gate
-        self._allocate_ancilla = allocate_ancilla
-
-    def num_qubits(self):
-        return 1
-
-    def _decompose_(self, qubits):
-        if self._allocate_ancilla:
-            yield ops.Z(ops.NamedQubit('DecomposableGateQubit'))
-        yield self._sub_gate(qubits[0])
-
-
 class GateThatAllocatesAQubit(ops.Gate):
     def __init__(self, theta: float) -> None:
         super().__init__()

--- a/cirq-core/cirq/testing/sample_gates.py
+++ b/cirq-core/cirq/testing/sample_gates.py
@@ -1,0 +1,99 @@
+# Copyright 2023 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+import numpy as np
+from cirq import ops
+
+
+class NotDecomposableGate(ops.Gate):
+    def num_qubits(self):
+        return 1
+
+
+class DecomposableGate(ops.Gate):
+    def __init__(self, sub_gate: ops.Gate, allocate_ancilla: bool) -> None:
+        super().__init__()
+        self._sub_gate = sub_gate
+        self._allocate_ancilla = allocate_ancilla
+
+    def num_qubits(self):
+        return 1
+
+    def _decompose_(self, qubits):
+        if self._allocate_ancilla:
+            yield ops.Z(ops.NamedQubit('DecomposableGateQubit'))
+        yield self._sub_gate(qubits[0])
+
+
+class GateThatAllocatesAQubit(ops.Gate):
+    def __init__(self, theta: float) -> None:
+        super().__init__()
+        self._theta = theta
+
+    def _num_qubits_(self):
+        return 1
+
+    def _decompose_(self, q):
+        anc = ops.NamedQubit("anc")
+        yield ops.CX(*q, anc)
+        yield (ops.Z**self._theta)(anc)
+        yield ops.CX(*q, anc)
+
+    def target_unitary(self) -> np.ndarray:
+        return np.array([[1, 0], [0, (-1 + 0j) ** self._theta]])
+
+
+class GateThatAllocatesTwoQubits(ops.Gate):
+    def _num_qubits_(self):
+        return 2
+
+    def _decompose_(self, qs):
+        q0, q1 = qs
+        anc = ops.NamedQubit.range(2, prefix='two_ancillas_')
+
+        yield ops.X(anc[0])
+        yield ops.CX(q0, anc[0])
+        yield (ops.Y)(anc[0])
+        yield ops.CX(q0, anc[0])
+
+        yield ops.CX(q1, anc[1])
+        yield (ops.Z)(anc[1])
+        yield ops.CX(q1, anc[1])
+
+    @classmethod
+    def target_unitary(cls) -> np.ndarray:
+        # Unitary = (-j I_2) \otimes Z
+        return np.array([[-1j, 0, 0, 0], [0, 1j, 0, 0], [0, 0, 1j, 0], [0, 0, 0, -1j]])
+
+
+class GateThatDecomposesIntoNGates(ops.Gate):
+    def __init__(self, n: int, sub_gate: ops.Gate, theta: float) -> None:
+        super().__init__()
+        self._n = n
+        self._subgate = sub_gate
+        self._name = str(sub_gate)
+        self._theta = theta
+
+    def _num_qubits_(self) -> int:
+        return self._n
+
+    def _decompose_(self, qs):
+        ancilla = ops.NamedQubit.range(self._n, prefix=self._name)
+        yield self._subgate.on_each(ancilla)
+        yield (ops.Z**self._theta).on_each(qs)
+        yield self._subgate.on_each(ancilla)
+
+    def target_unitary(self) -> np.ndarray:
+        U = np.array([[1, 0], [0, (-1 + 0j) ** self._theta]])
+        return functools.reduce(np.kron, [U] * self._n)

--- a/cirq-core/cirq/testing/sample_gates_test.py
+++ b/cirq-core/cirq/testing/sample_gates_test.py
@@ -1,0 +1,58 @@
+# Copyright 2023 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+import pytest
+
+import numpy as np
+from cirq.testing import sample_gates
+from cirq import protocols, ops
+
+
+@pytest.mark.parametrize('theta', np.linspace(0, 2 * np.pi, 20))
+def test_GateThatAllocatesAQubit(theta: float):
+    g = sample_gates.GateThatAllocatesAQubit(theta)
+
+    want = np.array([[1, 0], [0, (-1 + 0j) ** theta]], dtype=np.complex128)
+    # test unitary
+    np.testing.assert_allclose(g.target_unitary(), want)
+
+    # test decomposition
+    np.testing.assert_allclose(protocols.unitary(g), g.target_unitary())
+
+
+def test_GateThatAllocatesTwoQubits():
+    g = sample_gates.GateThatAllocatesTwoQubits()
+
+    Z = np.array([[1, 0], [0, -1]])
+    want = -1j * np.kron(Z, Z)
+    # test unitary
+    np.testing.assert_allclose(g.target_unitary(), want)
+
+    # test decomposition
+    np.testing.assert_allclose(protocols.unitary(g), g.target_unitary())
+
+
+@pytest.mark.parametrize('n', [*range(1, 6)])
+@pytest.mark.parametrize('subgate', [ops.Z, ops.X, ops.Y, ops.T])
+@pytest.mark.parametrize('theta', np.linspace(0, 2 * np.pi, 5))
+def test_GateThatDecomposesIntoNGates(n: int, subgate: ops.Gate, theta: float):
+    g = sample_gates.GateThatDecomposesIntoNGates(n, subgate, theta)
+
+    U = np.array([[1, 0], [0, (-1 + 0j) ** theta]], dtype=np.complex128)
+    want = functools.reduce(np.kron, [U] * n)
+    # test unitary
+    np.testing.assert_allclose(g.target_unitary(), want)
+
+    # test decomposition
+    np.testing.assert_allclose(protocols.unitary(g), g.target_unitary())


### PR DESCRIPTION
This is the simplest implementation to do this in order to unblock cirq-ft. 
This implementation only satisfies the first requirement of https://github.com/quantumlib/Cirq/issues/6101#issuecomment-1568686661
In followup PRs I will address other requirements.
