### PR TITLE
Change str of ResultDict to print out repeated measurements

### DIFF
--- a/cirq-core/cirq/study/result.py
+++ b/cirq-core/cirq/study/result.py
@@ -74,6 +74,18 @@ def _keyed_repeated_bitstrings(vals: Mapping[str, np.ndarray]) -> str:
     return '\n'.join(keyed_bitstrings)
 
 
+def _keyed_repeated_records(vals: Mapping[str, np.ndarray]) -> str:
+    keyed_bitstrings = []
+    for key in sorted(vals.keys()):
+        reps = vals[key]
+        n = reps.shape[2]
+        num_records = reps.shape[1]
+        for j in range(num_records):
+            all_bits = ', '.join(_bitstring(reps[:, j, i]) for i in range(n))
+            keyed_bitstrings.append(f'{key}={all_bits}')
+    return '\n'.join(keyed_bitstrings)
+
+
 def _key_to_str(key: TMeasurementKey) -> str:
     if isinstance(key, str):
         return key
@@ -388,6 +400,8 @@ class ResultDict(Result):
             p.text(str(self))
 
     def __str__(self) -> str:
+        if self._records:
+            return _keyed_repeated_records(self.records)
         return _keyed_repeated_bitstrings(self.measurements)
 
     def _json_dict_(self):

--- a/cirq-core/cirq/study/result_test.py
+++ b/cirq-core/cirq/study/result_test.py
@@ -127,6 +127,12 @@ def test_str():
     )
     assert str(result) == 'ab=13579, 2 4 6 8 10\nc=01234'
 
+    result = cirq.ResultDict(records={'c': np.array([[[True], [True]]])})
+    assert str(result) == 'c=1\nc=1'
+
+    result = cirq.ResultDict(records={'c': np.array([[[True, False], [False, True]]])})
+    assert str(result) == 'c=1, 0\nc=0, 1'
+
 
 def test_df():
     result = cirq.ResultDict(


### PR DESCRIPTION
- ResultDict will now print out repeated measurements on each line, as opposed to throwing ValueError

Fixes: #6447