### PR TITLE
Update exception in preparation of numpy 2.0.0

### DIFF
--- a/cirq-core/cirq/protocols/apply_unitary_protocol.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol.py
@@ -390,7 +390,7 @@ def apply_unitary(
     # Try each strategy, stopping if one works.
     # Also catch downcasting warnings and throw an error: #2041
     with warnings.catch_warnings():
-        warnings.filterwarnings(action="error", category=np.ComplexWarning)
+        warnings.filterwarnings(action="error", category=np.exceptions.ComplexWarning)
         for strat in strats:
             result = strat(unitary_value, args)
             if result is None:

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -714,7 +714,8 @@ def test_cast_to_complex():
     )
 
     with pytest.raises(
-        np.ComplexWarning, match='Casting complex values to real discards the imaginary part'
+        np.exceptions.ComplexWarning,
+        match='Casting complex values to real discards the imaginary part',
     ):
         cirq.apply_unitary(y0, args)
 


### PR DESCRIPTION
- Per numpy 2.0.0 release docs:

"Warnings and exceptions present in numpy.exceptions (e.g, ComplexWarning, VisibleDeprecationWarning) are no longer exposed in the main namespace."