### PR TITLE
Implement _act_on_ for SingleQubitCliffordGate

### DIFF
--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -790,7 +790,7 @@ class SingleQubitCliffordGate(CliffordGate):
             case SingleQubitCliffordGate.Z_nsqrt:
                 stabilizer.apply_z(axis, -0.5)
             case _:
-                return NotImplemented  # Unnamed Cliffords will be decomposed.
+                return super()._act_on_(sim_state, qubits)
         return True
 
     # Single Clifford Gate decomposition is more efficient than the general Tableau decomposition.

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -789,8 +789,8 @@ class SingleQubitCliffordGate(CliffordGate):
                 stabilizer.apply_y(axis, -0.5)
             case SingleQubitCliffordGate.Z_nsqrt:
                 stabilizer.apply_z(axis, -0.5)
-            case _:  # pragma: no cover
-                raise ValueError(f'Unexpected SingleQubitCliffordGate {self}.')
+            case _:
+                return NotImplemented  # Unnamed Cliffords will be decomposed.
         return True
 
     # Single Clifford Gate decomposition is more efficient than the general Tableau decomposition.

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -790,7 +790,7 @@ class SingleQubitCliffordGate(CliffordGate):
             case SingleQubitCliffordGate.Z_nsqrt:
                 stabilizer.apply_z(axis, -0.5)
             case _:
-                return super()._act_on_(sim_state, qubits)
+                return NotImplemented  # Unnamed Cliffords will be decomposed.
         return True
 
     # Single Clifford Gate decomposition is more efficient than the general Tableau decomposition.

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -759,13 +759,38 @@ class SingleQubitCliffordGate(CliffordGate):
 
         return NotImplemented
 
-    def _act_on_(
-        self,
-        sim_state: 'cirq.SimulationStateBase',  # pylint: disable=unused-argument
-        qubits: Sequence['cirq.Qid'],  # pylint: disable=unused-argument
-    ):
-        # TODO(#5256) Add the implementation of _act_on_ with CliffordTableauSimulationState.
-        return NotImplemented
+    def _act_on_(self, sim_state: 'cirq.SimulationStateBase', qubits: Sequence['cirq.Qid']):
+        from cirq.sim.clifford.stabilizer_simulation_state import StabilizerSimulationState
+
+        if not isinstance(sim_state, StabilizerSimulationState):
+            return NotImplemented
+        if self is SingleQubitCliffordGate.I:
+            return True
+        axis = sim_state.get_axes(qubits)[0]
+        stabilizer = sim_state._state
+        if self is SingleQubitCliffordGate.X:
+            stabilizer.apply_x(axis)
+        elif self is SingleQubitCliffordGate.Y:
+            stabilizer.apply_y(axis)
+        elif self is SingleQubitCliffordGate.Z:
+            stabilizer.apply_z(axis)
+        elif self is SingleQubitCliffordGate.H:
+            stabilizer.apply_h(axis)
+        elif self is SingleQubitCliffordGate.X_sqrt:
+            stabilizer.apply_x(axis, 0.5)
+        elif self is SingleQubitCliffordGate.Y_sqrt:
+            stabilizer.apply_y(axis, 0.5)
+        elif self is SingleQubitCliffordGate.Z_sqrt:
+            stabilizer.apply_z(axis, 0.5)
+        elif self is SingleQubitCliffordGate.X_nsqrt:
+            stabilizer.apply_x(axis, -0.5)
+        elif self is SingleQubitCliffordGate.Y_nsqrt:
+            stabilizer.apply_y(axis, -0.5)
+        elif self is SingleQubitCliffordGate.Z_nsqrt:
+            stabilizer.apply_z(axis, -0.5)
+        else:
+            raise ValueError(f'Unexpected SingleQubitCliffordGate {self}.')  # pragma: no cover
+        return True
 
     # Single Clifford Gate decomposition is more efficient than the general Tableau decomposition.
     def _decompose_(self, qubits: Sequence['cirq.Qid']) -> 'cirq.OP_TREE':

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -764,32 +764,33 @@ class SingleQubitCliffordGate(CliffordGate):
 
         if not isinstance(sim_state, StabilizerSimulationState):
             return NotImplemented
-        if self is SingleQubitCliffordGate.I:
+        if self == SingleQubitCliffordGate.I:
             return True
         axis = sim_state.get_axes(qubits)[0]
         stabilizer = sim_state._state
-        if self is SingleQubitCliffordGate.X:
-            stabilizer.apply_x(axis)
-        elif self is SingleQubitCliffordGate.Y:
-            stabilizer.apply_y(axis)
-        elif self is SingleQubitCliffordGate.Z:
-            stabilizer.apply_z(axis)
-        elif self is SingleQubitCliffordGate.H:
-            stabilizer.apply_h(axis)
-        elif self is SingleQubitCliffordGate.X_sqrt:
-            stabilizer.apply_x(axis, 0.5)
-        elif self is SingleQubitCliffordGate.Y_sqrt:
-            stabilizer.apply_y(axis, 0.5)
-        elif self is SingleQubitCliffordGate.Z_sqrt:
-            stabilizer.apply_z(axis, 0.5)
-        elif self is SingleQubitCliffordGate.X_nsqrt:
-            stabilizer.apply_x(axis, -0.5)
-        elif self is SingleQubitCliffordGate.Y_nsqrt:
-            stabilizer.apply_y(axis, -0.5)
-        elif self is SingleQubitCliffordGate.Z_nsqrt:
-            stabilizer.apply_z(axis, -0.5)
-        else:
-            raise ValueError(f'Unexpected SingleQubitCliffordGate {self}.')  # pragma: no cover
+        match self:
+            case SingleQubitCliffordGate.X:
+                stabilizer.apply_x(axis)
+            case SingleQubitCliffordGate.Y:
+                stabilizer.apply_y(axis)
+            case SingleQubitCliffordGate.Z:
+                stabilizer.apply_z(axis)
+            case SingleQubitCliffordGate.H:
+                stabilizer.apply_h(axis)
+            case SingleQubitCliffordGate.X_sqrt:
+                stabilizer.apply_x(axis, 0.5)
+            case SingleQubitCliffordGate.Y_sqrt:
+                stabilizer.apply_y(axis, 0.5)
+            case SingleQubitCliffordGate.Z_sqrt:
+                stabilizer.apply_z(axis, 0.5)
+            case SingleQubitCliffordGate.X_nsqrt:
+                stabilizer.apply_x(axis, -0.5)
+            case SingleQubitCliffordGate.Y_nsqrt:
+                stabilizer.apply_y(axis, -0.5)
+            case SingleQubitCliffordGate.Z_nsqrt:
+                stabilizer.apply_z(axis, -0.5)
+            case _:  # pragma: no cover
+                raise ValueError(f'Unexpected SingleQubitCliffordGate {self}.')
         return True
 
     # Single Clifford Gate decomposition is more efficient than the general Tableau decomposition.

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -143,10 +143,6 @@ def _gate_tableau(num_qubits: int, gate: raw_types.Gate) -> 'cirq.CliffordTablea
 class CommonCliffordGateMetaClass(value.ABCMetaImplementAnyOneOf):
     """A metaclass used to lazy initialize several common Clifford Gate as class attributes."""
 
-    # These are class properties so we define them as properties on a metaclass.
-    # Note that in python 3.9+ @classmethod can be used with @property, so these
-    # can be moved to CommonCliffordGates.
-
     @property
     def all_single_qubit_cliffords(cls) -> Sequence['cirq.SingleQubitCliffordGate']:
         """All 24 single-qubit Clifford gates."""

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -820,8 +820,8 @@ def test_clifford_gate_act_on_small_case():
     expected_args = cirq.CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=5), qubits=qubits, prng=np.random.RandomState()
     )
-    cirq.act_on(cirq.H, expected_args, qubits=[qubits[0]], allow_decompose=False)
-    cirq.act_on(cirq.CliffordGate.H, args, qubits=[qubits[0]], allow_decompose=False)
+    cirq.act_on(cirq.I, expected_args, qubits=[qubits[0]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.I, args, qubits=[qubits[0]], allow_decompose=False)
     assert args.tableau == expected_args.tableau
 
     cirq.act_on(cirq.CNOT, expected_args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
@@ -838,6 +838,38 @@ def test_clifford_gate_act_on_small_case():
 
     cirq.act_on(cirq.X, expected_args, qubits=[qubits[2]], allow_decompose=False)
     cirq.act_on(cirq.CliffordGate.X, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.Y, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.Y, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.Z, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.Z, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.X**0.5, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.X_sqrt, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.Y**0.5, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.Y_sqrt, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.Z**0.5, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.Z_sqrt, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.X**-0.5, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.X_nsqrt, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.Y**-0.5, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.Y_nsqrt, args, qubits=[qubits[2]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.Z**-0.5, expected_args, qubits=[qubits[2]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.Z_nsqrt, args, qubits=[qubits[2]], allow_decompose=False)
     assert args.tableau == expected_args.tableau
 
 

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -824,12 +824,20 @@ def test_clifford_gate_act_on_small_case():
     cirq.act_on(cirq.CliffordGate.I, args, qubits=[qubits[0]], allow_decompose=False)
     assert args.tableau == expected_args.tableau
 
+    cirq.act_on(cirq.H, expected_args, qubits=[qubits[0]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.H, args, qubits=[qubits[0]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
     cirq.act_on(cirq.CNOT, expected_args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
     cirq.act_on(cirq.CliffordGate.CNOT, args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
     assert args.tableau == expected_args.tableau
 
-    cirq.act_on(cirq.H, expected_args, qubits=[qubits[0]], allow_decompose=False)
-    cirq.act_on(cirq.CliffordGate.H, args, qubits=[qubits[0]], allow_decompose=False)
+    cirq.act_on(cirq.CZ, expected_args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.CZ, args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
+    assert args.tableau == expected_args.tableau
+
+    cirq.act_on(cirq.SWAP, expected_args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
+    cirq.act_on(cirq.CliffordGate.SWAP, args, qubits=[qubits[0], qubits[1]], allow_decompose=False)
     assert args.tableau == expected_args.tableau
 
     cirq.act_on(cirq.S, expected_args, qubits=[qubits[0]], allow_decompose=False)

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -881,6 +881,20 @@ def test_clifford_gate_act_on_small_case():
     assert args.tableau == expected_args.tableau
 
 
+def test_act_on_all_single_qubit_cliffords_have_distinct_results():
+    q = cirq.LineQubit.range(1)
+    results = set()
+    # Indirectly test tableau __eq__ by running loop twice.
+    for gate in cirq.SingleQubitCliffordGate.all_single_qubit_cliffords * 2:
+        args = cirq.CliffordTableauSimulationState(
+            tableau=cirq.CliffordTableau(num_qubits=1), qubits=q
+        )
+        cirq.act_on(gate, args, qubits=q, allow_decompose=False)
+        results.add(args.tableau)
+    # If _act_on_ works properly, then the resulting tableaux should all be distinct.
+    assert len(results) == len(cirq.SingleQubitCliffordGate.all_single_qubit_cliffords)
+
+
 def test_clifford_gate_act_on_large_case():
     n, num_ops = 50, 1000  # because we don't need unitary, it is fast.
     gate_candidate = [cirq.X, cirq.Y, cirq.Z, cirq.H, cirq.S, cirq.CNOT, cirq.CZ]


### PR DESCRIPTION
Maybe fixes #5256 

@BichengYing is this something like what you were looking for?

As background on the sim architecture, there's two levels: `SimulationState`, and `QuantumStateRepresentation`. 

`QuantumStateRepresentation` is a container for the quantum state piece only, so there's implementations for `BufferedStateVector`, `BufferedDensityMatrix`, `CliffordTableau`, `ChForm`, and others. The latter two inherit from `StabilizerState`, which provides the interface `apply_x(axis, exponent, phase)`, `apply_y`, etc that those two subclasses implement. This layer is also meant to be low-level and only works on axes/indexes and unitaries/channels/tableaux, not `Qid`s or `Gate`s.

`SimulationState` is a layer above that, and it contains a `QuantumStateRepresentation`, as well as the RNG, a place to store measurements that have been taken, and the qubit->index mapping. This layer has a parallel type hierarchy, `StateVectorSimulationState`, `StabilizerSimulationState`, `CliffordTableauSimulationState`, and so on, which I don't love, but was hard to avoid. This is the layer that `_act_on_`/`_act_on_fallback_` works with. So that's why `_act_on_` has the annoying `sim_state._state`.

There's also a `Simulator` layer on top of that, but that's out of scope for this topic.

`_act_on_` then, is mostly used for delegation. If you search for `def _act_on_(`, you can see most of the implementations are for "composite" ops that delegate to sub-ops. `CircuitOperation`, `ClassicallyControlledOperation`, `TaggedOperation`, and so on. But in most cases, `_act_on_fallback_` defined in the `SimulationState` itself knows how to handle the op efficiently. So for instance `StateVectorSimulationState` tries the `apply_unitary` protocol first, which `XPowGate` has an efficient implementation for, that's faster than generating the unitary matrix and applying it generically. So `XPowGate` does not need an explicit `_act_on_` implementation to achieve this efficiency increase. So in general, we've tried to avoid having `Gate` classes need to be aware of any specific `SimulationState` classes, or do any `if isinstance(sim_state, XYZSimState)` in `_act_on_` implementations.

I think `SingleQubitCliffordGate` is different in this regard: it's specifically designed to be used only in Clifford simulators, and so perhaps having an explicit `isinstance(sim_state, ...)` in an `_act_on_` makes sense. That's what this PR does. Another approach could be to make the `StabilizerSimulationState` aware of those gates in `_strat_apply_gate`. That approach flips the dependency upside-down, so that the simulator is aware of the gate, rather than the gate being aware of the simulator. A third approach could be that we make `CliffordGates` the _only_ thing that `StabilizerSimulationState` is aware of, remove the special-case handling of e.g. `XPowGate`, and change the `_strat_decompose` into `_strat_decompose_into_cliffords`, such that `XPowGate` gets decomposed into `CliffordGate.X` before it can be applied.

...Now that I think about it, the third strategy may make the most sense: have Clifford simulators only work with Clifford gates and things that decompose into Cliffords. That way we could maybe get rid of the `apply_x`, `apply_y` etc. of the `StabilizerState` interface and replace them all with something more generic. (I'm not all that familiar with Cliffords, so you'd probably know more about that than me).

Anyway, the current PR is the lowest-hanging quick fix for #5256. LMK if this is what you were looking for.