### PR TITLE
make DensityMatrixSimulator more numerically stable

### DIFF
--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -161,7 +161,6 @@ def measure_density_matrix(
 
     # Calculate the measurement probabilities and then make the measurement.
     probs = _probs(density_matrix, indices, qid_shape)
-    probs = np.clip(probs, 0, 1)
     result = prng.choice(len(probs), p=probs)
     measurement_bits = value.big_endian_int_to_digits(result, base=meas_shape)
 

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -161,6 +161,7 @@ def measure_density_matrix(
 
     # Calculate the measurement probabilities and then make the measurement.
     probs = _probs(density_matrix, indices, qid_shape)
+    probs = np.clip(probs, 0, 1)
     result = prng.choice(len(probs), p=probs)
     measurement_bits = value.big_endian_int_to_digits(result, base=meas_shape)
 

--- a/cirq-core/cirq/sim/simulation_utils.py
+++ b/cirq-core/cirq/sim/simulation_utils.py
@@ -56,6 +56,6 @@ def state_probabilities_by_indices(
         probs = np.sum(probs, axis=-1)
 
     # To deal with rounding issues, ensure that the probabilities sum to 1.
-    probs.clip(0, None, out=probs)
+    probs = np.clip(probs, 0, None)
     probs /= probs.sum()
     return probs

--- a/cirq-core/cirq/sim/simulation_utils.py
+++ b/cirq-core/cirq/sim/simulation_utils.py
@@ -56,4 +56,6 @@ def state_probabilities_by_indices(
         probs = np.sum(probs, axis=-1)
 
     # To deal with rounding issues, ensure that the probabilities sum to 1.
-    return np.clip(probs / np.sum(probs), 0, 1)
+    probs.clip(0, None, out=probs)
+    probs /= probs.sum()
+    return probs

--- a/cirq-core/cirq/sim/simulation_utils.py
+++ b/cirq-core/cirq/sim/simulation_utils.py
@@ -56,4 +56,4 @@ def state_probabilities_by_indices(
         probs = np.sum(probs, axis=-1)
 
     # To deal with rounding issues, ensure that the probabilities sum to 1.
-    return probs / np.sum(probs)
+    return np.clip(probs / np.sum(probs), 0, 1)


### PR DESCRIPTION
due to numerical instabilities the probabilities might be slightly outside the range $[0, 1]$ ... this issue is annoying and shows up with medium to large circuits even with `dtype=np.complex128`

fixes: https://github.com/quantumlib/Cirq/issues/6719