### PR TITLE
Remove `v` in `git remote` command in dev installation

### DIFF
--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -71,7 +71,7 @@ This remote can be used to merge changes from Cirq's main repository into your l
     ```
    
     You can check the branches that are on the ```upstream``` remote by
-    running ```git remote -v``` or ```git branch -r```.
+    running `git ls-remote --heads upstream` or `git branch -r`.
 Most importantly you should see ```upstream/main``` listed.
 1. Merge the upstream main into your local main so that it is up to date.
     

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -71,7 +71,7 @@ This remote can be used to merge changes from Cirq's main repository into your l
     ```
    
     You can check the branches that are on the ```upstream``` remote by
-    running ```git remote -va``` or ```git branch -r```.
+    running ```git remote -v``` or ```git branch -r```.
 Most importantly you should see ```upstream/main``` listed.
 1. Merge the upstream main into your local main so that it is up to date.
     


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/6686