### PR TITLE
Loosen the scipy condition in requirements.txt

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -7,7 +7,7 @@ networkx>=2.4
 numpy~=1.16
 pandas
 sortedcontainers~=2.0
-scipy~=1.12.0
+scipy<=1.12.0
 sympy
 typing_extensions>=4.2
 tqdm

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -7,7 +7,7 @@ networkx>=2.4
 numpy~=1.16
 pandas
 sortedcontainers~=2.0
-scipy<=1.12.0
+scipy<1.13.0
 sympy
 typing_extensions>=4.2
 tqdm


### PR DESCRIPTION
In order to avoid the conflict of dependency with pyle
```
  SolverProblemError

  Because pyle depends on cirq-core (1.4.0.dev20240404120310) which depends on scipy (>=1.12.0,<1.13.0), scipy is required.
  So, because pyle depends on scipy (~1.9.2), version solving failed.
```
Previous context for scipy ~=1.12 see #6545