### PR TITLE
Add warning when converting global phase operator to OpenQASM 2.0

### DIFF
--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -191,6 +191,24 @@ ry(pi*-0.25) q[0];
     )
 
 
+def test_qasm_global_pahse():
+    (q0,) = _make_qubits(1)
+    output = cirq.QasmOutput((cirq.global_phase_operation(np.exp(1j * 5)), cirq.X(q0)), (q0,))
+    assert (
+        str(output)
+        == """OPENQASM 2.0;
+include "qelib1.inc";
+
+
+// Qubits: [q0]
+qreg q[1];
+
+
+x q[0];
+"""
+    )
+
+
 def test_precision():
     (q0,) = _make_qubits(1)
     output = cirq.QasmOutput((cirq.X(q0) ** 0.1234567,), (q0,), precision=3)
@@ -318,16 +336,18 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
         cirq.PhasedXPowGate(phase_exponent=0.333, exponent=0.5).on(q1),
         cirq.PhasedXPowGate(phase_exponent=0.777, exponent=-0.5).on(q1),
         (
-            cirq.measure(q0, key='xX'),
-            cirq.measure(q2, key='x_a'),
-            cirq.measure(q1, key='x?'),
-            cirq.measure(q3, key='X'),
-            cirq.measure(q4, key='_x'),
-            cirq.measure(q2, key='x_a'),
-            cirq.measure(q1, q2, q3, key='multi', invert_mask=(False, True)),
-        )
-        if include_measurements
-        else (),
+            (
+                cirq.measure(q0, key='xX'),
+                cirq.measure(q2, key='x_a'),
+                cirq.measure(q1, key='x?'),
+                cirq.measure(q3, key='X'),
+                cirq.measure(q4, key='_x'),
+                cirq.measure(q2, key='x_a'),
+                cirq.measure(q1, q2, q3, key='multi', invert_mask=(False, True)),
+            )
+            if include_measurements
+            else ()
+        ),
         ExampleOperation(),
         ExampleCompositeOperation(),
     )

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -15,6 +15,7 @@
 """Basic types defining qubits, gates, and operations."""
 
 import re
+import warnings
 from typing import (
     AbstractSet,
     Any,
@@ -35,7 +36,7 @@ from typing_extensions import Self
 
 import numpy as np
 
-from cirq import protocols, value
+from cirq import ops, protocols, value
 from cirq.ops import raw_types, gate_features, control_values as cv
 from cirq.type_workarounds import NotImplementedType
 
@@ -348,6 +349,14 @@ class GateOperation(raw_types.Operation):
         return self.gate._rmul_with_qubits(self._qubits, other)
 
     def _qasm_(self, args: 'protocols.QasmArgs') -> Optional[str]:
+        if isinstance(self.gate, ops.GlobalPhaseGate):
+            warnings.warn(
+                "OpenQASM 2.0 does not support global phase."
+                "Since the global phase does not affect the measurement results, "
+                "the conversion to QASM is disregarded."
+            )
+            return ""
+
         return protocols.qasm(self.gate, args=args, qubits=self.qubits, default=None)
 
     def _equal_up_to_global_phase_(

--- a/cirq-core/cirq/testing/consistent_qasm.py
+++ b/cirq-core/cirq/testing/consistent_qasm.py
@@ -42,6 +42,7 @@ def assert_qasm_is_consistent_with_unitary(val: Any):
     if isinstance(val, ops.Operation):
         qubits: Sequence[ops.Qid] = val.qubits
         op = val
+        gate = val.gate
     elif isinstance(val, ops.Gate):
         qid_shape = protocols.qid_shape(val)
         remaining_shape = list(qid_shape)
@@ -52,8 +53,13 @@ def assert_qasm_is_consistent_with_unitary(val: Any):
                     remaining_shape.pop(i)
         qubits = devices.LineQid.for_qid_shape(remaining_shape)
         op = val.on(*qubits)
+        gate = val
     else:
         raise NotImplementedError(f"Don't know how to test {val!r}")
+
+    if isinstance(gate, ops.GlobalPhaseGate):
+        # OpenQASM 2.0 does not support global phase gates.
+        return
 
     args = protocols.QasmArgs(qubit_id_map={q: f'q[{i}]' for i, q in enumerate(qubits)})
     qasm = protocols.qasm(op, args=args, default=None)


### PR DESCRIPTION
OpenQASM 2.0 does not support global phase (https://github.com/Qiskit/qiskit/issues/7167#issuecomment-947821313). 
Therefore, the current implementation generated an error and terminated the program. Since the global phase does not affect the observation results, I have changed it to be supported as a warning and the program can be executed.

The following is how to handle the situation.
1. Determine if the operator passed to `qasm()` is an instance of `ops.GlobalPhaseGate`. If a Circuit is passed, it is deployed to each operator by existing implementations and a decision is made for each.
2. If it is an instance of `ops.GlobalPhaseGate`, generate a warning and return an empty string for compatibility with previous implementations.
3. Otherwise, the operation is the same as before.