### PR TITLE
Remove apt package pandoc and add shellcheck

### DIFF
--- a/dev_tools/conf/apt-list-dev-tools.txt
+++ b/dev_tools/conf/apt-list-dev-tools.txt
@@ -1,3 +1,3 @@
-virtualenvwrapper
-pandoc
 docker-ce
+shellcheck
+virtualenvwrapper


### PR DESCRIPTION
pandoc is not used since #3587, but we do use shellcheck.

Also sort package names.
