### PR TITLE
Fix conjugated_by of PauliString.

### DIFF
--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -377,7 +377,10 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
         #  ZI  [ 0  0 | 1  0  | 1 ]
         #  IZ  [ 1  0 | 1  1  | 0 ]
         # Take the third row as example: this means the ZI gate after the this gate,
-        # more precisely the conjugate transformation of ZI by this gate, becomes -ZI.
+        # more precisely the conjugate transformation of ZI by this gate, becomes -ZI:
+        #   ---(CliffordGate^-1)---ZI---CliffordGate---
+        # = unitary(CliffordGate)@unitary(ZI)@unitary(CliffordGate).conj().T
+        # = -ZI.
         # (Note the real clifford tableau has to satify the Symplectic property.
         # here is just for illustration)
         object.__setattr__(self, '_clifford_tableau', _clifford_tableau.copy())
@@ -438,7 +441,7 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
     def _commutes_(
         self, other: Any, *, atol: float = 1e-8
     ) -> Union[bool, NotImplementedType, None]:
-        # Note even if we assume two gates define the tabluea based on the same qubit order,
+        # Note even if we assume two gates define the tableau based on the same qubit order,
         # the following approach cannot judge it:
         # self.clifford_tableau.then(other.clifford_tableau) == other.clifford_tableau.then(
         #     self.clifford_tableau

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -982,11 +982,11 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         all_ops = list(op_tree.flatten_to_ops(clifford))
         all_qubits = set.union(set(self.qubits), [q for op in all_ops for q in op.qubits])
 
-        # Iterative calculate the conjugation in reverse order of ops.
+        # Iteratively calculate the conjugation in reverse order of ops.
         for op in all_ops[::-1]:
-            # To calcuate the conjugation of P (`ps`) with respect to C (`clifford_op`)
-            # Decompose P = Pc⊗R, where Pc acts on the same qubits as C, R acts ont the remaining.
-            # Then the conjugation C.conj(Pc) = (C^{-1}⊗I Pc⊗R C⊗I) = (C^{-1} Pc C)⊗R.
+            # To calcuate the conjugation of P (`ps`) with respect to C (`op`)
+            # Decompose P = Pc⊗R, where Pc acts on the same qubits as C, R acts on the remaining.
+            # Then the conjugation = (C^{-1}⊗I·Pc⊗R·C⊗I) = (C^{-1}·Pc·C)⊗R.
 
             # Isolate R
             remain: 'cirq.PauliString' = PauliString()
@@ -1012,7 +1012,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
                 gate_in_clifford = clifford_gate.CliffordGate.from_op_list([op], op.qubits)
             tableau = gate_in_clifford.clifford_tableau.inverse()
 
-            # Calculate the conjugation of clifford_op by mutiplying the conjugation of each Pauli:
+            # Calculate the conjugation by `op` via mutiplying the conjugation of each Pauli:
             #   C^{-1}·(P_1⊗...⊗P_n)·C
             # = C^{-1}·(P_1⊗I) ...·(P_n⊗I)·C
             # = (C^{-1}(P_1⊗I)C)·...·(C^{-1}(P_n⊗I)C)

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -57,6 +57,22 @@ def _small_sample_qubit_pauli_maps():
     yield {qubits[0]: cirq.Z, qubits[1]: cirq.X, qubits[2]: cirq.Y}
 
 
+def assert_conjugation(
+    input_ps: cirq.PauliString,
+    op: cirq.Operation,
+    expected: cirq.PauliString | None,
+    compare_unitary: bool = False,
+):
+    conjugation = input_ps.conjugated_by(op)
+    if expected is not None:
+        assert conjugation == expected
+    if compare_unitary:
+        actual_unitary = cirq.unitary(conjugation.dense(op.qubits))
+        c = cirq.unitary(op)
+        expected_unitary = np.conj(c.T) @ cirq.unitary(input_ps.dense(op.qubits)) @ c
+        assert np.allclose(actual_unitary, expected_unitary, atol=1e-8)
+
+
 def test_eq_ne_hash():
     q0, q1, q2 = _make_qubits(3)
     eq = cirq.testing.EqualsTester()
@@ -1381,13 +1397,26 @@ def test_pauli_string_expectation_from_state_vector_mixed_state_linearity():
 def test_conjugated_by_normal_gates():
     a = cirq.LineQubit(0)
 
-    assert cirq.X(a).conjugated_by(cirq.H(a)) == cirq.Z(a)
-    assert cirq.Y(a).conjugated_by(cirq.H(a)) == -cirq.Y(a)
-    assert cirq.Z(a).conjugated_by(cirq.H(a)) == cirq.X(a)
+    assert_conjugation(cirq.X(a), cirq.H(a), cirq.Z(a), True)
+    assert_conjugation(cirq.Y(a), cirq.H(a), -cirq.Y(a), True)
+    assert_conjugation(cirq.Z(a), cirq.H(a), cirq.X(a), True)
 
-    assert cirq.X(a).conjugated_by(cirq.S(a)) == -cirq.Y(a)
-    assert cirq.Y(a).conjugated_by(cirq.S(a)) == cirq.X(a)
-    assert cirq.Z(a).conjugated_by(cirq.S(a)) == cirq.Z(a)
+    assert_conjugation(cirq.X(a), cirq.S(a), -cirq.Y(a), True)
+    assert_conjugation(cirq.Y(a), cirq.S(a), cirq.X(a), True)
+    assert_conjugation(cirq.Z(a), cirq.S(a), cirq.Z(a), True)
+
+    clifford_op = cirq.PhasedXZGate(axis_phase_exponent=0.25, x_exponent=-1, z_exponent=0).on(a)
+    assert_conjugation(cirq.X(a), clifford_op, cirq.Y(a), True)
+    assert_conjugation(cirq.Y(a), clifford_op, cirq.X(a), True)
+    assert_conjugation(cirq.Z(a), clifford_op, -cirq.Z(a), True)
+
+
+def test_conjugated_by_op_gate_of_clifford_gate_type():
+    a = cirq.LineQubit(0)
+
+    assert_conjugation(
+        cirq.X(a), cirq.CliffordGate.from_op_list([cirq.H(a)], [a]).on(a), cirq.Z(a), True
+    )
 
 
 def test_dense():
@@ -1430,16 +1459,25 @@ def test_conjugated_by_incorrectly_powered_cliffords():
         cirq.ZZ(a, b),
     ]
     for c in cliffords:
-        with pytest.raises(TypeError, match='not a known Clifford'):
+        with pytest.raises(
+            ValueError,
+            match='Clifford Gate can only be constructed from the operations'
+            ' that has stabilizer effect.',
+        ):
             _ = p.conjugated_by(c**0.1)
-        with pytest.raises(TypeError, match='not a known Clifford'):
+        with pytest.raises(
+            ValueError,
+            match='Clifford Gate can only be constructed from the operations'
+            ' that has stabilizer effect.',
+        ):
             _ = p.conjugated_by(c ** sympy.Symbol('t'))
 
 
 def test_conjugated_by_global_phase():
+    """Global phase gate preserves PauliString."""
     a = cirq.LineQubit(0)
-    assert cirq.X(a).conjugated_by(cirq.global_phase_operation(1j)) == cirq.X(a)
-    assert cirq.Z(a).conjugated_by(cirq.global_phase_operation(np.exp(1.1j))) == cirq.Z(a)
+    assert_conjugation(cirq.X(a), cirq.global_phase_operation(1j), cirq.X(a))
+    assert_conjugation(cirq.X(a), cirq.global_phase_operation(np.exp(1.1j)), cirq.X(a))
 
     class DecomposeGlobal(cirq.Gate):
         def num_qubits(self):
@@ -1448,7 +1486,7 @@ def test_conjugated_by_global_phase():
         def _decompose_(self, qubits):
             yield cirq.global_phase_operation(1j)
 
-    assert cirq.X(a).conjugated_by(DecomposeGlobal().on(a)) == cirq.X(a)
+    assert_conjugation(cirq.X(a), DecomposeGlobal().on(a), cirq.X(a))
 
 
 def test_conjugated_by_composite_with_disjoint_sub_gates():
@@ -1461,8 +1499,10 @@ def test_conjugated_by_composite_with_disjoint_sub_gates():
         def _decompose_(self, qubits):
             yield cirq.H(qubits[1])
 
-    assert cirq.X(a).conjugated_by(DecomposeDisjoint().on(a, b)) == cirq.X(a)
-    assert cirq.X(a).pass_operations_over([DecomposeDisjoint().on(a, b)]) == cirq.X(a)
+    for g1 in [cirq.X, cirq.Y]:
+        for g2 in [cirq.X, cirq.Y]:
+            ps = g1(a) * g2(b)
+            assert ps.conjugated_by(DecomposeDisjoint().on(a, b)) == ps.conjugated_by(cirq.H(b))
 
 
 def test_conjugated_by_clifford_composite():
@@ -1477,16 +1517,16 @@ def test_conjugated_by_clifford_composite():
             yield cirq.SWAP(qubits[2], qubits[3])
 
     a, b, c, d = cirq.LineQubit.range(4)
-    p = cirq.X(a) * cirq.Z(b)
+    ps = cirq.X(a) * cirq.Z(b)
     u = UnknownGate()
-    assert p.conjugated_by(u(a, b, c, d)) == cirq.Z(a) * cirq.X(b)
+    assert_conjugation(ps, u(a, b, c, d), cirq.Z(a) * cirq.X(b))
 
 
 def test_conjugated_by_move_into_uninvolved():
     a, b, c, d = cirq.LineQubit.range(4)
-    p = cirq.X(a) * cirq.Z(b)
-    assert p.conjugated_by([cirq.SWAP(c, d), cirq.SWAP(b, c)]) == cirq.X(a) * cirq.Z(d)
-    assert p.conjugated_by([cirq.SWAP(b, c), cirq.SWAP(c, d)]) == cirq.X(a) * cirq.Z(c)
+    ps = cirq.X(a) * cirq.Z(b)
+    assert_conjugation(ps, [cirq.SWAP(c, d), cirq.SWAP(b, c)], cirq.X(a) * cirq.Z(d))
+    assert_conjugation(ps, [cirq.SWAP(b, c), cirq.SWAP(c, d)], cirq.X(a) * cirq.Z(c))
 
 
 def test_conjugated_by_common_single_qubit_gates():
@@ -1508,21 +1548,13 @@ def test_conjugated_by_common_single_qubit_gates():
     single_qubit_gates = [g**i for i in range(4) for g in base_single_qubit_gates]
     for p in [cirq.X, cirq.Y, cirq.Z]:
         for g in single_qubit_gates:
-            assert p.on(a).conjugated_by(g.on(b)) == p.on(a)
-
-            actual = cirq.unitary(p.on(a).conjugated_by(g.on(a)))
-            u = cirq.unitary(g)
-            expected = np.conj(u.T) @ cirq.unitary(p) @ u
-            assert cirq.allclose_up_to_global_phase(actual, expected, atol=1e-8)
+            # pauli gate on a, clifford on b: pauli gate preserves.
+            assert_conjugation(p(a), g(b), p(a))
+            # pauli gate on a, clifford on a: check conjugation in matrices.
+            assert_conjugation(p(a), g(a), None, compare_unitary=True)
 
 
 def test_conjugated_by_common_two_qubit_gates():
-    class OrderSensitiveGate(cirq.Gate):
-        def num_qubits(self):
-            return 2
-
-        def _decompose_(self, qubits):
-            return [cirq.Y(qubits[0]) ** -0.5, cirq.CNOT(*qubits)]
 
     a, b, c, d = cirq.LineQubit.range(4)
     two_qubit_gates = [
@@ -1541,34 +1573,25 @@ def test_conjugated_by_common_two_qubit_gates():
         cirq.YY**-0.5,
         cirq.ZZ**-0.5,
     ]
-    two_qubit_gates.extend([OrderSensitiveGate()])
     for p1 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
         for p2 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
             pd = cirq.DensePauliString([p1, p2])
-            p = pd.sparse()
+            p = pd.sparse([a, b])
             for g in two_qubit_gates:
-                assert p.conjugated_by(g.on(c, d)) == p
-
-                actual = cirq.unitary(p.conjugated_by(g.on(a, b)).dense([a, b]))
-                u = cirq.unitary(g)
-                expected = np.conj(u.T) @ cirq.unitary(pd) @ u
-                np.testing.assert_allclose(actual, expected, atol=1e-8)
+                # pauli_string on (a,b), clifford on (c,d): pauli_string preserves.
+                assert_conjugation(p, g(c, d), p)
+                # pauli_string on (a,b), clifford on (a,b): compare unitaries of
+                # the conjugated_by and actual matrix conjugation.
+                assert_conjugation(p, g.on(a, b), None, compare_unitary=True)
 
 
 def test_conjugated_by_ordering():
-    class OrderSensitiveGate(cirq.Gate):
-        def num_qubits(self):
-            return 2
-
-        def _decompose_(self, qubits):
-            return [cirq.Y(qubits[0]) ** -0.5, cirq.CNOT(*qubits)]
-
+    """Tests .conjugated_by([op1, op2]) == .conjugated_by(op2).conjugated_by(op1)"""
     a, b = cirq.LineQubit.range(2)
     inp = cirq.Z(b)
-    out1 = inp.conjugated_by(OrderSensitiveGate().on(a, b))
-    out2 = inp.conjugated_by([cirq.H(a), cirq.CNOT(a, b)])
-    out3 = inp.conjugated_by(cirq.CNOT(a, b)).conjugated_by(cirq.H(a))
-    assert out1 == out2 == out3 == cirq.X(a) * cirq.Z(b)
+    out1 = inp.conjugated_by([cirq.H(a), cirq.CNOT(a, b)])
+    out2 = inp.conjugated_by(cirq.CNOT(a, b)).conjugated_by(cirq.H(a))
+    assert out1 == out2 == cirq.X(a) * cirq.Z(b)
 
 
 def test_pass_operations_over_ordering():

--- a/cirq-core/cirq/ops/swap_gates.py
+++ b/cirq-core/cirq/ops/swap_gates.py
@@ -219,6 +219,11 @@ class ISwapPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate
         ]
         # yapf: enable
 
+    def _has_stabilizer_effect_(self) -> Optional[bool]:
+        if self._is_parameterized_():
+            return None
+        return self.exponent % 1 == 0
+
     def _decompose_(self, qubits):
         a, b = qubits
 


### PR DESCRIPTION
Rewrite PauliString.conjugated_by.

Context: previous conjugated_by relies on _decompose_into_cliffords_ which crashes in for some cliffords: #6946.

Followup: note `pass_operations_over()` and `inplace_after()` still rely on `_decompose_into_cliffords_ `and `_pass_operation_over_`, I will clean them up in the followup PRs. (tried to clean them up in the same pr, but too many nit updates are needed in both the class itself and the tests)