### PR TITLE
Variable spacing QROM should depend upon structure of different data sequences and not exact elements

### DIFF
--- a/cirq-ft/cirq_ft/algos/qrom.py
+++ b/cirq-ft/cirq_ft/algos/qrom.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Sequence, Tuple, Set
+from typing import Callable, Sequence, Tuple
 
 import attr
 import cirq
@@ -166,13 +166,9 @@ class QROM(unary_iteration_gate.UnaryIterationGate):
             context.qubit_manager.qfree(and_ancilla + [and_target])
 
     def _break_early(self, selection_index_prefix: Tuple[int, ...], l: int, r: int):
-        global_unique_element: Set[int] = set()
         for data in self.data:
             unique_element = np.unique(data[selection_index_prefix][l:r])
             if len(unique_element) > 1:
-                return False
-            global_unique_element.add(unique_element[0])
-            if len(global_unique_element) > 1:
                 return False
         return True
 

--- a/cirq-ft/cirq_ft/algos/qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/qrom_test.py
@@ -141,8 +141,10 @@ def test_qrom_variable_spacing():
     assert cirq_ft.t_complexity(cirq_ft.QROM.build(data)).t == (8 - 2) * 4
     # Works as expected when multiple data arrays are to be loaded.
     data = [1, 2, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5]
+    # (a) Both data sequences are identical
     assert cirq_ft.t_complexity(cirq_ft.QROM.build(data, data)).t == (5 - 2) * 4
-    assert cirq_ft.t_complexity(cirq_ft.QROM.build(data, 2 * np.array(data))).t == (16 - 2) * 4
+    # (b) Both data sequences have identical structure, even though the elements are not same.
+    assert cirq_ft.t_complexity(cirq_ft.QROM.build(data, 2 * np.array(data))).t == (5 - 2) * 4
     # Works as expected when multidimensional input data is to be loaded
     qrom = cirq_ft.QROM.build(
         np.array(


### PR DESCRIPTION


Fixes https://github.com/quantumlib/Cirq/issues/6279