### PR TITLE
Replace functions deprecated in NumPy 1.25

### DIFF
--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -29,12 +29,12 @@ def test_single_qubit_init():
     m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
     x2 = cirq.MatrixGate(m)
     assert cirq.has_unitary(x2)
-    assert np.alltrue(cirq.unitary(x2) == m)
+    assert np.all(cirq.unitary(x2) == m)
     assert cirq.qid_shape(x2) == (2,)
 
     x2 = cirq.MatrixGate(PLUS_ONE, qid_shape=(3,))
     assert cirq.has_unitary(x2)
-    assert np.alltrue(cirq.unitary(x2) == PLUS_ONE)
+    assert np.all(cirq.unitary(x2) == PLUS_ONE)
     assert cirq.qid_shape(x2) == (3,)
 
     with pytest.raises(ValueError, match='Not a .*unitary matrix'):
@@ -97,7 +97,7 @@ def test_single_qubit_extrapolate():
 def test_two_qubit_init():
     x2 = cirq.MatrixGate(QFT2)
     assert cirq.has_unitary(x2)
-    assert np.alltrue(cirq.unitary(x2) == QFT2)
+    assert np.all(cirq.unitary(x2) == QFT2)
 
 
 def test_two_qubit_eq():

--- a/cirq-core/cirq/testing/circuit_compare.py
+++ b/cirq-core/cirq/testing/circuit_compare.py
@@ -329,7 +329,7 @@ def assert_has_consistent_apply_unitary(val: Any, *, atol: float = 1e-8) -> None
     # If you applied a unitary, it should match the one you say you have.
     if actual is not None:
         assert expected is not None
-        n = np.product([2, *qid_shape])
+        n = np.prod([2, *qid_shape])
         np.testing.assert_allclose(actual.reshape(n, n), expected, atol=atol)
 
 
@@ -373,7 +373,7 @@ def assert_has_consistent_apply_channel(val: Any, *, atol: float = 1e-8) -> None
     # If you applied a channel, it should match the superoperator you say you have.
     if actual is not None:
         assert expected is not None
-        n = np.product(qid_shape) ** 2
+        n = np.prod(qid_shape) ** 2
         np.testing.assert_allclose(actual.reshape((n, n)), expected, atol=atol)
 
 

--- a/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils.py
@@ -164,8 +164,8 @@ def kak_vector_infidelity(
 
     if ignore_equivalent_vectors:
         k_diff = k_vec_a - k_vec_b
-        out = 1 - np.product(np.cos(k_diff), axis=-1) ** 2
-        out -= np.product(np.sin(k_diff), axis=-1) ** 2
+        out = 1 - np.prod(np.cos(k_diff), axis=-1) ** 2
+        out -= np.prod(np.sin(k_diff), axis=-1) ** 2
         return out
 
     # We must take the minimum infidelity over all possible locally equivalent
@@ -181,8 +181,8 @@ def kak_vector_infidelity(
 
     k_diff = k_vec_a - k_vec_b
 
-    out = 1 - np.product(np.cos(k_diff), axis=-1) ** 2
-    out -= np.product(np.sin(k_diff), axis=-1) ** 2  # (...,192)
+    out = 1 - np.prod(np.cos(k_diff), axis=-1) ** 2
+    out -= np.prod(np.sin(k_diff), axis=-1) ** 2  # (...,192)
 
     return out.min(axis=-1)
 


### PR DESCRIPTION
Co-authored-by: @hawkinsp
