### PR TITLE
Increase time stale issue time & enhance config a tiny bit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,12 @@ name: "Label and close stale issues & PRs"
 on:
   schedule:
   - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: "Run in debug mode (dry run)"
+        type: boolean
+        default: true
 
 jobs:
   stale:
@@ -10,7 +16,8 @@ jobs:
     steps:
     - uses: actions/stale@v9
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{secrets.GITHUB_TOKEN}}
+        debug-only: ${{inputs.debug || false}}
         days-before-stale: 90
         days-before-close: 60
         stale-issue-label: 'status/stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,5 @@
-name: "Mark and close stale issues"
+name: "Label and close stale issues & PRs"
+
 on:
   schedule:
   - cron: "0 0 * * *"
@@ -10,10 +11,31 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment on this issue, or it will be closed in 60 days.'
         days-before-stale: 90
         days-before-close: 60
-        close-issue-message: 'Issue closed due to inactivity.'
         stale-issue-label: 'status/stale'
         stale-pr-label: 'status/stale'
         exempt-issue-labels: 'triage/accepted,triage/discuss,kind/design-issue,kind/health,kind/roadmap-item,kind/task'
+        stale-issue-message: >
+          This issue has been automatically labeled as stale because 90 days
+          have passed without comments or other activity. If no further
+          activity occurs and the `status/stale` label is not removed within
+          60 days, it will be closed. If you believe this is in error or would
+          like to discuss it further, please leave a comment here.
+        stale-pr-message: >
+          This pull request has been automatically labeled as stale because 90
+          days have passed without comments or other activity. If no further
+          activity occurs and the `status/stale` label is not removed within 60
+          days, it will be closed. If you believe this is in error or would
+          like to discuss it further, please leave a comment here.
+        close-issue-message: >
+          This issue has been closed due to inactivity for 60 days since the
+          time the stale label was applied. If you believe this is in error or
+          would like to discuss it further, please either open a new issue
+          (and reference this one in it, for continuity) or reach out to the
+          Cirq project maintainers at quantum-oss-maintainers@google.com.
+        close-pr-message: >
+          This pull-request has been closed due to inactivity for 60 days
+          since the time the stale label was applied. If you believe this is
+          in error or would like to discuss it further, please reach out to
+          the Cirq project maintainers at quantum-oss-maintainers@google.com.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,9 +10,9 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days'
-        days-before-stale: 30
-        days-before-close: 30
+        stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment on this issue, or it will be closed in 60 days.'
+        days-before-stale: 90
+        days-before-close: 60
         close-issue-message: 'Issue closed due to inactivity.'
         stale-issue-label: 'status/stale'
         stale-pr-label: 'status/stale'


### PR DESCRIPTION
Until we have time to revisit the auto-closing policy (issue #6866), we decided we could increase the duration before issues and PRs are marked as stale and closed. This PR changes the  durations to 90 days before marking as stale and 60 days before closing. It also adds a couple of enhancements:

- Revised and hopefully somewhat friendlier messages left as comments
- The addition of a manual run trigger, to allow manual invocation and dry runs