### PR TITLE
Revert "#6586 - Avoid DivisionByZero error when TensorNetwork simplifies to a scalar"

### DIFF
--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -170,15 +170,8 @@ def tensor_expectation_value(
         )
     else:
         tn.rank_simplify(inplace=True)
-    # TODO(#6586): revert when our minimum quimb version has bugfix for quimb#231
-    # Skip path-info evaluation when TensorNetwork consists of scalar Tensors.
-    # Avoid bug in quimb-1.8.0.
-    # Ref: https://github.com/jcmgray/quimb/issues/231
-    if tn.ind_map:
-        path_info = tn.contract(get='path-info')
-        ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
-    else:
-        ram_gb = 0
+    path_info = tn.contract(get='path-info')
+    ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
     if ram_gb > max_ram_gb:
         raise MemoryError(f"We estimate that this contraction will take too much RAM! {ram_gb} GB")
     e_val = tn.contract(inplace=True)


### PR DESCRIPTION
The workaround is not needed after upstream fixes in quimb and
our upgraded requirements for a later quimb version.

This reverts commit bfba9653a058af975289a96e1572f97305ea165b.
