### PR TITLE
Update directories searched by Dependabot for pip case

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Dependabot config file for the Cirq project.
+
 # Copyright 2024 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,13 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Summary: Dependabot config file, to adjust things for the Cirq project.
-#
-# By default, Dependabot labels all pull requests with label 'dependencies'.
-# We prefer `area/dependencies`, so have to configure Dependabot appropriately.
-# ─────────────────────────────────────────────────────────────────────────────
 
 version: 2
 updates:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,16 +67,7 @@ updates:
   - package-ecosystem: "pip"
     # Cirq has requirements.txt files in multiple places. N.b. the use of
     # attribute "directories" instead of "directory" here.
-    directories:
-      - "/"
-      - "/cirq-aqt"
-      - "/cirq-core"
-      - "/cirq-google"
-      - "/cirq-ionq"
-      - "/cirq-pasqal"
-      - "/cirq-rigetti"
-      - "/cirq-web"
-      - "/dev_tools/requirements"
+    directory: "/dev_tools/requirements/deps"
     schedule:
       interval: "weekly"
     versioning-strategy: "increase-if-necessary"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     # in the specified directory.
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "area/dependencies"
       - "area/docker"
@@ -32,7 +32,7 @@ updates:
     # value "/" is given for the directory attribute. Yes, that's confusing.
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "area/dependencies"
       - "area/github"
@@ -60,11 +60,9 @@ updates:
       - "kind/health"
 
   - package-ecosystem: "pip"
-    # Cirq has requirements.txt files in multiple places. N.b. the use of
-    # attribute "directories" instead of "directory" here.
     directory: "/dev_tools/requirements/deps"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     versioning-strategy: "increase-if-necessary"
     labels:
       - "area/dependencies"

--- a/dev_tools/requirements/deps/cirq-all-no-contrib.txt
+++ b/dev_tools/requirements/deps/cirq-all-no-contrib.txt
@@ -1,5 +1,9 @@
 # captures all the modules
+
 -r ../../../cirq-aqt/requirements.txt
 -r ../../../cirq-core/requirements.txt
 -r ../../../cirq-google/requirements.txt
+-r ../../../cirq-ionq/requirements.txt
+-r ../../../cirq-pasqal/requirements.txt
 -r ../../../cirq-rigetti/requirements.txt
+-r ../../../cirq-web/requirements.txt


### PR DESCRIPTION
Having multiple directories listed is probably the reason why Dependabot sometimes opens multiple PRs for the same thing (e.g., #7142 (comment)). The requirements files include each other, and Dependabot is probably finding the same file by different paths.

Changing this to use only dev_tools/requirements/deps because the requirements in there are the basis for all the other requirements.txt files.