### PR TITLE
Support inverse gate JSON seralization

### DIFF
--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -287,4 +287,5 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'sympy.EulerGamma': lambda: sympy.EulerGamma,
         'complex': complex,
         'datetime.datetime': _datetime,
+        '_InverseCompositeGate': cirq.inverse,
     }

--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -150,6 +150,7 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'IdentityGate': cirq.IdentityGate,
         'InitObsSetting': cirq.work.InitObsSetting,
         'InsertionNoiseModel': InsertionNoiseModel,
+        '_InverseCompositeGate': raw_types._InverseCompositeGate,
         'KeyCondition': cirq.KeyCondition,
         'KrausChannel': cirq.KrausChannel,
         'LinearDict': cirq.LinearDict,
@@ -287,5 +288,4 @@ def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:
         'sympy.EulerGamma': lambda: sympy.EulerGamma,
         'complex': complex,
         'datetime.datetime': _datetime,
-        '_InverseCompositeGate': cirq.inverse,
     }

--- a/cirq-core/cirq/ops/gate_operation_test.py
+++ b/cirq-core/cirq/ops/gate_operation_test.py
@@ -506,7 +506,6 @@ def test_gate_to_operation_to_gate_round_trips():
         cirq.transformers.measurement_transformers._ConfusionChannel,
         cirq.transformers.measurement_transformers._ModAdd,
         cirq.transformers.routing.visualize_routed_circuit._SwapPrintGate,
-        cirq.ops.raw_types._InverseCompositeGate,
         cirq.circuits.qasm_output.QasmTwoQubitGate,
         cirq.ops.MSGate,
         # Interop gates

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -1005,7 +1005,6 @@ class _InverseCompositeGate(Gate):
 
     def __init__(self, original: Gate) -> None:
         self._original = original
-        self.val = original
 
     def _qid_shape_(self):
         return protocols.qid_shape(self._original)
@@ -1068,7 +1067,7 @@ class _InverseCompositeGate(Gate):
         return f'{self._original!s}†'
 
     def _json_dict_(self) -> Dict[str, Any]:
-        return protocols.obj_to_dict_helper(self, attribute_names=["val"])
+        return {'original': self._original}
 
 
 def _validate_qid_shape(val: Any, qubits: Sequence['cirq.Qid']) -> None:

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -1066,7 +1066,7 @@ class _InverseCompositeGate(Gate):
 
     def __str__(self) -> str:
         return f'{self._original!s}†'
-    
+
     def _json_dict_(self) -> Dict[str, Any]:
         return protocols.obj_to_dict_helper(self, attribute_names=["val"])
 

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -1005,6 +1005,7 @@ class _InverseCompositeGate(Gate):
 
     def __init__(self, original: Gate) -> None:
         self._original = original
+        self.val = original
 
     def _qid_shape_(self):
         return protocols.qid_shape(self._original)
@@ -1065,6 +1066,9 @@ class _InverseCompositeGate(Gate):
 
     def __str__(self) -> str:
         return f'{self._original!s}†'
+    
+    def _json_dict_(self) -> Dict[str, Any]:
+        return protocols.obj_to_dict_helper(self, attribute_names=["val"])
 
 
 def _validate_qid_shape(val: Any, qubits: Sequence['cirq.Qid']) -> None:

--- a/cirq-core/cirq/protocols/json_test_data/_InverseCompositeGate.json
+++ b/cirq-core/cirq/protocols/json_test_data/_InverseCompositeGate.json
@@ -1,0 +1,10 @@
+{
+    "cirq_type": "_InverseCompositeGate",
+    "val": {
+        "cirq_type": "QubitPermutationGate",
+        "permutation": [
+        0,
+        1,
+        2
+    ]}
+}

--- a/cirq-core/cirq/protocols/json_test_data/_InverseCompositeGate.json
+++ b/cirq-core/cirq/protocols/json_test_data/_InverseCompositeGate.json
@@ -1,6 +1,6 @@
 {
     "cirq_type": "_InverseCompositeGate",
-    "val": {
+    "original": {
         "cirq_type": "QubitPermutationGate",
         "permutation": [
         0,

--- a/cirq-core/cirq/protocols/json_test_data/_InverseCompositeGate.repr
+++ b/cirq-core/cirq/protocols/json_test_data/_InverseCompositeGate.repr
@@ -1,0 +1,1 @@
+(cirq.QubitPermutationGate(permutation=(0, 1, 2))**-1)


### PR DESCRIPTION
Response to issue #6769

### Fix validation
Running the code snippet provided in #6769 now yields correct result:

```
0: ───[0>0]──────
      │
1: ───[1>1]──────
      │
2: ───[2>2]^-1───
{
  "cirq_type": "Circuit",
  "moments": [
    {
      "cirq_type": "Moment",
      "operations": [
        {
          "cirq_type": "GateOperation",
          "gate": {
            "cirq_type": "_InverseCompositeGate",
            "val": {
              "cirq_type": "QubitPermutationGate",
              "permutation": [
                0,
                1,
                2
              ]
            }
          },
          "qubits": [
            {
              "cirq_type": "LineQubit",
              "x": 0
            },
            {
              "cirq_type": "LineQubit",
              "x": 1
            },
            {
              "cirq_type": "LineQubit",
              "x": 2
            }
          ]
        }
      ]
    }
  ]
}
0: ───[0>0]──────
      │
1: ───[1>1]──────
      │
2: ───[2>2]^-1───
```
