### PR TITLE
Fix equality of cphase gates initialized from sympy constants

### DIFF
--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -899,8 +899,6 @@ def test_cphase_unitary(angle_rads, expected_unitary):
     np.testing.assert_allclose(cirq.unitary(cirq.cphase(angle_rads)), expected_unitary)
 
 
-# TODO(#6663): fix this use case.
-@pytest.mark.xfail
 def test_parameterized_cphase():
     assert cirq.cphase(sympy.pi) == cirq.CZ
     assert cirq.cphase(sympy.pi / 2) == cirq.CZ**0.5

--- a/cirq-core/cirq/ops/eigen_gate.py
+++ b/cirq-core/cirq/ops/eigen_gate.py
@@ -309,8 +309,12 @@ class EigenGate(raw_types.Gate):
     def _canonical_exponent(self):
         if self._canonical_exponent_cached is None:
             period = self._period()
-            if not period or protocols.is_parameterized(self._exponent):
+            if not period:
                 self._canonical_exponent_cached = self._exponent
+            elif protocols.is_parameterized(self._exponent):
+                self._canonical_exponent_cached = self._exponent
+                if isinstance(self._exponent, sympy.Expr) and self._exponent.is_constant():
+                    self._canonical_exponent_cached = float(self._exponent)
             else:
                 self._canonical_exponent_cached = self._exponent % period
         return self._canonical_exponent_cached


### PR DESCRIPTION
Problem: In sympy-1.13.0 the expressions `sympy.S.One == 1.0` and
`sympy.S.Half == 0.5` evaluate to False which causes
inequality between `cirq.cphase(sympy.pi)` and `cirq.CZ`.

Solution: Check equality with parametrized exponents converted to float.

Fixes: #6663
