### PR TITLE
Use np.complex128 for simulating xeb circuits

### DIFF
--- a/cirq-core/cirq/experiments/xeb_simulation.py
+++ b/cirq-core/cirq/experiments/xeb_simulation.py
@@ -107,7 +107,7 @@ def simulate_2q_xeb_circuits(
         # Need an actual object; not np.random or else multiprocessing will
         # fail to pickle the closure object:
         # https://github.com/quantumlib/Cirq/issues/3717
-        simulator = sim.Simulator(seed=np.random.RandomState())
+        simulator = sim.Simulator(seed=np.random.RandomState(), dtype=np.complex128)
     _simulate_2q_xeb_circuit = _Simulate_2q_XEB_Circuit(simulator=simulator)
 
     tasks = tuple(

--- a/cirq-core/cirq/experiments/xeb_simulation_test.py
+++ b/cirq-core/cirq/experiments/xeb_simulation_test.py
@@ -76,7 +76,7 @@ def _ref_simulate_2q_xeb_circuit(task: Dict[str, Any]):
     tcircuit = circuit[:circuit_depth]
     tcircuit = cirq.resolve_parameters_once(tcircuit, param_resolver=param_resolver)
 
-    pure_sim = cirq.Simulator()
+    pure_sim = cirq.Simulator(dtype=np.complex128)
     psi = pure_sim.simulate(tcircuit)
     psi_vector = psi.final_state_vector
     pure_probs = cirq.state_vector_to_probabilities(psi_vector)


### PR DESCRIPTION
Fixes a bug where, for deep XEB circuits (depth=300), the simulator complains that the statevector is not normalized.