### PR TITLE
Add contents write to job permissions

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -45,6 +45,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      administration: write
     steps:
       # We need a copy of the repo so the action can read the config file.
       - name: Check out a copy of the git repository

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -40,12 +40,7 @@ jobs:
   label-pr-size:
     name: Update PR size labels
     runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
-      issues: write
-      administration: write
+    permissions: write-all
     steps:
       # We need a copy of the repo so the action can read the config file.
       - name: Check out a copy of the git repository

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
     steps:

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -34,7 +34,7 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+# permissions: read-all
 
 jobs:
   label-pr-size:


### PR DESCRIPTION

This may be the reason for the "403 Resource not accessible by integration"
errors.