### PR TITLE
Make cirq.Zip twenty times faster

### DIFF
--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -372,7 +372,7 @@ class Zip(Sweep):
     def param_tuples(self) -> Iterator[Params]:
         iters = [sweep.param_tuples() for sweep in self.sweeps]
         for values in zip(*iters):
-            yield sum(values, ())
+            yield tuple(itertools.chain.from_iterable(values))
 
     def __repr__(self) -> str:
         sweeps_repr = ', '.join(repr(s) for s in self.sweeps)

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -76,6 +76,11 @@ def test_zip():
     assert len(sweep) == 3
     assert _values(sweep, 'a') == [1, 2, 3]
     assert _values(sweep, 'b') == [4, 5, 6]
+    assert list(sweep.param_tuples()) == [
+        (('a', 1), ('b', 4)),
+        (('a', 2), ('b', 5)),
+        (('a', 3), ('b', 6)),
+    ]
 
 
 def test_zip_longest():


### PR DESCRIPTION
- cirq.Zip param_tuples was doing a sum of tuples, which was creating n^2 tuples over the course of the calculations.
- Use itertools to do this correctly.

Using a zip of 1000 different values of 10000 different values: Before: 110 seconds.  After: 5.6 seconds

```
%timeit sum(values, ())
111 ms ± 3.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit tuple(itertools.chain.from_iterable(values))
431 µs ± 3.98 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```