### PR TITLE
Make the pypirc generation script safer

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -26,9 +26,7 @@ jobs:
           CIRQ_PYPI_TOKEN: ${{ secrets.CIRQ_PYPI_TOKEN }}
           CIRQ_TEST_PYPI_TOKEN: ${{ secrets.CIRQ_TEST_PYPI_TOKEN }}
         run: |
-          echo hello > ~/.pypirc
-          head ~/.pypirc
-          exit 77
+          dev_tools/packaging/create_pypirc.sh > ~/.pypirc
       - name: Build and publish
         run: |
           export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -26,7 +26,7 @@ jobs:
           CIRQ_PYPI_TOKEN: ${{ secrets.CIRQ_PYPI_TOKEN }}
           CIRQ_TEST_PYPI_TOKEN: ${{ secrets.CIRQ_TEST_PYPI_TOKEN }}
         run: |
-          dev_tools/packaging/create_pypirc.sh
+          dev_tools/packaging/create_pypirc.sh > ~/.pypirc
       - name: Build and publish
         run: |
           export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -26,7 +26,9 @@ jobs:
           CIRQ_PYPI_TOKEN: ${{ secrets.CIRQ_PYPI_TOKEN }}
           CIRQ_TEST_PYPI_TOKEN: ${{ secrets.CIRQ_TEST_PYPI_TOKEN }}
         run: |
-          dev_tools/packaging/create_pypirc.sh > ~/.pypirc
+          echo hello > ~/.pypirc
+          head ~/.pypirc
+          exit 77
       - name: Build and publish
         run: |
           export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)

--- a/dev_tools/packaging/create_pypirc.sh
+++ b/dev_tools/packaging/create_pypirc.sh
@@ -1,13 +1,14 @@
-#!bin/bash
+#!/bin/bash
 
-# Create default pypi config file with token authentication.
+# Output default pypi config file with token authentication.
 # refrence: https://packaging.python.org/en/latest/specifications/pypirc/#common-configurations
-echo """
+
+echo "\
 [pypi]
 username = __token__
-password = ${CIRQ_PYPI_TOKEN}
+password = ${CIRQ_PYPI_TOKEN:?}
 
 [testpypi]
 username = __token__
-password = ${CIRQ_TEST_PYPI_TOKEN}
-""" >> $HOME/.pypirc
+password = ${CIRQ_TEST_PYPI_TOKEN:?}
+"


### PR DESCRIPTION
* avoid accidental modification of user's pypirc, instead
  have the script output new config without changing any file.

* use absolute path in the shebang.

* drop unnecessary triple quotes.
  In bash they just concatenate an empty string.

* fail script early if required environment variables do not exist.
