### PR TITLE
Add at least one output to the start notebook 

### DIFF
--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -175,12 +175,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "metadata": {
         "cellView": "both",
-        "id": "EQoTYZIEPa9S"
+        "id": "EQoTYZIEPa9S",
+        "outputId": "43c72568-3bc8-4b44-871b-b9db19c9e672",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Circuit:\n",
+            "(0, 0): ───X───M('result')───\n"
+          ]
+        }
+      ],
       "source": [
         "# Define a qubit at an arbitrary grid location.\n",
         "qubit = cirq.GridQubit(0, 0)\n",


### PR DESCRIPTION
The tensorflow import tool will skip trying to run any notebook that has **any** output, and instead publishes the notebook as is to the website. This includes a print of a simple circuit to get around the import tool.