### PR TITLE
Fix notebook failure in CI tests

### DIFF
--- a/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
@@ -19,7 +19,7 @@
     "    import quimb\n",
     "except ImportError:\n",
     "    print(\"installing cirq-core[contrib]...\")\n",
-    "    !pip install --quiet cirq-core[contrib]\n",
+    "    !pip install --quiet 'cirq-core[contrib]'\n",
     "    print(\"installed cirq-core[contrib].\")\n",
     "        "
    ]

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -19,7 +19,7 @@
     "    import quimb\n",
     "except ImportError:\n",
     "    print(\"installing cirq-core[contrib]...\")\n",
-    "    !pip install --quiet cirq-core[contrib]\n",
+    "    !pip install --quiet 'cirq-core[contrib]'\n",
     "    print(\"installed cirq-core[contrib].\")"
    ]
   },

--- a/cirq-core/cirq/work/observable_measurement_data_test.py
+++ b/cirq-core/cirq/work/observable_measurement_data_test.py
@@ -112,7 +112,7 @@ def test_observable_measured_result():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def example_bsa() -> 'cw.BitstringAccumulator':
     """Test fixture to create an (empty) example BitstringAccumulator"""
     q0, q1 = cirq.LineQubit.range(2)

--- a/cirq-rigetti/cirq_rigetti/aspen_device_test.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device_test.py
@@ -21,7 +21,7 @@ dir_path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
 fixture_path = dir_path / '__fixtures__'
 
 
-@pytest.fixture()
+@pytest.fixture
 def qcs_aspen8_isa() -> InstructionSetArchitecture:
     with open(fixture_path / 'QCS-Aspen-8-ISA.json', 'r') as f:
         return InstructionSetArchitecture.from_dict(json.load(f))

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -68,7 +68,7 @@ def require_packages_not_changed():
     assert packages_after == packages_before
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def env_with_temporary_pip_target():
     """Setup system environment that tells pip to install packages to a temporary directory."""
     with tempfile.TemporaryDirectory(suffix='-notebook-site-packages') as tmpdirname:

--- a/docs/hardware/azure-quantum/access.md
+++ b/docs/hardware/azure-quantum/access.md
@@ -17,7 +17,7 @@ Create an Azure Quantum Workspace and enable the hardware providers you would li
 To connect to your Workspace from Python and submit jobs with Cirq, install the `azure-quantum` client package with the optional `cirq` dependencies as follows:
 
 ```bash
-pip install azure-quantum[cirq]
+pip install 'azure-quantum[cirq]'
 ```
 
 ## 4. Next Steps

--- a/docs/hardware/azure-quantum/getting_started_honeywell.ipynb
+++ b/docs/hardware/azure-quantum/getting_started_honeywell.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install azure-quantum[cirq] --quiet"
+    "!pip install 'azure-quantum[cirq]' --quiet"
    ]
   },
   {

--- a/docs/hardware/azure-quantum/getting_started_ionq.ipynb
+++ b/docs/hardware/azure-quantum/getting_started_ionq.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install azure-quantum[cirq] --quiet"
+    "!pip install 'azure-quantum[cirq]' --quiet"
    ]
   },
   {

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -38,7 +38,7 @@ or internal Google systems.
     Install dependencies of features in `cirq.contrib`.
 
     ```bash
-    python -m pip install cirq-core[contrib]
+    python -m pip install 'cirq-core[contrib]'
     ```
 
     Install system dependencies that pip can't handle.
@@ -103,7 +103,7 @@ or internal Google systems.
 3. (Optional) install dependencies of features in `cirq.contrib`.
 
     ```bash
-    python -m pip install cirq-core[contrib]
+    python -m pip install 'cirq-core[contrib]'
     ```
 
     Install system dependencies that pip can't handle.
@@ -168,7 +168,7 @@ or internal Google systems.
 3. (Optional) install dependencies of features in `cirq.contrib`.
 
     ```bash
-    python -m pip install cirq-core[contrib]
+    python -m pip install 'cirq-core[contrib]'
     ```
 
 4. Check that it works!


### PR DESCRIPTION
* Avoid interference between notebook tests.
  Use separate pip target directory for each notebook test that may
  pip-install additional packages.  This prevents pip upgrade of numpy in one
  notebook breaking another notebook.  Even if second notebook downgrades the
  numpy package with `!pip install ...` command, the high version may be
  already loaded in memory and effective until kernel restart.

* Quote brackets in pip shell arguments, prevent shell globing errors.

* Clean redundant parentheses after @pytest.fixture.

Fixes #6213
