### PR TITLE
Update ubuntu-20.04 to 22.04

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # partitions should be named partition-0 to partition-(NOTEBOOK_PARTITIONS-1)
         partition: [partition-0, partition-1, partition-2, partition-3]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   quick_test:
     name: Misc check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
         run: check/misc
   packaging_test:
     name: Packaging test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
         run: ./dev_tools/packaging/packaging_test.sh
   format:
     name: Format check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
         run: check/format-incremental
   mypy:
     name: Type check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
         run: check/mypy
   changed_files:
     name: Changed files test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
         run: check/pytest-changed-files -n auto
   lint:
     name: Lint check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
         run: check/pylint -v
   doc_test:
     name: Doc test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
         run: check/doctest -q
   nbformat:
     name: Notebook formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
         run: check/nbformat
   shellcheck:
     name: Shell check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
         run: check/shellcheck
   isolated-modules:
     name: Isolated pytest Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -170,7 +170,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -222,7 +222,7 @@ jobs:
         run: check/pytest -n auto --warn-numpy-data-promotion --durations=20 --ignore=cirq-rigetti
   pip-compile:
     name: Check consistency of requirements
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -238,7 +238,7 @@ jobs:
           pip-compile --resolver=backtracking dev_tools/requirements/deps/cirq-all.txt -o-
   build_protos:
     name: Build protos
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -256,7 +256,7 @@ jobs:
         run: check/protos-up-to-date
   coverage:
     name: Coverage check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -347,7 +347,7 @@ jobs:
       matrix:
         # partitions should be named partition-0 to partition-(NOTEBOOK_PARTITIONS-1)
         partition: [partition-0, partition-1, partition-2, partition-3]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -370,7 +370,7 @@ jobs:
           path: out
   notebooks-branch:
     name: Notebook Tests against PR
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -391,7 +391,7 @@ jobs:
           path: out
   ts-build:
     name: Bundle file consistency
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -405,7 +405,7 @@ jobs:
         run: check/ts-build-current
   ts-lint:
     name: Typescript lint check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -419,7 +419,7 @@ jobs:
         run: check/ts-lint
   ts-test:
     name: Typescript tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4
@@ -435,7 +435,7 @@ jobs:
         run: check/ts-test-e2e
   ts-coverage:
     name: Typescript tests coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out source repository
         uses: actions/checkout@v4

--- a/.github/workflows/pytest-debug.yaml
+++ b/.github/workflows/pytest-debug.yaml
@@ -27,11 +27,15 @@ on:
         type: choice
         default: ubuntu-20.04
         options:
+          - ubuntu-latest
+          - ubuntu-24.04
           - ubuntu-22.04
           - ubuntu-20.04
+          - macos-latest
           - macos-15
           - macos-14
           - macos-13
+          - windows-latest
           - windows-2025
           - windows-2022
           - windows-2019

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -8,7 +8,7 @@ jobs:
   push_to_pypi:
     if: github.repository == 'quantumlib/Cirq'
     name: Push to PyPi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       NAME: dev-release
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   stale:
     name: Label and/or close stale issues and PRs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/stale@v9
       with:


### PR DESCRIPTION
The GitHub Ubuntu 20.04 runner images will be removed in 2 weeks, so we should probably update our workflows now.

https://github.com/actions/runner-images/issues/11101