### PR TITLE
CI - fix type check with a temporary pin to numpy-1

### DIFF
--- a/dev_tools/requirements/mypy.env.txt
+++ b/dev_tools/requirements/mypy.env.txt
@@ -4,3 +4,6 @@
 
 -r deps/cirq-all.txt
 -r deps/mypy.txt
+
+# TODO: #7323 - remove after fixing type annotations for NumPy-2
+numpy<2.0


### PR DESCRIPTION
Problem: Type checking fails in an environment with numpy-2.

Solution: Unblock the ci by pinning to numpy-1.  Fix annotations for numpy-2 ASAP.

Partially resolves #7323
