### PR TITLE
Parameterize LinearDict

### DIFF
--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -258,11 +258,12 @@ class XPowGate(eigen_gate.EigenGate):
         return result
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
-        if protocols.is_parameterized(self) or self._dimension != 2:
+        if self._dimension != 2:
             return NotImplemented
         phase = 1j ** (2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return value.LinearDict({'I': phase * np.cos(angle), 'X': -1j * phase * np.sin(angle)})
+        lib = sympy if protocols.is_parameterized(self) else np
+        return value.LinearDict({'I': phase * lib.cos(angle), 'X': -1j * phase * lib.sin(angle)})
 
     def _circuit_diagram_info_(
         self, args: 'cirq.CircuitDiagramInfoArgs'

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -465,11 +465,10 @@ class YPowGate(eigen_gate.EigenGate):
         return abs(np.sin(self._exponent * 0.5 * np.pi))
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
-        if protocols.is_parameterized(self):
-            return NotImplemented
         phase = 1j ** (2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return value.LinearDict({'I': phase * np.cos(angle), 'Y': -1j * phase * np.sin(angle)})
+        lib = sympy if protocols.is_parameterized(self) else np
+        return value.LinearDict({'I': phase * lib.cos(angle), 'Y': -1j * phase * lib.sin(angle)})
 
     def _circuit_diagram_info_(
         self, args: 'cirq.CircuitDiagramInfoArgs'
@@ -765,11 +764,12 @@ class ZPowGate(eigen_gate.EigenGate):
         return abs(np.sin(self._exponent * 0.5 * np.pi))
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:
-        if protocols.is_parameterized(self) or self._dimension != 2:
+        if self._dimension != 2:
             return NotImplemented
         phase = 1j ** (2 * self._exponent * (self._global_shift + 0.5))
         angle = np.pi * self._exponent / 2
-        return value.LinearDict({'I': phase * np.cos(angle), 'Z': -1j * phase * np.sin(angle)})
+        lib = sympy if protocols.is_parameterized(self) else np
+        return value.LinearDict({'I': phase * lib.cos(angle), 'Z': -1j * phase * lib.sin(angle)})
 
     def _phase_by_(self, phase_turns: float, qubit_index: int):
         return self

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -1300,3 +1300,11 @@ def test_wrong_dims():
 
     with pytest.raises(ValueError, match='Wrong shape'):
         _ = cirq.Z.on(cirq.LineQid(0, dimension=3))
+
+
+def test_parameterized_pauli():
+    gate = cirq.XPowGate(exponent=sympy.Symbol('exp'))
+    pauli = cirq.pauli_expansion(gate)
+    gate_resolved = cirq.resolve_parameters(gate, {'exp': 0.5})
+    pauli_resolved = cirq.resolve_parameters(pauli, {'exp': 0.5})
+    assert pauli_resolved == cirq.pauli_expansion(gate_resolved)

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -1302,9 +1302,11 @@ def test_wrong_dims():
         _ = cirq.Z.on(cirq.LineQid(0, dimension=3))
 
 
-def test_parameterized_pauli():
-    gate = cirq.XPowGate(exponent=sympy.Symbol('exp'))
+@pytest.mark.parametrize('gate_type', [cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate])
+@pytest.mark.parametrize('exponent', [sympy.Symbol('s'), sympy.Symbol('s') * 2])
+def test_parameterized_pauli_expansion(gate_type, exponent):
+    gate = gate_type(exponent=exponent)
     pauli = cirq.pauli_expansion(gate)
-    gate_resolved = cirq.resolve_parameters(gate, {'exp': 0.5})
-    pauli_resolved = cirq.resolve_parameters(pauli, {'exp': 0.5})
-    assert pauli_resolved == cirq.pauli_expansion(gate_resolved)
+    gate_resolved = cirq.resolve_parameters(gate, {'s': 0.5})
+    pauli_resolved = cirq.resolve_parameters(pauli, {'s': 0.5})
+    assert cirq.approx_eq(pauli_resolved, cirq.pauli_expansion(gate_resolved))

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -283,7 +283,7 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
         result *= a
         return result.copy()
 
-    def __rmul__(self, a: Scalar) -> Self:  # type: ignore
+    def __rmul__(self, a: Scalar) -> Self:
         return self.__mul__(a)
 
     def __truediv__(self, a: Scalar) -> Self:
@@ -361,7 +361,7 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
         return any(protocols.is_parameterized(v) for v in self._terms.values())
 
     def _parameter_names_(self) -> AbstractSet[str]:
-        return set(protocols.parameter_names(v) for v in self._terms.values())
+        return set(name for v in self._terms.values() for name in protocols.parameter_names(v))
 
     def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'LinearDict':
         result = self.copy()

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -357,14 +357,14 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
         return cls(terms=dict(zip(keys, values)))
 
     def _is_parameterized_(self) -> bool:
-        return protocols.is_parameterized(self._terms.values())
+        return any(protocols.is_parameterized(v) for v in self._terms.values())
 
     def _parameter_names_(self) -> AbstractSet[str]:
-        return protocols.parameter_names(self._terms.values())
+        return set(protocols.parameter_names(v) for v in self._terms.values())
 
     def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'LinearDict':
         result = self.copy()
         result.update(
-            {k: protocols.resolve_parameters(v, resolver, recursive) for k, v in self._terms}
+            {k: protocols.resolve_parameters(v, resolver, recursive) for k, v in self._terms.items()}
         )
         return result

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -57,7 +57,8 @@ class _SympyPrinter(sympy.printing.str.StrPrinter):
     def _print(self, expr, **kwargs):
         if expr.is_complex:
             coefficient = complex(expr)
-            return _format_coefficient(self._format_spec, coefficient)
+            s = _format_coefficient(self._format_spec, coefficient)
+            return s[1:-1] if s[0] == '(' else s
         return super()._print(expr, **kwargs)
 
 
@@ -280,7 +281,7 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
     def __mul__(self, a: Scalar) -> Self:
         result = self.copy()
         result *= a
-        return result
+        return result.copy()
 
     def __rmul__(self, a: Scalar) -> Self:  # type: ignore
         return self.__mul__(a)

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -15,6 +15,7 @@
 """Linear combination represented as mapping of things to coefficients."""
 
 from typing import (
+    AbstractSet,
     Any,
     Callable,
     Dict,
@@ -28,6 +29,7 @@ from typing import (
     Optional,
     overload,
     Tuple,
+    TYPE_CHECKING,
     TypeVar,
     Union,
     ValuesView,
@@ -37,6 +39,9 @@ from typing_extensions import Self
 import sympy
 from cirq.value import type_alias
 from cirq import protocols
+
+if TYPE_CHECKING:
+    import cirq
 
 Scalar = type_alias.TParamValComplex
 TVector = TypeVar('TVector')
@@ -359,5 +364,7 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
 
     def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'LinearDict':
         result = self.copy()
-        result.update({k: protocols.resolve_parameters(v) for k, v in self._terms})
+        result.update(
+            {k: protocols.resolve_parameters(v, resolver, recursive) for k, v in self._terms}
+        )
         return result

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -365,6 +365,9 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, Scalar]):
     def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> 'LinearDict':
         result = self.copy()
         result.update(
-            {k: protocols.resolve_parameters(v, resolver, recursive) for k, v in self._terms.items()}
+            {
+                k: protocols.resolve_parameters(v, resolver, recursive)
+                for k, v in self._terms.items()
+            }
         )
         return result

--- a/cirq-core/cirq/value/type_alias.py
+++ b/cirq-core/cirq/value/type_alias.py
@@ -14,10 +14,10 @@
 
 from typing import Union
 
+import numpy as np
 import sympy
 
 from cirq._doc import document
-from cirq.value import linear_dict
 
 """Supply aliases for commonly used types.
 """
@@ -28,5 +28,5 @@ document(TParamKey, """A parameter that a parameter resolver may map to a value.
 TParamVal = Union[float, sympy.Expr]
 document(TParamVal, """A value that a parameter resolver may return for a parameter.""")
 
-TParamValComplex = Union[linear_dict.Scalar, sympy.Expr]
+TParamValComplex = Union[complex, np.number, sympy.Expr]
 document(TParamValComplex, """A complex value that parameter resolvers may use for parameters.""")


### PR DESCRIPTION
Allows symbolic scalars in LinearDict, plus implementations of Pauli expansions for symbolic exponents in X, Y, and Z gates.

Resolves #1617