### PR TITLE
Fix quoting in shell scripts per shellcheck-0.9

### DIFF
--- a/check/build-changed-protos
+++ b/check/build-changed-protos
@@ -47,8 +47,8 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base ${rev} HEAD)"
-if [ "$(git rev-parse ${rev})" == "${base}" ]; then
+base="$(git merge-base "${rev}" HEAD)"
+if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else
     echo -e "Comparing against revision '${rev}' (merge base ${base})." >&2

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -72,8 +72,8 @@ if (( only_changed == 1 )); then
             exit 1
         fi
     fi
-    base="$(git merge-base ${rev} HEAD)"
-    if [ "$(git rev-parse ${rev})" == "${base}" ]; then
+    base="$(git merge-base "${rev}" HEAD)"
+    if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
         echo -e "Comparing against revision '${rev}'." >&2
     else
         echo -e "Comparing against revision '${rev}' (merge base ${base})." >&2

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -46,8 +46,8 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base ${rev} HEAD)"
-if [ "$(git rev-parse ${rev})" == "${base}" ]; then
+base="$(git merge-base "${rev}" HEAD)"
+if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else
     echo -e "Comparing against revision '${rev}' (merge base ${base})." >&2

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -60,8 +60,8 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base ${rev} HEAD)"
-if [ "$(git rev-parse ${rev})" == "${base}" ]; then
+base="$(git merge-base "${rev}" HEAD)"
+if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else
     echo -e "Comparing against revision '${rev}' (merge base ${base})." >&2

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -56,7 +56,7 @@ echo "Comparing against revision '${rev}'." >&2
 # Get the _test version of changed python files.
 typeset -a changed
 IFS=$'\n' read -r -d '' -a changed < \
-    <(git diff --name-only ${rev} -- \
+    <(git diff --name-only "${rev}" -- \
     | grep "\.py$" \
     | sed -e "s/\.py$/_test.py/" \
     | sed -e "s/_test_test\.py$/_test.py/" \

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -49,8 +49,8 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/master' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base ${rev} HEAD)"
-if [ "$(git rev-parse ${rev})" == "${base}" ]; then
+base="$(git merge-base "${rev}" HEAD)"
+if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else
     echo -e "Comparing against revision '${rev}' (merge base ${base})." >&2


### PR DESCRIPTION
Fix instances of `SC2086: Double quote to prevent globbing and word splitting`.

Ref: https://www.shellcheck.net/wiki/SC2086
