### PR TITLE
Fix syntax of warning statement

### DIFF
--- a/docs/hardware/rigetti/access.md
+++ b/docs/hardware/rigetti/access.md
@@ -1,6 +1,6 @@
 # Access and Authentication
 
-**Warning: the `cirq-rigetti` module was deprecated in Cirq version 1.5**, and will be removed in a subsequent version.
+Warning: the `cirq-rigetti` module was deprecated in Cirq version 1.5, and will be removed in a subsequent version.
 
 The Rigetti QCS API provides access to and descriptions of Rigetti quantum processors. The Rigetti QCS [online documentation](https://docs.rigetti.com) details:
 


### PR DESCRIPTION

It turns out that the TensorFlow documentation pipeline recognizes plain "Warning:" text and formats it specially, and attempting to do Markdown bold face actually creates trouble. So, let's take out the bold face.