### PR TITLE
NEP-29 - enforce minimum Python version 3.10

### DIFF
--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -60,7 +60,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.9.0'),
+    python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 """Define version number here, read it from setup.py automatically,
-and warn users that the latest version of cirq uses python 3.9+"""
+and warn users that the latest version of cirq uses python 3.10+"""
 
 import sys
 
-if sys.version_info < (3, 9, 0):  # pragma: no cover
+if sys.version_info < (3, 10, 0):  # pragma: no cover
     raise SystemError(
-        "You installed the latest version of cirq but aren't on python 3.9+.\n"
+        "You installed the latest version of cirq but aren't on python 3.10+.\n"
         'To fix this error, you need to either:\n'
         '\n'
-        'A) Update to python 3.9 or later.\n'
+        'A) Update to python 3.10 or later.\n'
         '- OR -\n'
         'B) Explicitly install an older deprecated-but-compatible version '
         'of cirq (e.g. "python -m pip install cirq==1.1.*")'

--- a/cirq-core/cirq/ops/qid_util.py
+++ b/cirq-core/cirq/ops/qid_util.py
@@ -41,8 +41,7 @@ def q(*args: Union[int, str]) -> Union['cirq.LineQubit', 'cirq.GridQubit', 'cirq
     >>> cirq.q("foo") == cirq.NamedQubit("foo")
     True
 
-    Note that arguments should be treated as positional only, even
-    though this is only enforceable in python 3.8 or later.
+    Note that arguments should be treated as positional only.
 
     Args:
         *args: One or two ints, or a single str, as described above.

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import contextlib
 import dataclasses
 import datetime
@@ -19,7 +20,6 @@ import io
 import json
 import os
 import pathlib
-import sys
 import warnings
 from typing import Dict, List, Optional, Tuple, Type
 from unittest import mock

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -56,12 +56,6 @@ TESTED_MODULES: Dict[str, Optional[_ModuleDeprecation]] = {
 }
 
 
-# pyQuil 3.0, necessary for cirq_rigetti module requires
-# python >= 3.9
-if sys.version_info < (3, 9):  # pragma: no cover
-    del TESTED_MODULES['cirq_rigetti']
-
-
 def _get_testspecs_for_modules() -> List[ModuleJsonTestSpec]:
     modules = []
     for m in TESTED_MODULES.keys():

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -4,7 +4,7 @@ attrs
 duet>=0.2.8
 matplotlib~=3.0
 networkx>=2.4
-numpy~=1.16
+numpy~=1.22
 pandas
 sortedcontainers~=2.0
 scipy<1.13.0

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -63,7 +63,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.9.0'),
+    python_requires=('>=3.10.0'),
     install_requires=requirements,
     extras_require={'contrib': contrib_requirements},
     license='Apache 2',

--- a/cirq-ft/setup.py
+++ b/cirq-ft/setup.py
@@ -59,7 +59,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 """Define version number here, read it from setup.py automatically,
-and warn users that the latest version of cirq uses python 3.9+"""
+and warn users that the latest version of cirq uses python 3.10+"""
 
 import sys
 
-if sys.version_info < (3, 9, 0):  # pragma: no cover
+if sys.version_info < (3, 10, 0):  # pragma: no cover
     raise SystemError(
-        "You installed the latest version of cirq but aren't on python 3.9+.\n"
+        "You installed the latest version of cirq but aren't on python 3.10+.\n"
         'To fix this error, you need to either:\n'
         '\n'
-        'A) Update to python 3.9 or later.\n'
+        'A) Update to python 3.10 or later.\n'
         '- OR -\n'
         'B) Explicitly install an older deprecated-but-compatible version '
         'of cirq (e.g. "python -m pip install cirq==1.1.*")'

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -62,7 +62,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.9.0'),
+    python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -59,7 +59,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.9.0'),
+    python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -58,7 +58,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -60,7 +60,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -62,7 +62,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/dev_tools/modules_test.py
+++ b/dev_tools/modules_test.py
@@ -37,7 +37,7 @@ def test_modules():
             'url': 'http://github.com/quantumlib/cirq',
             'author': 'The Cirq Developers',
             'author_email': 'cirq-dev@googlegroups.com',
-            'python_requires': '>=3.9.0',
+            'python_requires': '>=3.10.0',
             'install_requires': ['req1', 'req2'],
             'license': 'Apache 2',
             'packages': ['pack1', 'pack1.sub'],

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -22,7 +22,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires=('>=3.9.0'),
+    python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',
     packages=pack1_packages,

--- a/dev_tools/snippets_test.py
+++ b/dev_tools/snippets_test.py
@@ -761,13 +761,13 @@ print("abc")
 
     with pytest.raises(AssertionError):
         assert_code_snippet_executes_correctly(
-                """
+            """
 print("abc")
 # prints
 # def
                 """,
-                {},
-            )
+            {},
+        )
 
     assert_code_snippet_executes_correctly(
         """

--- a/dev_tools/snippets_test.py
+++ b/dev_tools/snippets_test.py
@@ -54,8 +54,8 @@ In addition to checking that the code executes:
       where pattern is the regex matching pattern (passed to re.compile) and
       substitution is the replacement string.
 """
+
 import inspect
-import sys
 from typing import Any, Dict, List, Optional, Pattern, Tuple, Iterator
 
 import os

--- a/dev_tools/snippets_test.py
+++ b/dev_tools/snippets_test.py
@@ -759,9 +759,8 @@ print("abc")
         {},
     )
 
-    if sys.version_info[0] >= 3:  # Our print capture only works in python 3.
-        with pytest.raises(AssertionError):
-            assert_code_snippet_executes_correctly(
+    with pytest.raises(AssertionError):
+        assert_code_snippet_executes_correctly(
                 """
 print("abc")
 # prints

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
-    python_requires='>=3.9.0',
+    python_requires='>=3.10.0',
     install_requires=requirements,
     extras_require={'dev_env': dev_requirements},
     license='Apache 2',


### PR DESCRIPTION
- Raise exception if running with Python <= 3.9.x
- Clean up checks and notes relevant for old Pythons
- Bump up to numpy~=1.22 which is effectively the minimum version
  that works with Python 3.10.  We are a bit more permissive than
  NEP 29 which suggests numpy-1.23+.

Fixes: #6463
Ref: https://numpy.org/neps/nep-0029-deprecation_policy.html
