### PR TITLE
codecov - fix syntax for excluding code lines from coverage

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -351,7 +351,7 @@ def test_repeat_zero_times(add_measurements, use_repetition_ids, initial_reps):
 
 
 def test_no_repetition_ids():
-    def default_repetition_ids(self):
+    def default_repetition_ids(self):  # pragma: no cover
         assert False, "Should not call default_repetition_ids"
 
     with mock.patch.object(circuit_operation, 'default_repetition_ids', new=default_repetition_ids):

--- a/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation.py
@@ -407,8 +407,7 @@ def two_qubit_gate_product_tabulation(
     # If all KAK vectors in the mesh have been tabulated, return.
     missing_vec_inds = np.logical_not(tabulated_kak_inds).nonzero()[0]
 
-    if not np.any(missing_vec_inds):
-        # coverage: ignore
+    if not np.any(missing_vec_inds):  # pragma: no cover
         return TwoQubitGateTabulation(
             base_gate, np.array(kak_vecs), sq_cycles, max_infidelity, summary, ()
         )

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,0 @@
-coverage:
-  precision: 1
-  round: nearest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 coverage:
   precision: 1
+  round: nearest

--- a/examples/bernstein_vazirani.py
+++ b/examples/bernstein_vazirani.py
@@ -88,7 +88,7 @@ def make_oracle(input_qubits, output_qubit, secret_factor_bits, secret_bias_bit)
         yield cirq.X(output_qubit)
 
     for qubit, bit in zip(input_qubits, secret_factor_bits):
-        if bit:
+        if bit:  # pragma: no cover
             yield cirq.CNOT(qubit, output_qubit)
 
 

--- a/examples/deutsch.py
+++ b/examples/deutsch.py
@@ -56,11 +56,10 @@ def main():
 def make_oracle(q0, q1, secret_function):
     """Gates implementing the secret function f(x)."""
 
-    # coverage: ignore
-    if secret_function[0]:
+    if secret_function[0]:  # pragma: no cover
         yield [CNOT(q0, q1), X(q1)]
 
-    if secret_function[1]:
+    if secret_function[1]:  # pragma: no cover
         yield CNOT(q0, q1)
 
 

--- a/examples/shor.py
+++ b/examples/shor.py
@@ -264,10 +264,10 @@ def quantum_order_finder(x: int, n: int) -> Optional[int]:
     eigenphase = read_eigenphase(result)
     f = fractions.Fraction.from_float(eigenphase).limit_denominator(n)
     if f.numerator == 0:
-        return None  # coverage: ignore
+        return None  # pragma: no cover
     r = f.denominator
     if x**r % n != 1:
-        return None  # coverage: ignore
+        return None  # pragma: no cover
     return r
 
 
@@ -311,18 +311,18 @@ def find_factor(
         x = random.randint(2, n - 1)
         c = math.gcd(x, n)
         if 1 < c < n:
-            return c  # coverage: ignore
+            return c  # pragma: no cover
         r = order_finder(x, n)
         if r is None:
-            continue  # coverage: ignore
+            continue  # pragma: no cover
         if r % 2 != 0:
-            continue  # coverage: ignore
+            continue  # pragma: no cover
         y = x ** (r // 2) % n
         assert 1 < y < n
         c = math.gcd(y - 1, n)
         if 1 < c < n:
             return c
-    return None  # coverage: ignore
+    return None  # pragma: no cover
 
 
 def main(n: int, order_finder: Callable[[int, int], Optional[int]] = naive_order_finder):
@@ -340,8 +340,7 @@ def main(n: int, order_finder: Callable[[int, int], Optional[int]] = naive_order
         assert n % d == 0
 
 
-if __name__ == '__main__':
-    # coverage: ignore
+if __name__ == '__main__':  # pragma: no cover
     ORDER_FINDERS = {'naive': naive_order_finder, 'quantum': quantum_order_finder}
     args = parser.parse_args()
     main(n=args.n, order_finder=ORDER_FINDERS[args.order_finder])


### PR DESCRIPTION
The `coverage` tool understands `# pragma: no cover` markup comments to exclude
code lines from coverage analysis.    The previous syntax `# coverage: ignore`
had no effect and resulted in spurious coverage changes for a different code
paths taken.

Removing the codecov.yml file, because coverage precision had no effect on
codecov complaints about decreased coverage.