### PR TITLE
Roll forward #6910 - CircuitOperation: change use_repetition_ids default to False

### DIFF
--- a/cirq-core/cirq/protocols/json_test_data/CircuitOperation.json
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitOperation.json
@@ -133,7 +133,8 @@
     "parent_path": [],
     "repetition_ids": [
       "0"
-    ]
+    ],
+    "use_repetition_ids": true
   },
   {
     "cirq_type": "CircuitOperation",
@@ -187,7 +188,8 @@
     "repetition_ids": [
       "a",
       "b"
-    ]
+    ],
+    "use_repetition_ids": true
   },
   {
     "cirq_type": "CircuitOperation",
@@ -217,7 +219,8 @@
     "repetition_ids": [
       "a",
       "b"
-    ]
+    ],
+    "use_repetition_ids": true
   },
   {
     "cirq_type": "CircuitOperation",

--- a/cirq-core/cirq/protocols/json_test_data/CircuitOperation.repr_inward
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitOperation.repr_inward
@@ -25,10 +25,12 @@ cirq.CircuitOperation(circuit=cirq.FrozenCircuit([
         (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
     ),
 ]),
-param_resolver={sympy.Symbol('theta'): 1.5}),
+param_resolver={sympy.Symbol('theta'): 1.5},
+use_repetition_ids=True),
 cirq.CircuitOperation(circuit=cirq.FrozenCircuit([
     cirq.Moment(
         (cirq.X**sympy.Symbol('theta')).on(cirq.LineQubit(0)),
     ),
 ]),
-param_resolver={sympy.Symbol('theta'): 1.5})]
+param_resolver={sympy.Symbol('theta'): 1.5},
+use_repetition_ids=True)]


### PR DESCRIPTION
Revert "Flip back to default `use_repetition_ids=True` in CircuitOperation (#7237)"

This reverts commit 58d9619a2a420c1a0a721b28e7d784bcc0a8ec81.

This also finalizes #7232
