### PR TITLE
Undo temporary version pin of mpmath

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -2,9 +2,6 @@
 
 duet>=0.2.8
 matplotlib~=3.0
-# Temporary fix for https://github.com/sympy/sympy/issues/26273
-# TODO: remove once `pip install --pre sympy` works in a fresh environment
-mpmath<1.4
 networkx>=2.4
 numpy~=1.16
 pandas


### PR DESCRIPTION
Version limit on mpmath is unnecessary after #6534 because
cirq pre-releases are now installed with stable dependencies.

This reverts commit e11132e391c5c13377416b62af6a9aad8861f839 (#6477).

Related to #6475
