### PR TITLE
Allow passing `None` to `AbstractCircuit.from_moments`

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -145,29 +145,31 @@ class AbstractCircuit(abc.ABC):
     """
 
     @classmethod
-    def from_moments(cls: Type[CIRCUIT_TYPE], *moments: 'cirq.OP_TREE') -> CIRCUIT_TYPE:
+    def from_moments(cls: Type[CIRCUIT_TYPE], *moments: Optional['cirq.OP_TREE']) -> CIRCUIT_TYPE:
         """Create a circuit from moment op trees.
 
         Args:
-            *moments: Op tree for each moment. If an op tree is a moment, it
-                will be included directly in the new circuit. If an op tree is
-                a circuit, it will be frozen, wrapped in a CircuitOperation, and
-                included in its own moment in the new circuit. Otherwise, the
-                op tree will be passed to `cirq.Moment` to create a new moment
-                which is then included in the new circuit. Note that in the
-                latter case we have the normal restriction that operations in a
-                moment must be applied to disjoint sets of qubits.
+            *moments: Op trees for each moment, which can be one of the following:
+                - Moment: will be included directly in the new circuit.
+                - AbstractCircuit: will be frozen, wrapped in a CircuitOperation,
+                    and included in its own moment in the new circuit.
+                - None: will be skipped and omitted from the circuit. This can be
+                    used to include or skip a moment based on a conditional, for example.
+                - Other OP_TREE: will be passed to `cirq.Moment` to create a new moment
+                    which is then included in the new circuit. Note that in this
+                    case we have the normal restriction that operations in a
+                    moment must be applied to disjoint sets of qubits.
         """
         return cls._from_moments(cls._make_moments(moments))
 
     @staticmethod
-    def _make_moments(moments: Iterable['cirq.OP_TREE']) -> Iterator['cirq.Moment']:
+    def _make_moments(moments: Iterable[Optional['cirq.OP_TREE']]) -> Iterator['cirq.Moment']:
         for m in moments:
             if isinstance(m, Moment):
                 yield m
             elif isinstance(m, AbstractCircuit):
                 yield Moment(m.freeze().to_op())
-            else:
+            elif m is not None:
                 yield Moment(m)
 
     @classmethod

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -80,6 +80,7 @@ def test_from_moments():
         [cirq.X(c)],
         [],
         cirq.Z(d),
+        None,
         [cirq.measure(a, b, key='ab'), cirq.measure(c, d, key='cd')],
     )
     assert circuit == cirq.Circuit(


### PR DESCRIPTION
When constructing circuits with `Circuit.from_moments` we often want to conditionally include a moment and we often end up with awkward expressions like:
```python
Circuit.from_moments(prepare_ops, *([flip_ops] if flip else []), measure_ops)
```
This PR would allow us to pass `None` as an arg to `from_moments` in which case that arg would be skipped and not included in the circuit (not even as an empty moment). The above code can then be written more clearly as:
```python
Circuit.from_moments(prepare_ops, flip_ops if flip else None, measure_ops)
```
