### PR TITLE
Replace references to "master" branch with "main"

### DIFF
--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -430,7 +430,7 @@ class GridDevice(cirq.Device):
 
     For Google devices, the
     [DeviceSpecification proto](
-        https://github.com/quantumlib/Cirq/blob/master/cirq-google/cirq_google/api/v2/device.proto
+        https://github.com/quantumlib/Cirq/blob/main/cirq-google/cirq_google/api/v2/device.proto
     )
     is the main specification for device information surfaced by the Quantum Computing Service.
     Thus, this class should typically be instantiated using a `DeviceSpecification` proto via the

--- a/cirq-web/README.rst
+++ b/cirq-web/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://raw.githubusercontent.com/quantumlib/Cirq/master/docs/images/Cirq_logo_color.png
+.. image:: https://raw.githubusercontent.com/quantumlib/Cirq/main/docs/images/Cirq_logo_color.png
   :target: https://github.com/quantumlib/cirq
   :alt: Cirq
   :width: 500px

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams,pylint_copyright_checker
 max-line-length=100
 disable=all

--- a/dev_tools/triage-party/README.md
+++ b/dev_tools/triage-party/README.md
@@ -5,7 +5,7 @@ See the [triaging process](../../docs/dev/triage.md)
 # Configuration 
 
 For the dashboard you will have to edit the embedded YAML config in [configmap.yaml](kubernetes/02_deployment/configmap.yaml).
-Please refer to the [triage party docs](https://github.com/google/triage-party/blob/master/docs/config.md) for configuration details.
+Please refer to the [triage party docs](https://github.com/google/triage-party/blob/main/docs/config.md) for configuration details.
 
 ## Secret 
 

--- a/release.md
+++ b/release.md
@@ -58,7 +58,7 @@ We use github's release system for creating releases.  Release are listed
 [on the Cirq release page](https://github.com/quantumlib/Cirq/releases).
 
 Our development process uses the `main` branch for development.
-Master will always use the next unreleased minor version with the suffix
+Main will always use the next unreleased minor version with the suffix
 of ".dev".  When a release is performed, the ".dev" will be removed and tagged
 in a release branch with a version tag (vX.X.X).  Then, main will be updated
 to the next minor version.  This can always be found in the
@@ -158,7 +158,7 @@ git commit -m "Bump cirq version to ${NEXT_VER}"
 git push origin "version_bump_${NEXT_VER}"
 ```
 
-Master branch should never see a non-dev version specifier.
+The main branch should never see a non-dev version specifier.
 
 ### Create distribution wheel
 


### PR DESCRIPTION
Not all cases can be replaced; some refer to repositories where the main branch is still called master. This changes all the ones that I could find and that can be done.