### PR TITLE
Allow using protobuf version 5 and later

### DIFF
--- a/cirq-google/cirq_google/serialization/arg_func_langs_test.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs_test.py
@@ -38,7 +38,11 @@ from cirq.qis import CliffordTableau
 
 
 def _json_format_kwargs() -> Dict[str, bool]:
-    """Determine kwargs to pass to json_format.MessageToDict."""
+    """Determine kwargs to pass to json_format.MessageToDict.
+
+    Protobuf v5 has a different signature for MessageToDict. If we ever move to requiring
+    protobuf >= 5 this can be removed.
+    """
     sig = inspect.signature(json_format.MessageToDict)
     new_arg = "always_print_fields_with_no_presence"
     old_arg = "including_default_value_fields"

--- a/cirq-google/cirq_google/serialization/arg_func_langs_test.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs_test.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+from typing import Dict
+
 import numpy as np
 import pytest
 import sympy
-
 from google.protobuf import json_format
 
 import cirq_google
@@ -33,6 +35,15 @@ from cirq_google.serialization.arg_func_langs import (
 )
 from cirq_google.api import v2
 from cirq.qis import CliffordTableau
+
+
+def _json_format_kwargs() -> Dict[str, bool]:
+    """Determine kwargs to pass to json_format.MessageToDict."""
+    sig = inspect.signature(json_format.MessageToDict)
+    new_arg = "always_print_fields_with_no_presence"
+    old_arg = "including_default_value_fields"
+    arg = new_arg if new_arg in sig.parameters else old_arg
+    return {arg: True}
 
 
 @pytest.mark.parametrize(
@@ -85,7 +96,7 @@ def test_correspondence(min_lang: str, value: ARG_LIKE, proto: v2.program_pb2.Ar
             parsed = arg_from_proto(msg, arg_function_language=lang)
             packed = json_format.MessageToDict(
                 arg_to_proto(value, arg_function_language=lang),
-                including_default_value_fields=True,
+                **_json_format_kwargs(),
                 preserving_proto_field_name=True,
                 use_integers_for_enums=True,
             )
@@ -109,7 +120,7 @@ def test_serialize_sympy_constants():
     proto = arg_to_proto(sympy.pi, arg_function_language='')
     packed = json_format.MessageToDict(
         proto,
-        including_default_value_fields=True,
+        **_json_format_kwargs(),
         preserving_proto_field_name=True,
         use_integers_for_enums=True,
     )
@@ -153,7 +164,7 @@ def test_serialize_conversion(value: ARG_LIKE, proto: v2.program_pb2.Arg):
     json_format.ParseDict(proto, msg)
     packed = json_format.MessageToDict(
         arg_to_proto(value, arg_function_language=''),
-        including_default_value_fields=True,
+        **_json_format_kwargs(),
         preserving_proto_field_name=True,
         use_integers_for_enums=True,
     )

--- a/cirq-google/requirements.txt
+++ b/cirq-google/requirements.txt
@@ -1,3 +1,3 @@
 google-api-core[grpc] >= 1.14.0
 proto-plus >= 1.20.0
-protobuf >= 3.15.0, < 5.0.0
+protobuf >= 3.15.0

--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -4,6 +4,6 @@ mypy==1.2.0
 # packages with stub types for various libraries
 types-backports==0.1.3
 types-cachetools
-types-protobuf>=3.20.0,<5.0.0
+types-protobuf>=3.20.0
 types-requests==2.28.1
 types-setuptools==62.6.1


### PR DESCRIPTION
Fixes #6651

I've updated `arg_func_lang_test.py` to pass the new or old kwarg to `json_format.MessageToDict` based on inspecting the function signature, so it works with old and new versions of protobuf. This will unblock upgrades that we need to do internally to work with python 3.12.