### PR TITLE
Fix Rigetti check for Aspen family device kind

### DIFF
--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -66,7 +66,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
         else:
             self.isa = InstructionSetArchitecture.from_raw(json.dumps(isa))
 
-        if self.isa.architecture.family != Family.Aspen:
+        if not Family.is_aspen(self.isa.architecture.family):
             raise UnsupportedRigettiQCSQuantumProcessor(
                 'this integration currently only supports Aspen devices, '
                 f'but client provided a {self.isa.architecture.family} device'

--- a/cirq-rigetti/cirq_rigetti/aspen_device_test.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device_test.py
@@ -253,10 +253,10 @@ def test_rigetti_qcs_aspen_device_repr(qcs_aspen8_isa: InstructionSetArchitectur
 def test_rigetti_qcs_aspen_device_family_validation(qcs_aspen8_isa: InstructionSetArchitecture):
     """test RigettiQCSAspenDevice validates architecture family on initialization"""
     non_aspen_isa = InstructionSetArchitecture.from_raw(qcs_aspen8_isa.json())
-    non_aspen_isa.architecture.family = Family.NONE
+    non_aspen_isa.architecture.family = Family.new_none()
 
-    assert (
-        non_aspen_isa.architecture.family == Family.Aspen
+    assert Family.is_aspen(
+        non_aspen_isa.architecture.family
     ), 'ISA family is read-only and should still be Aspen'
 
 

--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,1 +1,4 @@
 pyquil>=4.11.0,<5.0.0
+
+# TODO - remove once pyquil requires qcs-sdk-python >= 0.20.1
+qcs-sdk-python>=0.20.1


### PR DESCRIPTION
* Sync with new API for checking device family in qcs-sdk-python,
  Ref: https://github.com/rigetti/qcs-sdk-rust/pull/463 in isa.pyi

* Require qcs-sdk-python-0.20.1 which introduced the new family API

Fixes #6732
