### PR TITLE
ci - skip slow tests on PR, run them in daily ci instead

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Run Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
-        run: check/pytest --ignore=cirq-core/cirq/contrib --rigetti-integration
+        run: check/pytest --ignore=cirq-core/cirq/contrib --rigetti-integration --enable-slow-tests
       - name: Stop Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -28,14 +28,65 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install --pre cirq
+          pip install --pre cirq &&
           pip install \
-          -r dev_tools/requirements/deps/format.txt \
-          -r dev_tools/requirements/deps/pylint.txt \
-          -r dev_tools/requirements/deps/pytest.txt
+            -r dev_tools/requirements/deps/format.txt \
+            -r dev_tools/requirements/deps/pylint.txt \
+            -r dev_tools/requirements/deps/pytest.txt
       - name: Run Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
-        run: check/pytest --ignore=cirq-core/cirq/contrib --rigetti-integration --enable-slow-tests
+        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --rigetti-integration --enable-slow-tests
       - name: Stop Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
+  windows:
+    name: Pytest Windows
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+      - name: Install requirements
+        run: |
+          pip install --pre cirq &&
+          pip install \
+            -r dev_tools/requirements/deps/format.txt \
+            -r dev_tools/requirements/deps/pylint.txt \
+            -r dev_tools/requirements/deps/pytest.txt
+      - name: Pytest Windows
+        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
+        shell: bash
+  macos:
+    name: Pytest MacOS
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11']
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+      - name: Install requirements
+        run: |
+          pip install --pre cirq &&
+          pip install \
+            -r dev_tools/requirements/deps/format.txt \
+            -r dev_tools/requirements/deps/pylint.txt \
+            -r dev_tools/requirements/deps/pytest.txt
+      - name: Pytest check
+        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests

--- a/cirq-ft/cirq_ft/algos/qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/qrom_test.py
@@ -24,9 +24,20 @@ from cirq_ft.infra.jupyter_tools import execute_notebook
 
 
 @pytest.mark.parametrize(
-    "data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]], [[1], [2], [3], [4], [5], [6]]]
+    "data,num_controls",
+    [
+        pytest.param(
+            data,
+            num_controls,
+            id=f"{num_controls}-data{idx}",
+            marks=pytest.mark.slow if num_controls == 2 and idx == 2 else (),
+        )
+        for idx, data in enumerate(
+            [[[1, 2, 3, 4, 5]], [[1, 2, 3], [4, 5, 10]], [[1], [2], [3], [4], [5], [6]]]
+        )
+        for num_controls in [0, 1, 2]
+    ],
 )
-@pytest.mark.parametrize("num_controls", [0, 1, 2])
 def test_qrom_1d(data, num_controls):
     qrom = cirq_ft.QROM.build(*data, num_controls=num_controls)
     greedy_mm = cirq.GreedyQubitManager('a', maximize_reuse=True)

--- a/cirq-ft/cirq_ft/algos/qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/qrom_test.py
@@ -195,10 +195,23 @@ target01: ────────────────X───────
 
 
 @pytest.mark.parametrize(
-    "data",
-    [[np.arange(6).reshape(2, 3), 4 * np.arange(6).reshape(2, 3)], [np.arange(8).reshape(2, 2, 2)]],
+    "data,num_controls",
+    [
+        pytest.param(
+            data,
+            num_controls,
+            id=f"{num_controls}-data{idx}",
+            marks=pytest.mark.slow if num_controls == 2 and idx == 0 else (),
+        )
+        for idx, data in enumerate(
+            [
+                [np.arange(6).reshape(2, 3), 4 * np.arange(6).reshape(2, 3)],
+                [np.arange(8).reshape(2, 2, 2)],
+            ]
+        )
+        for num_controls in [0, 1, 2]
+    ],
 )
-@pytest.mark.parametrize("num_controls", [0, 1, 2])
 def test_qrom_multi_dim(data, num_controls):
     selection_bitsizes = tuple((s - 1).bit_length() for s in data[0].shape)
     target_bitsizes = tuple(int(np.max(d)).bit_length() for d in data)

--- a/cirq-ft/cirq_ft/algos/qubitization_walk_operator_test.py
+++ b/cirq-ft/cirq_ft/algos/qubitization_walk_operator_test.py
@@ -46,6 +46,7 @@ def get_walk_operator_for_1d_Ising_model(
     return walk_operator_for_pauli_hamiltonian(ham, eps)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('num_sites,eps', [(4, 2e-1), (3, 1e-1)])
 def test_qubitization_walk_operator(num_sites: int, eps: float):
     ham = get_1d_Ising_hamiltonian(cirq.LineQubit.range(num_sites))

--- a/cirq-ft/cirq_ft/algos/reflection_using_prepare_test.py
+++ b/cirq-ft/cirq_ft/algos/reflection_using_prepare_test.py
@@ -78,6 +78,7 @@ def get_3q_uniform_dirac_notation(signs):
     return ret
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize('num_ones', [*range(5, 9)])
 @pytest.mark.parametrize('eps', [0.01])
 def test_reflection_using_prepare(num_ones, eps):

--- a/cirq-ft/cirq_ft/algos/select_swap_qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/select_swap_qrom_test.py
@@ -20,8 +20,19 @@ from cirq_ft import infra
 from cirq_ft.infra.bit_tools import iter_bits
 
 
-@pytest.mark.parametrize("data", [[[1, 2, 3, 4, 5]], [[1, 2, 3], [3, 2, 1]]])
-@pytest.mark.parametrize("block_size", [None, 1, 2, 3])
+@pytest.mark.parametrize(
+    "data,block_size",
+    [
+        pytest.param(
+            data,
+            block_size,
+            id=f"{block_size}-data{didx}",
+            marks=pytest.mark.slow if block_size == 3 and didx == 1 else (),
+        )
+        for didx, data in enumerate([[[1, 2, 3, 4, 5]], [[1, 2, 3], [3, 2, 1]]])
+        for block_size in [None, 1, 2, 3]
+    ],
+)
 def test_select_swap_qrom(data, block_size):
     qrom = cirq_ft.SelectSwapQROM(*data, block_size=block_size)
     qubit_regs = infra.get_named_qubits(qrom.signature)

--- a/cirq-ft/cirq_ft/algos/selected_majorana_fermion_test.py
+++ b/cirq-ft/cirq_ft/algos/selected_majorana_fermion_test.py
@@ -20,7 +20,14 @@ from cirq_ft import infra
 from cirq_ft.infra.bit_tools import iter_bits
 
 
-@pytest.mark.parametrize("selection_bitsize, target_bitsize", [(2, 4), (3, 8), (4, 9)])
+@pytest.mark.parametrize(
+    "selection_bitsize, target_bitsize",
+    [
+        (2, 4),
+        pytest.param(3, 8, marks=pytest.mark.slow),
+        pytest.param(4, 9, marks=pytest.mark.slow),
+    ],
+)
 @pytest.mark.parametrize("target_gate", [cirq.X, cirq.Y])
 def test_selected_majorana_fermion_gate(selection_bitsize, target_bitsize, target_gate):
     gate = cirq_ft.SelectedMajoranaFermionGate(

--- a/cirq-ft/cirq_ft/algos/state_preparation_test.py
+++ b/cirq-ft/cirq_ft/algos/state_preparation_test.py
@@ -20,7 +20,15 @@ from cirq_ft.algos.generic_select_test import get_1d_Ising_lcu_coeffs
 from cirq_ft.infra.jupyter_tools import execute_notebook
 
 
-@pytest.mark.parametrize("num_sites, epsilon", [[2, 3e-3], [3, 3.0e-3], [4, 5.0e-3], [7, 8.0e-3]])
+@pytest.mark.parametrize(
+    "num_sites, epsilon",
+    [
+        pytest.param(2, 3e-3, marks=pytest.mark.slow),
+        (3, 3.0e-3),
+        pytest.param(4, 5.0e-3, marks=pytest.mark.slow),
+        (7, 8.0e-3),
+    ],
+)
 def test_state_preparation_via_coherent_alias_sampling(num_sites, epsilon):
     lcu_coefficients = get_1d_Ising_lcu_coeffs(num_sites)
     gate = cirq_ft.StatePreparationAliasSampling.from_lcu_probs(

--- a/cirq-ft/cirq_ft/algos/state_preparation_test.py
+++ b/cirq-ft/cirq_ft/algos/state_preparation_test.py
@@ -23,10 +23,10 @@ from cirq_ft.infra.jupyter_tools import execute_notebook
 @pytest.mark.parametrize(
     "num_sites, epsilon",
     [
-        pytest.param(2, 3e-3, marks=pytest.mark.slow),
-        (3, 3.0e-3),
+        (2, 3e-3),
+        pytest.param(3, 3.0e-3, marks=pytest.mark.slow),
         pytest.param(4, 5.0e-3, marks=pytest.mark.slow),
-        (7, 8.0e-3),
+        pytest.param(7, 8.0e-3, marks=pytest.mark.slow),
     ],
 )
 def test_state_preparation_via_coherent_alias_sampling(num_sites, epsilon):

--- a/cirq-ft/cirq_ft/algos/unary_iteration_gate_test.py
+++ b/cirq-ft/cirq_ft/algos/unary_iteration_gate_test.py
@@ -118,7 +118,9 @@ class ApplyXToIJKthQubit(cirq_ft.UnaryIterationGate):
         yield [cirq.CNOT(control, t1[i]), cirq.CNOT(control, t2[j]), cirq.CNOT(control, t3[k])]
 
 
-@pytest.mark.parametrize("target_shape", [(2, 3, 2), (2, 2, 2)])
+@pytest.mark.parametrize(
+    "target_shape", [pytest.param((2, 3, 2), marks=pytest.mark.slow), (2, 2, 2)]
+)
 def test_multi_dimensional_unary_iteration_gate(target_shape: Tuple[int, int, int]):
     greedy_mm = cirq.GreedyQubitManager(prefix="_a", maximize_reuse=True)
     gate = ApplyXToIJKthQubit(target_shape)


### PR DESCRIPTION
* Add slow marks to the unit tests with over 20 second duration.
* Adjust ci-daily job so it runs all slow tests.
* And add ci-daily jobs for Windows and MacOS operating systems
  so that slow tests get tested on those platforms too.

Refs: 
* https://github.com/quantumlib/Cirq/issues/6211#issuecomment-1780471939
* https://github.com/quantumlib/Cirq/issues/6211#issuecomment-1784412539

Resolves #6211
