### PR TITLE
Fix flaky behavior of test_xeb_fidelity

### DIFF
--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -81,7 +81,7 @@ def test_xeb_fidelity(depolarization, estimator):
         f2 = cirq.xeb_fidelity(
             circuit, bitstrings, qubits, amplitudes=amplitudes, estimator=estimator
         )
-        assert np.abs(f - f2) < 1e-6
+        assert np.abs(f - f2) < 2e-6
 
         fs.append(f)
 

--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -81,7 +81,7 @@ def test_xeb_fidelity(depolarization, estimator):
         f2 = cirq.xeb_fidelity(
             circuit, bitstrings, qubits, amplitudes=amplitudes, estimator=estimator
         )
-        assert np.allclose(f, f2, rtol=1e-6)
+        assert np.allclose(f, f2, rtol=5e-5)
 
         fs.append(f)
 

--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -81,7 +81,7 @@ def test_xeb_fidelity(depolarization, estimator):
         f2 = cirq.xeb_fidelity(
             circuit, bitstrings, qubits, amplitudes=amplitudes, estimator=estimator
         )
-        assert np.allclose(f, f2, rtol=5e-5)
+        assert np.abs(f - f2) < 2e-6
 
         fs.append(f)
 

--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -81,7 +81,7 @@ def test_xeb_fidelity(depolarization, estimator):
         f2 = cirq.xeb_fidelity(
             circuit, bitstrings, qubits, amplitudes=amplitudes, estimator=estimator
         )
-        assert np.abs(f - f2) < 2e-6
+        assert np.allclose(f, f2, rtol=1e-6)
 
         fs.append(f)
 


### PR DESCRIPTION
Increase tolerance for fidelities calculated with and without state
vector amplitudes.  Avoid flaky, random-seed dependent test failures
on a slightly excessive difference.

Example: https://github.com/quantumlib/Cirq/actions/runs/6726576064/job/18283075054#step:6:598
