### PR TITLE
Add Markdown file linter

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,18 @@
+# Summary: markdownlint-cli config file for Cirq
+#
+# Note: there are multiple programs programs named "markdownlint". For Cirq,
+# we use https://github.com/igorshubovych/markdownlint-cli/, which is the one
+# you get with "brew install markdownlint" on MacOS.
+
+# For a list of configuration options, see the following page:
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# (Beware that the above looks similar but is NOT the same as the page
+# https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md.)
+
+# Make exception to the line-length limit of 80 chars in code blocks & tables.
+line-length:
+  code_blocks: false
+  tables: false
+
+# Raw HTML is allowed in Markdown, and supported by GitHub.
+no-inline-html: false

--- a/check/markdownlint
+++ b/check/markdownlint
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Runs markdownlint recursively from the top of the source tree.
+#
+# Note: there are multiple programs programs named "markdownlint". For Cirq,
+# we use https://github.com/igorshubovych/markdownlint-cli/, which is the one
+# you get with "brew install markdownlint" on MacOS.
+#
+# Usage:
+#     check/markdownlint [--flags for markdownlint]
+#
+# This script assumes the markdownlint configuration file .markdownlint.yaml
+# is located at the top of the Cirq source tree.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Get the working directory to the repo root.
+thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
+topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+cd "${topdir}" || exit $?
+
+markdownlint "${@:-.}"


### PR DESCRIPTION
This adds `check/markdownlint` and a corresponding configuration file `.markdownlint.yaml`. Running `./check/markdownlint` will check all `.md` files recursively from the top of the source tree, ignoring subdirectories whose names start with a `.`. Arguments can be passed to the script so that, e.g., `./check/markdownlint somefilename` will lint just _somefilename_.