### PR TITLE
Support creating XEB calibration options for arbitary FSim like gates

### DIFF
--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -441,6 +441,7 @@ def parallel_two_qubit_xeb(
     **plot_kwargs,
 ) -> TwoQubitXEBResult:
     """A convenience method that runs the full XEB workflow.
+
     Args:
         sampler: The quantum engine or simulator to run the circuits.
         qubits: Qubits under test. If none, uses all qubits on the sampler's device.

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -148,7 +148,7 @@ class XEBCharacterizationOptions(ABC):
 
 def _try_defaults_from_unitary(gate: 'cirq.Gate') -> Optional[Dict[str, 'cirq.TParamVal']]:
     r"""Try to figure out the PhasedFSim angles from the unitary of the gate.
-    
+
     The unitary of a PhasedFSimGate has the form:
     $$
     \begin{bmatrix}
@@ -164,10 +164,10 @@ def _try_defaults_from_unitary(gate: 'cirq.Gate') -> Optional[Dict[str, 'cirq.TP
 
     Args:
         A cirq gate.
-    
+
     Returns:
-        A dictionary mapping angles to values or None if the gate doesn't have a unitary or if it can't
-        be represented by a PhasedFSimGate.
+        A dictionary mapping angles to values or None if the gate doesn't have a unitary or if it
+        can't be represented by a PhasedFSimGate.
     """
     u = protocols.unitary(gate, default=None)
     if u is None:

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -146,6 +146,47 @@ class XEBCharacterizationOptions(ABC):
         """Return an initial Nelder-Mead simplex and the names for each parameter."""
 
 
+def _try_defaults_from_unitary(gate: 'cirq.Gate') -> Optional[Dict[str, 'cirq.TParamVal']]:
+    u = protocols.unitary(gate, default=None)
+    if u is None:
+        return None
+
+    gamma = np.angle(u[1, 1] * u[2, 2] - u[1, 2] * u[2, 1]) / -2
+    phi = -np.angle(u[3, 3]) - 2 * gamma
+    phased_c_theta_2 = u[1, 1] * u[2, 2]
+    if phased_c_theta_2 == 0:
+        # The zeta phase is multiplied with cos(theta),
+        # so if cos(theta) is zero then any value is possible.
+        zeta = 0
+    else:
+        zeta = np.angle(u[2, 2] / u[1, 1]) / 2
+
+    phased_s_theta_2 = u[1, 2] * u[2, 1]
+    if phased_s_theta_2 == 0:
+        # The chi phase is multiplied with sin(theta),
+        # so if sin(theta) is zero then any value is possible.
+        chi = 0
+    else:
+        chi = np.angle(u[1, 2] / u[2, 1]) / 2
+
+    theta = np.angle(np.exp(1j * (gamma + zeta)) * u[1, 1] - np.exp(1j * (gamma + chi)) * u[1, 2])
+
+    if np.allclose(
+        u,
+        protocols.unitary(
+            ops.PhasedFSimGate(theta=theta, phi=phi, chi=chi, zeta=zeta, gamma=gamma)
+        ),
+    ):
+        return {
+            'theta_default': theta,
+            'phi_default': phi,
+            'gamma_default': gamma,
+            'zeta_default': zeta,
+            'chi_default': chi,
+        }
+    return None
+
+
 def phased_fsim_angles_from_gate(gate: 'cirq.Gate') -> Dict[str, 'cirq.TParamVal']:
     """For a given gate, return a dictionary mapping '{angle}_default' to its noiseless value
     for the five PhasedFSim angles."""
@@ -174,6 +215,11 @@ def phased_fsim_angles_from_gate(gate: 'cirq.Gate') -> Dict[str, 'cirq.TParamVal
             'gamma_default': gate.gamma,
             'phi_default': gate.phi,
         }
+
+    # Handle all gates that can be represented using an FSimGate.
+    from_unitary = _try_defaults_from_unitary(gate)
+    if from_unitary is not None:
+        return from_unitary
 
     raise ValueError(f"Unknown default angles for {gate}.")
 
@@ -578,15 +624,6 @@ def _fit_exponential_decay(
 
     a_std, layer_fid_std = np.sqrt(np.diag(pcov))
     return a, layer_fid, a_std, layer_fid_std
-
-
-def _one_unique(df, name, default):
-    """Helper function to assert that there's one unique value in a column and return it."""
-    if name not in df.columns:
-        return default
-    vals = df[name].unique()
-    assert len(vals) == 1, name
-    return vals[0]
 
 
 def fit_exponential_decays(fidelities_df: pd.DataFrame) -> pd.DataFrame:

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -169,7 +169,7 @@ def _try_defaults_from_unitary(gate: 'cirq.Gate') -> Optional[Dict[str, 'cirq.TP
     else:
         chi = np.angle(u[1, 2] / u[2, 1]) / 2
 
-    theta = np.angle(np.exp(1j * (gamma + zeta)) * u[1, 1] - np.exp(1j * (gamma + chi)) * u[1, 2])
+    theta = np.angle(np.exp(1j * (gamma + zeta)) * u[1, 1] - np.exp(1j * (gamma - chi)) * u[1, 2])
 
     if np.allclose(
         u,

--- a/cirq-core/cirq/experiments/xeb_fitting_test.py
+++ b/cirq-core/cirq/experiments/xeb_fitting_test.py
@@ -408,7 +408,8 @@ def test_options_defaults_set():
         cirq.ISWAP_INV,
         cirq.cphase(0.1),
         cirq.CZ**0.2,
-    ],
+    ]
+    + [cirq.PhasedFSimGate(*r) for r in (np.pi * np.random.default_rng(0).random((10, 5)))],
 )
 def test_phased_fsim_angles_from_gate(gate):
     angles = phased_fsim_angles_from_gate(gate)

--- a/cirq-core/cirq/experiments/xeb_fitting_test.py
+++ b/cirq-core/cirq/experiments/xeb_fitting_test.py
@@ -398,6 +398,12 @@ def test_options_defaults_set():
     assert o3.defaults_set() is True
 
 
+def _random_angles(n, seed):
+    rng = np.random.default_rng(seed)
+    r = 2 * rng.random((n, 5)) - 1
+    return np.pi * r
+
+
 @pytest.mark.parametrize(
     'gate',
     [
@@ -409,7 +415,7 @@ def test_options_defaults_set():
         cirq.cphase(0.1),
         cirq.CZ**0.2,
     ]
-    + [cirq.PhasedFSimGate(*r) for r in (np.pi * np.random.default_rng(0).random((10, 5)))],
+    + [cirq.PhasedFSimGate(*r) for r in _random_angles(10, 0)],
 )
 def test_phased_fsim_angles_from_gate(gate):
     angles = phased_fsim_angles_from_gate(gate)

--- a/cirq-core/cirq/experiments/xeb_fitting_test.py
+++ b/cirq-core/cirq/experiments/xeb_fitting_test.py
@@ -415,3 +415,8 @@ def test_phased_fsim_angles_from_gate(gate):
     angles = {k.removesuffix('_default'): v for k, v in angles.items()}
     phasedfsim = cirq.PhasedFSimGate(**angles)
     np.testing.assert_allclose(cirq.unitary(phasedfsim), cirq.unitary(gate), atol=1e-9)
+
+
+def test_phased_fsim_angles_from_gate_unsupporet_gate():
+    with pytest.raises(ValueError, match='Unknown default angles'):
+        _ = phased_fsim_angles_from_gate(cirq.testing.TwoQubitGate())


### PR DESCRIPTION
This PR supports creating FSim calibration options for arbitary FSim like gates. It also split the XEB function in two in prerpartion for implmenting XEB calibration for arbitary gates.

part of breaking https://github.com/quantumlib/Cirq/pull/6568 into smaller PRs.