### PR TITLE
Fix "ambiguous redirect" error in check/shellcheck

### DIFF
--- a/check/shellcheck
+++ b/check/shellcheck
@@ -30,11 +30,11 @@ for arg in "$@"; do
 done
 
 # Find all shell scripts in this repository.
-IFS=$'\n' read -r -d '' -a our_shell_scripts < \
-    <(git ls-files -z -- \
+IFS=$'\n' read -r -d '' -a our_shell_scripts <<< \
+    "$(git ls-files -z -- \
         ':(exclude)*.'{py,json,json_inward,repr,repr_inward,ipynb,txt,md} \
         ':(exclude)*.'{yaml,ts,tst,rst,pyi,cfg} | \
-        xargs -0 file | grep -i 'shell script' | cut -d: -f1)
+        xargs -0 file | grep -i 'shell script' | cut -d: -f1)"
 
 # Verify our_shell_scripts array - require it must contain files below.
 typeset -a required_shell_scripts


### PR DESCRIPTION
On my system, running `check/shellcheck` results in an error:

```
check/shellcheck: line 33: 0: ambiguous redirect
```

The reason concerned the use of the shell `<(...)` construct. It seems
that with some combination of user Bash options, versions of Bash, and
possibly other factors, the output is not compatible with using a `<`
redirection; however, I was unable to figure out exactly why. I
ultimately resolved it by using a slightly different syntax for the
git/pipeline output and variable assignment.