### PR TITLE
Remove rST-specific code in snippets_test.py

### DIFF
--- a/dev_tools/snippets_test.py
+++ b/dev_tools/snippets_test.py
@@ -14,9 +14,8 @@
 
 """Tests for executable snippets in documentation.
 
-This tests runs code snippets that are executable in `.md` and `.rst`
-documentation. It covers all such files under the docs directory, as well as
-the top level README file.
+This tests code snippets that are executable in `.md` documentation. It covers
+all such files under the docs directory, as well as the top-level README file.
 
 In addition to checking that the code executes:
 
@@ -45,12 +44,6 @@ In addition to checking that the code executes:
             substitution
             --->
 
-      and for `.rst` the substitution is of the form
-
-            .. test-substitution::
-                pattern
-                substitution
-
       where pattern is the regex matching pattern (passed to re.compile) and
       substitution is the replacement string.
 """
@@ -78,8 +71,6 @@ def test_can_run_readme_code_snippets():
 def find_docs_code_snippets_paths() -> Iterator[str]:
     docs_folder = pathlib.Path(__file__).parent
     for filename in docs_folder.rglob('*.md'):
-        yield str(filename.relative_to(docs_folder))
-    for filename in docs_folder.rglob('*.rst'):
         yield str(filename.relative_to(docs_folder))
 
 
@@ -136,120 +127,6 @@ def deindent_snippet(snippet: str) -> str:
         else:
             deindented_lines.append(line)
     return '\n'.join(deindented_lines)
-
-
-def find_rst_code_snippets(content: str) -> List[Tuple[str, int]]:
-    snippets = find_code_snippets(
-        r'\n.. code-block:: python\n(?:\s+:.*?\n)*\n(.*?)(?:\n\S|\Z)', content
-    )
-    return [(deindent_snippet(content), line_number) for content, line_number in snippets]
-
-
-def find_rst_test_overrides(content: str) -> List[Tuple[Pattern, str]]:
-    # Find ".. test-substitution::"
-    test_sub_text = find_code_snippets(r'.. test-substitution::\n(([^\n]*\n){2})', content)
-    substitutions = [line.split('\n')[:-1] for line, _ in test_sub_text]
-    return [(re.compile(match.lstrip()), sub.lstrip()) for match, sub in substitutions]
-
-
-def test_find_rst_code_snippets():
-    snippets = find_rst_code_snippets(
-        """
-A 3 by 3 grid of qubits using
-
-.. code-block:: python
-
-    print("hello world")
-
-The next level up.
-
-.. code-block:: python
-    :emphasize-lines: 3,5
-
-    print("hello 1")
-
-    for i in range(10):
-        print(f"hello {i}")
-
-More text.
-
-.. code-block:: python
-
-    print("last line")
-"""
-    )
-
-    assert snippets == [
-        ('print("hello world")\n', 4),
-        ('print("hello 1")\n\nfor i in range(10):\n    print(f"hello {i}")\n', 10),
-        ('print("last line")\n', 20),
-    ]
-
-
-def test_find_rst_overrides():
-    overrides = find_rst_test_overrides(
-        """
-A 3 by 3 grid of qubits using
-
-.. code-block:: python
-
-    print("hello world")
-    print("golden")
-
-.. test-substitution::
-    hello world
-    goodbye cruel world
-
-.. test-substitution::
-    golden
-    yellow
-"""
-    )
-    assert len(overrides) == 2
-    assert overrides[0][0].match('hello world')
-    assert overrides[1][0].match('golden')
-    assert overrides[0][1] == 'goodbye cruel world'
-    assert overrides[1][1] == 'yellow'
-
-
-def test_apply_rst_overrides():
-    content = """
-A 3 by 3 grid of qubits using
-
-.. code-block:: python
-
-    print("hello world")
-    print("golden")
-
-.. test-substitution::
-    hello world
-    goodbye cruel world
-
-.. test-substitution::
-    golden
-    yellow
-"""
-    overrides = find_rst_test_overrides(content)
-    print(overrides)
-    assert (
-        apply_overrides(content, overrides)
-        == """
-A 3 by 3 grid of qubits using
-
-.. code-block:: python
-
-    print("goodbye cruel world")
-    print("yellow")
-
-.. test-substitution::
-    goodbye cruel world
-    goodbye cruel world
-
-.. test-substitution::
-    yellow
-    yellow
-"""
-    )
 
 
 def test_find_markdown_code_snippets():
@@ -359,10 +236,6 @@ def assert_file_has_working_code_snippets(path: str, assume_import: bool):
         overrides = find_markdown_test_overrides(content)
         content = apply_overrides(content, overrides)
         snippets = find_markdown_code_snippets(content)
-    else:
-        overrides = find_rst_test_overrides(content)
-        content = apply_overrides(content, overrides)
-        snippets = find_rst_code_snippets(content)
     assert_code_snippets_run_in_sequence(snippets, assume_import)
 
 


### PR DESCRIPTION
A regex in this file (on line 143) triggered a code scan security warning:(https://github.com/quantumlib/Cirq/security/code-scanning/97):

```python
def find_rst_code_snippets(content: str) -> List[Tuple[str, int]]:
    snippets = find_code_snippets(
        r'\n.. code-block:: python\n(?:\s+:.*?\n)*\n(.*?)(?:\n\S|\Z)', content
                                           ^^^
```
> This part of the regular expression may cause exponential
> backtracking on strings starting with '\naa code-block:: python\n :'
> and containing many repetitions of '\n :'.

This was in code for testing reStructuredText files. Since we no longer have any `.rst` files in the code base, it seemed more sensible to remove all the rST-specific code in here. Doing that not only resolves the code scan warning – it also reduces the maintenance burden going forward.