### PR TITLE
Add note about cirq-ft status on PyPI and suggest alternatives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ For a comprehensive list all of the interactive Jupyter Notebooks in our repo (i
 
 For the latest news regarding Cirq, sign up to the `Cirq-announce email list <https://groups.google.com/forum/#!forum/cirq-announce>`__!
 
+**Note:** `cirq-ft` is no longer maintained. Please use `Qualtran` as an alternative for similar functionalities.
+
 
 Hello Qubit
 -----------


### PR DESCRIPTION
## Changes - Added a note in the README.rst file about `cirq-ft` being no longer maintained. - Suggested `Qualtran` as an alternative. 
## Related Issue Addresses [#6862](https://github.com/quantumlib/Cirq/issues/6862)
