### PR TITLE
Ensure InsertStrategy.NAME is identical after pickle round-trip

### DIFF
--- a/cirq-core/cirq/circuits/insert_strategy.py
+++ b/cirq-core/cirq/circuits/insert_strategy.py
@@ -23,6 +23,16 @@ class InsertStrategy:
     INLINE: 'InsertStrategy'
     EARLIEST: 'InsertStrategy'
 
+    def __new__(cls, name: str, doc: str) -> 'InsertStrategy':
+        inst = getattr(cls, name, None)
+        if not inst or not isinstance(inst, cls):
+            inst = super().__new__(cls)
+        return inst
+
+    def __getnewargs__(self):
+        """Returns a tuple of args to pass to __new__ when unpickling."""
+        return (self.name, self.__doc__)
+
     def __init__(self, name: str, doc: str):
         self.name = name
         self.__doc__ = doc

--- a/cirq-core/cirq/circuits/insert_strategy_test.py
+++ b/cirq-core/cirq/circuits/insert_strategy_test.py
@@ -12,8 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
+
+import pytest
+
 import cirq
 
 
 def test_repr():
     assert repr(cirq.InsertStrategy.NEW) == 'cirq.InsertStrategy.NEW'
+
+
+@pytest.mark.parametrize(
+    'strategy',
+    [
+        cirq.InsertStrategy.NEW,
+        cirq.InsertStrategy.NEW_THEN_INLINE,
+        cirq.InsertStrategy.INLINE,
+        cirq.InsertStrategy.EARLIEST,
+    ],
+    ids=lambda strategy: strategy.name,
+)
+def test_identity_after_pickling(strategy: cirq.InsertStrategy):
+    unpickled_strategy = pickle.loads(pickle.dumps(strategy))
+    assert unpickled_strategy is strategy


### PR DESCRIPTION
The `Circuit.insert` uses identity to determine the `InsertStrategy` kind.
Here we ensure that `InsertStrategy.NAME` is restored to the same object
after pickle-unpickle round trip.  This should prevent unexpected
behavior if `cirq.Insert` is used in a multiprocessing call.
