### PR TITLE
Add a default fallback for the equal_up_to_global_phase protocol

### DIFF
--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -468,9 +468,13 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         self, other: Any, atol: Union[int, float] = 1e-8
     ) -> Union[NotImplementedType, bool]:
         """Default fallback for gates that do not implement this protocol."""
-        return protocols.equal_up_to_global_phase(
-            protocols.unitary(self), protocols.unitary(other), atol=atol
-        )
+        try:
+            return protocols.equal_up_to_global_phase(
+                protocols.unitary(self), protocols.unitary(other), atol=atol
+            )
+        except TypeError:
+            # Gate has no unitary protocol
+            return NotImplemented
 
     def _commutes_on_qids_(
         self, qids: 'Sequence[cirq.Qid]', other: Any, *, atol: float = 1e-8

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -464,6 +464,14 @@ class Gate(metaclass=value.ABCMetaImplementAnyOneOf):
         """
         raise NotImplementedError
 
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: Union[int, float] = 1e-8
+    ) -> Union[NotImplementedType, bool]:
+        """Default fallback for gates that do not implement this protocol."""
+        return protocols.equal_up_to_global_phase(
+            protocols.unitary(self), protocols.unitary(other), atol=atol
+        )
+
     def _commutes_on_qids_(
         self, qids: 'Sequence[cirq.Qid]', other: Any, *, atol: float = 1e-8
     ) -> Union[bool, NotImplementedType, None]:

--- a/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
@@ -117,3 +117,9 @@ def test_equal_up_to_global_phase_eq_supported():
     # cast types
     assert cirq.equal_up_to_global_phase(A(0.1), A(0.1j), atol=1e-2)
     assert not cirq.equal_up_to_global_phase(1e-8j, B(0.0), atol=1e-10)
+
+
+def test_equal_up_to_global_phase_non_eigen_gates():
+    gate1 = cirq.PhasedXPowGate(phase_exponent=1.5, exponent=1.0)
+    gate2 = cirq.PhasedXPowGate(phase_exponent=0.5, exponent=1.0)
+    assert cirq.equal_up_to_global_phase(gate1, gate2)


### PR DESCRIPTION
- This will add a default fallback for cirq.Gate instances to use their unitary decomposition for the equal_up_to_global_phase protocol.

Fixes: #6574