### PR TITLE
Rewrite inefficient `sum(..., [])` and `sum(..., ())`

### DIFF
--- a/cirq-core/cirq/contrib/acquaintance/gates.py
+++ b/cirq-core/cirq/contrib/acquaintance/gates.py
@@ -51,7 +51,7 @@ def operations_to_part_lens(
     part_sort_key = lambda p: min(qubit_sort_key(q) for q in p)
     parts = tuple(tuple(part) for part in sorted(singletons + op_parts, key=part_sort_key))
 
-    if sum(parts, ()) != tuple(qubit_order):
+    if tuple(itertools.chain.from_iterable(parts)) != tuple(qubit_order):
         raise ValueError('sum(parts, ()) != tuple(qubit_order)')
 
     return tuple(len(part) for part in parts)

--- a/cirq-core/cirq/ops/boolean_hamiltonian_test.py
+++ b/cirq-core/cirq/ops/boolean_hamiltonian_test.py
@@ -211,7 +211,7 @@ def test_simplify_cnots_triplets(
     assert actual_output_cnots == expected_output_cnots
 
     # Check that the unitaries are the same.
-    qubit_ids = set(sum(input_cnots, ()))
+    qubit_ids = set(itertools.chain.from_iterable(input_cnots))
     qubits = {qubit_id: cirq.NamedQubit(f"{qubit_id}") for qubit_id in qubit_ids}
 
     target, control = (0, 1) if input_flip_control_and_target else (1, 0)

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -237,7 +237,7 @@ class Product(Sweep):
 
     @property
     def keys(self) -> List[cirq.TParamKey]:
-        return sum((factor.keys for factor in self.factors), [])
+        return list(itertools.chain.from_iterable(factor.keys for factor in self.factors))
 
     def __len__(self) -> int:
         length = 1
@@ -365,7 +365,7 @@ class Zip(Sweep):
 
     @property
     def keys(self) -> List[cirq.TParamKey]:
-        return sum((sweep.keys for sweep in self.sweeps), [])
+        return list(itertools.chain.from_iterable(sweep.keys for sweep in self.sweeps))
 
     def __len__(self) -> int:
         if not self.sweeps:

--- a/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import itertools
 from typing import List, Tuple, TYPE_CHECKING
 
 import numpy as np
@@ -36,7 +37,7 @@ def _is_identity(matrix):
 
 
 def _flatten(x):
-    return sum(x, [])
+    return list(itertools.chain.from_iterable(x))
 
 
 def _decompose_abc(matrix: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, float]:


### PR DESCRIPTION
Such summations create many temporary lists or tuples which is slow.
Instantiate just one list or tuple instead.
