### PR TITLE
Fix CI lint failure by pinning to protobuf-4

### DIFF
--- a/cirq-google/requirements.txt
+++ b/cirq-google/requirements.txt
@@ -1,3 +1,3 @@
 google-api-core[grpc] >= 1.14.0
 proto-plus >= 1.20.0
-protobuf >= 3.15.0
+protobuf >= 3.15.0, < 5.0.0

--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -4,6 +4,6 @@ mypy==1.2.0
 # packages with stub types for various libraries
 types-backports==0.1.3
 types-cachetools
-types-protobuf~=3.20
+types-protobuf>=3.20.0,<5.0.0
 types-requests==2.28.1
 types-setuptools==62.6.1

--- a/dev_tools/requirements/deps/protos.txt
+++ b/dev_tools/requirements/deps/protos.txt
@@ -3,4 +3,4 @@
 # This bundles protoc 3.24.3, which we use for generating proto code.
 grpcio-tools~=1.59.0
 
-mypy-protobuf==3.4
+mypy-protobuf~=3.4


### PR DESCRIPTION
* Pin `protobuf` to version 4 to fix "Lint check" CI failure such as
  https://github.com/quantumlib/Cirq/actions/runs/9654153610/job/26627844188

* Also bump `types-protobuf` `mypy-protobuf` for consistency with protobuf-4.x
