### PR TITLE
Eliminate awful slowdown of `EigenGate._value_equality_values_`

### DIFF
--- a/cirq-core/cirq/ops/eigen_gate.py
+++ b/cirq-core/cirq/ops/eigen_gate.py
@@ -313,7 +313,7 @@ class EigenGate(raw_types.Gate):
                 self._canonical_exponent_cached = self._exponent
             elif protocols.is_parameterized(self._exponent):
                 self._canonical_exponent_cached = self._exponent
-                if isinstance(self._exponent, sympy.Expr) and self._exponent.is_constant():
+                if isinstance(self._exponent, sympy.Number):
                     self._canonical_exponent_cached = float(self._exponent)
             else:
                 self._canonical_exponent_cached = self._exponent % period


### PR DESCRIPTION
Problem: The `sympy.Expr.is_constant()` introduced in #6669 is very
slow causing glacial-speed equality checks of parameterized gates.

Solution: Check if expression is sympy.Number instead which still
satisfies the equality fix added in #6669.

Timing of
  check/pytest --numprocesses=0 --randomly-seed=0 \
    cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_sqrt_iswap_test.py
Before: 945 s   After: 18 s,  Before #6669: 18 s.
