### PR TITLE
fix ms gate equality

### DIFF
--- a/cirq-core/cirq/ops/parity_gates.py
+++ b/cirq-core/cirq/ops/parity_gates.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     import cirq
 
 
+@value.value_equality
 class XXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
     r"""The X-parity gate, possibly raised to a power.
 
@@ -133,6 +134,7 @@ class XXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         )
 
 
+@value.value_equality
 class YYPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
     r"""The Y-parity gate, possibly raised to a power.
 
@@ -237,6 +239,7 @@ class YYPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         )
 
 
+@value.value_equality
 class ZZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
     r"""The Z-parity gate, possibly raised to a power.
 

--- a/cirq-core/cirq/ops/parity_gates_test.py
+++ b/cirq-core/cirq/ops/parity_gates_test.py
@@ -257,8 +257,17 @@ def test_trace_distance():
 
 def test_ms_arguments():
     eq_tester = cirq.testing.EqualsTester()
-    eq_tester.add_equality_group(cirq.ms(np.pi / 2), cirq.ops.MSGate(rads=np.pi / 2))
-    eq_tester.add_equality_group(cirq.XXPowGate(global_shift=-0.5))
+    eq_tester.add_equality_group(
+        cirq.ms(np.pi / 2), cirq.ops.MSGate(rads=np.pi / 2), cirq.XXPowGate(global_shift=-0.5)
+    )
+    eq_tester.add_equality_group(
+        cirq.ms(np.pi / 4), cirq.XXPowGate(exponent=0.5, global_shift=-0.5)
+    )
+    eq_tester.add_equality_group(cirq.XX)
+    eq_tester.add_equality_group(cirq.XX**0.5)
+
+    assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 2), cirq.XX)
+    assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX**0.5)
 
 
 def test_ms_str():

--- a/cirq-core/cirq/ops/parity_gates_test.py
+++ b/cirq-core/cirq/ops/parity_gates_test.py
@@ -266,8 +266,15 @@ def test_ms_arguments():
     eq_tester.add_equality_group(cirq.XX)
     eq_tester.add_equality_group(cirq.XX**0.5)
 
+
+def test_ms_equal_up_to_global_phase():
     assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 2), cirq.XX)
     assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX**0.5)
+    assert not cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX)
+
+    assert cirq.ms(np.pi / 2) in cirq.GateFamily(cirq.XX)
+    assert cirq.ms(np.pi / 4) in cirq.GateFamily(cirq.XX**0.5)
+    assert cirq.ms(np.pi / 4) not in cirq.GateFamily(cirq.XX)
 
 
 def test_ms_str():


### PR DESCRIPTION
fixes #6230 by adding a `value_equality` decorator to `XXPowGate`, `YYPowGate` and `ZZPowGate` in order to override the `distinct_child_types=True` configuration they inherit from `EigenGate`

this mimics what is [already done](https://github.com/quantumlib/Cirq/blob/701538c381b13479cf6ba09216b364b43b01d2ac/cirq-core/cirq/ops/common_gates.py#L70) for `cirq.XPowGate`, `cirq.ZPowGate`, and `cirq.ZPowGate`