### PR TITLE
Fix bug in cirq-ft due to which T-complexity fails for gates with an empty decomposition / no-op

### DIFF
--- a/cirq-ft/cirq_ft/algos/select_swap_qrom.py
+++ b/cirq-ft/cirq_ft/algos/select_swap_qrom.py
@@ -124,7 +124,7 @@ class SelectSwapQROM(infra.GateWithRegisters):
         assert len(target_bitsizes) == len(data)
         assert all(t >= max(d).bit_length() for t, d in zip(target_bitsizes, data))
         self._num_sequences = len(data)
-        self._target_bitsizes = target_bitsizes
+        self._target_bitsizes = tuple(target_bitsizes)
         self._iteration_length = len(data[0])
         if block_size is None:
             # Figure out optimal value of block_size

--- a/cirq-ft/cirq_ft/algos/select_swap_qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/select_swap_qrom_test.py
@@ -101,3 +101,9 @@ def test_qroam_diagram():
 def test_qroam_raises():
     with pytest.raises(ValueError, match="must be of equal length"):
         _ = cirq_ft.SelectSwapQROM([1, 2], [1, 2, 3])
+
+
+def test_qroam_hashable():
+    qrom = cirq_ft.SelectSwapQROM([1, 2, 5, 6, 7, 8])
+    assert hash(qrom) is not None
+    assert cirq_ft.t_complexity(qrom) == cirq_ft.TComplexity(32, 160, 0)

--- a/cirq-ft/cirq_ft/infra/decompose_protocol.py
+++ b/cirq-ft/cirq_ft/infra/decompose_protocol.py
@@ -98,4 +98,4 @@ def _decompose_once_considering_known_decomposition(val: Any) -> DecomposeResult
     else:
         decomposed = cirq.decompose_once(val, context=context, flatten=False, default=None)
 
-    return [*cirq.flatten_to_ops(decomposed)] if decomposed else None
+    return [*cirq.flatten_to_ops(decomposed)] if decomposed is not None else None

--- a/cirq-ft/cirq_ft/infra/decompose_protocol_test.py
+++ b/cirq-ft/cirq_ft/infra/decompose_protocol_test.py
@@ -15,7 +15,11 @@
 import cirq
 import numpy as np
 import pytest
-from cirq_ft.infra.decompose_protocol import _fredkin, _try_decompose_from_known_decompositions
+from cirq_ft.infra.decompose_protocol import (
+    _fredkin,
+    _try_decompose_from_known_decompositions,
+    _decompose_once_considering_known_decomposition,
+)
 
 
 def test_fredkin_unitary():
@@ -43,3 +47,12 @@ def test_decompose_fredkin(gate):
         for o in cirq.flatten_op_tree(_fredkin((c, t1, t2), context))
     )
     assert want == _try_decompose_from_known_decompositions(op, context)
+
+
+def test_known_decomposition_empty_unitary():
+    class DecomposeEmptyList(cirq.testing.SingleQubitGate):
+        def _decompose_(self, _):
+            return []
+
+    gate = DecomposeEmptyList()
+    assert _decompose_once_considering_known_decomposition(gate) == []


### PR DESCRIPTION
This PR fixes two bugs in Cirq-FT

1) `SelectSwapQROM` is now hashable
2) `cirq_ft.t_complexity(gate)` failed for some corner cases like `cirq_ft.SwapWithZeroGate(0,4,1)**-1)` because if a gate has an empty decomposition (i.e. it's a no-op) the `_decompose_once_considering_known_decomposition` method would return a `None` instead of an empty list. The former implies we don't know the decomposition whereas the latter means the T-complexity is all 0. 