### PR TITLE
Remove unused warnings filter for pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,7 +27,7 @@ def pytest_configure(config):
         "FileDescriptor",
         "OneofDescriptor",
     ):
-        config.addinivalue_line("filterwarnings", f"ignore:Call to deprecated create function {f}")
+        config.addinivalue_line("filterwarnings", f"error:Call to deprecated create function {f}")
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -15,21 +15,6 @@
 import pytest
 
 
-def pytest_configure(config):
-    # Ignore deprecation warnings in python code generated from our protobuf definitions.
-    # Eventually, the warnings will be removed by upgrading protoc compiler. See issues
-    # #4161 and #4737.
-    for f in (
-        "FieldDescriptor",
-        "Descriptor",
-        "EnumDescriptor",
-        "EnumValueDescriptor",
-        "FileDescriptor",
-        "OneofDescriptor",
-    ):
-        config.addinivalue_line("filterwarnings", f"error:Call to deprecated create function {f}")
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--rigetti-integration",


### PR DESCRIPTION
Verify that warning filter rules are not matched and then remove them.

Clean up after #4737 which does not bite anymore