### PR TITLE
Use absolute URL for Cirq education resources

### DIFF
--- a/docs/start/start.ipynb
+++ b/docs/start/start.ipynb
@@ -114,7 +114,7 @@
     "\n",
     "To learn about running a circuit on a virtual machine that mimics existing quantum hardware, see [Quantum Virtual Machine](../simulate/quantum_virtual_machine.ipynb).\n",
     "\n",
-    "If you would like to learn more about quantum computing, check out our [education page](/education). The Full API reference for Cirq can be found [here](/reference/python/cirq). If you are looking for vendor specific information that can be found on our vendor sub-pages:\n",
+    "If you would like to learn more about quantum computing, check out our [education page](https://quantumai.google/resources). The Full API reference for Cirq can be found [here](/reference/python/cirq). If you are looking for vendor specific information that can be found on our vendor sub-pages:\n",
     "\n",
     "\n",
     "  [Alpine Quantum Technologies](../hardware/aqt/getting_started.ipynb)\n",


### PR DESCRIPTION
Problem: Documentation build converts root-anchored reference /REF
in notebook markdown to https://quantumai.google/cirq/REF
but education page is at https://quantumai.google/resources.

Solution: Use absolute URL to the education page.

Fixes: #6646