### PR TITLE
[Bugfix] Re-allow non-integral line/grid qubits

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -213,8 +213,6 @@ class GridQid(_BaseGridQid):
             dimension: The dimension of the qid's Hilbert space, i.e.
                 the number of quantum levels.
         """
-        row = int(row)
-        col = int(col)
         dimension = int(dimension)
         key = (row, col, dimension)
         inst = cls._cache.get(key)
@@ -224,7 +222,7 @@ class GridQid(_BaseGridQid):
             inst._row = row
             inst._col = col
             inst._dimension = dimension
-            inst._hash = ((dimension - 2) * 1_000_003 + col) * 1_000_003 + row
+            inst._hash = hash(((dimension - 2) * 1_000_003 + col) * 1_000_003 + row)
             cls._cache[key] = inst
         return inst
 
@@ -380,15 +378,13 @@ class GridQubit(_BaseGridQid):
             row: the row coordinate
             col: the column coordinate
         """
-        row = int(row)
-        col = int(col)
         key = (row, col)
         inst = cls._cache.get(key)
         if inst is None:
             inst = super().__new__(cls)
             inst._row = row
             inst._col = col
-            inst._hash = col * 1_000_003 + row
+            inst._hash = hash(col * 1_000_003 + row)
             cls._cache[key] = inst
         return inst
 

--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -222,7 +222,7 @@ class GridQid(_BaseGridQid):
             inst._row = row
             inst._col = col
             inst._dimension = dimension
-            inst._hash = hash(((dimension - 2) * 1_000_003 + col) * 1_000_003 + row)
+            inst._hash = ((dimension - 2) * 1_000_003 + hash(col)) * 1_000_003 + hash(row)
             cls._cache[key] = inst
         return inst
 
@@ -384,7 +384,7 @@ class GridQubit(_BaseGridQid):
             inst = super().__new__(cls)
             inst._row = row
             inst._col = col
-            inst._hash = hash(col * 1_000_003 + row)
+            inst._hash = hash(col) * 1_000_003 + hash(row)
             cls._cache[key] = inst
         return inst
 

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -400,8 +400,6 @@ def test_numpy_index():
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 2
-    assert isinstance(q.row, int)
-    assert isinstance(q.col, int)
     assert isinstance(q.dimension, int)
 
     q = cirq.GridQid(np5, np6, dimension=np3)
@@ -409,6 +407,4 @@ def test_numpy_index():
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 3
-    assert isinstance(q.row, int)
-    assert isinstance(q.col, int)
     assert isinstance(q.dimension, int)

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -401,8 +401,6 @@ def test_numpy_index(dtype):
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 2
-    assert isinstance(q.row, dtype)
-    assert isinstance(q.col, dtype)
     assert isinstance(q.dimension, int)
 
     q = cirq.GridQid(np5, np6, dimension=np3)
@@ -410,8 +408,6 @@ def test_numpy_index(dtype):
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 3
-    assert isinstance(q.row, dtype)
-    assert isinstance(q.col, dtype)
     assert isinstance(q.dimension, int)
 
 

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -397,14 +397,14 @@ def test_complex():
 def test_numpy_index(dtype):
     np5, np6, np3 = [dtype(i) for i in [5, 6, 3]]
     q = cirq.GridQubit(np5, np6)
-    hash(q)  # doesn't throw
+    assert hash(q) == hash(cirq.GridQubit(5, 6))
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 2
     assert isinstance(q.dimension, int)
 
     q = cirq.GridQid(np5, np6, dimension=np3)
-    hash(q)  # doesn't throw
+    assert hash(q) == hash(cirq.GridQid(5, 6, dimension=3))
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 3
@@ -413,8 +413,9 @@ def test_numpy_index(dtype):
 
 @pytest.mark.parametrize('dtype', (float, np.float64))
 def test_non_integer_index(dtype):
+    # Not supported type-wise, but is used in practice, so behavior needs to be preserved.
     q = cirq.GridQubit(dtype(5.5), dtype(6.5))
-    hash(q)  # doesn't throw
+    assert hash(q) == hash(cirq.GridQubit(5.5, 6.5))
     assert q.row == 5.5
     assert q.col == 6.5
     assert isinstance(q.row, dtype)

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -393,7 +393,7 @@ def test_complex():
     assert isinstance(complex(cirq.GridQubit(row=1, col=2)), complex)
 
 
-@pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float128))
+@pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float64))
 def test_numpy_index(dtype):
     np5, np6, np3 = [dtype(i) for i in [5, 6, 3]]
     q = cirq.GridQubit(np5, np6)
@@ -411,7 +411,7 @@ def test_numpy_index(dtype):
     assert isinstance(q.dimension, int)
 
 
-@pytest.mark.parametrize('dtype', (float, np.float128))
+@pytest.mark.parametrize('dtype', (float, np.float64))
 def test_non_integer_index(dtype):
     q = cirq.GridQubit(dtype(5.5), dtype(6.5))
     hash(q)  # doesn't throw

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -393,13 +393,16 @@ def test_complex():
     assert isinstance(complex(cirq.GridQubit(row=1, col=2)), complex)
 
 
-def test_numpy_index():
-    np5, np6, np3 = [np.int64(i) for i in [5, 6, 3]]
+@pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float128))
+def test_numpy_index(dtype):
+    np5, np6, np3 = [dtype(i) for i in [5, 6, 3]]
     q = cirq.GridQubit(np5, np6)
     hash(q)  # doesn't throw
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 2
+    assert isinstance(q.row, dtype)
+    assert isinstance(q.col, dtype)
     assert isinstance(q.dimension, int)
 
     q = cirq.GridQid(np5, np6, dimension=np3)
@@ -407,11 +410,16 @@ def test_numpy_index():
     assert q.row == 5
     assert q.col == 6
     assert q.dimension == 3
+    assert isinstance(q.row, dtype)
+    assert isinstance(q.col, dtype)
     assert isinstance(q.dimension, int)
 
 
-def test_non_integer_index():
-    q = cirq.GridQubit(5.5, 6.5)
+@pytest.mark.parametrize('dtype', (float, np.float128))
+def test_non_integer_index(dtype):
+    q = cirq.GridQubit(dtype(5.5), dtype(6.5))
     hash(q)  # doesn't throw
     assert q.row == 5.5
     assert q.col == 6.5
+    assert isinstance(q.row, dtype)
+    assert isinstance(q.col, dtype)

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -408,3 +408,10 @@ def test_numpy_index():
     assert q.col == 6
     assert q.dimension == 3
     assert isinstance(q.dimension, int)
+
+
+def test_non_integer_index():
+    q = cirq.GridQubit(5.5, 6.5)
+    hash(q)  # doesn't throw
+    assert q.row == 5.5
+    assert q.col == 6.5

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -191,7 +191,6 @@ class LineQid(_BaseLineQid):
             dimension: The dimension of the qid's Hilbert space, i.e.
                 the number of quantum levels.
         """
-        x = int(x)
         dimension = int(dimension)
         key = (x, dimension)
         inst = cls._cache.get(key)
@@ -200,7 +199,7 @@ class LineQid(_BaseLineQid):
             inst = super().__new__(cls)
             inst._x = x
             inst._dimension = dimension
-            inst._hash = (dimension - 2) * 1_000_003 + x
+            inst._hash = hash((dimension - 2) * 1_000_003 + x)
             cls._cache[key] = inst
         return inst
 
@@ -302,12 +301,11 @@ class LineQubit(_BaseLineQid):
         Args:
             x: The x coordinate.
         """
-        x = int(x)
         inst = cls._cache.get(x)
         if inst is None:
             inst = super().__new__(cls)
             inst._x = x
-            inst._hash = x
+            inst._hash = hash(x)
             cls._cache[x] = inst
         return inst
 

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -199,7 +199,7 @@ class LineQid(_BaseLineQid):
             inst = super().__new__(cls)
             inst._x = x
             inst._dimension = dimension
-            inst._hash = hash((dimension - 2) * 1_000_003 + x)
+            inst._hash = (dimension - 2) * 1_000_003 + hash(x)
             cls._cache[key] = inst
         return inst
 

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -295,7 +295,6 @@ def test_numpy_index(dtype):
     assert q.x == 5
     assert q.x == dtype(5)
     assert q.dimension == 2
-    assert isinstance(q.x, dtype)
     assert isinstance(q.dimension, int)
 
     q = cirq.LineQid(np5, dtype(3))
@@ -303,7 +302,6 @@ def test_numpy_index(dtype):
     assert q.x == 5
     assert q.x == dtype(5)
     assert q.dimension == 3
-    assert isinstance(q.x, dtype)
     assert isinstance(q.dimension, int)
 
 

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -287,7 +287,7 @@ def test_numeric():
     assert isinstance(complex(cirq.LineQubit(x=5)), complex)
 
 
-@pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float128))
+@pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float64))
 def test_numpy_index(dtype):
     np5 = dtype(5)
     q = cirq.LineQubit(np5)
@@ -305,7 +305,7 @@ def test_numpy_index(dtype):
     assert isinstance(q.dimension, int)
 
 
-@pytest.mark.parametrize('dtype', (float, np.float128))
+@pytest.mark.parametrize('dtype', (float, np.float64))
 def test_non_integer_index(dtype):
     q = cirq.LineQubit(dtype(5.5))
     assert q.x == 5.5

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -300,3 +300,8 @@ def test_numpy_index():
     assert q.x == 5
     assert q.dimension == 3
     assert isinstance(q.dimension, int)
+
+
+def test_non_integer_index():
+    q = cirq.LineQubit(5.5)
+    assert q.x == 5.5

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -287,21 +287,29 @@ def test_numeric():
     assert isinstance(complex(cirq.LineQubit(x=5)), complex)
 
 
-def test_numpy_index():
-    np5 = np.int64(5)
+@pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float128))
+def test_numpy_index(dtype):
+    np5 = dtype(5)
     q = cirq.LineQubit(np5)
     assert hash(q) == 5
     assert q.x == 5
+    assert q.x == dtype(5)
     assert q.dimension == 2
+    assert isinstance(q.x, dtype)
     assert isinstance(q.dimension, int)
 
-    q = cirq.LineQid(np5, np.int64(3))
+    q = cirq.LineQid(np5, dtype(3))
     hash(q)  # doesn't throw
     assert q.x == 5
+    assert q.x == dtype(5)
     assert q.dimension == 3
+    assert isinstance(q.x, dtype)
     assert isinstance(q.dimension, int)
 
 
-def test_non_integer_index():
-    q = cirq.LineQubit(5.5)
+@pytest.mark.parametrize('dtype', (float, np.float128))
+def test_non_integer_index(dtype):
+    q = cirq.LineQubit(dtype(5.5))
     assert q.x == 5.5
+    assert q.x == dtype(5.5)
+    assert isinstance(q.x, dtype)

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -293,20 +293,19 @@ def test_numpy_index(dtype):
     q = cirq.LineQubit(np5)
     assert hash(q) == 5
     assert q.x == 5
-    assert q.x == dtype(5)
     assert q.dimension == 2
     assert isinstance(q.dimension, int)
 
     q = cirq.LineQid(np5, dtype(3))
     hash(q)  # doesn't throw
     assert q.x == 5
-    assert q.x == dtype(5)
     assert q.dimension == 3
     assert isinstance(q.dimension, int)
 
 
 @pytest.mark.parametrize('dtype', (float, np.float64))
 def test_non_integer_index(dtype):
+    # Not supported type-wise, but is used in practice, so behavior needs to be preserved.
     q = cirq.LineQubit(dtype(5.5))
     assert q.x == 5.5
     assert q.x == dtype(5.5)

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -293,12 +293,10 @@ def test_numpy_index():
     assert hash(q) == 5
     assert q.x == 5
     assert q.dimension == 2
-    assert isinstance(q.x, int)
     assert isinstance(q.dimension, int)
 
     q = cirq.LineQid(np5, np.int64(3))
     hash(q)  # doesn't throw
     assert q.x == 5
     assert q.dimension == 3
-    assert isinstance(q.x, int)
     assert isinstance(q.dimension, int)


### PR DESCRIPTION
Fixes #7102. No longer coerces x/row/col to int. Wraps hash expression with `hash` instead.

On my laptop it's also a _tiny_ bit faster. It creates 10,000,000 LineQubits in 2.1s; old code took 2.5s.

Also, note that I left all the type annotations `int`, which is what they have always been. I looked into changing these into `numbers.Rational` or `SupportsFloat` or something, but it's too invasive. Lots of code seems to assume integral x/row/col values, and mypy blows up when you try to expand it.