### PR TITLE
Adjust some more TeX expressions for rendering in web docs

### DIFF
--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -130,7 +130,7 @@ class RandomizedBenchMarkResult:
 
         $$r_p = (1 - 1/d^2) * (1 - p),$$
 
-        where $d = 2^N_Q$ is the Hilbert space dimension and $N_Q$ is the number of qubits.
+        where $d = 2^{N_Q}$ is the Hilbert space dimension and $N_Q$ is the number of qubits.
         """
         opt_params, _ = self._fit_exponential()
         p = opt_params[2]

--- a/cirq-core/cirq/ops/common_channels.py
+++ b/cirq-core/cirq/ops/common_channels.py
@@ -333,7 +333,7 @@ class DepolarizingChannel(raw_types.Gate):
         """The probability that one of the Pauli gates is applied.
 
         Each of the Pauli gates is applied independently with probability
-        $p / (4^n_qubits - 1)$.
+        $p / (4^n - 1)$, where $n$ is `n_qubits`.
         """
         return self._p
 
@@ -372,7 +372,7 @@ def depolarize(p: float, n_qubits: int = 1) -> DepolarizingChannel:
     Args:
         p: The probability that one of the Pauli gates is applied. Each of
             the Pauli gates is applied independently with probability
-            $p / (4^n - 1)$.
+            $p / (4^n - 1)$, where $n$ is n_qubits.
         n_qubits: The number of qubits.
 
     Raises:

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -80,7 +80,7 @@ class PhasedXZGate(raw_types.Gate):
     def from_zyz_exponents(cls, z0: float, y: float, z1: float) -> 'cirq.PhasedXZGate':
         """Create a PhasedXZGate from ZYZ exponents.
 
-        The returned gate is equivalent to $Z^z0 Y^y Z^z1$ (in time order).
+        The returned gate is equivalent to $Z^{z0} Y^y Z^{z1}$ (in time order).
         """
         return PhasedXZGate(axis_phase_exponent=-z0 + 0.5, x_exponent=y, z_exponent=z0 + z1)
 

--- a/cirq-core/cirq/testing/sample_gates.py
+++ b/cirq-core/cirq/testing/sample_gates.py
@@ -29,7 +29,7 @@ def _matrix_for_phasing_state(num_qubits, phase_state, phase):
 
 @dataclasses.dataclass(frozen=True)
 class PhaseUsingCleanAncilla(ops.Gate):
-    r"""Phases the state $|phase_state>$ by $\exp(1j * \pi * \theta)$ using one clean ancilla."""
+    r"""Phases the state $|phase\_state>$ by $\exp(1j * \pi * \theta)$ using one clean ancilla."""
 
     theta: float
     phase_state: int = 1
@@ -56,7 +56,7 @@ class PhaseUsingCleanAncilla(ops.Gate):
 
 @dataclasses.dataclass(frozen=True)
 class PhaseUsingDirtyAncilla(ops.Gate):
-    r"""Phases the state $|phase_state>$ by -1 using one dirty ancilla."""
+    r"""Phases the state $|phase\_state>$ by -1 using one dirty ancilla."""
 
     phase_state: int = 1
     target_bitsize: int = 1


### PR DESCRIPTION
Avoid spurious one-character subscripts and superscripts in HTML docs.

Follow-up to #6870
