### PR TITLE
Silence pytest warnings about asyncio fixture scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,5 @@ markers = [
     "slow: slow tests that should be skipped by default.",
     "weekly: tests to be run only by weekly CI automation.",
 ]
+# Silence deprecation warnings about option "asyncio_default_fixture_loop_scope"
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
In the current version of pytest (8.3.3) with the pytest-asyncio module version 0.24.0, we see the following warnings at the beginning of a pytest run:

```
warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))

..../lib/python3.10/site-packages/pytest_asyncio/plugin.py:208:
PytestDeprecationWarning: The configuration option
"asyncio_default_fixture_loop_scope" is unset. The event loop scope for
asynchronous fixtures will default to the fixture caching scope. Future
versions of pytest-asyncio will default the loop scope for asynchronous
fixtures to function scope. Set the default fixture loop scope explicitly in
order to avoid unexpected behavior in the future. Valid fixture loop scopes
are: "function", "class", "module", "package", "session"
```

A [currently-open issue and discussion over in the pytest-asyncio repo](https://github.com/pytest-dev/pytest-asyncio/issues/924) suggests that this is an undesired side-effect of a recent change in pytest-asyncio and is not actually a significant warning. Moreover, the discussion suggests the warning will be removed or changed in the future.

In the meantime, the warning is confusing because it makes it sound like something is wrong. This simple PR silences the warning by adding a suitable pytest init flag to `pyproject.toml'.