### PR TITLE
Simplify decomposition of controlled eigengates with global phase

### DIFF
--- a/cirq-core/cirq/ops/classically_controlled_operation_test.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation_test.py
@@ -473,7 +473,8 @@ def test_decompose():
     op = cirq.H(q0).with_classical_controls('a')
     assert cirq.decompose(op) == [
         (cirq.Y(q0) ** 0.5).with_classical_controls('a'),
-        cirq.XPowGate(exponent=1.0, global_shift=-0.25).on(q0).with_classical_controls('a'),
+        cirq.X(q0).with_classical_controls('a'),
+        cirq.global_phase_operation(1j**-0.5).with_classical_controls('a'),
     ]
 
 

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -352,6 +352,12 @@ class Rx(XPowGate):
     def _with_exponent(self, exponent: value.TParamVal) -> 'Rx':
         return Rx(rads=exponent * _pi(exponent))
 
+    def _decompose_(self, qubits: Tuple['cirq.Qid', ...]) -> NotImplementedType:
+        """Returns:
+        NotImplemented, to signify the gate doesn't decompose further.
+        """
+        return NotImplemented
+
     def _circuit_diagram_info_(
         self, args: 'cirq.CircuitDiagramInfoArgs'
     ) -> Union[str, 'protocols.CircuitDiagramInfo']:
@@ -536,6 +542,12 @@ class Ry(YPowGate):
 
     def _with_exponent(self, exponent: value.TParamVal) -> 'Ry':
         return Ry(rads=exponent * _pi(exponent))
+
+    def _decompose_(self, qubits: Tuple['cirq.Qid', ...]) -> NotImplementedType:
+        """Returns:
+        NotImplemented, to signify the gate doesn't decompose further.
+        """
+        return NotImplemented
 
     def _circuit_diagram_info_(
         self, args: 'cirq.CircuitDiagramInfoArgs'
@@ -881,6 +893,12 @@ class Rz(ZPowGate):
 
     def _with_exponent(self, exponent: value.TParamVal) -> 'Rz':
         return Rz(rads=exponent * _pi(exponent))
+
+    def _decompose_(self, qubits: Tuple['cirq.Qid', ...]) -> NotImplementedType:
+        """Returns:
+        NotImplemented, to signify the gate doesn't decompose further.
+        """
+        return NotImplemented
 
     def _circuit_diagram_info_(
         self, args: 'cirq.CircuitDiagramInfoArgs'

--- a/cirq-core/cirq/ops/controlled_gate_test.py
+++ b/cirq-core/cirq/ops/controlled_gate_test.py
@@ -494,6 +494,22 @@ def _test_controlled_gate_is_consistent(
         np.testing.assert_allclose(cirq.unitary(cgate), cirq.unitary(circuit), atol=1e-13)
 
 
+@pytest.mark.parametrize(
+    'sub_gate, expected_decomposition',
+    [
+        (cirq.XPowGate(global_shift=0.22), [cirq.Y**-0.5, cirq.CZ, cirq.Y**0.5, cirq.Z**0.22]),
+        (cirq.ZPowGate(exponent=1.2, global_shift=0.3), [cirq.CZ**1.2, cirq.Z**0.36]),
+    ],
+)
+def test_decompose_takes_out_global_phase(
+    sub_gate: cirq.Gate, expected_decomposition: Sequence[cirq.Gate]
+):
+    cgate = cirq.ControlledGate(sub_gate, num_controls=1)
+    qubits = cirq.LineQubit.range(cgate.num_qubits())
+    dec = cirq.decompose(cgate.on(*qubits))
+    assert [op.gate for op in dec] == expected_decomposition
+
+
 def test_pow_inverse():
     assert cirq.inverse(CRestricted, None) is None
     assert cirq.pow(CRestricted, 1.5, None) is None

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -647,7 +647,7 @@ def test_tagged_operation_forwards_protocols():
     np.testing.assert_equal(cirq.unitary(tagged_h), cirq.unitary(h))
     assert cirq.has_unitary(tagged_h)
     assert cirq.decompose(tagged_h) == cirq.decompose(h)
-    assert [*tagged_h._decompose_()] == cirq.decompose(h)
+    assert [*tagged_h._decompose_()] == cirq.decompose_once(h)
     assert cirq.pauli_expansion(tagged_h) == cirq.pauli_expansion(h)
     assert cirq.equal_up_to_global_phase(h, tagged_h)
     assert np.isclose(cirq.kraus(h), cirq.kraus(tagged_h)).all()

--- a/cirq-core/cirq/transformers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates.py
@@ -116,7 +116,7 @@ def merge_single_qubit_moments_to_phxz(
 
     def can_merge_moment(m: 'cirq.Moment'):
         return all(
-            protocols.num_qubits(op) == 1
+            (protocols.num_qubits(op) == 1 or protocols.num_qubits(op) == 0)
             and protocols.has_unitary(op)
             and tags_to_ignore.isdisjoint(op.tags)
             for op in m
@@ -144,6 +144,10 @@ def merge_single_qubit_moments_to_phxz(
                     )
                     if gate:
                         ret_ops.append(gate(q))
+        # Transfer global phase
+        for op in m1.operations + m2.operations:
+            if protocols.num_qubits(op) == 0:
+                ret_ops.append(op)
         return circuits.Moment(ret_ops)
 
     return transformer_primitives.merge_moments(

--- a/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
@@ -221,13 +221,45 @@ def test_merge_single_qubit_moments_to_phxz_deep():
     )
 
 
-def test_merge_single_qubit_moments_to_phxz_global_phase():
+def test_merge_single_qubit_gates_to_phxz_global_phase():
     c = cirq.Circuit(cirq.GlobalPhaseGate(1j).on())
     c2 = cirq.merge_single_qubit_gates_to_phxz(c)
     assert c == c2
 
 
-def test_merge_single_qubit_moments_to_phased_x_and_z_global_phase():
+def test_merge_single_qubit_gates_to_phased_x_and_z_global_phase():
     c = cirq.Circuit(cirq.GlobalPhaseGate(1j).on())
     c2 = cirq.merge_single_qubit_gates_to_phased_x_and_z(c)
     assert c == c2
+
+
+def test_merge_single_qubit_moments_to_phxz_with_global_phase_in_first_moment():
+    q0 = cirq.LineQubit(0)
+    c_orig = cirq.Circuit(
+        cirq.Moment(cirq.Y(q0) ** 0.5, cirq.GlobalPhaseGate(1j**0.5).on()), cirq.Moment(cirq.X(q0))
+    )
+    c_expected = cirq.Circuit(
+        cirq.Moment(
+            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=-1.0).on(q0),
+            cirq.GlobalPhaseGate(1j**0.5).on(),
+        )
+    )
+    context = cirq.TransformerContext(tags_to_ignore=["ignore"])
+    c_new = cirq.merge_single_qubit_moments_to_phxz(c_orig, context=context)
+    assert c_new == c_expected
+
+
+def test_merge_single_qubit_moments_to_phxz_with_global_phase_in_second_moment():
+    q0 = cirq.LineQubit(0)
+    c_orig = cirq.Circuit(
+        cirq.Moment(cirq.Y(q0) ** 0.5), cirq.Moment(cirq.X(q0), cirq.GlobalPhaseGate(1j**0.5).on())
+    )
+    c_expected = cirq.Circuit(
+        cirq.Moment(
+            cirq.PhasedXZGate(axis_phase_exponent=-0.5, x_exponent=0.5, z_exponent=-1.0).on(q0),
+            cirq.GlobalPhaseGate(1j**0.5).on(),
+        )
+    )
+    context = cirq.TransformerContext(tags_to_ignore=["ignore"])
+    c_new = cirq.merge_single_qubit_moments_to_phxz(c_orig, context=context)
+    assert c_new == c_expected


### PR DESCRIPTION
Fixes #7238 following the recommendations in the issue description: I added a `_decompose_` method to `EigenGate` that extracts global phase, and updated `ControlledGate._decompose_with_context_` to try to extract the global phase first.

This PR may be undesirable because gates that fix `global_shift` need to implement their own `_decompose_` method. I did this for `Rx`, `Ry` and `Rz`, but I don't have a nice solution for a not-yet implemented gate that derives from `EigenGate` and fixes `global_shift`: any such gate must have a `_decompose_` method. See the discussion in #7238.

While implementing this change I found two issues:
* On line 650 in cirq-core/cirq/ops/raw_types_test.py, the check should be `assert [*tagged_h._decompose_()] == cirq.decompose_once(h)`. `tagged_h._decompose_` calls `decompose_once`, so it must be compared with `cirq.decompose_once`, not with `cirq.decompose`. The difference became visible when a second step in the decomposition extracted the global phase.
* `merge_single_qubit_moments_to_phxz` doesn't handle well global phase. A global phase gate gets assigned to the first moment, and in the current implementation this makes it unmergeable with the next moment. I found this while examining a test failure. I fixed this, and created a test case to show the problem.

It may make sense to address these issues in separate PRs, independent of this one. Let me know!