### PR TITLE
Fix format issues flagged by black

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device_metadata.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-"""DeviceMetadata for ion trap device with mutually linked qubits placed on a line.
-"""
+"""DeviceMetadata for ion trap device with mutually linked qubits placed on a line."""
 
 from typing import Any, Iterable, Mapping
 

--- a/cirq-aqt/cirq_aqt/aqt_target_gateset.py
+++ b/cirq-aqt/cirq_aqt/aqt_target_gateset.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Target gateset for ion trap device with mutually linked qubits placed on a line.
-"""
+"""Target gateset for ion trap device with mutually linked qubits placed on a line."""
 
 from typing import List
 

--- a/cirq-core/cirq/contrib/acquaintance/strategies/quartic_paired.py
+++ b/cirq-core/cirq/contrib/acquaintance/strategies/quartic_paired.py
@@ -47,7 +47,7 @@ def qubit_pairs_to_qubit_order(qubit_pairs: Sequence[Sequence['cirq.Qid']]) -> L
 
 
 def quartic_paired_acquaintance_strategy(
-    qubit_pairs: Iterable[Tuple['cirq.Qid', ops.Qid]]
+    qubit_pairs: Iterable[Tuple['cirq.Qid', ops.Qid]],
 ) -> Tuple['cirq.Circuit', Sequence['cirq.Qid']]:
     """Acquaintance strategy for pairs of pairs.
 

--- a/cirq-core/cirq/contrib/json.py
+++ b/cirq-core/cirq/contrib/json.py
@@ -1,6 +1,5 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-"""Functions for JSON serialization and de-serialization for classes in Contrib.
-"""
+"""Functions for JSON serialization and de-serialization for classes in Contrib."""
 
 from cirq.protocols.json_serialization import DEFAULT_RESOLVERS
 

--- a/cirq-core/cirq/interop/quirk/cells/parse_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/parse_test.py
@@ -102,7 +102,7 @@ def test_parse_complex_raw_cases_from_quirk():
 
     assert parse_complex("3/2i") == 1.5j
 
-    assert parse_complex("\u221A2-\u2153i") == np.sqrt(2) - 1j / 3
+    assert parse_complex("\u221a2-\u2153i") == np.sqrt(2) - 1j / 3
 
     assert parse_complex("1e-10") == 0.0000000001
     assert parse_complex("1e+10") == 10000000000

--- a/cirq-core/cirq/ops/__init__.py
+++ b/cirq-core/cirq/ops/__init__.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Gates (unitary and non-unitary), operations, base types, and gate sets.
-"""
+"""Gates (unitary and non-unitary), operations, base types, and gate sets."""
 
 from cirq.ops.arithmetic_operation import ArithmeticGate as ArithmeticGate
 

--- a/cirq-core/cirq/ops/op_tree.py
+++ b/cirq-core/cirq/ops/op_tree.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A recursive type describing trees of operations, and utility methods for it.
-"""
+"""A recursive type describing trees of operations, and utility methods for it."""
 
 from typing import Callable, Iterable, Iterator, NoReturn, Union, TYPE_CHECKING
 

--- a/cirq-core/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator.py
@@ -15,8 +15,8 @@
 """An efficient simulator for Clifford circuits.
 
 Allowed operations include:
-        - X,Y,Z,H,S,CNOT,CZ
-        - measurements in the computational basis
+    - X,Y,Z,H,S,CNOT,CZ
+    - measurements in the computational basis
 
 The quantum state is specified in two forms:
     1. In terms of stabilizer generators. These are a set of n Pauli operators

--- a/cirq-core/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator.py
@@ -15,8 +15,8 @@
 """An efficient simulator for Clifford circuits.
 
 Allowed operations include:
-	- X,Y,Z,H,S,CNOT,CZ
-	- measurements in the computational basis
+        - X,Y,Z,H,S,CNOT,CZ
+        - measurements in the computational basis
 
 The quantum state is specified in two forms:
     1. In terms of stabilizer generators. These are a set of n Pauli operators

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """A protocol for implementing high performance clifford tableau evolutions
- for Clifford Simulator."""
+for Clifford Simulator."""
 
 from typing import Optional, Sequence, TYPE_CHECKING
 

--- a/cirq-core/cirq/study/sweepable.py
+++ b/cirq-core/cirq/study/sweepable.py
@@ -72,7 +72,7 @@ def to_sweeps(sweepable: Sweepable, metadata: Optional[dict] = None) -> List[Swe
 def to_sweep(
     sweep_or_resolver_list: Union[
         'Sweep', ParamResolverOrSimilarType, Iterable[ParamResolverOrSimilarType]
-    ]
+    ],
 ) -> 'Sweep':
     """Converts the argument into a ``cirq.Sweep``.
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim.py
@@ -56,7 +56,7 @@ def compute_cphase_exponents_for_fsim_decomposition(
     """
 
     def nonempty_intervals(
-        intervals: Sequence[Tuple[float, float]]
+        intervals: Sequence[Tuple[float, float]],
     ) -> Sequence[Tuple[float, float]]:
         return tuple((a, b) for a, b in intervals if a < b)
 

--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -83,7 +83,7 @@ def _validate_dd_sequence(dd_sequence: Tuple[ops.Gate, ...]) -> None:
 
 
 def _parse_dd_sequence(
-    schema: Union[str, Tuple[ops.Gate, ...]]
+    schema: Union[str, Tuple[ops.Gate, ...]],
 ) -> Tuple[Tuple[ops.Gate, ...], Dict[ops.Gate, ops.Pauli]]:
     """Parses and returns dynamical decoupling sequence and its associated pauli map from schema."""
     dd_sequence = None

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset_test.py
@@ -327,7 +327,7 @@ def test_optimize_for_target_gateset_multiple_passes(max_num_passes: Union[int, 
 
 @pytest.mark.parametrize('max_num_passes', [2, None])
 def test_optimize_for_target_gateset_multiple_passes_dont_preserve_moment_structure(
-    max_num_passes: Union[int, None]
+    max_num_passes: Union[int, None],
 ):
     gateset = cirq.CZTargetGateset(preserve_moment_structure=False)
 

--- a/cirq-google/cirq_google/api/v2/run_context.py
+++ b/cirq-google/cirq_google/api/v2/run_context.py
@@ -28,7 +28,7 @@ def to_device_parameters_diff(
             run_context_pb2.DeviceParameter,
             program_pb2.ArgValue | run_context_pb2.DeviceParametersDiff.GenericValue,
         ]
-    ]
+    ],
 ) -> run_context_pb2.DeviceParametersDiff:
     """Constructs a DeviceParametersDiff from multiple DeviceParameters and values.
 

--- a/cirq-google/cirq_google/engine/__init__.py
+++ b/cirq-google/cirq_google/engine/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Client for running on Google's Quantum Engine.
-"""
+"""Client for running on Google's Quantum Engine."""
 
 from cirq_google.engine.abstract_engine import AbstractEngine as AbstractEngine
 

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 def _date_to_timestamp(
-    union_time: Optional[Union[datetime.datetime, datetime.date, int]]
+    union_time: Optional[Union[datetime.datetime, datetime.date, int]],
 ) -> Optional[int]:
     if isinstance(union_time, int):
         return union_time

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -33,7 +33,7 @@ VALID_LANGUAGES = ['type.googleapis.com/cirq.google.api.v2.Program']
 
 
 def _date_to_timestamp(
-    union_time: Optional[Union[datetime.datetime, datetime.date, int]]
+    union_time: Optional[Union[datetime.datetime, datetime.date, int]],
 ) -> Optional[int]:
     if isinstance(union_time, int):
         return union_time

--- a/cirq-google/cirq_google/workflow/__init__.py
+++ b/cirq-google/cirq_google/workflow/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Utilities for running end-to-end experiments using Quantum Computing Service (QCS). """
+"""Utilities for running end-to-end experiments using Quantum Computing Service (QCS)."""
 
 from cirq_google.workflow.quantum_executable import (
     ExecutableSpec as ExecutableSpec,

--- a/cirq-rigetti/cirq_rigetti/circuit_transformers_test.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_transformers_test.py
@@ -10,7 +10,7 @@ from cirq_rigetti import circuit_transformers as transformers
 
 
 def test_transform_cirq_circuit_to_pyquil_program(
-    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace]
+    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
     """test that a user can transform a `cirq.Circuit` to a `pyquil.Program`
     functionally.
@@ -30,7 +30,7 @@ def test_transform_cirq_circuit_to_pyquil_program(
 
 
 def test_transform_cirq_circuit_to_pyquil_program_with_qubit_id_map(
-    bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.Qid]]
+    bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.Qid]],
 ) -> None:
     """test that a user can transform a `cirq.Circuit` to a `pyquil.Program`
     functionally with explicit physical qubit address mapping.
@@ -56,7 +56,7 @@ def test_transform_cirq_circuit_to_pyquil_program_with_qubit_id_map(
 
 
 def test_transform_with_post_transformation_hooks(
-    bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.Qid]]
+    bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.Qid]],
 ) -> None:
     """test that a user can transform a `cirq.Circuit` to a `pyquil.Program`
     functionally with explicit physical qubit address mapping.
@@ -101,7 +101,7 @@ def test_transform_with_post_transformation_hooks(
 
 
 def test_transform_cirq_circuit_with_explicit_decompose(
-    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace]
+    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
     """test that a user add a custom circuit decomposition function"""
 

--- a/cirq-rigetti/cirq_rigetti/sampler_parametric_circuit_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_parametric_circuit_test.py
@@ -9,7 +9,7 @@ from cirq_rigetti import RigettiQCSSampler, circuit_sweep_executors
 
 @pytest.mark.rigetti_integration
 def test_parametric_circuit_through_sampler(
-    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace]
+    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
     """test that RigettiQCSSampler can run a basic parametric circuit on the
     QVM and return an accurate list of `cirq.study.Result`.
@@ -42,7 +42,7 @@ def test_parametric_circuit_through_sampler(
 
 @pytest.mark.rigetti_integration
 def test_parametric_circuit_through_sampler_with_parametric_compilation(
-    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace]
+    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
     """test that RigettiQCSSampler can run a basic parametric circuit on the QVM using parametric
     compilation and return an accurate list of `cirq.study.Result`.

--- a/cirq-rigetti/cirq_rigetti/sampler_readout_reassigned_qubits_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_readout_reassigned_qubits_test.py
@@ -24,7 +24,7 @@ def circuit_data() -> Tuple[cirq.Circuit, List[cirq.LineQubit], cirq.Linspace]:
 
 @pytest.mark.rigetti_integration
 def test_readout_on_reassigned_qubits(
-    circuit_data: Tuple[cirq.Circuit, List[cirq.LineQubit], cirq.Linspace]
+    circuit_data: Tuple[cirq.Circuit, List[cirq.LineQubit], cirq.Linspace],
 ) -> None:
     """test that RigettiQCSSampler can properly readout qubits after quilc has
     reassigned those qubits in the compiled native Quil.

--- a/cirq-rigetti/cirq_rigetti/sampler_readout_separate_memory_regions_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_readout_separate_memory_regions_test.py
@@ -24,7 +24,7 @@ def circuit_with_separate_readout_keys() -> Tuple[cirq.Circuit, cirq.Linspace]:
 
 @pytest.mark.rigetti_integration
 def test_circuit_with_separate_readout_keys_through_sampler(
-    circuit_with_separate_readout_keys: Tuple[cirq.Circuit, cirq.Linspace]
+    circuit_with_separate_readout_keys: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
     """test that RigettiQCSSampler can properly readout from separate memory
     regions.

--- a/cirq-rigetti/cirq_rigetti/service_parametric_circuit_test.py
+++ b/cirq-rigetti/cirq_rigetti/service_parametric_circuit_test.py
@@ -9,7 +9,7 @@ from cirq_rigetti import RigettiQCSService
 
 @pytest.mark.rigetti_integration
 def test_parametric_circuit_through_service(
-    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace]
+    parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
     """test that RigettiQCSService can run a basic parametric circuit on
     the QVM and return an accurate `cirq.study.Result`.

--- a/examples/bb84.py
+++ b/examples/bb84.py
@@ -1,5 +1,5 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-""" Example program to demonstrate BB84 QKD Protocol
+"""Example program to demonstrate BB84 QKD Protocol
 
 BB84 [1] is a quantum key distribution (QKD) protocol developed by
 Charles Bennett and Gilles Brassard in 1984. It was the first quantum

--- a/examples/shors_code.py
+++ b/examples/shors_code.py
@@ -1,5 +1,5 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
-""" Shor's code is a stabilizer code for quantum error correction.
+"""Shor's code is a stabilizer code for quantum error correction.
 It uses 9 qubits to encode 1 logic qubit and is able to correct
 at most one bit flip and one sign flip or their combination.
 


### PR DESCRIPTION
When I run `check/format-incremental`, it reports two trivial formatting errors as shown below. This commit fixes that.

```diff
Comparing against revision 'upstream/main'.
Running the black formatter... (version: black, 25.1.0 (compiled: yes)
Python (CPython) 3.10.14)
--- cirq-core/cirq/ops/op_tree.py	2025-01-30 20:52:25.721992+00:00
+++ cirq-core/cirq/ops/op_tree.py	2025-02-23 18:32:17.923984+00:00
@@ -10,12 +10,11 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

-"""A recursive type describing trees of operations, and utility methods for it.
-"""
+"""A recursive type describing trees of operations, and utility methods for it."""

 from typing import Callable, Iterable, Iterator, NoReturn, Union, TYPE_CHECKING

 from cirq._doc import document
 from cirq._import import LazyLoader
would reformat cirq-core/cirq/ops/op_tree.py
--- cirq-core/cirq/transformers/dynamical_decoupling.py	2025-01-30 20:52:25.732467+00:00
+++ cirq-core/cirq/transformers/dynamical_decoupling.py	2025-02-23 18:32:18.291548+00:00
@@ -81,11 +81,11 @@
             f' identity up to a global phase, got {product}.'.replace('\n', ' ')
         )

 def _parse_dd_sequence(
-    schema: Union[str, Tuple[ops.Gate, ...]]
+    schema: Union[str, Tuple[ops.Gate, ...]],
 ) -> Tuple[Tuple[ops.Gate, ...], Dict[ops.Gate, ops.Pauli]]:
     """Parses and returns dynamical decoupling sequence and its associated pauli map from schema."""
     dd_sequence = None
     if isinstance(schema, str):
         dd_sequence = _get_dd_sequence_from_schema_name(schema)
would reformat cirq-core/cirq/transformers/dynamical_decoupling.py

Oh no! 💥 💔 💥
2 files would be reformatted, 167 files would be left unchanged.
```