### PR TITLE
CI - add temporary job pytest-numpy-2 to test with NumPy-2 on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,32 @@ jobs:
         run: check/pytest -n auto --durations=20 --ignore=cirq-core/cirq/contrib --rigetti-integration
       - name: Stop Quil dependencies
         run: docker compose -f cirq-rigetti/docker-compose.test.yaml down
+  # TODO(#6706) remove after we start using NumPy 2.0 in regular pytest
+  pytest-numpy-2:
+    name: Pytest Ubuntu with NumPy-2
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v4
+      - name: Set up Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - name: Set up caching of dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+      - name: Install requirements
+        run: |
+          pip install wheel
+          pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev-np2.env.txt
+      - name: Pytest check
+        run: check/pytest -n auto --warn-numpy-data-promotion --durations=20 --ignore=cirq-rigetti
   pip-compile:
     name: Check consistency of requirements
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Note cirq-rigetti is excluded, because it is not yet NumPy-2 compatible.
The test is only run on Ubuntu for the sake of speed and simplicity.

Related to #6706
