### PR TITLE
ci-daily - explicitly install cirq-rigetti for the tests

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -35,12 +35,14 @@ jobs:
           sudo apt-get install libffi7
       - name: Install requirements
         run: |
-          pip install cirq~=1.0.dev &&
-          pip install \
-            -r dev_tools/requirements/deps/format.txt \
-            -r dev_tools/requirements/deps/pylint.txt \
-            -r dev_tools/requirements/deps/pytest.txt \
-            -r dev_tools/requirements/deps/notebook.txt
+          pip install --upgrade cirq~=1.0.dev &&
+            version=$(pip show cirq | sed -n "s/^Version: //p" | grep .) &&
+            pip install "cirq-rigetti==${version}" &&
+            pip install \
+              -r dev_tools/requirements/deps/format.txt \
+              -r dev_tools/requirements/deps/pylint.txt \
+              -r dev_tools/requirements/deps/pytest.txt \
+              -r dev_tools/requirements/deps/notebook.txt
       - name: Run Quil dependencies
         run: docker compose -f cirq-rigetti/docker-compose.test.yaml up -d
       - name: Pytest check
@@ -65,7 +67,8 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install cirq~=1.0.dev &&
+          pip install --upgrade cirq~=1.0.dev &&
+            pip install --upgrade cirq-rigetti~=1.0.dev &&
             pip install -r dev_tools/requirements/deps/format.txt &&
             pip install -r dev_tools/requirements/deps/pylint.txt &&
             pip install -r dev_tools/requirements/deps/pytest.txt &&
@@ -91,11 +94,13 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install cirq~=1.0.dev &&
-          pip install \
-            -r dev_tools/requirements/deps/format.txt \
-            -r dev_tools/requirements/deps/pylint.txt \
-            -r dev_tools/requirements/deps/pytest.txt \
-            -r dev_tools/requirements/deps/notebook.txt
+          pip install --upgrade cirq~=1.0.dev &&
+            version=$(pip show cirq | sed -n "s/^Version: //p" | grep .) &&
+            pip install "cirq-rigetti==${version}" &&
+            pip install \
+              -r dev_tools/requirements/deps/format.txt \
+              -r dev_tools/requirements/deps/pylint.txt \
+              -r dev_tools/requirements/deps/pytest.txt \
+              -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest check
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests


### PR DESCRIPTION
cirq-rigetti is not included in cirq metapackage anymore.
Make sure to install an exactly matching dev version.

Related to #7058, #7170
