### PR TITLE
Combine 2q parallel XEB into one methods to simplify the XEB workflow

### DIFF
--- a/cirq-core/cirq/experiments/__init__.py
+++ b/cirq-core/cirq/experiments/__init__.py
@@ -64,3 +64,5 @@ from cirq.experiments.t1_decay_experiment import t1_decay, T1DecayResult
 from cirq.experiments.t2_decay_experiment import t2_decay, T2DecayResult
 
 from cirq.experiments.xeb_fitting import XEBPhasedFSimCharacterizationOptions
+
+from cirq.experiments.two_qubit_xeb import TwoQubitXEBResult, parallel_two_qubit_xeb

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -64,7 +64,7 @@ class TwoQubitXEBResult:
     def all_qubit_pairs(self) -> Tuple[Tuple['cirq.GridQubit', 'cirq.GridQubit'], ...]:
         return tuple(sorted(self._qubit_pair_map.keys()))
 
-    def plot_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
+    def plot_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs) -> plt.Axes:
         """plot the heatmap for xeb error.
 
         Args:
@@ -73,19 +73,19 @@ class TwoQubitXEBResult:
             **plot_kwargs: Arguments to be passed to 'plt.Axes.plot'.
         """
         show_plot = not ax
-        if ax is None:
+        if not isinstance(ax, plt.Axes):
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
 
         heatmap_data: Dict[Tuple['cirq.GridQubit', ...], float] = {
             pair: self.xeb_error(*pair) for pair in self.all_qubit_pairs
         }
 
-        if ax is not None:
-            ax.set_title('device xeb error heatmap')
+        ax.set_title('device xeb error heatmap')
 
         vis.TwoQubitInteractionHeatmap(heatmap_data).plot(ax=ax, **plot_kwargs)
         if show_plot:
             fig.show()
+        return ax
 
     def plot_fitted_exponential(
         self,
@@ -93,7 +93,7 @@ class TwoQubitXEBResult:
         q1: 'cirq.GridQubit',
         ax: Optional[plt.Axes] = None,
         **plot_kwargs,
-    ):
+    ) -> plt.Axes:
         """plot the fitted model to for xeb error of a qubit pair.
 
         Args:
@@ -104,27 +104,27 @@ class TwoQubitXEBResult:
             **plot_kwargs: Arguments to be passed to 'plt.Axes.plot'.
         """
         show_plot = not ax
-        if not ax:
+        if not isinstance(ax, plt.Axes):
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
+
         record = self._record(q0, q1)
 
-        plt.axhline(1, color='grey', ls='--')
-        plt.plot(record['cycle_depths'], record['fidelities'], 'o')
-        xx = np.linspace(0, np.max(record['cycle_depths']))
-
-        if ax is not None:
-            ax.plot(
-                xx,
-                exponential_decay(xx, a=record['a'], layer_fid=record['layer_fid']),
-                label='estimated exponential decay',
-                **plot_kwargs,
-            )
-            ax.set_title(f'{q0}-{q1}')
-            ax.set_ylabel('Circuit fidelity')
-            ax.set_xlabel('Cycle Depth $d$')
-            ax.legend(loc='best')
+        ax.axhline(1, color='grey', ls='--')
+        ax.plot(record['cycle_depths'], record['fidelities'], 'o')
+        depths = np.linspace(0, np.max(record['cycle_depths']))
+        ax.plot(
+            depths,
+            exponential_decay(depths, a=record['a'], layer_fid=record['layer_fid']),
+            label='estimated exponential decay',
+            **plot_kwargs,
+        )
+        ax.set_title(f'{q0}-{q1}')
+        ax.set_ylabel('Circuit fidelity')
+        ax.set_xlabel('Cycle Depth $d$')
+        ax.legend(loc='best')
         if show_plot:
             fig.show()
+        return ax
 
     def _record(self, q0, q1) -> pd.Series:
         if q0 > q1:
@@ -140,7 +140,7 @@ class TwoQubitXEBResult:
         """Return the XEB error of all qubit pairs."""
         return {(q0, q1): self.xeb_error(q0, q1) for q0, q1 in self.all_qubit_pairs}
 
-    def plot_histogram(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
+    def plot_histogram(self, ax: Optional[plt.Axes] = None, **plot_kwargs) -> plt.Axes:
         """plot a histogram of all xeb errors
 
         Args:
@@ -154,6 +154,7 @@ class TwoQubitXEBResult:
         vis.integrated_histogram(data=self.all_errors(), ax=ax, **plot_kwargs)
         if fig is not None:
             fig.show(**plot_kwargs)
+        return ax
 
 
 def parallel_two_qubit_xeb(

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -64,7 +64,7 @@ class TwoQubitXEBResult:
             error_func = self.average_error
         heatmap_data = {pair: error_func(*pair) for pair in self.all_qubit_pairs}
 
-        ax.title('device depolarization error heatmap')
+        ax.title(f'device {target_error} error heatmap')
         vis.TwoQubitInteractionHeatmap(heatmap_data).plot(ax=ax, **plot_kwargs)
         if show_plot:
             fig.show()

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -103,7 +103,7 @@ class TwoQubitRandomizedBenchMarkResult:
         return 1 - p
 
     def pauli_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit'):
-        return self.depolarization_error(q0, q1) * (1 - 1 / 8)
+        return self.depolarization_error(q0, q1) * (1 - 1 / 16)
 
     def average_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit'):
         return self.depolarization_error() * (1 - 1 / 4)

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -1,0 +1,131 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Sequence, TYPE_CHECKING
+
+from matplotlib import pyplot as plt
+import networkx as nx
+import numpy as np
+import pandas as pd
+import seaborn as sns  # type: ignore
+
+from cirq import ops, devices, value, vis
+import cirq.contrib.routing as ccr
+from cirq.experiments.xeb_sampling import sample_2q_xeb_circuits
+from cirq.experiments.xeb_fitting import benchmark_2q_xeb_fidelities
+from cirq.experiments.xeb_fitting import fit_exponential_decays, exponential_decay
+from cirq.experiments import random_quantum_circuit_generation as rqcg
+
+if TYPE_CHECKING:
+    import cirq
+
+
+def grid_qubits_for_sampler(sampler: 'cirq.Sampler'):
+    if hasattr(sampler, 'processor'):
+        device = sampler.processor.get_device()
+        return sorted(device.metadata.qubit_set)
+    else:
+        qubits = devices.GridQubit.rect(3, 2, 4, 3)
+        # Delete one qubit from the rectangular arangement to
+        # 1) make it irregular 2) simplify simulation.
+        return qubits[:-1]
+
+
+def parallel_two_qubit_randomized_benchmarking(
+    sampler: 'cirq.Sampler',
+    entangling_gate: 'cirq.Gate' = ops.CZ,
+    n_repetitions: int = 10**4,
+    n_combinations: int = 10,
+    n_circuits: int = 20,
+    cycle_depths: Sequence[int] = tuple(np.arange(3, 100, 20)),
+    random_state: 'value.RANDOM_STATE_OR_SEED_LIKE' = 42,
+):
+    rs = value.parse_random_state(random_state)
+
+    qubits = grid_qubits_for_sampler(sampler)
+    n_rows = max(q.row for q in qubits) * 2 + 1
+    n_cols = max(q.col for q in qubits) * 2 + 1
+    plt.figure(2, figsize=(n_cols, n_rows))
+    graph = ccr.gridqubits_to_graph_device(qubits)
+    nx.draw_networkx(graph, pos={q: (q.row, q.col) for q in qubits})
+    plt.title('device layout')
+    plt.show()
+
+    print('Generate circuit library')
+    circuit_library = rqcg.generate_library_of_2q_circuits(
+        n_library_circuits=n_circuits, two_qubit_gate=entangling_gate, random_state=rs
+    )
+
+    print('Generate random two qubit combinations')
+    combs_by_layer = rqcg.get_random_combinations_for_device(
+        n_library_circuits=len(circuit_library),
+        n_combinations=n_combinations,
+        device_graph=graph,
+        random_state=rs,
+    )
+
+    pos = {q: (q.row, q.col) for q in qubits}
+    _, axes = plt.subplots(2, 2, figsize=(n_cols, n_rows))
+    for comb_layer, ax in zip(combs_by_layer, axes.reshape(-1)):
+        active_qubits = np.array(comb_layer.pairs).reshape(-1)
+        colors = ['red' if q in active_qubits else 'blue' for q in graph.nodes]
+        nx.draw_networkx(graph, pos=pos, node_color=colors, ax=ax)
+        nx.draw_networkx_edges(
+            graph, pos=pos, edgelist=comb_layer.pairs, width=3, edge_color='red', ax=ax
+        )
+
+    plt.tight_layout()
+
+    print('Run circuits')
+    sampled_df = sample_2q_xeb_circuits(
+        sampler=sampler,
+        circuits=circuit_library,
+        cycle_depths=cycle_depths,
+        combinations_by_layer=combs_by_layer,
+        shuffle=rs,
+        repetitions=n_repetitions,
+    )
+
+    print('Compute fidelities')
+    fids = benchmark_2q_xeb_fidelities(
+        sampled_df=sampled_df, circuits=circuit_library, cycle_depths=cycle_depths
+    )
+
+    print('Fit exponential decays')
+    return fit_exponential_decays(fids)
+
+
+def visulaize_fidelities(fidelities: pd.DataFrame):
+    heatmap_data = {}
+    for (_, _, pair), fidelity in fidelities.layer_fid.items():
+        heatmap_data[pair] = 1.0 - fidelity
+
+    vis.TwoQubitInteractionHeatmap(heatmap_data).plot()
+    plt.title('device fidelity heatmap')
+    plt.show()
+
+    for i, record in fidelities.iterrows():
+        plt.axhline(1, color='grey', ls='--')
+        plt.plot(record['cycle_depths'], record['fidelities'], 'o')
+        xx = np.linspace(0, np.max(record['cycle_depths']))
+        plt.plot(
+            xx,
+            exponential_decay(xx, a=record['a'], layer_fid=record['layer_fid']),
+            label='estimated exponential decay',
+        )
+        q0, q1 = i[-1]
+        plt.title(f'{q0}-{q1}')
+        plt.ylabel('Circuit fidelity')
+        plt.xlabel('Cycle Depth $d$')
+        plt.legend(loc='best')
+        plt.show()

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -14,6 +14,7 @@
 from typing import Sequence, TYPE_CHECKING, Optional, Tuple
 
 import itertools
+import functools
 
 from matplotlib import pyplot as plt
 import networkx as nx
@@ -51,16 +52,14 @@ class TwoQubitRandomizedBenchMarkResult:
         self.fidelities = fidelities
         self._qubit_pair_map = {idx[-1]: i for i, idx in enumerate(fidelities.index)}
 
-    def plot_device_fidelities_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
+    def plot_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
         show_plot = not ax
         if not ax:
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
 
-        heatmap_data = {}
-        for (_, _, pair), fidelity in self.fidelities.layer_fid.items():
-            heatmap_data[pair] = 1.0 - fidelity
+        heatmap_data = {pair: self.depolarization_error(*pair) for pair in self.all_qubit_pairs}
 
-        ax.title('device fidelity heatmap')
+        ax.title('device depolarization error heatmap')
         vis.TwoQubitInteractionHeatmap(heatmap_data).plot(ax=ax, **plot_kwargs)
         if show_plot:
             fig.show()
@@ -108,6 +107,7 @@ class TwoQubitRandomizedBenchMarkResult:
     def average_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit'):
         return self.depolarization_error() * (1 - 1 / 4)
 
+    @functools.cached_property
     def all_qubit_pairs(self) -> frozenset[Tuple['cirq.GridQubit', 'Cirq.GridQubit']]:
         return frozenset(self._qubit_pair_map.keys())
 

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-def grid_qubits_for_sampler(sampler: 'cirq.Sampler'):
+def _grid_qubits_for_sampler(sampler: 'cirq.Sampler'):
     if hasattr(sampler, 'processor'):
         device = sampler.processor.get_device()
         return sorted(device.metadata.qubit_set)
@@ -48,12 +48,12 @@ def parallel_two_qubit_randomized_benchmarking(
     n_combinations: int = 10,
     n_circuits: int = 20,
     cycle_depths: Sequence[int] = tuple(np.arange(3, 100, 20)),
-    random_state: 'value.RANDOM_STATE_OR_SEED_LIKE' = 42,
+    random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = 42,
 ):
     rs = value.parse_random_state(random_state)
 
-    qubits = grid_qubits_for_sampler(sampler)
-    n_rows = max(q.row for q in qubits) * 2 + 1
+    qubits = _grid_qubits_for_sampler(sampler)
+    n_rows = max(q.row for q in qubits) + 1
     n_cols = max(q.col for q in qubits) * 2 + 1
     plt.figure(2, figsize=(n_cols, n_rows))
     graph = ccr.gridqubits_to_graph_device(qubits)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -1,0 +1,97 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wraps Parallel Two Qubit XEB into a few convenience methods."""
+from contextlib import redirect_stdout, redirect_stderr
+import itertools
+import io
+import random
+
+import matplotlib.pyplot as plt
+import numpy as np
+import networkx as nx
+import pytest
+
+import cirq
+
+
+def _manhattan_distance(qubit1: 'cirq.GridQubit', qubit2: 'cirq.GridQubit') -> int:
+    return abs(qubit1.row - qubit2.row) + abs(qubit1.col - qubit2.col)
+
+
+class MockDevice(cirq.Device):
+    @property
+    def metadata(self):
+        qubits = cirq.GridQubit.rect(3, 2, 4, 3)
+        graph = nx.Graph(
+            pair for pair in itertools.combinations(qubits, 2) if _manhattan_distance(*pair) == 1
+        )
+        return cirq.DeviceMetadata(qubits, graph)
+
+
+class MockProcessor:
+    def get_device(self):
+        return MockDevice()
+
+
+class DensityMatrixSimulatorWithProcessor(cirq.DensityMatrixSimulator):
+    @property
+    def processor(self):
+        return MockProcessor()
+
+
+@pytest.mark.parametrize(
+    'sampler',
+    [
+        cirq.DensityMatrixSimulator(
+            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+        ),
+        DensityMatrixSimulatorWithProcessor(
+            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+        ),
+    ],
+)
+def test_parallel_two_qubit_xeb(sampler: cirq.Sampler):
+    np.random.seed(0)
+    random.seed(0)
+
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        res = cirq.experiments.parallel_two_qubit_xeb(
+            sampler=sampler,
+            n_repetitions=100,
+            n_combinations=1,
+            n_circuits=1,
+            cycle_depths=[3, 4, 5],
+            random_state=0,
+        )
+
+        got = [res.xeb_error(*reversed(pair)) for pair in res.all_qubit_pairs]
+        np.testing.assert_allclose(got, 0.1, atol=1e-1)
+
+
+@pytest.mark.parametrize(
+    'sampler', [cirq.DensityMatrixSimulator(seed=0), DensityMatrixSimulatorWithProcessor(seed=0)]
+)
+@pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
+def test_plotting(sampler, ax):
+    res = cirq.experiments.parallel_two_qubit_xeb(
+        sampler=sampler,
+        n_repetitions=1,
+        n_combinations=1,
+        n_circuits=1,
+        cycle_depths=[3, 4, 5],
+        random_state=0,
+        ax=ax,
+    )
+    res.plot_heatmap(ax=ax)
+    res.plot_fitted_exponential(cirq.GridQubit(4, 4), cirq.GridQubit(4, 3), ax=ax)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -18,6 +18,7 @@ import io
 import random
 
 import matplotlib.pyplot as plt
+
 import numpy as np
 import networkx as nx
 import pytest
@@ -79,6 +80,7 @@ def test_parallel_two_qubit_xeb(sampler: cirq.Sampler):
         np.testing.assert_allclose(got, 0.1, atol=1e-1)
 
 
+@pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize(
     'sampler', [cirq.DensityMatrixSimulator(seed=0), DensityMatrixSimulatorWithProcessor(seed=0)]
 )

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -95,3 +95,4 @@ def test_plotting(sampler, ax):
     )
     res.plot_heatmap(ax=ax)
     res.plot_fitted_exponential(cirq.GridQubit(4, 4), cirq.GridQubit(4, 3), ax=ax)
+    res.plot_histogram(ax=ax)


### PR DESCRIPTION
This way the notebook https://quantumai.google/cirq/noise/qcvv/parallel_xeb becomes
```py3
>>> res = cirq.experiments.parallel_two_qubit_xeb(sampler)
>>> res.plot_heatmap()
```