### PR TITLE
CircuitOperation: change use_repetition_ids default to False

### DIFF
--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -89,7 +89,7 @@ class CircuitOperation(ops.Operation):
         repetition_ids: Optional[Sequence[str]] = None,
         parent_path: Tuple[str, ...] = (),
         extern_keys: FrozenSet['cirq.MeasurementKey'] = frozenset(),
-        use_repetition_ids: bool = True,
+        use_repetition_ids: Optional[bool] = None,
         repeat_until: Optional['cirq.Condition'] = None,
     ):
         """Initializes a CircuitOperation.
@@ -156,6 +156,8 @@ class CircuitOperation(ops.Operation):
         # Ensure that the circuit is invertible if the repetitions are negative.
         self._repetitions = repetitions
         self._repetition_ids = None if repetition_ids is None else list(repetition_ids)
+        if use_repetition_ids is None:
+            use_repetition_ids = repetition_ids is not None
         self._use_repetition_ids = use_repetition_ids
         if isinstance(self._repetitions, float):
             if math.isclose(self._repetitions, round(self._repetitions)):
@@ -263,7 +265,7 @@ class CircuitOperation(ops.Operation):
             'repetition_ids': self.repetition_ids,
             'parent_path': self.parent_path,
             'extern_keys': self._extern_keys,
-            'use_repetition_ids': self.use_repetition_ids,
+            'use_repetition_ids': True if 'repetition_ids' in changes else self.use_repetition_ids,
             'repeat_until': self.repeat_until,
             **changes,
         }
@@ -448,11 +450,9 @@ class CircuitOperation(ops.Operation):
             args += f'param_resolver={proper_repr(self.param_resolver)},\n'
         if self.parent_path:
             args += f'parent_path={proper_repr(self.parent_path)},\n'
-        if self.repetition_ids != self._default_repetition_ids():
+        if self.use_repetition_ids:
             # Default repetition_ids need not be specified.
             args += f'repetition_ids={proper_repr(self.repetition_ids)},\n'
-        if not self.use_repetition_ids:
-            args += 'use_repetition_ids=False,\n'
         if self.repeat_until:
             args += f'repeat_until={self.repeat_until!r},\n'
         indented_args = args.replace('\n', '\n    ')
@@ -477,14 +477,12 @@ class CircuitOperation(ops.Operation):
             args.append(f'params={self.param_resolver.param_dict}')
         if self.parent_path:
             args.append(f'parent_path={self.parent_path}')
-        if self.repetition_ids != self._default_repetition_ids():
+        if self.use_repetition_ids:
             # Default repetition_ids need not be specified.
             args.append(f'repetition_ids={self.repetition_ids}')
         elif self.repetitions != 1:
             # Only add loops if we haven't added repetition_ids.
             args.append(f'loops={self.repetitions}')
-        if not self.use_repetition_ids:
-            args.append('no_rep_ids')
         if self.repeat_until:
             args.append(f'until={self.repeat_until}')
         if not args:
@@ -529,10 +527,9 @@ class CircuitOperation(ops.Operation):
             'measurement_key_map': self.measurement_key_map,
             'param_resolver': self.param_resolver,
             'repetition_ids': self.repetition_ids,
+            'use_repetition_ids': self.use_repetition_ids,
             'parent_path': self.parent_path,
         }
-        if not self.use_repetition_ids:
-            resp['use_repetition_ids'] = False
         if self.repeat_until:
             resp['repeat_until'] = self.repeat_until
         return resp
@@ -566,7 +563,10 @@ class CircuitOperation(ops.Operation):
     # Methods for constructing a similar object with one field modified.
 
     def repeat(
-        self, repetitions: Optional[IntParam] = None, repetition_ids: Optional[Sequence[str]] = None
+        self,
+        repetitions: Optional[IntParam] = None,
+        repetition_ids: Optional[Sequence[str]] = None,
+        use_repetition_ids: Optional[bool] = None,
     ) -> 'CircuitOperation':
         """Returns a copy of this operation repeated 'repetitions' times.
          Each repetition instance will be identified by a single repetition_id.
@@ -577,6 +577,10 @@ class CircuitOperation(ops.Operation):
                 defaults to the length of `repetition_ids`.
             repetition_ids: List of IDs, one for each repetition. If unset,
                 defaults to `default_repetition_ids(repetitions)`.
+            use_repetition_ids: If given, this specifies the value for `use_repetition_ids`
+                of the resulting circuit operation. If the not given, we enable
+                ids if `repetition_ids` is not None, and otherwise fall back to
+                `self.use_repetition_ids`.
 
         Returns:
             A copy of this operation repeated `repetitions` times with the
@@ -591,6 +595,9 @@ class CircuitOperation(ops.Operation):
             ValueError: Unexpected length of `repetition_ids`.
             ValueError: Both `repetitions` and `repetition_ids` are None.
         """
+        if use_repetition_ids is None:
+            use_repetition_ids = True if repetition_ids is not None else self.use_repetition_ids
+
         if repetitions is None:
             if repetition_ids is None:
                 raise ValueError('At least one of repetitions and repetition_ids must be set')
@@ -604,7 +611,7 @@ class CircuitOperation(ops.Operation):
             expected_repetition_id_length: int = np.abs(repetitions)
 
             if repetition_ids is None:
-                if self.use_repetition_ids:
+                if use_repetition_ids:
                     repetition_ids = default_repetition_ids(expected_repetition_id_length)
             elif len(repetition_ids) != expected_repetition_id_length:
                 raise ValueError(
@@ -617,7 +624,12 @@ class CircuitOperation(ops.Operation):
 
         # The eventual number of repetitions of the returned CircuitOperation.
         final_repetitions = protocols.mul(self.repetitions, repetitions)
-        return self.replace(repetitions=final_repetitions, repetition_ids=repetition_ids)
+        print(f"repeat: {repetitions=}. {repetition_ids=}, {use_repetition_ids=}")
+        return self.replace(
+            repetitions=final_repetitions,
+            repetition_ids=repetition_ids,
+            use_repetition_ids=use_repetition_ids,
+        )
 
     def __pow__(self, power: IntParam) -> 'cirq.CircuitOperation':
         return self.repeat(power)

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -120,7 +120,8 @@ class CircuitOperation(ops.Operation):
             use_repetition_ids: When True, any measurement key in the subcircuit
                 will have its path prepended with the repetition id for each
                 repetition. When False, this will not happen and the measurement
-                key will be repeated.
+                key will be repeated. When None, default to False unless the caller
+                passes `repetition_ids` explicitly.
             repeat_until: A condition that will be tested after each iteration of
                 the subcircuit. The subcircuit will repeat until condition returns
                 True, but will always run at least once, and the measurement key
@@ -478,8 +479,11 @@ class CircuitOperation(ops.Operation):
         if self.parent_path:
             args.append(f'parent_path={self.parent_path}')
         if self.use_repetition_ids:
-            # Default repetition_ids need not be specified.
-            args.append(f'repetition_ids={self.repetition_ids}')
+            if self.repetition_ids != self._default_repetition_ids():
+                args.append(f'repetition_ids={self.repetition_ids}')
+            else:
+                # Default repetition_ids need not be specified.
+                args.append(f'loops={self.repetitions}, use_repetition_ids=True')
         elif self.repetitions != 1:
             # Only add loops if we haven't added repetition_ids.
             args.append(f'loops={self.repetitions}')
@@ -578,8 +582,8 @@ class CircuitOperation(ops.Operation):
             repetition_ids: List of IDs, one for each repetition. If unset,
                 defaults to `default_repetition_ids(repetitions)`.
             use_repetition_ids: If given, this specifies the value for `use_repetition_ids`
-                of the resulting circuit operation. If the not given, we enable
-                ids if `repetition_ids` is not None, and otherwise fall back to
+                of the resulting circuit operation. If not given, we enable ids if
+                `repetition_ids` is not None, and otherwise fall back to
                 `self.use_repetition_ids`.
 
         Returns:

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -624,7 +624,6 @@ class CircuitOperation(ops.Operation):
 
         # The eventual number of repetitions of the returned CircuitOperation.
         final_repetitions = protocols.mul(self.repetitions, repetitions)
-        print(f"repeat: {repetitions=}. {repetition_ids=}, {use_repetition_ids=}")
         return self.replace(
             repetitions=final_repetitions,
             repetition_ids=repetition_ids,

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -485,7 +485,7 @@ class CircuitOperation(ops.Operation):
                 # Default repetition_ids need not be specified.
                 args.append(f'loops={self.repetitions}, use_repetition_ids=True')
         elif self.repetitions != 1:
-            # Only add loops if we haven't added repetition_ids.
+            # Add loops if not using repetition_ids.
             args.append(f'loops={self.repetitions}')
         if self.repeat_until:
             args.append(f'until={self.repeat_until}')

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -294,15 +294,15 @@ def test_repeat(add_measurements: bool, use_default_ids_for_initial_rep: bool) -
     op_with_reps: Optional[cirq.CircuitOperation] = None
     rep_ids = []
     if use_default_ids_for_initial_rep:
-        op_with_reps = op_base.repeat(initial_repetitions)
         rep_ids = ['0', '1', '2']
-        assert op_base**initial_repetitions == op_with_reps
+        op_with_reps = op_base.repeat(initial_repetitions, use_repetition_ids=True)
     else:
         rep_ids = ['a', 'b', 'c']
         op_with_reps = op_base.repeat(initial_repetitions, rep_ids)
-        assert op_base**initial_repetitions != op_with_reps
-        assert (op_base**initial_repetitions).replace(repetition_ids=rep_ids) == op_with_reps
+    assert op_base**initial_repetitions != op_with_reps
+    assert (op_base**initial_repetitions).replace(repetition_ids=rep_ids) == op_with_reps
     assert op_with_reps.repetitions == initial_repetitions
+    assert op_with_reps.use_repetition_ids
     assert op_with_reps.repetition_ids == rep_ids
     assert op_with_reps.repeat(1) is op_with_reps
 
@@ -436,6 +436,7 @@ def test_parameterized_repeat_side_effects():
     op = cirq.CircuitOperation(
         cirq.FrozenCircuit(cirq.X(q).with_classical_controls('c'), cirq.measure(q, key='m')),
         repetitions=sympy.Symbol('a'),
+        use_repetition_ids=True,
     )
 
     # Control keys can be calculated because they only "lift" if there's a matching
@@ -689,7 +690,6 @@ cirq.CircuitOperation(
             ),
         ),
     ]),
-    use_repetition_ids=False,
 )"""
     )
     op7 = cirq.CircuitOperation(
@@ -706,7 +706,6 @@ cirq.CircuitOperation(
             cirq.measure(cirq.LineQubit(0), key=cirq.MeasurementKey(name='a')),
         ),
     ]),
-    use_repetition_ids=False,
     repeat_until=cirq.KeyCondition(cirq.MeasurementKey(name='a')),
 )"""
     )
@@ -737,6 +736,7 @@ def test_json_dict():
         'param_resolver': op.param_resolver,
         'parent_path': op.parent_path,
         'repetition_ids': None,
+        'use_repetition_ids': False,
     }
 
 
@@ -842,6 +842,26 @@ def test_decompose_loops_with_measurements():
     a, b = cirq.LineQubit.range(2)
     circuit = cirq.FrozenCircuit(cirq.H(a), cirq.CX(a, b), cirq.measure(a, b, key='m'))
     base_op = cirq.CircuitOperation(circuit)
+
+    op = base_op.with_qubits(b, a).repeat(3)
+    expected_circuit = cirq.Circuit(
+        cirq.H(b),
+        cirq.CX(b, a),
+        cirq.measure(b, a, key=cirq.MeasurementKey.parse_serialized('m')),
+        cirq.H(b),
+        cirq.CX(b, a),
+        cirq.measure(b, a, key=cirq.MeasurementKey.parse_serialized('m')),
+        cirq.H(b),
+        cirq.CX(b, a),
+        cirq.measure(b, a, key=cirq.MeasurementKey.parse_serialized('m')),
+    )
+    assert cirq.Circuit(cirq.decompose_once(op)) == expected_circuit
+
+
+def test_decompose_loops_with_measurements_use_rep_ids():
+    a, b = cirq.LineQubit.range(2)
+    circuit = cirq.FrozenCircuit(cirq.H(a), cirq.CX(a, b), cirq.measure(a, b, key='m'))
+    base_op = cirq.CircuitOperation(circuit, use_repetition_ids=True)
 
     op = base_op.with_qubits(b, a).repeat(3)
     expected_circuit = cirq.Circuit(
@@ -999,7 +1019,9 @@ def test_keys_under_parent_path():
     op3 = cirq.with_key_path_prefix(op2, ('C',))
     assert cirq.measurement_key_names(op3) == {'C:B:A'}
     op4 = op3.repeat(2)
-    assert cirq.measurement_key_names(op4) == {'C:B:0:A', 'C:B:1:A'}
+    assert cirq.measurement_key_names(op4) == {'C:B:A'}
+    op4_rep = op3.repeat(2).replace(use_repetition_ids=True)
+    assert cirq.measurement_key_names(op4_rep) == {'C:B:0:A', 'C:B:1:A'}
 
 
 def test_mapped_circuit_preserves_moments():
@@ -1077,12 +1099,8 @@ def test_mapped_circuit_allows_repeated_keys():
 def test_simulate_no_repetition_ids_both_levels(sim):
     q = cirq.LineQubit(0)
     inner = cirq.Circuit(cirq.measure(q, key='a'))
-    middle = cirq.Circuit(
-        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=False)
-    )
-    outer_subcircuit = cirq.CircuitOperation(
-        middle.freeze(), repetitions=2, use_repetition_ids=False
-    )
+    middle = cirq.Circuit(cirq.CircuitOperation(inner.freeze(), repetitions=2))
+    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
     circuit = cirq.Circuit(outer_subcircuit)
     result = sim.run(circuit)
     assert result.records['a'].shape == (1, 4, 1)
@@ -1092,10 +1110,10 @@ def test_simulate_no_repetition_ids_both_levels(sim):
 def test_simulate_no_repetition_ids_outer(sim):
     q = cirq.LineQubit(0)
     inner = cirq.Circuit(cirq.measure(q, key='a'))
-    middle = cirq.Circuit(cirq.CircuitOperation(inner.freeze(), repetitions=2))
-    outer_subcircuit = cirq.CircuitOperation(
-        middle.freeze(), repetitions=2, use_repetition_ids=False
+    middle = cirq.Circuit(
+        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=True)
     )
+    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
     circuit = cirq.Circuit(outer_subcircuit)
     result = sim.run(circuit)
     assert result.records['0:a'].shape == (1, 2, 1)
@@ -1106,10 +1124,10 @@ def test_simulate_no_repetition_ids_outer(sim):
 def test_simulate_no_repetition_ids_inner(sim):
     q = cirq.LineQubit(0)
     inner = cirq.Circuit(cirq.measure(q, key='a'))
-    middle = cirq.Circuit(
-        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=False)
+    middle = cirq.Circuit(cirq.CircuitOperation(inner.freeze(), repetitions=2))
+    outer_subcircuit = cirq.CircuitOperation(
+        middle.freeze(), repetitions=2, use_repetition_ids=True
     )
-    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
     circuit = cirq.Circuit(outer_subcircuit)
     result = sim.run(circuit)
     assert result.records['0:a'].shape == (1, 2, 1)
@@ -1124,7 +1142,6 @@ def test_repeat_until(sim):
         cirq.X(q),
         cirq.CircuitOperation(
             cirq.FrozenCircuit(cirq.X(q), cirq.measure(q, key=key)),
-            use_repetition_ids=False,
             repeat_until=cirq.KeyCondition(key),
         ),
     )
@@ -1139,7 +1156,6 @@ def test_repeat_until_sympy(sim):
     q1, q2 = cirq.LineQubit.range(2)
     circuitop = cirq.CircuitOperation(
         cirq.FrozenCircuit(cirq.X(q2), cirq.measure(q2, key='b')),
-        use_repetition_ids=False,
         repeat_until=cirq.SympyCondition(sympy.Eq(sympy.Symbol('a'), sympy.Symbol('b'))),
     )
     c = cirq.Circuit(cirq.measure(q1, key='a'), circuitop)
@@ -1159,7 +1175,6 @@ def test_post_selection(sim):
     c = cirq.Circuit(
         cirq.CircuitOperation(
             cirq.FrozenCircuit(cirq.X(q) ** 0.2, cirq.measure(q, key=key)),
-            use_repetition_ids=False,
             repeat_until=cirq.KeyCondition(key),
         )
     )
@@ -1175,14 +1190,13 @@ def test_repeat_until_diagram():
     c = cirq.Circuit(
         cirq.CircuitOperation(
             cirq.FrozenCircuit(cirq.X(q) ** 0.2, cirq.measure(q, key=key)),
-            use_repetition_ids=False,
             repeat_until=cirq.KeyCondition(key),
         )
     )
     cirq.testing.assert_has_diagram(
         c,
         """
-0: ───[ 0: ───X^0.2───M('m')─── ](no_rep_ids, until=m)───
+0: ───[ 0: ───X^0.2───M('m')─── ](until=m)───
 """,
         use_unicode_characters=True,
     )
@@ -1199,7 +1213,6 @@ def test_repeat_until_error():
     with pytest.raises(ValueError, match='Infinite loop'):
         cirq.CircuitOperation(
             cirq.FrozenCircuit(cirq.measure(q, key='m')),
-            use_repetition_ids=False,
             repeat_until=cirq.KeyCondition(cirq.MeasurementKey('a')),
         )
 

--- a/cirq-core/cirq/ops/classically_controlled_operation_test.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation_test.py
@@ -358,7 +358,9 @@ def test_subcircuit_key_unset(sim):
         cirq.measure(q1, key='b'),
     )
     circuit = cirq.Circuit(
-        cirq.CircuitOperation(inner.freeze(), repetitions=2, measurement_key_map={'c': 'a'})
+        cirq.CircuitOperation(
+            inner.freeze(), repetitions=2, use_repetition_ids=True, measurement_key_map={'c': 'a'}
+        )
     )
     result = sim.run(circuit)
     assert result.measurements['0:a'] == 0
@@ -377,7 +379,9 @@ def test_subcircuit_key_set(sim):
         cirq.measure(q1, key='b'),
     )
     circuit = cirq.Circuit(
-        cirq.CircuitOperation(inner.freeze(), repetitions=4, measurement_key_map={'c': 'a'})
+        cirq.CircuitOperation(
+            inner.freeze(), repetitions=4, use_repetition_ids=True, measurement_key_map={'c': 'a'}
+        )
     )
     result = sim.run(circuit)
     assert result.measurements['0:a'] == 1
@@ -486,8 +490,12 @@ def test_str():
 def test_scope_local():
     q = cirq.LineQubit(0)
     inner = cirq.Circuit(cirq.measure(q, key='a'), cirq.X(q).with_classical_controls('a'))
-    middle = cirq.Circuit(cirq.CircuitOperation(inner.freeze(), repetitions=2))
-    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
+    middle = cirq.Circuit(
+        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=True)
+    )
+    outer_subcircuit = cirq.CircuitOperation(
+        middle.freeze(), repetitions=2, use_repetition_ids=True
+    )
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_control_keys = [
         str(condition) for op in circuit.all_operations() for condition in cirq.control_keys(op)
@@ -498,9 +506,9 @@ def test_scope_local():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [       [ 0: ───M───X─── ]             ]
-0: ───[ 0: ───[       ║   ║    ]──────────── ]────────────
-      [       [ a: ═══@═══^═══ ](loops=2)    ](loops=2)
+      [       [ 0: ───M───X─── ]                               ]
+0: ───[ 0: ───[       ║   ║    ]────────────────────────────── ]──────────────────────────────
+      [       [ a: ═══@═══^═══ ](repetition_ids=['0', '1'])    ](repetition_ids=['0', '1'])
 """,
         use_unicode_characters=True,
     )
@@ -541,9 +549,9 @@ def test_scope_flatten_both():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [       [ 0: ───M───X─── ]                         ]
-0: ───[ 0: ───[       ║   ║    ]──────────────────────── ]────────────────────────
-      [       [ a: ═══@═══^═══ ](loops=2, no_rep_ids)    ](loops=2, no_rep_ids)
+      [       [ 0: ───M───X─── ]             ]
+0: ───[ 0: ───[       ║   ║    ]──────────── ]────────────
+      [       [ a: ═══@═══^═══ ](loops=2)    ](loops=2)
 """,
         use_unicode_characters=True,
     )
@@ -561,10 +569,10 @@ a: ═══@═══^═══@═══^═══@═══^═══@══�
 def test_scope_flatten_inner():
     q = cirq.LineQubit(0)
     inner = cirq.Circuit(cirq.measure(q, key='a'), cirq.X(q).with_classical_controls('a'))
-    middle = cirq.Circuit(
-        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=False)
+    middle = cirq.Circuit(cirq.CircuitOperation(inner.freeze(), repetitions=2))
+    outer_subcircuit = cirq.CircuitOperation(
+        middle.freeze(), repetitions=2, use_repetition_ids=True
     )
-    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_control_keys = [
         str(condition) for op in circuit.all_operations() for condition in cirq.control_keys(op)
@@ -575,9 +583,9 @@ def test_scope_flatten_inner():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [       [ 0: ───M───X─── ]                         ]
-0: ───[ 0: ───[       ║   ║    ]──────────────────────── ]────────────
-      [       [ a: ═══@═══^═══ ](loops=2, no_rep_ids)    ](loops=2)
+      [       [ 0: ───M───X─── ]             ]
+0: ───[ 0: ───[       ║   ║    ]──────────── ]──────────────────────────────
+      [       [ a: ═══@═══^═══ ](loops=2)    ](repetition_ids=['0', '1'])
 """,
         use_unicode_characters=True,
     )
@@ -597,10 +605,10 @@ def test_scope_flatten_inner():
 def test_scope_flatten_outer():
     q = cirq.LineQubit(0)
     inner = cirq.Circuit(cirq.measure(q, key='a'), cirq.X(q).with_classical_controls('a'))
-    middle = cirq.Circuit(cirq.CircuitOperation(inner.freeze(), repetitions=2))
-    outer_subcircuit = cirq.CircuitOperation(
-        middle.freeze(), repetitions=2, use_repetition_ids=False
+    middle = cirq.Circuit(
+        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=True)
     )
+    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_control_keys = [
         str(condition) for op in circuit.all_operations() for condition in cirq.control_keys(op)
@@ -611,9 +619,9 @@ def test_scope_flatten_outer():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [       [ 0: ───M───X─── ]             ]
-0: ───[ 0: ───[       ║   ║    ]──────────── ]────────────────────────
-      [       [ a: ═══@═══^═══ ](loops=2)    ](loops=2, no_rep_ids)
+      [       [ 0: ───M───X─── ]                               ]
+0: ───[ 0: ───[       ║   ║    ]────────────────────────────── ]────────────
+      [       [ a: ═══@═══^═══ ](repetition_ids=['0', '1'])    ](loops=2)
 """,
         use_unicode_characters=True,
     )
@@ -635,9 +643,11 @@ def test_scope_extern():
     inner = cirq.Circuit(cirq.measure(q, key='a'), cirq.X(q).with_classical_controls('b'))
     middle = cirq.Circuit(
         cirq.measure(q, key=cirq.MeasurementKey('b')),
-        cirq.CircuitOperation(inner.freeze(), repetitions=2),
+        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=True),
     )
-    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
+    outer_subcircuit = cirq.CircuitOperation(
+        middle.freeze(), repetitions=2, use_repetition_ids=True
+    )
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_control_keys = [
         str(condition) for op in circuit.all_operations() for condition in cirq.control_keys(op)
@@ -645,17 +655,19 @@ def test_scope_extern():
     assert internal_control_keys == ['0:b', '0:b', '1:b', '1:b']
     assert not cirq.control_keys(outer_subcircuit)
     assert not cirq.control_keys(circuit)
+    # pylint: disable=line-too-long
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [           [ 0: ───M('a')───X─── ]             ]
-      [ 0: ───M───[                ║    ]──────────── ]
-0: ───[       ║   [ b: ════════════^═══ ](loops=2)    ]────────────
-      [       ║   ║                                   ]
-      [ b: ═══@═══╩══════════════════════════════════ ](loops=2)
+      [           [ 0: ───M('a')───X─── ]                               ]
+      [ 0: ───M───[                ║    ]────────────────────────────── ]
+0: ───[       ║   [ b: ════════════^═══ ](repetition_ids=['0', '1'])    ]──────────────────────────────
+      [       ║   ║                                                     ]
+      [ b: ═══@═══╩════════════════════════════════════════════════════ ](repetition_ids=['0', '1'])
 """,
         use_unicode_characters=True,
     )
+    # pylint: enable=line-too-long
     cirq.testing.assert_has_diagram(
         circuit,
         """
@@ -683,9 +695,9 @@ def test_scope_extern_wrapping_with_non_repeating_subcircuits():
     )
     middle = wrap_frozen(
         wrap(cirq.measure(q, key=cirq.MeasurementKey('b'))),
-        wrap(cirq.CircuitOperation(inner, repetitions=2)),
+        wrap(cirq.CircuitOperation(inner, repetitions=2, use_repetition_ids=True)),
     )
-    outer_subcircuit = cirq.CircuitOperation(middle, repetitions=2)
+    outer_subcircuit = cirq.CircuitOperation(middle, repetitions=2, use_repetition_ids=True)
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_control_keys = [
         str(condition) for op in circuit.all_operations() for condition in cirq.control_keys(op)
@@ -738,9 +750,9 @@ b: ═══╩═════════════════════�
     cirq.testing.assert_has_diagram(
         circuit,
         """
-0: ───M('0:c')───M('0:0:a')───X───M('0:1:a')───X───M('1:c')───M('1:0:a')───X───M('1:1:a')───X───
-                              ║                ║                           ║                ║
-b: ═══════════════════════════^════════════════^═══════════════════════════^════════════════^═══
+0: ───M('c')───M('a')───X───M('a')───X───M('c')───M('a')───X───M('a')───X───
+                        ║            ║                     ║            ║
+b: ═════════════════════^════════════^═════════════════════^════════════^═══
 """,
         use_unicode_characters=True,
     )
@@ -752,9 +764,11 @@ def test_scope_extern_mismatch():
     inner = cirq.Circuit(cirq.measure(q, key='a'), cirq.X(q).with_classical_controls('b'))
     middle = cirq.Circuit(
         cirq.measure(q, key=cirq.MeasurementKey('b', ('0',))),
-        cirq.CircuitOperation(inner.freeze(), repetitions=2),
+        cirq.CircuitOperation(inner.freeze(), repetitions=2, use_repetition_ids=True),
     )
-    outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
+    outer_subcircuit = cirq.CircuitOperation(
+        middle.freeze(), repetitions=2, use_repetition_ids=True
+    )
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_control_keys = [
         str(condition) for op in circuit.all_operations() for condition in cirq.control_keys(op)
@@ -762,19 +776,21 @@ def test_scope_extern_mismatch():
     assert internal_control_keys == ['b', 'b', 'b', 'b']
     assert cirq.control_keys(outer_subcircuit) == {cirq.MeasurementKey('b')}
     assert cirq.control_keys(circuit) == {cirq.MeasurementKey('b')}
+    # pylint: disable=line-too-long
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [                  [ 0: ───M('a')───X─── ]             ]
-      [ 0: ───M('0:b')───[                ║    ]──────────── ]
-0: ───[                  [ b: ════════════^═══ ](loops=2)    ]────────────
-      [                  ║                                   ]
-      [ b: ══════════════╩══════════════════════════════════ ](loops=2)
+      [                  [ 0: ───M('a')───X─── ]                               ]
+      [ 0: ───M('0:b')───[                ║    ]────────────────────────────── ]
+0: ───[                  [ b: ════════════^═══ ](repetition_ids=['0', '1'])    ]──────────────────────────────
+      [                  ║                                                     ]
+      [ b: ══════════════╩════════════════════════════════════════════════════ ](repetition_ids=['0', '1'])
       ║
-b: ═══╩═══════════════════════════════════════════════════════════════════
+b: ═══╩═══════════════════════════════════════════════════════════════════════════════════════════════════════
 """,
         use_unicode_characters=True,
     )
+    # pylint: enable=line-too-long
     cirq.testing.assert_has_diagram(
         circuit,
         """
@@ -934,7 +950,7 @@ def test_sympy_scope():
     outer_subcircuit = cirq.CircuitOperation(middle.freeze(), repetitions=2)
     circuit = outer_subcircuit.mapped_circuit(deep=True)
     internal_controls = [str(k) for op in circuit.all_operations() for k in cirq.control_keys(op)]
-    assert set(internal_controls) == {'0:0:a', '0:1:a', '1:0:a', '1:1:a', '0:b', '1:b', 'c', 'd'}
+    assert set(internal_controls) == {'a', 'b', 'c', 'd'}
     assert cirq.control_keys(outer_subcircuit) == {'c', 'd'}
     assert cirq.control_keys(circuit) == {'c', 'd'}
     assert circuit == cirq.Circuit(cirq.decompose(outer_subcircuit))
@@ -968,23 +984,15 @@ d: ═══╩═════════════════════�
     cirq.testing.assert_has_diagram(
         circuit,
         """
-0: ───────M───M('0:0:c')───M───X(conditions=[c | d, 0:0:a & 0:b])───M───X(conditions=[c | d, 0:1:a & 0:b])───M───M('1:0:c')───M───X(conditions=[c | d, 1:0:a & 1:b])───M───X(conditions=[c | d, 1:1:a & 1:b])───
-          ║                ║   ║                                    ║   ║                                    ║                ║   ║                                    ║   ║
-0:0:a: ═══╬════════════════@═══^════════════════════════════════════╬═══╬════════════════════════════════════╬════════════════╬═══╬════════════════════════════════════╬═══╬════════════════════════════════════
-          ║                    ║                                    ║   ║                                    ║                ║   ║                                    ║   ║
-0:1:a: ═══╬════════════════════╬════════════════════════════════════@═══^════════════════════════════════════╬════════════════╬═══╬════════════════════════════════════╬═══╬════════════════════════════════════
-          ║                    ║                                        ║                                    ║                ║   ║                                    ║   ║
-0:b: ═════@════════════════════^════════════════════════════════════════^════════════════════════════════════╬════════════════╬═══╬════════════════════════════════════╬═══╬════════════════════════════════════
-                               ║                                        ║                                    ║                ║   ║                                    ║   ║
-1:0:a: ════════════════════════╬════════════════════════════════════════╬════════════════════════════════════╬════════════════@═══^════════════════════════════════════╬═══╬════════════════════════════════════
-                               ║                                        ║                                    ║                    ║                                    ║   ║
-1:1:a: ════════════════════════╬════════════════════════════════════════╬════════════════════════════════════╬════════════════════╬════════════════════════════════════@═══^════════════════════════════════════
-                               ║                                        ║                                    ║                    ║                                        ║
-1:b: ══════════════════════════╬════════════════════════════════════════╬════════════════════════════════════@════════════════════^════════════════════════════════════════^════════════════════════════════════
-                               ║                                        ║                                                         ║                                        ║
-c: ════════════════════════════^════════════════════════════════════════^═════════════════════════════════════════════════════════^════════════════════════════════════════^════════════════════════════════════
-                               ║                                        ║                                                         ║                                        ║
-d: ════════════════════════════^════════════════════════════════════════^═════════════════════════════════════════════════════════^════════════════════════════════════════^════════════════════════════════════
+0: ───M───M('0:c')───M───X(conditions=[c | d, a & b])───M───X(conditions=[c | d, a & b])───M───M('0:c')───M───X(conditions=[c | d, a & b])───M───X(conditions=[c | d, a & b])───
+      ║              ║   ║                              ║   ║                              ║              ║   ║                              ║   ║
+a: ═══╬══════════════@═══^══════════════════════════════@═══^══════════════════════════════╬══════════════@═══^══════════════════════════════@═══^══════════════════════════════
+      ║                  ║                                  ║                              ║                  ║                                  ║
+b: ═══@══════════════════^══════════════════════════════════^══════════════════════════════@══════════════════^══════════════════════════════════^══════════════════════════════
+                         ║                                  ║                                                 ║                                  ║
+c: ══════════════════════^══════════════════════════════════^═════════════════════════════════════════════════^══════════════════════════════════^══════════════════════════════
+                         ║                                  ║                                                 ║                                  ║
+d: ══════════════════════^══════════════════════════════════^═════════════════════════════════════════════════^══════════════════════════════════^══════════════════════════════
 """,
         use_unicode_characters=True,
     )

--- a/cirq-core/cirq/ops/classically_controlled_operation_test.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation_test.py
@@ -503,15 +503,17 @@ def test_scope_local():
     assert internal_control_keys == ['0:0:a', '0:1:a', '1:0:a', '1:1:a']
     assert not cirq.control_keys(outer_subcircuit)
     assert not cirq.control_keys(circuit)
+    # pylint: disable=line-too-long
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [       [ 0: ───M───X─── ]                               ]
-0: ───[ 0: ───[       ║   ║    ]────────────────────────────── ]──────────────────────────────
-      [       [ a: ═══@═══^═══ ](repetition_ids=['0', '1'])    ](repetition_ids=['0', '1'])
+      [       [ 0: ───M───X─── ]                                      ]
+0: ───[ 0: ───[       ║   ║    ]───────────────────────────────────── ]─────────────────────────────────────
+      [       [ a: ═══@═══^═══ ](loops=2, use_repetition_ids=True)    ](loops=2, use_repetition_ids=True)
 """,
         use_unicode_characters=True,
     )
+    # pylint: enable=line-too-long
     cirq.testing.assert_has_diagram(
         circuit,
         """
@@ -584,8 +586,8 @@ def test_scope_flatten_inner():
         cirq.Circuit(outer_subcircuit),
         """
       [       [ 0: ───M───X─── ]             ]
-0: ───[ 0: ───[       ║   ║    ]──────────── ]──────────────────────────────
-      [       [ a: ═══@═══^═══ ](loops=2)    ](repetition_ids=['0', '1'])
+0: ───[ 0: ───[       ║   ║    ]──────────── ]─────────────────────────────────────
+      [       [ a: ═══@═══^═══ ](loops=2)    ](loops=2, use_repetition_ids=True)
 """,
         use_unicode_characters=True,
     )
@@ -619,9 +621,9 @@ def test_scope_flatten_outer():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [       [ 0: ───M───X─── ]                               ]
-0: ───[ 0: ───[       ║   ║    ]────────────────────────────── ]────────────
-      [       [ a: ═══@═══^═══ ](repetition_ids=['0', '1'])    ](loops=2)
+      [       [ 0: ───M───X─── ]                                      ]
+0: ───[ 0: ───[       ║   ║    ]───────────────────────────────────── ]────────────
+      [       [ a: ═══@═══^═══ ](loops=2, use_repetition_ids=True)    ](loops=2)
 """,
         use_unicode_characters=True,
     )
@@ -659,11 +661,11 @@ def test_scope_extern():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [           [ 0: ───M('a')───X─── ]                               ]
-      [ 0: ───M───[                ║    ]────────────────────────────── ]
-0: ───[       ║   [ b: ════════════^═══ ](repetition_ids=['0', '1'])    ]──────────────────────────────
-      [       ║   ║                                                     ]
-      [ b: ═══@═══╩════════════════════════════════════════════════════ ](repetition_ids=['0', '1'])
+      [           [ 0: ───M('a')───X─── ]                                      ]
+      [ 0: ───M───[                ║    ]───────────────────────────────────── ]
+0: ───[       ║   [ b: ════════════^═══ ](loops=2, use_repetition_ids=True)    ]─────────────────────────────────────
+      [       ║   ║                                                            ]
+      [ b: ═══@═══╩═══════════════════════════════════════════════════════════ ](loops=2, use_repetition_ids=True)
 """,
         use_unicode_characters=True,
     )
@@ -780,13 +782,13 @@ def test_scope_extern_mismatch():
     cirq.testing.assert_has_diagram(
         cirq.Circuit(outer_subcircuit),
         """
-      [                  [ 0: ───M('a')───X─── ]                               ]
-      [ 0: ───M('0:b')───[                ║    ]────────────────────────────── ]
-0: ───[                  [ b: ════════════^═══ ](repetition_ids=['0', '1'])    ]──────────────────────────────
-      [                  ║                                                     ]
-      [ b: ══════════════╩════════════════════════════════════════════════════ ](repetition_ids=['0', '1'])
+      [                  [ 0: ───M('a')───X─── ]                                      ]
+      [ 0: ───M('0:b')───[                ║    ]───────────────────────────────────── ]
+0: ───[                  [ b: ════════════^═══ ](loops=2, use_repetition_ids=True)    ]─────────────────────────────────────
+      [                  ║                                                            ]
+      [ b: ══════════════╩═══════════════════════════════════════════════════════════ ](loops=2, use_repetition_ids=True)
       ║
-b: ═══╩═══════════════════════════════════════════════════════════════════════════════════════════════════════
+b: ═══╩═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 """,
         use_unicode_characters=True,
     )

--- a/cirq-core/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitOperation.json
@@ -133,7 +133,8 @@
     "parent_path": [],
     "repetition_ids": [
       "0"
-    ]
+    ],
+    "use_repetition_ids": true
   },
   {
     "cirq_type": "CircuitOperation",
@@ -187,7 +188,8 @@
     "repetition_ids": [
       "a",
       "b"
-    ]
+    ],
+    "use_repetition_ids": true
   },
   {
     "cirq_type": "CircuitOperation",
@@ -217,7 +219,8 @@
     "repetition_ids": [
       "a",
       "b"
-    ]
+    ],
+    "use_repetition_ids": true
   },
   {
     "cirq_type": "CircuitOperation",

--- a/cirq-core/cirq/protocols/json_test_data/CircuitOperation.repr_inward
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitOperation.repr_inward
@@ -25,10 +25,12 @@ cirq.CircuitOperation(circuit=cirq.FrozenCircuit([
         (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
     ),
 ]),
-param_resolver={sympy.Symbol('theta'): 1.5}),
+param_resolver={sympy.Symbol('theta'): 1.5},
+use_repetition_ids=True),
 cirq.CircuitOperation(circuit=cirq.FrozenCircuit([
     cirq.Moment(
         (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
     ),
 ]),
-param_resolver={sympy.Symbol('theta'): 1.5})]
+param_resolver={sympy.Symbol('theta'): 1.5},
+use_repetition_ids=True)]


### PR DESCRIPTION
This changes `CircuitOperation` so that `use_repetition_ids` defaults to False rather than True. If explicit `repetition_ids` are provided (to the constructor or to the `replace` method), we set `repetition_ids` to True automatically. The motivation for this is that internally we have never used repetition_ids and in fact we have helper methods for creating looped circuit operations since it is easy to forget to pass `use_repetition_ids=False` to override the default. The history here is that we started implementing repetition_ids at about the same time as we started implementing support for repeated measurement keys, and unfortunately I think we picked the wrong default for the keys. All of our internal experiments such as QEC and looped sampling experiments have set `use_repetition_ids=False` because repeated keys make it much more efficient to retrieve and manipulate data (one can get a single 3D array of bits for the repeated key instead of separate 2D arrays for each key instance with a different id) and so this better aligns cirq defaults with actual usage.