### PR TITLE
Force decimals in scientific notation for OpenQASM 2.0

### DIFF
--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -57,14 +57,9 @@ class QasmArgs(string.Formatter):
 
     def _format_number(self, value) -> str:
         """OpenQASM 2.0 does not support '1e-5' and wants '1.0e-5'"""
-        return (
-            f'{value}'
-            if self.version != '2.0'
-            or isinstance(value, int)
-            or abs(value) > 1e-5
-            or self.precision <= 5
-            else f'{value:.{self.precision-5}E}'
-        )
+        s = f'{value}'
+        if 'e' in s and not '.' in s:
+            s = s.replace('e', '.0e')
 
     def format_field(self, value: Any, spec: str) -> str:
         """Method of string.Formatter that specifies the output of format()."""

--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -61,7 +61,7 @@ class QasmArgs(string.Formatter):
             f'{value}'
             if self.version != '2.0'
             or isinstance(value, int)
-            or value > 1e-5
+            or abs(value) > 1e-5
             or self.precision <= 5
             else f'{value:.{self.precision-5}E}'
         )

--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -59,7 +59,8 @@ class QasmArgs(string.Formatter):
         """OpenQASM 2.0 does not support '1e-5' and wants '1.0e-5'"""
         s = f'{value}'
         if 'e' in s and not '.' in s:
-            s = s.replace('e', '.0e')
+            return s.replace('e', '.0e')
+        return s
 
     def format_field(self, value: Any, spec: str) -> str:
         """Method of string.Formatter that specifies the output of format()."""

--- a/cirq-core/cirq/protocols/qasm_test.py
+++ b/cirq-core/cirq/protocols/qasm_test.py
@@ -58,9 +58,9 @@ def test_qasm_args_formatting():
     args = cirq.QasmArgs()
     assert args.format_field(0.01, '') == '0.01'
     assert args.format_field(0.01, 'half_turns') == 'pi*0.01'
-    assert args.format_field(0.00001, '') == '1.00000E-05'
-    assert args.format_field(0.00001, 'half_turns') == 'pi*1.00000E-05'
-    assert args.format_field(1e-10, 'half_turns') == 'pi*1.00000E-10'
+    assert args.format_field(0.00001, '') == '1.0e-05'
+    assert args.format_field(0.00001, 'half_turns') == 'pi*1.0e-05'
+    assert args.format_field(1e-10, 'half_turns') == 'pi*1.0e-10'
     args = cirq.QasmArgs(precision=6)
     assert args.format_field(0.00001234, '') == '1.2e-05'
     assert args.format_field(0.00001234, 'half_turns') == 'pi*1.2e-05'

--- a/cirq-core/cirq/protocols/qasm_test.py
+++ b/cirq-core/cirq/protocols/qasm_test.py
@@ -52,3 +52,15 @@ def test_qasm():
 
     assert cirq.qasm(ExpectsArgs(), args=cirq.QasmArgs()) == 'text'
     assert cirq.qasm(ExpectsArgsQubits(), args=cirq.QasmArgs(), qubits=()) == 'text'
+
+
+def test_qasm_args_formatting():
+    args = cirq.QasmArgs()
+    assert args.format_field(0.01, '') == '0.01'
+    assert args.format_field(0.01, 'half_turns') == 'pi*0.01'
+    assert args.format_field(0.00001, '') == '1.00000E-05'
+    assert args.format_field(0.00001, 'half_turns') == 'pi*1.00000E-05'
+    assert args.format_field(1e-10, 'half_turns') == 'pi*1.00000E-10'
+    args = cirq.QasmArgs(precision=6)
+    assert args.format_field(0.00001234, '') == '1.2e-05'
+    assert args.format_field(0.00001234, 'half_turns') == 'pi*1.2e-05'


### PR DESCRIPTION
- OpenQASM 2.0 grammar requires decimal points in scientific notation.  For instance, 1e-10 is not allowed according to a strict interpretation of the grammar.
- This PR forces the formatter to use a decimal when printing out scientific notation.

Fixes: #6550