### PR TITLE
Add FSimViaModelTag

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -57,6 +57,7 @@ from cirq_google.line import (
 from cirq_google.ops import (
     CalibrationTag,
     FSimGateFamily,
+    FSimViaModelTag,
     InternalGate,
     PhysicalZTag,
     SYC,

--- a/cirq-google/cirq_google/json_resolver_cache.py
+++ b/cirq-google/cirq_google/json_resolver_cache.py
@@ -50,6 +50,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'GateTabulation': TwoQubitGateTabulation,
         'PhysicalZTag': cirq_google.PhysicalZTag,
         'FSimGateFamily': cirq_google.FSimGateFamily,
+        'FSimViaModelTag': cirq_google.FSimViaModelTag,
         'SycamoreTargetGateset': cirq_google.SycamoreTargetGateset,
         'cirq.google.BitstringsMeasurement': cirq_google.BitstringsMeasurement,
         'cirq.google.QuantumExecutable': cirq_google.QuantumExecutable,

--- a/cirq-google/cirq_google/json_test_data/FSimViaModelTag.json
+++ b/cirq-google/cirq_google/json_test_data/FSimViaModelTag.json
@@ -1,0 +1,3 @@
+{
+    "cirq_type": "FSimViaModelTag"
+}

--- a/cirq-google/cirq_google/json_test_data/FSimViaModelTag.repr
+++ b/cirq-google/cirq_google/json_test_data/FSimViaModelTag.repr
@@ -1,0 +1,1 @@
+cirq_google.FSimViaModelTag()

--- a/cirq-google/cirq_google/ops/__init__.py
+++ b/cirq-google/cirq_google/ops/__init__.py
@@ -18,6 +18,8 @@ from cirq_google.ops.calibration_tag import CalibrationTag
 
 from cirq_google.ops.fsim_gate_family import FSimGateFamily
 
+from cirq_google.ops.fsim_via_model_tag import FSimViaModelTag
+
 from cirq_google.ops.physical_z_tag import PhysicalZTag
 
 from cirq_google.ops.sycamore_gate import SycamoreGate, SYC

--- a/cirq-google/cirq_google/ops/fsim_via_model_tag.py
+++ b/cirq-google/cirq_google/ops/fsim_via_model_tag.py
@@ -1,0 +1,44 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A class that can be used to denote FSim gate implementation using polynomial model."""
+from typing import Any, Dict
+
+import cirq
+
+
+class FSimViaModelTag:
+    """A tag class to denote FSim gate implementation using polynomial model.
+
+    By default, the translation of FSim gate implementation is possible for a certain
+    angles. For example, when theta=pi/2, phi=0, it translates into the same implementation
+    as the SWAP gate. If FSimGate is tagged with this class, the translation will become
+    a coupler gate that with proper coupler strength and coupler length via some polynomial
+    modelling. Note not all combination of theta and phi in FSim gate are feasible and
+    you need the calibration for these angle in advance before using them.
+    """
+
+    def __str__(self) -> str:
+        return 'FSimViaModelTag()'
+
+    def __repr__(self) -> str:
+        return 'cirq_google.FSimViaModelTag()'
+
+    def _json_dict_(self) -> Dict[str, Any]:
+        return cirq.obj_to_dict_helper(self, [])
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, FSimViaModelTag)
+
+    def __hash__(self) -> int:
+        return 12345

--- a/cirq-google/cirq_google/ops/fsim_via_model_tag.py
+++ b/cirq-google/cirq_google/ops/fsim_via_model_tag.py
@@ -20,7 +20,7 @@ import cirq
 class FSimViaModelTag:
     """A tag class to denote FSim gate implementation using polynomial model.
 
-    By default, the translation of FSim gate implementation is possible for a certain
+    Without the tag, the translation of FSim gate implementation is possible only for a certain
     angles. For example, when theta=pi/2, phi=0, it translates into the same implementation
     as the SWAP gate. If FSimGate is tagged with this class, the translation will become
     a coupler gate that with proper coupler strength and coupler length via some polynomial

--- a/cirq-google/cirq_google/ops/fsim_via_model_tag.py
+++ b/cirq-google/cirq_google/ops/fsim_via_model_tag.py
@@ -41,4 +41,4 @@ class FSimViaModelTag:
         return isinstance(other, FSimViaModelTag)
 
     def __hash__(self) -> int:
-        return 12345
+        return hash("FSimViaModelTag")

--- a/cirq-google/cirq_google/ops/fsim_via_model_tag_test.py
+++ b/cirq-google/cirq_google/ops/fsim_via_model_tag_test.py
@@ -20,7 +20,7 @@ def test_equality():
     assert hash(cirq_google.FSimViaModelTag()) == hash(cirq_google.FSimViaModelTag())
 
 
-def test_syc_str_repr():
+def test_str_repr():
     assert str(cirq_google.FSimViaModelTag()) == 'FSimViaModelTag()'
     assert repr(cirq_google.FSimViaModelTag()) == 'cirq_google.FSimViaModelTag()'
     cirq.testing.assert_equivalent_repr(

--- a/cirq-google/cirq_google/ops/fsim_via_model_tag_test.py
+++ b/cirq-google/cirq_google/ops/fsim_via_model_tag_test.py
@@ -1,0 +1,28 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import cirq
+import cirq_google
+
+
+def test_equality():
+    assert cirq_google.FSimViaModelTag() == cirq_google.FSimViaModelTag()
+    assert hash(cirq_google.FSimViaModelTag()) == hash(cirq_google.FSimViaModelTag())
+
+
+def test_syc_str_repr():
+    assert str(cirq_google.FSimViaModelTag()) == 'FSimViaModelTag()'
+    assert repr(cirq_google.FSimViaModelTag()) == 'cirq_google.FSimViaModelTag()'
+    cirq.testing.assert_equivalent_repr(
+        cirq_google.FSimViaModelTag(), setup_code=('import cirq\nimport cirq_google\n')
+    )


### PR DESCRIPTION
The motivation of creating this tag is for the qcc/translate part. We can use this tag to control which implementation gate we want to translate it into.

CC: @maffoo @eliottrosenberg 