### PR TITLE
Fix isolated notebooks tests against stable Cirq

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -85,6 +85,9 @@ PACKAGES = [
     "jupyter",
     # assumed to be part of colab
     "seaborn~=0.12",
+    # TODO: remove after the fix of https://github.com/rigetti/qcs-sdk-rust/issues/531
+    "qcs-sdk-python<=0.21.12",
+    "numpy~=1.25",
 ]
 
 


### PR DESCRIPTION
Pre-install a working version of qcs-sdk-python package.

Ref: https://github.com/rigetti/qcs-sdk-rust/issues/531
Ref: https://github.com/quantumlib/Cirq/pull/7126
