### PR TITLE
Specify `long_description_content_type` so that PyPI accepts wheels

### DIFF
--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -71,6 +71,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=cirq_packages,
     package_data={'cirq_aqt': ['py.typed'], 'cirq_aqt.json_test_data': ['*']},
     classifiers=[

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -75,6 +75,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=cirq_packages,
     package_data={'cirq': ['py.typed'], 'cirq.protocols.json_test_data': ['*']},
     classifiers=[

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -73,6 +73,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=packs,
     package_data={
         'cirq_google': ['py.typed'],

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -70,6 +70,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=cirq_packages,
     package_data={'cirq_ionq': ['py.typed'], 'cirq_ionq.json_test_data': ['*']},
     classifiers=[

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -69,6 +69,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=cirq_packages,
     package_data={'cirq_pasqal': ['py.typed'], 'cirq_pasqal.json_test_data': ['*']},
     classifiers=[

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -71,6 +71,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=cirq_packages,
     package_data={'cirq_rigetti': ['py.typed'], 'cirq_rigetti.json_test_data': ['*']},
     classifiers=[

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -73,6 +73,7 @@ setup(
     license='Apache 2',
     description=description,
     long_description=long_description,
+    long_description_content_type='text/markdown',
     packages=packs,
     package_data={'cirq_web': ['dist/*'], 'cirq_ts': ['dist/*.bundle.js']},
     classifiers=[


### PR DESCRIPTION
Fixes #7028
