### PR TITLE
Optimize Clifford.__pow__ by using binary exponentiation

### DIFF
--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -419,9 +419,12 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
             exponent = int(abs(exponent))
 
         # https://cp-algorithms.com/algebra/binary-exp.html
-        aux = qis.CliffordTableau(num_qubits=self.clifford_tableau.n)  # this tableau collects the odd terms
+        aux = qis.CliffordTableau(
+            num_qubits=self.clifford_tableau.n
+        )  # this tableau collects the odd terms
         while exponent > 1:
-            if exponent & 1: aux = aux.then(base_tableau)
+            if exponent & 1:
+                aux = aux.then(base_tableau)
             base_tableau = base_tableau.then(base_tableau)
             exponent >>= 1
 

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -400,7 +400,7 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
         # By definition, Clifford Gate should always return True.
         return True
 
-    def __pow__(self, exponent: int) -> 'CliffordGate':
+    def __pow__(self, exponent: Union[float, int]) -> 'CliffordGate':
         if exponent != int(exponent):
             return NotImplemented
 

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -416,7 +416,7 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
         base_tableau = self.clifford_tableau.copy()
         if exponent < 0:
             base_tableau = base_tableau.inverse()
-            exponent = int(abs(exponent))
+            exponent = abs(exponent)
 
         # https://cp-algorithms.com/algebra/binary-exp.html
         aux = qis.CliffordTableau(

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -400,9 +400,10 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
         # By definition, Clifford Gate should always return True.
         return True
 
-    def __pow__(self, exponent: Union[float, int]) -> 'CliffordGate':
+    def __pow__(self, exponent: float) -> 'CliffordGate':
         if exponent != int(exponent):
             return NotImplemented
+        exponent = int(exponent)
 
         if exponent == -1:
             return CliffordGate.from_clifford_tableau(self.clifford_tableau.inverse())

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -129,8 +129,9 @@ class StabilizerState(
 
 class CliffordTableau(StabilizerState):
     """Tableau representation of a stabilizer state
-    (based on Aaronson and Gottesman 2004).
-    # https://arxiv.org/pdf/quant-ph/0406196
+
+    References:
+        - [Aaronson and Gottesman](https://arxiv.org/pdf/quant-ph/0406196)
 
     The tableau stores the stabilizer generators of
     the state using three binary arrays: xs, zs, and rs.

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -131,7 +131,7 @@ class CliffordTableau(StabilizerState):
     """Tableau representation of a stabilizer state
 
     References:
-        - [Aaronson and Gottesman](https://arxiv.org/pdf/quant-ph/0406196)
+        - [Aaronson and Gottesman](https://arxiv.org/abs/quant-ph/0406196)
 
     The tableau stores the stabilizer generators of
     the state using three binary arrays: xs, zs, and rs.

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -129,7 +129,8 @@ class StabilizerState(
 
 class CliffordTableau(StabilizerState):
     """Tableau representation of a stabilizer state
-    (based on Aaronson and Gottesman 2006).
+    (based on Aaronson and Gottesman 2004).
+    # https://arxiv.org/pdf/quant-ph/0406196
 
     The tableau stores the stabilizer generators of
     the state using three binary arrays: xs, zs, and rs.


### PR DESCRIPTION
Implements binary exponentiation as described in https://github.com/quantumlib/Cirq/issues/6327
This change does not include the feature of exponentiation for non-integer exponents. This still needs to be discussed, since $\frac{5}{2}$ might be supported ( i.e. the square root is clear ), but other values might not. Knowing which non-integers to support needs to be discussed