### PR TITLE
Adjust quantum_order_finder result for power-of-two multiples of the actual order

### DIFF
--- a/examples/shor.py
+++ b/examples/shor.py
@@ -268,6 +268,8 @@ def quantum_order_finder(x: int, n: int) -> Optional[int]:
     r = f.denominator
     if x**r % n != 1:
         return None  # pragma: no cover
+    while r % 2 == 0 and x ** (r // 2) > n:
+        r //= 2  # pragma: no cover
     return r
 
 


### PR DESCRIPTION
Fix test failure where order of 2 for 7 is returned as 6 instead of 3:

  pytest --randomly-seed=2114237555 examples/examples_test.py
