### PR TITLE
Remove leftover dummy terms from Cirq sources

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_sampler_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler_test.py
@@ -204,7 +204,7 @@ def test_aqt_sampler_ms():
     _, qubits = get_aqt_device(num_qubits)
     sampler = AQTSamplerLocalSimulator()
     circuit = cirq.Circuit(cirq.Z.on_each(*qubits), cirq.Z.on_each(*qubits))
-    for _dummy in range(9):
+    for _ in range(9):
         circuit.append(cirq.XX(qubits[0], qubits[1]) ** 0.5)
     circuit.append(cirq.Z(qubits[0]) ** 0.5)
     results = sampler.run(circuit, repetitions=repetitions)

--- a/cirq-ft/cirq_ft/algos/mean_estimation/complex_phase_oracle_test.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/complex_phase_oracle_test.py
@@ -27,7 +27,7 @@ from cirq_ft.infra import testing as cq_testing
 
 
 @frozen
-class DummySelect(cirq_ft.SelectOracle):
+class ExampleSelect(cirq_ft.SelectOracle):
     bitsize: int
     control_val: Optional[int] = None
 
@@ -50,7 +50,7 @@ class DummySelect(cirq_ft.SelectOracle):
 @pytest.mark.parametrize('bitsize', [2, 3, 4, 5])
 @pytest.mark.parametrize('arctan_bitsize', [5, 6, 7])
 def test_phase_oracle(bitsize: int, arctan_bitsize: int):
-    phase_oracle = ComplexPhaseOracle(DummySelect(bitsize), arctan_bitsize)
+    phase_oracle = ComplexPhaseOracle(ExampleSelect(bitsize), arctan_bitsize)
     g = cq_testing.GateHelper(phase_oracle)
 
     # Prepare uniform superposition state on selection register and apply phase oracle.
@@ -78,6 +78,6 @@ def test_phase_oracle(bitsize: int, arctan_bitsize: int):
 
 def test_phase_oracle_consistent_protocols():
     bitsize, arctan_bitsize = 3, 5
-    gate = ComplexPhaseOracle(DummySelect(bitsize, 1), arctan_bitsize)
+    gate = ComplexPhaseOracle(ExampleSelect(bitsize, 1), arctan_bitsize)
     expected_symbols = ('@',) + ('ROTy',) * bitsize
     assert cirq.circuit_diagram_info(gate).wire_symbols == expected_symbols

--- a/cirq-ft/cirq_ft/infra/jupyter_tools_test.py
+++ b/cirq-ft/cirq_ft/infra/jupyter_tools_test.py
@@ -39,10 +39,10 @@ def test_svg_circuit():
 def test_display_gate_and_compilation(monkeypatch):
     call_args = []
 
-    def _dummy_display(stuff):
+    def _mock_display(stuff):
         call_args.append(stuff)
 
-    monkeypatch.setattr(IPython.display, "display", _dummy_display)
+    monkeypatch.setattr(IPython.display, "display", _mock_display)
     g = cq_testing.GateHelper(cirq_ft.And(cv=(1, 1, 1)))
     display_gate_and_compilation(g)
 

--- a/cirq-google/cirq_google/calibration/engine_simulator_test.py
+++ b/cirq-google/cirq_google/calibration/engine_simulator_test.py
@@ -27,7 +27,7 @@ import cirq
 SQRT_ISWAP_INV_GATE = cirq.FSimGate(np.pi / 4, 0.0)
 
 
-class DummyPhasedFSimCalibrationRequest(PhasedFSimCalibrationRequest):
+class ExamplePhasedFSimCalibrationRequest(PhasedFSimCalibrationRequest):
     def to_calibration_layer(self) -> cirq_google.CalibrationLayer:
         return NotImplemented
 
@@ -39,7 +39,7 @@ class DummyPhasedFSimCalibrationRequest(PhasedFSimCalibrationRequest):
 
 def test_test_calibration_request():
     a, b = cirq.LineQubit.range(2)
-    request = DummyPhasedFSimCalibrationRequest(
+    request = ExamplePhasedFSimCalibrationRequest(
         gate=cirq.FSimGate(np.pi / 4, 0.5),
         pairs=((a, b),),
         options=ALL_ANGLES_FLOQUET_PHASED_FSIM_CHARACTERIZATION,
@@ -108,7 +108,7 @@ def test_floquet_get_calibrations_when_invalid_request_fails():
     with pytest.raises(ValueError):
         engine_simulator.get_calibrations(
             [
-                DummyPhasedFSimCalibrationRequest(
+                ExamplePhasedFSimCalibrationRequest(
                     gate=cirq.FSimGate(np.pi / 4, 0.5),
                     pairs=((a, b),),
                     options=ALL_ANGLES_FLOQUET_PHASED_FSIM_CHARACTERIZATION,

--- a/cirq-google/cirq_google/workflow/processor_record_test.py
+++ b/cirq-google/cirq_google/workflow/processor_record_test.py
@@ -20,13 +20,13 @@ import cirq
 import cirq_google as cg
 
 
-class _DummyProcessorRecord(cg.ProcessorRecord):
+class _ExampleProcessorRecord(cg.ProcessorRecord):
     def get_processor(self) -> 'cg.engine.AbstractProcessor':
-        return cg.engine.SimulatedLocalProcessor(processor_id='dummy')
+        return cg.engine.SimulatedLocalProcessor(processor_id='example')
 
 
 def test_abstract_processor_record():
-    proc_rec = _DummyProcessorRecord()
+    proc_rec = _ExampleProcessorRecord()
     assert isinstance(proc_rec.get_processor(), cg.engine.AbstractProcessor)
     assert isinstance(proc_rec.get_sampler(), cirq.Sampler)
     assert isinstance(proc_rec.get_device(), cirq.Device)


### PR DESCRIPTION
Follow up to #6356.  Replace non-inclusive terminology.
