### PR TITLE
[draft] Fix insert on different qubits

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2169,9 +2169,9 @@ class Circuit(AbstractCircuit):
             ValueError: Bad insertion strategy.
         """
         # limit index to 0..len(self._moments), also deal with indices smaller 0
-        k = max(min(index if index >= 0 else len(self._moments) + index, len(self._moments)), 0)
+        k = index % (len(self._moments) + 1)
         qks: Dict['cirq.Qid', int] = {}
-        if strategy != InsertStrategy.EARLIEST or index != len(self._moments):
+        if strategy != InsertStrategy.EARLIEST or k != len(self._moments):
             self._placement_cache = None
         for moment_or_op in list(ops.flatten_to_ops_or_moments(moment_or_operation_tree)):
             if self._placement_cache:

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2194,19 +2194,12 @@ class Circuit(AbstractCircuit):
                 else:
                     break
             if (
-                strategy is InsertStrategy.EARLIEST
+                strategy in [InsertStrategy.INLINE, InsertStrategy.EARLIEST]
                 and not isinstance(batch[0], Moment)
                 and not all(
                     self._can_add_op_at(k, op) or k > 0 and self._can_add_op_at(k - 1, op)
                     for op in batch
                 )
-            ):
-                self._moments.insert(k, Moment())
-            elif (
-                strategy is InsertStrategy.INLINE
-                and k > 0
-                and not isinstance(batch[0], Moment)
-                and not all(self._can_add_op_at(k, op) for op in batch)
             ):
                 self._moments.insert(k, Moment())
             for moment_or_op in batch:

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2190,11 +2190,12 @@ class Circuit(AbstractCircuit):
                 prefix._moments.append(Moment(moment_or_op))
             else:
                 prefix._moments[p] = prefix._moments[p].with_operation(moment_or_op)
+            k = max(k, p + 1)
             if strategy is InsertStrategy.NEW_THEN_INLINE:
                 strategy = InsertStrategy.INLINE
-            k = max(k, p + 1)
         if suffix:
-            prefix.concat_ragged(Circuit.from_moments(suffix))
+            circuit = prefix.concat_ragged(Circuit.from_moments(suffix))
+            self._moments = circuit._moments
         self._mutated(preserve_placement_cache=True)
         return k
 

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2175,8 +2175,8 @@ class Circuit(AbstractCircuit):
         stuff = list(ops.flatten_to_ops_or_moments(moment_or_operation_tree))
         i = 0
         while i < len(stuff):
-            batch = []
-            batch_qubits = set()
+            batch: List[Union['cirq.Moment', 'cirq.Operation']] = []
+            batch_qubits: Set['cirq.Qid'] = set()
             while i < len(stuff):
                 thing = stuff[i]
                 if isinstance(thing, Moment):

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2198,7 +2198,7 @@ class Circuit(AbstractCircuit):
                 and not isinstance(batch[0], Moment)
                 and not all(
                     self._can_add_op_at(k, op) or k > 0 and self._can_add_op_at(k - 1, op)
-                    for op in batch
+                    for op in cast(List['cirq.Operation'], batch)
                 )
             ):
                 self._moments.insert(k, Moment())

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2204,10 +2204,11 @@ class Circuit(AbstractCircuit):
                 self._moments.insert(k, Moment())
             elif (
                 strategy is InsertStrategy.INLINE
+                and k > 0
                 and not isinstance(batch[0], Moment)
-                and not all(k > 0 and self._can_add_op_at(k - 1, op) for op in batch)
+                and not all(self._can_add_op_at(k, op) for op in batch)
             ):
-                self._moments.insert(k - 1, Moment())
+                self._moments.insert(k, Moment())
             for moment_or_op in batch:
                 if self._placement_cache:
                     p = self._placement_cache.append(moment_or_op)

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -3558,9 +3558,9 @@ def test_insert_operations_random_circuits(circuit):
 def test_insert_qubit_order():
     q0, q1 = cirq.LineQubit.range(2)
     c0 = cirq.Circuit(cirq.X(q0))
-    c0.insert(0, [cirq.Y.on_each(q0, q1)])
+    c0.insert(0, cirq.Y.on_each(q0, q1))
     c1 = cirq.Circuit(cirq.X(q0))
-    c1.insert(0, [cirq.Y.on_each(q1, q0)])
+    c1.insert(0, cirq.Y.on_each(q1, q0))
     assert c0 == c1
     cirq.testing.assert_has_diagram(c0,'')
 

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -3555,6 +3555,16 @@ def test_insert_operations_random_circuits(circuit):
     assert circuit == other_circuit
 
 
+def test_insert_qubit_order():
+    q0, q1 = cirq.LineQubit.range(2)
+    c0 = cirq.Circuit(cirq.X(q0))
+    c0.insert(0, [cirq.Y.on_each(q0, q1)])
+    c1 = cirq.Circuit(cirq.X(q0))
+    c1.insert(0, [cirq.Y.on_each(q1, q0)])
+    assert c0 == c1
+    cirq.testing.assert_has_diagram(c0,'')
+
+
 def test_insert_operations_errors():
     a, b, c = (cirq.NamedQubit(s) for s in 'abc')
     with pytest.raises(ValueError):

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -3562,7 +3562,27 @@ def test_insert_qubit_order():
     c1 = cirq.Circuit(cirq.X(q0))
     c1.insert(0, cirq.Y.on_each(q1, q0))
     assert c0 == c1
-    cirq.testing.assert_has_diagram(c0,'')
+    cirq.testing.assert_has_diagram(c0, '')
+
+
+def test_insert_qubit_order2():
+    q0, q1 = cirq.LineQubit.range(2)
+    c0 = cirq.Circuit(cirq.X(q0))
+    c0.insert(0, cirq.Y.on_each(q0, q1), strategy=cirq.InsertStrategy.INLINE)
+    c1 = cirq.Circuit(cirq.X(q0))
+    c1.insert(0, cirq.Y.on_each(q1, q0), strategy=cirq.InsertStrategy.INLINE)
+    assert c0 == c1
+    cirq.testing.assert_has_diagram(c0, '')
+
+
+def test_insert_qubit_order3():
+    q0, q1 = cirq.LineQubit.range(2)
+    c0 = cirq.Circuit(cirq.X(q0))
+    c0.insert(1, cirq.Y.on_each(q0, q1), strategy=cirq.InsertStrategy.INLINE)
+    c1 = cirq.Circuit(cirq.X(q0))
+    c1.insert(1, cirq.Y.on_each(q1, q0), strategy=cirq.InsertStrategy.INLINE)
+    assert c0 == c1
+    cirq.testing.assert_has_diagram(c0, '')
 
 
 def test_insert_operations_errors():

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -3564,21 +3564,12 @@ def test_insert_qubit_order():
     assert c0 == c1
 
 
-def test_insert_qubit_order2():
+def test_insert_qubit_order_inline():
     q0, q1 = cirq.LineQubit.range(2)
     c0 = cirq.Circuit(cirq.X(q0))
     c0.insert(0, cirq.Y.on_each(q0, q1), strategy=cirq.InsertStrategy.INLINE)
     c1 = cirq.Circuit(cirq.X(q0))
     c1.insert(0, cirq.Y.on_each(q1, q0), strategy=cirq.InsertStrategy.INLINE)
-    assert c0 == c1
-
-
-def test_insert_qubit_order3():
-    q0, q1 = cirq.LineQubit.range(2)
-    c0 = cirq.Circuit(cirq.X(q0))
-    c0.insert(1, cirq.Y.on_each(q0, q1), strategy=cirq.InsertStrategy.INLINE)
-    c1 = cirq.Circuit(cirq.X(q0))
-    c1.insert(1, cirq.Y.on_each(q1, q0), strategy=cirq.InsertStrategy.INLINE)
     assert c0 == c1
 
 

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -3562,7 +3562,6 @@ def test_insert_qubit_order():
     c1 = cirq.Circuit(cirq.X(q0))
     c1.insert(0, cirq.Y.on_each(q1, q0))
     assert c0 == c1
-    cirq.testing.assert_has_diagram(c0, '')
 
 
 def test_insert_qubit_order2():
@@ -3572,7 +3571,6 @@ def test_insert_qubit_order2():
     c1 = cirq.Circuit(cirq.X(q0))
     c1.insert(0, cirq.Y.on_each(q1, q0), strategy=cirq.InsertStrategy.INLINE)
     assert c0 == c1
-    cirq.testing.assert_has_diagram(c0, '')
 
 
 def test_insert_qubit_order3():
@@ -3582,7 +3580,6 @@ def test_insert_qubit_order3():
     c1 = cirq.Circuit(cirq.X(q0))
     c1.insert(1, cirq.Y.on_each(q1, q0), strategy=cirq.InsertStrategy.INLINE)
     assert c0 == c1
-    cirq.testing.assert_has_diagram(c0, '')
 
 
 def test_insert_operations_errors():


### PR DESCRIPTION
Fixes #6711

Works but ugly, and a little slow (test_append_speed about 30% slower). The idea is, instead of looking at one op at a time, to look at all ops that could fit together on one moment, and if any of them would require inserting a new moment, then insert that new moment before placing any of them. That avoids the problem where the earlier ops of that group get shifted forward when the new moment is inserted after they've been placed. 