### PR TITLE
Correction to the FSimGate docstring

### DIFF
--- a/cirq-aqt/cirq_aqt/_version.py
+++ b/cirq-aqt/cirq_aqt/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -29,4 +29,4 @@ if sys.version_info < (3, 9, 0):
         'of cirq (e.g. "python -m pip install cirq==1.1.*")'
     )
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-core/cirq/ops/fsim_gate.py
+++ b/cirq-core/cirq/ops/fsim_gate.py
@@ -81,7 +81,7 @@ class FSimGate(gate_features.InterchangeableQubitsGate, raw_types.Gate):
     $$
 
     $$
-    c = e^{i \phi}
+    c = e^{-i \phi}
     $$
 
     Note the difference in sign conventions between FSimGate and the

--- a/cirq-ft/cirq_ft/_version.py
+++ b/cirq-ft/cirq_ft/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -29,4 +29,4 @@ if sys.version_info < (3, 9, 0):
         'of cirq (e.g. "python -m pip install cirq==1.1.*")'
     )
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-ionq/cirq_ionq/_version.py
+++ b/cirq-ionq/cirq_ionq/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-pasqal/cirq_pasqal/_version.py
+++ b/cirq-pasqal/cirq_pasqal/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-rigetti/cirq_rigetti/_version.py
+++ b/cirq-rigetti/cirq_rigetti/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"

--- a/cirq-web/cirq_web/_version.py
+++ b/cirq-web/cirq_web/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.2.0.dev"
+__version__ = "1.2.0"


### PR DESCRIPTION
In the docstring for the FSimGate, the unitary is reported to be:

```python
    a = cos(theta)
    b = -1j*sin(theta)
    c = exp(+1j*phi)
        [
            [1, 0, 0, 0],
            [0, a, b, 0],
            [0, b, a, 0],
            [0, 0, 0, c],
        ]
```

However, the actual unitary produced by the gate is slightly different. Specifically, the term `c` is exp(-1j*phi). The snippet below demonstrates:

```python
import numpy as np
import cirq

theta = np.pi/4
phi = np.pi/6

# Unitary of FSIM gate is:
        
cirq.unitary(cirq.FSimGate(theta, phi))

actual_c = cirq.unitary(cirq.FSimGate(theta, phi))[3,3]
doc_c = np.exp(1j*phi)

print(f"FSimGate element (3,3) is {actual_c:.4f}, Documentation is {doc_c:.4f}")
```

The snippet reports that the value of `c` is `0.8660-0.5000j` while the documentation indicates it should be `0.8660+0.5000j`.

I believe the gate definition is correct and the documentation is wrong for the following reasons:
1. The documentation also states that the FSim is equal to `FSimGate(θ, φ) = ISWAP**(-2θ/π) CZPowGate(exponent=-φ/π)` which is consistent with c=exp(-i*φ).
2. The PhasedFSimGate docstring has the conditional phase term as exp(-i*φ) and it would make sense for FSim and PhasedFSim to be consistent.

Thus, this MR modifies the docstring to reflect the unitary produced by the gate.