### PR TITLE
Add an optional CompilationTargetGateset postprocessor to contract the circuit

### DIFF
--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -103,7 +103,6 @@ def optimize_for_target_gateset(
     gateset: Optional['cirq.CompilationTargetGateset'] = None,
     ignore_failures: bool = True,
     max_num_passes: Union[int, None] = 1,
-    preserve_moment_structure: bool = True,
 ) -> 'cirq.Circuit':
     """Transforms the given circuit into an equivalent circuit using gates accepted by `gateset`.
 
@@ -126,7 +125,6 @@ def optimize_for_target_gateset(
             conversion failures raise a ValueError.
         max_num_passes: The maximum number of passes to do. A value of `None` means to keep
             iterating until no further improvements can be made.
-        preserve_moment_structure: Whether to preserve moment structure or not.
     Returns:
         An equivalent circuit containing gates accepted by `gateset`.
 
@@ -159,11 +157,6 @@ def optimize_for_target_gateset(
         )
         for transformer in gateset.postprocess_transformers:
             circuit = transformer(circuit, context=context)
-
-        if not preserve_moment_structure:
-            circuit = circuits.Circuit(
-                op for op in circuit.all_operations()
-            )  # Contract the moments.
 
         num_moments, num_ops = len(circuit), len(tuple(circuit.all_operations()))
         if (num_moments, num_ops) == (initial_num_moments, initial_num_ops):

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -113,7 +113,7 @@ def optimize_for_target_gateset(
 
     Note:
         The optimizer is a heuristic and may not produce optimal results even with
-        max_num_passes=None. The prerprocessors and postprocessors of the gate set
+        max_num_passes=None. The preprocessors and postprocessors of the gate set
         as well as their order yield different results.
 
 
@@ -124,7 +124,8 @@ def optimize_for_target_gateset(
         ignore_failures: If set, operations that fail to convert are left unchanged. If not set,
             conversion failures raise a ValueError.
         max_num_passes: The maximum number of passes to do. A value of `None` means to keep
-            iterating until no further improvements can be made.
+            iterating until no more changes happen to the number of moments or operations.
+
     Returns:
         An equivalent circuit containing gates accepted by `gateset`.
 
@@ -143,7 +144,7 @@ def optimize_for_target_gateset(
             while True:
                 yield 0
 
-    initial_num_moments, initial_num_ops = len(circuit), len(tuple(circuit.all_operations()))
+    initial_num_moments, initial_num_ops = len(circuit), sum(1 for _ in circuit.all_operations())
     for _ in _outerloop():
         for transformer in gateset.preprocess_transformers:
             circuit = transformer(circuit, context=context)
@@ -158,7 +159,7 @@ def optimize_for_target_gateset(
         for transformer in gateset.postprocess_transformers:
             circuit = transformer(circuit, context=context)
 
-        num_moments, num_ops = len(circuit), len(tuple(circuit.all_operations()))
+        num_moments, num_ops = len(circuit), sum(1 for _ in circuit.all_operations())
         if (num_moments, num_ops) == (initial_num_moments, initial_num_ops):
             # Stop early. No further optimizations can be done.
             break

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -14,7 +14,7 @@
 
 """Transformers to rewrite a circuit using gates from a given target gateset."""
 
-from typing import Optional, Callable, Hashable, Sequence, TYPE_CHECKING
+from typing import Optional, Callable, Hashable, Sequence, TYPE_CHECKING, Union
 
 from cirq import circuits
 from cirq.protocols import decompose_protocol as dp
@@ -102,12 +102,17 @@ def optimize_for_target_gateset(
     context: Optional['cirq.TransformerContext'] = None,
     gateset: Optional['cirq.CompilationTargetGateset'] = None,
     ignore_failures: bool = True,
+    max_num_passes: Union[int, None] = 1,
 ) -> 'cirq.Circuit':
     """Transforms the given circuit into an equivalent circuit using gates accepted by `gateset`.
 
+    Repeat max_num_passes times or when `max_num_passes=None` until no further changes can be done
     1. Run all `gateset.preprocess_transformers`
     2. Convert operations using built-in cirq decompose + `gateset.decompose_to_target_gateset`.
     3. Run all `gateset.postprocess_transformers`
+
+    Note:
+      The optimizer is heuristic and may not produce optimal results even with max_num_passes=None.
 
     Args:
         circuit: Input circuit to transform. It will not be modified.
@@ -115,7 +120,8 @@ def optimize_for_target_gateset(
         gateset: Target gateset, which should be an instance of `cirq.CompilationTargetGateset`.
         ignore_failures: If set, operations that fail to convert are left unchanged. If not set,
             conversion failures raise a ValueError.
-
+        max_num_passes: The maximum number of passes to do. A value of `None` means keep iterating
+            until no further improvements can be done.
     Returns:
         An equivalent circuit containing gates accepted by `gateset`.
 
@@ -126,20 +132,38 @@ def optimize_for_target_gateset(
         return _decompose_operations_to_target_gateset(
             circuit, context=context, ignore_failures=ignore_failures
         )
+    if isinstance(max_num_passes, int):
+        _outerloop = lambda: range(max_num_passes)
+    else:
 
-    for transformer in gateset.preprocess_transformers:
-        circuit = transformer(circuit, context=context)
+        def _outerloop():
+            while True:
+                yield 0
 
-    circuit = _decompose_operations_to_target_gateset(
-        circuit,
-        context=context,
-        gateset=gateset,
-        decomposer=gateset.decompose_to_target_gateset,
-        ignore_failures=ignore_failures,
-        tags_to_decompose=(gateset._intermediate_result_tag,),
-    )
+    initial_num_moments, initial_num_ops = len(circuit), len(tuple(circuit.all_operations()))
+    for _ in _outerloop():
+        for transformer in gateset.preprocess_transformers:
+            circuit = transformer(circuit, context=context)
 
-    for transformer in gateset.postprocess_transformers:
-        circuit = transformer(circuit, context=context)
+        circuit = _decompose_operations_to_target_gateset(
+            circuit,
+            context=context,
+            gateset=gateset,
+            decomposer=gateset.decompose_to_target_gateset,
+            ignore_failures=ignore_failures,
+            tags_to_decompose=(gateset._intermediate_result_tag,),
+        )
 
+        for transformer in gateset.postprocess_transformers:
+            circuit = transformer(circuit, context=context)
+
+        circuit = circuits.Circuit(
+            op for op in circuit.all_operations()
+        )  # Ensure the circuit is contracted.
+
+        num_moments, num_ops = len(circuit), len(tuple(circuit.all_operations()))
+        if (num_moments, num_ops) == (initial_num_moments, initial_num_ops):
+            # Stop early. No further optimizations can be done.
+            break
+        initial_num_moments, initial_num_ops = num_moments, num_ops
     return circuit.unfreeze(copy=False)

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
@@ -284,37 +284,43 @@ def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, 
         ]
     )
 
-    desired_circuit = cirq.Circuit(
-        cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
-            cirq.LineQubit(4)
+    desired_circuit = cirq.Circuit.from_moments(
+        cirq.Moment(
+            cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+                cirq.LineQubit(4)
+            )
         ),
-        cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
-            cirq.LineQubit(1)
+        cirq.Moment(cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5))),
+        cirq.Moment(
+            cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+                cirq.LineQubit(1)
+            ),
+            cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+                cirq.LineQubit(0)
+            ),
+            cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+                cirq.LineQubit(3)
+            ),
+            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+                cirq.LineQubit(2)
+            ),
         ),
-        cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-            cirq.LineQubit(2)
+        cirq.Moment(
+            cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
+            cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
         ),
-        cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
-            cirq.LineQubit(0)
+        cirq.Moment(
+            cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
+            cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
         ),
-        cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
-            cirq.LineQubit(3)
+        cirq.Moment(
+            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+                cirq.LineQubit(6)
+            )
         ),
-        cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-            cirq.LineQubit(6)
-        ),
-        cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
-        cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
-        cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
-        cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
-        cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
-        cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
+        cirq.Moment(cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5))),
     )
-
     got = cirq.optimize_for_target_gateset(
-        input_circuit,
-        gateset=gateset,
-        max_num_passes=max_num_passes,
-        preserve_moment_structure=False,
+        input_circuit, gateset=gateset, max_num_passes=max_num_passes
     )
     assert got == desired_circuit

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
@@ -248,11 +248,8 @@ def test_optimize_for_target_gateset_deep():
 
 
 @pytest.mark.parametrize('max_num_passes', [2, None])
-@pytest.mark.parametrize('preserve_moment_structure', [False, True])
-def test_optimize_for_target_gateset_multiple_passes(
-    max_num_passes: Union[int, None], preserve_moment_structure: bool
-):
-    gateset = cirq.CZTargetGateset(preserve_moment_structure=preserve_moment_structure)
+def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, None]):
+    gateset = cirq.CZTargetGateset()
 
     input_circuit = cirq.Circuit(
         [
@@ -286,53 +283,16 @@ def test_optimize_for_target_gateset_multiple_passes(
             ),
         ]
     )
-    if preserve_moment_structure:
-        desired_circuit = cirq.Circuit.from_moments(
-            cirq.Moment(
-                cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
-                    cirq.LineQubit(4)
-                )
-            ),
-            cirq.Moment(cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5))),
-            cirq.Moment(
-                cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
-                    cirq.LineQubit(1)
-                ),
-                cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
-                    cirq.LineQubit(0)
-                ),
-                cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
-                    cirq.LineQubit(3)
-                ),
-                cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-                    cirq.LineQubit(2)
-                ),
-            ),
-            cirq.Moment(
-                cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
-                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
-            ),
-            cirq.Moment(
-                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
-                cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
-            ),
-            cirq.Moment(
-                cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-                    cirq.LineQubit(6)
-                )
-            ),
-            cirq.Moment(cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5))),
-        )
-    else:
-        desired_circuit = cirq.Circuit(
+    desired_circuit = cirq.Circuit.from_moments(
+        cirq.Moment(
             cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
                 cirq.LineQubit(4)
-            ),
+            )
+        ),
+        cirq.Moment(cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5))),
+        cirq.Moment(
             cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
                 cirq.LineQubit(1)
-            ),
-            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-                cirq.LineQubit(2)
             ),
             cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
                 cirq.LineQubit(0)
@@ -341,16 +301,95 @@ def test_optimize_for_target_gateset_multiple_passes(
                 cirq.LineQubit(3)
             ),
             cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-                cirq.LineQubit(6)
+                cirq.LineQubit(2)
             ),
-            cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
+        ),
+        cirq.Moment(
             cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
             cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
+        ),
+        cirq.Moment(
             cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
             cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
-            cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
-        )
+        ),
+        cirq.Moment(
+            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+                cirq.LineQubit(6)
+            )
+        ),
+        cirq.Moment(cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5))),
+    )
     got = cirq.optimize_for_target_gateset(
         input_circuit, gateset=gateset, max_num_passes=max_num_passes
     )
-    assert got == desired_circuit
+    cirq.testing.assert_same_circuits(got, desired_circuit)
+
+
+@pytest.mark.parametrize('max_num_passes', [2, None])
+def test_optimize_for_target_gateset_multiple_passes_dont_preserve_moment_structure(
+    max_num_passes: Union[int, None]
+):
+    gateset = cirq.CZTargetGateset(preserve_moment_structure=False)
+
+    input_circuit = cirq.Circuit(
+        [
+            cirq.Moment(
+                cirq.X(cirq.LineQubit(1)),
+                cirq.X(cirq.LineQubit(2)),
+                cirq.X(cirq.LineQubit(3)),
+                cirq.X(cirq.LineQubit(6)),
+            ),
+            cirq.Moment(
+                cirq.H(cirq.LineQubit(0)),
+                cirq.H(cirq.LineQubit(1)),
+                cirq.H(cirq.LineQubit(2)),
+                cirq.H(cirq.LineQubit(3)),
+                cirq.H(cirq.LineQubit(4)),
+                cirq.H(cirq.LineQubit(5)),
+                cirq.H(cirq.LineQubit(6)),
+            ),
+            cirq.Moment(
+                cirq.H(cirq.LineQubit(1)), cirq.H(cirq.LineQubit(3)), cirq.H(cirq.LineQubit(5))
+            ),
+            cirq.Moment(
+                cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
+                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
+                cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
+            ),
+            cirq.Moment(
+                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
+                cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
+                cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
+            ),
+        ]
+    )
+    desired_circuit = cirq.Circuit(
+        cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+            cirq.LineQubit(4)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+            cirq.LineQubit(1)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+            cirq.LineQubit(2)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+            cirq.LineQubit(0)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+            cirq.LineQubit(3)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+            cirq.LineQubit(6)
+        ),
+        cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
+        cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
+        cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
+        cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
+        cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
+        cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
+    )
+    got = cirq.optimize_for_target_gateset(
+        input_circuit, gateset=gateset, max_num_passes=max_num_passes
+    )
+    cirq.testing.assert_same_circuits(got, desired_circuit)

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Union
+
 import cirq
 from cirq.protocols.decompose_protocol import DecomposeResult
 from cirq.transformers.optimize_for_target_gateset import _decompose_operations_to_target_gateset
@@ -243,3 +245,73 @@ def test_optimize_for_target_gateset_deep():
 1: ───#2───────────────────────────────────────────────────────────────────────────
 ''',
     )
+
+
+@pytest.mark.parametrize('max_num_passes', [2, None])
+def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, None]):
+    gateset = cirq.CZTargetGateset()
+
+    input_circuit = cirq.Circuit(
+        [
+            cirq.Moment(
+                cirq.X(cirq.LineQubit(1)),
+                cirq.X(cirq.LineQubit(2)),
+                cirq.X(cirq.LineQubit(3)),
+                cirq.X(cirq.LineQubit(6)),
+            ),
+            cirq.Moment(
+                cirq.H(cirq.LineQubit(0)),
+                cirq.H(cirq.LineQubit(1)),
+                cirq.H(cirq.LineQubit(2)),
+                cirq.H(cirq.LineQubit(3)),
+                cirq.H(cirq.LineQubit(4)),
+                cirq.H(cirq.LineQubit(5)),
+                cirq.H(cirq.LineQubit(6)),
+            ),
+            cirq.Moment(
+                cirq.H(cirq.LineQubit(1)), cirq.H(cirq.LineQubit(3)), cirq.H(cirq.LineQubit(5))
+            ),
+            cirq.Moment(
+                cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
+                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
+                cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
+            ),
+            cirq.Moment(
+                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
+                cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
+                cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
+            ),
+        ]
+    )
+
+    desired_circuit = cirq.Circuit(
+        cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+            cirq.LineQubit(4)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+            cirq.LineQubit(1)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+            cirq.LineQubit(2)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+            cirq.LineQubit(0)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+            cirq.LineQubit(3)
+        ),
+        cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+            cirq.LineQubit(6)
+        ),
+        cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
+        cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
+        cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
+        cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
+        cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
+        cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
+    )
+
+    got = cirq.optimize_for_target_gateset(
+        input_circuit, gateset=gateset, max_num_passes=max_num_passes
+    )
+    assert got == desired_circuit

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
@@ -312,6 +312,9 @@ def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, 
     )
 
     got = cirq.optimize_for_target_gateset(
-        input_circuit, gateset=gateset, max_num_passes=max_num_passes
+        input_circuit,
+        gateset=gateset,
+        max_num_passes=max_num_passes,
+        preserve_moment_structure=False,
     )
     assert got == desired_circuit

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
@@ -248,8 +248,11 @@ def test_optimize_for_target_gateset_deep():
 
 
 @pytest.mark.parametrize('max_num_passes', [2, None])
-def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, None]):
-    gateset = cirq.CZTargetGateset()
+@pytest.mark.parametrize('preserve_moment_structure', [False, True])
+def test_optimize_for_target_gateset_multiple_passes(
+    max_num_passes: Union[int, None], preserve_moment_structure: bool
+):
+    gateset = cirq.CZTargetGateset(preserve_moment_structure=preserve_moment_structure)
 
     input_circuit = cirq.Circuit(
         [
@@ -283,17 +286,53 @@ def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, 
             ),
         ]
     )
-
-    desired_circuit = cirq.Circuit.from_moments(
-        cirq.Moment(
+    if preserve_moment_structure:
+        desired_circuit = cirq.Circuit.from_moments(
+            cirq.Moment(
+                cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+                    cirq.LineQubit(4)
+                )
+            ),
+            cirq.Moment(cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5))),
+            cirq.Moment(
+                cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+                    cirq.LineQubit(1)
+                ),
+                cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
+                    cirq.LineQubit(0)
+                ),
+                cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
+                    cirq.LineQubit(3)
+                ),
+                cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+                    cirq.LineQubit(2)
+                ),
+            ),
+            cirq.Moment(
+                cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
+                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
+            ),
+            cirq.Moment(
+                cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
+                cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
+            ),
+            cirq.Moment(
+                cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+                    cirq.LineQubit(6)
+                )
+            ),
+            cirq.Moment(cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5))),
+        )
+    else:
+        desired_circuit = cirq.Circuit(
             cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
                 cirq.LineQubit(4)
-            )
-        ),
-        cirq.Moment(cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5))),
-        cirq.Moment(
+            ),
             cirq.PhasedXZGate(axis_phase_exponent=-1.0, x_exponent=1, z_exponent=0).on(
                 cirq.LineQubit(1)
+            ),
+            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
+                cirq.LineQubit(2)
             ),
             cirq.PhasedXZGate(axis_phase_exponent=0.5, x_exponent=-0.5, z_exponent=1.0).on(
                 cirq.LineQubit(0)
@@ -302,24 +341,15 @@ def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, 
                 cirq.LineQubit(3)
             ),
             cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-                cirq.LineQubit(2)
+                cirq.LineQubit(6)
             ),
-        ),
-        cirq.Moment(
+            cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(5)),
             cirq.CZ(cirq.LineQubit(0), cirq.LineQubit(1)),
             cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(3)),
-        ),
-        cirq.Moment(
             cirq.CZ(cirq.LineQubit(2), cirq.LineQubit(1)),
             cirq.CZ(cirq.LineQubit(4), cirq.LineQubit(3)),
-        ),
-        cirq.Moment(
-            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=0.0).on(
-                cirq.LineQubit(6)
-            )
-        ),
-        cirq.Moment(cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5))),
-    )
+            cirq.CZ(cirq.LineQubit(6), cirq.LineQubit(5)),
+        )
     got = cirq.optimize_for_target_gateset(
         input_circuit, gateset=gateset, max_num_passes=max_num_passes
     )

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
@@ -84,9 +84,10 @@ class CompilationTargetGateset(ops.Gateset, metaclass=abc.ABCMeta):
         self,
         *gates: Union[Type['cirq.Gate'], 'cirq.Gate', 'cirq.GateFamily'],
         name: Optional[str] = None,
+        unroll_circuit_op: bool = True,
         preserve_moment_structure: bool = True,
     ):
-        super().__init__(*gates, name=name)
+        super().__init__(*gates, name=name, unroll_circuit_op=unroll_circuit_op)
         self._preserve_moment_structure = preserve_moment_structure
 
     @property

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
@@ -14,7 +14,7 @@
 
 """Base class for creating custom target gatesets which can be used for compilation."""
 
-from typing import Optional, List, Hashable, TYPE_CHECKING
+from typing import Optional, List, Hashable, TYPE_CHECKING, Union, Type
 import abc
 
 from cirq import circuits, ops, protocols, transformers
@@ -80,6 +80,15 @@ class CompilationTargetGateset(ops.Gateset, metaclass=abc.ABCMeta):
     which can transform any given circuit to contain gates accepted by this gateset.
     """
 
+    def __init__(
+        self,
+        *gates: Union[Type['cirq.Gate'], 'cirq.Gate', 'cirq.GateFamily'],
+        name: Optional[str] = None,
+        preserve_moment_structure: bool = True,
+    ):
+        super().__init__(*gates, name=name)
+        self._preserve_moment_structure = preserve_moment_structure
+
     @property
     @abc.abstractmethod
     def num_qubits(self) -> int:
@@ -144,7 +153,7 @@ class CompilationTargetGateset(ops.Gateset, metaclass=abc.ABCMeta):
             merge_single_qubit_gates.merge_single_qubit_moments_to_phxz,
             transformers.drop_negligible_operations,
             transformers.drop_empty_moments,
-        ]
+        ] + ([] if self._preserve_moment_structure else [transformers.stratified_circuit])
 
 
 class TwoQubitCompilationTargetGateset(CompilationTargetGateset):

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
@@ -87,6 +87,17 @@ class CompilationTargetGateset(ops.Gateset, metaclass=abc.ABCMeta):
         unroll_circuit_op: bool = True,
         preserve_moment_structure: bool = True,
     ):
+        """Initializes CompilationTargetGateset.
+
+        Args:
+            *gates: A list of `cirq.Gate` subclasses / `cirq.Gate` instances /
+                `cirq.GateFamily` instances to initialize the Gateset.
+            name: (Optional) Name for the Gateset. Useful for description.
+            unroll_circuit_op: If True, `cirq.CircuitOperation` is recursively
+                validated by validating the underlying `cirq.Circuit`.
+            preserve_moment_structure: Whether to preserve the moment structure of the
+                circuit during compilation or not.
+        """
         super().__init__(*gates, name=name, unroll_circuit_op=unroll_circuit_op)
         self._preserve_moment_structure = preserve_moment_structure
 

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
@@ -150,11 +150,14 @@ class CompilationTargetGateset(ops.Gateset, metaclass=abc.ABCMeta):
     @property
     def postprocess_transformers(self) -> List['cirq.TRANSFORMER']:
         """List of transformers which should be run after decomposing individual operations."""
-        return [
+        processors: List['cirq.TRANSFORMER'] = [
             merge_single_qubit_gates.merge_single_qubit_moments_to_phxz,
             transformers.drop_negligible_operations,
             transformers.drop_empty_moments,
-        ] + ([] if self._preserve_moment_structure else [transformers.stratified_circuit])
+        ]
+        if not self._preserve_moment_structure:
+            processors.append(transformers.stratified_circuit)
+        return processors
 
 
 class TwoQubitCompilationTargetGateset(CompilationTargetGateset):

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset.py
@@ -48,6 +48,7 @@ class CZTargetGateset(compilation_target_gateset.TwoQubitCompilationTargetGatese
         atol: float = 1e-8,
         allow_partial_czs: bool = False,
         additional_gates: Sequence[Union[Type['cirq.Gate'], 'cirq.Gate', 'cirq.GateFamily']] = (),
+        preserve_moment_structure: bool = True,
     ) -> None:
         """Initializes CZTargetGateset
 
@@ -65,6 +66,7 @@ class CZTargetGateset(compilation_target_gateset.TwoQubitCompilationTargetGatese
             ops.GlobalPhaseGate,
             *additional_gates,
             name='CZPowTargetGateset' if allow_partial_czs else 'CZTargetGateset',
+            preserve_moment_structure=preserve_moment_structure,
         )
         self.additional_gates = tuple(
             g if isinstance(g, ops.GateFamily) else ops.GateFamily(gate=g) for g in additional_gates

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset.py
@@ -58,6 +58,8 @@ class CZTargetGateset(compilation_target_gateset.TwoQubitCompilationTargetGatese
              `cirq.CZ`, are part of this gateset.
             additional_gates: Sequence of additional gates / gate families which should also
               be "accepted" by this gateset. This is empty by default.
+            preserve_moment_structure: Whether to preserve the moment structure of the
+                circuit during compilation or not.
         """
         super().__init__(
             ops.CZPowGate if allow_partial_czs else ops.CZ,


### PR DESCRIPTION
fixes https://github.com/quantumlib/Cirq/issues/6422 as suggested by @tanujkhattar https://github.com/quantumlib/Cirq/issues/6422#issuecomment-1915363510


calling `optimize_for_target_gateset` with `gateset=cirq.CZTargetGateset(preserve_moment_structure=True)` and `max_num_passes` equal a value >= 2 or None) produces the desired result