### PR TITLE
Specify CODECOV_TOKEN for uploading coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,8 @@ jobs:
         run: check/pytest-and-incremental-coverage -n auto --rigetti-integration
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Stop Quil dependencies
         run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
   windows:


### PR DESCRIPTION
Ref: https://docs.codecov.com/docs/adding-the-codecov-token

This should fix `Codecov: Failed to properly create commit`
warnings in the CI output.
