### PR TITLE
Fix gitignore to track maintained sources in docs/build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ build/
 
 # API docs
 docs/api_docs
+# files in docs/build/ are hand maintained
+!/docs/build/
 
 # swap files
 *.swp
@@ -45,4 +47,4 @@ docs/api_docs
 .python-version
 
 # notebook test output
-out
+/out


### PR DESCRIPTION
While most `build` directories are generated and should be ignored,
`docs/build` has legitimate sources and should be tracked.

Also ignore the `out/` directory only at the repository root.
