### PR TITLE
Apply some minor doc fixes

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1465,14 +1465,14 @@ class AbstractCircuit(abc.ABC):
 
         Beware that this method is *not* associative. For example:
 
-            >>> a, b = cirq.LineQubit.range(2)
-            >>> A = cirq.Circuit(cirq.H(a))
-            >>> B = cirq.Circuit(cirq.H(b))
-            >>> f = cirq.Circuit.concat_ragged
-            >>> f(f(A, B), A) == f(A, f(B, A))
-            False
-            >>> len(f(f(f(A, B), A), B)) == len(f(f(A, f(B, A)), B))
-            False
+        >>> a, b = cirq.LineQubit.range(2)
+        >>> A = cirq.Circuit(cirq.H(a))
+        >>> B = cirq.Circuit(cirq.H(b))
+        >>> f = cirq.Circuit.concat_ragged
+        >>> f(f(A, B), A) == f(A, f(B, A))
+        False
+        >>> len(f(f(f(A, B), A), B)) == len(f(f(A, f(B, A)), B))
+        False
 
         Args:
             *circuits: The circuits to concatenate.

--- a/cirq-core/cirq/interop/quirk/url_to_circuit.py
+++ b/cirq-core/cirq/interop/quirk/url_to_circuit.py
@@ -77,39 +77,40 @@ def quirk_url_to_circuit(
             a billion laughs attack in the form of nested custom gates.
 
     Examples:
-        >>> print(cirq.quirk_url_to_circuit(
-        ...     'http://algassert.com/quirk#circuit={"cols":[["H"],["•","X"]]}'
-        ... ))
-        0: ───H───@───
+
+    >>> print(cirq.quirk_url_to_circuit(
+    ...     'http://algassert.com/quirk#circuit={"cols":[["H"],["•","X"]]}'
+    ... ))
+    0: ───H───@───
+              │
+    1: ───────X───
+
+    >>> print(cirq.quirk_url_to_circuit(
+    ...     'http://algassert.com/quirk#circuit={"cols":[["H"],["•","X"]]}',
+    ...     qubits=[cirq.NamedQubit('Alice'), cirq.NamedQubit('Bob')]
+    ... ))
+    Alice: ───H───@───
                   │
-        1: ───────X───
+    Bob: ─────────X───
 
-        >>> print(cirq.quirk_url_to_circuit(
-        ...     'http://algassert.com/quirk#circuit={"cols":[["H"],["•","X"]]}',
-        ...     qubits=[cirq.NamedQubit('Alice'), cirq.NamedQubit('Bob')]
-        ... ))
-        Alice: ───H───@───
-                      │
-        Bob: ─────────X───
+    >>> print(cirq.quirk_url_to_circuit(
+    ...     'http://algassert.com/quirk#circuit={"cols":[["iswap"]]}',
+    ...     extra_cell_makers={'iswap': cirq.ISWAP}))
+    0: ───iSwap───
+          │
+    1: ───iSwap───
 
-        >>> print(cirq.quirk_url_to_circuit(
-        ...     'http://algassert.com/quirk#circuit={"cols":[["iswap"]]}',
-        ...     extra_cell_makers={'iswap': cirq.ISWAP}))
-        0: ───iSwap───
-              │
-        1: ───iSwap───
-
-        >>> print(cirq.quirk_url_to_circuit(
-        ...     'http://algassert.com/quirk#circuit={"cols":[["iswap"]]}',
-        ...     extra_cell_makers=[
-        ...         cirq.interop.quirk.cells.CellMaker(
-        ...             identifier='iswap',
-        ...             size=2,
-        ...             maker=lambda args: cirq.ISWAP(*args.qubits))
-        ...     ]))
-        0: ───iSwap───
-              │
-        1: ───iSwap───
+    >>> print(cirq.quirk_url_to_circuit(
+    ...     'http://algassert.com/quirk#circuit={"cols":[["iswap"]]}',
+    ...     extra_cell_makers=[
+    ...         cirq.interop.quirk.cells.CellMaker(
+    ...             identifier='iswap',
+    ...             size=2,
+    ...             maker=lambda args: cirq.ISWAP(*args.qubits))
+    ...     ]))
+    0: ───iSwap───
+          │
+    1: ───iSwap───
 
     Returns:
         The parsed circuit.
@@ -172,12 +173,13 @@ def quirk_json_to_circuit(
             a billion laughs attack in the form of nested custom gates.
 
     Examples:
-        >>> print(cirq.quirk_json_to_circuit(
-        ...     {"cols":[["H"], ["•", "X"]]}
-        ... ))
-        0: ───H───@───
-                  │
-        1: ───────X───
+
+    >>> print(cirq.quirk_json_to_circuit(
+    ...     {"cols":[["H"], ["•", "X"]]}
+    ... ))
+    0: ───H───@───
+              │
+    1: ───────X───
 
     Returns:
         The parsed circuit.

--- a/cirq-core/cirq/protocols/apply_channel_protocol.py
+++ b/cirq-core/cirq/protocols/apply_channel_protocol.py
@@ -41,13 +41,16 @@ class ApplyChannelArgs:
     r"""Arguments for efficiently performing a channel.
 
     A channel performs the mapping
-        $$
-        X \rightarrow \sum_i A_i X A_i^\dagger
-        $$
+
+    $$
+    X \rightarrow \sum_i A_i X A_i^\dagger
+    $$
+
     for operators $A_i$ that satisfy the normalization condition
-        $$
-        \sum_i A_i^\dagger A_i = I.
-        $$
+
+    $$
+    \sum_i A_i^\dagger A_i = I.
+    $$
 
     The receiving object is expected to mutate `target_tensor` so that it
     contains the density matrix after multiplication, and then return


### PR DESCRIPTION
- quirk_url_to_circuit and quirk_json_to_circuit had weird HTML in them.
- concat_ragged had a bunch of pre tags in the output.

I believe these changes fix the markdown generation.