### PR TITLE
Fix qubit metadata in identifying_hardware_changes

### DIFF
--- a/docs/tutorials/google/identifying_hardware_changes.ipynb
+++ b/docs/tutorials/google/identifying_hardware_changes.ipynb
@@ -283,14 +283,16 @@
     "sampler = qcs_objects.sampler\n",
     "\n",
     "# Get qubit set\n",
-    "qubits = device.qubit_set()\n",
+    "qubits = device.metadata.qubit_set()\n",
     "\n",
     "# Limit device qubits to only those before row/column `device_limit`\n",
     "device_limit = 10 #@param {type:\"integer\"}\n",
     "qubits = {qb for qb in qubits if qb.row<device_limit and qb.col<device_limit}\n",
     "\n",
-    "# Visualize the qubits on a grid by putting them in a throwaway device object used only for this print statement\n",
-    "print(cg.devices.XmonDevice(0,0,0,qubits))"
+    "# Print out the qubits.",
+    "print('')",
+    "print('Qubits used:')",
+    "print(qubits)"
    ]
   },
   {


### PR DESCRIPTION
- This fixes the simple errors in the identifying_hardware_changes notebook from #5588.
- I am not sure this notebook is runnable though, as we no longer use sqrt ISWAP and the two-qubit metrics are missing.