### PR TITLE
Update tags in stale issue handling GitHub Actions workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,13 +47,14 @@ env:
   exempt-issue-labels-list:
     kind/design-issue
     kind/health
-    kind/roadmap-item
     kind/task
+    roadmap
     triage/accepted
     triage/discuss
   exempt-pr-labels-list:
-    kind/roadmap-item
+    roadmap
     triage/accepted
+    triage/discuss
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION

We deleted or renamed a couple of tags, but I forgot to update this
file. Also, we decided to allow the use of `triage/discuss` for PRs
too, so I added it to the pr-labels-list.