### PR TITLE
Add badge for OpenSSF score

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ and simulators.
 license](https://img.shields.io/badge/License-Apache%202.0-3c60b1.svg?logo=opensourceinitiative&logoColor=white&style=flat-square)](https://github.com/quantumlib/Cirq/blob/main/LICENSE)
 [![Compatible with Python versions 3.10 and
 higher](https://img.shields.io/badge/Python-3.10+-fcbc2c.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![OpenSSF Best Practices](https://img.shields.io/badge/dynamic/json?label=OpenSSF&logo=springsecurity&logoColor=white&style=flat-square&colorA=gray&colorB=d56420&suffix=%25&query=$.badge_percentage_0&uri=https://bestpractices.coreinfrastructure.org/projects/10063.json)](https://www.bestpractices.dev/projects/10063)
 [![Cirq project on
 PyPI](https://img.shields.io/pypi/v/cirq.svg?logo=python&logoColor=white&label=PyPI&style=flat-square&color=fcbc2c)](https://pypi.org/project/cirq)
 [![Archived in
-Zenodo](https://img.shields.io/badge/10.5281%2Fzenodo.4062499-gray.svg?label=DOI&style=flat-square&colorA=gray&colorB=3c60b1)](https://doi.org/10.5281/zenodo.4062499)
+Zenodo](https://img.shields.io/badge/10.5281%2Fzenodo.4062499-gray.svg?label=DOI&logo=doi&logoColor=white&style=flat-square&colorA=gray&colorB=3c60b1)](https://doi.org/10.5281/zenodo.4062499)
 
 [Features](#features) &ndash;
 [Installation](#installation) &ndash;


### PR DESCRIPTION
Resolves https://github.com/quantumlib/Cirq/security/code-scanning/399

(A bit annoying to get a code scanning alert for a missing badge. OTOH, it helps highlight that the Cirq project strives to meet open-source community standards.)

Also added a missing logo to the DOI badge.