### PR TITLE
Fix failing CI tests due to old setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
           sudo apt-get install libffi7
       - name: Install requirements
         run: |
-          pip install wheel
+          pip install --upgrade setuptools wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Run Quil dependencies
         run: docker compose -f cirq-rigetti/docker-compose.test.yaml up -d
@@ -289,7 +289,7 @@ jobs:
           sudo apt-get install libffi7
       - name: Install requirements
         run: |
-          pip install wheel
+          pip install --upgrade setuptools wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Run Quil dependencies
         run: docker compose -f cirq-rigetti/docker-compose.test.yaml up -d
@@ -322,7 +322,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install wheel
+          pip install --upgrade setuptools wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/no-contrib.env.txt
       - name: Pytest Windows
         run: |
@@ -350,7 +350,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
       - name: Install requirements
         run: |
-          pip install wheel
+          pip install --upgrade setuptools wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/no-contrib.env.txt
       - name: Pytest check
         run: check/pytest -n auto --durations=20 --ignore=cirq-core/cirq/contrib

--- a/dev_tools/requirements/deps/packaging.txt
+++ b/dev_tools/requirements/deps/packaging.txt
@@ -3,7 +3,7 @@ virtualenv
 
 # for creating packages
 # TODO (juhas) - remove when pyquil allows packaging-24
-setuptools<77
+setuptools>=70,<77
 wheel
 
 # for uploading packages to pypi


### PR DESCRIPTION
Upgrade setuptools and wheel before installing the dev.env requirements
for the CI.  The Python environments in GHA comes with old setuptools
which makes the installation of dev.env fail.

Same for Python environment used in the Packaging Test CI.