### PR TITLE
Removed deprecated processor_ids

### DIFF
--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -27,7 +27,7 @@ import datetime
 import enum
 import random
 import string
-from typing import Dict, List, Optional, Sequence, Set, TypeVar, Union, TYPE_CHECKING
+from typing import Dict, List, Optional, Set, TypeVar, Union, TYPE_CHECKING
 
 import duet
 import google.auth
@@ -210,7 +210,6 @@ class Engine(abstract_engine.AbstractEngine):
     def __str__(self) -> str:
         return f'Engine(project_id={self.project_id!r})'
 
-    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     def run(
         self,
         program: cirq.AbstractCircuit,
@@ -218,13 +217,12 @@ class Engine(abstract_engine.AbstractEngine):
         job_id: Optional[str] = None,
         param_resolver: cirq.ParamResolver = cirq.ParamResolver({}),
         repetitions: int = 1,
-        processor_ids: Sequence[str] = ('xmonsim',),
+        processor_id: str = "xmonsim",
         program_description: Optional[str] = None,
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
         *,
-        processor_id: str = "",
         run_name: str = "",
         device_config_name: str = "",
     ) -> cirq.Result:
@@ -244,15 +242,11 @@ class Engine(abstract_engine.AbstractEngine):
                 and day.
             param_resolver: Parameters to run with the program.
             repetitions: The number of repetitions to simulate.
-            processor_ids: Deprecated list of candidate processor ids to run the program.
-                Only allowed to contain one processor_id. If the argument `processor_id`
-                is non-empty, `processor_ids` will be ignored.
             program_description: An optional description to set on the program.
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
-            processor_id: Processor id for running the program. If not set,
-                `processor_ids` will be used.
+            processor_id: Processor id for running the program.
             run_name: A unique identifier representing an automation run for the
                 specified processor. An Automation Run contains a collection of
                 device configurations for a processor. If specified, `processor_id`
@@ -267,9 +261,8 @@ class Engine(abstract_engine.AbstractEngine):
 
         Raises:
             ValueError: If no gate set is provided.
-            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If `processor_id` is not set.
             ValueError: If only one of `run_name` and `device_config_name` are specified.
-            ValueError: If `processor_ids` has more than one processor id.
             ValueError: If either `run_name` and `device_config_name` are set but
                 `processor_id` is empty.
         """
@@ -280,18 +273,16 @@ class Engine(abstract_engine.AbstractEngine):
                 job_id=job_id,
                 params=[param_resolver],
                 repetitions=repetitions,
-                processor_ids=processor_ids,
+                processor_id=processor_id,
                 program_description=program_description,
                 program_labels=program_labels,
                 job_description=job_description,
                 job_labels=job_labels,
-                processor_id=processor_id,
                 run_name=run_name,
                 device_config_name=device_config_name,
             )
         )[0]
 
-    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_sweep_async(
         self,
         program: cirq.AbstractCircuit,
@@ -299,13 +290,12 @@ class Engine(abstract_engine.AbstractEngine):
         job_id: Optional[str] = None,
         params: cirq.Sweepable = None,
         repetitions: int = 1,
-        processor_ids: Sequence[str] = ('xmonsim',),
+        processor_id: str = "xmonsim",
         program_description: Optional[str] = None,
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
         *,
-        processor_id: str = "",
         run_name: str = "",
         device_config_name: str = "",
     ) -> engine_job.EngineJob:
@@ -328,15 +318,11 @@ class Engine(abstract_engine.AbstractEngine):
                 and day.
             params: Parameters to run with the program.
             repetitions: The number of circuit repetitions to run.
-            processor_ids: Deprecated list of candidate processor ids to run the program.
-                Only allowed to contain one processor_id. If the argument `processor_id`
-                is non-empty, `processor_ids` will be ignored.
             program_description: An optional description to set on the program.
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
-            processor_id: Processor id for running the program. If not set,
-                `processor_ids` will be used.
+            processor_id: Processor id for running the program.
             run_name: A unique identifier representing an automation run for the
                 specified processor. An Automation Run contains a collection of
                 device configurations for a processor. If specified, `processor_id`
@@ -352,22 +338,13 @@ class Engine(abstract_engine.AbstractEngine):
 
         Raises:
             ValueError: If no gate set is provided.
-            ValueError: If neither `processor_id` or `processor_ids` are set.
+            ValueError: If `processor_id` is not set.
             ValueError: If  only one of `run_name` and `device_config_name` are specified.
-            ValueError: If `processor_ids` has more than one processor id.
             ValueError: If either `run_name` and `device_config_name` are set but
                 `processor_id` is empty.
         """
 
         if self.context.enable_streaming:
-            # This logic is temporary prior to deprecating the processor_ids parameter.
-            # TODO(#6271) Remove after deprecating processor_ids elsewhere prior to v1.4.
-            if processor_ids:
-                if len(processor_ids) > 1:
-                    raise ValueError("The use of multiple processors is no longer supported.")
-                if len(processor_ids) == 1 and not processor_id:
-                    processor_id = processor_ids[0]
-
             if not program_id:
                 program_id = _make_random_id('prog-')
             if not job_id:
@@ -403,10 +380,9 @@ class Engine(abstract_engine.AbstractEngine):
             job_id=job_id,
             params=params,
             repetitions=repetitions,
-            processor_ids=processor_ids,
+            processor_id=processor_id,
             description=job_description,
             labels=job_labels,
-            processor_id=processor_id,
             run_name=run_name,
             device_config_name=device_config_name,
         )

--- a/cirq-google/cirq_google/engine/engine_client_test.py
+++ b/cirq-google/cirq_google/engine/engine_client_test.py
@@ -361,7 +361,7 @@ def test_create_job(client_constructor):
     labels = {'hello': 'world'}
     client = EngineClient()
     assert client.create_job(
-        'proj', 'prog', 'job0', ['processor0'], run_context, 10, 'A job', labels
+        'proj', 'prog', 'job0', 'processor0', run_context, 10, 'A job', labels
     ) == ('job0', result)
     grpc_client.create_quantum_job.assert_called_with(
         quantum.CreateQuantumJobRequest(
@@ -384,7 +384,7 @@ def test_create_job(client_constructor):
         )
     )
 
-    assert client.create_job('proj', 'prog', 'job0', ['processor0'], run_context, 10, 'A job') == (
+    assert client.create_job('proj', 'prog', 'job0', 'processor0', run_context, 10, 'A job') == (
         'job0',
         result,
     )
@@ -409,7 +409,7 @@ def test_create_job(client_constructor):
     )
 
     assert client.create_job(
-        'proj', 'prog', 'job0', ['processor0'], run_context, 10, labels=labels
+        'proj', 'prog', 'job0', 'processor0', run_context, 10, labels=labels
     ) == ('job0', result)
     grpc_client.create_quantum_job.assert_called_with(
         quantum.CreateQuantumJobRequest(
@@ -431,7 +431,7 @@ def test_create_job(client_constructor):
         )
     )
 
-    assert client.create_job('proj', 'prog', 'job0', ['processor0'], run_context, 10) == (
+    assert client.create_job('proj', 'prog', 'job0', 'processor0', run_context, 10) == (
         'job0',
         result,
     )
@@ -458,7 +458,7 @@ def test_create_job(client_constructor):
         'proj',
         'prog',
         job_id=None,
-        processor_ids=['processor0'],
+        processor_id='processor0',
         run_context=run_context,
         priority=10,
     ) == ('job0', result)
@@ -485,7 +485,7 @@ def test_create_job(client_constructor):
             'proj',
             'prog',
             job_id=None,
-            processor_ids=['processor0'],
+            processor_id='processor0',
             run_context=run_context,
             priority=5000,
         )
@@ -494,32 +494,22 @@ def test_create_job(client_constructor):
 @mock.patch.dict(os.environ, clear='CIRQ_TESTING')
 @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
 @pytest.mark.parametrize(
-    'processor_ids, processor_id, run_name, device_config_name, error_message',
+    'processor_id, run_name, device_config_name, error_message',
     [
         (
-            ['processor0'],
             '',
             'RUN_NAME',
             'CONFIG_ALIAS',
             'Cannot specify `run_name` or `device_config_name` if `processor_id` is empty',
         ),
+        ('', '', '', 'Must specify a processor id when creating a job.'),
         (
-            ['processor0', 'processor1'],
-            '',
-            '',
-            '',
-            'The use of multiple processors is no longer supported.',
-        ),
-        (None, '', '', '', 'Must specify a processor id when creating a job.'),
-        (
-            None,
             'processor0',
             'RUN_NAME',
             '',
             'Cannot specify only one of `run_name` and `device_config_name`',
         ),
         (
-            None,
             'processor0',
             '',
             'CONFIG_ALIAS',
@@ -528,7 +518,7 @@ def test_create_job(client_constructor):
     ],
 )
 def test_create_job_with_invalid_processor_and_device_config_arguments_throws(
-    client_constructor, processor_ids, processor_id, run_name, device_config_name, error_message
+    client_constructor, processor_id, run_name, device_config_name, error_message
 ):
     grpc_client = _setup_client_mock(client_constructor)
     result = quantum.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
@@ -540,7 +530,6 @@ def test_create_job_with_invalid_processor_and_device_config_arguments_throws(
             project_id='proj',
             program_id='prog',
             job_id=None,
-            processor_ids=processor_ids,
             processor_id=processor_id,
             run_name=run_name,
             device_config_name=device_config_name,
@@ -550,11 +539,11 @@ def test_create_job_with_invalid_processor_and_device_config_arguments_throws(
 @mock.patch.dict(os.environ, clear='CIRQ_TESTING')
 @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
 @pytest.mark.parametrize(
-    'processor_ids, processor_id', [(None, 'processor0'), (['ignored-processor'], 'processor0')]
+    'processor_id', [('processor0'), ('processor0')]
 )
 @pytest.mark.parametrize('run_name, device_config_name', [('RUN_NAME', 'CONFIG_NAME'), ('', '')])
 def test_create_job_with_run_name_and_device_config_name(
-    client_constructor, processor_ids, processor_id, run_name, device_config_name
+    client_constructor, processor_id, run_name, device_config_name
 ):
     grpc_client = _setup_client_mock(client_constructor)
     result = quantum.QuantumJob(name='projects/proj/programs/prog/jobs/job0')
@@ -566,7 +555,6 @@ def test_create_job_with_run_name_and_device_config_name(
         project_id='proj',
         program_id='prog',
         job_id='job0',
-        processor_ids=processor_ids,
         processor_id=processor_id,
         run_name=run_name,
         device_config_name=device_config_name,

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -60,17 +60,15 @@ class EngineProgram(abstract_program.AbstractProgram):
         self.context = context
         self._program = _program
 
-    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_sweep_async(
         self,
         job_id: Optional[str] = None,
         params: cirq.Sweepable = None,
         repetitions: int = 1,
-        processor_ids: Sequence[str] = ('xmonsim',),
+        processor_id: str = "xmonsim",
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
         *,
-        processor_id: str = "",
         run_name: str = "",
         device_config_name: str = "",
     ) -> engine_job.EngineJob:
@@ -86,13 +84,9 @@ class EngineProgram(abstract_program.AbstractProgram):
                 and day.
             params: Parameters to run with the program.
             repetitions: The number of circuit repetitions to run.
-            processor_ids: Deprecated list of candidate processor ids to run the program.
-                Only allowed to contain one processor_id. If the argument `processor_id`
-                is non-empty, `processor_ids` will be ignored.
             description: An optional description to set on the job.
             labels: Optional set of labels to set on the job.
-            processor_id: Processor id for running the program. If not set,
-                `processor_ids` will be used.
+            processor_id: Processor id for running the program.
             run_name: A unique identifier representing an automation run for the
                 specified processor. An Automation Run contains a collection of
                 device configurations for a processor. If specified, `processor_id`
@@ -109,7 +103,6 @@ class EngineProgram(abstract_program.AbstractProgram):
         Raises:
             ValueError: If a processor id hasn't been specified to run the job
             ValueError: If  only one of `run_name` and `device_config_name` are specified.
-            ValueError: If `processor_ids` has more than one processor id.
             ValueError: If either `run_name` and `device_config_name` are set but
                 `processor_id` is empty.
         """
@@ -123,11 +116,10 @@ class EngineProgram(abstract_program.AbstractProgram):
             project_id=self.project_id,
             program_id=self.program_id,
             job_id=job_id,
-            processor_ids=processor_ids,
+            processor_id=processor_id,
             run_context=run_context,
             description=description,
             labels=labels,
-            processor_id=processor_id,
             run_name=run_name,
             device_config_name=device_config_name,
         )
@@ -137,17 +129,15 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     run_sweep = duet.sync(run_sweep_async)
 
-    # TODO(#6271): Deprecate and remove processor_ids before v1.4
     async def run_async(
         self,
         job_id: Optional[str] = None,
         param_resolver: cirq.ParamResolver = cirq.ParamResolver({}),
         repetitions: int = 1,
-        processor_ids: Sequence[str] = ('xmonsim',),
+        processor_id: str = "xmonsim",
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
         *,
-        processor_id: str = "",
         run_name: str = "",
         device_config_name: str = "",
     ) -> cirq.Result:
@@ -160,13 +150,9 @@ class EngineProgram(abstract_program.AbstractProgram):
                 and day.
             param_resolver: Parameters to run with the program.
             repetitions: The number of repetitions to simulate.
-            processor_ids: Deprecated list of candidate processor ids to run the program.
-                Only allowed to contain one processor_id. If the argument `processor_id`
-                is non-empty, `processor_ids` will be ignored.
             description: An optional description to set on the job.
             labels: Optional set of labels to set on the job.
-            processor_id: Processor id for running the program. If not set,
-                `processor_ids` will be used.
+            processor_id: Processor id for running the program.
             run_name: A unique identifier representing an automation run for the
                 specified processor. An Automation Run contains a collection of
                 device configurations for a processor. If specified, `processor_id`
@@ -182,7 +168,6 @@ class EngineProgram(abstract_program.AbstractProgram):
         Raises:
             ValueError: If a processor id hasn't been specified to run the job
             ValueError: If  only one of `run_name` and `device_config_name` are specified.
-            ValueError: If `processor_ids` has more than one processor id.
             ValueError: If either `run_name` and `device_config_name` are set but
                 `processor_id` is empty.
         """
@@ -190,10 +175,9 @@ class EngineProgram(abstract_program.AbstractProgram):
             job_id=job_id,
             params=[param_resolver],
             repetitions=repetitions,
-            processor_ids=processor_ids,
+            processor_id=processor_id,
             description=description,
             labels=labels,
-            processor_id=processor_id,
             run_name=run_name,
             device_config_name=device_config_name,
         )

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -85,7 +85,7 @@ def test_run_sweeps_delegation(create_job_async):
     program = cg.EngineProgram('my-proj', 'my-prog', EngineContext())
     param_resolver = cirq.ParamResolver({})
     job = program.run_sweep(
-        job_id='steve', repetitions=10, params=param_resolver, processor_ids=['mine']
+        job_id='steve', repetitions=10, params=param_resolver, processor_id='mine'
     )
     assert job._job == quantum.QuantumJob()
 
@@ -134,7 +134,7 @@ def test_run_delegation(create_job_async, get_results_async):
     program = cg.EngineProgram('a', 'b', EngineContext())
     param_resolver = cirq.ParamResolver({})
     results = program.run(
-        job_id='steve', repetitions=10, param_resolver=param_resolver, processor_ids=['mine']
+        job_id='steve', repetitions=10, param_resolver=param_resolver, processor_id='mine'
     )
 
     assert results == cg.EngineResult(

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -255,7 +255,7 @@ def test_run_circuit_with_unary_rpcs(client):
         context=EngineContext(service_args={'client_info': 1}, enable_streaming=False),
     )
     result = engine.run(
-        program=_CIRCUIT, program_id='prog', job_id='job-id', processor_ids=['mysim']
+        program=_CIRCUIT, program_id='prog', job_id='job-id', processor_id='mysim'
     )
 
     assert result.repetitions == 1
@@ -267,7 +267,7 @@ def test_run_circuit_with_unary_rpcs(client):
         project_id='proj',
         program_id='prog',
         job_id='job-id',
-        processor_ids=['mysim'],
+        processor_id='mysim',
         run_context=util.pack_any(
             v2.run_context_pb2.RunContext(
                 parameter_sweeps=[v2.run_context_pb2.ParameterSweep(repetitions=1)]
@@ -275,7 +275,6 @@ def test_run_circuit_with_unary_rpcs(client):
         ),
         description=None,
         labels=None,
-        processor_id='',
         run_name='',
         device_config_name='',
     )
@@ -292,7 +291,7 @@ def test_run_circuit_with_stream_rpcs(client):
         context=EngineContext(service_args={'client_info': 1}, enable_streaming=True),
     )
     result = engine.run(
-        program=_CIRCUIT, program_id='prog', job_id='job-id', processor_ids=['mysim']
+        program=_CIRCUIT, program_id='prog', job_id='job-id', processor_id='mysim'
     )
 
     assert result.repetitions == 1
@@ -526,21 +525,6 @@ def test_run_sweep_params_with_stream_rpcs(client):
     for i, v in enumerate([1.0, 2.0]):
         assert sweeps[i].repetitions == 1
         assert sweeps[i].sweep.sweep_function.sweeps[0].single_sweep.points.points == [v]
-
-
-def test_run_sweep_with_multiple_processor_ids():
-    engine = cg.Engine(
-        project_id='proj',
-        context=EngineContext(
-            proto_version=cg.engine.engine.ProtoVersion.V2, enable_streaming=True
-        ),
-    )
-    with pytest.raises(ValueError, match='multiple processors is no longer supported'):
-        _ = engine.run_sweep(
-            program=_CIRCUIT,
-            params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
-            processor_ids=['mysim', 'mysim2'],
-        )
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)


### PR DESCRIPTION
Removed deprecated processor_ids in `Engine`, `EngineProgram` and `EngineClient` from issue #6271
