### PR TITLE
Allow cirq-google installation with protobuf-5

### DIFF
--- a/cirq-google/requirements.txt
+++ b/cirq-google/requirements.txt
@@ -1,4 +1,4 @@
 google-api-core[grpc] >= 1.14.0
 proto-plus >= 1.20.0
-protobuf ~= 4.25
+protobuf >= 4.25, <6.0
 typedunits


### PR DESCRIPTION
Unit tests pass with protobuf-5.29.3 (latest in the 5.x series).
Python protobuf sources are still generated with protobuf-4
so cirq-google can be used in environments with protobuf-4 too.

Related to #7145
