### PR TITLE
Make InternalGate hashable if all gate args are hashable

### DIFF
--- a/cirq-google/cirq_google/ops/internal_gate.py
+++ b/cirq-google/cirq_google/ops/internal_gate.py
@@ -72,9 +72,15 @@ class InternalGate(ops.Gate):
         )
 
     def _value_equality_values_(self):
+        hashable = True
+        for arg in self.gate_args.values():
+            try:
+                hash(arg)
+            except TypeError:
+                hashable = False
         return (
             self.gate_module,
             self.gate_name,
             self._num_qubits,
-            frozenset(self.gate_args.items()),
+            frozenset(self.gate_args.items()) if hashable else self.gate_args,
         )

--- a/cirq-google/cirq_google/ops/internal_gate.py
+++ b/cirq-google/cirq_google/ops/internal_gate.py
@@ -43,7 +43,7 @@ class InternalGate(ops.Gate):
         self.gate_module = gate_module
         self.gate_name = gate_name
         self._num_qubits = num_qubits
-        self.gate_args = {arg: val for arg, val in kwargs.items()}
+        self.gate_args = kwargs
 
     def _num_qubits_(self) -> int:
         return self._num_qubits
@@ -72,4 +72,9 @@ class InternalGate(ops.Gate):
         )
 
     def _value_equality_values_(self):
-        return (self.gate_module, self.gate_name, self._num_qubits, self.gate_args)
+        return (
+            self.gate_module,
+            self.gate_name,
+            self._num_qubits,
+            frozenset(self.gate_args.items()),
+        )

--- a/cirq-google/cirq_google/ops/internal_gate_test.py
+++ b/cirq-google/cirq_google/ops/internal_gate_test.py
@@ -14,6 +14,7 @@
 
 import cirq
 import cirq_google
+import pytest
 
 
 def test_internal_gate():
@@ -39,7 +40,30 @@ def test_internal_gate_with_no_args():
     g = cirq_google.InternalGate(gate_name="GateWithNoArgs", gate_module='test', num_qubits=3)
     assert str(g) == 'test.GateWithNoArgs()'
     want_repr = (
-        "cirq_google.InternalGate(gate_name='GateWithNoArgs', " "gate_module='test', num_qubits=3)"
+        "cirq_google.InternalGate(gate_name='GateWithNoArgs', gate_module='test', num_qubits=3)"
     )
     assert repr(g) == want_repr
     assert cirq.qid_shape(g) == (2, 2, 2)
+
+
+def test_internal_gate_with_hashable_args_is_hashable():
+    hashable = cirq_google.InternalGate(
+        gate_name="GateWithHashableArgs",
+        gate_module='test',
+        num_qubits=3,
+        foo=1,
+        bar="2",
+        baz=(("a", 1),),
+    )
+    _ = hash(hashable)
+
+    unhashable = cirq_google.InternalGate(
+        gate_name="GateWithHashableArgs",
+        gate_module='test',
+        num_qubits=3,
+        foo=1,
+        bar="2",
+        baz={"a": 1},
+    )
+    with pytest.raises(TypeError, match="unhashable"):
+        _ = hash(unhashable)


### PR DESCRIPTION
Currently `InternalGate` includes a dict in `_value_equality_values_`, so it is never hashable even if all gate args are hashable. Change to use a frozenset of items instead to make it hashable. We also change to store constructor kwargs directly instead of copying the kwargs dict, since `**kwargs` passed in to a function is always a unique dictionary which won't alias a caller's dict.