### PR TITLE
docs - unblock execution of cirq_pasqal getting_started notebook

### DIFF
--- a/docs/hardware/pasqal/getting_started.ipynb
+++ b/docs/hardware/pasqal/getting_started.ipynb
@@ -205,10 +205,15 @@
     "pasqal_gateset=cirq_pasqal.PasqalGateset(include_additional_controlled_ops=False)\n",
     "pasqal_circuit = cirq.optimize_for_target_gateset(initial_circuit,\n",
     "                                                  gateset=pasqal_gateset)\n",
+    "\n",
+    "# TODO(https://github.com/quantumlib/Cirq/issues/6655) - remove after fixup\n",
+    "pasqal_circuit = cirq.Circuit(pasqal_circuit.all_operations(),\n",
+    "                              strategy=cirq.InsertStrategy.NEW)\n",
+    "\n",
     "print(pasqal_circuit)\n",
     "\n",
     "# Now the circuit validates correctly!\n",
-    "p_device.validate_circuit(pasqal_circuit)\n"
+    "p_device.validate_circuit(pasqal_circuit)"
    ]
   },
   {


### PR DESCRIPTION
This is a workaround to allow execution of getting_started.ipynb
notebook as a part of documentation build.

Here we manually convert optimized circuit to have 1 operation per moment
so it passes validation w/r to the PasqalVirtualDevice.

Related to #6655
