### PR TITLE
Enforces specifying run_name and device_config_name on Engine interfaces

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -64,8 +64,9 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-        run_name: str = "",
-        device_config_name: str = "",
+        *,
+        run_name: str,
+        device_config_name: str,
     ) -> cirq.Result:
         """Runs the supplied Circuit on this processor.
 
@@ -125,8 +126,9 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-        run_name: str = "",
-        device_config_name: str = "",
+        *,
+        run_name: str,
+        device_config_name: str,
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuit on this processor.
 

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -56,6 +56,8 @@ class AbstractProcessor(abc.ABC):
     async def run_async(
         self,
         program: cirq.Circuit,
+        run_name: str,
+        device_config_name: str,
         program_id: Optional[str] = None,
         job_id: Optional[str] = None,
         param_resolver: Optional[cirq.ParamResolver] = None,
@@ -64,15 +66,18 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-        *,
-        run_name: str,
-        device_config_name: str,
     ) -> cirq.Result:
         """Runs the supplied Circuit on this processor.
 
         Args:
             program: The Circuit to execute. If a circuit is
                 provided, a moment by moment schedule will be used.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
             program_id: A user-provided identifier for the program. This must
                 be unique within the Google Cloud project being used. If this
                 parameter is not provided, a random id of the format
@@ -88,12 +93,7 @@ class AbstractProcessor(abc.ABC):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
-            run_name: A unique identifier representing an automation run for the
-                processor. An Automation Run contains a collection of device
-                configurations for the processor.
-            device_config_name: An identifier used to select the processor configuration
-                utilized to run the job. A configuration identifies the set of
-                available qubits, couplers, and supported gates in the processor.
+
         Returns:
             A single Result for this run.
         """
@@ -118,6 +118,8 @@ class AbstractProcessor(abc.ABC):
     async def run_sweep_async(
         self,
         program: cirq.AbstractCircuit,
+        run_name: str,
+        device_config_name: str,
         program_id: Optional[str] = None,
         job_id: Optional[str] = None,
         params: cirq.Sweepable = None,
@@ -126,9 +128,6 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-        *,
-        run_name: str,
-        device_config_name: str,
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuit on this processor.
 
@@ -137,6 +136,12 @@ class AbstractProcessor(abc.ABC):
         Args:
             program: The Circuit to execute. If a circuit is
                 provided, a moment by moment schedule will be used.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
             program_id: A user-provided identifier for the program. This must
                 be unique within the Google Cloud project being used. If this
                 parameter is not provided, a random id of the format
@@ -152,12 +157,7 @@ class AbstractProcessor(abc.ABC):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
-            run_name: A unique identifier representing an automation run for the
-                processor. An Automation Run contains a collection of device
-                configurations for the processor.
-            device_config_name: An identifier used to select the processor configuration
-                utilized to run the job. A configuration identifies the set of
-                available qubits, couplers, and supported gates in the processor.
+
         Returns:
             An AbstractJob. If this is iterated over it returns a list of
             `cirq.Result`, one for each parameter sweep.

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -56,6 +56,7 @@ class AbstractProcessor(abc.ABC):
     async def run_async(
         self,
         program: cirq.Circuit,
+        *,
         run_name: str,
         device_config_name: str,
         program_id: Optional[str] = None,
@@ -118,6 +119,7 @@ class AbstractProcessor(abc.ABC):
     async def run_sweep_async(
         self,
         program: cirq.AbstractCircuit,
+        *,
         run_name: str,
         device_config_name: str,
         program_id: Optional[str] = None,

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -123,8 +123,9 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-        run_name: str = "",
-        device_config_name: str = "",
+        *,
+        run_name: str,
+        device_config_name: str,
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuit on this processor.
 

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -115,6 +115,9 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
     async def run_sweep_async(
         self,
         program: cirq.AbstractCircuit,
+        *,
+        run_name: str,
+        device_config_name: str,
         program_id: Optional[str] = None,
         job_id: Optional[str] = None,
         params: cirq.Sweepable = None,
@@ -123,9 +126,6 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-        *,
-        run_name: str,
-        device_config_name: str,
     ) -> 'abstract_job.AbstractJob':
         """Runs the supplied Circuit on this processor.
 
@@ -135,6 +135,12 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         Args:
             program: The Circuit to execute. If a circuit is
                 provided, a moment by moment schedule will be used.
+            run_name: A unique identifier representing an automation run for the
+                processor. An Automation Run contains a collection of device
+                configurations for the processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
             program_id: A user-provided identifier for the program. This must
                 be unique within the Google Cloud project being used. If this
                 parameter is not provided, a random id of the format
@@ -150,12 +156,6 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             program_labels: Optional set of labels to set on the program.
             job_description: An optional description to set on the job.
             job_labels: Optional set of labels to set on the job.
-            run_name: A unique identifier representing an automation run for the
-                processor. An Automation Run contains a collection of device
-                configurations for the processor.
-            device_config_name: An identifier used to select the processor configuration
-                utilized to run the job. A configuration identifies the set of
-                available qubits, couplers, and supported gates in the processor.
         Returns:
             An AbstractJob. If this is iterated over it returns a list of
             `cirq.Result`, one for each parameter sweep.

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -848,7 +848,10 @@ def test_run_sweep_params_with_unary_rpcs(client):
 
     processor = cg.EngineProcessor('a', 'p', EngineContext(enable_streaming=False))
     job = processor.run_sweep(
-        program=_CIRCUIT, params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})]
+        program=_CIRCUIT,
+        params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
+        run_name="run",
+        device_config_name="config_alias",
     )
     results = job.results()
     assert len(results) == 2
@@ -932,7 +935,10 @@ def test_sampler_with_unary_rpcs(client):
     processor = cg.EngineProcessor('proj', 'mysim', EngineContext(enable_streaming=False))
     sampler = processor.get_sampler()
     results = sampler.run_sweep(
-        program=_CIRCUIT, params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})]
+        program=_CIRCUIT,
+        params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
+        run_name="run",
+        device_config_name="config_alias",
     )
     assert len(results) == 2
     for i, v in enumerate([1, 2]):
@@ -955,7 +961,10 @@ def test_sampler_with_stream_rpcs(client):
     processor = cg.EngineProcessor('proj', 'mysim', EngineContext(enable_streaming=True))
     sampler = processor.get_sampler()
     results = sampler.run_sweep(
-        program=_CIRCUIT, params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})]
+        program=_CIRCUIT,
+        params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
+        run_name="run",
+        device_config_name="config_alias",
     )
     assert len(results) == 2
     for i, v in enumerate([1, 2]):

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -890,7 +890,10 @@ def test_run_sweep_params_with_stream_rpcs(client):
 
     processor = cg.EngineProcessor('a', 'p', EngineContext(enable_streaming=True))
     job = processor.run_sweep(
-        program=_CIRCUIT, params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})]
+        program=_CIRCUIT,
+        params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
+        run_name="run",
+        device_config_name="config_alias",
     )
     results = job.results()
     assert len(results) == 2
@@ -935,10 +938,7 @@ def test_sampler_with_unary_rpcs(client):
     processor = cg.EngineProcessor('proj', 'mysim', EngineContext(enable_streaming=False))
     sampler = processor.get_sampler()
     results = sampler.run_sweep(
-        program=_CIRCUIT,
-        params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
-        run_name="run",
-        device_config_name="config_alias",
+        program=_CIRCUIT, params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})]
     )
     assert len(results) == 2
     for i, v in enumerate([1, 2]):
@@ -961,10 +961,7 @@ def test_sampler_with_stream_rpcs(client):
     processor = cg.EngineProcessor('proj', 'mysim', EngineContext(enable_streaming=True))
     sampler = processor.get_sampler()
     results = sampler.run_sweep(
-        program=_CIRCUIT,
-        params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})],
-        run_name="run",
-        device_config_name="config_alias",
+        program=_CIRCUIT, params=[cirq.ParamResolver({'a': 1}), cirq.ParamResolver({'a': 2})]
     )
     assert len(results) == 2
     for i, v in enumerate([1, 2]):

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -78,6 +78,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         does not block until a result is returned.
 
         Args:
+            processor_id: Processor id for running the program.
             job_id: Optional job id to use. If this is not provided, a random id
                 of the format 'job-################YYMMDD' will be generated,
                 where # is alphanumeric and YYMMDD is the current year, month,
@@ -86,15 +87,12 @@ class EngineProgram(abstract_program.AbstractProgram):
             repetitions: The number of circuit repetitions to run.
             description: An optional description to set on the job.
             labels: Optional set of labels to set on the job.
-            processor_id: Processor id for running the program.
             run_name: A unique identifier representing an automation run for the
                 specified processor. An Automation Run contains a collection of
-                device configurations for a processor. If specified, `processor_id`
-                is required to be set.
+                device configurations for a processor.
             device_config_name: An identifier used to select the processor configuration
                 utilized to run the job. A configuration identifies the set of
                 available qubits, couplers, and supported gates in the processor.
-                If specified, `processor_id` is required to be set.
 
         Returns:
             An EngineJob. If this is iterated over it returns a list of
@@ -144,6 +142,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         """Runs the supplied Circuit via Quantum Engine.
 
         Args:
+            processor_id: Processor id for running the program.
             job_id: Optional job id to use. If this is not provided, a random id
                 of the format 'job-################YYMMDD' will be generated,
                 where # is alphanumeric and YYMMDD is the current year, month,
@@ -152,15 +151,12 @@ class EngineProgram(abstract_program.AbstractProgram):
             repetitions: The number of repetitions to simulate.
             description: An optional description to set on the job.
             labels: Optional set of labels to set on the job.
-            processor_id: Processor id for running the program.
             run_name: A unique identifier representing an automation run for the
                 specified processor. An Automation Run contains a collection of
-                device configurations for a processor. If specified, `processor_id`
-                is required to be set.
+                device configurations for a processor.
             device_config_name: An identifier used to select the processor configuration
                 utilized to run the job. A configuration identifies the set of
                 available qubits, couplers, and supported gates in the processor.
-                If specified, `processor_id` is required to be set.
 
         Returns:
             A single Result for this run.

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -69,8 +69,8 @@ class EngineProgram(abstract_program.AbstractProgram):
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
         *,
-        run_name: str = "",
-        device_config_name: str = "",
+        run_name: str,
+        device_config_name: str,
     ) -> engine_job.EngineJob:
         """Runs the program on the QuantumEngine.
 
@@ -138,8 +138,8 @@ class EngineProgram(abstract_program.AbstractProgram):
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
         *,
-        run_name: str = "",
-        device_config_name: str = "",
+        run_name: str,
+        device_config_name: str,
     ) -> cirq.Result:
         """Runs the supplied Circuit via Quantum Engine.
 

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -63,6 +63,7 @@ class EngineProgram(abstract_program.AbstractProgram):
     async def run_sweep_async(
         self,
         processor_id: str,
+        *,
         run_name: str,
         device_config_name: str,
         job_id: Optional[str] = None,
@@ -128,6 +129,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     async def run_async(
         self,
+        *,
         processor_id: str,
         run_name: str,
         device_config_name: str,

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -63,14 +63,13 @@ class EngineProgram(abstract_program.AbstractProgram):
     async def run_sweep_async(
         self,
         processor_id: str,
+        run_name: str,
+        device_config_name: str,
         job_id: Optional[str] = None,
         params: cirq.Sweepable = None,
         repetitions: int = 1,
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
-        *,
-        run_name: str,
-        device_config_name: str,
     ) -> engine_job.EngineJob:
         """Runs the program on the QuantumEngine.
 
@@ -79,6 +78,12 @@ class EngineProgram(abstract_program.AbstractProgram):
 
         Args:
             processor_id: Processor id for running the program.
+            run_name: A unique identifier representing an automation run for the
+                specified processor. An Automation Run contains a collection of
+                device configurations for a processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
             job_id: Optional job id to use. If this is not provided, a random id
                 of the format 'job-################YYMMDD' will be generated,
                 where # is alphanumeric and YYMMDD is the current year, month,
@@ -87,12 +92,6 @@ class EngineProgram(abstract_program.AbstractProgram):
             repetitions: The number of circuit repetitions to run.
             description: An optional description to set on the job.
             labels: Optional set of labels to set on the job.
-            run_name: A unique identifier representing an automation run for the
-                specified processor. An Automation Run contains a collection of
-                device configurations for a processor.
-            device_config_name: An identifier used to select the processor configuration
-                utilized to run the job. A configuration identifies the set of
-                available qubits, couplers, and supported gates in the processor.
 
         Returns:
             An EngineJob. If this is iterated over it returns a list of
@@ -130,19 +129,24 @@ class EngineProgram(abstract_program.AbstractProgram):
     async def run_async(
         self,
         processor_id: str,
+        run_name: str,
+        device_config_name: str,
         job_id: Optional[str] = None,
         param_resolver: cirq.ParamResolver = cirq.ParamResolver({}),
         repetitions: int = 1,
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
-        *,
-        run_name: str,
-        device_config_name: str,
     ) -> cirq.Result:
         """Runs the supplied Circuit via Quantum Engine.
 
         Args:
             processor_id: Processor id for running the program.
+            run_name: A unique identifier representing an automation run for the
+                specified processor. An Automation Run contains a collection of
+                device configurations for a processor.
+            device_config_name: An identifier used to select the processor configuration
+                utilized to run the job. A configuration identifies the set of
+                available qubits, couplers, and supported gates in the processor.
             job_id: Optional job id to use. If this is not provided, a random id
                 of the format 'job-################YYMMDD' will be generated,
                 where # is alphanumeric and YYMMDD is the current year, month,
@@ -151,12 +155,6 @@ class EngineProgram(abstract_program.AbstractProgram):
             repetitions: The number of repetitions to simulate.
             description: An optional description to set on the job.
             labels: Optional set of labels to set on the job.
-            run_name: A unique identifier representing an automation run for the
-                specified processor. An Automation Run contains a collection of
-                device configurations for a processor.
-            device_config_name: An identifier used to select the processor configuration
-                utilized to run the job. A configuration identifies the set of
-                available qubits, couplers, and supported gates in the processor.
 
         Returns:
             A single Result for this run.

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -85,7 +85,12 @@ def test_run_sweeps_delegation(create_job_async):
     program = cg.EngineProgram('my-proj', 'my-prog', EngineContext())
     param_resolver = cirq.ParamResolver({})
     job = program.run_sweep(
-        job_id='steve', repetitions=10, params=param_resolver, processor_id='mine'
+        job_id='steve',
+        repetitions=10,
+        params=param_resolver,
+        processor_id='mine',
+        run_name="run_name",
+        device_config_name="config",
     )
     assert job._job == quantum.QuantumJob()
 
@@ -134,7 +139,12 @@ def test_run_delegation(create_job_async, get_results_async):
     program = cg.EngineProgram('a', 'b', EngineContext())
     param_resolver = cirq.ParamResolver({})
     results = program.run(
-        job_id='steve', repetitions=10, param_resolver=param_resolver, processor_id='mine'
+        job_id='steve',
+        repetitions=10,
+        param_resolver=param_resolver,
+        processor_id='mine',
+        run_name="run_name",
+        device_config_name="config",
     )
 
     assert results == cg.EngineResult(

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -533,12 +533,21 @@ def test_run_multiple_times(client):
 
     engine = cg.Engine(project_id='proj', proto_version=cg.engine.engine.ProtoVersion.V2)
     program = engine.create_program(program=_CIRCUIT)
-    program.run(processor_id='processor0', param_resolver=cirq.ParamResolver({'a': 1}))
+    program.run(
+        processor_id='processor0',
+        param_resolver=cirq.ParamResolver({'a': 1}),
+        run_name="run",
+        device_config_name="config_alias",
+    )
     run_context = v2.run_context_pb2.RunContext()
     client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
     sweeps1 = run_context.parameter_sweeps
     job2 = program.run_sweep(
-        processor_id='processor0', repetitions=2, params=cirq.Points('a', [3, 4])
+        processor_id='processor0',
+        repetitions=2,
+        params=cirq.Points('a', [3, 4]),
+        run_name="run",
+        device_config_name="config_alias",
     )
     client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
     sweeps2 = run_context.parameter_sweeps
@@ -629,7 +638,9 @@ def test_bad_sweep_proto():
     engine = cg.Engine(project_id='project-id', proto_version=cg.ProtoVersion.UNDEFINED)
     program = cg.EngineProgram('proj', 'prog', engine.context)
     with pytest.raises(ValueError, match='invalid run context proto version'):
-        program.run_sweep(processor_id='processor0')
+        program.run_sweep(
+            processor_id='processor0', run_name="run", device_config_name="config_alias"
+        )
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)

--- a/cirq-google/cirq_google/engine/simulated_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor_test.py
@@ -128,7 +128,7 @@ def test_run():
     proc = SimulatedLocalProcessor(processor_id='test_proc')
     q = cirq.GridQubit(5, 4)
     circuit = cirq.Circuit(cirq.X(q), cirq.measure(q, key='m'))
-    result = proc.run(circuit, repetitions=100)
+    result = proc.run(circuit, repetitions=100, run_name="run", device_config_name="config_alias")
     assert np.all(result.measurements['m'] == 1)
 
 

--- a/cirq-google/cirq_google/engine/virtual_engine_factory_test.py
+++ b/cirq-google/cirq_google/engine/virtual_engine_factory_test.py
@@ -26,20 +26,22 @@ def _test_processor(processor: cg.engine.abstract_processor.AbstractProcessor):
     Also tests the non-Sycamore qubits and gates fail."""
     good_qubit = cirq.GridQubit(5, 4)
     circuit = cirq.Circuit(cirq.X(good_qubit), cirq.measure(good_qubit))
-    results = processor.run(circuit, repetitions=100)
+    results = processor.run(circuit, repetitions=100, run_name="run", device_config_name="config")
     assert np.all(results.measurements[str(good_qubit)] == 1)
     with pytest.raises(RuntimeError, match='requested total repetitions'):
-        _ = processor.run(circuit, repetitions=100_000_000)
+        _ = processor.run(
+            circuit, repetitions=100_000_000, run_name="run", device_config_name="config"
+        )
 
     bad_qubit = cirq.GridQubit(10, 10)
     circuit = cirq.Circuit(cirq.X(bad_qubit), cirq.measure(bad_qubit))
     with pytest.raises(ValueError, match='Qubit not on device'):
-        _ = processor.run(circuit, repetitions=100)
+        _ = processor.run(circuit, repetitions=100, run_name="run", device_config_name="config")
     circuit = cirq.Circuit(
         cirq.testing.DoesNotSupportSerializationGate()(good_qubit), cirq.measure(good_qubit)
     )
     with pytest.raises(ValueError, match='Cannot serialize op'):
-        _ = processor.run(circuit, repetitions=100)
+        _ = processor.run(circuit, repetitions=100, run_name="run", device_config_name="config")
 
 
 def test_create_device_from_processor_id():
@@ -195,13 +197,13 @@ def test_create_default_noisy_quantum_virtual_machine():
         bad_qubit = cirq.GridQubit(10, 10)
         circuit = cirq.Circuit(cirq.X(bad_qubit), cirq.measure(bad_qubit))
         with pytest.raises(ValueError, match='Qubit not on device'):
-            _ = processor.run(circuit, repetitions=100)
+            _ = processor.run(circuit, repetitions=100, run_name="run", device_config_name="config")
         good_qubit = cirq.GridQubit(5, 4)
         circuit = cirq.Circuit(
             cirq.testing.DoesNotSupportSerializationGate()(good_qubit), cirq.measure(good_qubit)
         )
         with pytest.raises(ValueError, match='.* contains a gate which is not supported.'):
-            _ = processor.run(circuit, repetitions=100)
+            _ = processor.run(circuit, repetitions=100, run_name="run", device_config_name="config")
         device_specification = processor.get_device_specification()
         expected = factory.create_device_spec_from_processor_id(processor_id)
         assert device_specification is not None

--- a/cirq-google/cirq_google/workflow/processor_record_test.py
+++ b/cirq-google/cirq_google/workflow/processor_record_test.py
@@ -148,7 +148,7 @@ def test_engine_result():
 
     circ = cirq.Circuit(cirq.measure(cirq.GridQubit(5, 4)))
 
-    res1 = proc.run(circ)
+    res1 = proc.run(circ, run_name="run", device_config_name="config_alias")
     assert isinstance(res1, cg.EngineResult)
     res2 = samp.run(circ)
     assert isinstance(res2, cg.EngineResult)


### PR DESCRIPTION
Removes default values and enforces specifying `run_name` and `device_config_name`

Special note that this does not disrupt the workflow
```
sampler = processor.get_sampler(  
        run_name="run_name", device_config_name="config_alias"
    )

sampler.run_batch([circuit] * 20, repetitions=500) 
## or
sampler.run_sweep(circuit, params=[...], repetitions=500) 
```