### PR TITLE
Set permissions for CI job

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,9 @@ jobs:
   stale:
     name: Label and/or close stale issues and PRs
     runs-on: ubuntu-20.04
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@v9
       with:


### PR DESCRIPTION
Google is about to change the security settings on all repositories. One of the changes is this:

> [Workflow permissions](https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise#workflow-permissions) will be changed from "Read and write permissions" to "Read repository contents and packages permissions." With this change the `GITHUB_TOKEN` will only have read access for the contents and packages scopes by default. The more permissive setting **cannot** be chosen as the default for individual organizations or repositories.

This PR sets the job permission as suggested by the [documentation for `actions/stale`](https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions).