### PR TITLE
Increase min version of Python Requests for multiple security advisories

### DIFF
--- a/cirq-aqt/requirements.txt
+++ b/cirq-aqt/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.18
+requests~=2.32

--- a/cirq-ionq/requirements.txt
+++ b/cirq-ionq/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.18
+requests~=2.32

--- a/cirq-pasqal/requirements.txt
+++ b/cirq-pasqal/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.18
+requests~=2.32

--- a/dev_tools/pr_monitor/requirements.txt
+++ b/dev_tools/pr_monitor/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.32.0
+requests~=2.32
 google-cloud-secret-manager==1.0.0

--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -3,4 +3,4 @@ mypy==1.15.0
 
 # packages with stub types for various libraries
 types-protobuf>=4.24
-types-requests==2.32.0.20241016
+types-requests~=2.32.0.20241016

--- a/dev_tools/requirements/isolated-base.env.txt
+++ b/dev_tools/requirements/isolated-base.env.txt
@@ -4,4 +4,4 @@
 -r deps/notebook.txt
 
 # for shell_tools
-requests
+requests>=2.32

--- a/dev_tools/requirements/isolated-base.env.txt
+++ b/dev_tools/requirements/isolated-base.env.txt
@@ -4,4 +4,4 @@
 -r deps/notebook.txt
 
 # for shell_tools
-requests>=2.32
+requests~=2.32


### PR DESCRIPTION
The Requests library has several vulnerabilities in older versions. The following security advisories can all be remedied by increasing the minimum version of the package `requests` to 2.32 or higher:

- https://osv.dev/vulnerability/PYSEC-2018-28
- https://osv.dev/vulnerability/PYSEC-2023-74
- https://osv.dev/vulnerability/GHSA-9wx4-h78v-vm56

These vulnerabilities were flagged by the Scorecard scanning workflow.