### PR TITLE
Temporarily skip quimb notebook tests until numba supports higher numpy versions

### DIFF
--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -53,6 +53,8 @@ SKIP_NOTEBOOKS = [
     'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
     # shouldn't have outputs generated for style reasons
     'docs/simulate/qvm_builder_code.ipynb',
+    # Temporarily skip until numba supports higher numpy versions #6213.
+    'cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb',
 ]
 
 

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -54,7 +54,7 @@ SKIP_NOTEBOOKS = [
     # shouldn't have outputs generated for style reasons
     'docs/simulate/qvm_builder_code.ipynb',
     # Temporarily skip until numba supports higher numpy versions #6213.
-    'cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb',
+    'cirq-core/cirq/contrib/quimb/*.ipynb',
 ]
 
 


### PR DESCRIPTION
Temporary fix for #6213