### PR TITLE
Ensure that cirq.decompose traverses the yielded OP-TREE in dfs ordering

### DIFF
--- a/check/mypy
+++ b/check/mypy
@@ -18,7 +18,7 @@ read -r -a CIRQ_PACKAGES < \
     <(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
 
 echo -e -n "\033[31m"
-mypy --config-file=dev_tools/conf/$CONFIG_FILE "$@" "${CIRQ_PACKAGES[@]}" dev_tools examples
+mypy --config-file=dev_tools/conf/$CONFIG_FILE "$@" "${CIRQ_PACKAGES[@]}" 
 result=$?
 echo -e -n "\033[0m"
 

--- a/check/mypy
+++ b/check/mypy
@@ -18,7 +18,7 @@ read -r -a CIRQ_PACKAGES < \
     <(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
 
 echo -e -n "\033[31m"
-mypy --config-file=dev_tools/conf/$CONFIG_FILE "$@" "${CIRQ_PACKAGES[@]}" 
+mypy --config-file=dev_tools/conf/$CONFIG_FILE "$@" "${CIRQ_PACKAGES[@]}" dev_tools examples
 result=$?
 echo -e -n "\033[0m"
 

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -28,7 +28,7 @@ from typing import (
 import sympy
 
 from cirq import protocols, value
-from cirq.ops import raw_types
+from cirq.ops import op_tree, raw_types
 
 if TYPE_CHECKING:
     import cirq
@@ -105,11 +105,13 @@ class ClassicallyControlledOperation(raw_types.Operation):
         )
 
     def _decompose_(self):
-        result = protocols.decompose_once(self._sub_operation, NotImplemented)
+        result = protocols.decompose_once(self._sub_operation, NotImplemented, flatten=False)
         if result is NotImplemented:
             return NotImplemented
 
-        return [ClassicallyControlledOperation(op, self._conditions) for op in result]
+        return op_tree.transform_op_tree(
+            result, lambda op: ClassicallyControlledOperation(op, self._conditions)
+        )
 
     def _value_equality_values_(self):
         return (frozenset(self._conditions), self._sub_operation)

--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -34,6 +34,7 @@ from cirq.ops import (
     eigen_gate,
     gate_operation,
     matrix_gates,
+    op_tree,
     raw_types,
     control_values as cv,
 )
@@ -145,7 +146,9 @@ class ControlledOperation(raw_types.Operation):
         )
 
     def _decompose_(self):
-        result = protocols.decompose_once_with_qubits(self.gate, self.qubits, NotImplemented)
+        result = protocols.decompose_once_with_qubits(
+            self.gate, self.qubits, NotImplemented, flatten=False
+        )
         if result is not NotImplemented:
             return result
 
@@ -154,13 +157,13 @@ class ControlledOperation(raw_types.Operation):
             # local phase in the controlled variant and hence cannot be ignored.
             return NotImplemented
 
-        result = protocols.decompose_once(self.sub_operation, NotImplemented)
+        result = protocols.decompose_once(self.sub_operation, NotImplemented, flatten=False)
         if result is NotImplemented:
             return NotImplemented
 
-        return [
-            op.controlled_by(*self.controls, control_values=self.control_values) for op in result
-        ]
+        return op_tree.transform_op_tree(
+            result, lambda op: op.controlled_by(*self.controls, control_values=self.control_values)
+        )
 
     def _value_equality_values_(self):
         sorted_controls, expanded_cvals = tuple(

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -160,7 +160,9 @@ class GateOperation(raw_types.Operation):
         return len(self._qubits)
 
     def _decompose_(self) -> 'cirq.OP_TREE':
-        return protocols.decompose_once_with_qubits(self.gate, self.qubits, NotImplemented)
+        return protocols.decompose_once_with_qubits(
+            self.gate, self.qubits, NotImplemented, flatten=False
+        )
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
         getter = getattr(self.gate, '_pauli_expansion_', None)

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -830,7 +830,7 @@ class TaggedOperation(Operation):
         return protocols.obj_to_dict_helper(self, ['sub_operation', 'tags'])
 
     def _decompose_(self) -> 'cirq.OP_TREE':
-        return protocols.decompose_once(self.sub_operation, default=None)
+        return protocols.decompose_once(self.sub_operation, default=None, flatten=False)
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
         return protocols.pauli_expansion(self.sub_operation)

--- a/cirq-core/cirq/protocols/decompose_protocol_test.py
+++ b/cirq-core/cirq/protocols/decompose_protocol_test.py
@@ -337,7 +337,7 @@ def test_decompose_recursive_dfs():
         mock.call.qfree(False),
         mock.call.qfree(True),
     ]
-    mock_qm = mock.Mock()
+    mock_qm = mock.Mock(spec=["qalloc", "qfree"])
     q = cirq.LineQubit.range(3)
     gate = RecursiveDecompose(mock_qm=mock_qm)
     gate_op = gate.on(*q[:2])
@@ -346,4 +346,4 @@ def test_decompose_recursive_dfs():
     for op in [gate_op, controlled_op, classically_controlled_op]:
         mock_qm.reset_mock()
         _ = cirq.decompose(op)
-        mock_qm.assert_has_calls(expected_calls, any_order=False)
+        assert mock_qm.method_calls == expected_calls

--- a/cirq-core/cirq/protocols/decompose_protocol_test.py
+++ b/cirq-core/cirq/protocols/decompose_protocol_test.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+from unittest import mock
 import pytest
 
 import cirq
@@ -308,3 +310,40 @@ def test_decompose_tagged_operation():
         'tag',
     )
     assert cirq.decompose_once(op) == cirq.decompose_once(op.untagged)
+
+
+def test_decompose_recursive_dfs():
+    class RecursiveDecompose(cirq.Gate):
+        def __init__(self, recurse: bool = True, mock_qm: Optional[mock.Mock] = None):
+            self.recurse = recurse
+            self.mock_qm = mock.Mock() if mock_qm is None else mock_qm
+
+        def _num_qubits_(self) -> int:
+            return 2
+
+        def _decompose_(self, qubits):
+            self.mock_qm.qalloc(self.recurse)
+            yield RecursiveDecompose(recurse=False, mock_qm=self.mock_qm).on(
+                *qubits
+            ) if self.recurse else cirq.Z.on_each(*qubits)
+            self.mock_qm.qfree(self.recurse)
+
+        def _has_unitary_(self):
+            return True
+
+    expected_calls = [
+        mock.call.qalloc(True),
+        mock.call.qalloc(False),
+        mock.call.qfree(False),
+        mock.call.qfree(True),
+    ]
+    mock_qm = mock.Mock()
+    q = cirq.LineQubit.range(3)
+    gate = RecursiveDecompose(mock_qm=mock_qm)
+    gate_op = gate.on(*q[:2])
+    controlled_op = gate_op.controlled_by(q[2])
+    classically_controlled_op = gate_op.with_classical_controls('key')
+    for op in [gate_op, controlled_op, classically_controlled_op]:
+        mock_qm.reset_mock()
+        _ = cirq.decompose(op)
+        mock_qm.assert_has_calls(expected_calls, any_order=False)


### PR DESCRIPTION
This is a follow-up of https://github.com/quantumlib/Cirq/pull/6116

The goal is to make sure that if a gate or operation has a `_decompose_` defined such that operations are yielded one by one (i.e. the `_decompose_()` is a generator); then `cirq.decompose(op)`  protocol should recursively decompose the yielded operations one by one. 

This guarantee ensures that, if a user allocates / deallocates new qubits as part of the `_decompose_` protocol; then all operations yielded between an allocation / deallocation request are recursively decomposed in order after the initial allocation request and before the deallocation request. 

See the added test using mocks for more details. 

Note that the default recommendation to users would be to use a `SimpleQubitManager` so they do not need to worry about this ordering. The guarantees here are brittle and depend largely on assuming that the user is doing the right thing; but this best effort implementation gets us closer to "doing the right thing" for the user with minimal changes to existing code. 


cc @95-martin-orion @NoureldinYosri 

Part of https://github.com/quantumlib/Cirq/issues/6040