### PR TITLE
Make `cirq.FREDKIN` gate self-inverse

### DIFF
--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -661,6 +661,11 @@ class CSwapGate(gate_features.InterchangeableQubitsGate, raw_types.Gate):
     def _value_equality_values_(self):
         return ()
 
+    def __pow__(self, power):
+        if power == 1 or power == -1:
+            return self
+        return NotImplemented
+
     def __str__(self) -> str:
         return 'FREDKIN'
 

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -110,6 +110,11 @@ def test_unitary():
         ),
         atol=1e-8,
     )
+    np.testing.assert_allclose(
+        cirq.unitary(cirq.FREDKIN**-1),
+        cirq.linalg.map_eigenvalues(cirq.unitary(cirq.FREDKIN), lambda b: b**-1),
+        atol=1e-6
+    )
 
     diagonal_angles = [2, 3, 5, 7, 11, 13, 17, 19]
     assert cirq.has_unitary(cirq.ThreeQubitDiagonalGate(diagonal_angles))
@@ -156,7 +161,7 @@ def test_eq():
     eq.add_equality_group(cirq.TOFFOLI(a, b, c), cirq.CCX(a, b, c))
     eq.add_equality_group(cirq.TOFFOLI(a, c, b), cirq.TOFFOLI(c, a, b))
     eq.add_equality_group(cirq.TOFFOLI(a, b, d))
-    eq.add_equality_group(cirq.CSWAP(a, b, c), cirq.FREDKIN(a, b, c))
+    eq.add_equality_group(cirq.CSWAP(a, b, c), cirq.FREDKIN(a, b, c), cirq.FREDKIN(a, b, c) ** -1)
     eq.add_equality_group(cirq.CSWAP(b, a, c), cirq.CSWAP(b, c, a))
 
 

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -113,7 +113,7 @@ def test_unitary():
     np.testing.assert_allclose(
         cirq.unitary(cirq.FREDKIN**-1),
         cirq.linalg.map_eigenvalues(cirq.unitary(cirq.FREDKIN), lambda b: b**-1),
-        atol=1e-6
+        atol=1e-6,
     )
 
     diagonal_angles = [2, 3, 5, 7, 11, 13, 17, 19]

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -94,8 +94,9 @@ def test_unitary():
     )
 
     assert cirq.has_unitary(cirq.CSWAP)
+    u = cirq.unitary(cirq.CSWAP)
     np.testing.assert_allclose(
-        cirq.unitary(cirq.CSWAP),
+        u,
         np.array(
             [
                 [1, 0, 0, 0, 0, 0, 0, 0],
@@ -110,11 +111,7 @@ def test_unitary():
         ),
         atol=1e-8,
     )
-    np.testing.assert_allclose(
-        cirq.unitary(cirq.FREDKIN**-1),
-        cirq.linalg.map_eigenvalues(cirq.unitary(cirq.FREDKIN), lambda b: b**-1),
-        atol=1e-6,
-    )
+    np.testing.assert_allclose(u @ u, np.eye(8))
 
     diagonal_angles = [2, 3, 5, 7, 11, 13, 17, 19]
     assert cirq.has_unitary(cirq.ThreeQubitDiagonalGate(diagonal_angles))


### PR DESCRIPTION
The `CSWAP` / `FREDKIN` gate is self inverse but currently `cirq.FREDKIN ** -1` returns a `_InverseCompositeGate(cirq.FREDKIN)`. This PR adds a `__pow__` method to `CSwapGate` so that `cirq.FREDKIN ** -1` returns a `cirq.FREDKIN`. 