### PR TITLE
 heatmap.py

### DIFF
--- a/heatmap.py
+++ b/heatmap.py
@@ -1,0 +1,58 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import cirq
+
+class HighlightedHeatmap(cirq.Heatmap):
+    def __init__(self, error_rates, selected_qubits=None):
+        super().__init__(error_rates)
+        self.selected_qubits = selected_qubits
+
+    def plot(self, ax=None, collection_options=None, **kwargs):
+        if ax is None:
+            ax = plt.gca()
+        
+        if collection_options is None:
+            collection_options = {}
+        
+        if self.selected_qubits:
+            edge_colors = ['red' if q in self.selected_qubits else 'grey' for q in self.qubits]
+            linewidths = [4 if q in self.selected_qubits else 2 for q in self.qubits]
+            collection_options['linewidths'] = linewidths
+            collection_options['edgecolors'] = edge_colors
+        
+        super().plot(ax=ax, collection_options=collection_options, **kwargs)
+
+
+class HighlightedTwoQubitInteractionHeatmap(cirq.TwoQubitInteractionHeatmap):
+    def __init__(self, interaction_graph, error_rates, selected_qubits=None):
+        super().__init__(interaction_graph, error_rates)
+        self.selected_qubits = selected_qubits
+
+    def plot(self, ax=None, collection_options=None, **kwargs):
+        if ax is None:
+            ax = plt.gca()
+        
+        if collection_options is None:
+            collection_options = {}
+        
+        if self.selected_qubits:
+            edge_colors = ['red' if q in self.selected_qubits else 'grey' for q in self.qubits]
+            linewidths = [4 if q in self.selected_qubits else 2 for q in self.qubits]
+            collection_options['linewidths'] = linewidths
+            collection_options['edgecolors'] = edge_colors
+        
+        super().plot(ax=ax, collection_options=collection_options, **kwargs)
+
+
+# Example usage
+device = cirq.google.Foxtail
+
+# Define selected qubits
+selected_qubits = [device.qubits[0], device.qubits[1], device.qubits[2]]
+
+# Create heatmap with selected qubits highlighted
+fig, ax = plt.subplots(figsize=(12, 10))
+heatmap = HighlightedHeatmap({q: 0.0 for q in device.qubits}, selected_qubits=selected_qubits)
+heatmap.plot(ax=ax, collection_options={'cmap': 'binary'}, plot_colorbar=False, annotation_format=None)
+heatmap._plot_on_axis(ax)
+fig.show()


### PR DESCRIPTION
HighlightedHeatmap: Extends the cirq.Heatmap class to incorporate the highlighting functionality. It accepts an additional parameter, selected_qubits, which is a list of qubits to be highlighted on the heatmap.

HighlightedTwoQubitInteractionHeatmap: Similar to HighlightedHeatmap, but extends the cirq.TwoQubitInteractionHeatmap class instead. This class is specifically designed for visualizing interactions between pairs of qubits in quantum devices.

Plotting Method:

Both custom classes override the plot method inherited from their respective parent classes. Within the plot method, the code checks if selected_qubits are provided. If so, it adjusts the edge colors and widths of the heatmap to highlight the specified qubits. Example Usage:

The example usage section demonstrates how to create a heatmap with selected qubits highlighted. It initializes the HighlightedHeatmap class with error rates for the qubits and specifies the selected qubits to highlight. Then, it plots the heatmap using Matplotlib. Visualization:

The resulting heatmap visualizes error metrics for qubits in a quantum device. Selected qubits are highlighted with distinct colors or thicker borders, making them stand out for easier identification and analysis.