### PR TITLE
Fix tiny misformatting of comments by Stale issue handler

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -89,7 +89,7 @@ jobs:
         close-pr-label: 'status/stale'
         exempt-issue-labels: ${{steps.converted.outputs.exempt-issue-labels}}
         exempt-pr-labels: ${{steps.converted.outputs.exempt-pr-labels}}
-        stale-issue-message: >
+        stale-issue-message: >-
           This issue has been automatically labeled as stale because
           ${{env.days-before-stale}} days have passed without comments or other
           activity. If no further activity occurs on this issue and the
@@ -98,12 +98,13 @@ jobs:
           would like to restore its status, please leave a comment here; doing
           so will cause the staleness handler to remove the label.
 
+
           If you have questions or feedback about this process, we welcome your
           input. You can open a new issue to let us know (please also reference
           this issue there, for continuity), or reach out to the project
           maintainers at quantum-oss-maintainers@google.com.
 
-        stale-pr-message: >
+        stale-pr-message: >-
           This pull request has been automatically labeled as stale because
           ${{env.days-before-stale}} days have passed without comments or other
           activity. If no further activity occurs and the `status/stale` label
@@ -112,28 +113,31 @@ jobs:
           its active status, please leave a comment here; doing so will cause
           the staleness handler to remove the label.
 
+
           If you have questions or feedback about this process, we welcome your
           input. You can open a new issue to let us know (please also reference
           this issue there, for continuity), or reach out to the project
           maintainers at quantum-oss-maintainers@google.com.
 
-        close-issue-message: >
+        close-issue-message: >-
           This issue has been closed due to inactivity for
           ${{env.days-before-close}} days since the time the `status/stale`
           label was applied. If you believe the issue is still relevant and
           would like to restore its active status, please feel free to reopen
           it.
 
+
           If you have questions or feedback about this process, we welcome your
           input. You can open a new issue to let us know (please also reference
           this issue there, for continuity), or reach out to the project
           maintainers at quantum-oss-maintainers@google.com.
 
-        close-pr-message: >
+        close-pr-message: >-
           This pull request has been closed due to inactivity for
           ${{env.days-before-close}} days since the time the `status/stale`
           label was applied. If you would like to continue working on this PR,
           please feel free to reopen it.
+
 
           If you have questions or feedback about this process, we welcome your
           input. You can open a new issue to let us know (please also reference


### PR DESCRIPTION
The comment on GitHub are ending up without a break between paragraphs. I seems to require two blank lines in YAML.