### PR TITLE
Skip cloned env tests on macOS

### DIFF
--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -24,6 +24,7 @@ import pytest
 
 from dev_tools import shell_tools
 
+
 # These tests fail in a macOS virtual environment.
 # Related: https://github.com/quantumlib/Cirq/issues/6377
 @pytest.mark.skipif(sys.platform == "darwin", reason="Non-macOS test")

--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -25,6 +25,7 @@ import pytest
 from dev_tools import shell_tools
 from dev_tools.test_utils import only_on_posix
 
+
 # due to shell_tools dependencies windows builds break on this
 # see https://github.com/quantumlib/Cirq/issues/4394
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")

--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -25,9 +25,11 @@ import pytest
 from dev_tools import shell_tools
 
 
+# due to shell_tools dependencies windows builds break on this
+# see https://github.com/quantumlib/Cirq/issues/4394
 # These tests fail in a macOS virtual environment.
 # Related: https://github.com/quantumlib/Cirq/issues/6377
-@pytest.mark.skipif(sys.platform == "darwin", reason="Non-macOS test")
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 # ensure that no cirq packages are on the PYTHONPATH, this is important, otherwise
 # the "isolation" fails and all the cirq modules would be in the list
 @mock.patch.dict(os.environ, {"PYTHONPATH": ""})

--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -23,12 +23,10 @@ from unittest import mock
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.test_utils import only_on_posix
 
-
-# due to shell_tools dependencies windows builds break on this
-# see https://github.com/quantumlib/Cirq/issues/4394
-@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
+# These tests fail in a macOS virtual environment.
+# Related: https://github.com/quantumlib/Cirq/issues/6377
+@pytest.mark.skipif(sys.platform == "darwin", reason="Non-macOS test")
 # ensure that no cirq packages are on the PYTHONPATH, this is important, otherwise
 # the "isolation" fails and all the cirq modules would be in the list
 @mock.patch.dict(os.environ, {"PYTHONPATH": ""})

--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -17,6 +17,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from unittest import mock
 
 import pytest
@@ -24,10 +25,9 @@ import pytest
 from dev_tools import shell_tools
 from dev_tools.test_utils import only_on_posix
 
-
 # due to shell_tools dependencies windows builds break on this
 # see https://github.com/quantumlib/Cirq/issues/4394
-@only_on_posix
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only test")
 # ensure that no cirq packages are on the PYTHONPATH, this is important, otherwise
 # the "isolation" fails and all the cirq modules would be in the list
 @mock.patch.dict(os.environ, {"PYTHONPATH": ""})


### PR DESCRIPTION
Related issue: #6377

Make cloned environment tests skip on macOS due to failure. I followed the instructions in [`development.md`](https://github.com/quantumlib/Cirq/blob/main/docs/dev/development.md) exactly, but no luck with these specific tests. Until that issue is resolved, they should only be run on linux.