### PR TITLE
Ensure SycamoreGate instances are preserved over serialization

### DIFF
--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -790,6 +790,7 @@ class CircuitSerializer(serializer.Serializer):
                     and isinstance(phi, float)
                     and np.isclose(theta, np.pi / 2)
                     and np.isclose(phi, np.pi / 6)
+                    and not operation_proto.fsimgate.translate_via_model
                 ):
                     op = SYC(*qubits)
                 else:

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -16,6 +16,7 @@
 
 from typing import Any, Dict, List, Optional
 import warnings
+import numpy as np
 import sympy
 
 import cirq
@@ -26,6 +27,7 @@ from cirq_google.ops import (
     InternalTag,
     FSimViaModelTag,
     DynamicalDecouplingTag,
+    SYC,
 )
 from cirq_google.ops.calibration_tag import CalibrationTag
 from cirq_google.experimental.ops import CouplerPulse
@@ -783,7 +785,15 @@ class CircuitSerializer(serializer.Serializer):
             if isinstance(theta, (int, float, sympy.Basic)) and isinstance(
                 phi, (int, float, sympy.Basic)
             ):
-                op = cirq.FSimGate(theta=theta, phi=phi)(*qubits)
+                if (
+                    isinstance(theta, float)
+                    and isinstance(phi, float)
+                    and np.isclose(theta, np.pi / 2)
+                    and np.isclose(phi, np.pi / 6)
+                ):
+                    op = SYC(*qubits)
+                else:
+                    op = cirq.FSimGate(theta=theta, phi=phi)(*qubits)
             else:
                 raise ValueError('theta and phi must be specified for FSimGate')
             if operation_proto.fsimgate.translate_via_model:

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -991,6 +991,15 @@ class BingBongDeserializer(OpDeserializer):
         )
 
 
+def test_serdes_preserves_syc():
+    serializer = cg.CircuitSerializer()
+    c = cirq.Circuit(cg.SYC(cirq.q(0, 0), cirq.q(0, 1)))
+    msg = serializer.serialize(c)
+    deserialized_circuit = serializer.deserialize(msg)
+    assert deserialized_circuit == c
+    assert isinstance(c[0][cirq.q(0, 0)].gate, cg.SycamoreGate)
+
+
 @pytest.mark.parametrize('use_constants_table', [True, False])
 def test_custom_serializer(use_constants_table: bool):
     c = cirq.Circuit(BingBongGate(param=2.5)(cirq.q(0, 0)))


### PR DESCRIPTION
- Put in a special case for fsimgate deserialization so that sycamore gates are serialized to that representation.
- This will avoid potential floating point errors when deserializing.