### PR TITLE
[Cirq-FT] Fix typo and add more helpful assertion message.

### DIFF
--- a/cirq-ft/cirq_ft/infra/gate_with_registers.py
+++ b/cirq-ft/cirq_ft/infra/gate_with_registers.py
@@ -122,7 +122,9 @@ class Registers:
     ) -> List[cirq.Qid]:
         ret: List[cirq.Qid] = []
         for reg in self:
-            assert reg.name in qubit_regs, "All qubit registers must pe present"
+            assert (
+                reg.name in qubit_regs
+            ), f"All qubit registers must be present. {reg.name} not in qubit_regs"
             qubits = qubit_regs[reg.name]
             qubits = np.array([qubits] if isinstance(qubits, cirq.Qid) else qubits)
             assert (


### PR DESCRIPTION
I often hit this assertion and have to poke around to figure out which register is missing. pe -> be.