### PR TITLE
Use a different action for size labeler GHA

### DIFF
--- a/.github/pr-size-labels.yaml
+++ b/.github/pr-size-labels.yaml
@@ -19,7 +19,7 @@
 
 # List of files to exclude from size calculations.
 exclude_files:
-  - "cirq-web/cirq_ts/package-lock.json"
+  - "package-lock.json"
   - "*_pb2.py"
   - "*_pb2.pyi"
   - "*.bundle.js"

--- a/.github/pr-size-labels.yaml
+++ b/.github/pr-size-labels.yaml
@@ -24,9 +24,12 @@ exclude_files:
   - "*_pb2.pyi"
   - "*.bundle.js"
 
-# cbrgm/pr-size-labeler-action can assign labels based on both "size" (= lines
-# added + lines deleted) and number of files changed.
-
+# cbrgm/pr-size-labeler-action labels based on both "size" (= lines added +
+# lines deleted) and number of files changed in a PR. The action looks for the
+# largest matching configuration, considering numer of files changed first.
+# Reasoning about changes along two dimensions simultaneously is difficult, so
+# for simplicity, the settings below simply use the same value for both. This
+# lets us think in terms of "changes" more broadly, regardless of what kind.
 label_configs:
   - size: xs
     diff: 10           # Threshold for total LoC changed (additions + deletions)
@@ -48,9 +51,9 @@ label_configs:
     files: 1000
     labels: ["size: L"]
 
-  # Although it's not obvious from the docs of the action, the way it handles
-  # the final entry in the configs is it uses it for all cases that exceed the
-  # given value too. I.e., anything that exceeds this is lumped together as xl.
+  # Although it's not obvious from the docs of the action, it uses the final
+  # config for all cases that exceed the given values too. I.e., anything that
+  # hits 1001 or more will be lumped together as xl.
   - size: xl
     diff: 1001
     files: 1001

--- a/.github/pr-size-labels.yaml
+++ b/.github/pr-size-labels.yaml
@@ -20,6 +20,9 @@
 # List of files to exclude from size calculations.
 exclude_files:
   - "cirq-web/cirq_ts/package-lock.json"
+  - "*_pb2.py"
+  - "*_pb2.pyi"
+  - "*.bundle.js"
 
 # cbrgm/pr-size-labeler-action can assign labels based on both "size" (= lines
 # added + lines deleted) and number of files changed.

--- a/.github/pr-size-labels.yaml
+++ b/.github/pr-size-labels.yaml
@@ -1,0 +1,54 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Configure PR size labeler action in workflows/pr-labeler.yaml
+# For more information, see https://github.com/cbrgm/pr-size-labeler-action
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# List of files to exclude from size calculations.
+exclude_files:
+  - "cirq-web/cirq_ts/package-lock.json"
+
+# cbrgm/pr-size-labeler-action can assign labels based on both "size" (= lines
+# added + lines deleted) and number of files changed.
+
+label_configs:
+  - size: xs
+    diff: 10           # Threshold for total LoC changed (additions + deletions)
+    files: 10          # Threshold for total number of files changed
+    labels: ["size: XS"]  # Labels to be applied for this size
+
+  - size: s
+    diff: 50
+    files: 50
+    labels: ["size: S"]
+
+  - size: m
+    diff: 250
+    files: 250
+    labels: ["size: M"]
+
+  - size: l
+    diff: 1000
+    files: 1000
+    labels: ["size: L"]
+
+  # Although it's not obvious from the docs of the action, the way it handles
+  # the final entry in the configs is it uses it for all cases that exceed the
+  # given value too. I.e., anything that exceeds this is lumped together as xl.
+  - size: xl
+    diff: 1001
+    files: 1001
+    labels: ["size: XL"]

--- a/.github/pr-size-labels.yaml
+++ b/.github/pr-size-labels.yaml
@@ -26,15 +26,15 @@ exclude_files:
 
 # cbrgm/pr-size-labeler-action labels based on both "size" (= lines added +
 # lines deleted) and number of files changed in a PR. The action looks for the
-# largest matching configuration, considering numer of files changed first.
-# Reasoning about changes along two dimensions simultaneously is difficult, so
-# for simplicity, the settings below simply use the same value for both. This
-# lets us think in terms of "changes" more broadly, regardless of what kind.
+# largest matching configuration, using number of files changed first. Trying
+# to think about the implications of values on two dimensions is difficult, so
+# for simplicity, the settings below use the same value for both. This lets us
+# think in terms of "changes" more broadly, regardless of what kind.
 label_configs:
   - size: xs
     diff: 10           # Threshold for total LoC changed (additions + deletions)
     files: 10          # Threshold for total number of files changed
-    labels: ["size: XS"]  # Labels to be applied for this size
+    labels: ["size: XS"]  # Label(s) to be applied for this size
 
   - size: s
     diff: 50

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -37,6 +37,7 @@ jobs:
     name: Update size labels on a PR
     runs-on: ubuntu-24.04
     permissions:
+      id-token: write
       contents: read
       pull-requests: write
       issues: write

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -22,7 +22,9 @@ run-name: >-
 
 on:
   pull_request:
-    types: [opened]
+    types:
+      - opened
+      - synchronize
 
   # Allow manual invocation.
   workflow_dispatch:
@@ -32,30 +34,23 @@ permissions: read-all
 
 jobs:
   label-pr-size:
-    name: Add size label to new pull request
+    name: Update size labels on a PR
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write
       issues: write
     steps:
-      - name: Label the PR with a size label
-        uses: codelytv/pr-size-labeler@c7a55a022747628b50f3eb5bf863b9e796b8f274 # v1
+      # We need a copy of the repo so the action can read the config file.
+      - name: Check out a copy of the git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Don't count file deletions, per suggestion in Small CLs.
-          ignore_file_deletions: 'true'
+          fetch-depth: 0
 
-          xs_label: 'Size: XS'
-          xs_max_size: '10'
-
-          s_label: 'size: S'
-          s_max_size: '50'
-
-          m_label: 'size: M'
-          m_max_size: '250'
-
-          l_label: 'size: L'
-          l_max_size: '1000'
-
-          xl_label: 'size: XL'
-          fail_if_xl: 'false'
+      - name: Label the PR with a size label
+        uses: cbrgm/pr-size-labeler-action@85f918ef4ef0a7dbc08166774f9158697584bc8c # v1
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_pr_number: ${{github.event.number}}
+          github_repository: ${{github.repository}}
+          config_file_path: '.github/pr-size-labels.yaml'

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -14,6 +14,10 @@
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Label PRs with labels such as size.
+#
+# This workflow is designed not to fail if labeling actions encounter errors;
+# instead, the actions write annotations on the workflow run summary page. If
+# labels don't seem to be getting applied as expected, check there for errors.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 name: Pull request labeler
@@ -34,7 +38,7 @@ permissions: read-all
 
 jobs:
   label-pr-size:
-    name: Update size labels on a PR
+    name: Update PR size labels
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
@@ -45,14 +49,31 @@ jobs:
       # We need a copy of the repo so the action can read the config file.
       - name: Check out a copy of the git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
 
       - name: Label the PR with a size label
-        uses: cbrgm/pr-size-labeler-action@85f918ef4ef0a7dbc08166774f9158697584bc8c # v1
+        id: label
         continue-on-error: true
-        with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          github_pr_number: ${{github.event.number}}
-          github_repository: ${{github.repository}}
-          config_file_path: '.github/pr-size-labels.yaml'
+        run: |
+          set -x +e
+          podman --out action.out run -v .github:/tmp/.github --rm -it \
+            ghcr.io/cbrgm/pr-size-labeler-action:v1 \
+            --githubtoken ${{secrets.GITHUB_TOKEN}} \
+            --eventname pull_request \
+            --reponame ${{github.repository}} \
+            --prnumber ${{github.event.number}} \
+            --configfilepath /tmp/.github/pr-size-labels.yaml
+          status=$?
+          echo '::group::Labeler action output'
+          cat action.out
+          echo '::endgroup::'
+          exit $status
+
+      - name: Detect and report errors in labeler action
+        if: steps.label.outcome == 'failure' || steps.label.outcome == 'error'
+        run: |
+          {
+          echo "<h4>‼️ Failed to label PR ${{github.event.number}}</h4>"
+          echo "<pre>"
+          cat action.out
+          echo "</pre>"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Label the PR with a size label
         uses: cbrgm/pr-size-labeler-action@85f918ef4ef0a7dbc08166774f9158697584bc8c # v1
+        continue-on-error: true
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           github_pr_number: ${{github.event.number}}


### PR DESCRIPTION
The previous GitHub Actions used as the labeling action was buggy. Switching to a different action that looks more promising.