### PR TITLE
Modify IdentityGate to reject input when num_qubits is 0

### DIFF
--- a/cirq-core/cirq/ops/identity.py
+++ b/cirq-core/cirq/ops/identity.py
@@ -48,10 +48,14 @@ class IdentityGate(raw_types.Gate):
                 applies to.  The default is 2 for every qubit.
 
         Raises:
-            ValueError: If the length of qid_shape doesn't equal num_qubits, or
-                neither `num_qubits` or `qid_shape` is supplied.
+            ValueError: If any of the following conditions are met:
+                - The length of `qid_shape` does not equal `num_qubits`.
+                - Neither `num_qubits` nor `qid_shape` is provided.
+                - `num_qubits` is 0.
 
         """
+        if num_qubits == 0:
+            raise ValueError('Cannot create an identity gate on 0 qubits.')
         if qid_shape is None:
             if num_qubits is None:
                 raise ValueError('Specify either the num_qubits or qid_shape argument.')

--- a/cirq-core/cirq/ops/identity_test.py
+++ b/cirq-core/cirq/ops/identity_test.py
@@ -32,6 +32,8 @@ def test_identity_init(num_qubits):
         cirq.IdentityGate(5, qid_shape=(1, 2))
     with pytest.raises(ValueError, match='Specify either'):
         cirq.IdentityGate()
+    with pytest.raises(ValueError, match='Cannot create an identity gate on 0 qubits.'):
+        cirq.IdentityGate(0)
 
 
 def test_identity_on_each():


### PR DESCRIPTION
- Updated IdentityGate to reject input with a message instead of raising an error when num_qubits is set to 0.
- Added corresponding test case in identity_test.py to verify the new behavior.

Fixes #6768