### PR TITLE
Flush deprecations before minor release

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -15,7 +15,6 @@
 """Classes for working with Google's Quantum Engine API."""
 
 import sys
-from cirq import _compat
 from cirq_google import api
 
 from cirq_google._version import __version__
@@ -114,26 +113,3 @@ from cirq.protocols.json_serialization import _register_resolver
 from cirq_google.json_resolver_cache import _class_resolver_dictionary
 
 _register_resolver(_class_resolver_dictionary)
-
-
-_SERIALIZABLE_GATESET_DEPRECATION_MESSAGE = (
-    'SerializableGateSet and associated classes (GateOpSerializer, GateOpDeserializer,'
-    ' SerializingArgs, DeserializingArgs) will no longer be supported.'
-    ' In cirq_google.GridDevice, the new representation of Google devices, the gateset of a device'
-    ' is represented as a cirq.Gateset and is available as'
-    ' GridDevice.metadata.gateset.'
-    ' Engine methods no longer require gate sets to be passed in.'
-    ' In addition, circuit serialization is replaced by cirq_google.CircuitSerializer.'
-)
-
-
-_compat.deprecate_attributes(
-    __name__,
-    {
-        'XMON': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
-        'FSIM_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
-        'SQRT_ISWAP_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
-        'SYC_GATESET': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
-        'NAMED_GATESETS': ('v0.16', _SERIALIZABLE_GATESET_DEPRECATION_MESSAGE),
-    },
-)

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -34,7 +34,6 @@ import google.auth
 from google.protobuf import any_pb2
 
 import cirq
-from cirq._compat import deprecated
 from cirq_google.api import v2
 from cirq_google.engine import (
     abstract_engine,
@@ -563,21 +562,6 @@ class Engine(abstract_engine.AbstractEngine):
             A EngineProcessor for the processor.
         """
         return engine_processor.EngineProcessor(self.project_id, processor_id, self.context)
-
-    @deprecated(deadline="v1.0", fix="Use get_sampler instead.")
-    def sampler(self, processor_id: Union[str, List[str]]) -> 'cirq_google.ProcessorSampler':
-        """Returns a sampler backed by the engine.
-
-        Args:
-            processor_id: String identifier, or list of string identifiers,
-                determining which processors may be used when sampling.
-
-        Returns:
-            A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`
-            that will send circuits to the Quantum Computing Service
-            when sampled.
-        """
-        return self.get_sampler(processor_id)
 
     def get_sampler(
         self, processor_id: Union[str, List[str]], run_name: str = "", device_config_name: str = ""

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -42,16 +42,6 @@ def _date_to_timestamp(
     return None
 
 
-def _fix_deprecated_seconds_kwargs(kwargs):
-    if 'earliest_timestamp_seconds' in kwargs:
-        kwargs['earliest_timestamp'] = kwargs['earliest_timestamp_seconds']
-        del kwargs['earliest_timestamp_seconds']
-    if 'latest_timestamp_seconds' in kwargs:
-        kwargs['latest_timestamp'] = kwargs['latest_timestamp_seconds']
-        del kwargs['latest_timestamp_seconds']
-    return kwargs
-
-
 class EngineProcessor(abstract_processor.AbstractProcessor):
     """A processor available via the Quantum Engine API.
 
@@ -238,20 +228,6 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             raise ValueError('Processor does not have a device specification')
         return grid_device.GridDevice.from_proto(spec)
 
-    @cirq._compat.deprecated_parameter(
-        deadline='v1.0',
-        fix='Change earliest_timestamp_seconds to earliest_timestamp.',
-        parameter_desc='earliest_timestamp_seconds',
-        match=lambda args, kwargs: 'earliest_timestamp_seconds' in kwargs,
-        rewrite=lambda args, kwargs: (args, _fix_deprecated_seconds_kwargs(kwargs)),
-    )
-    @cirq._compat.deprecated_parameter(
-        deadline='v1.0',
-        fix='Change latest_timestamp_seconds to latest_timestamp.',
-        parameter_desc='latest_timestamp_seconds',
-        match=lambda args, kwargs: 'latest_timestamp_seconds' in kwargs,
-        rewrite=lambda args, kwargs: (args, _fix_deprecated_seconds_kwargs(kwargs)),
-    )
     def list_calibrations(
         self,
         earliest_timestamp: Optional[Union[datetime.datetime, datetime.date, int]] = None,
@@ -260,10 +236,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         """Retrieve metadata about a specific calibration run.
 
         Params:
-            earliest_timestamp_seconds: The earliest timestamp of a calibration
-                to return in UTC.
-            latest_timestamp_seconds: The latest timestamp of a calibration to
-                return in UTC.
+            earliest_timestamp: The earliest timestamp of a calibration to return in UTC.
+            latest_timestamp: The latest timestamp of a calibration to return in UTC.
 
         Returns:
             The list of calibration data with the most recent first.

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -414,24 +414,6 @@ def test_list_calibrations(list_calibrations):
     list_calibrations.assert_called_with('a', 'p', f'timestamp >= {today_midnight_timestamp}')
 
 
-@mock.patch('cirq_google.engine.engine_client.EngineClient.list_calibrations_async')
-def test_list_calibrations_old_params(list_calibrations):
-    # Disable pylint warnings for use of deprecated parameters
-    # pylint: disable=unexpected-keyword-arg
-    list_calibrations.return_value = [_CALIBRATION]
-    processor = cg.EngineProcessor('a', 'p', EngineContext())
-    with cirq.testing.assert_deprecated('Change earliest_timestamp_seconds', deadline='v1.0'):
-        assert [
-            c.timestamp for c in processor.list_calibrations(earliest_timestamp_seconds=1562500000)
-        ] == [1562544000021]
-    list_calibrations.assert_called_with('a', 'p', 'timestamp >= 1562500000')
-    with cirq.testing.assert_deprecated('Change latest_timestamp_seconds', deadline='v1.0'):
-        assert [
-            c.timestamp for c in processor.list_calibrations(latest_timestamp_seconds=1562600000)
-        ] == [1562544000021]
-    list_calibrations.assert_called_with('a', 'p', 'timestamp <= 1562600000')
-
-
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_calibration_async')
 def test_get_calibration(get_calibration):
     get_calibration.return_value = _CALIBRATION

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -741,9 +741,6 @@ def test_sampler_with_unary_rpcs(client):
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
     assert client().create_program_async.call_args[0][0] == 'proj'
 
-    with cirq.testing.assert_deprecated('sampler', deadline='1.0'):
-        _ = engine.sampler(processor_id='tmp')
-
     with pytest.raises(ValueError, match='list of processors'):
         _ = engine.get_sampler(['test1', 'test2'])
 
@@ -763,9 +760,6 @@ def test_sampler_with_stream_rpcs(client):
         assert results[i].params.param_dict == {'a': v}
         assert results[i].measurements == {'q': np.array([[0]], dtype='uint8')}
     assert client().run_job_over_stream.call_args[1]['project_id'] == 'proj'
-
-    with cirq.testing.assert_deprecated('sampler', deadline='1.0'):
-        _ = engine.sampler(processor_id='tmp')
 
     with pytest.raises(ValueError, match='list of processors'):
         _ = engine.get_sampler(['test1', 'test2'])

--- a/cirq-ionq/cirq_ionq/__init__.py
+++ b/cirq-ionq/cirq_ionq/__init__.py
@@ -16,7 +16,7 @@ from cirq_ionq._version import __version__
 
 from cirq_ionq.calibration import Calibration
 
-from cirq_ionq.ionq_devices import IonQAPIDevice, decompose_to_device
+from cirq_ionq.ionq_devices import IonQAPIDevice
 
 from cirq_ionq.ionq_gateset import IonQTargetGateset, decompose_all_to_all_connect_ccz_gate
 

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -72,34 +72,3 @@ class IonQAPIDevice(cirq.Device):
 
     def is_api_gate(self, operation: cirq.Operation) -> bool:
         return operation in self.gateset
-
-
-@cirq._compat.deprecated(
-    deadline='v0.16',
-    fix='Use cirq.optimize_for_target_gateset(circuit, '
-    'gateset=cirq_ionq.IonQTargetGateset(atol)) '
-    'instead.',
-)
-def decompose_to_device(operation: cirq.Operation, atol: float = 1e-8) -> cirq.OP_TREE:
-    """Decompose operation to ionq native operations.
-
-
-    Merges single qubit operations and decomposes two qubit operations
-    into CZ gates.
-
-    Args:
-        operation: `cirq.Operation` to decompose.
-        atol: absolute error tolerance to use when declaring two unitary
-            operations equal.
-
-    Returns:
-        cirq.OP_TREE containing decomposed operations.
-
-    Raises:
-        ValueError: If supplied operation cannot be decomposed
-            for the ionq device.
-
-    """
-    return cirq.optimize_for_target_gateset(
-        cirq.Circuit(operation), gateset=ionq_gateset.IonQTargetGateset(), ignore_failures=False
-    ).all_operations()

--- a/docs/google/devices.md
+++ b/docs/google/devices.md
@@ -191,8 +191,7 @@ $$
 \right]
 $$
 
-This gate has a duration of 12ns and can be used in `cirq_google.SYC_GATESET`
-or in the `cirq_google.FSIM_GATESET`.
+This gate has a duration of 12ns.
 
 #### Square root of iSWAP
 
@@ -214,8 +213,7 @@ $$
 \right]
 $$
 
-This gate has a duration of 32ns and can be used in
-`cirq_google.SQRT_ISWAP_GATESET` or in the `cirq_google.FSIM_GATESET`.
+This gate has a duration of 32ns.
 
 This gate is implemented by using an entangling gate surrounded by
 Z gates.  The preceding Z gates are physical Z gates and will absorb
@@ -236,15 +234,6 @@ to see if it is available on the processor you are using.
 
 This gate is equivalent to FSimGate(0, π).  It has an approximate duration
 of 26ns.
-
-#### FSim gateset
-
-The `cirq.FSIM_GATESET` provides all three of the above gates in one set.
-In addition, by using this combined gate set, the FSimGate can be parameterized,
-which allows for efficient sweeps across varying two-qubit gates.
-Note that providing a theta/phi combination that
-is not one of the above gates will cause an error when run on hardware.
-
 
 ### Wait gate
 

--- a/docs/google/engine.md
+++ b/docs/google/engine.md
@@ -193,7 +193,6 @@ engine = cirq_google.Engine(project_id='YOUR_PROJECT_ID')
 # Create a sampler from the engine
 job = engine.run_batch(circuit_list,
                        processor_id='PROCESSOR_ID',
-                       gate_set=cirq_google.FSIM_GATESET,
                        repetitions=1000,
                        params_list=param_list)
 results = job.results()

--- a/docs/google/engine.md
+++ b/docs/google/engine.md
@@ -80,7 +80,7 @@ circuit = cirq.Circuit(
 engine = cg.Engine(project_id=YOUR_PROJECT_ID)
 
 # Create a sampler from the engine
-sampler = engine.sampler(processor_id='PROCESSOR_ID', gate_set=cg.SYC_GATESET)
+sampler = engine.get_sampler(processor_id='PROCESSOR_ID')
 
 # This will run the circuit and return the results in a 'Result'
 results = sampler.run(circuit, repetitions=1000)


### PR DESCRIPTION
* Remove deprecated constants from cirq_google module.
  Long past the `v0.16` deprecation deadline, constants
  were invalid for almost 2 years after #5762.

* Remove deprecated method `cirq_google.Engine.sampler()`
  Long past the `v1.0` deprecation deadline.

* Purge deprecated arguments to `EngineProcessor.list_calibrations`
  `earliest_timestamp_seconds` and `latest_timestamp_seconds` are
  long past the `v1.0` deadline.

* Remove deprecated function `cirq_ionq.ionq_devices.decompose_to_device`.
  Long past the `v0.16` deadline.

Ref: https://github.com/quantumlib/Cirq/blob/main/release.md#before-you-release-flush-the-deprecation-backlog
