### PR TITLE
Address pandas warning about deprecated DataFrameGroupBy.apply default

### DIFF
--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -138,7 +138,10 @@ def benchmark_2q_xeb_fidelities(
     else:
         groupby_names = ['cycle_depth']
 
-    return df.groupby(groupby_names).apply(per_cycle_depth).reset_index()
+    v0 = df.groupby(groupby_names).apply(per_cycle_depth).reset_index()
+    v1 = df.groupby(groupby_names).apply(per_cycle_depth, include_groups=False).reset_index()
+    assert v0.equals(v1)
+    return df.groupby(groupby_names).apply(per_cycle_depth, include_groups=False).reset_index()
 
 
 class XEBCharacterizationOptions(ABC):
@@ -702,7 +705,10 @@ def fit_exponential_decays(fidelities_df: pd.DataFrame) -> pd.DataFrame:
         groupby = ['layer_i', 'pair_i', 'pair']
     else:
         groupby = ['pair']
-    return fidelities_df.groupby(groupby).apply(_per_pair)
+    v0 = fidelities_df.groupby(groupby).apply(_per_pair)
+    v1 = fidelities_df.groupby(groupby).apply(_per_pair, include_groups=False)
+    assert v0.equals(v1)
+    return fidelities_df.groupby(groupby).apply(_per_pair, include_groups=False)
 
 
 def before_and_after_characterization(

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -138,9 +138,6 @@ def benchmark_2q_xeb_fidelities(
     else:
         groupby_names = ['cycle_depth']
 
-    v0 = df.groupby(groupby_names).apply(per_cycle_depth).reset_index()
-    v1 = df.groupby(groupby_names).apply(per_cycle_depth, include_groups=False).reset_index()
-    assert v0.equals(v1)
     return df.groupby(groupby_names).apply(per_cycle_depth, include_groups=False).reset_index()
 
 
@@ -705,9 +702,6 @@ def fit_exponential_decays(fidelities_df: pd.DataFrame) -> pd.DataFrame:
         groupby = ['layer_i', 'pair_i', 'pair']
     else:
         groupby = ['pair']
-    v0 = fidelities_df.groupby(groupby).apply(_per_pair)
-    v1 = fidelities_df.groupby(groupby).apply(_per_pair, include_groups=False)
-    assert v0.equals(v1)
     return fidelities_df.groupby(groupby).apply(_per_pair, include_groups=False)
 
 


### PR DESCRIPTION
The current default is to pass grouping columns to the apply function,
which in our case does not use them at all.  Here we exclude them with
`include_groups=False` adopting the new behavior.

This fixes DataFramgeGroupBy.apply warning in

```
$ check/pytest -Werror:DataFrameGroupBy cirq-core/cirq/experiments
...
FAILED cirq-core/cirq/experiments/xeb_fitting_test.py::test_parallel_full_workflow[True] - DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated,...
```
