### PR TITLE
Add maintainer and maintainer_email fields to setup.py

### DIFF
--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -60,6 +60,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -63,6 +63,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires=('>=3.10.0'),
     install_requires=requirements,
     extras_require={'contrib': contrib_requirements},

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -62,6 +62,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -59,6 +59,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -58,6 +58,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -60,6 +60,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -62,6 +62,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',

--- a/dev_tools/modules_test.py
+++ b/dev_tools/modules_test.py
@@ -37,6 +37,8 @@ def test_modules():
             'url': 'http://github.com/quantumlib/cirq',
             'author': 'The Cirq Developers',
             'author_email': 'cirq-dev@googlegroups.com',
+            'maintainer': 'The Quantum AI open-source software maintainers',
+            'maintainer_email': 'quantum-oss-maintainers@google.com',
             'python_requires': '>=3.10.0',
             'install_requires': ['req1', 'req2'],
             'license': 'Apache 2',

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -22,6 +22,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires=('>=3.10.0'),
     install_requires=requirements,
     license='Apache 2',

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
     url='http://github.com/quantumlib/cirq',
     author='The Cirq Developers',
     author_email='cirq-dev@googlegroups.com',
+    maintainer="The Quantum AI open-source software maintainers",
+    maintainer_email="quantum-oss-maintainers@google.com",
     python_requires='>=3.10.0',
     install_requires=requirements,
     extras_require={'dev_env': dev_requirements},


### PR DESCRIPTION
The `setup.py` files (at the top level as well as the various Cirq modules) currently define the `author` and `author_email` fields. The set of authors of Cirq, and the set of maintainers of Cirq at any given time, are somewhat overlapping but not identical. The [Python Packaging User Guide](https://packaging.python.org/en/latest/specifications/core-metadata/#maintainer) defines `maintainer` and `maintainer_email` fields to identify the maintainer contact info. This PR adds the values to the `setup.py` files.