### PR TITLE
Fix bug in controlled() method of CCX and CCZ gates

### DIFF
--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -206,12 +206,11 @@ class CCZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         """
         if num_controls == 0:
             return self
+        sub_gate: 'cirq.Gate' = self
         if self._global_shift == 0:
             sub_gate = controlled_gate.ControlledGate(
                 common_gates.ZPowGate(exponent=self._exponent), num_controls=2
             )
-        else:
-            sub_gate = self
         return controlled_gate.ControlledGate(
             sub_gate,
             num_controls=num_controls,
@@ -521,12 +520,11 @@ class CCXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         """
         if num_controls == 0:
             return self
+        sub_gate: 'cirq.Gate' = self
         if self._global_shift == 0:
             sub_gate = controlled_gate.ControlledGate(
                 common_gates.XPowGate(exponent=self._exponent), num_controls=2
             )
-        else:
-            sub_gate = self
         return controlled_gate.ControlledGate(
             sub_gate,
             num_controls=num_controls,

--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -206,11 +206,14 @@ class CCZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         """
         if num_controls == 0:
             return self
+        if self._global_shift == 0:
+            sub_gate = controlled_gate.ControlledGate(
+                common_gates.ZPowGate(exponent=self._exponent), num_controls=2
+            )
+        else:
+            sub_gate = self
         return controlled_gate.ControlledGate(
-            controlled_gate.ControlledGate(
-                common_gates.ZPowGate(exponent=self._exponent, global_shift=self._global_shift),
-                num_controls=2,
-            ),
+            sub_gate,
             num_controls=num_controls,
             control_values=control_values,
             control_qid_shape=control_qid_shape,
@@ -518,11 +521,14 @@ class CCXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         """
         if num_controls == 0:
             return self
+        if self._global_shift == 0:
+            sub_gate = controlled_gate.ControlledGate(
+                common_gates.XPowGate(exponent=self._exponent), num_controls=2
+            )
+        else:
+            sub_gate = self
         return controlled_gate.ControlledGate(
-            controlled_gate.ControlledGate(
-                common_gates.XPowGate(exponent=self._exponent, global_shift=self._global_shift),
-                num_controls=2,
-            ),
+            sub_gate,
             num_controls=num_controls,
             control_values=control_values,
             control_qid_shape=control_qid_shape,

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -30,7 +30,10 @@ from cirq.testing.consistent_act_on import assert_all_implemented_act_on_effects
 
 from cirq.testing.consistent_channels import assert_consistent_channel, assert_consistent_mixture
 
-from cirq.testing.consistent_controlled_gate_op import assert_controlled_and_controlled_by_identical
+from cirq.testing.consistent_controlled_gate_op import (
+    assert_controlled_and_controlled_by_identical,
+    assert_controlled_unitary_consistent,
+)
 
 from cirq.testing.consistent_decomposition import (
     assert_decompose_ends_at_default_gateset,

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op.py
@@ -14,7 +14,8 @@
 
 from typing import Sequence, Optional, Union, Collection
 
-from cirq import devices, ops
+from cirq import devices, ops, protocols
+import numpy as np
 
 
 def assert_controlled_and_controlled_by_identical(
@@ -32,6 +33,19 @@ def assert_controlled_and_controlled_by_identical(
         if control_value is not None and len(control_value) != num_control:
             raise ValueError(f"len(control_values[{i}]) != num_controls[{i}]")
         _assert_gate_consistent(gate, num_control, control_value)
+
+
+def assert_controlled_unitary_consistent(gate: ops.Gate):
+    """Checks that unitary of ControlledGate(gate) is consistent with gate.controlled()."""
+
+    u_orig = protocols.unitary(ops.ControlledGate(gate))
+    u_controlled = protocols.unitary(gate.controlled())
+    np.testing.assert_allclose(
+        u_orig,
+        u_controlled,
+        atol=1e-6,
+        err_msg=f"Unitary for gate.controlled() is inconsistent for {gate=}",
+    )
 
 
 def _assert_gate_consistent(

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
@@ -76,3 +76,14 @@ def test_assert_controlled_and_controlled_by_identical():
         cirq.testing.assert_controlled_and_controlled_by_identical(
             GoodGate(), num_controls=[1, 2], control_values=[(1,), (1, 1, 1)]
         )
+
+
+def test_assert_controlled_unitary_consistent():
+    cirq.testing.assert_controlled_and_controlled_by_identical(
+        GoodGate(exponent=0.5, global_shift=1 / 3)
+    )
+
+    with pytest.raises(AssertionError):
+        cirq.testing.assert_controlled_and_controlled_by_identical(
+            BadGate(exponent=0.5, global_shift=1 / 3)
+        )

--- a/cirq-core/cirq/testing/consistent_protocols.py
+++ b/cirq-core/cirq/testing/consistent_protocols.py
@@ -36,7 +36,10 @@ from cirq.testing.consistent_pauli_expansion import (
 from cirq.testing.consistent_resolve_parameters import assert_consistent_resolve_parameters
 from cirq.testing.consistent_specified_has_unitary import assert_specifies_has_unitary_if_unitary
 from cirq.testing.equivalent_repr_eval import assert_equivalent_repr
-from cirq.testing.consistent_controlled_gate_op import assert_controlled_and_controlled_by_identical
+from cirq.testing.consistent_controlled_gate_op import (
+    assert_controlled_and_controlled_by_identical,
+    assert_controlled_unitary_consistent,
+)
 from cirq.testing.consistent_unitary import assert_unitary_is_consistent
 
 
@@ -167,6 +170,8 @@ def _assert_meets_standards_helper(
         assert_eigen_shifts_is_consistent_with_eigen_components(val)
     if isinstance(val, ops.Gate) and protocols.has_mixture(val):
         assert_controlled_and_controlled_by_identical(val)
+        if protocols.has_unitary(val):
+            assert_controlled_unitary_consistent(val)
 
 
 def assert_commutes_magic_method_consistent_with_unitaries(


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/6235

Also adds a consistency test `assert_controlled_unitary_consistent` to the standard suite of `assert_implements_consistent_protocols` to make sure unitaries of `gate.controlled()` and `ControlledGate()` are identical. This consistency test would have caught the bug in the original PR. 