### PR TITLE
Fix documentation for IonQ native gates

### DIFF
--- a/cirq-ionq/cirq_ionq/ionq_native_gates.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_gates.py
@@ -31,7 +31,7 @@ class GPIGate(cirq.Gate):
     $$
     \begin{bmatrix}
       0 & e^{-i 2\pi\phi} \\
-      e^{-i2\pi\phi} & 0
+      e^{i 2\pi\phi} & 0
     \end{bmatrix}
     $$
 
@@ -107,7 +107,7 @@ class GPI2Gate(cirq.Gate):
     \frac{1}{\sqrt{2}}
     \begin{bmatrix}
         1 & -i e^{-i \phi} \\
-        -i e^{-i \phi} & 1
+        -i e^{i \phi} & 1
     \end{bmatrix}
     $$
 

--- a/cirq-ionq/cirq_ionq/ionq_native_gates.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_gates.py
@@ -106,8 +106,8 @@ class GPI2Gate(cirq.Gate):
     $$
     \frac{1}{\sqrt{2}}
     \begin{bmatrix}
-        1 & -i e^{-i \phi} \\
-        -i e^{i \phi} & 1
+        1 & -i e^{-i 2\pi \phi} \\
+        -i e^{i 2\pi \phi} & 1
     \end{bmatrix}
     $$
 
@@ -183,10 +183,10 @@ class MSGate(cirq.Gate):
 
     $$
     \begin{bmatrix}
-        \cos\frac{\theta}{2} & 0 & 0 & -ie^{-i2\pi(\phi_0+\phi_1)}\sin\frac{\theta}{2} \\
-        0 & \cos\frac{\theta}{2} & -ie^{-i2\pi(\phi_0-\phi_1)}\sin\frac{\theta}{2} & 0 \\
-        0 & -ie^{i2\pi(\phi_0-\phi_1)}\sin\frac{\theta}{2} & \cos\frac{\theta}{2} & 0 \\
-        -ie^{i2\pi(\phi_0+\phi_1)}\sin\frac{\theta}{2} & 0 & 0 & \cos\frac{\theta}{2}
+        \cos\frac{\theta}{2} & 0 & 0 & -ie^{-i2\pi(\phi_0+\phi_1)}\sin(\pi \theta) \\
+        0 & \cos\frac{\theta}{2} & -ie^{-i2\pi(\phi_0-\phi_1)}\sin(\pi \theta) & 0 \\
+        0 & -ie^{i2\pi(\phi_0-\phi_1)}\sin\sin(\pi \theta) & \cos\frac{\theta}{2} & 0 \\
+        -ie^{i2\pi(\phi_0+\phi_1)}\sin(\pi \theta) & 0 & 0 & \cos\frac{\theta}{2}
     \end{bmatrix}
     $$
 

--- a/cirq-ionq/cirq_ionq/ionq_native_gates.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_gates.py
@@ -186,7 +186,7 @@ class MSGate(cirq.Gate):
         \cos\frac{\theta}{2} & 0 & 0 & -ie^{-i2\pi(\phi_0+\phi_1)}\sin\frac{\theta}{2} \\
         0 & \cos\frac{\theta}{2} & -ie^{-i2\pi(\phi_0-\phi_1)}\sin\frac{\theta}{2} & 0 \\
         0 & -ie^{i2\pi(\phi_0-\phi_1)}\sin\frac{\theta}{2} & \cos\frac{\theta}{2} & 0 \\
-        -ie^{i2\pi(\phi_0+\phi_1)}\sin{\theta/2} & 0 & 0 & \cos\frac{\theta}{2}
+        -ie^{i2\pi(\phi_0+\phi_1)}\sin\frac{\theta}{2} & 0 & 0 & \cos\frac{\theta}{2}
     \end{bmatrix}
     $$
 

--- a/cirq-ionq/cirq_ionq/ionq_native_gates.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_gates.py
@@ -179,14 +179,14 @@ document(
 class MSGate(cirq.Gate):
     r"""The Mølmer–Sørensen (MS) gate is a two qubit gate native to trapped ions.
 
-    The unitary matrix of this gate for parameters $\phi_0$, $\phi_1$ and $\theta is
+    The unitary matrix of this gate for parameters $\phi_0$, $\phi_1$ and $\theta$ is
 
     $$
     \begin{bmatrix}
-        cos{\theta/2} & 0 & 0 & -i*e^{-i*2*\pi(\phi_0+\phi_1)}*sin{\theta/2} \\
-        0 & cos{\theta/2} & -i*e^{-i*2*\pi(\phi_0-\phi_1)}*sin{\theta/2} & 0 \\
-        0 & -i*e^{i*2*\pi(\phi_0-\phi_1)}*sin(\theta/2) & cos{\theta/2} & 0 \\
-        -i*e^{i*2*\pi(\phi_0+\phi_1)}*sin{\theta/2} & 0 & 0 & cos{\theta/2}
+        \cos\frac{\theta}{2} & 0 & 0 & -ie^{-i2\pi(\phi_0+\phi_1)}\sin\frac{\theta}{2} \\
+        0 & \cos\frac{\theta}{2} & -ie^{-i2\pi(\phi_0-\phi_1)}\sin\frac{\theta}{2} & 0 \\
+        0 & -ie^{i2\pi(\phi_0-\phi_1)}\sin\frac{\theta}{2} & \cos\frac{\theta}{2} & 0 \\
+        -ie^{i2\pi(\phi_0+\phi_1)}\sin{\theta/2} & 0 & 0 & \cos\frac{\theta}{2}
     \end{bmatrix}
     $$
 


### PR DESCRIPTION
For these two gates, the documentation shows the angle parameter in radians, which differs from the actual implementation. Also, there were a few typos for GPi and GPi2 gates (some entries including minus signs).