### PR TITLE
Update pyquil dependency and remove workaround pinning of quil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,8 @@ RUN rm -f /usr/bin/python \
      && ln -s /usr/bin/python3 /usr/bin/python
 #cirq stable image
 FROM cirq_base AS cirq_stable
-# TODO: #6754 - adjust or remove the quil pin
-RUN pip3 install cirq "quil<0.13.0"
+RUN pip3 install cirq
 
 ##cirq pre_release image
 FROM cirq_base AS cirq_pre_release
-# TODO: #6754 - adjust or remove the quil pin
-RUN pip3 install cirq~=1.0.dev "quil<0.13.0"
+RUN pip3 install cirq~=1.0.dev

--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,4 +1,1 @@
-pyquil>=4.11.0,<5.0.0
-
-# TODO - remove once pyquil requires qcs-sdk-python >= 0.20.1
-qcs-sdk-python>=0.20.1
+pyquil>=4.14.3,<5.0.0

--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,7 +1,4 @@
 pyquil>=4.11.0,<5.0.0
 
-# TODO: #6754 - adjust or remove if binary wheels are provided again
-quil<0.13.0
-
 # TODO - remove once pyquil requires qcs-sdk-python >= 0.20.1
 qcs-sdk-python>=0.20.1


### PR DESCRIPTION
* Unpin the quil package
  The latest release quil-0.13.1 includes binary wheels.
  Wheels were omitted unintentionally before due to a CI error at 
  the quil project.

* Update to pyquil>=4.14.3 as it requires good qcs-sdk-python,
  and remove now unnecessary version spec of qcs-sdk-python.

Fixes: #6754
