### PR TITLE
Fix flakes in pauli_string_measurement_with_readout_mitigation_test

### DIFF
--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation.py
@@ -83,8 +83,8 @@ def _validate_input(
 
             if all(q == ops.I for q in pauli_str):
                 raise ValueError(
-                    "Empty Pauli strings or Pauli strings consisting"
-                    "only of Pauli I are not allowed. Please provide"
+                    "Empty Pauli strings or Pauli strings consisting "
+                    "only of Pauli I are not allowed. Please provide "
                     "valid input Pauli strings."
                 )
             if pauli_str.coefficient.imag != 0:

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -35,14 +35,11 @@ def _create_ghz(number_of_qubits: int, qubits: Sequence[cirq.Qid]) -> cirq.Circu
 
 def _generate_random_pauli_string(qubits: Sequence[cirq.Qid], enable_coeff: bool = False):
     pauli_ops = [cirq.I, cirq.X, cirq.Y, cirq.Z]
+    pauli_xyz = [cirq.X, cirq.Y, cirq.Z]
 
-    # Ensure at least one non-identity.
-    operators = {q: cirq.I(q) for q in qubits}  # Start with all identities
-    # Choose a random subset of qubits to have non-identity operators
-    non_identity_qubits = random.sample(qubits, random.randint(1, len(qubits)))
-    for q in non_identity_qubits:
-        operators[q] = random.choice([cirq.X, cirq.Y, cirq.Z])(q)  # Only non-identity ops
     operators = {q: random.choice(pauli_ops) for q in qubits}
+    # Ensure at least one non-identity.
+    operators[random.choice(qubits)] = random.choice(pauli_xyz)
 
     if enable_coeff:
         coefficient = (2 * random.random() - 1) * 100

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -458,8 +458,8 @@ def test_all_pauli_strings_are_pauli_i() -> None:
 
     with pytest.raises(
         ValueError,
-        match="Empty Pauli strings or Pauli strings consisting"
-        "only of Pauli I are not allowed. Please provide"
+        match="Empty Pauli strings or Pauli strings consisting "
+        "only of Pauli I are not allowed. Please provide "
         "valid input Pauli strings.",
     ):
         measure_pauli_strings(


### PR DESCRIPTION
Ensure random Pauli strings have a non-identity operator for real.
Also add missing spaces to the exception message.

This fixes randomly-seed dependent test failure for

```
check/pytest -n0 --randomly-seed=3289494540 \
    cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py::test_many_circuits_input_measurement_with_noise \
    cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py::test_many_circuits_with_coefficient
```
