### PR TITLE
Fixes crash when printing circuit with controlled MatrixGate

### DIFF
--- a/cirq-core/cirq/ops/matrix_gates.py
+++ b/cirq-core/cirq/ops/matrix_gates.py
@@ -187,6 +187,9 @@ class MatrixGate(raw_types.Gate):
         self, args: 'cirq.CircuitDiagramInfoArgs'
     ) -> 'cirq.CircuitDiagramInfo':
         n_qubits = len(self._qid_shape)
+        # No diagram for zero-qubit gates; let fallback handle it
+        if n_qubits == 0:
+            return NotImplemented
         if self._name is not None:
             symbols = (
                 [self._name] if n_qubits == 1 else [f'{self._name}[{i+1}]' for i in range(n_qubits)]

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
@@ -115,6 +115,13 @@ def test_circuit_diagram_info_pass_fail():
     assert cirq.circuit_diagram_info(E()) == cirq.CircuitDiagramInfo(('X',))
 
 
+def test_controlled_1x1_matrixgate_diagram_error():
+    q = cirq.LineQubit(0)
+    g = cirq.MatrixGate(np.array([[1j]])).controlled()
+    c = cirq.Circuit(g(q))
+    assert str(c) == "0: ───C[[0.+1.j]]───"
+
+
 def test_circuit_diagram_info_args_eq():
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.CircuitDiagramInfoArgs.UNINFORMED_DEFAULT)


### PR DESCRIPTION
## Description

Fixes #7243 
This PR corrects the way Cirq prints a controlled 1×1 MatrixGate in ASCII/Unicode circuit diagrams and tidies up the underlying protocol behavior. Previously, attempting to draw a 1×1 controlled gate raised a TypeError. Now it will render correctly, and a unit test has been created to verify the output.

## Changes:

matrix_gates.py
Early‑return NotImplemented for zero‑qubit MatrixGate, deferring to the fallback renderer.

circuit_diagram_info_protocol_test.py
Updated test_controlled_1x1_matrixgate_diagram_error to assert the exact rendered string:
0: ───C[[0.+1.j]]───  

## Testing:
Ran pytest cirq/protocols/circuit_diagram_info_protocol_test.py — all relevant tests pass.
