### PR TITLE
CI - fix failing pre-release workflow

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install --upgrade setuptools wheel twine
       - name: Create PYPI config file
         env:
           CIRQ_PYPI_TOKEN: ${{ secrets.CIRQ_PYPI_TOKEN }}


### PR DESCRIPTION
Upgrade setuptools before creating wheel archives.

Follow-up of #7249
