### PR TITLE
Change a list of if statements into Python match statements in cirq-google/cirq_google/serialization/arg_func_langs.py

### DIFF
--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -235,7 +235,7 @@ def float_arg_from_proto(
         case 'func':
             func = _arg_func_from_proto(arg_proto.func, required_arg_name=required_arg_name)
             if func is None and required_arg_name is not None:
-                raise ValueError(
+                raise ValueError(  # pragma: nocover
                     f'Arg {arg_proto.func} could not be processed for {required_arg_name}.'
                 )
             return cast(FLOAT_ARG_LIKE, func)
@@ -299,7 +299,7 @@ def arg_from_proto(
                     return tunits.Value.from_proto(arg_value.value_with_unit)
                 case 'bytes_value':
                     return bytes(arg_value.bytes_value)
-            raise ValueError(f'Unrecognized value type: {which_val!r}')
+            raise ValueError(f'Unrecognized value type: {which_val!r}')  # pragma: nocover
         case 'symbol':
             return sympy.Symbol(arg_proto.symbol)
         case 'func':

--- a/cirq-google/cirq_google/serialization/arg_func_langs_test.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs_test.py
@@ -55,6 +55,7 @@ def _json_format_kwargs() -> Dict[str, bool]:
     'value,proto',
     [
         (1.0, {'arg_value': {'float_value': 1.0}}),
+        (1.5, {'arg_value': {'float_value': 1.5}}),
         (1, {'arg_value': {'float_value': 1.0}}),
         (b'abcdef', {'arg_value': {'bytes_value': base64.b64encode(b'abcdef').decode("ascii")}}),
         ('abc', {'arg_value': {'string_value': 'abc'}}),
@@ -111,6 +112,10 @@ def test_double_value():
     msg.arg_value.double_value = 1.0
     parsed = arg_from_proto(msg)
     assert parsed == 1
+    msg = v2.program_pb2.Arg()
+    msg.arg_value.double_value = 1.5
+    parsed = arg_from_proto(msg)
+    assert parsed == 1.5
 
 
 def test_serialize_sympy_constants():
@@ -177,6 +182,7 @@ def test_missing_required_arg():
     with pytest.raises(ValueError, match='unrecognized argument type'):
         _ = arg_from_proto(v2.program_pb2.Arg(), required_arg_name='blah')
     assert arg_from_proto(v2.program_pb2.Arg()) is None
+    assert float_arg_from_proto(v2.program_pb2.FloatArg()) is None
 
 
 def test_invalid_float_arg():


### PR DESCRIPTION
- Match is supported as of python 3.10.
- This changes a chain of if statements in arg_func_langs to a match statement.
- Follow up to #7201