### PR TITLE
Fix the format of CliffordGate repr.

### DIFF
--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -433,7 +433,7 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
         return CliffordGate.from_clifford_tableau(base_tableau)
 
     def __repr__(self) -> str:
-        return f"Clifford Gate with Tableau:\n {self.clifford_tableau._str_full_()}"
+        return f"Clifford Gate with Tableau:\n{self.clifford_tableau._str_full_()}"
 
     def _commutes_(
         self, other: Any, *, atol: float = 1e-8

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -941,6 +941,18 @@ def test_clifford_gate_repr():
         t = gate.clifford_tableau
         assert repr(gate) == f"Clifford Gate with Tableau:\n{t._str_full_()}"
 
+    # Check repr without calling _str_full_() for one gate of CliffordGate type.
+    # This verifies that repr output is as expected with correct stabilizers and destabilizers.
+    assert (
+        repr(cirq.ops.CliffordGate.CNOT)
+        == """Clifford Gate with Tableau:
+stable | destable
+-------+----------
++ Z0   | + X0X1
++ Z0Z1 | +   X1
+"""
+    )
+
 
 def test_single_qubit_clifford_gate_repr():
     # Common gates

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -925,24 +925,16 @@ def test_all_single_qubit_clifford_unitaries():
 
 def test_clifford_gate_repr():
     q0, q1, q2 = cirq.LineQubit.range(3)
-    gates: list[cirq.ops.CliffordGate] = [
-        # Common gates
-        cirq.ops.CliffordGate.CNOT,
-        cirq.ops.CliffordGate.CZ,
-        cirq.ops.CliffordGate.SWAP,
-        # Other gates
-        cirq.ops.CliffordGate.from_op_list(
-            [cirq.ops.PhasedXZGate(axis_phase_exponent=0.25, x_exponent=-1, z_exponent=0).on(q0)],
-            [q0],
-        ),
-        cirq.ops.CliffordGate.from_op_list([cirq.ops.X(q0), cirq.CZ(q1, q2)], [q0, q1, q2]),
-    ]
-    for gate in gates:
-        t = gate.clifford_tableau
-        assert repr(gate) == f"Clifford Gate with Tableau:\n{t._str_full_()}"
-
-    # Check repr without calling _str_full_() for one gate of CliffordGate type.
-    # This verifies that repr output is as expected with correct stabilizers and destabilizers.
+    assert (
+        repr(cirq.ops.CliffordGate.from_op_list([cirq.ops.X(q0), cirq.CZ(q1, q2)], [q0, q1, q2]))
+        == """Clifford Gate with Tableau:
+stable   | destable
+---------+----------
+- Z0     | + X0    
++   Z1   | +   X1Z2
++     Z2 | +   Z1X2
+"""
+    )
     assert (
         repr(cirq.ops.CliffordGate.CNOT)
         == """Clifford Gate with Tableau:

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -930,7 +930,7 @@ def test_clifford_gate_repr():
         == """Clifford Gate with Tableau:
 stable   | destable
 ---------+----------
-- Z0     | + X0    
+- Z0     | + X0
 +   Z1   | +   X1Z2
 +     Z2 | +   Z1X2
 """

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -923,7 +923,27 @@ def test_all_single_qubit_clifford_unitaries():
     assert cirq.equal_up_to_global_phase(cs[23], (i - 1j * (-x - y - z)) / 2)
 
 
+def test_clifford_gate_repr():
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    gates: list[cirq.ops.CliffordGate] = [
+        # Common gates
+        cirq.ops.CliffordGate.CNOT,
+        cirq.ops.CliffordGate.CZ,
+        cirq.ops.CliffordGate.SWAP,
+        # Other gates
+        cirq.ops.CliffordGate.from_op_list(
+            [cirq.ops.PhasedXZGate(axis_phase_exponent=0.25, x_exponent=-1, z_exponent=0).on(q0)],
+            [q0],
+        ),
+        cirq.ops.CliffordGate.from_op_list([cirq.ops.X(q0), cirq.CZ(q1, q2)], [q0, q1, q2]),
+    ]
+    for gate in gates:
+        t = gate.clifford_tableau
+        assert repr(gate) == f"Clifford Gate with Tableau:\n{t._str_full_()}"
+
+
 def test_single_qubit_clifford_gate_repr():
+    # Common gates
     assert repr(cirq.ops.SingleQubitCliffordGate.X) == (
         'cirq.ops.SingleQubitCliffordGate(_clifford_tableau=cirq.CliffordTableau(1, '
         'rs=np.array([False, True]), xs=np.array([[True], [False]]), '
@@ -950,8 +970,22 @@ def test_single_qubit_clifford_gate_repr():
         'zs=np.array([[False], [True]])))'
     )
 
-    assert str(cirq.ops.SingleQubitCliffordGate.X) == (
+    assert repr(cirq.ops.SingleQubitCliffordGate.X) == (
         'cirq.ops.SingleQubitCliffordGate(_clifford_tableau=cirq.CliffordTableau(1, '
         'rs=np.array([False, True]), xs=np.array([[True], [False]]), '
         'zs=np.array([[False], [True]])))'
+    )
+
+    # Other gates
+    qa = cirq.NamedQubit('a')
+    gate = cirq.ops.SingleQubitCliffordGate.from_clifford_tableau(
+        cirq.ops.CliffordGate.from_op_list(
+            [cirq.ops.PhasedXZGate(axis_phase_exponent=0.25, x_exponent=-1, z_exponent=0).on(qa)],
+            [qa],
+        ).clifford_tableau
+    )
+    assert repr(gate) == (
+        'cirq.ops.SingleQubitCliffordGate(_clifford_tableau=cirq.CliffordTableau(1, '
+        'rs=np.array([False, True]), xs=np.array([[True], [False]]), '
+        'zs=np.array([[True], [True]])))'
     )


### PR DESCRIPTION
Remove one space to align output CliffordTableau correctly.

Before:
```
Clifford Gate with Tableau:
 stable | destable
-------+----------
- Z0   | + Y0
```
After:
```
Clifford Gate with Tableau:
stable | destable
-------+----------
- Z0   | + Y0
```