### PR TITLE
Ignore spurious PollerCompletionQueue errors in AsyncioExecutor

### DIFF
--- a/cirq-google/cirq_google/engine/asyncio_executor.py
+++ b/cirq-google/cirq_google/engine/asyncio_executor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import errno
 import threading
 from typing import Awaitable, Callable, Optional, TypeVar
 
@@ -38,7 +39,15 @@ class AsyncioExecutor:
 
     @staticmethod
     async def _main(loop_future: duet.AwaitableFuture) -> None:
+        def handle_exception(loop, context) -> None:  # pragma: no cover
+            # Ignore PollerCompletionQueue errors (see https://github.com/grpc/grpc/issues/25364)
+            exc = context.get("exception")
+            if exc and isinstance(exc, BlockingIOError) and exc.errno == errno.EAGAIN:
+                return
+            loop.default_exception_handler(context)
+
         loop = asyncio.get_running_loop()
+        loop.set_exception_handler(handle_exception)
         loop_future.set_result(loop)
         while True:
             await asyncio.sleep(1)


### PR DESCRIPTION
When using grpc with asyncio from multiple threads, spurious `PollerCompletionQueue` errors are printed due to multiple event loops listening a socket to be notified of grpc events. More than one event loop may be woken when the completion queue writes a byte to the notification socket, but only one of the loops receives the data and the others raise a `BlockingIOError`. This doesn't actually cause a problem in the grpc still works with asyncio in multiple threads, but lots of spurious error messages are printed by the default exception handler. (See https://github.com/grpc/grpc/issues/25364 for discussion of the issue.)

This configures the asyncio event loop used for grpc with an exception handler that ignores these `BlockingIOError`s from the `PollerCompletionQueue` so that we don't spam the logs with scary-looking messages when using grpc with asyncio from multiple threads.