### PR TITLE
CI - run the pytest-numpy-2 job also with Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     name: Pytest Ubuntu with NumPy-2
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ubuntu-20.04
     steps:
       - name: Check out source repository

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -376,12 +376,12 @@ def test_get_sampler_with_incomplete_device_configuration_errors(
         )
 
 
-def test_get_sampler_loads_processor_with_default_device_configuration() -> None:
-    client = mock.Mock(engine_client.EngineClient)
-    client.get_processor.return_value = quantum.QuantumProcessor(
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_processor_async')
+def test_get_sampler_loads_processor_with_default_device_configuration(get_processor) -> None:
+    get_processor.return_value = quantum.QuantumProcessor(
         default_device_config_key=quantum.DeviceConfigKey(run="run", config_alias="config_alias")
     )
-
+    client = engine_client.EngineClient()
     processor = cg.EngineProcessor('a', 'p', FakeEngineContext(client=client))
     sampler = processor.get_sampler()
 

--- a/dev_tools/requirements/dev-np2.env.txt
+++ b/dev_tools/requirements/dev-np2.env.txt
@@ -10,7 +10,11 @@
 -r ../../cirq-google/requirements.txt
 -r ../../cirq-core/cirq/contrib/requirements.txt
 
--r deps/dev-tools.txt
+# pytest-minimal.env.txt without cirq-all-no-contrib.txt ---------------------
+
+-r deps/pytest.txt
+-r deps/ipython.txt
+-r deps/pylint.txt
 
 # own rules ------------------------------------------------------------------
 


### PR DESCRIPTION
The pytest-numpy-2 job excludes cirq-rigetti which is not yet compatible with
Python 3.13.  This activates Python 3.13 testing for other Cirq packages.

Related to #6932
