### PR TITLE
Fix font family for svg

### DIFF
--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     import cirq
 
 QBLUE = '#1967d2'
-FONT = matplotlib.font_manager.FontProperties(family="Arial")
+FONT = matplotlib.font_manager.FontProperties(family="sans-serif")
 EMPTY_MOMENT_COLWIDTH = float(21)  # assumed default column width
 
 

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     import cirq
 
 QBLUE = '#1967d2'
-FONT = matplotlib.font_manager.FontProperties(family="sans-serif")
+FONT = matplotlib.font_manager.FontProperties()
 EMPTY_MOMENT_COLWIDTH = float(21)  # assumed default column width
 
 


### PR DESCRIPTION
As per https://matplotlib.org/3.5.0/api/font_manager_api.html#matplotlib.font_manager.FontProperties `Arial` is not a valid font family with the only options being ` 'sans-serif' (default), 'serif', 'cursive', 'fantasy', or 'monospace'`

The invalid input doesn't raise an error and instead fails silently with a warning message which is visible [in the notebooks](https://quantumai.google/cirq/noise/qcvv/xeb_theory#random_circuit) 
![image](https://github.com/quantumlib/Cirq/assets/5949112/1b577be9-c2ea-49a2-9b72-9b78c74b660c)

As per https://github.com/matplotlib/matplotlib/blob/f0c4c41d1a08bc3f53824cddc8fef7f88fc52a43/lib/matplotlib/mpl-data/stylelib/seaborn-v0_8.mplstyle#L18 Arial is part of the `sans-serif` family which is the default