### PR TITLE
Fix maximum version limit for mpmath

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -4,7 +4,7 @@ duet>=0.2.8
 matplotlib~=3.0
 # Temporary fix for https://github.com/sympy/sympy/issues/26273
 # TODO: remove once `pip install --pre sympy` works in a fresh environment
-mpmath<=1.3.*
+mpmath<1.4
 networkx>=2.4
 numpy~=1.16
 pandas


### PR DESCRIPTION
The `1.3.*` pattern is invalid in `install_requires` context.
The `mpmath<1.4` spec prohibits pre-releases of 1.4 such as 1.4.0a0.

Related to #6475
