### PR TITLE
WIP - disable validation checks during non-debug mode to boost performance

### DIFF
--- a/cirq-core/cirq/transformers/routing/initial_mapper.py
+++ b/cirq-core/cirq/transformers/routing/initial_mapper.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Dict
 import abc
 
 from cirq import value
+from cirq._compat import __cirq_debug__
 
 if TYPE_CHECKING:
     import cirq
@@ -67,7 +68,7 @@ class HardCodedInitialMapper(AbstractInitialMapper):
         Raises:
             ValueError: if the qubits in circuit are not a subset of the qubit keys in the mapping.
         """
-        if not circuit.all_qubits().issubset(set(self._map.keys())):
+        if __cirq_debug__ and not circuit.all_qubits().issubset(set(self._map.keys())):
             raise ValueError("The qubits in circuit must be a subset of the keys in the mapping")
         return self._map
 


### PR DESCRIPTION
For #5988.
```
(base) ➜  Cirq git:(master) asv run --python=same --bench XOnAllQubitsCircuit
Couldn't load asv.plugins.mamba because
No module named 'mamba.api'
/Users/sanujs/opt/anaconda3/lib/python3.9/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 2 environments * 1 benchmarks)
[ 0.00%] ·· Benchmarking existing-py_Users_sanujs_opt_anaconda3_bin_python-PYTHONOPTIMIZE-O
[25.00%] ··· Running (circuit_construction.XOnAllQubitsCircuit.time_circuit_construction--).
[50.00%] ··· circuit_construction.XOnAllQubitsCircuit.time_circuit_construction                                                                                                                                                                            ok
[50.00%] ··· ===================== ============ ============= ============ ============
             --                                          Depth(D)
             --------------------- ----------------------------------------------------
              Number of Qubits(N)       1             10          100          1000
             ===================== ============ ============= ============ ============
                       1            18.8±0.1μs     131±20μs    1.40±0.3ms   11.5±0.4ms
                       10           80.5±10μs      579±8μs     5.75±0.2ms   55.3±0.6ms
                      100            590±10μs    5.03±0.07ms    48.7±2ms     523±4ms
                      1000          5.86±0.5ms    49.4±0.9ms    543±20ms    5.45±0.2s
             ===================== ============ ============= ============ ============

[50.00%] ·· Benchmarking existing-py_Users_sanujs_opt_anaconda3_bin_python-PYTHONOPTIMIZE
[75.00%] ··· Running (circuit_construction.XOnAllQubitsCircuit.time_circuit_construction--).
[100.00%] ··· circuit_construction.XOnAllQubitsCircuit.time_circuit_construction                                                                                                                                                                            ok
[100.00%] ··· ===================== ============ ============ ============= ============
              --                                          Depth(D)
              --------------------- ----------------------------------------------------
               Number of Qubits(N)       1            10           100          1000
              ===================== ============ ============ ============= ============
                        1            20.9±0.2μs    131±3μs     1.30±0.01ms   12.3±0.3ms
                        10            88.2±1μs     752±8μs      7.56±0.3ms    77.1±1ms
                       100            777±50μs    6.92±0.1ms     70.1±4ms     717±10ms
                       1000          7.71±0.2ms    71.6±3ms      703±10ms     7.29±0s
              ===================== ============ ============ ============= ============
```

Getting an improvement of ~25%, without the changes it is ~23%.