### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,8 @@ spelling_language = en-US
 trim_trailing_whitespace = true
 
 [*.md]
-# Important setting: trailing whitspace is meaningful in Markdown.
+# Important: trailing whitspace is meaningful in Markdown. Two spaces at the end
+# of a line = line break. Ref: https://en.wikipedia.org/wiki/Markdown#Examples
 trim_trailing_whitespace = false
 
 [*.py]

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,11 +13,6 @@ insert_final_newline = true
 spelling_language = en-US
 trim_trailing_whitespace = true
 
-[*.md]
-# Important: trailing whitspace is meaningful in Markdown. Two spaces at the end
-# of a line = line break. Ref: https://en.wikipedia.org/wiki/Markdown#Examples
-trim_trailing_whitespace = false
-
 [*.py]
 indent_size = 4
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# Summary: coding style configuration for editors that read .editorconfig.
+#
+# EditorConfig defines a file format for specifying some common coding style
+# parameters. Many editors recognize .editorconfig files automatically, and
+# there exist plugins for other editors. See https://spec.editorconfig.org/.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+spelling_language = en-US
+trim_trailing_whitespace = true
+
+[*.md]
+# Important setting: trailing whitspace is meaningful in Markdown.
+trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4
+indent_style = space
+max_line_length = 100
+
+[*.sh]
+indent_size = 4
+indent_style = space
+max_line_length = 100
+
+[*.yml,*.yaml]
+indent_size = 2


### PR DESCRIPTION
This adds settings based on some common-sense values and the Cirq project's current conventions, such as line length and use of spaces instead of tabs.

This resolves #6998.