### PR TITLE
Fix np.einsum type annotations

### DIFF
--- a/cirq-core/cirq/experiments/readout_confusion_matrix.py
+++ b/cirq-core/cirq/experiments/readout_confusion_matrix.py
@@ -173,13 +173,12 @@ class TensoredConfusionMatrices:
         return in_vars + out_vars
 
     def _confusion_matrix(self, qubits: Sequence['cirq.Qid']) -> np.ndarray:
-        ein_input = []
+        ein_input: List[np.ndarray | List[int]] = []
         for qs, cm in zip(self.measure_qubits, self.confusion_matrices):
             ein_input.extend([cm.reshape((2, 2) * len(qs)), self._get_vars(qs)])
         ein_out = self._get_vars(qubits)
 
-        # TODO(#5757): remove type ignore when numpy has proper override signature.
-        ret = np.einsum(*ein_input, ein_out).reshape((2 ** len(qubits),) * 2)  # type: ignore
+        ret = np.einsum(*ein_input, ein_out).reshape((2 ** len(qubits),) * 2)
         return ret / ret.sum(axis=1)
 
     def confusion_matrix(self, qubits: Optional[Sequence['cirq.Qid']] = None) -> np.ndarray:

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -153,7 +153,6 @@ def targeted_left_multiply(
 
     all_indices = set(input_indices + data_indices + tuple(output_indices))
 
-    # TODO(#5757): remove type ignore when numpy has proper override signature.
     return np.einsum(
         left_matrix,
         input_indices,
@@ -164,10 +163,8 @@ def targeted_left_multiply(
         # but this is a workaround for a bug in numpy:
         #     https://github.com/numpy/numpy/issues/10926
         optimize=len(all_indices) >= 26,
-        # And this is workaround for *another* bug!
-        # Supposed to be able to just say 'old=old'.
-        **({'out': out} if out is not None else {}),
-    )  # type: ignore
+        out=out,
+    )
 
 
 @dataclasses.dataclass

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -409,7 +409,6 @@ def partial_trace(tensor: np.ndarray, keep_indices: Sequence[int]) -> np.ndarray
     keep_map = dict(zip(keep_indices, sorted(keep_indices)))
     left_indices = [keep_map[i] if i in keep_set else i for i in range(ndim)]
     right_indices = [ndim + i if i in keep_set else i for i in left_indices]
-    # TODO(#5757): remove type ignore when numpy has proper override signature.
     return np.einsum(tensor, left_indices + right_indices)
 
 

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -677,7 +677,6 @@ def density_matrix_from_state_vector(
     sum_inds = np.array(range(n_qubits))
     sum_inds[indices] += n_qubits
 
-    # TODO(#5757): remove type ignore when numpy has proper override signature.
     rho = np.einsum(
         state_vector,
         list(range(n_qubits)),


### PR DESCRIPTION
Clean redundant type-ignores in np.einsum calls.

Fixes #5757
