### PR TITLE
Exclude conftest.py files from enforcing changed-code coverage

### DIFF
--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -20,7 +20,7 @@ import re
 from dev_tools import env_tools, shell_tools
 
 IGNORED_FILE_PATTERNS = [
-    r'^(.+/)?conftest\.py$'
+    r'^(.+/)?conftest\.py$',
     r'^dev_tools/.+',  # Environment-heavy code.
     r'^.+_pb2(_grpc)?\.py$',  # Auto-generated protobuf code.
     r'^(.+/)?setup\.py$',  # Installation code.

--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -20,6 +20,7 @@ import re
 from dev_tools import env_tools, shell_tools
 
 IGNORED_FILE_PATTERNS = [
+    r'^(.+/)?conftest\.py$'
     r'^dev_tools/.+',  # Environment-heavy code.
     r'^.+_pb2(_grpc)?\.py$',  # Auto-generated protobuf code.
     r'^(.+/)?setup\.py$',  # Installation code.


### PR DESCRIPTION
Avoid spurious CI failure due to missing coverage of changed conftest.py lines.
conftest.py configures the pytest session.  It is tricky and not worthwhile to
ensure it is test-covered.
