### PR TITLE
Fix brew cask install mactex command in macOS tutorial.

### DIFF
--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -109,7 +109,7 @@ or internal Google systems.
     Install system dependencies that pip can't handle.
 
     ```bash
-    brew cask install mactex
+    brew install --cask mactex
     ```
 
     - Without `mactex`, pdf writing functionality will not work.


### PR DESCRIPTION
To install the mactex cask with the current version of Homebrew, the command should be changed.

See also https://github.com/orgs/Homebrew/discussions/902