### PR TITLE
Combine RB and XEB to compute inferred errors

### DIFF
--- a/cirq-core/cirq/experiments/__init__.py
+++ b/cirq-core/cirq/experiments/__init__.py
@@ -67,6 +67,6 @@ from cirq.experiments.xeb_fitting import XEBPhasedFSimCharacterizationOptions
 
 from cirq.experiments.two_qubit_xeb import (
     TwoQubitXEBResult,
-    CombinedXEBRBResult,
+    InferredXEBResult,
     parallel_two_qubit_xeb,
 )

--- a/cirq-core/cirq/experiments/__init__.py
+++ b/cirq-core/cirq/experiments/__init__.py
@@ -64,3 +64,5 @@ from cirq.experiments.t1_decay_experiment import t1_decay, T1DecayResult
 from cirq.experiments.t2_decay_experiment import t2_decay, T2DecayResult
 
 from cirq.experiments.xeb_fitting import XEBPhasedFSimCharacterizationOptions
+
+from cirq.experiments.two_qubit_xeb import TwoQubitXEBResult, parallel_two_qubit_xeb

--- a/cirq-core/cirq/experiments/__init__.py
+++ b/cirq-core/cirq/experiments/__init__.py
@@ -65,4 +65,8 @@ from cirq.experiments.t2_decay_experiment import t2_decay, T2DecayResult
 
 from cirq.experiments.xeb_fitting import XEBPhasedFSimCharacterizationOptions
 
-from cirq.experiments.two_qubit_xeb import TwoQubitXEBResult, parallel_two_qubit_xeb
+from cirq.experiments.two_qubit_xeb import (
+    TwoQubitXEBResult,
+    CombinedXEBRBResult,
+    parallel_two_qubit_xeb,
+)

--- a/cirq-core/cirq/experiments/__init__.py
+++ b/cirq-core/cirq/experiments/__init__.py
@@ -66,7 +66,7 @@ from cirq.experiments.t2_decay_experiment import t2_decay, T2DecayResult
 from cirq.experiments.xeb_fitting import XEBPhasedFSimCharacterizationOptions
 
 from cirq.experiments.two_qubit_xeb import (
-    TwoQubitXEBResult,
     InferredXEBResult,
+    TwoQubitXEBResult,
     parallel_two_qubit_xeb,
 )

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -186,11 +186,12 @@ class CombinedXEBRBResult:
 
     @cached_method
     def pauli_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
+        """Return the equivalent pauli error for all pairs."""
         return {pair: self._pauli_error(*pair) for pair in self.all_qubit_pairs}
 
     @cached_method
     def decay_constant(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
-        """Return the equivalent decay constant."""
+        """Return the equivalent decay constant for all pairs."""
         return {
             pair: noise_utils.pauli_error_to_decay_constant(pauli, 2)
             for pair, pauli in self.pauli_error().items()
@@ -198,7 +199,7 @@ class CombinedXEBRBResult:
 
     @cached_method
     def xeb_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
-        """Return the equivalent XEB error."""
+        """Return the equivalent XEB error for all pairs."""
         return {
             pair: 1 - noise_utils.decay_constant_to_xeb_fidelity(decay, 2)
             for pair, decay in self.decay_constant().items()

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -184,9 +184,11 @@ class CombinedXEBRBResult:
         single_q_paulis = self.rb_result.pauli_error()
         return self.xeb_result.pauli_error()[(q0, q1)] + single_q_paulis[q0] + single_q_paulis[q1]
 
+    @cached_method
     def pauli_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
         return {pair: self._pauli_error(*pair) for pair in self.all_qubit_pairs}
 
+    @cached_method
     def decay_constant(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
         """Return the equivalent decay constant."""
         return {
@@ -194,6 +196,7 @@ class CombinedXEBRBResult:
             for pair, pauli in self.pauli_error().items()
         }
 
+    @cached_method
     def xeb_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
         """Return the equivalent XEB error."""
         return {

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -64,7 +64,7 @@ class TwoQubitXEBResult:
     def all_qubit_pairs(self) -> Tuple[Tuple['cirq.GridQubit', 'cirq.GridQubit'], ...]:
         return tuple(sorted(self._qubit_pair_map.keys()))
 
-    def plot_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
+    def plot_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs) -> plt.Axes:
         """plot the heatmap for xeb error.
 
         Args:
@@ -73,19 +73,19 @@ class TwoQubitXEBResult:
             **plot_kwargs: Arguments to be passed to 'plt.Axes.plot'.
         """
         show_plot = not ax
-        if ax is None:
+        if not isinstance(ax, plt.Axes):
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
 
         heatmap_data: Dict[Tuple['cirq.GridQubit', ...], float] = {
             pair: self.xeb_error(*pair) for pair in self.all_qubit_pairs
         }
 
-        if ax is not None:
-            ax.set_title('device xeb error heatmap')
+        ax.set_title('device xeb error heatmap')
 
         vis.TwoQubitInteractionHeatmap(heatmap_data).plot(ax=ax, **plot_kwargs)
         if show_plot:
             fig.show()
+        return ax
 
     def plot_fitted_exponential(
         self,
@@ -93,7 +93,7 @@ class TwoQubitXEBResult:
         q1: 'cirq.GridQubit',
         ax: Optional[plt.Axes] = None,
         **plot_kwargs,
-    ):
+    ) -> plt.Axes:
         """plot the fitted model to for xeb error of a qubit pair.
 
         Args:
@@ -104,27 +104,27 @@ class TwoQubitXEBResult:
             **plot_kwargs: Arguments to be passed to 'plt.Axes.plot'.
         """
         show_plot = not ax
-        if not ax:
+        if not isinstance(ax, plt.Axes):
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
+
         record = self._record(q0, q1)
 
-        plt.axhline(1, color='grey', ls='--')
-        plt.plot(record['cycle_depths'], record['fidelities'], 'o')
-        xx = np.linspace(0, np.max(record['cycle_depths']))
-
-        if ax is not None:
-            ax.plot(
-                xx,
-                exponential_decay(xx, a=record['a'], layer_fid=record['layer_fid']),
-                label='estimated exponential decay',
-                **plot_kwargs,
-            )
-            ax.set_title(f'{q0}-{q1}')
-            ax.set_ylabel('Circuit fidelity')
-            ax.set_xlabel('Cycle Depth $d$')
-            ax.legend(loc='best')
+        ax.axhline(1, color='grey', ls='--')
+        ax.plot(record['cycle_depths'], record['fidelities'], 'o')
+        depths = np.linspace(0, np.max(record['cycle_depths']))
+        ax.plot(
+            depths,
+            exponential_decay(depths, a=record['a'], layer_fid=record['layer_fid']),
+            label='estimated exponential decay',
+            **plot_kwargs,
+        )
+        ax.set_title(f'{q0}-{q1}')
+        ax.set_ylabel('Circuit fidelity')
+        ax.set_xlabel('Cycle Depth $d$')
+        ax.legend(loc='best')
         if show_plot:
             fig.show()
+        return ax
 
     def _record(self, q0, q1) -> pd.Series:
         if q0 > q1:
@@ -140,7 +140,7 @@ class TwoQubitXEBResult:
         """Return the XEB error of all qubit pairs."""
         return {(q0, q1): self.xeb_error(q0, q1) for q0, q1 in self.all_qubit_pairs}
 
-    def plot_histogram(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
+    def plot_histogram(self, ax: Optional[plt.Axes] = None, **plot_kwargs) -> plt.Axes:
         """plot a histogram of all xeb errors
 
         Args:
@@ -154,6 +154,7 @@ class TwoQubitXEBResult:
         vis.integrated_histogram(data=self.all_errors(), ax=ax, **plot_kwargs)
         if fig is not None:
             fig.show(**plot_kwargs)
+        return ax
 
 
 def parallel_two_qubit_xeb(

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -64,7 +64,7 @@ class TwoQubitXEBResult:
             error_func = self.average_error
         heatmap_data = {pair: error_func(*pair) for pair in self.all_qubit_pairs}
 
-        ax.title('device depolarization error heatmap')
+        ax.title(f'device {target_error} error heatmap')
         vis.TwoQubitInteractionHeatmap(heatmap_data).plot(ax=ax, **plot_kwargs)
         if show_plot:
             fig.show()

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -103,7 +103,7 @@ class TwoQubitRandomizedBenchMarkResult:
         return 1 - p
 
     def pauli_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit'):
-        return self.depolarization_error(q0, q1) * (1 - 1 / 8)
+        return self.depolarization_error(q0, q1) * (1 - 1 / 16)
 
     def average_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit'):
         return self.depolarization_error() * (1 - 1 / 4)

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -1,0 +1,131 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Sequence, TYPE_CHECKING
+
+from matplotlib import pyplot as plt
+import networkx as nx
+import numpy as np
+import pandas as pd
+import seaborn as sns  # type: ignore
+
+from cirq import ops, devices, value, vis
+import cirq.contrib.routing as ccr
+from cirq.experiments.xeb_sampling import sample_2q_xeb_circuits
+from cirq.experiments.xeb_fitting import benchmark_2q_xeb_fidelities
+from cirq.experiments.xeb_fitting import fit_exponential_decays, exponential_decay
+from cirq.experiments import random_quantum_circuit_generation as rqcg
+
+if TYPE_CHECKING:
+    import cirq
+
+
+def grid_qubits_for_sampler(sampler: 'cirq.Sampler'):
+    if hasattr(sampler, 'processor'):
+        device = sampler.processor.get_device()
+        return sorted(device.metadata.qubit_set)
+    else:
+        qubits = devices.GridQubit.rect(3, 2, 4, 3)
+        # Delete one qubit from the rectangular arangement to
+        # 1) make it irregular 2) simplify simulation.
+        return qubits[:-1]
+
+
+def parallel_two_qubit_randomized_benchmarking(
+    sampler: 'cirq.Sampler',
+    entangling_gate: 'cirq.Gate' = ops.CZ,
+    n_repetitions: int = 10**4,
+    n_combinations: int = 10,
+    n_circuits: int = 20,
+    cycle_depths: Sequence[int] = tuple(np.arange(3, 100, 20)),
+    random_state: 'value.RANDOM_STATE_OR_SEED_LIKE' = 42,
+):
+    rs = value.parse_random_state(random_state)
+
+    qubits = grid_qubits_for_sampler(sampler)
+    n_rows = max(q.row for q in qubits) * 2 + 1
+    n_cols = max(q.col for q in qubits) * 2 + 1
+    plt.figure(2, figsize=(n_cols, n_rows))
+    graph = ccr.gridqubits_to_graph_device(qubits)
+    nx.draw_networkx(graph, pos={q: (q.row, q.col) for q in qubits})
+    plt.title('device layout')
+    plt.show()
+
+    print('Generate circuit library')
+    circuit_library = rqcg.generate_library_of_2q_circuits(
+        n_library_circuits=n_circuits, two_qubit_gate=entangling_gate, random_state=rs
+    )
+
+    print('Generate random two qubit combinations')
+    combs_by_layer = rqcg.get_random_combinations_for_device(
+        n_library_circuits=len(circuit_library),
+        n_combinations=n_combinations,
+        device_graph=graph,
+        random_state=rs,
+    )
+
+    pos = {q: (q.row, q.col) for q in qubits}
+    _, axes = plt.subplots(2, 2, figsize=(n_cols, n_rows))
+    for comb_layer, ax in zip(combs_by_layer, axes.reshape(-1)):
+        active_qubits = np.array(comb_layer.pairs).reshape(-1)
+        colors = ['red' if q in active_qubits else 'blue' for q in graph.nodes]
+        nx.draw_networkx(graph, pos=pos, node_color=colors, ax=ax)
+        nx.draw_networkx_edges(
+            graph, pos=pos, edgelist=comb_layer.pairs, width=3, edge_color='red', ax=ax
+        )
+
+    plt.tight_layout()
+
+    print('Run circuits')
+    sampled_df = sample_2q_xeb_circuits(
+        sampler=sampler,
+        circuits=circuit_library,
+        cycle_depths=cycle_depths,
+        combinations_by_layer=combs_by_layer,
+        shuffle=rs,
+        repetitions=n_repetitions,
+    )
+
+    print('Compute fidelities')
+    fids = benchmark_2q_xeb_fidelities(
+        sampled_df=sampled_df, circuits=circuit_library, cycle_depths=cycle_depths
+    )
+
+    print('Fit exponential decays')
+    return fit_exponential_decays(fids)
+
+
+def visulaize_fidelities(fidelities: pd.DataFrame):
+    heatmap_data = {}
+    for (_, _, pair), fidelity in fidelities.layer_fid.items():
+        heatmap_data[pair] = 1.0 - fidelity
+
+    vis.TwoQubitInteractionHeatmap(heatmap_data).plot()
+    plt.title('device fidelity heatmap')
+    plt.show()
+
+    for i, record in fidelities.iterrows():
+        plt.axhline(1, color='grey', ls='--')
+        plt.plot(record['cycle_depths'], record['fidelities'], 'o')
+        xx = np.linspace(0, np.max(record['cycle_depths']))
+        plt.plot(
+            xx,
+            exponential_decay(xx, a=record['a'], layer_fid=record['layer_fid']),
+            label='estimated exponential decay',
+        )
+        q0, q1 = i[-1]
+        plt.title(f'{q0}-{q1}')
+        plt.ylabel('Circuit fidelity')
+        plt.xlabel('Cycle Depth $d$')
+        plt.legend(loc='best')
+        plt.show()

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -160,7 +160,7 @@ class TwoQubitXEBResult:
 
     @cached_method
     def pauli_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
-        """Return the Pauli error of a qubit pair."""
+        """Return the Pauli error of all qubit pairs."""
         return {
             pair: noise_utils.decay_constant_to_pauli_error(
                 noise_utils.xeb_fidelity_to_decay_constant(self.xeb_fidelity(*pair), num_qubits=2),

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -179,19 +179,19 @@ class CombinedXEBRBResult:
         return self.xeb_result.all_qubit_pairs
 
     def _pauli_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit') -> float:
-        """Return the total pauli error."""
+        """Return the inferred pauli error."""
         q0, q1 = sorted([q0, q1])
         single_q_paulis = self.rb_result.pauli_error()
-        return self.xeb_result.pauli_error()[(q0, q1)] + single_q_paulis[q0] + single_q_paulis[q1]
+        return self.xeb_result.pauli_error()[(q0, q1)] - single_q_paulis[q0] - single_q_paulis[q1]
 
     @cached_method
     def pauli_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
-        """Return the equivalent pauli error for all pairs."""
+        """Return the inferred pauli error for all pairs."""
         return {pair: self._pauli_error(*pair) for pair in self.all_qubit_pairs}
 
     @cached_method
     def decay_constant(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
-        """Return the equivalent decay constant for all pairs."""
+        """Return the inferred decay constant for all pairs."""
         return {
             pair: noise_utils.pauli_error_to_decay_constant(pauli, 2)
             for pair, pauli in self.pauli_error().items()
@@ -199,7 +199,7 @@ class CombinedXEBRBResult:
 
     @cached_method
     def xeb_error(self) -> Dict[Tuple['cirq.GridQubit', 'cirq.GridQubit'], float]:
-        """Return the equivalent XEB error for all pairs."""
+        """Return the inferred XEB error for all pairs."""
         return {
             pair: 1 - noise_utils.decay_constant_to_xeb_fidelity(decay, 2)
             for pair, decay in self.decay_constant().items()

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -292,7 +292,7 @@ class InferredXEBResult:
         if ax is None:
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
 
-        alpha = 1 / (1 + int(kind == 'both'))
+        alpha = 0.5 if kind == 'both' else 1.0
         if kind == 'single_qubit' or kind == 'both':
             self.rb_result.plot_integrated_histogram(
                 ax=ax, alpha=alpha, label='single qubit', color='green', **plot_kwargs

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -14,6 +14,7 @@
 from typing import Sequence, TYPE_CHECKING, Optional, Tuple
 
 import itertools
+import functools
 
 from matplotlib import pyplot as plt
 import networkx as nx
@@ -51,16 +52,14 @@ class TwoQubitRandomizedBenchMarkResult:
         self.fidelities = fidelities
         self._qubit_pair_map = {idx[-1]: i for i, idx in enumerate(fidelities.index)}
 
-    def plot_device_fidelities_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
+    def plot_heatmap(self, ax: Optional[plt.Axes] = None, **plot_kwargs):
         show_plot = not ax
         if not ax:
             fig, ax = plt.subplots(1, 1, figsize=(8, 8))
 
-        heatmap_data = {}
-        for (_, _, pair), fidelity in self.fidelities.layer_fid.items():
-            heatmap_data[pair] = 1.0 - fidelity
+        heatmap_data = {pair: self.depolarization_error(*pair) for pair in self.all_qubit_pairs}
 
-        ax.title('device fidelity heatmap')
+        ax.title('device depolarization error heatmap')
         vis.TwoQubitInteractionHeatmap(heatmap_data).plot(ax=ax, **plot_kwargs)
         if show_plot:
             fig.show()
@@ -108,6 +107,7 @@ class TwoQubitRandomizedBenchMarkResult:
     def average_error(self, q0: 'cirq.GridQubit', q1: 'cirq.GridQubit'):
         return self.depolarization_error() * (1 - 1 / 4)
 
+    @functools.cached_property
     def all_qubit_pairs(self) -> frozenset[Tuple['cirq.GridQubit', 'Cirq.GridQubit']]:
         return frozenset(self._qubit_pair_map.keys())
 

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-def grid_qubits_for_sampler(sampler: 'cirq.Sampler'):
+def _grid_qubits_for_sampler(sampler: 'cirq.Sampler'):
     if hasattr(sampler, 'processor'):
         device = sampler.processor.get_device()
         return sorted(device.metadata.qubit_set)
@@ -48,12 +48,12 @@ def parallel_two_qubit_randomized_benchmarking(
     n_combinations: int = 10,
     n_circuits: int = 20,
     cycle_depths: Sequence[int] = tuple(np.arange(3, 100, 20)),
-    random_state: 'value.RANDOM_STATE_OR_SEED_LIKE' = 42,
+    random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = 42,
 ):
     rs = value.parse_random_state(random_state)
 
-    qubits = grid_qubits_for_sampler(sampler)
-    n_rows = max(q.row for q in qubits) * 2 + 1
+    qubits = _grid_qubits_for_sampler(sampler)
+    n_rows = max(q.row for q in qubits) + 1
     n_cols = max(q.col for q in qubits) * 2 + 1
     plt.figure(2, figsize=(n_cols, n_rows))
     graph = ccr.gridqubits_to_graph_device(qubits)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Wraps Parallel Two Qubit XEB into a few convenience methods."""
+from typing import Optional, Sequence, Dict
 from contextlib import redirect_stdout, redirect_stderr
 import itertools
 import io
@@ -21,9 +22,11 @@ import matplotlib.pyplot as plt
 
 import numpy as np
 import networkx as nx
+import pandas as pd
 import pytest
 
 import cirq
+from cirq.experiments.qubit_characterizations import ParallelRandomizedBenchmarkingResult
 
 
 def _manhattan_distance(qubit1: 'cirq.GridQubit', qubit2: 'cirq.GridQubit') -> int:
@@ -51,24 +54,49 @@ class DensityMatrixSimulatorWithProcessor(cirq.DensityMatrixSimulator):
         return MockProcessor()
 
 
-@pytest.mark.parametrize(
-    'sampler',
-    [
+def test_parallel_two_qubit_xeb_simulator_without_processor_fails():
+    sampler = (
         cirq.DensityMatrixSimulator(
             seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
         ),
-        DensityMatrixSimulatorWithProcessor(
-            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+    )
+
+    with pytest.raises(ValueError):
+        _ = cirq.experiments.parallel_two_qubit_xeb(
+            sampler=sampler,
+            n_repetitions=1,
+            n_combinations=1,
+            n_circuits=1,
+            cycle_depths=[3, 4, 5],
+            random_state=0,
+        )
+
+
+@pytest.mark.parametrize(
+    'sampler,qubits',
+    [
+        (
+            cirq.DensityMatrixSimulator(
+                seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+            ),
+            cirq.GridQubit.rect(3, 2, 4, 3),
+        ),
+        (
+            DensityMatrixSimulatorWithProcessor(
+                seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+            ),
+            None,
         ),
     ],
 )
-def test_parallel_two_qubit_xeb(sampler: cirq.Sampler):
+def test_parallel_two_qubit_xeb(sampler: cirq.Sampler, qubits: Optional[Sequence[cirq.GridQubit]]):
     np.random.seed(0)
     random.seed(0)
 
     with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
         res = cirq.experiments.parallel_two_qubit_xeb(
             sampler=sampler,
+            qubits=qubits,
             n_repetitions=100,
             n_combinations=1,
             n_circuits=1,
@@ -82,12 +110,17 @@ def test_parallel_two_qubit_xeb(sampler: cirq.Sampler):
 
 @pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize(
-    'sampler', [cirq.DensityMatrixSimulator(seed=0), DensityMatrixSimulatorWithProcessor(seed=0)]
+    'sampler,qubits',
+    [
+        (cirq.DensityMatrixSimulator(seed=0), cirq.GridQubit.rect(3, 2, 4, 3)),
+        (DensityMatrixSimulatorWithProcessor(seed=0), None),
+    ],
 )
 @pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
-def test_plotting(sampler, ax):
+def test_plotting(sampler, qubits, ax):
     res = cirq.experiments.parallel_two_qubit_xeb(
         sampler=sampler,
+        qubits=qubits,
         n_repetitions=1,
         n_combinations=1,
         n_circuits=1,
@@ -98,3 +131,81 @@ def test_plotting(sampler, ax):
     res.plot_heatmap(ax=ax)
     res.plot_fitted_exponential(cirq.GridQubit(4, 4), cirq.GridQubit(4, 3), ax=ax)
     res.plot_histogram(ax=ax)
+
+
+_TEST_RESULT = cirq.experiments.TwoQubitXEBResult(
+    pd.read_csv(
+        io.StringIO(
+            """layer_i,pair_i,pair,a,layer_fid,cycle_depths,fidelities,a_std,layer_fid_std
+0,0,"(cirq.GridQubit(4, 4), cirq.GridQubit(5, 4))",,0.9,[],[],,
+0,1,"(cirq.GridQubit(5, 3), cirq.GridQubit(6, 3))",,0.8,[],[],,
+1,0,"(cirq.GridQubit(4, 3), cirq.GridQubit(5, 3))",,0.3,[],[],,
+1,1,"(cirq.GridQubit(5, 4), cirq.GridQubit(6, 4))",,0.2,[],[],,
+2,0,"(cirq.GridQubit(4, 3), cirq.GridQubit(4, 4))",,0.1,[],[],,
+2,1,"(cirq.GridQubit(6, 3), cirq.GridQubit(6, 4))",,0.5,[],[],,
+3,0,"(cirq.GridQubit(5, 3), cirq.GridQubit(5, 4))",,0.4,[],[],"""
+        ),
+        index_col=[0, 1, 2],
+        converters={2: lambda s: eval(s)},
+    )
+)
+
+
+@pytest.mark.parametrize(
+    'q0,q1,pauli',
+    [
+        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 1 / 8),
+        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 1 / 4),
+        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 0.8 + 3 / 40),
+        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 5 / 8),
+    ],
+)
+def test_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
+    assert _TEST_RESULT.pauli_error()[(q0, q1)] == pytest.approx(pauli)
+
+
+class MockParallelRandomizedBenchmarkingResult(ParallelRandomizedBenchmarkingResult):
+    def pauli_error(self) -> Dict[cirq.Qid, float]:
+        return {
+            cirq.GridQubit(4, 4): 0.1,
+            cirq.GridQubit(5, 4): 0.2,
+            cirq.GridQubit(5, 3): 0.3,
+            cirq.GridQubit(5, 6): 0.4,
+            cirq.GridQubit(4, 3): 0.5,
+            cirq.GridQubit(6, 3): 0.6,
+            cirq.GridQubit(6, 4): 0.7,
+        }
+
+
+@pytest.mark.parametrize(
+    'q0,q1,pauli',
+    [
+        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 1 / 8 + 0.3),
+        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 1 / 4 + 0.9),
+        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 0.8 + 3 / 40 + 0.8),
+        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 5 / 8 + 1.3),
+    ],
+)
+def test_combined_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
+    combined_results = cirq.experiments.CombinedXEBRBResult(
+        rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
+    )
+
+    assert combined_results.pauli_error()[(q0, q1)] == pytest.approx(pauli)
+
+
+@pytest.mark.parametrize(
+    'q0,q1,xeb',
+    [
+        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 0.34),
+        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 0.92),
+        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 1.34),
+        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 1.54),
+    ],
+)
+def test_combined_xeb_error(q0: cirq.GridQubit, q1: cirq.GridQubit, xeb: float):
+    combined_results = cirq.experiments.CombinedXEBRBResult(
+        rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
+    )
+
+    assert combined_results.xeb_error()[(q0, q1)] == pytest.approx(xeb)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -1,0 +1,97 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wraps Parallel Two Qubit XEB into a few convenience methods."""
+from contextlib import redirect_stdout, redirect_stderr
+import itertools
+import io
+import random
+
+import matplotlib.pyplot as plt
+import numpy as np
+import networkx as nx
+import pytest
+
+import cirq
+
+
+def _manhattan_distance(qubit1: 'cirq.GridQubit', qubit2: 'cirq.GridQubit') -> int:
+    return abs(qubit1.row - qubit2.row) + abs(qubit1.col - qubit2.col)
+
+
+class MockDevice(cirq.Device):
+    @property
+    def metadata(self):
+        qubits = cirq.GridQubit.rect(3, 2, 4, 3)
+        graph = nx.Graph(
+            pair for pair in itertools.combinations(qubits, 2) if _manhattan_distance(*pair) == 1
+        )
+        return cirq.DeviceMetadata(qubits, graph)
+
+
+class MockProcessor:
+    def get_device(self):
+        return MockDevice()
+
+
+class DensityMatrixSimulatorWithProcessor(cirq.DensityMatrixSimulator):
+    @property
+    def processor(self):
+        return MockProcessor()
+
+
+@pytest.mark.parametrize(
+    'sampler',
+    [
+        cirq.DensityMatrixSimulator(
+            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+        ),
+        DensityMatrixSimulatorWithProcessor(
+            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
+        ),
+    ],
+)
+def test_parallel_two_qubit_xeb(sampler: cirq.Sampler):
+    np.random.seed(0)
+    random.seed(0)
+
+    with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+        res = cirq.experiments.parallel_two_qubit_xeb(
+            sampler=sampler,
+            n_repetitions=100,
+            n_combinations=1,
+            n_circuits=1,
+            cycle_depths=[3, 4, 5],
+            random_state=0,
+        )
+
+        got = [res.xeb_error(*reversed(pair)) for pair in res.all_qubit_pairs]
+        np.testing.assert_allclose(got, 0.1, atol=1e-1)
+
+
+@pytest.mark.parametrize(
+    'sampler', [cirq.DensityMatrixSimulator(seed=0), DensityMatrixSimulatorWithProcessor(seed=0)]
+)
+@pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
+def test_plotting(sampler, ax):
+    res = cirq.experiments.parallel_two_qubit_xeb(
+        sampler=sampler,
+        n_repetitions=1,
+        n_combinations=1,
+        n_circuits=1,
+        cycle_depths=[3, 4, 5],
+        random_state=0,
+        ax=ax,
+    )
+    res.plot_heatmap(ax=ax)
+    res.plot_fitted_exponential(cirq.GridQubit(4, 4), cirq.GridQubit(4, 3), ax=ax)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -245,9 +245,8 @@ def test_inferred_two_qubit_pauli(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli:
 
 @pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
 @pytest.mark.parametrize('target_error', ['pauli', 'xeb', 'decay_constant'])
-@pytest.mark.parametrize('single_qubit', [False, True])
-@pytest.mark.parametrize('two_qubit', [False, True])
-def test_inferred_plots(ax, target_error, single_qubit, two_qubit):
+@pytest.mark.parametrize('kind', ['single_qubit', 'two_qubit', 'both', ''])
+def test_inferred_plots(ax, target_error, kind):
     combined_results = cirq.experiments.InferredXEBResult(
         rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
     )
@@ -255,17 +254,13 @@ def test_inferred_plots(ax, target_error, single_qubit, two_qubit):
     combined_results.plot_heatmap(target_error=target_error, ax=ax)
 
     raise_error = False
-    if not (single_qubit or two_qubit):
+    if kind not in ('single_qubit', 'two_qubit', 'both'):
         raise_error = True
-    if single_qubit and target_error != 'pauli':
+    if kind != 'two_qubit' and target_error != 'pauli':
         raise_error = True
 
     if raise_error:
         with pytest.raises(ValueError):
-            combined_results.plot_histogram(
-                target_error=target_error, single_qubit=single_qubit, two_qubit=two_qubit, ax=ax
-            )
+            combined_results.plot_histogram(target_error=target_error, kind=kind, ax=ax)
     else:
-        combined_results.plot_histogram(
-            target_error=target_error, single_qubit=single_qubit, two_qubit=two_qubit, ax=ax
-        )
+        combined_results.plot_histogram(target_error=target_error, kind=kind, ax=ax)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -18,6 +18,7 @@ import io
 import random
 
 import matplotlib.pyplot as plt
+
 import numpy as np
 import networkx as nx
 import pytest
@@ -79,6 +80,7 @@ def test_parallel_two_qubit_xeb(sampler: cirq.Sampler):
         np.testing.assert_allclose(got, 0.1, atol=1e-1)
 
 
+@pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize(
     'sampler', [cirq.DensityMatrixSimulator(seed=0), DensityMatrixSimulatorWithProcessor(seed=0)]
 )

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -209,3 +209,14 @@ def test_combined_xeb_error(q0: cirq.GridQubit, q1: cirq.GridQubit, xeb: float):
     )
 
     assert combined_results.xeb_error()[(q0, q1)] == pytest.approx(xeb)
+
+
+@pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
+@pytest.mark.parametrize('target_error', ['pauli', 'xeb', 'decay_constant'])
+def test_combined_plots(ax, target_error):
+    combined_results = cirq.experiments.CombinedXEBRBResult(
+        rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
+    )
+
+    combined_results.plot_heatmap(target_error=target_error, ax=ax)
+    combined_results.plot_histogram(target_error=target_error, ax=ax)

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -167,23 +167,23 @@ def test_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
 class MockParallelRandomizedBenchmarkingResult(ParallelRandomizedBenchmarkingResult):
     def pauli_error(self) -> Dict[cirq.Qid, float]:
         return {
-            cirq.GridQubit(4, 4): 0.1,
-            cirq.GridQubit(5, 4): 0.2,
-            cirq.GridQubit(5, 3): 0.3,
-            cirq.GridQubit(5, 6): 0.4,
-            cirq.GridQubit(4, 3): 0.5,
-            cirq.GridQubit(6, 3): 0.6,
-            cirq.GridQubit(6, 4): 0.7,
+            cirq.GridQubit(4, 4): 0.01,
+            cirq.GridQubit(5, 4): 0.02,
+            cirq.GridQubit(5, 3): 0.03,
+            cirq.GridQubit(5, 6): 0.04,
+            cirq.GridQubit(4, 3): 0.05,
+            cirq.GridQubit(6, 3): 0.06,
+            cirq.GridQubit(6, 4): 0.07,
         }
 
 
 @pytest.mark.parametrize(
     'q0,q1,pauli',
     [
-        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 1 / 8 + 0.3),
-        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 1 / 4 + 0.9),
-        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 0.8 + 3 / 40 + 0.8),
-        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 5 / 8 + 1.3),
+        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 1 / 8 - 0.03),
+        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 1 / 4 - 0.09),
+        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 0.8 + 3 / 40 - 0.08),
+        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 5 / 8 - 0.13),
     ],
 )
 def test_combined_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
@@ -197,10 +197,10 @@ def test_combined_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: flo
 @pytest.mark.parametrize(
     'q0,q1,xeb',
     [
-        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 0.34),
-        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 0.92),
-        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 1.34),
-        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 1.54),
+        (cirq.GridQubit(4, 4), cirq.GridQubit(5, 4), 0.076),
+        (cirq.GridQubit(5, 3), cirq.GridQubit(6, 3), 0.128),
+        (cirq.GridQubit(4, 3), cirq.GridQubit(5, 3), 0.636),
+        (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 0.396),
     ],
 )
 def test_combined_xeb_error(q0: cirq.GridQubit, q1: cirq.GridQubit, xeb: float):

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -95,3 +95,4 @@ def test_plotting(sampler, ax):
     )
     res.plot_heatmap(ax=ax)
     res.plot_fitted_exponential(cirq.GridQubit(4, 4), cirq.GridQubit(4, 3), ax=ax)
+    res.plot_histogram(ax=ax)


### PR DESCRIPTION
This PR:
- Adds the option to specify the qubits to the XEB workflow
- Adds pauli error computation for 2q XEB
- Adds `InferredXEBResult` class which
    - computes inferred errors: pauli, XEB, and decay constant
    - has a convenience method to plot heatmap for each of the errors
    - has a convenience method to plot histogram of each of the erros.