### PR TITLE
Fix flaky curve fitting tests

### DIFF
--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -655,7 +655,7 @@ def _fit_exponential_decay(
             cycle_depths,
             fidelities,
             p0=(a_0, layer_fid_0),
-            bounds=((0, 0), (1, 1))
+            bounds=((0, 0), (1, 1)),
         )
         try:
             return curve_fit()

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -14,7 +14,6 @@
 """Estimation of fidelity associated with experimental circuit executions."""
 import dataclasses
 from abc import abstractmethod, ABC
-from functools import partial
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -648,24 +647,15 @@ def _fit_exponential_decay(
     layer_fid_0 = np.clip(np.exp(slope), 0, 1)
     a_0 = np.clip(np.exp(intercept), 0, 1)
 
-    def do_curve_fit():
-        curve_fit = partial(
-            optimize.curve_fit,
+    try:
+        (a, layer_fid), pcov = optimize.curve_fit(
             exponential_decay,
             cycle_depths,
             fidelities,
             p0=(a_0, layer_fid_0),
             bounds=((0, 0), (1, 1)),
+            maxfev=1000,
         )
-        try:
-            return curve_fit()
-        except RuntimeError:  # pragma: no cover
-            # Curve_fit didn't find a solution. Try once more w/ higher maxfev.
-            # Default (in SciPy v.1.14) is 100*(1+len(p0)) = 300 for our p0.
-            return curve_fit(maxfev=1000)
-
-    try:
-        (a, layer_fid), pcov = do_curve_fit()
     except ValueError:  # pragma: no cover
         return 0, 0, np.inf, np.inf
 


### PR DESCRIPTION
The test function `test_calibrate_z_phases()` in the file `cirq-core/cirq/experiments/z_phase_calibration_test.py` eventually ends up calling `fit_exponential_decays()` in `xeb_fitting.py`. That function uses SciPy's `curve_fit()` to fit an exponential function to data. For some unlucky combination of random seed and problem cases, `curve_fit()` can fail to find a solution, and raises `RuntimeError` when that happens.

This PR simply changes the call to `curve_fit()` to use a higher number for the maximum function evaluations. The following is a test case that fails without the change and succeeds with it:

```bash
./check/pytest -v --randomly-seed=3258636985 \
cirq-core/cirq/experiments/z_phase_calibration_test.py::test_calibrate_z_phases_no_options
```

Fixes #6906.