### PR TITLE
Add metadata into single sweep

### DIFF
--- a/cirq-google/cirq_google/api/v2/run_context.proto
+++ b/cirq-google/cirq_google/api/v2/run_context.proto
@@ -126,6 +126,19 @@ message DeviceParameter {
     // by the sweep values themselves.
 }
 
+message Metadata {
+    // Optional arguments for if this is a device parameter.
+    // Note one single_sweep may associated with multiple device parameters.
+    repeated DeviceParameter device_parameters = 1;
+
+    // If specified, use this label instead of pameter_key as the independent
+    // column name in returned dataset.
+    optional string label = 2;
+
+    // If true, store this sweep as parameters instead of the independent axes.
+    optional bool as_parameter = 3;
+}
+
 // A bundle of multiple DeviceParameters and their values.
 // The main use case is to set those parameters with the
 // values from this bundle before executing a circuit sweep.
@@ -203,6 +216,9 @@ message SingleSweep {
   // Optional arguments for if this is a device parameter.
   // (as opposed to a circuit symbol)
   DeviceParameter parameter = 4;
+
+  // Optional arguments for storing extra metadata information.
+  Metadata metadata = 6;
 }
 
 

--- a/cirq-google/cirq_google/api/v2/run_context_pb2.py
+++ b/cirq-google/cirq_google/api/v2/run_context_pb2.py
@@ -15,7 +15,7 @@ from . import program_pb2 as cirq__google_dot_api_dot_v2_dot_program__pb2
 from tunits.proto import tunits_pb2 as tunits_dot_proto_dot_tunits__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n$cirq_google/api/v2/run_context.proto\x12\x12\x63irq.google.api.v2\x1a cirq_google/api/v2/program.proto\x1a\x19tunits/proto/tunits.proto\"\x98\x01\n\nRunContext\x12<\n\x10parameter_sweeps\x18\x01 \x03(\x0b\x32\".cirq.google.api.v2.ParameterSweep\x12L\n\x1a\x64\x65vice_parameters_override\x18\x02 \x01(\x0b\x32(.cirq.google.api.v2.DeviceParametersDiff\"O\n\x0eParameterSweep\x12\x13\n\x0brepetitions\x18\x01 \x01(\x05\x12(\n\x05sweep\x18\x02 \x01(\x0b\x32\x19.cirq.google.api.v2.Sweep\"\x86\x01\n\x05Sweep\x12;\n\x0esweep_function\x18\x01 \x01(\x0b\x32!.cirq.google.api.v2.SweepFunctionH\x00\x12\x37\n\x0csingle_sweep\x18\x02 \x01(\x0b\x32\x1f.cirq.google.api.v2.SingleSweepH\x00\x42\x07\n\x05sweep\"\xe3\x01\n\rSweepFunction\x12\x45\n\rfunction_type\x18\x01 \x01(\x0e\x32..cirq.google.api.v2.SweepFunction.FunctionType\x12)\n\x06sweeps\x18\x02 \x03(\x0b\x32\x19.cirq.google.api.v2.Sweep\"`\n\x0c\x46unctionType\x12\x1d\n\x19\x46UNCTION_TYPE_UNSPECIFIED\x10\x00\x12\x0b\n\x07PRODUCT\x10\x01\x12\x07\n\x03ZIP\x10\x02\x12\x0f\n\x0bZIP_LONGEST\x10\x03\x12\n\n\x06\x43ONCAT\x10\x04\"W\n\x0f\x44\x65viceParameter\x12\x0c\n\x04path\x18\x01 \x03(\t\x12\x10\n\x03idx\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\x12\n\x05units\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x06\n\x04_idxB\x08\n\x06_units\"\xcf\x03\n\x14\x44\x65viceParametersDiff\x12\x46\n\x06groups\x18\x01 \x03(\x0b\x32\x36.cirq.google.api.v2.DeviceParametersDiff.ResourceGroup\x12>\n\x06params\x18\x02 \x03(\x0b\x32..cirq.google.api.v2.DeviceParametersDiff.Param\x12\x0c\n\x04strs\x18\x04 \x03(\t\x1a-\n\rResourceGroup\x12\x0e\n\x06parent\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\x05\x1a\x36\n\x0cGenericValue\x12\x17\n\x0ftype_descriptor\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c\x1a\xb9\x01\n\x05Param\x12\x16\n\x0eresource_group\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\x05\x12-\n\x05value\x18\x03 \x01(\x0b\x32\x1c.cirq.google.api.v2.ArgValueH\x00\x12N\n\rgeneric_value\x18\x04 \x01(\x0b\x32\x35.cirq.google.api.v2.DeviceParametersDiff.GenericValueH\x00\x42\x0b\n\tparam_val\"\xfc\x01\n\x0bSingleSweep\x12\x15\n\rparameter_key\x18\x01 \x01(\t\x12,\n\x06points\x18\x02 \x01(\x0b\x32\x1a.cirq.google.api.v2.PointsH\x00\x12\x30\n\x08linspace\x18\x03 \x01(\x0b\x32\x1c.cirq.google.api.v2.LinspaceH\x00\x12\x35\n\x0b\x63onst_value\x18\x05 \x01(\x0b\x32\x1e.cirq.google.api.v2.ConstValueH\x00\x12\x36\n\tparameter\x18\x04 \x01(\x0b\x32#.cirq.google.api.v2.DeviceParameterB\x07\n\x05sweep\"5\n\x06Points\x12\x0e\n\x06points\x18\x01 \x03(\x02\x12\x1b\n\x04unit\x18\x02 \x01(\x0b\x32\r.tunits.Value\"d\n\x08Linspace\x12\x13\n\x0b\x66irst_point\x18\x01 \x01(\x02\x12\x12\n\nlast_point\x18\x02 \x01(\x02\x12\x12\n\nnum_points\x18\x03 \x01(\x03\x12\x1b\n\x04unit\x18\x04 \x01(\x0b\x32\r.tunits.Value\"\x96\x01\n\nConstValue\x12\x11\n\x07is_none\x18\x01 \x01(\x08H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x02H\x00\x12\x13\n\tint_value\x18\x03 \x01(\x03H\x00\x12\x16\n\x0cstring_value\x18\x04 \x01(\tH\x00\x12(\n\x0fwith_unit_value\x18\x05 \x01(\x0b\x32\r.tunits.ValueH\x00\x42\x07\n\x05valueB2\n\x1d\x63om.google.cirq.google.api.v2B\x0fRunContextProtoP\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n$cirq_google/api/v2/run_context.proto\x12\x12\x63irq.google.api.v2\x1a cirq_google/api/v2/program.proto\x1a\x19tunits/proto/tunits.proto\"\x98\x01\n\nRunContext\x12<\n\x10parameter_sweeps\x18\x01 \x03(\x0b\x32\".cirq.google.api.v2.ParameterSweep\x12L\n\x1a\x64\x65vice_parameters_override\x18\x02 \x01(\x0b\x32(.cirq.google.api.v2.DeviceParametersDiff\"O\n\x0eParameterSweep\x12\x13\n\x0brepetitions\x18\x01 \x01(\x05\x12(\n\x05sweep\x18\x02 \x01(\x0b\x32\x19.cirq.google.api.v2.Sweep\"\x86\x01\n\x05Sweep\x12;\n\x0esweep_function\x18\x01 \x01(\x0b\x32!.cirq.google.api.v2.SweepFunctionH\x00\x12\x37\n\x0csingle_sweep\x18\x02 \x01(\x0b\x32\x1f.cirq.google.api.v2.SingleSweepH\x00\x42\x07\n\x05sweep\"\xe3\x01\n\rSweepFunction\x12\x45\n\rfunction_type\x18\x01 \x01(\x0e\x32..cirq.google.api.v2.SweepFunction.FunctionType\x12)\n\x06sweeps\x18\x02 \x03(\x0b\x32\x19.cirq.google.api.v2.Sweep\"`\n\x0c\x46unctionType\x12\x1d\n\x19\x46UNCTION_TYPE_UNSPECIFIED\x10\x00\x12\x0b\n\x07PRODUCT\x10\x01\x12\x07\n\x03ZIP\x10\x02\x12\x0f\n\x0bZIP_LONGEST\x10\x03\x12\n\n\x06\x43ONCAT\x10\x04\"W\n\x0f\x44\x65viceParameter\x12\x0c\n\x04path\x18\x01 \x03(\t\x12\x10\n\x03idx\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\x12\n\x05units\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x06\n\x04_idxB\x08\n\x06_units\"\x94\x01\n\x08Metadata\x12>\n\x11\x64\x65vice_parameters\x18\x01 \x03(\x0b\x32#.cirq.google.api.v2.DeviceParameter\x12\x12\n\x05label\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x19\n\x0c\x61s_parameter\x18\x03 \x01(\x08H\x01\x88\x01\x01\x42\x08\n\x06_labelB\x0f\n\r_as_parameter\"\xcf\x03\n\x14\x44\x65viceParametersDiff\x12\x46\n\x06groups\x18\x01 \x03(\x0b\x32\x36.cirq.google.api.v2.DeviceParametersDiff.ResourceGroup\x12>\n\x06params\x18\x02 \x03(\x0b\x32..cirq.google.api.v2.DeviceParametersDiff.Param\x12\x0c\n\x04strs\x18\x04 \x03(\t\x1a-\n\rResourceGroup\x12\x0e\n\x06parent\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\x05\x1a\x36\n\x0cGenericValue\x12\x17\n\x0ftype_descriptor\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c\x1a\xb9\x01\n\x05Param\x12\x16\n\x0eresource_group\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\x05\x12-\n\x05value\x18\x03 \x01(\x0b\x32\x1c.cirq.google.api.v2.ArgValueH\x00\x12N\n\rgeneric_value\x18\x04 \x01(\x0b\x32\x35.cirq.google.api.v2.DeviceParametersDiff.GenericValueH\x00\x42\x0b\n\tparam_val\"\xac\x02\n\x0bSingleSweep\x12\x15\n\rparameter_key\x18\x01 \x01(\t\x12,\n\x06points\x18\x02 \x01(\x0b\x32\x1a.cirq.google.api.v2.PointsH\x00\x12\x30\n\x08linspace\x18\x03 \x01(\x0b\x32\x1c.cirq.google.api.v2.LinspaceH\x00\x12\x35\n\x0b\x63onst_value\x18\x05 \x01(\x0b\x32\x1e.cirq.google.api.v2.ConstValueH\x00\x12\x36\n\tparameter\x18\x04 \x01(\x0b\x32#.cirq.google.api.v2.DeviceParameter\x12.\n\x08metadata\x18\x06 \x01(\x0b\x32\x1c.cirq.google.api.v2.MetadataB\x07\n\x05sweep\"5\n\x06Points\x12\x0e\n\x06points\x18\x01 \x03(\x02\x12\x1b\n\x04unit\x18\x02 \x01(\x0b\x32\r.tunits.Value\"d\n\x08Linspace\x12\x13\n\x0b\x66irst_point\x18\x01 \x01(\x02\x12\x12\n\nlast_point\x18\x02 \x01(\x02\x12\x12\n\nnum_points\x18\x03 \x01(\x03\x12\x1b\n\x04unit\x18\x04 \x01(\x0b\x32\r.tunits.Value\"\x96\x01\n\nConstValue\x12\x11\n\x07is_none\x18\x01 \x01(\x08H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x02H\x00\x12\x13\n\tint_value\x18\x03 \x01(\x03H\x00\x12\x16\n\x0cstring_value\x18\x04 \x01(\tH\x00\x12(\n\x0fwith_unit_value\x18\x05 \x01(\x0b\x32\r.tunits.ValueH\x00\x42\x07\n\x05valueB2\n\x1d\x63om.google.cirq.google.api.v2B\x0fRunContextProtoP\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,20 +35,22 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_SWEEPFUNCTION_FUNCTIONTYPE']._serialized_end=722
   _globals['_DEVICEPARAMETER']._serialized_start=724
   _globals['_DEVICEPARAMETER']._serialized_end=811
-  _globals['_DEVICEPARAMETERSDIFF']._serialized_start=814
-  _globals['_DEVICEPARAMETERSDIFF']._serialized_end=1277
-  _globals['_DEVICEPARAMETERSDIFF_RESOURCEGROUP']._serialized_start=988
-  _globals['_DEVICEPARAMETERSDIFF_RESOURCEGROUP']._serialized_end=1033
-  _globals['_DEVICEPARAMETERSDIFF_GENERICVALUE']._serialized_start=1035
-  _globals['_DEVICEPARAMETERSDIFF_GENERICVALUE']._serialized_end=1089
-  _globals['_DEVICEPARAMETERSDIFF_PARAM']._serialized_start=1092
-  _globals['_DEVICEPARAMETERSDIFF_PARAM']._serialized_end=1277
-  _globals['_SINGLESWEEP']._serialized_start=1280
-  _globals['_SINGLESWEEP']._serialized_end=1532
-  _globals['_POINTS']._serialized_start=1534
-  _globals['_POINTS']._serialized_end=1587
-  _globals['_LINSPACE']._serialized_start=1589
-  _globals['_LINSPACE']._serialized_end=1689
-  _globals['_CONSTVALUE']._serialized_start=1692
-  _globals['_CONSTVALUE']._serialized_end=1842
+  _globals['_METADATA']._serialized_start=814
+  _globals['_METADATA']._serialized_end=962
+  _globals['_DEVICEPARAMETERSDIFF']._serialized_start=965
+  _globals['_DEVICEPARAMETERSDIFF']._serialized_end=1428
+  _globals['_DEVICEPARAMETERSDIFF_RESOURCEGROUP']._serialized_start=1139
+  _globals['_DEVICEPARAMETERSDIFF_RESOURCEGROUP']._serialized_end=1184
+  _globals['_DEVICEPARAMETERSDIFF_GENERICVALUE']._serialized_start=1186
+  _globals['_DEVICEPARAMETERSDIFF_GENERICVALUE']._serialized_end=1240
+  _globals['_DEVICEPARAMETERSDIFF_PARAM']._serialized_start=1243
+  _globals['_DEVICEPARAMETERSDIFF_PARAM']._serialized_end=1428
+  _globals['_SINGLESWEEP']._serialized_start=1431
+  _globals['_SINGLESWEEP']._serialized_end=1731
+  _globals['_POINTS']._serialized_start=1733
+  _globals['_POINTS']._serialized_end=1786
+  _globals['_LINSPACE']._serialized_start=1788
+  _globals['_LINSPACE']._serialized_end=1888
+  _globals['_CONSTVALUE']._serialized_start=1891
+  _globals['_CONSTVALUE']._serialized_end=2041
 # @@protoc_insertion_point(module_scope)

--- a/cirq-google/cirq_google/api/v2/run_context_pb2.pyi
+++ b/cirq-google/cirq_google/api/v2/run_context_pb2.pyi
@@ -278,6 +278,41 @@ class DeviceParameter(google.protobuf.message.Message):
 global___DeviceParameter = DeviceParameter
 
 @typing.final
+class Metadata(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    DEVICE_PARAMETERS_FIELD_NUMBER: builtins.int
+    LABEL_FIELD_NUMBER: builtins.int
+    AS_PARAMETER_FIELD_NUMBER: builtins.int
+    label: builtins.str
+    """If specified, use this label instead of pameter_key as the independent
+    column name in returned dataset.
+    """
+    as_parameter: builtins.bool
+    """If true, store this sweep as parameters instead of the independent axes."""
+    @property
+    def device_parameters(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___DeviceParameter]:
+        """Optional arguments for if this is a device parameter.
+        Note one single_sweep may associated with multiple device parameters.
+        """
+
+    def __init__(
+        self,
+        *,
+        device_parameters: collections.abc.Iterable[global___DeviceParameter] | None = ...,
+        label: builtins.str | None = ...,
+        as_parameter: builtins.bool | None = ...,
+    ) -> None: ...
+    def HasField(self, field_name: typing.Literal["_as_parameter", b"_as_parameter", "_label", b"_label", "as_parameter", b"as_parameter", "label", b"label"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing.Literal["_as_parameter", b"_as_parameter", "_label", b"_label", "as_parameter", b"as_parameter", "device_parameters", b"device_parameters", "label", b"label"]) -> None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing.Literal["_as_parameter", b"_as_parameter"]) -> typing.Literal["as_parameter"] | None: ...
+    @typing.overload
+    def WhichOneof(self, oneof_group: typing.Literal["_label", b"_label"]) -> typing.Literal["label"] | None: ...
+
+global___Metadata = Metadata
+
+@typing.final
 class DeviceParametersDiff(google.protobuf.message.Message):
     """A bundle of multiple DeviceParameters and their values.
     The main use case is to set those parameters with the
@@ -414,6 +449,7 @@ class SingleSweep(google.protobuf.message.Message):
     LINSPACE_FIELD_NUMBER: builtins.int
     CONST_VALUE_FIELD_NUMBER: builtins.int
     PARAMETER_FIELD_NUMBER: builtins.int
+    METADATA_FIELD_NUMBER: builtins.int
     parameter_key: builtins.str
     """The parameter key being varied. This cannot be the empty string.
     These are must appear as string Args in the quantum program.
@@ -436,6 +472,10 @@ class SingleSweep(google.protobuf.message.Message):
         (as opposed to a circuit symbol)
         """
 
+    @property
+    def metadata(self) -> global___Metadata:
+        """Optional arguments for storing extra metadata information."""
+
     def __init__(
         self,
         *,
@@ -444,9 +484,10 @@ class SingleSweep(google.protobuf.message.Message):
         linspace: global___Linspace | None = ...,
         const_value: global___ConstValue | None = ...,
         parameter: global___DeviceParameter | None = ...,
+        metadata: global___Metadata | None = ...,
     ) -> None: ...
-    def HasField(self, field_name: typing.Literal["const_value", b"const_value", "linspace", b"linspace", "parameter", b"parameter", "points", b"points", "sweep", b"sweep"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing.Literal["const_value", b"const_value", "linspace", b"linspace", "parameter", b"parameter", "parameter_key", b"parameter_key", "points", b"points", "sweep", b"sweep"]) -> None: ...
+    def HasField(self, field_name: typing.Literal["const_value", b"const_value", "linspace", b"linspace", "metadata", b"metadata", "parameter", b"parameter", "points", b"points", "sweep", b"sweep"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing.Literal["const_value", b"const_value", "linspace", b"linspace", "metadata", b"metadata", "parameter", b"parameter", "parameter_key", b"parameter_key", "points", b"points", "sweep", b"sweep"]) -> None: ...
     def WhichOneof(self, oneof_group: typing.Literal["sweep", b"sweep"]) -> typing.Literal["points", "linspace", "const_value"] | None: ...
 
 global___SingleSweep = SingleSweep


### PR DESCRIPTION
The motivation of adding this metadata field (will replace `DeviceParameter` at least internal usage) is because of the headache during we develop the cirq server.

This is mainly to address the following three issues:

- One sweep may associated with multiple registry parameters (compared with using zip, this is more compact representation)
- We may want different column name from the symbol name (or reg_parameter).
- We may or may not want to include the axes value in the returned dataset. (Internally, we use Const or Var to represent it, it is better to be explicitly in the proto instead)