### PR TITLE
Update T1 experiment

### DIFF
--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -137,9 +137,8 @@ class T1DecayResult:
 
         # Fit to exponential decay to find the t1 constant
         try:
-            popt, _ = optimize.curve_fit(exp_decay, xs, probs, p0=[t1_guess, 1.0, 0.0])
-            self.popt = popt
-            t1 = popt[0]
+            self.popt, _ = optimize.curve_fit(exp_decay, xs, probs, p0=[t1_guess, 1.0, 0.0])
+            t1 = self.popt[0]
             return t1
         except RuntimeError:
             warnings.warn("Optimal parameters could not be found for curve fit", RuntimeWarning)

--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -80,7 +80,7 @@ def t1_decay(
     if min_delay_nanos == 0:
         min_delay_nanos = 0.4
     sweep_vals_ns = np.unique(
-        np.logspace(np.log10(min_delay_nanos), np.log10(max_delay_nanos), num_points, dtype=int)
+        np.round(np.logspace(np.log10(min_delay_nanos), np.log10(max_delay_nanos), num_points))
     )
     sweep = study.Points(var, sweep_vals_ns)
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, Sequence, TYPE_CHECKING, cast
 
 import warnings
 import pandas as pd
@@ -82,7 +82,7 @@ def t1_decay(
     sweep_vals_ns = np.unique(
         np.round(np.logspace(np.log10(min_delay_nanos), np.log10(max_delay_nanos), num_points))
     )
-    sweep = study.Points(var, sweep_vals_ns)
+    sweep = study.Points(var, cast(Sequence[float], sweep_vals_ns))
 
     circuit = circuits.Circuit(
         ops.X(qubit), ops.wait(qubit, nanos=var), ops.measure(qubit, key='output')

--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -123,8 +123,8 @@ class T1DecayResult:
     def constant(self) -> float:
         """The t1 decay constant."""
 
-        def exp_decay(x, t1, A, B):
-            return A * np.exp(-x / t1) + B
+        def exp_decay(x, t1, a, b):
+            return a * np.exp(-x / t1) + b
 
         xs = self._data['delay_ns']
         ts = self._data['true_count']
@@ -173,8 +173,8 @@ class T1DecayResult:
 
         if include_fit and not np.isnan(self.constant):
             t1 = self.constant
-            t1, A, B = self.popt
-            ax.plot(xs, A * np.exp(-xs / t1) + B, label='curve fit')
+            t1, a, b = self.popt
+            ax.plot(xs, a * np.exp(-xs / t1) + b, label='curve fit')
             plt.legend()
 
         ax.set_xlabel(r"Delay between initialization and measurement (nanoseconds)")

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -117,13 +117,14 @@ def test_all_on_results():
         min_delay=cirq.Duration(nanos=100),
         max_delay=cirq.Duration(micros=1),
     )
-    assert results == cirq.experiments.T1DecayResult(
+    desired = cirq.experiments.T1DecayResult(
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
             data=[[100, 0, 10], [215, 0, 10], [464, 0, 10], [1000, 0, 10]],
         )
     )
+    assert results == desired, f'{results.data=} {desired.data=}'
 
 
 def test_all_off_results():
@@ -135,13 +136,14 @@ def test_all_off_results():
         min_delay=cirq.Duration(nanos=100),
         max_delay=cirq.Duration(micros=1),
     )
-    assert results == cirq.experiments.T1DecayResult(
+    desired = cirq.experiments.T1DecayResult(
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
             data=[[100, 10, 0], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
         )
     )
+    assert results == desired, f'{results.data=} {desired.data=}'
 
 
 @pytest.mark.usefixtures('closefigures')

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -53,7 +53,7 @@ def test_plot_does_not_raise_error():
         repetitions=10,
         max_delay=cirq.Duration(nanos=500),
     )
-    results.plot()
+    results.plot(include_fit=True)
 
 
 def test_result_eq():
@@ -182,10 +182,10 @@ def test_noise_model_continous(t1):
     results = cirq.experiments.t1_decay(
         sampler=cirq.DensityMatrixSimulator(noise=GradualDecay(t1)),
         qubit=cirq.GridQubit(0, 0),
-        num_points=4,
+        num_points=10,
         repetitions=10,
-        min_delay=cirq.Duration(nanos=100),
-        max_delay=cirq.Duration(micros=1),
+        min_delay=cirq.Duration(nanos=1),
+        max_delay=cirq.Duration(micros=10),
     )
 
     assert np.isclose(results.constant, t1, 50)

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -103,7 +103,7 @@ def test_sudden_decay_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 0, 10], [215, 0, 10], [700, 10, 0], [1000, 10, 0]],
+            data=[[100, 0, 10], [215, 0, 10], [464, 10, 0], [1000, 10, 0]],
         )
     )
 
@@ -155,20 +155,6 @@ def test_curve_fit_plot_works():
     )
 
     good_fit.plot(include_fit=True)
-
-
-@pytest.mark.usefixtures('closefigures')
-def test_curve_fit_plot_warning():
-    bad_fit = cirq.experiments.T1DecayResult(
-        data=pd.DataFrame(
-            columns=['delay_ns', 'false_count', 'true_count'],
-            index=range(4),
-            data=[[100, 10, 0], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
-        )
-    )
-
-    with pytest.warns(RuntimeWarning, match='Optimal parameters could not be found for curve fit'):
-        bad_fit.plot(include_fit=True)
 
 
 @pytest.mark.parametrize('t1', [200, 500, 700])

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -121,7 +121,7 @@ def test_all_on_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 0, 10], [400.0, 0, 10], [700.0, 0, 10], [1000.0, 0, 10]],
+            data=[[100.0, 0, 10], [215.0, 0, 10], [464.0, 0, 10], [1000.0, 0, 10]],
         )
     )
 
@@ -139,7 +139,7 @@ def test_all_off_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 10, 0], [400.0, 10, 0], [700.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100.0, 10, 0], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
         )
     )
 
@@ -150,7 +150,7 @@ def test_curve_fit_plot_works():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 6, 4], [400.0, 10, 0], [700.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100.0, 6, 4], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
         )
     )
 
@@ -163,7 +163,7 @@ def test_curve_fit_plot_warning():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 10, 0], [400.0, 10, 0], [700.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100.0, 10, 0], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
         )
     )
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -103,7 +103,7 @@ def test_sudden_decay_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 0, 10], [215, 0, 10], [464, 10, 10], [1000, 10, 0]],
+            data=[[100, 0, 10], [215, 0, 10], [464, 0, 10], [1000, 10, 0]],
         )
     )
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -25,7 +25,7 @@ def test_init_result():
     data = pd.DataFrame(
         columns=['delay_ns', 'false_count', 'true_count'],
         index=range(2),
-        data=[[100.0, 0, 10], [1000.0, 10, 0]],
+        data=[[100, 0, 10], [1000, 10, 0]],
     )
     result = cirq.experiments.T1DecayResult(data)
     assert result.data is data
@@ -103,7 +103,7 @@ def test_sudden_decay_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 0, 10], [400, 0, 10], [700, 10, 0], [1000, 10, 0]],
+            data=[[100, 0, 10], [215, 0, 10], [700, 10, 0], [1000, 10, 0]],
         )
     )
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -25,7 +25,7 @@ def test_init_result():
     data = pd.DataFrame(
         columns=['delay_ns', 'false_count', 'true_count'],
         index=range(2),
-        data=[[100, 0, 10], [1000, 10, 0]],
+        data=[[100.0, 0, 10], [1000.0, 10, 0]],
     )
     result = cirq.experiments.T1DecayResult(data)
     assert result.data is data
@@ -103,7 +103,7 @@ def test_sudden_decay_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 0, 10], [215, 0, 10], [464, 0, 10], [1000, 10, 0]],
+            data=[[100.0, 0, 10], [215.0, 0, 10], [464.0, 0, 10], [1000.0, 10, 0]],
         )
     )
 
@@ -121,7 +121,7 @@ def test_all_on_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 0, 10], [215, 0, 10], [464, 0, 10], [1000, 0, 10]],
+            data=[[100.0, 0, 10], [215.0, 0, 10], [464.0, 0, 10], [1000.0, 0, 10]],
         )
     )
     assert results == desired, f'{results.data=} {desired.data=}'
@@ -140,7 +140,7 @@ def test_all_off_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 10, 0], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
+            data=[[100.0, 10, 0], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
         )
     )
     assert results == desired, f'{results.data=} {desired.data=}'
@@ -152,14 +152,14 @@ def test_curve_fit_plot_works():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 6, 4], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
+            data=[[100.0, 6, 4], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
         )
     )
 
     good_fit.plot(include_fit=True)
 
 
-@pytest.mark.parametrize('t1', [200, 500, 700])
+@pytest.mark.parametrize('t1', [200.0, 500.0, 700.0])
 def test_noise_model_continous(t1):
     class GradualDecay(cirq.NoiseModel):
         def __init__(self, t1: float):

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -103,7 +103,7 @@ def test_sudden_decay_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100, 0, 10], [215, 0, 10], [464, 10, 0], [1000, 10, 0]],
+            data=[[100, 0, 10], [215, 0, 10], [464, 10, 10], [1000, 10, 0]],
         )
     )
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -61,7 +61,7 @@ def test_result_eq():
     eq.make_equality_group(
         lambda: cirq.experiments.T1DecayResult(
             data=pd.DataFrame(
-                columns=['delay_ns', 'false_count', 'true_count'], index=[0], data=[[100.0, 2, 8]]
+                columns=['delay_ns', 'false_count', 'true_count'], index=[0], data=[[100, 2, 8]]
             )
         )
     )
@@ -103,7 +103,7 @@ def test_sudden_decay_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 0, 10], [400.0, 0, 10], [700.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100, 0, 10], [400, 0, 10], [700, 10, 0], [1000, 10, 0]],
         )
     )
 
@@ -121,7 +121,7 @@ def test_all_on_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 0, 10], [215.0, 0, 10], [464.0, 0, 10], [1000.0, 0, 10]],
+            data=[[100, 0, 10], [215, 0, 10], [464, 0, 10], [1000, 0, 10]],
         )
     )
 
@@ -139,7 +139,7 @@ def test_all_off_results():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 10, 0], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100, 10, 0], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
         )
     )
 
@@ -150,7 +150,7 @@ def test_curve_fit_plot_works():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 6, 4], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100, 6, 4], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
         )
     )
 
@@ -163,7 +163,7 @@ def test_curve_fit_plot_warning():
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
             index=range(4),
-            data=[[100.0, 10, 0], [215.0, 10, 0], [464.0, 10, 0], [1000.0, 10, 0]],
+            data=[[100, 10, 0], [215, 10, 0], [464, 10, 0], [1000, 10, 0]],
         )
     )
 


### PR DESCRIPTION
Makes two changes to the $T_1$ experiment in Cirq:

1.  Changes the fit function to $f(t) = A e^{-t/T_1} + B$ instead of just $f(t) = e^{-t/T_1}$ to capture the effects of SPAM errors.
2. Makes the wait times logarithmically spaced instead of linearly spaced, which is more suitable since we expect an exponential decay.