### PR TITLE
Preserve subcircuits passed to `[Frozen]Circuit.from_moments`

### DIFF
--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -23,7 +23,6 @@ import pytest
 import sympy
 
 import cirq
-import cirq.testing
 from cirq import circuits
 from cirq import ops
 from cirq.testing.devices import ValidatingTestDevice
@@ -72,19 +71,32 @@ moment_and_op_type_validating_device = _MomentAndOpTypeValidatingDeviceType()
 
 def test_from_moments():
     a, b, c, d = cirq.LineQubit.range(4)
-    assert cirq.Circuit.from_moments(
+    moment = cirq.Moment(cirq.Z(a), cirq.Z(b))
+    subcircuit = cirq.FrozenCircuit.from_moments(cirq.X(c), cirq.Y(d))
+    circuit = cirq.Circuit.from_moments(
+        moment,
+        subcircuit,
         [cirq.X(a), cirq.Y(b)],
         [cirq.X(c)],
         [],
         cirq.Z(d),
         [cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')],
-    ) == cirq.Circuit(
+    )
+    assert circuit == cirq.Circuit(
+        cirq.Moment(cirq.Z(a), cirq.Z(b)),
+        cirq.Moment(
+            cirq.CircuitOperation(
+                cirq.FrozenCircuit(cirq.Moment(cirq.X(c)), cirq.Moment(cirq.Y(d)))
+            )
+        ),
         cirq.Moment(cirq.X(a), cirq.Y(b)),
         cirq.Moment(cirq.X(c)),
         cirq.Moment(),
         cirq.Moment(cirq.Z(d)),
         cirq.Moment(cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')),
     )
+    assert circuit[0] is moment
+    assert circuit[1].operations[0].circuit is subcircuit
 
 
 def test_alignment():

--- a/cirq-core/cirq/circuits/frozen_circuit_test.py
+++ b/cirq-core/cirq/circuits/frozen_circuit_test.py
@@ -24,19 +24,32 @@ import cirq
 
 def test_from_moments():
     a, b, c, d = cirq.LineQubit.range(4)
-    assert cirq.FrozenCircuit.from_moments(
+    moment = cirq.Moment(cirq.Z(a), cirq.Z(b))
+    subcircuit = cirq.FrozenCircuit.from_moments(cirq.X(c), cirq.Y(d))
+    circuit = cirq.FrozenCircuit.from_moments(
+        moment,
+        subcircuit,
         [cirq.X(a), cirq.Y(b)],
         [cirq.X(c)],
         [],
         cirq.Z(d),
         [cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')],
-    ) == cirq.FrozenCircuit(
+    )
+    assert circuit == cirq.FrozenCircuit(
+        cirq.Moment(cirq.Z(a), cirq.Z(b)),
+        cirq.Moment(
+            cirq.CircuitOperation(
+                cirq.FrozenCircuit(cirq.Moment(cirq.X(c)), cirq.Moment(cirq.Y(d)))
+            )
+        ),
         cirq.Moment(cirq.X(a), cirq.Y(b)),
         cirq.Moment(cirq.X(c)),
         cirq.Moment(),
         cirq.Moment(cirq.Z(d)),
         cirq.Moment(cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')),
     )
+    assert circuit[0] is moment
+    assert circuit[1].operations[0].circuit is subcircuit
 
 
 def test_freeze_and_unfreeze():


### PR DESCRIPTION
Preserving subcircuits is very useful internally because we use subcircuit identity when compiling to hardware to guide waveform reuse. Note that previously if a circuit was passed to `from_moments` it would be passed to `Moment` which would fail for any circuit that had multiple moments with gates on the same qubit, because those could not be collapsed into a single moment. Single-moment circuits would've worked in the past and they will continue to work but will now being contained in a circuit operation.

Here's an example of a single-moment circuit:
```python
circuit = Circuit.from_moments(
    FrozenCircuit(Moment(X(q0), X(q1)))
)

# previously:
circuit == Circuit(
    Moment(X(q0), X(q1))
)

# with this PR:
circuit == Circuit(
    Moment(
        CircuitOperation(
            FrozenCircuit(Moment(X(q0), X(q1)))
        )
    )
)
```

Here's an example of a multi-moment circuit with repeated operations:
```python
circuit = Circuit.from_moments(
    FrozenCircuit(
        Moment(X(q0)),
        Moment(Y(q0)),
    )
)

# previously:
# exception! can't put X(q0) and Y(q0) in a single moment

# with this PR:
circuit == Circuit(
    Moment(
        CircuitOperation(
            FrozenCircuit(
                Moment(X(q0)),
                Moment(Y(q0)),
            )
        )
    )
)
```
