### PR TITLE
Disable CI unit tests for MacOS Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,8 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        # TODO(#6147) - restore 3.7 after upstream fix in actions/runner-images
+        python-version: [ '3.8', '3.9', '3.10' ]
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI seems to provide broken installation.

Temporary workaround for #6147
