### PR TITLE
Allow measure_single_paulistring to have negative coefficient

### DIFF
--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -46,18 +46,18 @@ def measure_single_paulistring(
 
     Raises:
         ValueError: if the observable is not an instance of PauliString or if the coefficient
-            is not +1.
+            is not +1 or -1.
     """
     if not isinstance(pauli_observable, pauli_string.PauliString):
         raise ValueError(
             f'Pauli observable {pauli_observable} should be an instance of cirq.PauliString.'
         )
-    if pauli_observable.coefficient != 1:
-        raise ValueError(f"Pauli observable {pauli_observable} must have a coefficient of +1.")
+    if abs(pauli_observable.coefficient) != 1:
+        raise ValueError(f"Pauli observable {pauli_observable} must have a coefficient of +1 or -1.")
 
     if key is None:
         key = _default_measurement_key(pauli_observable)
-    return PauliMeasurementGate(pauli_observable.values(), key).on(*pauli_observable.keys())
+    return PauliMeasurementGate(pauli_observable.dense(pauli_observable.keys()), key).on(*pauli_observable.keys())
 
 
 def measure_paulistring_terms(

--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -59,7 +59,7 @@ def measure_single_paulistring(
 
     if key is None:
         key = _default_measurement_key(pauli_observable)
-    return PauliMeasurementGate(pauli_observable.dense(pauli_observable.keys()), key).on(
+    return PauliMeasurementGate(pauli_observable.dense(list(pauli_observable.keys())), key).on(
         *pauli_observable.keys()
     )
 

--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -53,11 +53,15 @@ def measure_single_paulistring(
             f'Pauli observable {pauli_observable} should be an instance of cirq.PauliString.'
         )
     if abs(pauli_observable.coefficient) != 1:
-        raise ValueError(f"Pauli observable {pauli_observable} must have a coefficient of +1 or -1.")
+        raise ValueError(
+            f"Pauli observable {pauli_observable} must have a coefficient of +1 or -1."
+        )
 
     if key is None:
         key = _default_measurement_key(pauli_observable)
-    return PauliMeasurementGate(pauli_observable.dense(pauli_observable.keys()), key).on(*pauli_observable.keys())
+    return PauliMeasurementGate(pauli_observable.dense(pauli_observable.keys()), key).on(
+        *pauli_observable.keys()
+    )
 
 
 def measure_paulistring_terms(

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -105,7 +105,7 @@ def test_measure_single_paulistring():
 
     # Coefficient != +1 or -1
     with pytest.raises(ValueError, match='must have a coefficient'):
-        _ = cirq.measure_single_paulistring(-2*ps)
+        _ = cirq.measure_single_paulistring(-2 * ps)
 
 
 def test_measure_paulistring_terms():

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -95,6 +95,12 @@ def test_measure_single_paulistring():
         ps.values(), key='a'
     ).on(*ps.keys())
 
+    # Test with negative coefficient
+    ps_neg = -cirq.Y(cirq.LineQubit(0)) * cirq.Y(cirq.LineQubit(1))
+    assert cirq.measure_single_paulistring(ps_neg, key='1') == cirq.PauliMeasurementGate(
+        ps_neg.dense(ps_neg.keys()), key='1'
+    ).on(*ps_neg.keys())
+
     # Empty application
     with pytest.raises(ValueError, match='should be an instance of cirq.PauliString'):
         _ = cirq.measure_single_paulistring(cirq.I(q[0]) * cirq.I(q[1]))

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -97,9 +97,9 @@ def test_measure_single_paulistring():
 
     # Test with negative coefficient
     ps_neg = -cirq.Y(cirq.LineQubit(0)) * cirq.Y(cirq.LineQubit(1))
-    assert cirq.measure_single_paulistring(ps_neg, key='1') == cirq.PauliMeasurementGate(
-        ps_neg.dense(ps_neg.keys()), key='1'
-    ).on(*ps_neg.keys())
+    assert cirq.measure_single_paulistring(ps_neg, key='1').gate == cirq.PauliMeasurementGate(
+        cirq.DensePauliString('YY', coefficient=-1), key='1'
+    )
 
     # Empty application
     with pytest.raises(ValueError, match='should be an instance of cirq.PauliString'):

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -103,9 +103,9 @@ def test_measure_single_paulistring():
     with pytest.raises(ValueError, match='should be an instance of cirq.PauliString'):
         _ = cirq.measure_single_paulistring(q)
 
-    # Coefficient != +1
+    # Coefficient != +1 or -1
     with pytest.raises(ValueError, match='must have a coefficient'):
-        _ = cirq.measure_single_paulistring(-ps)
+        _ = cirq.measure_single_paulistring(-2*ps)
 
 
 def test_measure_paulistring_terms():


### PR DESCRIPTION
Previously we had a check to make sure the coefficient of the paulistring passed to measure_single_paulistring had a coefficient of 1 but we support +1 and -1. Check out https://github.com/quantumlib/Cirq/issues/6137 for context.

Fixes https://github.com/quantumlib/Cirq/issues/6137