### PR TITLE
Add more informative message for improper cirq.qasm arguments.

### DIFF
--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -147,7 +147,7 @@ def qasm(
             involving qubits that the operation wouldn't otherwise know about.
         qubits: A list of qubits that the value is being applied to. This is
             needed for `cirq.Gate` values, which otherwise wouldn't know what
-            qubits to talk about.
+            qubits to talk about.  It should generally not be specified otherwise.
         default: A default result to use if the value doesn't have a
             `_qasm_` method or that method returns `NotImplemented` or `None`.
             If not specified, non-decomposable values cause a `TypeError`.
@@ -168,10 +168,16 @@ def qasm(
         kwargs: Dict[str, Any] = {}
         if args is not None:
             kwargs['args'] = args
+        # pylint: disable=not-callable
         if qubits is not None:
             kwargs['qubits'] = tuple(qubits)
-        # pylint: disable=not-callable
-        result = method(**kwargs)
+        try:
+            result = method(**kwargs)
+        except TypeError as error:
+            raise TypeError(
+                "cirq.qasm does not expect qubits or args to be specified"
+                f"for the given value of type {type(val)}."
+            ) from error
         # pylint: enable=not-callable
     if result is not None and result is not NotImplemented:
         return result

--- a/cirq-core/cirq/protocols/qasm_test.py
+++ b/cirq-core/cirq/protocols/qasm_test.py
@@ -54,6 +54,11 @@ def test_qasm():
     assert cirq.qasm(ExpectsArgsQubits(), args=cirq.QasmArgs(), qubits=()) == 'text'
 
 
+def test_qasm_qubits_improperly_supplied():
+    with pytest.raises(TypeError, match="does not expect qubits or args to be specified"):
+        _ = cirq.qasm(cirq.Circuit(), qubits=[cirq.LineQubit(1)])
+
+
 def test_qasm_args_formatting():
     args = cirq.QasmArgs()
     assert args.format_field(0.01, '') == '0.01'


### PR DESCRIPTION
- Qubits is an optional parameter, only used for certain types (usually `cirq.Gate`), and, if supplied elsewhere, can raise an error.
- Print out a more informative message.

Fixes: #6016