### PR TITLE
Exclude proto-generated Python files from black formatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ line-length = 100
 target_version = ['py310', 'py311', 'py312']
 skip-string-normalization = true
 skip-magic-trailing-comma = true
+extend-exclude = ".*_pb2[.]py[i]?"
 
 
 [tool.coverage.run]


### PR DESCRIPTION
Enable formatting of all Python sources using `black .`
