### PR TITLE
Exclude all setup.py files from typecheck

### DIFF
--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = /setup\.py|cirq-rigetti/(?!__init__.)*\.py  # Temporarily exclude cirq-rigetti (see #6661)
+exclude = /setup\.py
 show_error_codes = true
 plugins = duet.typing
 warn_unused_ignores = true

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = dev_tools/modules_test_data/.*/setup\.py|cirq-rigetti/(?!__init__.)*\.py  # Temporarily exclude cirq-rigetti (see #6661)
+exclude = /setup\.py|cirq-rigetti/(?!__init__.)*\.py  # Temporarily exclude cirq-rigetti (see #6661)
 show_error_codes = true
 plugins = duet.typing
 warn_unused_ignores = true


### PR DESCRIPTION
setup.py files define distributions of cirq and cirq subpackages.
There is no much value to enforce type annotations in their code.

Also clean up ineffective exclusion pattern for cirq-rigetti (related to #6661).

Fixes #6687
