### PR TITLE
convert identity to phased xz in qubit characterization

### DIFF
--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -693,7 +693,9 @@ def _create_parallel_rb_circuit(
     num_moments = max(len(sequence) for sequence in sequences_to_zip)
     for q, sequence in zip(qubits, sequences_to_zip):
         if (n := len(sequence)) < num_moments:
-            sequence.extend([ops.SingleQubitCliffordGate.I(q)] * (num_moments - n))
+            sequence.extend(
+                [ops.SingleQubitCliffordGate.I.to_phased_xz_gate()(q)] * (num_moments - n)
+            )
     moments = zip(*sequences_to_zip)
     return circuits.Circuit.from_moments(*moments, ops.measure_each(*qubits))
 

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -230,12 +230,12 @@ def test_tomography_plot_raises_for_incorrect_number_of_axes():
 
 
 def test_single_qubit_cliffords_gateset():
-    qubit = GridQubit(0, 0)
+    qubits = [GridQubit(0, i) for i in range(4)]
     clifford_group = cirq.experiments.qubit_characterizations._single_qubit_cliffords()
     c = cirq.experiments.qubit_characterizations._create_parallel_rb_circuit(
-        (qubit,), 3, clifford_group.c1_in_xy
+        qubits, 5, clifford_group.c1_in_xy
     )
     device = cirq.testing.ValidatingTestDevice(
-        qubits=(qubit,), allowed_gates=(cirq.ops.PhasedXZGate, cirq.MeasurementGate)
+        qubits=qubits, allowed_gates=(cirq.ops.PhasedXZGate, cirq.MeasurementGate)
     )
     device.validate_circuit(c)


### PR DESCRIPTION
SingleQubitCliffordGates fail the gateset check of the grid device https://github.com/quantumlib/Cirq/blob/a3eed6b97490556cf1dda82928a0aa9ea8798da1/cirq-google/cirq_google/devices/grid_device.py#L43-L64. while the objects fail the check the operations themselves are supported but after coversion to a supported format like phased xz

this was missed from #6420
