### PR TITLE
Avoid broken wheels for qcs-sdk-python

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=4.14.3,<5.0.0
 
 # TODO: remove after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
-qcs-sdk-python!=0.21.9; sys_platform == "win32"
+qcs-sdk-python<=0.21.8


### PR DESCRIPTION
The installation of `qcs-sdk-python==0.21.11` fails on Linux Python 3.12
with `zlib.error: Error -3 while decompressing data: invalid block type`.

Block new versions of qcs-sdk-python until this gets sorted out.

Ref: https://github.com/rigetti/qcs-sdk-rust/issues/531
