### PR TITLE
fix Moment.resolve_parameter not resolving all the expressions 

### DIFF
--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -275,7 +275,7 @@ class Moment:
         resolved_ops: List['cirq.Operation'] = []
         for op in self:
             resolved_op = protocols.resolve_parameters(op, resolver, recursive)
-            if resolved_op != op:
+            if resolved_op is not op:
                 changed = True
             resolved_ops.append(resolved_op)
         if not changed:


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/6778
Fix Moment._resolve_parameters_ to properly resolve symbolic expressions


- Changed equality check from '!=' to 'is not' to handle cases where symbolic parameters  are equivalent but not identical objects

- Ensured that the method returns a new object only when a variable is resolved, maintaining efficient behavior.
- Tested the fix with existing cases for Rx, Ry, and Rz gates to confirm correct behavior when parameters are resolved or remain unchanged.