### PR TITLE
Update docs to use quantumai-oss-maintainers@googlegroups.com

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ representative at an online or offline event. Representation of a project may be
 further defined and clarified by project maintainers.
 
 This Code of Conduct also applies outside the project spaces when the Project
-Steward has a reasonable belief that an individual's behavior may have a
+Stewards have a reasonable belief that an individual's behavior may have a
 negative impact on the project or its community.
 
 ## Conflict Resolution
@@ -69,12 +69,11 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to balintp@google.com, the Project Steward for 
-Cirq. It is the Project Steward’s duty to receive and address reported 
-violations of the Code of Conduct. They will then work with a committee 
-consisting of representatives from the Open Source Programs Office and the 
-Google Open Source Strategy team. If for any reason you are uncomfortable 
-reaching out to the Project Steward, please email opensource@google.com.
+Reports should be directed to [quantumai-oss-maintainers@googlegroups.com](mailto:quantumai-oss-maintainers@googlegroups.com),
+the project stewards at Google Quantum AI. They will then work with a committee
+consisting of representatives from the Open Source Programs Office and the
+Google Open Source Strategy team. If for any reason you are uncomfortable
+reaching out to the Project Stewards, please email [opensource@google.com](opensource@google.com).
 
 We will investigate every complaint, but you may not receive a direct response.
 We will use our discretion in determining when and how to follow up on reported

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,6 @@ Please read our `code of conduct <https://github.com/quantumlib/cirq/blob/main/C
 **Cirq Cynque** is our weekly meeting for contributors to discuss upcoming features, designs, issues, community and status of different efforts.
 To get an invitation please join the `cirq-dev email list <https://groups.google.com/forum/#!forum/cirq-dev>`__ which also serves as yet another platform to discuss contributions and design ideas.
 
-
 See Also
 --------
 
@@ -117,5 +116,11 @@ For machine learning enthusiasts, `Tensorflow Quantum <https://github.com/tensor
 For a powerful quantum circuit simulator that integrates well with Cirq, we recommend looking at `qsim <https://github.com/quantumlib/qsim>`__.
 
 Finally, `ReCirq <https://github.com/quantumlib/ReCirq>`__ contains real world experiments using Cirq.
+
+Contact
+-------
+
+For any questions or concerns not addressed here, please feel free to reach out to
+`quantumai-oss-maintainers@googlegroups.com <mailto:quantumai-oss-maintainers@googlegroups.com>`__
 
 Cirq is not an official Google product. Copyright 2019 The Cirq Developers


### PR DESCRIPTION
The Code of Conduct still referred people to Bálint, so that needed to be changed. Also, it seems like a good idea to mention the maintainers' address in the top-level README file.