### PR TITLE
add request limiter when polling for results

### DIFF
--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -15,7 +15,18 @@
 
 import collections
 from itertools import islice
-from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 
 import duet
 import pandas as pd
@@ -36,6 +47,9 @@ if TYPE_CHECKING:
 class Sampler(metaclass=value.ABCMetaImplementAnyOneOf):
     """Something capable of sampling quantum circuits. Simulator or hardware."""
 
+    # Users have a rate limit of 1000 QPM for read/write requests to
+    # the Quantum Engine. 1000/60 ~= 16 QPS. So requests are sent
+    # in chunks of size 16 per second.
     CHUNK_SIZE: int = 16
 
     def run(
@@ -472,6 +486,6 @@ class Sampler(metaclass=value.ABCMetaImplementAnyOneOf):
         return {k: (num_instances[k], qid_shape) for k, qid_shape in qid_shapes.items()}
 
 
-def _chunked(iterable, n):  # pragma: no cover
+def _chunked(iterable: Sequence[Any], n: int) -> Iterator[tuple[Any, ...]]:  # pragma: no cover
     it = iter(iterable)  # pragma: no cover
     return iter(lambda: tuple(islice(it, n)), ())  # pragma: no cover

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -24,6 +24,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     TYPE_CHECKING,
     Union,
 )
@@ -42,6 +43,8 @@ from cirq.work.observable_settings import _hashable_param
 
 if TYPE_CHECKING:
     import cirq
+
+T = TypeVar('T')
 
 
 class Sampler(metaclass=value.ABCMetaImplementAnyOneOf):
@@ -486,6 +489,6 @@ class Sampler(metaclass=value.ABCMetaImplementAnyOneOf):
         return {k: (num_instances[k], qid_shape) for k, qid_shape in qid_shapes.items()}
 
 
-def _chunked(iterable: Sequence[Any], n: int) -> Iterator[tuple[Any, ...]]:  # pragma: no cover
-    it = iter(iterable)  # pragma: no cover
-    return iter(lambda: tuple(islice(it, n)), ())  # pragma: no cover
+def _chunked(iterable: Sequence[T], n: int) -> Iterator[tuple[T, ...]]:
+    it = iter(iterable)
+    return iter(lambda: tuple(islice(it, n)), ())

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -16,7 +16,6 @@
 import collections
 from itertools import islice
 from typing import (
-    Any,
     Dict,
     FrozenSet,
     Iterator,

--- a/cirq-core/cirq/work/sampler_test.py
+++ b/cirq-core/cirq/work/sampler_test.py
@@ -269,6 +269,7 @@ def test_sampler_run_batch_bad_input_lengths():
 
 @mock.patch('duet.pstarmap_async')
 @pytest.mark.parametrize('call_count', [1, 2, 3])
+@duet.sync
 async def test_run_batch_async_sends_circuits_in_chunks(spy, call_count):
     class AsyncSampler(cirq.Sampler):
         CHUNK_SIZE = 3
@@ -289,6 +290,7 @@ async def test_run_batch_async_sends_circuits_in_chunks(spy, call_count):
 
 
 @pytest.mark.parametrize('call_count', [1, 2, 3])
+@duet.sync
 async def test_run_batch_async_runs_runs_sequentially(call_count):
     a = cirq.LineQubit(0)
     finished = []

--- a/cirq-core/cirq/work/sampler_test.py
+++ b/cirq-core/cirq/work/sampler_test.py
@@ -267,7 +267,6 @@ def test_sampler_run_batch_bad_input_lengths():
         )
 
 
-@duet.sync
 @mock.patch('duet.pstarmap_async')
 @pytest.mark.parametrize('call_count', [1, 2, 3])
 async def test_run_batch_async_sends_circuits_in_chunks(spy, call_count):
@@ -289,7 +288,6 @@ async def test_run_batch_async_sends_circuits_in_chunks(spy, call_count):
     assert spy.call_count == call_count
 
 
-@duet.sync
 @pytest.mark.parametrize('call_count', [1, 2, 3])
 async def test_run_batch_async_runs_runs_sequentially(call_count):
     a = cirq.LineQubit(0)


### PR DESCRIPTION
Related to b/372751875

Throttle in-flight requests which otherwise would cause a `Quota exceeded exception`

Where as before sending `50 circuits` to `sampler.run_batch` would cause an exception, now it completes in `~31s`, `100 jobs in ~61s`, and `500 jobs in ~276s` for longer circuits.