### PR TITLE
CI - replace actions/cache with setup-python package caching

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install system requirements
         run: |
           sudo apt-get update
@@ -61,10 +61,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
           pip install --upgrade cirq~=1.0.dev &&
@@ -88,10 +88,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
           pip install --upgrade cirq~=1.0.dev &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,11 +182,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - name: Set up caching of dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install system packages
         run: |
           sudo apt-get update
@@ -216,11 +215,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - name: Set up caching of dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: numpy2-${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install system packages
         run: |
           sudo apt-get update
@@ -278,11 +276,10 @@ jobs:
         with:
           python-version: '3.10'
           architecture: 'x64'
-      - name: Set up caching of dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install system requirements
         run: |
           sudo apt-get update
@@ -315,11 +312,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - name: Set up caching of dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
           pip install --upgrade setuptools wheel
@@ -343,11 +339,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
-      - name: Set up caching of dependencies
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('**/requirements.txt', 'dev_tools/requirements/**/*.txt') }}
+          cache: 'pip'
+          cache-dependency-path: |
+            **/requirements.txt
+            dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
           pip install --upgrade setuptools wheel


### PR DESCRIPTION
This should prevent failures of pip-install due to incompatibility
between cached Python environment and active pip tool.
See https://github.com/quantumlib/Cirq/pull/7302 for example failures.

Ref: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages
