### PR TITLE
append unit as metadata to sweeps if present

### DIFF
--- a/cirq-core/cirq/study/sweepable.py
+++ b/cirq-core/cirq/study/sweepable.py
@@ -115,12 +115,12 @@ def _add_unit_to_metadata_if_present(k, v):
     import cirq_google
 
     value_unit = str(v).split(" ")
-    value = float(value_unit[0])
+    value = value_unit[0]
     unit = value_unit[1] if len(value_unit) > 1 else None
 
     if unit:
         # Append the unit as metadata so the parameter can be resolved server side during
         # internal use. See https://github.com/qh-lab/pyle/pull/46133.
         descriptor = cirq_google.study.DeviceParameter(path=None, value=value, units=unit)
-        return Points(k, [cast(float, value)], metadata=descriptor)
-    return Points(k, [cast(float, value)])
+        return Points(k, [float(value)], metadata=descriptor)
+    return Points(k, [cast(float, v)])

--- a/cirq-core/cirq/study/sweepable_test.py
+++ b/cirq-core/cirq/study/sweepable_test.py
@@ -147,3 +147,42 @@ def test_to_sweep_resolver_list(r_list_gen):
 def test_to_sweep_type_error():
     with pytest.raises(TypeError, match='Unexpected sweep'):
         cirq.to_sweep(5)
+
+
+@pytest.mark.parametrize(
+    'sweepables',
+    [
+        [{'a': sympy.Symbol('1 GHZ')}, {'a': sympy.Symbol('1.5 GHZ')}, {'b': 2}],
+        [
+            cirq.ParamResolver({'a': sympy.Symbol('1 GHZ')}),
+            cirq.ParamResolver({'a': sympy.Symbol('1.5 GHZ')}),
+            cirq.ParamResolver({'b': 2}),
+        ],
+    ],
+)
+def test_to_sweeps_resolver_appends_any_units_as_device_parameters(sweepables):
+    import cirq_google
+
+    sweeps = cirq.to_sweeps(sweepables)
+
+    assert list(sweeps) == [
+        cirq.Zip(
+            cirq.Points(
+                'a',
+                [1.0],
+                metadata=cirq_google.study.DeviceParameter(
+                    path=None, idx=None, value=1.0, units='GHZ'
+                ),
+            )
+        ),
+        cirq.Zip(
+            cirq.Points(
+                'a',
+                [1.5],
+                metadata=cirq_google.study.DeviceParameter(
+                    path=None, idx=None, value=1.5, units='GHZ'
+                ),
+            )
+        ),
+        cirq.Zip(cirq.Points('b', [2])),
+    ]


### PR DESCRIPTION
It's possible for internal users to pass values with units to the cirq sweep resolver. In order to support this, and so we can resolve the parameter correctly on the server side this PR does two things:

1. Splices the value and only passes the numerical value as float to `cirq.Points` which only supports `floats`.
2. Saves the unit as `metadata` in the `DeviceParameter` proto without setting a path. See https://github.com/qh-lab/pyle/pull/46133 for how this gets resolved server side.