### PR TITLE
Remove python3.9 from CI tests

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -14,7 +14,7 @@ jobs:
     name: Pytest Ubuntu
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
     name: Pytest Windows
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: pip install -r dev_tools/requirements/isolated-base.env.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Misc
         run: check/misc
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/deps/packaging.txt
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/deps/format.txt
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install mypy
         run: pip install -r dev_tools/requirements/mypy.env.txt
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install changed files test dependencies
         run: dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install pylint
         run: pip install -r dev_tools/requirements/pylint.env.txt
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: pip install -r dev_tools/requirements/dev.env.txt
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: pip install -r dev_tools/requirements/deps/tensorflow-docs.txt
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/isolated-base.env.txt
@@ -149,7 +149,7 @@ jobs:
     name: Pytest Ubuntu
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11' ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: pip install pip-tools
@@ -194,7 +194,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: |
@@ -210,7 +210,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - uses: actions/cache@v4
         with:
@@ -234,7 +234,7 @@ jobs:
     name: Pytest Windows
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11' ]
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
@@ -259,7 +259,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11' ]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -292,7 +292,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: pip install -r dev_tools/requirements/isolated-base.env.txt
@@ -310,7 +310,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install requirements
         run: pip install -r dev_tools/requirements/notebooks.env.txt

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim AS cirq_base
+FROM python:3.10-slim AS cirq_base
 
 # Install dependencies.
 # rm -rf /var/lib/apt/lists/* cleans up apt cache. See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -8,7 +8,7 @@
     "dvcs": "git",
     "environment_type": "virtualenv",
     "show_commit_url": "https://github.com/quantumlib/Cirq/commit/",
-    "pythons": ["3.9"],
+    "pythons": ["3.10"],
     "matrix": {"env_nobuild": {"PYTHONOPTIMIZE": ["-O", ""]}},
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv/env",

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,7 +13,7 @@ To run all benchmarks, navigate to the root Cirq directory at the command line a
 
 You can also pass arguments to the script, which would be forwarded to the `asv run` command. For eg:
 ```bash
-./check/asv_run --quick --bench bench_examples --python 3.9
+./check/asv_run --quick --bench bench_examples --python 3.10
 ```
 
 Please refer [Running Benchmarks guide by ASV](https://asv.readthedocs.io/en/stable/using.html#running-benchmarks) for more information. 

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -28,7 +28,7 @@ trap '{ rm -rf "${tmp_dir}"; }' EXIT
 
 # New virtual environment
 echo "Working in a fresh virtualenv at ${tmp_dir}/env"
-python3.9 -m venv "${tmp_dir}/env"
+python3.10 -m venv "${tmp_dir}/env"
 
 export CIRQ_PRE_RELEASE_VERSION
 CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)

--- a/dev_tools/pr_monitor/Dockerfile
+++ b/dev_tools/pr_monitor/Dockerfile
@@ -23,7 +23,7 @@
 # value of the cirqbot-api-key secret.
 ########################################################################################
 
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 RUN mkdir -p /app/dev_tools/pr_monitor
 WORKDIR /app

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -94,7 +94,7 @@ See the previous section for instructions.
 
 1. Install system dependencies.
 
-    Make sure you have python 3.9 or greater.
+    Make sure you have python 3.10 or greater.
     You can install most other dependencies via `apt-get`:
 
     ```bash

--- a/docs/start/install.md
+++ b/docs/start/install.md
@@ -12,7 +12,7 @@ If you want to create a development environment, see the [development page](../d
 
 ## Python version support
 
-Cirq currently supports python 3.9 and later.
+Cirq currently supports python 3.10 and later.
 We follow numpy's schedule for python version support defined in [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html),
 though we may deviate from that schedule by extending support for older python
 versions if they are needed by [Colab](https://colab.research.google.com/)
@@ -20,7 +20,7 @@ or internal Google systems.
 
 ## Installing on Linux
 
-0. Make sure you have python 3.9.0 or greater.
+0. Make sure you have python 3.10.0 or greater.
 
     See [Installing Python 3 on Linux](https://docs.python-guide.org/starting/install3/linux/) @ the hitchhiker's guide to python.
 
@@ -87,7 +87,7 @@ or internal Google systems.
 
 ## Installing on Mac OS X
 
-0. Make sure you have python 3.9.0 or greater.
+0. Make sure you have python 3.10.0 or greater.
 
     See [Installing Python 3 on Mac OS X](https://docs.python-guide.org/starting/install3/osx/) @ the hitchhiker's guide to python.
 
@@ -154,7 +154,7 @@ or internal Google systems.
 
 0. If you are using the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/about), use the [Linux install instructions](#installing-on-linux) instead of these instructions.
 
-1. Make sure you have python 3.9.0 or greater.
+1. Make sure you have python 3.10.0 or greater.
 
     See [Installing Python 3 on Windows](https://docs.python-guide.org/starting/install3/win/) @ the hitchhiker's guide to python.
 

--- a/release.md
+++ b/release.md
@@ -82,7 +82,7 @@ release.
 
 ### Preparation
 
-System requirements: Linux, python3.9
+System requirements: Linux, python3.10
 
 For MINOR / MAJOR release: Make sure you're on an up-to-date main branch and 
 in cirq's root directory.


### PR DESCRIPTION
first step towards dropping py3.9 in cirq1.4 https://github.com/quantumlib/Cirq/issues/6463
