### PR TITLE
Delete dependencies pinning done over 2 years ago

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -99,14 +99,6 @@ PACKAGES = [
     "jupyter",
     # assumed to be part of colab
     "seaborn~=0.11.1",
-    # https://github.com/nteract/papermill/issues/519
-    'ipykernel==5.3.4',
-    # https://github.com/ipython/ipython/issues/12941
-    'ipython==7.22',
-    # to ensure networkx works nicely
-    # https://github.com/networkx/networkx/issues/4718 pinned networkx 2.5.1 to 4.4.2
-    # however, jupyter brings in 5.0.6
-    'decorator<5',
 ]
 
 


### PR DESCRIPTION
Chances are bugs that required those pins were fixed by now.
