### PR TITLE
Short-circuit value equality with an identity check

### DIFF
--- a/cirq-core/cirq/_compat_test.py
+++ b/cirq-core/cirq/_compat_test.py
@@ -636,6 +636,7 @@ _repeated_child_deprecation_msg = [
 
 
 def _trace_unhandled_exceptions(*args, queue: 'multiprocessing.Queue', func: Callable, **kwargs):
+    logging.basicConfig(level=logging.DEBUG)
     try:
         func(*args, **kwargs)
         queue.put(None)

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -70,6 +70,8 @@ class _SupportsValueEquality(Protocol):
 
 
 def _value_equality_eq(self: _SupportsValueEquality, other: _SupportsValueEquality) -> bool:
+    if other is self:
+        return True
     cls_self = self._value_equality_values_cls_()
     get_cls_other = getattr(other, '_value_equality_values_cls_', None)
     if get_cls_other is None:
@@ -91,6 +93,8 @@ def _value_equality_hash(self: _SupportsValueEquality) -> int:
 def _value_equality_approx_eq(
     self: _SupportsValueEquality, other: _SupportsValueEquality, atol: float
 ) -> bool:
+    if other is self:
+        return True
     cls_self = self._value_equality_values_cls_()
     get_cls_other = getattr(other, '_value_equality_values_cls_', None)
     if get_cls_other is None:


### PR DESCRIPTION
We often reuse instances of objects with value semantics, and in such cases equality checking can be short-circuited by first checking for object identity before falling back to actually comparing the values of two objects. This is particular beneficial if we actually take care to reuse instances, which is something we should consider doing more generally to avoid object allocation and repeated computation of various properties such as hashes (see https://github.com/quantumlib/Cirq/pull/6371).