### PR TITLE
CI - deflake `Isolated pytest Ubuntu`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/isolated-base.env.txt
       - name: Test each module in isolation
-        run: pytest -n auto -m slow dev_tools/packaging/isolated_packages_test.py
+        run: pytest -n auto --enable-slow-tests dev_tools/packaging/isolated_packages_test.py
   pytest:
     name: Pytest Ubuntu
     strategy:

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -39,7 +39,7 @@ def test_isolated_packages(cloned_env, module):
         assert f'cirq-core=={module.version}' in module.install_requires
 
     result = shell_tools.run(
-        f"{env}/bin/pip install ./{module.root} ./cirq-core".split(),
+        f"{env}/bin/pip install --no-clean ./{module.root} ./cirq-core".split(),
         stderr=subprocess.PIPE,
         check=False,
     )


### PR DESCRIPTION
Problem: `test_isolated_packages` may run clashing parallel builds
of a local `cirq_core` wheel.

Solution: Run pip-install with the `--no-clean` option so parallel
builds do not delete active files.

Also invoke isolated_packages_test.py with `--enable-slow-tests` in CI
to include non-slow tests if ever added to that file.
