### PR TITLE
Install cirq pre-release with stable dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN pip3 install cirq
 
 ##cirq pre_release image
 FROM cirq_base AS cirq_pre_release
-RUN pip3 install cirq --pre
+RUN pip3 install cirq~=1.0.dev

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Installation and Documentation
 
 Cirq documentation is available at `quantumai.google/cirq <https://quantumai.google/cirq>`_.
 
-Documentation for the latest **pre-release** version of cirq (tracks the repository's main branch; what you get if you ``pip install --pre cirq``), is available `here <https://quantumai.google/reference/python/cirq/all_symbols?version=nightly>`__.
+Documentation for the latest **pre-release** version of cirq (tracks the repository's main branch; what you get if you ``pip install cirq~=1.0.dev``), is available `here <https://quantumai.google/reference/python/cirq/all_symbols?version=nightly>`__.
 
 Documentation for the latest **stable** version of cirq (what you get if you ``pip install cirq``) is available `here <https://quantumai.google/reference/python/cirq/all_symbols>`__.
 

--- a/cirq-aqt/README.rst
+++ b/cirq-aqt/README.rst
@@ -20,8 +20,8 @@ Installation
 ------------
 
 To install the stable version of only **cirq-aqt**, use `pip install cirq-aqt`.
-To install the pre-release version of only **cirq-aqt**, use `pip install cirq-aqt --pre`.
+To install the pre-release version of only **cirq-aqt**, use `pip install cirq-aqt~=1.0.dev`.
 
 Note, that this will install both cirq-aqt and cirq-core as well.
 
-To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.

--- a/cirq-core/README.rst
+++ b/cirq-core/README.rst
@@ -13,6 +13,6 @@ Installation
 ------------
 
 To install the stable version of only **cirq-core**, use `pip install cirq-core`.
-To install the pre-release version of only **cirq-core**, use `pip install cirq-core --pre`.
+To install the pre-release version of only **cirq-core**, use `pip install cirq-core~=1.0.dev`.
 
-To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.

--- a/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Cirq-to-Tensor-Networks.ipynb
@@ -89,7 +89,7 @@
     "### Circuit to Tensors\n",
     "The circuit defines a tensor network representation. By default, the initial state is the `|0...0>` state (represented by the \"zero qubit\" operations labeled \"Q0\" in the legend. \"Q1\" are single qubit operations and \"Q2\" are two qubit operations. The open legs are the indices into the state vector and are of the form \"i{m}_q{n}\" where `m` is the time index (given by the returned `qubit_frontier` dictionary) and \"n\" is the qubit string.\n",
     "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {

--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -20,14 +20,14 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "\n",
     "try:\n",
     "    import quimb\n",
     "except ImportError:\n",
     "    print(\"installing cirq-core[contrib]...\")\n",
-    "    !pip install --quiet 'cirq-core[contrib]' --pre\n",
+    "    !pip install --quiet 'cirq-core[contrib]~=1.0.dev'\n",
     "    print(\"installed cirq-core[contrib].\")"
    ]
   },
@@ -38,7 +38,7 @@
     "# Contract a Grid Circuit\n",
     "Shallow circuits on a planar grid with low-weight observables permit easy contraction.\n",
     "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {

--- a/cirq-ft/README.rst
+++ b/cirq-ft/README.rst
@@ -16,11 +16,11 @@ To install the pre-release version of **cirq-ft**, use
 
 .. code-block:: bash
 
-    pip install cirq-ft --pre
+    pip install cirq-ft~=1.0.dev
 
 
 
 Note, that this will install both cirq-ft and cirq-core as well.
 
 To get all the optional **Cirq** modules installed as well, use `pip install cirq` or
-`pip install cirq --pre` for the pre-release version.
+`pip install cirq~=1.0.dev` for the pre-release version.

--- a/cirq-google/README.rst
+++ b/cirq-google/README.rst
@@ -23,8 +23,8 @@ Installation
 ------------
 
 To install the stable version of only **cirq-google**, use `pip install cirq-google`.
-To install the pre-release version of only **cirq-google**, use `pip install cirq-google --pre`.
+To install the pre-release version of only **cirq-google**, use `pip install cirq-google~=1.0.dev`.
 
 Note, that this will install both cirq-google and cirq-core as well.
 
-To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.

--- a/cirq-ionq/README.rst
+++ b/cirq-ionq/README.rst
@@ -20,8 +20,8 @@ Installation
 ------------
 
 To install the stable version of only **cirq-ionq**, use `pip install cirq-ionq`.
-To install the pre-release version of only **cirq-ionq**, use `pip install cirq-ionq --pre`.
+To install the pre-release version of only **cirq-ionq**, use `pip install cirq-ionq~=1.0.dev`.
 
 Note, that this will install both **cirq-ionq** and **cirq-core**.
 
-To get all the optional modules installed, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.

--- a/cirq-pasqal/README.rst
+++ b/cirq-pasqal/README.rst
@@ -20,8 +20,8 @@ Installation
 ------------
 
 To install the stable version of only **cirq-pasqal**, use `pip install cirq-pasqal`.
-To install the pre-release version of only **cirq-pasqal**, use `pip install cirq-pasqal --pre`.
+To install the pre-release version of only **cirq-pasqal**, use `pip install cirq-pasqal~=1.0.dev`.
 
 Note, that this will install both **cirq-pasqal** and **cirq-core**.
 
-To get all the optional modules installed, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.

--- a/cirq-rigetti/README.rst
+++ b/cirq-rigetti/README.rst
@@ -20,11 +20,11 @@ Installation
 ------------
 
 To install the stable version of only **cirq-rigetti**, use `pip install cirq-rigetti`.
-To install the pre-release version of only **cirq-rigetti**, use `pip install cirq-rigetti --pre`.
+To install the pre-release version of only **cirq-rigetti**, use `pip install cirq-rigetti~=1.0.dev`.
 
 Note, that this will install both **cirq-rigetti** and **cirq-core**.
 
-To get all the optional modules installed, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.
 
 Development
 ------------

--- a/cirq-web/README.rst
+++ b/cirq-web/README.rst
@@ -55,8 +55,8 @@ Installation
 
 Cirq-web is currently in development, and therefore is only available via pre-release.
 
-To install the pre-release version of only **cirq-web**, use `pip install cirq-web --pre`.
+To install the pre-release version of only **cirq-web**, use `pip install cirq-web~=1.0.dev`.
 
 Note, that this will install both cirq-web and cirq-core.
 
-To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq --pre` for the pre-release version.
+To get all the optional modules installed as well, you'll have to use `pip install cirq` or `pip install cirq~=1.0.dev` for the pre-release version.

--- a/dev_tools/docs/build_api_docs.py
+++ b/dev_tools/docs/build_api_docs.py
@@ -17,7 +17,7 @@
 In order to publish to our site, devsite runs two jobs for us: stable and nightly.
 The stable one downloads the latest cirq release from pypi and uses that to generate the reference
 API docs.
-The nightly one downloads the latest cirq pre-release (pip install cirq --pre) and uses that to
+The nightly one downloads the latest cirq pre-release (pip install cirq~=1.0.dev) and uses that to
 generate the "nightly diff".
 
 This script needs to cater for both of these cases.

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -183,7 +183,7 @@ papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
             f"notebook (in Github Actions, you can download it from the workflow artifact"
             f" 'notebook-outputs'). \n"
             f"If this is a new failure in this notebook due to a new change, "
-            f"that is only available in main for now, consider adding `pip install --pre cirq` "
+            f"that is only available in main for now, consider adding `pip install cirq~=1.0.dev` "
             f"instead of `pip install cirq` to this notebook, and exclude it from "
             f"dev_tools/notebooks/isolated_notebook_test.py."
         )
@@ -231,10 +231,10 @@ def test_ensure_unreleased_notebooks_install_cirq_pre(notebook_path):
     with open(notebook_path, encoding="utf-8") as notebook:
         content = notebook.read()
         mandatory_matches = [
-            r"!pip install --quiet cirq(-google)? --pre",
+            r"!pip install --quiet cirq(-google)?~=1.0.dev",
             r"Note: this notebook relies on unreleased Cirq features\. "
             r"If you want to try these features, make sure you install cirq(-google)? via "
-            r"`pip install cirq(-google)? --pre`\.",
+            r"`pip install cirq(-google)?~=1.0.dev`\.",
         ]
 
         for m in mandatory_matches:

--- a/docs/dev/notebooks.md
+++ b/docs/dev/notebooks.md
@@ -77,7 +77,7 @@ You should configure notebooks differently depending on whether they rely on fea
 
 When you introduce a notebook that depends on pre-release features of Cirq, make sure to
 
- - mark the notebook at the top that `Note: this notebook relies on unreleased Cirq features. If you want to try these feature, make sure you install cirq via pip install cirq --pre`.
+ - mark the notebook at the top that `Note: this notebook relies on unreleased Cirq features. If you want to try these feature, make sure you install cirq via pip install cirq~=1.0.dev`.
  - use `pip install cirq —pre`  in the installation instructions
  - make sure [notebook_test.py](https://github.com/quantumlib/Cirq/blob/main/dev_tools/notebooks/notebook_test.py) covers the notebook
  - exclude the notebook from the [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/main/dev_tools/notebooks/isolated_notebook_test.py) by adding it to `NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES`
@@ -85,7 +85,7 @@ When you introduce a notebook that depends on pre-release features of Cirq, make
 ### Stable notebooks
 
 When you introduce a notebook that only uses already released features of Cirq, make sure to
- - use `pip install cirq` (NOT `pip install cirq --pre`)
+ - use `pip install cirq` (NOT `pip install cirq~=1.0.dev`)
  - ensure the notebook is not excluded from either [notebook_test.py](https://github.com/quantumlib/Cirq/blob/main/dev_tools/notebooks/notebook_test.py) or [isolated_notebook_test.py](https://github.com/quantumlib/Cirq/blob/main/dev_tools/notebooks/isolated_notebook_test.py)  (except if the notebook has external dependencies, in which case you should exclude this from both!)
 
 ### Release

--- a/docs/gatezoo.ipynb
+++ b/docs/gatezoo.ipynb
@@ -61,7 +61,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`"
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`"
    ]
   },
   {
@@ -76,7 +76,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet --pre cirq\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    \n",
     "import IPython.display as ipd\n",

--- a/docs/google/qubit-placement.ipynb
+++ b/docs/google/qubit-placement.ipynb
@@ -40,7 +40,7 @@
     "# Qubit Placement\n",
     "\n",
     "This notebooks walks through qubit placement runtime features exposed through the `cirq_google.workflow` tools.",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -78,7 +78,7 @@
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
     "    # This depends on unreleased (as of 1.14) qubit placement functions.\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq"
    ]

--- a/docs/named_topologies.ipynb
+++ b/docs/named_topologies.ipynb
@@ -70,7 +70,7 @@
     "id": "ea381f53cf89"
    },
    "source": [
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -85,7 +85,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    \n",
     "import cirq"

--- a/docs/noise/calibration_api.ipynb
+++ b/docs/noise/calibration_api.ipynb
@@ -80,7 +80,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -103,7 +103,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "print(\"Using cirq version\", cirq.__version__)"

--- a/docs/noise/floquet_calibration_example.ipynb
+++ b/docs/noise/floquet_calibration_example.ipynb
@@ -80,7 +80,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -106,7 +106,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "print(\"Using cirq version\", cirq.__version__)"

--- a/docs/noise/qcvv/parallel_xeb.ipynb
+++ b/docs/noise/qcvv/parallel_xeb.ipynb
@@ -65,7 +65,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/noise/qcvv/xeb_calibration_example.ipynb
+++ b/docs/noise/qcvv/xeb_calibration_example.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -116,7 +116,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install --quiet cirq --pre"
+    "    !pip install --quiet cirq~=1.0.dev"
    ]
   },
   {

--- a/docs/simulate/qvm_stabilizer_example.ipynb
+++ b/docs/simulate/qvm_stabilizer_example.ipynb
@@ -504,7 +504,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q cirq-web --pre\n",
+    "!pip install -q cirq-web~=1.0.dev\n",
     "import cirq_web\n",
     "\n",
     "circuit_vis = cirq_web.Circuit3D(stabilizer_grid_circuit)\n",

--- a/docs/start/intro.ipynb
+++ b/docs/start/intro.ipynb
@@ -85,7 +85,7 @@
     "> Different notebook execution systems exist, but for most part they have \"run\" button on a cell which you can click, or \"shift + enter\" is often the shortcut to run the cell. \n",
     "\n",
     "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`.\n"
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`.\n"
    ]
   },
   {
@@ -100,7 +100,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "\n",

--- a/docs/transform/routing_transformer.ipynb
+++ b/docs/transform/routing_transformer.ipynb
@@ -70,7 +70,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -85,7 +85,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    import cirq\n",
     "\n",
     "    print(\"installed cirq.\")"

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -69,7 +69,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -85,7 +85,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq-google --pre\n",
+    "    !pip install --quiet cirq-google~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google"
@@ -158,7 +158,7 @@
     "\n",
     "For details of authentication and installation, please see [Get started with Quantum Computing Service](start.ipynb).\n",
     "\n",
-    "Note:  The below code will install the latest stable release of Cirq.  If you need the latest and greatest features and don't mind if a few things aren't quite working correctly, you can install the pre-release version of `cirq` using `pip install --pre cirq` instead of `pip install cirq` to get the most up-to-date features of Cirq.\n",
+    "Note:  The below code will install the latest stable release of Cirq.  If you need the latest and greatest features and don't mind if a few things aren't quite working correctly, you can install the pre-release version of `cirq` using `pip install cirq~=1.0.dev` instead of `pip install cirq` to get the most up-to-date features of Cirq.\n",
     "\n",
     "1. Enter the Cloud project ID you'd like to use in the `project_id` field.\n",
     "2. Then run the cell below (and go through the auth flow for access to the project id you entered).\n",

--- a/docs/tutorials/google/echoes.ipynb
+++ b/docs/tutorials/google/echoes.ipynb
@@ -101,7 +101,7 @@
    "source": [
     "We first install Cirq then import packages we will use.\n",
     "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -115,7 +115,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install --quiet cirq --pre"
+    "    !pip install --quiet cirq~=1.0.dev"
    ]
   },
   {

--- a/docs/tutorials/google/identifying_hardware_changes.ipynb
+++ b/docs/tutorials/google/identifying_hardware_changes.ipynb
@@ -139,7 +139,7 @@
     "\n",
     "First, install Cirq and import the necessary packages.\n",
     "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -188,7 +188,7 @@
     "try:\n",
     "    import cirq\n",
     "except ImportError:\n",
-    "    !pip install --quiet cirq --pre"
+    "    !pip install --quiet cirq~=1.0.dev"
    ]
   },
   {

--- a/docs/tutorials/google/spin_echoes.ipynb
+++ b/docs/tutorials/google/spin_echoes.ipynb
@@ -94,7 +94,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -109,7 +109,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/tutorials/google/start.ipynb
+++ b/docs/tutorials/google/start.ipynb
@@ -69,7 +69,7 @@
       },
       "source": [
         "## Setup\n",
-        "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq-google --pre`."
+        "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq-google~=1.0.dev`."
       ]
     },
     {
@@ -85,7 +85,7 @@
         "    import cirq_google as cg\n",
         "except ImportError:\n",
         "    print(\"installing cirq-google and cirq...\")\n",
-        "    !pip install --quiet cirq-google --pre cirq --pre\n",
+        "    !pip install --quiet cirq-google~=1.0.dev cirq~=1.0.dev\n",
         "    print(\"installed cirq-google and cirq.\")\n",
         "    import cirq\n",
         "    import cirq_google as cg"

--- a/docs/tutorials/google/visualizing_calibration_metrics.ipynb
+++ b/docs/tutorials/google/visualizing_calibration_metrics.ipynb
@@ -71,7 +71,7 @@
    },
    "source": [
     "## Setup\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq --pre`."
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install cirq~=1.0.dev`."
    ]
   },
   {
@@ -88,7 +88,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq --pre\n",
+    "    !pip install --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "import cirq\n",
     "import cirq_google\n",
@@ -106,7 +106,7 @@
     "\n",
     "For details of authentication and installation, please see [Get started with Quantum Computing Service](start.ipynb).\n",
     "\n",
-    "Note:  The below code will install the latest stable release of cirq.  If you need the latest and greatest features and don't mind if a few things aren't quite working correctly, you can install the pre-release version of `cirq` using `pip install --pre cirq` instead of `pip install cirq` to get the most up-to-date features of cirq.\n",
+    "Note:  The below code will install the latest stable release of cirq.  If you need the latest and greatest features and don't mind if a few things aren't quite working correctly, you can install the pre-release version of `cirq` using `pip install cirq~=1.0.dev` instead of `pip install cirq` to get the most up-to-date features of cirq.\n",
     "\n",
     "1. Enter the Cloud project ID you'd like to use in the `YOUR_PROJECT_ID` field.\n",
     "2. Then run the cell below (and go through the auth flow for access to the project id you entered).\n",

--- a/release.md
+++ b/release.md
@@ -5,7 +5,7 @@ themselves are created. Note that development is done on the `main`
 branch, so if you want to use a more stable version you should use one
 of the [releases](https://github.com/quantumlib/Cirq/releases) or
 install from pypi using `pip install cirq`.  The release from the
-latest commit to main can be installed with `pip install --pre cirq`.
+latest commit to main can be installed with `pip install cirq~=1.0.dev`.
 
 ## Versioning
 


### PR DESCRIPTION
Update instructions to use `pip install cirq~=1.0.dev` for cirq pre-release.
This matches the latest pre-release with the major version 1.

Avoid using the pip-install `--pre` option as it applies to all
direct and transitive dependencies that get installed with cirq.
