### PR TITLE
Create read only simulation state vector

### DIFF
--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -336,8 +336,10 @@ class _ReadOnlyStateVector(qis.QuantumStateRepresentation):
             'resultant state object.'
         )
 
-    def to_mutable_state(self) -> _BufferedStateVector:
-        return _BufferedStateVector.create(initial_state=self._state_vector.copy())
+    def to_mutable_state(self, qid_shape: Tuple[int, ...] | None = None) -> _BufferedStateVector:
+        return _BufferedStateVector.create(
+            initial_state=self._state_vector.copy(), qid_shape=qid_shape
+        )
 
     def apply_unitary(self, action: Any, axes: Sequence[int]) -> bool:
         return NotImplemented

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -336,7 +336,7 @@ class _ReadOnlyStateVector(qis.QuantumStateRepresentation):
             'resultant state object.'
         )
 
-    def to_mutable_state(self, qid_shape: Tuple[int, ...] | None = None) -> _BufferedStateVector:
+    def to_mutable_state(self, qid_shape: Optional[Tuple[int, ...]] = None) -> _BufferedStateVector:
         return _BufferedStateVector.create(
             initial_state=self._state_vector.copy(), qid_shape=qid_shape
         )


### PR DESCRIPTION
This class provides a limited set of functionalities provided by simulation state vector classes and bypasses the numpy limit on the number of dimensions https://github.com/numpy/numpy/issues/5744 by not reshaping the array.

This class will be used as the return result for qsim simulator which will store the 1D numpy array representation of the simulation result without reshaping it. This is inorder to mitigate https://github.com/quantumlib/Cirq/issues/6031

The user of qsim simulator will choose through a parameter whether they want the current behaviour or to use the new one.

Users can convert objects of this class to the buffered version using `to_mutable_state` which will only succeed if the number of qubits is less than or equal to the dimension limit of numpy (currently 32)