### PR TITLE
Fix #7267: reorder cirq + cirq-rigetti module installation & import

### DIFF
--- a/docs/hardware/rigetti/getting_started.ipynb
+++ b/docs/hardware/rigetti/getting_started.ipynb
@@ -115,11 +115,12 @@
     "    import cirq\n",
     "    import cirq_rigetti\n",
     "except ImportError:\n",
-    "    print(\"installing cirq-rigetti...\")\n",
-    "    !pip install --quiet cirq-rigetti\n",
-    "    print(\"installed cirq-rigetti.\")\n",
+    "    print(\"Installing packages cirq and cirq-rigetti...\")\n",
+    "    !pip install --quiet cirq\n",
     "    import cirq\n",
+    "    !pip install --quiet cirq-rigetti\n",
     "    import cirq_rigetti"
+    "    print(\"Installed packages cirq and cirq-rigetti.\")\n",
    ]
   },
   {
@@ -128,7 +129,7 @@
     "id": "jApPwKwJZ76B"
    },
    "source": [
-    "Running this notebook requires the pyQuil QVM and Compiler. If you are running on Google Colab or a Linux Debian machine, you can run the below cell to install them if necessary. If you are on a non-Linux Debian machine, see [these instructions](https://pyquil-docs.rigetti.com/en/stable/start.html#downloading-the-qvm-and-compiler){:.external} for installation."
+    "Running this notebook requires the pyQuil QVM and Compiler. If you are running on Google Colab or a Linux Debian machine, you can run the cell below to install them if necessary. If you are on a non-Linux Debian machine, see [these instructions](https://pyquil-docs.rigetti.com/en/stable/start.html#downloading-the-qvm-and-compiler){:.external} for installation."
    ]
   },
   {


### PR DESCRIPTION

Pasting the following code into a cell in a fresh notebook in colab.research.google.com,

```python
try:
    import cirq
    import cirq_rigetti
except ImportError:
    print("installing cirq-rigetti...")
    !pip install --quiet cirq-rigetti
    print("installed cirq-rigetti.")
    import cirq
    import cirq_rigetti
```

produces the error described in issue #7267. The reason is the following. The `cirq-rigetti` module requires NumPy version 1.x, so pip-installing the Rigetti module causes NumPy 1.x to be installed. However, the Colab environment comes with version 2.x preloaded. When Cirq is imported, it results in an import of `numpy`, which (because the NumPy module outside the Python environment has been changed) results in NumPy 1.x being imported into a Python runtime that already has NumPy 2 loaded.

Changing the order a little bit seems to work: pip-install Cirq first, import it (which doesn't result in errors because it doesn't load a conflicting version of NumPy), then after that, pip-install cirq-rigetti separately, followed by importing it.

This allows the packages to load. Unfortunately, I can't get the forest-sdk package to install in my Colab environment, so I can't go far in testing whether the rest of the notebook works.