### PR TITLE
Test qcircuit pdf generation without extra `prepare_only` argument

### DIFF
--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf.py
@@ -29,7 +29,6 @@ def circuit_to_pdf_using_qcircuit_via_tex(
     qcircuit_kwargs=None,
     clean_ext=('dvi', 'ps'),
     documentclass='article',
-    prepare_only=False,
 ):
     """Compiles the QCircuit-based latex diagram of the given circuit.
 
@@ -43,8 +42,6 @@ def circuit_to_pdf_using_qcircuit_via_tex(
             default, latexmk is used with the '-pdfps' flag, which produces
             intermediary dvi and ps files.
         documentclass: The documentclass of the latex file.
-        prepare_only: If True, only prepare the document, do not generate PDF.
-            Used only for testing.
 
     Raises:
         OSError, IOError: If cleanup fails.
@@ -61,11 +58,10 @@ def circuit_to_pdf_using_qcircuit_via_tex(
     doc.packages.append(Package('qcircuit'))
     doc.preamble.append(Package('inputenc', options=['utf8']))
     doc.append(NoEscape(tex))
-    if not prepare_only:  # pragma: nocover
-        doc.generate_pdf(filepath, **pdf_kwargs)
-        for ext in clean_ext:
-            try:
-                os.remove(filepath + '.' + ext)
-            except (OSError, IOError) as e:
-                if e.errno != errno.ENOENT:
-                    raise
+    doc.generate_pdf(filepath, **pdf_kwargs)
+    for ext in clean_ext:
+        try:
+            os.remove(filepath + '.' + ext)
+        except (OSError, IOError) as e:
+            if e.errno != errno.ENOENT:
+                raise  # pragma: nocover

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf_test.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf_test.py
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
+
+import pylatex
+
 import cirq
 import cirq.contrib.qcircuit.qcircuit_pdf as qcircuit_pdf
 
 
-def test_qcircuit_pdf_prepare_only():
+@mock.patch.object(pylatex.Document, "generate_pdf")
+def test_qcircuit_pdf(mock_generate_pdf):
     circuit = cirq.Circuit(cirq.X(cirq.q(0)), cirq.CZ(cirq.q(0), cirq.q(1)))
-    qcircuit_pdf.circuit_to_pdf_using_qcircuit_via_tex(circuit, "/tmp/test_file", prepare_only=True)
+    qcircuit_pdf.circuit_to_pdf_using_qcircuit_via_tex(circuit, "/tmp/test_file")
+    mock_generate_pdf.assert_called_once_with(
+        "/tmp/test_file", compiler="latexmk", compiler_args=["-pdfps"]
+    )


### PR DESCRIPTION
Let us avoid test-only argument in `circuit_to_pdf_using_qcircuit_via_tex`.
Mock `Document.generate_pdf` instead so we can test without the `latexmk` program.

Related to #7220
