### PR TITLE
Let all sub-packages indicate when testing is in progress

### DIFF
--- a/cirq-pasqal/cirq_pasqal/conftest.py
+++ b/cirq-pasqal/cirq_pasqal/conftest.py
@@ -1,0 +1,19 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+
+def pytest_configure(config):
+    os.environ['CIRQ_TESTING'] = "true"

--- a/cirq-rigetti/cirq_rigetti/conftest.py
+++ b/cirq-rigetti/cirq_rigetti/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import (
     Any,
     Iterable,
@@ -47,6 +48,10 @@ import sympy
 import numpy as np
 
 T = TypeVar("T")
+
+
+def pytest_configure(config):
+    os.environ['CIRQ_TESTING'] = "true"
 
 
 class MockQAM(QAM, Generic[T]):

--- a/cirq-web/cirq_web/conftest.py
+++ b/cirq-web/cirq_web/conftest.py
@@ -1,0 +1,19 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+
+def pytest_configure(config):
+    os.environ['CIRQ_TESTING'] = "true"


### PR DESCRIPTION
Problem: Deprecation helpers in `cirq._compat` need to detect
if they are used in a test session, but that did not work in
some sub-packages.

Solution: Make every cirq-subpackage set `CIRQ_TESTING`.
