### PR TITLE
Align Black target versions with supported Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 100
-target_version = ['py39', 'py310', 'py311']
+target_version = ['py310', 'py311', 'py312']
 skip-string-normalization = true
 skip-magic-trailing-comma = true
 


### PR DESCRIPTION
Cirq now supports Python >=3.10 and <=3.12. This PR aligns the target versions of the `black` tool to Cirq supported Python versions.  Unless I am missing something, this is a leftover from https://github.com/quantumlib/Cirq/pull/6591/files.

Tested with `black==24.3.0` from https://github.com/cosenal/Cirq/blob/black-target-versions/dev_tools/requirements/deps/format.txt
 