### PR TITLE
Adjust labels added to PRs by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary: Dependabot config file, to adjust things for the Cirq project.
 #
-# By default, Dependabot raises all pull requests with the dependencies label.
+# By default, Dependabot labels all pull requests with label 'dependencies'.
 # We prefer `area/dependencies`, so have to configure Dependabot appropriately.
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary: Dependabot config file, to adjust things for the Cirq project.
+#
+# By default, Dependabot raises all pull requests with the dependencies label.
+# We prefer `area/dependencies`, so have to configure Dependabot appropriately.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Dependabot for Cirq
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
+      - "area/docker"
+      - "kind/health"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
+      - "area/github"
+      - "kind/health"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
+      - "area/javascript"
+      - "kind/health"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
+      - "area/python"
+      - "kind/health"


### PR DESCRIPTION
The default label added by Dependabot is `dependencies`, which doesn't align with our use of `area/dependencies`. This config file makes it use `area/dependencies` instead, plus adds some other labels that make sense to add at the same time:

* Docker items:
      - `area/dependencies`
      - `area/docker`
      - `kind/health`
* GitHub Actions items:
      - `area/dependencies`
      - `area/github`
      - `kind/health`
* Python items:
      - `area/dependencies`
      - `area/python`
      - `kind/health`
* JavaScript items:
      - `area/dependencies`
      - `area/javascript`
      - `kind/health`
