### PR TITLE
Format proto files

### DIFF
--- a/cirq-google/cirq_google/api/v1/program.proto
+++ b/cirq-google/cirq_google/api/v1/program.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
+package cirq.google.api.v1;
+
 import "cirq_google/api/v1/operations.proto";
 import "cirq_google/api/v1/params.proto";
-
-package cirq.google.api.v1;
 
 option java_package = "com.google.cirq.google.api.v1";
 option java_outer_classname = "ProgramProto";

--- a/cirq-google/cirq_google/api/v2/batch.proto
+++ b/cirq-google/cirq_google/api/v2/batch.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
+package cirq.google.api.v2;
+
 import "cirq_google/api/v2/program.proto";
 import "cirq_google/api/v2/result.proto";
 import "cirq_google/api/v2/run_context.proto";
-
-package cirq.google.api.v2;
 
 option java_package = "com.google.cirq.google.api.v2";
 option java_outer_classname = "BatchProto";
@@ -18,7 +18,6 @@ option java_multiple_files = true;
 // of the total batch and different hardware constraints may
 // cause the programs to be executed separately on the hardware.
 message BatchProgram {
-
   // The circuits that should be bundled together as one program
   repeated Program programs = 1;
 }
@@ -26,7 +25,6 @@ message BatchProgram {
 // A batch of contexts for running a bundled batch of programs
 // To be used in conjunction with BatchProgram
 message BatchRunContext {
-
   // Run contexts for each program in the BatchProgram
   // Each RunContext should map directly to a Program in the corresponding
   // BatchProgram.
@@ -37,10 +35,8 @@ message BatchRunContext {
   repeated RunContext run_contexts = 1;
 }
 
-
 // The result returned from running a BatchProgram/BatchRunContext
 message BatchResult {
-
   // Results returned from executing a BatchProgram/BatchRunContext pair.
   //
   // After a BatchProgram and BatchRunContext is successfully run in
@@ -55,4 +51,3 @@ message BatchResult {
   // populated for programs that were not able to be run correctly.
   repeated Result results = 1;
 }
-

--- a/cirq-google/cirq_google/api/v2/calibration.proto
+++ b/cirq-google/cirq_google/api/v2/calibration.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
+package cirq.google.api.v2;
+
 import "cirq_google/api/v2/metrics.proto";
 import "cirq_google/api/v2/program.proto";
-
-package cirq.google.api.v2;
 
 option java_package = "com.google.cirq.google.api.v2";
 option java_outer_classname = "FocusedCalibrationProto";
@@ -12,96 +12,93 @@ option java_multiple_files = true;
 //  This message represents a request to execute a custom calibration routine.
 //
 message FocusedCalibration {
-     // The layers field represents each invocation of a calibration
-     // procedure.
-     //
-     // For instance, each (unique) moment of a circuit could be
-     // calibrated using parallel_xeb.  In this case,
-     // each moment would have its own CalibrationLayer.
-     //
-     // Some calibrations, such as a readout calibration,
-     // will only have one layer.
-     repeated CalibrationLayer layers = 1;
+  // The layers field represents each invocation of a calibration
+  // procedure.
+  //
+  // For instance, each (unique) moment of a circuit could be
+  // calibrated using parallel_xeb.  In this case,
+  // each moment would have its own CalibrationLayer.
+  //
+  // Some calibrations, such as a readout calibration,
+  // will only have one layer.
+  repeated CalibrationLayer layers = 1;
 }
 
 // Each CalibrationLayer represents one invocation
 // of a calibration procedure.
 message CalibrationLayer {
-     // The type of the calibration procedure to execute.
-     // The value of this field must be in one of the acceptable
-     // values found in the cirq enum TBD.
-     // TODO(dstrain): Point to the cirq enum once it exists.
-     string calibration_type = 1;
+  // The type of the calibration procedure to execute.
+  // The value of this field must be in one of the acceptable
+  // values found in the cirq enum TBD.
+  // TODO(dstrain): Point to the cirq enum once it exists.
+  string calibration_type = 1;
 
-     // A circuit that identifies the layer or circuit to optimize
-     // if the calibration requires this.  For many calibrations,
-     // this will be a single moment representing the layer to
-     // optimize for.
-     Program layer = 2;
+  // A circuit that identifies the layer or circuit to optimize
+  // if the calibration requires this.  For many calibrations,
+  // this will be a single moment representing the layer to
+  // optimize for.
+  Program layer = 2;
 
-     // Arguments that can be specified to the calibration procedure,
-     // such as the number of layers, which angles to optimize, etc
-     map<string, Arg> args = 3;
+  // Arguments that can be specified to the calibration procedure,
+  // such as the number of layers, which angles to optimize, etc
+  map<string, Arg> args = 3;
 }
 
 // The results returned by a FocusedCalibration request.
 message FocusedCalibrationResult {
-
-     // The results of each CalibrationLayer request.
-     // There will be one CalibrationLayerResults message for each
-     // CalibrationLayer in the request, and the results will
-     // correspond to the order of the requests.
-     repeated CalibrationLayerResult results = 1;
+  // The results of each CalibrationLayer request.
+  // There will be one CalibrationLayerResults message for each
+  // CalibrationLayer in the request, and the results will
+  // correspond to the order of the requests.
+  repeated CalibrationLayerResult results = 1;
 }
 
 // Response codes for Calibration requests
 enum CalibrationLayerCode {
+  // Zero is a default value and means the value was unknown or unset.
+  CALIBRATION_RESULT_UNSPECIFIED = 0;
 
-     // Zero is a default value and means the value was unknown or unset.
-     CALIBRATION_RESULT_UNSPECIFIED = 0;
+  // Successful run of the calibration.
+  SUCCESS = 1;
 
-     // Successful run of the calibration.
-     SUCCESS = 1;
+  // Miscellaenous errors not covered by the below conditions.
+  ERROR_OTHER = 2;
 
-     // Miscellaenous errors not covered by the below conditions.
-     ERROR_OTHER = 2;
+  // The parameters given to the calibration were not valid.
+  // For instance, multiple moments were given to a type of calibration
+  // that expects a single moment.
+  ERROR_INVALID_PARAMETERS = 3;
 
-     // The parameters given to the calibration were not valid.
-     // For instance, multiple moments were given to a type of calibration
-     // that expects a single moment.
-     ERROR_INVALID_PARAMETERS = 3;
+  // The calibration took too long and was aborted.
+  ERROR_TIMEOUT = 4;
 
-     // The calibration took too long and was aborted.
-     ERROR_TIMEOUT = 4;
-
-     // The calibration failed for internal reasons.  For instance,
-     // suitable device parameters could not be acheived or dependencies
-     // needed by the calibration did not exist.
-     ERROR_CALIBRATION_FAILED = 5;
+  // The calibration failed for internal reasons.  For instance,
+  // suitable device parameters could not be acheived or dependencies
+  // needed by the calibration did not exist.
+  ERROR_CALIBRATION_FAILED = 5;
 }
 
-
 message CalibrationLayerResult {
-     // Whether the calibration procedure was a success or failure.
-     CalibrationLayerCode code = 1;
+  // Whether the calibration procedure was a success or failure.
+  CalibrationLayerCode code = 1;
 
-     // On non-successful results, contains additional information
-     // about the details of the error.
-     string error_message = 2;
+  // On non-successful results, contains additional information
+  // about the details of the error.
+  string error_message = 2;
 
-     // A token identifying the calibration result.
-     // If a token exists in the response, it can be used to tag
-     // focused circuits that use parameters
-     // derived from this calibration.
-     // If no token exists, then the calibration was purely diagnostic.
-     string token = 3;
+  // A token identifying the calibration result.
+  // If a token exists in the response, it can be used to tag
+  // focused circuits that use parameters
+  // derived from this calibration.
+  // If no token exists, then the calibration was purely diagnostic.
+  string token = 3;
 
-     // Results, such as gate fidelities, gate angles, etc
-     // would be returned in a similar format to calibration metrics.
-     // This allows the return result to be easily extensible.
-     MetricsSnapshot metrics = 4;
+  // Results, such as gate fidelities, gate angles, etc
+  // would be returned in a similar format to calibration metrics.
+  // This allows the return result to be easily extensible.
+  MetricsSnapshot metrics = 4;
 
-     // Timestamp of when the calibration is valid until, specified as
-     // milliseconds since the Unix epoch time.
-     uint64 valid_until_ms = 5;
+  // Timestamp of when the calibration is valid until, specified as
+  // milliseconds since the Unix epoch time.
+  uint64 valid_until_ms = 5;
 }

--- a/cirq-google/cirq_google/api/v2/metrics.proto
+++ b/cirq-google/cirq_google/api/v2/metrics.proto
@@ -9,7 +9,6 @@ option java_multiple_files = true;
 // A snapshot of the performance metrics for a quantum processor at a
 // particular time.
 message MetricsSnapshot {
-
   // The time the metrics were collected, in unix time (milliseconds since
   // Epoch minus leap seconds). Metric collection take time, so this is the
   // time at which all of the metrics have been collected.

--- a/cirq-google/cirq_google/api/v2/ndarrays.proto
+++ b/cirq-google/cirq_google/api/v2/ndarrays.proto
@@ -20,12 +20,12 @@
  * type and not the data.)
  */
 syntax = "proto3";
+
 package cirq.google.api.v2;
 
 option java_package = "com.google.cirq.google.api.v2";
 option java_outer_classname = "NDArrayProto";
 option java_multiple_files = true;
-
 
 enum Endianness {
   LITTLE_ENDIAN = 0;
@@ -33,7 +33,8 @@ enum Endianness {
 }
 
 /*
- * Array of interleaved (real, imaginary) pairs, each of which are 64-bit floats.
+ * Array of interleaved (real, imaginary) pairs, each of which are 64-bit
+ * floats.
  */
 message Complex128Array {
   repeated uint32 shape = 1;
@@ -44,7 +45,8 @@ message Complex128Array {
 }
 
 /*
- * Array of interleaved (real, imaginary) pairs, each of which are 32-bit floats.
+ * Array of interleaved (real, imaginary) pairs, each of which are 32-bit
+ * floats.
  */
 message Complex64Array {
   repeated uint32 shape = 1;

--- a/cirq-google/cirq_google/api/v2/ndarrays_pb2.pyi
+++ b/cirq-google/cirq_google/api/v2/ndarrays_pb2.pyi
@@ -57,7 +57,8 @@ global___Endianness = Endianness
 @typing.final
 class Complex128Array(google.protobuf.message.Message):
     """
-    Array of interleaved (real, imaginary) pairs, each of which are 64-bit floats.
+    Array of interleaved (real, imaginary) pairs, each of which are 64-bit
+    floats.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
@@ -85,7 +86,8 @@ global___Complex128Array = Complex128Array
 @typing.final
 class Complex64Array(google.protobuf.message.Message):
     """
-    Array of interleaved (real, imaginary) pairs, each of which are 32-bit floats.
+    Array of interleaved (real, imaginary) pairs, each of which are 32-bit
+    floats.
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor

--- a/cirq-google/cirq_google/api/v2/program.proto
+++ b/cirq-google/cirq_google/api/v2/program.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "tunits/proto/tunits.proto";
-
 package cirq.google.api.v2;
+
+import "tunits/proto/tunits.proto";
 
 option java_package = "com.google.cirq.google.api.v2";
 option java_outer_classname = "ProgramProto";
@@ -11,7 +11,7 @@ option java_multiple_files = true;
 // A quantum program.
 message Program {
   // The language in which the program is written.
-  Language language = 1 [deprecated=true];
+  Language language = 1 [deprecated = true];
 
   // Programs can be specified by a circuit or a schedule.
   oneof program {
@@ -45,7 +45,7 @@ message Constant {
 
     // Moments used multiple times in a circuit
     Moment moment_value = 4;
-    
+
     // Operations used multiple times in a circuit
     Operation operation_value = 5;
 
@@ -73,8 +73,7 @@ message Circuit {
   // The moments of the circuit, with the first element corresponding to the
   // first set of operations to apply, etc.
   repeated Moment moments = 2;
-  
-  
+
   // The index of the moment in the top-level constant table.
   // In order to preserve ordering, either this field should be populated
   // or the moments field, but not both.
@@ -143,7 +142,7 @@ message Language {
   //
   // Valid names for the arg function language can be found in
   // cirq/google/arg_func_langs.py
-  string arg_function_language = 2 [deprecated=true];
+  string arg_function_language = 2 [deprecated = true];
 }
 
 // Argument that is constrained to a float or symbolic expression
@@ -283,7 +282,6 @@ message DynamicalDecouplingTag {
   optional string protocol = 1;
 }
 
-
 // Messages for tags that can modify operations
 // These are often directives to hardware specifying
 // how the operation should be executed.
@@ -323,44 +321,37 @@ message Tag {
   }
 }
 
-
 // Tag for operations that should do phase matching to match phase
 // required for subsequent operations
-message PhaseMatchTag {
-}
+message PhaseMatchTag {}
 
-message PhysicalZTag {
-}
+message PhysicalZTag {}
 
 // Tag to indicate that a state prep circuit produces a classical state.
 // This serves as a hint to the compiler that we can ignore virtual Z phases
-message ClassicalStateTag {
-}
+message ClassicalStateTag {}
 
-
-message FSimViaModelTag {
-}
+message FSimViaModelTag {}
 
 // Tag to remove moment-based synchronization
 // The reverse and forward arguments control the
 // number of moments to reverse synchronization.
 message NoSyncTag {
-    oneof rev {
-        // Number of synchronizations before the operation to remove
-        int32 reverse = 1;
+  oneof rev {
+    // Number of synchronizations before the operation to remove
+    int32 reverse = 1;
 
-        // Remove all possible synchronizations
-        bool remove_all_syncs_before = 2;
-    }
-    oneof fwd {
-        // Number of synchronizations after the operation to remove
-        int32 forward = 3;
+    // Remove all possible synchronizations
+    bool remove_all_syncs_before = 2;
+  }
+  oneof fwd {
+    // Number of synchronizations after the operation to remove
+    int32 forward = 3;
 
-        // Remove all possible synchronizations
-        bool remove_all_syncs_after = 4;
-    }
+    // Remove all possible synchronizations
+    bool remove_all_syncs_after = 4;
+  }
 }
-
 
 // Tag to represent any internal tags or tags not yet
 // implemented in the proto.
@@ -374,7 +365,6 @@ message InternalTag {
   map<string, Arg> tag_args = 3;
   map<string, CustomArg> custom_args = 4;
 }
-
 
 // The instruction identifying the action taken on the quantum computer.
 message Gate {
@@ -568,8 +558,8 @@ message FunctionInterpolation {
   repeated float x_values = 1 [packed = true];  // The independent variable.
   repeated float y_values = 2 [packed = true];  // The dependent variable.
 
-  // Currently only piecewise linear interpolation (i.e. np.interp) is supported.
-  // That's we connect (x[i], y[i]) to (x[i+1], y[i+1]))
+  // Currently only piecewise linear interpolation (i.e. np.interp) is
+  // supported. That's we connect (x[i], y[i]) to (x[i+1], y[i+1]))
 }
 
 message CustomArg {
@@ -578,21 +568,22 @@ message CustomArg {
   }
 }
 
-message InternalGate{
-  string name = 1;  // Gate name.
-  string module = 2;  // Gate module. 
+message InternalGate {
+  string name = 1;       // Gate name.
+  string module = 2;     // Gate module.
   int32 num_qubits = 3;  // Number of qubits. Required during deserialization.
   map<string, Arg> gate_args = 4;  // Gate args.
 
-  // Custom args are arguments that require special processing during deserialization.
-  // The `key` is the argument in the internal class's constructor, the `value`
-  // is a representation from which an internal object can be constructed.
+  // Custom args are arguments that require special processing during
+  // deserialization. The `key` is the argument in the internal class's
+  // constructor, the `value` is a representation from which an internal object
+  // can be constructed.
   map<string, CustomArg> custom_args = 5;
 }
 
-message CouplerPulseGate{
-  optional FloatArg hold_time_ps = 1;  // ps=picoseconds.
-  optional FloatArg rise_time_ps = 2;  // ps=picoseconds.
+message CouplerPulseGate {
+  optional FloatArg hold_time_ps = 1;     // ps=picoseconds.
+  optional FloatArg rise_time_ps = 2;     // ps=picoseconds.
   optional FloatArg padding_time_ps = 3;  // ps=picoseconds.
   optional FloatArg coupling_mhz = 4;
   optional FloatArg q0_detune_mhz = 5;
@@ -625,12 +616,12 @@ message HPowGate {
 }
 
 message ResetGate {
-    // Type of reset to be executed (hardware dependent)
-    // Internal users should use the name of the class.
-    // (Note that this is not used for public-facing circuits,
-    //  which will default to cirq.ResetChannel)
-    string reset_type = 1;
+  // Type of reset to be executed (hardware dependent)
+  // Internal users should use the name of the class.
+  // (Note that this is not used for public-facing circuits,
+  //  which will default to cirq.ResetChannel)
+  string reset_type = 1;
 
-    // Additional arguments that can be sent to the reset implementation.
-    map<string, Arg> arguments = 2;
+  // Additional arguments that can be sent to the reset implementation.
+  map<string, Arg> arguments = 2;
 }

--- a/cirq-google/cirq_google/api/v2/program.proto
+++ b/cirq-google/cirq_google/api/v2/program.proto
@@ -600,11 +600,16 @@ message CouplerPulseGate{
 }
 
 message CliffordTableau {
-  optional int32 num_qubits = 1;  // Number of qubits the CliffordTableau acts on.
-  optional int32 initial_state = 2;  // The initial state.
-  repeated bool rs = 3;  // A flattened version of the `rs` array.
-  repeated bool xs = 4;  // A flattened version of the `xs` array.
-  repeated bool zs = 5;  // A flattened version of the `zs` array.
+  // Number of qubits the CliffordTableau acts on.
+  optional int32 num_qubits = 1;
+  // The initial state.
+  optional int32 initial_state = 2;
+  // A flattened version of the `rs` array.
+  repeated bool rs = 3;
+  // A flattened version of the `xs` array.
+  repeated bool xs = 4;
+  // A flattened version of the `zs` array.
+  repeated bool zs = 5;
 }
 
 message SingleQubitCliffordGate {

--- a/cirq-google/cirq_google/api/v2/program_pb2.pyi
+++ b/cirq-google/cirq_google/api/v2/program_pb2.pyi
@@ -1552,9 +1552,10 @@ class InternalGate(google.protobuf.message.Message):
 
     @property
     def custom_args(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___CustomArg]:
-        """Custom args are arguments that require special processing during deserialization.
-        The `key` is the argument in the internal class's constructor, the `value`
-        is a representation from which an internal object can be constructed.
+        """Custom args are arguments that require special processing during
+        deserialization. The `key` is the argument in the internal class's
+        constructor, the `value` is a representation from which an internal object
+        can be constructed.
         """
 
     def __init__(

--- a/cirq-google/cirq_google/api/v2/result.proto
+++ b/cirq-google/cirq_google/api/v2/result.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-import "cirq_google/api/v2/program.proto";
-
 package cirq.google.api.v2;
+
+import "cirq_google/api/v2/program.proto";
 
 option java_package = "com.google.cirq.google.api.v2";
 option java_outer_classname = "ResultProto";
@@ -60,8 +60,8 @@ message QubitMeasurementResult {
 
   // These are the results of a measurement on a qubit. The number of bits
   // measured is equal to repetitions * instances, where repetitions is defined
-  // in the SweepResult message, and instances is defined in the MeasurementResult
-  // message.
+  // in the SweepResult message, and instances is defined in the
+  // MeasurementResult message.
   //
   // The bytes in this field are constructed as follows:
   //
@@ -86,4 +86,3 @@ message ParameterDict {
   // Maps parameter names to values.
   map<string, float> assignments = 1;
 }
-

--- a/cirq-google/cirq_google/api/v2/result_pb2.pyi
+++ b/cirq-google/cirq_google/api/v2/result_pb2.pyi
@@ -137,8 +137,8 @@ class QubitMeasurementResult(google.protobuf.message.Message):
     results: builtins.bytes
     """These are the results of a measurement on a qubit. The number of bits
     measured is equal to repetitions * instances, where repetitions is defined
-    in the SweepResult message, and instances is defined in the MeasurementResult
-    message.
+    in the SweepResult message, and instances is defined in the
+    MeasurementResult message.
 
     The bytes in this field are constructed as follows:
 

--- a/cirq-google/cirq_google/api/v2/run_context.proto
+++ b/cirq-google/cirq_google/api/v2/run_context.proto
@@ -255,7 +255,8 @@ message Linspace {
 message ConstValue {
   // The values.
   oneof value {
-    // This value should always be true if set, which represent the python None object.
+    // This value should always be true if set, which represents the python None
+    // object.
     bool is_none = 1;
     float float_value = 2;
     int64 int_value = 3;

--- a/cirq-google/cirq_google/api/v2/run_context.proto
+++ b/cirq-google/cirq_google/api/v2/run_context.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 
+package cirq.google.api.v2;
+
 import "cirq_google/api/v2/program.proto";
 import "tunits/proto/tunits.proto";
-
-package cirq.google.api.v2;
 
 option java_package = "com.google.cirq.google.api.v2";
 option java_outer_classname = "RunContextProto";
@@ -40,7 +40,6 @@ message ParameterSweep {
 
 // A sweep over all of the parameters in a program.
 message Sweep {
-
   // The sweep is either a function of sweeps or an actual assignment of
   // a symbol to a list of values.
   oneof sweep {
@@ -111,35 +110,34 @@ message SweepFunction {
 }
 
 message DeviceParameter {
+  // Path to the parameter key
+  repeated string path = 1;
 
-    // Path to the parameter key
-    repeated string path = 1;
+  // If the value is an array, the index of the array to change.
+  optional int64 idx = 2;
 
-    // If the value is an array, the index of the array to change.
-    optional int64 idx = 2;
+  // String representation of the units, if any.
+  // Examples: "GHz", "ns", etc.
+  optional string units = 3;
 
-    // String representation of the units, if any.
-    // Examples: "GHz", "ns", etc.
-    optional string units = 3;
-
-    // Note that the device parameter values will be populated
-    // by the sweep values themselves.
+  // Note that the device parameter values will be populated
+  // by the sweep values themselves.
 }
 
 message Metadata {
-    // Optional arguments for if this is a device parameter.
-    // Note one single_sweep may be associated with multiple device parameters.
-    repeated DeviceParameter device_parameters = 1;
+  // Optional arguments for if this is a device parameter.
+  // Note one single_sweep may be associated with multiple device parameters.
+  repeated DeviceParameter device_parameters = 1;
 
-    // If specified, use this label instead of parameter_key as the independent
-    // column name in returned dataset.
-    optional string label = 2;
+  // If specified, use this label instead of parameter_key as the independent
+  // column name in returned dataset.
+  optional string label = 2;
 
-    // If true, store this sweep as parameters instead of the independent axes.
-    optional bool is_const = 3;
+  // If true, store this sweep as parameters instead of the independent axes.
+  optional bool is_const = 3;
 
-    // A temporary solution that we store the unit information here.
-    optional string unit = 4;
+  // A temporary solution that we store the unit information here.
+  optional string unit = 4;
 }
 
 // A bundle of multiple DeviceParameters and their values.
@@ -167,8 +165,8 @@ message DeviceParametersDiff {
   message GenericValue {
     // Type description of the value representation. Eg. if the following value
     // bytes field is a JSON string, type_descriptor can be its JSON namespace;
-    // or if the following value field is a protobuf serialization, type_descriptor
-    // can be its protobuf definition URL.
+    // or if the following value field is a protobuf serialization,
+    // type_descriptor can be its protobuf definition URL.
     string type_descriptor = 1;
 
     // The value in client's encoding.
@@ -187,8 +185,8 @@ message DeviceParametersDiff {
       // string, double, float and arrays.
       ArgValue value = 3;
 
-      // this param's new value, and its type is not among the variants supported
-      // by ArgValue.
+      // this param's new value, and its type is not among the variants
+      // supported by ArgValue.
       GenericValue generic_value = 4;
     }
   }
@@ -196,7 +194,8 @@ message DeviceParametersDiff {
   repeated Param params = 2;
 
   // List of all key, dir, and deletion names in these contents.
-  // ResourceGroup.name, Param.name, and Deletion.name are indexes into this list.
+  // ResourceGroup.name, Param.name, and Deletion.name are indexes into this
+  // list.
   repeated string strs = 4;
 }
 
@@ -223,7 +222,6 @@ message SingleSweep {
   // Optional arguments for storing extra metadata information.
   Metadata metadata = 6;
 }
-
 
 // A list of explicit values.
 message Points {

--- a/cirq-google/cirq_google/api/v2/run_context_pb2.pyi
+++ b/cirq-google/cirq_google/api/v2/run_context_pb2.pyi
@@ -369,8 +369,8 @@ class DeviceParametersDiff(google.protobuf.message.Message):
         type_descriptor: builtins.str
         """Type description of the value representation. Eg. if the following value
         bytes field is a JSON string, type_descriptor can be its JSON namespace;
-        or if the following value field is a protobuf serialization, type_descriptor
-        can be its protobuf definition URL.
+        or if the following value field is a protobuf serialization,
+        type_descriptor can be its protobuf definition URL.
         """
         value: builtins.bytes
         """The value in client's encoding."""
@@ -404,8 +404,8 @@ class DeviceParametersDiff(google.protobuf.message.Message):
 
         @property
         def generic_value(self) -> global___DeviceParametersDiff.GenericValue:
-            """this param's new value, and its type is not among the variants supported
-            by ArgValue.
+            """this param's new value, and its type is not among the variants
+            supported by ArgValue.
             """
 
         def __init__(
@@ -430,7 +430,8 @@ class DeviceParametersDiff(google.protobuf.message.Message):
     @property
     def strs(self) -> google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.str]:
         """List of all key, dir, and deletion names in these contents.
-        ResourceGroup.name, Param.name, and Deletion.name are indexes into this list.
+        ResourceGroup.name, Param.name, and Deletion.name are indexes into this
+        list.
         """
 
     def __init__(
@@ -574,7 +575,9 @@ class ConstValue(google.protobuf.message.Message):
     STRING_VALUE_FIELD_NUMBER: builtins.int
     WITH_UNIT_VALUE_FIELD_NUMBER: builtins.int
     is_none: builtins.bool
-    """This value should always be true if set, which represent the python None object."""
+    """This value should always be true if set, which represents the python None
+    object.
+    """
     float_value: builtins.float
     int_value: builtins.int
     string_value: builtins.str


### PR DESCRIPTION
No change in the effective content.

- Adjust comments to be more readable after formatting

- Format proto sources using
  ```
  protofmt --remove_unused_imports --in_place $(git ls-files "*.proto")
  ```
