### PR TITLE
Tell Dependabot to ignore higher versions of chai and pixelmatch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,9 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: "widen"
+    ignore:
+      - dependency-name: "chai"
+        versions: [">= 5.0.0"]
     groups:
       # Group non-security version minor & patch updates into one PR.
       # Security and major update versions will be done as individual PRs.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,8 @@ updates:
     ignore:
       - dependency-name: "chai"
         versions: [">= 5.0.0"]
+      - dependency-name: "pixelmatch"
+        versions: ["> 5.3.0"]
     groups:
       # Group non-security version minor & patch updates into one PR.
       # Security and major update versions will be done as individual PRs.


### PR DESCRIPTION
Updating chai and pixelmatch seems to cause the ts checks to fail. Based on [this comment](https://github.com/chaijs/chai/issues/1568#issuecomment-1873883627) and others in an issue thread in the Chai project repo, version 5.0.0 and higher of chai requires the use of a certain type of JavaScript modularization/packaging, and this may not be what other modules use. Perhaps this is the reason why the tests fail for us -- I can't tell without looking more closely. Right now, though, this is not an essential update to do. We need to stop Dependabot trying to update these two dependencies every time it runs.