### PR TITLE
Make dependabot ignore patch versions for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
       - "area/dependencies"
       - "area/github"
       - "kind/health"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "npm"
     # The "npm" ecosystem directive makes Dependabot look for package.json in


### PR DESCRIPTION

It's currently generating too many insignificant PRs.