### PR TITLE
Avoid broken wheels for qcs-sdk-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,19 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteract
 
 # Configure UTF-8 encoding.
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Make python3 default
 RUN rm -f /usr/bin/python \
      && ln -s /usr/bin/python3 /usr/bin/python
 #cirq stable image
 FROM cirq_base AS cirq_stable
-RUN pip3 install cirq
+# TODO: adjust after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
+RUN pip3 install cirq "qcs-sdk-python<=0.21.12"
 
 ##cirq pre_release image
 FROM cirq_base AS cirq_pre_release
-RUN pip3 install cirq~=1.0.dev
+# TODO: adjust after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
+RUN pip3 install cirq~=1.0.dev "qcs-sdk-python<=0.21.12"

--- a/cirq-rigetti/requirements.txt
+++ b/cirq-rigetti/requirements.txt
@@ -1,1 +1,4 @@
 pyquil>=4.14.3,<5.0.0
+
+# TODO: remove after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
+qcs-sdk-python<=0.21.12


### PR DESCRIPTION
The installation of `qcs-sdk-python==0.21.13` fails on Linux Python 3.10 with
`zipfile.BadZipFile: Bad CRC-32 for file 'qcs_sdk/qcs_sdk.cpython-310-x86_64-linux-gnu.so'`

Block new versions of qcs-sdk-python until this is fixed.

Ref: https://github.com/rigetti/qcs-sdk-rust/issues/531
