### PR TITLE
Address warning about node_link_data, node_link_graph defaults

### DIFF
--- a/cirq-core/cirq/devices/device.py
+++ b/cirq-core/cirq/devices/device.py
@@ -146,12 +146,12 @@ class DeviceMetadata:
         return self._qubits_set, graph_equality
 
     def _json_dict_(self):
-        graph_payload = nx.readwrite.json_graph.node_link_data(self._nx_graph)
+        graph_payload = nx.readwrite.json_graph.node_link_data(self._nx_graph, edges='links')
         qubits_payload = sorted(list(self._qubits_set))
 
         return {'qubits': qubits_payload, 'nx_graph': graph_payload}
 
     @classmethod
     def _from_json_dict_(cls, qubits: Iterable[cirq.Qid], nx_graph: nx.Graph, **kwargs):
-        graph_obj = nx.readwrite.json_graph.node_link_graph(nx_graph)
+        graph_obj = nx.readwrite.json_graph.node_link_graph(nx_graph, edges='links')
         return cls(qubits, graph_obj)


### PR DESCRIPTION
The default value of the `edges` argument will change.  Here we
future-proof the code by providing the current default value.

This fixes  pytest -Werror cirq-core/cirq/devices/device_test.py
