### PR TITLE
Add JSON file linter

### DIFF
--- a/.jsonlintrc.yaml
+++ b/.jsonlintrc.yaml
@@ -1,0 +1,20 @@
+# Summary: Cirq configuration for using @prantlf/jsonlint
+#
+# Note: there are multiple programs programs named "jsonlint". The one you get
+# using "brew install jsonlint" (as of late 2024) is NOT the preferred one for
+# Cirq. We use https://github.com/prantlf/jsonlint. The latter is installed
+# using "npm install -g @prantlf/jsonlint". The version is 16.0.0 (Aug. 2024).
+
+comments: false
+continue: true
+duplicate-keys: false
+log-files: true
+patterns:
+  - "**/*.json"
+  - "!**/.git"
+  - "!**/.mypy_cache"
+  - "!**/.pytest_cache"
+  - "!**/node_modules"
+quiet: true
+trailing-commas: false
+trailing-newline: true

--- a/check/jsonlint
+++ b/check/jsonlint
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Runs jsonlint recursively from the top of the source tree.
+#
+# Note: there are multiple programs programs named "jsonlint". The one we
+# use is https://github.com/prantlf/jsonlint.
+#
+# Usage:
+#     check/jsonlint [--flags for jsonlint]
+#
+# This script assumes the jsonlint configuration file .jsonlintrc.yaml is
+# located at the top of the Cirq source tree.
+
+# Get the working directory to the repo root.
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
+
+# Note: we cannot use check/npx here, because check/npx unconditionally
+# changes the current working directory into cirq-web/cirq_ts before it
+# actually invokes npx. While it's possible to use jsonlint command-line args
+# to supply the config file and the directory from which to start checking,
+# the resulting jsonlint behavior is still different with respect to
+# interpreting the "patterns" option in the config file. It has so far been
+# impossible to find a pattern definition that would make it exclude the
+# .mypy_cache and other directories from checking.
+npx @prantlf/jsonlint "$@"

--- a/check/jsonlint
+++ b/check/jsonlint
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Runs jsonlint recursively from the top of the source tree.
 #
 # Note: there are multiple programs programs named "jsonlint". The one we
@@ -9,6 +11,7 @@
 #
 # This script assumes the jsonlint configuration file .jsonlintrc.yaml is
 # located at the top of the Cirq source tree.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Get the working directory to the repo root.
 thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?


### PR DESCRIPTION
This adds `check/jsonlint` and a corresponding configuration file `.jsonlintrc.yaml`. Running `./check/jsonlint` will check all `.json` files recursively from the top of the source tree, ignoring subdirectories like `.mypy_cache` that might contain files that should be ignored for purposes of linting JSON files.