### PR TITLE
Make Dependabot ignore patch updates to JS dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,15 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: "widen"
+    groups:
+      # Group non-security version minor & patch updates into one PR.
+      # Security and major update versions will be done as individual PRs.
+      non-security:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "area/dependencies"
       - "area/javascript"


### PR DESCRIPTION
This PR is in response to issue #6966.

It seems like the greatest number of Dependabot PR spam comes from the JavaScript dependencies for cirq-web. This change to the "npm" Dependabot config to make it group minor and/or patch version updates into a single PR if they are not security-related changes; all other updates (meaning, any security updates, and any major version updates) will be handled using the default method, which is separate PRs.

This `groups` configuration is based on [an example in the Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates).

With respect to this week's Dependabot activity, this configuration would only have affected the [one for ts-loader](https://github.com/quantumlib/Cirq/pull/6961/files); the others were all major version changes, and (unfortunately for us) probably should remain as individual PRs so they can be checked by a human.