### PR TITLE
Correct the sweep order example in the docstring

### DIFF
--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -212,7 +212,8 @@ class Product(Sweep):
     If one sweep assigns 'a' to the values 0, 1, 2, and the second sweep
     assigns 'b' to the values 2, 3, then the product is a sweep that
     assigns the tuple ('a','b') to all possible combinations of these
-    assignments: (0, 2), (1, 2), (2, 2), (0, 3), (1, 3), (2, 3).
+    assignments: (0, 2), (0, 3), (1, 2), (1, 3), (2, 2), (2, 3).
+    That is, the leftmost sweep is the outer loop in a product of sweeps.
     """
 
     def __init__(self, *factors: Sweep) -> None:


### PR DESCRIPTION
The following code can be used to confirm the order of loops:
```
sweep = cirq.Product(cirq.Points('a', [0, 1 ,2]), cirq.Points('b', [2, 3]))
list(sweep)
```

Outputs:
```
[cirq.ParamResolver({'a': 0, 'b': 2}),
 cirq.ParamResolver({'a': 0, 'b': 3}),
 cirq.ParamResolver({'a': 1, 'b': 2}),
 cirq.ParamResolver({'a': 1, 'b': 3}),
 cirq.ParamResolver({'a': 2, 'b': 2}),
 cirq.ParamResolver({'a': 2, 'b': 3})]
```

Leftmost sweep is the outer loop in a product of sweeps.