### PR TITLE
Add additional permissions to the job definition

### DIFF
--- a/.github/workflows/first-interaction.yaml
+++ b/.github/workflows/first-interaction.yaml
@@ -22,8 +22,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
+      contents: read
       issues: write
       pull-requests: write
+      id-token: write
     env:
       repo: ${{github.server_url}}/${{github.repository}}
       files: ${{github.server_url}}/${{github.repository}}/blob/${{github.ref_name}}


### PR DESCRIPTION
This will hopefully solve the problem that external contributors get a "resource is not accessible by integration" error.