### PR TITLE
Improve replace_version tool and development wheels

### DIFF
--- a/dev_tools/modules_test.py
+++ b/dev_tools/modules_test.py
@@ -149,6 +149,7 @@ def test_get_version_on_no_modules():
 def test_get_version_on_inconsistent_version_modules():
     modules.replace_version(search_dir=Path("./mod2"), old="1.2.3.dev", new="1.2.4.dev")
     assert modules.get_version(search_dir=Path("./mod2")) == "1.2.4.dev"
+    assert "1.2.4.dev" in Path("./mod2/pack2/_version_test.py").read_text("UTF-8")
     with pytest.raises(ValueError, match="Versions should be the same, instead:"):
         modules.get_version(search_dir=Path("."))
 
@@ -158,6 +159,8 @@ def test_replace_version(tmpdir_factory):
     assert modules.get_version() == "1.2.3.dev"
     modules.replace_version(old="1.2.3.dev", new="1.2.4.dev")
     assert modules.get_version() == "1.2.4.dev"
+    assert "1.2.4.dev" in Path("./mod1/pack1/_version_test.py").read_text("UTF-8")
+    assert "1.2.4.dev" in Path("./mod2/pack2/_version_test.py").read_text("UTF-8")
 
 
 @chdir(target_dir="dev_tools/modules_test_data")

--- a/dev_tools/modules_test_data/mod1/pack1/_version_test.py
+++ b/dev_tools/modules_test_data/mod1/pack1/_version_test.py
@@ -1,5 +1,5 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-import pack1._version
+import pack1._version  # type: ignore
 
 
 def test_version():

--- a/dev_tools/modules_test_data/mod1/pack1/_version_test.py
+++ b/dev_tools/modules_test_data/mod1/pack1/_version_test.py
@@ -1,0 +1,6 @@
+# pylint: disable=wrong-or-nonexistent-copyright-notice
+import pack1._version
+
+
+def test_version():
+    assert pack1._version.__version__ == "1.2.3.dev"

--- a/dev_tools/modules_test_data/mod2/pack2/_version_test.py
+++ b/dev_tools/modules_test_data/mod2/pack2/_version_test.py
@@ -1,5 +1,5 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-import pack2._version
+import pack2._version  # type: ignore
 
 
 def test_version():

--- a/dev_tools/modules_test_data/mod2/pack2/_version_test.py
+++ b/dev_tools/modules_test_data/mod2/pack2/_version_test.py
@@ -1,0 +1,6 @@
+# pylint: disable=wrong-or-nonexistent-copyright-notice
+import pack2._version
+
+
+def test_version():
+    assert pack2._version.__version__ == "1.2.3.dev"

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -47,10 +47,9 @@ if [ -n "$(git status --short)" ]; then
 fi
 tmp_git_dir=$(mktemp -d "/tmp/produce-package-git.XXXXXXXXXXXXXXXX")
 trap '{ rm -rf "${tmp_git_dir}"; }' EXIT
+echo "Creating pristine repository clone at ${tmp_git_dir}"
+git clone --shared --quiet "${repo_dir}" "${tmp_git_dir}"
 cd "${tmp_git_dir}"
-git init --quiet
-git fetch "${repo_dir}" HEAD --quiet --depth=1
-git checkout FETCH_HEAD -b work --quiet
 if [ -n "${SPECIFIED_VERSION}" ]; then
     CIRQ_PACKAGES=$(env PYTHONPATH=. python3 dev_tools/modules.py list --mode package-path)
     for PROJECT_NAME in $CIRQ_PACKAGES; do

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -36,6 +36,13 @@ out_dir=$(realpath "${1}")
 
 SPECIFIED_VERSION="${2}"
 
+# Helper to run dev_tools/modules.py without CIRQ_PRE_RELEASE_VERSION
+# to avoid environment version override in setup.py.
+my_dev_tools_modules() {
+    env -u CIRQ_PRE_RELEASE_VERSION PYTHONPATH=. \
+        python3 dev_tools/modules.py "$@"
+}
+
 # Get the working directory to the repo root.
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 repo_dir=$(git rev-parse --show-toplevel)
@@ -51,16 +58,14 @@ echo "Creating pristine repository clone at ${tmp_git_dir}"
 git clone --shared --quiet "${repo_dir}" "${tmp_git_dir}"
 cd "${tmp_git_dir}"
 if [ -n "${SPECIFIED_VERSION}" ]; then
-    CIRQ_PACKAGES=$(env PYTHONPATH=. python3 dev_tools/modules.py list --mode package-path)
-    for PROJECT_NAME in $CIRQ_PACKAGES; do
-      echo '__version__ = "'"${SPECIFIED_VERSION}"'"' > "${tmp_git_dir}/${PROJECT_NAME}/_version.py"
-    done
+    CURRENT_VERSION=$(my_dev_tools_modules print_version)
+    my_dev_tools_modules replace_version --old="${CURRENT_VERSION}" --new="${SPECIFIED_VERSION}"
 fi
 
 # Python 3 wheel.
 echo "Producing python 3 package files."
 
-CIRQ_MODULES=$(env PYTHONPATH=. python3 dev_tools/modules.py list --mode folder --include-parent)
+CIRQ_MODULES=$(my_dev_tools_modules list --mode folder --include-parent)
 
 for m in $CIRQ_MODULES; do
   echo "processing $m/setup.py..."

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -52,7 +52,7 @@ git init --quiet
 git fetch "${repo_dir}" HEAD --quiet --depth=1
 git checkout FETCH_HEAD -b work --quiet
 if [ -n "${SPECIFIED_VERSION}" ]; then
-    CIRQ_PACKAGES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)
+    CIRQ_PACKAGES=$(env PYTHONPATH=. python3 dev_tools/modules.py list --mode package-path)
     for PROJECT_NAME in $CIRQ_PACKAGES; do
       echo '__version__ = "'"${SPECIFIED_VERSION}"'"' > "${tmp_git_dir}/${PROJECT_NAME}/_version.py"
     done
@@ -61,7 +61,7 @@ fi
 # Python 3 wheel.
 echo "Producing python 3 package files."
 
-CIRQ_MODULES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode folder --include-parent)
+CIRQ_MODULES=$(env PYTHONPATH=. python3 dev_tools/modules.py list --mode folder --include-parent)
 
 for m in $CIRQ_MODULES; do
   echo "processing $m/setup.py..."


### PR DESCRIPTION
- Make `dev_tools/modules.py replace_version` update also the
  version expected in unit tests

- Skip type check in the new test-only source files

- Update `dev_tools/packaging/produce-package.sh` to use the `replace_version`
  utility when building development wheels
