### PR TITLE
Remove temporary directories after test done

### DIFF
--- a/cirq-core/cirq/vis/heatmap_test.py
+++ b/cirq-core/cirq/vis/heatmap_test.py
@@ -14,6 +14,7 @@
 """Tests for Heatmap."""
 
 import pathlib
+import shutil
 import string
 from tempfile import mkdtemp
 
@@ -309,6 +310,7 @@ def test_colorbar(ax, position, size, pad):
 
     plt.close(fig1)
     plt.close(fig2)
+    shutil.rmtree(tmp_dir)
 
 
 @pytest.mark.usefixtures('closefigures')

--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -15,6 +15,7 @@
 """Tests the cloned_env fixture in conftest.py"""
 import json
 import os
+import shutil
 import subprocess
 from unittest import mock
 
@@ -39,3 +40,4 @@ def test_isolated_env_cloning(cloned_env, param):
     packages = json.loads(result.stdout)
     assert {"name": "flynt", "version": "0.64"} in packages
     assert {"astor", "flynt", "pip", "setuptools", "wheel"} == set(p['name'] for p in packages)
+    shutil.rmtree(env)

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -27,6 +27,7 @@
 import os
 import re
 import subprocess
+import shutil
 import warnings
 from typing import Set, List
 
@@ -188,6 +189,7 @@ papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
             f"dev_tools/notebooks/isolated_notebook_test.py."
         )
     os.remove(rewritten_notebook_path)
+    shutil.rmtree(notebook_env)
 
 
 @pytest.mark.slow

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import subprocess
 from unittest import mock
 
@@ -48,3 +49,4 @@ def test_isolated_packages(cloned_env, module):
         check=False,
     )
     assert result.returncode == 0, f"Failed isolated tests for {module.name}:\n{result.stdout}"
+    shutil.rmtree(env)


### PR DESCRIPTION
* remove temporary isolated venv after isolated notebook/packaging test done

* remove temporary venv after cloned env test done

* remove temporary directories for figures after heatmap testings

Fix pytest and TMPDIR housekeeping (#6036)