### PR TITLE
Check if python starts python3

### DIFF
--- a/check/doctest
+++ b/check/doctest
@@ -18,6 +18,6 @@ thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
 topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
 cd "${topdir}" || exit $?
 
-source dev_tools/pypath
+source dev_tools/pypath || exit $?
 
 python dev_tools/docs/run_doctest.py "$@"

--- a/check/pytest
+++ b/check/pytest
@@ -20,7 +20,7 @@ cd "${topdir}" || exit $?
 # (the last `-n` option wins)
 PYTEST_ARGS=( "-n=auto" "$@" )
 
-source dev_tools/pypath
+source dev_tools/pypath || exit $?
 
 pytest "${PYTEST_ARGS[@]}"
 RESULT=$?

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -68,7 +68,7 @@ else
     rev="${base}"
 fi
 
-source dev_tools/pypath
+source dev_tools/pypath || exit $?
 
 # Run tests while producing coverage files.
 check/pytest --cov \

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -76,6 +76,6 @@ if [ "${num_changed}" -eq 0 ]; then
     exit 0
 fi
 
-source dev_tools/pypath
+source dev_tools/pypath || exit $?
 
 pytest "${rest[@]}" "${changed[@]}"

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -87,7 +87,7 @@ if [ "${#changed_python_tests[@]}" -eq 0 ]; then
     exit 0
 fi
 
-source dev_tools/pypath
+source dev_tools/pypath || exit $?
 
 # Run tests while producing coverage files.
 check/pytest "${changed_python_tests[@]}" \

--- a/dev_tools/pypath
+++ b/dev_tools/pypath
@@ -29,6 +29,12 @@ else
     _PYPATH_BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 
+if ! python --version | grep -q -F "Python 3."; then
+    echo "python command does not start Python 3" >&2
+    echo "Please use a virtual environment created for Python 3." >&2
+    return 2
+fi
+
 _PYPATH_PREFIX="${_PYPATH_BASE_DIR}$(
     cd "${_PYPATH_BASE_DIR}" &&
         env PYTHONPATH=. python dev_tools/modules.py list --mode folder |


### PR DESCRIPTION
Problem: dev_tools/pypath does not work when `python` command does
not exist causing a failure in `check/pytest` (PYTHONPATH not set).

Solution: Require that `python` starts Python 3.
Bail out from the check scripts otherwise.
