### PR TITLE
Remove dummy from cirq-core

### DIFF
--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -248,18 +248,18 @@ def test_unsupported_operation():
 
 
 def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
-    class DummyOperation(cirq.Operation):
+    class ExampleOperation(cirq.Operation):
         qubits = (q0,)
         with_qubits = NotImplemented
 
         def _qasm_(self, args: cirq.QasmArgs) -> str:
-            return '// Dummy operation\n'
+            return '// Example operation\n'
 
         def _decompose_(self):
             # Only used by test_output_unitary_same_as_qiskit
             return ()  # pragma: no cover
 
-    class DummyCompositeOperation(cirq.Operation):
+    class ExampleCompositeOperation(cirq.Operation):
         qubits = (q0,)
         with_qubits = NotImplemented
 
@@ -267,7 +267,7 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
             return cirq.X(self.qubits[0])
 
         def __repr__(self):
-            return 'DummyCompositeOperation()'
+            return 'ExampleCompositeOperation()'
 
     return (
         cirq.I(q0),
@@ -328,8 +328,8 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
         )
         if include_measurements
         else (),
-        DummyOperation(),
-        DummyCompositeOperation(),
+        ExampleOperation(),
+        ExampleCompositeOperation(),
     )
 
 
@@ -539,9 +539,9 @@ measure q[2] -> m_multi[1];
 x q[2];  // Undo the inversion
 measure q[3] -> m_multi[2];
 
-// Dummy operation
+// Example operation
 
-// Operation: DummyCompositeOperation()
+// Operation: ExampleCompositeOperation()
 x q[0];
 """
     )

--- a/cirq-core/cirq/contrib/paulistring/clifford_target_gateset_test.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_target_gateset_test.py
@@ -182,11 +182,11 @@ def test_already_converted():
 
 
 def test_ignore_unsupported_gate():
-    class UnsupportedDummy(cirq.testing.TwoQubitGate):
+    class UnsupportedGate(cirq.testing.TwoQubitGate):
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit(UnsupportedDummy()(q0, q1), cirq.X(q0) ** sympy.Symbol("theta"))
+    c_orig = cirq.Circuit(UnsupportedGate()(q0, q1), cirq.X(q0) ** sympy.Symbol("theta"))
     c_new = cirq.optimize_for_target_gateset(
         c_orig, gateset=CliffordTargetGateset(), ignore_failures=True
     )
@@ -194,11 +194,11 @@ def test_ignore_unsupported_gate():
 
 
 def test_fail_unsupported_gate():
-    class UnsupportedDummy(cirq.testing.TwoQubitGate):
+    class UnsupportedGate(cirq.testing.TwoQubitGate):
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    c_orig = cirq.Circuit(UnsupportedDummy()(q0, q1))
+    c_orig = cirq.Circuit(UnsupportedGate()(q0, q1))
     with pytest.raises(ValueError):
         _ = cirq.optimize_for_target_gateset(
             c_orig, gateset=CliffordTargetGateset(), ignore_failures=False

--- a/cirq-core/cirq/experiments/xeb_fitting_test.py
+++ b/cirq-core/cirq/experiments/xeb_fitting_test.py
@@ -129,8 +129,8 @@ def test_benchmark_2q_xeb_fidelities_parallel():
 
 def test_benchmark_2q_xeb_fidelities_vectorized():
     rs = np.random.RandomState(52)
-    dummy_records = [{'pure_probs': rs.rand(4), 'sampled_probs': rs.rand(4)} for _ in range(100)]
-    df = pd.DataFrame(dummy_records)
+    mock_records = [{'pure_probs': rs.rand(4), 'sampled_probs': rs.rand(4)} for _ in range(100)]
+    df = pd.DataFrame(mock_records)
 
     # Using `df.apply` is wayyyy slower than the new implementation!
     # but they should give the same results

--- a/cirq-core/cirq/experiments/xeb_sampling.py
+++ b/cirq-core/cirq/experiments/xeb_sampling.py
@@ -130,7 +130,7 @@ def _verify_two_line_qubits_from_circuits(circuits: Sequence['cirq.Circuit']):
 
 
 class _NoProgress:
-    """Dummy (lack of) tqdm-style progress bar."""
+    """Lack of tqdm-style progress bar."""
 
     def __init__(self, total: int):
         pass

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq.protocols.act_on_protocol_test import DummySimulationState
+from cirq.protocols.act_on_protocol_test import ExampleSimulationState
 from cirq.testing import EqualsTester, assert_allclose_up_to_global_phase
 
 _bools = (False, True)
@@ -47,7 +47,7 @@ def _assert_no_collision(gate) -> None:
 
 
 def _all_rotations():
-    for (pauli, flip) in itertools.product(_paulis, _bools):
+    for pauli, flip in itertools.product(_paulis, _bools):
         yield (pauli, flip)
 
 
@@ -490,7 +490,6 @@ def test_commutes_pauli(gate, pauli, half_turns):
 
 
 def test_to_clifford_tableau_util_function():
-
     tableau = cirq.ops.clifford_gate._to_clifford_tableau(
         x_to=(cirq.X, False), z_to=(cirq.Z, False)
     )
@@ -879,7 +878,7 @@ def test_clifford_gate_act_on_ch_form():
 
 def test_clifford_gate_act_on_fail():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.CliffordGate.X, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.CliffordGate.X, ExampleSimulationState(), qubits=())
 
 
 def test_all_single_qubit_clifford_unitaries():

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq.protocols.act_on_protocol_test import DummySimulationState
+from cirq.protocols.act_on_protocol_test import ExampleSimulationState
 
 X = np.array([[0, 1], [1, 0]])
 Y = np.array([[0, -1j], [1j, 0]])
@@ -87,7 +87,6 @@ def test_asymmetric_depolarizing_channel_str():
 
 
 def test_asymmetric_depolarizing_channel_eq():
-
     a = cirq.asymmetric_depolarize(0.0099999, 0.01)
     b = cirq.asymmetric_depolarize(0.01, 0.0099999)
     c = cirq.asymmetric_depolarize(0.0, 0.0, 0.0)
@@ -492,7 +491,7 @@ def test_reset_channel_text_diagram():
 
 def test_reset_act_on():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.ResetChannel(), DummySimulationState(), qubits=())
+        cirq.act_on(cirq.ResetChannel(), ExampleSimulationState(), qubits=())
 
     args = cirq.StateVectorSimulationState(
         available_buffer=np.empty(shape=(2, 2, 2, 2, 2), dtype=np.complex64),
@@ -697,7 +696,6 @@ def test_bit_flip_channel_str():
 
 
 def test_bit_flip_channel_eq():
-
     a = cirq.bit_flip(0.0099999)
     b = cirq.bit_flip(0.01)
     c = cirq.bit_flip(0.0)
@@ -735,7 +733,7 @@ def test_bit_flip_channel_text_diagram():
 def test_stabilizer_supports_depolarize():
     with pytest.raises(TypeError, match="act_on"):
         for _ in range(100):
-            cirq.act_on(cirq.depolarize(3 / 4), DummySimulationState(), qubits=())
+            cirq.act_on(cirq.depolarize(3 / 4), ExampleSimulationState(), qubits=())
 
     q = cirq.LineQubit(0)
     c = cirq.Circuit(cirq.depolarize(3 / 4).on(q), cirq.measure(q, key='m'))

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -17,7 +17,7 @@ import pytest
 import sympy
 
 import cirq
-from cirq.protocols.act_on_protocol_test import DummySimulationState
+from cirq.protocols.act_on_protocol_test import ExampleSimulationState
 
 H = np.array([[1, 1], [1, -1]]) * np.sqrt(0.5)
 HH = cirq.kron(H, H)
@@ -310,7 +310,7 @@ def test_h_str():
 
 def test_x_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.X, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.X, ExampleSimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
     flipped_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=23)
 
@@ -359,7 +359,7 @@ class MinusOnePhaseGate(cirq.testing.SingleQubitGate):
 
 def test_y_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.Y, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.Y, ExampleSimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
     flipped_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=23)
 
@@ -397,9 +397,9 @@ def test_y_act_on_tableau():
 
 def test_z_h_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.Z, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.Z, ExampleSimulationState(), qubits=())
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.H, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.H, ExampleSimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
     flipped_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=23)
 
@@ -450,7 +450,7 @@ def test_z_h_act_on_tableau():
 
 def test_cx_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.CX, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.CX, ExampleSimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
 
     state = cirq.CliffordTableauSimulationState(
@@ -494,7 +494,7 @@ def test_cx_act_on_tableau():
 
 def test_cz_act_on_tableau():
     with pytest.raises(TypeError, match="Failed to act"):
-        cirq.act_on(cirq.CZ, DummySimulationState(), qubits=())
+        cirq.act_on(cirq.CZ, ExampleSimulationState(), qubits=())
     original_tableau = cirq.CliffordTableau(num_qubits=5, initial_state=31)
 
     state = cirq.CliffordTableauSimulationState(

--- a/cirq-core/cirq/ops/gate_features_test.py
+++ b/cirq-core/cirq/ops/gate_features_test.py
@@ -53,7 +53,7 @@ def test_qasm_output_args_format():
 
 
 def test_multi_qubit_gate_validate():
-    class Dummy(cirq.Gate):
+    class Example(cirq.Gate):
         def _num_qubits_(self) -> int:
             return self._num_qubits
 
@@ -62,7 +62,7 @@ def test_multi_qubit_gate_validate():
 
     a, b, c, d = cirq.LineQubit.range(4)
 
-    g = Dummy(3)
+    g = Example(3)
 
     assert g.num_qubits() == 3
     g.validate_args([a, b, c])

--- a/cirq-core/cirq/ops/pauli_string_raw_types_test.py
+++ b/cirq-core/cirq/ops/pauli_string_raw_types_test.py
@@ -48,12 +48,12 @@ def test_op_calls_validate():
 def test_on_wrong_number_qubits():
     q0, q1, q2 = _make_qubits(3)
 
-    class DummyGate(cirq.PauliStringGateOperation):
+    class ExampleGate(cirq.PauliStringGateOperation):
         def map_qubits(self, qubit_map):
             ps = self.pauli_string.map_qubits(qubit_map)
-            return DummyGate(ps)
+            return ExampleGate(ps)
 
-    g = DummyGate(cirq.PauliString({q0: cirq.X, q1: cirq.Y}))
+    g = ExampleGate(cirq.PauliString({q0: cirq.X, q1: cirq.Y}))
 
     _ = g.with_qubits(q1, q2)
     with pytest.raises(ValueError):

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -732,11 +732,11 @@ def test_pass_operations_over_cz():
 
 
 def test_pass_operations_over_no_common_qubits():
-    class DummyGate(cirq.testing.SingleQubitGate):
+    class ExampleGate(cirq.testing.SingleQubitGate):
         pass
 
     q0, q1 = _make_qubits(2)
-    op0 = DummyGate()(q1)
+    op0 = ExampleGate()(q1)
     ps_before = cirq.PauliString({q0: cirq.Z})
     ps_after = cirq.PauliString({q0: cirq.Z})
     _assert_pass_over([op0], ps_before, ps_after)

--- a/cirq-core/cirq/ops/random_gate_channel_test.py
+++ b/cirq-core/cirq/ops/random_gate_channel_test.py
@@ -219,13 +219,13 @@ def test_stabilizer_supports_probability():
 
 
 def test_unsupported_stabilizer_safety():
-    from cirq.protocols.act_on_protocol_test import DummySimulationState
+    from cirq.protocols.act_on_protocol_test import ExampleSimulationState
 
     with pytest.raises(TypeError, match="act_on"):
         for _ in range(100):
-            cirq.act_on(cirq.X.with_probability(0.5), DummySimulationState(), qubits=())
+            cirq.act_on(cirq.X.with_probability(0.5), ExampleSimulationState(), qubits=())
     with pytest.raises(TypeError, match="act_on"):
-        cirq.act_on(cirq.X.with_probability(sympy.Symbol('x')), DummySimulationState(), qubits=())
+        cirq.act_on(cirq.X.with_probability(sympy.Symbol('x')), ExampleSimulationState(), qubits=())
 
     q = cirq.LineQubit(0)
     c = cirq.Circuit((cirq.X(q) ** 0.25).with_probability(0.5), cirq.measure(q, key='m'))

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -787,9 +787,9 @@ def test_tagged_act_on():
             pass
 
     q = cirq.LineQubit(1)
-    from cirq.protocols.act_on_protocol_test import DummySimulationState
+    from cirq.protocols.act_on_protocol_test import ExampleSimulationState
 
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     cirq.act_on(YesActOn()(q).with_tags("test"), args)
     with pytest.raises(TypeError, match="Failed to act"):
         cirq.act_on(NoActOn()(q).with_tags("test"), args)
@@ -798,11 +798,11 @@ def test_tagged_act_on():
 
 
 def test_single_qubit_gate_validates_on_each():
-    class Dummy(cirq.testing.SingleQubitGate):
+    class Example(cirq.testing.SingleQubitGate):
         def matrix(self):
             pass
 
-    g = Dummy()
+    g = Example()
     assert g.num_qubits() == 1
 
     test_qubits = [cirq.NamedQubit(str(i)) for i in range(3)]

--- a/cirq-core/cirq/protocols/act_on_protocol_test.py
+++ b/cirq-core/cirq/protocols/act_on_protocol_test.py
@@ -20,7 +20,7 @@ import pytest
 import cirq
 
 
-class DummyQuantumState(cirq.QuantumStateRepresentation):
+class ExampleQuantumState(cirq.QuantumStateRepresentation):
     def copy(self, deep_copy_buffers=True):
         pass
 
@@ -28,9 +28,9 @@ class DummyQuantumState(cirq.QuantumStateRepresentation):
         pass
 
 
-class DummySimulationState(cirq.SimulationState):
+class ExampleSimulationState(cirq.SimulationState):
     def __init__(self, fallback_result: Any = NotImplemented):
-        super().__init__(prng=np.random.RandomState(), state=DummyQuantumState())
+        super().__init__(prng=np.random.RandomState(), state=ExampleQuantumState())
         self.fallback_result = fallback_result
 
     def _act_on_fallback_(
@@ -43,18 +43,18 @@ op = cirq.X(cirq.LineQubit(0))
 
 
 def test_act_on_fallback_succeeds():
-    state = DummySimulationState(fallback_result=True)
+    state = ExampleSimulationState(fallback_result=True)
     cirq.act_on(op, state)
 
 
 def test_act_on_fallback_fails():
-    state = DummySimulationState(fallback_result=NotImplemented)
+    state = ExampleSimulationState(fallback_result=NotImplemented)
     with pytest.raises(TypeError, match='Failed to act'):
         cirq.act_on(op, state)
 
 
 def test_act_on_fallback_errors():
-    state = DummySimulationState(fallback_result=False)
+    state = ExampleSimulationState(fallback_result=False)
     with pytest.raises(ValueError, match='_act_on_fallback_ must return True or NotImplemented'):
         cirq.act_on(op, state)
 
@@ -71,7 +71,7 @@ def test_act_on_errors():
         def _act_on_(self, sim_state):
             return False
 
-    state = DummySimulationState(fallback_result=True)
+    state = ExampleSimulationState(fallback_result=True)
     with pytest.raises(ValueError, match='_act_on_ must return True or NotImplemented'):
         cirq.act_on(Op(), state)
 
@@ -85,7 +85,7 @@ def test_qubits_not_allowed_for_operations():
         def with_qubits(self, *new_qubits: 'cirq.Qid') -> Self:  # type: ignore[empty-body]
             pass
 
-    state = DummySimulationState()
+    state = ExampleSimulationState()
     with pytest.raises(
         ValueError, match='Calls to act_on should not supply qubits if the action is an Operation'
     ):
@@ -93,6 +93,6 @@ def test_qubits_not_allowed_for_operations():
 
 
 def test_qubits_should_be_defined_for_operations():
-    state = DummySimulationState()
+    state = ExampleSimulationState()
     with pytest.raises(ValueError, match='Calls to act_on should'):
         cirq.act_on(cirq.KrausChannel([np.array([[1, 0], [0, 0]])]), state, qubits=None)

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -201,7 +201,7 @@ def test_apply_unitary_args_tensor_manipulation():
                 )
                 * 1j
             )  # yapf: disable
-            # Flatten last two axes and add a dummy index to the end of
+            # Flatten last two axes and add another fake index to the end of
             # target_tensor so np.matmul treats it like an array of two-qubit
             # column vectors.
             new_shape = args.target_tensor.shape[:-2] + (4, 1)

--- a/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
@@ -83,7 +83,7 @@ def test_equal_up_to_global_mixed_array_types():
     assert not cirq.equal_up_to_global_phase([], [[]], atol=0.0)
 
 
-# Dummy container class implementing _equal_up_to_global_phase_
+# Example container class implementing _equal_up_to_global_phase_
 # for homogeneous comparison, with nontrivial getter.
 class A:
     def __init__(self, val):
@@ -95,7 +95,7 @@ class A:
         return cirq.equal_up_to_global_phase(self.val[0], other.val[0], atol=atol)
 
 
-# Dummy container class implementing _equal_up_to_global_phase_
+# Example container class implementing _equal_up_to_global_phase_
 # for heterogeneous comparison.
 class B:
     def __init__(self, val):

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -131,7 +131,7 @@ class DecomposableNoUnitary(cirq.Operation):
             yield ReturnsNotImplemented()(q)
 
 
-class DummyOperation(cirq.Operation):
+class ExampleOperation(cirq.Operation):
     qubits = ()
     with_qubits = NotImplemented
 
@@ -142,7 +142,7 @@ class DummyOperation(cirq.Operation):
         return ()
 
 
-class DummyComposite:
+class ExampleComposite:
     def _decompose_(self):
         return ()
 
@@ -231,9 +231,9 @@ def test_decompose_and_get_unitary():
         _strat_unitary_from_decompose(DecomposableOperation((a, b), True)), m2
     )
     np.testing.assert_allclose(_strat_unitary_from_decompose(DecomposableOrder((a, b, c))), m3)
-    np.testing.assert_allclose(_strat_unitary_from_decompose(DummyOperation((a,))), np.eye(2))
-    np.testing.assert_allclose(_strat_unitary_from_decompose(DummyOperation((a, b))), np.eye(4))
-    np.testing.assert_allclose(_strat_unitary_from_decompose(DummyComposite()), np.eye(1))
+    np.testing.assert_allclose(_strat_unitary_from_decompose(ExampleOperation((a,))), np.eye(2))
+    np.testing.assert_allclose(_strat_unitary_from_decompose(ExampleOperation((a, b))), np.eye(4))
+    np.testing.assert_allclose(_strat_unitary_from_decompose(ExampleComposite()), np.eye(1))
     np.testing.assert_allclose(_strat_unitary_from_decompose(OtherComposite()), m2)
 
 
@@ -248,11 +248,11 @@ def test_decomposed_has_unitary():
 
     # Operations
     assert cirq.has_unitary(DecomposableOperation((a, b), True))
-    assert cirq.has_unitary(DummyOperation((a,)))
-    assert cirq.has_unitary(DummyOperation((a, b)))
+    assert cirq.has_unitary(ExampleOperation((a,)))
+    assert cirq.has_unitary(ExampleOperation((a, b)))
 
     # No qid shape
-    assert cirq.has_unitary(DummyComposite())
+    assert cirq.has_unitary(ExampleComposite())
     assert cirq.has_unitary(OtherComposite())
 
 
@@ -267,12 +267,12 @@ def test_decomposed_unitary():
     np.testing.assert_allclose(cirq.unitary(DecomposableOperation((a,), True)), m1)
     np.testing.assert_allclose(cirq.unitary(DecomposableOperation((a, b), True)), m2)
     np.testing.assert_allclose(cirq.unitary(DecomposableOrder((a, b, c))), m3)
-    np.testing.assert_allclose(cirq.unitary(DummyOperation((a,))), np.eye(2))
-    np.testing.assert_allclose(cirq.unitary(DummyOperation((a, b))), np.eye(4))
+    np.testing.assert_allclose(cirq.unitary(ExampleOperation((a,))), np.eye(2))
+    np.testing.assert_allclose(cirq.unitary(ExampleOperation((a, b))), np.eye(4))
     assert cirq.unitary(DecomposableNoUnitary((a,)), None) is None
 
     # No qid shape
-    np.testing.assert_allclose(cirq.unitary(DummyComposite()), np.eye(1))
+    np.testing.assert_allclose(cirq.unitary(ExampleComposite()), np.eye(1))
     np.testing.assert_allclose(cirq.unitary(OtherComposite()), m2)
 
 

--- a/cirq-core/cirq/sim/simulation_state_test.py
+++ b/cirq-core/cirq/sim/simulation_state_test.py
@@ -22,7 +22,7 @@ from cirq.sim import simulation_state
 from cirq.testing import PhaseUsingCleanAncilla, PhaseUsingDirtyAncilla
 
 
-class DummyQuantumState(cirq.QuantumStateRepresentation):
+class ExampleQuantumState(cirq.QuantumStateRepresentation):
     def copy(self, deep_copy_buffers=True):
         pass
 
@@ -33,9 +33,9 @@ class DummyQuantumState(cirq.QuantumStateRepresentation):
         return self
 
 
-class DummySimulationState(cirq.SimulationState):
+class ExampleSimulationState(cirq.SimulationState):
     def __init__(self, qubits=cirq.LineQubit.range(2)):
-        super().__init__(state=DummyQuantumState(), qubits=qubits)
+        super().__init__(state=ExampleQuantumState(), qubits=qubits)
 
     def _act_on_fallback_(
         self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
@@ -73,13 +73,13 @@ class Composite(cirq.Gate):
 
 
 def test_measurements():
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     args.measure([cirq.LineQubit(0)], "test", [False], {})
     assert args.log_of_measurement_results["test"] == [5]
 
 
 def test_decompose():
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     assert simulation_state.strat_act_on_from_apply_decompose(
         Composite(), args, [cirq.LineQubit(0)]
     )
@@ -91,14 +91,14 @@ def test_decompose_for_gate_allocating_qubits_raises():
             anc = cirq.NamedQubit("anc")
             yield cirq.CNOT(*qubits, anc)
 
-    args = DummySimulationState()
+    args = ExampleSimulationState()
 
     with pytest.raises(TypeError, match="add_qubits but not remove_qubits"):
         simulation_state.strat_act_on_from_apply_decompose(Composite(), args, [cirq.LineQubit(0)])
 
 
 def test_mapping():
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     assert list(iter(args)) == cirq.LineQubit.range(2)
     r1 = args[cirq.LineQubit(0)]
     assert args is r1
@@ -109,7 +109,7 @@ def test_mapping():
 def test_swap_bad_dimensions():
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQid(1, 3)
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     with pytest.raises(ValueError, match='Cannot swap different dimensions'):
         args.swap(q0, q1)
 
@@ -117,14 +117,14 @@ def test_swap_bad_dimensions():
 def test_rename_bad_dimensions():
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQid(1, 3)
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     with pytest.raises(ValueError, match='Cannot rename to different dimensions'):
         args.rename(q0, q1)
 
 
 def test_transpose_qubits():
     q0, q1, q2 = cirq.LineQubit.range(3)
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     assert args.transpose_to_qubit_order((q1, q0)).qubits == (q1, q0)
     with pytest.raises(ValueError, match='Qubits do not match'):
         args.transpose_to_qubit_order((q0, q2))
@@ -133,7 +133,7 @@ def test_transpose_qubits():
 
 
 def test_field_getters():
-    args = DummySimulationState()
+    args = ExampleSimulationState()
     assert args.prng is np.random
     assert args.qubit_map == {q: i for i, q in enumerate(cirq.LineQubit.range(2))}
 

--- a/cirq-core/cirq/sim/simulator_test.py
+++ b/cirq-core/cirq/sim/simulator_test.py
@@ -432,7 +432,7 @@ def test_monte_carlo_on_unknown_channel():
 
 
 def test_iter_definitions():
-    dummy_trial_result = SimulationTrialResult(params={}, measurements={}, final_simulator_state=[])
+    mock_trial_result = SimulationTrialResult(params={}, measurements={}, final_simulator_state=[])
 
     class FakeNonIterSimulatorImpl(
         SimulatesAmplitudes, SimulatesExpectationValues, SimulatesFinalState
@@ -469,7 +469,7 @@ def test_iter_definitions():
             qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
             initial_state: Any = None,
         ) -> List[SimulationTrialResult]:
-            return [dummy_trial_result]
+            return [mock_trial_result]
 
     non_iter_sim = FakeNonIterSimulatorImpl()
     q0 = cirq.LineQubit(0)
@@ -485,9 +485,9 @@ def test_iter_definitions():
     ev_iter = non_iter_sim.simulate_expectation_values_sweep_iter(circuit, obs, params)
     assert next(ev_iter) == [1.0]
 
-    assert non_iter_sim.simulate_sweep(circuit, params) == [dummy_trial_result]
+    assert non_iter_sim.simulate_sweep(circuit, params) == [mock_trial_result]
     state_iter = non_iter_sim.simulate_sweep_iter(circuit, params)
-    assert next(state_iter) == dummy_trial_result
+    assert next(state_iter) == mock_trial_result
 
 
 def test_missing_iter_definitions():

--- a/cirq-core/cirq/testing/gate_features_test.py
+++ b/cirq-core/cirq/testing/gate_features_test.py
@@ -26,11 +26,11 @@ def test_two_qubit_gate_is_abstract_can_implement():
 
 
 def test_two_qubit_gate_validate_pass():
-    class Dummy(cirq.testing.TwoQubitGate):
+    class Example(cirq.testing.TwoQubitGate):
         def matrix(self):
             pass
 
-    g = Dummy()
+    g = Example()
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     q3 = cirq.NamedQubit('q3')
@@ -42,11 +42,11 @@ def test_two_qubit_gate_validate_pass():
 
 
 def test_two_qubit_gate_validate_wrong_number():
-    class Dummy(cirq.testing.TwoQubitGate):
+    class Example(cirq.testing.TwoQubitGate):
         def matrix(self):
             pass
 
-    g = Dummy()
+    g = Example()
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     q3 = cirq.NamedQubit('q3')
@@ -60,11 +60,11 @@ def test_two_qubit_gate_validate_wrong_number():
 
 
 def test_three_qubit_gate_validate():
-    class Dummy(cirq.testing.ThreeQubitGate):
+    class Example(cirq.testing.ThreeQubitGate):
         def matrix(self):
             pass
 
-    g = Dummy()
+    g = Example()
     a, b, c, d = cirq.LineQubit.range(4)
 
     assert g.num_qubits() == 3

--- a/cirq-core/cirq/transformers/expand_composite_test.py
+++ b/cirq-core/cirq/transformers/expand_composite_test.py
@@ -105,14 +105,14 @@ def test_recursive_composite():
 
 
 def test_decompose_returns_not_flat_op_tree():
-    class DummyGate(cirq.testing.SingleQubitGate):
+    class ExampleGate(cirq.testing.SingleQubitGate):
         def _decompose_(self, qubits):
             (q0,) = qubits
             # Yield a tuple of gates instead of yielding a gate
             yield cirq.X(q0),
 
     q0 = cirq.NamedQubit('q0')
-    circuit = cirq.Circuit(DummyGate()(q0))
+    circuit = cirq.Circuit(ExampleGate()(q0))
 
     circuit = cirq.expand_composite(circuit)
     expected = cirq.Circuit(cirq.X(q0))
@@ -120,7 +120,7 @@ def test_decompose_returns_not_flat_op_tree():
 
 
 def test_decompose_returns_deep_op_tree():
-    class DummyGate(cirq.testing.TwoQubitGate):
+    class ExampleGate(cirq.testing.TwoQubitGate):
         def _decompose_(self, qubits):
             q0, q1 = qubits
             # Yield a tuple
@@ -139,7 +139,7 @@ def test_decompose_returns_deep_op_tree():
             yield generator(2)
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit(DummyGate()(q0, q1))
+    circuit = cirq.Circuit(ExampleGate()(q0, q1))
 
     circuit = cirq.expand_composite(circuit)
     expected = cirq.Circuit(

--- a/cirq-core/cirq/transformers/merge_k_qubit_gates_test.py
+++ b/cirq-core/cirq/transformers/merge_k_qubit_gates_test.py
@@ -74,10 +74,10 @@ def test_ignores_2qubit_target():
 
 
 def test_ignore_unsupported_gate():
-    class UnsupportedDummy(cirq.testing.SingleQubitGate):
+    class UnsupportedExample(cirq.testing.SingleQubitGate):
         pass
 
-    c = cirq.Circuit(UnsupportedDummy()(cirq.LineQubit(0)))
+    c = cirq.Circuit(UnsupportedExample()(cirq.LineQubit(0)))
     assert_optimizes(optimized=cirq.merge_k_qubit_unitaries(c, k=1), expected=c)
 
 

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -222,7 +222,7 @@ def _category_to_classifier(category) -> Classifier:
 
 
 def _mock_classifier(op: 'cirq.Operation') -> bool:
-    """Dummy classifier, used to "complete" a collection of classifiers and make it exhaustive."""
+    """Mock classifier, used to "complete" a collection of classifiers and make it exhaustive."""
     return False  # pragma: no cover
 
 

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -182,9 +182,9 @@ def _get_classifiers(
     - Exhaustive, meaning every operation in the circuit is classified by at least one classifier.
     - Minimal, meaning unused classifiers are forgotten.
     """
-    # Convert all categories into classifiers, and make the list exhaustive by adding a dummy
-    # classifier for otherwise unclassified ops.
-    classifiers = [_category_to_classifier(cat) for cat in categories] + [_dummy_classifier]
+    # Convert all categories into classifiers, and make the list exhaustive by
+    # adding an example classifier for otherwise unclassified ops.
+    classifiers = [_category_to_classifier(cat) for cat in categories] + [_mock_classifier]
 
     # Figure out which classes are actually used in the circuit.
     class_is_used = [False for _ in classifiers]
@@ -221,7 +221,7 @@ def _category_to_classifier(category) -> Classifier:
         )
 
 
-def _dummy_classifier(op: 'cirq.Operation') -> bool:
+def _mock_classifier(op: 'cirq.Operation') -> bool:
     """Dummy classifier, used to "complete" a collection of classifiers and make it exhaustive."""
     return False  # pragma: no cover
 
@@ -229,13 +229,13 @@ def _dummy_classifier(op: 'cirq.Operation') -> bool:
 def _get_op_class(op: 'cirq.Operation', classifiers: Sequence[Classifier]) -> int:
     """Get the "class" of an operator, by index."""
     for class_index, classifier in enumerate(classifiers):
-        if classifier is _dummy_classifier:
-            dummy_classifier_index = class_index
+        if classifier is _mock_classifier:
+            mock_classifier_index = class_index
         elif classifier(op):
             return class_index
     # If we got this far, the operation did not match any "actual" classifier,
-    # so return the index of the dummy classifer.
+    # so return the index of the mock classifer.
     try:
-        return dummy_classifier_index
+        return mock_classifier_index
     except NameError:
         raise ValueError(f"Operation {op} not identified by any classifier")

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset_test.py
@@ -19,7 +19,7 @@ from cirq.protocols.decompose_protocol import DecomposeResult
 
 
 def test_compilation_target_gateset():
-    class DummyTargetGateset(cirq.CompilationTargetGateset):
+    class ExampleTargetGateset(cirq.CompilationTargetGateset):
         def __init__(self):
             super().__init__(cirq.AnyUnitaryGateFamily(2))
 
@@ -34,7 +34,7 @@ def test_compilation_target_gateset():
         def preprocess_transformers(self) -> List[cirq.TRANSFORMER]:
             return []
 
-    gateset = DummyTargetGateset()
+    gateset = ExampleTargetGateset()
 
     q = cirq.LineQubit.range(2)
     assert cirq.X(q[0]) not in gateset
@@ -57,7 +57,7 @@ def test_compilation_target_gateset():
     ]
 
 
-class DummyCXTargetGateset(cirq.TwoQubitCompilationTargetGateset):
+class ExampleCXTargetGateset(cirq.TwoQubitCompilationTargetGateset):
     def __init__(self):
         super().__init__(cirq.AnyUnitaryGateFamily(1), cirq.CNOT)
 
@@ -90,7 +90,7 @@ class DummyCXTargetGateset(cirq.TwoQubitCompilationTargetGateset):
 
 def test_two_qubit_compilation_leaves_single_gates_in_gateset():
     q = cirq.LineQubit.range(2)
-    gateset = DummyCXTargetGateset()
+    gateset = ExampleCXTargetGateset()
 
     c = cirq.Circuit(cirq.X(q[0]) ** 0.5)
     cirq.testing.assert_same_circuits(cirq.optimize_for_target_gateset(c, gateset=gateset), c)
@@ -103,7 +103,7 @@ def test_two_qubit_compilation_merges_runs_of_single_qubit_gates():
     q = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CNOT(*q), cirq.X(q[0]), cirq.Y(q[0]), cirq.CNOT(*q))
     cirq.testing.assert_same_circuits(
-        cirq.optimize_for_target_gateset(c, gateset=DummyCXTargetGateset()),
+        cirq.optimize_for_target_gateset(c, gateset=ExampleCXTargetGateset()),
         cirq.Circuit(
             cirq.CNOT(*q),
             cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0, z_exponent=-1).on(q[0]),
@@ -113,7 +113,7 @@ def test_two_qubit_compilation_merges_runs_of_single_qubit_gates():
 
 
 def test_two_qubit_compilation_decompose_operation_not_implemented():
-    gateset = DummyCXTargetGateset()
+    gateset = ExampleCXTargetGateset()
     q = cirq.LineQubit.range(3)
     assert gateset.decompose_to_target_gateset(cirq.measure(q[0]), 1) is NotImplemented
     assert gateset.decompose_to_target_gateset(cirq.measure(*q[:2]), 1) is NotImplemented
@@ -145,7 +145,7 @@ def test_two_qubit_compilation_merge_and_replace_to_target_gateset():
     )
     c_new = cirq.optimize_for_target_gateset(
         c_orig,
-        gateset=DummyCXTargetGateset(),
+        gateset=ExampleCXTargetGateset(),
         context=cirq.TransformerContext(tags_to_ignore=("no_compile",)),
     )
     cirq.testing.assert_has_diagram(
@@ -187,7 +187,7 @@ m: ═════════════════════════�
     )
     c_new = cirq.optimize_for_target_gateset(
         c_orig,
-        gateset=DummyCXTargetGateset(),
+        gateset=ExampleCXTargetGateset(),
         context=cirq.TransformerContext(tags_to_ignore=("no_compile",)),
     )
     cirq.testing.assert_has_diagram(
@@ -203,7 +203,7 @@ m: ═════════════════════════�
 
 
 def test_two_qubit_compilation_replaces_only_if_2q_gate_count_is_less():
-    class DummyTargetGateset(cirq.TwoQubitCompilationTargetGateset):
+    class ExampleTargetGateset(cirq.TwoQubitCompilationTargetGateset):
         def __init__(self):
             super().__init__(cirq.X, cirq.CNOT)
 
@@ -218,7 +218,7 @@ def test_two_qubit_compilation_replaces_only_if_2q_gate_count_is_less():
     ops = [cirq.Y.on_each(*q), cirq.CNOT(*q), cirq.Z.on_each(*q)]
     c_orig = cirq.Circuit(ops)
     c_expected = cirq.Circuit(cirq.X.on_each(*q), ops[-2:])
-    c_new = cirq.optimize_for_target_gateset(c_orig, gateset=DummyTargetGateset())
+    c_new = cirq.optimize_for_target_gateset(c_orig, gateset=ExampleTargetGateset())
     cirq.testing.assert_same_circuits(c_new, c_expected)
 
 

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
@@ -260,18 +260,18 @@ def test_avoids_decompose_when_matrix_available():
 
 
 def test_composite_gates_without_matrix():
-    class CompositeDummy(cirq.testing.SingleQubitGate):
+    class CompositeExample(cirq.testing.SingleQubitGate):
         def _decompose_(self, qubits):
             yield cirq.X(qubits[0])
             yield cirq.Y(qubits[0]) ** 0.5
 
-    class CompositeDummy2(cirq.testing.TwoQubitGate):
+    class CompositeExample2(cirq.testing.TwoQubitGate):
         def _decompose_(self, qubits):
             yield cirq.CZ(qubits[0], qubits[1])
-            yield CompositeDummy()(qubits[1])
+            yield CompositeExample()(qubits[1])
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit(CompositeDummy()(q0), CompositeDummy2()(q0, q1))
+    circuit = cirq.Circuit(CompositeExample()(q0), CompositeExample2()(q0, q1))
     expected = cirq.Circuit(
         cirq.X(q0), cirq.Y(q0) ** 0.5, cirq.CZ(q0, q1), cirq.X(q1), cirq.Y(q1) ** 0.5
     )
@@ -288,11 +288,11 @@ def test_composite_gates_without_matrix():
 
 
 def test_unsupported_gate():
-    class UnsupportedDummy(cirq.testing.TwoQubitGate):
+    class UnsupportedExample(cirq.testing.TwoQubitGate):
         pass
 
     q0, q1 = cirq.LineQubit.range(2)
-    circuit = cirq.Circuit(UnsupportedDummy()(q0, q1))
+    circuit = cirq.Circuit(UnsupportedExample()(q0, q1))
     assert circuit == cirq.optimize_for_target_gateset(circuit, gateset=cirq.CZTargetGateset())
     with pytest.raises(ValueError, match='Unable to convert'):
         _ = cirq.optimize_for_target_gateset(

--- a/cirq-core/cirq/work/observable_measurement_test.py
+++ b/cirq-core/cirq/work/observable_measurement_test.py
@@ -432,7 +432,7 @@ def _get_some_grouped_settings():
 
 
 def test_measure_grouped_settings_calibration_validation():
-    dummy_ro_calib = _MockBitstringAccumulator()
+    mock_ro_calib = _MockBitstringAccumulator()
     grouped_settings, qubits = _get_some_grouped_settings()
 
     with pytest.raises(
@@ -443,7 +443,7 @@ def test_measure_grouped_settings_calibration_validation():
             grouped_settings=grouped_settings,
             sampler=cirq.Simulator(),
             stopping_criteria=cw.RepetitionsStoppingCriteria(10_000),
-            readout_calibrations=dummy_ro_calib,
+            readout_calibrations=mock_ro_calib,
             readout_symmetrization=False,  # no-no!
         )
 

--- a/cirq-core/cirq/work/zeros_sampler.py
+++ b/cirq-core/cirq/work/zeros_sampler.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class ZerosSampler(work.Sampler, metaclass=abc.ABCMeta):
-    """A dummy sampler for testing. Immediately returns zeroes."""
+    """A mock sampler for testing. Immediately returns zeroes."""
 
     def __init__(self, device: Optional[devices.Device] = None):
         """Construct a sampler that returns 0 for all measurements.


### PR DESCRIPTION
- Latest best practice advice is to remove all mentions of the word 'dummy' as it is problematic terminology.