### PR TITLE
CI - downgrade to macos-13 which has the needed Python versions

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -71,7 +71,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
-    runs-on: macos-latest
+    # TODO(#6577): upgrade to macos-latest when it runs Python 3.10
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,8 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.10', '3.11' ]
-    runs-on: macos-latest
+    # TODO(#6577): upgrade to macos-latest when it runs Python 3.10
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Problem: macos-latest currently does not provide Python 3.10
Workaround: temporarily switch to the previous runner macos-13

Fixes #6573
Related to #6577
