### PR TITLE
Fix CI requirements for Changed files test

### DIFF
--- a/cirq-ft/cirq_ft/algos/qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/qrom_test.py
@@ -22,6 +22,7 @@ from cirq_ft.infra.bit_tools import iter_bits
 from cirq_ft.infra.jupyter_tools import execute_notebook
 
 
+# TODO(juhas) - delete this comment - trigger for Changed files test
 @pytest.mark.parametrize(
     "data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]], [[1], [2], [3], [4], [5], [6]]]
 )

--- a/cirq-ft/cirq_ft/algos/qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/qrom_test.py
@@ -22,7 +22,6 @@ from cirq_ft.infra.bit_tools import iter_bits
 from cirq_ft.infra.jupyter_tools import execute_notebook
 
 
-# TODO(juhas) - delete this comment - trigger for Changed files test
 @pytest.mark.parametrize(
     "data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]], [[1], [2], [3], [4], [5], [6]]]
 )

--- a/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
+++ b/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -20,7 +20,10 @@ set -e
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd "$(git rev-parse --show-toplevel)"
 
-reqs=( -r dev_tools/requirements/pytest-minimal.env.txt )
+reqs=(
+    -r dev_tools/requirements/pytest-minimal.env.txt
+    -r dev_tools/requirements/deps/notebook.txt
+)
 
 # Install contrib requirements only if needed.
 changed=$(git diff --name-only origin/master | grep "cirq/contrib" || true)


### PR DESCRIPTION
Problem: cirq-ft/cirq_ft/algos/qrom_test.py::test_notebook fails when
executed from `Changed files test` CI because of missing dependencies.

Solution: Install notebook-testing requirements for this CI job.
