### PR TITLE
Apply as_sweep for iswap_gauge, spin_inversion_gauge, sqrt_iswap_gauge

### DIFF
--- a/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge.py
@@ -56,6 +56,7 @@ class RZRotation(Gauge):
             pre_q1=n_rz if flip_diangonal else rz,
             post_q0=rz if flip_diangonal else n_rz,
             post_q1=n_rz,
+            support_sweep=True,
         )
 
     def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:
@@ -88,7 +89,12 @@ class XYRotation(Gauge):
         xy_a = self._xy(a)
         xy_b = self._xy(b)
         return ConstantGauge(
-            two_qubit_gate=ops.ISWAP, pre_q0=xy_a, pre_q1=xy_b, post_q0=xy_b, post_q1=xy_a
+            two_qubit_gate=ops.ISWAP,
+            pre_q0=xy_a,
+            pre_q1=xy_b,
+            post_q0=xy_b,
+            post_q1=xy_a,
+            support_sweep=True,
         )
 
     def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:

--- a/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge_test.py
@@ -21,3 +21,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestISWAPGauge(GaugeTester):
     two_qubit_gate = cirq.ISWAP
     gauge_transformer = ISWAPGaugeTransformer
+    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge.py
@@ -23,8 +23,8 @@ from cirq import ops
 
 SpinInversionGaugeSelector = GaugeSelector(
     gauges=[
-        SameGateGauge(pre_q0=ops.X, post_q0=ops.X, pre_q1=ops.X, post_q1=ops.X),
-        SameGateGauge(),
+        SameGateGauge(pre_q0=ops.X, post_q0=ops.X, pre_q1=ops.X, post_q1=ops.X, support_sweep=True),
+        SameGateGauge(support_sweep=True),
     ]
 )
 

--- a/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge_test.py
@@ -20,18 +20,22 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestSpinInversionGauge_0(GaugeTester):
     two_qubit_gate = cirq.ZZ
     gauge_transformer = SpinInversionGaugeTransformer
+    sweep_must_pass = True
 
 
 class TestSpinInversionGauge_1(GaugeTester):
     two_qubit_gate = cirq.ZZ**0.1
     gauge_transformer = SpinInversionGaugeTransformer
+    sweep_must_pass = True
 
 
 class TestSpinInversionGauge_2(GaugeTester):
     two_qubit_gate = cirq.ZZ**-1
     gauge_transformer = SpinInversionGaugeTransformer
+    sweep_must_pass = True
 
 
 class TestSpinInversionGauge_3(GaugeTester):
     two_qubit_gate = cirq.ZZ**0.3
     gauge_transformer = SpinInversionGaugeTransformer
+    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge.py
@@ -49,7 +49,12 @@ class RZRotation(Gauge):
         rz = ops.rz(theta)
         n_rz = ops.rz(-theta)
         return ConstantGauge(
-            two_qubit_gate=ops.SQRT_ISWAP, pre_q0=rz, pre_q1=rz, post_q0=n_rz, post_q1=n_rz
+            two_qubit_gate=ops.SQRT_ISWAP,
+            pre_q0=rz,
+            pre_q1=rz,
+            post_q0=n_rz,
+            post_q1=n_rz,
+            support_sweep=True,
         )
 
     def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:
@@ -80,7 +85,12 @@ class XYRotation(Gauge):
     def _xy_gauge(self, theta: float) -> ConstantGauge:
         xy = self._xy(theta)
         return ConstantGauge(
-            two_qubit_gate=ops.SQRT_ISWAP, pre_q0=xy, pre_q1=xy, post_q0=xy, post_q1=xy
+            two_qubit_gate=ops.SQRT_ISWAP,
+            pre_q0=xy,
+            pre_q1=xy,
+            post_q0=xy,
+            post_q1=xy,
+            support_sweep=True,
         )
 
     def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge_test.py
@@ -20,3 +20,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestSqrtISWAPGauge(GaugeTester):
     two_qubit_gate = cirq.SQRT_ISWAP
     gauge_transformer = SqrtISWAPGaugeTransformer
+    sweep_must_pass = True


### PR DESCRIPTION
This is a followup pr of https://github.com/quantumlib/Cirq/pull/6852 to enable as_sweep() for 3 more gauges.

The only remaining gauge is sqrt_cz_gauge, which requires additional parameters for the 2-qubit gates to reflect the swap behavior.