### PR TITLE
Add `bitsize` field to Cirq-FT Registers

### DIFF
--- a/cirq-ft/cirq_ft/algos/swap_network.py
+++ b/cirq-ft/cirq_ft/algos/swap_network.py
@@ -152,7 +152,9 @@ class SwapWithZeroGate(infra.GateWithRegisters):
 
     @cached_property
     def target_registers(self) -> Tuple[infra.Register, ...]:
-        return (infra.Register('target', (self.n_target_registers, self.target_bitsize)),)
+        return (
+            infra.Register('target', bitsize=self.target_bitsize, shape=self.n_target_registers),
+        )
 
     @cached_property
     def registers(self) -> infra.Registers:

--- a/cirq-ft/cirq_ft/infra/gate_with_registers.ipynb
+++ b/cirq-ft/cirq_ft/infra/gate_with_registers.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "## `Registers`\n",
     "\n",
-    "`Register` objects have a name and a shape. `Registers` is an ordered collection of `Register` with some helpful methods."
+    "`Register` objects have a name, a bitsize and a shape. `Registers` is an ordered collection of `Register` with some helpful methods."
    ]
   },
   {
@@ -51,8 +51,8 @@
    "source": [
     "from cirq_ft import Register, Registers, infra\n",
     "\n",
-    "control_reg = Register(name='control', shape=(2,))\n",
-    "target_reg = Register(name='target', shape=(3,))\n",
+    "control_reg = Register(name='control', bitsize=2)\n",
+    "target_reg = Register(name='target', bitsize=3)\n",
     "control_reg, target_reg"
    ]
   },

--- a/cirq-ft/cirq_ft/infra/gate_with_registers_test.py
+++ b/cirq-ft/cirq_ft/infra/gate_with_registers_test.py
@@ -21,8 +21,9 @@ from cirq_ft.infra import split_qubits, merge_qubits, get_named_qubits
 
 
 def test_register():
-    r = cirq_ft.Register("my_reg", 5)
-    assert r.shape == (5,)
+    r = cirq_ft.Register("my_reg", 5, (1, 2))
+    assert r.bitsize == 5
+    assert r.shape == (1, 2)
 
 
 def test_registers():
@@ -103,12 +104,12 @@ def test_selection_registers_consistent():
         _ = cirq_ft.SelectionRegister('a', 3, 10)
 
     with pytest.raises(ValueError, match="should be flat"):
-        _ = cirq_ft.SelectionRegister('a', (3, 5), 5)
+        _ = cirq_ft.SelectionRegister('a', bitsize=1, shape=(3, 5), iteration_length=5)
 
     selection_reg = cirq_ft.Registers(
         [
-            cirq_ft.SelectionRegister('n', shape=3, iteration_length=5),
-            cirq_ft.SelectionRegister('m', shape=4, iteration_length=12),
+            cirq_ft.SelectionRegister('n', bitsize=3, iteration_length=5),
+            cirq_ft.SelectionRegister('m', bitsize=4, iteration_length=12),
         ]
     )
     assert selection_reg[0] == cirq_ft.SelectionRegister('n', 3, 5)
@@ -122,7 +123,9 @@ def test_registers_getitem_raises():
     with pytest.raises(IndexError, match="must be of the type"):
         _ = g[2.5]
 
-    selection_reg = cirq_ft.Registers([cirq_ft.SelectionRegister('n', shape=3, iteration_length=5)])
+    selection_reg = cirq_ft.Registers(
+        [cirq_ft.SelectionRegister('n', bitsize=3, iteration_length=5)]
+    )
     with pytest.raises(IndexError, match='must be of the type'):
         _ = selection_reg[2.5]
 


### PR DESCRIPTION
Adds back the `bitsize` field to Cirq-FT registers. This brings the Cirq-FT registers another step closer to Qualtran registers and makes the interop easier. 

This PR follows a brute force approach where the special meaning of `bitsize` is lost. In general, a qubit register with `bitsize=K`  should behave like a `2 ** K` dimension Qudit, instead of a K-qubit register. However, Cirq currently does not provide any way to express decomposition of gates acting on qudits in terms of other "simpler" gates that act on individual qubits. In Qualtran, this is expressed using `Split` and `Join` operations, but Cirq does not have an analogous concept. 

In future, we can consider extending the Cirq infrastructure to support gates acting on Qudits with decompositions that manipulate the 2 dimensional subspaces corresponding to individual qubits that can be used to make up the qudit register. But it's out of scope for this PR. 