### PR TITLE
Add problem matchers

### DIFF
--- a/.github/problem-matchers/README.md
+++ b/.github/problem-matchers/README.md
@@ -1,0 +1,35 @@
+# Problem Matchers
+
+GitHub [Problem
+Matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md)
+are a mechanism that enable workflow steps to scan the outputs of GitHub
+Actions for regex patterns and automatically write annotations in the workflow
+summary page. Using Problem Matchers allows information to be displayed more
+prominently in the GitHub user interface.
+
+This directory contains Problem Matchers used by the GitHub Actions workflows
+in the [`workflows`](./workflows) subdirectory.
+
+## Original sources
+
+The following problem matcher JSON files found in this directory were copied
+from the [Home Assistant](https://github.com/home-assistant/core) project on
+GitHub. The Home Assistant project is licensed under the Apache 2.0 open-source
+license. The version of the files at the time they were copied was 2025.1.2.
+
+- [`pylint.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/pylint.json)
+- [`yamllint.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/yamllint.json)
+- [`mypy.json`](https://github.com/home-assistant/core/blob/dev/.github/workflows/matchers/pypy.json)
+
+The following problem matcher for Black came from a fork of the
+[MLflow](https://github.com/mlflow/mlflow) project by user Sumanth077 on GitHub.
+The MLflow project is licensed under the Apache 2.0 open-source license. The
+version of the file copied was dated 2022-05-29.
+
+- [`black.json`](https://github.com/Sumanth077/mlflow/blob/problem-matcher-for-black/.github/workflows/matchers/black.json)
+
+The Shellcheck problem matcher JSON file came from the
+[shellcheck-problem-matchers](uhttps://github.com/lumaxis/shellcheck-problem-matchers)
+repository (copied 2025-02-26, version v2.1.0).
+
+- [`shellcheck-tty.json`](https://github.com/lumaxis/shellcheck-problem-matchers/blob/main/.github/shellcheck-tty.json)

--- a/.github/problem-matchers/black.json
+++ b/.github/problem-matchers/black.json
@@ -1,0 +1,15 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "black",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(would reformat) (.+)$",
+          "file": 2,
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/mypy.json
+++ b/.github/problem-matchers/mypy.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "mypy",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):\\s(error|warning):\\s(.+)$",
+          "file": 1,
+          "line": 2,
+          "severity": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/pylint.json
+++ b/.github/problem-matchers/pylint.json
@@ -1,0 +1,32 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "pylint-error",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([EF]\\d{4}):\\s.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    },
+    {
+      "owner": "pylint-warning",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(([CRW]\\d{4}):\\s.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/shellcheck.json
+++ b/.github/problem-matchers/shellcheck.json
@@ -1,0 +1,24 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "shellcheck",
+      "pattern": [
+        {
+            "regexp": "^In\\s(.+)\\sline\\s(\\d+):$",
+            "file": 1,
+            "line": 2
+        },
+        {
+          "regexp": ".*"
+        },
+        {
+            "regexp": "SC(\\d+)(\\s\\((note|warning|error)\\))?:\\s(.+)$",
+            "code": 1,
+            "severity": 3,
+            "message": 4,
+            "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/yamllint.json
+++ b/.github/problem-matchers/yamllint.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "yamllint",
+      "pattern": [
+        {
+          "regexp": "^(.*\\.ya?ml)$",
+          "file": 1
+        },
+        {
+          "regexp": "^\\s{2}(\\d+):(\\d+)\\s+(error|warning)\\s+(.*?)\\s+\\((.*)\\)$",
+          "line": 1,
+          "column": 2,
+          "severity": 3,
+          "message": 4,
+          "code": 5,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           architecture: 'x64'
       - name: Install dependencies
         run: pip install -r dev_tools/requirements/deps/format.txt
+      - name: Set up problem matcher for Black output
+        run: echo '::add-matcher::.github/problem-matchers/black.json'
       - name: Format
         run: check/format-incremental
   mypy:
@@ -77,6 +79,8 @@ jobs:
           architecture: 'x64'
       - name: Install mypy
         run: pip install -r dev_tools/requirements/mypy.env.txt
+      - name: Set up problem matcher for Mypy output
+        run: echo '::add-matcher::.github/problem-matchers/mypy.json'
       - name: Type check
         run: check/mypy
   changed_files:
@@ -109,6 +113,8 @@ jobs:
           architecture: 'x64'
       - name: Install pylint
         run: pip install -r dev_tools/requirements/pylint.env.txt
+      - name: Set up problem matcher for Pylint output
+        run: echo '::add-matcher::.github/problem-matchers/pylint.json'
       - name: Display version
         run: check/pylint --version
       - name: Lint
@@ -151,6 +157,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+      - name: Set up problem matcher for Shellcheck output
+        run: echo '::add-matcher::.github/problem-matchers/shellcheck.json'
       - name: Run shellcheck
         run: check/shellcheck
   isolated-modules:


### PR DESCRIPTION
GitHub [Problem Matchers](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) are a mechanism that enable workflow steps to scan the outputs of GitHub Actions for regex patterns and automatically write annotations in the workflow summary page. Using Problem Matchers allows information to be displayed more prominently in the GitHub user interface.

This add problem matchers for Pylint and Black output. More problem matchers can be added in the future as more checks are added to the CI workflows.
