### PR TITLE
Avoid frequent test failure in greedy_test.py by increasing timeout

### DIFF
--- a/cirq-core/cirq/contrib/routing/greedy_test.py
+++ b/cirq-core/cirq/contrib/routing/greedy_test.py
@@ -49,7 +49,7 @@ def create_hanging_routing_instance(circuit, device_graph):
 
 
 def test_router_hanging():
-    """Run a separate process and check if greedy router hits timeout (5s)."""
+    """Run a separate process and check if greedy router hits timeout (20s)."""
     circuit, device_graph = create_circuit_and_device()
     process = Process(target=create_hanging_routing_instance, args=[circuit, device_graph])
     process.start()

--- a/cirq-core/cirq/contrib/routing/greedy_test.py
+++ b/cirq-core/cirq/contrib/routing/greedy_test.py
@@ -53,7 +53,7 @@ def test_router_hanging():
     circuit, device_graph = create_circuit_and_device()
     process = Process(target=create_hanging_routing_instance, args=[circuit, device_graph])
     process.start()
-    process.join(timeout=5)
+    process.join(timeout=20)
     try:
         assert not process.is_alive(), "Greedy router timeout"
     finally:


### PR DESCRIPTION
On my MacOS 15.x Apple M1 laptop, I frequently get a test failure in `cirq-core/cirq/contrib/routing/greedy_test.py`:

```
[gw2] darwin -- Python 3.11.9 /Users/mhucka/.pyenv/versions/cirq-py311-np1/bin/python3

    def test_router_hanging():
        """Run a separate process and check if greedy router hits timeout (5s)."""
        circuit, device_graph = create_circuit_and_device()
        process = Process(target=create_hanging_routing_instance, args=[circuit, device_graph])
        process.start()
        process.join(timeout=5)
        try:
>           assert not process.is_alive(), "Greedy router timeout"
E           AssertionError: Greedy router timeout
E           assert not True
E            +  where True = is_alive()
E            +    where is_alive = <Process name='Process-1' pid=58097 parent=56380 started>.is_alive

cirq-core/cirq/contrib/routing/greedy_test.py:58: AssertionError
```

This happens with Python 3.10 and 3.12 as well.

Since assertion being tested is that the process is _not_ alive, it seems that 5 seconds can be too short. And indeed, if the timeout is increased to 20 seconds, the error never seems to occur in my local Mac testing.

It's not obvious to me whether a short timeout is needed for the purposes of the test. Shortening the duration to 10 sec also works, but might not in other people's environments. So, 20 sec seems safer. However, if it needs to be as short as possible, then 10 seconds seems workable too.