### PR TITLE
Fix coverage exclusion syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # How to Contribute
 
 We'd love to accept your patches and contributions to this project.
-We do have some guidelines to follow, covered in this document, but don't 
+We do have some guidelines to follow, covered in this document, but don't
 worry about (or expect to) get everything right the first time!
-Create a pull request and we'll nudge you in the right direction. Please also 
+Create a pull request and we'll nudge you in the right direction. Please also
 note that we have a [code of conduct](CODE_OF_CONDUCT.md) to make Cirq an
 open and welcoming environment.
 
@@ -83,7 +83,7 @@ on setting up your local development environment.
 
 ## Code Testing Standards
 
-When a pull request is created or updated, various automatic checks will 
+When a pull request is created or updated, various automatic checks will
 run to ensure that the change won't break Cirq and meets our coding standards.
 
 Cirq contains a continuous integration tool to verify testing.  See our
@@ -94,36 +94,36 @@ Please be aware of the following code standards that will be applied to any
 new changes.
 
 - **Tests**.
-Existing tests must continue to pass (or be updated) when new changes are 
-introduced. We use [pytest](https://docs.pytest.org/en/latest/) to run our 
+Existing tests must continue to pass (or be updated) when new changes are
+introduced. We use [pytest](https://docs.pytest.org/en/latest/) to run our
 tests.
 - **Coverage**.
 Code should be covered by tests.
-We use [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) to compute 
+We use [pytest-cov](https://pytest-cov.readthedocs.io/en/latest/) to compute
 coverage, and custom tooling to filter down the output to only include new or
-changed code. We don't require 100% coverage, but any uncovered code must 
-be annotated with `# coverage: ignore`. To ignore coverage of a single line, 
-place `# coverage: ignore` at the end of the line. To ignore coverage for 
-an entire block, start the block with a `# coverage: ignore` comment on its 
+changed code. We don't require 100% coverage, but any uncovered code must
+be annotated with `# pragma: no cover`. To ignore coverage of a single line,
+place `# pragma: no cover` at the end of the line. To ignore coverage for
+an entire block, start the block with a `# pragma: no cover` comment on its
 own line.
 - **Lint**.
-Code should meet common style standards for python and be free of error-prone 
+Code should meet common style standards for python and be free of error-prone
 constructs. We use [pylint](https://www.pylint.org/) to check for lint.
-To see which lint checks we enforce, see the 
+To see which lint checks we enforce, see the
 [dev_tools/conf/.pylintrc](dev_tools/conf/.pylintrc) file. When pylint produces
-a false positive, it can be squashed with annotations like 
+a false positive, it can be squashed with annotations like
 `# pylint: disable=unused-import`.
 - **Types**.
 Code should have [type annotations](https://www.python.org/dev/peps/pep-0484/).
 We use [mypy](http://mypy-lang.org/) to check that type annotations are correct.
-When type checking produces a false positive, it can be ignored with 
+When type checking produces a false positive, it can be ignored with
 annotations like `# type: ignore`.
 
 ## Request For Comment Process for New Major Features
 
-For larger contributions that will benefit from design reviews, please use the 
+For larger contributions that will benefit from design reviews, please use the
 [Request for Comment](docs/dev/rfc_process.md) process.
 
-## Developing notebooks 
+## Developing notebooks
 
 Please refer to our [notebooks guide](docs/dev/notebooks.md) on how to develop iPython notebooks for documentation.

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -17,8 +17,7 @@ and warn users that the latest version of cirq uses python 3.9+"""
 
 import sys
 
-if sys.version_info < (3, 9, 0):
-    # pragma: no cover
+if sys.version_info < (3, 9, 0):  # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.9+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -18,7 +18,7 @@ and warn users that the latest version of cirq uses python 3.9+"""
 import sys
 
 if sys.version_info < (3, 9, 0):
-    # coverage: ignore
+    # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.9+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -61,9 +61,9 @@ def _full_join_string_lists(
     list1: Optional[Sequence[str]], list2: Optional[Sequence[str]]
 ) -> Optional[Sequence[str]]:
     if list1 is None and list2 is None:
-        return None  # coverage: ignore
+        return None  # pragma: no cover
     if list1 is None:
-        return list2  # coverage: ignore
+        return list2  # pragma: no cover
     if list2 is None:
         return list1
     return [f'{first}{REPETITION_ID_SEPARATOR}{second}' for first in list1 for second in list2]

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -257,7 +257,7 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
 
         def _decompose_(self):
             # Only used by test_output_unitary_same_as_qiskit
-            return ()  # coverage: ignore
+            return ()  # pragma: no cover
 
     class DummyCompositeOperation(cirq.Operation):
         qubits = (q0,)

--- a/cirq-core/cirq/conftest.py
+++ b/cirq-core/cirq/conftest.py
@@ -27,7 +27,7 @@ def pytest_configure(config):
 
 def pytest_pyfunc_call(pyfuncitem):
     if inspect.iscoroutinefunction(pyfuncitem._obj):
-        # coverage: ignore
+        # pragma: no cover
         raise ValueError(
             f'{pyfuncitem._obj.__name__} is a bare async function. '
             f'It should be decorated with "@duet.sync".'

--- a/cirq-core/cirq/conftest.py
+++ b/cirq-core/cirq/conftest.py
@@ -27,8 +27,7 @@ def pytest_configure(config):
 
 def pytest_pyfunc_call(pyfuncitem):
     if inspect.iscoroutinefunction(pyfuncitem._obj):
-        # pragma: no cover
-        raise ValueError(
+        raise ValueError(  # pragma: no cover
             f'{pyfuncitem._obj.__name__} is a bare async function. '
             f'It should be decorated with "@duet.sync".'
         )

--- a/cirq-core/cirq/contrib/acquaintance/devices.py
+++ b/cirq-core/cirq/contrib/acquaintance/devices.py
@@ -68,7 +68,7 @@ class _UnconstrainedAcquaintanceDevice(AcquaintanceDevice):
     """An acquaintance device with no constraints other than of the gate types."""
 
     def __repr__(self) -> str:
-        return 'UnconstrainedAcquaintanceDevice'  # coverage: ignore
+        return 'UnconstrainedAcquaintanceDevice'  # pragma: no cover
 
 
 UnconstrainedAcquaintanceDevice = _UnconstrainedAcquaintanceDevice()

--- a/cirq-core/cirq/contrib/hacks/disable_validation_test.py
+++ b/cirq-core/cirq/contrib/hacks/disable_validation_test.py
@@ -29,7 +29,7 @@ def test_disable_op_validation():
     with pytest.raises(ValueError, match='mysterious and terrible'):
         with disable_op_validation():
             # This does not run - the with condition errors out first.
-            _ = cirq.H(q0, q1)  # coverage: ignore
+            _ = cirq.H(q0, q1)  # pragma: no cover
 
     # Passes, skipping validation.
     with disable_op_validation(accept_debug_responsibility=True):

--- a/cirq-core/cirq/contrib/noise_models/noise_models.py
+++ b/cirq-core/cirq/contrib/noise_models/noise_models.py
@@ -41,8 +41,7 @@ class DepolarizingNoiseModel(devices.NoiseModel):
         self._prepend = prepend
 
     def noisy_moment(self, moment: 'cirq.Moment', system_qubits: Sequence['cirq.Qid']):
-        if validate_all_measurements(moment) or self.is_virtual_moment(moment):
-            # pragma: no cover
+        if validate_all_measurements(moment) or self.is_virtual_moment(moment):  # pragma: no cover
             return moment
 
         output = [

--- a/cirq-core/cirq/contrib/noise_models/noise_models.py
+++ b/cirq-core/cirq/contrib/noise_models/noise_models.py
@@ -42,7 +42,7 @@ class DepolarizingNoiseModel(devices.NoiseModel):
 
     def noisy_moment(self, moment: 'cirq.Moment', system_qubits: Sequence['cirq.Qid']):
         if validate_all_measurements(moment) or self.is_virtual_moment(moment):
-            # coverage: ignore
+            # pragma: no cover
             return moment
 
         output = [

--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
@@ -161,7 +161,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit, atol: float = 1e-8) ->
             else:
                 # Two CZ gates that share one qubit
                 # Pass through and keep looking
-                continue  # coverage: ignore
+                continue  # pragma: no cover
                 # The above line is covered by test_remove_staggered_czs but the
                 # coverage checker disagrees.
         return 0

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# coverage: ignore
+# pragma: no cover
 
 import errno
 import os

--- a/cirq-core/cirq/contrib/quimb/density_matrix.py
+++ b/cirq-core/cirq/contrib/quimb/density_matrix.py
@@ -106,7 +106,7 @@ def circuit_to_density_matrix_tensors(
         ValueError: If an op is encountered that cannot be converted.
     """
     if qubits is None:
-        # coverage: ignore
+        # pragma: no cover
         qubits = sorted(circuit.all_qubits())
     qubits = tuple(qubits)
 
@@ -190,7 +190,7 @@ def circuit_to_density_matrix_tensors(
                 )
                 kraus_frontier += 1
             else:
-                raise ValueError(repr(op))  # coverage: ignore
+                raise ValueError(repr(op))  # pragma: no cover
 
             _positions(mi + 1, op.qubits)
     return tensors, qubit_frontier, positions

--- a/cirq-core/cirq/contrib/quimb/density_matrix.py
+++ b/cirq-core/cirq/contrib/quimb/density_matrix.py
@@ -106,8 +106,7 @@ def circuit_to_density_matrix_tensors(
         ValueError: If an op is encountered that cannot be converted.
     """
     if qubits is None:
-        # pragma: no cover
-        qubits = sorted(circuit.all_qubits())
+        qubits = sorted(circuit.all_qubits())  # pragma: no cover
     qubits = tuple(qubits)
 
     qubit_frontier: Dict[cirq.Qid, int] = {q: 0 for q in qubits}

--- a/cirq-core/cirq/contrib/quimb/grid_circuits.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits.py
@@ -54,12 +54,12 @@ def get_grid_moments(
             for col in range(col_start + col_start_offset, col_end + col_end_offset, col_step):
                 node1 = (row, col)
                 if node1 not in problem_graph.nodes:
-                    continue  # coverage: ignore
+                    continue  # pragma: no cover
                 node2 = get_neighbor(row, col)
                 if node2 not in problem_graph.nodes:
-                    continue  # coverage: ignore
+                    continue  # pragma: no cover
                 if (node1, node2) not in problem_graph.edges:
-                    continue  # coverage: ignore
+                    continue  # pragma: no cover
 
                 weight = problem_graph.edges[node1, node2].get('weight', 1)
                 yield two_qubit_gate(exponent=weight, global_shift=-0.5).on(

--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -9,7 +9,7 @@ import quimb.tensor as qtn
 import cirq
 
 
-# coverage: ignore
+# pragma: no cover
 def _get_quimb_version():
     """Returns the quimb version and parsed (major,minor) numbers if possible.
     Returns:
@@ -59,7 +59,7 @@ def circuit_to_tensors(
             corresponding to the |0> state.
     """
     if qubits is None:
-        qubits = sorted(circuit.all_qubits())  # coverage: ignore
+        qubits = sorted(circuit.all_qubits())  # pragma: no cover
 
     qubit_frontier = {q: 0 for q in qubits}
     positions = None
@@ -163,7 +163,7 @@ def tensor_expectation_value(
     ]
     tn = qtn.TensorNetwork(tensors + end_bras)
     if QUIMB_VERSION[0] < (1, 3):
-        # coverage: ignore
+        # pragma: no cover
         warnings.warn(
             f'quimb version {QUIMB_VERSION[1]} detected. Please use '
             f'quimb>=1.3 for optimal performance in '

--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -9,7 +9,6 @@ import quimb.tensor as qtn
 import cirq
 
 
-# pragma: no cover
 def _get_quimb_version():
     """Returns the quimb version and parsed (major,minor) numbers if possible.
     Returns:
@@ -18,7 +17,7 @@ def _get_quimb_version():
     version = quimb.__version__
     try:
         return tuple(int(x) for x in version.split('.')), version
-    except:
+    except:  # pragma: no cover
         return (0, 0), version
 
 
@@ -163,8 +162,7 @@ def tensor_expectation_value(
     ]
     tn = qtn.TensorNetwork(tensors + end_bras)
     if QUIMB_VERSION[0] < (1, 3):
-        # pragma: no cover
-        warnings.warn(
+        warnings.warn(  # pragma: no cover
             f'quimb version {QUIMB_VERSION[1]} detected. Please use '
             f'quimb>=1.3 for optimal performance in '
             '`tensor_expectation_value`. '

--- a/cirq-core/cirq/contrib/routing/utils.py
+++ b/cirq-core/cirq/contrib/routing/utils.py
@@ -96,8 +96,7 @@ def get_circuit_connectivity(circuit: 'cirq.Circuit') -> nx.Graph:
     for op in circuit.all_operations():
         n_qubits = len(op.qubits)
         if n_qubits > 2:
-            # pragma: no cover
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 f"Cannot build a graph out of a circuit that "
                 f"contains {n_qubits}-qubit operations"
             )

--- a/cirq-core/cirq/contrib/routing/utils.py
+++ b/cirq-core/cirq/contrib/routing/utils.py
@@ -96,7 +96,7 @@ def get_circuit_connectivity(circuit: 'cirq.Circuit') -> nx.Graph:
     for op in circuit.all_operations():
         n_qubits = len(op.qubits)
         if n_qubits > 2:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError(
                 f"Cannot build a graph out of a circuit that "
                 f"contains {n_qubits}-qubit operations"

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -145,7 +145,7 @@ def _debug_spacing(col_starts, row_starts):
     draws green lines where columns and rows start. This is very useful
     if you're developing this code and are debugging spacing issues.
     """
-    # coverage: ignore
+    # pragma: no cover
     t = ''
     for i, cs in enumerate(col_starts):
         t += (
@@ -198,7 +198,7 @@ def tdd_to_svg(
             # qubits start at far left and their wires shall be blue
             stroke = QBLUE
         else:
-            # coverage: ignore
+            # pragma: no cover
             stroke = 'black'
         t += f'<line x1="{x1}" x2="{x2}" y1="{y}" y2="{y}" stroke="{stroke}" stroke-width="1" />'
 
@@ -261,11 +261,11 @@ class SVGCircuit:
     """
 
     def __init__(self, circuit: 'cirq.Circuit'):
-        # coverage: ignore
+        # pragma: no cover
         self.circuit = circuit
 
     def _repr_svg_(self) -> str:
-        # coverage: ignore
+        # pragma: no cover
         return circuit_to_svg(self.circuit)
 
 

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -140,12 +140,11 @@ def _fit_vertical(
     return row_starts, row_heights, yi_map
 
 
-def _debug_spacing(col_starts, row_starts):
+def _debug_spacing(col_starts, row_starts):  # pragma: no cover
     """Return a string suitable for inserting inside an <svg> tag that
     draws green lines where columns and rows start. This is very useful
     if you're developing this code and are debugging spacing issues.
     """
-    # pragma: no cover
     t = ''
     for i, cs in enumerate(col_starts):
         t += (
@@ -198,7 +197,6 @@ def tdd_to_svg(
             # qubits start at far left and their wires shall be blue
             stroke = QBLUE
         else:
-            # pragma: no cover
             stroke = 'black'
         t += f'<line x1="{x1}" x2="{x2}" y1="{y}" y2="{y}" stroke="{stroke}" stroke-width="1" />'
 
@@ -261,11 +259,9 @@ class SVGCircuit:
     """
 
     def __init__(self, circuit: 'cirq.Circuit'):
-        # pragma: no cover
         self.circuit = circuit
 
     def _repr_svg_(self) -> str:
-        # pragma: no cover
         return circuit_to_svg(self.circuit)
 
 

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -295,8 +295,7 @@ def get_placements(
     for big_to_small_map in matcher.subgraph_monomorphisms_iter():
         dedupe[frozenset(big_to_small_map.keys())] = big_to_small_map
         if len(dedupe) > max_placements:
-            # pragma: no cover
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 f"We found more than {max_placements} placements. Please use a "
                 f"more constraining `big_graph` or a more constrained `small_graph`."
             )
@@ -367,27 +366,23 @@ def draw_placements(
             this callback is called. The callback should accept `ax` and `i` keyword arguments
             for the current axis and mapping index, respectively.
     """
-    if len(small_to_big_mappings) > max_plots:
-        # pragma: no cover
+    if len(small_to_big_mappings) > max_plots:  # pragma: no cover
         warnings.warn(f"You've provided a lot of mappings. Only plotting the first {max_plots}")
         small_to_big_mappings = small_to_big_mappings[:max_plots]
 
     call_show = False
     if axes is None:
-        # pragma: no cover
-        call_show = True
+        call_show = True  # pragma: no cover
 
     for i, small_to_big_map in enumerate(small_to_big_mappings):
         if axes is not None:
             ax = axes[i]
-        else:
-            # pragma: no cover
+        else:  # pragma: no cover
             ax = plt.gca()
 
         small_mapped = nx.relabel_nodes(small_graph, small_to_big_map)
         if bad_placement_callback is not None:
-            # pragma: no cover
-            if not _is_valid_placement_helper(
+            if not _is_valid_placement_helper(  # pragma: no cover
                 big_graph=big_graph,
                 small_mapped=small_mapped,
                 small_to_big_mapping=small_to_big_map,
@@ -406,7 +401,6 @@ def draw_placements(
         )
         ax.axis('equal')
         if call_show:
-            # pragma: no cover
             # poor man's multi-axis figure: call plt.show() after each plot
             # and jupyter will put the plots one after another.
-            plt.show()
+            plt.show()  # pragma: no cover

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -93,7 +93,7 @@ def draw_gridlike(
         to NetworkX plotting functionality.
     """
     if ax is None:
-        ax = plt.gca()  # coverage: ignore
+        ax = plt.gca()  # pragma: no cover
 
     if tilted:
         pos = {node: (y, -x) for node, (x, y) in _node_and_coordinates(graph.nodes)}
@@ -295,7 +295,7 @@ def get_placements(
     for big_to_small_map in matcher.subgraph_monomorphisms_iter():
         dedupe[frozenset(big_to_small_map.keys())] = big_to_small_map
         if len(dedupe) > max_placements:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError(
                 f"We found more than {max_placements} placements. Please use a "
                 f"more constraining `big_graph` or a more constrained `small_graph`."
@@ -368,25 +368,25 @@ def draw_placements(
             for the current axis and mapping index, respectively.
     """
     if len(small_to_big_mappings) > max_plots:
-        # coverage: ignore
+        # pragma: no cover
         warnings.warn(f"You've provided a lot of mappings. Only plotting the first {max_plots}")
         small_to_big_mappings = small_to_big_mappings[:max_plots]
 
     call_show = False
     if axes is None:
-        # coverage: ignore
+        # pragma: no cover
         call_show = True
 
     for i, small_to_big_map in enumerate(small_to_big_mappings):
         if axes is not None:
             ax = axes[i]
         else:
-            # coverage: ignore
+            # pragma: no cover
             ax = plt.gca()
 
         small_mapped = nx.relabel_nodes(small_graph, small_to_big_map)
         if bad_placement_callback is not None:
-            # coverage: ignore
+            # pragma: no cover
             if not _is_valid_placement_helper(
                 big_graph=big_graph,
                 small_mapped=small_mapped,
@@ -406,7 +406,7 @@ def draw_placements(
         )
         ax.axis('equal')
         if call_show:
-            # coverage: ignore
+            # pragma: no cover
             # poor man's multi-axis figure: call plt.show() after each plot
             # and jupyter will put the plots one after another.
             plt.show()

--- a/cirq-core/cirq/devices/noise_properties.py
+++ b/cirq-core/cirq/devices/noise_properties.py
@@ -97,7 +97,7 @@ class NoiseModelFromNoiseProperties(devices.NoiseModel):
             # only ops with PHYSICAL_GATE_TAG will receive noise.
             if virtual_ops:
                 # Only subclasses will trigger this case.
-                new_moments.append(circuits.Moment(virtual_ops))  # coverage: ignore
+                new_moments.append(circuits.Moment(virtual_ops))  # pragma: no cover
             if physical_ops:
                 new_moments.append(circuits.Moment(physical_ops))
 

--- a/cirq-core/cirq/experiments/readout_confusion_matrix.py
+++ b/cirq-core/cirq/experiments/readout_confusion_matrix.py
@@ -278,7 +278,7 @@ class TensoredConfusionMatrices:
             raise ValueError(f"method: {method} should be 'pseudo_inverse' or 'least_squares'.")
 
         if method == 'pseudo_inverse':
-            return result @ self.correction_matrix(qubits)  # coverage: ignore
+            return result @ self.correction_matrix(qubits)  # pragma: no cover
 
         # Least squares minimization.
         cm = self.confusion_matrix(qubits)
@@ -291,11 +291,11 @@ class TensoredConfusionMatrices:
         res = scipy.optimize.minimize(
             func, result, method='SLSQP', constraints=constraints, bounds=bounds
         )
-        if res.success is False:  # coverage: ignore
-            raise ValueError(  # coverage: ignore
-                f"SLSQP optimization for constrained minimization "  # coverage: ignore
-                f"did not converge. Result:\n{res}"  # coverage: ignore
-            )  # coverage: ignore
+        if res.success is False:  # pragma: no cover
+            raise ValueError(  # pragma: no cover
+                f"SLSQP optimization for constrained minimization "  # pragma: no cover
+                f"did not converge. Result:\n{res}"  # pragma: no cover
+            )  # pragma: no cover
         return res.x
 
     def __repr__(self) -> str:

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -108,12 +108,12 @@ def benchmark_2q_xeb_fidelities(
         def _try_keep(k):
             """If all the values for a key `k` are the same in this group, we can keep it."""
             if k not in df.columns:
-                return  # coverage: ignore
+                return  # pragma: no cover
             vals = df[k].unique()
             if len(vals) == 1:
                 ret[k] = vals[0]
             else:
-                # coverage: ignore
+                # pragma: no cover
                 raise AssertionError(
                     f"When computing per-cycle-depth fidelity, multiple "
                     f"values for {k} were grouped together: {vals}"
@@ -574,8 +574,8 @@ def _fit_exponential_decay(
             p0=(a_0, layer_fid_0),
             bounds=((0, 0), (1, 1)),
         )
-    except ValueError:  # coverage: ignore
-        # coverage: ignore
+    except ValueError:  # pragma: no cover
+        # pragma: no cover
         return 0, 0, np.inf, np.inf
 
     a_std, layer_fid_std = np.sqrt(np.diag(pcov))

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -112,8 +112,7 @@ def benchmark_2q_xeb_fidelities(
             vals = df[k].unique()
             if len(vals) == 1:
                 ret[k] = vals[0]
-            else:
-                # pragma: no cover
+            else:  # pragma: no cover
                 raise AssertionError(
                     f"When computing per-cycle-depth fidelity, multiple "
                     f"values for {k} were grouped together: {vals}"
@@ -575,7 +574,6 @@ def _fit_exponential_decay(
             bounds=((0, 0), (1, 1)),
         )
     except ValueError:  # pragma: no cover
-        # pragma: no cover
         return 0, 0, np.inf, np.inf
 
     a_std, layer_fid_std = np.sqrt(np.diag(pcov))

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -155,7 +155,7 @@ class ClassicallyControlledOperation(raw_types.Operation):
         )
         sub_info = protocols.circuit_diagram_info(self._sub_operation, sub_args, None)
         if sub_info is None:
-            return NotImplemented  # coverage: ignore
+            return NotImplemented  # pragma: no cover
         control_label_count = 0
         if args.label_map is not None:
             control_label_count = len({k for c in self._conditions for k in c.keys})

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -846,8 +846,7 @@ class SingleQubitCliffordGate(CliffordGate):
                 ]
 
             return [(pauli_gates.Z, 1 if y_rot[1] else -1), (pauli_gates.X, 1 if z_rot[1] else -1)]
-        # pragma: no cover
-        assert (
+        assert (  # pragma: no cover
             False
         ), 'Impossible condition where this gate only rotates one Pauli to a different Pauli.'
 

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -448,7 +448,7 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
             sim_state._state = sim_state.tableau.then(padded_tableau)
             return True
 
-        if isinstance(sim_state, sim.clifford.StabilizerChFormSimulationState):  # coverage: ignore
+        if isinstance(sim_state, sim.clifford.StabilizerChFormSimulationState):  # pragma: no cover
             # Do we know how to apply CliffordTableau on StabilizerChFormSimulationState?
             # It should be unlike because CliffordTableau ignores the global phase but CHForm
             # is aimed to fix that.
@@ -846,7 +846,7 @@ class SingleQubitCliffordGate(CliffordGate):
                 ]
 
             return [(pauli_gates.Z, 1 if y_rot[1] else -1), (pauli_gates.X, 1 if z_rot[1] else -1)]
-        # coverage: ignore
+        # pragma: no cover
         assert (
             False
         ), 'Impossible condition where this gate only rotates one Pauli to a different Pauli.'

--- a/cirq-core/cirq/ops/controlled_operation_test.py
+++ b/cirq-core/cirq/ops/controlled_operation_test.py
@@ -446,10 +446,10 @@ def test_controlled_operation_gate():
     class Gateless(cirq.Operation):
         @property
         def qubits(self):
-            return ()  # coverage: ignore
+            return ()  # pragma: no cover
 
         def with_qubits(self, *new_qubits):
-            return self  # coverage: ignore
+            return self  # pragma: no cover
 
         def _has_mixture_(self):
             return True

--- a/cirq-core/cirq/ops/eigen_gate_test.py
+++ b/cirq-core/cirq/ops/eigen_gate_test.py
@@ -201,8 +201,7 @@ def test_trace_distance_bound():
     assert cirq.approx_eq(cirq.trace_distance_bound(CExpZinGate(2)), 1)
 
     class E(cirq.EigenGate):
-        def _num_qubits_(self):
-            # pragma: no cover
+        def _num_qubits_(self):  # pragma: no cover
             return 1
 
         def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:

--- a/cirq-core/cirq/ops/eigen_gate_test.py
+++ b/cirq-core/cirq/ops/eigen_gate_test.py
@@ -227,7 +227,6 @@ def test_extrapolate():
 
 
 def test_matrix():
-
     for n in [1, 2, 3, 4, 0.0001, 3.9999]:
         assert cirq.has_unitary(CExpZinGate(n))
 

--- a/cirq-core/cirq/ops/eigen_gate_test.py
+++ b/cirq-core/cirq/ops/eigen_gate_test.py
@@ -202,7 +202,7 @@ def test_trace_distance_bound():
 
     class E(cirq.EigenGate):
         def _num_qubits_(self):
-            # coverage: ignore
+            # pragma: no cover
             return 1
 
         def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:

--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -147,7 +147,7 @@ class PhaseGradientGate(raw_types.Gate):
     def __pow__(self, power):
         new_exponent = cirq.mul(self.exponent, power, NotImplemented)
         if new_exponent is NotImplemented:
-            # coverage: ignore
+            # pragma: no cover
             return NotImplemented
         return PhaseGradientGate(num_qubits=self._num_qubits, exponent=new_exponent)
 

--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -146,8 +146,7 @@ class PhaseGradientGate(raw_types.Gate):
 
     def __pow__(self, power):
         new_exponent = cirq.mul(self.exponent, power, NotImplemented)
-        if new_exponent is NotImplemented:
-            # pragma: no cover
+        if new_exponent is NotImplemented:  # pragma: no cover
             return NotImplemented
         return PhaseGradientGate(num_qubits=self._num_qubits, exponent=new_exponent)
 

--- a/cirq-core/cirq/ops/gate_operation_test.py
+++ b/cirq-core/cirq/ops/gate_operation_test.py
@@ -523,7 +523,7 @@ def test_gate_to_operation_to_gate_round_trips():
             if gate_cls in skip_classes:
                 skipped.add(gate_cls)
                 continue
-            # coverage:ignore
+            # pragma: no cover
             raise AssertionError(
                 f"{gate_cls} has no json file, please add a json file or add to the list of "
                 "classes to be skipped if there is a reason this gate should not round trip "

--- a/cirq-core/cirq/ops/gate_operation_test.py
+++ b/cirq-core/cirq/ops/gate_operation_test.py
@@ -523,8 +523,7 @@ def test_gate_to_operation_to_gate_round_trips():
             if gate_cls in skip_classes:
                 skipped.add(gate_cls)
                 continue
-            # pragma: no cover
-            raise AssertionError(
+            raise AssertionError(  # pragma: no cover
                 f"{gate_cls} has no json file, please add a json file or add to the list of "
                 "classes to be skipped if there is a reason this gate should not round trip "
                 "to a gate via creating an operation."

--- a/cirq-core/cirq/ops/pauli_gates.py
+++ b/cirq-core/cirq/ops/pauli_gates.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
         _XEigenState,
         _YEigenState,
         _ZEigenState,
-    )  # coverage: ignore
+    )  # pragma: no cover
 
 
 class Pauli(raw_types.Gate, metaclass=abc.ABCMeta):

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -1388,7 +1388,7 @@ class MutablePauliString(Generic[TKey]):
                         self.inplace_after(gate.pauli0(q0))
 
                 else:
-                    # coverage: ignore
+                    # pragma: no cover
                     raise NotImplementedError(f"Unrecognized decomposed Clifford: {op!r}")
         return self
 
@@ -1617,7 +1617,7 @@ def _pass_single_clifford_gate_over(
     after_to_before: bool = False,
 ) -> bool:
     if qubit not in pauli_map:
-        return False  # coverage: ignore
+        return False  # pragma: no cover
     if not after_to_before:
         gate **= -1
     pauli, inv = gate.pauli_tuple(pauli_map[qubit])

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -92,7 +92,7 @@ document(
     """,
 )
 
-PAULI_GATE_LIKE = Union['cirq.Pauli', 'cirq.IdentityGate', str, int,]
+PAULI_GATE_LIKE = Union['cirq.Pauli', 'cirq.IdentityGate', str, int]
 document(
     PAULI_GATE_LIKE,
     """An object that can be interpreted as a Pauli gate.

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -1387,8 +1387,7 @@ class MutablePauliString(Generic[TKey]):
                     if gate.invert1:
                         self.inplace_after(gate.pauli0(q0))
 
-                else:
-                    # pragma: no cover
+                else:  # pragma: no cover
                     raise NotImplementedError(f"Unrecognized decomposed Clifford: {op!r}")
         return self
 

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -1766,7 +1766,7 @@ def test_mutable_pauli_string_inplace_conjugate_by():
 
         @property
         def qubits(self):
-            # coverage: ignore
+            # pragma: no cover
             return self._qubits
 
         def with_qubits(self, *new_qubits):

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -1765,8 +1765,7 @@ def test_mutable_pauli_string_inplace_conjugate_by():
             self._qubits = qubits
 
         @property
-        def qubits(self):
-            # pragma: no cover
+        def qubits(self):  # pragma: no cover
             return self._qubits
 
         def with_qubits(self, *new_qubits):

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -671,7 +671,7 @@ class Operation(metaclass=abc.ABCMeta):
         # Don't create gigantic matrices.
         shape = protocols.qid_shape_protocol.qid_shape(circuit12)
         if np.prod(shape, dtype=np.int64) > 2**10:
-            return NotImplemented  # coverage: ignore
+            return NotImplemented  # pragma: no cover
 
         m12 = protocols.unitary_protocol.unitary(circuit12, default=None)
         m21 = protocols.unitary_protocol.unitary(circuit21, default=None)

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -356,7 +356,7 @@ def test_gate_shape_protocol():
 def test_operation_shape():
     class FixedQids(cirq.Operation):
         def with_qubits(self, *new_qids):
-            raise NotImplementedError  # coverage: ignore
+            raise NotImplementedError  # pragma: no cover
 
     class QubitOp(FixedQids):
         @property

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -49,11 +49,11 @@ class EmptyOp(cirq.Operation):
 
     @property
     def qubits(self):
-        # coverage: ignore
+        # pragma: no cover
         return (q,)
 
     def with_qubits(self, *new_qubits):
-        # coverage: ignore
+        # pragma: no cover
         return self
 
 

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -49,11 +49,9 @@ class EmptyOp(cirq.Operation):
 
     @property
     def qubits(self):
-        # pragma: no cover
         return (q,)
 
-    def with_qubits(self, *new_qubits):
-        # pragma: no cover
+    def with_qubits(self, *new_qubits):  # pragma: no cover
         return self
 
 

--- a/cirq-core/cirq/protocols/has_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_unitary_protocol_test.py
@@ -213,9 +213,9 @@ class EmptyOp(cirq.Operation):
 
     @property
     def qubits(self):
-        # coverage: ignore
+        # pragma: no cover
         return ()
 
     def with_qubits(self, *new_qubits):
-        # coverage: ignore
+        # pragma: no cover
         return self

--- a/cirq-core/cirq/protocols/has_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_unitary_protocol_test.py
@@ -213,9 +213,7 @@ class EmptyOp(cirq.Operation):
 
     @property
     def qubits(self):
-        # pragma: no cover
         return ()
 
-    def with_qubits(self, *new_qubits):
-        # pragma: no cover
+    def with_qubits(self, *new_qubits):  # pragma: no cover
         return self

--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -303,7 +303,7 @@ class CirqEncoder(json.JSONEncoder):
         if isinstance(o, datetime.datetime):
             return {'cirq_type': 'datetime.datetime', 'timestamp': o.timestamp()}
 
-        return super().default(o)  # coverage: ignore
+        return super().default(o)  # pragma: no cover
 
 
 def _cirq_object_hook(d, resolvers: Sequence[JsonResolver], context_map: Dict[str, Any]):
@@ -631,7 +631,7 @@ def to_json(
                             return _json_dict_with_cirq_type(candidate.obj)
                         else:
                             return _json_dict_with_cirq_type(_SerializedKey(candidate.key))
-                raise ValueError("Object mutated during serialization.")  # coverage: ignore
+                raise ValueError("Object mutated during serialization.")  # pragma: no cover
 
         cls = ContextualEncoder
 

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -490,7 +490,7 @@ def test_json_test_data_coverage(mod_spec: ModuleJsonTestSpec, cirq_obj_name: st
     deprecation_deadline = mod_spec.deprecated.get(cirq_obj_name)
 
     if not json_path.exists() and not json_path2.exists():
-        # coverage: ignore
+        # pragma: no cover
         pytest.fail(
             f"Hello intrepid developer. There is a new public or "
             f"serializable object named '{cirq_obj_name}' in the module '{mod_spec.name}' "
@@ -637,7 +637,7 @@ def _eval_repr_data_file(path: pathlib.Path, deprecation_deadline: Optional[str]
     if deprecation_deadline:
         # we ignore coverage here, because sometimes there are no deprecations at all in any of the
         # modules
-        # coverage: ignore
+        # pragma: no cover
         ctx_managers = [cirq.testing.assert_deprecated(deadline=deprecation_deadline, count=None)]
 
     for deprecation in TESTED_MODULES.values():
@@ -681,12 +681,12 @@ def assert_repr_and_json_test_data_agree(
         )
         with ctx_manager:
             json_obj = cirq.read_json(json_text=json_from_file)
-    except ValueError as ex:  # coverage: ignore
-        # coverage: ignore
+    except ValueError as ex:  # pragma: no cover
+        # pragma: no cover
         if "Could not resolve type" in str(ex):
             mod_path = mod_spec.name.replace(".", "/")
             rel_resolver_cache_path = f"{mod_path}/json_resolver_cache.py"
-            # coverage: ignore
+            # pragma: no cover
             pytest.fail(
                 f"{rel_json_path} can't be parsed to JSON.\n"
                 f"Maybe an entry is missing from the "
@@ -694,17 +694,17 @@ def assert_repr_and_json_test_data_agree(
             )
         else:
             raise ValueError(f"deprecation: {deprecation_deadline} - got error: {ex}")
-    except AssertionError as ex:  # coverage: ignore
-        # coverage: ignore
+    except AssertionError as ex:  # pragma: no cover
+        # pragma: no cover
         raise ex
-    except Exception as ex:  # coverage: ignore
-        # coverage: ignore
+    except Exception as ex:  # pragma: no cover
+        # pragma: no cover
         raise IOError(f'Failed to parse test json data from {rel_json_path}.') from ex
 
     try:
         repr_obj = _eval_repr_data_file(repr_path, deprecation_deadline)
-    except Exception as ex:  # coverage: ignore
-        # coverage: ignore
+    except Exception as ex:  # pragma: no cover
+        # pragma: no cover
         raise IOError(f'Failed to parse test repr data from {rel_repr_path}.') from ex
 
     assert proper_eq(json_obj, repr_obj), (

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -489,8 +489,7 @@ def test_json_test_data_coverage(mod_spec: ModuleJsonTestSpec, cirq_obj_name: st
     json_path2 = test_data_path / f'{cirq_obj_name}.json_inward'
     deprecation_deadline = mod_spec.deprecated.get(cirq_obj_name)
 
-    if not json_path.exists() and not json_path2.exists():
-        # pragma: no cover
+    if not json_path.exists() and not json_path2.exists():  # pragma: no cover
         pytest.fail(
             f"Hello intrepid developer. There is a new public or "
             f"serializable object named '{cirq_obj_name}' in the module '{mod_spec.name}' "
@@ -634,10 +633,9 @@ def test_to_from_json_gzip():
 def _eval_repr_data_file(path: pathlib.Path, deprecation_deadline: Optional[str]):
     content = path.read_text()
     ctx_managers: List[contextlib.AbstractContextManager] = [contextlib.suppress()]
-    if deprecation_deadline:
+    if deprecation_deadline:  # pragma: no cover
         # we ignore coverage here, because sometimes there are no deprecations at all in any of the
         # modules
-        # pragma: no cover
         ctx_managers = [cirq.testing.assert_deprecated(deadline=deprecation_deadline, count=None)]
 
     for deprecation in TESTED_MODULES.values():
@@ -682,11 +680,9 @@ def assert_repr_and_json_test_data_agree(
         with ctx_manager:
             json_obj = cirq.read_json(json_text=json_from_file)
     except ValueError as ex:  # pragma: no cover
-        # pragma: no cover
         if "Could not resolve type" in str(ex):
             mod_path = mod_spec.name.replace(".", "/")
             rel_resolver_cache_path = f"{mod_path}/json_resolver_cache.py"
-            # pragma: no cover
             pytest.fail(
                 f"{rel_json_path} can't be parsed to JSON.\n"
                 f"Maybe an entry is missing from the "
@@ -695,16 +691,13 @@ def assert_repr_and_json_test_data_agree(
         else:
             raise ValueError(f"deprecation: {deprecation_deadline} - got error: {ex}")
     except AssertionError as ex:  # pragma: no cover
-        # pragma: no cover
         raise ex
     except Exception as ex:  # pragma: no cover
-        # pragma: no cover
         raise IOError(f'Failed to parse test json data from {rel_json_path}.') from ex
 
     try:
         repr_obj = _eval_repr_data_file(repr_path, deprecation_deadline)
     except Exception as ex:  # pragma: no cover
-        # pragma: no cover
         raise IOError(f'Failed to parse test repr data from {rel_repr_path}.') from ex
 
     assert proper_eq(json_obj, repr_obj), (

--- a/cirq-core/cirq/protocols/measurement_key_protocol_test.py
+++ b/cirq-core/cirq/protocols/measurement_key_protocol_test.py
@@ -146,7 +146,7 @@ def test_non_measurement_with_key():
             assert False
 
         def num_qubits(self) -> int:
-            return 2  # coverage: ignore
+            return 2  # pragma: no cover
 
     assert not cirq.is_measurement(NonMeasurementGate())
 

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -64,7 +64,7 @@ class ReturnsMatrix(cirq.Gate):
         return m1
 
     def num_qubits(self):
-        return 1  # coverage: ignore
+        return 1  # pragma: no cover
 
 
 class FullyImplemented(cirq.Gate):
@@ -306,7 +306,7 @@ def test_unitary_from_apply_unitary():
             return (self.q,)
 
         def with_qubits(self, *new_qubits):
-            # coverage: ignore
+            # pragma: no cover
             return ApplyOp(*new_qubits)
 
         def _apply_unitary_(self, args):

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -209,7 +209,6 @@ def _test_gate_that_allocates_qubits(gate):
 def test_decompose_gate_that_allocates_clean_qubits(
     theta: float, phase_state: int, target_bitsize: int, ancilla_bitsize: int
 ):
-
     gate = testing.PhaseUsingCleanAncilla(theta, phase_state, target_bitsize, ancilla_bitsize)
     _test_gate_that_allocates_qubits(gate)
 
@@ -220,7 +219,6 @@ def test_decompose_gate_that_allocates_clean_qubits(
 def test_decompose_gate_that_allocates_dirty_qubits(
     phase_state: int, target_bitsize: int, ancilla_bitsize: int
 ):
-
     gate = testing.PhaseUsingDirtyAncilla(phase_state, target_bitsize, ancilla_bitsize)
     _test_gate_that_allocates_qubits(gate)
 

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -303,8 +303,7 @@ def test_unitary_from_apply_unitary():
         def qubits(self):
             return (self.q,)
 
-        def with_qubits(self, *new_qubits):
-            # pragma: no cover
+        def with_qubits(self, *new_qubits):  # pragma: no cover
             return ApplyOp(*new_qubits)
 
         def _apply_unitary_(self, args):

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -275,8 +275,7 @@ class CliffordTableau(StabilizerState):
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
-            # pragma: no cover
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
         return (
             self.n == other.n
             and np.array_equal(self.rs, other.rs)

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -275,7 +275,7 @@ class CliffordTableau(StabilizerState):
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
-            # coverage: ignore
+            # pragma: no cover
             return NotImplemented
         return (
             self.n == other.n
@@ -551,7 +551,7 @@ class CliffordTableau(StabilizerState):
         if exponent % 2 == 0:
             return
         if exponent % 0.5 != 0.0:
-            raise ValueError('X exponent must be half integer')  # coverage: ignore
+            raise ValueError('X exponent must be half integer')  # pragma: no cover
         effective_exponent = exponent % 2
         if effective_exponent == 0.5:
             self.xs[:, axis] ^= self.zs[:, axis]
@@ -566,7 +566,7 @@ class CliffordTableau(StabilizerState):
         if exponent % 2 == 0:
             return
         if exponent % 0.5 != 0.0:
-            raise ValueError('Y exponent must be half integer')  # coverage: ignore
+            raise ValueError('Y exponent must be half integer')  # pragma: no cover
         effective_exponent = exponent % 2
         if effective_exponent == 0.5:
             self.rs[:] ^= self.xs[:, axis] & (~self.zs[:, axis])
@@ -587,7 +587,7 @@ class CliffordTableau(StabilizerState):
         if exponent % 2 == 0:
             return
         if exponent % 0.5 != 0.0:
-            raise ValueError('Z exponent must be half integer')  # coverage: ignore
+            raise ValueError('Z exponent must be half integer')  # pragma: no cover
         effective_exponent = exponent % 2
         if effective_exponent == 0.5:
             self.rs[:] ^= self.xs[:, axis] & self.zs[:, axis]
@@ -602,7 +602,7 @@ class CliffordTableau(StabilizerState):
         if exponent % 2 == 0:
             return
         if exponent % 1 != 0:
-            raise ValueError('H exponent must be integer')  # coverage: ignore
+            raise ValueError('H exponent must be integer')  # pragma: no cover
         self.apply_y(axis, 0.5)
         self.apply_x(axis)
 
@@ -612,7 +612,7 @@ class CliffordTableau(StabilizerState):
         if exponent % 2 == 0:
             return
         if exponent % 1 != 0:
-            raise ValueError('CZ exponent must be integer')  # coverage: ignore
+            raise ValueError('CZ exponent must be integer')  # pragma: no cover
         (self.xs[:, target_axis], self.zs[:, target_axis]) = (
             self.zs[:, target_axis].copy(),
             self.xs[:, target_axis].copy(),
@@ -637,7 +637,7 @@ class CliffordTableau(StabilizerState):
         if exponent % 2 == 0:
             return
         if exponent % 1 != 0:
-            raise ValueError('CX exponent must be integer')  # coverage: ignore
+            raise ValueError('CX exponent must be integer')  # pragma: no cover
         self.rs[:] ^= (
             self.xs[:, control_axis]
             & self.zs[:, target_axis]

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -525,7 +525,7 @@ class _QidShapeSet:
                 f'{self.min_qudit_dimensions}.'
             )
         if len(self.explicit_qid_shapes) > 1:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError(
                 f'Qid shape is ambiguous: Could be any one of {self.explicit_qid_shapes}.'
             )

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -524,8 +524,7 @@ class _QidShapeSet:
                 'with the corresponding qudit dimensions being at least '
                 f'{self.min_qudit_dimensions}.'
             )
-        if len(self.explicit_qid_shapes) > 1:
-            # pragma: no cover
+        if len(self.explicit_qid_shapes) > 1:  # pragma: no cover
             raise ValueError(
                 f'Qid shape is ambiguous: Could be any one of {self.explicit_qid_shapes}.'
             )

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -373,19 +373,19 @@ def test_clifford_circuit_2(qubits, split):
         x = np.random.randint(7)
 
         if x == 0:
-            circuit.append(cirq.X(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.X(np.random.choice(qubits)))  # pragma: no cover
         elif x == 1:
-            circuit.append(cirq.Z(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.Z(np.random.choice(qubits)))  # pragma: no cover
         elif x == 2:
-            circuit.append(cirq.Y(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.Y(np.random.choice(qubits)))  # pragma: no cover
         elif x == 3:
-            circuit.append(cirq.S(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.S(np.random.choice(qubits)))  # pragma: no cover
         elif x == 4:
-            circuit.append(cirq.H(np.random.choice(qubits)))  # coverage: ignore
+            circuit.append(cirq.H(np.random.choice(qubits)))  # pragma: no cover
         elif x == 5:
-            circuit.append(cirq.CNOT(qubits[0], qubits[1]))  # coverage: ignore
+            circuit.append(cirq.CNOT(qubits[0], qubits[1]))  # pragma: no cover
         elif x == 6:
-            circuit.append(cirq.CZ(qubits[0], qubits[1]))  # coverage: ignore
+            circuit.append(cirq.CZ(qubits[0], qubits[1]))  # pragma: no cover
 
     circuit.append(cirq.measure(qubits[0]))
     result = cirq.CliffordSimulator(split_untangled_states=split).run(circuit, repetitions=100)

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
@@ -84,7 +84,7 @@ class StabilizerSimulationState(
     ):
         """Apply a SWAP gate"""
         if exponent % 1 != 0:
-            raise ValueError('Swap exponent must be integer')  # coverage: ignore
+            raise ValueError('Swap exponent must be integer')  # pragma: no cover
         self._state.apply_cx(control_axis, target_axis)
         self._state.apply_cx(target_axis, control_axis, exponent, global_shift)
         self._state.apply_cx(control_axis, target_axis)
@@ -122,7 +122,7 @@ class StabilizerSimulationState(
         if mixture is None:
             return NotImplemented
         if not all(linalg.is_unitary(m) for _, m in mixture):
-            return NotImplemented  # coverage: ignore
+            return NotImplemented  # pragma: no cover
         probabilities, unitaries = zip(*mixture)
         index = self.prng.choice(len(unitaries), p=probabilities)
         return self._strat_act_from_single_qubit_decompose(

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -54,7 +54,7 @@ class StabilizerStateChForm(qis.StabilizerState):
         self.omega: complex = 1
 
         # Apply X for every non-zero element of initial_state
-        for (i, val) in enumerate(
+        for i, val in enumerate(
             big_endian_int_to_digits(initial_state, digit_count=num_qubits, base=2)
         ):
             if val:

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -295,7 +295,7 @@ class StabilizerStateChForm(qis.StabilizerState):
     def apply_x(self, axis: int, exponent: float = 1, global_shift: float = 0):
         if exponent % 2 != 0:
             if exponent % 0.5 != 0.0:
-                raise ValueError('X exponent must be half integer')  # coverage: ignore
+                raise ValueError('X exponent must be half integer')  # pragma: no cover
             self.apply_h(axis)
             self.apply_z(axis, exponent)
             self.apply_h(axis)
@@ -303,7 +303,7 @@ class StabilizerStateChForm(qis.StabilizerState):
 
     def apply_y(self, axis: int, exponent: float = 1, global_shift: float = 0):
         if exponent % 0.5 != 0.0:
-            raise ValueError('Y exponent must be half integer')  # coverage: ignore
+            raise ValueError('Y exponent must be half integer')  # pragma: no cover
         shift = _phase(exponent, global_shift)
         if exponent % 2 == 0:
             self.omega *= shift
@@ -325,7 +325,7 @@ class StabilizerStateChForm(qis.StabilizerState):
     def apply_z(self, axis: int, exponent: float = 1, global_shift: float = 0):
         if exponent % 2 != 0:
             if exponent % 0.5 != 0.0:
-                raise ValueError('Z exponent must be half integer')  # coverage: ignore
+                raise ValueError('Z exponent must be half integer')  # pragma: no cover
             effective_exponent = exponent % 2
             for _ in range(int(effective_exponent * 2)):
                 # Prescription for S left multiplication.
@@ -337,7 +337,7 @@ class StabilizerStateChForm(qis.StabilizerState):
     def apply_h(self, axis: int, exponent: float = 1, global_shift: float = 0):
         if exponent % 2 != 0:
             if exponent % 1 != 0:
-                raise ValueError('H exponent must be integer')  # coverage: ignore
+                raise ValueError('H exponent must be integer')  # pragma: no cover
             # Prescription for H left multiplication
             # Reference: https://arxiv.org/abs/1808.00128
             # Equations 48, 49 and Proposition 4
@@ -357,7 +357,7 @@ class StabilizerStateChForm(qis.StabilizerState):
     ):
         if exponent % 2 != 0:
             if exponent % 1 != 0:
-                raise ValueError('CZ exponent must be integer')  # coverage: ignore
+                raise ValueError('CZ exponent must be integer')  # pragma: no cover
             # Prescription for CZ left multiplication.
             # Reference: https://arxiv.org/abs/1808.00128 Proposition 4 end
             self.M[control_axis, :] ^= self.G[target_axis, :]
@@ -369,7 +369,7 @@ class StabilizerStateChForm(qis.StabilizerState):
     ):
         if exponent % 2 != 0:
             if exponent % 1 != 0:
-                raise ValueError('CX exponent must be integer')  # coverage: ignore
+                raise ValueError('CX exponent must be integer')  # pragma: no cover
             # Prescription for CX left multiplication.
             # Reference: https://arxiv.org/abs/1808.00128 Proposition 4 end
             self.gamma[control_axis] = (

--- a/cirq-core/cirq/sim/density_matrix_simulation_state.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state.py
@@ -47,8 +47,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         if buffer is None:
             buffer = [np.empty_like(density_matrix) for _ in range(3)]
         self._buffer = buffer
-        if len(density_matrix.shape) % 2 != 0:
-            # pragma: no cover
+        if len(density_matrix.shape) % 2 != 0:  # pragma: no cover
             raise ValueError('The dimension of target_tensor is not divisible by 2.')
         self._qid_shape = density_matrix.shape[: len(density_matrix.shape) // 2]
 

--- a/cirq-core/cirq/sim/density_matrix_simulation_state.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state.py
@@ -48,7 +48,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
             buffer = [np.empty_like(density_matrix) for _ in range(3)]
         self._buffer = buffer
         if len(density_matrix.shape) % 2 != 0:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError('The dimension of target_tensor is not divisible by 2.')
         self._qid_shape = density_matrix.shape[: len(density_matrix.shape) // 2]
 
@@ -86,7 +86,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
                     initial_state, len(qid_shape), qid_shape=qid_shape, dtype=dtype
                 ).reshape(qid_shape * 2)
             else:
-                density_matrix = initial_state  # coverage: ignore
+                density_matrix = initial_state  # pragma: no cover
             if np.may_share_memory(density_matrix, initial_state):
                 density_matrix = density_matrix.copy()
         density_matrix = density_matrix.astype(dtype, copy=False)
@@ -299,7 +299,7 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
         for strat in strats:
             result = strat(action, self, qubits)
             if result is False:
-                break  # coverage: ignore
+                break  # pragma: no cover
             if result is True:
                 return True
             assert result is NotImplemented, str(result)

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -140,7 +140,7 @@ def test_run_not_channel_op(dtype: Type[np.complexfloating], split: bool):
             return self._qubits
 
         def with_qubits(self, *new_qubits):
-            # coverage: ignore
+            # pragma: no cover
             return BadOp(self._qubits)
 
     q0 = cirq.LineQubit(0)
@@ -1050,39 +1050,39 @@ def test_density_matrix_trial_result_repr():
 
 class XAsOp(cirq.Operation):
     def __init__(self, q):
-        # coverage: ignore
+        # pragma: no cover
         self.q = q
 
     @property
     def qubits(self):
-        # coverage: ignore
+        # pragma: no cover
         return (self.q,)
 
     def with_qubits(self, *new_qubits):
-        # coverage: ignore
+        # pragma: no cover
         return XAsOp(new_qubits[0])
 
     def _kraus_(self):
-        # coverage: ignore
+        # pragma: no cover
         return cirq.kraus(cirq.X)
 
 
 def test_works_on_operation():
     class XAsOp(cirq.Operation):
         def __init__(self, q):
-            # coverage: ignore
+            # pragma: no cover
             self.q = q
 
         @property
         def qubits(self):
-            # coverage: ignore
+            # pragma: no cover
             return (self.q,)
 
         def with_qubits(self, *new_qubits):
             raise NotImplementedError()
 
         def _kraus_(self):
-            # coverage: ignore
+            # pragma: no cover
             return cirq.kraus(cirq.X)
 
     s = cirq.DensityMatrixSimulator()

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -139,8 +139,7 @@ def test_run_not_channel_op(dtype: Type[np.complexfloating], split: bool):
         def qubits(self):
             return self._qubits
 
-        def with_qubits(self, *new_qubits):
-            # pragma: no cover
+        def with_qubits(self, *new_qubits):  # pragma: no cover
             return BadOp(self._qubits)
 
     q0 = cirq.LineQubit(0)
@@ -1050,39 +1049,32 @@ def test_density_matrix_trial_result_repr():
 
 class XAsOp(cirq.Operation):
     def __init__(self, q):
-        # pragma: no cover
-        self.q = q
+        self.q = q  # pragma: no cover
 
     @property
     def qubits(self):
-        # pragma: no cover
-        return (self.q,)
+        return (self.q,)  # pragma: no cover
 
     def with_qubits(self, *new_qubits):
-        # pragma: no cover
-        return XAsOp(new_qubits[0])
+        return XAsOp(new_qubits[0])  # pragma: no cover
 
     def _kraus_(self):
-        # pragma: no cover
-        return cirq.kraus(cirq.X)
+        return cirq.kraus(cirq.X)  # pragma: no cover
 
 
 def test_works_on_operation():
     class XAsOp(cirq.Operation):
         def __init__(self, q):
-            # pragma: no cover
             self.q = q
 
         @property
         def qubits(self):
-            # pragma: no cover
             return (self.q,)
 
         def with_qubits(self, *new_qubits):
             raise NotImplementedError()
 
         def _kraus_(self):
-            # pragma: no cover
             return cirq.kraus(cirq.X)
 
     s = cirq.DensityMatrixSimulator()

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -387,7 +387,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         for strat in strats:
             result = strat(action, self, qubits)
             if result is False:
-                break  # coverage: ignore
+                break  # pragma: no cover
             if result is True:
                 return True
             assert result is NotImplemented, str(result)

--- a/cirq-core/cirq/testing/circuit_compare.py
+++ b/cirq-core/cirq/testing/circuit_compare.py
@@ -218,7 +218,7 @@ def _first_differing_moment_index(
     for i, (m1, m2) in enumerate(itertools.zip_longest(circuit1, circuit2)):
         if m1 != m2:
             return i
-    return None  # coverage: ignore
+    return None  # pragma: no cover
 
 
 def assert_circuits_have_same_unitary_given_final_permutation(

--- a/cirq-core/cirq/testing/circuit_compare_test.py
+++ b/cirq-core/cirq/testing/circuit_compare_test.py
@@ -484,7 +484,7 @@ def test_assert_has_consistent_qid_shape():
 
     class ConsistentOp(cirq.Operation):
         def with_qubits(self, *qubits):
-            raise NotImplementedError  # coverage: ignore
+            raise NotImplementedError  # pragma: no cover
 
         @property
         def qubits(self):
@@ -496,47 +496,47 @@ def test_assert_has_consistent_qid_shape():
         def _qid_shape_(self):
             return (1, 2, 3, 4)
 
-    # The 'coverage: ignore' comments in the InconsistentOp classes is needed
+    # The 'pragma: no cover' comments in the InconsistentOp classes is needed
     # because test_assert_has_consistent_qid_shape may only need to check two of
     # the three methods before finding an inconsistency and throwing an error.
     class InconsistentOp1(cirq.Operation):
         def with_qubits(self, *qubits):
-            raise NotImplementedError  # coverage: ignore
+            raise NotImplementedError  # pragma: no cover
 
         @property
         def qubits(self):
             return cirq.LineQubit.range(2)
 
         def _num_qubits_(self):
-            return 4  # coverage: ignore
+            return 4  # pragma: no cover
 
         def _qid_shape_(self):
-            return (1, 2, 3, 4)  # coverage: ignore
+            return (1, 2, 3, 4)  # pragma: no cover
 
     class InconsistentOp2(cirq.Operation):
         def with_qubits(self, *qubits):
-            raise NotImplementedError  # coverage: ignore
+            raise NotImplementedError  # pragma: no cover
 
         @property
         def qubits(self):
-            return cirq.LineQubit.range(4)  # coverage: ignore
+            return cirq.LineQubit.range(4)  # pragma: no cover
 
         def _num_qubits_(self):
             return 2
 
         def _qid_shape_(self):
-            return (1, 2, 3, 4)  # coverage: ignore
+            return (1, 2, 3, 4)  # pragma: no cover
 
     class InconsistentOp3(cirq.Operation):
         def with_qubits(self, *qubits):
-            raise NotImplementedError  # coverage: ignore
+            raise NotImplementedError  # pragma: no cover
 
         @property
         def qubits(self):
-            return cirq.LineQubit.range(4)  # coverage: ignore
+            return cirq.LineQubit.range(4)  # pragma: no cover
 
         def _num_qubits_(self):
-            return 4  # coverage: ignore
+            return 4  # pragma: no cover
 
         def _qid_shape_(self):
             return 1, 2

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
@@ -23,8 +23,7 @@ from cirq.ops import control_values as cv
 
 
 class GoodGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
-    def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
-        # pragma: no cover
+    def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:  # pragma: no cover
         return [(0, np.diag([1, 0])), (1, np.diag([0, 1]))]
 
 
@@ -41,7 +40,6 @@ class BadGateOperation(cirq.GateOperation):
 
 class BadGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
     def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
-        # pragma: no cover
         return [(0, np.diag([1, 0])), (1, np.diag([0, 1]))]
 
     def on(self, *qubits: 'cirq.Qid') -> 'cirq.Operation':

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
@@ -24,7 +24,7 @@ from cirq.ops import control_values as cv
 
 class GoodGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
     def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
-        # coverage: ignore
+        # pragma: no cover
         return [(0, np.diag([1, 0])), (1, np.diag([0, 1]))]
 
 
@@ -41,7 +41,7 @@ class BadGateOperation(cirq.GateOperation):
 
 class BadGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
     def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
-        # coverage: ignore
+        # pragma: no cover
         return [(0, np.diag([1, 0])), (1, np.diag([0, 1]))]
 
     def on(self, *qubits: 'cirq.Qid') -> 'cirq.Operation':

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -54,7 +54,6 @@ def assert_decompose_is_consistent_with_unitary(val: Any, ignoring_global_phase:
     if ignoring_global_phase:
         lin_alg_utils.assert_allclose_up_to_global_phase(actual, expected, atol=1e-8)
     else:
-        # pragma: no cover
         np.testing.assert_allclose(actual, expected, atol=1e-8)
 
 

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -54,7 +54,7 @@ def assert_decompose_is_consistent_with_unitary(val: Any, ignoring_global_phase:
     if ignoring_global_phase:
         lin_alg_utils.assert_allclose_up_to_global_phase(actual, expected, atol=1e-8)
     else:
-        # coverage: ignore
+        # pragma: no cover
         np.testing.assert_allclose(actual, expected, atol=1e-8)
 
 

--- a/cirq-core/cirq/testing/consistent_protocols_test.py
+++ b/cirq-core/cirq/testing/consistent_protocols_test.py
@@ -87,7 +87,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
     def __pow__(self, exponent: Union[float, sympy.Expr]) -> 'GoodGate':
         new_exponent = cirq.mul(self.exponent, exponent, NotImplemented)
         if new_exponent is NotImplemented:
-            # coverage: ignore
+            # pragma: no cover
             return NotImplemented
         return GoodGate(phase_exponent=self.phase_exponent, exponent=new_exponent)
 
@@ -114,7 +114,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
-            # coverage: ignore
+            # pragma: no cover
             return NotImplemented
         return self._identity_tuple() == other._identity_tuple()
 
@@ -132,7 +132,7 @@ class BadGateParameterNames(GoodGate):
 class BadGateApplyUnitaryToTensor(GoodGate):
     def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> Union[np.ndarray, NotImplementedType]:
         if self.exponent != 1 or cirq.is_parameterized(self):
-            # coverage: ignore
+            # pragma: no cover
             return NotImplemented
 
         zero = cirq.slice_for_qubits_equal_to(args.axes, 0)
@@ -154,7 +154,7 @@ class BadGateDecompose(GoodGate):
         z = cirq.Z(q) ** self.phase_exponent
         x = cirq.X(q) ** (2 * self.exponent)
         if cirq.is_parameterized(z):
-            # coverage: ignore
+            # pragma: no cover
             return NotImplemented
         return z**-1, x, z
 
@@ -176,7 +176,7 @@ class BadGateRepr(GoodGate):
     def __repr__(self):
         args = [f'phase_exponent={2 * self.phase_exponent!r}']
         if self.exponent != 1:
-            # coverage: ignore
+            # pragma: no cover
             args.append(f'exponent={proper_repr(self.exponent)}')
         return f"BadGateRepr({', '.join(args)})"
 

--- a/cirq-core/cirq/testing/consistent_protocols_test.py
+++ b/cirq-core/cirq/testing/consistent_protocols_test.py
@@ -87,8 +87,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
     def __pow__(self, exponent: Union[float, sympy.Expr]) -> 'GoodGate':
         new_exponent = cirq.mul(self.exponent, exponent, NotImplemented)
         if new_exponent is NotImplemented:
-            # pragma: no cover
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
         return GoodGate(phase_exponent=self.phase_exponent, exponent=new_exponent)
 
     def __repr__(self):
@@ -114,8 +113,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
-            # pragma: no cover
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
         return self._identity_tuple() == other._identity_tuple()
 
 
@@ -132,8 +130,7 @@ class BadGateParameterNames(GoodGate):
 class BadGateApplyUnitaryToTensor(GoodGate):
     def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> Union[np.ndarray, NotImplementedType]:
         if self.exponent != 1 or cirq.is_parameterized(self):
-            # pragma: no cover
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
 
         zero = cirq.slice_for_qubits_equal_to(args.axes, 0)
         one = cirq.slice_for_qubits_equal_to(args.axes, 1)
@@ -154,8 +151,7 @@ class BadGateDecompose(GoodGate):
         z = cirq.Z(q) ** self.phase_exponent
         x = cirq.X(q) ** (2 * self.exponent)
         if cirq.is_parameterized(z):
-            # pragma: no cover
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
         return z**-1, x, z
 
 
@@ -176,8 +172,7 @@ class BadGateRepr(GoodGate):
     def __repr__(self):
         args = [f'phase_exponent={2 * self.phase_exponent!r}']
         if self.exponent != 1:
-            # pragma: no cover
-            args.append(f'exponent={proper_repr(self.exponent)}')
+            args.append(f'exponent={proper_repr(self.exponent)}')  # pragma: no cover
         return f"BadGateRepr({', '.join(args)})"
 
 

--- a/cirq-core/cirq/testing/consistent_qasm.py
+++ b/cirq-core/cirq/testing/consistent_qasm.py
@@ -27,8 +27,7 @@ def assert_qasm_is_consistent_with_unitary(val: Any):
     # Only test if qiskit is installed.
     try:
         import qiskit
-    except ImportError:
-        # pragma: no cover
+    except ImportError:  # pragma: no cover
         warnings.warn(
             "Skipped assert_qasm_is_consistent_with_unitary because "
             "qiskit isn't installed to verify against."
@@ -101,8 +100,7 @@ qreg q[{num_qubits}];
         )
 
 
-def assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, unitary):
-    # pragma: no cover
+def assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, unitary):  # pragma: no cover
     try:
         # We don't want to require qiskit as a dependency but
         # if Qiskit is installed, test QASM output against it.

--- a/cirq-core/cirq/testing/consistent_qasm.py
+++ b/cirq-core/cirq/testing/consistent_qasm.py
@@ -28,7 +28,7 @@ def assert_qasm_is_consistent_with_unitary(val: Any):
     try:
         import qiskit
     except ImportError:
-        # coverage: ignore
+        # pragma: no cover
         warnings.warn(
             "Skipped assert_qasm_is_consistent_with_unitary because "
             "qiskit isn't installed to verify against."
@@ -102,7 +102,7 @@ qreg q[{num_qubits}];
 
 
 def assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, unitary):
-    # coverage: ignore
+    # pragma: no cover
     try:
         # We don't want to require qiskit as a dependency but
         # if Qiskit is installed, test QASM output against it.

--- a/cirq-core/cirq/testing/consistent_qasm_test.py
+++ b/cirq-core/cirq/testing/consistent_qasm_test.py
@@ -54,8 +54,7 @@ class QuditGate(cirq.Gate):
 def test_assert_qasm_is_consistent_with_unitary():
     try:
         import qiskit as _
-    except ImportError:
-        # pragma: no cover
+    except ImportError:  # pragma: no cover
         warnings.warn(
             "Skipped test_assert_qasm_is_consistent_with_unitary "
             "because qiskit isn't installed to verify against."

--- a/cirq-core/cirq/testing/consistent_qasm_test.py
+++ b/cirq-core/cirq/testing/consistent_qasm_test.py
@@ -55,7 +55,7 @@ def test_assert_qasm_is_consistent_with_unitary():
     try:
         import qiskit as _
     except ImportError:
-        # coverage: ignore
+        # pragma: no cover
         warnings.warn(
             "Skipped test_assert_qasm_is_consistent_with_unitary "
             "because qiskit isn't installed to verify against."

--- a/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
+++ b/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
@@ -32,12 +32,10 @@ def test_assert_specifies_has_unitary_if_unitary_from_apply():
     class Bad(cirq.Operation):
         @property
         def qubits(self):
-            # pragma: no cover
             return ()
 
         def with_qubits(self, *new_qubits):
-            # pragma: no cover
-            return self
+            return self  # pragma: no cover
 
         def _apply_unitary_(self, args):
             return args.target_tensor

--- a/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
+++ b/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
@@ -32,11 +32,11 @@ def test_assert_specifies_has_unitary_if_unitary_from_apply():
     class Bad(cirq.Operation):
         @property
         def qubits(self):
-            # coverage: ignore
+            # pragma: no cover
             return ()
 
         def with_qubits(self, *new_qubits):
-            # coverage: ignore
+            # pragma: no cover
             return self
 
         def _apply_unitary_(self, args):

--- a/cirq-core/cirq/testing/equals_tester.py
+++ b/cirq-core/cirq/testing/equals_tester.py
@@ -157,7 +157,7 @@ class _TestsForNotImplemented:
 
     def __eq__(self, other: object) -> bool:
         if other is not self.other:
-            return NotImplemented  # coverage: ignore
+            return NotImplemented  # pragma: no cover
         return True
 
 

--- a/cirq-core/cirq/testing/equals_tester_test.py
+++ b/cirq-core/cirq/testing/equals_tester_test.py
@@ -169,16 +169,16 @@ def test_fails_when_ne_is_inconsistent():
 
         def __eq__(self, other):
             if not isinstance(other, type(self)):
-                return NotImplemented  # coverage: ignore
+                return NotImplemented  # pragma: no cover
             return self.x == other.x
 
         def __ne__(self, other):
             if not isinstance(other, type(self)):
-                return NotImplemented  # coverage: ignore
+                return NotImplemented  # pragma: no cover
             return self.x == other.x
 
         def __hash__(self):
-            return hash(self.x)  # coverage: ignore
+            return hash(self.x)  # pragma: no cover
 
     with pytest.raises(AssertionError, match='inconsistent'):
         eq.make_equality_group(InconsistentNeImplementation)
@@ -278,7 +278,7 @@ def test_returns_not_implemented_for_other_types():
             if isinstance(other, (FirstClass, SecondClass)):
                 return self.val == other.val
             # Ignore coverage, this is just for illustrative purposes.
-            return NotImplemented  # coverage: ignore
+            return NotImplemented  # pragma: no cover
 
     # But we see that this does not work because it fails commutativity of ==
     assert SecondClass("a") == FirstClass("a")
@@ -306,7 +306,7 @@ def test_returns_not_implemented_for_other_types():
             if isinstance(other, (ThirdClass, FourthClass)):
                 return self.val == other.val
             # Ignore coverage, this is just for illustrative purposes.
-            return NotImplemented  # coverage: ignore
+            return NotImplemented  # pragma: no cover
 
     # We see this is fixed:
     assert ThirdClass("a") == FourthClass("a")

--- a/cirq-core/cirq/testing/equivalent_repr_eval_test.py
+++ b/cirq-core/cirq/testing/equivalent_repr_eval_test.py
@@ -30,9 +30,7 @@ def test_external():
 
 
 def test_custom_class_repr():
-    class CustomRepr:
-        # pragma: no cover
-
+    class CustomRepr:  # pragma: no cover
         setup_code = """class CustomRepr:
             def __init__(self, eq_val):
                 self.eq_val = eq_val

--- a/cirq-core/cirq/testing/equivalent_repr_eval_test.py
+++ b/cirq-core/cirq/testing/equivalent_repr_eval_test.py
@@ -31,7 +31,7 @@ def test_external():
 
 def test_custom_class_repr():
     class CustomRepr:
-        # coverage: ignore
+        # pragma: no cover
 
         setup_code = """class CustomRepr:
             def __init__(self, eq_val):

--- a/cirq-core/cirq/testing/order_tester_test.py
+++ b/cirq-core/cirq/testing/order_tester_test.py
@@ -90,7 +90,7 @@ def test_add_ordering_group_incorrect():
 
 def test_propagates_internal_errors():
     class UnorderableClass:
-        # coverage: ignore
+        # pragma: no cover
 
         def __eq__(self, other):
             return NotImplemented

--- a/cirq-core/cirq/testing/order_tester_test.py
+++ b/cirq-core/cirq/testing/order_tester_test.py
@@ -89,9 +89,7 @@ def test_add_ordering_group_incorrect():
 
 
 def test_propagates_internal_errors():
-    class UnorderableClass:
-        # pragma: no cover
-
+    class UnorderableClass:  # pragma: no cover
         def __eq__(self, other):
             return NotImplemented
 

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -60,8 +60,7 @@ def _cases_for_random_circuit():
             # number of qubits greater that the number of qubits for the
             # circuit. In this case, try again.
             if all(n > n_qubits for n in gate_domain.values()):
-                # pragma: no cover
-                continue
+                continue  # pragma: no cover
         else:
             gate_domain = None
         pass_qubits = random.choice((True, False))

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -107,7 +107,6 @@ def test_random_circuit_reproducible_with_seed(seed):
 
 
 def test_random_circuit_not_expected_number_of_qubits():
-
     circuit = cirq.testing.random_circuit(
         qubits=3, n_moments=1, op_density=1.0, gate_domain={cirq.CNOT: 2}
     )

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -60,7 +60,7 @@ def _cases_for_random_circuit():
             # number of qubits greater that the number of qubits for the
             # circuit. In this case, try again.
             if all(n > n_qubits for n in gate_domain.values()):
-                # coverage: ignore
+                # pragma: no cover
                 continue
         else:
             gate_domain = None

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
@@ -56,8 +56,8 @@ def three_qubit_matrix_to_operations(
 
     try:
         from scipy.linalg import cossin
-    except ImportError:  # coverage: ignore
-        # coverage: ignore
+    except ImportError:  # pragma: no cover
+        # pragma: no cover
         raise ImportError(
             "cirq.three_qubit_unitary_to_operations requires "
             "SciPy 1.5.0+, as it uses the cossin function. Please"

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
@@ -57,7 +57,6 @@ def three_qubit_matrix_to_operations(
     try:
         from scipy.linalg import cossin
     except ImportError:  # pragma: no cover
-        # pragma: no cover
         raise ImportError(
             "cirq.three_qubit_unitary_to_operations requires "
             "SciPy 1.5.0+, as it uses the cossin function. Please"

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -30,15 +30,13 @@ from cirq.transformers.analytical_decompositions.three_qubit_decomposition impor
 
 
 def _skip_if_scipy(*, version_is_greater_than_1_5_0: bool) -> Callable[[Callable], Callable]:
-    def decorator(func):
+    def decorator(func):  # pragma: no cover
         try:
             # pylint: disable=unused-import
             from scipy.linalg import cossin
 
-            # pragma: no cover
             return None if version_is_greater_than_1_5_0 else func
         except ImportError:
-            # pragma: no cover
             return func if version_is_greater_than_1_5_0 else None
 
     return decorator
@@ -84,8 +82,7 @@ def test_three_qubit_matrix_to_operations_errors():
 # environment like that, we'll need to ignore the coverage somehow conditionally on
 # the scipy version.
 @_skip_if_scipy(version_is_greater_than_1_5_0=True)
-# pragma: no cover
-def test_three_qubit_matrix_to_operations_scipy_error():
+def test_three_qubit_matrix_to_operations_scipy_error():  # pragma: no cover
     a, b, c = cirq.LineQubit.range(3)
     with pytest.raises(ImportError, match="three_qubit.*1.5.0+"):
         cirq.three_qubit_matrix_to_operations(a, b, c, np.eye(8))

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -35,10 +35,10 @@ def _skip_if_scipy(*, version_is_greater_than_1_5_0: bool) -> Callable[[Callable
             # pylint: disable=unused-import
             from scipy.linalg import cossin
 
-            # coverage: ignore
+            # pragma: no cover
             return None if version_is_greater_than_1_5_0 else func
         except ImportError:
-            # coverage: ignore
+            # pragma: no cover
             return func if version_is_greater_than_1_5_0 else None
 
     return decorator
@@ -84,7 +84,7 @@ def test_three_qubit_matrix_to_operations_errors():
 # environment like that, we'll need to ignore the coverage somehow conditionally on
 # the scipy version.
 @_skip_if_scipy(version_is_greater_than_1_5_0=True)
-# coverage: ignore
+# pragma: no cover
 def test_three_qubit_matrix_to_operations_scipy_error():
     a, b, c = cirq.LineQubit.range(3)
     with pytest.raises(ImportError, match="three_qubit.*1.5.0+"):

--- a/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils.py
@@ -174,7 +174,7 @@ def kak_vector_infidelity(
 
     # Ensure we consider equivalent vectors for only the smallest input.
     if k_vec_a.size < k_vec_b.size:
-        k_vec_a, k_vec_b = k_vec_b, k_vec_a  # coverage: ignore
+        k_vec_a, k_vec_b = k_vec_b, k_vec_a  # pragma: no cover
 
     k_vec_a = k_vec_a[..., np.newaxis, :]  # (...,1,3)
     k_vec_b = _kak_equivalent_vectors(k_vec_b)  # (...,192,3)

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -224,7 +224,7 @@ def _category_to_classifier(category) -> Classifier:
 
 def _dummy_classifier(op: 'cirq.Operation') -> bool:
     """Dummy classifier, used to "complete" a collection of classifiers and make it exhaustive."""
-    return False  # coverage: ignore
+    return False  # pragma: no cover
 
 
 def _get_op_class(op: 'cirq.Operation', classifiers: Sequence[Classifier]) -> int:

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -130,7 +130,6 @@ def _stratify_circuit(
         ignored_ops = []
         op_time_indices = {}
         for op in moment:
-
             # Identify the earliest moment that can accommodate this op.
             min_time_index_for_op = circuits.circuit.get_earliest_accommodating_moment_index(
                 op, qubit_time_index, measurement_time_index, control_time_index

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
@@ -232,7 +232,7 @@ def test_not_decompose_partial_czs():
 
 def test_avoids_decompose_when_matrix_available():
     class OtherXX(cirq.testing.TwoQubitGate):
-        # coverage: ignore
+        # pragma: no cover
         def _has_unitary_(self) -> bool:
             return True
 
@@ -244,7 +244,7 @@ def test_avoids_decompose_when_matrix_available():
             assert False
 
     class OtherOtherXX(cirq.testing.TwoQubitGate):
-        # coverage: ignore
+        # pragma: no cover
         def _has_unitary_(self) -> bool:
             return True
 

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
@@ -231,8 +231,7 @@ def test_not_decompose_partial_czs():
 
 
 def test_avoids_decompose_when_matrix_available():
-    class OtherXX(cirq.testing.TwoQubitGate):
-        # pragma: no cover
+    class OtherXX(cirq.testing.TwoQubitGate):  # pragma: no cover
         def _has_unitary_(self) -> bool:
             return True
 
@@ -243,8 +242,7 @@ def test_avoids_decompose_when_matrix_available():
         def _decompose_(self, qubits):
             assert False
 
-    class OtherOtherXX(cirq.testing.TwoQubitGate):
-        # pragma: no cover
+    class OtherOtherXX(cirq.testing.TwoQubitGate):  # pragma: no cover
         def _has_unitary_(self) -> bool:
             return True
 

--- a/cirq-core/cirq/value/abc_alt_test.py
+++ b/cirq-core/cirq/value/abc_alt_test.py
@@ -140,7 +140,7 @@ def test_classcell_in_namespace():
     class _(metaclass=ABCMetaImplementAnyOneOf):
         def other_method(self):
             # Triggers __classcell__ to be added to the class namespace
-            super()  # coverage: ignore
+            super()  # pragma: no cover
 
 
 def test_two_alternatives():
@@ -170,17 +170,17 @@ def test_two_alternatives():
             return 'alt1'
 
         def alt2(self) -> NoReturn:
-            raise RuntimeError  # coverage: ignore
+            raise RuntimeError  # pragma: no cover
 
     class TwoAlternativesOverride(TwoAlternatives):
         def my_method(self, arg, kw=99) -> str:
             return 'override'
 
         def alt1(self) -> NoReturn:
-            raise RuntimeError  # coverage: ignore
+            raise RuntimeError  # pragma: no cover
 
         def alt2(self) -> NoReturn:
-            raise RuntimeError  # coverage: ignore
+            raise RuntimeError  # pragma: no cover
 
     class TwoAlternativesForceSecond(TwoAlternatives):
         def _do_alt1_with_my_method(self):

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -43,7 +43,7 @@ def test_eq_and_hash():
             self.some_str = some_str
 
         def __str__(self):
-            return self.some_str  # coverage: ignore
+            return self.some_str  # pragma: no cover
 
     mkey = cirq.MeasurementKey('key')
     assert mkey == 'key'

--- a/cirq-core/cirq/value/product_state.py
+++ b/cirq-core/cirq/value/product_state.py
@@ -61,7 +61,7 @@ class ProductState:
 
     def __init__(self, states=None):
         if states is None:
-            # coverage: ignore
+            # pragma: no cover
             states = dict()
 
         object.__setattr__(self, 'states', states)
@@ -200,7 +200,7 @@ class _XEigenState(_PauliEigenState):
             return np.array([1, 1]) / np.sqrt(2)
         elif self.eigenvalue == -1:
             return np.array([1, -1]) / np.sqrt(2)
-        # coverage: ignore
+        # pragma: no cover
         raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")
 
     def stabilized_by(self) -> Tuple[int, 'cirq.Pauli']:
@@ -218,7 +218,7 @@ class _YEigenState(_PauliEigenState):
             return np.array([1, 1j]) / np.sqrt(2)
         elif self.eigenvalue == -1:
             return np.array([1, -1j]) / np.sqrt(2)
-        # coverage: ignore
+        # pragma: no cover
         raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")
 
     def stabilized_by(self) -> Tuple[int, 'cirq.Pauli']:
@@ -235,7 +235,7 @@ class _ZEigenState(_PauliEigenState):
             return np.array([1, 0])
         elif self.eigenvalue == -1:
             return np.array([0, 1])
-        # coverage: ignore
+        # pragma: no cover
         raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")
 
     def stabilized_by(self) -> Tuple[int, 'cirq.Pauli']:

--- a/cirq-core/cirq/value/product_state.py
+++ b/cirq-core/cirq/value/product_state.py
@@ -61,8 +61,7 @@ class ProductState:
 
     def __init__(self, states=None):
         if states is None:
-            # pragma: no cover
-            states = dict()
+            states = dict()  # pragma: no cover
 
         object.__setattr__(self, 'states', states)
 
@@ -200,8 +199,7 @@ class _XEigenState(_PauliEigenState):
             return np.array([1, 1]) / np.sqrt(2)
         elif self.eigenvalue == -1:
             return np.array([1, -1]) / np.sqrt(2)
-        # pragma: no cover
-        raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")
+        raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")  # pragma: no cover
 
     def stabilized_by(self) -> Tuple[int, 'cirq.Pauli']:
         # Prevent circular import from `value.value_equality`
@@ -218,8 +216,7 @@ class _YEigenState(_PauliEigenState):
             return np.array([1, 1j]) / np.sqrt(2)
         elif self.eigenvalue == -1:
             return np.array([1, -1j]) / np.sqrt(2)
-        # pragma: no cover
-        raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")
+        raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")  # pragma: no cover
 
     def stabilized_by(self) -> Tuple[int, 'cirq.Pauli']:
         from cirq import ops
@@ -235,8 +232,7 @@ class _ZEigenState(_PauliEigenState):
             return np.array([1, 0])
         elif self.eigenvalue == -1:
             return np.array([0, 1])
-        # pragma: no cover
-        raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")
+        raise ValueError(f"Bad eigenvalue: {self.eigenvalue}")  # pragma: no cover
 
     def stabilized_by(self) -> Tuple[int, 'cirq.Pauli']:
         from cirq import ops

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -50,8 +50,7 @@ class _SupportsValueEquality(Protocol):
         Returns:
             Any type supported by `cirq.approx_eq()`.
         """
-        # pragma: no cover
-        return self._value_equality_values_()
+        return self._value_equality_values_()  # pragma: no cover
 
     def _value_equality_values_cls_(self) -> Any:
         """Automatically implemented by the `cirq.value_equality` decorator.

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -50,7 +50,7 @@ class _SupportsValueEquality(Protocol):
         Returns:
             Any type supported by `cirq.approx_eq()`.
         """
-        # coverage: ignore
+        # pragma: no cover
         return self._value_equality_values_()
 
     def _value_equality_values_cls_(self) -> Any:

--- a/cirq-ft/cirq_ft/algos/and_gate.py
+++ b/cirq-ft/cirq_ft/algos/and_gate.py
@@ -66,7 +66,7 @@ class And(infra.GateWithRegisters):
             return self
         if power == -1:
             return And(self.cv, adjoint=self.adjoint ^ True)
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
     def __str__(self) -> str:
         suffix = "" if self.cv == (1,) * len(self.cv) else str(self.cv)

--- a/cirq-ft/cirq_ft/algos/arithmetic_gates.py
+++ b/cirq-ft/cirq_ft/algos/arithmetic_gates.py
@@ -47,7 +47,7 @@ class LessThanGate(cirq.ArithmeticGate):
     def __pow__(self, power: int):
         if power in [1, -1]:
             return self
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
     def __repr__(self) -> str:
         return f'cirq_ft.LessThanGate({self.bitsize}, {self.less_than_val})'
@@ -200,7 +200,7 @@ class BiQubitsMixer(infra.GateWithRegisters):
             return self
         if power == -1:
             return BiQubitsMixer(adjoint=not self.adjoint)
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
     def _t_complexity_(self) -> infra.TComplexity:
         if self.adjoint:
@@ -302,7 +302,7 @@ class LessThanEqualGate(cirq.ArithmeticGate):
     def __pow__(self, power: int):
         if power in [1, -1]:
             return self
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
     def __repr__(self) -> str:
         return f'cirq_ft.LessThanEqualGate({self.x_bitsize}, {self.y_bitsize})'
@@ -506,7 +506,7 @@ class ContiguousRegisterGate(cirq.ArithmeticGate):
     def __pow__(self, power: int):
         if power in [1, -1]:
             return self
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
 
 @attr.frozen

--- a/cirq-ft/cirq_ft/algos/mean_estimation/arctan.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/arctan.py
@@ -56,4 +56,4 @@ class ArcTan(cirq.ArithmeticGate):
     def __pow__(self, power) -> 'ArcTan':
         if power in [+1, -1]:
             return self
-        raise NotImplementedError("__pow__ is only implemented for +1/-1.")  # coverage: ignore
+        raise NotImplementedError("__pow__ is only implemented for +1/-1.")  # pragma: no cover

--- a/cirq-ft/cirq_ft/algos/mean_estimation/mean_estimation_operator_test.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/mean_estimation_operator_test.py
@@ -76,9 +76,9 @@ class BernoulliEncoder(cirq_ft.SelectOracle):
 
         for y0, y1, tq in zip(y0_bin, y1_bin, t):
             if y0:
-                yield cirq.X(tq).controlled_by(  # coverage: ignore
-                    *q, control_values=[0] * self.selection_bitsize  # coverage: ignore
-                )  # coverage: ignore
+                yield cirq.X(tq).controlled_by(  # pragma: no cover
+                    *q, control_values=[0] * self.selection_bitsize  # pragma: no cover
+                )  # pragma: no cover
             if y1:
                 yield cirq.X(tq).controlled_by(*q, control_values=[1] * self.selection_bitsize)
 
@@ -185,7 +185,7 @@ class GroverSynthesizer(cirq_ft.PrepareOracle):
     def __pow__(self, power):
         if power in [+1, -1]:
             return self
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
 
 @frozen

--- a/cirq-ft/cirq_ft/algos/qrom.py
+++ b/cirq-ft/cirq_ft/algos/qrom.py
@@ -169,7 +169,7 @@ class QROM(unary_iteration_gate.UnaryIterationGate):
     def __pow__(self, power: int):
         if power in [1, -1]:
             return self
-        return NotImplemented  # coverage: ignore
+        return NotImplemented  # pragma: no cover
 
     def _value_equality_values_(self):
         return (self.selection_registers, self.target_registers, self.control_registers)

--- a/cirq-ft/cirq_ft/infra/qubit_management_transformers.py
+++ b/cirq-ft/cirq_ft/infra/qubit_management_transformers.py
@@ -140,8 +140,8 @@ def map_clean_and_borrowable_qubits(
                 assert st < idx and q in allocated_map
                 # This line is actually covered by
                 # `test_map_clean_and_borrowable_qubits_deallocates_only_once` but pytest-cov seems
-                # to not recognize it and hence the coverage: ignore.
-                continue  # coverage: ignore
+                # to not recognize it and hence the pragma: no cover.
+                continue  # pragma: no cover
 
             # This is the first time we are seeing this temporary qubit and need to find a mapping.
             if isinstance(q, cirq.ops.CleanQubit):

--- a/cirq-ft/cirq_ft/infra/t_complexity_protocol_test.py
+++ b/cirq-ft/cirq_ft/infra/t_complexity_protocol_test.py
@@ -186,7 +186,7 @@ def test_cache_clear():
 
         @property
         def qubits(self):
-            return [cirq.LineQubit(3)]  # coverage: ignore
+            return [cirq.LineQubit(3)]  # pragma: no cover
 
         def with_qubits(self, _):
             ...

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -17,8 +17,7 @@ and warn users that the latest version of cirq uses python 3.9+"""
 
 import sys
 
-if sys.version_info < (3, 9, 0):
-    # pragma: no cover
+if sys.version_info < (3, 9, 0):  # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.9+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -18,7 +18,7 @@ and warn users that the latest version of cirq uses python 3.9+"""
 import sys
 
 if sys.version_info < (3, 9, 0):
-    # coverage: ignore
+    # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.9+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-google/cirq_google/api/v1/programs.py
+++ b/cirq-google/cirq_google/api/v1/programs.py
@@ -41,40 +41,35 @@ def gate_to_proto(
 
     if isinstance(gate, cirq.XPowGate):
         if len(qubits) != 1:
-            # pragma: no cover
-            raise ValueError('Wrong number of qubits.')
+            raise ValueError('Wrong number of qubits.')  # pragma: no cover
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_w=_x_to_proto(gate, qubits[0])
         )
 
     if isinstance(gate, cirq.YPowGate):
         if len(qubits) != 1:
-            # pragma: no cover
-            raise ValueError('Wrong number of qubits.')
+            raise ValueError('Wrong number of qubits.')  # pragma: no cover
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_w=_y_to_proto(gate, qubits[0])
         )
 
     if isinstance(gate, cirq.PhasedXPowGate):
         if len(qubits) != 1:
-            # pragma: no cover
-            raise ValueError('Wrong number of qubits.')
+            raise ValueError('Wrong number of qubits.')  # pragma: no cover
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_w=_phased_x_to_proto(gate, qubits[0])
         )
 
     if isinstance(gate, cirq.ZPowGate):
         if len(qubits) != 1:
-            # pragma: no cover
-            raise ValueError('Wrong number of qubits.')
+            raise ValueError('Wrong number of qubits.')  # pragma: no cover
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_z=_z_to_proto(gate, qubits[0])
         )
 
     if isinstance(gate, cirq.CZPowGate):
         if len(qubits) != 2:
-            # pragma: no cover
-            raise ValueError('Wrong number of qubits.')
+            raise ValueError('Wrong number of qubits.')  # pragma: no cover
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_11=_cz_to_proto(gate, *qubits)
         )

--- a/cirq-google/cirq_google/api/v1/programs.py
+++ b/cirq-google/cirq_google/api/v1/programs.py
@@ -41,7 +41,7 @@ def gate_to_proto(
 
     if isinstance(gate, cirq.XPowGate):
         if len(qubits) != 1:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError('Wrong number of qubits.')
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_w=_x_to_proto(gate, qubits[0])
@@ -49,7 +49,7 @@ def gate_to_proto(
 
     if isinstance(gate, cirq.YPowGate):
         if len(qubits) != 1:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError('Wrong number of qubits.')
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_w=_y_to_proto(gate, qubits[0])
@@ -57,7 +57,7 @@ def gate_to_proto(
 
     if isinstance(gate, cirq.PhasedXPowGate):
         if len(qubits) != 1:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError('Wrong number of qubits.')
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_w=_phased_x_to_proto(gate, qubits[0])
@@ -65,7 +65,7 @@ def gate_to_proto(
 
     if isinstance(gate, cirq.ZPowGate):
         if len(qubits) != 1:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError('Wrong number of qubits.')
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_z=_z_to_proto(gate, qubits[0])
@@ -73,7 +73,7 @@ def gate_to_proto(
 
     if isinstance(gate, cirq.CZPowGate):
         if len(qubits) != 2:
-            # coverage: ignore
+            # pragma: no cover
             raise ValueError('Wrong number of qubits.')
         return operations_pb2.Operation(
             incremental_delay_picoseconds=delay, exp_11=_cz_to_proto(gate, *qubits)

--- a/cirq-google/cirq_google/api/v1/programs_test.py
+++ b/cirq-google/cirq_google/api/v1/programs_test.py
@@ -57,7 +57,7 @@ def make_bytes(s: str) -> bytes:
         elif c == '1':
             byte |= 1 << idx
         else:
-            # coverage: ignore
+            # pragma: no cover
             continue
         idx += 1
         if idx == 8:

--- a/cirq-google/cirq_google/api/v1/programs_test.py
+++ b/cirq-google/cirq_google/api/v1/programs_test.py
@@ -56,8 +56,7 @@ def make_bytes(s: str) -> bytes:
             pass
         elif c == '1':
             byte |= 1 << idx
-        else:
-            # pragma: no cover
+        else:  # pragma: no cover
             continue
         idx += 1
         if idx == 8:

--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -122,8 +122,7 @@ def sweep_from_proto(msg: run_context_pb2.Sweep) -> cirq.Sweep:
 
         raise ValueError(f'single sweep type not set: {msg}')
 
-    # pragma: no cover
-    raise ValueError(f'sweep type not set: {msg}')
+    raise ValueError(f'sweep type not set: {msg}')  # pragma: no cover
 
 
 def run_context_to_proto(

--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -122,7 +122,7 @@ def sweep_from_proto(msg: run_context_pb2.Sweep) -> cirq.Sweep:
 
         raise ValueError(f'single sweep type not set: {msg}')
 
-    # coverage: ignore
+    # pragma: no cover
     raise ValueError(f'sweep type not set: {msg}')
 
 

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -24,16 +24,13 @@ from cirq_google.api import v2
 
 
 class UnknownSweep(sweeps.SingleSweep):
-    def _tuple(self):
-        # pragma: no cover
+    def _tuple(self):  # pragma: no cover
         return self.key, tuple(range(10))
 
     def __len__(self) -> int:
-        # pragma: no cover
         return 10
 
     def _values(self) -> Iterator[float]:
-        # pragma: no cover
         return iter(range(10))
 
 

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -25,15 +25,15 @@ from cirq_google.api import v2
 
 class UnknownSweep(sweeps.SingleSweep):
     def _tuple(self):
-        # coverage: ignore
+        # pragma: no cover
         return self.key, tuple(range(10))
 
     def __len__(self) -> int:
-        # coverage: ignore
+        # pragma: no cover
         return 10
 
     def _values(self) -> Iterator[float]:
-        # coverage: ignore
+        # pragma: no cover
         return iter(range(10))
 
 

--- a/cirq-google/cirq_google/calibration/phased_fsim.py
+++ b/cirq-google/cirq_google/calibration/phased_fsim.py
@@ -1048,7 +1048,7 @@ class PhaseCalibratedFSimGate:
             engine_gate = self.engine_gate
         else:
             if cirq.num_qubits(engine_gate) != 2:
-                raise ValueError('Engine gate must be a two-qubit gate')  # coverage: ignore
+                raise ValueError('Engine gate must be a two-qubit gate')  # pragma: no cover
 
         a, b = qubits
 

--- a/cirq-google/cirq_google/calibration/workflow.py
+++ b/cirq-google/cirq_google/calibration/workflow.py
@@ -820,7 +820,7 @@ def run_calibrations(
 
     if isinstance(sampler, AbstractEngine):
         if processor_id is None:
-            raise ValueError('processor_id must be provided.')  # coverage: ignore
+            raise ValueError('processor_id must be provided.')  # pragma: no cover
         processor: Optional[AbstractProcessor] = sampler.get_processor(processor_id=processor_id)
     elif isinstance(sampler, ProcessorSampler):
         processor = sampler.processor

--- a/cirq-google/cirq_google/calibration/workflow.py
+++ b/cirq-google/cirq_google/calibration/workflow.py
@@ -828,7 +828,6 @@ def run_calibrations(
         processor = None
 
     if processor is not None:
-
         if calibration_request_type == LocalXEBPhasedFSimCalibrationRequest:
             engine_sampler = processor.get_sampler()
             return _run_local_calibrations_via_sampler(calibrations, engine_sampler)

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -250,7 +250,7 @@ def _deserialize_gateset_and_gate_durations(
 
         gate_rep = next((gr for gr in _GATES if gr.gate_spec_name == gate_name), None)
         if gate_rep is None:
-            # coverage: ignore
+            # pragma: no cover
             warnings.warn(
                 f"The DeviceSpecification contains the gate '{gate_name}' which is not recognized"
                 " by Cirq and will be ignored. This may be due to an out-of-date Cirq version.",
@@ -460,9 +460,9 @@ class GridDevice(cirq.Device):
                 all_qubits=all_qubits,
                 compilation_target_gatesets=_build_compilation_target_gatesets(gateset),
             )
-        except ValueError as ve:  # coverage: ignore
+        except ValueError as ve:  # pragma: no cover
             # Spec errors should have been caught in validation above.
-            raise ValueError("DeviceSpecification is invalid.") from ve  # coverage: ignore
+            raise ValueError("DeviceSpecification is invalid.") from ve  # pragma: no cover
 
         return GridDevice(metadata)
 

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -249,8 +249,7 @@ def _deserialize_gateset_and_gate_durations(
         gate_name = gate_spec.WhichOneof('gate')
 
         gate_rep = next((gr for gr in _GATES if gr.gate_spec_name == gate_name), None)
-        if gate_rep is None:
-            # pragma: no cover
+        if gate_rep is None:  # pragma: no cover
             warnings.warn(
                 f"The DeviceSpecification contains the gate '{gate_name}' which is not recognized"
                 " by Cirq and will be ignored. This may be due to an out-of-date Cirq version.",

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -33,7 +33,7 @@ class NothingJob(AbstractLocalJob):
         return self._status
 
     def failure(self) -> Optional[Tuple[str, str]]:
-        return ('failed', 'failure code')  # coverage: ignore
+        return ('failed', 'failure code')  # pragma: no cover
 
     def cancel(self) -> None:
         pass
@@ -42,13 +42,13 @@ class NothingJob(AbstractLocalJob):
         pass
 
     async def batched_results_async(self) -> Sequence[Sequence[EngineResult]]:
-        return []  # coverage: ignore
+        return []  # pragma: no cover
 
     async def results_async(self) -> Sequence[EngineResult]:
-        return []  # coverage: ignore
+        return []  # pragma: no cover
 
     async def calibration_results_async(self) -> Sequence[CalibrationResult]:
-        return []  # coverage: ignore
+        return []  # pragma: no cover
 
 
 def test_description_and_labels():

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -341,7 +341,6 @@ class EngineJob(abstract_job.AbstractJob):
         return self._calibration_results
 
     def _get_job_results_v1(self, result: v1.program_pb2.Result) -> Sequence[EngineResult]:
-        # pragma: no cover
         job_id = self.id()
         job_finished = self.update_time()
 

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -286,7 +286,7 @@ class EngineJob(abstract_job.AbstractJob):
                 or result_type == 'cirq.api.google.v1.Result'
             ):
                 v1_parsed_result = v1.program_pb2.Result.FromString(result.value)
-                self._results = self._get_job_results_v1(v1_parsed_result)  # coverage: ignore
+                self._results = self._get_job_results_v1(v1_parsed_result)  # pragma: no cover
             elif (
                 result_type == 'cirq.google.api.v2.Result'
                 or result_type == 'cirq.api.google.v2.Result'
@@ -341,7 +341,7 @@ class EngineJob(abstract_job.AbstractJob):
         return self._calibration_results
 
     def _get_job_results_v1(self, result: v1.program_pb2.Result) -> Sequence[EngineResult]:
-        # coverage: ignore
+        # pragma: no cover
         job_id = self.id()
         job_finished = self.update_time()
 

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -701,8 +701,7 @@ def _allow_deprecated_freezegun(func):
             if orig_exist:
                 # mypy can't resolve that orig_exist ensures that orig_value
                 # of type Optional[str] can't be None
-                # pragma: no cover
-                os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value
+                os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value  # pragma: no cover
             else:
                 del os.environ[ALLOW_DEPRECATION_IN_TEST]
 

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -701,7 +701,7 @@ def _allow_deprecated_freezegun(func):
             if orig_exist:
                 # mypy can't resolve that orig_exist ensures that orig_value
                 # of type Optional[str] can't be None
-                # coverage: ignore
+                # pragma: no cover
                 os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value
             else:
                 del os.environ[ALLOW_DEPRECATION_IN_TEST]

--- a/cirq-google/cirq_google/engine/engine_result_test.py
+++ b/cirq-google/cirq_google/engine/engine_result_test.py
@@ -95,7 +95,7 @@ class MyResult(cirq.Result):
 
     @property
     def data(self) -> pd.DataFrame:
-        # coverage: ignore
+        # pragma: no cover
         return cirq.Result.dataframe_from_measurements(self.measurements)
 
 

--- a/cirq-google/cirq_google/engine/engine_result_test.py
+++ b/cirq-google/cirq_google/engine/engine_result_test.py
@@ -94,8 +94,7 @@ class MyResult(cirq.Result):
         return {k: v[:, np.newaxis, :] for k, v in self.measurements.items()}
 
     @property
-    def data(self) -> pd.DataFrame:
-        # pragma: no cover
+    def data(self) -> pd.DataFrame:  # pragma: no cover
         return cirq.Result.dataframe_from_measurements(self.measurements)
 
 

--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -274,8 +274,7 @@ class StreamManager:
                     _to_create_job_request(create_program_and_job_request),
                 )
                 continue
-            else:
-                # pragma: no cover
+            else:  # pragma: no cover
                 raise ValueError(
                     'The Quantum Engine response type is not recognized by this client. '
                     'This may be due to an outdated version of cirq-google'

--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -230,7 +230,7 @@ class StreamManager:
             # Ignoring coverage since this is rarely triggered.
             # TODO(#5996) Consider awaiting for the queue to become available, once it is changed
             # to be local to the asyncio thread.
-            await asyncio.sleep(1)  # coverage: ignore
+            await asyncio.sleep(1)  # pragma: no cover
 
         current_request = create_program_and_job_request
         while True:
@@ -275,7 +275,7 @@ class StreamManager:
                 )
                 continue
             else:
-                # coverage: ignore
+                # pragma: no cover
                 raise ValueError(
                     'The Quantum Engine response type is not recognized by this client. '
                     'This may be due to an outdated version of cirq-google'

--- a/cirq-google/cirq_google/engine/virtual_engine_factory.py
+++ b/cirq-google/cirq_google/engine/virtual_engine_factory.py
@@ -401,12 +401,12 @@ def create_default_noisy_quantum_virtual_machine(
     """
 
     if simulator_class is None:
-        try:  # coverage: ignore
+        try:  # pragma: no cover
             import qsimcirq  # type: ignore
 
-            simulator_class = qsimcirq.QSimSimulator  # coverage: ignore
+            simulator_class = qsimcirq.QSimSimulator  # pragma: no cover
         except ImportError:
-            simulator_class = cirq.Simulator  # coverage: ignore
+            simulator_class = cirq.Simulator  # pragma: no cover
 
     calibration = load_median_device_calibration(processor_id)
     noise_properties = noise_properties_from_calibration(calibration)

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -576,10 +576,10 @@ def test_serialize_op_bad_operation():
     class NullOperation(cirq.Operation):
         @property
         def qubits(self):
-            return tuple()  # coverage: ignore
+            return tuple()  # pragma: no cover
 
         def with_qubits(self, *qubits):
-            return self  # coverage: ignore
+            return self  # pragma: no cover
 
     null_op = NullOperation()
     with pytest.raises(ValueError, match='Cannot serialize op'):

--- a/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
+++ b/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
@@ -244,7 +244,7 @@ def test_unsupported_gate_ignoring_failures():
             return self._qubits
 
         def with_qubits(self, *new_qubits):
-            # coverage: ignore
+            # pragma: no cover
             return UnknownOperation(self._qubits)
 
     q0 = cirq.LineQubit(0)

--- a/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
+++ b/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
@@ -244,8 +244,7 @@ def test_unsupported_gate_ignoring_failures():
             return self._qubits
 
         def with_qubits(self, *new_qubits):
-            # pragma: no cover
-            return UnknownOperation(self._qubits)
+            return UnknownOperation(self._qubits)  # pragma: no cover
 
     q0 = cirq.LineQubit(0)
     circuit = cirq.Circuit(UnknownOperation([q0]))

--- a/cirq-google/cirq_google/workflow/quantum_runtime.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime.py
@@ -69,7 +69,7 @@ def _try_tuple(k: Any) -> Any:
     """If we serialize a dictionary that had tuple keys, they get turned to json lists."""
     if isinstance(k, list):
         return tuple(k)
-    return k  # coverage: ignore
+    return k  # pragma: no cover
 
 
 @dataclasses.dataclass
@@ -260,7 +260,7 @@ def execute(
 
     # base_data_dir handling.
     if not base_data_dir:
-        # coverage: ignore
+        # pragma: no cover
         raise ValueError("Please provide a non-empty `base_data_dir`.")
 
     sampler = rt_config.processor_record.get_sampler()

--- a/cirq-google/cirq_google/workflow/quantum_runtime.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime.py
@@ -259,8 +259,7 @@ def execute(
         run_id = rt_config.run_id
 
     # base_data_dir handling.
-    if not base_data_dir:
-        # pragma: no cover
+    if not base_data_dir:  # pragma: no cover
         raise ValueError("Please provide a non-empty `base_data_dir`.")
 
     sampler = rt_config.processor_record.get_sampler()

--- a/cirq-google/cirq_google/workflow/quantum_runtime_test.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime_test.py
@@ -80,7 +80,7 @@ def rt_config(request):
             target_gateset=cirq.CZTargetGateset(),
         )
 
-    raise ValueError(f"Unknown flavor {request}")  # coverage: ignore
+    raise ValueError(f"Unknown flavor {request}")  # pragma: no cover
 
 
 def test_quantum_runtime_configuration_sampler(rt_config):

--- a/cirq-google/cirq_google/workflow/qubit_placement.py
+++ b/cirq-google/cirq_google/workflow/qubit_placement.py
@@ -202,8 +202,7 @@ class HardcodedQubitPlacer(QubitPlacer):
 
     def __eq__(self, other):
         if not isinstance(other, HardcodedQubitPlacer):
-            # pragma: no cover
-            return False
+            return False  # pragma: no cover
 
         return self._mapping == other._mapping
 

--- a/cirq-google/cirq_google/workflow/qubit_placement.py
+++ b/cirq-google/cirq_google/workflow/qubit_placement.py
@@ -202,7 +202,7 @@ class HardcodedQubitPlacer(QubitPlacer):
 
     def __eq__(self, other):
         if not isinstance(other, HardcodedQubitPlacer):
-            # coverage: ignore
+            # pragma: no cover
             return False
 
         return self._mapping == other._mapping

--- a/cirq-ionq/cirq_ionq/ionq_client.py
+++ b/cirq-ionq/cirq_ionq/ionq_client.py
@@ -345,8 +345,8 @@ class _IonQClient:
                     error = {}
                     try:
                         error = response.json()
-                    except jd.JSONDecodeError:  # coverage: ignore
-                        pass  # coverage: ignore
+                    except jd.JSONDecodeError:  # pragma: no cover
+                        pass  # pragma: no cover
                     raise ionq_exceptions.IonQException(
                         'Non-retry-able error making request to IonQ API. '
                         f'Request Body: {json} '

--- a/cirq-ionq/cirq_ionq/json_resolver_cache.py
+++ b/cirq-ionq/cirq_ionq/json_resolver_cache.py
@@ -19,8 +19,8 @@ import cirq_ionq
 from cirq.protocols.json_serialization import ObjectFactory
 
 
-@functools.lru_cache()  # coverage: ignore
-def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # coverage: ignore
+@functools.lru_cache()  # pragma: no cover
+def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # pragma: no cover
     return {
         "GPIGate": cirq_ionq.GPIGate,
         "GPI2Gate": cirq_ionq.GPI2Gate,

--- a/cirq-rigetti/cirq_rigetti/_qcs_api_client_decorator.py
+++ b/cirq-rigetti/cirq_rigetti/_qcs_api_client_decorator.py
@@ -37,7 +37,6 @@ def _provide_default_client(function):
             return function(*args, **kwargs)
 
         with build_sync_client() as client:  # pragma: no cover
-            # pragma: no cover
             kwargs['client'] = client
             return function(*args, **kwargs)
 

--- a/cirq-rigetti/cirq_rigetti/_qcs_api_client_decorator.py
+++ b/cirq-rigetti/cirq_rigetti/_qcs_api_client_decorator.py
@@ -36,8 +36,8 @@ def _provide_default_client(function):
         if 'client' in kwargs:
             return function(*args, **kwargs)
 
-        with build_sync_client() as client:  # coverage: ignore
-            # coverage: ignore
+        with build_sync_client() as client:  # pragma: no cover
+            # pragma: no cover
             kwargs['client'] = client
             return function(*args, **kwargs)
 

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -126,8 +126,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
         if isinstance(valid_qubit, (OctagonalQubit, AspenQubit)):
             return valid_qubit.index
 
-        else:
-            # pragma: no cover
+        else:  # pragma: no cover
             raise UnsupportedQubit(f'unsupported Qid type {type(valid_qubit)}')
 
     def validate_qubit(self, qubit: 'cirq.Qid') -> None:
@@ -182,8 +181,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
                 )
             return
 
-        else:
-            # pragma: no cover
+        else:  # pragma: no cover
             raise UnsupportedQubit(f'unsupported Qid type {type(qubit)}')
 
     def validate_operation(self, operation: 'cirq.Operation') -> None:
@@ -233,7 +231,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
         return cls(isa=InstructionSetArchitecture.from_dict(isa))
 
 
-@_provide_default_client
+@_provide_default_client  # pragma: no cover
 def get_rigetti_qcs_aspen_device(
     quantum_processor_id: str, client: Optional[httpx.Client]
 ) -> RigettiQCSAspenDevice:
@@ -252,7 +250,6 @@ def get_rigetti_qcs_aspen_device(
         set and architecture.
 
     """
-    # pragma: no cover
     isa = cast(
         InstructionSetArchitecture,
         get_instruction_set_architecture(

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -127,7 +127,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
             return valid_qubit.index
 
         else:
-            # coverage: ignore
+            # pragma: no cover
             raise UnsupportedQubit(f'unsupported Qid type {type(valid_qubit)}')
 
     def validate_qubit(self, qubit: 'cirq.Qid') -> None:
@@ -183,7 +183,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
             return
 
         else:
-            # coverage: ignore
+            # pragma: no cover
             raise UnsupportedQubit(f'unsupported Qid type {type(qubit)}')
 
     def validate_operation(self, operation: 'cirq.Operation') -> None:
@@ -252,7 +252,7 @@ def get_rigetti_qcs_aspen_device(
         set and architecture.
 
     """
-    # coverage: ignore
+    # pragma: no cover
     isa = cast(
         InstructionSetArchitecture,
         get_instruction_set_architecture(

--- a/cirq-rigetti/cirq_rigetti/conftest.py
+++ b/cirq-rigetti/cirq_rigetti/conftest.py
@@ -31,8 +31,7 @@ import sympy
 import numpy as np
 
 
-def pytest_collection_modifyitems(config, items):
-    # pragma: no cover
+def pytest_collection_modifyitems(config, items):  # pragma: no cover
     # do not skip integration tests if --rigetti-integration option passed
     if config.getoption('--rigetti-integration'):
         return

--- a/cirq-rigetti/cirq_rigetti/conftest.py
+++ b/cirq-rigetti/cirq_rigetti/conftest.py
@@ -32,7 +32,7 @@ import numpy as np
 
 
 def pytest_collection_modifyitems(config, items):
-    # coverage: ignore
+    # pragma: no cover
     # do not skip integration tests if --rigetti-integration option passed
     if config.getoption('--rigetti-integration'):
         return

--- a/cirq-rigetti/cirq_rigetti/json_resolver_cache.py
+++ b/cirq-rigetti/cirq_rigetti/json_resolver_cache.py
@@ -19,8 +19,8 @@ import cirq_rigetti
 from cirq.protocols.json_serialization import ObjectFactory
 
 
-@functools.lru_cache()  # coverage: ignore
-def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # coverage: ignore
+@functools.lru_cache()  # pragma: no cover
+def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # pragma: no cover
     return {
         'RigettiQCSAspenDevice': cirq_rigetti.RigettiQCSAspenDevice,
         'AspenQubit': cirq_rigetti.AspenQubit,

--- a/cirq-rigetti/cirq_rigetti/json_test_data/spec.py
+++ b/cirq-rigetti/cirq_rigetti/json_test_data/spec.py
@@ -19,7 +19,6 @@ from cirq_rigetti.json_resolver_cache import _class_resolver_dictionary
 
 from cirq.testing.json import ModuleJsonTestSpec
 
-# pragma: no cover
 TestSpec = ModuleJsonTestSpec(
     name="cirq_rigetti",
     packages=[cirq_rigetti],

--- a/cirq-rigetti/cirq_rigetti/json_test_data/spec.py
+++ b/cirq-rigetti/cirq_rigetti/json_test_data/spec.py
@@ -19,7 +19,7 @@ from cirq_rigetti.json_resolver_cache import _class_resolver_dictionary
 
 from cirq.testing.json import ModuleJsonTestSpec
 
-# coverage: ignore
+# pragma: no cover
 TestSpec = ModuleJsonTestSpec(
     name="cirq_rigetti",
     packages=[cirq_rigetti],

--- a/cirq-rigetti/cirq_rigetti/quil_output.py
+++ b/cirq-rigetti/cirq_rigetti/quil_output.py
@@ -428,10 +428,9 @@ class QuilOutput:
             # Following code is a safety measure
             # Could not find a gate that doesn't decompose into a gate
             # with a _quil_ implementation
-            # pragma: no cover
-            if len(op.qubits) == 1:
+            if len(op.qubits) == 1:  # pragma: no cover
                 return QuilOneQubitGate(mat).on(*op.qubits)
-            return QuilTwoQubitGate(mat).on(*op.qubits)
+            return QuilTwoQubitGate(mat).on(*op.qubits)  # pragma: no cover
 
         def on_stuck(bad_op):
             return ValueError(f'Cannot output operation as QUIL: {bad_op!r}')

--- a/cirq-rigetti/cirq_rigetti/quil_output.py
+++ b/cirq-rigetti/cirq_rigetti/quil_output.py
@@ -428,7 +428,7 @@ class QuilOutput:
             # Following code is a safety measure
             # Could not find a gate that doesn't decompose into a gate
             # with a _quil_ implementation
-            # coverage: ignore
+            # pragma: no cover
             if len(op.qubits) == 1:
                 return QuilOneQubitGate(mat).on(*op.qubits)
             return QuilTwoQubitGate(mat).on(*op.qubits)

--- a/cirq-rigetti/cirq_rigetti/service.py
+++ b/cirq-rigetti/cirq_rigetti/service.py
@@ -107,7 +107,7 @@ class RigettiQCSService:
     @_provide_default_client
     def list_quantum_processors(
         client: Optional[httpx.Client],
-    ) -> ListQuantumProcessorsResponse:  # coverage: ignore
+    ) -> ListQuantumProcessorsResponse:  # pragma: no cover
         """Retrieve a list of available Rigetti quantum processors.
 
         Args:
@@ -140,7 +140,7 @@ class RigettiQCSService:
             A qcs_api_client.models.GetQuiltCalibrationsResponse containing the
             device calibrations.
         """
-        # coverage: ignore
+        # pragma: no cover
         return cast(
             GetQuiltCalibrationsResponse,
             get_quilt_calibrations(client=client, quantum_processor_id=quantum_processor_id).parsed,
@@ -150,7 +150,7 @@ class RigettiQCSService:
     @_provide_default_client
     def get_instruction_set_architecture(
         quantum_processor_id: str, client: Optional[httpx.Client]
-    ) -> InstructionSetArchitecture:  # coverage: ignore
+    ) -> InstructionSetArchitecture:  # pragma: no cover
         """Retrieve the Instruction Set Architecture of a QuantumProcessor by ID. This
         includes site specific operations and native gate capabilities.
 
@@ -164,7 +164,7 @@ class RigettiQCSService:
         Returns:
             A qcs_api_client.models.InstructionSetArchitecture containing the device specification.
         """
-        # coverage: ignore
+        # pragma: no cover
         return cast(
             InstructionSetArchitecture,
             get_instruction_set_architecture(

--- a/cirq-rigetti/cirq_rigetti/service.py
+++ b/cirq-rigetti/cirq_rigetti/service.py
@@ -140,8 +140,7 @@ class RigettiQCSService:
             A qcs_api_client.models.GetQuiltCalibrationsResponse containing the
             device calibrations.
         """
-        # pragma: no cover
-        return cast(
+        return cast(  # pragma: no cover
             GetQuiltCalibrationsResponse,
             get_quilt_calibrations(client=client, quantum_processor_id=quantum_processor_id).parsed,
         )
@@ -164,7 +163,6 @@ class RigettiQCSService:
         Returns:
             A qcs_api_client.models.InstructionSetArchitecture containing the device specification.
         """
-        # pragma: no cover
         return cast(
             InstructionSetArchitecture,
             get_instruction_set_architecture(

--- a/cirq-rigetti/cirq_rigetti/service_test.py
+++ b/cirq-rigetti/cirq_rigetti/service_test.py
@@ -20,7 +20,7 @@ def test_rigetti_qcs_service_api_call():
 
     class Response(httpx.Response):
         def iter_bytes(self, chunk_size: Optional[int] = None) -> Iterator[bytes]:
-            yield b"{\"quantumProcessors\": [{\"id\": \"Aspen-8\"}]}"  # pragma: nocover
+            yield b"{\"quantumProcessors\": [{\"id\": \"Aspen-8\"}]}"  # pragma: no cover
 
     class Transport(httpx.BaseTransport):
         def handle_request(self, request: httpx.Request) -> httpx.Response:

--- a/dev_tools/import_test.py
+++ b/dev_tools/import_test.py
@@ -211,11 +211,9 @@ def test_no_circular_imports():
     before in an earlier test but this test needs to control the import process.
     """
     status = subprocess.call([sys.executable, __file__])
-    if status == FAIL_EXIT_CODE:
-        # pragma: no cover
+    if status == FAIL_EXIT_CODE:  # pragma: no cover
         raise Exception('Invalid import. See captured output for details.')
-    elif status != 0:
-        # pragma: no cover
+    elif status != 0:  # pragma: no cover
         raise RuntimeError('Error in subprocess')
 
 

--- a/dev_tools/import_test.py
+++ b/dev_tools/import_test.py
@@ -212,10 +212,10 @@ def test_no_circular_imports():
     """
     status = subprocess.call([sys.executable, __file__])
     if status == FAIL_EXIT_CODE:
-        # coverage: ignore
+        # pragma: no cover
         raise Exception('Invalid import. See captured output for details.')
     elif status != 0:
-        # coverage: ignore
+        # pragma: no cover
         raise RuntimeError('Error in subprocess')
 
 

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -54,7 +54,7 @@ IGNORED_LINE_PATTERNS = [
     # Body of mypy Protocol methods.
     r'\.\.\.',
 ]
-EXPLICIT_OPT_OUT_COMMENT = '#coverage:ignore'
+EXPLICIT_OPT_OUT_PATTERN = r'#\s*pragma:\s*no cover\s*$'
 
 
 def diff_to_new_interesting_lines(unified_diff_lines: List[str]) -> Dict[int, str]:
@@ -194,23 +194,21 @@ def determine_ignored_lines(content: str) -> Set[int]:
     lines = content.split('\n')
     result: List[int] = []
 
+    explicit_opt_out_regexp = re.compile(EXPLICIT_OPT_OUT_PATTERN)
     i = 0
     while i < len(lines):
         line = lines[i]
-
-        # Drop spacing, including internal spacing within the comment.
-        joined_line = re.sub(r'\s+', '', line)
 
         if any(re.match(pat, line) for pat in IGNORED_BLOCK_PATTERNS):
             end = naive_find_end_of_scope(lines, i + 1)
             result.extend(range(i, end))
             i = end
-        elif joined_line == EXPLICIT_OPT_OUT_COMMENT:
+        elif explicit_opt_out_regexp.match(line.strip()):
             # Ignore the rest of a block.
             end = naive_find_end_of_scope(lines, i)
             result.extend(range(i, end))
             i = end
-        elif joined_line.endswith(EXPLICIT_OPT_OUT_COMMENT):
+        elif explicit_opt_out_regexp.search(line):
             # Ignore a single line.
             result.append(i)
             i += 1

--- a/dev_tools/incremental_coverage_test.py
+++ b/dev_tools/incremental_coverage_test.py
@@ -18,12 +18,12 @@ from dev_tools import incremental_coverage
 def test_determine_ignored_lines():
     f = incremental_coverage.determine_ignored_lines
 
-    assert f("a = 0  # coverage: ignore") == {1}
+    assert f("a = 0  # pragma: no cover") == {1}
 
     assert (
         f(
             """
-        a = 0  # coverage: ignore
+        a = 0  # pragma: no cover
         b = 0
     """
         )
@@ -34,7 +34,7 @@ def test_determine_ignored_lines():
         f(
             """
         a = 0
-        b = 0  # coverage: ignore
+        b = 0  # pragma: no cover
     """
         )
         == {3}
@@ -43,8 +43,8 @@ def test_determine_ignored_lines():
     assert (
         f(
             """
-        a = 0  # coverage: ignore
-        b = 0  # coverage: ignore
+        a = 0  # pragma: no cover
+        b = 0  # pragma: no cover
     """
         )
         == {2, 3}
@@ -54,7 +54,7 @@ def test_determine_ignored_lines():
         f(
             """
         if True:
-            a = 0  # coverage: ignore
+            a = 0  # pragma: no cover
 
             b = 0
     """
@@ -66,7 +66,7 @@ def test_determine_ignored_lines():
         f(
             """
         if True:
-            # coverage: ignore
+            # pragma: no cover
             a = 0
 
             b = 0
@@ -79,7 +79,7 @@ def test_determine_ignored_lines():
         f(
             """
         if True:
-            # coverage: ignore
+            # pragma: no cover
             a = 0
 
             b = 0
@@ -93,7 +93,7 @@ def test_determine_ignored_lines():
         f(
             """
         if True:
-            # coverage: ignore
+            # pragma: no cover
             a = 0
 
             b = 0
@@ -109,12 +109,12 @@ def test_determine_ignored_lines():
             """
         if True:
             while False:
-                # coverage: ignore
+                # pragma: no cover
                 a = 0
 
             b = 0
         else:
-            c = 0  # coverage: ignore
+            c = 0  # pragma: no cover
     """
         )
         == {4, 5, 6, 9}
@@ -123,20 +123,20 @@ def test_determine_ignored_lines():
     assert (
         f(
             """
-        a = 2#coverage:ignore
-        a = 3 #coverage:ignore
-        a = 4# coverage:ignore
-        a = 5#coverage :ignore
-        a = 6#coverage: ignore
-        a = 7#coverage: ignore\t
-        a = 8#coverage:\tignore\t
+        a = 2#pragma:no cover
+        a = 3 #pragma:no cover
+        a = 4# pragma:no cover
+        a = 5#pragma :no cover
+        a = 6#pragma: no cover
+        a = 7#pragma: no cover\t
+        a = 8#pragma:\tno cover\t
 
         b = 1 # no cover
         b = 2 # coverage: definitely
         b = 3 # lint: ignore
     """
         )
-        == {2, 3, 4, 5, 6, 7, 8}
+        == {2, 3, 4, 6, 7, 8}
     )
 
     assert (

--- a/dev_tools/modules.py
+++ b/dev_tools/modules.py
@@ -319,4 +319,4 @@ def main(argv: List[str]):
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])  # coverage: ignore
+    main(sys.argv[1:])  # pragma: no cover

--- a/docs/dev/modules.md
+++ b/docs/dev/modules.md
@@ -51,8 +51,8 @@ To setup a new module follow these steps:
 
 1. Add the `<top_level_package>/json_resolver_cache.py` file
     ```python
-    @functools.lru_cache()  # coverage: ignore
-    def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # coverage: ignore
+    @functools.lru_cache()  # pragma: no cover
+    def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # pragma: no cover
         return {}
     ```
 2. Register the resolver cache - at _the end_ of the `<top_level_package>/__init__.py`:

--- a/examples/heatmaps.py
+++ b/examples/heatmaps.py
@@ -38,10 +38,9 @@ def two_qubit_interaction_heatmap():
 
 
 def main():
-    # pragma: no cover
     single_qubit_heatmap()
     two_qubit_interaction_heatmap()
 
 
-if __name__ == '__main__':
+if __name__ == '__main__':  # pragma: no cover
     main()

--- a/examples/heatmaps.py
+++ b/examples/heatmaps.py
@@ -38,7 +38,7 @@ def two_qubit_interaction_heatmap():
 
 
 def main():
-    # coverage: ignore
+    # pragma: no cover
     single_qubit_heatmap()
     two_qubit_interaction_heatmap()
 

--- a/examples/shors_code.py
+++ b/examples/shors_code.py
@@ -108,7 +108,7 @@ class OneQubitShorsCode:
 
 
 if __name__ == '__main__':
-    # coverage: ignore
+    # pragma: no cover
 
     # create circuit with 9 physical qubits
     code = OneQubitShorsCode()

--- a/examples/shors_code.py
+++ b/examples/shors_code.py
@@ -107,9 +107,7 @@ class OneQubitShorsCode:
         )
 
 
-if __name__ == '__main__':
-    # pragma: no cover
-
+if __name__ == '__main__':  # pragma: no cover
     # create circuit with 9 physical qubits
     code = OneQubitShorsCode()
 

--- a/examples/two_qubit_gate_compilation.py
+++ b/examples/two_qubit_gate_compilation.py
@@ -83,8 +83,7 @@ def main(samples: int = 1000, max_infidelity: float = 0.01):
     infidelities_arr = np.array(infidelities)
     failed_infidelities_arr = np.array(failed_infidelities)
 
-    if np.size(failed_infidelities_arr):
-        # pragma: no cover
+    if np.size(failed_infidelities_arr):  # pragma: no cover
         print(f'Number of "failed" compilations: {np.size(failed_infidelities_arr)}.')
         print(f'Maximum infidelity of "failed" compilation: {np.max(failed_infidelities_arr)}')
 

--- a/examples/two_qubit_gate_compilation.py
+++ b/examples/two_qubit_gate_compilation.py
@@ -75,7 +75,7 @@ def main(samples: int = 1000, max_infidelity: float = 0.01):
         if result.success:
             infidelities.append(infidelity)
         else:
-            failed_infidelities.append(infidelity)  # coverage: ignore
+            failed_infidelities.append(infidelity)  # pragma: no cover
     t_comp = time() - start
 
     print(f'Gate compilation time : {t_comp:.3f} seconds ({t_comp / samples:.4f} s per gate)')
@@ -84,7 +84,7 @@ def main(samples: int = 1000, max_infidelity: float = 0.01):
     failed_infidelities_arr = np.array(failed_infidelities)
 
     if np.size(failed_infidelities_arr):
-        # coverage: ignore
+        # pragma: no cover
         print(f'Number of "failed" compilations: {np.size(failed_infidelities_arr)}.')
         print(f'Maximum infidelity of "failed" compilation: {np.max(failed_infidelities_arr)}')
 

--- a/rtd_docs/conf.py
+++ b/rtd_docs/conf.py
@@ -1,4 +1,4 @@
-# coverage: ignore
+# pragma: no cover
 
 # The content for all documentation lives in ../docs. That folder is
 # following the structure for the Google Quantum site configured for the


### PR DESCRIPTION
* switch to standard opt-out comments for code exclusion from coverage
* fix placement of `# pragma: no cover` markup comments,
  so they are either on the affected line or at the preceding block
 * remove no-cover comments for code that is covered
 * remove redundant no-cover comments
