### PR TITLE
Avoid Moment typechecks when (un)freezing circuits

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1867,7 +1867,7 @@ class Circuit(AbstractCircuit):
         from cirq.circuits.frozen_circuit import FrozenCircuit
 
         if self._frozen is None:
-            self._frozen = FrozenCircuit.from_moments(*self._moments)
+            self._frozen = FrozenCircuit._from_moments(self._moments)
         return self._frozen
 
     def unfreeze(self, copy: bool = True) -> 'cirq.Circuit':

--- a/cirq-core/cirq/circuits/frozen_circuit.py
+++ b/cirq-core/cirq/circuits/frozen_circuit.py
@@ -84,7 +84,7 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
         return self
 
     def unfreeze(self, copy: bool = True) -> 'cirq.Circuit':
-        return Circuit.from_moments(*self)
+        return Circuit._from_moments(self._moments)
 
     @property
     def tags(self) -> Tuple[Hashable, ...]:


### PR DESCRIPTION
When freezing or unfreezing circuits, we have a list or tuple of `Moment` objects so we can call the `_from_moments` classmethod on the relevant target type which avoids the `isinstance` typechecks that are needed when calling `from_moments` as we do currently.

See below for a microbenchmark of this change. On main, freezing an example circuit with 10_001 moments takes something like 550us, while on this branch the same freeze operation takes about 40us (note that we have to copy the circuit before freezing because we cache the result of `freeze` if a circuit has not been mutated).

With main:
```profile
In [1]: import cirq; q = cirq.q(0); c = cirq.Circuit([cirq.X(q)] * 10_000, cirq.M(q))

In [2]: %timeit c.copy()
25.6 μs ± 135 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit c.copy().freeze()
575 μs ± 821 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

With this branch:
```profile
In [1]: import cirq; q = cirq.q(0); c = cirq.Circuit([cirq.X(q)] * 10_000, cirq.M(q))

In [2]: %timeit c.copy()
26 μs ± 137 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [3]: %timeit c.copy().freeze()
66.2 μs ± 1.78 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
