### PR TITLE
Preserve moment structure in `cirq.decompose_once`

### DIFF
--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -381,7 +381,7 @@ def decompose_once(
         decomposed = NotImplemented if method is None else method(*args, **kwargs)
 
     if decomposed is not NotImplemented and decomposed is not None:
-        return list(ops.flatten_to_ops(decomposed)) if flatten else decomposed
+        return list(ops.flatten_to_ops_or_moments(decomposed)) if flatten else decomposed
 
     if default is not RaiseTypeErrorIfNotProvided:
         return default

--- a/cirq-core/cirq/protocols/decompose_protocol_test.py
+++ b/cirq-core/cirq/protocols/decompose_protocol_test.py
@@ -59,6 +59,10 @@ class DecomposeQuditGate:
     def _decompose_(self, qids):
         yield cirq.identity_each(*qids)
 
+class DecomposePreserveMomentStructure:
+    def _decompose_(self):
+        yield cirq.Moment(cirq.X(cirq.LineQubit(0)))
+        yield cirq.Moment(cirq.Y(cirq.LineQubit(1)))
 
 def test_decompose_once():
     # No default value results in descriptive error.
@@ -84,6 +88,10 @@ def test_decompose_once():
     assert cirq.decompose_once(DecomposeGenerated()) == [
         cirq.X(cirq.LineQubit(0)),
         cirq.Y(cirq.LineQubit(1)),
+    ]
+    assert cirq.decompose_once(DecomposePreserveMomentStructure()) == [
+        cirq.Moment(cirq.X(cirq.LineQubit(0))),
+        cirq.Moment(cirq.Y(cirq.LineQubit(1))),
     ]
 
 


### PR DESCRIPTION
This is helpful for specifying decompositions where preserving moment structure is important. Users can always do `cirq.Circuit(cirq.decompose_once(op))` to go back to the original behavior.  