### PR TITLE
Fix nightly build of the staging cirq website

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -22,8 +22,6 @@ upper_tabs:
 - name: "Software"
   path: /software
   is_default: true
-  menu:
-  - include: /_book/menu_software.yaml
   lower_tabs:
     # Subsite tabs
     other:

--- a/docs/build/_index.yaml
+++ b/docs/build/_index.yaml
@@ -4,46 +4,47 @@ title: Build a circuit
 landing_page:
   nav: left
   rows:
-    - heading: Build a circuit
-      description: At the core of Cirq is the ability to construct quantum circuits. These are the methods and data structures necessary to do so.
-    - heading: Circuit construction
-      description: The core data structures that compose a circuit and how to use them.
-      options:
-        - cards
-      items:
-      - heading: Circuits
-        description: Quantum circuits and how to create them.
-        path: /cirq/build/circuits
-      - heading: Qubits
-        description: The quantum bit data structure.
-        path: /cirq/build/qubits
-      - heading: Gates and Operations
-        description: Quantum gates to apply to qubits in a circuit.
-        path: /cirq/build/gates
-      - heading: Custom gates
-        description: Create your own gates with unitaries or decomposition.
-        path: /cirq/build/custom_gates
-      - heading: Import/export circuits
-        description: Importing or exporting circuits into/out of Cirq.
-        path: /cirq/build/interop
+  - heading: Build a circuit
+    description: At the core of Cirq is the ability to construct quantum circuits.
+      These are the methods and data structures necessary to do so.
+  - heading: Circuit construction
+    description: The core data structures that compose a circuit and how to use them.
+    options:
+    - cards
+    items:
+    - heading: Circuits
+      description: Quantum circuits and how to create them.
+      path: /cirq/build/circuits
+    - heading: Qubits
+      description: The quantum bit data structure.
+      path: /cirq/build/qubits
+    - heading: Gates and Operations
+      description: Quantum gates to apply to qubits in a circuit.
+      path: /cirq/build/gates
+    - heading: Custom gates
+      description: Create your own gates with unitaries or decomposition.
+      path: /cirq/build/custom_gates
+    - heading: Import/export circuits
+      description: Importing or exporting circuits into/out of Cirq.
+      path: /cirq/build/interop
 
-    - heading: Advanced construction
-      description: More elaborate ways to build quantum circuits.
-      options:
-        - cards
-      items:
-      - heading: Operators
-        description: Unitary operators, measurements and noise channels.
-        path: /cirq/build/operators
-      - heading: Observables and PauliStrings
-        description: Build and measure observables from sums and products of Pauli operators.
-        path: /cirq/build/pauli_observables
-      - heading: Qudits
-        description: Qutrits and higher dimensional quantum systems.
-        path: /cirq/build/qudits
-      - heading: Protocols
-        description: Magic methods supported by Cirq's classes.
-        path: /cirq/build/protocols
-      - heading: Tools ecosystem
-        description: External tools for circuit construction.
-        path: /cirq/build/ecosystem
+  - heading: Advanced construction
+    description: More elaborate ways to build quantum circuits.
+    options:
+    - cards
+    items:
+    - heading: Operators
+      description: Unitary operators, measurements and noise channels.
+      path: /cirq/build/operators
+    - heading: Observables and PauliStrings
+      description: Build and measure observables from sums and products of Pauli operators.
+      path: /cirq/build/pauli_observables
+    - heading: Qudits
+      description: Qutrits and higher dimensional quantum systems.
+      path: /cirq/build/qudits
+    - heading: Protocols
+      description: Magic methods supported by Cirq's classes.
+      path: /cirq/build/protocols
+    - heading: Tools ecosystem
+      description: External tools for circuit construction.
+      path: /cirq/build/ecosystem

--- a/docs/experiments/_index.yaml
+++ b/docs/experiments/_index.yaml
@@ -4,37 +4,43 @@ title: Experiments using quantum circuits
 landing_page:
   nav: left
   rows:
-    - heading: Experiments using quantum circuits
-      description: This is a collection of algorithms and experiments written in and using Cirq. A couple of them use only base Cirq, but the rest use additional code stored in ReCirq, a GitHub repository for research code that uses and builds upon Cirq.
-    - buttons:
-      - label: Cirq GitHub
-        path: https://github.com/quantumlib/Cirq
-      - label: ReCirq GitHub
-        path: https://github.com/quantumlib/ReCirq
-    - heading: Algorithms in base Cirq
-      description: Algorithms and experiments executable using only default Cirq code.
-      options:
-        - cards
-      items:
-      - heading: Textbook Algorithms Workshop
-        description: A workshop notebook with examples that covers algorithms commonly shown in quantum textbooks.
-        path: /cirq/experiments/textbook_algorithms
-      - heading: Shor's Algorithm
-        description: The famous integer factorization algorithm by Peter Shor.
-        path: /cirq/experiments/shor
-      - heading: Variational Quantum Eigensolver
-        description: Compute the ground state of a Hamiltonian using the variational principle.
-        path: /cirq/experiments/variational_algorithm
-      - heading: Quantum Walks
-        description: The quantum analog of a random walk algorithm.
-        path: /cirq/experiments/quantum_walks
-      - heading: Fourier Checking
-        description: Demonstrate the separation between quantum and classical computers.
-        path: /cirq/experiments/fourier_checking
-      - heading: Hidden Linear Function problem
-        description: Show quantum separation with a constant depth solution.
-        path: /cirq/experiments/hidden_linear_function
+  - heading: Experiments using quantum circuits
+    description: This is a collection of algorithms and experiments written in and
+      using Cirq. A couple of them use only base Cirq, but the rest use additional
+      code stored in ReCirq, a GitHub repository for research code that uses and builds
+      upon Cirq.
+  - buttons:
+    - label: Cirq GitHub
+      path: https://github.com/quantumlib/Cirq
+    - label: ReCirq GitHub
+      path: https://github.com/quantumlib/ReCirq
+  - heading: Algorithms in base Cirq
+    description: Algorithms and experiments executable using only default Cirq code.
+    options:
+    - cards
+    items:
+    - heading: Textbook Algorithms Workshop
+      description: A workshop notebook with examples that covers algorithms commonly
+        shown in quantum textbooks.
+      path: /cirq/experiments/textbook_algorithms
+    - heading: Shor's Algorithm
+      description: The famous integer factorization algorithm by Peter Shor.
+      path: /cirq/experiments/shor
+    - heading: Variational Quantum Eigensolver
+      description: Compute the ground state of a Hamiltonian using the variational
+        principle.
+      path: /cirq/experiments/variational_algorithm
+    - heading: Quantum Walks
+      description: The quantum analog of a random walk algorithm.
+      path: /cirq/experiments/quantum_walks
+    - heading: Fourier Checking
+      description: Demonstrate the separation between quantum and classical computers.
+      path: /cirq/experiments/fourier_checking
+    - heading: Hidden Linear Function problem
+      description: Show quantum separation with a constant depth solution.
+      path: /cirq/experiments/hidden_linear_function
 
-    - heading: ReCirq Experiments
-      description: Research experiments that use additional library code that resides in the external ReCirq repository.
-    - include: /cirq/experiments/_index_included.yaml
+  - heading: ReCirq Experiments
+    description: Research experiments that use additional library code that resides
+      in the external ReCirq repository.
+  - include: /cirq/experiments/_index_included.yaml

--- a/docs/hardware/_index.yaml
+++ b/docs/hardware/_index.yaml
@@ -4,101 +4,105 @@ title: Hardware
 landing_page:
   nav: left
   rows:
-    - heading: Represent a quantum hardware device
-      description: Define the characteristics and constraints of quantum hardware devices, to support running circuits on those devices.
-      options:
-        - cards
-      items:
-      - heading: Devices
-        description: Represent the constraints a device imposes on runnable circuits with the Device class.
-        path: /cirq/hardware/devices
+  - heading: Represent a quantum hardware device
+    description: Define the characteristics and constraints of quantum hardware devices,
+      to support running circuits on those devices.
+    options:
+    - cards
+    items:
+    - heading: Devices
+      description: Represent the constraints a device imposes on runnable circuits
+        with the Device class.
+      path: /cirq/hardware/devices
 
-    - heading: Run a circuit on a hardware device
-      description: Cirq provides interfaces for running your circuits on quantum hardware provided by many different services.
-      options:
-        - cards
-      items:
-      - heading: Qubit Picking
-        description: Information to help you pick good qubits for running your circuit on a hardware or hardware-like device.
-        path: /cirq/hardware/qubit_picking
+  - heading: Run a circuit on a hardware device
+    description: Cirq provides interfaces for running your circuits on quantum hardware
+      provided by many different services.
+    options:
+    - cards
+    items:
+    - heading: Qubit Picking
+      description: Information to help you pick good qubits for running your circuit
+        on a hardware or hardware-like device.
+      path: /cirq/hardware/qubit_picking
 
-    - heading: AQT hardware
-      description: Cirq's interface with Alpine Quantum Technologies hardware.
-      options:
-        - cards
-      items:
-      - heading: Access and authentication
-        description: How to gain access.
-        path: /cirq/hardware/aqt/access
-      - heading: Getting started with AQT hardware
-        description: How to run your first circuit.
-        path: /cirq/hardware/aqt/getting_started
+  - heading: AQT hardware
+    description: Cirq's interface with Alpine Quantum Technologies hardware.
+    options:
+    - cards
+    items:
+    - heading: Access and authentication
+      description: How to gain access.
+      path: /cirq/hardware/aqt/access
+    - heading: Getting started with AQT hardware
+      description: How to run your first circuit.
+      path: /cirq/hardware/aqt/getting_started
 
-    - heading: Azure Quantum
-      description: Cirq's interface with Microsoft Azure Quantum services.
-      options:
-        - cards
-      items:
-      - heading: Access and authentication
-        description: How to gain access.
-        path: /cirq/hardware/azure-quantum/access
-      - heading: Getting started with Honeywell on AQT hardware
-        description: How to run your first circuit on a Honeywell device.
-        path: /cirq/hardware/azure-quantum/getting_started_honeywell
-      - heading: Getting started with IonQ on AQT hardware
-        description: How to run your first circuit on an IonQ device.
-        path: /cirq/hardware/azure-quantum/getting_started_ionq
+  - heading: Azure Quantum
+    description: Cirq's interface with Microsoft Azure Quantum services.
+    options:
+    - cards
+    items:
+    - heading: Access and authentication
+      description: How to gain access.
+      path: /cirq/hardware/azure-quantum/access
+    - heading: Getting started with Honeywell on AQT hardware
+      description: How to run your first circuit on a Honeywell device.
+      path: /cirq/hardware/azure-quantum/getting_started_honeywell
+    - heading: Getting started with IonQ on AQT hardware
+      description: How to run your first circuit on an IonQ device.
+      path: /cirq/hardware/azure-quantum/getting_started_ionq
 
-    - heading: IonQ hardware
-      description: Cirq's interface with IonQ hardware.
-      options:
-        - cards
-      items:
-      - heading: Access and authentication
-        description: How to gain access.
-        path: /cirq/hardware/ionq/access
-      - heading: Getting started with IonQ hardware
-        description: How to run your first circuit.
-        path: /cirq/hardware/ionq/getting_started
-      - heading: IonQ API Service
-        description: Using the IonQ API.
-        path: /cirq/hardware/ionq/service
-      - heading: IonQ API circuits
-        description: Writing circuits for the IonQ API.
-        path: /cirq/hardware/ionq/circuits
-      - heading: Running IonQ API jobs
-        description: How to run jobs with the IonQ API.
-        path: /cirq/hardware/ionq/jobs
-      - heading: IonQ API calibrations
-        description: How to get hardware device calibration data through the IonQ API.
-        path: /cirq/hardware/ionq/calibrations
+  - heading: IonQ hardware
+    description: Cirq's interface with IonQ hardware.
+    options:
+    - cards
+    items:
+    - heading: Access and authentication
+      description: How to gain access.
+      path: /cirq/hardware/ionq/access
+    - heading: Getting started with IonQ hardware
+      description: How to run your first circuit.
+      path: /cirq/hardware/ionq/getting_started
+    - heading: IonQ API Service
+      description: Using the IonQ API.
+      path: /cirq/hardware/ionq/service
+    - heading: IonQ API circuits
+      description: Writing circuits for the IonQ API.
+      path: /cirq/hardware/ionq/circuits
+    - heading: Running IonQ API jobs
+      description: How to run jobs with the IonQ API.
+      path: /cirq/hardware/ionq/jobs
+    - heading: IonQ API calibrations
+      description: How to get hardware device calibration data through the IonQ API.
+      path: /cirq/hardware/ionq/calibrations
 
-    - heading: Pasqal hardware
-      description: Cirq's interface with Pasqal hardware.
-      options:
-        - cards
-      items:
-      - heading: Access and authentication
-        description: How to gain access.
-        path: /cirq/hardware/pasqal/access
-      - heading: Getting started with Pasqal hardware
-        description: How to run your first circuit.
-        path: /cirq/hardware/pasqal/getting_started
-      - heading: Pasqal devices
-        description: Device objects to specify Pasqal hardware.
-        path: /cirq/hardware/pasqal/devices
-      - heading: Pasqal sampler
-        description: Sampler objects to run on Pasqal hardware.
-        path: /cirq/hardware/pasqal/sampler
+  - heading: Pasqal hardware
+    description: Cirq's interface with Pasqal hardware.
+    options:
+    - cards
+    items:
+    - heading: Access and authentication
+      description: How to gain access.
+      path: /cirq/hardware/pasqal/access
+    - heading: Getting started with Pasqal hardware
+      description: How to run your first circuit.
+      path: /cirq/hardware/pasqal/getting_started
+    - heading: Pasqal devices
+      description: Device objects to specify Pasqal hardware.
+      path: /cirq/hardware/pasqal/devices
+    - heading: Pasqal sampler
+      description: Sampler objects to run on Pasqal hardware.
+      path: /cirq/hardware/pasqal/sampler
 
-    - heading: Rigetti hardware
-      description: Cirq's interface with Rigetti hardware.
-      options:
-        - cards
-      items:
-      - heading: Access and authentication
-        description: How to gain access.
-        path: /cirq/hardware/rigetti/access
-      - heading: Getting started with Rigetti hardware
-        description: How to run your first circuit.
-        path: /cirq/hardware/rigetti/getting_started
+  - heading: Rigetti hardware
+    description: Cirq's interface with Rigetti hardware.
+    options:
+    - cards
+    items:
+    - heading: Access and authentication
+      description: How to gain access.
+      path: /cirq/hardware/rigetti/access
+    - heading: Getting started with Rigetti hardware
+      description: How to run your first circuit.
+      path: /cirq/hardware/rigetti/getting_started

--- a/docs/noise/_index.yaml
+++ b/docs/noise/_index.yaml
@@ -6,12 +6,12 @@ landing_page:
   rows:
     - heading: Manage noise when running circuits
       description: Running circuits on quantum hardware devices means dealing with the noise those devices introduce to the computation. Cirq provides the following ways of managing that noise, to improve the quality of the measured results.
-    options:
-      - cards
-    items:
-      - heading: Representing Noise
-        description: Noise models and channels and what types of error they replicate.
-        path: /cirq/noise/representing_noise
+      options:
+        - cards
+      items:
+        - heading: Representing Noise
+          description: Noise models and channels and what types of error they replicate.
+          path: /cirq/noise/representing_noise
     - heading: Characterization and compensation
       description: Characterize the error a device is exhibiting, then compensate for that error by changing the circuit or reinterpreting the results.
       options:

--- a/docs/noise/_index.yaml
+++ b/docs/noise/_index.yaml
@@ -4,33 +4,36 @@ title: Noise management for running circuits
 landing_page:
   nav: left
   rows:
-    - heading: Manage noise when running circuits
-      description: Running circuits on quantum hardware devices means dealing with the noise those devices introduce to the computation. Cirq provides the following ways of managing that noise, to improve the quality of the measured results.
-      options:
-        - cards
-      items:
-        - heading: Representing Noise
-          description: Noise models and channels and what types of error they replicate.
-          path: /cirq/noise/representing_noise
-    - heading: Characterization and compensation
-      description: Characterize the error a device is exhibiting, then compensate for that error by changing the circuit or reinterpreting the results.
-      options:
-        - cards
-      items:
-        - heading: Calibration FAQ
-          description: Frequently asked questions about characterization and compensation.
-          path: /cirq/noise/calibration_faq
-        - heading: Floquet Calibration
-          description: A characterization method using Floquet theory.
-          path: /cirq/noise/floquet_calibration_example
-        - heading: Cross Entropy Benchmarking (XEB)
-          description: A characterization benchmarking method using cross entropy.
-          path: /cirq/noise/qcvv/xeb_theory
-    - heading: Visualizing noise
-      description: Graphing and plotting methods for visualizing noise.
-      options:
-        - cards
-      items:
-        - heading: Heatmaps
-          description: Functions to plot noise characteristics across a 2D grid device.
-          path: /cirq/noise/heatmaps
+  - heading: Manage noise when running circuits
+    description: Running circuits on quantum hardware devices means dealing with the
+      noise those devices introduce to the computation. Cirq provides the following
+      ways of managing that noise, to improve the quality of the measured results.
+    options:
+    - cards
+    items:
+    - heading: Representing Noise
+      description: Noise models and channels and what types of error they replicate.
+      path: /cirq/noise/representing_noise
+  - heading: Characterization and compensation
+    description: Characterize the error a device is exhibiting, then compensate for
+      that error by changing the circuit or reinterpreting the results.
+    options:
+    - cards
+    items:
+    - heading: Calibration FAQ
+      description: Frequently asked questions about characterization and compensation.
+      path: /cirq/noise/calibration_faq
+    - heading: Floquet Calibration
+      description: A characterization method using Floquet theory.
+      path: /cirq/noise/floquet_calibration_example
+    - heading: Cross Entropy Benchmarking (XEB)
+      description: A characterization benchmarking method using cross entropy.
+      path: /cirq/noise/qcvv/xeb_theory
+  - heading: Visualizing noise
+    description: Graphing and plotting methods for visualizing noise.
+    options:
+    - cards
+    items:
+    - heading: Heatmaps
+      description: Functions to plot noise characteristics across a 2D grid device.
+      path: /cirq/noise/heatmaps

--- a/docs/simulate/_index.yaml
+++ b/docs/simulate/_index.yaml
@@ -4,41 +4,47 @@ title: Simulate a circuit
 landing_page:
   nav: left
   rows:
-    - heading: Simulate a circuit
-      description: Compute the effects of a quantum circuit, by simulating a quantum computer with a classical one.
-      options:
-        - cards
-      items:
-      - heading: Exact Simulation
-        description: Simulate a perfectly noiseless quantum computer.
-        path: /cirq/simulate/simulation
-      - heading: Noisy Simulation
-        description: Simulate a more realistic quantum computer, subject to error and noise.
-        path: /cirq/simulate/noisy_simulation
-      - heading: Parameter Sweeps
-        description: Efficiently evaluate many circuits which only differ in operation parameter values.
-        path: /cirq/simulate/params
-      - heading: State Histograms
-        description: Visualize the results of simulation as a histogram over basis states.
-        path: /cirq/simulate/state_histograms
+  - heading: Simulate a circuit
+    description: Compute the effects of a quantum circuit, by simulating a quantum
+      computer with a classical one.
+    options:
+    - cards
+    items:
+    - heading: Exact Simulation
+      description: Simulate a perfectly noiseless quantum computer.
+      path: /cirq/simulate/simulation
+    - heading: Noisy Simulation
+      description: Simulate a more realistic quantum computer, subject to error and
+        noise.
+      path: /cirq/simulate/noisy_simulation
+    - heading: Parameter Sweeps
+      description: Efficiently evaluate many circuits which only differ in operation
+        parameter values.
+      path: /cirq/simulate/params
+    - heading: State Histograms
+      description: Visualize the results of simulation as a histogram over basis states.
+      path: /cirq/simulate/state_histograms
 
+  - heading: Quantum Virtual Machine
+    description: Run circuits on a virtual version of quantum hardware, complete with
+      an identical interface and noisy simulation that mimics hardware devices.
+    options:
+    - cards
+    items:
     - heading: Quantum Virtual Machine
-      description: Run circuits on a virtual version of quantum hardware, complete with an identical interface and noisy simulation that mimics hardware devices.
-      options:
-        - cards
-      items:
-      - heading: Quantum Virtual Machine
-        description: Build and use a QVM with a virtual Engine and realistic noise model.
-        path: /cirq/simulate/quantum_virtual_machine
-      - heading: QVM Circuit Preparation
-        description: Prepare and run a circuit on a QVM in detail.
-        path: /cirq/simulate/qvm_basic_example
-      - heading: QVM Stabilizer Example
-        description: Run a stabilizer circuit on QVMs representing different devices and different noise.
-        path: /cirq/simulate/qvm_stabilizer_example
-      - heading: QVM Creation Template
-        description: Run a device-ready circuit on a QVM with default settings.
-        path: /cirq/simulate/qvm_builder_code
-      - heading: Virtual Engine Interface
-        description: Details on the virtual version of the hardware Engine API and how to use it.
-        path: /cirq/simulate/virtual_engine_interface
+      description: Build and use a QVM with a virtual Engine and realistic noise model.
+      path: /cirq/simulate/quantum_virtual_machine
+    - heading: QVM Circuit Preparation
+      description: Prepare and run a circuit on a QVM in detail.
+      path: /cirq/simulate/qvm_basic_example
+    - heading: QVM Stabilizer Example
+      description: Run a stabilizer circuit on QVMs representing different devices
+        and different noise.
+      path: /cirq/simulate/qvm_stabilizer_example
+    - heading: QVM Creation Template
+      description: Run a device-ready circuit on a QVM with default settings.
+      path: /cirq/simulate/qvm_builder_code
+    - heading: Virtual Engine Interface
+      description: Details on the virtual version of the hardware Engine API and how
+        to use it.
+      path: /cirq/simulate/virtual_engine_interface

--- a/docs/transform/_index.yaml
+++ b/docs/transform/_index.yaml
@@ -4,17 +4,19 @@ title: Transform a circuit
 landing_page:
   nav: left
   rows:
-    - heading: Transform a circuit
-      description: Programmatically transform a provided circuit into another one to implement any compilation or optimization process that changes a circuit.
-      options:
-        - cards
-      items:
-      - heading: Circuit Transformers
-        description: The Transformer class and contract to represent some process that changes a supplied circuit.
-        path: /cirq/transform/transformers
-      - heading: Custom Transformers
-        description: Write your own Transformer with decorators, primitives and decompositions.
-        path: /cirq/transform/custom_transformers
-      - heading: Routing as a Transformer
-        description: Qubit Routing utilities for easily executing circuits on hardware.
-        path: /cirq/transform/routing_transformer
+  - heading: Transform a circuit
+    description: Programmatically transform a provided circuit into another one to
+      implement any compilation or optimization process that changes a circuit.
+    options:
+    - cards
+    items:
+    - heading: Circuit Transformers
+      description: The Transformer class and contract to represent some process that
+        changes a supplied circuit.
+      path: /cirq/transform/transformers
+    - heading: Custom Transformers
+      description: Write your own Transformer with decorators, primitives and decompositions.
+      path: /cirq/transform/custom_transformers
+    - heading: Routing as a Transformer
+      description: Qubit Routing utilities for easily executing circuits on hardware.
+      path: /cirq/transform/routing_transformer


### PR DESCRIPTION
- Fix syntax error in `docs/noise/_index.yaml`
- Stop including deleted yaml file
- Format with the yaml_format Google tool

Fixes #6587
