### PR TITLE
Add new processor selector parameters in cirq-google/engine run methods

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -272,6 +272,7 @@ class AbstractProcessor(abc.ABC):
         self, run_name: str = "", device_config_name: str = ""
     ) -> 'cg.ProcessorSampler':
         """Returns a sampler backed by the processor.
+
         Args:
             run_name: A unique identifier representing an automation run for the
                 processor. An Automation Run contains a collection of device

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -64,6 +64,8 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> cirq.Result:
         """Runs the supplied Circuit on this processor.
 
@@ -85,6 +87,12 @@ class AbstractProcessor(abc.ABC):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
         Returns:
             A single Result for this run.
         """
@@ -115,6 +123,8 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuit on this processor.
 
@@ -138,6 +148,12 @@ class AbstractProcessor(abc.ABC):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
         Returns:
             An AbstractJob. If this is iterated over it returns a list of
             `cirq.Result`, one for each parameter sweep.
@@ -157,6 +173,8 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuits on this processor.
 
@@ -188,6 +206,12 @@ class AbstractProcessor(abc.ABC):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
         Returns:
             An AbstractJob. If this is iterated over it returns a list of
             `cirq.Result`. All Results for the first circuit are listed
@@ -244,8 +268,18 @@ class AbstractProcessor(abc.ABC):
     run_calibration = duet.sync(run_calibration_async)
 
     @abc.abstractmethod
-    def get_sampler(self) -> 'cg.ProcessorSampler':
-        """Returns a sampler backed by the processor."""
+    def get_sampler(
+        self, run_name: str = "", device_config_name: str = ""
+    ) -> 'cg.ProcessorSampler':
+        """Returns a sampler backed by the processor.
+        Args:
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
+        """
 
     @abc.abstractmethod
     def engine(self) -> Optional['abstract_engine.AbstractEngine']:

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -106,6 +106,8 @@ class AbstractProcessor(abc.ABC):
             program_labels=program_labels,
             job_description=job_description,
             job_labels=job_labels,
+            run_name=run_name,
+            device_config_name=device_config_name,
         )
         return job.results()[0]
 

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -207,6 +207,7 @@ class Engine(abstract_engine.AbstractEngine):
     def __str__(self) -> str:
         return f'Engine(project_id={self.project_id!r})'
 
+    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     def run(
         self,
         program: cirq.AbstractCircuit,
@@ -264,7 +265,7 @@ class Engine(abstract_engine.AbstractEngine):
         Raises:
             ValueError: If no gate set is provided.
             ValueError: If neither `processor_id` or `processor_ids` are set.
-            ValueError: If  only one of `run_name` and `device_config_name` are specified.
+            ValueError: If only one of `run_name` and `device_config_name` are specified.
             ValueError: If `processor_ids` has more than one processor id.
             ValueError: If either `run_name` and `device_config_name` are set but
                 `processor_id` is empty.
@@ -287,6 +288,7 @@ class Engine(abstract_engine.AbstractEngine):
             )
         )[0]
 
+    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_sweep_async(
         self,
         program: cirq.AbstractCircuit,
@@ -370,6 +372,7 @@ class Engine(abstract_engine.AbstractEngine):
 
     run_sweep = duet.sync(run_sweep_async)
 
+    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_batch_async(
         self,
         programs: Sequence[cirq.AbstractCircuit],

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -851,6 +851,12 @@ class Engine(abstract_engine.AbstractEngine):
 
         Args:
             processor_id: String identifier of which processor should be used to sample.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -219,6 +219,10 @@ class Engine(abstract_engine.AbstractEngine):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        *,
+        processor_id: str = "",
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> cirq.Result:
         """Runs the supplied Circuit via Quantum Engine.
 
@@ -236,19 +240,34 @@ class Engine(abstract_engine.AbstractEngine):
                 and day.
             param_resolver: Parameters to run with the program.
             repetitions: The number of repetitions to simulate.
-            processor_ids: The engine processors that should be candidates
-                to run the program. Only one of these will be scheduled for
-                execution.
+            processor_ids: Deprecated list of candidate processor ids to run the program.
+                Only allowed to contain one processor_id. If the argument `processor_id`
+                is non-empty, `processor_ids` will be ignored.
             program_description: An optional description to set on the program.
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            processor_id: Processor id for running the program. If not set,
+                `processor_ids` will be used.
+            run_name: A unique identifier representing an automation run for the
+                specified processor. An Automation Run contains a collection of
+                device configurations for a processor. If specified, `processor_id`
+                is required to be set.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
+                If specified, `processor_id` is required to be set.
 
         Returns:
             A single Result for this run.
 
         Raises:
             ValueError: If no gate set is provided.
+            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If  only one of `run_name` and `device_config_name` are specified.
+            ValueError: If `processor_ids` has more than one processor id.
+            ValueError: If either `run_name` and `device_config_name` are set but
+                `processor_id` is empty.
         """
         return list(
             self.run_sweep(
@@ -262,6 +281,9 @@ class Engine(abstract_engine.AbstractEngine):
                 program_labels=program_labels,
                 job_description=job_description,
                 job_labels=job_labels,
+                processor_id=processor_id,
+                run_name=run_name,
+                device_config_name=device_config_name,
             )
         )[0]
 
@@ -277,6 +299,10 @@ class Engine(abstract_engine.AbstractEngine):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        *,
+        processor_id: str = "",
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> engine_job.EngineJob:
         """Runs the supplied Circuit via Quantum Engine.Creates
 
@@ -297,13 +323,23 @@ class Engine(abstract_engine.AbstractEngine):
                 and day.
             params: Parameters to run with the program.
             repetitions: The number of circuit repetitions to run.
-            processor_ids: The engine processors that should be candidates
-                to run the program. Only one of these will be scheduled for
-                execution.
+            processor_ids: Deprecated list of candidate processor ids to run the program.
+                Only allowed to contain one processor_id. If the argument `processor_id`
+                is non-empty, `processor_ids` will be ignored.
             program_description: An optional description to set on the program.
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            processor_id: Processor id for running the program. If not set,
+                `processor_ids` will be used.
+            run_name: A unique identifier representing an automation run for the
+                specified processor. An Automation Run contains a collection of
+                device configurations for a processor. If specified, `processor_id`
+                is required to be set.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
+                If specified, `processor_id` is required to be set.
 
         Returns:
             An EngineJob. If this is iterated over it returns a list of
@@ -311,6 +347,11 @@ class Engine(abstract_engine.AbstractEngine):
 
         Raises:
             ValueError: If no gate set is provided.
+            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If  only one of `run_name` and `device_config_name` are specified.
+            ValueError: If `processor_ids` has more than one processor id.
+            ValueError: If either `run_name` and `device_config_name` are set but
+                `processor_id` is empty.
         """
         engine_program = await self.create_program_async(
             program, program_id, description=program_description, labels=program_labels
@@ -322,6 +363,9 @@ class Engine(abstract_engine.AbstractEngine):
             processor_ids=processor_ids,
             description=job_description,
             labels=job_labels,
+            processor_id=processor_id,
+            run_name=run_name,
+            device_config_name=device_config_name,
         )
 
     run_sweep = duet.sync(run_sweep_async)
@@ -338,6 +382,10 @@ class Engine(abstract_engine.AbstractEngine):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        *,
+        processor_id: str = "",
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> engine_job.EngineJob:
         """Runs the supplied Circuits via Quantum Engine.Creates
 
@@ -367,13 +415,23 @@ class Engine(abstract_engine.AbstractEngine):
                 require sweeps.
             repetitions: Number of circuit repetitions to run.  Each sweep value
                 of each circuit in the batch will run with the same repetitions.
-            processor_ids: The engine processors that should be candidates
-                to run the program. Only one of these will be scheduled for
-                execution.
+            processor_ids: Deprecated list of candidate processor ids to run the program.
+                Only allowed to contain one processor_id. If the argument `processor_id`
+                is non-empty, `processor_ids` will be ignored.
             program_description: An optional description to set on the program.
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            processor_id: Processor id for running the program. If not set,
+                `processor_ids` will be used.
+            run_name: A unique identifier representing an automation run for the
+                specified processor. An Automation Run contains a collection of
+                device configurations for a processor. If specified, `processor_id`
+                is required to be set.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
+                If specified, `processor_id` is required to be set.
 
         Returns:
             An EngineJob. If this is iterated over it returns a list of
@@ -385,12 +443,17 @@ class Engine(abstract_engine.AbstractEngine):
         Raises:
             ValueError: If the length of programs mismatches that of params_list, or
                 `processor_ids` is not supplied.
+            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If  only one of `run_name` and `device_config_name` are specified.
+            ValueError: If `processor_ids` has more than one processor id.
+            ValueError: If either `run_name` and `device_config_name` are set but
+                `processor_id` is empty.
         """
         if params_list is None:
             params_list = [None] * len(programs)
         elif len(programs) != len(params_list):
             raise ValueError('Number of circuits and sweeps must match')
-        if not processor_ids:
+        if not processor_ids and not processor_id:
             raise ValueError('Processor id must be specified.')
         engine_program = await self.create_batch_program_async(
             programs, program_id, description=program_description, labels=program_labels
@@ -402,6 +465,9 @@ class Engine(abstract_engine.AbstractEngine):
             processor_ids=processor_ids,
             description=job_description,
             labels=job_labels,
+            processor_id=processor_id,
+            run_name=run_name,
+            device_config_name=device_config_name,
         )
 
     run_batch = duet.sync(run_batch_async)
@@ -778,7 +844,9 @@ class Engine(abstract_engine.AbstractEngine):
         """
         return self.get_sampler(processor_id)
 
-    def get_sampler(self, processor_id: Union[str, List[str]]) -> 'cirq_google.ProcessorSampler':
+    def get_sampler(
+        self, processor_id: Union[str, List[str]], run_name: str = "", device_config_name: str = ""
+    ) -> 'cirq_google.ProcessorSampler':
         """Returns a sampler backed by the engine.
 
         Args:
@@ -798,7 +866,9 @@ class Engine(abstract_engine.AbstractEngine):
                 'to get_sampler() no longer supported. Use Engine.run() instead if '
                 'you need to specify a list.'
             )
-        return self.get_processor(processor_id).get_sampler()
+        return self.get_processor(processor_id).get_sampler(
+            run_name=run_name, device_config_name=device_config_name
+        )
 
 
 def get_engine(project_id: Optional[str] = None) -> Engine:

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -395,14 +395,16 @@ class EngineClient:
         run_name: str = "",
         device_config_name: str = "",
     ) -> Tuple[str, quantum.QuantumJob]:
-        """Creates and runs a job on Quantum Engine.
+        """Creates and runs a job on Quantum Engine. Either both `run_name` and
+        `device_config_name` must be set, or neither of them must be set.
+        If none of them are set, a default internal device configuration will be used.
 
         Args:
             project_id: A project_id of the parent Google Cloud Project.
             program_id: Unique ID of the program within the parent project.
             job_id: Unique ID of the job within the parent program.
             run_context: Properly serialized run context.
-            processor_ids: Deprecated list of processor ids for running the program.
+            processor_ids: Deprecated list of candidate processor ids to run the program.
                 Only allowed to contain one processor_id. If the argument `processor_id`
                 is non-empty, `processor_ids` will be ignored. Otherwise the deprecated
                 decorator will fix the arguments and call create_job_async using

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -395,9 +395,11 @@ class EngineClient:
         run_name: str = "",
         device_config_name: str = "",
     ) -> Tuple[str, quantum.QuantumJob]:
-        """Creates and runs a job on Quantum Engine. Either both `run_name` and
-        `device_config_name` must be set, or neither of them must be set.
-        If none of them are set, a default internal device configuration will be used.
+        """Creates and runs a job on Quantum Engine.
+
+        Either both `run_name` and `device_config_name` must be set, or neither
+        of them must be set. If none of them are set, a default internal device
+        configuration will be used.
 
         Args:
             project_id: A project_id of the parent Google Cloud Project.

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -102,15 +102,25 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
 
         return engine_base.Engine(self.project_id, context=self.context)
 
-    def get_sampler(self) -> 'cg.engine.ProcessorSampler':
+    def get_sampler(
+        self, run_name: str = "", device_config_name=""
+    ) -> 'cg.engine.ProcessorSampler':
         """Returns a sampler backed by the engine.
-
+        Args:
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`
             that will send circuits to the Quantum Computing Service
             when sampled.1
         """
-        return processor_sampler.ProcessorSampler(processor=self)
+        return processor_sampler.ProcessorSampler(
+            processor=self, run_name=run_name, device_config_name=device_config_name
+        )
 
     async def run_batch_async(
         self,
@@ -123,6 +133,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuits on this processor.
 
@@ -154,16 +166,27 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
         Returns:
             An `abstract_job.AbstractJob`. If this is iterated over it returns
             a list of `cirq.Result`. All Results for the first circuit are listed
             first, then the Results for the second, etc. The Results
             for a circuit are listed in the order imposed by the associated
             parameter sweep.
+        Raises:
+            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If  only one of `run_name` and `device_config_name` are specified.
+            ValueError: If `processor_ids` has more than one processor id.
+            ValueError: If either `run_name` and `device_config_name` are set but
+                `processor_id` is empty.
         """
         return await self.engine().run_batch_async(
             programs=programs,
-            processor_ids=[self.processor_id],
             program_id=program_id,
             params_list=list(params_list) if params_list is not None else None,
             repetitions=repetitions,
@@ -171,6 +194,9 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             program_labels=program_labels,
             job_description=job_description,
             job_labels=job_labels,
+            processor_id=self.processor_id,
+            run_name=run_name,
+            device_config_name=device_config_name,
         )
 
     async def run_calibration_async(
@@ -237,6 +263,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuit on this processor.
 
@@ -261,12 +289,23 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
         Returns:
             An AbstractJob. If this is iterated over it returns a list of
             `cirq.Result`, one for each parameter sweep.
+        Raises:
+            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If  only one of `run_name` and `device_config_name` are specified.
+            ValueError: If `processor_ids` has more than one processor id.
+            ValueError: If either `run_name` and `device_config_name` are set but
+                `processor_id` is empty.
         """
         return await self.engine().run_sweep_async(
-            processor_ids=[self.processor_id],
             program=program,
             program_id=program_id,
             job_id=job_id,
@@ -276,6 +315,9 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             program_labels=program_labels,
             job_description=job_description,
             job_labels=job_labels,
+            processor_id=self.processor_id,
+            run_name=run_name,
+            device_config_name=device_config_name,
         )
 
     def _inner_processor(self) -> quantum.QuantumProcessor:

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -103,7 +103,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         return engine_base.Engine(self.project_id, context=self.context)
 
     def get_sampler(
-        self, run_name: str = "", device_config_name=""
+        self, run_name: str = "", device_config_name: str = ""
     ) -> 'cg.engine.ProcessorSampler':
         """Returns a sampler backed by the engine.
         Args:

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -64,6 +64,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         self._program = _program
         self.result_type = result_type
 
+    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_sweep_async(
         self,
         job_id: Optional[str] = None,
@@ -143,6 +144,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     run_sweep = duet.sync(run_sweep_async)
 
+    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_batch_async(
         self,
         job_id: Optional[str] = None,
@@ -312,6 +314,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     run_calibration = duet.sync(run_calibration_async)
 
+    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_async(
         self,
         job_id: Optional[str] = None,

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -376,6 +376,9 @@ def test_run_circuit(client):
         ),
         description=None,
         labels=None,
+        processor_id='',
+        run_name='',
+        device_config_name='',
     )
     client().get_job_async.assert_called_once_with('proj', 'prog', 'job-id', False)
     client().get_job_results_async.assert_called_once_with('proj', 'prog', 'job-id')

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -24,19 +24,45 @@ if TYPE_CHECKING:
 class ProcessorSampler(cirq.Sampler):
     """A wrapper around AbstractProcessor to implement the cirq.Sampler interface."""
 
-    def __init__(self, *, processor: 'cg.engine.AbstractProcessor'):
-        """Inits ProcessorSampler.
+    def __init__(
+        self,
+        *,
+        processor: 'cg.engine.AbstractProcessor',
+        run_name: str = "",
+        device_config_name: str = "",
+    ):
+        """Inits ProcessorSampler. Either both `run_name` and `device_config_name`
+        must be set, or neither of them must be set. If none of them are set, a
+        default internal device configuration will be used.
 
         Args:
             processor: AbstractProcessor instance to use.
+            run_name: A unique identifier representing an automation run for the
+                specified processor. An Automation Run contains a collection of
+                device configurations for a processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
+
+        Raises:
+            ValueError: If  only one of `run_name` and `device_config_name` are specified.
         """
+        if bool(run_name) ^ bool(device_config_name):
+            raise ValueError('Cannot specify only one of `run_name` and `device_config_name`')
+
         self._processor = processor
+        self._run_name = run_name
+        self._device_config_name = device_config_name
 
     async def run_sweep_async(
         self, program: 'cirq.AbstractCircuit', params: cirq.Sweepable, repetitions: int = 1
     ) -> Sequence['cg.EngineResult']:
         job = await self._processor.run_sweep_async(
-            program=program, params=params, repetitions=repetitions
+            program=program,
+            params=params,
+            repetitions=repetitions,
+            run_name=self._run_name,
+            device_config_name=self._device_config_name,
         )
         return await job.results_async()
 
@@ -61,7 +87,11 @@ class ProcessorSampler(cirq.Sampler):
         if len(set(repetitions)) == 1:
             # All repetitions are the same so batching can be done efficiently
             job = await self._processor.run_batch_async(
-                programs=programs, params_list=params_list, repetitions=repetitions[0]
+                programs=programs,
+                params_list=params_list,
+                repetitions=repetitions[0],
+                run_name=self._run_name,
+                device_config_name=self._device_config_name,
             )
             return await job.batched_results_async()
         # Varying number of repetitions so no speedup

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -31,9 +31,11 @@ class ProcessorSampler(cirq.Sampler):
         run_name: str = "",
         device_config_name: str = "",
     ):
-        """Inits ProcessorSampler. Either both `run_name` and `device_config_name`
-        must be set, or neither of them must be set. If none of them are set, a
-        default internal device configuration will be used.
+        """Inits ProcessorSampler.
+
+        Either both `run_name` and `device_config_name` must be set, or neither of
+        them must be set. If none of them are set, a default internal device configuration
+        will be used.
 
         Args:
             processor: AbstractProcessor instance to use.

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -22,10 +22,11 @@ from cirq_google.engine.abstract_processor import AbstractProcessor
 
 
 @pytest.mark.parametrize('circuit', [cirq.Circuit(), cirq.FrozenCircuit()])
-def test_run_circuit(circuit):
+@pytest.mark.parametrize(
+    'run_name, device_config_name', [('run_name', 'device_config_alias'), ('', '')]
+)
+def test_run_circuit(circuit, run_name, device_config_name):
     processor = mock.create_autospec(AbstractProcessor)
-    run_name = "RUN_NAME"
-    device_config_name = "DEVICE_CONFIG_NAME"
     sampler = cg.ProcessorSampler(
         processor=processor, run_name=run_name, device_config_name=device_config_name
     )
@@ -40,10 +41,11 @@ def test_run_circuit(circuit):
     )
 
 
-def test_run_batch():
+@pytest.mark.parametrize(
+    'run_name, device_config_name', [('run_name', 'device_config_alias'), ('', '')]
+)
+def test_run_batch(run_name, device_config_name):
     processor = mock.create_autospec(AbstractProcessor)
-    run_name = "RUN_NAME"
-    device_config_name = "DEVICE_CONFIG_NAME"
     sampler = cg.ProcessorSampler(
         processor=processor, run_name=run_name, device_config_name=device_config_name
     )
@@ -64,10 +66,11 @@ def test_run_batch():
     )
 
 
-def test_run_batch_identical_repetitions():
+@pytest.mark.parametrize(
+    'run_name, device_config_name', [('run_name', 'device_config_alias'), ('', '')]
+)
+def test_run_batch_identical_repetitions(run_name, device_config_name):
     processor = mock.create_autospec(AbstractProcessor)
-    run_name = "RUN_NAME"
-    device_config_name = "DEVICE_CONFIG_NAME"
     sampler = cg.ProcessorSampler(
         processor=processor, run_name=run_name, device_config_name=device_config_name
     )

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -145,3 +145,16 @@ def test_with_local_processor():
     assert isinstance(r, cg.EngineResult)
     assert r.job_id == 'projects/fake_project/processors/my-fancy-processor/job/2'
     assert r.measurements['z'] == [[0]]
+
+
+@pytest.mark.parametrize(
+    'run_name, device_config_name', [('run_name', ''), ('', 'device_config_name')]
+)
+def test_processor_sampler_with_invalid_configuration_throws(run_name, device_config_name):
+    processor = mock.create_autospec(AbstractProcessor)
+    with pytest.raises(
+        ValueError, match='Cannot specify only one of `run_name` and `device_config_name`'
+    ):
+        cg.ProcessorSampler(
+            processor=processor, run_name=run_name, device_config_name=device_config_name
+        )

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -24,15 +24,29 @@ from cirq_google.engine.abstract_processor import AbstractProcessor
 @pytest.mark.parametrize('circuit', [cirq.Circuit(), cirq.FrozenCircuit()])
 def test_run_circuit(circuit):
     processor = mock.create_autospec(AbstractProcessor)
-    sampler = cg.ProcessorSampler(processor=processor)
+    run_name = "RUN_NAME"
+    device_config_name = "DEVICE_CONFIG_NAME"
+    sampler = cg.ProcessorSampler(
+        processor=processor, run_name=run_name, device_config_name=device_config_name
+    )
     params = [cirq.ParamResolver({'a': 1})]
     sampler.run_sweep(circuit, params, 5)
-    processor.run_sweep_async.assert_called_with(params=params, program=circuit, repetitions=5)
+    processor.run_sweep_async.assert_called_with(
+        params=params,
+        program=circuit,
+        repetitions=5,
+        run_name=run_name,
+        device_config_name=device_config_name,
+    )
 
 
 def test_run_batch():
     processor = mock.create_autospec(AbstractProcessor)
-    sampler = cg.ProcessorSampler(processor=processor)
+    run_name = "RUN_NAME"
+    device_config_name = "DEVICE_CONFIG_NAME"
+    sampler = cg.ProcessorSampler(
+        processor=processor, run_name=run_name, device_config_name=device_config_name
+    )
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -42,13 +56,21 @@ def test_run_batch():
     params_list = [params1, params2]
     sampler.run_batch(circuits, params_list, 5)
     processor.run_batch_async.assert_called_with(
-        params_list=params_list, programs=circuits, repetitions=5
+        params_list=params_list,
+        programs=circuits,
+        repetitions=5,
+        run_name=run_name,
+        device_config_name=device_config_name,
     )
 
 
 def test_run_batch_identical_repetitions():
     processor = mock.create_autospec(AbstractProcessor)
-    sampler = cg.ProcessorSampler(processor=processor)
+    run_name = "RUN_NAME"
+    device_config_name = "DEVICE_CONFIG_NAME"
+    sampler = cg.ProcessorSampler(
+        processor=processor, run_name=run_name, device_config_name=device_config_name
+    )
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -58,7 +80,11 @@ def test_run_batch_identical_repetitions():
     params_list = [params1, params2]
     sampler.run_batch(circuits, params_list, [5, 5])
     processor.run_batch_async.assert_called_with(
-        params_list=params_list, programs=circuits, repetitions=5
+        params_list=params_list,
+        programs=circuits,
+        repetitions=5,
+        run_name=run_name,
+        device_config_name=device_config_name,
     )
 
 
@@ -78,10 +104,14 @@ def test_run_batch_bad_number_of_repetitions():
 
 def test_run_batch_differing_repetitions():
     processor = mock.create_autospec(AbstractProcessor)
+    run_name = "RUN_NAME"
+    device_config_name = "DEVICE_CONFIG_NAME"
+    sampler = cg.ProcessorSampler(
+        processor=processor, run_name=run_name, device_config_name=device_config_name
+    )
     job = mock.Mock()
     job.results.return_value = []
     processor.run_sweep.return_value = job
-    sampler = cg.ProcessorSampler(processor=processor)
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -91,7 +121,13 @@ def test_run_batch_differing_repetitions():
     params_list = [params1, params2]
     repetitions = [1, 2]
     sampler.run_batch(circuits, params_list, repetitions)
-    processor.run_sweep_async.assert_called_with(params=params2, program=circuit2, repetitions=2)
+    processor.run_sweep_async.assert_called_with(
+        params=params2,
+        program=circuit2,
+        repetitions=2,
+        run_name=run_name,
+        device_config_name=device_config_name,
+    )
     processor.run_batch_async.assert_not_called()
 
 

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -158,8 +158,10 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             if earliest_timestamp_seconds <= cal[0] <= latest_timestamp_seconds
         ]
 
-    def get_sampler(self) -> ProcessorSampler:
-        return ProcessorSampler(processor=self)
+    def get_sampler(self, run_name: str = "", device_config_name="") -> ProcessorSampler:
+        return ProcessorSampler(
+            processor=self, run_name=run_name, device_config_name=device_config_name
+        )
 
     def supported_languages(self) -> List[str]:
         return VALID_LANGUAGES
@@ -208,6 +210,8 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> SimulatedLocalJob:
         if program_id is None:
             program_id = self._create_id(id_type='program')
@@ -244,6 +248,8 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
+        run_name: str = "",
+        device_config_name: str = "",
     ) -> SimulatedLocalJob:
         if program_id is None:
             program_id = self._create_id(id_type='program')


### PR DESCRIPTION
This pull request (PR) adds two new parameters to the run methods of `EngineProgram`, `Engine`, and `EngineProcessor`: `run_name` and `device_configuration_name`. These parameters allow users to select a specific configuration for the processor when running the circuit. They are also added to the `init` function of `ProcessorSampler` (and the `get_sampler` methods within `Engine` and `EngineProcessor`).

Additionally, the run methods of `EngineProgram` and `Engine` now include a parameter called `processor_id`. This parameter can be used to specify a specific processor for the run, and will substitute the deprecated parameter `processor_ids` , because allowing multiple candidate processors was not useful in practice.