### PR TITLE
Demonstration of bad hashing

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -61,14 +61,20 @@ def test_grid_qid_pickled_hash():
 def _test_qid_pickled_hash(q: 'cirq.Qid', q_bad: 'cirq.Qid') -> None:
     """Test that hashes are not pickled with Qid instances."""
     assert q_bad is not q
-    _ = hash(q_bad)  # compute hash to ensure it is cached.
+    previous_hash = hash(q_bad)  # compute hash to ensure it is cached.
     q_bad._hash = q_bad._hash + 1  # type: ignore[attr-defined]
     assert q_bad == q
     assert hash(q_bad) != hash(q)
+    # Hash is okay here:
+    assert hash(q) == previous_hash
+
     data = pickle.dumps(q_bad)
     q_ok = pickle.loads(data)
     assert q_ok == q
     assert hash(q_ok) == hash(q)
+
+    # Hash is broken here:
+    assert hash(q) == previous_hash
 
 
 def test_str():


### PR DESCRIPTION
- I still think hashing is broken across pickling.
- I discovered this while creating the Coupler Qid without caching.

This example shows that the test for this is broken, as, when unpickling, the act of unpickling actually corrupts the cache. Both the unpickled Qid and original Qid have the same hash, but it is the BAD HASH!!!!

This can be demonstrated by comparing the hash to the previous hash saved before pickling.

I am not quite sure how to fix it.  Maybe use `__getstate__` and `__setstate__` instead