### PR TITLE
CI - update GitHub actions to node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Coverage check
         run: check/pytest-and-incremental-coverage -n auto --rigetti-integration
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
       - name: Stop Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
   windows:


### PR DESCRIPTION
Bump up to codecov/codecov-action@v4 compatible with node20 per
https://github.com/codecov/codecov-action/releases/tag/v4.0.0

Finalizes #6445
