### PR TITLE
Clean up after compatibility with numpy-1.24

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -3,7 +3,7 @@
 duet~=0.2.8
 matplotlib~=3.0
 networkx>=2.4
-numpy>=1.16
+numpy~=1.16
 pandas
 sortedcontainers~=2.0
 scipy

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -107,8 +107,6 @@ PACKAGES = [
     # https://github.com/networkx/networkx/issues/4718 pinned networkx 2.5.1 to 4.4.2
     # however, jupyter brings in 5.0.6
     'decorator<5',
-    # TODO(#5967): allow numpy-1.24 when it is supported in Cirq and numba
-    'numpy>=1.16,<1.24',
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,4 @@ skip-magic-trailing-comma = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:Matplotlib is currently using agg:UserWarning",
-    # TODO(#5967) - remove after upgrade to NumPy 1.24
-    # Enforce NumPy 1.20 deprecations.
-    # Ref: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
-    "error:`np.bool` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.int` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.float` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.complex` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.object` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.str` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.long` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
-    "error:`np.unicode` is a deprecated alias:DeprecationWarning:(cirq|<string>)",
 ]


### PR DESCRIPTION
- remove numpy version pinning, but require major version 1
- remove warning filters which are not relevant after numpy-1.24

Follow up to #5967
