### PR TITLE
Replace uses of word "secret" with "hidden"

### DIFF
--- a/docs/experiments/textbook_algorithms.ipynb
+++ b/docs/experiments/textbook_algorithms.ipynb
@@ -1338,7 +1338,7 @@
     "frequencies = result.histogram(key=\"result\", fold_func=bitstring)\n",
     "print('Sampled results:\\n{}'.format(frequencies))\n",
     "\n",
-    "# Check if we actually found the secret value.\n",
+    "# Check if we actually found the hidden value.\n",
     "most_common_bitstring = frequencies.most_common(1)[0][0]\n",
     "print(\"\\nMost common bitstring: {}\".format(most_common_bitstring))\n",
     "print(\"Found a match? {}\".format(most_common_bitstring == bitstring(xprime)))"

--- a/examples/bernstein_vazirani.py
+++ b/examples/bernstein_vazirani.py
@@ -14,7 +14,7 @@ SIAM Journal on Computing 26.5 (1997): 1411-1473.
 
 === EXAMPLE OUTPUT ===
 
-Secret function:
+Hidden function:
 f(a) = a·<0, 1, 1, 1, 0, 0, 1, 0> + 1 (mod 2)
 Circuit:
 (0, 0): ───────H───────────────────────H───M───
@@ -36,7 +36,7 @@ Circuit:
 (8, 0): ───X───H───X───X───X───X───X───────────
 Sampled results:
 Counter({'01110010': 3})
-Most common matches secret factors:
+Most common matches hidden factors:
 True
 """
 
@@ -53,13 +53,13 @@ def main(qubit_count=8):
     output_qubit = cirq.GridQubit(qubit_count, 0)
 
     # Pick coefficients for the oracle and create a circuit to query it.
-    secret_bias_bit = random.randint(0, 1)
-    secret_factor_bits = [random.randint(0, 1) for _ in range(qubit_count)]
-    oracle = make_oracle(input_qubits, output_qubit, secret_factor_bits, secret_bias_bit)
+    hidden_bias_bit = random.randint(0, 1)
+    hidden_factor_bits = [random.randint(0, 1) for _ in range(qubit_count)]
+    oracle = make_oracle(input_qubits, output_qubit, hidden_factor_bits, hidden_bias_bit)
     print(
-        'Secret function:\nf(a) = '
-        f"a·<{', '.join(str(e) for e in secret_factor_bits)}> + "
-        f"{secret_bias_bit} (mod 2)"
+        'Hidden function:\nf(a) = '
+        f"a·<{', '.join(str(e) for e in hidden_factor_bits)}> + "
+        f"{hidden_bias_bit} (mod 2)"
     )
 
     # Embed the oracle into a special quantum circuit querying it exactly once.
@@ -73,21 +73,21 @@ def main(qubit_count=8):
     frequencies = result.histogram(key='result', fold_func=bitstring)
     print(f'Sampled results:\n{frequencies}')
 
-    # Check if we actually found the secret value.
+    # Check if we actually found the hidden value.
     most_common_bitstring = frequencies.most_common(1)[0][0]
     print(
-        'Most common matches secret factors:\n'
-        f'{most_common_bitstring == bitstring(secret_factor_bits)}'
+        'Most common matches hidden factors:\n'
+        f'{most_common_bitstring == bitstring(hidden_factor_bits)}'
     )
 
 
-def make_oracle(input_qubits, output_qubit, secret_factor_bits, secret_bias_bit):
+def make_oracle(input_qubits, output_qubit, hidden_factor_bits, hidden_bias_bit):
     """Gates implementing the function f(a) = a·factors + bias (mod 2)."""
 
-    if secret_bias_bit:
+    if hidden_bias_bit:
         yield cirq.X(output_qubit)
 
-    for qubit, bit in zip(input_qubits, secret_factor_bits):
+    for qubit, bit in zip(input_qubits, hidden_factor_bits):
         if bit:  # pragma: no cover
             yield cirq.CNOT(qubit, output_qubit)
 

--- a/examples/deutsch.py
+++ b/examples/deutsch.py
@@ -16,7 +16,7 @@ quantum computer." Proc. R. Soc. Lond. A, 400:97, 1985.
 
 === EXAMPLE OUTPUT ===
 
-Secret function:
+Hidden function:
 f(x) = <0, 1>
 Circuit:
 0: ───────H───@───H───M('result')───
@@ -36,10 +36,10 @@ def main():
     # Choose qubits to use.
     q0, q1 = cirq.LineQubit.range(2)
 
-    # Pick a secret 2-bit function and create a circuit to query the oracle.
-    secret_function = [random.randint(0, 1) for _ in range(2)]
-    oracle = make_oracle(q0, q1, secret_function)
-    print(f"Secret function:\nf(x) = <{', '.join(str(e) for e in secret_function)}>")
+    # Pick a hidden 2-bit function and create a circuit to query the oracle.
+    hidden_function = [random.randint(0, 1) for _ in range(2)]
+    oracle = make_oracle(q0, q1, hidden_function)
+    print(f"Hidden function:\nf(x) = <{', '.join(str(e) for e in hidden_function)}>")
 
     # Embed the oracle into a quantum circuit querying it exactly once.
     circuit = make_deutsch_circuit(q0, q1, oracle)
@@ -53,13 +53,13 @@ def main():
     print(result)
 
 
-def make_oracle(q0, q1, secret_function):
-    """Gates implementing the secret function f(x)."""
+def make_oracle(q0, q1, hidden_function):
+    """Gates implementing the hidden function f(x)."""
 
-    if secret_function[0]:  # pragma: no cover
+    if hidden_function[0]:  # pragma: no cover
         yield [CNOT(q0, q1), X(q1)]
 
-    if secret_function[1]:  # pragma: no cover
+    if hidden_function[1]:  # pragma: no cover
         yield CNOT(q0, q1)
 
 

--- a/examples/grover.py
+++ b/examples/grover.py
@@ -14,7 +14,7 @@ Coles, Eidenbenz et al. Quantum Algorithm Implementations for Beginners
 https://arxiv.org/abs/1804.03719
 
 === EXAMPLE OUTPUT ===
-Secret bit sequence: [1, 0]
+Hidden bit sequence: [1, 0]
 Circuit:
 (0, 0): ───────H───────@───────H───X───────@───────X───H───M───
                        │                   │               │
@@ -88,7 +88,7 @@ def main():
 
     # Choose the x' and make an oracle which can recognize it.
     x_bits = [random.randint(0, 1) for _ in range(qubit_count)]
-    print(f'Secret bit sequence: {x_bits}')
+    print(f'Hidden bit sequence: {x_bits}')
 
     # Make oracle (black box)
     oracle = make_oracle(input_qubits, output_qubit, x_bits)
@@ -105,7 +105,7 @@ def main():
     frequencies = result.histogram(key='result', fold_func=bitstring)
     print(f'Sampled results:\n{frequencies}')
 
-    # Check if we actually found the secret value.
+    # Check if we actually found the hidden value.
     most_common_bitstring = frequencies.most_common(1)[0][0]
     print(f'Most common bitstring: {most_common_bitstring}')
     print(f'Found a match: {most_common_bitstring == bitstring(x_bits)}')

--- a/examples/hidden_shift_algorithm.py
+++ b/examples/hidden_shift_algorithm.py
@@ -61,7 +61,7 @@ doi: 10.1137/1.9781611973075.37
 
 
 === EXAMPLE OUTPUT ===
-Secret shift sequence: [1, 0, 0, 1, 0, 1]
+Hidden shift sequence: [1, 0, 0, 1, 0, 1]
 Circuit:
 (0, 0): ───H───X───@───X───H───@───H───M('result')───
                    │           │       │
@@ -135,9 +135,9 @@ def main():
     # Set up input qubits.
     input_qubits = set_qubits(qubit_count)
 
-    # Define secret shift
+    # Define hidden shift
     shift = [random.randint(0, 1) for _ in range(qubit_count)]
-    print(f'Secret shift sequence: {shift}')
+    print(f'Hidden shift sequence: {shift}')
 
     # Make oracles (black box)
     oracle_f = make_oracle_f(input_qubits)
@@ -154,7 +154,7 @@ def main():
     frequencies = result.histogram(key='result', fold_func=bitstring)
     print(f'Sampled results:\n{frequencies}')
 
-    # Check if we actually found the secret value.
+    # Check if we actually found the hidden value.
     most_common_bitstring = frequencies.most_common(1)[0][0]
     print(f'Most common bitstring: {most_common_bitstring}')
     print(f'Found a match: {most_common_bitstring == bitstring(shift)}')

--- a/examples/simon_algorithm.py
+++ b/examples/simon_algorithm.py
@@ -22,7 +22,7 @@ D. R. Simon. On the power of quantum cryptography. In35th FOCS, pages 116–123,
 Santa Fe,New Mexico, 1994. IEEE Computer Society Press.
 
 === EXAMPLE OUTPUT ===
-Secret string = [1, 0, 0, 1, 0, 0]
+Hidden string = [1, 0, 0, 1, 0, 0]
 Circuit:
                 ┌──────┐   ┌───────────┐
 (0, 0): ────H────@──────────@─────@──────H───M('result')───
@@ -62,10 +62,10 @@ def main(qubit_count=3):
 
     data = []  # we'll store here the results
 
-    # define a secret string:
-    secret_string = np.random.randint(2, size=qubit_count)
+    # define a hidden string:
+    hidden_string = np.random.randint(2, size=qubit_count)
 
-    print(f'Secret string = {secret_string}')
+    print(f'Hidden string = {hidden_string}')
 
     n_samples = 100
     for _ in range(n_samples):
@@ -78,7 +78,7 @@ def main(qubit_count=3):
             ]  # output f(x)
 
             # Pick coefficients for the oracle and create a circuit to query it.
-            oracle = make_oracle(input_qubits, output_qubits, secret_string)
+            oracle = make_oracle(input_qubits, output_qubits, hidden_string)
 
             # Embed oracle into special quantum circuit querying it exactly once
             circuit = make_simon_circuit(input_qubits, output_qubits, oracle)
@@ -98,31 +98,31 @@ def main(qubit_count=3):
     print(f'Most common answer was : {freqs.most_common(1)[0]}')
 
 
-def make_oracle(input_qubits, output_qubits, secret_string):
+def make_oracle(input_qubits, output_qubits, hidden_string):
     """Gates implementing the function f(a) = f(b) iff a ⨁ b = s"""
     # Copy contents to output qubits:
     for control_qubit, target_qubit in zip(input_qubits, output_qubits):
         yield cirq.CNOT(control_qubit, target_qubit)
 
     # Create mapping:
-    if sum(secret_string):  # check if the secret string is non-zero
-        # Find significant bit of secret string (first non-zero bit)
-        significant = list(secret_string).index(1)
+    if sum(hidden_string):  # check if the hidden string is non-zero
+        # Find significant bit of hidden string (first non-zero bit)
+        significant = list(hidden_string).index(1)
 
-        # Add secret string to input according to the significant bit:
-        for j in range(len(secret_string)):
-            if secret_string[j] > 0:
+        # Add hidden string to input according to the significant bit:
+        for j in range(len(hidden_string)):
+            if hidden_string[j] > 0:
                 yield cirq.CNOT(input_qubits[significant], output_qubits[j])
     # Apply a random permutation:
     pos = [
         0,
-        len(secret_string) - 1,
+        len(hidden_string) - 1,
     ]  # Swap some qubits to define oracle. We choose first and last:
     yield cirq.SWAP(output_qubits[pos[0]], output_qubits[pos[1]])
 
 
 def make_simon_circuit(input_qubits, output_qubits, oracle):
-    """Solves for the secret period s of a 2-to-1 function such that
+    """Solves for the hidden period s of a 2-to-1 function such that
     f(x) = f(y) iff x ⨁ y = s
     """
 


### PR DESCRIPTION
The code scanning tools like CodeQL are not always able to distinguish real problems from coincidences. One such situations is the use of the word "secret" in some of the Cirq example programs. CodeQL is flagging some of the code as printing plain-text secrets. The examples actually _are_ about secrets, but they're examples, and what's being printed in these cases is not actual passwords. Nevertheless, the simplest way to avoid the problem (and possibly similar false-positives with other security scanning software) is to use some other word, for example "hidden", instead of the word "secret". The result seems clear enough (IMHO) and close enough to the concept intended in these algorithms.

This resolves the following code scanning alerts:

- https://github.com/quantumlib/Cirq/security/code-scanning/90
- https://github.com/quantumlib/Cirq/security/code-scanning/91
- https://github.com/quantumlib/Cirq/security/code-scanning/92