### PR TITLE
Deprecate Cirq-Rigetti

### DIFF
--- a/cirq-core/cirq/protocols/hash_from_pickle_test.py
+++ b/cirq-core/cirq/protocols/hash_from_pickle_test.py
@@ -50,6 +50,11 @@ _EXCLUDE_JSON_FILES = (
     "cirq/protocols/json_test_data/sympy.Indexed.json",
     "cirq/protocols/json_test_data/sympy.IndexedBase.json",
     "cirq/protocols/json_test_data/sympy.pi.json",
+    # Cirq-Rigetti is deprecated per #7058
+    # Instead of handling deprecation-in-test errors we exclude
+    # all cirq_rigetti classes here.
+    "cirq_rigetti/json_test_data/AspenQubit.json",
+    "cirq_rigetti/json_test_data/OctagonalQubit.json",
     # RigettiQCSAspenDevice does not pickle
     "cirq_rigetti/json_test_data/RigettiQCSAspenDevice.json",
 )

--- a/cirq-rigetti/README.md
+++ b/cirq-rigetti/README.md
@@ -1,4 +1,8 @@
 <div align="center">
+| ⚠️ WARNING |
+|:----------:|
+| **Cirq-Rigetti is deprecated.  For more details or to provide feedback see https://github.com/quantumlib/Cirq/issues/7058 |
+
 <img width="190px" alt="Cirq logo"
 src="https://raw.githubusercontent.com/quantumlib/Cirq/refs/heads/main/docs/images/Cirq_logo_color.svg"
 ><img width="60px" height="0" alt=""><img width="190px" alt="Rigetti logo"

--- a/cirq-rigetti/README.md
+++ b/cirq-rigetti/README.md
@@ -1,8 +1,12 @@
 <div align="center">
+
 | ⚠️ WARNING |
 |:----------:|
-| **Cirq-Rigetti is deprecated.  For more details or to provide feedback see https://github.com/quantumlib/Cirq/issues/7058 |
+| Cirq-Rigetti is deprecated.  For more details or to provide feedback see https://github.com/quantumlib/Cirq/issues/7058 |
 
+</div>
+
+<div align="center">
 <img width="190px" alt="Cirq logo"
 src="https://raw.githubusercontent.com/quantumlib/Cirq/refs/heads/main/docs/images/Cirq_logo_color.svg"
 ><img width="60px" height="0" alt=""><img width="190px" alt="Rigetti logo"

--- a/cirq-rigetti/cirq_rigetti/aspen_device.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device.py
@@ -21,16 +21,20 @@ import cirq
 from pyquil.quantum_processor import QCSQuantumProcessor
 from qcs_sdk.client import QCSClient
 from qcs_sdk.qpu.isa import get_instruction_set_architecture, InstructionSetArchitecture, Family
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
+@deprecated_cirq_rigetti_class()
 class UnsupportedQubit(ValueError):
     pass
 
 
+@deprecated_cirq_rigetti_class()
 class UnsupportedRigettiQCSOperation(ValueError):
     pass
 
 
+@deprecated_cirq_rigetti_class()
 class UnsupportedRigettiQCSQuantumProcessor(ValueError):
     pass
 
@@ -45,6 +49,7 @@ _forward_line_qubit_mapping = [5, 4, 3, 2]
 _reverse_line_qubit_mapping = [1, 0, 7, 6]
 
 
+@deprecated_cirq_rigetti_class()
 @cirq.value.value_equality
 class RigettiQCSAspenDevice(cirq.devices.Device):
     """A cirq.Qid supporting Rigetti QCS Aspen device topology."""
@@ -232,6 +237,7 @@ class RigettiQCSAspenDevice(cirq.devices.Device):
         return cls(isa=InstructionSetArchitecture.from_raw(json.dumps(isa)))
 
 
+@deprecated_cirq_rigetti_function()
 def get_rigetti_qcs_aspen_device(
     quantum_processor_id: str, client: Optional[QCSClient] = None
 ) -> RigettiQCSAspenDevice:
@@ -254,6 +260,7 @@ def get_rigetti_qcs_aspen_device(
     return RigettiQCSAspenDevice(isa=isa)
 
 
+@deprecated_cirq_rigetti_class()
 class OctagonalQubit(cirq.ops.Qid):
     """A cirq.Qid supporting Octagonal indexing."""
 
@@ -369,6 +376,7 @@ class OctagonalQubit(cirq.ops.Qid):
         return {'octagon_position': self.octagon_position}
 
 
+@deprecated_cirq_rigetti_class()
 class AspenQubit(OctagonalQubit):
     def __init__(self, octagon: int, octagon_position: int):
         super(AspenQubit, self).__init__(octagon_position)

--- a/cirq-rigetti/cirq_rigetti/aspen_device_test.py
+++ b/cirq-rigetti/cirq_rigetti/aspen_device_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
 import os
+import warnings
 from unittest.mock import patch, PropertyMock
 from math import sqrt
 import pathlib
@@ -12,11 +13,28 @@ from cirq_rigetti import (
     UnsupportedQubit,
     UnsupportedRigettiQCSOperation,
 )
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 from qcs_sdk.qpu.isa import InstructionSetArchitecture, Family
 import numpy as np
+from cirq._compat import ALLOW_DEPRECATION_IN_TEST
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 dir_path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
 fixture_path = dir_path / '__fixtures__'
+
+# test parameterization uses deprecated classes, therefore we need to have
+# ALLOW_DEPRECATION_IN_TEST set during import time.  The initial environment
+# is restored at the end of the module.
+
+_SAVE_ENVIRON = {k: os.environ[k] for k in [ALLOW_DEPRECATION_IN_TEST] if k in os.environ}
+os.environ[ALLOW_DEPRECATION_IN_TEST] = "True"
+
+warnings.filterwarnings(
+    "ignore",
+    message="(.|\n)*Cirq-Rigetti is deprecated.",
+    category=DeprecationWarning,
+    module=__name__,
+)
 
 
 @pytest.fixture
@@ -25,6 +43,7 @@ def qcs_aspen8_isa() -> InstructionSetArchitecture:
         return InstructionSetArchitecture.from_raw(f.read())
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_octagonal_qubit_index():
     """test that OctagonalQubit properly calculates index and uses it for comparison"""
     qubit0 = OctagonalQubit(0)
@@ -32,12 +51,14 @@ def test_octagonal_qubit_index():
     assert OctagonalQubit(1) > qubit0
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_octagonal_qubit_repr():
     """test OctagonalQubit.__repr__"""
     qubit5 = OctagonalQubit(5)
     assert "cirq_rigetti.OctagonalQubit(octagon_position=5)" == repr(qubit5)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_octagonal_qubit_positions():
     """test OctagonalQubit 2D position and distance calculations"""
     qubit0 = OctagonalQubit(0)
@@ -77,12 +98,14 @@ def test_octagonal_qubit_positions():
         _ = qubit0.distance(AspenQubit(0, 0))
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_octagonal_position_validation():
     """test OctagonalQubit validates octagon position when initialized"""
     with pytest.raises(ValueError):
         _ = OctagonalQubit(8)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_aspen_qubit_index():
     """test that AspenQubit properly calculates index and uses it for comparison"""
     qubit10 = AspenQubit(1, 0)
@@ -90,12 +113,14 @@ def test_aspen_qubit_index():
     assert qubit10 > AspenQubit(0, 5)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_aspen_qubit_repr():
     """test AspenQubit.__repr__"""
     qubit10 = AspenQubit(1, 0)
     assert "cirq_rigetti.AspenQubit(octagon=1, octagon_position=0)" == repr(qubit10)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_aspen_qubit_positions_and_distance():
     """test AspenQubit 2D position and distance calculations"""
     qubit10 = AspenQubit(1, 0)
@@ -131,6 +156,7 @@ def test_aspen_qubit_positions_and_distance():
         _ = AspenQubit(1, 9)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_aspen_qubit_qid_conversions():
     """test AspenQubit conversion to and from other `cirq.Qid` implementations"""
     qubit10 = AspenQubit(1, 0)
@@ -152,6 +178,7 @@ def test_aspen_qubit_qid_conversions():
         _ = AspenQubit.from_grid_qubit(cirq.GridQubit(3, 4))
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_topology(qcs_aspen8_isa: InstructionSetArchitecture):
     """test RigettiQCSAspenDevice topological nodes and edges"""
     device = RigettiQCSAspenDevice(isa=qcs_aspen8_isa)
@@ -171,6 +198,7 @@ def test_rigetti_qcs_aspen_device_topology(qcs_aspen8_isa: InstructionSetArchite
         OctagonalQubit(6),
     ],
 )
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_valid_qubit(
     qubit: cirq.Qid, qcs_aspen8_isa: InstructionSetArchitecture
 ):
@@ -191,6 +219,7 @@ def test_rigetti_qcs_aspen_device_valid_qubit(
         AspenQubit(4, 0),
     ],
 )
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_invalid_qubit(
     qubit: cirq.Qid, qcs_aspen8_isa: InstructionSetArchitecture
 ):
@@ -212,6 +241,7 @@ def test_rigetti_qcs_aspen_device_invalid_qubit(
         cirq.CNOT(AspenQubit(0, 1), AspenQubit(1, 1)),
     ],
 )
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_invalid_operation(
     operation: cirq.Operation, qcs_aspen8_isa: InstructionSetArchitecture
 ):
@@ -224,6 +254,7 @@ def test_rigetti_qcs_aspen_device_invalid_operation(
 
 
 @pytest.mark.parametrize('operation', [cirq.CNOT(AspenQubit(0, 1), AspenQubit(0, 2))])
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_valid_operation(
     operation: cirq.Operation, qcs_aspen8_isa: InstructionSetArchitecture
 ):
@@ -234,6 +265,7 @@ def test_rigetti_qcs_aspen_device_valid_operation(
     device.validate_operation(operation)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_qubits(qcs_aspen8_isa: InstructionSetArchitecture):
     """test RigettiQCSAspenDevice returns accurate set of qubits"""
     device = RigettiQCSAspenDevice(isa=qcs_aspen8_isa)
@@ -244,12 +276,14 @@ def test_rigetti_qcs_aspen_device_qubits(qcs_aspen8_isa: InstructionSetArchitect
     assert expected_qubits == set(device.qubits())
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_repr(qcs_aspen8_isa: InstructionSetArchitecture):
     """test RigettiQCSAspenDevice.__repr__"""
     device = RigettiQCSAspenDevice(isa=qcs_aspen8_isa)
     assert f'cirq_rigetti.RigettiQCSAspenDevice(isa={qcs_aspen8_isa!r})' == repr(device)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_rigetti_qcs_aspen_device_family_validation(qcs_aspen8_isa: InstructionSetArchitecture):
     """test RigettiQCSAspenDevice validates architecture family on initialization"""
     non_aspen_isa = InstructionSetArchitecture.from_raw(qcs_aspen8_isa.json())
@@ -260,6 +294,7 @@ def test_rigetti_qcs_aspen_device_family_validation(qcs_aspen8_isa: InstructionS
     ), 'ISA family is read-only and should still be Aspen'
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_get_rigetti_qcs_aspen_device(qcs_aspen8_isa: InstructionSetArchitecture):
     with patch('cirq_rigetti.aspen_device.get_instruction_set_architecture') as mock:
         mock.return_value = qcs_aspen8_isa
@@ -267,3 +302,8 @@ def test_get_rigetti_qcs_aspen_device(qcs_aspen8_isa: InstructionSetArchitecture
         from cirq_rigetti.aspen_device import get_rigetti_qcs_aspen_device
 
         assert get_rigetti_qcs_aspen_device('Aspen-8') == RigettiQCSAspenDevice(isa=qcs_aspen8_isa)
+
+
+# clean up extra environment variable
+del os.environ[ALLOW_DEPRECATION_IN_TEST]
+os.environ.update(_SAVE_ENVIRON)

--- a/cirq-rigetti/cirq_rigetti/circuit_sweep_executors.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_sweep_executors.py
@@ -24,6 +24,7 @@ import sympy
 from typing_extensions import Protocol
 from cirq_rigetti.logging import logger
 from cirq_rigetti import circuit_transformers as transformers
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
 def _execute_and_read_result(
@@ -128,6 +129,7 @@ def _prepend_real_declarations(
     return program
 
 
+@deprecated_cirq_rigetti_class()
 class CircuitSweepExecutor(Protocol):
     """A type definition for circuit sweep execution functions."""
 
@@ -158,6 +160,7 @@ class CircuitSweepExecutor(Protocol):
         """
 
 
+@deprecated_cirq_rigetti_function()
 def without_quilc_compilation(
     *,
     quantum_computer: QuantumComputer,
@@ -199,6 +202,7 @@ def without_quilc_compilation(
     return cirq_results
 
 
+@deprecated_cirq_rigetti_function()
 def with_quilc_compilation_and_cirq_parameter_resolution(
     *,
     quantum_computer: QuantumComputer,
@@ -242,6 +246,7 @@ def with_quilc_compilation_and_cirq_parameter_resolution(
     return cirq_results
 
 
+@deprecated_cirq_rigetti_function()
 def with_quilc_parametric_compilation(
     *,
     quantum_computer: QuantumComputer,

--- a/cirq-rigetti/cirq_rigetti/circuit_sweep_executors_test.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_sweep_executors_test.py
@@ -6,8 +6,10 @@ from pyquil import Program
 import numpy as np
 import sympy
 from cirq_rigetti import circuit_sweep_executors as executors, circuit_transformers
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_with_quilc_compilation_and_cirq_parameter_resolution(
     mock_qpu_implementer: Any, parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Sweepable]
 ) -> None:
@@ -46,6 +48,7 @@ def test_with_quilc_compilation_and_cirq_parameter_resolution(
 
 
 @pytest.mark.parametrize('pass_dict', [True, False])
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_with_quilc_parametric_compilation(
     mock_qpu_implementer: Any,
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
@@ -88,6 +91,7 @@ def test_with_quilc_parametric_compilation(
         ), "should return an ordered list of results with correct set of measurements"
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parametric_with_symbols(
     mock_qpu_implementer: Any, parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace]
 ):
@@ -106,6 +110,7 @@ def test_parametric_with_symbols(
         )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_without_quilc_compilation(
     mock_qpu_implementer: Any, parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Sweepable]
 ) -> None:
@@ -143,6 +148,7 @@ def test_without_quilc_compilation(
         ), "should return an ordered list of results with correct set of measurements"
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_invalid_pyquil_region_measurement(
     mock_qpu_implementer: Any, parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Sweepable]
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/circuit_transformers.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_transformers.py
@@ -19,8 +19,10 @@ from pyquil import Program
 import cirq
 from cirq_rigetti.quil_output import RigettiQCSQuilOutput
 from typing_extensions import Protocol
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
+@deprecated_cirq_rigetti_class()
 class _PostTransformationHook(Protocol):
     def __call__(
         self, *, program: Program, measurement_id_map: Dict[str, str]
@@ -57,6 +59,7 @@ def _transform_cirq_circuit_to_pyquil_program(
     return program, measurement_id_map
 
 
+@deprecated_cirq_rigetti_class()
 class CircuitTransformer(Protocol):
     """A type definition for `cirq.Circuit` to `pyquil.Program` transformer functions."""
 
@@ -72,6 +75,7 @@ class CircuitTransformer(Protocol):
         """
 
 
+@deprecated_cirq_rigetti_function()
 def build(
     *,
     qubits: Optional[Tuple[cirq.Qid, ...]] = None,
@@ -111,6 +115,7 @@ def build(
     return cast(CircuitTransformer, transformer)
 
 
+@deprecated_cirq_rigetti_function()
 def default(*, circuit: cirq.Circuit) -> Tuple[Program, Dict[str, str]]:
     """The default `CircuitTransformer` uses the default behavior of cirq's Quil
     protocol to transform a `cirq.Circuit` into a `pyquil.Program`.

--- a/cirq-rigetti/cirq_rigetti/circuit_transformers_test.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_transformers_test.py
@@ -7,8 +7,10 @@ from pyquil import Program
 from pyquil.gates import MEASURE, RX, DECLARE, H, CNOT, I
 from pyquil.quilbase import Pragma, Reset
 from cirq_rigetti import circuit_transformers as transformers
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_transform_cirq_circuit_to_pyquil_program(
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
@@ -29,6 +31,7 @@ def test_transform_cirq_circuit_to_pyquil_program(
     ), "executable should measure the read out bit"
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_transform_cirq_circuit_to_pyquil_program_with_qubit_id_map(
     bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.Qid]],
 ) -> None:
@@ -55,6 +58,7 @@ def test_transform_cirq_circuit_to_pyquil_program_with_qubit_id_map(
     ), "executable should measure the second qubit to the second read out bit"
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_transform_with_post_transformation_hooks(
     bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.Qid]],
 ) -> None:
@@ -100,6 +104,7 @@ def test_transform_with_post_transformation_hooks(
     ), "executable should measure the second qubit to the second read out bit"
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_transform_cirq_circuit_with_explicit_decompose(
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/conftest.py
+++ b/cirq-rigetti/cirq_rigetti/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import (
     Any,
     Iterable,
@@ -47,6 +48,10 @@ import sympy
 import numpy as np
 
 T = TypeVar("T")
+
+
+def pytest_configure(config):
+    os.environ['CIRQ_TESTING'] = "true"
 
 
 class MockQAM(QAM, Generic[T]):

--- a/cirq-rigetti/cirq_rigetti/deprecation.py
+++ b/cirq-rigetti/cirq_rigetti/deprecation.py
@@ -1,0 +1,48 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import os
+import unittest.mock
+from typing import Callable, Type
+
+from cirq._compat import block_overlapping_deprecation, deprecated, deprecated_class
+
+_DEPRECATION_DEADLINE = "v1.6"
+_DEPRECATION_FIX_MSG = (
+    "Cirq-Rigetti is deprecated.  For more details or to provide feedback see "
+    "https://github.com/quantumlib/Cirq/issues/7058"
+)
+
+
+def deprecated_cirq_rigetti_class() -> Callable[[Type], Type]:  # coverage: ignore
+    """Decorator to mark a class in Cirq-Rigetti deprecated."""
+    return deprecated_class(deadline=_DEPRECATION_DEADLINE, fix=_DEPRECATION_FIX_MSG)
+
+
+def deprecated_cirq_rigetti_function() -> Callable[[Callable], Callable]:  # coverage: ignore
+    """Decorator to mark a function in Cirq-Rigetti deprecated."""
+    return deprecated(deadline=_DEPRECATION_DEADLINE, fix=_DEPRECATION_FIX_MSG)
+
+
+def allow_deprecated_cirq_rigetti_use_in_tests(func):  # coverage: ignore
+    """Decorator to allow deprecated classes and functions in tests and to suppress warnings."""
+
+    @functools.wraps(func)
+    @unittest.mock.patch.dict(os.environ, ALLOW_DEPRECATION_IN_TEST="True")
+    def wrapper(*args, **kwargs):
+        with block_overlapping_deprecation(_DEPRECATION_FIX_MSG):
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/cirq-rigetti/cirq_rigetti/json_resolver_cache.py
+++ b/cirq-rigetti/cirq_rigetti/json_resolver_cache.py
@@ -17,8 +17,10 @@ from typing import Dict
 
 import cirq_rigetti
 from cirq.protocols.json_serialization import ObjectFactory
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_function
 
 
+@deprecated_cirq_rigetti_function()
 @functools.lru_cache()  # pragma: no cover
 def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # pragma: no cover
     return {

--- a/cirq-rigetti/cirq_rigetti/json_resolver_cache.py
+++ b/cirq-rigetti/cirq_rigetti/json_resolver_cache.py
@@ -17,10 +17,8 @@ from typing import Dict
 
 import cirq_rigetti
 from cirq.protocols.json_serialization import ObjectFactory
-from cirq_rigetti.deprecation import deprecated_cirq_rigetti_function
 
 
-@deprecated_cirq_rigetti_function()
 @functools.lru_cache()  # pragma: no cover
 def _class_resolver_dictionary() -> Dict[str, ObjectFactory]:  # pragma: no cover
     return {

--- a/cirq-rigetti/cirq_rigetti/json_test_data/spec.py
+++ b/cirq-rigetti/cirq_rigetti/json_test_data/spec.py
@@ -32,5 +32,5 @@ TestSpec = ModuleJsonTestSpec(
         "UnsupportedRigettiQCSQuantumProcessor",
     ],
     resolver_cache=_class_resolver_dictionary(),
-    deprecated={},
+    deprecated=dict.fromkeys(_class_resolver_dictionary(), "v1.6"),
 )

--- a/cirq-rigetti/cirq_rigetti/qcs_sampler_and_service_test.py
+++ b/cirq-rigetti/cirq_rigetti/qcs_sampler_and_service_test.py
@@ -10,6 +10,7 @@ from cirq_rigetti import RigettiQCSService
 from typing_extensions import Protocol
 from cirq_rigetti import circuit_transformers as transformers
 from cirq_rigetti import circuit_sweep_executors as executors
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 _default_executor = executors.with_quilc_compilation_and_cirq_parameter_resolution
@@ -85,6 +86,7 @@ def _build_sampler_results(
 
 
 @pytest.mark.parametrize("result_builder", [_build_service_results, _build_sampler_results])
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parametric_circuit(
     mock_qpu_implementer: Any,
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Sweepable],
@@ -149,6 +151,7 @@ def test_parametric_circuit(
 
 
 @pytest.mark.parametrize("result_builder", [_build_service_results, _build_sampler_results])
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_bell_circuit(
     mock_qpu_implementer: Any, bell_circuit: cirq.Circuit, result_builder: _ResultBuilder
 ) -> None:
@@ -207,6 +210,7 @@ def test_bell_circuit(
 
 
 @pytest.mark.parametrize("result_builder", [_build_service_results, _build_sampler_results])
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_explicit_qubit_id_map(
     mock_qpu_implementer: Any,
     bell_circuit_with_qids: Tuple[cirq.Circuit, List[cirq.LineQubit]],
@@ -272,6 +276,7 @@ def test_explicit_qubit_id_map(
 
 
 @pytest.mark.parametrize("result_builder", [_build_service_results, _build_sampler_results])
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_run_without_quilc_compilation(
     mock_qpu_implementer: Any, bell_circuit: cirq.Circuit, result_builder: _ResultBuilder
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/qcs_sampler_and_service_test.py
+++ b/cirq-rigetti/cirq_rigetti/qcs_sampler_and_service_test.py
@@ -223,7 +223,7 @@ def test_explicit_qubit_id_map(
         mock_qpu_implementer,
         bell_circuit,
         param_resolvers,
-        transformer=transformers.build(qubit_id_map=qubit_id_map),  # type: ignore
+        transformer=transformers.build(qubit_id_map=qubit_id_map),
     )
 
     assert len(param_resolvers) == len(

--- a/cirq-rigetti/cirq_rigetti/quil_input.py
+++ b/cirq-rigetti/cirq_rigetti/quil_input.py
@@ -68,12 +68,15 @@ from cirq.ops.three_qubit_gates import CCNOT, CSWAP
 from cirq.ops.raw_types import Gate
 from cirq.ops.kraus_channel import KrausChannel
 from cirq._compat import cached_method
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
+@deprecated_cirq_rigetti_class()
 class UndefinedQuilGate(Exception):
     """Error for a undefined Quil Gate."""
 
 
+@deprecated_cirq_rigetti_class()
 class UnsupportedQuilInstruction(Exception):
     """Error for a unsupported instruction."""
 
@@ -83,6 +86,7 @@ class UnsupportedQuilInstruction(Exception):
 #
 
 
+@deprecated_cirq_rigetti_class()
 @value_equality(distinct_child_types=True, approximate=True)
 class CPHASE00(Gate):
     """Cirq equivalent to Quil CPHASE00."""
@@ -122,6 +126,7 @@ class CPHASE00(Gate):
         return (self.phi,)
 
 
+@deprecated_cirq_rigetti_class()
 @value_equality(distinct_child_types=True, approximate=True)
 class CPHASE01(Gate):
     """Cirq equivalent to Quil CPHASE01."""
@@ -161,6 +166,7 @@ class CPHASE01(Gate):
         return (self.phi,)
 
 
+@deprecated_cirq_rigetti_class()
 @value_equality(distinct_child_types=True, approximate=True)
 class CPHASE10(Gate):
     """Cirq equivalent to Quil CPHASE10."""
@@ -200,6 +206,7 @@ class CPHASE10(Gate):
         return (self.phi,)
 
 
+@deprecated_cirq_rigetti_class()
 @value_equality(distinct_child_types=True, approximate=True)
 class PSWAP(Gate):
     """Cirq equivalent to Quil PSWAP."""
@@ -304,6 +311,7 @@ PARAMETRIC_TRANSFORMERS: Dict[str, Callable] = {
 }
 
 
+@deprecated_cirq_rigetti_function()
 def circuit_from_quil(quil: Union[str, Program]) -> Circuit:
     """Convert a Quil program to a Cirq Circuit.
 
@@ -450,6 +458,7 @@ def circuit_from_quil(quil: Union[str, Program]) -> Circuit:
     return circuit
 
 
+@deprecated_cirq_rigetti_function()
 def get_defined_gates(program: Program) -> Tuple[Dict, Dict]:
     """Get the gate definitions for the program. Will include the default SUPPORTED_GATES, in
     addition to any gates defined in the Quil
@@ -476,6 +485,7 @@ def get_defined_gates(program: Program) -> Tuple[Dict, Dict]:
     return defined_gates, parameter_transformers
 
 
+@deprecated_cirq_rigetti_function()
 def kraus_noise_model_to_cirq(
     kraus_noise_model: Dict[Tuple[QubitDesignator, ...], List[NDArray[np.complex128]]],
     defined_gates: Optional[Dict[QubitDesignator, Gate]] = None,
@@ -516,6 +526,7 @@ def kraus_noise_model_to_cirq(
     return noise_model
 
 
+@deprecated_cirq_rigetti_function()
 def quil_expression_to_sympy(expression: ParameterDesignator):
     """Convert a quil expression to a Sympy expression.
 
@@ -579,6 +590,7 @@ def quil_expression_to_sympy(expression: ParameterDesignator):
         )
 
 
+@deprecated_cirq_rigetti_function()
 @cached_method
 def defgate_to_cirq(defgate: DefGate):
     """Convert a Quil DefGate to a Cirq Gate class.
@@ -636,6 +648,7 @@ def defgate_to_cirq(defgate: DefGate):
     return gate
 
 
+@deprecated_cirq_rigetti_function()
 def remove_gate_from_kraus(
     kraus_ops: List[NDArray[np.complex128]], gate_matrix: NDArray[np.complex128]
 ):  # pragma: no cover

--- a/cirq-rigetti/cirq_rigetti/quil_input_test.py
+++ b/cirq-rigetti/cirq_rigetti/quil_input_test.py
@@ -40,6 +40,7 @@ from cirq_rigetti.quil_input import (
     circuit_from_quil,
     defgate_to_cirq,
 )
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 from cirq.ops.common_gates import CNOT, CZ, CZPowGate, H, S, T, ZPowGate, YPowGate, XPowGate
 from cirq.ops.pauli_gates import X, Y, Z
@@ -49,6 +50,7 @@ from cirq.ops.swap_gates import ISWAP, ISwapPowGate, SWAP
 from cirq.ops.three_qubit_gates import CCNOT, CSWAP
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_gate_conversion():
     """Check that the gates all convert with matching unitaries."""
     for quil_gate, cirq_gate in SUPPORTED_GATES.items():
@@ -101,6 +103,7 @@ MEASURE 2 ro[2]
 """
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_circuit_from_quil():
     """Convert a test circuit from Quil with a wide range of gates."""
     q0, q1, q2 = LineQubit.range(3)
@@ -164,6 +167,7 @@ MYZ 0
 """
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_with_defgate():
     """Convert a Quil program with a DefGate."""
     q0 = LineQubit(0)
@@ -182,6 +186,7 @@ MYPHASE(pi/2) 0
 """
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_program_with_parameterized_defgate():
     """Convert a Quil program with a parameterized DefGate."""
     program = Program(QUIL_PROGRAM_WITH_PARAMETERIZED_DEFGATE)
@@ -193,6 +198,7 @@ def test_program_with_parameterized_defgate():
     assert allclose_up_to_global_phase(pyquil_unitary, cirq_unitary, atol=1e-8)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_unsupported_quil_instruction():
     """Convert a program with invalid or unsupported instructions."""
     with pytest.raises(UnsupportedQuilInstruction):
@@ -202,6 +208,7 @@ def test_unsupported_quil_instruction():
         circuit_from_quil("RESET")
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_undefined_quil_gate():
     """There are no such things as FREDKIN & TOFFOLI in Quil. The standard
     names for those gates in Quil are CSWAP and CCNOT. Of course, they can
@@ -224,6 +231,7 @@ RX(2*COS(theta[3])*EXP(i*theta[3])) 4
 """
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parametric_quil():
     """Convert a program which uses parameters and expressions."""
     program = Program(QUIL_PROGRAM_WITH_PARAMETERS)
@@ -253,6 +261,7 @@ def test_parametric_quil():
     assert cirq_circuit == circuit
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_measurement_without_classical_reg():
     """Measure operations must declare a classical register."""
     with pytest.raises(UnsupportedQuilInstruction):
@@ -270,6 +279,7 @@ MEASURE 0 ro[0]
 """
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_readout_noise():
     """Convert a program with readout noise."""
     program = Program(QUIL_PROGRAM_WITH_READOUT_NOISE)
@@ -280,6 +290,7 @@ def test_readout_noise():
     assert result.histogram(key="ro[0]")[1] > 900
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_resolve_parameters():
     """Test that parameters are correctly resolved for defined parametric gate."""
     theta, beta = Parameter("theta"), Parameter("beta")
@@ -303,6 +314,7 @@ def test_resolve_parameters():
     op._resolve_parameters_({"beta": 1.0, "theta": 2.0}, True)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_op_identifier():
     """Check that converted parametric defgates will be correctly identified."""
     theta, beta = Parameter("theta"), Parameter("beta")

--- a/cirq-rigetti/cirq_rigetti/quil_output.py
+++ b/cirq-rigetti/cirq_rigetti/quil_output.py
@@ -17,14 +17,17 @@ import numpy as np
 import cirq
 import cirq_rigetti
 from cirq import protocols, value, ops
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
+@deprecated_cirq_rigetti_function()
 def to_quil_complex_format(num) -> str:
     """A function for outputting a number to a complex string in QUIL format."""
     cnum = complex(str(num))
     return f"{cnum.real}+{cnum.imag}i"
 
 
+@deprecated_cirq_rigetti_class()
 class QuilFormatter(string.Formatter):
     """A unique formatter to correctly output values to QUIL."""
 
@@ -52,6 +55,7 @@ class QuilFormatter(string.Formatter):
         return super().format_field(value, spec)
 
 
+@deprecated_cirq_rigetti_class()
 @value.value_equality(approximate=True)
 class QuilOneQubitGate(ops.Gate):
     """A QUIL gate representing any single qubit unitary with a DEFGATE and
@@ -76,6 +80,7 @@ class QuilOneQubitGate(ops.Gate):
         return self.matrix
 
 
+@deprecated_cirq_rigetti_class()
 @value.value_equality(approximate=True)
 class QuilTwoQubitGate(ops.Gate):
     """A two qubit gate represented in QUIL with a DEFGATE and it's 4x4
@@ -334,6 +339,7 @@ SUPPORTED_GATES = {
 }
 
 
+@deprecated_cirq_rigetti_class()
 class QuilOutput:
     """An object for passing operations and qubits then outputting them to
     QUIL format. The string representation returns the QUIL output for the
@@ -475,6 +481,7 @@ class QuilOutput:
         return result
 
 
+@deprecated_cirq_rigetti_class()
 class RigettiQCSQuilOutput(QuilOutput):
     """A sub-class of `cirq.circuits.quil_output.QuilOutput` that additionally accepts a
     `qubit_id_map` for explicitly mapping logical qubits to physical qubits.

--- a/cirq-rigetti/cirq_rigetti/quil_output_test.py
+++ b/cirq-rigetti/cirq_rigetti/quil_output_test.py
@@ -21,12 +21,14 @@ from cirq.ops.pauli_interaction_gate import PauliInteractionGate
 
 import cirq_rigetti
 from cirq_rigetti.quil_output import QuilOutput
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 def _make_qubits(n):
     return [cirq.NamedQubit(f'q{i}') for i in range(n)]
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_single_gate_no_parameter():
     (q0,) = _make_qubits(1)
     output = cirq_rigetti.quil_output.QuilOutput((cirq.X(q0),), (q0,))
@@ -38,6 +40,7 @@ X 0\n"""
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_single_gate_with_parameter():
     (q0,) = _make_qubits(1)
     output = cirq_rigetti.quil_output.QuilOutput((cirq.X(q0) ** 0.5,), (q0,))
@@ -49,6 +52,7 @@ RX({np.pi / 2}) 0\n"""
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_single_gate_named_qubit():
     q = cirq.NamedQubit('qTest')
     output = cirq_rigetti.quil_output.QuilOutput((cirq.X(q),), (q,))
@@ -61,6 +65,7 @@ X 0\n"""
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_h_gate_with_parameter():
     (q0,) = _make_qubits(1)
     output = cirq_rigetti.quil_output.QuilOutput((cirq.H(q0) ** 0.25,), (q0,))
@@ -74,6 +79,7 @@ RY({-np.pi / 4}) 0\n"""
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_save_to_file(tmpdir):
     file_path = os.path.join(tmpdir, 'test.quil')
     (q0,) = _make_qubits(1)
@@ -89,6 +95,7 @@ X 0\n"""
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_one_qubit_gate_repr():
     gate = cirq_rigetti.quil_output.QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
     assert repr(gate) == (
@@ -99,6 +106,7 @@ def test_quil_one_qubit_gate_repr():
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_two_qubit_gate_repr():
     gate = cirq_rigetti.quil_output.QuilTwoQubitGate(
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
@@ -113,6 +121,7 @@ def test_quil_two_qubit_gate_repr():
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_one_qubit_gate_eq():
     gate = cirq_rigetti.quil_output.QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
     gate2 = cirq_rigetti.quil_output.QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
@@ -122,6 +131,7 @@ def test_quil_one_qubit_gate_eq():
     assert not cirq.approx_eq(gate4, gate3, atol=1e-16)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_two_qubit_gate_eq():
     gate = cirq_rigetti.quil_output.QuilTwoQubitGate(
         np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
@@ -139,6 +149,7 @@ def test_quil_two_qubit_gate_eq():
     assert not cirq.approx_eq(gate4, gate3, atol=1e-8)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_one_qubit_gate_output():
     (q0,) = _make_qubits(1)
     gate = cirq_rigetti.quil_output.QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
@@ -155,6 +166,7 @@ USERGATE1 0
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_two_quil_one_qubit_gate_output():
     (q0,) = _make_qubits(1)
     gate = cirq_rigetti.quil_output.QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
@@ -176,6 +188,7 @@ USERGATE2 0
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_quil_two_qubit_gate_output():
     (q0, q1) = _make_qubits(2)
     gate = cirq_rigetti.quil_output.QuilTwoQubitGate(
@@ -196,6 +209,7 @@ USERGATE1 0 1
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_unsupported_operation():
     (q0,) = _make_qubits(1)
 
@@ -208,6 +222,7 @@ def test_unsupported_operation():
         _ = str(output)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_i_swap_with_power():
     q0, q1 = _make_qubits(2)
 
@@ -221,6 +236,7 @@ XY({np.pi / 4}) 0 1
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_all_operations():
     qubits = tuple(_make_qubits(5))
     operations = _all_operations(*qubits, include_measurements=False)
@@ -369,6 +385,7 @@ def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_fails_on_big_unknowns():
     class UnrecognizedGate(cirq.testing.ThreeQubitGate):
         pass
@@ -379,6 +396,7 @@ def test_fails_on_big_unknowns():
         _ = str(res)
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_pauli_interaction_gate():
     (q0, q1) = _make_qubits(2)
     output = cirq_rigetti.quil_output.QuilOutput(PauliInteractionGate.CZ.on(q0, q1), (q0, q1))
@@ -391,6 +409,7 @@ CZ 0 1
     )
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_equivalent_unitaries():
     """This test covers the factor of pi change. However, it will be skipped
     if pyquil is unavailable for import.
@@ -435,6 +454,7 @@ X 1
 """
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_two_qubit_diagonal_gate_quil_output():
     pyquil = pytest.importorskip("pyquil")
     pyquil_simulation_tools = pytest.importorskip("pyquil.simulation.tools")
@@ -460,6 +480,7 @@ def test_two_qubit_diagonal_gate_quil_output():
     assert f"\n{program.out()}" == QUIL_DIAGONAL_DECOMPOSE_PROGRAM
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parseable_defgate_output():
     pyquil = pytest.importorskip("pyquil")
     q0, q1 = _make_qubits(2)
@@ -474,6 +495,7 @@ def test_parseable_defgate_output():
     pyquil.Program(str(output))
 
 
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_unconveritble_op():
     (q0,) = _make_qubits(1)
 

--- a/cirq-rigetti/cirq_rigetti/sampler.py
+++ b/cirq-rigetti/cirq_rigetti/sampler.py
@@ -18,11 +18,13 @@ from pyquil.api import QuantumComputer
 import cirq
 from cirq_rigetti import circuit_transformers as transformers
 from cirq_rigetti import circuit_sweep_executors as executors
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
 _default_executor = executors.with_quilc_compilation_and_cirq_parameter_resolution
 
 
+@deprecated_cirq_rigetti_class()
 class RigettiQCSSampler(cirq.Sampler):
     """This class supports running circuits on QCS quantum hardware as well as pyQuil's
     quantum virtual machine (QVM). It implements the `cirq.Sampler` interface and
@@ -77,6 +79,7 @@ class RigettiQCSSampler(cirq.Sampler):
         )
 
 
+@deprecated_cirq_rigetti_function()
 def get_rigetti_qcs_sampler(
     quantum_processor_id: str,
     *,

--- a/cirq-rigetti/cirq_rigetti/sampler_bell_circuit_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_bell_circuit_test.py
@@ -5,9 +5,11 @@ import cirq
 from pyquil import get_qc
 from pyquil.api import QVM
 from cirq_rigetti import RigettiQCSSampler
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_bell_circuit_through_sampler(bell_circuit: cirq.Circuit) -> None:
     """test that RigettiQCSSampler can run a basic bell circuit on the QVM and return an accurate
     ``cirq.study.Result``.

--- a/cirq-rigetti/cirq_rigetti/sampler_parametric_circuit_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_parametric_circuit_test.py
@@ -5,9 +5,11 @@ import cirq
 from pyquil import get_qc
 from pyquil.api import QVM
 from cirq_rigetti import RigettiQCSSampler, circuit_sweep_executors
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parametric_circuit_through_sampler(
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:
@@ -41,6 +43,7 @@ def test_parametric_circuit_through_sampler(
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parametric_circuit_through_sampler_with_parametric_compilation(
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/sampler_readout_reassigned_qubits_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_readout_reassigned_qubits_test.py
@@ -7,6 +7,7 @@ from pyquil import get_qc
 from pyquil.api import QVM
 from cirq_rigetti import RigettiQCSSampler
 from cirq_rigetti import circuit_transformers
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.fixture
@@ -23,6 +24,7 @@ def circuit_data() -> Tuple[cirq.Circuit, List[cirq.LineQubit], cirq.Linspace]:
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_readout_on_reassigned_qubits(
     circuit_data: Tuple[cirq.Circuit, List[cirq.LineQubit], cirq.Linspace],
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/sampler_readout_separate_memory_regions_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_readout_separate_memory_regions_test.py
@@ -6,6 +6,7 @@ import sympy
 from pyquil import get_qc
 from pyquil.api import QVM
 from cirq_rigetti import RigettiQCSSampler
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.fixture
@@ -23,6 +24,7 @@ def circuit_with_separate_readout_keys() -> Tuple[cirq.Circuit, cirq.Linspace]:
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_circuit_with_separate_readout_keys_through_sampler(
     circuit_with_separate_readout_keys: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/sampler_test.py
+++ b/cirq-rigetti/cirq_rigetti/sampler_test.py
@@ -1,9 +1,11 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
 import pytest
 from cirq_rigetti import get_rigetti_qcs_sampler
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_get_rigetti_qcs_sampler():
     """test that get_rigetti_qcs_sampler can initialize a `RigettiQCSSampler`
     through `pyquil.get_qc`."""

--- a/cirq-rigetti/cirq_rigetti/service.py
+++ b/cirq-rigetti/cirq_rigetti/service.py
@@ -23,11 +23,13 @@ from pyquil.api import QuantumComputer
 from cirq_rigetti.sampler import RigettiQCSSampler
 from cirq_rigetti import circuit_transformers as transformers
 from cirq_rigetti import circuit_sweep_executors as executors
+from cirq_rigetti.deprecation import deprecated_cirq_rigetti_class, deprecated_cirq_rigetti_function
 
 
 _default_executor = executors.with_quilc_compilation_and_cirq_parameter_resolution
 
 
+@deprecated_cirq_rigetti_class()
 class RigettiQCSService:
     """This class supports running circuits on QCS quantum hardware as well as
     pyQuil's quantum virtual machine (QVM). When sampling a parametric circuit
@@ -152,6 +154,7 @@ class RigettiQCSService:
         )
 
 
+@deprecated_cirq_rigetti_function()
 def get_rigetti_qcs_service(
     quantum_processor_id: str,
     *,

--- a/cirq-rigetti/cirq_rigetti/service_bell_circuit_test.py
+++ b/cirq-rigetti/cirq_rigetti/service_bell_circuit_test.py
@@ -5,9 +5,11 @@ import cirq
 from pyquil import get_qc
 from pyquil.api import QVM
 from cirq_rigetti import RigettiQCSService
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_bell_circuit_through_service(bell_circuit: cirq.Circuit) -> None:
     """test that RigettiQCSService can run a basic bell circuit on the QVM and return an accurate
     ``cirq.study.Result``.

--- a/cirq-rigetti/cirq_rigetti/service_parametric_circuit_test.py
+++ b/cirq-rigetti/cirq_rigetti/service_parametric_circuit_test.py
@@ -5,9 +5,11 @@ import cirq
 from pyquil import get_qc
 from pyquil.api import QVM
 from cirq_rigetti import RigettiQCSService
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_parametric_circuit_through_service(
     parametric_circuit_with_params: Tuple[cirq.Circuit, cirq.Linspace],
 ) -> None:

--- a/cirq-rigetti/cirq_rigetti/service_test.py
+++ b/cirq-rigetti/cirq_rigetti/service_test.py
@@ -2,9 +2,11 @@
 from unittest.mock import patch
 import pytest
 from cirq_rigetti import get_rigetti_qcs_service
+from cirq_rigetti.deprecation import allow_deprecated_cirq_rigetti_use_in_tests
 
 
 @pytest.mark.rigetti_integration
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_get_rigetti_qcs_service():
     """test that get_rigetti_qcs_service can initialize a `RigettiQCSService`
     through `pyquil.get_qc`."""
@@ -15,6 +17,7 @@ def test_get_rigetti_qcs_service():
 @pytest.mark.rigetti_integration
 @patch('cirq_rigetti.service.QCSClient')
 @patch('cirq_rigetti.service.list_quantum_processors')
+@allow_deprecated_cirq_rigetti_use_in_tests
 def test_list_quantum_processors(mock_list_quantum_processors, MockQCSClient):
     client = MockQCSClient()
 

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -34,15 +34,6 @@ long_description = io.open('README.md', encoding='utf-8').read()
 # for more details.
 if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
     __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-rigetti` and may be<br>"
-        "unstable. For the latest stable release of `cirq-rigetti`,<br>"
-        "please visit** <https://pypi.org/project/cirq-rigetti>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/dev_tools/docs/run_doctest.py
+++ b/dev_tools/docs/run_doctest.py
@@ -181,9 +181,8 @@ def exec_tests(
         if r.failed != 0:
             try_print('F', end='', flush=True)
             error = shell_tools.highlight(
-                '{}\n{} failed, {} passed, {} total\n'.format(
-                    test.file_name, r.failed, r.attempted - r.failed, r.attempted
-                ),
+                f'{test.file_name}\n'
+                f'{r.failed} failed, {r.attempted - r.failed} passed, {r.attempted} total\n',
                 shell_tools.RED,
             )
             error += out.content()

--- a/dev_tools/docs/run_doctest.py
+++ b/dev_tools/docs/run_doctest.py
@@ -230,6 +230,7 @@ def main():
     excluded = [
         'cirq-google/cirq_google/api/',
         'cirq-google/cirq_google/cloud/',
+        'cirq-rigetti/',
         'cirq-web/cirq_ts/node_modules/',
     ]
     file_names = [


### PR DESCRIPTION
- Add helper module `cirq_rigetti.deprecation`
- Add deprecation warnings for public functions and classes
- Let deprecation wrappers detect `cirq_rigetti` tests
- Suppress Cirq-Rigetti deprecation warnings in `cirq_rigetti` tests
- Add deprecation note to the Cirq-Rigetti README

Partially implements #7058
