### PR TITLE
BugFix in `cirq.map_operations`

### DIFF
--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -158,7 +158,8 @@ def map_operations(
 
     return map_moments(
         circuit,
-        lambda m, i: [circuits.Moment(apply_map(op, i) for op in m.operations)],
+        lambda m, i: circuits.Circuit(apply_map(op, i) for op in m.operations).moments
+        or [circuits.Moment()],
         deep=deep,
         tags_to_ignore=tags_to_ignore,
     )

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -414,6 +414,18 @@ def test_map_operations_can_add_qubits_if_flag_false():
     cirq.testing.assert_same_circuits(c_mapped, cirq.Circuit(cirq.CNOT(q[0], q[1])))
 
 
+def test_map_operations_maps_different_ops_from_same_moment_to_shared_qubits():
+    q = cirq.LineQubit.range(3)
+    c = cirq.Circuit(cirq.H.on_each(q[:2]))
+    # Also test that the new op-tree can span multiple moments.
+    c_mapped = cirq.map_operations(
+        c, lambda op, _: op.controlled_by(q[2]), raise_if_add_qubits=False
+    )
+    cirq.testing.assert_same_circuits(
+        c_mapped, cirq.Circuit(cirq.H(q[0]).controlled_by(q[2]), cirq.H(q[1]).controlled_by(q[2]))
+    )
+
+
 def test_map_operations_can_drop_operations():
     q = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.X(q[0]), cirq.Y(q[1]), cirq.X(q[1]), cirq.Y(q[0]))

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -417,7 +417,6 @@ def test_map_operations_can_add_qubits_if_flag_false():
 def test_map_operations_maps_different_ops_from_same_moment_to_shared_qubits():
     q = cirq.LineQubit.range(3)
     c = cirq.Circuit(cirq.H.on_each(q[:2]))
-    # Also test that the new op-tree can span multiple moments.
     c_mapped = cirq.map_operations(
         c, lambda op, _: op.controlled_by(q[2]), raise_if_add_qubits=False
     )


### PR DESCRIPTION
`cirq.map_operations` raises an error right now in the case where you map more than one operation in the same moment to an op-tree that acts on overlapping qubits. A trivial example is the case where you map every `op` to `op.controlled_by(fixed_qubit)`. 

This PR fixes the bug. See the newly added test for more context, which fails in the current version and passes after the change in this PR. 