### PR TITLE
work around ci build failure on windows

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,1 +1,4 @@
 pyquil>=4.11.0,<5.0.0
+
+# TODO(#6684,pavoljuhas) - remove when upstream releases Windows wheels
+qcs-sdk-python<=0.19.0; sys_platform == "win32"


### PR DESCRIPTION
Pin qcs-sdk-python <= 0.19.0 for Windows

Temporary workaround for #6684.