### PR TITLE
Simplify controlled decomp

### DIFF
--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -117,20 +117,11 @@ class CCZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
             elif not b.is_adjacent(c):
                 a, b = b, a
 
-        p = common_gates.T**self._exponent
+        exp = self._exponent
+        p = common_gates.T**exp
         sweep_abc = [common_gates.CNOT(a, b), common_gates.CNOT(b, c)]
-        global_phase = 1j ** (2 * self.global_shift * self._exponent)
-        global_phase = (
-            complex(global_phase)
-            if protocols.is_parameterized(global_phase) and global_phase.is_complex
-            else global_phase
-        )
-        global_phase_operation = (
-            [global_phase_op.global_phase_operation(global_phase)]
-            if protocols.is_parameterized(global_phase) or abs(global_phase - 1.0) > 0
-            else []
-        )
-        return global_phase_operation + [
+        phase_gate = global_phase_op.from_phase_and_exponent(self.global_shift, exp)
+        return ([] if phase_gate.is_identity else [phase_gate()]) + [
             p(a),
             p(b),
             p(c),


### PR DESCRIPTION
Sharing as a PoC for removing the special casing (via instanceof) of CZ and GP ops from the controlled subgate decomposition function. The idea is to modify these gates' `controlled` implementation such that they only return things that are decomposable, and then change the `ControlledGate._decompose_` implementation to first call `subgate.controlled()` to get the canonical representation of it.

I like that it removes the `instanceof` checks and makes things consistent. But I'm not sure this is exactly the right approach. Forcing `controlled` to return something decomposable feels like an unnatural restriction. For instance, this approach forces some `global_phase.controlled(...)` to return a `DiagonalGate`, since it's decomposable. But `DiagonalGate` is kind of an odd `controlled` return value.

Ultimately I think there probably should be a `decompose_controlled` protocol that passes in the control parameters, that CZ, GP, and any other gates that don't decompose generically when controlled would implement.

Will close this immediately after opening, but wanted to point out that cleaning up that particular hacky-looking function is possible. @tanujkhattar @pavoljuhas 