### PR TITLE
CI - skip sorting of imports with isort

### DIFF
--- a/check/format-incremental
+++ b/check/format-incremental
@@ -109,9 +109,9 @@ if (( only_print == 1 )); then
     args+=("--check" "--diff")
 fi
 
-echo "skipped"; ISORTSTATUS=0
-# isort "${args[@]}" "${format_files[@]}"
-# ISORTSTATUS=$?
+# TODO(#4863, #7181) - exclude __init__.py from isort arguments and enable
+echo "isort is temporarily disabled"
+ISORTSTATUS=$?
 
 BLACKVERSION="$(black --version | head -1)"
 

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -109,8 +109,9 @@ if (( only_print == 1 )); then
     args+=("--check" "--diff")
 fi
 
-isort "${args[@]}" "${format_files[@]}"
-ISORTSTATUS=$?
+echo "skipped"; ISORTSTATUS=0
+# isort "${args[@]}" "${format_files[@]}"
+# ISORTSTATUS=$?
 
 BLACKVERSION="$(black --version | head -1)"
 


### PR DESCRIPTION
The `check/format-incremental` needs more work.
isort invocation should skip `__init__.py` files, but it does not.

Related to #7181
