### PR TITLE
Avoid CI flakes due to random-seed-dependent unit tests

### DIFF
--- a/cirq-core/cirq/linalg/decompositions_test.py
+++ b/cirq-core/cirq/linalg/decompositions_test.py
@@ -741,6 +741,7 @@ def test_kak_decompose(unitary: np.ndarray):
     assert len(list(circuit.all_operations())) == 8
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_num_two_qubit_gates_required():
     for i in range(4):
         assert (

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -108,6 +108,8 @@ from cirq.testing.repr_pretty_tester import (
     FakePrinter,
 )
 
+from cirq.testing.pytest_randomly_utils import retry_once_with_later_random_values
+
 from cirq.testing.routing_devices import (
     construct_grid_device,
     construct_ring_device,

--- a/cirq-core/cirq/testing/__init__.py
+++ b/cirq-core/cirq/testing/__init__.py
@@ -96,6 +96,8 @@ from cirq.testing.op_tree import assert_equivalent_op_tree
 
 from cirq.testing.order_tester import OrderTester
 
+from cirq.testing.pytest_randomly_utils import retry_once_with_later_random_values
+
 from cirq.testing.random_circuit import (
     DEFAULT_GATE_DOMAIN,
     random_circuit,
@@ -107,8 +109,6 @@ from cirq.testing.repr_pretty_tester import (
     assert_repr_pretty_contains,
     FakePrinter,
 )
-
-from cirq.testing.pytest_randomly_utils import retry_once_with_later_random_values
 
 from cirq.testing.routing_devices import (
     construct_grid_device,

--- a/cirq-core/cirq/testing/pytest_randomly_utils.py
+++ b/cirq-core/cirq/testing/pytest_randomly_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Support one retry of tests that fail for a specific seed from pytest-randomly."""
+
+import functools
+import warnings
+from typing import Any, Callable
+
+
+def retry_once_with_later_random_values(testfunc: Callable) -> Callable:
+    """Marks a test function for one retry with later random values.
+
+    This decorator is intended for test functions which occasionally fail
+    for specific random seeds from pytest-randomly.
+    """
+
+    @functools.wraps(testfunc)
+    def wrapped_func(*args, **kwargs) -> Any:
+        try:
+            return testfunc(*args, **kwargs)
+        except AssertionError:
+            pass
+        warnings.warn("Retrying in case we got a failing seed from pytest-randomly.")
+        return testfunc(*args, **kwargs)
+
+    return wrapped_func

--- a/cirq-core/cirq/testing/pytest_randomly_utils_test.py
+++ b/cirq-core/cirq/testing/pytest_randomly_utils_test.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from unittest.mock import Mock
-import cirq
 
 import pytest
+
+import cirq
 
 
 def test_retry_once_with_later_random_values():

--- a/cirq-core/cirq/testing/pytest_randomly_utils_test.py
+++ b/cirq-core/cirq/testing/pytest_randomly_utils_test.py
@@ -1,0 +1,26 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+import cirq
+
+import pytest
+
+
+def test_retry_once_with_later_random_values():
+    testfunc = Mock(side_effect=[AssertionError("first call fails"), None])
+    decoratedfunc = cirq.testing.retry_once_with_later_random_values(testfunc)
+    with pytest.warns(UserWarning, match="Retrying.*failing seed.*pytest-randomly"):
+        decoratedfunc()
+    assert testfunc.call_count == 2

--- a/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py
@@ -87,6 +87,7 @@ def test_decompose_specific_matrices():
             _test_decompose(cirq.unitary(gate), controls_count)
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_decompose_random_unitary():
     for controls_count in range(5):
         for _ in range(10):


### PR DESCRIPTION
Add testing decorator `retry_once_with_later_random_values` to repeat
test once with subsequent random values.

This reduces CI failures for random seed choices by pytest-randomly, e.g.,

```
check/pytest --numprocesses=0 --randomly-seed=1783995880 \
    cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py::test_decompose_random_unitary

check/pytest --numprocesses=0 --randomly-seed=1454822943 \
    cirq-core/cirq/linalg/decompositions_test.py::test_num_two_qubit_gates_required
```
