### PR TITLE
decrease polling rate for `QuantumJob`

### DIFF
--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -304,7 +304,7 @@ class EngineJob(abstract_job.AbstractJob):
                 job = await self._refresh_job_async()
                 if job.execution_status.state in TERMINAL_STATES:
                     break
-                await duet.sleep(0.5)
+                await duet.sleep(1)
         _raise_on_failure(job)
         response = await self.context.client.get_job_results_async(
             self.project_id, self.program_id, self.job_id


### PR DESCRIPTION
For simple circuits RT time from our hardware is:
```
1. Engine without stream: 3.3s
2. Engine with streaming: 1.14s
```
Increasing our polling rate to 1s enables sending 2x simultaneous jobs without explicitly increasing our quota, with minimal increase to RT latency (250ms)

Fixes: b/372751875 