### PR TITLE
Increase min version of Python tqdm for security advisory PYSEC-2023-74

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -10,4 +10,4 @@ sortedcontainers~=2.0
 scipy~=1.11
 sympy
 typing_extensions>=4.2
-tqdm
+tqdm>=4.12


### PR DESCRIPTION
The Python tqdm package prior to version 4.11.2 has a vulnerability that could allow attackers to execute arbitrary code, as documented in this security advisory:

- https://osv.dev/vulnerability/PYSEC-2017-74

Increasing the minimum version to 4.12 or higher seems like the easiest solution.