### PR TITLE
Add exponential fitting to RandomizedBenchMarkResult

### DIFF
--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -107,6 +107,7 @@ class RandomizedBenchMarkResult:
     def pauli_error(self) -> float:
         r"""Returns the Pauli error inferred from randomized benchmarking.
         
+        
         If sequence fidelity $F$ decays with number of gates $m$ as
 
         $F = A p^m + B$

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -121,7 +121,7 @@ class RandomizedBenchMarkResult:
         p = opt_params[2]
         return (1.0 - 1.0 / 4.0) * (1.0 - p)
 
-    def _fit_exponential(self) -> tuple:
+    def _fit_exponential(self) -> Tuple[np.ndarray, np.ndarray]:
         exp_fit = lambda x, A, B, p: A * p**x + B
         return curve_fit(
             f=exp_fit,

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -93,23 +93,24 @@ class RandomizedBenchMarkResult:
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))  # pragma: no cover
             ax = cast(plt.Axes, ax)  # pragma: no cover
         ax.set_ylim((0.0, 1.0))  # pragma: no cover
-        ax.plot(self._num_cfds_seq, self._gnd_state_probs, 'ro', **plot_kwargs)
+        ax.plot(self._num_cfds_seq, self._gnd_state_probs, 'ro', label='data', **plot_kwargs)
         x = np.linspace(self._num_cfds_seq[0], self._num_cfds_seq[-1], 100)
         fit = self._fit_exponential()
-        ax.plot(x, fit[0][0] * fit[0][2] ** x + fit[0][1], '--k')
+        ax.plot(x, fit[0][0] * fit[0][2] ** x + fit[0][1], '--k', label='fit')
+        ax.legend(loc='upper right')
         ax.set_xlabel(r"Number of Cliffords")
         ax.set_ylabel('Ground State Probability')
         if show_plot:
             fig.show()
         return ax
 
-    def pauli_error(self):
+    def pauli_error(self) -> float:
         """Returns the Pauli error inferred from randomized benchmarking."""
         fit = self._fit_exponential()
         p = fit[0][2]
         return (1.0 - 1.0 / 4.0) * (1.0 - p)
 
-    def _fit_exponential(self):
+    def _fit_exponential(self) -> np.ndarray:
         exp_fit = lambda x, A, B, p: A * p**x + B
         return curve_fit(
             exp_fit,

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -95,8 +95,8 @@ class RandomizedBenchMarkResult:
         ax.set_ylim((0.0, 1.0))  # pragma: no cover
         ax.plot(self._num_cfds_seq, self._gnd_state_probs, 'ro', label='data', **plot_kwargs)
         x = np.linspace(self._num_cfds_seq[0], self._num_cfds_seq[-1], 100)
-        fit = self._fit_exponential()
-        ax.plot(x, fit[0][0] * fit[0][2] ** x + fit[0][1], '--k', label='fit')
+        opt_params, *_ = self._fit_exponential()
+        ax.plot(x, opt_params[0] * opt_params[2] ** x + opt_params[1], '--k', label='fit')
         ax.legend(loc='upper right')
         ax.set_xlabel(r"Number of Cliffords")
         ax.set_ylabel('Ground State Probability')
@@ -105,29 +105,29 @@ class RandomizedBenchMarkResult:
         return ax
 
     def pauli_error(self) -> float:
-        """Returns the Pauli error inferred from randomized benchmarking.
+        r"""Returns the Pauli error inferred from randomized benchmarking.
+        
+        If sequence fidelity $F$ decays with number of gates $m$ as
 
-        If sequence fidelity (F) decays with number of gates (m) as
+        $F = A p^m + B$
 
-        F = A p^m + B
+        where $0 < p < 1$, then the Pauli error $r_p$ is given by
 
-        where 0 < p < 1, then the Pauli error (r_p) is given by
+        $r_p = (1 - 1/d^2) * (1 - p)$
 
-        r_p = (1 - 1/d^2) * (1 - p)
-
-        Where d = 2^num_qubits is the Hilbert space dimension.
+        Where $d = 2^N_Q$ is the Hilbert space dimension and $N_Q$ is the number of qubits.
         """
-        fit = self._fit_exponential()
-        p = fit[0][2]
+        opt_params, *_ = self._fit_exponential()
+        p = opt_params[2]
         return (1.0 - 1.0 / 4.0) * (1.0 - p)
 
     def _fit_exponential(self) -> np.ndarray:
         exp_fit = lambda x, A, B, p: A * p**x + B
         return curve_fit(
-            exp_fit,
-            self._num_cfds_seq,
-            self._gnd_state_probs,
-            [0.5, 0.5, 1.0 - 1e-3],
+            f=exp_fit,
+            xdata=self._num_cfds_seq,
+            ydata=self._gnd_state_probs,
+            p0=[0.5, 0.5, 1.0 - 1e-3],
             bounds=([0, 0.25, 0], [0.5, 0.75, 1]),
         )
 

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -109,13 +109,13 @@ class RandomizedBenchMarkResult:
 
         If sequence fidelity $F$ decays with number of gates $m$ as
 
-        $F = A p^m + B$
+        $$F = A p^m + B,$$
 
         where $0 < p < 1$, then the Pauli error $r_p$ is given by
 
-        $r_p = (1 - 1/d^2) * (1 - p)$
+        $$r_p = (1 - 1/d^2) * (1 - p),$$
 
-        Where $d = 2^N_Q$ is the Hilbert space dimension and $N_Q$ is the number of qubits.
+        where $d = 2^N_Q$ is the Hilbert space dimension and $N_Q$ is the number of qubits.
         """
         opt_params, _ = self._fit_exponential()
         p = opt_params[2]

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -106,8 +106,7 @@ class RandomizedBenchMarkResult:
 
     def pauli_error(self) -> float:
         r"""Returns the Pauli error inferred from randomized benchmarking.
-        
-        
+
         If sequence fidelity $F$ decays with number of gates $m$ as
 
         $F = A p^m + B$

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -105,7 +105,18 @@ class RandomizedBenchMarkResult:
         return ax
 
     def pauli_error(self) -> float:
-        """Returns the Pauli error inferred from randomized benchmarking."""
+        """Returns the Pauli error inferred from randomized benchmarking.
+
+        If sequence fidelity (F) decays with number of gates (m) as
+
+        F = A p^m + B
+
+        where 0 < p < 1, then the Pauli error (r_p) is given by
+
+        r_p = (1 - 1/d^2) * (1 - p)
+
+        Where d = 2^num_qubits is the Hilbert space dimension.
+        """
         fit = self._fit_exponential()
         p = fit[0][2]
         return (1.0 - 1.0 / 4.0) * (1.0 - p)

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -95,7 +95,7 @@ class RandomizedBenchMarkResult:
         ax.set_ylim((0.0, 1.0))  # pragma: no cover
         ax.plot(self._num_cfds_seq, self._gnd_state_probs, 'ro', label='data', **plot_kwargs)
         x = np.linspace(self._num_cfds_seq[0], self._num_cfds_seq[-1], 100)
-        opt_params, *_ = self._fit_exponential()
+        opt_params, _ = self._fit_exponential()
         ax.plot(x, opt_params[0] * opt_params[2] ** x + opt_params[1], '--k', label='fit')
         ax.legend(loc='upper right')
         ax.set_xlabel(r"Number of Cliffords")
@@ -117,11 +117,11 @@ class RandomizedBenchMarkResult:
 
         Where $d = 2^N_Q$ is the Hilbert space dimension and $N_Q$ is the number of qubits.
         """
-        opt_params, *_ = self._fit_exponential()
+        opt_params, _ = self._fit_exponential()
         p = opt_params[2]
         return (1.0 - 1.0 / 4.0) * (1.0 - p)
 
-    def _fit_exponential(self) -> np.ndarray:
+    def _fit_exponential(self) -> tuple:
         exp_fit = lambda x, A, B, p: A * p**x + B
         return curve_fit(
             f=exp_fit,

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -91,6 +91,7 @@ def test_single_qubit_randomized_benchmarking():
     )
     g_pops = np.asarray(results.data)[:, 1]
     assert np.isclose(np.mean(g_pops), 1.0)
+    assert np.isclose(results.pauli_error(), 0.0)  # warning is expected
 
 
 def test_two_qubit_randomized_benchmarking():

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -89,7 +89,7 @@ def test_single_qubit_randomized_benchmarking():
     results = single_qubit_randomized_benchmarking(simulator, qubit, num_clifford_range=num_cfds)
     g_pops = np.asarray(results.data)[:, 1]
     assert np.isclose(np.mean(g_pops), 1.0)
-    assert np.isclose(results.pauli_error(), 0.0)  # warning is expected
+    assert np.isclose(results.pauli_error(), 0.0, atol=1e-7)  # warning is expected
 
 
 def test_two_qubit_randomized_benchmarking():

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -85,10 +85,8 @@ def test_single_qubit_randomized_benchmarking():
     # sequences is always unity.
     simulator = sim.Simulator()
     qubit = GridQubit(0, 0)
-    num_cfds = range(5, 20, 5)
-    results = single_qubit_randomized_benchmarking(
-        simulator, qubit, num_clifford_range=num_cfds, repetitions=100
-    )
+    num_cfds = tuple(np.logspace(np.log10(5), 3, 5, dtype=int))
+    results = single_qubit_randomized_benchmarking(simulator, qubit, num_clifford_range=num_cfds)
     g_pops = np.asarray(results.data)[:, 1]
     assert np.isclose(np.mean(g_pops), 1.0)
     assert np.isclose(results.pauli_error(), 0.0)  # warning is expected


### PR DESCRIPTION
Adds exponential fitting in order to extract the single-qubit error rates from the measured data.