### PR TITLE
Fix ci-daily workflow failures on Mac OS X

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
+  # FIXME - for PR testing only, remove before merge
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install --pre cirq &&
+          pip install cirq~=1.0.dev &&
           pip install \
             -r dev_tools/requirements/deps/format.txt \
             -r dev_tools/requirements/deps/pylint.txt \
@@ -62,7 +62,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install "cirq~=1.0.dev0" &&
+          pip install cirq~=1.0.dev &&
             pip install -r dev_tools/requirements/deps/format.txt &&
             pip install -r dev_tools/requirements/deps/pylint.txt &&
             pip install -r dev_tools/requirements/deps/pytest.txt &&
@@ -88,7 +88,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install --pre cirq &&
+          pip install cirq~=1.0.dev &&
           pip install \
             -r dev_tools/requirements/deps/format.txt \
             -r dev_tools/requirements/deps/pylint.txt \

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
-  # FIXME - for PR testing only, remove before merge
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -62,7 +62,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install --pre cirq &&
+          pip install "cirq~=1.0.dev0" &&
             pip install -r dev_tools/requirements/deps/format.txt &&
             pip install -r dev_tools/requirements/deps/pylint.txt &&
             pip install -r dev_tools/requirements/deps/pytest.txt &&


### PR DESCRIPTION
Install development version of cirq, but with stable dependencies.
Avoid using the pip-install `--pre` option because it installs
pre-release of every direct and transitive dependency.

Example failure: https://github.com/quantumlib/Cirq/actions/runs/8444592307/job/23130415923
Pass with this change: https://github.com/quantumlib/Cirq/actions/runs/8460206027/job/23179852811

Related to #6336
