### PR TITLE
Update scientific Python core dependencies per NEP-29 and SPEC-0

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -4,7 +4,7 @@ attrs>=21.3.0
 duet>=0.2.8
 matplotlib~=3.0
 networkx>=2.4
-numpy>=1.24
+numpy>=1.25
 pandas
 sortedcontainers~=2.0
 scipy~=1.8

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -7,7 +7,7 @@ networkx>=2.4
 numpy>=1.25
 pandas
 sortedcontainers~=2.0
-scipy~=1.8
+scipy~=1.11
 sympy
 typing_extensions>=4.2
 tqdm

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -3,7 +3,7 @@
 attrs>=21.3.0
 duet>=0.2.8
 matplotlib~=3.7
-networkx>=2.4
+networkx~=3.1
 numpy>=1.25
 pandas~=2.0
 sortedcontainers~=2.0

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -5,7 +5,7 @@ duet>=0.2.8
 matplotlib~=3.7
 networkx>=2.4
 numpy>=1.25
-pandas
+pandas~=2.0
 sortedcontainers~=2.0
 scipy~=1.11
 sympy

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -2,7 +2,7 @@
 
 attrs>=21.3.0
 duet>=0.2.8
-matplotlib~=3.0
+matplotlib~=3.7
 networkx>=2.4
 numpy>=1.25
 pandas

--- a/dev_tools/requirements/deps/ipython.txt
+++ b/dev_tools/requirements/deps/ipython.txt
@@ -1,1 +1,1 @@
-ipython>=7.34.0
+ipython~=8.10


### PR DESCRIPTION
Choose wider compatibility window when NEP-29 and SPEC-0
guidance differ.

- Drop numpy-1.24 per NEP-29 and SPEC-0
- Drop scipy-1.10 per SPEC-0
- Drop matplotlib-3.6 per SPEC-0
- Drop pandas-1 per SPEC-0
- Drop networkx-3.0 per SPEC-0
- Drop ipython-8.9 per SPEC-0

Refs:

- https://numpy.org/neps/nep-0029-deprecation_policy.html
- https://scientific-python.org/specs/spec-0000
