### PR TITLE
codecov - evaluate coverage at 0.1% resolution

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+coverage:
+  precision: 1


### PR DESCRIPTION
Avoid spurious decreases of coverage because of varying code paths
being visited at different random seeds.

Ref: https://docs.codecov.com/docs/codecovyml-reference#coverageprecision