### PR TITLE
Enable testing of quimb-dependent notebook

### DIFF
--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -12,14 +20,14 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --quiet cirq --pre\n",
     "    print(\"installed cirq.\")\n",
     "\n",
     "try:\n",
     "    import quimb\n",
     "except ImportError:\n",
     "    print(\"installing cirq-core[contrib]...\")\n",
-    "    !pip install --quiet 'cirq-core[contrib]'\n",
+    "    !pip install --quiet 'cirq-core[contrib]' --pre\n",
     "    print(\"installed cirq-core[contrib].\")"
    ]
   },

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -20,9 +20,7 @@
     "except ImportError:\n",
     "    print(\"installing cirq-core[contrib]...\")\n",
     "    !pip install --quiet 'cirq-core[contrib]'\n",
-    "    print(\"installed cirq-core[contrib].\")\n",
-    "\n",
-    "!pip freeze\n"
+    "    print(\"installed cirq-core[contrib].\")"
    ]
   },
   {
@@ -404,7 +402,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ccq.tensor_expectation_value(circuit, ZZ)"
+    "ccq.tensor_expectation_value(circuit, ZZ)"
    ]
   }
  ],

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -20,7 +20,9 @@
     "except ImportError:\n",
     "    print(\"installing cirq-core[contrib]...\")\n",
     "    !pip install --quiet 'cirq-core[contrib]'\n",
-    "    print(\"installed cirq-core[contrib].\")"
+    "    print(\"installed cirq-core[contrib].\")\n",
+    "\n",
+    "!pip freeze\n"
    ]
   },
   {
@@ -402,7 +404,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccq.tensor_expectation_value(circuit, ZZ)"
+    "# ccq.tensor_expectation_value(circuit, ZZ)"
    ]
   }
  ],

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert False, 'intentional failure to ensure notebook is tested in CI'\n",
     "import importlib.util\n",
     "\n",
     "try:\n",

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert False, 'intentional failure to ensure notebook is tested in CI'\n",
     "import importlib.util\n",
     "\n",
     "try:\n",

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -63,9 +63,6 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
 # By default all notebooks should be tested, however, this list contains exceptions to the rule
 # please always add a reason for skipping.
 SKIP_NOTEBOOKS = [
-    # TODO(#6088) - enable notebooks below
-    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
-    # End of TODO(#6088)
     # skipping vendor notebooks as we don't have auth sorted out
     "**/aqt/*.ipynb",
     "**/azure-quantum/*.ipynb",

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -42,6 +42,8 @@ from dev_tools.notebooks import list_all_notebooks, filter_notebooks, rewrite_no
 # Please, always indicate in comments the feature used for easier bookkeeping.
 
 NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: List[str] = [
+    # Requires pinned quimb from #6438
+    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
     # Hardcoded qubit placement
     'docs/google/qubit-placement.ipynb',
     # get_qcs_objects_for_notebook


### PR DESCRIPTION
Enable Contract-a-Grid-Circuit.ipynb in notebook tests

Fixes #6088
