### PR TITLE
CI - remove rstcheck as there are no rst files left

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,6 @@ jobs:
           architecture: 'x64'
       - name: Install requirements
         run: pip install -r dev_tools/requirements/dev.env.txt
-      - name: RST check
-        run: find . -type f -name "*.rst" | xargs rstcheck
       - name: Doc check
         run: check/doctest -q
   nbformat:

--- a/dev_tools/requirements/deps/dev-tools.txt
+++ b/dev_tools/requirements/deps/dev-tools.txt
@@ -12,6 +12,3 @@ asv
 
 # For verifying behavior of qasm output.
 qiskit-aer~=0.12.0
-
-# For verifying rst
-rstcheck


### PR DESCRIPTION
Recent documentation updates converted rst files to markdown.
Remove rstcheck execution in the CI and drop it from requirements.
