### PR TITLE
Optimize qubit hash for Set operations

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -38,7 +38,36 @@ class _BaseGridQid(ops.Qid):
 
     def __hash__(self) -> int:
         if self._hash is None:
-            self._hash = hash((self._row, self._col, self._dimension))
+            # This approach seems to perform better than traditional "random" hash in `Set`
+            # operations for typical circuits, as it reduces bucket collisions. Caveat: it does not
+            # include dimension, so sets with qudits of different dimensions but same location will
+            # have degenerate performance.
+            # Indexes the plane by squares around the origin.
+            #    | -2 -1  0  1  2
+            # ---+---------------
+            # -2 |  9 10 11 12 13
+            # -1 | 19  1  2  3 22
+            #  0 | 20  7  0  8 23
+            #  1 | 21  4  5  6 24
+            #  2 | 14 15 16 17 18
+            row = self._row
+            col = self._col
+            if row == 0 and col == 0:
+                self._hash = 0
+                return 0
+            abs_row = abs(row)
+            abs_col = abs(col)
+            square_index = max(abs_row, abs_col)
+            inner_square_side_len = square_index * 2 - 1
+            outer_square_side_len = inner_square_side_len + 2
+            inner_square_area = inner_square_side_len ** 2
+            if abs_row == square_index:
+                offset = 0 if row < 0 else outer_square_side_len
+                i = inner_square_area + offset + (col + square_index)
+            else:
+                offset = (2 * outer_square_side_len) + (0 if col < 0 else inner_square_side_len)
+                i = inner_square_area + offset + (row + (square_index - 1))
+            self._hash = hash(i)
         return self._hash
 
     def __eq__(self, other) -> bool:

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -71,6 +71,12 @@ def _test_qid_pickled_hash(q: 'cirq.Qid', q_bad: 'cirq.Qid') -> None:
     assert hash(q_ok) == hash(q)
 
 
+def test_hash_fills_plane():
+    qubits = cirq.GridQubit.square(7, -3, -3)
+    hashes = [hash(q) for q in qubits]
+    assert sorted(hashes) == list(range(49))
+
+
 def test_str():
     assert str(cirq.GridQubit(5, 2)) == 'q(5, 2)'
     assert str(cirq.GridQid(5, 2, dimension=3)) == 'q(5, 2) (d=3)'

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -33,8 +33,12 @@ class _BaseLineQid(ops.Qid):
     _hash: Optional[int] = None
 
     def __hash__(self) -> int:
+        # This approach seems to perform better than traditional "random" hash in `Set`
+        # operations for typical circuits, as it reduces bucket collisions. Caveat: it does not
+        # include dimension, so sets with qudits of different dimensions but same location will
+        # have degenerate performance.
         if self._hash is None:
-            self._hash = hash((self._x, self._dimension))
+            self._hash = hash(self._x) # hash(i) returns i except for huge numbers
         return self._hash
 
     def __eq__(self, other) -> bool:


### PR DESCRIPTION
Improves amortized `Set` operations perf by around 50%, though with the caveat that sets with qudits of different dimensions but the same index will always have the same key (not just the same bucket), and thus have to check `__eq__`, causing degenerate perf impact. It seems unlikely that anyone would intentionally do this though.

```python
s = set()
for q in cirq.GridQubit.square(100):
    s = s.union({q})
```

Fixes #6886, if we decide to do this.