### PR TITLE
Fix density matrix references in other simulators

### DIFF
--- a/cirq-core/cirq/sim/simulation_state.py
+++ b/cirq-core/cirq/sim/simulation_state.py
@@ -111,7 +111,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         return [self.qubit_map[q] for q in qubits]
 
     def _perform_measurement(self, qubits: Sequence['cirq.Qid']) -> List[int]:
-        """Delegates the call to measure the density matrix."""
+        """Delegates the call to measure the `QuantumStateRepresentation`."""
         if self._state is not None:
             return self._state.measure(self.get_axes(qubits), self.prng)
         raise NotImplementedError()

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -60,11 +60,11 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         This initializer creates the buffer if necessary.
 
         Args:
-            initial_state: The density matrix, must be correctly formatted. The data is not
+            initial_state: The state vector, must be correctly formatted. The data is not
                 checked for validity here due to performance concerns.
-            qid_shape: The shape of the density matrix, if the initial state is provided as an int.
-            dtype: The dtype of the density matrix, if the initial state is provided as an int.
-            buffer: Optional, must be length 3 and same shape as the density matrix. If not
+            qid_shape: The shape of the state vector, if the initial state is provided as an int.
+            dtype: The dtype of the state vector, if the initial state is provided as an int.
+            buffer: Optional, must be length 3 and same shape as the state vector. If not
                 provided, a buffer will be created automatically.
         Raises:
             ValueError: If initial state is provided as integer, but qid_shape is not provided.


### PR DESCRIPTION
- These simulators do not use density matrices.

Fixes: #6225