### PR TITLE
Fix ci-daily pytest failure

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out master by default.
     - cron: '0 0 * * *'
+  # FIXME - remove this before submitting #6335
+  pull_request:
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -58,10 +58,9 @@ jobs:
       - name: Install requirements
         run: |
           pip install --pre cirq &&
-          pip install \
-            -r dev_tools/requirements/deps/format.txt \
-            -r dev_tools/requirements/deps/pylint.txt \
-            -r dev_tools/requirements/deps/pytest.txt
+            pip install -r dev_tools/requirements/deps/format.txt &&
+            pip install -r dev_tools/requirements/deps/pylint.txt &&
+            pip install -r dev_tools/requirements/deps/pytest.txt
       - name: Pytest Windows
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
         shell: bash

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out master by default.
     - cron: '0 0 * * *'
-  # FIXME - remove this before submitting #6335
-  pull_request:
-    branches:
-      - master
 
 concurrency:
   group: ${{ github.workflow }}

--- a/cirq-ft/cirq_ft/algos/and_gate_test.py
+++ b/cirq-ft/cirq_ft/algos/and_gate_test.py
@@ -14,6 +14,7 @@
 
 import itertools
 import random
+import sys
 from typing import List, Tuple
 
 import cirq
@@ -203,6 +204,7 @@ def test_and_gate_adjoint(cv: Tuple[int, int]):
         cirq_ft.testing.assert_circuit_inp_out_cirqsim(circuit, [c1, c2, t], inp, out)
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('and_gate')
 

--- a/cirq-ft/cirq_ft/algos/apply_gate_to_lth_target_test.py
+++ b/cirq-ft/cirq_ft/algos/apply_gate_to_lth_target_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import cirq
 import cirq_ft
 import pytest
@@ -101,5 +103,6 @@ def test_apply_gate_to_lth_qubit_make_on():
     assert op.gate.control_regs == op2.gate.control_regs
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('apply_gate_to_lth_target')

--- a/cirq-ft/cirq_ft/algos/generic_select_test.py
+++ b/cirq-ft/cirq_ft/algos/generic_select_test.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import sys
 from typing import List, Sequence
 
 import cirq
@@ -276,5 +278,6 @@ def test_generic_select_consistent_protocols_and_controlled():
         _ = gate.controlled(num_controls=2)
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('generic_select')

--- a/cirq-ft/cirq_ft/algos/hubbard_model_test.py
+++ b/cirq-ft/cirq_ft/algos/hubbard_model_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import cirq
 import cirq_ft
 import pytest
@@ -72,5 +74,6 @@ def test_hubbard_model_consistent_protocols():
     assert cirq.circuit_diagram_info(select_gate).wire_symbols == tuple(expected_symbols)
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('hubbard_model')

--- a/cirq-ft/cirq_ft/algos/qrom_test.py
+++ b/cirq-ft/cirq_ft/algos/qrom_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+import sys
 
 import cirq
 import cirq_ft
@@ -114,6 +115,7 @@ def test_qrom_repr():
     cirq.testing.assert_equivalent_repr(qrom, setup_code="import cirq_ft\nimport numpy as np")
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('qrom')
 

--- a/cirq-ft/cirq_ft/algos/qubitization_walk_operator_test.py
+++ b/cirq-ft/cirq_ft/algos/qubitization_walk_operator_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import cirq
 import cirq_ft
 import numpy as np
@@ -240,6 +242,7 @@ def test_qubitization_walk_operator_consistent_protocols_and_controlled():
         _ = gate.controlled(num_controls=2)
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('qubitization_walk_operator')
     execute_notebook('phase_estimation_of_quantum_walk')

--- a/cirq-ft/cirq_ft/algos/state_preparation_test.py
+++ b/cirq-ft/cirq_ft/algos/state_preparation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import cirq
 import cirq_ft
 import numpy as np
@@ -93,5 +95,6 @@ less_than_equal: ─────────────────────
     )
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('state_preparation')

--- a/cirq-ft/cirq_ft/algos/swap_network_test.py
+++ b/cirq-ft/cirq_ft/algos/swap_network_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import random
+import sys
 
 import cirq
 import cirq_ft
@@ -146,6 +147,7 @@ def test_multi_target_cswap_make_on():
     assert cswap1 == cswap2
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('swap_network')
 

--- a/cirq-ft/cirq_ft/algos/unary_iteration_gate_test.py
+++ b/cirq-ft/cirq_ft/algos/unary_iteration_gate_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+import sys
 from typing import Sequence, Tuple
 
 import cirq
@@ -198,5 +199,6 @@ def test_unary_iteration_loop_empty_range():
     assert list(cirq_ft.unary_iteration(4, 3, [], [], [cirq.q('s')], qm)) == []
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('unary_iteration')

--- a/cirq-ft/cirq_ft/infra/gate_with_registers_test.py
+++ b/cirq-ft/cirq_ft/infra/gate_with_registers_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import cirq
 import cirq_ft
 import numpy as np
@@ -169,5 +171,6 @@ def test_gate_with_registers():
     assert op1 == op2
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('gate_with_registers')

--- a/cirq-ft/cirq_ft/infra/t_complexity_protocol_test.py
+++ b/cirq-ft/cirq_ft/infra/t_complexity_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import cirq
 import cirq_ft
 import pytest
@@ -207,5 +209,6 @@ def test_cache_clear():
     cirq_ft.t_complexity.cache_clear()
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 def test_notebook():
     execute_notebook('t_complexity')

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -21,6 +21,7 @@
 
 import importlib.metadata
 import os
+import sys
 import tempfile
 
 import pytest
@@ -86,6 +87,7 @@ def env_with_temporary_pip_target():
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 @pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
 def test_notebooks_against_cirq_head(
     notebook_path, require_packages_not_changed, env_with_temporary_pip_target

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -21,10 +21,12 @@ import pytest
 
 from dev_tools import shell_tools
 from dev_tools.modules import list_modules
+from dev_tools.test_utils import only_on_posix
 
 PACKAGES = ["-r", "dev_tools/requirements/isolated-base.env.txt"]
 
 
+@only_on_posix
 @pytest.mark.slow
 # ensure that no cirq packages are on the PYTHONPATH, this is important, otherwise
 # the "isolation" fails and for example cirq-core would be on the PATH


### PR DESCRIPTION
* Fix requirements installation for Windows
* Run notebook tests only on Linux platform
* Run test_isolated_packages on POSIX platforms only

Temporary workaround for #6336 