### PR TITLE
Bugfix in `_strat_has_stabilizer_effect_from_decompose`

### DIFF
--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -102,11 +102,7 @@ def _strat_has_stabilizer_effect_from_unitary(val: Any) -> Optional[bool]:
 
 
 def _strat_has_stabilizer_effect_from_decompose(val: Any) -> Optional[bool]:
-    qid_shape = qid_shape_protocol.qid_shape(val, default=None)
-    if qid_shape is None or len(qid_shape) <= 3:
-        return None
-
-    decomposition = decompose_protocol.decompose_once(val, default=None)
+    decomposition, _, _ = decompose_protocol._try_decompose_into_operations_and_qubits(val)
     if decomposition is None:
         return None
     for op in decomposition:

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -41,15 +41,15 @@ class Yes:
         return True
 
 
-q = cirq.LineQubit(0)
-
-
 class EmptyOp(cirq.Operation):
     """A trivial operation."""
 
+    def __init__(self, q: cirq.Qid = cirq.LineQubit(0)):
+        self.q = q
+
     @property
     def qubits(self):
-        return (q,)
+        return (self.q,)
 
     def with_qubits(self, *new_qubits):  # pragma: no cover
         return self
@@ -95,6 +95,14 @@ class OpWithUnitary(EmptyOp):
     @property
     def qubits(self):
         return cirq.LineQubit.range(self.unitary.shape[0].bit_length() - 1)
+
+
+class GateDecomposes(cirq.Gate):
+    def _num_qubits_(self):
+        return 1
+
+    def _decompose_(self, qubits):
+        yield YesOp(*qubits)
 
 
 def test_inconclusive():
@@ -146,3 +154,4 @@ def test_via_decompose():
     assert not cirq.has_stabilizer_effect(
         OpWithUnitary(cirq.unitary(cirq.Circuit(cirq.T.on_each(cirq.LineQubit.range(4)))))
     )
+    assert cirq.has_stabilizer_effect(GateDecomposes())


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Qualtran/issues/665


@NoureldinYosri Do you remember why you added the following check? 

```python
    qid_shape = qid_shape_protocol.qid_shape(val, default=None)
    if qid_shape is None or len(qid_shape) <= 3:
        return None

```