### PR TITLE
Set cachetools min version to 5.3

### DIFF
--- a/cirq-ft/requirements.txt
+++ b/cirq-ft/requirements.txt
@@ -1,5 +1,5 @@
 attrs
-cachetools
+cachetools>=5.3
 ipywidgets
 nbconvert
 nbformat


### PR DESCRIPTION
The `info` arg for `cachetools.cached()` is introduced in cachetools 5.3.0.