### PR TITLE
Use a different GHA for the PR size labeler

### DIFF
--- a/.github/pr-size-labels.yaml
+++ b/.github/pr-size-labels.yaml
@@ -1,0 +1,60 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Configure PR size labeler action in workflows/pr-labeler.yaml
+# For more information, see https://github.com/cbrgm/pr-size-labeler-action
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# List of files to exclude from size calculations.
+exclude_files:
+  - "cirq-web/cirq_ts/package-lock.json"
+
+# cbrgm/pr-size-labeler-action can assign labels based on both "size" (= lines
+# added + lines deleted) and number of files changed. Our current config only
+# uses size (achieved by setting all files threshold to 1). The labeler decides
+# on labels as follows. It calculates the size of the PR; let's call this value
+# "S". It then looks sequentially through the label_config entries until it
+# finds one where S <= config.size. So, e.g., "M" implies 250 < S <= 1000.
+
+label_configs:
+  - size: xs
+    diff: 10           # Threshold for total LoC changed (additions + deletions)
+    files: 1           # Threshold for total number of files changed
+    labels: ["size: XS"]  # Labels to be applied for this size
+
+  - size: s
+    diff: 50
+    files: 1
+    labels: ["size: S"]
+
+  - size: m
+    diff: 250
+    files: 1
+    labels: ["size: M"]
+
+  - size: l
+    diff: 1000
+    files: 1
+    labels: ["size: L"]
+
+  - size: xl
+    diff: 5000
+    files: 1
+    labels: ["size: XL"]
+
+  - size: xxl
+    diff: 100000
+    files: 1
+    labels: ["size: XXL"]

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -22,7 +22,7 @@ run-name: >-
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
   # Allow manual invocation.
   workflow_dispatch:
@@ -32,7 +32,7 @@ permissions: read-all
 
 jobs:
   label-pr-size:
-    name: Add size label to new pull request
+    name: Update size labels on a PR
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -40,22 +40,9 @@ jobs:
       issues: write
     steps:
       - name: Label the PR with a size label
-        uses: codelytv/pr-size-labeler@c7a55a022747628b50f3eb5bf863b9e796b8f274 # v1
+        uses: cbrgm/pr-size-labeler-action@85f918ef4ef0a7dbc08166774f9158697584bc8c # v1
         with:
-          # Don't count file deletions, per suggestion in Small CLs.
-          ignore_file_deletions: 'true'
-
-          xs_label: 'Size: XS'
-          xs_max_size: '10'
-
-          s_label: 'size: S'
-          s_max_size: '50'
-
-          m_label: 'size: M'
-          m_max_size: '250'
-
-          l_label: 'size: L'
-          l_max_size: '1000'
-
-          xl_label: 'size: XL'
-          fail_if_xl: 'false'
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_pr_number: ${{github.event.number}}
+          github_repository: ${{github.repository}}
+          config_file_path: '.github/pr-size-labels.yaml'


### PR DESCRIPTION

The action used in the previous version was buggy. Replaced it with a
different one that will be hopefully better.