### PR TITLE
Remove cached_property backport 

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -61,12 +61,6 @@ def with_debug(value: bool) -> Iterator[None]:
         __cirq_debug__.reset(token)
 
 
-try:
-    from functools import cached_property  # pylint: disable=unused-import
-except ImportError:
-    from backports.cached_property import cached_property  # type: ignore[no-redef]
-
-
 # Sentinel used by wrapped_no_args below when method has not yet been cached.
 _NOT_FOUND = object()
 

--- a/cirq-core/cirq/_compat_test.py
+++ b/cirq-core/cirq/_compat_test.py
@@ -38,7 +38,6 @@ import cirq.testing
 from cirq._compat import (
     block_overlapping_deprecation,
     cached_method,
-    cached_property,
     proper_repr,
     dataclass_repr,
     deprecated,
@@ -1009,23 +1008,6 @@ def test_block_overlapping_deprecation():
 
     with cirq.testing.assert_deprecated('f', deadline='v1000.0', count=1):
         f(5)
-
-
-def test_cached_property():
-    class Foo:
-        def __init__(self):
-            self.bar_calls = 0
-
-        @cached_property
-        def bar(self):
-            self.bar_calls += 1
-            return []
-
-    foo = Foo()
-    bar = foo.bar
-    bar2 = foo.bar
-    assert bar2 is bar
-    assert foo.bar_calls == 1
 
 
 class Bar:

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -19,6 +19,7 @@ applied as part of a larger circuit, a CircuitOperation will execute all
 component operations in order, including any nested CircuitOperations.
 """
 import math
+from functools import cached_property
 from typing import (
     Callable,
     cast,
@@ -38,7 +39,7 @@ import numpy as np
 import sympy
 
 from cirq import circuits, ops, protocols, value, study
-from cirq._compat import cached_property, proper_repr
+from cirq._compat import proper_repr
 
 if TYPE_CHECKING:
     import cirq

--- a/cirq-core/cirq/circuits/frozen_circuit.py
+++ b/cirq-core/cirq/circuits/frozen_circuit.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """An immutable version of the Circuit data structure."""
+from functools import cached_property
 from typing import (
     AbstractSet,
     FrozenSet,
@@ -90,7 +91,7 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
         """Returns a tuple of the Circuit's tags."""
         return self._tags
 
-    @_compat.cached_property
+    @cached_property
     def untagged(self) -> 'cirq.FrozenCircuit':
         """Returns the underlying FrozenCircuit without any tags."""
         return self._from_moments(self._moments) if self.tags else self
@@ -148,7 +149,7 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
     def all_qubits(self) -> FrozenSet['cirq.Qid']:
         return super().all_qubits()
 
-    @_compat.cached_property
+    @cached_property
     def _all_operations(self) -> Tuple['cirq.Operation', ...]:
         return tuple(super().all_operations())
 

--- a/cirq-core/cirq/devices/superconducting_qubits_noise_properties.py
+++ b/cirq-core/cirq/devices/superconducting_qubits_noise_properties.py
@@ -17,9 +17,10 @@
 
 import abc
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Dict, TYPE_CHECKING, List, Set, Type
 
-from cirq import _compat, ops, devices
+from cirq import ops, devices
 from cirq.devices import noise_utils
 
 if TYPE_CHECKING:
@@ -131,7 +132,7 @@ class SuperconductingQubitsNoiseProperties(devices.NoiseProperties, abc.ABC):
             p_error -= noise_utils.decoherence_pauli_error(self.t1_ns[q], self.tphi_ns[q], time_ns)
         return p_error
 
-    @_compat.cached_property
+    @cached_property
     def _depolarizing_error(self) -> Dict[noise_utils.OpIdentifier, float]:
         """Returns the portion of Pauli error from depolarization."""
         depol_errors = {}

--- a/cirq-core/cirq/ops/control_values.py
+++ b/cirq-core/cirq/ops/control_values.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
+from functools import cached_property
 from typing import Collection, Tuple, TYPE_CHECKING, Any, Dict, Iterator, Optional, Sequence, Union
 import itertools
 
-from cirq import protocols, value, _compat
+from cirq import protocols, value
 
 if TYPE_CHECKING:
     import cirq
@@ -144,7 +145,7 @@ class ProductOfSums(AbstractControlValues):
             (cv,) if isinstance(cv, int) else tuple(sorted(set(cv))) for cv in data
         )
 
-    @_compat.cached_property
+    @cached_property
     def is_trivial(self) -> bool:
         return self._qubit_sums == ((1,),) * self._num_qubits_()
 
@@ -252,7 +253,7 @@ class SumOfProducts(AbstractControlValues):
         if not all(len(p) == num_qubits for p in self._conjunctions):
             raise ValueError(f'Each term of {self._conjunctions} should be of length {num_qubits}.')
 
-    @_compat.cached_property
+    @cached_property
     def is_trivial(self) -> bool:
         return self._conjunctions == ((1,) * self._num_qubits_(),)
 

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -14,6 +14,7 @@
 """Abstract classes for simulations which keep track of state vector."""
 
 import abc
+from functools import cached_property
 from typing import Any, Dict, Iterator, Sequence, Type, TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
@@ -121,7 +122,7 @@ class StateVectorTrialResult(
             qubit_map=final_simulator_state.qubit_map,
         )
 
-    @_compat.cached_property
+    @cached_property
     def final_state_vector(self) -> np.ndarray:
         return self._get_merged_sim_state().target_tensor.reshape(-1)
 

--- a/cirq-ft/cirq_ft/algos/and_gate.py
+++ b/cirq-ft/cirq_ft/algos/and_gate.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Sequence, Tuple
 
 import numpy as np
@@ -19,7 +20,6 @@ from numpy.typing import NDArray
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from cirq_ft import infra
 
 

--- a/cirq-ft/cirq_ft/algos/apply_gate_to_lth_target.py
+++ b/cirq-ft/cirq_ft/algos/apply_gate_to_lth_target.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 import itertools
 from typing import Callable, Sequence, Tuple
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import unary_iteration_gate
 

--- a/cirq-ft/cirq_ft/algos/arithmetic_gates.py
+++ b/cirq-ft/cirq_ft/algos/arithmetic_gates.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Iterable, Iterator, List, Optional, Sequence, Tuple, Union
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from numpy.typing import NDArray
 
 from cirq_ft import infra

--- a/cirq-ft/cirq_ft/algos/generic_select.py
+++ b/cirq-ft/cirq_ft/algos/generic_select.py
@@ -14,13 +14,13 @@
 
 """Gates for applying generic selected unitaries."""
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 from numpy.typing import NDArray
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import select_and_prepare, unary_iteration_gate
 

--- a/cirq-ft/cirq_ft/algos/hubbard_model.py
+++ b/cirq-ft/cirq_ft/algos/hubbard_model.py
@@ -46,13 +46,13 @@ considered in both the PREPARE and SELECT operations corresponding to the terms 
 
 See the documentation for `PrepareHubbard` and `SelectHubbard` for details.
 """
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 from numpy.typing import NDArray
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import and_gate, apply_gate_to_lth_target, arithmetic_gates
 from cirq_ft.algos import prepare_uniform_superposition as prep_u

--- a/cirq-ft/cirq_ft/algos/mean_estimation/complex_phase_oracle.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/complex_phase_oracle.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 from numpy.typing import NDArray
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import select_and_prepare
 from cirq_ft.algos.mean_estimation import arctan

--- a/cirq-ft/cirq_ft/algos/mean_estimation/complex_phase_oracle_test.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/complex_phase_oracle_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 import math
 from typing import Optional, Tuple
 
@@ -20,7 +21,6 @@ import cirq_ft
 import numpy as np
 import pytest
 from attr import frozen
-from cirq._compat import cached_property
 from cirq_ft.algos.mean_estimation.complex_phase_oracle import ComplexPhaseOracle
 from cirq_ft.infra import bit_tools
 from cirq_ft.infra import testing as cq_testing

--- a/cirq-ft/cirq_ft/algos/mean_estimation/mean_estimation_operator.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/mean_estimation_operator.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 from numpy.typing import NDArray
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import reflection_using_prepare as rup
 from cirq_ft.algos import select_and_prepare as sp

--- a/cirq-ft/cirq_ft/algos/mean_estimation/mean_estimation_operator_test.py
+++ b/cirq-ft/cirq_ft/algos/mean_estimation/mean_estimation_operator_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Optional, Sequence, Tuple
 
 import cirq
@@ -20,7 +21,6 @@ import numpy as np
 import pytest
 from attr import frozen
 from cirq_ft import infra
-from cirq._compat import cached_property
 from cirq_ft.algos.mean_estimation import CodeForRandomVariable, MeanEstimationOperator
 from cirq_ft.infra import bit_tools
 from cirq_ft.deprecation import allow_deprecated_cirq_ft_use_in_tests

--- a/cirq-ft/cirq_ft/algos/multi_control_multi_target_pauli.py
+++ b/cirq-ft/cirq_ft/algos/multi_control_multi_target_pauli.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 from numpy.typing import NDArray
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import and_gate
 

--- a/cirq-ft/cirq_ft/algos/prepare_uniform_superposition.py
+++ b/cirq-ft/cirq_ft/algos/prepare_uniform_superposition.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 from numpy.typing import NDArray
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import and_gate, arithmetic_gates
 

--- a/cirq-ft/cirq_ft/algos/programmable_rotation_gate_array.py
+++ b/cirq-ft/cirq_ft/algos/programmable_rotation_gate_array.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import abc
+from functools import cached_property
 from typing import Sequence, Tuple
 from numpy.typing import NDArray
 
 import cirq
 import numpy as np
-from cirq._compat import cached_method, cached_property
+from cirq._compat import cached_method
 from cirq_ft import infra
 from cirq_ft.algos import qrom
 from cirq_ft.infra.bit_tools import iter_bits

--- a/cirq-ft/cirq_ft/algos/programmable_rotation_gate_array_test.py
+++ b/cirq-ft/cirq_ft/algos/programmable_rotation_gate_array_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Tuple
 from numpy.typing import NDArray
 
@@ -20,7 +21,6 @@ import cirq_ft
 import numpy as np
 import pytest
 from cirq_ft import infra
-from cirq._compat import cached_property
 from cirq_ft.infra.bit_tools import iter_bits
 from cirq_ft.deprecation import allow_deprecated_cirq_ft_use_in_tests
 

--- a/cirq-ft/cirq_ft/algos/qrom.py
+++ b/cirq-ft/cirq_ft/algos/qrom.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Callable, Sequence, Tuple
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import and_gate, unary_iteration_gate
 from numpy.typing import ArrayLike, NDArray

--- a/cirq-ft/cirq_ft/algos/qubitization_walk_operator.py
+++ b/cirq-ft/cirq_ft/algos/qubitization_walk_operator.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 from numpy.typing import NDArray
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import reflection_using_prepare, select_and_prepare
 

--- a/cirq-ft/cirq_ft/algos/reflection_using_prepare.py
+++ b/cirq-ft/cirq_ft/algos/reflection_using_prepare.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Collection, Optional, Sequence, Tuple, Union
 from numpy.typing import NDArray
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import multi_control_multi_target_pauli as mcmt
 from cirq_ft.algos import select_and_prepare

--- a/cirq-ft/cirq_ft/algos/select_and_prepare.py
+++ b/cirq-ft/cirq_ft/algos/select_and_prepare.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import abc
+from functools import cached_property
 from typing import Tuple
 
-from cirq._compat import cached_property
 from cirq_ft import infra
 
 

--- a/cirq-ft/cirq_ft/algos/select_swap_qrom.py
+++ b/cirq-ft/cirq_ft/algos/select_swap_qrom.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import List, Optional, Sequence, Tuple
 from numpy.typing import NDArray
 
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import qrom, swap_network
 

--- a/cirq-ft/cirq_ft/algos/selected_majorana_fermion.py
+++ b/cirq-ft/cirq_ft/algos/selected_majorana_fermion.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Sequence, Union, Tuple
 from numpy.typing import NDArray
 
@@ -19,7 +20,6 @@ import attr
 import cirq
 import numpy as np
 
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import unary_iteration_gate
 

--- a/cirq-ft/cirq_ft/algos/state_preparation.py
+++ b/cirq-ft/cirq_ft/algos/state_preparation.py
@@ -20,13 +20,13 @@ database) with a number of T gates scaling as 4L + O(log(1/eps)) where eps is th
 largest absolute error that one can tolerate in the prepared amplitudes.
 """
 
+from functools import cached_property
 from typing import List, Tuple
 from numpy.typing import NDArray
 
 import attr
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft import infra, linalg
 from cirq_ft.algos import (
     arithmetic_gates,

--- a/cirq-ft/cirq_ft/algos/swap_network.py
+++ b/cirq-ft/cirq_ft/algos/swap_network.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 from typing import Sequence, Union, Tuple
 from numpy.typing import NDArray
 
 import attr
 import cirq
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import multi_control_multi_target_pauli as mcmtp
 

--- a/cirq-ft/cirq_ft/algos/unary_iteration.ipynb
+++ b/cirq-ft/cirq_ft/algos/unary_iteration.ipynb
@@ -260,10 +260,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from functools import cached_property\n",
     "import cirq\n",
     "from cirq_ft import Signature, GateWithRegisters\n",
     "from cirq_ft.infra.bit_tools import iter_bits\n",
-    "from functools import cached_property\n",
     "\n",
     "class TotallyControlledNot(GateWithRegisters):\n",
     "    \n",

--- a/cirq-ft/cirq_ft/algos/unary_iteration.ipynb
+++ b/cirq-ft/cirq_ft/algos/unary_iteration.ipynb
@@ -261,9 +261,9 @@
    "outputs": [],
    "source": [
     "import cirq\n",
-    "from cirq._compat import cached_property\n",
     "from cirq_ft import Signature, GateWithRegisters\n",
     "from cirq_ft.infra.bit_tools import iter_bits\n",
+    "from functools import cached_property\n",
     "\n",
     "class TotallyControlledNot(GateWithRegisters):\n",
     "    \n",
@@ -472,7 +472,7 @@
    "outputs": [],
    "source": [
     "from cirq_ft import Register, SelectionRegister, UnaryIterationGate\n",
-    "from cirq._compat import cached_property\n",
+    "from functools import cached_property\n",
     "\n",
     "class ApplyXToLthQubit(UnaryIterationGate):\n",
     "    def __init__(self, selection_bitsize: int, target_bitsize: int, control_bitsize: int = 1):\n",

--- a/cirq-ft/cirq_ft/algos/unary_iteration_gate.py
+++ b/cirq-ft/cirq_ft/algos/unary_iteration_gate.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import abc
+from functools import cached_property
 from typing import Callable, Dict, Iterator, List, Sequence, Tuple
 from numpy.typing import NDArray
 
 import cirq
 import numpy as np
 
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.algos import and_gate
 from cirq_ft.deprecation import deprecated_cirq_ft_function

--- a/cirq-ft/cirq_ft/algos/unary_iteration_gate_test.py
+++ b/cirq-ft/cirq_ft/algos/unary_iteration_gate_test.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import cached_property
 import itertools
 from typing import Sequence, Tuple
 
 import cirq
 import cirq_ft
 import pytest
-from cirq._compat import cached_property
 from cirq_ft import infra
 from cirq_ft.infra.bit_tools import iter_bits
 from cirq_ft.infra.jupyter_tools import execute_notebook

--- a/cirq-ft/cirq_ft/infra/testing.py
+++ b/cirq-ft/cirq_ft/infra/testing.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Any, Dict, List, Sequence, Tuple
 from numpy.typing import NDArray
 import cirq
 import numpy as np
-from cirq._compat import cached_property
 from cirq_ft.infra import gate_with_registers, t_complexity_protocol, merge_qubits, get_named_qubits
 from cirq_ft.infra.decompose_protocol import _decompose_once_considering_known_decomposition
 

--- a/cirq-google/cirq_google/devices/google_noise_properties.py
+++ b/cirq-google/cirq_google/devices/google_noise_properties.py
@@ -16,6 +16,7 @@
 """Class for representing noise on a Google device."""
 
 import dataclasses
+from functools import cached_property
 from typing import Any, Dict, List, Sequence, Set, Type, TypeVar, Union
 import numpy as np
 
@@ -204,7 +205,7 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
     def asymmetric_two_qubit_gates(cls) -> Set[type]:
         return set()
 
-    @_compat.cached_property
+    @cached_property
     def _depolarizing_error(self) -> Dict[noise_utils.OpIdentifier, float]:
         depol_errors = super()._depolarizing_error
 

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+from functools import cached_property
 import sys
 from typing import (
     AsyncIterable,
@@ -35,7 +36,6 @@ from google.api_core.exceptions import GoogleAPICallError, NotFound
 from google.protobuf import any_pb2, field_mask_pb2
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from cirq._compat import cached_property
 from cirq._compat import deprecated_parameter
 from cirq_google.cloud import quantum
 from cirq_google.engine.asyncio_executor import AsyncioExecutor


### PR DESCRIPTION
As described in this issue:
https://github.com/quantumlib/Cirq/issues/6395

The backport is no longer necessary and is therefore removed.