### PR TITLE
Don't create a new list of qubits in `Gate.on`

### DIFF
--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -230,7 +230,7 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         Returns: a `cirq.Operation` which is this gate applied to the given
             qubits.
         """
-        return ops.gate_operation.GateOperation(self, list(qubits))
+        return ops.gate_operation.GateOperation(self, qubits)
 
     def on_each(self, *targets: Union[Qid, Iterable[Any]]) -> List['cirq.Operation']:
         """Returns a list of operations applying the gate to all targets.


### PR DESCRIPTION
The value received from `*qubits` is a tuple, and `GateOperation.__init__` would immediately convert the passed-in list back to a tuple anyway, so we can save on lots of small allocations by just passing the tuple of args through to `GateOperation`.