### PR TITLE
[cirq-ft] Add Indexed Prepare primitive to state preparation.

### DIFF
--- a/cirq-ft/cirq_ft/__init__.py
+++ b/cirq-ft/cirq_ft/__init__.py
@@ -39,6 +39,7 @@ from cirq_ft.algos import (
     SelectOracle,
     SelectSwapQROM,
     StatePreparationAliasSampling,
+    IndexedPrepare,
     SwapWithZeroGate,
     UnaryIterationGate,
     unary_iteration,

--- a/cirq-ft/cirq_ft/algos/__init__.py
+++ b/cirq-ft/cirq_ft/algos/__init__.py
@@ -37,6 +37,6 @@ from cirq_ft.algos.reflection_using_prepare import ReflectionUsingPrepare
 from cirq_ft.algos.select_and_prepare import PrepareOracle, SelectOracle
 from cirq_ft.algos.select_swap_qrom import SelectSwapQROM
 from cirq_ft.algos.selected_majorana_fermion import SelectedMajoranaFermionGate
-from cirq_ft.algos.state_preparation import StatePreparationAliasSampling
+from cirq_ft.algos.state_preparation import StatePreparationAliasSampling, IndexedPrepare
 from cirq_ft.algos.swap_network import MultiTargetCSwap, MultiTargetCSwapApprox, SwapWithZeroGate
 from cirq_ft.algos.unary_iteration_gate import UnaryIterationGate, unary_iteration

--- a/cirq-ft/cirq_ft/algos/state_preparation.ipynb
+++ b/cirq-ft/cirq_ft/algos/state_preparation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "ce48b2ae",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "1e7c27f6",
    "metadata": {
     "cq.autogen": "top_imports"
@@ -111,12 +111,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "4f9f2b46",
    "metadata": {
     "cq.autogen": "_make_StatePreparationAliasSampling.py"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ea2866374a0b4133886d45191abf0e85",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Output(outputs=({'output_type': 'display_data', 'data': {'text/plain': '<IPython.core.display.S…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "coeffs = np.array([1.0, 1, 3, 2])\n",
     "mu = 3\n",
@@ -132,9 +147,68 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "21048fcb",
+   "metadata": {},
+   "source": [
+    "# Indexed Prepare\n",
+    "\n",
+    "Initialize a state with $L\\times M$ unique coefficients using coherent alias sampling.\n",
+    "\n",
+    "In particular, implement:\n",
+    "\n",
+    "$$\n",
+    "(\\mathrm{In}_l-\\mathrm{prep}_l) |l\\rangle|0\\rangle = \\sum_m \\sqrt{q_m^{l}} |\\ell\\rangle|m\\rangle |\\mathrm{temp}_m\\rangle\n",
+    "$$\n",
+    "\n",
+    "where the probabilities $q^\\ell_m$ are $\\mu$-bit binary approximations to\n",
+    "the true values similar to the `StatePreparationAliasSampling` gate above.\n",
+    "\n",
+    "#### References:\n",
+    "[Even more efficient quantum computations of chemistry through tensor hypercontraction](https://arxiv.org/pdf/2011.03494.pdf).  Lee et. al. (2018). Appendix B. Sec 1. Fig. 15. This is the In_l-prep_l gate. Here we used QROM rather than QRO(A)M.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "539d4b8d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "44990e09608243aeb902d5ecd3e1e189",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Output(outputs=({'output_type': 'display_data', 'data': {'text/plain': '<IPython.core.display.S…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "coeffs = np.array([[1.0, 1, 3], [2, 4, 5], [6, 7, 8]])\n",
+    "mu = 3\n",
+    "\n",
+    "from cirq_ft.algos.state_preparation import IndexedPrepare\n",
+    "\n",
+    "state_prep = IndexedPrepare.from_lcu_probs(\n",
+    "    coeffs, probability_epsilon=2**-mu / len(coeffs)\n",
+    ")\n",
+    "g = cq_testing.GateHelper(\n",
+    "    state_prep\n",
+    ")\n",
+    "\n",
+    "display_gate_and_compilation(g)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26c46f4b",
+   "id": "4c861fc2",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -156,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/cirq-ft/cirq_ft/algos/state_preparation_test.py
+++ b/cirq-ft/cirq_ft/algos/state_preparation_test.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 from cirq_ft.algos.generic_select_test import get_1d_Ising_lcu_coeffs
 from cirq_ft.infra.jupyter_tools import execute_notebook
+from cirq_ft.infra.bit_tools import iter_bits
 
 
 @pytest.mark.parametrize("num_sites, epsilon", [[2, 3e-3], [3, 3.0e-3], [4, 5.0e-3], [7, 8.0e-3]])
@@ -45,6 +46,41 @@ def test_state_preparation_via_coherent_alias_sampling(num_sites, epsilon):
     # Assert that the absolute square of prepared state (probabilities instead of amplitudes) is
     # same as `lcu_coefficients` upto `epsilon`.
     np.testing.assert_allclose(lcu_coefficients, abs(prepared_state) ** 2, atol=epsilon)
+
+
+def test_indexed_prepare():
+    coeffs = np.array([[0.424, 0.1], [0.555, 0.232], [0.314, 0.9], [0.222, 0.4]])
+    norms = np.einsum('lp->l', coeffs)
+    coeffs = coeffs / norms[:, None]
+    mu = 4
+    gate = cirq_ft.IndexedPrepare.from_lcu_probs(
+        lcu_probabilities=coeffs, probability_epsilon=2**(-mu) / (coeffs.size)
+    )
+    g = cirq_ft.testing.GateHelper(gate)
+    qubit_order = g.operation.qubits
+    for l in range(4):
+        qubit_vals = {q: 0 for q in g.operation.qubits}
+        qubit_vals.update(zip(g.quregs['sel_l'], iter_bits(l, 2)))
+        initial_state = [qubit_vals[x] for x in g.operation.qubits]
+        print(initial_state)
+        result = cirq.Simulator(dtype=np.complex128).simulate(g.circuit,
+                            qubit_order=qubit_order, initial_state=initial_state)
+        state_vector = result.final_state_vector
+        # State vector is of the form |lm>|temp_{l}>. We trace out the |temp_{l}> part to
+        # get the coefficients corresponding to |lm>.
+        LM, logLM = coeffs.size, sum(gate.selection_bitsizes)
+        # print(cirq.dirac_notation(state_vector))
+        state_vector = state_vector.reshape(2**logLM, len(state_vector) // 2**logLM)
+        num_non_zero = (abs(state_vector) > 1e-6).sum(axis=1)
+        prepared_state = state_vector.sum(axis=1)
+        qubit_slice = slice(l * coeffs[l].size, (l+1)*coeffs[l].size)
+        assert all(num_non_zero[qubit_slice] > 0) and all(num_non_zero[LM:] == 0)
+        assert all(np.abs(prepared_state[qubit_slice]) > 1e-6)
+        assert all(np.abs(prepared_state[LM:]) <= 1e-6)
+        prepared_state = prepared_state[qubit_slice] / np.sqrt(num_non_zero[qubit_slice])
+        # Assert that the absolute square of prepared state (probabilities instead of amplitudes) is
+        # same as `lcu_coefficients` upto `epsilon`.
+        np.testing.assert_allclose(coeffs[l], abs(prepared_state) ** 2, atol=2**(-mu) / coeffs.size)
 
 
 def test_state_preparation_via_coherent_alias_sampling_diagram():


### PR DESCRIPTION
Adds a simple extension of the regular state preparation primitive, (indexed prepare), which is used for the single- and double-factorized second quantized chemistry hamiltonians. For those specific cases there are some additional complications but I thought it was helpful to test this slightly simpler case first.