### PR TITLE
CI - fix failing test with Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,7 @@ jobs:
     name: Pytest Ubuntu with NumPy-2
     strategy:
       matrix:
-        # TODO: #6995 - put back test for '3.13'
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ubuntu-20.04
     steps:
       - name: Check out source repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,8 @@ jobs:
     name: Pytest Ubuntu with NumPy-2
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        # TODO: #6995 - put back test for '3.13'
+        python-version: ['3.10', '3.11', '3.12']
     runs-on: ubuntu-20.04
     steps:
       - name: Check out source repository

--- a/dev_tools/pypath
+++ b/dev_tools/pypath
@@ -36,10 +36,11 @@ if ! python --version | grep -q -F "Python 3."; then
 fi
 
 _PYPATH_PREFIX="${_PYPATH_BASE_DIR}$(
+    set -o pipefail
     cd "${_PYPATH_BASE_DIR}" &&
         env PYTHONPATH=. python dev_tools/modules.py list --mode folder |
         xargs printf ":${_PYPATH_BASE_DIR}/%s"
-)"
+)" || return $?
 
 [[ $PYTHONPATH == ${_PYPATH_PREFIX}* ]] ||
     export PYTHONPATH="${_PYPATH_PREFIX}${PYTHONPATH:+:}${PYTHONPATH}"

--- a/dev_tools/requirements/dev-np2.env.txt
+++ b/dev_tools/requirements/dev-np2.env.txt
@@ -10,6 +10,10 @@
 -r ../../cirq-google/requirements.txt
 -r ../../cirq-core/cirq/contrib/requirements.txt
 
+# setuptools so we can import dev_tools.modules
+
+setuptools
+
 # pytest-minimal.env.txt without cirq-all-no-contrib.txt ---------------------
 
 -r deps/pytest.txt


### PR DESCRIPTION
Add missing `setuptools` dependency when testing with Python 3.13.

Fixes #6995
