### PR TITLE
Fix capitalization of GitHub in docs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -9,5 +9,5 @@
         }
     ],
     "access_right": "open",
-    "notes": "See full list of authors on Github: https://github.com/quantumlib/Cirq/graphs/contributors"
+    "notes": "See full list of authors on GitHub: https://github.com/quantumlib/Cirq/graphs/contributors"
 }

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Example output:
 Feature requests / Bugs / Questions
 -----------------------------------
 
-If you have feature requests or you found a bug, please `file them on Github <https://github.com/quantumlib/Cirq/issues/new/choose>`__.
+If you have feature requests or you found a bug, please `file them on GitHub <https://github.com/quantumlib/Cirq/issues/new/choose>`__.
 
 For questions about how to use Cirq post to
 `Quantum Computing Stack Exchange <https://quantumcomputing.stackexchange.com/>`__ with the

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -124,7 +124,7 @@ papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
         print(result.stderr)
         pytest.fail(
             f"Notebook failure: {notebook_file}, please see {out_path} for the output "
-            f"notebook (in Github Actions, you can download it from the workflow artifact"
+            f"notebook (in GitHub Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs')"
         )
     os.remove(rewritten_notebook_path)

--- a/docs/dev/rfc_process.md
+++ b/docs/dev/rfc_process.md
@@ -26,7 +26,7 @@ The following are NOT major features:
 *   Fixing a bug.
 *   Extending the functionality of an existing method in a natural way.
 
-If you are not sure if a feature constitute as a “major feature”, just submit a Github issue with a description, 
+If you are not sure if a feature constitute as a “major feature”, just submit a GitHub issue with a description, 
 and one of the maintainers will flag the issue as a major feature if necessary.
 
 ## How to submit an RFC
@@ -37,12 +37,12 @@ Open a [feature request](https://github.com/quantumlib/Cirq/issues/new?assignees
 and have a discussion with the maintainers. Mention that you are willing to write an RFC.
 2. [Join the cirq-dev Google Group](https://groups.google.com/forum/#!forum/cirq-dev) to get an invitation to our weekly Cirq Cynq meeting. 
 3. Draft your RFC. 
-    * Follow the [RFC template](https://tinyurl.com/cirq-rfc-template), link the Github issue in your RFC.
+    * Follow the [RFC template](https://tinyurl.com/cirq-rfc-template), link the GitHub issue in your RFC.
     * Make sure to share your doc with cirq-dev@googlegroups.com for comments.
     * Link the RFC in your issue.
 4. Recruiting a sponsor:
     * A sponsor must be a maintainer of the project or the product manager.
-    * Write a comment in your Github issue that calls out that you are "Looking for a sponsor". A maintainer will mark the issue with a label: "rfc/needs-sponsor".
+    * Write a comment in your GitHub issue that calls out that you are "Looking for a sponsor". A maintainer will mark the issue with a label: "rfc/needs-sponsor".
     * While it might take some time to get a maintainer to sponsor your RFC, it is essential, as the sponsor will facilitate the process for reviewing your design.
     * Tips to recruit a sponsor: 1) keep commenting on the issue weekly 2) attend Cirq Cynq and push for a sponsor.
 5. Agree with your sponsor on a Cirq Cync meeting to present the RFC so that other contributors and maintainers can become more familiar with your design.

--- a/docs/dev/triage.md
+++ b/docs/dev/triage.md
@@ -10,13 +10,13 @@ The goals for this document are as follows:
 
 * provide visibility for project and release status 
 
-## Automation: Triage party and Github Actions
+## Automation: Triage party and GitHub Actions
 
 [Triage Party](https://github.com/google/triage-party) is a stateless web app to optimize issue and PR triage for large open-source projects using the GitHub API. 
 
 Our deployed version is here (a static IP, domain request is in progress): [http://bit.do/cirq-triage-party](http://bit.do/cirq-triage-party)
 
-[Github Actions](https://github.com/features/actions) is Github's workflow automation platform. We use it for continuous integration testing as well as for stale issue handling later described here.
+[GitHub Actions](https://github.com/features/actions) is GitHub's workflow automation platform. We use it for continuous integration testing as well as for stale issue handling later described here.
 
 ## Issue states and labels
 
@@ -55,7 +55,7 @@ Triage states are
 * `triage/needs-reproduction` - for bugs only
 * `triage/needs-feasibility` - for feature requests (maybe bugs).
 * `triage/needs-more-evidence` - for feature requests - the feature request seems plausible but we need more understanding if it is valuable for enough users to warrant implementing and maintaining it. 
-* `triage/stale` - Github actions automatically marks some of the issues stale and then it closes them in case of 30 days of inactivity.
+* `triage/stale` - GitHub actions automatically marks some of the issues stale and then it closes them in case of 30 days of inactivity.
 * `triage/duplicate` - we mark duplicated issues with this label.
 
 While these are fairly straightforward and intuitive the workflows are depicted below. 
@@ -156,7 +156,7 @@ To summarize, **all issues** are subject to staleness-check, **except** the foll
 * `kind/roadmap-item`
 * `kind/task` 
 
-The staleness check automation is implemented via Github Actions, the latest definition of staleness is defined in [our staleness Github Action workflow](https://github.com/quantumlib/Cirq/blob/main/.github/workflows/stale.yml).
+The staleness check automation is implemented via GitHub Actions, the latest definition of staleness is defined in [our staleness GitHub Action workflow](https://github.com/quantumlib/Cirq/blob/main/.github/workflows/stale.yml).
 
 
 ## Processes
@@ -170,7 +170,7 @@ The staleness check automation is implemented via Github Actions, the latest def
     - maintain a backlog that makes it easy to match contributors as well as maintainers to work items.
     - for pull requests we are aiming for 
         * **responsiveness** - people can get their work done - we don't want to block community / our team members.
-        * **clean workspace** - stale PRs are wasteful as clutter is cognitive cost for maintainers. Stale PRs also a resource cost on Github - eating into other contributors' capacity to execute Github Actions / checks.
+        * **clean workspace** - stale PRs are wasteful as clutter is cognitive cost for maintainers. Stale PRs also a resource cost on GitHub - eating into other contributors' capacity to execute GitHub Actions / checks.
 
 **Who**
 

--- a/docs/experiments/_index.yaml
+++ b/docs/experiments/_index.yaml
@@ -5,11 +5,11 @@ landing_page:
   nav: left
   rows:
     - heading: Experiments using quantum circuits
-      description: This is a collection of algorithms and experiments written in and using Cirq. A couple of them use only base Cirq, but the rest use additional code stored in ReCirq, a Github repository for research code that uses and builds upon Cirq.
+      description: This is a collection of algorithms and experiments written in and using Cirq. A couple of them use only base Cirq, but the rest use additional code stored in ReCirq, a GitHub repository for research code that uses and builds upon Cirq.
     - buttons:
-      - label: Cirq Github
+      - label: Cirq GitHub
         path: https://github.com/quantumlib/Cirq
-      - label: ReCirq Github
+      - label: ReCirq GitHub
         path: https://github.com/quantumlib/ReCirq
     - heading: Algorithms in base Cirq
       description: Algorithms and experiments executable using only default Cirq code.

--- a/docs/simulate/virtual_engine_interface.ipynb
+++ b/docs/simulate/virtual_engine_interface.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "The easiest way to create a `cirq_google.SimulatedLocalEngine` is to make one from one or more processor templates. \n",
     "Example processor device specifications can be found in \n",
-    "the [devices/specifications](https://github.com/quantumlib/Cirq/tree/main/cirq-google/cirq_google/devices/specifications) folder of `cirq_google` in the Cirq Github repository.  These device specifications closely match previous versions of Google quantum hardware, and can serve as templates for processors in a `SimulatedLocalEngine`. When Google hardware becomes publicly available again in the future, it will have device specifications like these that differ in details, but not in format.\n",
+    "the [devices/specifications](https://github.com/quantumlib/Cirq/tree/main/cirq-google/cirq_google/devices/specifications) folder of `cirq_google` in the Cirq GitHub repository.  These device specifications closely match previous versions of Google quantum hardware, and can serve as templates for processors in a `SimulatedLocalEngine`. When Google hardware becomes publicly available again in the future, it will have device specifications like these that differ in details, but not in format.\n",
     "\n",
     "You can create a `cirq_google.SimulatedLocalEngine` that includes these example device specifications using `cirq_google.engine.create_noiseless_virtual_engine_from_latest_templates()`.  For example:"
    ]


### PR DESCRIPTION
- Saw an old PR to replace Github with proper capitalization of GitHub.
- This PR does this on a more consistent basis and updates that PR.
- Replaces #5961