### PR TITLE
Fix controlled gate decomposition test on certain machines

### DIFF
--- a/cirq-core/cirq/ops/controlled_gate_test.py
+++ b/cirq-core/cirq/ops/controlled_gate_test.py
@@ -431,10 +431,23 @@ def test_controlled_gate_is_consistent(gate: cirq.Gate, should_decompose_to_targ
 @pytest.mark.parametrize(
     'gate',
     [
+        cirq.I,
+        cirq.GlobalPhaseGate(1),
+        cirq.GlobalPhaseGate(-1),
+        cirq.GlobalPhaseGate(1j),
         cirq.GlobalPhaseGate(1j**0.7),
+        cirq.Z,
         cirq.ZPowGate(exponent=1.2, global_shift=0.3),
+        cirq.CZ,
         cirq.CZPowGate(exponent=1.2, global_shift=0.3),
+        cirq.CCZ,
         cirq.CCZPowGate(exponent=1.2, global_shift=0.3),
+        cirq.X,
+        cirq.XPowGate(exponent=1.2, global_shift=0.3),
+        cirq.CX,
+        cirq.CXPowGate(exponent=1.2, global_shift=0.3),
+        cirq.CCX,
+        cirq.CCXPowGate(exponent=1.2, global_shift=0.3),
     ],
 )
 @pytest.mark.parametrize(
@@ -476,10 +489,9 @@ def _test_controlled_gate_is_consistent(
         shape = cirq.qid_shape(cgate)
         qids = cirq.LineQid.for_qid_shape(shape)
         decomposed = cirq.decompose(cgate.on(*qids))
-        if len(decomposed) < 1000:  # CCCCCZ rounding error explodes
-            first_op = cirq.IdentityGate(qid_shape=shape).on(*qids)  # To ensure same qid order
-            circuit = cirq.Circuit(first_op, *decomposed)
-            np.testing.assert_allclose(cirq.unitary(cgate), cirq.unitary(circuit), atol=1e-1)
+        first_op = cirq.IdentityGate(qid_shape=shape).on(*qids)  # To ensure same qid order
+        circuit = cirq.Circuit(first_op, *decomposed)
+        assert cirq.equal_up_to_global_phase(cirq.unitary(cgate), cirq.unitary(circuit))
 
 
 def test_pow_inverse():


### PR DESCRIPTION
When decomposing `CCCCCX` and such large multi-controlled gates, intermediate `MatrixGates` get created (notably not _controlled_ `MatrixGates`, which would be problematic; just top-level `MatrixGates` as part of the decomposition). These then get further decomposed to a different set of gates.

On some systems, due to rounding error, they get decomposed to a different set of gates that usual, which are equivalent but have different global phase than the standard decomposition. Again, these are top-level `MatrixGates`, not controlled ones, so its "okay" that their decompositions have different global phase. However, the test tested for `np.allclose`, and this test would fail on such systems. This PR changes the test to `cirq.equal_up_to_global_phase`, which should fix the tests on those systems.

xref https://github.com/quantumlib/Cirq/pull/7071#issuecomment-2693409814

Also adding back some test parameters I'd removed earlier because they were failing on Windows, and I'd assumed it was due to general rounding error; it didn't occur to me that it could be a phase difference. Let's see if the change allows them to pass.