### PR TITLE
Release pins from all pytest-related packages

### DIFF
--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -346,8 +346,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py HEAD\n'
@@ -372,8 +370,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py main\n'
@@ -390,8 +386,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py origin/main\n'
@@ -408,8 +402,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py upstream/main\n'
@@ -426,8 +418,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py upstream/main\n'
@@ -456,8 +446,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py HEAD\n'
@@ -474,8 +462,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout == (
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py main\n'
@@ -499,8 +485,6 @@ def test_pytest_and_incremental_coverage_branch_selection(tmpdir_factory):
     assert result.stdout.startswith(
         'INTERCEPTED check/pytest '
         '--cov --cov-config=dev_tools/conf/.coveragerc\n'
-        'The annotate command will be removed in a future version.\n'
-        'Get in touch if you still use it: ned@nedbatchelder.com\n'
         'No data to report.\n'
         'INTERCEPTED '
         'python dev_tools/check_incremental_coverage_annotations.py '

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -2,18 +2,16 @@
 
 pytest
 pytest-asyncio
-# pytest-cov 4.1.0 discards line hits in subprocess (coverage failures in #6208)
-pytest-cov~=3.0
+pytest-cov
 pytest-randomly
-# Notebook >=6.4.8 + coverage > 6.2 hangs CI: https://github.com/quantumlib/Cirq/issues/4897
-coverage<=6.2
+coverage
 
 # for parallel testing notebooks
-pytest-xdist~=2.2.0
+pytest-xdist
 filelock~=3.1
 
 # For testing time specific logic
-freezegun~=0.3.15
+freezegun
 
 # For test_metadata_distributions_after_deprecated_submodule
 importlib-metadata

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -4,7 +4,7 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-randomly
-coverage
+coverage~=7.4
 
 # for parallel testing notebooks
 pytest-xdist


### PR DESCRIPTION
Remove top-version limits on the pytest-related package.
These pins were introduced a while ago and are hopefully
not needed anymore.