### PR TITLE
Allow measurement keys with differing qubits in OpenQASM

### DIFF
--- a/cirq-core/cirq/circuits/qasm_output.py
+++ b/cirq-core/cirq/circuits/qasm_output.py
@@ -294,13 +294,12 @@ class QasmOutput:
         for meas in self.measurements:
             key = protocols.measurement_key_name(meas)
             meas_id = self.args.meas_key_id_map[key]
-            
+
             if self.meas_comments[key] is not None:
                 comment = f'  // Measurement: {self.meas_comments[key]}'
             else:
                 comment = ''
-                
-            comment = self.meas_comments[key]
+
             if meas_id not in cregs or cregs[meas_id][0] < len(meas.qubits):
                 cregs[meas_id] = (len(meas.qubits), comment)
         for meas_id in cregs:

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -615,7 +615,8 @@ measure q[0] -> m_c[0];
 
 // Gate: cirq.MeasurementGate(2, cirq.MeasurementKey(name='c'), ())
 measure q[0] -> m_c[0];
-measure q[1] -> m_c[1];"""
+measure q[1] -> m_c[1];
+"""
     )
     # OPENQASM 3.0
     output3 = cirq.QasmOutput(

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -599,7 +599,7 @@ def test_different_sized_registers():
         c.all_operations(), tuple(sorted(c.all_qubits())), header='Generated from Cirq!'
     )
     assert (
-        str(output).strip()
+        str(output)
         == """// Generated from Cirq!
 
 OPENQASM 2.0;

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -617,3 +617,30 @@ measure q[0] -> m_c[0];
 measure q[0] -> m_c[0];
 measure q[1] -> m_c[1];"""
     )
+    # OPENQASM 3.0
+    output3 = cirq.QasmOutput(
+        c.all_operations(),
+        tuple(sorted(c.all_qubits())),
+        header='Generated from Cirq!',
+        version='3.0',
+    )
+    assert (
+        str(output3)
+        == """// Generated from Cirq!
+
+OPENQASM 3.0;
+include "stdgates.inc";
+
+
+// Qubits: [q(0), q(1)]
+qubit[2] q;
+bit[2] m_c;
+
+
+m_c[0] = measure q[0];
+
+// Gate: cirq.MeasurementGate(2, cirq.MeasurementKey(name='c'), ())
+m_c[0] = measure q[0];
+m_c[1] = measure q[1];
+"""
+    )

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -590,3 +590,30 @@ reset q[0];
 reset q[1];
     """.strip()
     )
+
+
+def test_different_sized_registers():
+    qubits = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.measure(qubits[0], key='c'), cirq.measure(qubits, key='c'))
+    output = cirq.QasmOutput(
+        c.all_operations(), tuple(sorted(c.all_qubits())), header='Generated from Cirq!'
+    )
+    assert (
+        str(output).strip()
+        == """// Generated from Cirq!
+
+OPENQASM 2.0;
+include "qelib1.inc";
+
+
+// Qubits: [q(0), q(1)]
+qreg q[2];
+creg m_c[2];
+
+
+measure q[0] -> m_c[0];
+
+// Gate: cirq.MeasurementGate(2, cirq.MeasurementKey(name='c'), ())
+measure q[0] -> m_c[0];
+measure q[1] -> m_c[1];"""
+    )


### PR DESCRIPTION
- Previously, if there was a measurement with the same key but two differently sized registers, then the qasm output might select the wrong key and size the register incorrectly.
- This PR examines all the measurements first, and selects the biggest one, so to correctly size the classical register.
- Adds unit test t demonstrate.

Fixes: #6508