### PR TITLE
Fix isort invocation in format-incremental

### DIFF
--- a/check/format-incremental
+++ b/check/format-incremental
@@ -57,7 +57,7 @@ for arg in "$@"; do
     fi
 done
 
-typeset -a format_files
+declare -a format_files=()
 if (( only_changed == 1 )); then
     # Figure out which branch to compare against.
     if [ -z "${rev}" ]; then
@@ -82,7 +82,8 @@ if (( only_changed == 1 )); then
 
     # Get the modified, added and moved python files.
     IFS=$'\n' read -r -d '' -a format_files < \
-        <(git diff --name-only --diff-filter=MAR "${rev}" -- '*.py' ':(exclude)cirq-google/cirq_google/cloud/*' ':(exclude)*_pb2.py')
+        <(git diff --name-only --diff-filter=MAR "${rev}" -- \
+        '*.py' ':(exclude)*_pb2.py')
 else
     echo -e "Formatting all python files." >&2
     IFS=$'\n' read -r -d '' -a format_files < \
@@ -90,11 +91,11 @@ else
 fi
 
 if (( ${#format_files[@]} == 0 )); then
-    echo -e "\033[32mNo files to format\033[0m."
+    echo -e "\033[32mNo files to format.\033[0m"
     exit 0
 fi
 
-# color the output if it goes to a terminal or GitHub Actions log
+# Color the output if it goes to a terminal or GitHub Actions log
 arg_color=()
 if [[ -t 1 || "${CI}" == true ]]; then
     arg_color=("--color")

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -95,6 +95,14 @@ if (( ${#format_files[@]} == 0 )); then
     exit 0
 fi
 
+# Exclude __init__.py files from isort targets
+declare -a isort_files=()
+for f in "${format_files[@]}"; do
+    if [[ "${f##*/}" != __init__.py ]]; then
+        isort_files+=("${f}")
+    fi
+done
+
 # Color the output if it goes to a terminal or GitHub Actions log
 arg_color=()
 if [[ -t 1 || "${CI}" == true ]]; then
@@ -110,9 +118,11 @@ if (( only_print == 1 )); then
     args+=("--check" "--diff")
 fi
 
-# TODO(#4863, #7181) - exclude __init__.py from isort arguments and enable
-echo "isort is temporarily disabled"
-ISORTSTATUS=$?
+ISORTSTATUS=0
+if (( "${#isort_files[@]}" )); then
+    isort "${args[@]}" "${isort_files[@]}"
+    ISORTSTATUS=$?
+fi
 
 BLACKVERSION="$(black --version | head -1)"
 


### PR DESCRIPTION
- Exclude `__init__.py` files from isort targets.
  Skip isort execution altogether if only `__init__.py` files changed.

- Make files in `cirq-google/cirq_google/cloud` subject to formatting.
  They were already formatted by black.

Follow up to #7190, #7181

Fixes #4863
