### PR TITLE
doctest - exclude third-party sources in node_modules

### DIFF
--- a/dev_tools/docs/run_doctest.py
+++ b/dev_tools/docs/run_doctest.py
@@ -227,11 +227,10 @@ def main():
 
     file_names = glob.glob('cirq**/cirq**/**/*.py', recursive=True)
     assert file_names
-    # Remove the engine client code.
     excluded = [
-        'cirq-google/cirq_google/engine/client/',
-        'cirq-google/cirq_google/cloud/',
         'cirq-google/cirq_google/api/',
+        'cirq-google/cirq_google/cloud/',
+        'cirq-web/cirq_ts/node_modules/',
     ]
     file_names = [
         f


### PR DESCRIPTION
`cirq-web` tests may store external Python sources in node_modules.
Exclude them from the doctest test.

Also remove obsolete pattern for 'cirq-google/cirq_google/engine/client/'
as that directory does not exist anymore.
