### PR TITLE
Re-enable streaming Engine interface by default

### DIFF
--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -86,8 +86,7 @@ class EngineContext:
         timeout: Optional[int] = None,
         serializer: Serializer = CIRCUIT_SERIALIZER,
         # TODO(#5996) Remove enable_streaming once the feature is stable.
-        # TODO(#6817): Reenable streaming by default once there's a fix.
-        enable_streaming: bool = False,
+        enable_streaming: bool = True,
     ) -> None:
         """Context and client for using Quantum Engine.
 


### PR DESCRIPTION
Streaming is again working on the service. Re-enabling this feature as the default interaction method.

Fixes #6817.