### PR TITLE
Update SciPy requirement to 1.15

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -7,7 +7,7 @@ networkx~=3.1
 numpy>=1.25
 pandas~=2.0
 sortedcontainers~=2.0
-scipy~=1.11
+scipy~=1.15
 sympy
 typing_extensions>=4.2
 tqdm


### PR DESCRIPTION
A serendipitous comment by @mpharrigan in a chat exchange today led to the discovery that Qualtran uses SciPy version 1.15, and that installing Cirq has always ended up downgrading the SciPy version for him. Trying Cirq out with SciPy 1.15, it doesn't seem that any tests fail. It seems like we could up the version of SciPy to 1.15 and avoid the compatibility hassles.