### PR TITLE
Try to make docstring render correctly

### DIFF
--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -400,7 +400,7 @@ class GeneralizedAmplitudeDampingChannel(raw_types.Gate):
     This channel evolves a density matrix via
 
     $$
-    \rho \rightarrow M_0 \rho M_0^\dagger + M_1 \rho M_1^\dagger + M_2 \rho M_2^\dagger + M_3 \rho M_3^\dagger
+    \rho \rightarrow \sum_{i=0}^3 M_i \rho M_i^\dagger
     $$
 
     with

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -400,13 +400,10 @@ class GeneralizedAmplitudeDampingChannel(raw_types.Gate):
     This channel evolves a density matrix via
 
     $$
-    \rho \rightarrow M_0 \rho M_0^\dagger
-                       + M_1 \rho M_1^\dagger
-                       + M_2 \rho M_2^\dagger
-                       + M_3 \rho M_3^\dagger
+    \rho \rightarrow M_0 \rho M_0^\dagger + M_1 \rho M_1^\dagger + M_2 \rho M_2^\dagger + M_3 \rho M_3^\dagger
     $$
 
-    With
+    with
 
     $$
     \begin{aligned}


### PR DESCRIPTION
Docstring does not render correctly on the website: https://quantumai.google/reference/python/cirq/GeneralizedAmplitudeDampingChannel

Maybe putting this equation on one line will fix it?