### PR TITLE
Clarify instructions for release process

### DIFF
--- a/release.md
+++ b/release.md
@@ -203,7 +203,7 @@ file).
 
 ```bash
 twine upload --repository-url=https://test.pypi.org/legacy/ \
-  -u="$TEST_TWINE_USERNAME" -p="$TEST_TWINE_PASSWORD" "dist/*"
+  --password="$CIRQ_TEST_PYPI_TOKEN" "dist/*"
 ```
 
 Next, run automated verification. Note: sometimes the first verification from
@@ -221,7 +221,7 @@ any high-risk features that have changed this release.
 ```bash
 mkvirtualenv "verify_test_${VER}" --python=/usr/bin/python3
 pip install -r dev_tools/requirements/dev.env.txt
-pip install --index-url=https://test.pypi.org/simple/ cirq=="${VER}"
+pip install --extra-index-url=https://test.pypi.org/simple/ cirq=="${VER}"
 python -c "import cirq; print(cirq.__version__)"
 python  # just do some stuff checking that latest features are present
 ```
@@ -264,8 +264,7 @@ git log <previous version>..HEAD --pretty="%an" | sort |\
 Upload to prod PyPI using the following command:
 
 ```bash
-twine upload --username="$PROD_TWINE_USERNAME" \
-  --password="$PROD_TWINE_PASSWORD" "dist/*"
+twine upload --password="$CIRQ_PYPI_TOKEN" "dist/*"
 ```
 
 Perform automated verification tests:

--- a/release.md
+++ b/release.md
@@ -126,11 +126,7 @@ distribution. This can be done by visiting https://test.pypi.org, logging in,
 and accessing the https://test.pypi.org/project/cirq page.
 
 For the following script to work, you will need the following environment
-variables defined: `TEST_TWINE_USERNAME`, `TEST_TWINE_PASSWORD`,
-`PROD_TWINE_USERNAME`, `PROD_TWINE_PASSWORD`.
-
-It is highly recommended to use different passwords for test and prod to avoid
-accidentally pushing to prod.
+variables defined: `CIRQ_TEST_PYPI_TOKEN`, `CIRQ_PYPI_TOKEN`.
 
 Also define these variables for the versions you are releasing:
 


### PR DESCRIPTION
- update twine authentication arguments

- when installing from Test PyPI pass it via `--extra-index-url`
  so that standard index remains in use for cirq dependencies
