### PR TITLE
Fix `__len__` of empty Product sweep to match actual length

### DIFF
--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -236,8 +236,6 @@ class Product(Sweep):
         return sum((factor.keys for factor in self.factors), [])
 
     def __len__(self) -> int:
-        if not self.factors:
-            return 0
         length = 1
         for factor in self.factors:
             length *= len(factor)

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -142,6 +142,11 @@ def test_product():
     assert _values(sweep, 'b') == [4, 5, 6, 7, 4, 5, 6, 7, 4, 5, 6, 7]
 
 
+def test_empty_product():
+    sweep = cirq.Product()
+    assert len(sweep) == len(list(sweep)) == 1
+
+
 def test_slice_access_error():
     sweep = cirq.Points('a', [1, 2, 3])
     with pytest.raises(TypeError, match='<class \'str\'>'):


### PR DESCRIPTION
An empty `cirq.Product()` sweep yields one empty param resolver, but was reporting a length of 0 when calling `__len__`. This fixes the `__len__` computation so it agrees with the actual length of the sweep when iterating.