### PR TITLE
Change pr-labeler action trigger to solve permissions problem

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -25,7 +25,7 @@ run-name: >-
   Label pull request ${{github.event.pull_request.number}} by ${{github.actor}}
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
In theory, this should allow access to org-level secrets. 

Although using `pull_request_target` raises security concerns, I don't see a way to exploit it with this particular workflow. We control the workflow (not the PR author), and no code from the PR gets executed, so it shouldn't be possible to exploit the permissions that the workflow has.