### PR TITLE
Add noise amplification transformer

### DIFF
--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -57,7 +57,9 @@ class DepolerizingNoiseTransformer:
                 + "sorted qubit pairs to floats"  # pragma: no cover
             )  # pragma: no cover
         self.p = p
-        self.p_func = lambda _: p if isinstance(p, (int, float)) else lambda pair: p.get(pair, 0.0)
+        self.p_func = (
+            (lambda _: p) if isinstance(p, (int, float)) else (lambda pair: p.get(pair, 0.0))
+        )
         self.target_gate = target_gate
 
     def __call__(

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -55,12 +55,11 @@ class DepolerizingNoiseTransformer:
 
     def __call__(
         self,
-        circuit: circuits.Circuit,
+        circuit: circuits.AbstractCircuit,
         *,
         context: transformer_api.TransformerContext | None = None,
     ):
-        """
-        Apply the transformer to the given circuit.
+        """Apply the transformer to the given circuit.
 
         Args:
             circuit: The circuit to add noise to.
@@ -70,7 +69,8 @@ class DepolerizingNoiseTransformer:
             The transformed circuit.
 
         Raises:
-            TypeError: If `p` is not either be a float or a mapping from sorted qubit pairs to floats.
+            TypeError: If `p` is not either be a float or a mapping from sorted qubit pairs to
+                       floats.
         """
 
         p = self.p
@@ -97,7 +97,8 @@ class DepolerizingNoiseTransformer:
                         p_i = p[pair_sorted_tuple]
                     else:  # pragma: no cover
                         raise TypeError(  # pragma: no cover
-                            "p must either be a float or a mapping from sorted qubit pairs to floats"  # pragma: no cover
+                            "p must either be a float or a mapping from"  # pragma: no cover
+                            + "sorted qubit pairs to floats"  # pragma: no cover
                         )  # pragma: no cover
                     apply = rng.choice([True, False], p=[p_i, 1 - p_i])
                     if apply:

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -17,6 +17,7 @@ from collections.abc import Mapping
 from cirq import ops, circuits
 from cirq.transformers import transformer_api
 import numpy as np
+from typing import cast
 
 
 def _gate_in_moment(gate: ops.Gate, moment: circuits.Moment) -> bool:
@@ -58,7 +59,9 @@ class DepolerizingNoiseTransformer:
             )  # pragma: no cover
         self.p = p
         self.p_func = (
-            (lambda _: p) if isinstance(p, (int, float)) else (lambda pair: p.get(pair, 0.0))
+            (lambda _: p)
+            if isinstance(p, (int, float))
+            else (lambda pair: cast(Mapping, p).get(pair, 0.0))
         )
         self.target_gate = target_gate
 

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections.abc import Mapping
 
 import cirq

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -4,6 +4,16 @@ import cirq
 import numpy as np
 
 
+def _gate_in_moment(gate: cirq.Gate, moment: cirq.Moment) -> bool:
+    """Check whether `gate` is in `moment`."""
+    target_gate_in_moment = False
+    for op in moment.operations:
+        if op.gate == gate:
+            target_gate_in_moment = True
+            break
+    return target_gate_in_moment
+
+
 def add_depolarizing_noise_to_two_qubit_gates(
     circuit: cirq.Circuit,
     p: float | Mapping[tuple[cirq.Qid, cirq.Qid], float],

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -30,65 +30,84 @@ def _gate_in_moment(gate: ops.Gate, moment: circuits.Moment) -> bool:
 
 
 @transformer_api.transformer
-def add_depolarizing_noise_to_two_qubit_gates(
-    circuit: circuits.Circuit,
-    *,
-    p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
-    target_gate: ops.Gate = ops.CZ,
-    rng: np.random.Generator | None = None,
-    context: transformer_api.TransformerContext | None = None,
-) -> circuits.Circuit:
+class DepolerizingNoiseTransformer:
     """Add local depolarizing noise after two-qubit gates in a specified circuit. More specifically,
     with probability p, append a random non-identity two-qubit Pauli operator after each specified
     two-qubit gate.
 
-    Args:
-        circuit: The circuit to add noise to.
+    Attrs:
         p: The probability with which to add noise.
         target_gate: Add depolarizing nose after this type of gate
         rng: The pseudorandom number generator to use.
-        context: Not used; to satisfy transformer API.
-
-    Returns:
-        The transformed circuit.
-
-    Raises:
-        TypeError: If `p` is not either be a float or a mapping from sorted qubit pairs to floats.
     """
-    if rng is None:
-        rng = np.random.default_rng()
 
-    # add random Pauli gates with probability p after each of the specified gate
-    assert target_gate.num_qubits() == 2, "`target_gate` must be a two-qubit gate."
-    paulis = [ops.I, ops.X, ops.Y, ops.Z]
-    new_moments = []
-    for moment in circuit:
-        new_moments.append(moment)
-        if _gate_in_moment(target_gate, moment):
-            # add a new moment with the Paulis
-            target_pairs = {
-                tuple(sorted(op.qubits)) for op in moment.operations if op.gate == target_gate
-            }
-            added_moment_ops = []
-            for pair in target_pairs:
-                if isinstance(p, float):
-                    p_i = p
-                elif isinstance(p, Mapping):
-                    pair_sorted_tuple = (pair[0], pair[1])
-                    p_i = p[pair_sorted_tuple]
-                else:
-                    raise TypeError(
-                        "p must either be a float or a mapping from sorted qubit pairs to floats"
-                    )
-                apply = rng.choice([True, False], p=[p_i, 1 - p_i])
-                if apply:
-                    choices = [
-                        (pauli_a(pair[0]), pauli_b(pair[1]))
-                        for pauli_a in paulis
-                        for pauli_b in paulis
-                    ][1:]
-                    pauli_to_apply = rng.choice(np.array(choices, dtype=object))
-                    added_moment_ops.append(pauli_to_apply)
-            if len(added_moment_ops) > 0:
-                new_moments.append(circuits.Moment(*added_moment_ops))
-    return circuits.Circuit.from_moments(*new_moments)
+    def __init__(
+        self,
+        p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
+        target_gate: ops.Gate = ops.CZ,
+        rng: np.random.Generator | None = None,
+    ):
+        if rng is None:
+            rng = np.random.default_rng()
+        self.p = p
+        self.target_gate = target_gate
+        self.rng = rng
+
+    def __call__(
+        self,
+        circuit: circuits.Circuit,
+        *,
+        context: transformer_api.TransformerContext | None = None,
+    ):
+        """
+        Apply the transformer to the given circuit.
+
+        Args:
+            circuit: The circuit to add noise to.
+            context: Not used; to satisfy transformer API.
+
+        Returns:
+            The transformed circuit.
+
+        Raises:
+            TypeError: If `p` is not either be a float or a mapping from sorted qubit pairs to floats.
+        """
+
+        p = self.p
+        rng = self.rng
+        target_gate = self.target_gate
+
+        # add random Pauli gates with probability p after each of the specified gate
+        assert target_gate.num_qubits() == 2, "`target_gate` must be a two-qubit gate."
+        paulis = [ops.I, ops.X, ops.Y, ops.Z]
+        new_moments = []
+        for moment in circuit:
+            new_moments.append(moment)
+            if _gate_in_moment(target_gate, moment):
+                # add a new moment with the Paulis
+                target_pairs = {
+                    tuple(sorted(op.qubits)) for op in moment.operations if op.gate == target_gate
+                }
+                added_moment_ops = []
+                for pair in target_pairs:
+                    if isinstance(p, float):
+                        p_i = p
+                    elif isinstance(p, Mapping):
+                        pair_sorted_tuple = (pair[0], pair[1])
+                        p_i = p[pair_sorted_tuple]
+                    else:  # pragma: no cover
+                        raise TypeError(  # pragma: no cover
+                            "p must either be a float or a mapping from sorted qubit pairs to floats"  # pragma: no cover
+                        )  # pragma: no cover
+                    apply = rng.choice([True, False], p=[p_i, 1 - p_i])
+                    if apply:
+                        choices = [
+                            (pauli_a(pair[0]), pauli_b(pair[1]))
+                            for pauli_a in paulis
+                            for pauli_b in paulis
+                        ][1:]
+                        pauli_to_apply = rng.choice(np.array(choices, dtype=object))
+                        added_moment_ops.append(pauli_to_apply)
+                if len(added_moment_ops) > 0:
+                    new_moments.append(circuits.Moment(*added_moment_ops))
+        return circuits.Circuit.from_moments(*new_moments)

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -14,10 +14,10 @@
 
 from collections.abc import Mapping
 
+from typing import cast
 from cirq import ops, circuits
 from cirq.transformers import transformer_api
 import numpy as np
-from typing import cast
 
 
 def _gate_in_moment(gate: ops.Gate, moment: circuits.Moment) -> bool:

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -32,7 +32,8 @@ def _gate_in_moment(gate: ops.Gate, moment: circuits.Moment) -> bool:
 @transformer_api.transformer
 def add_depolarizing_noise_to_two_qubit_gates(
     circuit: circuits.Circuit,
-    *, p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
+    *,
+    p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
     target_gate: ops.Gate = ops.CZ,
     rng: np.random.Generator | None = None,
     context: transformer_api.TransformerContext | None = None,

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -51,7 +51,7 @@ class DepolerizingNoiseTransformer:
                        floats.
         """
 
-        if not (isinstance(p, float) or isinstance(p, Mapping)):
+        if not isinstance(p, (Mapping, float)):
             raise TypeError(  # pragma: no cover
                 "p must either be a float or a mapping from"  # pragma: no cover
                 + "sorted qubit pairs to floats"  # pragma: no cover

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -15,6 +15,7 @@
 from collections.abc import Mapping
 
 from cirq import ops, circuits
+from cirq.transformers import transformer_api
 import numpy as np
 
 
@@ -34,6 +35,7 @@ def add_depolarizing_noise_to_two_qubit_gates(
     p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
     target_gate: ops.Gate = ops.CZ,
     rng: np.random.Generator | None = None,
+    context: transformer_api.TransformerContext | None = None,
 ) -> circuits.Circuit:
     """Add local depolarizing noise after two-qubit gates in a specified circuit. More specifically,
     with probability p, append a random non-identity two-qubit Pauli operator after each specified
@@ -44,6 +46,7 @@ def add_depolarizing_noise_to_two_qubit_gates(
         p: The probability with which to add noise.
         target_gate: Add depolarizing nose after this type of gate
         rng: The pseudorandom number generator to use.
+        context: Not used; to satisfy transformer API.
 
     Returns:
         The transformed circuit.

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -57,6 +57,7 @@ class DepolerizingNoiseTransformer:
                 + "sorted qubit pairs to floats"  # pragma: no cover
             )  # pragma: no cover
         self.p = p
+        self.p_func = lambda _: p if isinstance(p, (int, float)) else lambda pair: p.get(pair, 0.0)
         self.target_gate = target_gate
 
     def __call__(
@@ -77,7 +78,6 @@ class DepolerizingNoiseTransformer:
         """
         if rng is None:
             rng = np.random.default_rng()
-        p = self.p
         target_gate = self.target_gate
 
         # add random Pauli gates with probability p after each of the specified gate
@@ -93,11 +93,8 @@ class DepolerizingNoiseTransformer:
                 }
                 added_moment_ops = []
                 for pair in target_pairs:
-                    if isinstance(p, float):
-                        p_i = p
-                    elif isinstance(p, Mapping):
-                        pair_sorted_tuple = (pair[0], pair[1])
-                        p_i = p[pair_sorted_tuple]
+                    pair_sorted_tuple = (pair[0], pair[1])
+                    p_i = self.p_func(pair_sorted_tuple)
                     apply = rng.choice([True, False], p=[p_i, 1 - p_i])
                     if apply:
                         choices = [

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -32,7 +32,7 @@ def _gate_in_moment(gate: ops.Gate, moment: circuits.Moment) -> bool:
 @transformer_api.transformer
 def add_depolarizing_noise_to_two_qubit_gates(
     circuit: circuits.Circuit,
-    p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
+    *, p: float | Mapping[tuple[ops.Qid, ops.Qid], float],
     target_gate: ops.Gate = ops.CZ,
     rng: np.random.Generator | None = None,
     context: transformer_api.TransformerContext | None = None,

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -1,0 +1,62 @@
+from collections.abc import Mapping
+
+import cirq
+import numpy as np
+
+
+def add_depolarizing_noise_to_two_qubit_gates(
+    circuit: cirq.Circuit,
+    p: float | Mapping[tuple[cirq.Qid, cirq.Qid], float],
+    target_gate: cirq.Gate = cirq.CZ,
+    rng: np.random.Generator | None = None,
+) -> cirq.Circuit:
+    """Add local depolarizing noise after two-qubit gates in a specified circuit. More specifically,
+    with probability p, append a random non-identity two-qubit Pauli operator after each specified
+    two-qubit gate.
+
+    Args:
+        circuit: The circuit to add noise to.
+        p: The probability with which to add noise.
+        target_gate: Add depolarizing nose after this type of gate
+        rng: The pseudorandom number generator to use.
+
+    Returns:
+        The transformed circuit.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+
+    # add random Pauli gates with probability p after each of the specified gate
+    assert target_gate.num_qubits() == 2, "`target_gate` must be a two-qubit gate."
+    paulis = [cirq.I, cirq.X, cirq.Y, cirq.Z]
+    new_moments = []
+    for moment in circuit:
+        new_moments.append(moment)
+        if _gate_in_moment(target_gate, moment):
+            # add a new moment with the Paulis
+            target_pairs = {
+                tuple(sorted(op.qubits)) for op in moment.operations if op.gate == target_gate
+            }
+            added_moment_ops = []
+            for pair in target_pairs:
+                if isinstance(p, float):
+                    p_i = p
+                elif isinstance(p, Mapping):
+                    pair_sorted_tuple = (pair[0], pair[1])
+                    p_i = p[pair_sorted_tuple]
+                else:
+                    raise TypeError(
+                        "p must either be a float or a mapping from sorted qubit pairs to floats"
+                    )
+                apply = rng.choice([True, False], p=[p_i, 1 - p_i])
+                if apply:
+                    choices = [
+                        (pauli_a(pair[0]), pauli_b(pair[1]))
+                        for pauli_a in paulis
+                        for pauli_b in paulis
+                    ][1:]
+                    pauli_to_apply = rng.choice(np.array(choices, dtype=object))
+                    added_moment_ops.append(pauli_to_apply)
+            if len(added_moment_ops) > 0:
+                new_moments.append(cirq.Moment(*added_moment_ops))
+    return cirq.Circuit.from_moments(*new_moments)

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import cirq
 import cirq.transformers.noise_adding as na
 

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -19,13 +19,13 @@ import cirq.transformers.noise_adding as na
 def test_noise_adding():
     qubits = devices.LineQubit.range(4)
     circuit = circuits.Circuit(ops.CZ(*qubits[:2]), ops.CZ(*qubits[2:])) * 10
-    transformed_circuit_p0 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 0.0)
+    transformed_circuit_p0 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, p=0.0)
     assert transformed_circuit_p0 == circuit
-    transformed_circuit_p1 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 1.0)
+    transformed_circuit_p1 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, p=1.0)
     assert len(transformed_circuit_p1) == 20
-    transformed_circuit_p0_03 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 0.03)
+    transformed_circuit_p0_03 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, p=0.03)
     assert 10 <= len(transformed_circuit_p0_03) <= 20
     transformed_circuit_p_dict = na.add_depolarizing_noise_to_two_qubit_gates(
-        circuit, {tuple(qubits[:2]): 1.0, tuple(qubits[2:]): 0.0}
+        circuit, p={tuple(qubits[:2]): 1.0, tuple(qubits[2:]): 0.0}
     )
     assert len(transformed_circuit_p_dict) == 20

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -1,0 +1,12 @@
+import cirq
+import cirq.transformers.noise_adding as na
+
+
+def test_noise_adding():
+    qubits = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(cirq.CZ(*qubits[:2]), cirq.CZ(*qubits[2:])) * 10
+    transformed_circuit_p0 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 0.0)
+    assert transformed_circuit_p0 == circuit
+    transformed_circuit_p1 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 1.0)
+    assert len(transformed_circuit_p1) == 20
+    transformed_circuit_p0_03 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 0.03)

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cirq
+from cirq import ops, circuits, devices
 import cirq.transformers.noise_adding as na
 
 
 def test_noise_adding():
-    qubits = cirq.LineQubit.range(4)
-    circuit = cirq.Circuit(cirq.CZ(*qubits[:2]), cirq.CZ(*qubits[2:])) * 10
+    qubits = devices.LineQubit.range(4)
+    circuit = circuits.Circuit(ops.CZ(*qubits[:2]), ops.CZ(*qubits[2:])) * 10
     transformed_circuit_p0 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 0.0)
     assert transformed_circuit_p0 == circuit
     transformed_circuit_p1 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 1.0)
     assert len(transformed_circuit_p1) == 20
     transformed_circuit_p0_03 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, 0.03)
+    assert 10 <= len(transformed_circuit_p0_03) <= 20
+    transformed_circuit_p_dict = na.add_depolarizing_noise_to_two_qubit_gates(
+        circuit, {tuple(qubits[:2]): 1.0, tuple(qubits[2:]): 0.0}
+    )
+    assert len(transformed_circuit_p_dict) == 20

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -14,18 +14,40 @@
 
 from cirq import ops, circuits, devices
 import cirq.transformers.noise_adding as na
+import numpy as np
 
 
 def test_noise_adding():
     qubits = devices.LineQubit.range(4)
-    circuit = circuits.Circuit(ops.CZ(*qubits[:2]), ops.CZ(*qubits[2:])) * 10
+    one_layer = circuits.Circuit(ops.CZ(*qubits[:2]), ops.CZ(*qubits[2:]))
+    circuit = one_layer * 10
+
+    # test that p=0 does nothing
     transformed_circuit_p0 = na.DepolerizingNoiseTransformer(0.0)(circuit)
     assert transformed_circuit_p0 == circuit
+
+    # test that p=1 doubles the circuit depth
     transformed_circuit_p1 = na.DepolerizingNoiseTransformer(1.0)(circuit)
     assert len(transformed_circuit_p1) == 20
-    transformed_circuit_p0_03 = na.DepolerizingNoiseTransformer(0.03)(circuit)
-    assert 10 <= len(transformed_circuit_p0_03) <= 20
+
+    # test that we get a deterministic result when using a specific rng
+    rng = np.random.default_rng(0)
+    transformed_circuit_p0_03 = na.DepolerizingNoiseTransformer(0.03)(circuit, rng=rng)
+    expected_circuit = (
+        one_layer * 2
+        + circuits.Circuit(ops.I(qubits[2]), ops.Z(qubits[3]))
+        + one_layer * 4
+        + circuits.Circuit(ops.Z(qubits[0]), ops.X(qubits[1]))
+        + one_layer * 4
+        + circuits.Circuit(ops.I(qubits[2]), ops.X(qubits[3]))
+    )
+    assert transformed_circuit_p0_03 == expected_circuit
+
+    # test that supplying a dictionary for p works
     transformed_circuit_p_dict = na.DepolerizingNoiseTransformer(
         {tuple(qubits[:2]): 1.0, tuple(qubits[2:]): 0.0}
     )(circuit)
-    assert len(transformed_circuit_p_dict) == 20
+    assert len(transformed_circuit_p_dict) == 20  # depth should be doubled
+    assert transformed_circuit_p_dict[1::2].all_qubits() == frozenset(
+        qubits[:2]
+    )  # no single-qubit gates get added to qubits[2:]

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -19,13 +19,13 @@ import cirq.transformers.noise_adding as na
 def test_noise_adding():
     qubits = devices.LineQubit.range(4)
     circuit = circuits.Circuit(ops.CZ(*qubits[:2]), ops.CZ(*qubits[2:])) * 10
-    transformed_circuit_p0 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, p=0.0)
+    transformed_circuit_p0 = na.DepolerizingNoiseTransformer(0.0)(circuit)
     assert transformed_circuit_p0 == circuit
-    transformed_circuit_p1 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, p=1.0)
+    transformed_circuit_p1 = na.DepolerizingNoiseTransformer(1.0)(circuit)
     assert len(transformed_circuit_p1) == 20
-    transformed_circuit_p0_03 = na.add_depolarizing_noise_to_two_qubit_gates(circuit, p=0.03)
+    transformed_circuit_p0_03 = na.DepolerizingNoiseTransformer(0.03)(circuit)
     assert 10 <= len(transformed_circuit_p0_03) <= 20
-    transformed_circuit_p_dict = na.add_depolarizing_noise_to_two_qubit_gates(
-        circuit, p={tuple(qubits[:2]): 1.0, tuple(qubits[2:]): 0.0}
-    )
+    transformed_circuit_p_dict = na.DepolerizingNoiseTransformer(
+        {tuple(qubits[:2]): 1.0, tuple(qubits[2:]): 0.0}
+    )(circuit)
     assert len(transformed_circuit_p_dict) == 20


### PR DESCRIPTION
Adds a tool for adding depolarizing noise after the specified gate, which can be used on hardware for probabilistic error amplification and zero noise extrapolation.