### PR TITLE
ci - show 20 slowest tests on Linux, Windows and Mac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Run Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
-        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --rigetti-integration
+        run: check/pytest -n auto --durations=20 --ignore=cirq-core/cirq/contrib --rigetti-integration
       - name: Stop Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
   pip-compile:
@@ -265,7 +265,7 @@ jobs:
       - name: Pytest Windows
         run: |
           source dev_tools/pypath
-          check/pytest -n auto --ignore=cirq-core/cirq/contrib
+          check/pytest -n auto --durations=20 --ignore=cirq-core/cirq/contrib
         shell: bash
   macos:
     name: Pytest MacOS
@@ -288,7 +288,7 @@ jobs:
           pip install wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/no-contrib.env.txt
       - name: Pytest check
-        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib
+        run: check/pytest -n auto --durations=20 --ignore=cirq-core/cirq/contrib
   notebooks-stable:
     name: Changed Notebooks Isolated Test against Cirq stable
     env:


### PR DESCRIPTION
No change in the test execution, just a bit more output for the
`Pytest Ubuntu`, `Pytest Windows`, and `Pytest MacOS` jobs.

Related to #6211
