### PR TITLE
Fix "Build docs" CI job by temporarily pinning alabaster to 0.7.13

### DIFF
--- a/rtd_docs/requirements.txt
+++ b/rtd_docs/requirements.txt
@@ -1,4 +1,6 @@
 # For generating documentation.
+# TODO(#6400,juhas) - upgrade Sphinx and remove the alabaster pin below
+alabaster<=0.7.13
 myst-parser
 Sphinx~=3.2.0
 sphinx_rtd_theme


### PR DESCRIPTION
As of alabaster-0.7.14 the alabaster theme package requires sphinx 3.4
which conflicts with the current sphinx requirement.

As a quick fix we pin to alabaster-0.7.13 here.

Temporary workaround for #6400 
