### PR TITLE
CI - deflake `Isolated pytest Ubuntu`

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
+  # FIXME - for PR testing only, remove before merge
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
-  # FIXME - for PR testing only, remove before merge
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -96,7 +96,7 @@ PACKAGES = [
     "papermill",
     "jupyter",
     # assumed to be part of colab
-    "seaborn~=0.11.1",
+    "seaborn~=0.12",
 ]
 
 

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -26,6 +26,7 @@ import tempfile
 import pytest
 
 from dev_tools import shell_tools
+from dev_tools.modules import list_modules
 from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_notebook
 from dev_tools.test_utils import only_on_posix
 
@@ -63,9 +64,18 @@ def require_packages_not_changed():
 
     Raise AssertionError if the pre-existing set of Python packages changes in any way.
     """
-    packages_before = set((d.name, d.version) for d in importlib.metadata.distributions())
+    cirq_packages = set(m.name for m in list_modules()).union(["cirq"])
+    packages_before = set(
+        (d.name, d.version)
+        for d in importlib.metadata.distributions()
+        if d.name not in cirq_packages
+    )
     yield
-    packages_after = set((d.name, d.version) for d in importlib.metadata.distributions())
+    packages_after = set(
+        (d.name, d.version)
+        for d in importlib.metadata.distributions()
+        if d.name not in cirq_packages
+    )
     assert packages_after == packages_before
 
 

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -39,7 +39,7 @@ def test_isolated_packages(cloned_env, module):
         assert f'cirq-core=={module.version}' in module.install_requires
 
     result = shell_tools.run(
-        f"{env}/bin/pip install --no-clean ./{module.root} ./cirq-core".split(),
+        f"{env}/bin/pip install ./{module.root} ./cirq-core".split(),
         stderr=subprocess.PIPE,
         check=False,
     )

--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -13,4 +13,4 @@ papermill~=2.3.2
 -r ../../../cirq-core/cirq/contrib/requirements.txt
 
 # assumed to be part of colab
-seaborn~=0.11.1
+seaborn~=0.12


### PR DESCRIPTION
Problem: `test_isolated_packages.py` is still flaky and can fail on
parallel builds of a local `cirq_core` wheel.

Solution: Use per-worker copy of the cirq-core sources so that parallel
builds do not have conflicting build files.

Follow-up to #6593
