### PR TITLE
Integrate StreamManager with run_sweep()

### DIFF
--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -340,7 +340,6 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_sweep = duet.sync(run_sweep_async)
 
-    # TODO update
     async def run_batch_async(
         self,
         programs: Sequence[cirq.AbstractCircuit],
@@ -586,6 +585,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     create_batch_program = duet.sync(create_batch_program_async)
 
+    # TODO(#5996) Migrate to stream client
     async def create_calibration_program_async(
         self,
         layers: List['cirq_google.CalibrationLayer'],

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -320,11 +320,11 @@ class Engine(abstract_engine.AbstractEngine):
 
         stream_job_response_future = self.context.client.run_job_over_stream(
             project_id=self.project_id,
-            program_id=program_id,
+            program_id=str(program_id),
             program_description=program_description,
             program_labels=program_labels,
             code=self.context._serialize_program(program),
-            job_id=job_id,
+            job_id=str(job_id),
             processor_ids=processor_ids,
             run_context=run_context,
             job_description=job_description,
@@ -332,8 +332,8 @@ class Engine(abstract_engine.AbstractEngine):
         )
         return engine_job.EngineJob(
             self.project_id,
-            program_id,
-            job_id,
+            str(program_id),
+            str(job_id),
             self.context,
             stream_job_response_future=stream_job_response_future,
         )

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -340,6 +340,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_sweep = duet.sync(run_sweep_async)
 
+    # TODO(#5996) Migrate to stream client
     async def run_batch_async(
         self,
         programs: Sequence[cirq.AbstractCircuit],
@@ -420,7 +421,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_batch = duet.sync(run_batch_async)
 
-    # TODO update
+    # TODO(#5996) Migrate to stream client
     async def run_calibration_async(
         self,
         layers: List['cirq_google.CalibrationLayer'],
@@ -585,7 +586,6 @@ class Engine(abstract_engine.AbstractEngine):
 
     create_batch_program = duet.sync(create_batch_program_async)
 
-    # TODO(#5996) Migrate to stream client
     async def create_calibration_program_async(
         self,
         layers: List['cirq_google.CalibrationLayer'],

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -38,7 +38,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from cirq._compat import cached_property
 from cirq_google.cloud import quantum
 from cirq_google.engine.asyncio_executor import AsyncioExecutor
-from cirq_google.engine.stream_manager import StreamManager
+from cirq_google.engine import stream_manager
 
 _M = TypeVar('_M', bound=proto.Message)
 _R = TypeVar('_R')
@@ -107,8 +107,8 @@ class EngineClient:
         return self._executor.submit(make_client).result()
 
     @cached_property
-    def _stream_manager(self) -> StreamManager:
-        return StreamManager(self.grpc_client)
+    def _stream_manager(self) -> stream_manager.StreamManager:
+        return stream_manager.StreamManager(self.grpc_client)
 
     async def _send_request_async(self, func: Callable[[_M], Awaitable[_R]], request: _M) -> _R:
         """Sends a request by invoking an asyncio callable."""
@@ -721,6 +721,19 @@ class EngineClient:
         Sends the request over the Quantum Engine QuantumRunStream bidirectional stream, and returns
         a future for the stream response. The future will be completed with a `QuantumResult` if
         the job is successful; otherwise, it will be completed with a QuantumJob.
+
+        Args:
+            project_id: A project_id of the parent Google Cloud Project.
+            program_id: Unique ID of the program within the parent project.
+            code: Properly serialized program code.
+            job_id: Unique ID of the job within the parent program.
+            run_context: Properly serialized run context.
+            processor_ids: List of processor id for running the program.
+            program_description: An optional description to set on the program.
+            program_labels: Optional set of labels to set on the program.
+            priority: Optional priority to run at, 0-1000.
+            job_description: Optional description to set on the job.
+            job_labels: Optional set of labels to set on the job.
         """
         # Check program to run and program parameters.
         if priority and not 0 <= priority < 1000:

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -734,6 +734,12 @@ class EngineClient:
             priority: Optional priority to run at, 0-1000.
             job_description: Optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+
+        Returns:
+            A future for the job result, or the job if the job has failed.
+
+        Raises:
+            ValueError: If the priority is not between 0 and 1000.
         """
         # Check program to run and program parameters.
         if priority and not 0 <= priority < 1000:

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -38,6 +38,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from cirq._compat import cached_property
 from cirq_google.cloud import quantum
 from cirq_google.engine.asyncio_executor import AsyncioExecutor
+from cirq_google.engine.stream_manager import StreamManager
 
 _M = TypeVar('_M', bound=proto.Message)
 _R = TypeVar('_R')
@@ -104,6 +105,10 @@ class EngineClient:
                 return quantum.QuantumEngineServiceAsyncClient(**self._service_args)
 
         return self._executor.submit(make_client).result()
+
+    @cached_property
+    def _stream_manager(self) -> StreamManager:
+        return StreamManager(self.grpc_client)
 
     async def _send_request_async(self, func: Callable[[_M], Awaitable[_R]], request: _M) -> _R:
         """Sends a request by invoking an asyncio callable."""
@@ -696,6 +701,60 @@ class EngineClient:
         return await self._send_request_async(self.grpc_client.get_quantum_result, request)
 
     get_job_results = duet.sync(get_job_results_async)
+
+    def run_job_over_stream(
+        self,
+        project_id: str,
+        program_id: str,
+        code: any_pb2.Any,
+        job_id: str,
+        processor_ids: Sequence[str],
+        run_context: any_pb2.Any,
+        program_description: Optional[str] = None,
+        program_labels: Optional[Dict[str, str]] = None,
+        priority: Optional[int] = None,
+        job_description: Optional[str] = None,
+        job_labels: Optional[Dict[str, str]] = None,
+    ) -> duet.AwaitableFuture[Union[quantum.QuantumResult, quantum.QuantumJob]]:
+        """Runs a job with the given program and job information over a stream.
+
+        Sends the request over the Quantum Engine QuantumRunStream bidirectional stream, and returns
+        a future for the stream response. The future will be completed with a `QuantumResult` if
+        the job is successful; otherwise, it will be completed with a QuantumJob.
+        """
+        # Check program to run and program parameters.
+        if priority and not 0 <= priority < 1000:
+            raise ValueError('priority must be between 0 and 1000')
+
+        project_name = _project_name(project_id)
+
+        program_name = _program_name_from_ids(project_id, program_id)
+        program = quantum.QuantumProgram(name=program_name, code=code)
+        if program_description:
+            program.description = program_description
+        if program_labels:
+            program.labels.update(program_labels)
+
+        job = quantum.QuantumJob(
+            name=_job_name_from_ids(project_id, program_id, job_id),
+            scheduling_config=quantum.SchedulingConfig(
+                processor_selector=quantum.SchedulingConfig.ProcessorSelector(
+                    processor_names=[
+                        _processor_name_from_ids(project_id, processor_id)
+                        for processor_id in processor_ids
+                    ]
+                )
+            ),
+            run_context=run_context,
+        )
+        if priority:
+            job.scheduling_config.priority = priority
+        if job_description:
+            job.description = job_description
+        if job_labels:
+            job.labels.update(job_labels)
+
+        return self._stream_manager.submit(project_name, program, job)
 
     async def list_processors_async(self, project_id: str) -> List[quantum.QuantumProcessor]:
         """Returns a list of Processors that the user has visibility to in the

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -286,7 +286,8 @@ class EngineJob(abstract_job.AbstractJob):
         import cirq_google.engine.engine as engine_base
 
         if self._results is None:
-            result = await self._await_result_async()
+            result_response = await self._await_result_async()
+            result = result_response.result
             result_type = result.type_url[len(engine_base.TYPE_PREFIX) :]
             if (
                 result_type == 'cirq.google.api.v1.Result'
@@ -330,7 +331,7 @@ class EngineJob(abstract_job.AbstractJob):
         response = await self.context.client.get_job_results_async(
             self.project_id, self.program_id, self.job_id
         )
-        return response.result
+        return response
 
     async def calibration_results_async(self) -> Sequence[CalibrationResult]:
         """Returns the results of a run_calibration() call.
@@ -341,7 +342,8 @@ class EngineJob(abstract_job.AbstractJob):
         import cirq_google.engine.engine as engine_base
 
         if self._calibration_results is None:
-            result = await self._await_result_async()
+            result_response = await self._await_result_async()
+            result = result_response.result
             result_type = result.type_url[len(engine_base.TYPE_PREFIX) :]
             if result_type != 'cirq.google.api.v2.FocusedCalibrationResult':
                 raise ValueError(f'Did not find calibration results, instead found: {result_type}')

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -15,6 +15,7 @@
 from unittest import mock
 import datetime
 
+import duet
 import pytest
 import freezegun
 import numpy as np
@@ -799,22 +800,13 @@ def test_list_reservations_time_filter_behavior(list_reservations):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_sweep_params(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
     client().get_job_async.return_value = quantum.QuantumJob(
         execution_status={'state': 'SUCCESS'}, update_time=_to_timestamp('2019-07-09T23:39:59Z')
     )
-    client().get_job_results_async.return_value = quantum.QuantumResult(
-        result=util.pack_any(_RESULTS_V2)
-    )
+    expected_result = quantum.QuantumResult(result=util.pack_any(_RESULTS_V2))
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(expected_result)
+    client().run_job_over_stream.return_value = stream_future
 
     processor = cg.EngineProcessor('a', 'p', EngineContext())
     job = processor.run_sweep(
@@ -831,18 +823,15 @@ def test_run_sweep_params(client):
         assert result.job_finished_time is not None
     assert results == cirq.read_json(json_text=cirq.to_json(results))
 
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once()
+    client().run_job_over_stream.assert_called_once()
 
     run_context = v2.run_context_pb2.RunContext()
-    client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
+    client().run_job_over_stream.call_args[1]['run_context'].Unpack(run_context)
     sweeps = run_context.parameter_sweeps
     assert len(sweeps) == 2
     for i, v in enumerate([1.0, 2.0]):
         assert sweeps[i].repetitions == 1
         assert sweeps[i].sweep.sweep_function.sweeps[0].single_sweep.points.points == [v]
-    client().get_job_async.assert_called_once()
-    client().get_job_results_async.assert_called_once()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -943,22 +932,14 @@ def test_run_calibration(client):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_sampler(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
     client().get_job_async.return_value = quantum.QuantumJob(
         execution_status={'state': 'SUCCESS'}, update_time=_to_timestamp('2019-07-09T23:39:59Z')
     )
-    client().get_job_results_async.return_value = quantum.QuantumResult(
-        result=util.pack_any(_RESULTS_V2)
-    )
+    expected_result = quantum.QuantumResult(result=util.pack_any(_RESULTS_V2))
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(expected_result)
+    client().run_job_over_stream.return_value = stream_future
+
     processor = cg.EngineProcessor('proj', 'mysim', EngineContext())
     sampler = processor.get_sampler()
     results = sampler.run_sweep(
@@ -969,7 +950,7 @@ def test_sampler(client):
         assert results[i].repetitions == 1
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
-    assert client().create_program_async.call_args[0][0] == 'proj'
+    assert client().run_job_over_stream.call_args[1]['project_id'] == 'proj'
 
 
 def test_str():

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -19,6 +19,7 @@ import time
 import numpy as np
 import pytest
 
+import duet
 from google.protobuf import any_pb2, timestamp_pb2
 from google.protobuf.text_format import Merge
 
@@ -348,6 +349,9 @@ def setup_run_circuit_with_result_(client, result):
         execution_status={'state': 'SUCCESS'}, update_time=_DT
     )
     client().get_job_results_async.return_value = quantum.QuantumResult(result=result)
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(quantum.QuantumResult(result=result))
+    client().run_job_over_stream.return_value = stream_future
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -363,10 +367,10 @@ def test_run_circuit(client):
     assert result.params.param_dict == {'a': 1}
     assert result.measurements == {'q': np.array([[0]], dtype='uint8')}
     client.assert_called_with(service_args={'client_info': 1}, verbose=None)
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once_with(
+    client().run_job_over_stream.assert_called_once_with(
         project_id='proj',
         program_id='prog',
+        code=mock.ANY,
         job_id='job-id',
         processor_ids=['mysim'],
         run_context=util.pack_any(
@@ -374,11 +378,11 @@ def test_run_circuit(client):
                 parameter_sweeps=[v2.run_context_pb2.ParameterSweep(repetitions=1)]
             )
         ),
-        description=None,
-        labels=None,
+        program_description=None,
+        program_labels=None,
+        job_description=None,
+        job_labels=None,
     )
-    client().get_job_async.assert_called_once_with('proj', 'prog', 'job-id', False)
-    client().get_job_results_async.assert_called_once_with('proj', 'prog', 'job-id')
 
 
 def test_no_gate_set():
@@ -394,17 +398,7 @@ def test_unsupported_program_type():
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_circuit_failed(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
+    failed_job = quantum.QuantumJob(
         name='projects/proj/programs/prog/jobs/job-id',
         execution_status={
             'state': 'FAILURE',
@@ -412,6 +406,9 @@ def test_run_circuit_failed(client):
             'failure': {'error_code': 'SYSTEM_ERROR', 'error_message': 'Not good'},
         },
     )
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(failed_job)
+    client().run_job_over_stream.return_value = stream_future
 
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
@@ -424,23 +421,16 @@ def test_run_circuit_failed(client):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_circuit_failed_missing_processor_name(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
+    failed_job = quantum.QuantumJob(
         name='projects/proj/programs/prog/jobs/job-id',
         execution_status={
             'state': 'FAILURE',
             'failure': {'error_code': 'SYSTEM_ERROR', 'error_message': 'Not good'},
         },
     )
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(failed_job)
+    client().run_job_over_stream.return_value = stream_future
 
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
@@ -453,45 +443,17 @@ def test_run_circuit_failed_missing_processor_name(client):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
 def test_run_circuit_cancelled(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
+    canceled_job = quantum.QuantumJob(
         name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'CANCELLED'}
     )
+    stream_future = duet.AwaitableFuture()
+    stream_future.try_set_result(canceled_job)
+    client().run_job_over_stream.return_value = stream_future
 
     engine = cg.Engine(project_id='proj')
     with pytest.raises(
         RuntimeError, match='Job projects/proj/programs/prog/jobs/job-id failed in state CANCELLED.'
     ):
-        engine.run(program=_CIRCUIT)
-
-
-@mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
-def test_run_circuit_timeout(client):
-    client().create_program_async.return_value = (
-        'prog',
-        quantum.QuantumProgram(name='projects/proj/programs/prog'),
-    )
-    client().create_job_async.return_value = (
-        'job-id',
-        quantum.QuantumJob(
-            name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'READY'}
-        ),
-    )
-    client().get_job_async.return_value = quantum.QuantumJob(
-        name='projects/proj/programs/prog/jobs/job-id', execution_status={'state': 'RUNNING'}
-    )
-
-    engine = cg.Engine(project_id='project-id', timeout=1)
-    with pytest.raises(TimeoutError):
         engine.run(program=_CIRCUIT)
 
 
@@ -510,18 +472,15 @@ def test_run_sweep_params(client):
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
 
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once()
+    client().run_job_over_stream.assert_called_once()
 
     run_context = v2.run_context_pb2.RunContext()
-    client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
+    client().run_job_over_stream.call_args[1]['run_context'].Unpack(run_context)
     sweeps = run_context.parameter_sweeps
     assert len(sweeps) == 2
     for i, v in enumerate([1.0, 2.0]):
         assert sweeps[i].repetitions == 1
         assert sweeps[i].sweep.sweep_function.sweeps[0].single_sweep.points.points == [v]
-    client().get_job_async.assert_called_once()
-    client().get_job_results_async.assert_called_once()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -567,16 +526,13 @@ def test_run_sweep_v2(client):
         assert results[i].repetitions == 1
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
-    client().create_program_async.assert_called_once()
-    client().create_job_async.assert_called_once()
+    client().run_job_over_stream.assert_called_once()
     run_context = v2.run_context_pb2.RunContext()
-    client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
+    client().run_job_over_stream.call_args[1]['run_context'].Unpack(run_context)
     sweeps = run_context.parameter_sweeps
     assert len(sweeps) == 1
     assert sweeps[0].repetitions == 1
     assert sweeps[0].sweep.single_sweep.points.points == [1, 2]
-    client().get_job_async.assert_called_once()
-    client().get_job_results_async.assert_called_once()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
@@ -732,7 +688,7 @@ def test_bad_program_proto():
     engine = cg.Engine(
         project_id='project-id', proto_version=cg.engine.engine.ProtoVersion.UNDEFINED
     )
-    with pytest.raises(ValueError, match='invalid program proto version'):
+    with pytest.raises(ValueError, match='invalid (program|run context) proto version'):
         engine.run_sweep(program=_CIRCUIT)
     with pytest.raises(ValueError, match='invalid program proto version'):
         engine.create_program(_CIRCUIT)
@@ -817,7 +773,7 @@ def test_sampler(client):
         assert results[i].repetitions == 1
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
-    assert client().create_program_async.call_args[0][0] == 'proj'
+    assert client().run_job_over_stream.call_args[1]['project_id'] == 'proj'
 
     with cirq.testing.assert_deprecated('sampler', deadline='1.0'):
         _ = engine.sampler(processor_id='tmp')


### PR DESCRIPTION
* Connects the user interface of engine circuit execution with the `StreamManager` introduced in https://github.com/quantumlib/Cirq/pull/6199.
* `QuantumRunStream` supports `CreateQuantumProgramAndJob` requests, so the implementation here bypasses `EngineProgram` altogether, which will continue to use unary RPCs. This also aligns with our eventual goal of removing programs as a resource.
* `ProcessorSampler`, the recommended interface to run circuits on QuantumEngine, uses `Engine.run_sweep()` under the hood.

*Note*: Previous review history is in [this PR](https://github.com/verult/Cirq/pull/17) against my own fork. I wanted to test something with GitHub's workflow, but it totally did not work :)

@dstrain115
cc @maffoo @wcourtney 