### PR TITLE
Unpin the qcs-sdk-python dependency

### DIFF
--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,4 +1,1 @@
 pyquil>=4.14.3,<5.0.0
-
-# TODO: remove after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
-qcs-sdk-python<=0.21.8


### PR DESCRIPTION
The recent release qcs-sdk-python-0.21.12 should be fixed per
https://github.com/rigetti/qcs-sdk-rust/issues/531.

This rolls back #7056 and #7026
