### PR TITLE
Add UNKNOWN status code to retryable Quantum Engine errors

### DIFF
--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -339,13 +339,6 @@ def _get_retry_request_or_raise(
         if not 'get_quantum_result' in current_request:
             return get_result_request
 
-    # Code.JOB_ALREADY_EXISTS should never happen.
-    # The first stream request is always a CreateQuantumProgramAndJobRequest, which never fails
-    # with this error because jobs are scoped within a program.
-    # CreateQuantumJobRequests would fail with a PROGRAM_ALREADY_EXISTS if the job already
-    # exists because program and job creation happen atomically for a
-    # CreateQuantumProgramAndJobRequest.
-
     raise StreamError(error.message)
 
 

--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -27,7 +27,7 @@ Code = quantum.StreamError.Code
 RETRYABLE_GOOGLE_API_EXCEPTIONS = [
     google_exceptions.InternalServerError,
     google_exceptions.ServiceUnavailable,
-    google_exceptions.Unknown, # 408 Timeouts sometimes show up as UNKNOWN.
+    google_exceptions.Unknown,  # 408 Timeouts sometimes show up as UNKNOWN.
 ]
 
 

--- a/cirq-google/cirq_google/engine/stream_manager_test.py
+++ b/cirq-google/cirq_google/engine/stream_manager_test.py
@@ -364,6 +364,7 @@ class TestStreamManager:
         [
             google_exceptions.InternalServerError('server error'),
             google_exceptions.ServiceUnavailable('unavailable'),
+            google_exceptions.Unknown('timeout'),
         ],
     )
     @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)

--- a/cirq-google/cirq_google/engine/stream_manager_test.py
+++ b/cirq-google/cirq_google/engine/stream_manager_test.py
@@ -404,7 +404,6 @@ class TestStreamManager:
             google_exceptions.TooManyRequests('too many requests'),
             google_exceptions.Unauthenticated('unauthenticated'),
             google_exceptions.Unauthorized('unauthorized'),
-            google_exceptions.Unknown('unknown'),
         ],
     )
     @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)


### PR DESCRIPTION
Users have reported intermittent errors where requests are halted due to a timeout. Within a provided stacktrace, I found:

```
<AioRpcError of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = "408:Request Timeout"
	debug_error_string = "<...>"
>
```

The stack trace also indicated that the [`_is_retryable_error`](https://github.com/quantumlib/Cirq/blob/2eb6d63880a4cc96f96ee764da79df70442aca0c/cirq-google/cirq_google/engine/stream_manager.py#L264) check failed and so raised the exception.

This change adds the `UNKNOWN` error code to retry in these cases.