### PR TITLE
Avoid DivisionByZero error when TensorNetwork simplifies to a scalar

### DIFF
--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -170,6 +170,7 @@ def tensor_expectation_value(
         )
     else:
         tn.rank_simplify(inplace=True)
+    # TODO(#6586): revert when our minimum quimb version has bugfix for quimb#231
     # Skip path-info evaluation when TensorNetwork consists of scalar Tensors.
     # Avoid bug in quimb-1.8.0.
     # Ref: https://github.com/jcmgray/quimb/issues/231

--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -170,8 +170,14 @@ def tensor_expectation_value(
         )
     else:
         tn.rank_simplify(inplace=True)
-    path_info = tn.contract(get='path-info')
-    ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
+    # Skip path-info evaluation when TensorNetwork consists of scalar Tensors.
+    # Avoid bug in quimb-1.8.0.
+    # Ref: https://github.com/jcmgray/quimb/issues/231
+    if tn.ind_map:
+        path_info = tn.contract(get='path-info')
+        ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
+    else:
+        ram_gb = 0
     if ram_gb > max_ram_gb:
         raise MemoryError(f"We estimate that this contraction will take too much RAM! {ram_gb} GB")
     e_val = tn.contract(inplace=True)


### PR DESCRIPTION
Problem: Python 3.12 requires quimb-1.8.0, but quimb-1.8.0 cannot
evaluate path-info for TensorNetwork consisting of a scalar Tensor.

Solution: Skip path-info evaluation for scalar TensorNetwork.
Path-info is used for RAM estimation only which is not a problem
for scalar TensorNetwork-s.

This fixes unit test failure for
cirq-core/cirq/contrib/quimb/grid_circuits_test.py::test_tensor_expectation_value

Ref: https://github.com/jcmgray/quimb/issues/231