### PR TITLE
Optimize ParamResolver.value_of

### DIFF
--- a/cirq-core/cirq/sim/simulator_test.py
+++ b/cirq-core/cirq/sim/simulator_test.py
@@ -134,8 +134,7 @@ def test_intermediate_simulator():
 
     simulator.simulate_moment_steps.side_effect = steps
     circuit = mock.Mock(cirq.Circuit)
-    param_resolver = mock.Mock(cirq.ParamResolver)
-    param_resolver.param_dict = {}
+    param_resolver = cirq.ParamResolver({})
     qubit_order = mock.Mock(cirq.QubitOrder)
     result = simulator.simulate(
         program=circuit, param_resolver=param_resolver, qubit_order=qubit_order, initial_state=2
@@ -163,9 +162,7 @@ def test_intermediate_sweeps():
 
     simulator.simulate_moment_steps.side_effect = steps
     circuit = mock.Mock(cirq.Circuit)
-    param_resolvers = [mock.Mock(cirq.ParamResolver), mock.Mock(cirq.ParamResolver)]
-    for resolver in param_resolvers:
-        resolver.param_dict = {}
+    param_resolvers = [cirq.ParamResolver({}), cirq.ParamResolver({})]
     qubit_order = mock.Mock(cirq.QubitOrder)
     results = simulator.simulate_sweep(
         program=circuit, params=param_resolvers, qubit_order=qubit_order, initial_state=2

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -255,9 +255,7 @@ class ParamResolver:
     def __repr__(self) -> str:
         param_dict_repr = (
             '{'
-            + ', '.join(
-                [f'{proper_repr(k)}: {proper_repr(v)}' for k, v in self._param_dict.items()]
-            )
+            + ', '.join(f'{proper_repr(k)}: {proper_repr(v)}' for k, v in self._param_dict.items())
             + '}'
         )
         return f'cirq.ParamResolver({param_dict_repr})'

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -136,7 +136,9 @@ class ParamResolver:
             v = _resolve_value(param_value)
             if v is not NotImplemented:
                 return v
-            if not isinstance(param_value, sympy.Basic):
+            if isinstance(param_value, str):
+                param_value = sympy.Symbol(param_value)
+            elif not isinstance(param_value, sympy.Basic):
                 return value  # type: ignore[return-value]
             if recursive:
                 param_value = self._value_of_recursive(value)

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -36,6 +36,9 @@ document(
     ParamResolverOrSimilarType, """Something that can be used to turn parameters into values."""
 )
 
+# Used to mark values that are not found in a dict.
+_NotFound = object()
+
 # Used to mark values that are being resolved recursively to detect loops.
 _RecursionFlag = object()
 
@@ -72,7 +75,7 @@ class ParamResolver:
 
         self._param_hash: Optional[int] = None
         self._param_dict = cast(ParamDictType, {} if param_dict is None else param_dict)
-        for key in self.param_dict:
+        for key in self._param_dict:
             if isinstance(key, sympy.Expr) and not isinstance(key, sympy.Symbol):
                 raise TypeError(f'ParamResolver keys cannot be (non-symbol) formulas ({key})')
         self._deep_eval_map: ParamDictType = {}
@@ -120,32 +123,28 @@ class ParamResolver:
         if v is not NotImplemented:
             return v
 
-        # Handles 2 cases:
-        # Input is a string and maps to a number in the dictionary
-        # Input is a symbol and maps to a number in the dictionary
-        # In both cases, return it directly.
-        if value in self.param_dict:
-            # Note: if the value is in the dictionary, it will be a key type
-            # Add a cast to make mypy happy.
-            param_value = self.param_dict[cast('cirq.TParamKey', value)]
+        # Handle string or symbol
+        if isinstance(value, (str, sympy.Symbol)):
+            string = value if isinstance(value, str) else value.name
+            symbol = value if isinstance(value, sympy.Symbol) else sympy.Symbol(value)
+            param_value = self._param_dict.get(string, _NotFound)
+            if param_value is _NotFound:
+                param_value = self._param_dict.get(symbol, _NotFound)
+            if param_value is _NotFound:
+                # Symbol or string that is not in the param_dict cannot be resolved futher; return as symbol.
+                return symbol
             v = _resolve_value(param_value)
             if v is not NotImplemented:
                 return v
+            if not isinstance(param_value, sympy.Basic):
+                return value
+            if recursive:
+                param_value = self._value_of_recursive(value)
+            return param_value
 
-        # Input is a string and is not in the dictionary.
-        # Treat it as a symbol instead.
-        if isinstance(value, str):
-            # If the string is in the param_dict as a value, return it.
-            # Otherwise, try using the symbol instead.
-            return self.value_of(sympy.Symbol(value), recursive)
-
-        # Input is a symbol (sympy.Symbol('a')) and its string maps to a number
-        # in the dictionary ({'a': 1.0}).  Return it.
-        if isinstance(value, sympy.Symbol) and value.name in self.param_dict:
-            param_value = self.param_dict[value.name]
-            v = _resolve_value(param_value)
-            if v is not NotImplemented:
-                return v
+        if not isinstance(value, sympy.Basic):
+            # No known way to resolve this variable, return unchanged.
+            return value
 
         # The following resolves common sympy expressions
         # If sympy did its job and wasn't slower than molasses,
@@ -171,10 +170,6 @@ class ParamResolver:
                 return np.float_power(cast(complex, base), cast(complex, exponent))
             return np.power(cast(complex, base), cast(complex, exponent))
 
-        if not isinstance(value, sympy.Basic):
-            # No known way to resolve this variable, return unchanged.
-            return value
-
         # Input is either a sympy formula or the dictionary maps to a
         # formula.  Use sympy to resolve the value.
         # Note that sympy.subs() is slow, so we want to avoid this and
@@ -186,7 +181,7 @@ class ParamResolver:
             # Note that a sympy.SympifyError here likely means
             # that one of the expressions was not parsable by sympy
             # (such as a function returning NotImplemented)
-            v = value.subs(self.param_dict, simultaneous=True)
+            v = value.subs(self._param_dict, simultaneous=True)
 
             if v.free_symbols:
                 return v
@@ -197,13 +192,18 @@ class ParamResolver:
             else:
                 return float(v)
 
+        return self._value_of_recursive(value)
+
+    def _value_of_recursive(
+        self, value: Union['cirq.TParamKey', 'cirq.TParamValComplex']
+    ) -> 'cirq.TParamValComplex':
         # Recursive parameter resolution. We can safely assume that value is a
         # single symbol, since combinations are handled earlier in the method.
         if value in self._deep_eval_map:
             v = self._deep_eval_map[value]
-            if v is not _RecursionFlag:
-                return v
-            raise RecursionError('Evaluation of {value} indirectly contains itself.')
+            if v is _RecursionFlag:
+                raise RecursionError('Evaluation of {value} indirectly contains itself.')
+            return v
 
         # There isn't a full evaluation for 'value' yet. Until it's ready,
         # map value to None to identify loops in component evaluation.
@@ -213,7 +213,7 @@ class ParamResolver:
         if v == value:
             self._deep_eval_map[value] = v
         else:
-            self._deep_eval_map[value] = self.value_of(v, recursive)
+            self._deep_eval_map[value] = self.value_of(v, recursive=True)
         return self._deep_eval_map[value]
 
     def _resolve_parameters_(self, resolver: 'ParamResolver', recursive: bool) -> 'ParamResolver':
@@ -224,17 +224,17 @@ class ParamResolver:
         new_dict.update(
             {k: resolver.value_of(v, recursive) for k, v in new_dict.items()}  # type: ignore[misc]
         )
-        if recursive and self.param_dict:
+        if recursive and self._param_dict:
             new_resolver = ParamResolver(cast(ParamDictType, new_dict))
             # Resolve down to single-step mappings.
             return ParamResolver()._resolve_parameters_(new_resolver, recursive=True)
         return ParamResolver(cast(ParamDictType, new_dict))
 
     def __iter__(self) -> Iterator[Union[str, sympy.Expr]]:
-        return iter(self.param_dict)
+        return iter(self._param_dict)
 
     def __bool__(self) -> bool:
-        return bool(self.param_dict)
+        return bool(self._param_dict)
 
     def __getitem__(
         self, key: Union['cirq.TParamKey', 'cirq.TParamValComplex']
@@ -243,13 +243,13 @@ class ParamResolver:
 
     def __hash__(self) -> int:
         if self._param_hash is None:
-            self._param_hash = hash(frozenset(self.param_dict.items()))
+            self._param_hash = hash(frozenset(self._param_dict.items()))
         return self._param_hash
 
     def __eq__(self, other):
         if not isinstance(other, ParamResolver):
             return NotImplemented
-        return self.param_dict == other.param_dict
+        return self._param_dict == other._param_dict
 
     def __ne__(self, other):
         return not self == other
@@ -257,7 +257,9 @@ class ParamResolver:
     def __repr__(self) -> str:
         param_dict_repr = (
             '{'
-            + ', '.join([f'{proper_repr(k)}: {proper_repr(v)}' for k, v in self.param_dict.items()])
+            + ', '.join(
+                [f'{proper_repr(k)}: {proper_repr(v)}' for k, v in self._param_dict.items()]
+            )
             + '}'
         )
         return f'cirq.ParamResolver({param_dict_repr})'
@@ -265,7 +267,7 @@ class ParamResolver:
     def _json_dict_(self) -> Dict[str, Any]:
         return {
             # JSON requires mappings to have keys of basic types.
-            'param_dict': list(self.param_dict.items())
+            'param_dict': list(self._param_dict.items())
         }
 
     @classmethod

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -37,10 +37,10 @@ document(
 )
 
 # Used to mark values that are not found in a dict.
-_NotFound = object()
+_NOT_FOUND = object()
 
 # Used to mark values that are being resolved recursively to detect loops.
-_RecursionFlag = object()
+_RECURSION_FLAG = object()
 
 
 def _is_param_resolver_or_similar_type(obj: Any):
@@ -127,10 +127,10 @@ class ParamResolver:
         if isinstance(value, (str, sympy.Symbol)):
             string = value if isinstance(value, str) else value.name
             symbol = value if isinstance(value, sympy.Symbol) else sympy.Symbol(value)
-            param_value = self._param_dict.get(string, _NotFound)
-            if param_value is _NotFound:
-                param_value = self._param_dict.get(symbol, _NotFound)
-            if param_value is _NotFound:
+            param_value = self._param_dict.get(string, _NOT_FOUND)
+            if param_value is _NOT_FOUND:
+                param_value = self._param_dict.get(symbol, _NOT_FOUND)
+            if param_value is _NOT_FOUND:
                 # Symbol or string cannot be resolved if not in param dict; return as symbol.
                 return symbol
             v = _resolve_value(param_value)
@@ -201,13 +201,13 @@ class ParamResolver:
         # single symbol, since combinations are handled earlier in the method.
         if value in self._deep_eval_map:
             v = self._deep_eval_map[value]
-            if v is _RecursionFlag:
+            if v is _RECURSION_FLAG:
                 raise RecursionError('Evaluation of {value} indirectly contains itself.')
             return v
 
         # There isn't a full evaluation for 'value' yet. Until it's ready,
         # map value to None to identify loops in component evaluation.
-        self._deep_eval_map[value] = _RecursionFlag  # type: ignore
+        self._deep_eval_map[value] = _RECURSION_FLAG  # type: ignore
 
         v = self.value_of(value, recursive=False)
         if v == value:

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -131,16 +131,16 @@ class ParamResolver:
             if param_value is _NotFound:
                 param_value = self._param_dict.get(symbol, _NotFound)
             if param_value is _NotFound:
-                # Symbol or string that is not in the param_dict cannot be resolved futher; return as symbol.
+                # Symbol or string cannot be resolved if not in param dict; return as symbol.
                 return symbol
             v = _resolve_value(param_value)
             if v is not NotImplemented:
                 return v
             if not isinstance(param_value, sympy.Basic):
-                return value
+                return value  # type: ignore[return-value]
             if recursive:
                 param_value = self._value_of_recursive(value)
-            return param_value
+            return param_value  # type: ignore[return-value]
 
         if not isinstance(value, sympy.Basic):
             # No known way to resolve this variable, return unchanged.
@@ -194,9 +194,7 @@ class ParamResolver:
 
         return self._value_of_recursive(value)
 
-    def _value_of_recursive(
-        self, value: Union['cirq.TParamKey', 'cirq.TParamValComplex']
-    ) -> 'cirq.TParamValComplex':
+    def _value_of_recursive(self, value: 'cirq.TParamKey') -> 'cirq.TParamValComplex':
         # Recursive parameter resolution. We can safely assume that value is a
         # single symbol, since combinations are handled earlier in the method.
         if value in self._deep_eval_map:

--- a/cirq-ionq/cirq_ionq/sampler_test.py
+++ b/cirq-ionq/cirq_ionq/sampler_test.py
@@ -119,7 +119,6 @@ def test_sampler_multiple_jobs():
         ]
     )
     assert mock_service.create_job.call_count == 2
-    raise ValueError()
 
 
 def test_sampler_run_sweep():

--- a/cirq-ionq/cirq_ionq/sampler_test.py
+++ b/cirq-ionq/cirq_ionq/sampler_test.py
@@ -100,7 +100,7 @@ def test_sampler_multiple_jobs():
     results = sampler.sample(
         program=circuit,
         repetitions=4,
-        params=[cirq.ParamResolver({x: '0.5'}), cirq.ParamResolver({x: '0.6'})],
+        params=[cirq.ParamResolver({x: 0.5}), cirq.ParamResolver({x: 0.6})],
     )
     pd.testing.assert_frame_equal(
         results,
@@ -119,6 +119,7 @@ def test_sampler_multiple_jobs():
         ]
     )
     assert mock_service.create_job.call_count == 2
+    raise ValueError()
 
 
 def test_sampler_run_sweep():


### PR DESCRIPTION
This cleans up the logic in `ParamResolver.value_of` and makes a few optimizations:
- Throughout `ParamResolver`, refer to `self._param_dict` instead of the `self.param_dict` property.
- In `ParamResolver.value_of`, handle the cases of resolving a string or symbol in a more straightforward way by checking for their presence in the param dict (when resolving a string we check for both a str and symbol, and similarly when resolving a symbol). If the str or symbol is not found, we can immediately return the symbol without calling through to sympy substitution logic, which was being invoked previously. If the value is found, we check whether it is a "pass through" resolvable value and whether it needs to be resolved recursively and then return.

These changes ensure that sympy substitution logic is not invoked unless trying to resolve a complex expression, which fixes `test_value_of_substituted_types` so that it doesn't actually invoke substitution on basic symbols (the test was claiming to assert this while actually asserting the opposite), and also greatly improves performance when resolving missing symbols. On master, getting the value of a missing symbol invokes sympy and is quite slow:

```
In [1]: import cirq, sympy
In [2]: %time cirq.ParamResolver({"a": 1, "b": 2}).value_of(sympy.Symbol("foo"))
CPU times: user 843 µs, sys: 691 µs, total: 1.53 ms
Wall time: 1.55 ms
```

while on this branch the same operation is more than 10x faster:

```
In [1]: import cirq, sympy
In [2]: %time cirq.ParamResolver({"a": 1, "b": 2}).value_of(sympy.Symbol("foo"))
CPU times: user 69 µs, sys: 56 µs, total: 125 µs
Wall time: 130 µs
```

Note that I also slightly changed the behavior of resolving a type with an explicit `_resolved_value_` method that returns `NotImplemented`. Previously this would raise an obscure sympy error, but here I've changed things so that the behavior of such an "explicitly not implemented" method is the same as if the method were omitted entirely (_actually_ not implemented). In the latter case we were previously returning the original symbol, and now we do that for both cases. I think it's debatable whether we should in fact return the symbol in such cases, but this at least makes things more consistent.