### PR TITLE
Suppress matplotlib warnings on non-interactive use of pyplot.show

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ skip-magic-trailing-comma = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:Matplotlib is currently using agg:UserWarning",
+    "ignore:FigureCanvasAgg is non-interactive.*cannot be shown:UserWarning",
 ]
 markers = [
     "rigetti_integration: tests that connect to Quil compiler or QVM.",


### PR DESCRIPTION
This is an intended behavior in tests.
