### PR TITLE
Simplify python package description

### DIFF
--- a/cirq-aqt/cirq_aqt/_version.py
+++ b/cirq-aqt/cirq_aqt/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-aqt/cirq_aqt/_version_test.py
+++ b/cirq-aqt/cirq_aqt/_version_test.py
@@ -3,4 +3,4 @@ import cirq_aqt
 
 
 def test_version():
-    assert cirq_aqt.__version__ == "1.5.0.dev"
+    assert cirq_aqt.__version__ == "1.5.0.dev0"

--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import io
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -28,23 +27,6 @@ description = (
 
 # README file as long_description.
 long_description = io.open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-aqt` and may be<br>"
-        "unstable. For the latest stable release of `cirq-aqt`,<br>"
-        "please visit** <https://pypi.org/project/cirq-aqt>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import runpy
 
 from setuptools import find_packages, setup
@@ -28,7 +27,7 @@ description = (
 )
 
 # README file as long_description.
-long_description = io.open('README.md', encoding='utf-8').read()
+long_description = open('README.md', encoding='utf-8').read()
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import io
+import runpy
+
 from setuptools import find_packages, setup
 
-# This reads the __version__ variable from cirq/_version.py
-__version__ = ''
-exec(open('cirq_aqt/_version.py').read())
+# This reads the __version__ variable from cirq_aqt/_version.py
+__version__ = runpy.run_path('cirq_aqt/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-aqt'
 
@@ -36,9 +38,6 @@ requirements += [f'cirq-core=={__version__}']
 cirq_packages = ['cirq_aqt'] + [
     'cirq_aqt.' + package for package in find_packages(where='cirq_aqt')
 ]
-
-# Sanity check
-assert __version__, 'Version string cannot be empty'
 
 setup(
     name=name,

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -28,4 +28,4 @@ if sys.version_info < (3, 10, 0):  # pragma: no cover
         'of cirq (e.g. "python -m pip install cirq==1.1.*")'
     )
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-core/cirq/_version_test.py
+++ b/cirq-core/cirq/_version_test.py
@@ -3,4 +3,4 @@ import cirq
 
 
 def test_version():
-    assert cirq.__version__ == "1.5.0.dev"
+    assert cirq.__version__ == "1.5.0.dev0"

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import runpy
 
 from setuptools import find_packages, setup
@@ -29,7 +28,7 @@ description = (
 )
 
 # README file as long_description.
-long_description = io.open('README.md', encoding='utf-8').read()
+long_description = open('README.md', encoding='utf-8').read()
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import io
+import runpy
+
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
-__version__ = ''
-exec(open('cirq/_version.py').read())
+__version__ = runpy.run_path('cirq/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-core'
 
@@ -39,9 +41,6 @@ contrib_requirements = [r.strip() for r in contrib_requirements]
 cirq_packages = ['cirq'] + [
     'cirq.' + package for package in find_packages(where='cirq', exclude=['google', 'google.*'])
 ]
-
-# Sanity check
-assert __version__, 'Version string cannot be empty'
 
 setup(
     name=name,

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import io
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -29,23 +28,6 @@ description = (
 
 # README file as long_description.
 long_description = io.open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-core` and may be<br>"
-        "unstable. For the latest stable release of `cirq-core`,<br>"
-        "please visit** <https://pypi.org/project/cirq-core>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -28,4 +28,4 @@ if sys.version_info < (3, 10, 0):  # pragma: no cover
         'of cirq (e.g. "python -m pip install cirq==1.1.*")'
     )
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-google/cirq_google/_version_test.py
+++ b/cirq-google/cirq_google/_version_test.py
@@ -3,4 +3,4 @@ import cirq_google
 
 
 def test_version():
-    assert cirq_google.__version__ == "1.5.0.dev"
+    assert cirq_google.__version__ == "1.5.0.dev0"

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq_google/_version.py
@@ -27,23 +26,6 @@ description = (
 
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-google` and may be<br>"
-        "unstable. For the latest stable release of `cirq-google`,<br>"
-        "please visit** <https://pypi.org/project/cirq-google>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import runpy
+
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq_google/_version.py
-__version__ = ''
-exec(open('cirq_google/_version.py').read())
+__version__ = runpy.run_path('cirq_google/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-google'
 
@@ -30,11 +32,6 @@ long_description = open('README.md', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
-
-# Sanity check
-assert __version__, 'Version string cannot be empty'
-
-# This is a pure metapackage that installs all our packages
 requirements += [f'cirq-core=={__version__}']
 
 

--- a/cirq-ionq/cirq_ionq/_version.py
+++ b/cirq-ionq/cirq_ionq/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-ionq/cirq_ionq/_version_test.py
+++ b/cirq-ionq/cirq_ionq/_version_test.py
@@ -3,4 +3,4 @@ import cirq_ionq
 
 
 def test_version():
-    assert cirq_ionq.__version__ == "1.5.0.dev"
+    assert cirq_ionq.__version__ == "1.5.0.dev0"

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import runpy
 
 from setuptools import find_packages, setup
@@ -26,7 +25,7 @@ name = 'cirq-ionq'
 description = 'A Cirq package to simulate and connect to IonQ quantum computers'
 
 # README file as long_description.
-long_description = io.open('README.md', encoding='utf-8').read()
+long_description = open('README.md', encoding='utf-8').read()
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import io
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -26,23 +25,6 @@ description = 'A Cirq package to simulate and connect to IonQ quantum computers'
 
 # README file as long_description.
 long_description = io.open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-ionq` and may be<br>"
-        "unstable. For the latest stable release of `cirq-ionq`,<br>"
-        "please visit** <https://pypi.org/project/cirq-ionq>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import io
+import runpy
+
 from setuptools import find_packages, setup
 
-# This reads the __version__ variable from cirq/_version.py
-__version__ = ''
-exec(open('cirq_ionq/_version.py').read())
+# This reads the __version__ variable from cirq_ionq/_version.py
+__version__ = runpy.run_path('cirq_ionq/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-ionq'
 
@@ -29,15 +31,12 @@ long_description = io.open('README.md', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
+requirements += [f'cirq-core=={__version__}']
 
 cirq_packages = ['cirq_ionq'] + [
     'cirq_ionq.' + package for package in find_packages(where='cirq_ionq')
 ]
 
-# Sanity check
-assert __version__, 'Version string cannot be empty'
-
-requirements += [f'cirq-core=={__version__}']
 
 setup(
     name=name,

--- a/cirq-pasqal/cirq_pasqal/_version.py
+++ b/cirq-pasqal/cirq_pasqal/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-pasqal/cirq_pasqal/_version_test.py
+++ b/cirq-pasqal/cirq_pasqal/_version_test.py
@@ -3,4 +3,4 @@ import cirq_pasqal
 
 
 def test_version():
-    assert cirq_pasqal.__version__ == "1.5.0.dev"
+    assert cirq_pasqal.__version__ == "1.5.0.dev0"

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import io
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -26,23 +25,6 @@ description = 'A Cirq package to simulate and connect to Pasqal quantum computer
 
 # README file as long_description.
 long_description = io.open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-pasqal` and may be<br>"
-        "unstable. For the latest stable release of `cirq-pasqal`,<br>"
-        "please visit** <https://pypi.org/project/cirq-pasqal>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import io
+import runpy
+
 from setuptools import find_packages, setup
 
-# This reads the __version__ variable from cirq/_version.py
-__version__ = ''
-exec(open('cirq_pasqal/_version.py').read())
+# This reads the __version__ variable from cirq_pasqal/_version.py
+__version__ = runpy.run_path('cirq_pasqal/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-pasqal'
 
@@ -29,9 +31,6 @@ long_description = io.open('README.md', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
-# Sanity check
-assert __version__, 'Version string cannot be empty'
-
 requirements += [f'cirq-core=={__version__}']
 
 cirq_packages = ['cirq_pasqal'] + [

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import runpy
 
 from setuptools import find_packages, setup
@@ -26,7 +25,7 @@ name = 'cirq-pasqal'
 description = 'A Cirq package to simulate and connect to Pasqal quantum computers'
 
 # README file as long_description.
-long_description = io.open('README.md', encoding='utf-8').read()
+long_description = open('README.md', encoding='utf-8').read()
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-rigetti/cirq_rigetti/_version.py
+++ b/cirq-rigetti/cirq_rigetti/_version.py
@@ -14,4 +14,4 @@
 
 """Define version number here, read it from setup.py automatically"""
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-rigetti/cirq_rigetti/_version_test.py
+++ b/cirq-rigetti/cirq_rigetti/_version_test.py
@@ -3,4 +3,4 @@ import cirq_rigetti
 
 
 def test_version():
-    assert cirq_rigetti.__version__ == "1.5.0.dev"
+    assert cirq_rigetti.__version__ == "1.5.0.dev0"

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import io
+import runpy
+
 from setuptools import find_packages, setup
 
-# This reads the __version__ variable from cirq/_version.py
-__version__ = ''
-exec(open('cirq_rigetti/_version.py').read())
+# This reads the __version__ variable from cirq_rigetti/_version.py
+__version__ = runpy.run_path('cirq_rigetti/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-rigetti'
 
@@ -29,10 +31,6 @@ long_description = io.open('README.md', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
-
-# Sanity check
-assert __version__, 'Version string cannot be empty'
-
 requirements += [f'cirq-core=={__version__}']
 
 cirq_packages = ['cirq_rigetti'] + [

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import runpy
 
 from setuptools import find_packages, setup
@@ -26,7 +25,7 @@ name = 'cirq-rigetti'
 description = 'A Cirq package to simulate and connect to Rigetti quantum computers and Quil QVM'
 
 # README file as long_description.
-long_description = io.open('README.md', encoding='utf-8').read()
+long_description = open('README.md', encoding='utf-8').read()
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import io
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -26,14 +25,6 @@ description = 'A Cirq package to simulate and connect to Rigetti quantum compute
 
 # README file as long_description.
 long_description = io.open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-web/cirq_web/_version.py
+++ b/cirq-web/cirq_web/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.0.dev"
+__version__ = "1.5.0.dev0"

--- a/cirq-web/cirq_web/_version_test.py
+++ b/cirq-web/cirq_web/_version_test.py
@@ -3,4 +3,4 @@ import cirq_web
 
 
 def test_version():
-    assert cirq_web.__version__ == "1.5.0.dev"
+    assert cirq_web.__version__ == "1.5.0.dev0"

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from setuptools import find_packages, setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -25,23 +24,6 @@ description = 'Web-based 3D visualization tools for Cirq.'
 
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of `cirq-web` and may be<br>"
-        "unstable. For the latest stable release of `cirq-web`,<br>"
-        "please visit** <https://pypi.org/project/cirq-web>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Read in requirements
 requirements = open('requirements.txt').readlines()

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import runpy
+
 from setuptools import find_packages, setup
 
-# This reads the __version__ variable from cirq/_version.py
-__version__ = ''
-exec(open('cirq_web/_version.py').read())
+# This reads the __version__ variable from cirq_web/_version.py
+__version__ = runpy.run_path('cirq_web/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq-web'
 
@@ -28,10 +30,6 @@ long_description = open('README.md', encoding='utf-8').read()
 # Read in requirements
 requirements = open('requirements.txt').readlines()
 requirements = [r.strip() for r in requirements]
-
-# Sanity check
-assert __version__, 'Version string cannot be empty'
-
 requirements += [f'cirq-core=={__version__}']
 
 # Gather all packages from cirq_web, and the dist/ folder from cirq_ts

--- a/dev_tools/modules.py
+++ b/dev_tools/modules.py
@@ -27,7 +27,7 @@ Version management:
  - Python: get_version and replace_version
  - CLI:
     - python3 dev_tools/modules.py print_version
-    - python3 dev_tools/modules.py replace_version --old v0.12.0.dev --new v0.12.1.dev
+    - python3 dev_tools/modules.py replace_version --old v1.5.0.dev0 --new v1.5.1.dev0
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -44,9 +44,9 @@ PROJECT_NAME=cirq-core/cirq
 ACTUAL_VERSION_LINE=$(tail -n 1 "${PROJECT_NAME}/_version.py")
 ACTUAL_VERSION=$(echo "$ACTUAL_VERSION_LINE" | cut -d'"' -f 2)
 
-if [[ ${ACTUAL_VERSION} == *"dev" ]]; then
-  echo "${ACTUAL_VERSION}$(date "+%Y%m%d%H%M%S")"
+if [[ ${ACTUAL_VERSION} == *"dev0" ]]; then
+  echo "${ACTUAL_VERSION%0}$(date "+%Y%m%d%H%M%S")"
 else
-  echo "Version doesn't end in dev: ${ACTUAL_VERSION_LINE}" >&2
+  echo "Version doesn't end in dev0: ${ACTUAL_VERSION_LINE}" >&2
   exit 1
 fi

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -50,9 +50,19 @@ echo =======================================
 echo Testing that all modules are installed
 echo =======================================
 
+python_test_template="\
+import @p
+print(@p)
+assert '${tmp_dir}' in @p.__file__, 'Package path seems invalid.'
+assert (
+    '@p' == 'cirq_ts' or
+    '${CIRQ_PRE_RELEASE_VERSION}' == @p.__version__
+), 'Package version is invalid'
+"
+
 CIRQ_PACKAGES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package)
 for p in $CIRQ_PACKAGES; do
   echo "--- Testing $p -----"
-  python_test="import $p; print($p); assert '${tmp_dir}' in $p.__file__, 'Package path seems invalid.'"
+  python_test="${python_test_template//@p/$p}"
   env PYTHONPATH='' "${tmp_dir}/env/bin/python" -c "$python_test" && echo -e "\033[32mPASS\033[0m"  || echo -e "\033[31mFAIL\033[0m"
 done

--- a/release.md
+++ b/release.md
@@ -21,7 +21,7 @@ numbers. The following guarantees are provided:
     ever becomes necessary to allow packages to have different version numbers,
     this policy will be updated.)
 
-1.  Libraries in the `cirq-core` directory (with the exception of
+2.  Libraries in the `cirq-core` directory (with the exception of
     `cirq-core/cirq/contrib`) adhere to the guarantees outlined in the Semantic
     Versioning specification. In summary:
 
@@ -34,14 +34,14 @@ numbers. The following guarantees are provided:
     *   Additions and/or changes that affect the API in a
         backwards-_incompatible_ way will increment the MAJOR version.
 
-1.  The contrib directory (at `cirq-core/cirq/contrib`) currently follows
+3.  The contrib directory (at `cirq-core/cirq/contrib`) currently follows
     Semantic Versioning except for the MINOR version increment policy: releases
     with MINOR version increments may contain backward-incompatible
     functionality changes to its public API. (They may be changed to strictly
     follow Semantic Versioning in the future, at which point this policy will
     be updated.)
 
-1.  Cirq vendor directories (`cirq-aqt`, `cirq-google`, `cirq-ionq`, etc.) follow
+4.  Cirq vendor directories (`cirq-aqt`, `cirq-google`, `cirq-ionq`, etc.) follow
     Semantic Versioning except the MINOR version increment policy: each vendor
     directory has a separate policy on whether MINOR version increments provide
     backward-compatibility guarantees, as described in `version_policy.md` in the
@@ -54,7 +54,7 @@ numbers. The following guarantees are provided:
     1.  For each vendor directory, version policies may be modified to strictly
         follow Semantic Versioning in the future.
 
-1.  Versions based on unreleased branches of `main` will be suffixed with `.dev`.
+5.  Versions based on unreleased branches of `main` will be suffixed with `.dev0`.
 
 The rules for version changes are:
 
@@ -76,7 +76,7 @@ We use GitHub's release system for creating releases.  Release are listed
 
 Our development process uses the branch named `main` for development. This
 branch will always use the next unreleased minor version number with the suffix
-of `.dev`. When a release is performed, the `.dev` will be removed and tagged
+of `.dev0`. When a release is performed, the `.dev0` will be removed and tagged
 in a release branch with a version tag (vX.X.X). Then, `main` will be updated
 to the next minor version. The version number of `main` can always be found in
 the [version file](./cirq-core/cirq/_version.py).
@@ -158,9 +158,9 @@ git cherry-pick <commit>
 Bump the version number on the release branch:
 
 ```bash
-python dev_tools/modules.py replace_version --old ${VER}.dev --new ${VER}
+python dev_tools/modules.py replace_version --old ${VER}.dev0 --new ${VER}
 git add .
-git commit -m "Removing ${VER}.dev -> ${VER}"
+git commit -m "Removing ${VER}.dev0 -> ${VER}"
 git push origin "v${VER}-dev"
 ```
 
@@ -171,7 +171,7 @@ updates, leave it as it is.
 
 ```bash
 git checkout main -b "version_bump_${NEXT_VER}"
-python dev_tools/modules.py replace_version --old ${VER}.dev --new ${NEXT_VER}.dev
+python dev_tools/modules.py replace_version --old ${VER}.dev0 --new ${NEXT_VER}.dev0
 git add .
 git commit -m "Bump cirq version to ${NEXT_VER}"
 git push origin "version_bump_${NEXT_VER}"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from setuptools import setup
 
 # This reads the __version__ variable from cirq/_version.py
@@ -32,23 +31,6 @@ description = (
 
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
-
-# If CIRQ_PRE_RELEASE_VERSION is set then we update the version to this value.
-# It is assumed that it ends with one of `.devN`, `.aN`, `.bN`, `.rcN` and hence
-# it will be a pre-release version on PyPi. See
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#pre-release-versioning
-# for more details.
-if 'CIRQ_PRE_RELEASE_VERSION' in os.environ:
-    __version__ = os.environ['CIRQ_PRE_RELEASE_VERSION']
-    long_description = (
-        "<div align='center' width='50%'>\n\n"
-        "| ⚠️ WARNING |\n"
-        "|:----------:|\n"
-        "| **This is a development version of Cirq and may be<br>"
-        "unstable. For the latest stable release of Cirq,<br>"
-        "please visit** <https://pypi.org/project/cirq>.|\n"
-        "\n</div>\n\n" + long_description
-    )
 
 # Sanity check
 assert __version__, 'Version string cannot be empty'

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup
+import runpy
 
-# This reads the __version__ variable from cirq/_version.py
-__version__ = ''
+from setuptools import setup
 
 from dev_tools import modules
 from dev_tools.requirements import explode
 
-exec(open('cirq-core/cirq/_version.py').read())
+# This reads the __version__ variable from cirq-core/cirq/_version.py
+__version__ = runpy.run_path('cirq-core/cirq/_version.py')['__version__']
+assert __version__, 'Version string cannot be empty'
 
 name = 'cirq'
 
@@ -31,9 +32,6 @@ description = (
 
 # README file as long_description.
 long_description = open('README.md', encoding='utf-8').read()
-
-# Sanity check
-assert __version__, 'Version string cannot be empty'
 
 # This is a pure metapackage that installs all our packages
 requirements = [f'{p.name}=={p.version}' for p in modules.list_modules()]


### PR DESCRIPTION
- Remove conditional dev-release note from package description as
  PyPI makes it clear enough when user visits development release.

- Make setup.py independent of `CIRQ_PRE_RELEASE_VERSION`.

- Validate dev-version value in packaging_test.sh

- Use `runpy` instead of `exec` to obtain version value.
  Make it less mysterious how is the `__version__` obtained.

- Clean up calls to io.open() which is an alias to open().

- Normalize `.dev` version value to `.dev0` per setuptools notice.
