### PR TITLE
Set CI workflow permissions

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   pytest:
     name: Pytest Ubuntu

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   notebooks-stable:
     name: All Notebooks Isolated Test against Cirq stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   quick_test:
     name: Misc check

--- a/.github/workflows/pytest-debug.yaml
+++ b/.github/workflows/pytest-debug.yaml
@@ -82,6 +82,9 @@ run-name: |
   Pytest ${{inputs.single-test || '(all tests)' }} on ${{inputs.os}}
   ${{inputs.arch}} with Python ${{inputs.py-version}}
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   pytest:
     name: Run pytest

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   push_to_pypi:
     if: github.repository == 'quantumlib/Cirq'


### PR DESCRIPTION
Best practices dictate that workflows should use the minimum permissions they need. This commit resolves the following code-scanning alerts:

https://github.com/quantumlib/Cirq/security/code-scanning/255 https://github.com/quantumlib/Cirq/security/code-scanning/257 https://github.com/quantumlib/Cirq/security/code-scanning/258 https://github.com/quantumlib/Cirq/security/code-scanning/259 https://github.com/quantumlib/Cirq/security/code-scanning/260 https://github.com/quantumlib/Cirq/security/code-scanning/263 https://github.com/quantumlib/Cirq/security/code-scanning/264 https://github.com/quantumlib/Cirq/security/code-scanning/265 https://github.com/quantumlib/Cirq/security/code-scanning/268 https://github.com/quantumlib/Cirq/security/code-scanning/270 https://github.com/quantumlib/Cirq/security/code-scanning/271 https://github.com/quantumlib/Cirq/security/code-scanning/272 https://github.com/quantumlib/Cirq/security/code-scanning/273 https://github.com/quantumlib/Cirq/security/code-scanning/275 https://github.com/quantumlib/Cirq/security/code-scanning/276 https://github.com/quantumlib/Cirq/security/code-scanning/277 https://github.com/quantumlib/Cirq/security/code-scanning/278 https://github.com/quantumlib/Cirq/security/code-scanning/279 https://github.com/quantumlib/Cirq/security/code-scanning/280 https://github.com/quantumlib/Cirq/security/code-scanning/281 https://github.com/quantumlib/Cirq/security/code-scanning/282 https://github.com/quantumlib/Cirq/security/code-scanning/283 https://github.com/quantumlib/Cirq/security/code-scanning/403 https://github.com/quantumlib/Cirq/security/code-scanning/404 https://github.com/quantumlib/Cirq/security/code-scanning/405 https://github.com/quantumlib/Cirq/security/code-scanning/406 https://github.com/quantumlib/Cirq/security/code-scanning/407 https://github.com/quantumlib/Cirq/security/code-scanning/408 https://github.com/quantumlib/Cirq/security/code-scanning/409