### PR TITLE
Fix deserialization of reset gates when dimensions missing.

### DIFF
--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -689,9 +689,11 @@ class CircuitSerializer(serializer.Serializer):
             )
             op = cirq.WaitGate(duration=cirq.Duration(nanos=total_nanos or 0.0))(*qubits)
         elif which_gate_type == 'resetgate':
-            dimensions = arg_func_langs.arg_from_proto(
-                operation_proto.resetgate.arguments.get('dimension', 2)
-            )
+            dimensions_proto = operation_proto.resetgate.arguments.get('dimension', None)
+            if dimensions_proto is not None:
+                dimensions = arg_func_langs.arg_from_proto(dimensions_proto)
+            else:
+                dimensions = 2
             if not isinstance(dimensions, int):
                 # This should always be int, if serialized from cirq.
                 raise ValueError(f"dimensions {dimensions} for ResetChannel must be an integer!")

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -1045,6 +1045,24 @@ def test_reset_gate_with_improper_argument():
         serializer.deserialize(circuit_proto)
 
 
+def test_reset_gate_with_no_dimension():
+    serializer = cg.CircuitSerializer()
+
+    op = v2.program_pb2.Operation()
+    op.resetgate.SetInParent()
+    op.qubit_constant_index.append(0)
+    circuit_proto = v2.program_pb2.Program(
+        language=v2.program_pb2.Language(arg_function_language='exp', gate_set=_SERIALIZER_NAME),
+        circuit=v2.program_pb2.Circuit(
+            scheduling_strategy=v2.program_pb2.Circuit.MOMENT_BY_MOMENT,
+            moments=[v2.program_pb2.Moment(operations=[op])],
+        ),
+        constants=[v2.program_pb2.Constant(qubit=v2.program_pb2.Qubit(id='1_2'))],
+    )
+    reset_circuit = serializer.deserialize(circuit_proto)
+    assert reset_circuit == cirq.Circuit(cirq.R(cirq.q(1, 2)))
+
+
 def test_stimcirq_gates():
     stimcirq = pytest.importorskip("stimcirq")
     serializer = cg.CircuitSerializer()


### PR DESCRIPTION
- If dimensions is missing, it should be set to 2.
- However, the previous code passed 2 to arg_from_proto.
- 2 is not a proto, it's a number, so this did not work.