### PR TITLE
Make mypy pass regardless if qsimcirq is installed or not

### DIFF
--- a/cirq-google/cirq_google/engine/virtual_engine_factory.py
+++ b/cirq-google/cirq_google/engine/virtual_engine_factory.py
@@ -402,7 +402,7 @@ def create_default_noisy_quantum_virtual_machine(
 
     if simulator_class is None:
         try:  # pragma: no cover
-            import qsimcirq  # type: ignore
+            import qsimcirq
 
             simulator_class = qsimcirq.QSimSimulator  # pragma: no cover
         except ImportError:

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -16,7 +16,7 @@ ignore_missing_imports = true
 # 3rd-party libs for which we don't have stubs
 
 # Google
-[mypy-google.api_core.*,google.auth.*,google.colab.*,google.cloud.*,google.oauth2.*]
+[mypy-google.api_core.*,google.auth.*,google.colab.*,google.cloud.*,google.oauth2.*,qsimcirq]
 follow_imports = silent
 ignore_missing_imports = true
 


### PR DESCRIPTION
Avoid `[unused-ignore]` error from `check/mypy` when qsimcirq is installed.
