### PR TITLE
Mark ProjectorSum class as unhashable

### DIFF
--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -870,7 +870,7 @@ def _projector_string_from_projector_dict(projector_dict, coefficient=1.0):
     return ProjectorString(dict(projector_dict), coefficient)
 
 
-@value.value_equality(approximate=True)
+@value.value_equality(approximate=True, unhashable=True)
 class ProjectorSum:
     """List of mappings representing a sum of projector operators."""
 

--- a/cirq-core/cirq/protocols/hash_from_pickle_test.py
+++ b/cirq-core/cirq/protocols/hash_from_pickle_test.py
@@ -46,8 +46,6 @@ _EXCLUDE_JSON_FILES = (
     "cirq/protocols/json_test_data/sympy.pi.json",
     # RigettiQCSAspenDevice does not pickle
     "cirq_rigetti/json_test_data/RigettiQCSAspenDevice.json",
-    # TODO(#6674,pavoljuhas) - fix pickling of ProjectorSum
-    "cirq/protocols/json_test_data/ProjectorSum.json",
 )
 
 


### PR DESCRIPTION
ProjectorSum stores data in a mutable LinearDict which is not hashable.
LinearDict also does not pickle, because by default it has a
lambda-function attribute.

This excludes ProjectorSum from the `test_hash_from_pickle` test.

Resolves #6674
