### PR TITLE
CI - migrate to docker compose v2

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -35,11 +35,11 @@ jobs:
             -r dev_tools/requirements/deps/pytest.txt \
             -r dev_tools/requirements/deps/notebook.txt
       - name: Run Quil dependencies
-        run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
+        run: docker compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --rigetti-integration --enable-slow-tests
       - name: Stop Quil dependencies
-        run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
+        run: docker compose -f cirq-rigetti/docker-compose.test.yaml down
   windows:
     name: Pytest Windows
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,11 @@ jobs:
           pip install wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Run Quil dependencies
-        run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
+        run: docker compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
         run: check/pytest -n auto --durations=20 --ignore=cirq-core/cirq/contrib --rigetti-integration
       - name: Stop Quil dependencies
-        run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
+        run: docker compose -f cirq-rigetti/docker-compose.test.yaml down
   pip-compile:
     name: Check consistency of requirements
     runs-on: ubuntu-20.04
@@ -221,7 +221,7 @@ jobs:
           pip install wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Run Quil dependencies
-        run: docker-compose -f cirq-rigetti/docker-compose.test.yaml up -d
+        run: docker compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Coverage check
         run: check/pytest-and-incremental-coverage -n auto --rigetti-integration
       - name: Upload coverage reports to Codecov
@@ -229,7 +229,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Stop Quil dependencies
-        run: docker-compose -f cirq-rigetti/docker-compose.test.yaml down
+        run: docker compose -f cirq-rigetti/docker-compose.test.yaml down
   windows:
     name: Pytest Windows
     strategy:

--- a/dev_tools/conf/apt-list-dev-tools.txt
+++ b/dev_tools/conf/apt-list-dev-tools.txt
@@ -1,4 +1,3 @@
 virtualenvwrapper
 pandoc
 docker-ce
-docker-compose

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -100,9 +100,9 @@ See the previous section for instructions.
     ```bash
     cat apt-system-requirements.txt dev_tools/conf/apt-list-dev-tools.txt | xargs sudo apt-get install --yes
     ```
-    
-    This installs docker and docker-compose among other things. You may need to restart
-    docker or configure permissions, see 
+
+    This installs docker among other things. You may need to restart
+    docker or configure permissions, see
     [docker install instructions](https://docs.docker.com/engine/install/ubuntu/).
     Note that docker is necessary only for cirq_rigetti.
 


### PR DESCRIPTION
Recent GHA runner images require docker-compose v2.

Refs:
https://github.com/actions/runner-images/blob/ubuntu20/20240401.4/images/ubuntu/Ubuntu2004-Readme.md
https://docs.docker.com/compose/migrate/

Fixes #6546
