### PR TITLE
Optimize cached_method when wrapping no-arg methods

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -67,6 +67,10 @@ except ImportError:
     from backports.cached_property import cached_property  # type: ignore[no-redef]
 
 
+# Sentinel used by wrapped_no_args below when method has not yet been cached.
+_NOT_FOUND = object()
+
+
 TFunc = TypeVar('TFunc', bound=Callable)
 
 
@@ -103,9 +107,11 @@ def cached_method(method: Optional[TFunc] = None, *, maxsize: int = 128) -> Any:
 
             @functools.wraps(func)
             def wrapped_no_args(self):
-                if not hasattr(self, cache_name):
-                    object.__setattr__(self, cache_name, func(self))
-                return getattr(self, cache_name)
+                result = getattr(self, cache_name, _NOT_FOUND)
+                if result is _NOT_FOUND:
+                    result = func(self)
+                    object.__setattr__(self, cache_name, result)
+                return result
 
             return wrapped_no_args
 


### PR DESCRIPTION
Previously, the first time a no-arg cached method was called the decorator would make three calls: `hasattr`, `object.__setattr__`, `getattr`, and when called subsequently it would make two calls: `hasattr`, `getattr`. Here we refactor the implementation to use a sentinel value so that on the first call we only make two calls: `getattr`, `object.__setattr__`, and when called subsequently we only make a single `getattr` call.