### PR TITLE
Fix broken development environment

### DIFF
--- a/dev_tools/requirements/deps/packaging.txt
+++ b/dev_tools/requirements/deps/packaging.txt
@@ -2,7 +2,8 @@
 virtualenv
 
 # for creating packages
-setuptools
+# TODO (juhas) - remove when pyquil allows packaging-24
+setuptools<77
 wheel
 
 # for uploading packages to pypi


### PR DESCRIPTION
Problem: setuptools-77 requires packaging>=24.2, but pyquil requires
packaging~=23.1.  setuptools-77 and packaging-23 do not work together.

Solution: Temporarily pin setuptools to 76.x.
