### PR TITLE
Change npm schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,7 @@ updates:
     # the specified directory.
     directory: "/cirq-web/cirq_ts/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     versioning-strategy: "widen"
     groups:
       # Group non-security version minor & patch updates into one PR.


### PR DESCRIPTION
The only JavaScript dependencies are in the cirq-web package, which isn't installed in a public-facing location anywhere. The frequency of Dependabot updates and PRs has been too high to justify the maintenance cost. Per internal discussions, we want to move to a monthly schedule for the npm/JavaScript checks.