### PR TITLE
Create multiprocessing/multithreading helper functions

### DIFF
--- a/cirq-core/cirq/work/__init__.py
+++ b/cirq-core/cirq/work/__init__.py
@@ -31,3 +31,4 @@ from cirq.work.observable_measurement import (
 from cirq.work.observable_readout_calibration import calibrate_readout_error
 from cirq.work.sampler import Sampler
 from cirq.work.zeros_sampler import ZerosSampler
+from cirq.work.multiprocessing import execute_with_progress_bar, starmap_with_progress_bar

--- a/cirq-core/cirq/work/multiprocessing.py
+++ b/cirq-core/cirq/work/multiprocessing.py
@@ -1,0 +1,118 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Union, List, Callable, TypeVar, Iterable, Optional, ContextManager
+
+import multiprocessing
+import concurrent.futures
+import tqdm
+
+
+_OUTPUT_T = TypeVar('_OUTPUT_T')
+
+
+def execute_with_progress_bar(
+    func: Callable[..., _OUTPUT_T],
+    inputs: Iterable[Any],
+    pool: Optional[
+        Union['multiprocessing.pool.Pool', concurrent.futures.ThreadPoolExecutor]
+    ] = None,
+    progress_bar: Callable[..., ContextManager] = tqdm.tqdm,
+    **progress_bar_args,
+) -> List[_OUTPUT_T]:
+    """Execute a function in parallel with progress bar.
+
+    Args:
+        func: The callable to execute, the function takes a single argument.
+        inputs: An iterable of the argument to pass to the function.
+        pool: An optional multiprocessing or threading pool.
+        progress_bar: A callable that creates a progress bar.
+        progress_bar_args: Arguments to pass to the progress bar.
+
+    Returns:
+        An out-of-order list of the results of the function calls.
+
+    Raises:
+        TypeError: If the pool is not a multiprocessing pool or threading pool or None.
+    """
+    sequential_inputs = [*inputs]
+    results: List[_OUTPUT_T] = []
+    if pool is None:
+        with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
+            for args in sequential_inputs:
+                results.append(func(args))
+                progress.update(1)
+        return results
+    if isinstance(pool, concurrent.futures.ThreadPoolExecutor):
+        futures = [pool.submit(func, args) for args in sequential_inputs]
+        with progress_bar(total=len(futures), **progress_bar_args) as progress:
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+                progress.update(1)
+        return results
+    if isinstance(pool, multiprocessing.pool.Pool):
+        with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
+            for res in pool.imap_unordered(func, sequential_inputs):
+                results.append(res)
+                progress.update(1)
+        return results
+    raise TypeError(f'type {type(pool)} of {pool=} is not supported')
+
+
+def starmap_with_progress_bar(
+    func: Callable[..., _OUTPUT_T],
+    inputs: Iterable[Iterable[Any]],
+    pool: Optional[
+        Union['multiprocessing.pool.Pool', concurrent.futures.ThreadPoolExecutor]
+    ] = None,
+    progress_bar: Callable[..., ContextManager] = tqdm.tqdm,
+    **progress_bar_args,
+) -> List[_OUTPUT_T]:
+    """Execute a function in parallel with progress bar.
+
+    Args:
+        func: The callable to execute, the function takes one or more arguments.
+        inputs: An iterable of the arguments to pass to the function.
+        pool: An optional multiprocessing or threading pool.
+        progress_bar: A callable that creates a progress bar.
+        progress_bar_args: Arguments to pass to the progress bar.
+
+    Returns:
+        An out-of-order list of the results of the function calls.
+
+    Raises:
+        TypeError: If the pool is not a multiprocessing pool or threading pool or None.
+    """
+    sequential_inputs = [*inputs]
+    results: List[_OUTPUT_T] = []
+    if pool is None:
+        with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
+            for args in sequential_inputs:
+                results.append(func(*args))
+                progress.update(1)
+        return results
+    if isinstance(pool, concurrent.futures.ThreadPoolExecutor):
+        futures = [pool.submit(func, *args) for args in sequential_inputs]
+        with progress_bar(total=len(futures), **progress_bar_args) as progress:
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+                progress.update(1)
+        return results
+    if isinstance(pool, multiprocessing.pool.Pool):
+        with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
+            for res in pool.starmap(func, sequential_inputs):
+                results.append(res)
+                progress.update(1)
+        return results
+    raise TypeError(f'type {type(pool)} of {pool=} is not supported')

--- a/cirq-core/cirq/work/multiprocessing.py
+++ b/cirq-core/cirq/work/multiprocessing.py
@@ -61,13 +61,11 @@ def execute_with_progress_bar(
                 results.append(future.result())
                 progress.update(1)
         return results
-    if isinstance(pool, multiprocessing.pool.Pool):
-        with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
-            for res in pool.imap_unordered(func, sequential_inputs):
-                results.append(res)
-                progress.update(1)
-        return results
-    raise TypeError(f'type {type(pool)} of {pool=} is not supported')
+    with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
+        for res in pool.imap_unordered(func, sequential_inputs):
+            results.append(res)
+            progress.update(1)
+    return results
 
 
 def starmap_with_progress_bar(
@@ -90,9 +88,6 @@ def starmap_with_progress_bar(
 
     Returns:
         An out-of-order list of the results of the function calls.
-
-    Raises:
-        TypeError: If the pool is not a multiprocessing pool or threading pool or None.
     """
     sequential_inputs = [*inputs]
     results: List[_OUTPUT_T] = []
@@ -109,10 +104,8 @@ def starmap_with_progress_bar(
                 results.append(future.result())
                 progress.update(1)
         return results
-    if isinstance(pool, multiprocessing.pool.Pool):
-        with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
-            for res in pool.starmap(func, sequential_inputs):
-                results.append(res)
-                progress.update(1)
-        return results
-    raise TypeError(f'type {type(pool)} of {pool=} is not supported')
+    with progress_bar(total=len(sequential_inputs), **progress_bar_args) as progress:
+        for res in pool.starmap(func, sequential_inputs):
+            results.append(res)
+            progress.update(1)
+    return results

--- a/cirq-core/cirq/work/multiprocessing.py
+++ b/cirq-core/cirq/work/multiprocessing.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Union, List, Callable, TypeVar, Iterable, Optional, ContextManager
+from typing import Any, Union, List, Callable, TypeVar, Iterable, Optional, ContextManager, TYPE_CHECKING
 
 import concurrent.futures
 import tqdm
 
+if TYPE_CHECKING:
+    import multiprocessing
 
 _OUTPUT_T = TypeVar('_OUTPUT_T')
 

--- a/cirq-core/cirq/work/multiprocessing.py
+++ b/cirq-core/cirq/work/multiprocessing.py
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Union, List, Callable, TypeVar, Iterable, Optional, ContextManager, TYPE_CHECKING
+from typing import (
+    Any,
+    Union,
+    List,
+    Callable,
+    TypeVar,
+    Iterable,
+    Optional,
+    ContextManager,
+    TYPE_CHECKING,
+)
 
 import concurrent.futures
 import tqdm

--- a/cirq-core/cirq/work/multiprocessing.py
+++ b/cirq-core/cirq/work/multiprocessing.py
@@ -14,7 +14,6 @@
 
 from typing import Any, Union, List, Callable, TypeVar, Iterable, Optional, ContextManager
 
-import multiprocessing
 import concurrent.futures
 import tqdm
 
@@ -42,9 +41,6 @@ def execute_with_progress_bar(
 
     Returns:
         An out-of-order list of the results of the function calls.
-
-    Raises:
-        TypeError: If the pool is not a multiprocessing pool or threading pool or None.
     """
     sequential_inputs = [*inputs]
     results: List[_OUTPUT_T] = []

--- a/cirq-core/cirq/work/multiprocessing_test.py
+++ b/cirq-core/cirq/work/multiprocessing_test.py
@@ -29,33 +29,37 @@ def _multi_arg_func(x: int, y: int) -> str:
 
 
 @pytest.mark.parametrize(
-    'pool', [None, multiprocessing.Pool(2), concurrent.futures.ThreadPoolExecutor(2)]
+    'pool_creator', [None, multiprocessing.Pool, concurrent.futures.ThreadPoolExecutor]
 )
-def test_execute_with_progress_bar(pool):
+def test_execute_with_progress_bar(pool_creator):
     desired = set([f'{x=}' for x in range(10)])
-    actual = set(execute_with_progress_bar(_sinle_arg_func, range(10), pool=pool))
+    if pool_creator is None:
+        actual = set(execute_with_progress_bar(_sinle_arg_func, range(10), pool=None))
+    else:
+        with pool_creator(2) as pool:
+            actual = set(execute_with_progress_bar(_sinle_arg_func, range(10), pool=pool))
     assert actual == desired
-    if isinstance(pool, multiprocessing.pool.Pool):
-        pool.close()
-    if isinstance(pool, concurrent.futures.ThreadPoolExecutor):
-        pool.shutdown()
 
 
 @pytest.mark.parametrize(
-    'pool', [None, multiprocessing.Pool(2), concurrent.futures.ThreadPoolExecutor(2)]
+    'pool_creator', [None, multiprocessing.Pool, concurrent.futures.ThreadPoolExecutor]
 )
-def test_starmap_with_progress_bar(pool):
+def test_starmap_with_progress_bar(pool_creator):
     desired = set([f'{x=}-{y=}' for x, y in zip(range(10), range(1000, 1000 + 10))])
-    actual = set(
-        starmap_with_progress_bar(
-            _multi_arg_func, zip(range(10), range(1000, 1000 + 10)), pool=pool
+    if pool_creator is None:
+        actual = set(
+            starmap_with_progress_bar(
+                _multi_arg_func, zip(range(10), range(1000, 1000 + 10)), pool=None
+            )
         )
-    )
+    else:
+        with pool_creator(2) as pool:
+            actual = set(
+                starmap_with_progress_bar(
+                    _multi_arg_func, zip(range(10), range(1000, 1000 + 10)), pool=pool
+                )
+            )
     assert actual == desired
-    if isinstance(pool, multiprocessing.pool.Pool):
-        pool.close()
-    if isinstance(pool, concurrent.futures.ThreadPoolExecutor):
-        pool.shutdown()
 
 
 def test_invalid_argument_raises_error():

--- a/cirq-core/cirq/work/multiprocessing_test.py
+++ b/cirq-core/cirq/work/multiprocessing_test.py
@@ -1,0 +1,68 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import multiprocessing
+import concurrent.futures
+import pytest
+
+from cirq.work.multiprocessing import execute_with_progress_bar, starmap_with_progress_bar
+
+
+def _sinle_arg_func(x: int) -> str:
+    return f'{x=}'
+
+
+def _multi_arg_func(x: int, y: int) -> str:
+    return f'{x=}-{y=}'
+
+
+@pytest.mark.parametrize(
+    'pool', [None, multiprocessing.Pool(2), concurrent.futures.ThreadPoolExecutor(2)]
+)
+def test_execute_with_progress_bar(pool):
+    desired = set([f'{x=}' for x in range(10)])
+    actual = set(execute_with_progress_bar(_sinle_arg_func, range(10), pool=pool))
+    assert actual == desired
+    if isinstance(pool, multiprocessing.pool.Pool):
+        pool.close()
+    if isinstance(pool, concurrent.futures.ThreadPoolExecutor):
+        pool.shutdown()
+
+
+@pytest.mark.parametrize(
+    'pool', [None, multiprocessing.Pool(2), concurrent.futures.ThreadPoolExecutor(2)]
+)
+def test_starmap_with_progress_bar(pool):
+    desired = set([f'{x=}-{y=}' for x, y in zip(range(10), range(1000, 1000 + 10))])
+    actual = set(
+        starmap_with_progress_bar(
+            _multi_arg_func, zip(range(10), range(1000, 1000 + 10)), pool=pool
+        )
+    )
+    assert actual == desired
+    if isinstance(pool, multiprocessing.pool.Pool):
+        pool.close()
+    if isinstance(pool, concurrent.futures.ThreadPoolExecutor):
+        pool.shutdown()
+
+
+def test_invalid_argument_raises_error():
+    with pytest.raises(TypeError):
+        _ = execute_with_progress_bar(_sinle_arg_func, range(10), pool=3)
+
+    with pytest.raises(TypeError):
+        _ = starmap_with_progress_bar(
+            _multi_arg_func, zip(range(10), range(1000, 1000 + 10)), pool=3
+        )

--- a/cirq-core/cirq/work/multiprocessing_test.py
+++ b/cirq-core/cirq/work/multiprocessing_test.py
@@ -60,13 +60,3 @@ def test_starmap_with_progress_bar(pool_creator):
                 )
             )
     assert actual == desired
-
-
-def test_invalid_argument_raises_error():
-    with pytest.raises(TypeError):
-        _ = execute_with_progress_bar(_sinle_arg_func, range(10), pool=3)
-
-    with pytest.raises(TypeError):
-        _ = starmap_with_progress_bar(
-            _multi_arg_func, zip(range(10), range(1000, 1000 + 10)), pool=3
-        )


### PR DESCRIPTION
Some code in `experiments` uses `multiprocessing.Pool` or `ThreadPoolExecutor` + there are places that could benefit from using either to speed things up. The methods introduced in this PR standardize the way this is done and runs the batches with a progress bar which would improve UX since batching/threading/multiprocessing is used when running long running processes so getting a progress bar is a nice feature.