### PR TITLE
Return NotImplemented for diagram info for empty PauliStringPhasors

### DIFF
--- a/cirq-core/cirq/ops/pauli_string_phasor.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor.py
@@ -189,6 +189,8 @@ class PauliStringPhasor(gate_operation.GateOperation):
         self, args: 'cirq.CircuitDiagramInfoArgs'
     ) -> 'cirq.CircuitDiagramInfo':
         qubits = self.qubits if args.known_qubits is None else args.known_qubits
+        if not qubits:
+            return NotImplemented
 
         def sym(qubit):
             if qubit in self.pauli_string:

--- a/cirq-core/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor_test.py
@@ -422,6 +422,13 @@ q2: ────────────────────[Z]───[X]^
     )
 
 
+def test_empty_phasor_diagram():
+    q = cirq.LineQubit(0)
+    op = cirq.PauliSumExponential(cirq.I(q))
+    circuit = cirq.Circuit(op)
+    cirq.testing.assert_has_diagram(circuit, '    (I)**-0.6366197723675815')
+
+
 def test_repr():
     q0, q1, q2 = _make_qubits(3)
     cirq.testing.assert_equivalent_repr(


### PR DESCRIPTION
This fixes problems created when diagramming a PauliSumExponential on an `I`, which gets stripped out.

Fixes #5944 