### PR TITLE
Remove sweep_must_pass in gauge_compiling tests

### DIFF
--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -20,28 +20,23 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCPhaseGauge_0_3(GaugeTester):
     two_qubit_gate = cirq.CZ**0.3
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestCPhaseGauge_m0_3(GaugeTester):
     two_qubit_gate = cirq.CZ ** (-0.3)
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestCPhaseGauge_0_1(GaugeTester):
     two_qubit_gate = cirq.CZ**0.1
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestCPhaseGauge_m0_1(GaugeTester):
     two_qubit_gate = cirq.CZ ** (-0.1)
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestCPhaseGauge_0_7(GaugeTester):
     two_qubit_gate = cirq.CZ**0.7
     gauge_transformer = CPhaseGaugeTransformer
-    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -21,4 +21,3 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestCZGauge(GaugeTester):
     two_qubit_gate = cirq.CZ
     gauge_transformer = CZGaugeTransformer
-    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge_test.py
@@ -20,22 +20,18 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestSpinInversionGauge_0(GaugeTester):
     two_qubit_gate = cirq.ZZ
     gauge_transformer = SpinInversionGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestSpinInversionGauge_1(GaugeTester):
     two_qubit_gate = cirq.ZZ**0.1
     gauge_transformer = SpinInversionGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestSpinInversionGauge_2(GaugeTester):
     two_qubit_gate = cirq.ZZ**-1
     gauge_transformer = SpinInversionGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestSpinInversionGauge_3(GaugeTester):
     two_qubit_gate = cirq.ZZ**0.3
     gauge_transformer = SpinInversionGaugeTransformer
-    sweep_must_pass = True

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_cz_gauge_test.py
@@ -20,10 +20,8 @@ from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTe
 class TestSqrtCZGauge(GaugeTester):
     two_qubit_gate = cirq.CZ**0.5
     gauge_transformer = SqrtCZGaugeTransformer
-    sweep_must_pass = True
 
 
 class TestAdjointSqrtCZGauge(GaugeTester):
     two_qubit_gate = cirq.CZ**-0.5
     gauge_transformer = SqrtCZGaugeTransformer
-    sweep_must_pass = True


### PR DESCRIPTION
sweep_must_pass var in test class was used during the multi-pr implementations of as_sweep for different gauges. Now all the gauges have been supported by as_sweep, so, we can safely remove the flag here as by default sweep is tested for gauges.