### PR TITLE
pin quimb and numba versions to fix CI

### DIFF
--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -4,7 +4,7 @@ ply>=3.6
 pylatex~=1.3.0
 
 # quimb
-quimb
+quimb>=1.7.2
 opt_einsum
 autoray
 # required for py39 opcodes.

--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -4,7 +4,7 @@ ply>=3.6
 pylatex~=1.3.0
 
 # quimb
-quimb<1.7.2
+quimb~=1.6.0
 opt_einsum
 autoray
 # required for py39 opcodes.

--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -8,4 +8,4 @@ quimb<1.7.2
 opt_einsum
 autoray
 # required for py39 opcodes.
-numba~=0.53.0
+numba~=0.58.0

--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -4,8 +4,8 @@ ply>=3.6
 pylatex~=1.3.0
 
 # quimb
-quimb>=1.7.2
+quimb<1.7.2
 opt_einsum
 autoray
 # required for py39 opcodes.
-numba>=0.53.0
+numba~=0.53.0

--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -8,7 +8,7 @@ ipykernel==5.3.4
 
 # for executing notebooks in tests
 papermill~=2.3.2
-quimb~=1.6.0
+quimb>=1.7.2
 
 # assumed to be part of colab
 seaborn~=0.11.1

--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -8,7 +8,7 @@ ipykernel==5.3.4
 
 # for executing notebooks in tests
 papermill~=2.3.2
-quimb<1.7.2
+quimb~=1.6.0
 
 # assumed to be part of colab
 seaborn~=0.11.1

--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -8,7 +8,7 @@ ipykernel==5.3.4
 
 # for executing notebooks in tests
 papermill~=2.3.2
-quimb>=1.7.2
+quimb<1.7.2
 
 # assumed to be part of colab
 seaborn~=0.11.1


### PR DESCRIPTION
fixes https://github.com/quantumlib/Cirq/issues/6437

older versions of quimb use a numbda decorator that no longer exists. the recent release of quimb fixes that https://github.com/jcmgray/quimb/blob/0f9db3f7b81e50375b5001296bfc2b767a7e557d/docs/changelog.md however it breaks tests in `/contrib/quimb` so will pin the versions for now.
