### PR TITLE
Relax version requirement on duet

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements for the python 3 version of cirq.
 
-duet~=0.2.8
+duet>=0.2.8
 matplotlib~=3.0
 networkx>=2.4
 numpy~=1.16


### PR DESCRIPTION
Duet is up to 0.3.0.dev and we'd like to continue to be able to use this internally with cirq.