### PR TITLE
codecov - exclude protobuf-generated sources from coverage analysis

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     project:
       default:
         threshold: 0.1%
+
+ignore:
+  - "**/*_pb2.py"


### PR DESCRIPTION
Ref: https://docs.codecov.com/docs/ignoring-paths
