### PR TITLE
Drop version pin of qcs-sdk-python on Windows

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,4 +1,1 @@
 pyquil>=4.11.0,<5.0.0
-
-# TODO(#6684,pavoljuhas) - remove when upstream releases Windows wheels
-qcs-sdk-python<=0.19.0; sys_platform == "win32"


### PR DESCRIPTION
The last release of qcs-sdk-python 0.19.2 includes binary wheels
for Windows so the CI should pass with the last package version.

This reverts commit c8f799e6e87ecc66a66a488bd101a09312ca2f1a,
"Pin qcs-sdk-python to 0.19.0 for Windows (#6685)".

Fixes #6684
