### PR TITLE
Switch to unquoted type annotations part 4

### DIFF
--- a/cirq-core/cirq/protocols/measurement_key_protocol.py
+++ b/cirq-core/cirq/protocols/measurement_key_protocol.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Protocol for object that have measurement keys."""
+
+from __future__ import annotations
 
 from types import NotImplementedType
 from typing import Any, FrozenSet, Mapping, Optional, Tuple, TYPE_CHECKING, Union
@@ -60,7 +63,7 @@ class SupportsMeasurementKey(Protocol):
         """Return if this object is (or contains) a measurement."""
 
     @doc_private
-    def _measurement_key_obj_(self) -> 'cirq.MeasurementKey':
+    def _measurement_key_obj_(self) -> cirq.MeasurementKey:
         """Return the key object that will be used to identify this measurement.
 
         When a measurement occurs, either on hardware, or in a simulation,
@@ -71,7 +74,7 @@ class SupportsMeasurementKey(Protocol):
     @doc_private
     def _measurement_key_objs_(
         self,
-    ) -> Union[FrozenSet['cirq.MeasurementKey'], NotImplementedType, None]:
+    ) -> Union[FrozenSet[cirq.MeasurementKey], NotImplementedType, None]:
         """Return the key objects for measurements performed by the receiving object.
 
         When a measurement occurs, either on hardware, or in a simulation,
@@ -175,7 +178,7 @@ def measurement_key_name(val: Any, default: Any = RaiseTypeErrorIfNotProvided):
 
 def _measurement_key_objs_from_magic_methods(
     val: Any,
-) -> Union[FrozenSet['cirq.MeasurementKey'], NotImplementedType, None]:
+) -> Union[FrozenSet[cirq.MeasurementKey], NotImplementedType, None]:
     """Uses the measurement key related magic methods to get the `MeasurementKey`s for this
     object."""
 
@@ -209,7 +212,7 @@ def _measurement_key_names_from_magic_methods(
     return result
 
 
-def measurement_key_objs(val: Any) -> FrozenSet['cirq.MeasurementKey']:
+def measurement_key_objs(val: Any) -> FrozenSet[cirq.MeasurementKey]:
     """Gets the measurement key objects of measurements within the given value.
 
     Args:
@@ -316,9 +319,7 @@ def with_key_path_prefix(val: Any, prefix: Tuple[str, ...]):
 
 
 def with_rescoped_keys(
-    val: Any,
-    path: Tuple[str, ...],
-    bindable_keys: Optional[FrozenSet['cirq.MeasurementKey']] = None,
+    val: Any, path: Tuple[str, ...], bindable_keys: Optional[FrozenSet[cirq.MeasurementKey]] = None
 ):
     """Rescopes any measurement and control keys to the provided path, given the existing keys.
 

--- a/cirq-core/cirq/protocols/pow_protocol.py
+++ b/cirq-core/cirq/protocols/pow_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Callable, Optional, overload, TYPE_CHECKING, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -26,29 +28,27 @@ TDefault = TypeVar('TDefault')
 
 # pylint: disable=function-redefined, redefined-builtin
 @overload
-def pow(val: 'cirq.Gate', exponent: Any) -> 'cirq.Gate':
+def pow(val: cirq.Gate, exponent: Any) -> cirq.Gate:
     pass
 
 
 @overload
-def pow(val: 'cirq.Operation', exponent: Any) -> 'cirq.Operation':
+def pow(val: cirq.Operation, exponent: Any) -> cirq.Operation:
     pass
 
 
 @overload
-def pow(val: 'cirq.Gate', exponent: Any, default: TDefault) -> Union[TDefault, 'cirq.Gate']:
+def pow(val: cirq.Gate, exponent: Any, default: TDefault) -> Union[TDefault, cirq.Gate]:
     pass
 
 
 @overload
-def pow(
-    val: 'cirq.Operation', exponent: Any, default: TDefault
-) -> Union[TDefault, 'cirq.Operation']:
+def pow(val: cirq.Operation, exponent: Any, default: TDefault) -> Union[TDefault, cirq.Operation]:
     pass
 
 
 @overload
-def pow(val: 'cirq.Circuit', exponent: int, default: TDefault) -> Union[TDefault, 'cirq.Circuit']:
+def pow(val: cirq.Circuit, exponent: int, default: TDefault) -> Union[TDefault, cirq.Circuit]:
     pass
 
 

--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import string
 from types import NotImplementedType
 from typing import Any, Dict, Iterable, Optional, Tuple, TYPE_CHECKING, TypeVar, Union
@@ -36,7 +38,7 @@ class QasmArgs(string.Formatter):
         self,
         precision: int = 10,
         version: str = '2.0',
-        qubit_id_map: Optional[Dict['cirq.Qid', str]] = None,
+        qubit_id_map: Optional[Dict[cirq.Qid, str]] = None,
         meas_key_id_map: Optional[Dict[str, str]] = None,
         meas_key_bitcount: Optional[Dict[str, int]] = None,
     ) -> None:
@@ -124,7 +126,7 @@ class SupportsQasmWithArgsAndQubits(Protocol):
 
     @doc_private
     def _qasm_(
-        self, qubits: Tuple['cirq.Qid'], args: QasmArgs
+        self, qubits: Tuple[cirq.Qid], args: QasmArgs
     ) -> Union[None, NotImplementedType, str]:
         pass
 
@@ -134,7 +136,7 @@ def qasm(
     val: Any,
     *,
     args: Optional[QasmArgs] = None,
-    qubits: Optional[Iterable['cirq.Qid']] = None,
+    qubits: Optional[Iterable[cirq.Qid]] = None,
     default: TDefault = RaiseTypeErrorIfNotProvided,
 ) -> Union[str, TDefault]:
     """Returns QASM code for the given value, if possible.

--- a/cirq-core/cirq/protocols/resolve_parameters.py
+++ b/cirq-core/cirq/protocols/resolve_parameters.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numbers
 from typing import AbstractSet, Any, cast, TYPE_CHECKING, TypeVar
 
@@ -48,7 +50,7 @@ class SupportsParameterization(Protocol):
         """
 
     @doc_private
-    def _resolve_parameters_(self, resolver: 'cirq.ParamResolver', recursive: bool) -> Self:
+    def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> Self:
         """Resolve the parameters in the effect."""
 
 
@@ -133,7 +135,7 @@ def parameter_symbols(val: Any) -> AbstractSet[sympy.Symbol]:
 
 
 def resolve_parameters(
-    val: T, param_resolver: 'cirq.ParamResolverOrSimilarType', recursive: bool = True
+    val: T, param_resolver: cirq.ParamResolverOrSimilarType, recursive: bool = True
 ) -> T:
     """Resolves symbol parameters in the effect using the param resolver.
 
@@ -195,6 +197,6 @@ def resolve_parameters(
         return val
 
 
-def resolve_parameters_once(val: Any, param_resolver: 'cirq.ParamResolverOrSimilarType'):
+def resolve_parameters_once(val: Any, param_resolver: cirq.ParamResolverOrSimilarType):
     """Performs a single parameter resolution step using the param resolver."""
     return resolve_parameters(val, param_resolver, False)

--- a/cirq-core/cirq/qis/clifford_tableau.py
+++ b/cirq-core/cirq/qis/clifford_tableau.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import abc
 from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
 
@@ -286,10 +288,10 @@ class CliffordTableau(StabilizerState):
             and np.array_equal(self.zs, other.zs)
         )
 
-    def __copy__(self) -> 'CliffordTableau':
+    def __copy__(self) -> CliffordTableau:
         return self.copy()
 
-    def copy(self, deep_copy_buffers: bool = True) -> 'CliffordTableau':
+    def copy(self, deep_copy_buffers: bool = True) -> CliffordTableau:
         state = CliffordTableau(self.n)
         state.rs = self.rs.copy()
         state.xs = self.xs.copy()
@@ -364,7 +366,7 @@ class CliffordTableau(StabilizerState):
 
         return '\n'.join([title_row, divider, *contents]) + '\n'
 
-    def then(self, second: 'CliffordTableau') -> 'CliffordTableau':
+    def then(self, second: CliffordTableau) -> CliffordTableau:
         """Returns a composed CliffordTableau of this tableau and the second tableau.
 
         Then composed tableau is equal to (up to global phase) the composed
@@ -431,7 +433,7 @@ class CliffordTableau(StabilizerState):
 
         return merged_tableau
 
-    def inverse(self) -> 'CliffordTableau':
+    def inverse(self) -> CliffordTableau:
         """Returns the inverse Clifford tableau of this tableau."""
         ret_table = CliffordTableau(num_qubits=self.n)
         # It relies on the symplectic property of Clifford tableau.
@@ -450,7 +452,7 @@ class CliffordTableau(StabilizerState):
         ret_table.rs = ret_table.then(self).rs
         return ret_table
 
-    def __matmul__(self, second: 'CliffordTableau'):
+    def __matmul__(self, second: CliffordTableau):
         if not isinstance(second, CliffordTableau):
             return NotImplemented
         return second.then(self)
@@ -481,7 +483,7 @@ class CliffordTableau(StabilizerState):
         self._xs[q1, :] ^= self._xs[q2, :]
         self._zs[q1, :] ^= self._zs[q2, :]
 
-    def _row_to_dense_pauli(self, i: int) -> 'cirq.DensePauliString':
+    def _row_to_dense_pauli(self, i: int) -> cirq.DensePauliString:
         """Return a dense Pauli string for the given row in the tableau.
 
         Args:
@@ -509,12 +511,12 @@ class CliffordTableau(StabilizerState):
                 pauli_mask += "I"
         return DensePauliString(pauli_mask, coefficient=coefficient)
 
-    def stabilizers(self) -> List['cirq.DensePauliString']:
+    def stabilizers(self) -> List[cirq.DensePauliString]:
         """Returns the stabilizer generators of the state. These
         are n operators {S_1,S_2,...,S_n} such that S_i |psi> = |psi>"""
         return [self._row_to_dense_pauli(i) for i in range(self.n, 2 * self.n)]
 
-    def destabilizers(self) -> List['cirq.DensePauliString']:
+    def destabilizers(self) -> List[cirq.DensePauliString]:
         """Returns the destabilizer generators of the state. These
         are n operators {S_1,S_2,...,S_n} such that along with the stabilizer
         generators above generate the full Pauli group on n qubits."""
@@ -662,7 +664,7 @@ class CliffordTableau(StabilizerState):
         pass
 
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         return [self._measure(axis, random_state.parse_random_state(seed)) for axis in axes]
 

--- a/cirq-core/cirq/qis/measures.py
+++ b/cirq-core/cirq/qis/measures.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Measures on and between quantum states and operations."""
 
+from __future__ import annotations
 
 from typing import Optional, Tuple, TYPE_CHECKING
 
@@ -58,9 +60,7 @@ def _validate_int_state(state: int, qid_shape: Optional[Tuple[int, ...]]) -> Non
             )
 
 
-def _validate_product_state(
-    state: 'cirq.ProductState', qid_shape: Optional[Tuple[int, ...]]
-) -> None:
+def _validate_product_state(state: cirq.ProductState, qid_shape: Optional[Tuple[int, ...]]) -> None:
     if qid_shape is not None and qid_shape != (2,) * len(state):
         raise ValueError(
             'Invalid state for given qid shape: '
@@ -70,8 +70,8 @@ def _validate_product_state(
 
 
 def fidelity(
-    state1: 'cirq.QUANTUM_STATE_LIKE',
-    state2: 'cirq.QUANTUM_STATE_LIKE',
+    state1: cirq.QUANTUM_STATE_LIKE,
+    state2: cirq.QUANTUM_STATE_LIKE,
     qid_shape: Optional[Tuple[int, ...]] = None,
     validate: bool = True,
     atol: float = 1e-7,
@@ -255,7 +255,7 @@ def _fidelity_state_vectors_or_density_matrices(state1: np.ndarray, state2: np.n
 
 
 def von_neumann_entropy(
-    state: 'cirq.QUANTUM_STATE_LIKE',
+    state: cirq.QUANTUM_STATE_LIKE,
     qid_shape: Optional[Tuple[int, ...]] = None,
     validate: bool = True,
     atol: float = 1e-7,
@@ -298,7 +298,7 @@ def von_neumann_entropy(
     return 0.0
 
 
-def entanglement_fidelity(operation: 'cirq.SupportsKraus') -> float:
+def entanglement_fidelity(operation: cirq.SupportsKraus) -> float:
     r"""Returns entanglement fidelity of a given quantum channel.
 
     Entanglement fidelity $F_e$ of a quantum channel $E: L(H) \to L(H)$ is the overlap between

--- a/cirq-core/cirq/qis/quantum_state_representation.py
+++ b/cirq-core/cirq/qis/quantum_state_representation.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import abc
 from typing import List, Sequence, Tuple, TYPE_CHECKING
 
@@ -38,7 +40,7 @@ class QuantumStateRepresentation(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         """Measures the state.
 
@@ -50,10 +52,7 @@ class QuantumStateRepresentation(metaclass=abc.ABCMeta):
         """
 
     def sample(
-        self,
-        axes: Sequence[int],
-        repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        self, axes: Sequence[int], repetitions: int = 1, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> np.ndarray:
         """Samples the state. Subclasses can override with more performant method.
 

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -14,6 +14,8 @@
 
 """Classes and methods for quantum states."""
 
+from __future__ import annotations
+
 import itertools
 from typing import Any, cast, Iterable, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
@@ -64,7 +66,7 @@ class QuantumState:
         data: np.ndarray,
         qid_shape: Optional[Tuple[int, ...]] = None,
         *,  # Force keyword arguments
-        dtype: Optional['DTypeLike'] = None,
+        dtype: Optional[DTypeLike] = None,
         validate: bool = True,
         atol: float = 1e-7,
     ) -> None:
@@ -156,7 +158,7 @@ class QuantumState:
         return self.data.shape == (self._dim, self._dim)
 
     def validate(
-        self, *, dtype: Optional['DTypeLike'] = None, atol=1e-7  # Force keyword arguments
+        self, *, dtype: Optional[DTypeLike] = None, atol=1e-7  # Force keyword arguments
     ) -> None:
         """Check if this quantum state is valid.
 
@@ -188,12 +190,12 @@ class QuantumState:
 
 
 def quantum_state(
-    state: 'cirq.QUANTUM_STATE_LIKE',
+    state: cirq.QUANTUM_STATE_LIKE,
     qid_shape: Optional[Tuple[int, ...]] = None,
     *,  # Force keyword arguments
     copy: bool = False,
     validate: bool = True,
-    dtype: Optional['DTypeLike'] = None,
+    dtype: Optional[DTypeLike] = None,
     atol: float = 1e-7,
 ) -> QuantumState:
     """Create a QuantumState object from a state-like object.
@@ -297,7 +299,7 @@ def density_matrix(
     *,  # Force keyword arguments
     copy: bool = False,
     validate: bool = True,
-    dtype: Optional['DTypeLike'] = None,
+    dtype: Optional[DTypeLike] = None,
     atol: float = 1e-7,
 ) -> QuantumState:
     """Create a QuantumState object from a density matrix.
@@ -350,7 +352,7 @@ _NON_INT_STATE_LIKE = Union[
 ]
 
 
-def infer_qid_shape(*states: 'cirq.QUANTUM_STATE_LIKE') -> Tuple[int, ...]:
+def infer_qid_shape(*states: cirq.QUANTUM_STATE_LIKE) -> Tuple[int, ...]:
     """Infer the qid shape of a set of states.
 
     This is a heuristic to determine a qid shape compatible with all of the
@@ -410,7 +412,7 @@ def infer_qid_shape(*states: 'cirq.QUANTUM_STATE_LIKE') -> Tuple[int, ...]:
     return qid_shape
 
 
-def _potential_qid_shapes(state: _NON_INT_STATE_LIKE) -> '_QidShapeSet':
+def _potential_qid_shapes(state: _NON_INT_STATE_LIKE) -> _QidShapeSet:
     """Return a set of qid shapes compatible with a given state."""
     if isinstance(state, QuantumState):
         return _QidShapeSet(explicit_qid_shapes={state.qid_shape})
@@ -472,7 +474,7 @@ class _QidShapeSet:
         self.unfactorized_total_dimension = unfactorized_total_dimension
         self.min_qudit_dimensions = min_qudit_dimensions
 
-    def intersection_subset(self, other: '_QidShapeSet'):
+    def intersection_subset(self, other: _QidShapeSet):
         """Return a subset of the intersection with other qid shape set."""
         explicit_qid_shapes = self.explicit_qid_shapes & other.explicit_qid_shapes
         unfactorized_total_dimension = None
@@ -761,11 +763,11 @@ def dirac_notation(
 
 
 def to_valid_state_vector(
-    state_rep: 'cirq.STATE_VECTOR_LIKE',
+    state_rep: cirq.STATE_VECTOR_LIKE,
     num_qubits: Optional[int] = None,
     *,  # Force keyword arguments
     qid_shape: Optional[Sequence[int]] = None,
-    dtype: Optional['DTypeLike'] = None,
+    dtype: Optional[DTypeLike] = None,
     atol: float = 1e-7,
 ) -> np.ndarray:
     """Verifies the state_rep is valid and converts it to ndarray form.
@@ -830,7 +832,7 @@ def to_valid_state_vector(
 
 
 def _qudit_values_to_state_tensor(
-    *, state_vector: np.ndarray, qid_shape: Tuple[int, ...], dtype: Optional['DTypeLike']
+    *, state_vector: np.ndarray, qid_shape: Tuple[int, ...], dtype: Optional[DTypeLike]
 ) -> np.ndarray:
     for i in range(len(qid_shape)):
         s = state_vector[i]
@@ -863,7 +865,7 @@ def validate_normalized_state_vector(
     state_vector: np.ndarray,
     *,  # Force keyword arguments
     qid_shape: Tuple[int, ...],
-    dtype: Optional['DTypeLike'] = None,
+    dtype: Optional[DTypeLike] = None,
     atol: float = 1e-7,
 ) -> None:
     """Checks that the given state vector is valid.
@@ -928,11 +930,11 @@ def validate_indices(num_qubits: int, indices: Sequence[int]) -> None:
 
 
 def to_valid_density_matrix(
-    density_matrix_rep: Union[np.ndarray, 'cirq.STATE_VECTOR_LIKE'],
+    density_matrix_rep: Union[np.ndarray, cirq.STATE_VECTOR_LIKE],
     num_qubits: Optional[int] = None,
     *,  # Force keyword arguments
     qid_shape: Optional[Tuple[int, ...]] = None,
-    dtype: Optional['DTypeLike'] = None,
+    dtype: Optional[DTypeLike] = None,
     atol: float = 1e-7,
 ) -> np.ndarray:
     """Verifies the density_matrix_rep is valid and converts it to ndarray form.
@@ -981,7 +983,7 @@ def validate_density_matrix(
     density_matrix: np.ndarray,
     *,  # Force keyword arguments
     qid_shape: Tuple[int, ...],
-    dtype: Optional['DTypeLike'] = None,
+    dtype: Optional[DTypeLike] = None,
     atol: float = 1e-7,
 ) -> None:
     """Checks that the given density matrix is valid.
@@ -1049,7 +1051,7 @@ def one_hot(
     index: Union[None, int, Sequence[int]] = None,
     shape: Union[int, Sequence[int]],
     value: Any = 1,
-    dtype: 'DTypeLike',
+    dtype: DTypeLike,
 ) -> np.ndarray:
     """Returns a numpy array with all 0s and a single non-zero entry(default 1).
 
@@ -1070,7 +1072,7 @@ def one_hot(
     return result
 
 
-def eye_tensor(half_shape: Tuple[int, ...], *, dtype: 'DTypeLike') -> np.ndarray:
+def eye_tensor(half_shape: Tuple[int, ...], *, dtype: DTypeLike) -> np.ndarray:
     """Returns an identity matrix reshaped into a tensor.
 
     Args:

--- a/cirq-core/cirq/sim/classical_simulator.py
+++ b/cirq-core/cirq/sim/classical_simulator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from copy import copy, deepcopy
 from typing import Any, Dict, Generic, List, Optional, Sequence, TYPE_CHECKING, Union
@@ -45,7 +46,7 @@ class ClassicalBasisState(qis.QuantumStateRepresentation):
         """
         self.basis = initial_state
 
-    def copy(self, deep_copy_buffers: bool = True) -> 'ClassicalBasisState':
+    def copy(self, deep_copy_buffers: bool = True) -> ClassicalBasisState:
         """Creates a copy of the ClassicalBasisState object.
 
         Args:
@@ -58,7 +59,7 @@ class ClassicalBasisState(qis.QuantumStateRepresentation):
         )
 
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         """Measures the density matrix.
 
@@ -77,8 +78,8 @@ class ClassicalBasisSimState(SimulationState[ClassicalBasisState]):
     def __init__(
         self,
         initial_state: Union[int, List[int]] = 0,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Initializes the ClassicalBasisSimState object.
 
@@ -105,7 +106,7 @@ class ClassicalBasisSimState(SimulationState[ClassicalBasisState]):
             raise ValueError('initial_state must be an int or List[int] or np.ndarray')
         super().__init__(state=state, qubits=qubits, classical_data=classical_data)
 
-    def _act_on_fallback_(self, action, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True):
+    def _act_on_fallback_(self, action, qubits: Sequence[cirq.Qid], allow_decompose: bool = True):
         """Acts on the state with a given operation.
 
         Args:
@@ -182,7 +183,7 @@ class ClassicalStateSimulator(
     """A simulator that accepts only gates with classical counterparts."""
 
     def __init__(
-        self, *, noise: 'cirq.NOISE_MODEL_LIKE' = None, split_untangled_states: bool = False
+        self, *, noise: cirq.NOISE_MODEL_LIKE = None, split_untangled_states: bool = False
     ):
         """Initializes a ClassicalStateSimulator.
 
@@ -199,10 +200,10 @@ class ClassicalStateSimulator(
 
     def _create_simulator_trial_result(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[ClassicalBasisSimState]',
-    ) -> 'ClassicalStateTrialResult[ClassicalBasisSimState]':
+        final_simulator_state: cirq.SimulationStateBase[ClassicalBasisSimState],
+    ) -> ClassicalStateTrialResult[ClassicalBasisSimState]:
         """Creates a trial result for the simulator.
 
         Args:
@@ -217,8 +218,8 @@ class ClassicalStateSimulator(
         )
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[ClassicalBasisSimState]'
-    ) -> 'ClassicalStateStepResult[ClassicalBasisSimState]':
+        self, sim_state: cirq.SimulationStateBase[ClassicalBasisSimState]
+    ) -> ClassicalStateStepResult[ClassicalBasisSimState]:
         """Creates a step result for the simulator.
 
         Args:
@@ -231,9 +232,9 @@ class ClassicalStateSimulator(
     def _create_partial_simulation_state(
         self,
         initial_state: Any,
-        qubits: Sequence['cirq.Qid'],
-        classical_data: 'cirq.ClassicalDataStore',
-    ) -> 'ClassicalBasisSimState':
+        qubits: Sequence[cirq.Qid],
+        classical_data: cirq.ClassicalDataStore,
+    ) -> ClassicalBasisSimState:
         """Creates a partial simulation state for the simulator.
 
         Args:

--- a/cirq-core/cirq/sim/clifford/clifford_simulator.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator.py
@@ -30,6 +30,8 @@ The quantum state is specified in two forms:
     to state vector amplitudes.
 """
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Sequence, Union
 
 import numpy as np
@@ -50,7 +52,7 @@ class CliffordSimulator(
     """An efficient simulator for Clifford circuits."""
 
     def __init__(
-        self, seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None, split_untangled_states: bool = False
+        self, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None, split_untangled_states: bool = False
     ):
         """Creates instance of `CliffordSimulator`.
 
@@ -63,17 +65,17 @@ class CliffordSimulator(
         super().__init__(seed=seed, split_untangled_states=split_untangled_states)
 
     @staticmethod
-    def is_supported_operation(op: 'cirq.Operation') -> bool:
+    def is_supported_operation(op: cirq.Operation) -> bool:
         """Checks whether given operation can be simulated by this simulator."""
         # TODO: support more general Pauli measurements
         return protocols.has_stabilizer_effect(op)
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union[int, 'cirq.StabilizerChFormSimulationState'],
-        qubits: Sequence['cirq.Qid'],
-        classical_data: 'cirq.ClassicalDataStore',
-    ) -> 'cirq.StabilizerChFormSimulationState':
+        initial_state: Union[int, cirq.StabilizerChFormSimulationState],
+        qubits: Sequence[cirq.Qid],
+        classical_data: cirq.ClassicalDataStore,
+    ) -> cirq.StabilizerChFormSimulationState:
         """Creates the StabilizerChFormSimulationState for a circuit.
 
         Args:
@@ -101,15 +103,15 @@ class CliffordSimulator(
         )
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[clifford.StabilizerChFormSimulationState]'
+        self, sim_state: cirq.SimulationStateBase[clifford.StabilizerChFormSimulationState]
     ):
         return CliffordSimulatorStepResult(sim_state=sim_state)
 
     def _create_simulator_trial_result(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StabilizerChFormSimulationState]',
+        final_simulator_state: cirq.SimulationStateBase[cirq.StabilizerChFormSimulationState],
     ):
         return CliffordTrialResult(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
@@ -121,16 +123,16 @@ class CliffordTrialResult(
 ):
     def __init__(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StabilizerChFormSimulationState]',
+        final_simulator_state: cirq.SimulationStateBase[cirq.StabilizerChFormSimulationState],
     ) -> None:
         super().__init__(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
         )
 
     @property
-    def final_state(self) -> 'cirq.CliffordState':
+    def final_state(self) -> cirq.CliffordState:
         state = self._get_merged_sim_state()
         clifford_state = CliffordState(state.qubit_map)
         clifford_state.ch_form = state.state.copy()
@@ -152,7 +154,7 @@ class CliffordSimulatorStepResult(
     """A `StepResult` that includes `StateVectorMixin` methods."""
 
     def __init__(
-        self, sim_state: 'cirq.SimulationStateBase[clifford.StabilizerChFormSimulationState]'
+        self, sim_state: cirq.SimulationStateBase[clifford.StabilizerChFormSimulationState]
     ):
         """Results of a step of the simulator.
         Attributes:
@@ -199,7 +201,7 @@ class CliffordState:
     Gates and measurements are applied to each representation in O(n^2) time.
     """
 
-    def __init__(self, qubit_map, initial_state: Union[int, 'cirq.StabilizerStateChForm'] = 0):
+    def __init__(self, qubit_map, initial_state: Union[int, cirq.StabilizerStateChForm] = 0):
         self.qubit_map = qubit_map
         self.n = len(qubit_map)
 
@@ -222,7 +224,7 @@ class CliffordState:
     def _value_equality_values_(self) -> Any:
         return self.qubit_map, self.ch_form
 
-    def copy(self) -> 'cirq.CliffordState':
+    def copy(self) -> cirq.CliffordState:
         state = CliffordState(self.qubit_map)
         state.ch_form = self.ch_form.copy()
 
@@ -241,7 +243,7 @@ class CliffordState:
     def state_vector(self):
         return self.ch_form.state_vector()
 
-    def apply_unitary(self, op: 'cirq.Operation'):
+    def apply_unitary(self, op: cirq.Operation):
         ch_form_args = clifford.StabilizerChFormSimulationState(
             prng=np.random.RandomState(), qubits=self.qubit_map.keys(), initial_state=self.ch_form
         )
@@ -253,7 +255,7 @@ class CliffordState:
 
     def apply_measurement(
         self,
-        op: 'cirq.Operation',
+        op: cirq.Operation,
         measurements: Dict[str, List[int]],
         prng: np.random.RandomState,
         collapse_state_vector=True,

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A protocol for implementing high performance clifford tableau evolutions
 for Clifford Simulator."""
+
+from __future__ import annotations
 
 from typing import Optional, Sequence, TYPE_CHECKING
 
@@ -30,10 +33,10 @@ class CliffordTableauSimulationState(StabilizerSimulationState[clifford_tableau.
 
     def __init__(
         self,
-        tableau: 'cirq.CliffordTableau',
+        tableau: cirq.CliffordTableau,
         prng: Optional[np.random.RandomState] = None,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Inits CliffordTableauSimulationState.
 
@@ -51,5 +54,5 @@ class CliffordTableauSimulationState(StabilizerSimulationState[clifford_tableau.
         super().__init__(state=tableau, prng=prng, qubits=qubits, classical_data=classical_data)
 
     @property
-    def tableau(self) -> 'cirq.CliffordTableau':
+    def tableau(self) -> cirq.CliffordTableau:
         return self.state

--- a/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional, Sequence, TYPE_CHECKING, Union
 
 import numpy as np
@@ -33,9 +35,9 @@ class StabilizerChFormSimulationState(
         self,
         *,
         prng: Optional[np.random.RandomState] = None,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        initial_state: Union[int, 'cirq.StabilizerStateChForm'] = 0,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        initial_state: Union[int, cirq.StabilizerStateChForm] = 0,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Initializes with the given state and the axes for the operation.
 

--- a/cirq-core/cirq/sim/clifford/stabilizer_sampler.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_sampler.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, List, Sequence
 
 import numpy as np
@@ -26,7 +28,7 @@ from cirq.work import sampler
 class StabilizerSampler(sampler.Sampler):
     """An efficient sampler for stabilizer circuits."""
 
-    def __init__(self, *, seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None):
+    def __init__(self, *, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None):
         """Inits StabilizerSampler.
 
         Args:
@@ -36,8 +38,8 @@ class StabilizerSampler(sampler.Sampler):
         self._prng = value.parse_random_state(seed)
 
     def run_sweep(
-        self, program: 'cirq.AbstractCircuit', params: 'cirq.Sweepable', repetitions: int = 1
-    ) -> Sequence['cirq.Result']:
+        self, program: cirq.AbstractCircuit, params: cirq.Sweepable, repetitions: int = 1
+    ) -> Sequence[cirq.Result]:
         results: List[cirq.Result] = []
         for param_resolver in cirq.to_resolvers(params):
             resolved_circuit = cirq.resolve_parameters(program, param_resolver)
@@ -45,7 +47,7 @@ class StabilizerSampler(sampler.Sampler):
             results.append(cirq.ResultDict(params=param_resolver, measurements=measurements))
         return results
 
-    def _run(self, circuit: 'cirq.AbstractCircuit', repetitions: int) -> Dict[str, np.ndarray]:
+    def _run(self, circuit: cirq.AbstractCircuit, repetitions: int) -> Dict[str, np.ndarray]:
 
         measurements: Dict[str, List[np.ndarray]] = {
             key: [] for key in protocols.measurement_key_names(circuit)

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import abc
 from types import NotImplementedType
 from typing import Any, cast, Generic, Optional, Sequence, TYPE_CHECKING, TypeVar, Union
@@ -42,8 +44,8 @@ class StabilizerSimulationState(
         *,
         state: TStabilizerState,
         prng: Optional[np.random.RandomState] = None,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Initializes the StabilizerSimulationState.
 
@@ -65,7 +67,7 @@ class StabilizerSimulationState(
         return self._state
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> Union[bool, NotImplementedType]:
         strats = [self._strat_apply_gate, self._strat_apply_mixture]
         if allow_decompose:
@@ -89,7 +91,7 @@ class StabilizerSimulationState(
         self._state.apply_cx(target_axis, control_axis, exponent, global_shift)
         self._state.apply_cx(control_axis, target_axis)
 
-    def _strat_apply_gate(self, val: Any, qubits: Sequence['cirq.Qid']) -> bool:
+    def _strat_apply_gate(self, val: Any, qubits: Sequence[cirq.Qid]) -> bool:
         if not protocols.has_stabilizer_effect(val):
             return NotImplemented
         gate = val.gate if isinstance(val, ops.Operation) else val
@@ -117,7 +119,7 @@ class StabilizerSimulationState(
             return NotImplemented
         return True
 
-    def _strat_apply_mixture(self, val: Any, qubits: Sequence['cirq.Qid']) -> bool:
+    def _strat_apply_mixture(self, val: Any, qubits: Sequence[cirq.Qid]) -> bool:
         mixture = protocols.mixture(val, None)
         if mixture is None:
             return NotImplemented
@@ -129,9 +131,7 @@ class StabilizerSimulationState(
             matrix_gates.MatrixGate(unitaries[index]), qubits
         )
 
-    def _strat_act_from_single_qubit_decompose(
-        self, val: Any, qubits: Sequence['cirq.Qid']
-    ) -> bool:
+    def _strat_act_from_single_qubit_decompose(self, val: Any, qubits: Sequence[cirq.Qid]) -> bool:
         if num_qubits(val) == 1:
             if not has_unitary(val):
                 return NotImplemented
@@ -148,7 +148,7 @@ class StabilizerSimulationState(
 
         return NotImplemented
 
-    def _strat_decompose(self, val: Any, qubits: Sequence['cirq.Qid']) -> bool:
+    def _strat_decompose(self, val: Any, qubits: Sequence[cirq.Qid]) -> bool:
         gate = val.gate if isinstance(val, ops.Operation) else val
         operations = protocols.decompose_once_with_qubits(gate, qubits, None)
         if operations is None or not all(protocols.has_stabilizer_effect(op) for op in operations):

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Sequence
 
 import numpy as np
@@ -81,7 +83,7 @@ class StabilizerStateChForm(qis.StabilizerState):
     def _value_equality_values_(self) -> Any:
         return (self.n, self.G, self.F, self.M, self.gamma, self.v, self.s, self.omega)
 
-    def copy(self, deep_copy_buffers: bool = True) -> 'cirq.StabilizerStateChForm':
+    def copy(self, deep_copy_buffers: bool = True) -> cirq.StabilizerStateChForm:
         copy = StabilizerStateChForm(self.n)
 
         copy.G = self.G.copy()
@@ -267,7 +269,7 @@ class StabilizerStateChForm(qis.StabilizerState):
 
         self.update_sum(t, u, delta=delta)
 
-    def kron(self, other: 'cirq.StabilizerStateChForm') -> 'cirq.StabilizerStateChForm':
+    def kron(self, other: cirq.StabilizerStateChForm) -> cirq.StabilizerStateChForm:
         n = self.n + other.n
         copy = StabilizerStateChForm(n)
         copy.G[: self.n, : self.n] = self.G
@@ -282,7 +284,7 @@ class StabilizerStateChForm(qis.StabilizerState):
         copy.omega = self.omega * other.omega
         return copy
 
-    def reindex(self, axes: Sequence[int]) -> 'cirq.StabilizerStateChForm':
+    def reindex(self, axes: Sequence[int]) -> cirq.StabilizerStateChForm:
         copy = StabilizerStateChForm(self.n)
         copy.G = self.G[axes][:, axes]
         copy.F = self.F[axes][:, axes]
@@ -387,7 +389,7 @@ class StabilizerStateChForm(qis.StabilizerState):
         self.omega *= coefficient
 
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         return [self._measure(axis, random_state.parse_random_state(seed)) for axis in axes]
 

--- a/cirq-core/cirq/sim/density_matrix_simulation_state.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state.py
@@ -14,6 +14,8 @@
 
 """Objects and methods for acting efficiently on a density matrix."""
 
+from __future__ import annotations
+
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, TYPE_CHECKING, Union
 
 import numpy as np
@@ -55,7 +57,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
     def create(
         cls,
         *,
-        initial_state: Union[np.ndarray, 'cirq.STATE_VECTOR_LIKE'] = 0,
+        initial_state: Union[np.ndarray, cirq.STATE_VECTOR_LIKE] = 0,
         qid_shape: Optional[Tuple[int, ...]] = None,
         dtype: Optional[Type[np.complexfloating]] = None,
         buffer: Optional[List[np.ndarray]] = None,
@@ -91,7 +93,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         density_matrix = density_matrix.astype(dtype, copy=False)
         return cls(density_matrix, buffer)
 
-    def copy(self, deep_copy_buffers: bool = True) -> '_BufferedDensityMatrix':
+    def copy(self, deep_copy_buffers: bool = True) -> _BufferedDensityMatrix:
         """Copies the object.
 
         Args:
@@ -104,7 +106,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
             buffer=[b.copy() for b in self._buffer] if deep_copy_buffers else self._buffer,
         )
 
-    def kron(self, other: '_BufferedDensityMatrix') -> '_BufferedDensityMatrix':
+    def kron(self, other: _BufferedDensityMatrix) -> _BufferedDensityMatrix:
         """Creates the Kronecker product with the other density matrix.
 
         Args:
@@ -119,7 +121,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
 
     def factor(
         self, axes: Sequence[int], *, validate=True, atol=1e-07
-    ) -> Tuple['_BufferedDensityMatrix', '_BufferedDensityMatrix']:
+    ) -> Tuple[_BufferedDensityMatrix, _BufferedDensityMatrix]:
         """Factors out the desired axes.
 
         Args:
@@ -141,7 +143,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         remainder = _BufferedDensityMatrix(density_matrix=remainder_tensor)
         return extracted, remainder
 
-    def reindex(self, axes: Sequence[int]) -> '_BufferedDensityMatrix':
+    def reindex(self, axes: Sequence[int]) -> _BufferedDensityMatrix:
         """Transposes the axes of a density matrix to a specified order.
 
         Args:
@@ -185,7 +187,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         return True
 
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         """Measures the density matrix.
 
@@ -205,10 +207,7 @@ class _BufferedDensityMatrix(qis.QuantumStateRepresentation):
         return bits
 
     def sample(
-        self,
-        axes: Sequence[int],
-        repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        self, axes: Sequence[int], repetitions: int = 1, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> np.ndarray:
         """Samples the density matrix.
 
@@ -248,10 +247,10 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
         *,
         available_buffer: Optional[List[np.ndarray]] = None,
         prng: Optional[np.random.RandomState] = None,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        initial_state: Union[np.ndarray, 'cirq.STATE_VECTOR_LIKE'] = 0,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        initial_state: Union[np.ndarray, cirq.STATE_VECTOR_LIKE] = 0,
         dtype: Type[np.complexfloating] = np.complex64,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Inits DensityMatrixSimulationState.
 
@@ -285,7 +284,7 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
         )
         super().__init__(state=state, prng=prng, qubits=qubits, classical_data=classical_data)
 
-    def add_qubits(self, qubits: Sequence['cirq.Qid']):
+    def add_qubits(self, qubits: Sequence[cirq.Qid]):
         ret = super().add_qubits(qubits)
         return (
             self.kronecker_product(type(self)(qubits=qubits), inplace=True)
@@ -293,7 +292,7 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
             else ret
         )
 
-    def remove_qubits(self, qubits: Sequence['cirq.Qid']):
+    def remove_qubits(self, qubits: Sequence[cirq.Qid]):
         ret = super().remove_qubits(qubits)
         if ret is not NotImplemented:
             return ret
@@ -302,9 +301,9 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
         return remainder
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> bool:
-        strats: List[Callable[[Any, Any, Sequence['cirq.Qid']], bool]] = [
+        strats: List[Callable[[Any, Any, Sequence[cirq.Qid]], bool]] = [
             _strat_apply_channel_to_state
         ]
         if allow_decompose:
@@ -346,7 +345,7 @@ class DensityMatrixSimulationState(SimulationState[_BufferedDensityMatrix]):
 
 
 def _strat_apply_channel_to_state(
-    action: Any, args: 'cirq.DensityMatrixSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: cirq.DensityMatrixSimulationState, qubits: Sequence[cirq.Qid]
 ) -> bool:
     """Apply channel to state."""
     if not args._state.apply_channel(action, args.get_axes(qubits)):

--- a/cirq-core/cirq/sim/density_matrix_simulator.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Simulator for density matrices that simulates noisy quantum circuits."""
+
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Sequence, Type, TYPE_CHECKING, Union
 
 import numpy as np
@@ -116,8 +120,8 @@ class DensityMatrixSimulator(
         self,
         *,
         dtype: Type[np.complexfloating] = np.complex64,
-        noise: 'cirq.NOISE_MODEL_LIKE' = None,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        noise: cirq.NOISE_MODEL_LIKE = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         split_untangled_states: bool = True,
     ):
         """Density matrix simulator.
@@ -147,12 +151,10 @@ class DensityMatrixSimulator(
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union[
-            np.ndarray, 'cirq.STATE_VECTOR_LIKE', 'cirq.DensityMatrixSimulationState'
-        ],
-        qubits: Sequence['cirq.Qid'],
-        classical_data: 'cirq.ClassicalDataStore',
-    ) -> 'cirq.DensityMatrixSimulationState':
+        initial_state: Union[np.ndarray, cirq.STATE_VECTOR_LIKE, cirq.DensityMatrixSimulationState],
+        qubits: Sequence[cirq.Qid],
+        classical_data: cirq.ClassicalDataStore,
+    ) -> cirq.DensityMatrixSimulationState:
         """Creates the DensityMatrixSimulationState for a circuit.
 
         Args:
@@ -183,16 +185,16 @@ class DensityMatrixSimulator(
         return not protocols.measurement_keys_touched(val)
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]'
+        self, sim_state: cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]
     ):
         return DensityMatrixStepResult(sim_state=sim_state, dtype=self._dtype)
 
     def _create_simulator_trial_result(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]',
-    ) -> 'cirq.DensityMatrixTrialResult':
+        final_simulator_state: cirq.SimulationStateBase[cirq.DensityMatrixSimulationState],
+    ) -> cirq.DensityMatrixTrialResult:
         return DensityMatrixTrialResult(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
         )
@@ -200,10 +202,10 @@ class DensityMatrixSimulator(
     # TODO(#4209): Deduplicate with identical code in sparse_simulator.
     def simulate_expectation_values_sweep(
         self,
-        program: 'cirq.AbstractCircuit',
-        observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> List[List[float]]:
@@ -242,7 +244,7 @@ class DensityMatrixStepResult(simulator_base.StepResultBase['cirq.DensityMatrixS
 
     def __init__(
         self,
-        sim_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]',
+        sim_state: cirq.SimulationStateBase[cirq.DensityMatrixSimulationState],
         dtype: Type[np.complexfloating] = np.complex64,
     ):
         """DensityMatrixStepResult.
@@ -353,9 +355,9 @@ class DensityMatrixTrialResult(
 
     def __init__(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.DensityMatrixSimulationState]',
+        final_simulator_state: cirq.SimulationStateBase[cirq.DensityMatrixSimulationState],
     ) -> None:
         super().__init__(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -14,6 +14,8 @@
 
 """Code to handle density matrices."""
 
+from __future__ import annotations
+
 from typing import List, Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -31,7 +33,7 @@ def sample_density_matrix(
     *,  # Force keyword arguments
     qid_shape: Optional[Tuple[int, ...]] = None,
     repetitions: int = 1,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> np.ndarray:
     """Samples repeatedly from measurements in the computational basis.
 
@@ -96,7 +98,7 @@ def measure_density_matrix(
     indices: Sequence[int],
     qid_shape: Optional[Tuple[int, ...]] = None,
     out: Optional[np.ndarray] = None,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> Tuple[List[int], np.ndarray]:
     """Performs a measurement of the density matrix in the computational basis.
 

--- a/cirq-core/cirq/sim/mux.py
+++ b/cirq-core/cirq/sim/mux.py
@@ -17,6 +17,8 @@
 Filename is a reference to multiplexing.
 """
 
+from __future__ import annotations
+
 from typing import List, Optional, Sequence, Type, TYPE_CHECKING, Union
 
 import numpy as np
@@ -39,7 +41,7 @@ document(
 )
 
 
-def _is_clifford_circuit(program: 'cirq.Circuit') -> bool:
+def _is_clifford_circuit(program: cirq.Circuit) -> bool:
     return all(
         clifford_simulator.CliffordSimulator.is_supported_operation(op)
         for op in program.all_operations()
@@ -47,14 +49,14 @@ def _is_clifford_circuit(program: 'cirq.Circuit') -> bool:
 
 
 def sample(
-    program: 'cirq.Circuit',
+    program: cirq.Circuit,
     *,
-    noise: 'cirq.NOISE_MODEL_LIKE' = None,
-    param_resolver: Optional['cirq.ParamResolver'] = None,
+    noise: cirq.NOISE_MODEL_LIKE = None,
+    param_resolver: Optional[cirq.ParamResolver] = None,
     repetitions: int = 1,
     dtype: Type[np.complexfloating] = np.complex64,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
-) -> 'cirq.Result':
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
+) -> cirq.Result:
     """Simulates sampling from the given circuit.
 
     Args:
@@ -90,7 +92,7 @@ def sample(
     ).run(program=program, param_resolver=param_resolver, repetitions=repetitions)
 
 
-def _to_circuit(program: 'cirq.CIRCUIT_LIKE') -> 'cirq.Circuit':
+def _to_circuit(program: cirq.CIRCUIT_LIKE) -> cirq.Circuit:
     if isinstance(program, circuits.Circuit):
         # No change needed.
         result = program
@@ -103,14 +105,14 @@ def _to_circuit(program: 'cirq.CIRCUIT_LIKE') -> 'cirq.Circuit':
 
 
 def final_state_vector(
-    program: 'cirq.CIRCUIT_LIKE',
+    program: cirq.CIRCUIT_LIKE,
     *,
-    initial_state: 'cirq.STATE_VECTOR_LIKE' = 0,
-    param_resolver: 'cirq.ParamResolverOrSimilarType' = None,
-    qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+    initial_state: cirq.STATE_VECTOR_LIKE = 0,
+    param_resolver: cirq.ParamResolverOrSimilarType = None,
+    qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ignore_terminal_measurements: bool = False,
     dtype: Type[np.complexfloating] = np.complex64,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> np.ndarray:
     """Returns the state vector resulting from acting operations on a state.
 
@@ -174,14 +176,14 @@ def final_state_vector(
 
 
 def sample_sweep(
-    program: 'cirq.Circuit',
-    params: 'cirq.Sweepable',
+    program: cirq.Circuit,
+    params: cirq.Sweepable,
     *,
-    noise: 'cirq.NOISE_MODEL_LIKE' = None,
+    noise: cirq.NOISE_MODEL_LIKE = None,
     repetitions: int = 1,
     dtype: Type[np.complexfloating] = np.complex64,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
-) -> Sequence['cirq.Result']:
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
+) -> Sequence[cirq.Result]:
     """Runs the supplied Circuit, mimicking quantum hardware.
 
     In contrast to run, this allows for sweeping over different parameter
@@ -219,16 +221,16 @@ def sample_sweep(
 
 
 def final_density_matrix(
-    program: 'cirq.CIRCUIT_LIKE',
+    program: cirq.CIRCUIT_LIKE,
     *,
-    noise: 'cirq.NOISE_MODEL_LIKE' = None,
-    initial_state: 'cirq.STATE_VECTOR_LIKE' = 0,
-    param_resolver: 'cirq.ParamResolverOrSimilarType' = None,
-    qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+    noise: cirq.NOISE_MODEL_LIKE = None,
+    initial_state: cirq.STATE_VECTOR_LIKE = 0,
+    param_resolver: cirq.ParamResolverOrSimilarType = None,
+    qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     dtype: Type[np.complexfloating] = np.complex64,
     seed: Optional[Union[int, np.random.RandomState]] = None,
     ignore_measurement_results: bool = True,
-) -> 'np.ndarray':
+) -> np.ndarray:
     """Returns the density matrix resulting from simulating the circuit.
 
     Note that, unlike `cirq.final_state_vector`, terminal measurements

--- a/cirq-core/cirq/sim/simulation_product_state.py
+++ b/cirq-core/cirq/sim/simulation_product_state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import abc
 from typing import Any, Dict, Generic, Iterator, List, Mapping, Optional, Sequence, TYPE_CHECKING
 
@@ -32,10 +34,10 @@ class SimulationProductState(
 
     def __init__(
         self,
-        sim_states: Dict[Optional['cirq.Qid'], TSimulationState],
-        qubits: Sequence['cirq.Qid'],
+        sim_states: Dict[Optional[cirq.Qid], TSimulationState],
+        qubits: Sequence[cirq.Qid],
         split_untangled_states: bool,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Initializes the class.
 
@@ -55,7 +57,7 @@ class SimulationProductState(
         self._split_untangled_states = split_untangled_states
 
     @property
-    def sim_states(self) -> Mapping[Optional['cirq.Qid'], TSimulationState]:
+    def sim_states(self) -> Mapping[Optional[cirq.Qid], TSimulationState]:
         return self._sim_states
 
     @property
@@ -78,7 +80,7 @@ class SimulationProductState(
         return merged_state.transpose_to_qubit_order(self.qubits, inplace=True)
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> bool:
         gate_opt = (
             action
@@ -136,9 +138,7 @@ class SimulationProductState(
                 self._sim_states[q] = op_args
         return True
 
-    def copy(
-        self, deep_copy_buffers: bool = True
-    ) -> 'cirq.SimulationProductState[TSimulationState]':
+    def copy(self, deep_copy_buffers: bool = True) -> cirq.SimulationProductState[TSimulationState]:
         classical_data = self._classical_data.copy()
         copies = {}
         for sim_state in set(self.sim_states.values()):
@@ -152,9 +152,9 @@ class SimulationProductState(
 
     def sample(
         self,
-        qubits: List['cirq.Qid'],
+        qubits: List[cirq.Qid],
         repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ) -> np.ndarray:
         columns = []
         selected_order: List[ops.Qid] = []
@@ -170,11 +170,11 @@ class SimulationProductState(
         index_order = [qubit_map[q] for q in qubits]
         return stacked[:, index_order]
 
-    def __getitem__(self, item: Optional['cirq.Qid']) -> TSimulationState:
+    def __getitem__(self, item: Optional[cirq.Qid]) -> TSimulationState:
         return self.sim_states[item]
 
     def __len__(self) -> int:
         return len(self.sim_states)
 
-    def __iter__(self) -> Iterator[Optional['cirq.Qid']]:
+    def __iter__(self) -> Iterator[Optional[cirq.Qid]]:
         return iter(self.sim_states)

--- a/cirq-core/cirq/sim/simulation_product_state_test.py
+++ b/cirq-core/cirq/sim/simulation_product_state_test.py
@@ -42,7 +42,7 @@ class EmptySimulationState(cirq.SimulationState):
         super().__init__(state=EmptyQuantumState(), qubits=qubits, classical_data=classical_data)
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> bool:
         return True
 
@@ -52,9 +52,9 @@ qs2 = cirq.LineQubit.range(2)
 
 
 def create_container(
-    qubits: Sequence['cirq.Qid'], split_untangled_states=True
+    qubits: Sequence[cirq.Qid], split_untangled_states=True
 ) -> cirq.SimulationProductState[EmptySimulationState]:
-    state_map: Dict[Optional['cirq.Qid'], EmptySimulationState] = {}
+    state_map: Dict[Optional[cirq.Qid], EmptySimulationState] = {}
     log = cirq.ClassicalDataDictionaryStore()
     if split_untangled_states:
         for q in reversed(qubits):

--- a/cirq-core/cirq/sim/simulation_state.py
+++ b/cirq-core/cirq/sim/simulation_state.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Objects and methods for acting efficiently on a state tensor."""
+
+from __future__ import annotations
+
 import abc
 import copy
 from typing import (
@@ -49,8 +53,8 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         *,
         state: TState,
         prng: Optional[np.random.RandomState] = None,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Inits SimulationState.
 
@@ -79,7 +83,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
 
     def measure(
         self,
-        qubits: Sequence['cirq.Qid'],
+        qubits: Sequence[cirq.Qid],
         key: str,
         invert_mask: Sequence[bool],
         confusion_map: Dict[Tuple[int, ...], np.ndarray],
@@ -106,10 +110,10 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
             value.MeasurementKey.parse_serialized(key), corrected, qubits
         )
 
-    def get_axes(self, qubits: Sequence['cirq.Qid']) -> List[int]:
+    def get_axes(self, qubits: Sequence[cirq.Qid]) -> List[int]:
         return [self.qubit_map[q] for q in qubits]
 
-    def _perform_measurement(self, qubits: Sequence['cirq.Qid']) -> List[int]:
+    def _perform_measurement(self, qubits: Sequence[cirq.Qid]) -> List[int]:
         """Delegates the call to measure the `QuantumStateRepresentation`."""
         if self._state is not None:
             return self._state.measure(self.get_axes(qubits), self.prng)
@@ -118,7 +122,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
     def _confuse_result(
         self,
         bits: List[int],
-        qubits: Sequence['cirq.Qid'],
+        qubits: Sequence[cirq.Qid],
         confusion_map: Dict[Tuple[int, ...], np.ndarray],
     ):
         """Applies confusion matrices to measured results.
@@ -138,9 +142,9 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
 
     def sample(
         self,
-        qubits: Sequence['cirq.Qid'],
+        qubits: Sequence[cirq.Qid],
         repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ) -> np.ndarray:
         if self._state is not None:
             return self._state.sample(self.get_axes(qubits), repetitions, seed)
@@ -166,7 +170,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         """Creates a final merged state."""
         return self
 
-    def add_qubits(self: Self, qubits: Sequence['cirq.Qid']) -> Self:
+    def add_qubits(self: Self, qubits: Sequence[cirq.Qid]) -> Self:
         """Add `qubits` in the `|0>` state to a new state space and take the kron product.
 
         Args:
@@ -181,7 +185,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
             return self
         return NotImplemented
 
-    def remove_qubits(self: Self, qubits: Sequence['cirq.Qid']) -> Self:
+    def remove_qubits(self: Self, qubits: Sequence[cirq.Qid]) -> Self:
         """Remove `qubits` from the state space.
 
         The qubits to be removed should be untangled from rest of the system and in the |0> state.
@@ -206,7 +210,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         return args
 
     def factor(
-        self, qubits: Sequence['cirq.Qid'], *, validate=True, atol=1e-07, inplace=False
+        self, qubits: Sequence[cirq.Qid], *, validate=True, atol=1e-07, inplace=False
     ) -> Tuple[Self, Self]:
         """Splits two state spaces after a measurement or reset."""
         extracted = copy.copy(self)
@@ -223,7 +227,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         """Subclasses that allow factorization should override this."""
         return self._state.supports_factor if self._state is not None else False
 
-    def transpose_to_qubit_order(self, qubits: Sequence['cirq.Qid'], *, inplace=False) -> Self:
+    def transpose_to_qubit_order(self, qubits: Sequence[cirq.Qid], *, inplace=False) -> Self:
         """Physically reindexes the state by the new basis.
 
         Args:
@@ -245,10 +249,10 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         return args
 
     @property
-    def qubits(self) -> Tuple['cirq.Qid', ...]:
+    def qubits(self) -> Tuple[cirq.Qid, ...]:
         return self._qubits
 
-    def swap(self, q1: 'cirq.Qid', q2: 'cirq.Qid', *, inplace=False):
+    def swap(self, q1: cirq.Qid, q2: cirq.Qid, *, inplace=False):
         """Swaps two qubits.
 
         This only affects the index, and does not modify the underlying
@@ -279,7 +283,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         args._set_qubits(qubits)
         return args
 
-    def rename(self, q1: 'cirq.Qid', q2: 'cirq.Qid', *, inplace=False):
+    def rename(self, q1: cirq.Qid, q2: cirq.Qid, *, inplace=False):
         """Renames `q1` to `q2`.
 
         Args:
@@ -306,7 +310,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
         args._set_qubits(qubits)
         return args
 
-    def __getitem__(self, item: Optional['cirq.Qid']) -> Self:
+    def __getitem__(self, item: Optional[cirq.Qid]) -> Self:
         if item not in self.qubit_map:
             raise IndexError(f'{item} not in {self.qubits}')
         return self
@@ -314,7 +318,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
     def __len__(self) -> int:
         return len(self.qubits)
 
-    def __iter__(self) -> Iterator[Optional['cirq.Qid']]:
+    def __iter__(self) -> Iterator[Optional[cirq.Qid]]:
         return iter(self.qubits)
 
     @property
@@ -323,7 +327,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
 
 
 def strat_act_on_from_apply_decompose(
-    val: Any, args: 'cirq.SimulationState', qubits: Sequence['cirq.Qid']
+    val: Any, args: cirq.SimulationState, qubits: Sequence[cirq.Qid]
 ) -> bool:
     if isinstance(val, ops.Gate):
         decomposed = protocols.decompose_once_with_qubits(val, qubits, flatten=False, default=None)
@@ -331,7 +335,7 @@ def strat_act_on_from_apply_decompose(
         decomposed = protocols.decompose_once(val, flatten=False, default=None)
     if decomposed is None:
         return NotImplemented
-    all_ancilla: Set['cirq.Qid'] = set()
+    all_ancilla: Set[cirq.Qid] = set()
     for operation in ops.flatten_to_ops(decomposed):
         curr_ancilla = tuple(q for q in operation.qubits if q not in args.qubits)
         args = args.add_qubits(curr_ancilla)

--- a/cirq-core/cirq/sim/simulation_state_base.py
+++ b/cirq-core/cirq/sim/simulation_state_base.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """An interface for quantum states as targets for operations."""
+
+from __future__ import annotations
+
 import abc
 from types import NotImplementedType
 from typing import (
@@ -47,8 +51,8 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
     def __init__(
         self,
         *,
-        qubits: Sequence['cirq.Qid'],
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        qubits: Sequence[cirq.Qid],
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Initializes the class.
 
@@ -61,19 +65,19 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
         self._classical_data = classical_data or value.ClassicalDataDictionaryStore()
 
     @property
-    def qubits(self) -> Tuple['cirq.Qid', ...]:
+    def qubits(self) -> Tuple[cirq.Qid, ...]:
         return self._qubits
 
     @property
-    def qubit_map(self) -> Mapping['cirq.Qid', int]:
+    def qubit_map(self) -> Mapping[cirq.Qid, int]:
         return self._qubit_map
 
-    def _set_qubits(self, qubits: Sequence['cirq.Qid']):
+    def _set_qubits(self, qubits: Sequence[cirq.Qid]):
         self._qubits = tuple(qubits)
         self._qubit_map = {q: i for i, q in enumerate(self.qubits)}
 
     @property
-    def classical_data(self) -> 'cirq.ClassicalDataStoreReader':
+    def classical_data(self) -> cirq.ClassicalDataStoreReader:
         return self._classical_data
 
     @abc.abstractmethod
@@ -82,7 +86,7 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> Union[bool, NotImplementedType]:
         """Handles the act_on protocol fallback implementation.
 
@@ -94,7 +98,7 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
         Returns:
             True if the fallback applies, else NotImplemented."""
 
-    def apply_operation(self, op: 'cirq.Operation'):
+    def apply_operation(self, op: cirq.Operation):
         protocols.act_on(op, self)
 
     @abc.abstractmethod
@@ -118,14 +122,14 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sample(
         self,
-        qubits: List['cirq.Qid'],
+        qubits: List[cirq.Qid],
         repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ) -> np.ndarray:
         """Samples the state value."""
 
     @abc.abstractmethod
-    def __getitem__(self, item: Optional['cirq.Qid']) -> TSimulationState:
+    def __getitem__(self, item: Optional[cirq.Qid]) -> TSimulationState:
         """Gets the item associated with the qubit."""
 
     @abc.abstractmethod
@@ -133,5 +137,5 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
         """Gets the number of items in the mapping."""
 
     @abc.abstractmethod
-    def __iter__(self) -> Iterator[Optional['cirq.Qid']]:
+    def __iter__(self) -> Iterator[Optional[cirq.Qid]]:
         """Iterates the keys of the mapping."""

--- a/cirq-core/cirq/sim/simulation_state_test.py
+++ b/cirq-core/cirq/sim/simulation_state_test.py
@@ -38,7 +38,7 @@ class ExampleSimulationState(cirq.SimulationState):
         super().__init__(state=ExampleQuantumState(), qubits=qubits)
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> bool:
         return True
 

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -27,6 +27,8 @@ Simulator types include:
         as the simulation iterates through the moments of a cirq.
 """
 
+from __future__ import annotations
+
 import abc
 import collections
 from typing import (
@@ -67,13 +69,13 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
     """
 
     def run_sweep(
-        self, program: 'cirq.AbstractCircuit', params: 'cirq.Sweepable', repetitions: int = 1
-    ) -> Sequence['cirq.Result']:
+        self, program: cirq.AbstractCircuit, params: cirq.Sweepable, repetitions: int = 1
+    ) -> Sequence[cirq.Result]:
         return list(self.run_sweep_iter(program, params, repetitions))
 
     def run_sweep_iter(
-        self, program: 'cirq.AbstractCircuit', params: 'cirq.Sweepable', repetitions: int = 1
-    ) -> Iterator['cirq.Result']:
+        self, program: cirq.AbstractCircuit, params: cirq.Sweepable, repetitions: int = 1
+    ) -> Iterator[cirq.Result]:
         """Runs the supplied Circuit, mimicking quantum hardware.
 
         In contrast to run, this allows for sweeping over different parameter
@@ -107,10 +109,7 @@ class SimulatesSamples(work.Sampler, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def _run(
-        self,
-        circuit: 'cirq.AbstractCircuit',
-        param_resolver: 'cirq.ParamResolver',
-        repetitions: int,
+        self, circuit: cirq.AbstractCircuit, param_resolver: cirq.ParamResolver, repetitions: int
     ) -> Dict[str, np.ndarray]:
         """Run a simulation, mimicking quantum hardware.
 
@@ -142,10 +141,10 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def compute_amplitudes(
         self,
-        program: 'cirq.AbstractCircuit',
+        program: cirq.AbstractCircuit,
         bitstrings: Sequence[int],
-        param_resolver: 'cirq.ParamResolverOrSimilarType' = None,
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        param_resolver: cirq.ParamResolverOrSimilarType = None,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> Sequence[complex]:
         """Computes the desired amplitudes.
 
@@ -173,10 +172,10 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def compute_amplitudes_sweep(
         self,
-        program: 'cirq.AbstractCircuit',
+        program: cirq.AbstractCircuit,
         bitstrings: Sequence[int],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> Sequence[Sequence[complex]]:
         """Wraps computed amplitudes in a list.
 
@@ -186,10 +185,10 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def _compute_amplitudes_sweep_to_iter(
         self,
-        program: 'cirq.AbstractCircuit',
+        program: cirq.AbstractCircuit,
         bitstrings: Sequence[int],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> Iterator[Sequence[complex]]:
         if type(self).compute_amplitudes_sweep == SimulatesAmplitudes.compute_amplitudes_sweep:
             raise RecursionError(
@@ -202,10 +201,10 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
     )
     def compute_amplitudes_sweep_iter(
         self,
-        program: 'cirq.AbstractCircuit',
+        program: cirq.AbstractCircuit,
         bitstrings: Sequence[int],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> Iterator[Sequence[complex]]:
         """Computes the desired amplitudes.
 
@@ -232,11 +231,11 @@ class SimulatesAmplitudes(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def sample_from_amplitudes(
         self,
-        circuit: 'cirq.AbstractCircuit',
-        param_resolver: 'cirq.ParamResolver',
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE',
+        circuit: cirq.AbstractCircuit,
+        param_resolver: cirq.ParamResolver,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE,
         repetitions: int = 1,
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> Dict[int, int]:
         """Uses amplitude simulation to sample from the given circuit.
 
@@ -315,10 +314,10 @@ class SimulatesExpectationValues(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def simulate_expectation_values(
         self,
-        program: 'cirq.AbstractCircuit',
-        observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-        param_resolver: 'cirq.ParamResolverOrSimilarType' = None,
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+        param_resolver: cirq.ParamResolverOrSimilarType = None,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> List[float]:
@@ -363,10 +362,10 @@ class SimulatesExpectationValues(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def simulate_expectation_values_sweep(
         self,
-        program: 'cirq.AbstractCircuit',
-        observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> List[List[float]]:
@@ -387,10 +386,10 @@ class SimulatesExpectationValues(metaclass=value.ABCMetaImplementAnyOneOf):
 
     def _simulate_expectation_values_sweep_to_iter(
         self,
-        program: 'cirq.AbstractCircuit',
-        observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> Iterator[List[float]]:
@@ -412,10 +411,10 @@ class SimulatesExpectationValues(metaclass=value.ABCMetaImplementAnyOneOf):
     )
     def simulate_expectation_values_sweep_iter(
         self,
-        program: 'cirq.AbstractCircuit',
-        observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> Iterator[List[float]]:
@@ -470,9 +469,9 @@ class SimulatesFinalState(
 
     def simulate(
         self,
-        program: 'cirq.AbstractCircuit',
-        param_resolver: 'cirq.ParamResolverOrSimilarType' = None,
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        param_resolver: cirq.ParamResolverOrSimilarType = None,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
     ) -> TSimulationTrialResult:
         """Simulates the supplied Circuit.
@@ -499,9 +498,9 @@ class SimulatesFinalState(
 
     def simulate_sweep(
         self,
-        program: 'cirq.AbstractCircuit',
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
     ) -> List[TSimulationTrialResult]:
         """Wraps computed states in a list.
@@ -512,9 +511,9 @@ class SimulatesFinalState(
 
     def _simulate_sweep_to_iter(
         self,
-        program: 'cirq.AbstractCircuit',
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
     ) -> Iterator[TSimulationTrialResult]:
         if type(self).simulate_sweep == SimulatesFinalState.simulate_sweep:
@@ -524,9 +523,9 @@ class SimulatesFinalState(
     @value.alternative(requires='simulate_sweep', implementation=_simulate_sweep_to_iter)
     def simulate_sweep_iter(
         self,
-        program: 'cirq.AbstractCircuit',
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
     ) -> Iterator[TSimulationTrialResult]:
         """Simulates the supplied Circuit.
@@ -572,9 +571,9 @@ class SimulatesIntermediateState(
 
     def simulate_sweep_iter(
         self,
-        program: 'cirq.AbstractCircuit',
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
     ) -> Iterator[TSimulationTrialResult]:
         """Simulates the supplied Circuit.
@@ -621,9 +620,9 @@ class SimulatesIntermediateState(
 
     def simulate_moment_steps(
         self,
-        circuit: 'cirq.AbstractCircuit',
-        param_resolver: 'cirq.ParamResolverOrSimilarType' = None,
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        circuit: cirq.AbstractCircuit,
+        param_resolver: cirq.ParamResolverOrSimilarType = None,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
     ) -> Iterator[TStepResult]:
         """Returns an iterator of StepResults for each moment simulated.
@@ -655,7 +654,7 @@ class SimulatesIntermediateState(
 
     @abc.abstractmethod
     def _base_iterator(
-        self, circuit: 'cirq.AbstractCircuit', qubits: Tuple['cirq.Qid', ...], initial_state: Any
+        self, circuit: cirq.AbstractCircuit, qubits: Tuple[cirq.Qid, ...], initial_state: Any
     ) -> Iterator[TStepResult]:
         """Iterator over StepResult from Moments of a Circuit.
 
@@ -675,7 +674,7 @@ class SimulatesIntermediateState(
     @abc.abstractmethod
     def _create_simulator_trial_result(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
         final_simulator_state: TSimulatorState,
     ) -> TSimulationTrialResult:
@@ -723,9 +722,9 @@ class StepResult(Generic[TSimulatorState], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sample(
         self,
-        qubits: List['cirq.Qid'],
+        qubits: List[cirq.Qid],
         repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ) -> np.ndarray:
         """Samples from the system at this point in the computation.
 
@@ -747,9 +746,9 @@ class StepResult(Generic[TSimulatorState], metaclass=abc.ABCMeta):
 
     def sample_measurement_ops(
         self,
-        measurement_ops: List['cirq.GateOperation'],
+        measurement_ops: List[cirq.GateOperation],
         repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         *,
         _allow_repeated=False,
     ) -> Dict[str, np.ndarray]:
@@ -837,9 +836,9 @@ class StepResult(Generic[TSimulatorState], metaclass=abc.ABCMeta):
     def _confuse_results(
         self,
         bits: np.ndarray,
-        qubits: Sequence['cirq.Qid'],
+        qubits: Sequence[cirq.Qid],
         confusion_map: Dict[Tuple[int, ...], np.ndarray],
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ) -> None:
         """Mutates `bits` using the confusion_map.
 
@@ -876,7 +875,7 @@ class SimulationTrialResult(Generic[TSimulatorState]):
 
     def __init__(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Mapping[str, np.ndarray],
         final_simulator_state: TSimulatorState,
     ) -> None:
@@ -895,7 +894,7 @@ class SimulationTrialResult(Generic[TSimulatorState]):
         self._final_simulator_state = final_simulator_state
 
     @property
-    def params(self) -> 'cirq.ParamResolver':
+    def params(self) -> cirq.ParamResolver:
         return self._params
 
     @property
@@ -932,7 +931,7 @@ class SimulationTrialResult(Generic[TSimulatorState]):
         return self.params, measurements, self._final_simulator_state
 
     @property
-    def qubit_map(self) -> Mapping['cirq.Qid', int]:
+    def qubit_map(self) -> Mapping[cirq.Qid, int]:
         """A map from Qid to index used to define the ordering of the basis in
         the result.
         """
@@ -942,7 +941,7 @@ class SimulationTrialResult(Generic[TSimulatorState]):
         return _qubit_map_to_shape(self.qubit_map)
 
 
-def _qubit_map_to_shape(qubit_map: Mapping['cirq.Qid', int]) -> Tuple[int, ...]:
+def _qubit_map_to_shape(qubit_map: Mapping[cirq.Qid, int]) -> Tuple[int, ...]:
     qid_shape: List[int] = [-1] * len(qubit_map)
     try:
         for q, i in qubit_map.items():
@@ -965,8 +964,8 @@ def check_all_resolved(circuit):
 
 
 def split_into_matching_protocol_then_general(
-    circuit: 'cirq.AbstractCircuit', predicate: Callable[['cirq.Operation'], bool]
-) -> Tuple['cirq.AbstractCircuit', 'cirq.AbstractCircuit']:
+    circuit: cirq.AbstractCircuit, predicate: Callable[[cirq.Operation], bool]
+) -> Tuple[cirq.AbstractCircuit, cirq.AbstractCircuit]:
     """Splits the circuit into a matching prefix and non-matching suffix.
 
     The splitting happens in a per-qubit fashion. A non-matching operation on

--- a/cirq-core/cirq/sim/simulator_base_test.py
+++ b/cirq-core/cirq/sim/simulator_base_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import math
 from typing import Any, Dict, List, Sequence, Tuple
 
@@ -29,12 +32,12 @@ class CountingState(cirq.qis.QuantumStateRepresentation):
         self.copy_count = copy_count
 
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         self.measurement_count += 1
         return [self.gate_count]
 
-    def kron(self, other: 'CountingState') -> 'CountingState':
+    def kron(self, other: CountingState) -> CountingState:
         return CountingState(
             self.data,
             self.gate_count + other.gate_count,
@@ -44,15 +47,15 @@ class CountingState(cirq.qis.QuantumStateRepresentation):
 
     def factor(
         self, axes: Sequence[int], *, validate=True, atol=1e-07
-    ) -> Tuple['CountingState', 'CountingState']:
+    ) -> Tuple[CountingState, CountingState]:
         return CountingState(
             self.data, self.gate_count, self.measurement_count, self.copy_count
         ), CountingState(self.data)
 
-    def reindex(self, axes: Sequence[int]) -> 'CountingState':
+    def reindex(self, axes: Sequence[int]) -> CountingState:
         return CountingState(self.data, self.gate_count, self.measurement_count, self.copy_count)
 
-    def copy(self, deep_copy_buffers: bool = True) -> 'CountingState':
+    def copy(self, deep_copy_buffers: bool = True) -> CountingState:
         return CountingState(
             self.data, self.gate_count, self.measurement_count, self.copy_count + 1
         )
@@ -64,7 +67,7 @@ class CountingSimulationState(cirq.SimulationState[CountingState]):
         super().__init__(state=state_obj, qubits=qubits, classical_data=classical_data)
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> bool:
         self._state.gate_count += 1
         return True
@@ -121,7 +124,7 @@ class CountingSimulator(
     def _create_partial_simulation_state(
         self,
         initial_state: Any,
-        qubits: Sequence['cirq.Qid'],
+        qubits: Sequence[cirq.Qid],
         classical_data: cirq.ClassicalDataStore,
     ) -> CountingSimulationState:
         return CountingSimulationState(
@@ -132,7 +135,7 @@ class CountingSimulator(
         self,
         params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[CountingSimulationState]',
+        final_simulator_state: cirq.SimulationStateBase[CountingSimulationState],
     ) -> CountingTrialResult:
         return CountingTrialResult(
             params, measurements, final_simulator_state=final_simulator_state
@@ -151,7 +154,7 @@ class SplittableCountingSimulator(CountingSimulator):
     def _create_partial_simulation_state(
         self,
         initial_state: Any,
-        qubits: Sequence['cirq.Qid'],
+        qubits: Sequence[cirq.Qid],
         classical_data: cirq.ClassicalDataStore,
     ) -> CountingSimulationState:
         return SplittableCountingSimulationState(

--- a/cirq-core/cirq/sim/simulator_test.py
+++ b/cirq-core/cirq/sim/simulator_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for simulator.py"""
+
+from __future__ import annotations
+
 import abc
 from typing import Any, Dict, Generic, List, Sequence, Union
 from unittest import mock
@@ -64,7 +68,7 @@ class FakeStepResult(cirq.StepResult):
 
 class SimulatesIntermediateStateImpl(
     Generic[TStepResult, TSimulationState],
-    SimulatesIntermediateState[TStepResult, 'SimulationTrialResult', TSimulationState],
+    SimulatesIntermediateState[TStepResult, SimulationTrialResult, TSimulationState],
     metaclass=abc.ABCMeta,
 ):
     """A SimulatesIntermediateState that uses the default SimulationTrialResult type."""
@@ -73,8 +77,8 @@ class SimulatesIntermediateStateImpl(
         self,
         params: study.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[TSimulationState]',
-    ) -> 'SimulationTrialResult':
+        final_simulator_state: cirq.SimulationStateBase[TSimulationState],
+    ) -> SimulationTrialResult:
         """This method creates a default trial result.
 
         Args:
@@ -455,7 +459,7 @@ def test_iter_definitions():
 
         def compute_amplitudes_sweep(
             self,
-            program: 'cirq.AbstractCircuit',
+            program: cirq.AbstractCircuit,
             bitstrings: Sequence[int],
             params: study.Sweepable,
             qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
@@ -464,9 +468,9 @@ def test_iter_definitions():
 
         def simulate_expectation_values_sweep(
             self,
-            program: 'cirq.AbstractCircuit',
-            observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-            params: 'study.Sweepable',
+            program: cirq.AbstractCircuit,
+            observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+            params: study.Sweepable,
             qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
             initial_state: Any = None,
             permit_terminal_measurements: bool = False,
@@ -475,7 +479,7 @@ def test_iter_definitions():
 
         def simulate_sweep(
             self,
-            program: 'cirq.AbstractCircuit',
+            program: cirq.AbstractCircuit,
             params: study.Sweepable,
             qubit_order: cirq.QubitOrderOrList = cirq.QubitOrder.DEFAULT,
             initial_state: Any = None,

--- a/cirq-core/cirq/sim/sparse_simulator.py
+++ b/cirq-core/cirq/sim/sparse_simulator.py
@@ -14,6 +14,8 @@
 
 """A simulator that uses numpy's einsum for sparse matrix operations."""
 
+from __future__ import annotations
+
 from typing import Any, Iterator, List, Optional, Sequence, Type, TYPE_CHECKING, Union
 
 import numpy as np
@@ -126,8 +128,8 @@ class Simulator(
         self,
         *,
         dtype: Type[np.complexfloating] = np.complex64,
-        noise: 'cirq.NOISE_MODEL_LIKE' = None,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        noise: cirq.NOISE_MODEL_LIKE = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         split_untangled_states: bool = True,
     ):
         """A sparse matrix simulator.
@@ -152,9 +154,9 @@ class Simulator(
 
     def _create_partial_simulation_state(
         self,
-        initial_state: Union['cirq.STATE_VECTOR_LIKE', 'cirq.StateVectorSimulationState'],
-        qubits: Sequence['cirq.Qid'],
-        classical_data: 'cirq.ClassicalDataStore',
+        initial_state: Union[cirq.STATE_VECTOR_LIKE, cirq.StateVectorSimulationState],
+        qubits: Sequence[cirq.Qid],
+        classical_data: cirq.ClassicalDataStore,
     ):
         """Creates the StateVectorSimulationState for a circuit.
 
@@ -183,16 +185,16 @@ class Simulator(
         )
 
     def _create_step_result(
-        self, sim_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]'
+        self, sim_state: cirq.SimulationStateBase[cirq.StateVectorSimulationState]
     ):
         return SparseSimulatorStep(sim_state=sim_state, dtype=self._dtype)
 
     def simulate_expectation_values_sweep_iter(
         self,
-        program: 'cirq.AbstractCircuit',
-        observables: Union['cirq.PauliSumLike', List['cirq.PauliSumLike']],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        program: cirq.AbstractCircuit,
+        observables: Union[cirq.PauliSumLike, List[cirq.PauliSumLike]],
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> Iterator[List[float]]:
@@ -222,7 +224,7 @@ class SparseSimulatorStep(
 
     def __init__(
         self,
-        sim_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]',
+        sim_state: cirq.SimulationStateBase[cirq.StateVectorSimulationState],
         dtype: Type[np.complexfloating] = np.complex64,
     ):
         """Results of a step of the simulator.

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Helpers for handling quantum state vectors."""
+
+from __future__ import annotations
 
 import abc
 from typing import List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING
@@ -31,7 +34,7 @@ if TYPE_CHECKING:
 class StateVectorMixin:
     """A mixin that provide methods for objects that have a state vector."""
 
-    def __init__(self, qubit_map: Optional[Mapping['cirq.Qid', int]] = None, *args, **kwargs):
+    def __init__(self, qubit_map: Optional[Mapping[cirq.Qid, int]] = None, *args, **kwargs):
         """Inits StateVectorMixin.
 
         Args:
@@ -47,7 +50,7 @@ class StateVectorMixin:
         self._qid_shape = None if qubit_map is None else qid_shape
 
     @property
-    def qubit_map(self) -> Mapping['cirq.Qid', int]:
+    def qubit_map(self) -> Mapping[cirq.Qid, int]:
         return self._qubit_map
 
     def _qid_shape_(self) -> Tuple[int, ...]:
@@ -102,7 +105,7 @@ class StateVectorMixin:
             and non-zero floats of the specified accuracy."""
         return qis.dirac_notation(self.state_vector(), decimals, qid_shape=self._qid_shape)
 
-    def density_matrix_of(self, qubits: Optional[List['cirq.Qid']] = None) -> np.ndarray:
+    def density_matrix_of(self, qubits: Optional[List[cirq.Qid]] = None) -> np.ndarray:
         r"""Returns the density matrix of the state.
 
         Calculate the density matrix for the system on the qubits provided.
@@ -141,7 +144,7 @@ class StateVectorMixin:
             qid_shape=self._qid_shape,
         )
 
-    def bloch_vector_of(self, qubit: 'cirq.Qid') -> np.ndarray:
+    def bloch_vector_of(self, qubit: cirq.Qid) -> np.ndarray:
         """Returns the bloch vector of a qubit in the state.
 
         Calculates the bloch vector of the given qubit
@@ -171,7 +174,7 @@ def sample_state_vector(
     *,  # Force keyword args
     qid_shape: Optional[Tuple[int, ...]] = None,
     repetitions: int = 1,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> np.ndarray:
     """Samples repeatedly from measurements in the computational basis.
 
@@ -236,7 +239,7 @@ def measure_state_vector(
     *,  # Force keyword args
     qid_shape: Optional[Tuple[int, ...]] = None,
     out: Optional[np.ndarray] = None,
-    seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> Tuple[List[int], np.ndarray]:
     """Performs a measurement of the state in the computational basis.
 

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Objects and methods for acting efficiently on a state vector."""
+
+from __future__ import annotations
+
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Type, TYPE_CHECKING, Union
 
 import numpy as np
@@ -50,7 +53,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
     def create(
         cls,
         *,
-        initial_state: Union[np.ndarray, 'cirq.STATE_VECTOR_LIKE'] = 0,
+        initial_state: Union[np.ndarray, cirq.STATE_VECTOR_LIKE] = 0,
         qid_shape: Optional[Tuple[int, ...]] = None,
         dtype: Optional[Type[np.complexfloating]] = None,
         buffer: Optional[np.ndarray] = None,
@@ -85,7 +88,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         state_vector = state_vector.astype(dtype, copy=False)
         return cls(state_vector, buffer)
 
-    def copy(self, deep_copy_buffers: bool = True) -> '_BufferedStateVector':
+    def copy(self, deep_copy_buffers: bool = True) -> _BufferedStateVector:
         """Copies the object.
 
         Args:
@@ -98,7 +101,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
             buffer=self._buffer.copy() if deep_copy_buffers else self._buffer,
         )
 
-    def kron(self, other: '_BufferedStateVector') -> '_BufferedStateVector':
+    def kron(self, other: _BufferedStateVector) -> _BufferedStateVector:
         """Creates the Kronecker product with the other state vector.
 
         Args:
@@ -113,7 +116,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
 
     def factor(
         self, axes: Sequence[int], *, validate=True, atol=1e-07
-    ) -> Tuple['_BufferedStateVector', '_BufferedStateVector']:
+    ) -> Tuple[_BufferedStateVector, _BufferedStateVector]:
         """Factors a state vector into two independent state vectors.
 
         This function should only be called on state vectors that are known to be separable, such
@@ -143,7 +146,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         )
         return extracted, remainder
 
-    def reindex(self, axes: Sequence[int]) -> '_BufferedStateVector':
+    def reindex(self, axes: Sequence[int]) -> _BufferedStateVector:
         """Transposes the axes of a state vector to a specified order.
 
         Args:
@@ -253,7 +256,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         return index
 
     def measure(
-        self, axes: Sequence[int], seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+        self, axes: Sequence[int], seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> List[int]:
         """Measures the state vector.
 
@@ -269,10 +272,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         return bits
 
     def sample(
-        self,
-        axes: Sequence[int],
-        repetitions: int = 1,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        self, axes: Sequence[int], repetitions: int = 1, seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None
     ) -> np.ndarray:
         """Samples the state vector.
 
@@ -322,10 +322,10 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         *,
         available_buffer: Optional[np.ndarray] = None,
         prng: Optional[np.random.RandomState] = None,
-        qubits: Optional[Sequence['cirq.Qid']] = None,
-        initial_state: Union[np.ndarray, 'cirq.STATE_VECTOR_LIKE'] = 0,
+        qubits: Optional[Sequence[cirq.Qid]] = None,
+        initial_state: Union[np.ndarray, cirq.STATE_VECTOR_LIKE] = 0,
         dtype: Type[np.complexfloating] = np.complex64,
-        classical_data: Optional['cirq.ClassicalDataStore'] = None,
+        classical_data: Optional[cirq.ClassicalDataStore] = None,
     ):
         """Inits StateVectorSimulationState.
 
@@ -356,7 +356,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         )
         super().__init__(state=state, prng=prng, qubits=qubits, classical_data=classical_data)
 
-    def add_qubits(self, qubits: Sequence['cirq.Qid']):
+    def add_qubits(self, qubits: Sequence[cirq.Qid]):
         ret = super().add_qubits(qubits)
         return (
             self.kronecker_product(type(self)(qubits=qubits), inplace=True)
@@ -364,7 +364,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
             else ret
         )
 
-    def remove_qubits(self, qubits: Sequence['cirq.Qid']):
+    def remove_qubits(self, qubits: Sequence[cirq.Qid]):
         ret = super().remove_qubits(qubits)
         if ret is not NotImplemented:
             return ret
@@ -373,9 +373,9 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         return remainder
 
     def _act_on_fallback_(
-        self, action: Any, qubits: Sequence['cirq.Qid'], allow_decompose: bool = True
+        self, action: Any, qubits: Sequence[cirq.Qid], allow_decompose: bool = True
     ) -> bool:
-        strats: List[Callable[[Any, Any, Sequence['cirq.Qid']], bool]] = [
+        strats: List[Callable[[Any, Any, Sequence[cirq.Qid]], bool]] = [
             _strat_act_on_state_vector_from_apply_unitary,
             _strat_act_on_state_vector_from_mixture,
             _strat_act_on_state_vector_from_channel,
@@ -415,7 +415,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
 
 
 def _strat_act_on_state_vector_from_apply_unitary(
-    action: Any, args: 'cirq.StateVectorSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: cirq.StateVectorSimulationState, qubits: Sequence[cirq.Qid]
 ) -> bool:
     if not args._state.apply_unitary(action, args.get_axes(qubits)):
         return NotImplemented
@@ -423,7 +423,7 @@ def _strat_act_on_state_vector_from_apply_unitary(
 
 
 def _strat_act_on_state_vector_from_mixture(
-    action: Any, args: 'cirq.StateVectorSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: cirq.StateVectorSimulationState, qubits: Sequence[cirq.Qid]
 ) -> bool:
     index = args._state.apply_mixture(action, args.get_axes(qubits), args.prng)
     if index is None:
@@ -435,7 +435,7 @@ def _strat_act_on_state_vector_from_mixture(
 
 
 def _strat_act_on_state_vector_from_channel(
-    action: Any, args: 'cirq.StateVectorSimulationState', qubits: Sequence['cirq.Qid']
+    action: Any, args: cirq.StateVectorSimulationState, qubits: Sequence[cirq.Qid]
 ) -> bool:
     index = args._state.apply_channel(action, args.get_axes(qubits), args.prng)
     if index is None:

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Abstract classes for simulations which keep track of state vector."""
+
+from __future__ import annotations
 
 import abc
 import warnings
@@ -48,8 +51,8 @@ class SimulatesIntermediateStateVector(
         self,
         *,
         dtype: Type[np.complexfloating] = np.complex64,
-        noise: 'cirq.NOISE_MODEL_LIKE' = None,
-        seed: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+        noise: cirq.NOISE_MODEL_LIKE = None,
+        seed: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
         split_untangled_states: bool = False,
     ):
         super().__init__(
@@ -58,20 +61,20 @@ class SimulatesIntermediateStateVector(
 
     def _create_simulator_trial_result(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]',
-    ) -> 'cirq.StateVectorTrialResult':
+        final_simulator_state: cirq.SimulationStateBase[cirq.StateVectorSimulationState],
+    ) -> cirq.StateVectorTrialResult:
         return StateVectorTrialResult(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
         )
 
     def compute_amplitudes_sweep_iter(
         self,
-        program: 'cirq.AbstractCircuit',
+        program: cirq.AbstractCircuit,
         bitstrings: Sequence[int],
-        params: 'cirq.Sweepable',
-        qubit_order: 'cirq.QubitOrderOrList' = ops.QubitOrder.DEFAULT,
+        params: cirq.Sweepable,
+        qubit_order: cirq.QubitOrderOrList = ops.QubitOrder.DEFAULT,
     ) -> Iterator[Sequence[complex]]:
         if isinstance(bitstrings, np.ndarray) and len(bitstrings.shape) > 1:
             raise ValueError(
@@ -112,9 +115,9 @@ class StateVectorTrialResult(
 
     def __init__(
         self,
-        params: 'cirq.ParamResolver',
+        params: cirq.ParamResolver,
         measurements: Dict[str, np.ndarray],
-        final_simulator_state: 'cirq.SimulationStateBase[cirq.StateVectorSimulationState]',
+        final_simulator_state: cirq.SimulationStateBase[cirq.StateVectorSimulationState],
     ) -> None:
         super().__init__(
             params=params,

--- a/cirq-core/cirq/study/flatten_expressions.py
+++ b/cirq-core/cirq/study/flatten_expressions.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Resolves symbolic expressions to unique symbols."""
+
+from __future__ import annotations
 
 import numbers
 from typing import Any, Callable, List, Optional, Tuple, TYPE_CHECKING, Union
@@ -25,7 +28,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-def flatten(val: Any) -> Tuple[Any, 'ExpressionMap']:
+def flatten(val: Any) -> Tuple[Any, ExpressionMap]:
     """Creates a copy of `val` with any symbols or expressions replaced with
     new symbols.  `val` can be a `Circuit`, `Gate`, `Operation`, or other
     type.
@@ -250,8 +253,8 @@ class _ParamFlattener(resolver.ParamResolver):
         return symbol
 
     def value_of(
-        self, value: Union['cirq.TParamKey', 'cirq.TParamValComplex'], recursive: bool = False
-    ) -> 'cirq.TParamValComplex':
+        self, value: Union[cirq.TParamKey, cirq.TParamValComplex], recursive: bool = False
+    ) -> cirq.TParamValComplex:
         """Resolves a symbol or expression to a new symbol unique to that value.
 
         - If value is a float, returns it.
@@ -380,8 +383,8 @@ class ExpressionMap(dict):
 
 
 def _ensure_not_str(
-    param: Union[sympy.Expr, 'cirq.TParamValComplex', str],
-) -> Union[sympy.Expr, 'cirq.TParamValComplex']:
+    param: Union[sympy.Expr, cirq.TParamValComplex, str],
+) -> Union[sympy.Expr, cirq.TParamValComplex]:
     if isinstance(param, str):
         return sympy.Symbol(param)
     return param

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Resolves ParameterValues to assigned values."""
+
+from __future__ import annotations
+
 import numbers
 from typing import Any, cast, Dict, Iterator, Mapping, Optional, TYPE_CHECKING, Union
 
@@ -61,12 +64,12 @@ class ParamResolver:
         TypeError if formulas are passed as keys.
     """
 
-    def __new__(cls, param_dict: 'cirq.ParamResolverOrSimilarType' = None):
+    def __new__(cls, param_dict: cirq.ParamResolverOrSimilarType = None):
         if isinstance(param_dict, ParamResolver):
             return param_dict
         return super().__new__(cls)
 
-    def __init__(self, param_dict: 'cirq.ParamResolverOrSimilarType' = None) -> None:
+    def __init__(self, param_dict: cirq.ParamResolverOrSimilarType = None) -> None:
         if hasattr(self, 'param_dict'):
             return  # Already initialized. Got wrapped as part of the __new__.
 
@@ -82,8 +85,8 @@ class ParamResolver:
         return self._param_dict
 
     def value_of(
-        self, value: Union['cirq.TParamKey', 'cirq.TParamValComplex'], recursive: bool = True
-    ) -> 'cirq.TParamValComplex':
+        self, value: Union[cirq.TParamKey, cirq.TParamValComplex], recursive: bool = True
+    ) -> cirq.TParamValComplex:
         """Attempt to resolve a parameter to its assigned value.
 
         Scalars are returned without modification.  Strings are resolved via
@@ -193,7 +196,7 @@ class ParamResolver:
 
         return self._value_of_recursive(value)
 
-    def _value_of_recursive(self, value: 'cirq.TParamKey') -> 'cirq.TParamValComplex':
+    def _value_of_recursive(self, value: cirq.TParamKey) -> cirq.TParamValComplex:
         # Recursive parameter resolution. We can safely assume that value is a
         # single symbol, since combinations are handled earlier in the method.
         if value in self._deep_eval_map:
@@ -213,8 +216,8 @@ class ParamResolver:
             self._deep_eval_map[value] = self.value_of(v, recursive=True)
         return self._deep_eval_map[value]
 
-    def _resolve_parameters_(self, resolver: 'ParamResolver', recursive: bool) -> 'ParamResolver':
-        new_dict: Dict['cirq.TParamKey', Union[float, str, sympy.Symbol, sympy.Expr]] = {
+    def _resolve_parameters_(self, resolver: ParamResolver, recursive: bool) -> ParamResolver:
+        new_dict: Dict[cirq.TParamKey, Union[float, str, sympy.Symbol, sympy.Expr]] = {
             k: k for k in resolver
         }
         new_dict.update({k: self.value_of(k, recursive) for k in self})
@@ -232,8 +235,8 @@ class ParamResolver:
         return bool(self._param_dict)
 
     def __getitem__(
-        self, key: Union['cirq.TParamKey', 'cirq.TParamValComplex']
-    ) -> 'cirq.TParamValComplex':
+        self, key: Union[cirq.TParamKey, cirq.TParamValComplex]
+    ) -> cirq.TParamValComplex:
         return self.value_of(key)
 
     def __hash__(self) -> int:

--- a/cirq-core/cirq/study/result.py
+++ b/cirq-core/cirq/study/result.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Defines trial results."""
+
+from __future__ import annotations
 
 import abc
 import collections
@@ -99,7 +102,7 @@ class Result(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def params(self) -> 'cirq.ParamResolver':
+    def params(self) -> cirq.ParamResolver:
         """A ParamResolver of settings used for this result."""
 
     @property
@@ -275,7 +278,7 @@ class Result(abc.ABC):
             and self.params == other.params
         )
 
-    def __add__(self, other: 'cirq.Result') -> 'cirq.Result':
+    def __add__(self, other: cirq.Result) -> cirq.Result:
         if not isinstance(other, Result):
             return NotImplemented
         if self.params != other.params:
@@ -341,7 +344,7 @@ class ResultDict(Result):
         self._data: Optional[pd.DataFrame] = None
 
     @property
-    def params(self) -> 'cirq.ParamResolver':
+    def params(self) -> cirq.ParamResolver:
         return self._params
 
     @property

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import abc
 import collections
 import itertools
@@ -71,7 +74,7 @@ class Sweep(metaclass=abc.ABCMeta):
     see the Product and Zip documentation.
     """
 
-    def __mul__(self, other: 'Sweep') -> 'Sweep':
+    def __mul__(self, other: Sweep) -> Sweep:
         factors: List[Sweep] = []
         if isinstance(self, Product):
             factors.extend(self.factors)
@@ -85,7 +88,7 @@ class Sweep(metaclass=abc.ABCMeta):
             raise TypeError(f'cannot multiply sweep and {type(other)}')
         return Product(*factors)
 
-    def __add__(self, other: 'Sweep') -> 'Sweep':
+    def __add__(self, other: Sweep) -> Sweep:
         sweeps: List[Sweep] = []
         if isinstance(self, Zip):
             sweeps.extend(self.sweeps)
@@ -108,7 +111,7 @@ class Sweep(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         """The keys for the all of the sympy.Symbols that are resolved."""
 
     @abc.abstractmethod
@@ -125,10 +128,10 @@ class Sweep(metaclass=abc.ABCMeta):
         pass
 
     @overload
-    def __getitem__(self, val: slice) -> 'Sweep':
+    def __getitem__(self, val: slice) -> Sweep:
         pass
 
-    def __getitem__(self, val: Union[int, slice]) -> Union[resolver.ParamResolver, 'Sweep']:
+    def __getitem__(self, val: Union[int, slice]) -> Union[resolver.ParamResolver, Sweep]:
         n = len(self)
         if isinstance(val, int):
             if val < -n or val >= n:
@@ -186,7 +189,7 @@ class _Unit(Sweep):
         return True
 
     @property
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         return []
 
     def __len__(self) -> int:
@@ -233,7 +236,7 @@ class Product(Sweep):
         return hash(tuple(self.factors))
 
     @property
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         return sum((factor.keys for factor in self.factors), [])
 
     def __len__(self) -> int:
@@ -308,7 +311,7 @@ class Concat(Sweep):
         return hash(tuple(self.sweeps))
 
     @property
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         return self.sweeps[0].keys
 
     def __len__(self) -> int:
@@ -361,7 +364,7 @@ class Zip(Sweep):
         return hash(tuple(self.sweeps))
 
     @property
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         return sum((sweep.keys for sweep in self.sweeps), [])
 
     def __len__(self) -> int:
@@ -449,7 +452,7 @@ class ZipLongest(Zip):
 class SingleSweep(Sweep):
     """A simple sweep over one parameter with values from an iterator."""
 
-    def __init__(self, key: 'cirq.TParamKey') -> None:
+    def __init__(self, key: cirq.TParamKey) -> None:
         if isinstance(key, sympy.Symbol):
             key = str(key)
         self.key = key
@@ -467,7 +470,7 @@ class SingleSweep(Sweep):
         pass
 
     @property
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         return [self.key]
 
     def param_tuples(self) -> Iterator[Params]:
@@ -483,7 +486,7 @@ class Points(SingleSweep):
     """A simple sweep with explicitly supplied values."""
 
     def __init__(
-        self, key: 'cirq.TParamKey', points: Sequence[float], metadata: Optional[Any] = None
+        self, key: cirq.TParamKey, points: Sequence[float], metadata: Optional[Any] = None
     ) -> None:
         """Creates a sweep on a variable with supplied values.
 
@@ -524,7 +527,7 @@ class Linspace(SingleSweep):
 
     def __init__(
         self,
-        key: 'cirq.TParamKey',
+        key: cirq.TParamKey,
         start: float,
         stop: float,
         length: int,
@@ -607,7 +610,7 @@ class ListSweep(Sweep):
         return not self == other
 
     @property
-    def keys(self) -> List['cirq.TParamKey']:
+    def keys(self) -> List[cirq.TParamKey]:
         if not self.resolver_list:
             return []
         return list(map(str, self.resolver_list[0].param_dict))

--- a/cirq-core/cirq/testing/consistent_act_on_test.py
+++ b/cirq-core/cirq/testing/consistent_act_on_test.py
@@ -24,7 +24,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
     def _unitary_(self):
         return np.array([[0, 1], [1, 0]])
 
-    def _act_on_(self, sim_state: 'cirq.SimulationStateBase', qubits: Sequence['cirq.Qid']):
+    def _act_on_(self, sim_state: cirq.SimulationStateBase, qubits: Sequence[cirq.Qid]):
         if isinstance(sim_state, cirq.CliffordTableauSimulationState):
             tableau = sim_state.tableau
             q = sim_state.qubit_map[qubits[0]]
@@ -37,7 +37,7 @@ class BadGate(cirq.testing.SingleQubitGate):
     def _unitary_(self):
         return np.array([[0, 1j], [1, 0]])
 
-    def _act_on_(self, sim_state: 'cirq.SimulationStateBase', qubits: Sequence['cirq.Qid']):
+    def _act_on_(self, sim_state: cirq.SimulationStateBase, qubits: Sequence[cirq.Qid]):
         if isinstance(sim_state, cirq.CliffordTableauSimulationState):
             tableau = sim_state.tableau
             q = sim_state.qubit_map[qubits[0]]

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Collection, List, Optional, Sequence, Tuple, Union
+from __future__ import annotations
+
+from typing import Collection, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import pytest
 
 import cirq
-from cirq.ops import control_values as cv
+
+if TYPE_CHECKING:
+    from cirq.ops import control_values as cv
 
 
 class GoodGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
@@ -29,11 +33,11 @@ class GoodGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
 class BadGateOperation(cirq.GateOperation):
     def controlled_by(
         self,
-        *control_qubits: 'cirq.Qid',
+        *control_qubits: cirq.Qid,
         control_values: Optional[
             Union[cv.AbstractControlValues, Sequence[Union[int, Collection[int]]]]
         ] = None,
-    ) -> 'cirq.Operation':
+    ) -> cirq.Operation:
         return cirq.ControlledOperation(control_qubits, self, control_values)
 
 
@@ -41,7 +45,7 @@ class BadGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
     def _eigen_components(self) -> List[Tuple[float, np.ndarray]]:
         return [(0, np.diag([1, 0])), (1, np.diag([0, 1]))]
 
-    def on(self, *qubits: 'cirq.Qid') -> 'cirq.Operation':
+    def on(self, *qubits: cirq.Qid) -> cirq.Operation:
         return BadGateOperation(self, list(qubits))
 
     def controlled(
@@ -51,7 +55,7 @@ class BadGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
             Union[cv.AbstractControlValues, Sequence[Union[int, Collection[int]]]]
         ] = None,
         control_qid_shape: Optional[Tuple[int, ...]] = None,
-    ) -> 'cirq.Gate':
+    ) -> cirq.Gate:
         ret = super().controlled(num_controls, control_values, control_qid_shape)
         if num_controls == 1 and control_values is None:
             return cirq.CZPowGate(exponent=self._exponent, global_shift=self._global_shift)

--- a/cirq-core/cirq/testing/lin_alg_utils.py
+++ b/cirq-core/cirq/testing/lin_alg_utils.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A testing class with utilities for checking linear algebra."""
+
+from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING
 
@@ -24,7 +27,7 @@ if TYPE_CHECKING:
 
 
 def random_superposition(
-    dim: int, *, random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+    dim: int, *, random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None
 ) -> np.ndarray:
     """Returns a random unit-length vector from the uniform distribution.
 
@@ -46,7 +49,7 @@ def random_superposition(
 
 
 def random_density_matrix(
-    dim: int, *, random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+    dim: int, *, random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None
 ) -> np.ndarray:
     """Returns a random density matrix distributed with Hilbert-Schmidt measure.
 
@@ -68,9 +71,7 @@ def random_density_matrix(
     return mat / np.trace(mat)
 
 
-def random_unitary(
-    dim: int, *, random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
-) -> np.ndarray:
+def random_unitary(dim: int, *, random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None) -> np.ndarray:
     """Returns a random unitary matrix distributed with Haar measure.
 
     Args:
@@ -93,7 +94,7 @@ def random_unitary(
 
 
 def random_orthogonal(
-    dim: int, *, random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+    dim: int, *, random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None
 ) -> np.ndarray:
     """Returns a random orthogonal matrix distributed with Haar measure.
 
@@ -139,7 +140,7 @@ def random_special_unitary(
 
 
 def random_special_orthogonal(
-    dim: int, *, random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None
+    dim: int, *, random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None
 ) -> np.ndarray:
     """Returns a random special orthogonal matrix distributed with Haar measure.
 

--- a/cirq-core/cirq/testing/random_circuit.py
+++ b/cirq-core/cirq/testing/random_circuit.py
@@ -12,27 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, List, Optional, Sequence, TYPE_CHECKING, Union
 
 from cirq import circuits, ops, value
 from cirq._doc import document
-from cirq.ops import Qid
 
 if TYPE_CHECKING:
     import cirq
 
 DEFAULT_GATE_DOMAIN: Dict[ops.Gate, int] = {
-    ops.CNOT: 2,
-    ops.CZ: 2,
-    ops.H: 1,
-    ops.ISWAP: 2,
+    ops.CNOT: 2,  # type: ignore[has-type]
+    ops.CZ: 2,  # type: ignore[has-type]
+    ops.H: 1,  # type: ignore[has-type]
+    ops.ISWAP: 2,  # type: ignore[has-type]
     ops.CZPowGate(): 2,
-    ops.S: 1,
-    ops.SWAP: 2,
-    ops.T: 1,
-    ops.X: 1,
-    ops.Y: 1,
-    ops.Z: 1,
+    ops.S: 1,  # type: ignore[has-type]
+    ops.SWAP: 2,  # type: ignore[has-type]
+    ops.T: 1,  # type: ignore[has-type]
+    ops.X: 1,  # type: ignore[has-type]
+    ops.Y: 1,  # type: ignore[has-type]
+    ops.Z: 1,  # type: ignore[has-type]
 }
 document(
     DEFAULT_GATE_DOMAIN,
@@ -45,11 +46,11 @@ and Z gates.
 
 
 def random_circuit(
-    qubits: Union[Sequence[ops.Qid], int],
+    qubits: Union[Sequence[cirq.Qid], int],
     n_moments: int,
     op_density: float,
     gate_domain: Optional[Dict[ops.Gate, int]] = None,
-    random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> circuits.Circuit:
     """Generates a random circuit.
 
@@ -125,9 +126,9 @@ def random_circuit(
 
 def random_two_qubit_circuit_with_czs(
     num_czs: int = 3,
-    q0: Optional[Qid] = None,
-    q1: Optional[Qid] = None,
-    random_state: 'cirq.RANDOM_STATE_OR_SEED_LIKE' = None,
+    q0: Optional[cirq.Qid] = None,
+    q1: Optional[cirq.Qid] = None,
+    random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
 ) -> circuits.Circuit:
     """Creates a random two qubit circuit with the given number of CNOTs.
 

--- a/cirq-core/cirq/testing/routing_devices.py
+++ b/cirq-core/cirq/testing/routing_devices.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Provides test devices that can validate circuits during a routing procedure."""
+
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
@@ -39,7 +42,7 @@ class RoutingTestingDevice(devices.Device):
     def metadata(self) -> devices.DeviceMetadata:
         return self._metadata
 
-    def validate_operation(self, operation: 'cirq.Operation') -> None:
+    def validate_operation(self, operation: cirq.Operation) -> None:
         if not self._metadata.qubit_set.issuperset(operation.qubits):
             raise ValueError(f'Qubits not on device: {operation.qubits!r}.')
 

--- a/cirq-core/cirq/testing/sample_circuits.py
+++ b/cirq-core/cirq/testing/sample_circuits.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from cirq import circuits, ops
@@ -19,7 +22,7 @@ if TYPE_CHECKING:
     import cirq
 
 
-def nonoptimal_toffoli_circuit(q0: 'cirq.Qid', q1: 'cirq.Qid', q2: 'cirq.Qid') -> circuits.Circuit:
+def nonoptimal_toffoli_circuit(q0: cirq.Qid, q1: cirq.Qid, q2: cirq.Qid) -> circuits.Circuit:
     ret = circuits.Circuit(
         ops.Y(q2) ** 0.5,
         ops.X(q2),

--- a/cirq-core/cirq/transformers/align.py
+++ b/cirq-core/cirq/transformers/align.py
@@ -14,6 +14,8 @@
 
 """Transformer passes which align operations to the left or right of the circuit."""
 
+from __future__ import annotations
+
 import dataclasses
 from typing import Optional, TYPE_CHECKING
 
@@ -26,8 +28,8 @@ if TYPE_CHECKING:
 
 @transformer_api.transformer(add_deep_support=True)
 def align_left(
-    circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
-) -> 'cirq.Circuit':
+    circuit: cirq.AbstractCircuit, *, context: Optional[cirq.TransformerContext] = None
+) -> cirq.Circuit:
     """Align gates to the left of the circuit.
 
     Note that tagged operations with tag in `context.tags_to_ignore` will continue to stay in their
@@ -58,8 +60,8 @@ def align_left(
 
 @transformer_api.transformer(add_deep_support=True)
 def align_right(
-    circuit: 'cirq.AbstractCircuit', *, context: Optional['cirq.TransformerContext'] = None
-) -> 'cirq.Circuit':
+    circuit: cirq.AbstractCircuit, *, context: Optional[cirq.TransformerContext] = None
+) -> cirq.Circuit:
     """Align gates to the right of the circuit.
 
     Note that tagged operations with tag in `context.tags_to_ignore` will continue to stay in their

--- a/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition.py
@@ -14,6 +14,8 @@
 
 """Utility methods to decompose Clifford gates into circuits."""
 
+from __future__ import annotations
+
 import functools
 from typing import List, TYPE_CHECKING
 
@@ -29,7 +31,7 @@ def _X(
     q: int,
     args: sim.CliffordTableauSimulationState,
     operations: List[ops.Operation],
-    qubits: List['cirq.Qid'],
+    qubits: List[cirq.Qid],
 ):
     protocols.act_on(ops.X, args, qubits=[qubits[q]], allow_decompose=False)
     operations.append(ops.X(qubits[q]))
@@ -39,7 +41,7 @@ def _Z(
     q: int,
     args: sim.CliffordTableauSimulationState,
     operations: List[ops.Operation],
-    qubits: List['cirq.Qid'],
+    qubits: List[cirq.Qid],
 ):
     protocols.act_on(ops.Z, args, qubits=[qubits[q]], allow_decompose=False)
     operations.append(ops.Z(qubits[q]))
@@ -49,7 +51,7 @@ def _Sdg(
     q: int,
     args: sim.CliffordTableauSimulationState,
     operations: List[ops.Operation],
-    qubits: List['cirq.Qid'],
+    qubits: List[cirq.Qid],
 ):
     # Apply the tableau with S^\{dagger}
     protocols.act_on(ops.S**-1, args, qubits=[qubits[q]], allow_decompose=False)
@@ -60,7 +62,7 @@ def _H(
     q: int,
     args: sim.CliffordTableauSimulationState,
     operations: List[ops.Operation],
-    qubits: List['cirq.Qid'],
+    qubits: List[cirq.Qid],
 ):
     protocols.act_on(ops.H, args, qubits=[qubits[q]], allow_decompose=False)
     operations.append(ops.H(qubits[q]))
@@ -71,7 +73,7 @@ def _CNOT(
     q2: int,
     args: sim.CliffordTableauSimulationState,
     operations: List[ops.Operation],
-    qubits: List['cirq.Qid'],
+    qubits: List[cirq.Qid],
 ):
     protocols.act_on(ops.CNOT, args, qubits=[qubits[q1], qubits[q2]], allow_decompose=False)
     operations.append(ops.CNOT(qubits[q1], qubits[q2]))
@@ -82,14 +84,14 @@ def _SWAP(
     q2: int,
     args: sim.CliffordTableauSimulationState,
     operations: List[ops.Operation],
-    qubits: List['cirq.Qid'],
+    qubits: List[cirq.Qid],
 ):
     protocols.act_on(ops.SWAP, args, qubits=[qubits[q1], qubits[q2]], allow_decompose=False)
     operations.append(ops.SWAP(qubits[q1], qubits[q2]))
 
 
 def decompose_clifford_tableau_to_operations(
-    qubits: List['cirq.Qid'], clifford_tableau: qis.CliffordTableau
+    qubits: List[cirq.Qid], clifford_tableau: qis.CliffordTableau
 ) -> List[ops.Operation]:
     """Decompose an n-qubit Clifford Tableau into a list of one/two qubit operations.
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -70,8 +72,8 @@ def _decompose_abc(matrix: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarr
 
 
 def _decompose_single_ctrl(
-    matrix: np.ndarray, control: 'cirq.Qid', target: 'cirq.Qid'
-) -> List['cirq.Operation']:
+    matrix: np.ndarray, control: cirq.Qid, target: cirq.Qid
+) -> List[cirq.Operation]:
     """Decomposes controlled gate with one control.
 
     See [1], chapter 5.1.
@@ -93,7 +95,7 @@ def _decompose_single_ctrl(
     return result
 
 
-def _ccnot_congruent(c0: 'cirq.Qid', c1: 'cirq.Qid', target: 'cirq.Qid') -> List['cirq.Operation']:
+def _ccnot_congruent(c0: cirq.Qid, c1: cirq.Qid, target: cirq.Qid) -> List[cirq.Operation]:
     """Implements 3-qubit gate 'congruent' to CCNOT.
 
     Returns sequence of operations which is equivalent to applying
@@ -111,8 +113,8 @@ def _ccnot_congruent(c0: 'cirq.Qid', c1: 'cirq.Qid', target: 'cirq.Qid') -> List
 
 
 def decompose_multi_controlled_x(
-    controls: List['cirq.Qid'], target: 'cirq.Qid', free_qubits: List['cirq.Qid']
-) -> List['cirq.Operation']:
+    controls: List[cirq.Qid], target: cirq.Qid, free_qubits: List[cirq.Qid]
+) -> List[cirq.Operation]:
     """Implements action of multi-controlled Pauli X gate.
 
     Result is guaranteed to consist exclusively of 1-qubit, CNOT and CCNOT
@@ -164,8 +166,8 @@ def decompose_multi_controlled_x(
 
 
 def _decompose_su(
-    matrix: np.ndarray, controls: List['cirq.Qid'], target: 'cirq.Qid'
-) -> List['cirq.Operation']:
+    matrix: np.ndarray, controls: List[cirq.Qid], target: cirq.Qid
+) -> List[cirq.Operation]:
     """Decomposes controlled special unitary gate into elementary gates.
 
     Result has O(len(controls)) operations.
@@ -190,10 +192,10 @@ def _decompose_su(
 def _decompose_recursive(
     matrix: np.ndarray,
     power: float,
-    controls: List['cirq.Qid'],
-    target: 'cirq.Qid',
-    free_qubits: List['cirq.Qid'],
-) -> List['cirq.Operation']:
+    controls: List[cirq.Qid],
+    target: cirq.Qid,
+    free_qubits: List[cirq.Qid],
+) -> List[cirq.Operation]:
     """Decomposes controlled unitary gate into elementary gates.
 
     Result has O(len(controls)^2) operations.
@@ -215,8 +217,8 @@ def _decompose_recursive(
 
 
 def decompose_multi_controlled_rotation(
-    matrix: np.ndarray, controls: List['cirq.Qid'], target: 'cirq.Qid'
-) -> List['cirq.Operation']:
+    matrix: np.ndarray, controls: List[cirq.Qid], target: cirq.Qid
+) -> List[cirq.Operation]:
     """Implements action of multi-controlled unitary gate.
 
     Returns a sequence of operations, which is equivalent to applying

--- a/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional, Sequence, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -32,7 +34,7 @@ def _asinsin(x: float) -> float:
 
 
 def compute_cphase_exponents_for_fsim_decomposition(
-    fsim_gate: 'cirq.FSimGate',
+    fsim_gate: cirq.FSimGate,
 ) -> Sequence[Tuple[float, float]]:
     """Returns intervals of CZPowGate exponents valid for FSim decomposition.
 
@@ -93,12 +95,12 @@ def compute_cphase_exponents_for_fsim_decomposition(
 
 
 def decompose_cphase_into_two_fsim(
-    cphase_gate: 'cirq.CZPowGate',
+    cphase_gate: cirq.CZPowGate,
     *,
-    fsim_gate: 'cirq.FSimGate',
-    qubits: Optional[Sequence['cirq.Qid']] = None,
+    fsim_gate: cirq.FSimGate,
+    qubits: Optional[Sequence[cirq.Qid]] = None,
     atol: float = 1e-8,
-) -> 'cirq.OP_TREE':
+) -> cirq.OP_TREE:
     """Decomposes CZPowGate into two FSimGates.
 
     This function implements the decomposition described in section VII F I

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """Utility methods for decomposing arbitrary n-qubit (2^n x 2^n) unitary.
 
 Based on:
 Synthesis of Quantum Logic Circuits. Tech. rep. 2006,
 https://arxiv.org/abs/quant-ph/0406176
 """
+
+from __future__ import annotations
+
 from typing import Callable, Iterable, List, TYPE_CHECKING
 
 import numpy as np
@@ -40,8 +42,8 @@ if TYPE_CHECKING:
 
 
 def quantum_shannon_decomposition(
-    qubits: 'List[cirq.Qid]', u: np.ndarray, atol: float = 1e-8
-) -> Iterable['cirq.Operation']:
+    qubits: List[cirq.Qid], u: np.ndarray, atol: float = 1e-8
+) -> Iterable[cirq.Operation]:
     """Decomposes n-qubit unitary 1-q, 2-q and GlobalPhase gates, preserving global phase.
 
     The gates used are CX/YPow/ZPow/CNOT/GlobalPhase/CZ/PhasedXZGate/PhasedXPowGate.
@@ -139,7 +141,7 @@ def quantum_shannon_decomposition(
     yield from _msb_demuxer(qubits, u1, u2)
 
 
-def _single_qubit_decomposition(qubit: 'cirq.Qid', u: np.ndarray) -> Iterable['cirq.Operation']:
+def _single_qubit_decomposition(qubit: cirq.Qid, u: np.ndarray) -> Iterable[cirq.Operation]:
     """Decomposes single-qubit gate, and returns list of operations, keeping phase invariant.
 
     Args:
@@ -183,8 +185,8 @@ def _single_qubit_decomposition(qubit: 'cirq.Qid', u: np.ndarray) -> Iterable['c
 
 
 def _msb_demuxer(
-    demux_qubits: 'List[cirq.Qid]', u1: np.ndarray, u2: np.ndarray
-) -> Iterable['cirq.Operation']:
+    demux_qubits: List[cirq.Qid], u1: np.ndarray, u2: np.ndarray
+) -> Iterable[cirq.Operation]:
     """Demultiplexes a unitary matrix that is multiplexed in its most-significant-qubit.
 
     Decomposition structure:
@@ -246,8 +248,8 @@ def _nth_gray(n: int) -> int:
 
 
 def _multiplexed_cossin(
-    cossin_qubits: 'List[cirq.Qid]', angles: List[float], rot_func: Callable = ops.ry
-) -> Iterable['cirq.Operation']:
+    cossin_qubits: List[cirq.Qid], angles: List[float], rot_func: Callable = ops.ry
+) -> Iterable[cirq.Operation]:
     """Performs a multiplexed rotation over all qubits in this unitary matrix,
 
     Uses ry and rz multiplexing for quantum shannon decomposition

--- a/cirq-core/cirq/transformers/analytical_decompositions/single_to_two_qubit_isometry.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/single_to_two_qubit_isometry.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Analytical decompositions for 2-qubit unitaries when one input qubit is in the |0> state."""
+
+from __future__ import annotations
+
 from typing import List, TYPE_CHECKING
 
 import numpy as np
@@ -25,13 +28,13 @@ if TYPE_CHECKING:
 
 
 def two_qubit_matrix_to_cz_isometry(
-    q0: 'cirq.Qid',
-    q1: 'cirq.Qid',
+    q0: cirq.Qid,
+    q1: cirq.Qid,
     mat: np.ndarray,
     allow_partial_czs: bool = False,
     atol: float = 1e-8,
     clean_operations: bool = True,
-) -> List['cirq.Operation']:
+) -> List[cirq.Operation]:
     """Decomposes a 2q operation into at-most 2 CZs + 1q rotations; assuming `q0` is initially |0>.
 
     The method implements isometry from one to two qubits; assuming qubit `q0` is always in the |0>

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_state_preparation.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_state_preparation.py
@@ -14,6 +14,8 @@
 
 """Utility methods for efficiently preparing two qubit states."""
 
+from __future__ import annotations
+
 from typing import List, TYPE_CHECKING
 
 import numpy as np
@@ -38,12 +40,8 @@ def _1q_matrices_to_ops(g0, g1, q0, q1, include_identity=False):
 
 
 def prepare_two_qubit_state_using_sqrt_iswap(
-    q0: 'cirq.Qid',
-    q1: 'cirq.Qid',
-    state: 'cirq.STATE_VECTOR_LIKE',
-    *,
-    use_sqrt_iswap_inv: bool = True,
-) -> List['cirq.Operation']:
+    q0: cirq.Qid, q1: cirq.Qid, state: cirq.STATE_VECTOR_LIKE, *, use_sqrt_iswap_inv: bool = True
+) -> List[cirq.Operation]:
     """Prepares the given 2q state from |00> using at-most 1 √iSWAP gate + single qubit rotations.
 
     Entangled states are prepared using exactly 1 √iSWAP gate while product states are prepared
@@ -77,8 +75,8 @@ def prepare_two_qubit_state_using_sqrt_iswap(
 
 
 def prepare_two_qubit_state_using_cz(
-    q0: 'cirq.Qid', q1: 'cirq.Qid', state: 'cirq.STATE_VECTOR_LIKE'
-) -> List['cirq.Operation']:
+    q0: cirq.Qid, q1: cirq.Qid, state: cirq.STATE_VECTOR_LIKE
+) -> List[cirq.Operation]:
     """Prepares the given 2q state from |00> using at-most 1 CZ gate + single qubit rotations.
 
     Entangled states are prepared using exactly 1 CZ gate while product states are prepared
@@ -110,8 +108,8 @@ def prepare_two_qubit_state_using_cz(
 
 
 def prepare_two_qubit_state_using_iswap(
-    q0: 'cirq.Qid', q1: 'cirq.Qid', state: 'cirq.STATE_VECTOR_LIKE', use_iswap_inv: bool = False
-) -> List['cirq.Operation']:
+    q0: cirq.Qid, q1: cirq.Qid, state: cirq.STATE_VECTOR_LIKE, use_iswap_inv: bool = False
+) -> List[cirq.Operation]:
     """Prepares the given 2q state from |00> using at-most 1 ISWAP gate + single qubit rotations.
 
     Entangled states are prepared using exactly 1 ISWAP gate while product states are prepared


### PR DESCRIPTION
No change in the effective code.  A batch of 50 files (49 changed, 1 good).

Passes  ruff check --target-version=py310 --select=UP037,TC001

Partially implements #1999
