### PR TITLE
Fix Quantum Shannon Decomposition

### DIFF
--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -41,7 +41,9 @@ if TYPE_CHECKING:
     from cirq.ops import op_tree
 
 
-def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'op_tree.OpTree':
+def quantum_shannon_decomposition(
+    qubits: 'List[cirq.Qid]', u: np.ndarray, atol: float = 1e-8
+) -> 'op_tree.OpTree':
     """Decomposes n-qubit unitary 1-q, 2-q and GlobalPhase gates, preserving global phase.
 
     The gates used are CX/YPow/ZPow/CNOT/GlobalPhase/CZ/PhasedXZGate/PhasedXPowGate.
@@ -58,6 +60,7 @@ def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'o
     Args:
         qubits: List of qubits in order of significance
         u: Numpy array for unitary matrix representing gate to be decomposed
+        atol: Absolute tolerance of floating point checks.
 
     Calls:
         (Base Case)
@@ -77,7 +80,7 @@ def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'o
         ValueError: If the u matrix is non-unitary
         ValueError: If the u matrix is not of shape (2^n,2^n)
     """
-    if not predicates.is_unitary(u):  # Check that u is unitary
+    if not predicates.is_unitary(u, atol=atol):  # Check that u is unitary
         raise ValueError(
             "Expected input matrix u to be unitary, \
                 but it fails cirq.is_unitary check"
@@ -226,7 +229,7 @@ def _msb_demuxer(
     # Last term is given by ( I ⊗ W ), demultiplexed
     # Remove most-significant (demuxed) control-qubit
     # Yield operations for QSD on W
-    yield from quantum_shannon_decomposition(demux_qubits[1:], W)
+    yield from quantum_shannon_decomposition(demux_qubits[1:], W, atol=1e-6)
 
     # Use complex phase of d_i to give theta_i (so d_i* gives -theta_i)
     # Observe that middle part looks like Σ_i( Rz(theta_i)⊗|i><i| )
@@ -234,7 +237,7 @@ def _msb_demuxer(
     yield from _multiplexed_cossin(demux_qubits, -np.angle(d), ops.rz)
 
     # Yield operations for QSD on V
-    yield from quantum_shannon_decomposition(demux_qubits[1:], V)
+    yield from quantum_shannon_decomposition(demux_qubits[1:], V, atol=1e-6)
 
 
 def _nth_gray(n: int) -> int:

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -161,22 +161,22 @@ def _single_qubit_decomposition(qubit: 'cirq.Qid', u: np.ndarray) -> 'op_tree.Op
     if np.abs(u[0, 0]) < 1e-9:
         global_phase = np.angle(u[1, 0]) + phi_0 / 2 - phi_2 / 2
 
-    if np.abs(phi_2) > 1e-16:
+    if np.abs(phi_2) > 1e-18:
         # Append first two operations operations
         yield ops.rz(phi_0).on(qubit)
         yield ops.ry(phi_1).on(qubit)
 
         # Append third operation with global phase added
         yield ops.ZPowGate(exponent=phi_2 / np.pi, global_shift=global_phase / phi_2 - 0.5)(qubit)
-    elif np.abs(phi_1) > 1e-16:
+    elif np.abs(phi_1) > 1e-18:
         # Just a Z -> Y rotation so we attach the global phase to the Y rotation.
-        if np.abs(phi_0) > 1e-16:
+        if np.abs(phi_0) > 1e-18:
             yield ops.rz(phi_0)(qubit)
         yield ops.YPowGate(exponent=phi_1 / np.pi, global_shift=global_phase / phi_1 - 0.5)(qubit)
-    elif np.abs(phi_0) > 1e-16:
+    elif np.abs(phi_0) > 1e-18:
         # Just an Rz with a potential global phase.
         yield ops.ZPowGate(exponent=phi_0 / np.pi, global_shift=global_phase / phi_0 - 0.5)(qubit)
-    elif np.abs(global_phase) > 1e-16:
+    elif np.abs(global_phase) > 1e-18:
         # Global Phase.
         yield ops.global_phase_operation(np.exp(1j * global_phase))
     else:

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -161,22 +161,22 @@ def _single_qubit_decomposition(qubit: 'cirq.Qid', u: np.ndarray) -> 'op_tree.Op
     if np.abs(u[0, 0]) < 1e-9:
         global_phase = np.angle(u[1, 0]) + phi_0 / 2 - phi_2 / 2
 
-    if np.abs(phi_2) > 1e-18:
+    if np.abs(phi_2) > 1e-16:
         # Append first two operations operations
         yield ops.rz(phi_0).on(qubit)
         yield ops.ry(phi_1).on(qubit)
 
         # Append third operation with global phase added
         yield ops.ZPowGate(exponent=phi_2 / np.pi, global_shift=global_phase / phi_2 - 0.5)(qubit)
-    elif np.abs(phi_1) > 1e-18:
+    elif np.abs(phi_1) > 1e-16:
         # Just a Z -> Y rotation so we attach the global phase to the Y rotation.
-        if np.abs(phi_0) > 1e-18:
+        if np.abs(phi_0) > 1e-16:
             yield ops.rz(phi_0)(qubit)
         yield ops.YPowGate(exponent=phi_1 / np.pi, global_shift=global_phase / phi_1 - 0.5)(qubit)
-    elif np.abs(phi_0) > 1e-18:
+    elif np.abs(phi_0) > 1e-16:
         # Just an Rz with a potential global phase.
         yield ops.ZPowGate(exponent=phi_0 / np.pi, global_shift=global_phase / phi_0 - 0.5)(qubit)
-    elif np.abs(global_phase) > 1e-18:
+    elif np.abs(global_phase) > 1e-16:
         # Global Phase.
         yield ops.global_phase_operation(np.exp(1j * global_phase))
     else:

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -33,9 +33,7 @@ if TYPE_CHECKING:
     from cirq.ops import op_tree
 
 
-def quantum_shannon_decomposition(
-    qubits: 'List[cirq.Qid]', u: np.ndarray, atol: float = 1e-8
-) -> 'op_tree.OpTree':
+def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'op_tree.OpTree':
     """Decomposes n-qubit unitary into CX/YPow/ZPow/CNOT gates, preserving global phase.
 
     The algorithm is described in Shende et al.:
@@ -43,14 +41,13 @@ def quantum_shannon_decomposition(
     https://arxiv.org/abs/quant-ph/0406176
 
     Note: Shannon decomposition is sensitive to the numerical accuracy of doing eigendecomposition.
-        Eigendecomposition is obtained using `np.linalg.eig`. The result of the decomposition may
-        have an absolute error ~5e-4 due to the numerical precision of `np.linalg.eig`.
+        Eigendecomposition is obtained using `np.linalg.eig` and the resulting difference between
+        the input and output unitary is heavily affected by the accuracy of `np.linalg.eig`.
 
 
     Args:
         qubits: List of qubits in order of significance
         u: Numpy array for unitary matrix representing gate to be decomposed
-        atol: absolute tolerance for floating point checks.
 
     Calls:
         (Base Case)
@@ -70,7 +67,7 @@ def quantum_shannon_decomposition(
         ValueError: If the u matrix is non-unitary
         ValueError: If the u matrix is not of shape (2^n,2^n)
     """
-    if not predicates.is_unitary(u, atol=atol):  # Check that u is unitary
+    if not predicates.is_unitary(u):  # Check that u is unitary
         raise ValueError(
             "Expected input matrix u to be unitary, \
                 but it fails cirq.is_unitary check"
@@ -199,7 +196,7 @@ def _msb_demuxer(
     # Yield operations for QSD on W
     # Note: Mathematically `W` is a unitary but it might fail `is_unitary`
     #   check due to numerical precision.
-    yield from quantum_shannon_decomposition(demux_qubits[1:], W, atol=1e-6)
+    yield from quantum_shannon_decomposition(demux_qubits[1:], W)
 
     # Use complex phase of d_i to give theta_i (so d_i* gives -theta_i)
     # Observe that middle part looks like Σ_i( Rz(theta_i)⊗|i><i| )
@@ -209,7 +206,7 @@ def _msb_demuxer(
     # Yield operations for QSD on V
     # Note: Mathematically `V` is a unitary but it might fail `is_unitary`
     #   check due to numerical precision.
-    yield from quantum_shannon_decomposition(demux_qubits[1:], V, atol=1e-6)
+    yield from quantum_shannon_decomposition(demux_qubits[1:], V)
 
 
 def _nth_gray(n: int) -> int:

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -96,7 +96,6 @@ def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'o
         return
 
     if n == 4:
-        global_phase = np.angle(np.linalg.det(u)) / u.shape[0]
         operations = tuple(
             two_qubit_matrix_to_cz_operations(
                 qubits[0], qubits[1], u, allow_partial_czs=True, clean_operations=True

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -194,8 +194,6 @@ def _msb_demuxer(
     # Last term is given by ( I ⊗ W ), demultiplexed
     # Remove most-significant (demuxed) control-qubit
     # Yield operations for QSD on W
-    # Note: Mathematically `W` is a unitary but it might fail `is_unitary`
-    #   check due to numerical precision.
     yield from quantum_shannon_decomposition(demux_qubits[1:], W)
 
     # Use complex phase of d_i to give theta_i (so d_i* gives -theta_i)
@@ -204,8 +202,6 @@ def _msb_demuxer(
     yield from _multiplexed_cossin(demux_qubits, -np.angle(d), ops.rz)
 
     # Yield operations for QSD on V
-    # Note: Mathematically `V` is a unitary but it might fail `is_unitary`
-    #   check due to numerical precision.
     yield from quantum_shannon_decomposition(demux_qubits[1:], V)
 
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -33,16 +33,24 @@ if TYPE_CHECKING:
     from cirq.ops import op_tree
 
 
-def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'op_tree.OpTree':
+def quantum_shannon_decomposition(
+    qubits: 'List[cirq.Qid]', u: np.ndarray, check_unitary: bool = True
+) -> 'op_tree.OpTree':
     """Decomposes n-qubit unitary into CX/YPow/ZPow/CNOT gates, preserving global phase.
 
     The algorithm is described in Shende et al.:
     Synthesis of Quantum Logic Circuits. Tech. rep. 2006,
     https://arxiv.org/abs/quant-ph/0406176
 
+    Note: Shannon decomposition is sensitive to the numerical accuracy of doing eigendecomposition.
+        Eigendecomposition is obtained using `np.linalg.eig`. The result of the decomposition may
+        have an absolute error ~5e-4 due to the numerical precision of `np.linalg.eig`.
+
+
     Args:
         qubits: List of qubits in order of significance
         u: Numpy array for unitary matrix representing gate to be decomposed
+        check_unitary: Whether to check if the input is a unitary.
 
     Calls:
         (Base Case)
@@ -62,7 +70,7 @@ def quantum_shannon_decomposition(qubits: 'List[cirq.Qid]', u: np.ndarray) -> 'o
         ValueError: If the u matrix is non-unitary
         ValueError: If the u matrix is not of shape (2^n,2^n)
     """
-    if not predicates.is_unitary(u):  # Check that u is unitary
+    if check_unitary and not predicates.is_unitary(u):  # Check that u is unitary
         raise ValueError(
             "Expected input matrix u to be unitary, \
                 but it fails cirq.is_unitary check"
@@ -108,17 +116,39 @@ def _single_qubit_decomposition(qubit: 'cirq.Qid', u: np.ndarray) -> 'op_tree.Op
         A single operation from OP TREE of 3 operations (rz,ry,ZPowGate)
     """
     # Perform native ZYZ decomposition
-    phi_0, phi_1, phi_2 = decompositions.deconstruct_single_qubit_matrix_into_angles(u)
+    phi_0, phi_1, phi_2 = np.array(
+        decompositions.deconstruct_single_qubit_matrix_into_angles(u)
+    ) % (2 * np.pi)
 
     # Determine global phase picked up
-    phase = np.angle(u[0, 0] / (np.exp(-1j * (phi_0) / 2) * np.cos(phi_1 / 2)))
+    global_phase = np.angle(u[0, 0]) + phi_0 / 2 + phi_2 / 2
+    if np.abs(u[0, 0]) < 1e-9:
+        global_phase = np.angle(u[1, 0]) + phi_0 / 2 - phi_2 / 2
 
-    # Append first two operations operations
-    yield ops.rz(phi_0).on(qubit)
-    yield ops.ry(phi_1).on(qubit)
+    if np.abs(phi_2) > 1e-18:
+        # Append first two operations operations
+        yield ops.rz(phi_0).on(qubit)
+        yield ops.ry(phi_1).on(qubit)
 
-    # Append third operation with global phase added
-    yield ops.ZPowGate(exponent=phi_2 / np.pi, global_shift=phase / phi_2).on(qubit)
+        # Append third operation with global phase added
+        yield ops.ZPowGate(exponent=phi_2 / np.pi, global_shift=global_phase / phi_2 - 0.5)(qubit)
+    elif np.abs(phi_1) > 1e-18:
+        # Just a Z -> Y rotation so we attach the global phase to the Y rotation.
+        if np.abs(phi_0) > 1e-18:
+            yield ops.rz(phi_0)(qubit)
+        yield ops.YPowGate(exponent=phi_1 / np.pi, global_shift=global_phase / phi_1 - 0.5)(qubit)
+    elif np.abs(phi_0) > 1e-18:
+        # Just an Rz with a potential global phase.
+        yield ops.ZPowGate(exponent=phi_0 / np.pi, global_shift=global_phase / phi_0 - 0.5)(qubit)
+    elif np.abs(global_phase) > 1e-18:
+        # Global Phase.
+        # We represent a global phase with a pair of ZPowGates that are conjugates of each other
+        # so that the overall effect is a global phase.
+        yield ops.ZPowGate(exponent=-0.5, global_shift=-global_phase / np.pi - 0.5)(qubit)
+        yield ops.ZPowGate(exponent=0.5, global_shift=global_phase / np.pi - 0.5)(qubit)
+    else:
+        # Identity.
+        return
 
 
 def _msb_demuxer(
@@ -146,16 +176,29 @@ def _msb_demuxer(
     Yields: Single operation from OP TREE of 2-qubit and 1-qubit operations
     """
     # Perform a diagonalization to find values
+    u1 = u1.astype(np.complex128)
+    u2 = u2.astype(np.complex128)
     u = u1 @ u2.T.conjugate()
-    dsquared, V = np.linalg.eig(u)
+    if predicates.is_hermitian(u):
+        # If `u` is hermitian, use the more accurate `eigh` method.
+        dsquared, V = np.linalg.eigh(u)
+    else:
+        dsquared, V = np.linalg.eig(u)
+        # Use Gram–Schmidt to optain orthonormal eigenvectors for each of the subspaces.
+        for i in range(V.shape[0]):
+            for j in range(i):
+                if np.abs(dsquared[i] - dsquared[j]) < 1e-9:
+                    V[:, i] -= np.dot(V[:, j].conj(), V[:, i]) * V[:, j]
+    dsquared = dsquared.astype(np.complex128)
     d = np.sqrt(dsquared)
     D = np.diag(d)
     W = D @ V.T.conjugate() @ u2
-
     # Last term is given by ( I ⊗ W ), demultiplexed
     # Remove most-significant (demuxed) control-qubit
     # Yield operations for QSD on W
-    yield from quantum_shannon_decomposition(demux_qubits[1:], W)
+    # Note: Mathematically `W` is a unitary but it might fail `is_unitary`
+    #   check due to numerical precision.
+    yield from quantum_shannon_decomposition(demux_qubits[1:], W, check_unitary=False)
 
     # Use complex phase of d_i to give theta_i (so d_i* gives -theta_i)
     # Observe that middle part looks like Σ_i( Rz(theta_i)⊗|i><i| )
@@ -163,7 +206,9 @@ def _msb_demuxer(
     yield from _multiplexed_cossin(demux_qubits, -np.angle(d), ops.rz)
 
     # Yield operations for QSD on V
-    yield from quantum_shannon_decomposition(demux_qubits[1:], V)
+    # Note: Mathematically `V` is a unitary but it might fail `is_unitary`
+    #   check due to numerical precision.
+    yield from quantum_shannon_decomposition(demux_qubits[1:], V, check_unitary=False)
 
 
 def _nth_gray(n: int) -> int:
@@ -223,8 +268,9 @@ def _multiplexed_cossin(
         #   so introduce max function
         select_qubit = max(-select_qubit - 1, -len(control_qubits))
 
-        # Add a rotation on the main qubit
-        yield rot_func(rotation).on(main_qubit)
+        if np.abs(rotation) > 1e-9:
+            # Add a rotation on the main qubit
+            yield rot_func(rotation).on(main_qubit)
 
         # Add a CNOT from the select qubit to the main qubit
         yield ops.CNOT(control_qubits[select_qubit], main_qubit)

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -101,7 +101,7 @@ def quantum_shannon_decomposition(
     if n == 4:
         operations = tuple(
             two_qubit_matrix_to_cz_operations(
-                qubits[0], qubits[1], u, allow_partial_czs=True, clean_operations=True
+                qubits[0], qubits[1], u, allow_partial_czs=True, clean_operations=True, atol=atol
             )
         )
         yield from operations
@@ -113,7 +113,9 @@ def quantum_shannon_decomposition(
         return
 
     if n == 8:
-        operations = tuple(three_qubit_matrix_to_operations(qubits[0], qubits[1], qubits[2], u))
+        operations = tuple(
+            three_qubit_matrix_to_operations(qubits[0], qubits[1], qubits[2], u, atol=atol)
+        )
         yield from operations
         i, j = np.unravel_index(np.argmax(np.abs(u)), u.shape)
         new_unitary = unitary_protocol.unitary(FrozenCircuit.from_moments(*operations))

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -184,7 +184,7 @@ def _msb_demuxer(
         dsquared, V = np.linalg.eigh(u)
     else:
         dsquared, V = np.linalg.eig(u)
-        # Use Gram–Schmidt to optain orthonormal eigenvectors for each of the subspaces.
+        # Use Gram–Schmidt to obtain orthonormal eigenvectors for each of the subspaces.
         for i in range(V.shape[0]):
             for j in range(i):
                 if np.abs(dsquared[i] - dsquared[j]) < 1e-9:

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
@@ -130,7 +130,7 @@ def test_qft_decomposes():
     qft_unitary = cirq.unitary(qft_circuit)
     decomposed_circuit = cirq.Circuit(quantum_shannon_decomposition(qs, qft_unitary))
     new_unitary = cirq.unitary(decomposed_circuit)
-    np.testing.assert_allclose(new_unitary, qft_unitary, atol=5e-4)
+    np.testing.assert_allclose(new_unitary, qft_unitary, atol=1e-6)
 
 
 # Cliffords test the different corner cases of the ZYZ decomposition.

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
@@ -151,17 +151,17 @@ def test_cliffords(gate, num_ops):
         np.testing.assert_allclose(new_unitary, desired_unitary)
 
 
-@pytest.mark.parametrize('global_phase', np.exp(1j * np.linspace(0.1, 2 * np.pi, 10)))
 @pytest.mark.parametrize('gate', [cirq.X, cirq.Y, cirq.Z, cirq.H, cirq.S])
-def test_cliffords_with_global_phase(gate, global_phase):
+def test_cliffords_with_global_phase(gate):
+    global_phase = np.exp(1j * np.random.choice(np.linspace(0.1, 2 * np.pi, 10)))
     desired_unitary = cirq.unitary(gate) * global_phase
     shannon_circuit = cirq.Circuit(quantum_shannon_decomposition((cirq.q(0),), desired_unitary))
     new_unitary = cirq.unitary(shannon_circuit)
     np.testing.assert_allclose(new_unitary, desired_unitary)
 
 
-@pytest.mark.parametrize('global_phase', np.exp(1j * np.linspace(0.1, 2 * np.pi, 10)))
-def test_global_phase(global_phase):
+def test_global_phase():
+    global_phase = np.exp(1j * np.random.choice(np.linspace(0, 2 * np.pi, 10)))
     shannon_circuit = cirq.Circuit(
         quantum_shannon_decomposition((cirq.q(0),), np.eye(2) * global_phase)
     )
@@ -170,8 +170,8 @@ def test_global_phase(global_phase):
 
 
 @pytest.mark.parametrize('gate', [cirq.CZ, cirq.CNOT, cirq.XX, cirq.YY, cirq.ZZ])
-@pytest.mark.parametrize('global_phase', np.exp(1j * np.linspace(0, 2 * np.pi, 10)))
 def test_two_qubit_gate(gate, global_phase):
+    global_phase = np.exp(1j * np.random.choice(np.linspace(0, 2 * np.pi, 10)))
     desired_unitary = cirq.unitary(gate) * global_phase
     shannon_circuit = cirq.Circuit(
         quantum_shannon_decomposition(cirq.LineQubit.range(2), desired_unitary)
@@ -181,8 +181,8 @@ def test_two_qubit_gate(gate, global_phase):
 
 
 @pytest.mark.parametrize('gate', [cirq.CCNOT, cirq.qft(*cirq.LineQubit.range(3))])
-@pytest.mark.parametrize('global_phase', np.exp(1j * np.linspace(0, 2 * np.pi, 10)))
 def test_three_qubit_gate(gate, global_phase):
+    global_phase = np.exp(1j * np.random.choice(np.linspace(0, 2 * np.pi, 10)))
     desired_unitary = cirq.unitary(gate) * global_phase
     shannon_circuit = cirq.Circuit(
         quantum_shannon_decomposition(cirq.LineQubit.range(3), desired_unitary)
@@ -191,8 +191,8 @@ def test_three_qubit_gate(gate, global_phase):
     np.testing.assert_allclose(new_unitary, desired_unitary, atol=1e-6)
 
 
-@pytest.mark.parametrize('global_phase', np.exp(1j * np.linspace(0, 2 * np.pi, 4)))
-def test_qft5(global_phase):
+def test_qft5():
+    global_phase = np.exp(1j * np.random.choice(np.linspace(0, 2 * np.pi, 10)))
     desired_unitary = cirq.unitary(cirq.qft(*cirq.LineQubit.range(5))) * global_phase
     shannon_circuit = cirq.Circuit(
         quantum_shannon_decomposition(cirq.LineQubit.range(5), desired_unitary)

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
@@ -170,7 +170,7 @@ def test_global_phase():
 
 
 @pytest.mark.parametrize('gate', [cirq.CZ, cirq.CNOT, cirq.XX, cirq.YY, cirq.ZZ])
-def test_two_qubit_gate(gate, global_phase):
+def test_two_qubit_gate(gate):
     global_phase = np.exp(1j * np.random.choice(np.linspace(0, 2 * np.pi, 10)))
     desired_unitary = cirq.unitary(gate) * global_phase
     shannon_circuit = cirq.Circuit(
@@ -181,7 +181,7 @@ def test_two_qubit_gate(gate, global_phase):
 
 
 @pytest.mark.parametrize('gate', [cirq.CCNOT, cirq.qft(*cirq.LineQubit.range(3))])
-def test_three_qubit_gate(gate, global_phase):
+def test_three_qubit_gate(gate):
     global_phase = np.exp(1j * np.random.choice(np.linspace(0, 2 * np.pi, 10)))
     desired_unitary = cirq.unitary(gate) * global_phase
     shannon_circuit = cirq.Circuit(


### PR DESCRIPTION
This PR:
- fixes how `_single_qubit_decomposition` handles global phase and reduces the number of operations it returns when possible.
- Makes the eigendecomposition  part resilient to numerical precision issues by:
    1. resorting to the more accurate`eigh` instead of `eig` when the unitary is hermitian.
    2. if the unitary is not hermitian then use Gram–Schmidt to make sure the eigenvectors are orthonormal (mathematically they should but we could get non orthognoal vectors either because of numerical precision or because an eigenvector is repeated and as a result the the eigenvector spanning that subspace are arbitary) 
- Reduce the number of operations by removing operations equaivalent to identity (e.g. rz($\phi$) with $\phi \approx 0$)
- Adds tests for the reported failures making sure they are fixed.
- Adds tests for the corner cases of the decomposition.

---
update: also add `two_qubit_matrix_to_cz_operations` and `three_qubit_matrix_to_operations` as base cases to reduce the depth of the circuit.

---

fixes #6666 
fixes #6725 

---

@ikd-sci let me know if this works for you.

---

@ACE07-Sev sorry I had to dive into this task because we had an urgent need for the decomposition. Does this PR fix the issues you found? also Does this fix the depth issue you found https://github.com/quantumlib/Cirq/issues/6666#issuecomment-2363137835?