### PR TITLE
cirq-google - get CZ gate noise properties from engine calibration data

### DIFF
--- a/cirq-google/cirq_google/engine/calibration_to_noise_properties.py
+++ b/cirq-google/cirq_google/engine/calibration_to_noise_properties.py
@@ -54,12 +54,12 @@ DEFAULT_GATE_NS: Dict[Type['cirq.Gate'], float] = {
 }
 GATE_PREFIX_PAIRS: Dict[Type['cirq.Gate'], str] = {
     cg_ops.SycamoreGate: 'two_qubit_parallel_sycamore_gate',
-    ops.CZ: 'two_qubit_parallel_cz_gate',
+    ops.CZPowGate: 'two_qubit_parallel_cz_gate',
     ops.ISwapPowGate: 'two_qubit_parallel_sqrt_iswap_gate',
 }
 GATE_ZPHASE_CODE_PAIRS: Dict[Type['cirq.Gate'], str] = {
     cg_ops.SycamoreGate: 'syc',
-    ops.CZ: 'cz',
+    ops.CZPowGate: 'cz',
     ops.ISwapPowGate: 'sqrt_iswap',
 }
 

--- a/cirq-google/cirq_google/engine/calibration_to_noise_properties.py
+++ b/cirq-google/cirq_google/engine/calibration_to_noise_properties.py
@@ -54,10 +54,12 @@ DEFAULT_GATE_NS: Dict[Type['cirq.Gate'], float] = {
 }
 GATE_PREFIX_PAIRS: Dict[Type['cirq.Gate'], str] = {
     cg_ops.SycamoreGate: 'two_qubit_parallel_sycamore_gate',
+    ops.CZ: 'two_qubit_parallel_cz_gate',
     ops.ISwapPowGate: 'two_qubit_parallel_sqrt_iswap_gate',
 }
 GATE_ZPHASE_CODE_PAIRS: Dict[Type['cirq.Gate'], str] = {
     cg_ops.SycamoreGate: 'syc',
+    ops.CZ: 'cz',
     ops.ISwapPowGate: 'sqrt_iswap',
 }
 


### PR DESCRIPTION
This adds 3 new CZ-gate calibration metrics to be translated from
`cirq_google.Calibration` to `cirq_google.GoogleNoiseProperties`

- two_qubit_parallel_cz_gate_xeb_pauli_error_per_cycle (gate_pauli_errors)
- two_qubit_parallel_cz_gate_xeb_entangler_theta_error_per_cycle (fsim_errors)
- two_qubit_parallel_cz_gate_xeb_entangler_phi_error_per_cycle (fsim_errors)
