### PR TITLE
Make `SingleQubitCompare` output registers directional

### DIFF
--- a/cirq-ft/cirq_ft/algos/arithmetic_gates.py
+++ b/cirq-ft/cirq_ft/algos/arithmetic_gates.py
@@ -222,7 +222,15 @@ class SingleQubitCompare(infra.GateWithRegisters):
 
     @cached_property
     def signature(self) -> infra.Signature:
-        return infra.Signature.build(a=1, b=1, less_than=1, greater_than=1)
+        one_side = infra.Side.RIGHT if not self.adjoint else infra.Side.LEFT
+        return infra.Signature(
+            [
+                infra.Register('a', 1),
+                infra.Register('b', 1),
+                infra.Register('less_than', 1, side=one_side),
+                infra.Register('greater_than', 1, side=one_side),
+            ]
+        )
 
     def __repr__(self) -> str:
         return f'cirq_ft.algos.SingleQubitCompare({self.adjoint})'

--- a/cirq-ft/cirq_ft/algos/arithmetic_gates_test.py
+++ b/cirq-ft/cirq_ft/algos/arithmetic_gates_test.py
@@ -357,6 +357,9 @@ def test_single_qubit_compare_protocols(adjoint: bool):
     g = cirq_ft.algos.SingleQubitCompare(adjoint=adjoint)
     cirq_ft.testing.assert_decompose_is_consistent_with_t_complexity(g)
     cirq.testing.assert_equivalent_repr(g, setup_code='import cirq_ft')
+    expected_side = cirq_ft.infra.Side.LEFT if adjoint else cirq_ft.infra.Side.RIGHT
+    assert g.signature[2] == cirq_ft.Register('less_than', 1, side=expected_side)
+    assert g.signature[3] == cirq_ft.Register('greater_than', 1, side=expected_side)
 
     with pytest.raises(ValueError):
         _ = g**0.5  # type: ignore


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/388

cc @fdmalone 