### PR TITLE
Fix WaitGate for multiple qubits in cirq_google proto

### DIFF
--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -702,7 +702,9 @@ class CircuitSerializer(serializer.Serializer):
             total_nanos = arg_func_langs.float_arg_from_proto(
                 operation_proto.waitgate.duration_nanos, required_arg_name=None
             )
-            op = cirq.WaitGate(duration=cirq.Duration(nanos=total_nanos or 0.0))(*qubits)
+            op = cirq.WaitGate(
+                duration=cirq.Duration(nanos=total_nanos or 0.0), num_qubits=len(qubits)
+            )(*qubits)
         elif which_gate_type == 'resetgate':
             dimensions_proto = operation_proto.resetgate.arguments.get('dimension', None)
             if dimensions_proto is not None:

--- a/cirq-google/cirq_google/serialization/circuit_serializer_test.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer_test.py
@@ -267,6 +267,12 @@ OPERATIONS = [
         ),
     ),
     (
+        cirq.WaitGate(duration=cirq.Duration(nanos=15), num_qubits=2)(Q0, Q1),
+        op_proto(
+            {'waitgate': {'duration_nanos': {'float_value': 15}}, 'qubit_constant_index': [0, 1]}
+        ),
+    ),
+    (
         cirq.R(Q0),
         op_proto(
             {


### PR DESCRIPTION
- WaitGate operations with multiple qubits need to specify the `num_qubits` parameter.
- This PR fixes this and adds an appropriate test case.