### PR TITLE
Add caching to `value_equality_values` decorator for auto generated methods.

### DIFF
--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -570,6 +570,9 @@ class MutableDensePauliString(BaseDensePauliString):
     def __str__(self) -> str:
         return super().__str__() + ' (mutable)'
 
+    def _value_equality_values_(self):
+        return self.coefficient, tuple(PAULI_CHARS[p] for p in self.pauli_mask)
+
     @classmethod
     def inline_gaussian_elimination(cls, rows: 'List[MutableDensePauliString]') -> None:
         if not rows:

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -357,7 +357,7 @@ def _pauli_string_from_unit(unit: UnitPauliStringT, coefficient: Union[int, floa
     return PauliString(qubit_pauli_map=dict(unit), coefficient=coefficient)
 
 
-@value.value_equality(approximate=True)
+@value.value_equality(approximate=True, unhashable=True)
 class PauliSum:
     """Represents operator defined by linear combination of PauliStrings.
 

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -228,10 +228,16 @@ def value_equality(
 
     if approximate:
         if not hasattr(cls, '_value_equality_approximate_values_'):
-            setattr(cls, '_value_equality_approximate_values_', _compat.cached_method(values_getter))
+            setattr(
+                cls, '_value_equality_approximate_values_', _compat.cached_method(values_getter)
+            )
         else:
             approx_values_getter = getattr(cls, '_value_equality_approximate_values_')
-            setattr(cls, '_value_equality_approximate_values_', _compat.cached_method(approx_values_getter))
+            setattr(
+                cls,
+                '_value_equality_approximate_values_',
+                _compat.cached_method(approx_values_getter),
+            )
         setattr(cls, '_approx_eq_', _value_equality_approx_eq)
 
     return cls

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -221,23 +221,21 @@ def value_equality(
             )
     else:
         setattr(cls, '_value_equality_values_cls_', lambda self: cls)
-    setattr(cls, '_value_equality_values_', _compat.cached_method(values_getter))
+    cached_values_getter = values_getter if unhashable else _compat.cached_method(values_getter)
+    setattr(cls, '_value_equality_values_', cached_values_getter)
     setattr(cls, '__hash__', None if unhashable else _compat.cached_method(_value_equality_hash))
     setattr(cls, '__eq__', _value_equality_eq)
     setattr(cls, '__ne__', _value_equality_ne)
 
     if approximate:
         if not hasattr(cls, '_value_equality_approximate_values_'):
-            setattr(
-                cls, '_value_equality_approximate_values_', _compat.cached_method(values_getter)
-            )
+            setattr(cls, '_value_equality_approximate_values_', cached_values_getter)
         else:
             approx_values_getter = getattr(cls, '_value_equality_approximate_values_')
-            setattr(
-                cls,
-                '_value_equality_approximate_values_',
-                _compat.cached_method(approx_values_getter),
+            cached_approx_values_getter = (
+                approx_values_getter if unhashable else _compat.cached_method(approx_values_getter)
             )
+            setattr(cls, '_value_equality_approximate_values_', cached_approx_values_getter)
         setattr(cls, '_approx_eq_', _value_equality_approx_eq)
 
     return cls

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -17,7 +17,7 @@ from typing import Any, Callable, Optional, overload, Union
 
 from typing_extensions import Protocol
 
-from cirq import protocols
+from cirq import protocols, _compat
 
 
 class _SupportsValueEquality(Protocol):
@@ -221,13 +221,17 @@ def value_equality(
             )
     else:
         setattr(cls, '_value_equality_values_cls_', lambda self: cls)
-    setattr(cls, '__hash__', None if unhashable else _value_equality_hash)
+    setattr(cls, '_value_equality_values_', _compat.cached_method(values_getter))
+    setattr(cls, '__hash__', None if unhashable else _compat.cached_method(_value_equality_hash))
     setattr(cls, '__eq__', _value_equality_eq)
     setattr(cls, '__ne__', _value_equality_ne)
 
     if approximate:
         if not hasattr(cls, '_value_equality_approximate_values_'):
-            setattr(cls, '_value_equality_approximate_values_', values_getter)
+            setattr(cls, '_value_equality_approximate_values_', _compat.cached_method(values_getter))
+        else:
+            approx_values_getter = getattr(cls, '_value_equality_approximate_values_')
+            setattr(cls, '_value_equality_approximate_values_', _compat.cached_method(approx_values_getter))
         setattr(cls, '_approx_eq_', _value_equality_approx_eq)
 
     return cls


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/6272
cc https://github.com/quantumlib/Cirq/issues/6097

Benchmarks can be seen by running
```python
>>> gate = cirq.PhasedXZGate.from_matrix(cirq.testing.random_unitary(2))
>>> %timeit hash(gate)
```

Before
```
2.67 µs ± 52.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
After
```
159 ns ± 2.75 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

A more real world example would be QROM in Cirq-FT, where `value_equality_values` returns all the data to be loaded by the QROM. Benchmarks as follows

```python
>>> qrom = cirq_ft.QROM.build([1, 2, 3, 4, 5] * 10_000)
>>> %timeit cirq_ft.t_complexity(qrom)
```
Before
```
# 3.39 ms ± 32.2 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After
```
# First Run
# The slowest run took 14.37 times longer than the fastest. This could mean that an intermediate result is being cached.
# 6.05 µs ± 9.3 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

# Second Run
# 1.85 µs ± 37.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```