### PR TITLE
Add cphase_gauge

### DIFF
--- a/cirq-core/cirq/transformers/gauge_compiling/__init__.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/__init__.py
@@ -38,3 +38,5 @@ from cirq.transformers.gauge_compiling.iswap_gauge import (
 from cirq.transformers.gauge_compiling.sqrt_iswap_gauge import (
     SqrtISWAPGaugeTransformer as SqrtISWAPGaugeTransformer,
 )
+
+from cirq.transformers.gauge_compiling.cphase_gaute import CPhaseGaugeTransformer

--- a/cirq-core/cirq/transformers/gauge_compiling/__init__.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/__init__.py
@@ -39,4 +39,4 @@ from cirq.transformers.gauge_compiling.sqrt_iswap_gauge import (
     SqrtISWAPGaugeTransformer as SqrtISWAPGaugeTransformer,
 )
 
-from cirq.transformers.gauge_compiling.cphase_gaute import CPhaseGaugeTransformer
+from cirq.transformers.gauge_compiling.cphase_gauge import CPhaseGaugeTransformer

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -81,8 +81,8 @@ class CPhasePauliGauge(Gauge):
                 two_qubit_gate=gate, pre_q0=pre_q0, pre_q1=pre_q1, post_q0=pre_q0, post_q1=pre_q1
             )
         elif pre_q0 in anticommuting_paulis and pre_q1 in commuting_paulis:
-            new_gate = cirq.CZ ** (-exponent)
-            post_q1 = cirq.Z ** (exponent) if pre_q1 == cirq.I else cirq.Z ** (1 + exponent)
+            new_gate = ops.CZ ** (-exponent)
+            post_q1 = ops.Z ** (exponent) if pre_q1 == ops.I else ops.Z ** (1 + exponent)
             return ConstantGauge(
                 two_qubit_gate=new_gate,
                 pre_q0=pre_q0,
@@ -91,8 +91,8 @@ class CPhasePauliGauge(Gauge):
                 post_q1=post_q1,
             )
         elif pre_q0 in commuting_paulis and pre_q1 in anticommuting_paulis:
-            new_gate = cirq.CZ ** (-exponent)
-            post_q0 = cirq.Z ** (exponent) if pre_q0 == cirq.I else cirq.Z ** (1 + exponent)
+            new_gate = ops.CZ ** (-exponent)
+            post_q0 = ops.Z ** (exponent) if pre_q0 == ops.I else ops.Z ** (1 + exponent)
             return ConstantGauge(
                 two_qubit_gate=new_gate,
                 pre_q0=pre_q0,

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -1,0 +1,133 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Gauge Transformer for the cphase gate."""
+
+from cirq.transformers.gauge_compiling.gauge_compiling import (
+    GaugeTransformer,
+    GaugeSelector,
+    SameGateGauge,
+    ConstantGauge,
+    Gauge,
+)
+from cirq import ops
+import numpy as np
+
+
+class CPhasePauliGauge(Gauge):
+    """Gauges for the cphase gate (CZPowGate). We identify 16 distinct gauges, corresponding to the
+    16 two-qubit Pauli operators that can be inserted before the cphase gate. When an anticommuting
+    gate is inserted, the cphase angle is negated (or equivalently, the exponent of the CZPowGate
+    is negated), so both postive and negative angles should be calibrated to use this.
+    """
+
+    def weight(self) -> float:
+        return 1.0
+
+    def _get_new_post(self, exponent: float, pre: 'cirq.Gate') -> 'cirq.Gate':
+        """Identify the new single-qubit gate that needs to be inserted in the case that both pre
+        gates are X or Y.
+
+        Args:
+            exponent: The exponent of the CZPowGate that is getting transformed.
+            pre: The gate (X or Y) that is inserted on a given qubit.
+
+        Returns:
+            The single-qubit gate to insert after the CZPowGate on the same qubit.
+
+        Raises:
+            ValueError: If pre is not X or Y.
+        """
+        if pre == ops.X:
+            return ops.PhasedXPowGate(exponent=1, phase_exponent=exponent / 2)
+        elif pre == ops.Y:
+            return ops.PhasedXZGate.from_zyz_exponents(z0=-exponent, y=1, z1=0)
+        else:
+            raise ValueError("pre should be cirq.X or cirq.Y")
+
+    def _get_constant_gauge(
+        self, gate: ops.CZPowGate, pre_q0: 'cirq.Gate', pre_q1: 'cirq.Gate'
+    ) -> ConstantGauge:
+        """Get the ConstantGauge corresponding to a given pre_q0 and pre_q1.
+
+        Args:
+            gate: The particular cphase gate to transform.
+            pre_q0: The Pauli (I, X, Y, or Z) to insert before the cphase gate on q0.
+            pre_q1: The Pauli (I, X, Y, or Z) to insert before the cphase gate on q1.
+
+        Returns:
+            The ConstantGauge implementing the given transformation.
+
+        Raises:
+            ValueError: If pre_q0 and pre_q1 are not both in {I, X, Y, Z}.
+        """
+
+        exponent = gate.exponent
+        commuting_paulis = {ops.I, ops.Z}
+        anticommuting_paulis = {ops.X, ops.Y}
+        if pre_q0 in commuting_paulis and pre_q1 in commuting_paulis:
+            return ConstantGauge(
+                two_qubit_gate=gate, pre_q0=pre_q0, pre_q1=pre_q1, post_q0=pre_q0, post_q1=pre_q1
+            )
+        elif pre_q0 in anticommuting_paulis and pre_q1 in commuting_paulis:
+            new_gate = cirq.CZ ** (-exponent)
+            post_q1 = cirq.Z ** (exponent) if pre_q1 == cirq.I else cirq.Z ** (1 + exponent)
+            return ConstantGauge(
+                two_qubit_gate=new_gate,
+                pre_q0=pre_q0,
+                pre_q1=pre_q1,
+                post_q0=pre_q0,
+                post_q1=post_q1,
+            )
+        elif pre_q0 in commuting_paulis and pre_q1 in anticommuting_paulis:
+            new_gate = cirq.CZ ** (-exponent)
+            post_q0 = cirq.Z ** (exponent) if pre_q0 == cirq.I else cirq.Z ** (1 + exponent)
+            return ConstantGauge(
+                two_qubit_gate=new_gate,
+                pre_q0=pre_q0,
+                pre_q1=pre_q1,
+                post_q0=post_q0,
+                post_q1=pre_q1,
+            )
+        elif pre_q0 in anticommuting_paulis and pre_q1 in anticommuting_paulis:
+            return ConstantGauge(
+                two_qubit_gate=gate,
+                pre_q0=pre_q0,
+                pre_q1=pre_q1,
+                post_q0=self._get_new_post(exponent, pre_q0),
+                post_q1=self._get_new_post(exponent, pre_q1),
+            )
+        else:
+            raise ValueError("pre_q0 and pre_q1 should be single-qubit Pauli operators")
+
+    def sample(self, gate: ops.CZPowGate, prng: np.random.Generator) -> ConstantGauge:
+        """Sample the 16 cphase gauges at random.
+
+        Args:
+            gate: The CZPowGate to transform.
+            prng: The pseudorandom number generator.
+
+        Returns:
+            A ConstantGauge implementing the transformation.
+        """
+
+        pre_q0, pre_q1 = prng.choice([ops.I, ops.X, ops.Y, ops.Z], size=2, replace=True)
+        return self._get_constant_gauge(gate, pre_q0, pre_q1)
+
+
+CPhaseGaugeSelector = GaugeSelector(gauges=[CPhasePauliGauge()])
+
+CPhaseGaugeTransformer = GaugeTransformer(
+    target=ops.Gateset(ops.CZPowGate), gauge_selector=CPhaseGaugeSelector
+)

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -14,11 +14,14 @@
 
 """A Gauge Transformer for the cphase gate."""
 
+import cirq.transformers.gauge_compiling.sqrt_cz_gauge as sqrt_cz_gauge
+
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     GaugeTransformer,
     GaugeSelector,
     ConstantGauge,
     Gauge,
+    TwoQubitGateSymbolizer,
 )
 from cirq import ops
 import numpy as np
@@ -133,5 +136,9 @@ class CPhasePauliGauge(Gauge):
 CPhaseGaugeSelector = GaugeSelector(gauges=[CPhasePauliGauge()])
 
 CPhaseGaugeTransformer = GaugeTransformer(
-    target=ops.Gateset(ops.CZPowGate), gauge_selector=CPhaseGaugeSelector
+    target=ops.Gateset(ops.CZPowGate),
+    gauge_selector=CPhaseGaugeSelector,
+    two_qubit_gate_symbolizer=TwoQubitGateSymbolizer(
+        symbolizer_fn=sqrt_cz_gauge._symbolize_as_cz_pow, n_symbols=1
+    ),
 )

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -17,7 +17,6 @@
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     GaugeTransformer,
     GaugeSelector,
-    SameGateGauge,
     ConstantGauge,
     Gauge,
 )
@@ -57,7 +56,7 @@ class CPhasePauliGauge(Gauge):
             raise ValueError("pre should be cirq.X or cirq.Y")
 
     def _get_constant_gauge(
-        self, gate: ops.CZPowGate, pre_q0: ops.Gate, pre_q1: ops.Gate
+        self, gate: ops.Gate, pre_q0: ops.Gate, pre_q1: ops.Gate
     ) -> ConstantGauge:
         """Get the ConstantGauge corresponding to a given pre_q0 and pre_q1.
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -56,7 +56,7 @@ class CPhasePauliGauge(Gauge):
         elif pre == ops.Y:
             return ops.PhasedXZGate.from_zyz_exponents(z0=-exponent, y=1, z1=0)
         else:
-            raise ValueError("pre should be cirq.X or cirq.Y")
+            raise ValueError("pre should be cirq.X or cirq.Y")  # pragma: no cover
 
     def _get_constant_gauge(
         self, gate: ops.CZPowGate, pre_q0: ops.Gate, pre_q1: ops.Gate
@@ -111,7 +111,7 @@ class CPhasePauliGauge(Gauge):
                 post_q1=self._get_new_post(exponent, pre_q1),
             )
         else:
-            raise ValueError("pre_q0 and pre_q1 should be single-qubit Pauli operators")
+            raise ValueError("pre_q0 and pre_q1 should be X, Y, Z, or I")  # pragma: no cover
 
     def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:
         """Sample the 16 cphase gauges at random.
@@ -128,7 +128,7 @@ class CPhasePauliGauge(Gauge):
         """
 
         if not type(gate) == ops.CZPowGate:
-            raise TypeError("gate must be a CZPowGate")
+            raise TypeError("gate must be a CZPowGate")  # pragma: no cover
         pre_q0, pre_q1 = prng.choice(np.array([ops.I, ops.X, ops.Y, ops.Z]), size=2, replace=True)
         return self._get_constant_gauge(gate, pre_q0, pre_q1)
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -35,7 +35,7 @@ class CPhasePauliGauge(Gauge):
     def weight(self) -> float:
         return 1.0
 
-    def _get_new_post(self, exponent: float, pre: 'cirq.Gate') -> 'cirq.Gate':
+    def _get_new_post(self, exponent: float, pre: ops.Gate) -> ops.Gate:
         """Identify the new single-qubit gate that needs to be inserted in the case that both pre
         gates are X or Y.
 
@@ -57,7 +57,7 @@ class CPhasePauliGauge(Gauge):
             raise ValueError("pre should be cirq.X or cirq.Y")
 
     def _get_constant_gauge(
-        self, gate: ops.CZPowGate, pre_q0: 'cirq.Gate', pre_q1: 'cirq.Gate'
+        self, gate: ops.CZPowGate, pre_q0: ops.Gate, pre_q1: ops.Gate
     ) -> ConstantGauge:
         """Get the ConstantGauge corresponding to a given pre_q0 and pre_q1.
 
@@ -111,7 +111,7 @@ class CPhasePauliGauge(Gauge):
         else:
             raise ValueError("pre_q0 and pre_q1 should be single-qubit Pauli operators")
 
-    def sample(self, gate: ops.CZPowGate, prng: np.random.Generator) -> ConstantGauge:
+    def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:
         """Sample the 16 cphase gauges at random.
 
         Args:
@@ -122,7 +122,7 @@ class CPhasePauliGauge(Gauge):
             A ConstantGauge implementing the transformation.
         """
 
-        pre_q0, pre_q1 = prng.choice([ops.I, ops.X, ops.Y, ops.Z], size=2, replace=True)
+        pre_q0, pre_q1 = prng.choice(np.array([ops.I, ops.X, ops.Y, ops.Z]), size=2, replace=True)
         return self._get_constant_gauge(gate, pre_q0, pre_q1)
 
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -22,7 +22,6 @@ from cirq.transformers.gauge_compiling.gauge_compiling import (
 )
 from cirq import ops
 import numpy as np
-from typing import cast
 
 
 class CPhasePauliGauge(Gauge):
@@ -128,7 +127,7 @@ class CPhasePauliGauge(Gauge):
         if not type(gate) == ops.CZPowGate:
             raise TypeError("gate must be a CZPowGate")
         pre_q0, pre_q1 = prng.choice(np.array([ops.I, ops.X, ops.Y, ops.Z]), size=2, replace=True)
-        return self._get_constant_gauge(cast(ops.CZPowGate, gate), pre_q0, pre_q1)
+        return self._get_constant_gauge(gate, pre_q0, pre_q1)
 
 
 CPhaseGaugeSelector = GaugeSelector(gauges=[CPhasePauliGauge()])

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -22,6 +22,7 @@ from cirq.transformers.gauge_compiling.gauge_compiling import (
 )
 from cirq import ops
 import numpy as np
+from typing import cast
 
 
 class CPhasePauliGauge(Gauge):
@@ -56,7 +57,7 @@ class CPhasePauliGauge(Gauge):
             raise ValueError("pre should be cirq.X or cirq.Y")
 
     def _get_constant_gauge(
-        self, gate: ops.Gate, pre_q0: ops.Gate, pre_q1: ops.Gate
+        self, gate: ops.CZPowGate, pre_q0: ops.Gate, pre_q1: ops.Gate
     ) -> ConstantGauge:
         """Get the ConstantGauge corresponding to a given pre_q0 and pre_q1.
 
@@ -119,10 +120,15 @@ class CPhasePauliGauge(Gauge):
 
         Returns:
             A ConstantGauge implementing the transformation.
+
+        Raises:
+            TypeError: if gate is not a CZPowGate
         """
 
+        if not type(gate) == ops.CZPowGate:
+            raise TypeError("gate must be a CZPowGate")
         pre_q0, pre_q1 = prng.choice(np.array([ops.I, ops.X, ops.Y, ops.Z]), size=2, replace=True)
-        return self._get_constant_gauge(gate, pre_q0, pre_q1)
+        return self._get_constant_gauge(cast(ops.CZPowGate, gate), pre_q0, pre_q1)
 
 
 CPhaseGaugeSelector = GaugeSelector(gauges=[CPhasePauliGauge()])

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Cirq Developers
+# Copyright 2025 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,10 +28,12 @@ import numpy as np
 
 
 class CPhasePauliGauge(Gauge):
-    """Gauges for the cphase gate (CZPowGate). We identify 16 distinct gauges, corresponding to the
-    16 two-qubit Pauli operators that can be inserted before the cphase gate. When an anticommuting
-    gate is inserted, the cphase angle is negated (or equivalently, the exponent of the CZPowGate
-    is negated), so both postive and negative angles should be calibrated to use this.
+    """Gauges for the cphase gate (CZPowGate).
+
+    We identify 16 distinct gauges, corresponding to the 16 two-qubit Pauli operators that can be
+    inserted before the cphase gate. When an anticommuting gate is inserted, the cphase angle is
+    negated (or equivalently, the exponent of the CZPowGate is negated), so both postive and
+    negative angles should be calibrated to use this.
     """
 
     def weight(self) -> float:

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -20,4 +20,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCPhaseGauge(GaugeTester):
     two_qubit_gate = cirq.CZ**0.3
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = False
+    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -20,4 +20,4 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCPhaseGauge(GaugeTester):
     two_qubit_gate = cirq.CZ**0.3
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = True
+    sweep_must_pass = False

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Cirq Developers
+# Copyright 2025 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,5 +19,29 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 
 class TestCPhaseGauge(GaugeTester):
     two_qubit_gate = cirq.CZ**0.3
+    gauge_transformer = CPhaseGaugeTransformer
+    sweep_must_pass = True
+
+
+class TestCPhaseGauge(GaugeTester):
+    two_qubit_gate = cirq.CZ ** (-0.3)
+    gauge_transformer = CPhaseGaugeTransformer
+    sweep_must_pass = True
+
+
+class TestCPhaseGauge(GaugeTester):
+    two_qubit_gate = cirq.CZ**0.1
+    gauge_transformer = CPhaseGaugeTransformer
+    sweep_must_pass = True
+
+
+class TestCPhaseGauge(GaugeTester):
+    two_qubit_gate = cirq.CZ ** (-0.1)
+    gauge_transformer = CPhaseGaugeTransformer
+    sweep_must_pass = True
+
+
+class TestCPhaseGauge(GaugeTester):
+    two_qubit_gate = cirq.CZ**0.7
     gauge_transformer = CPhaseGaugeTransformer
     sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -17,31 +17,31 @@ from cirq.transformers.gauge_compiling.cphase_gauge import CPhaseGaugeTransforme
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester
 
 
-class TestCPhaseGauge(GaugeTester):
+class TestCPhaseGauge_0_3(GaugeTester):
     two_qubit_gate = cirq.CZ**0.3
     gauge_transformer = CPhaseGaugeTransformer
     sweep_must_pass = True
 
 
-class TestCPhaseGauge(GaugeTester):
+class TestCPhaseGauge_m0_3(GaugeTester):
     two_qubit_gate = cirq.CZ ** (-0.3)
     gauge_transformer = CPhaseGaugeTransformer
     sweep_must_pass = True
 
 
-class TestCPhaseGauge(GaugeTester):
+class TestCPhaseGauge_0_1(GaugeTester):
     two_qubit_gate = cirq.CZ**0.1
     gauge_transformer = CPhaseGaugeTransformer
     sweep_must_pass = True
 
 
-class TestCPhaseGauge(GaugeTester):
+class TestCPhaseGauge_m0_1(GaugeTester):
     two_qubit_gate = cirq.CZ ** (-0.1)
     gauge_transformer = CPhaseGaugeTransformer
     sweep_must_pass = True
 
 
-class TestCPhaseGauge(GaugeTester):
+class TestCPhaseGauge_0_7(GaugeTester):
     two_qubit_gate = cirq.CZ**0.7
     gauge_transformer = CPhaseGaugeTransformer
     sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import cirq
-from cirq.transformers.gauge_compiling import CPhaseGaugeTransformer
+from cirq.transformers.gauge_compiling.cphase_gauge import CPhaseGaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester
 
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -1,0 +1,23 @@
+# Copyright 2024 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cirq
+from cirq.transformers.gauge_compiling import CPhaseGaugeTransformer
+from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester
+
+
+class TestCPhaseGauge(GaugeTester):
+    two_qubit_gate = cirq.CZ**0.3
+    gauge_transformer = CPhaseGaugeTransformer
+    sweep_must_pass = True


### PR DESCRIPTION
Add gauge compiling for arbitrary-angle cphase gates. Tested in [this](https://colab.sandbox.google.com/drive/15rBv6Zl5iDUDETpd-Kas50_O21fVhbwB) colab. Note that this contains the cz and sqrt_cz gauges as special cases.