### PR TITLE
Fix ci-daily notebook failures on Mac OS X

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
+  # FIXME - for PR testing only, remove before merge
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
-  # FIXME - for PR testing only, remove before merge
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -36,7 +36,8 @@ jobs:
           pip install \
             -r dev_tools/requirements/deps/format.txt \
             -r dev_tools/requirements/deps/pylint.txt \
-            -r dev_tools/requirements/deps/pytest.txt
+            -r dev_tools/requirements/deps/pytest.txt \
+            -r dev_tools/requirements/deps/notebook.txt
       - name: Run Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
@@ -64,7 +65,8 @@ jobs:
           pip install --pre cirq &&
             pip install -r dev_tools/requirements/deps/format.txt &&
             pip install -r dev_tools/requirements/deps/pylint.txt &&
-            pip install -r dev_tools/requirements/deps/pytest.txt
+            pip install -r dev_tools/requirements/deps/pytest.txt &&
+            pip install -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest Windows
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
         shell: bash

--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -8,7 +8,9 @@ ipykernel==5.3.4
 
 # for executing notebooks in tests
 papermill~=2.3.2
-quimb~=1.6.0
+
+# for notebooks that do `pip install cirq-core[contrib]`
+-r ../../../cirq-core/cirq/contrib/requirements.txt
 
 # assumed to be part of colab
 seaborn~=0.11.1


### PR DESCRIPTION
Use common version specification for quimb and numba as defined in
contrib/requirements.txt.  And install notebook dependencies for all CI platforms.

Avoid incompatible versions of quimb and numba in notebook environments.

Example failure: https://github.com/quantumlib/Cirq/actions/runs/7792626671/job/21250976788#step:6:580

Fix verified at https://github.com/quantumlib/Cirq/actions/runs/7805446772

Related to #6336
