### PR TITLE
Drop temporary warnings about changed data promotion in numpy-2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
           pip install wheel
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev-np2.env.txt
       - name: Pytest check
-        run: check/pytest -n auto --warn-numpy-data-promotion --durations=20 --ignore=cirq-rigetti
+        run: check/pytest -n auto --durations=20 --ignore=cirq-rigetti
   pip-compile:
     name: Check consistency of requirements
     runs-on: ubuntu-22.04

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import pytest
 
 
@@ -26,19 +25,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--enable-slow-tests", action="store_true", default=False, help="run slow tests"
     )
-    parser.addoption(
-        "--warn-numpy-data-promotion",
-        action="store_true",
-        default=False,
-        help="enable NumPy 2 data type promotion warnings",
-    )
-
-
-def pytest_configure(config):
-    # If requested, globally enable verbose NumPy 2 warnings about data type
-    # promotion. See https://numpy.org/doc/2.0/numpy_2_0_migration_guide.html.
-    if config.option.warn_numpy_data_promotion:
-        np._set_promotion_state("weak_and_warn")
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
numpy had a warnings helper for that which got removed in numpy-2.2.
Also remove the custom pytest option `--warn-numpy-data-promotion`.

Fixes numpy-2 test failure due to use of removed function.
