### PR TITLE
Fail early in `_strat_has_stabilizer_effect_from_unitary`

### DIFF
--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -63,7 +63,8 @@ def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
     """
     # Do not try this strategy if there is no unitary or if the number of
     # qubits is not 1 since that would be expensive.
-    if protocols.num_qubits(val) != 1 or not protocols.has_unitary(val):
+    qid_shape = protocols.qid_shape(val, default=None)
+    if qid_shape is None or len(qid_shape) != 1 or not protocols.has_unitary(val):
         return None
     unitary = protocols.unitary(val)
     return SingleQubitCliffordGate.from_unitary(unitary) is not None

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -63,7 +63,7 @@ def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
     """
     # Do not try this strategy if there is no unitary or if the number of
     # qubits is not 1 since that would be expensive.
-    if not protocols.has_unitary(val) or protocols.num_qubits(val) != 1:
+    if protocols.num_qubits(val) != 1 or not protocols.has_unitary(val):
         return None
     unitary = protocols.unitary(val)
     return SingleQubitCliffordGate.from_unitary(unitary) is not None


### PR DESCRIPTION
Minor fix, helps speed up `has_stabilizer_effect` protocol by not computing `has_unitary(val)` when `num_qubits(val) > 1`; which can be quite expensive because `has_unitary(val)` falls back to `_unitary_` 