### PR TITLE
Enable test of the Contract-a-Grid-Circuit.ipynb notebook

### DIFF
--- a/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.tst
+++ b/cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.tst
@@ -1,0 +1,18 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Replacements to apply during testing. See devtools/notebook_test.py for syntax.
+
+width = 8->width = 6
+height = 8->height = 6

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -37,8 +37,6 @@ SKIP_NOTEBOOKS = [
     '**/ionq/*.ipynb',
     '**/pasqal/*.ipynb',
     '**/rigetti/*.ipynb',
-    # disabled to unblock Python 3.12.  TODO(#6590) - fix and enable.
-    'cirq-core/cirq/contrib/quimb/Contract-a-Grid-Circuit.ipynb',
     # skipping fidelity estimation due to
     # skipping quantum utility simulation (too large)
     'examples/advanced/*quantum_utility*',


### PR DESCRIPTION
- Enable Contract-a-Grid-Circuit.ipynb quimb notebook
- Test it with a smaller grid circuit to prevent OOM on GitHub actions

Fixes #6590
