### PR TITLE
Revert "Add PyPI Trove classifiers to setup.py files"

### DIFF
--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -69,18 +69,4 @@ setup(
     long_description=long_description,
     packages=cirq_packages,
     package_data={'cirq_aqt': ['py.typed'], 'cirq_aqt.json_test_data': ['*']},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -73,18 +73,4 @@ setup(
     long_description=long_description,
     packages=cirq_packages,
     package_data={'cirq': ['py.typed'], 'cirq.protocols.json_test_data': ['*']},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -78,18 +78,4 @@ setup(
         'cirq_google.devices.specifications': ['*'],
         'cirq_google.json_test_data': ['*'],
     },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -68,18 +68,4 @@ setup(
     long_description=long_description,
     packages=cirq_packages,
     package_data={'cirq_ionq': ['py.typed'], 'cirq_ionq.json_test_data': ['*']},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -67,18 +67,4 @@ setup(
     long_description=long_description,
     packages=cirq_packages,
     package_data={'cirq_pasqal': ['py.typed'], 'cirq_pasqal.json_test_data': ['*']},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -69,18 +69,4 @@ setup(
     long_description=long_description,
     packages=cirq_packages,
     package_data={'cirq_rigetti': ['py.typed'], 'cirq_rigetti.json_test_data': ['*']},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -71,18 +71,4 @@ setup(
     long_description=long_description,
     packages=packs,
     package_data={'cirq_web': ['dist/*'], 'cirq_ts': ['dist/*.bundle.js']},
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -73,18 +73,4 @@ setup(
     description=description,
     long_description=long_description,
     packages=[],
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering :: Quantum Computing",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Typing :: Typed",
-    ],
 )


### PR DESCRIPTION
PyPI rejected the new Trove classifier term that was added a couple of days ago. I [opened an issue in pypi/warehouse](https://github.com/pypi/warehouse/issues/17379) to report the situation.

Reverting this change so that more workflows don't fail.