### PR TITLE
Escape `&` in SVG diagrams

### DIFF
--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -21,6 +21,7 @@ def fixup_text(text: str):
     # https://github.com/quantumlib/Cirq/issues/2905
     text = text.replace('[<virtual>]', '')
     text = text.replace('[cirq.VirtualTag()]', '')
+    text = text.replace('&', '&amp;')
     text = text.replace('<', '&lt;').replace('>', '&gt;')
     return text
 

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -65,6 +65,7 @@ def test_empty_moments():
     'symbol,svg_symbol',
     [
         ('<a', '&lt;a'),
+        ('<a&', '&lt;a&amp;'),
         ('<=b', '&lt;=b'),
         ('>c', '&gt;c'),
         ('>=d', '&gt;=d'),


### PR DESCRIPTION
We have bloqs in Qualtran that use `&` on one of the output wires. The corresponding SVG diagram fails. This PR fixes it. 