### PR TITLE
Support run_sweep in GaugeTransformer. Pioneered in the CZ Gauge.

### DIFF
--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
@@ -14,8 +14,6 @@
 
 """A Gauge Transformer for the CZ gate."""
 
-from typing import Dict, List
-
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     GaugeTransformer,
     GaugeSelector,
@@ -24,31 +22,136 @@ from cirq.transformers.gauge_compiling.gauge_compiling import (
 from cirq.ops.common_gates import CZ
 from cirq import ops
 
-_gauge_parameters: List[Dict[str, ops.Gate]] = [
-    {"pre_q0": ops.I, "pre_q1": ops.I, "post_q0": ops.I, "post_q1": ops.I},
-    {"pre_q0": ops.I, "pre_q1": ops.X, "post_q0": ops.Z, "post_q1": ops.X},
-    {"pre_q0": ops.I, "pre_q1": ops.Y, "post_q0": ops.Z, "post_q1": ops.Y},
-    {"pre_q0": ops.I, "pre_q1": ops.Z, "post_q0": ops.I, "post_q1": ops.Z},
-    {"pre_q0": ops.X, "pre_q1": ops.I, "post_q0": ops.X, "post_q1": ops.Z},
-    {"pre_q0": ops.X, "pre_q1": ops.X, "post_q0": ops.Y, "post_q1": ops.Y},
-    {"pre_q0": ops.X, "pre_q1": ops.Y, "post_q0": ops.Y, "post_q1": ops.X},
-    {"pre_q0": ops.X, "pre_q1": ops.Z, "post_q0": ops.X, "post_q1": ops.I},
-    {"pre_q0": ops.Y, "pre_q1": ops.I, "post_q0": ops.Y, "post_q1": ops.Z},
-    {"pre_q0": ops.Y, "pre_q1": ops.X, "post_q0": ops.X, "post_q1": ops.Y},
-    {"pre_q0": ops.Y, "pre_q1": ops.Y, "post_q0": ops.X, "post_q1": ops.X},
-    {"pre_q0": ops.Y, "pre_q1": ops.Z, "post_q0": ops.Y, "post_q1": ops.I},
-    {"pre_q0": ops.Z, "pre_q1": ops.I, "post_q0": ops.Z, "post_q1": ops.I},
-    {"pre_q0": ops.Z, "pre_q1": ops.X, "post_q0": ops.I, "post_q1": ops.X},
-    {"pre_q0": ops.Z, "pre_q1": ops.Y, "post_q0": ops.I, "post_q1": ops.Y},
-    {"pre_q0": ops.Z, "pre_q1": ops.Z, "post_q0": ops.Z, "post_q1": ops.Z},
-]
-
 CZGaugeSelector = GaugeSelector(
     gauges=[
         ConstantGauge(
-            two_qubit_gate=CZ, **params, swap_qubits=False, support_randomized_compiling=True
-        )
-        for params in _gauge_parameters
+            two_qubit_gate=CZ,
+            pre_q0=ops.I,
+            pre_q1=ops.I,
+            post_q0=ops.I,
+            post_q1=ops.I,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.I,
+            pre_q1=ops.X,
+            post_q0=ops.Z,
+            post_q1=ops.X,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.I,
+            pre_q1=ops.Y,
+            post_q0=ops.Z,
+            post_q1=ops.Y,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.I,
+            pre_q1=ops.Z,
+            post_q0=ops.I,
+            post_q1=ops.Z,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.X,
+            pre_q1=ops.I,
+            post_q0=ops.X,
+            post_q1=ops.Z,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.X,
+            pre_q1=ops.X,
+            post_q0=ops.Y,
+            post_q1=ops.Y,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.X,
+            pre_q1=ops.Y,
+            post_q0=ops.Y,
+            post_q1=ops.X,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.X,
+            pre_q1=ops.Z,
+            post_q0=ops.X,
+            post_q1=ops.I,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Y,
+            pre_q1=ops.I,
+            post_q0=ops.Y,
+            post_q1=ops.Z,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Y,
+            pre_q1=ops.X,
+            post_q0=ops.X,
+            post_q1=ops.Y,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Y,
+            pre_q1=ops.Y,
+            post_q0=ops.X,
+            post_q1=ops.X,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Y,
+            pre_q1=ops.Z,
+            post_q0=ops.Y,
+            post_q1=ops.I,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Z,
+            pre_q1=ops.I,
+            post_q0=ops.Z,
+            post_q1=ops.I,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Z,
+            pre_q1=ops.X,
+            post_q0=ops.I,
+            post_q1=ops.X,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Z,
+            pre_q1=ops.Y,
+            post_q0=ops.I,
+            post_q1=ops.Y,
+            support_sweep=True,
+        ),
+        ConstantGauge(
+            two_qubit_gate=CZ,
+            pre_q0=ops.Z,
+            pre_q1=ops.Z,
+            post_q0=ops.Z,
+            post_q1=ops.Z,
+            support_sweep=True,
+        ),
     ]
 )
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
@@ -14,6 +14,8 @@
 
 """A Gauge Transformer for the CZ gate."""
 
+from typing import Dict, List
+
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     GaugeTransformer,
     GaugeSelector,
@@ -22,24 +24,31 @@ from cirq.transformers.gauge_compiling.gauge_compiling import (
 from cirq.ops.common_gates import CZ
 from cirq import ops
 
+_gauge_parameters: List[Dict[str, ops.Gate]] = [
+    {"pre_q0": ops.I, "pre_q1": ops.I, "post_q0": ops.I, "post_q1": ops.I},
+    {"pre_q0": ops.I, "pre_q1": ops.X, "post_q0": ops.Z, "post_q1": ops.X},
+    {"pre_q0": ops.I, "pre_q1": ops.Y, "post_q0": ops.Z, "post_q1": ops.Y},
+    {"pre_q0": ops.I, "pre_q1": ops.Z, "post_q0": ops.I, "post_q1": ops.Z},
+    {"pre_q0": ops.X, "pre_q1": ops.I, "post_q0": ops.X, "post_q1": ops.Z},
+    {"pre_q0": ops.X, "pre_q1": ops.X, "post_q0": ops.Y, "post_q1": ops.Y},
+    {"pre_q0": ops.X, "pre_q1": ops.Y, "post_q0": ops.Y, "post_q1": ops.X},
+    {"pre_q0": ops.X, "pre_q1": ops.Z, "post_q0": ops.X, "post_q1": ops.I},
+    {"pre_q0": ops.Y, "pre_q1": ops.I, "post_q0": ops.Y, "post_q1": ops.Z},
+    {"pre_q0": ops.Y, "pre_q1": ops.X, "post_q0": ops.X, "post_q1": ops.Y},
+    {"pre_q0": ops.Y, "pre_q1": ops.Y, "post_q0": ops.X, "post_q1": ops.X},
+    {"pre_q0": ops.Y, "pre_q1": ops.Z, "post_q0": ops.Y, "post_q1": ops.I},
+    {"pre_q0": ops.Z, "pre_q1": ops.I, "post_q0": ops.Z, "post_q1": ops.I},
+    {"pre_q0": ops.Z, "pre_q1": ops.X, "post_q0": ops.I, "post_q1": ops.X},
+    {"pre_q0": ops.Z, "pre_q1": ops.Y, "post_q0": ops.I, "post_q1": ops.Y},
+    {"pre_q0": ops.Z, "pre_q1": ops.Z, "post_q0": ops.Z, "post_q1": ops.Z},
+]
+
 CZGaugeSelector = GaugeSelector(
     gauges=[
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.I, pre_q1=ops.I, post_q0=ops.I, post_q1=ops.I),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.I, pre_q1=ops.X, post_q0=ops.Z, post_q1=ops.X),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.I, pre_q1=ops.Y, post_q0=ops.Z, post_q1=ops.Y),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.I, pre_q1=ops.Z, post_q0=ops.I, post_q1=ops.Z),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.X, pre_q1=ops.I, post_q0=ops.X, post_q1=ops.Z),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.X, pre_q1=ops.X, post_q0=ops.Y, post_q1=ops.Y),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.X, pre_q1=ops.Y, post_q0=ops.Y, post_q1=ops.X),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.X, pre_q1=ops.Z, post_q0=ops.X, post_q1=ops.I),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Y, pre_q1=ops.I, post_q0=ops.Y, post_q1=ops.Z),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Y, pre_q1=ops.X, post_q0=ops.X, post_q1=ops.Y),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Y, pre_q1=ops.Y, post_q0=ops.X, post_q1=ops.X),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Y, pre_q1=ops.Z, post_q0=ops.Y, post_q1=ops.I),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Z, pre_q1=ops.I, post_q0=ops.Z, post_q1=ops.I),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Z, pre_q1=ops.X, post_q0=ops.I, post_q1=ops.X),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Z, pre_q1=ops.Y, post_q0=ops.I, post_q1=ops.Y),
-        ConstantGauge(two_qubit_gate=CZ, pre_q0=ops.Z, pre_q1=ops.Z, post_q0=ops.Z, post_q1=ops.Z),
+        ConstantGauge(
+            two_qubit_gate=CZ, **params, swap_qubits=False, support_randomized_compiling=True
+        )
+        for params in _gauge_parameters
     ]
 )
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -21,4 +21,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCZGauge(GaugeTester):
     two_qubit_gate = cirq.CZ
     gauge_transformer = CZGaugeTransformer
-    enable_test_sweep = True
+    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -21,4 +21,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCZGauge(GaugeTester):
     two_qubit_gate = cirq.CZ
     gauge_transformer = CZGaugeTransformer
-    test_randomized_compiling = True
+    enable_test_sweep = True

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -21,3 +21,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCZGauge(GaugeTester):
     two_qubit_gate = cirq.CZ
     gauge_transformer = CZGaugeTransformer
+    test_randomized_compiling = True

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test.py
@@ -15,7 +15,12 @@
 import pytest
 import numpy as np
 import cirq
-from cirq.transformers.gauge_compiling import GaugeTransformer, CZGaugeTransformer
+from cirq.transformers.gauge_compiling import (
+    GaugeTransformer,
+    CZGaugeTransformer,
+    ConstantGauge,
+    GaugeSelector,
+)
 
 
 def test_deep_transformation_not_supported():
@@ -25,10 +30,19 @@ def test_deep_transformation_not_supported():
             cirq.Circuit(), context=cirq.TransformerContext(deep=True)
         )
 
+    with pytest.raises(ValueError, match="cannot be used with deep=True"):
+        _ = GaugeTransformer(target=cirq.CZ, gauge_selector=lambda _: None).randomized_compiling(
+            cirq.Circuit(), context=cirq.TransformerContext(deep=True), N=1
+        )
+
 
 def test_ignore_tags():
     c = cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2)).with_tags('foo'))
     assert c == CZGaugeTransformer(c, context=cirq.TransformerContext(tags_to_ignore={"foo"}))
+    parameterized_circuit, _ = CZGaugeTransformer.randomized_compiling(
+        c, context=cirq.TransformerContext(tags_to_ignore={"foo"}), N=1
+    )
+    assert c == parameterized_circuit
 
 
 def test_target_can_be_gateset():
@@ -39,3 +53,54 @@ def test_target_can_be_gateset():
     )
     want = cirq.Circuit(cirq.Y.on_each(qs), cirq.CZ(*qs), cirq.X.on_each(qs))
     assert transformer(c, prng=np.random.default_rng(0)) == want
+
+
+def test_randomized_compiling_multi_pre_or_multi_post_moments_not_supported():
+    unsupported_transfomer = GaugeTransformer(
+        target=cirq.CZ,
+        gauge_selector=GaugeSelector(
+            gauges=[
+                ConstantGauge(
+                    two_qubit_gate=cirq.CZ,
+                    support_randomized_compiling=True,
+                    pre_q0=[cirq.X, cirq.Y],
+                    post_q0=[cirq.Z],
+                    pre_q1=[cirq.X],
+                    post_q1=[cirq.Z],
+                )
+            ]
+        ),
+    )
+    qs = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.CZ(*qs))
+    with pytest.raises(ValueError, match="generated more than 1 pre_q0 gates. Expect 1."):
+        unsupported_transfomer.randomized_compiling(c, N=1)
+
+
+def test_randomized_compiling_unsupported_parameterization():
+    unsupported_gates = cirq.measure, cirq.CZ
+    transfomers = [
+        GaugeTransformer(
+            target=cirq.CZ,
+            gauge_selector=GaugeSelector(
+                gauges=[
+                    ConstantGauge(
+                        two_qubit_gate=cirq.CZ,
+                        support_randomized_compiling=True,
+                        pre_q0=[unsupported_gate],
+                        post_q0=[cirq.Z],
+                        pre_q1=[cirq.X],
+                        post_q1=[cirq.Z],
+                    )
+                ]
+            ),
+        )
+        for unsupported_gate in unsupported_gates
+    ]
+    qs = cirq.LineQubit.range(2)
+    c = cirq.Circuit(cirq.CZ(*qs))
+    for unsupported_gate, transfomer in zip(unsupported_gates, transfomers):
+        with pytest.raises(
+            ValueError, match=f"Can't convert gate {unsupported_gate} to PhasedXZGate."
+        ):
+            transfomer.randomized_compiling(c, N=1)

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest.mock
 import pytest
 import numpy as np
 import cirq
@@ -21,6 +22,7 @@ from cirq.transformers.gauge_compiling import (
     ConstantGauge,
     GaugeSelector,
 )
+from cirq.transformers.analytical_decompositions import single_qubit_decompositions
 
 
 def test_deep_transformation_not_supported():
@@ -31,7 +33,7 @@ def test_deep_transformation_not_supported():
         )
 
     with pytest.raises(ValueError, match="cannot be used with deep=True"):
-        _ = GaugeTransformer(target=cirq.CZ, gauge_selector=lambda _: None).randomized_compiling(
+        _ = GaugeTransformer(target=cirq.CZ, gauge_selector=lambda _: None).as_sweep(
             cirq.Circuit(), context=cirq.TransformerContext(deep=True), N=1
         )
 
@@ -39,7 +41,7 @@ def test_deep_transformation_not_supported():
 def test_ignore_tags():
     c = cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2)).with_tags('foo'))
     assert c == CZGaugeTransformer(c, context=cirq.TransformerContext(tags_to_ignore={"foo"}))
-    parameterized_circuit, _ = CZGaugeTransformer.randomized_compiling(
+    parameterized_circuit, _ = CZGaugeTransformer.as_sweep(
         c, context=cirq.TransformerContext(tags_to_ignore={"foo"}), N=1
     )
     assert c == parameterized_circuit
@@ -55,15 +57,42 @@ def test_target_can_be_gateset():
     assert transformer(c, prng=np.random.default_rng(0)) == want
 
 
-def test_randomized_compiling_multi_pre_or_multi_post_moments_not_supported():
-    unsupported_transfomer = GaugeTransformer(
+def test_as_sweep_multi_pre_or_multi_post():
+    transformer = GaugeTransformer(
         target=cirq.CZ,
         gauge_selector=GaugeSelector(
             gauges=[
                 ConstantGauge(
                     two_qubit_gate=cirq.CZ,
-                    support_randomized_compiling=True,
-                    pre_q0=[cirq.X, cirq.Y],
+                    support_sweep=True,
+                    pre_q0=[cirq.X, cirq.X],
+                    post_q0=[cirq.Z],
+                    pre_q1=[cirq.Y],
+                    post_q1=[cirq.Y, cirq.Y, cirq.Y],
+                )
+            ]
+        ),
+    )
+    qs = cirq.LineQubit.range(2)
+    input_circuit = cirq.Circuit(cirq.CZ(*qs))
+    parameterized_circuit, sweeps = transformer.as_sweep(input_circuit, N=1)
+
+    for params in sweeps:
+        compiled_circuit = cirq.resolve_parameters(parameterized_circuit, params)
+        cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
+            input_circuit, compiled_circuit, qubit_map={q: q for q in input_circuit.all_qubits()}
+        )
+
+
+def test_as_sweep_invalid_gauge_sequence():
+    transfomer = GaugeTransformer(
+        target=cirq.CZ,
+        gauge_selector=GaugeSelector(
+            gauges=[
+                ConstantGauge(
+                    two_qubit_gate=cirq.CZ,
+                    support_sweep=True,
+                    pre_q0=[cirq.measure],
                     post_q0=[cirq.Z],
                     pre_q1=[cirq.X],
                     post_q1=[cirq.Z],
@@ -73,34 +102,24 @@ def test_randomized_compiling_multi_pre_or_multi_post_moments_not_supported():
     )
     qs = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CZ(*qs))
-    with pytest.raises(ValueError, match="generated more than 1 pre_q0 gates. Expect 1."):
-        unsupported_transfomer.randomized_compiling(c, N=1)
+    with pytest.raises(ValueError, match="Invalid gate sequence to be converted to PhasedXZGate."):
+        transfomer.as_sweep(c, N=1)
 
 
-def test_randomized_compiling_unsupported_parameterization():
-    unsupported_gates = cirq.measure, cirq.CZ
-    transfomers = [
-        GaugeTransformer(
-            target=cirq.CZ,
-            gauge_selector=GaugeSelector(
-                gauges=[
-                    ConstantGauge(
-                        two_qubit_gate=cirq.CZ,
-                        support_randomized_compiling=True,
-                        pre_q0=[unsupported_gate],
-                        post_q0=[cirq.Z],
-                        pre_q1=[cirq.X],
-                        post_q1=[cirq.Z],
-                    )
-                ]
-            ),
-        )
-        for unsupported_gate in unsupported_gates
-    ]
+def test_as_sweep_convert_to_phxz_failed():
     qs = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CZ(*qs))
-    for unsupported_gate, transfomer in zip(unsupported_gates, transfomers):
+
+    def mock_single_qubit_matrix_to_phxz(*args, **kwargs):
+        # Return an non PhasedXZ gate, so we expect errors from as_sweep().
+        return cirq.X
+
+    with unittest.mock.patch.object(
+        single_qubit_decompositions,
+        "single_qubit_matrix_to_phxz",
+        new=mock_single_qubit_matrix_to_phxz,
+    ):
         with pytest.raises(
-            ValueError, match=f"Can't convert gate {unsupported_gate} to PhasedXZGate."
+            ValueError, match="Failed to convert the gate sequence to a PhasedXZ gate."
         ):
-            transfomer.randomized_compiling(c, N=1)
+            _ = CZGaugeTransformer.as_sweep(c, context=cirq.TransformerContext(), N=1)

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils.py
@@ -27,7 +27,7 @@ class GaugeTester:
     two_qubit_gate: cirq.Gate
     gauge_transformer: GaugeTransformer
     must_fail: bool = False
-    enable_test_sweep: bool = False
+    sweep_must_pass: bool = False
 
     @pytest.mark.parametrize(
         ['generation_seed', 'transformation_seed'],
@@ -88,9 +88,7 @@ class GaugeTester:
             cirq.Moment([cirq.measure(q) for q in [a, b, c]]),
         )
 
-        supported_gates: set[cirq.Gate] = {cirq.CZ}
-
-        if self.two_qubit_gate not in supported_gates:
+        if not self.sweep_must_pass:
             with pytest.raises(NotImplementedError):
                 self.gauge_transformer.as_sweep(input_circuit, N=1)
             return

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils.py
@@ -75,23 +75,22 @@ class GaugeTester:
                 _check_equivalent_with_error_message(c, nc, gauge)
 
     def test_sweep(self):
-        a = cirq.NamedQubit('a')
-        b = cirq.NamedQubit('b')
-        c = cirq.NamedQubit('c')
-
-        input_circuit = cirq.Circuit(
-            cirq.Moment(cirq.H(a)),
-            cirq.Moment(self.two_qubit_gate(a, b)),
-            cirq.Moment(self.two_qubit_gate(b, c)),
-            cirq.Moment(self.two_qubit_gate(a, c)),
-            cirq.Moment([cirq.H(qubit) for qubit in [a, b, c]]),
-            cirq.Moment([cirq.measure(q) for q in [a, b, c]]),
-        )
+        qubits = cirq.LineQubit.range(3)
 
         if not self.sweep_must_pass:
             with pytest.raises(NotImplementedError):
-                self.gauge_transformer.as_sweep(input_circuit, N=1)
+                self.gauge_transformer.as_sweep(
+                    cirq.Circuit(cirq.Moment(self.two_qubit_gate(*qubits[:2]))), N=1
+                )
             return
+
+        input_circuit = cirq.Circuit(
+            cirq.Moment(cirq.H(qubits[0])),
+            cirq.Moment(self.two_qubit_gate(*qubits[:2])),
+            cirq.Moment(self.two_qubit_gate(*qubits[1:])),
+            cirq.Moment([cirq.H(q) for q in qubits]),
+            cirq.Moment([cirq.measure(q) for q in qubits]),
+        )
 
         n_samples = 5
         parameterized_circuit, sweeps = self.gauge_transformer.as_sweep(input_circuit, N=n_samples)

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils_test.py
@@ -26,7 +26,15 @@ class ExampleGate(cirq.testing.TwoQubitGate):
         return self.unitary
 
 
+class ExampleSweepGate(cirq.testing.TwoQubitGate):
+    unitary = cirq.unitary(cirq.CZ)
+
+    def _unitary_(self) -> np.ndarray:
+        return self.unitary
+
+
 _EXAMPLE_TARGET = ExampleGate()
+_EXAMPLE_SWEEP_TARGET = ExampleSweepGate()
 
 _GOOD_TRANSFORMER = GaugeTransformer(
     target=_EXAMPLE_TARGET,
@@ -40,6 +48,22 @@ _BAD_TRANSFORMER = GaugeTransformer(
     ),
 )
 
+_TRANSFORMER_WITH_SWEEP = GaugeTransformer(
+    target=_EXAMPLE_SWEEP_TARGET,
+    gauge_selector=GaugeSelector(
+        gauges=[
+            ConstantGauge(
+                two_qubit_gate=_EXAMPLE_SWEEP_TARGET,
+                pre_q0=cirq.Z,
+                pre_q1=cirq.Z,
+                post_q0=cirq.Z,
+                post_q1=cirq.Z,
+                support_sweep=True,
+            )
+        ]
+    ),
+)
+
 
 class TestValidTransformer(GaugeTester):
     two_qubit_gate = _EXAMPLE_TARGET
@@ -50,3 +74,9 @@ class TestInvalidTransformer(GaugeTester):
     two_qubit_gate = _EXAMPLE_TARGET
     gauge_transformer = _BAD_TRANSFORMER
     must_fail = True
+
+
+class TestSweep(GaugeTester):
+    two_qubit_gate = _EXAMPLE_SWEEP_TARGET
+    gauge_transformer = _TRANSFORMER_WITH_SWEEP
+    sweep_must_pass = True


### PR DESCRIPTION
Support run sweep output in gauge compiling.

Enables output parameterized circuit with sweepable parameters for CZ Gauge.

**Usage**:

Users can create a parameterized circuit with N set of parameters associated with it similar to:

```
parameterized_circuit, N_params = self.gauge_transformer.as_sweep(input_circuit, N=5)
```

Then, with the following input circuit

```
0: ───H───Y───@───M───
              │
1: ───Y───X───┼───M───
              │
2: ───────────@───M───
```

the outputs are similar to

```
circuit:

0: ───H───Y───PhXZ(a=a1,x=x1,z=z1)───@───PhXZ(a=a3,x=x3,z=z3)───M───
                                     │
1: ───Y───X──────────────────────────┼──────────────────────────M───
                                     │
2: ───────────PhXZ(a=a0,x=x0,z=z0)───@───PhXZ(a=a2,x=x2,z=z2)───M───

5 set of parameters:

Parameter set 0: {'x0': 1, 'z0': 0, 'a0': 0.5, 'x1': 0.0, 'z1': 0.0, 'a1': 0.0, 'x2': 1, 'z2': 0, 'a2': 0.5, 'x3': 0.0, 'z3': -1.0, 'a3': -0.5}
Parameter set 1: {'x0': 1, 'z0': 0, 'a0': -1.0, 'x1': 1, 'z1': 0, 'a1': 0.5, 'x2': 1, 'z2': 0, 'a2': 0.5, 'x3': 1, 'z3': 0, 'a3': -1.0}
Parameter set 2: {'x0': 1, 'z0': 0, 'a0': 0.5, 'x1': 1, 'z1': 0, 'a1': -1.0, 'x2': 1, 'z2': 0, 'a2': -1.0, 'x3': 1, 'z3': 0, 'a3': 0.5}
Parameter set 3: {'x0': 0.0, 'z0': -1.0, 'a0': -0.5, 'x1': 1, 'z1': 0, 'a1': -1.0, 'x2': 0.0, 'z2': 0.0, 'a2': 0.0, 'x3': 1, 'z3': 0, 'a3': -1.0}
Parameter set 4: {'x0': 1, 'z0': 0, 'a0': 0.5, 'x1': 1, 'z1': 0, 'a1': 0.5, 'x2': 1, 'z2': 0, 'a2': -1.0, 'x3': 1, 'z3': 0, 'a3': -1.0}
```
