### PR TITLE
Drop "requests" package from the isolated-base.env

### DIFF
--- a/dev_tools/requirements/isolated-base.env.txt
+++ b/dev_tools/requirements/isolated-base.env.txt
@@ -2,6 +2,3 @@
 
 -r deps/pytest.txt
 -r deps/notebook.txt
-
-# for shell_tools
-requests~=2.32


### PR DESCRIPTION
The dependency seems to be redundant.