### PR TITLE
CI - update GitHub actions to node20

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days'


### PR DESCRIPTION
Bump up to actions/stale@v9 compatible with node20 per
https://github.com/actions/stale/releases/tag/v9.0.0

Related to #6445
