### PR TITLE
Avoid broken wheel for qcs-sdk-python on Windows

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,1 +1,4 @@
 pyquil>=4.14.3,<5.0.0
+
+# TODO: remove after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
+qcs-sdk-python!=0.21.9; sys_platform == "win32"


### PR DESCRIPTION
The wheel installation fails on Windows Python 3.12 with
`Bad CRC-32 for file 'qcs_sdk/qcs_sdk.cp312-win_amd64.pyd'`

Revert after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
