### PR TITLE
Avoid CI flake due to random-seed-dependent test

### DIFF
--- a/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py
@@ -96,6 +96,7 @@ def test_decompose_random_unitary():
         _test_decompose(_random_unitary(), controls_count)
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_decompose_random_special_unitary():
     for controls_count in range(5):
         for _ in range(10):


### PR DESCRIPTION
This prevents test failure for

```
check/pytest --numprocesses=0 --randomly-seed=1589095746 \
    cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py::test_decompose_random_special_unitary
```
