### PR TITLE
pin scipy to ~1.12.0 to temporarily fix ci

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -6,7 +6,7 @@ networkx>=2.4
 numpy~=1.16
 pandas
 sortedcontainers~=2.0
-scipy
+scipy~=1.12.0
 sympy
 typing_extensions>=4.2
 tqdm


### PR DESCRIPTION
context: https://github.com/quantumlib/Cirq/issues/6543
