### PR TITLE
Limit maximum multiprocessing pool size in xeb tests

### DIFF
--- a/cirq-core/cirq/experiments/xeb_fitting_test.py
+++ b/cirq-core/cirq/experiments/xeb_fitting_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import itertools
 import multiprocessing
 from typing import Iterable
@@ -35,6 +36,8 @@ from cirq.experiments.xeb_fitting import (
     phased_fsim_angles_from_gate,
 )
 from cirq.experiments.xeb_sampling import sample_2q_xeb_circuits
+
+_POOL_NUM_PROCESSES = min(4, multiprocessing.cpu_count())
 
 
 @pytest.fixture(scope='module')
@@ -229,7 +232,7 @@ def test_characterize_phased_fsim_parameters_with_xeb():
         characterize_phi=False,
     )
     p_circuits = [parameterize_circuit(circuit, options) for circuit in circuits]
-    with multiprocessing.Pool() as pool:
+    with multiprocessing.Pool(_POOL_NUM_PROCESSES) as pool:
         result = characterize_phased_fsim_parameters_with_xeb(
             sampled_df=sampled_df,
             parameterized_circuits=p_circuits,
@@ -270,7 +273,7 @@ def test_parallel_full_workflow(use_pool):
     )
 
     if use_pool:
-        pool = multiprocessing.Pool()
+        pool = multiprocessing.Pool(_POOL_NUM_PROCESSES)
     else:
         pool = None
 

--- a/cirq-core/cirq/experiments/xeb_simulation_test.py
+++ b/cirq-core/cirq/experiments/xeb_simulation_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import multiprocessing
 from typing import Dict, Any, Optional
 from typing import Sequence
@@ -22,6 +23,8 @@ import pytest
 import cirq
 import cirq.experiments.random_quantum_circuit_generation as rqcg
 from cirq.experiments.xeb_simulation import simulate_2q_xeb_circuits
+
+_POOL_NUM_PROCESSES = min(4, multiprocessing.cpu_count())
 
 
 def test_simulate_2q_xeb_circuits():
@@ -42,7 +45,7 @@ def test_simulate_2q_xeb_circuits():
         assert len(row['pure_probs']) == 4
         assert np.isclose(np.sum(row['pure_probs']), 1)
 
-    with multiprocessing.Pool() as pool:
+    with multiprocessing.Pool(_POOL_NUM_PROCESSES) as pool:
         df2 = simulate_2q_xeb_circuits(circuits, cycle_depths, pool=pool)
 
     pd.testing.assert_frame_equal(df, df2)
@@ -130,7 +133,7 @@ def test_incremental_simulate(multiprocess):
     cycle_depths = np.arange(3, 100, 9, dtype=np.int64)
 
     if multiprocess:
-        pool = multiprocessing.Pool()
+        pool = multiprocessing.Pool(_POOL_NUM_PROCESSES)
     else:
         pool = None
 


### PR DESCRIPTION
Problem: `multiprocessing.Pool()` uses all available cores which can
cause problems on hardware with many cores.

Solution: Limit the maximum pool size to 4.
