### PR TITLE
Add return type for tests

### DIFF
--- a/cirq-core/cirq/_version_test.py
+++ b/cirq-core/cirq/_version_test.py
@@ -2,5 +2,5 @@
 import cirq
 
 
-def test_version():
+def test_version() -> None:
     assert cirq.__version__ == "1.6.0.dev0"

--- a/cirq-core/cirq/circuits/_block_diagram_drawer_test.py
+++ b/cirq-core/cirq/circuits/_block_diagram_drawer_test.py
@@ -54,7 +54,7 @@ def _curve_pieces_diagram(chars: BoxDrawCharacterSet) -> BlockDiagramDrawer:
     return d
 
 
-def test_block_curve():
+def test_block_curve() -> None:
     d = _curve_pieces_diagram(NORMAL_BOX_CHARS)
     actual = d.render(min_block_width=5, min_block_height=5)
     expected = """
@@ -177,7 +177,7 @@ def test_block_curve():
     _assert_same_diagram(actual, expected)
 
 
-def test_mixed_block_curve():
+def test_mixed_block_curve() -> None:
     diagram = BlockDiagramDrawer()
     for a, b, c, d in itertools.product(range(3), repeat=4):
         x = (a * 3 + b) * 2
@@ -244,7 +244,7 @@ def test_mixed_block_curve():
     _assert_same_diagram(actual, expected)
 
 
-def test_lines_meet_content():
+def test_lines_meet_content() -> None:
     d = BlockDiagramDrawer()
     b = d.mutable_block(0, 0)
     b.content = 'long text\nwith multiple lines'
@@ -409,7 +409,7 @@ with multiple lines
     )
 
 
-def test_content_stretches_other_blocks():
+def test_content_stretches_other_blocks() -> None:
     d = BlockDiagramDrawer()
     d.mutable_block(0, 0).horizontal_alignment = 0.5
     d.mutable_block(1, 0).horizontal_alignment = 0.5
@@ -430,7 +430,7 @@ with multiple lines│
     )
 
 
-def test_lines_stretch_content():
+def test_lines_stretch_content() -> None:
     d = BlockDiagramDrawer()
     d.mutable_block(0, 0).left = 'l'
     d.mutable_block(2, 4).right = 'r'
@@ -449,7 +449,7 @@ def test_lines_stretch_content():
     )
 
 
-def test_indices():
+def test_indices() -> None:
     d = BlockDiagramDrawer()
     with pytest.raises(IndexError):
         d.mutable_block(-1, -1)

--- a/cirq-core/cirq/circuits/_box_drawing_character_data_test.py
+++ b/cirq-core/cirq/circuits/_box_drawing_character_data_test.py
@@ -21,7 +21,7 @@ from cirq.circuits._box_drawing_character_data import (
 )
 
 
-def test_chars():
+def test_chars() -> None:
     assert NORMAL_BOX_CHARS.char() is None
     assert NORMAL_BOX_CHARS.char(top=True, bottom=True) == '│'
     assert NORMAL_THEN_BOLD_MIXED_BOX_CHARS.char() is None

--- a/cirq-core/cirq/circuits/insert_strategy_test.py
+++ b/cirq-core/cirq/circuits/insert_strategy_test.py
@@ -19,7 +19,7 @@ import pytest
 import cirq
 
 
-def test_repr():
+def test_repr() -> None:
     assert repr(cirq.InsertStrategy.NEW) == 'cirq.InsertStrategy.NEW'
     assert str(cirq.InsertStrategy.NEW) == 'NEW'
 
@@ -34,6 +34,6 @@ def test_repr():
     ],
     ids=lambda strategy: strategy.name,
 )
-def test_identity_after_pickling(strategy: cirq.InsertStrategy):
+def test_identity_after_pickling(strategy: cirq.InsertStrategy) -> None:
     unpickled_strategy = pickle.loads(pickle.dumps(strategy))
     assert unpickled_strategy is strategy

--- a/cirq-core/cirq/circuits/optimization_pass_test.py
+++ b/cirq-core/cirq/circuits/optimization_pass_test.py
@@ -21,7 +21,7 @@ from cirq import Operation, PointOptimizationSummary, PointOptimizer
 from cirq.testing import EqualsTester
 
 
-def test_equality():
+def test_equality() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     xa = cirq.X(a)
@@ -86,7 +86,7 @@ class ReplaceWithXGates(PointOptimizer):
         )
 
 
-def test_point_optimizer_can_write_new_gates_inline():
+def test_point_optimizer_can_write_new_gates_inline() -> None:
     x = cirq.NamedQubit('x')
     y = cirq.NamedQubit('y')
     z = cirq.NamedQubit('z')
@@ -116,7 +116,7 @@ z: ───────────────────X───X───
     assert actual_text_diagram == expected_text_diagram
 
 
-def test_point_optimizer_post_clean_up():
+def test_point_optimizer_post_clean_up() -> None:
     x = cirq.NamedQubit('x')
     y = cirq.NamedQubit('y')
     z = cirq.NamedQubit('z')
@@ -150,7 +150,7 @@ z: ─────────────────────────�
     assert actual_text_diagram == expected_text_diagram
 
 
-def test_point_optimizer_raises_on_gates_changing_qubits():
+def test_point_optimizer_raises_on_gates_changing_qubits() -> None:
     class EverythingIs42(cirq.PointOptimizer):
         """Changes all single qubit operations to act on LineQubit(42)"""
 
@@ -171,7 +171,7 @@ def test_point_optimizer_raises_on_gates_changing_qubits():
         EverythingIs42().optimize_circuit(c)
 
 
-def test_repr():
+def test_repr() -> None:
     assert (
         repr(cirq.PointOptimizationSummary(clear_span=0, clear_qubits=[], new_operations=[]))
         == 'cirq.PointOptimizationSummary(0, (), ())'

--- a/cirq-core/cirq/contrib/acquaintance/inspection_utils_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/inspection_utils_test.py
@@ -22,7 +22,7 @@ import cirq.contrib.acquaintance.inspection_utils as inspection_utils
 
 
 @pytest.mark.parametrize('n_qubits, acquaintance_size', product(range(2, 6), range(2, 5)))
-def test_get_logical_acquaintance_opportunities(n_qubits, acquaintance_size):
+def test_get_logical_acquaintance_opportunities(n_qubits, acquaintance_size) -> None:
     qubits = cirq.LineQubit.range(n_qubits)
     acquaintance_strategy = cca.complete_acquaintance_strategy(qubits, acquaintance_size)
     initial_mapping = {q: i for i, q in enumerate(qubits)}
@@ -30,5 +30,5 @@ def test_get_logical_acquaintance_opportunities(n_qubits, acquaintance_size):
     assert opps == set(frozenset(s) for s in combinations(range(n_qubits), acquaintance_size))
 
 
-def test_device():
+def test_device() -> None:
     assert inspection_utils.LogicalAnnotator({}).device == cirq.UNCONSTRAINED_DEVICE

--- a/cirq-core/cirq/contrib/acquaintance/mutation_utils_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/mutation_utils_test.py
@@ -20,7 +20,7 @@ import cirq
 import cirq.contrib.acquaintance as cca
 
 
-def test_complete_acquaintance_strategy():
+def test_complete_acquaintance_strategy() -> None:
     qubits = [cirq.NamedQubit(s) for s in alphabet]
 
     with pytest.raises(ValueError):
@@ -136,7 +136,7 @@ a      b      c      d
     assert cca.get_acquaintance_size(cubic_strategy) == 3
 
 
-def test_rectification():
+def test_rectification() -> None:
     qubits = cirq.LineQubit.range(4)
 
     perm_gate = cca.SwapPermutationGate()

--- a/cirq-core/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/optimizers_test.py
@@ -16,7 +16,7 @@ import cirq.contrib.acquaintance as cca
 import cirq.testing as ct
 
 
-def test_remove_redundant_acquaintance_opportunities():
+def test_remove_redundant_acquaintance_opportunities() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
     swap = cca.SwapPermutationGate()
 

--- a/cirq-core/cirq/contrib/acquaintance/shift_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/shift_test.py
@@ -16,7 +16,7 @@ import cirq
 import cirq.contrib.acquaintance as cca
 
 
-def test_circular_shift_gate_init():
+def test_circular_shift_gate_init() -> None:
     g = cca.CircularShiftGate(4, 2)
     assert g.num_qubits() == 4
     assert g.shift == 2
@@ -25,7 +25,7 @@ def test_circular_shift_gate_init():
     assert g.swap_gate == cirq.CZ
 
 
-def test_circular_shift_gate_eq():
+def test_circular_shift_gate_eq() -> None:
     equals_tester = cirq.testing.EqualsTester()
     equals_tester.add_equality_group(cca.CircularShiftGate(4, 1), cca.CircularShiftGate(4, 1))
     equals_tester.add_equality_group(cca.CircularShiftGate(4, 1, swap_gate=cirq.CZ))
@@ -34,19 +34,19 @@ def test_circular_shift_gate_eq():
     equals_tester.add_equality_group(cca.CircularShiftGate(3, 2, swap_gate=cirq.CZ))
 
 
-def test_circular_shift_gate_permutation():
+def test_circular_shift_gate_permutation() -> None:
     assert cca.CircularShiftGate(3, 4).permutation() == {0: 2, 1: 0, 2: 1}
     assert cca.CircularShiftGate(4, 0).permutation() == {0: 0, 1: 1, 2: 2, 3: 3}
 
     assert cca.CircularShiftGate(5, 2).permutation() == {0: 3, 1: 4, 2: 0, 3: 1, 4: 2}
 
 
-def test_circular_shift_gate_repr():
+def test_circular_shift_gate_repr() -> None:
     g = cca.CircularShiftGate(3, 2)
     cirq.testing.assert_equivalent_repr(g)
 
 
-def test_circular_shift_gate_decomposition():
+def test_circular_shift_gate_decomposition() -> None:
     qubits = [cirq.NamedQubit(q) for q in 'abcdef']
 
     circular_shift = cca.CircularShiftGate(2, 1, cirq.CZ)(*qubits[:2])
@@ -92,7 +92,7 @@ f: ───────────────×───────
     assert actual_text_diagram == expected_text_diagram
 
 
-def test_circular_shift_gate_wire_symbols():
+def test_circular_shift_gate_wire_symbols() -> None:
     qubits = [cirq.NamedQubit(q) for q in 'xyz']
     circuit = cirq.Circuit(cca.CircularShiftGate(3, 2)(*qubits))
     actual_text_diagram = circuit.to_text_diagram().strip()

--- a/cirq-core/cirq/contrib/acquaintance/strategies/cubic_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/strategies/cubic_test.py
@@ -21,7 +21,7 @@ import cirq.contrib.acquaintance as cca
 import cirq.contrib.acquaintance.strategies.cubic as ccasc
 
 
-def test_skip_and_wrap_around():
+def test_skip_and_wrap_around() -> None:
     assert ccasc.skip_and_wrap_around(range(3)) == (0, 2, 1)
     assert ccasc.skip_and_wrap_around(range(4)) == (0, 3, 1, 2)
     assert ccasc.skip_and_wrap_around('abcde') == tuple('aebdc')
@@ -29,7 +29,7 @@ def test_skip_and_wrap_around():
 
 
 @pytest.mark.parametrize('n_qubits', range(3, 9))
-def test_cubic_acquaintance_strategy(n_qubits):
+def test_cubic_acquaintance_strategy(n_qubits) -> None:
     qubits = tuple(cirq.LineQubit.range(n_qubits))
     strategy = cca.cubic_acquaintance_strategy(qubits)
     initial_mapping = {q: i for i, q in enumerate(qubits)}

--- a/cirq-core/cirq/contrib/acquaintance/topological_sort_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/topological_sort_test.py
@@ -29,7 +29,7 @@ import cirq.contrib.acquaintance as cca
         for _ in range(5)
     ],
 )
-def test_topological_sort(circuit_dag, sorted_nodes):
+def test_topological_sort(circuit_dag, sorted_nodes) -> None:
     sorted_nodes = list(sorted_nodes)
     assert cca.is_topologically_sorted(circuit_dag, (node.val for node in sorted_nodes))
 

--- a/cirq-core/cirq/contrib/hacks/disable_validation_test.py
+++ b/cirq-core/cirq/contrib/hacks/disable_validation_test.py
@@ -18,7 +18,7 @@ import cirq
 from cirq.contrib.hacks.disable_validation import disable_op_validation
 
 
-def test_disable_op_validation():
+def test_disable_op_validation() -> None:
     q0, q1 = cirq.LineQubit.range(2)
 
     # Fails normally.

--- a/cirq-core/cirq/contrib/json_test.py
+++ b/cirq-core/cirq/contrib/json_test.py
@@ -7,14 +7,14 @@ from cirq.contrib.quantum_volume import QuantumVolumeResult
 from cirq.testing import assert_json_roundtrip_works
 
 
-def test_bayesian_network_gate():
+def test_bayesian_network_gate() -> None:
     gate = BayesianNetworkGate(
         init_probs=[('q0', 0.125), ('q1', None)], arc_probs=[('q1', ('q0',), [0.25, 0.5])]
     )
     assert_json_roundtrip_works(gate, resolvers=DEFAULT_CONTRIB_RESOLVERS)
 
 
-def test_quantum_volume():
+def test_quantum_volume() -> None:
     qubits = cirq.LineQubit.range(5)
     qvr = QuantumVolumeResult(
         model_circuit=cirq.Circuit(cirq.H.on_each(qubits)),
@@ -25,6 +25,6 @@ def test_quantum_volume():
     assert_json_roundtrip_works(qvr, resolvers=DEFAULT_CONTRIB_RESOLVERS)
 
 
-def test_swap_permutation_gate():
+def test_swap_permutation_gate() -> None:
     gate = SwapPermutationGate(swap_gate=cirq.SWAP)
     assert_json_roundtrip_works(gate, resolvers=DEFAULT_CONTRIB_RESOLVERS)

--- a/cirq-core/cirq/contrib/noise_models/noise_models_test.py
+++ b/cirq-core/cirq/contrib/noise_models/noise_models_test.py
@@ -18,7 +18,7 @@ from cirq import ops
 from cirq.testing import assert_equivalent_op_tree
 
 
-def test_depol_noise():
+def test_depol_noise() -> None:
     noise_model = ccn.DepolarizingNoiseModel(depol_prob=0.005)
     qubits = cirq.LineQubit.range(2)
     moment = cirq.Moment([cirq.X(qubits[0]), cirq.Y(qubits[1])])
@@ -29,7 +29,7 @@ def test_depol_noise():
         assert isinstance(g.gate, cirq.DepolarizingChannel)
 
 
-def test_depol_noise_prepend():
+def test_depol_noise_prepend() -> None:
     noise_model = ccn.DepolarizingNoiseModel(depol_prob=0.005, prepend=True)
     qubits = cirq.LineQubit.range(2)
     moment = cirq.Moment([cirq.X(qubits[0]), cirq.Y(qubits[1])])
@@ -41,7 +41,7 @@ def test_depol_noise_prepend():
 
 
 # Composes depolarization noise with readout noise.
-def test_readout_noise_after_moment():
+def test_readout_noise_after_moment() -> None:
     program = cirq.Circuit()
     qubits = cirq.LineQubit.range(3)
     program.append(
@@ -92,7 +92,7 @@ def test_readout_noise_after_moment():
     assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
 
 
-def test_readout_noise_no_prepend():
+def test_readout_noise_no_prepend() -> None:
     noise_model = ccn.ReadoutNoiseModel(bitflip_prob=0.005, prepend=False)
     qubits = cirq.LineQubit.range(2)
     moment = cirq.Moment([cirq.measure(*qubits, key="meas")])
@@ -104,7 +104,7 @@ def test_readout_noise_no_prepend():
 
 
 # Composes depolarization, damping, and readout noise (in that order).
-def test_decay_noise_after_moment():
+def test_decay_noise_after_moment() -> None:
     program = cirq.Circuit()
     qubits = cirq.LineQubit.range(3)
     program.append(
@@ -160,7 +160,7 @@ def test_decay_noise_after_moment():
     assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
 
 
-def test_damped_readout_noise_no_prepend():
+def test_damped_readout_noise_no_prepend() -> None:
     noise_model = ccn.DampedReadoutNoiseModel(decay_prob=0.005, prepend=False)
     qubits = cirq.LineQubit.range(2)
     moment = cirq.Moment([cirq.measure(*qubits, key="meas")])
@@ -172,7 +172,7 @@ def test_damped_readout_noise_no_prepend():
 
 
 # Test the aggregate noise models.
-def test_aggregate_readout_noise_after_moment():
+def test_aggregate_readout_noise_after_moment() -> None:
     program = cirq.Circuit()
     qubits = cirq.LineQubit.range(3)
     program.append(
@@ -219,7 +219,7 @@ def test_aggregate_readout_noise_after_moment():
     assert_equivalent_op_tree(true_noisy_program, noisy_circuit)
 
 
-def test_aggregate_decay_noise_after_moment():
+def test_aggregate_decay_noise_after_moment() -> None:
     program = cirq.Circuit()
     qubits = cirq.LineQubit.range(3)
     program.append(

--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize_test.py
@@ -17,7 +17,7 @@ import cirq
 from cirq.contrib.paulistring import clifford_optimized_circuit, CliffordTargetGateset
 
 
-def test_optimize():
+def test_optimize() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.X(q1) ** 0.5,
@@ -49,7 +49,7 @@ def test_optimize():
     )
 
 
-def test_remove_czs():
+def test_remove_czs() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(cirq.CZ(q0, q1), cirq.Z(q0) ** 0.5, cirq.CZ(q0, q1))
     c_expected = cirq.optimize_for_target_gateset(
@@ -72,7 +72,7 @@ def test_remove_czs():
     )
 
 
-def test_remove_staggered_czs():
+def test_remove_staggered_czs() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.Circuit(cirq.CZ(q0, q1), cirq.CZ(q1, q2), cirq.CZ(q0, q1))
     c_expected = cirq.optimize_for_target_gateset(
@@ -97,7 +97,7 @@ def test_remove_staggered_czs():
     )
 
 
-def test_with_measurements():
+def test_with_measurements() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(cirq.X(q0), cirq.CZ(q0, q1), cirq.measure(q0, q1, key='m'))
     c_expected = cirq.optimize_for_target_gateset(
@@ -121,7 +121,7 @@ def test_with_measurements():
     )
 
 
-def test_optimize_large_circuit():
+def test_optimize_large_circuit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
 

--- a/cirq-core/cirq/contrib/paulistring/clifford_target_gateset_test.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_target_gateset_test.py
@@ -41,7 +41,7 @@ from cirq.contrib.paulistring.clifford_target_gateset import CliffordTargetGates
         )
     )(cirq.LineQubit(0), cirq.LineQubit(1)),
 )
-def test_converts_various_ops(op, expected_ops):
+def test_converts_various_ops(op, expected_ops) -> None:
     before = cirq.Circuit(op)
     expected = cirq.Circuit(expected_ops, strategy=cirq.InsertStrategy.EARLIEST)
     after = cirq.optimize_for_target_gateset(
@@ -58,7 +58,7 @@ def test_converts_various_ops(op, expected_ops):
     )
 
 
-def test_degenerate_single_qubit_decompose():
+def test_degenerate_single_qubit_decompose() -> None:
     q0 = cirq.LineQubit(0)
 
     before = cirq.Circuit(cirq.Z(q0) ** 0.1, cirq.X(q0) ** 1.0000000001, cirq.Z(q0) ** 0.1)
@@ -72,7 +72,7 @@ def test_degenerate_single_qubit_decompose():
     cirq.testing.assert_allclose_up_to_global_phase(after.unitary(), expected.unitary(), atol=1e-7)
 
 
-def test_converts_single_qubit_series():
+def test_converts_single_qubit_series() -> None:
     q0 = cirq.LineQubit(0)
 
     before = cirq.Circuit(
@@ -96,7 +96,7 @@ def test_converts_single_qubit_series():
     cirq.testing.assert_allclose_up_to_global_phase(before.unitary(), after.unitary(), atol=1e-7)
 
 
-def test_converts_single_qubit_then_two():
+def test_converts_single_qubit_then_two() -> None:
     q0, q1 = cirq.LineQubit.range(2)
 
     before = cirq.Circuit(cirq.X(q0), cirq.Y(q0), cirq.CZ(q0, q1))
@@ -107,7 +107,7 @@ def test_converts_single_qubit_then_two():
     cirq.testing.assert_allclose_up_to_global_phase(before.unitary(), after.unitary(), atol=1e-7)
 
 
-def test_converts_large_circuit():
+def test_converts_large_circuit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
 
     before = cirq.Circuit(
@@ -147,7 +147,7 @@ def test_converts_large_circuit():
     )
 
 
-def test_convert_to_pauli_string_phasors():
+def test_convert_to_pauli_string_phasors() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(cirq.X(q0), cirq.Y(q1) ** 0.25, cirq.Z(q0) ** 0.125, cirq.H(q1))
     c_new = cirq.optimize_for_target_gateset(
@@ -168,7 +168,7 @@ def test_convert_to_pauli_string_phasors():
     )
 
 
-def test_already_converted():
+def test_already_converted() -> None:
     q0 = cirq.LineQubit(0)
     c_orig = cirq.Circuit(cirq.PauliStringPhasor(cirq.X.on(q0)))
     c_new = cirq.optimize_for_target_gateset(
@@ -181,7 +181,7 @@ def test_already_converted():
     assert c_new == c_orig
 
 
-def test_ignore_unsupported_gate():
+def test_ignore_unsupported_gate() -> None:
     class UnsupportedGate(cirq.testing.TwoQubitGate):
         pass
 
@@ -193,7 +193,7 @@ def test_ignore_unsupported_gate():
     assert c_new == c_orig
 
 
-def test_fail_unsupported_gate():
+def test_fail_unsupported_gate() -> None:
     class UnsupportedGate(cirq.testing.TwoQubitGate):
         pass
 
@@ -205,7 +205,7 @@ def test_fail_unsupported_gate():
         )
 
 
-def test_convert_to_single_qubit_cliffords():
+def test_convert_to_single_qubit_cliffords() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.X(q0), cirq.Y(q1) ** 0.5, cirq.Z(q0) ** -0.5, cirq.Z(q1) ** 0, cirq.H(q0)
@@ -232,7 +232,7 @@ def test_convert_to_single_qubit_cliffords():
     )
 
 
-def test_convert_to_single_qubit_cliffords_ignores_non_clifford():
+def test_convert_to_single_qubit_cliffords_ignores_non_clifford() -> None:
     q0 = cirq.LineQubit(0)
     c_orig = cirq.Circuit(cirq.Z(q0) ** 0.25)
     c_new = cirq.optimize_for_target_gateset(

--- a/cirq-core/cirq/contrib/paulistring/optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/optimize_test.py
@@ -17,7 +17,7 @@ import cirq
 from cirq.contrib.paulistring import optimized_circuit
 
 
-def test_optimize():
+def test_optimize() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.Circuit(
         cirq.X(q0) ** 0.5,
@@ -61,7 +61,7 @@ def test_optimize():
     )
 
 
-def test_optimize_large_circuit():
+def test_optimize_large_circuit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
 
@@ -79,7 +79,7 @@ def test_optimize_large_circuit():
     )
 
 
-def test_repeat_limit():
+def test_repeat_limit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
 

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_dag_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_dag_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.contrib.paulistring import convert_and_separate_circuit, pauli_string_dag_from_circuit
 
 
-def test_pauli_string_dag_from_circuit():
+def test_pauli_string_dag_from_circuit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
     c_left, _ = convert_and_separate_circuit(c_orig)

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_optimize_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.contrib.paulistring import CliffordTargetGateset, pauli_string_optimized_circuit
 
 
-def test_optimize():
+def test_optimize() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.X(q0) ** 0.25, cirq.H(q0), cirq.CZ(q0, q1), cirq.H(q0), cirq.X(q0) ** 0.125
@@ -50,7 +50,7 @@ def test_optimize():
     )
 
 
-def test_handles_measurement_gate():
+def test_handles_measurement_gate() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.X(q0) ** 0.25,
@@ -75,7 +75,7 @@ def test_handles_measurement_gate():
     )
 
 
-def test_optimize_large_circuit():
+def test_optimize_large_circuit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
 

--- a/cirq-core/cirq/contrib/paulistring/recombine_test.py
+++ b/cirq-core/cirq/contrib/paulistring/recombine_test.py
@@ -26,7 +26,7 @@ def _assert_no_multi_qubit_pauli_strings(circuit: cirq.Circuit) -> None:
             assert len(op.pauli_string) == 1  # pragma: no cover
 
 
-def test_move_non_clifford_into_clifford():
+def test_move_non_clifford_into_clifford() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c_orig = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
 

--- a/cirq-core/cirq/contrib/paulistring/separate_test.py
+++ b/cirq-core/cirq/contrib/paulistring/separate_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.contrib.paulistring import convert_and_separate_circuit
 
 
-def test_toffoli_separate():
+def test_toffoli_separate() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     circuit = cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2)
 

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -29,7 +29,7 @@ from cirq.contrib.qasm_import._parser import QasmParser
 from cirq.testing import consistent_qasm as cq
 
 
-def test_format_header_circuit():
+def test_format_header_circuit() -> None:
     parser = QasmParser()
 
     parsed_qasm = parser.parse("OPENQASM 2.0;")
@@ -39,7 +39,7 @@ def test_format_header_circuit():
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
 
 
-def test_unsupported_format():
+def test_unsupported_format() -> None:
     qasm = "OPENQASM 2.1;"
     parser = QasmParser()
 
@@ -47,7 +47,7 @@ def test_unsupported_format():
         parser.parse(qasm)
 
 
-def test_format_header_with_quelibinc_circuit():
+def test_format_header_with_quelibinc_circuit() -> None:
     qasm = """OPENQASM 2.0;
 include "qelib1.inc";
 """
@@ -61,14 +61,14 @@ include "qelib1.inc";
 
 
 @pytest.mark.parametrize('qasm', ["include \"qelib1.inc\";", "", "qreg q[3];"])
-def test_error_not_starting_with_format(qasm: str):
+def test_error_not_starting_with_format(qasm: str) -> None:
     parser = QasmParser()
 
     with pytest.raises(QasmException, match="Missing 'OPENQASM 2.0;' statement"):
         parser.parse(qasm)
 
 
-def test_comments():
+def test_comments() -> None:
     parser = QasmParser()
 
     parsed_qasm = parser.parse(
@@ -87,7 +87,7 @@ def test_comments():
     ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
 
 
-def test_multiple_qreg_declaration():
+def test_multiple_qreg_declaration() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg a_quantum_register [ 1337 ];
@@ -116,7 +116,7 @@ def test_multiple_qreg_declaration():
                """,
     ],
 )
-def test_already_defined_error(qasm: str):
+def test_already_defined_error(qasm: str) -> None:
     parser = QasmParser()
 
     with pytest.raises(QasmException, match=r"q.*already defined.* line 3"):
@@ -134,14 +134,14 @@ def test_already_defined_error(qasm: str):
                """,
     ],
 )
-def test_zero_length_register(qasm: str):
+def test_zero_length_register(qasm: str) -> None:
     parser = QasmParser()
 
     with pytest.raises(QasmException, match=".* zero-length.*'q'.*line 2"):
         parser.parse(qasm)
 
 
-def test_unexpected_end_of_file():
+def test_unexpected_end_of_file() -> None:
     qasm = """OPENQASM 2.0;
               include "qelib1.inc";
               creg
@@ -152,7 +152,7 @@ def test_unexpected_end_of_file():
         parser.parse(qasm)
 
 
-def test_multiple_creg_declaration():
+def test_multiple_creg_declaration() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      creg a_classical_register [1337];
@@ -170,7 +170,7 @@ def test_multiple_creg_declaration():
     assert parsed_qasm.cregs == {'a_classical_register': 1337, 'c': 42}
 
 
-def test_syntax_error():
+def test_syntax_error() -> None:
     qasm = """OPENQASM 2.0;
          qreg q[2] bla;
          foobar q[0];
@@ -181,7 +181,7 @@ def test_syntax_error():
         parser.parse(qasm)
 
 
-def test_CX_gate():
+def test_CX_gate() -> None:
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[2];
@@ -215,7 +215,7 @@ def test_CX_gate():
     assert parsed_qasm.qregs == {'q1': 2, 'q2': 2}
 
 
-def test_classical_control():
+def test_classical_control() -> None:
     qasm = """OPENQASM 2.0;
         qreg q[2];
         creg a[1];
@@ -259,7 +259,7 @@ if (m_a_0==1) cx q[0],q[1];
     assert cirq.qasm(parsed_qasm.circuit) == expected_generated_qasm
 
 
-def test_classical_control_multi_bit():
+def test_classical_control_multi_bit() -> None:
     qasm = """OPENQASM 2.0;
         qreg q[2];
         creg a[2];
@@ -296,7 +296,7 @@ def test_classical_control_multi_bit():
         _ = cirq.qasm(parsed_qasm.circuit)
 
 
-def test_CX_gate_not_enough_args():
+def test_CX_gate_not_enough_args() -> None:
     qasm = """OPENQASM 2.0;
      qreg q[2];
      CX q[0];
@@ -307,7 +307,7 @@ def test_CX_gate_not_enough_args():
         parser.parse(qasm)
 
 
-def test_CX_gate_mismatched_registers():
+def test_CX_gate_mismatched_registers() -> None:
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[3];
@@ -319,7 +319,7 @@ def test_CX_gate_mismatched_registers():
         parser.parse(qasm)
 
 
-def test_CX_gate_bounds():
+def test_CX_gate_bounds() -> None:
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[3];
@@ -331,7 +331,7 @@ def test_CX_gate_bounds():
         parser.parse(qasm)
 
 
-def test_CX_gate_arg_overlap():
+def test_CX_gate_arg_overlap() -> None:
     qasm = """OPENQASM 2.0;
      qreg q1[2];
      qreg q2[3];
@@ -343,7 +343,7 @@ def test_CX_gate_arg_overlap():
         parser.parse(qasm)
 
 
-def test_U_gate():
+def test_U_gate() -> None:
     qasm = """
      OPENQASM 2.0;
      qreg q[2];
@@ -376,7 +376,7 @@ def test_U_gate():
     assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_U_angles():
+def test_U_angles() -> None:
     qasm = """
     OPENQASM 2.0;
     qreg q[1];
@@ -389,7 +389,7 @@ def test_U_angles():
     )
 
 
-def test_U_gate_zero_params_error():
+def test_U_gate_zero_params_error() -> None:
     qasm = """OPENQASM 2.0;
      qreg q[2];
      U q[1];"""
@@ -400,7 +400,7 @@ def test_U_gate_zero_params_error():
         parser.parse(qasm)
 
 
-def test_U_gate_too_much_params_error():
+def test_U_gate_too_much_params_error() -> None:
     qasm = """OPENQASM 2.0;
      qreg q[2];
      U(pi, pi, pi, pi) q[1];"""
@@ -439,7 +439,7 @@ def test_U_gate_too_much_params_error():
         'atan(0.2)',
     ],
 )
-def test_expressions(expr: str):
+def test_expressions(expr: str) -> None:
     qasm = f"""OPENQASM 2.0;
      qreg q[1];
      U({expr}, 2 * pi, pi / 2.0) q[0];
@@ -463,7 +463,7 @@ def test_expressions(expr: str):
     assert parsed_qasm.qregs == {'q': 1}
 
 
-def test_unknown_function():
+def test_unknown_function() -> None:
     qasm = """OPENQASM 2.0;
      qreg q[1];
      U(nonexistent(3), 2 * pi, pi / 3.0) q[0];
@@ -491,7 +491,7 @@ single_qubit_gates = [
 
 
 @pytest.mark.parametrize('qasm_gate,cirq_gate', rotation_gates)
-def test_rotation_gates(qasm_gate: str, cirq_gate: Callable[[float], cirq.Gate]):
+def test_rotation_gates(qasm_gate: str, cirq_gate: Callable[[float], cirq.Gate]) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -518,7 +518,7 @@ def test_rotation_gates(qasm_gate: str, cirq_gate: Callable[[float], cirq.Gate])
 
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
-def test_rotation_gates_wrong_number_of_args(qasm_gate: str):
+def test_rotation_gates_wrong_number_of_args(qasm_gate: str) -> None:
     qasm = f"""
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -533,7 +533,7 @@ def test_rotation_gates_wrong_number_of_args(qasm_gate: str):
 
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
-def test_rotation_gates_zero_params_error(qasm_gate: str):
+def test_rotation_gates_zero_params_error(qasm_gate: str) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -546,7 +546,7 @@ def test_rotation_gates_zero_params_error(qasm_gate: str):
         parser.parse(qasm)
 
 
-def test_qelib_gate_without_include_statement():
+def test_qelib_gate_without_include_statement() -> None:
     qasm = """OPENQASM 2.0;
          qreg q[2];
          x q[0];
@@ -557,7 +557,7 @@ def test_qelib_gate_without_include_statement():
         parser.parse(qasm)
 
 
-def test_undefined_register_from_qubit_arg():
+def test_undefined_register_from_qubit_arg() -> None:
     qasm = """OPENQASM 2.0;
             qreg q[2];
             CX q[0], q2[1];
@@ -568,7 +568,7 @@ def test_undefined_register_from_qubit_arg():
         parser.parse(qasm)
 
 
-def test_undefined_register_from_register_arg():
+def test_undefined_register_from_register_arg() -> None:
     qasm = """OPENQASM 2.0;
             qreg q[2];
             qreg q2[2];
@@ -580,7 +580,7 @@ def test_undefined_register_from_register_arg():
         parser.parse(qasm)
 
 
-def test_measure_individual_bits():
+def test_measure_individual_bits() -> None:
     qasm = """
          OPENQASM 2.0;
          include "qelib1.inc";
@@ -609,7 +609,7 @@ def test_measure_individual_bits():
     assert parsed_qasm.cregs == {'c1': 2}
 
 
-def test_measure_registers():
+def test_measure_registers() -> None:
     qasm = """OPENQASM 2.0;
          include "qelib1.inc";
          qreg q1[3];
@@ -638,7 +638,7 @@ def test_measure_registers():
     assert parsed_qasm.cregs == {'c1': 3}
 
 
-def test_measure_mismatched_register_size():
+def test_measure_mismatched_register_size() -> None:
     qasm = """OPENQASM 2.0;
          include "qelib1.inc";
          qreg q1[2];
@@ -652,7 +652,7 @@ def test_measure_mismatched_register_size():
         parser.parse(qasm)
 
 
-def test_measure_to_quantum_register():
+def test_measure_to_quantum_register() -> None:
     qasm = """OPENQASM 2.0;
          include "qelib1.inc";
          qreg q1[3];
@@ -667,7 +667,7 @@ def test_measure_to_quantum_register():
         parser.parse(qasm)
 
 
-def test_measure_undefined_classical_bit():
+def test_measure_undefined_classical_bit() -> None:
     qasm = """OPENQASM 2.0;
          include "qelib1.inc";
          qreg q1[3];
@@ -681,7 +681,7 @@ def test_measure_undefined_classical_bit():
         parser.parse(qasm)
 
 
-def test_measure_from_classical_register():
+def test_measure_from_classical_register() -> None:
     qasm = """OPENQASM 2.0;
          include "qelib1.inc";
          qreg q1[2];
@@ -696,7 +696,7 @@ def test_measure_from_classical_register():
         parser.parse(qasm)
 
 
-def test_measurement_bounds():
+def test_measurement_bounds() -> None:
     qasm = """OPENQASM 2.0;
      qreg q1[3];
      creg c1[3];
@@ -708,7 +708,7 @@ def test_measurement_bounds():
         parser.parse(qasm)
 
 
-def test_reset():
+def test_reset() -> None:
     qasm = textwrap.dedent(
         """\
         OPENQASM 2.0;
@@ -737,7 +737,7 @@ def test_reset():
     assert parsed_qasm.cregs == {'c': 1}
 
 
-def test_u1_gate():
+def test_u1_gate() -> None:
     qasm = """
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -760,7 +760,7 @@ def test_u1_gate():
     assert parsed_qasm.qregs == {'q': 1}
 
 
-def test_u2_gate():
+def test_u2_gate() -> None:
     qasm = """
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -783,7 +783,7 @@ def test_u2_gate():
     assert parsed_qasm.qregs == {'q': 1}
 
 
-def test_id_gate():
+def test_id_gate() -> None:
     qasm = """
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -808,7 +808,7 @@ def test_id_gate():
     assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_u3_gate():
+def test_u3_gate() -> None:
     qasm = """
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -842,7 +842,7 @@ def test_u3_gate():
     assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_r_gate():
+def test_r_gate() -> None:
     qasm = """
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -869,7 +869,7 @@ def test_r_gate():
     'qasm_gate',
     ['id', 'u2', 'u3', 'r'] + [g[0] for g in rotation_gates] + [g[0] for g in single_qubit_gates],
 )
-def test_standard_single_qubit_gates_wrong_number_of_args(qasm_gate):
+def test_standard_single_qubit_gates_wrong_number_of_args(qasm_gate) -> None:
     qasm = f"""
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -888,7 +888,7 @@ def test_standard_single_qubit_gates_wrong_number_of_args(qasm_gate):
     [['id', 0], ['u2', 2], ['u3', 3], ['rx', 1], ['ry', 1], ['rz', 1], ['r', 2]]
     + [[g[0], 0] for g in single_qubit_gates],
 )
-def test_standard_gates_wrong_params_error(qasm_gate: str, num_params: int):
+def test_standard_gates_wrong_params_error(qasm_gate: str, num_params: int) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -934,7 +934,7 @@ two_qubit_param_gates = {
 
 
 @pytest.mark.parametrize('qasm_gate,cirq_gate', two_qubit_gates)
-def test_two_qubit_gates(qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate):
+def test_two_qubit_gates(qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate) -> None:
     qasm = f"""
     OPENQASM 2.0;
     include "qelib1.inc";
@@ -1015,7 +1015,7 @@ def test_two_qubit_param_gates(
 @pytest.mark.parametrize(
     'qasm_gate', [g[0] for g in two_qubit_gates] + [g[0] for g in two_qubit_param_gates.keys()]
 )
-def test_two_qubit_gates_not_enough_qubits(qasm_gate: str):
+def test_two_qubit_gates_not_enough_qubits(qasm_gate: str) -> None:
     if qasm_gate in ('cu1', 'crz'):
         qasm = f"""
         OPENQASM 2.0;
@@ -1045,7 +1045,7 @@ def test_two_qubit_gates_not_enough_qubits(qasm_gate: str):
 
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in two_qubit_param_gates.keys()])
-def test_two_qubit_gates_not_enough_args(qasm_gate: str):
+def test_two_qubit_gates_not_enough_args(qasm_gate: str) -> None:
     qasm = f"""
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -1062,7 +1062,7 @@ def test_two_qubit_gates_not_enough_args(qasm_gate: str):
 @pytest.mark.parametrize(
     'qasm_gate', [g[0] for g in two_qubit_gates] + [g[0] for g in two_qubit_param_gates.keys()]
 )
-def test_two_qubit_gates_with_too_much_parameters(qasm_gate: str):
+def test_two_qubit_gates_with_too_much_parameters(qasm_gate: str) -> None:
     if qasm_gate in ('cu1', 'cu3', 'crz'):
         num_params_needed = 3 if qasm_gate == 'cu3' else 1
     else:
@@ -1088,7 +1088,7 @@ three_qubit_gates = [('ccx', cirq.TOFFOLI), ('cswap', cirq.CSWAP)]
 
 
 @pytest.mark.parametrize('qasm_gate,cirq_gate', three_qubit_gates)
-def test_three_qubit_gates(qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate):
+def test_three_qubit_gates(qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate) -> None:
     qasm = f"""
      OPENQASM 2.0;
      include "qelib1.inc";
@@ -1128,7 +1128,7 @@ def test_three_qubit_gates(qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate)
 
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in three_qubit_gates])
-def test_three_qubit_gates_not_enough_args(qasm_gate: str):
+def test_three_qubit_gates_not_enough_args(qasm_gate: str) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -1142,7 +1142,7 @@ def test_three_qubit_gates_not_enough_args(qasm_gate: str):
 
 
 @pytest.mark.parametrize('qasm_gate', [g[0] for g in three_qubit_gates])
-def test_three_qubit_gates_with_too_much_parameters(qasm_gate: str):
+def test_three_qubit_gates_with_too_much_parameters(qasm_gate: str) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[3];
@@ -1156,7 +1156,7 @@ def test_three_qubit_gates_with_too_much_parameters(qasm_gate: str):
 
 
 @pytest.mark.parametrize('qasm_gate,cirq_gate', single_qubit_gates)
-def test_single_qubit_gates(qasm_gate: str, cirq_gate: cirq.Gate):
+def test_single_qubit_gates(qasm_gate: str, cirq_gate: cirq.Gate) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -1180,7 +1180,7 @@ def test_single_qubit_gates(qasm_gate: str, cirq_gate: cirq.Gate):
     assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_openqasm_3_0_qubits():
+def test_openqasm_3_0_qubits() -> None:
     qasm = """OPENQASM 3.0;
      include "stdgates.inc";
      qubit[2] q;
@@ -1205,7 +1205,7 @@ def test_openqasm_3_0_qubits():
     assert parsed_qasm.qregs == {'q': 2}
 
 
-def test_openqasm_3_0_scalar_qubit():
+def test_openqasm_3_0_scalar_qubit() -> None:
     qasm = """OPENQASM 3.0;
      include "stdgates.inc";
      qubit q;
@@ -1230,7 +1230,7 @@ def test_openqasm_3_0_scalar_qubit():
     assert parsed_qasm.qregs == {'q': 1}
 
 
-def test_custom_gate():
+def test_custom_gate() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -1271,7 +1271,7 @@ def test_custom_gate():
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(unrolled))
 
 
-def test_custom_gate_parameterized():
+def test_custom_gate_parameterized() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -1320,7 +1320,7 @@ def test_custom_gate_parameterized():
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(unrolled))
 
 
-def test_custom_gate_broadcast():
+def test_custom_gate_broadcast() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[3];
@@ -1370,7 +1370,7 @@ def test_custom_gate_broadcast():
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(unrolled))
 
 
-def test_custom_gate_undefined_qubit_error():
+def test_custom_gate_undefined_qubit_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1384,7 +1384,7 @@ def test_custom_gate_undefined_qubit_error():
     )
 
 
-def test_custom_gate_qubit_scope_closure_error():
+def test_custom_gate_qubit_scope_closure_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1398,7 +1398,7 @@ def test_custom_gate_qubit_scope_closure_error():
     )
 
 
-def test_custom_gate_qubit_index_error():
+def test_custom_gate_qubit_index_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1412,7 +1412,7 @@ def test_custom_gate_qubit_index_error():
     )
 
 
-def test_custom_gate_qreg_count_error():
+def test_custom_gate_qreg_count_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[2];
@@ -1426,7 +1426,7 @@ def test_custom_gate_qreg_count_error():
     )
 
 
-def test_custom_gate_missing_param_error():
+def test_custom_gate_missing_param_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1440,7 +1440,7 @@ def test_custom_gate_missing_param_error():
     )
 
 
-def test_custom_gate_extra_param_error():
+def test_custom_gate_extra_param_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1454,7 +1454,7 @@ def test_custom_gate_extra_param_error():
     )
 
 
-def test_custom_gate_undefined_param_error():
+def test_custom_gate_undefined_param_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1468,7 +1468,7 @@ def test_custom_gate_undefined_param_error():
     )
 
 
-def test_top_level_param_error():
+def test_top_level_param_error() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
@@ -1495,7 +1495,7 @@ def _test_parse_exception(qasm: str, cirq_err: str, qiskit_err: str | None):
         qiskit.QuantumCircuit.from_qasm_str(qasm)
 
 
-def test_nested_custom_gate_has_keyword_in_name():
+def test_nested_custom_gate_has_keyword_in_name() -> None:
     qasm = """OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf_test.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf_test.py
@@ -21,7 +21,7 @@ import cirq.contrib.qcircuit.qcircuit_pdf as qcircuit_pdf
 
 
 @mock.patch.object(pylatex.Document, "generate_pdf")
-def test_qcircuit_pdf(mock_generate_pdf):
+def test_qcircuit_pdf(mock_generate_pdf) -> None:
     circuit = cirq.Circuit(cirq.X(cirq.q(0)), cirq.CZ(cirq.q(0), cirq.q(1)))
     qcircuit_pdf.circuit_to_pdf_using_qcircuit_via_tex(circuit, "/tmp/test_file")
     mock_generate_pdf.assert_called_once_with(

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_test.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_test.py
@@ -43,7 +43,7 @@ def assert_has_qcircuit_diagram(actual: cirq.Circuit, desired: str, **kwargs) ->
     )
 
 
-def test_fallback_diagram():
+def test_fallback_diagram() -> None:
     class MagicGate(cirq.testing.ThreeQubitGate):
         def __str__(self):
             return 'MagicGate'
@@ -77,7 +77,7 @@ def test_fallback_diagram():
     assert_has_qcircuit_diagram(circuit, expected_diagram)
 
 
-def test_teleportation_diagram():
+def test_teleportation_diagram() -> None:
     ali = cirq.NamedQubit('alice')
     car = cirq.NamedQubit('carrier')
     bob = cirq.NamedQubit('bob')
@@ -106,7 +106,7 @@ def test_teleportation_diagram():
     )
 
 
-def test_other_diagram():
+def test_other_diagram() -> None:
     a, b, c = cirq.LineQubit.range(3)
 
     circuit = cirq.Circuit(cirq.X(a), cirq.Y(b), cirq.Z(c))
@@ -122,7 +122,7 @@ def test_other_diagram():
     assert_has_qcircuit_diagram(circuit, expected_diagram)
 
 
-def test_qcircuit_qubit_namer():
+def test_qcircuit_qubit_namer() -> None:
     from cirq.contrib.qcircuit import qcircuit_diagram
 
     assert qcircuit_diagram.qcircuit_qubit_namer(cirq.NamedQubit('q')) == r'\lstick{\text{q}}&'
@@ -137,7 +137,7 @@ def test_qcircuit_qubit_namer():
     )
 
 
-def test_two_cx_diagram():
+def test_two_cx_diagram() -> None:
     # test for no moment indication
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(cirq.CX(q0, q2), cirq.CX(q1, q3), cirq.CX(q0, q2), cirq.CX(q1, q3))
@@ -153,7 +153,7 @@ def test_two_cx_diagram():
     assert_has_qcircuit_diagram(circuit, expected_diagram)
 
 
-def test_sqrt_iswap_diagram():
+def test_sqrt_iswap_diagram() -> None:
     # test for proper rendering of ISWAP^{0.5}
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.ISWAP(q0, q1) ** 0.5)

--- a/cirq-core/cirq/contrib/routing/greedy_test.py
+++ b/cirq-core/cirq/contrib/routing/greedy_test.py
@@ -21,7 +21,7 @@ import cirq.contrib.routing as ccr
 from cirq.contrib.routing.greedy import route_circuit_greedily
 
 
-def test_bad_args():
+def test_bad_args() -> None:
     """Test zero valued arguments in greedy router."""
     circuit = cirq.testing.random_circuit(4, 2, 0.5, random_state=5)
     device_graph = ccr.get_grid_device_graph(3, 2)
@@ -50,7 +50,7 @@ def create_hanging_routing_instance(circuit, device_graph):
     )
 
 
-def test_router_hanging():
+def test_router_hanging() -> None:
     """Run a separate process and check if greedy router hits timeout (20s)."""
     circuit, device_graph = create_circuit_and_device()
     process = Process(target=create_hanging_routing_instance, args=[circuit, device_graph])

--- a/cirq-core/cirq/contrib/routing/initialization_test.py
+++ b/cirq-core/cirq/contrib/routing/initialization_test.py
@@ -30,7 +30,7 @@ def get_seeded_initial_mapping(graph_seed, init_seed):
 
 
 @pytest.mark.parametrize('seed', [random.randint(0, 2**32) for _ in range(10)])
-def test_initialization_reproducible_with_seed(seed):
+def test_initialization_reproducible_with_seed(seed) -> None:
     wrappers = (lambda s: s, np.random.RandomState)
     mappings = [
         get_seeded_initial_mapping(seed, wrapper(seed)) for wrapper in wrappers for _ in range(5)
@@ -39,7 +39,7 @@ def test_initialization_reproducible_with_seed(seed):
     eq.add_equality_group(*mappings)
 
 
-def test_initialization_with_no_seed():
+def test_initialization_with_no_seed() -> None:
     graph_seed = random.randint(0, 2**32)
     state = np.random.get_state()
     mappings = []
@@ -50,7 +50,7 @@ def test_initialization_with_no_seed():
     eq.add_equality_group(*mappings)
 
 
-def test_initialization_reproducible_between_runs():
+def test_initialization_reproducible_between_runs() -> None:
     seed = 45
     logical_graph = nx.erdos_renyi_graph(6, 0.5, seed=seed)
     logical_graph = nx.relabel_nodes(logical_graph, cirq.LineQubit)

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -7,7 +7,7 @@ import cirq
 from cirq.contrib.svg import circuit_to_svg, SVGCircuit
 
 
-def test_svg():
+def test_svg() -> None:
     a, b, c = cirq.LineQubit.range(3)
 
     svg_text = circuit_to_svg(
@@ -26,7 +26,7 @@ def test_svg():
     assert '</svg>' in svg_text
 
 
-def test_svg_noise():
+def test_svg_noise() -> None:
     noise_model = cirq.ConstantQubitNoiseModel(cirq.DepolarizingChannel(p=1e-3))
     q = cirq.LineQubit(0)
     circuit = cirq.Circuit(cirq.X(q))
@@ -35,12 +35,12 @@ def test_svg_noise():
     assert '>D(0.001)</text>' in svg
 
 
-def test_validation():
+def test_validation() -> None:
     with pytest.raises(ValueError):
         circuit_to_svg(cirq.Circuit())
 
 
-def test_empty_moments():
+def test_empty_moments() -> None:
     a, b = cirq.LineQubit.range(2)
     svg_1 = circuit_to_svg(
         cirq.Circuit(
@@ -73,7 +73,7 @@ def test_empty_moments():
         ('A[<virtual>]B[cirq.VirtualTag()]C>D<E', 'ABC&gt;D&lt;E'),
     ],
 )
-def test_gate_with_less_greater_str(symbol, svg_symbol):
+def test_gate_with_less_greater_str(symbol, svg_symbol) -> None:
     class CustomGate(cirq.Gate):
         def _num_qubits_(self) -> int:
             return 1

--- a/cirq-core/cirq/devices/device_test.py
+++ b/cirq-core/cirq/devices/device_test.py
@@ -4,14 +4,14 @@ import networkx as nx
 import cirq
 
 
-def test_device_metadata():
+def test_device_metadata() -> None:
     class RawDevice(cirq.Device):
         pass
 
     assert RawDevice().metadata is None
 
 
-def test_metadata():
+def test_metadata() -> None:
     qubits = cirq.LineQubit.range(4)
     graph = nx.star_graph(3)
     metadata = cirq.DeviceMetadata(qubits, graph)
@@ -19,7 +19,7 @@ def test_metadata():
     assert metadata.nx_graph == graph
 
 
-def test_metadata_json_load_logic():
+def test_metadata_json_load_logic() -> None:
     qubits = cirq.LineQubit.range(4)
     graph = nx.star_graph(3)
     metadata = cirq.DeviceMetadata(qubits, graph)
@@ -27,7 +27,7 @@ def test_metadata_json_load_logic():
     assert metadata == cirq.read_json(json_text=str_rep)
 
 
-def test_metadata_equality():
+def test_metadata_equality() -> None:
     qubits = cirq.LineQubit.range(4)
     graph = nx.star_graph(3)
     graph2 = nx.star_graph(3)

--- a/cirq-core/cirq/devices/insertion_noise_model_test.py
+++ b/cirq-core/cirq/devices/insertion_noise_model_test.py
@@ -17,7 +17,7 @@ from cirq.devices.insertion_noise_model import InsertionNoiseModel
 from cirq.devices.noise_utils import OpIdentifier, PHYSICAL_GATE_TAG
 
 
-def test_insertion_noise():
+def test_insertion_noise() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     op_id0 = OpIdentifier(cirq.XPowGate, q0)
     op_id1 = OpIdentifier(cirq.ZPowGate, q1)
@@ -50,7 +50,7 @@ def test_insertion_noise():
     cirq.testing.assert_equivalent_repr(model)
 
 
-def test_colliding_noise_qubits():
+def test_colliding_noise_qubits() -> None:
     # Check that noise affecting other qubits doesn't cause issues.
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     op_id0 = OpIdentifier(cirq.CZPowGate)
@@ -66,7 +66,7 @@ def test_colliding_noise_qubits():
     cirq.testing.assert_equivalent_repr(model)
 
 
-def test_prepend():
+def test_prepend() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     op_id0 = OpIdentifier(cirq.XPowGate, q0)
     op_id1 = OpIdentifier(cirq.ZPowGate, q1)
@@ -81,7 +81,7 @@ def test_prepend():
     ]
 
 
-def test_require_physical_tag():
+def test_require_physical_tag() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     op_id0 = OpIdentifier(cirq.XPowGate, q0)
     op_id1 = OpIdentifier(cirq.ZPowGate, q1)
@@ -95,7 +95,7 @@ def test_require_physical_tag():
     ]
 
 
-def test_supertype_matching():
+def test_supertype_matching() -> None:
     # Demonstrate that the model applies the closest matching type
     # if multiple types match a given gate.
     q0 = cirq.LineQubit(0)

--- a/cirq-core/cirq/devices/named_topologies_test.py
+++ b/cirq-core/cirq/devices/named_topologies_test.py
@@ -29,7 +29,7 @@ from cirq import (
 
 
 @pytest.mark.parametrize('width, height', list(itertools.product([1, 2, 3, 24], repeat=2)))
-def test_tilted_square_lattice(width, height):
+def test_tilted_square_lattice(width, height) -> None:
     topo = TiltedSquareLattice(width, height)
     assert topo.graph.number_of_edges() == width * height
     assert all(1 <= topo.graph.degree[node] <= 4 for node in topo.graph.nodes)
@@ -41,14 +41,14 @@ def test_tilted_square_lattice(width, height):
     cirq.testing.assert_equivalent_repr(topo)
 
 
-def test_bad_tilted_square_lattice():
+def test_bad_tilted_square_lattice() -> None:
     with pytest.raises(ValueError):
         _ = TiltedSquareLattice(0, 3)
     with pytest.raises(ValueError):
         _ = TiltedSquareLattice(3, 0)
 
 
-def test_tilted_square_methods():
+def test_tilted_square_methods() -> None:
     topo = TiltedSquareLattice(5, 5)
     ax = MagicMock()
     topo.draw(ax=ax)
@@ -63,13 +63,13 @@ def test_tilted_square_methods():
     )
 
 
-def test_tilted_square_lattice_n_nodes():
+def test_tilted_square_lattice_n_nodes() -> None:
     for width, height in itertools.product(list(range(1, 4 + 1)), repeat=2):
         topo = TiltedSquareLattice(width, height)
         assert topo.n_nodes == topo.graph.number_of_nodes()
 
 
-def test_line_topology():
+def test_line_topology() -> None:
     n = 10
     topo = LineTopology(n)
     assert topo.n_nodes == n
@@ -94,13 +94,13 @@ def test_line_topology():
     cirq.testing.assert_equivalent_repr(topo)
 
 
-def test_line_topology_nodes_as_qubits():
+def test_line_topology_nodes_as_qubits() -> None:
     for n in range(2, 10, 2):
         assert LineTopology(n).nodes_as_linequbits() == cirq.LineQubit.range(n)
 
 
 @pytest.mark.parametrize('tilted', [True, False])
-def test_draw_gridlike(tilted):
+def test_draw_gridlike(tilted) -> None:
     graph = nx.grid_2d_graph(3, 3)
     ax = MagicMock()
     pos = draw_gridlike(graph, tilted=tilted, ax=ax)
@@ -111,7 +111,7 @@ def test_draw_gridlike(tilted):
 
 
 @pytest.mark.parametrize('tilted', [True, False])
-def test_draw_gridlike_qubits(tilted):
+def test_draw_gridlike_qubits(tilted) -> None:
     graph = nx.grid_2d_graph(3, 3)
     graph = nx.relabel_nodes(graph, {(r, c): cirq.GridQubit(r, c) for r, c in sorted(graph.nodes)})
     ax = MagicMock()
@@ -122,7 +122,7 @@ def test_draw_gridlike_qubits(tilted):
         assert 0 <= q.col < 3
 
 
-def test_get_placements():
+def test_get_placements() -> None:
     topo = TiltedSquareLattice(4, 2)
     syc23 = TiltedSquareLattice(8, 4).graph
     placements = get_placements(syc23, topo.graph)
@@ -134,7 +134,7 @@ def test_get_placements():
         ax.scatter.assert_called()
 
 
-def test_is_valid_placement():
+def test_is_valid_placement() -> None:
     topo = TiltedSquareLattice(4, 2)
     syc23 = TiltedSquareLattice(8, 4).graph
     placements = get_placements(syc23, topo.graph)

--- a/cirq-core/cirq/devices/noise_properties_test.py
+++ b/cirq-core/cirq/devices/noise_properties_test.py
@@ -35,7 +35,7 @@ class SampleNoiseProperties(NoiseProperties):
         return [add_h, add_iswap]
 
 
-def test_sample_model():
+def test_sample_model() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     props = SampleNoiseProperties([q0, q1], [(q0, q1), (q1, q0)])
     model = NoiseModelFromNoiseProperties(props)

--- a/cirq-core/cirq/experiments/n_qubit_tomography_test.py
+++ b/cirq-core/cirq/experiments/n_qubit_tomography_test.py
@@ -21,7 +21,7 @@ import cirq
 Q0, Q1, Q2, Q3 = cirq.LineQubit.range(4)
 
 
-def test_state_tomography_diagonal():
+def test_state_tomography_diagonal() -> None:
     n = 2
     qubits = cirq.LineQubit.range(n)
     for state in range(2**n):
@@ -42,7 +42,7 @@ def test_state_tomography_diagonal():
         assert np.allclose(res.data, should_be, atol=0.05)
 
 
-def test_state_tomography_ghz_state():
+def test_state_tomography_ghz_state() -> None:
     circuit = cirq.Circuit()
     circuit.append(cirq.H(cirq.LineQubit(0)))
     circuit.append(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
@@ -61,7 +61,7 @@ def test_state_tomography_ghz_state():
     assert np.allclose(res.data, should_be, atol=0.05)
 
 
-def test_make_experiment_no_rots():
+def test_make_experiment_no_rots() -> None:
     exp = cirq.experiments.StateTomographyExperiment(
         [cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2)]
     )
@@ -97,7 +97,7 @@ def compute_density_matrix(circuit: cirq.Circuit, qubits: Sequence[cirq.Qid]) ->
         ),
     ),
 )
-def test_density_matrix_from_state_tomography_is_correct(circuit, qubits):
+def test_density_matrix_from_state_tomography_is_correct(circuit, qubits) -> None:
     sim = cirq.Simulator(seed=87539319)
     tomography_result = cirq.experiments.state_tomography(sim, qubits, circuit, repetitions=5000)
     actual_rho = tomography_result.data
@@ -115,7 +115,7 @@ def test_density_matrix_from_state_tomography_is_correct(circuit, qubits):
         cirq.Circuit(cirq.X(Q0) ** 0.25, cirq.ISWAP(Q0, Q1)),
     ),
 )
-def test_agrees_with_two_qubit_state_tomography(circuit):
+def test_agrees_with_two_qubit_state_tomography(circuit) -> None:
     qubits = (Q0, Q1)
     sim = cirq.Simulator(seed=87539319)
     tomography_result = cirq.experiments.state_tomography(sim, qubits, circuit, repetitions=5000)

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -20,7 +20,7 @@ import sympy
 import cirq
 
 
-def test_init_result():
+def test_init_result() -> None:
     data = pd.DataFrame(
         columns=['delay_ns', 'false_count', 'true_count'],
         index=range(2),
@@ -31,7 +31,7 @@ def test_init_result():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_plot_does_not_raise_error():
+def test_plot_does_not_raise_error() -> None:
     class _TimeDependentDecay(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):
             duration = max(
@@ -55,7 +55,7 @@ def test_plot_does_not_raise_error():
     results.plot(include_fit=True)
 
 
-def test_result_eq():
+def test_result_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(
         lambda: cirq.experiments.T1DecayResult(
@@ -75,7 +75,7 @@ def test_result_eq():
     )
 
 
-def test_sudden_decay_results():
+def test_sudden_decay_results() -> None:
     class _SuddenDecay(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):
             duration = max(
@@ -107,7 +107,7 @@ def test_sudden_decay_results():
     )
 
 
-def test_all_on_results():
+def test_all_on_results() -> None:
     results = cirq.experiments.t1_decay(
         sampler=cirq.Simulator(),
         qubit=cirq.GridQubit(0, 0),
@@ -126,7 +126,7 @@ def test_all_on_results():
     assert results == desired, f'{results.data=} {desired.data=}'
 
 
-def test_all_off_results():
+def test_all_off_results() -> None:
     results = cirq.experiments.t1_decay(
         sampler=cirq.DensityMatrixSimulator(noise=cirq.amplitude_damp(1)),
         qubit=cirq.GridQubit(0, 0),
@@ -146,7 +146,7 @@ def test_all_off_results():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_curve_fit_plot_works():
+def test_curve_fit_plot_works() -> None:
     good_fit = cirq.experiments.T1DecayResult(
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],
@@ -159,7 +159,7 @@ def test_curve_fit_plot_works():
 
 
 @pytest.mark.parametrize('t1', [200.0, 500.0, 700.0])
-def test_noise_model_continous(t1):
+def test_noise_model_continous(t1) -> None:
     class GradualDecay(cirq.NoiseModel):
         def __init__(self, t1: float):
             self.t1 = t1
@@ -193,7 +193,7 @@ def test_noise_model_continous(t1):
 
 
 @pytest.mark.parametrize('gamma', [0.01, 0.05, 0.1])
-def test_noise_model_discrete(gamma):
+def test_noise_model_discrete(gamma) -> None:
     results = cirq.experiments.t1_decay(
         sampler=cirq.DensityMatrixSimulator(
             noise=cirq.NoiseModel.from_noise_model_like(cirq.amplitude_damp(gamma))
@@ -212,7 +212,7 @@ def test_noise_model_discrete(gamma):
     np.testing.assert_allclose(probs, np.mean(probs), atol=0.2)
 
 
-def test_bad_args():
+def test_bad_args() -> None:
     with pytest.raises(ValueError, match='repetitions <= 0'):
         _ = cirq.experiments.t1_decay(
             sampler=cirq.Simulator(),
@@ -253,7 +253,7 @@ def test_bad_args():
         )
 
 
-def test_str():
+def test_str() -> None:
     result = cirq.experiments.T1DecayResult(
         data=pd.DataFrame(
             columns=['delay_ns', 'false_count', 'true_count'],

--- a/cirq-core/cirq/interop/quirk/cells/arithmetic_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/arithmetic_cells_test.py
@@ -22,7 +22,7 @@ from cirq.interop.quirk.cells import arithmetic_cells
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_arithmetic_comparison_gates():
+def test_arithmetic_comparison_gates() -> None:
     with pytest.raises(ValueError, match='Missing input'):
         _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["^A<B"]]}')
     assert_url_to_circuit_returns(
@@ -73,7 +73,7 @@ def test_arithmetic_comparison_gates():
     )
 
 
-def test_arithmetic_unlisted_misc_gates():
+def test_arithmetic_unlisted_misc_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["^=A3",1,1,"inputA2"]]}',
         maps={
@@ -141,7 +141,7 @@ def test_arithmetic_unlisted_misc_gates():
     )
 
 
-def test_arithmetic_addition_gates():
+def test_arithmetic_addition_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["inc3"]]}',
         diagram="""
@@ -164,7 +164,7 @@ def test_arithmetic_addition_gates():
     )
 
 
-def test_arithmetic_multiply_accumulate_gates():
+def test_arithmetic_multiply_accumulate_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["+=AA4",1,1,1,"inputA2"]]}',
         maps={0b_0000_00: 0b_0000_00, 0b_0100_10: 0b_1000_10, 0b_1000_11: 0b_0001_11},
@@ -186,7 +186,7 @@ def test_arithmetic_multiply_accumulate_gates():
     )
 
 
-def test_modular_arithmetic_modulus_size():
+def test_modular_arithmetic_modulus_size() -> None:
     with pytest.raises(ValueError, match='too small for modulus'):
         _ = quirk_url_to_circuit(
             'https://algassert.com/quirk#circuit={"cols":['
@@ -208,7 +208,7 @@ def test_modular_arithmetic_modulus_size():
     assert_url_to_circuit_returns('{"cols":[["incmodR2",1,"inputR2"]]}')
 
 
-def test_arithmetic_modular_addition_gates():
+def test_arithmetic_modular_addition_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[[{"id":"setR","arg":16}],["incmodR4"]]}',
         diagram="""
@@ -242,7 +242,7 @@ def test_arithmetic_modular_addition_gates():
     )
 
 
-def test_arithmetic_modular_multiply_accumulate_gates():
+def test_arithmetic_modular_multiply_accumulate_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[[{"id":"setR","arg":5},{"id":"setA","arg":3},'
         '{"id":"setB","arg":4}],["+ABmodR4"]]}',
@@ -256,7 +256,7 @@ def test_arithmetic_modular_multiply_accumulate_gates():
     )
 
 
-def test_arithmetic_multiply_gates():
+def test_arithmetic_multiply_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[[{"id":"setA","arg":3}],["*A4"]]}', maps={0: 0, 1: 3, 3: 9, 9: 11, 11: 1}
     )
@@ -273,7 +273,7 @@ def test_arithmetic_multiply_gates():
     )
 
 
-def test_arithmetic_modular_multiply_gates():
+def test_arithmetic_modular_multiply_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[[{"id":"setA","arg":3},{"id":"setR","arg":7}],["*AmodR4"]]}',
         maps={0: 0, 1: 3, 3: 2, 2: 6, 6: 4, 4: 5, 5: 1, 7: 7, 15: 15},
@@ -294,7 +294,7 @@ def test_arithmetic_modular_multiply_gates():
     )
 
 
-def test_arithmetic_modular_exponentiation_gates():
+def test_arithmetic_modular_exponentiation_gates() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[[{"id":"setA","arg":5},{"id":"setB","arg":3},'
         '{"id":"setR","arg":7}],["*BToAmodR4"]]}',
@@ -318,7 +318,7 @@ def test_arithmetic_modular_exponentiation_gates():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     circuit = quirk_url_to_circuit(
         'https://algassert.com/quirk#circuit={"cols":'
         '['
@@ -336,7 +336,7 @@ def test_repr():
     )
 
 
-def test_with_registers():
+def test_with_registers() -> None:
     circuit = quirk_url_to_circuit(
         'https://algassert.com/quirk#circuit={"cols":'
         '['
@@ -363,7 +363,7 @@ def test_with_registers():
     )
 
 
-def test_helpers():
+def test_helpers() -> None:
     f = arithmetic_cells._popcnt
     assert f(0) == 0
     assert f(1) == 1
@@ -414,7 +414,7 @@ def test_helpers():
     assert h(7, 16) == 7
 
 
-def test_with_line_qubits_mapped_to():
+def test_with_line_qubits_mapped_to() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
     a2, b2, c2, d2, e2 = cirq.NamedQubit.range(5, prefix='p')
 

--- a/cirq-core/cirq/interop/quirk/cells/control_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/control_cells_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_controls():
+def test_controls() -> None:
     a, b = cirq.LineQubit.range(2)
 
     assert_url_to_circuit_returns('{"cols":[["•","X"]]}', cirq.Circuit(cirq.X(b).controlled_by(a)))
@@ -86,7 +86,7 @@ def test_controls():
     )
 
 
-def test_parity_controls():
+def test_parity_controls() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
 
     assert_url_to_circuit_returns(
@@ -106,7 +106,7 @@ def test_parity_controls():
     )
 
 
-def test_control_with_line_qubits_mapped_to():
+def test_control_with_line_qubits_mapped_to() -> None:
     a, b = cirq.LineQubit.range(2)
     a2, b2 = cirq.NamedQubit.range(2, prefix='q')
     cell = cirq.interop.quirk.cells.control_cells.ControlCell(a, [cirq.Y(b) ** 0.5])
@@ -115,7 +115,7 @@ def test_control_with_line_qubits_mapped_to():
     assert cell.with_line_qubits_mapped_to([a2, b2]) == mapped_cell
 
 
-def test_parity_control_with_line_qubits_mapped_to():
+def test_parity_control_with_line_qubits_mapped_to() -> None:
     a, b, c = cirq.LineQubit.range(3)
     a2, b2, c2 = cirq.NamedQubit.range(3, prefix='q')
     cell = cirq.interop.quirk.cells.control_cells.ParityControlCell([a, b], [cirq.Y(c) ** 0.5])
@@ -126,7 +126,7 @@ def test_parity_control_with_line_qubits_mapped_to():
     assert cell.with_line_qubits_mapped_to([a2, b2, c2]) == mapped_cell
 
 
-def test_repr():
+def test_repr() -> None:
     a, b, c = cirq.LineQubit.range(3)
     cirq.testing.assert_equivalent_repr(
         cirq.interop.quirk.cells.control_cells.ControlCell(a, [cirq.Y(b) ** 0.5])

--- a/cirq-core/cirq/interop/quirk/cells/frequency_space_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/frequency_space_cells_test.py
@@ -18,7 +18,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_frequency_space_gates():
+def test_frequency_space_gates() -> None:
     a, b, c = cirq.LineQubit.range(3)
 
     assert_url_to_circuit_returns('{"cols":[["QFT3"]]}', cirq.Circuit(cirq.qft(a, b, c)))

--- a/cirq-core/cirq/interop/quirk/cells/ignored_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/ignored_cells_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_displays():
+def test_displays() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["Amps2"],[1,"Amps3"],["Chance"],'
         '["Chance2"],["Density"],["Density3"],'

--- a/cirq-core/cirq/interop/quirk/cells/input_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_cells_test.py
@@ -19,12 +19,12 @@ from cirq.interop.quirk.cells.input_cells import SetDefaultInputCell
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_missing_input_cell():
+def test_missing_input_cell() -> None:
     with pytest.raises(ValueError, match='Missing input'):
         _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["+=A2"]]}')
 
 
-def test_input_cell():
+def test_input_cell() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["inputA4",1,1,1,"+=A4"]]}', maps={0x_0_0: 0x_0_0, 0x_2_3: 0x_2_5}
     )
@@ -41,7 +41,7 @@ def test_input_cell():
         )
 
 
-def test_reversed_input_cell():
+def test_reversed_input_cell() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["revinputA4",1,1,1,"+=A4"]]}',
         maps={0x_0_0: 0x_0_0, 0x_2_3: 0x_2_7, 0x_1_3: 0x_1_B},
@@ -59,7 +59,7 @@ def test_reversed_input_cell():
         )
 
 
-def test_set_default_input_cell():
+def test_set_default_input_cell() -> None:
     # Later column.
     assert_url_to_circuit_returns(
         '{"cols":[[{"id":"setA","arg":11}],["+=A4"]]}', maps={0: 11, 4: 15, 5: 0}
@@ -98,6 +98,6 @@ def test_set_default_input_cell():
         )
 
 
-def test_with_line_qubits_mapped_to():
+def test_with_line_qubits_mapped_to() -> None:
     cell = SetDefaultInputCell('a', 5)
     assert cell.with_line_qubits_mapped_to([]) is cell

--- a/cirq-core/cirq/interop/quirk/cells/input_rotation_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_rotation_cells_test.py
@@ -20,7 +20,7 @@ from cirq import quirk_url_to_circuit
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_input_rotation_cells():
+def test_input_rotation_cells() -> None:
     with pytest.raises(ValueError, match='classical constant'):
         _ = quirk_url_to_circuit(
             'https://algassert.com/quirk#circuit={"cols":[["Z^(A/2^n)",{"id":"setA","arg":3}]]}'
@@ -105,7 +105,7 @@ def test_input_rotation_cells():
     )
 
 
-def test_input_rotation_cells_repr():
+def test_input_rotation_cells_repr() -> None:
     circuit = quirk_url_to_circuit(
         'http://algassert.com/quirk#circuit={"cols":[["•","X^(-A/2^n)","inputA2"]]}'
     )
@@ -113,7 +113,7 @@ def test_input_rotation_cells_repr():
     cirq.testing.assert_equivalent_repr(op)
 
 
-def test_validation():
+def test_validation() -> None:
     with pytest.raises(ValueError, match='sign'):
         _ = cirq.interop.quirk.QuirkInputRotationOperation(
             identifier='xxx',
@@ -123,7 +123,7 @@ def test_validation():
         )
 
 
-def test_input_rotation_with_qubits():
+def test_input_rotation_with_qubits() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
     x, y, z, t, w = cirq.LineQubit.range(10, 15)
     op = cirq.interop.quirk.QuirkInputRotationOperation(
@@ -143,7 +143,7 @@ def test_input_rotation_with_qubits():
     )
 
 
-def test_input_rotation_cell_with_qubits():
+def test_input_rotation_cell_with_qubits() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
     x, y, z, t, w = cirq.LineQubit.range(10, 15)
     cell = cirq.interop.quirk.cells.input_rotation_cells.InputRotationCell(
@@ -162,7 +162,7 @@ def test_input_rotation_cell_with_qubits():
     )
 
 
-def test_input_rotation_cell_with_qubits_before_register_specified():
+def test_input_rotation_cell_with_qubits_before_register_specified() -> None:
     d, e = cirq.LineQubit.range(3, 5)
     x, y, z, t, w = cirq.LineQubit.range(10, 15)
     cell = cirq.interop.quirk.cells.input_rotation_cells.InputRotationCell(
@@ -181,7 +181,7 @@ def test_input_rotation_cell_with_qubits_before_register_specified():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
     cirq.testing.assert_equivalent_repr(
         cirq.interop.quirk.cells.input_rotation_cells.InputRotationCell(

--- a/cirq-core/cirq/interop/quirk/cells/measurement_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/measurement_cells_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_measurement_gates():
+def test_measurement_gates() -> None:
     a, b, c = cirq.LineQubit.range(3)
     assert_url_to_circuit_returns(
         '{"cols":[["Measure","Measure"],["Measure","Measure"]]}',

--- a/cirq-core/cirq/interop/quirk/cells/qubit_permutation_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/qubit_permutation_cells_test.py
@@ -17,7 +17,7 @@ from cirq.interop.quirk.cells.qubit_permutation_cells import QuirkQubitPermutati
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_equality():
+def test_equality() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: QuirkQubitPermutationGate('a', 'b', [0, 1]))
     eq.add_equality_group(QuirkQubitPermutationGate('x', 'b', [0, 1]))
@@ -25,11 +25,11 @@ def test_equality():
     eq.add_equality_group(QuirkQubitPermutationGate('a', 'b', [1, 0]))
 
 
-def test_repr():
+def test_repr() -> None:
     cirq.testing.assert_equivalent_repr(QuirkQubitPermutationGate('a', 'b', [0, 1]))
 
 
-def test_right_rotate():
+def test_right_rotate() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["X",">>4",1,1,1,"X"]]}',
         diagram="""
@@ -57,7 +57,7 @@ def test_right_rotate():
     )
 
 
-def test_left_rotate():
+def test_left_rotate() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["<<4"]]}',
         maps={
@@ -72,7 +72,7 @@ def test_left_rotate():
     )
 
 
-def test_reverse():
+def test_reverse() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["rev4"]]}',
         maps={
@@ -98,7 +98,7 @@ def test_reverse():
     )
 
 
-def test_interleave():
+def test_interleave() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["weave5"]]}',
         maps={
@@ -128,7 +128,7 @@ def test_interleave():
     )
 
 
-def test_deinterleave():
+def test_deinterleave() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["split5"]]}',
         maps={

--- a/cirq-core/cirq/interop/quirk/cells/scalar_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/scalar_cells_test.py
@@ -16,7 +16,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_scalar_operations():
+def test_scalar_operations() -> None:
     assert_url_to_circuit_returns('{"cols":[["…"]]}', cirq.Circuit())
 
     assert_url_to_circuit_returns(

--- a/cirq-core/cirq/interop/quirk/cells/single_qubit_rotation_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/single_qubit_rotation_cells_test.py
@@ -18,7 +18,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_fixed_single_qubit_rotations():
+def test_fixed_single_qubit_rotations() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
 
     assert_url_to_circuit_returns(
@@ -89,7 +89,7 @@ def test_fixed_single_qubit_rotations():
     )
 
 
-def test_dynamic_single_qubit_rotations():
+def test_dynamic_single_qubit_rotations() -> None:
     a, b, c = cirq.LineQubit.range(3)
     t = sympy.Symbol('t')
 
@@ -118,7 +118,7 @@ def test_dynamic_single_qubit_rotations():
     )
 
 
-def test_formulaic_gates():
+def test_formulaic_gates() -> None:
     a, b = cirq.LineQubit.range(2)
     t = sympy.Symbol('t')
 

--- a/cirq-core/cirq/interop/quirk/cells/swap_cell_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/swap_cell_test.py
@@ -19,7 +19,7 @@ from cirq import quirk_url_to_circuit
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_swap():
+def test_swap() -> None:
     a, b, c = cirq.LineQubit.range(3)
     assert_url_to_circuit_returns('{"cols":[["Swap","Swap"]]}', cirq.Circuit(cirq.SWAP(a, b)))
     assert_url_to_circuit_returns(
@@ -34,7 +34,7 @@ def test_swap():
         )
 
 
-def test_controlled_swap():
+def test_controlled_swap() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     assert_url_to_circuit_returns(
         '{"cols":[["Swap","•","Swap"]]}', cirq.Circuit(cirq.SWAP(a, c).controlled_by(b))
@@ -44,7 +44,7 @@ def test_controlled_swap():
     )
 
 
-def test_with_line_qubits_mapped_to():
+def test_with_line_qubits_mapped_to() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     a2, b2, c2, d2 = cirq.NamedQubit.range(4, prefix='q')
     cell = cirq.interop.quirk.cells.swap_cell.SwapCell(qubits=[a, b], controls=[c, d])
@@ -53,7 +53,7 @@ def test_with_line_qubits_mapped_to():
     assert cell.with_line_qubits_mapped_to([a2, b2, c2, d2]) == mapped_cell
 
 
-def test_repr():
+def test_repr() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     cirq.testing.assert_equivalent_repr(
         cirq.interop.quirk.cells.swap_cell.SwapCell(qubits=[a, b], controls=[c, d])

--- a/cirq-core/cirq/interop/quirk/cells/testing_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/testing_test.py
@@ -19,7 +19,7 @@ import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_assert_url_to_circuit_returns_circuit():
+def test_assert_url_to_circuit_returns_circuit() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["X"]]}', circuit=cirq.Circuit(cirq.X(cirq.LineQubit(0)))
     )
@@ -30,21 +30,21 @@ def test_assert_url_to_circuit_returns_circuit():
         )
 
 
-def test_assert_url_to_circuit_returns_unitary():
+def test_assert_url_to_circuit_returns_unitary() -> None:
     assert_url_to_circuit_returns('{"cols":[["X"]]}', unitary=cirq.unitary(cirq.X))
 
     with pytest.raises(AssertionError, match='Not equal to tolerance'):
         assert_url_to_circuit_returns('{"cols":[["X"]]}', unitary=np.eye(2))
 
 
-def test_assert_url_to_circuit_returns_diagram():
+def test_assert_url_to_circuit_returns_diagram() -> None:
     assert_url_to_circuit_returns('{"cols":[["X"]]}', diagram='0: ───X───')
 
     with pytest.raises(AssertionError, match='text diagram differs'):
         assert_url_to_circuit_returns('{"cols":[["X"]]}', diagram='not even close')
 
 
-def test_assert_url_to_circuit_returns_maps():
+def test_assert_url_to_circuit_returns_maps() -> None:
     assert_url_to_circuit_returns('{"cols":[["X"]]}', maps={0: 1})
     assert_url_to_circuit_returns('{"cols":[["X"]]}', maps={0: 1, 1: 0})
 
@@ -55,7 +55,7 @@ def test_assert_url_to_circuit_returns_maps():
         assert_url_to_circuit_returns('{"cols":[["H"]]}', maps={0: 0})
 
 
-def test_assert_url_to_circuit_returns_output_amplitudes_from_quirk():
+def test_assert_url_to_circuit_returns_output_amplitudes_from_quirk() -> None:
     assert_url_to_circuit_returns(
         '{"cols":[["X","Z"]]}',
         output_amplitudes_from_quirk=[
@@ -78,7 +78,7 @@ def test_assert_url_to_circuit_returns_output_amplitudes_from_quirk():
         )
 
 
-def test_assert_url_to_circuit_misc():
+def test_assert_url_to_circuit_misc() -> None:
     a, b = cirq.LineQubit.range(2)
 
     assert_url_to_circuit_returns(

--- a/cirq-core/cirq/interop/quirk/cells/unsupported_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/unsupported_cells_test.py
@@ -17,7 +17,7 @@ import pytest
 from cirq import quirk_url_to_circuit
 
 
-def test_non_physical_operations():
+def test_non_physical_operations() -> None:
     with pytest.raises(NotImplementedError, match="unphysical operation"):
         _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[["__error__"]]}')
     with pytest.raises(NotImplementedError, match="unphysical operation"):
@@ -26,7 +26,7 @@ def test_non_physical_operations():
         )
 
 
-def test_not_implemented_gates():
+def test_not_implemented_gates() -> None:
     # This test mostly exists to ensure the gates are tested if added.
 
     for k in ["X^⌈t⌉", "X^⌈t-¼⌉", "Counting4", "Uncounting4", ">>t3", "<<t3"]:

--- a/cirq-core/cirq/linalg/combinators_test.py
+++ b/cirq-core/cirq/linalg/combinators_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_dot():
+def test_dot() -> None:
     assert cirq.dot(2) == 2
     assert cirq.dot(2.5, 2.5) == 6.25
 
@@ -33,7 +33,7 @@ def test_dot():
         cirq.dot()
 
 
-def test_kron_multiplies_sizes():
+def test_kron_multiplies_sizes() -> None:
     assert cirq.kron(np.array([1, 2])).shape == (1, 2)
     assert cirq.kron(np.array([1, 2]), shape_len=1).shape == (2,)
     assert cirq.kron(np.array([1, 2]), np.array([3, 4, 5]), shape_len=1).shape == (6,)
@@ -51,7 +51,7 @@ def test_kron_multiplies_sizes():
     assert np.allclose(cirq.kron(np.eye(2), np.eye(3), np.eye(4)), np.eye(24))
 
 
-def test_kron_spreads_values():
+def test_kron_spreads_values() -> None:
     u = np.array([[2, 3], [5, 7]])
 
     assert np.allclose(
@@ -68,7 +68,7 @@ def test_kron_spreads_values():
     )
 
 
-def test_acts_like_kron_multiplies_sizes():
+def test_acts_like_kron_multiplies_sizes() -> None:
     assert np.allclose(cirq.kron_with_controls(), np.eye(1))
     assert np.allclose(cirq.kron_with_controls(np.eye(2), np.eye(3), np.eye(4)), np.eye(24))
 
@@ -79,7 +79,7 @@ def test_acts_like_kron_multiplies_sizes():
     )
 
 
-def test_supports_controls():
+def test_supports_controls() -> None:
     u = np.array([[2, 3], [5, 7]])
     assert np.allclose(cirq.kron_with_controls(cirq.CONTROL_TAG), np.array([[1, 0], [0, 1]]))
     assert np.allclose(
@@ -92,7 +92,7 @@ def test_supports_controls():
     )
 
 
-def test_block_diag():
+def test_block_diag() -> None:
     assert np.allclose(cirq.block_diag(), np.zeros((0, 0)))
 
     assert np.allclose(cirq.block_diag(np.array([[1, 2], [3, 4]])), np.array([[1, 2], [3, 4]]))
@@ -108,7 +108,7 @@ def test_block_diag():
         _ = cirq.block_diag(np.array([[1, 2, 3], [3, 4, 5]]))
 
 
-def test_block_diag_dtype():
+def test_block_diag_dtype() -> None:
     assert cirq.block_diag().dtype == np.complex128
 
     assert cirq.block_diag(np.array([[1]], dtype=np.int8)).dtype == np.int8

--- a/cirq-core/cirq/linalg/diagonalize_test.py
+++ b/cirq-core/cirq/linalg/diagonalize_test.py
@@ -107,7 +107,7 @@ def assert_bidiagonalized_by(m, p, q, rtol: float = 1e-5, atol: float = 1e-8):
     + [random_symmetric_matrix(4) for _ in range(10)]
     + [random_symmetric_matrix(k) for k in range(1, 10)],
 )
-def test_diagonalize_real_symmetric_matrix(matrix):
+def test_diagonalize_real_symmetric_matrix(matrix) -> None:
     p = cirq.diagonalize_real_symmetric_matrix(matrix)
     assert_diagonalized_by(matrix, p)
 
@@ -122,12 +122,12 @@ def test_diagonalize_real_symmetric_matrix(matrix):
         np.array([[3, 1], [7, 3]]),
     ],
 )
-def test_diagonalize_real_symmetric_matrix_fails(matrix):
+def test_diagonalize_real_symmetric_matrix_fails(matrix) -> None:
     with pytest.raises(ValueError):
         _ = cirq.diagonalize_real_symmetric_matrix(matrix)
 
 
-def test_diagonalize_real_symmetric_matrix_assertion_error():
+def test_diagonalize_real_symmetric_matrix_assertion_error() -> None:
     with pytest.raises(AssertionError):
         matrix = np.array([[0.5, 0], [0, 1]])
         m = np.array([[0, 1], [0, 0]])
@@ -151,7 +151,7 @@ def test_diagonalize_real_symmetric_matrix_assertion_error():
     ]
     + [([6, 6, 5, 5, 5], random_block_diagonal_symmetric_matrix(2, 3)) for _ in range(10)],
 )
-def test_simultaneous_diagonalize_real_symmetric_matrix_vs_singulars(s, m):
+def test_simultaneous_diagonalize_real_symmetric_matrix_vs_singulars(s, m) -> None:
     m = np.array(m)
     s = np.diag(s)
     p = cirq.diagonalize_real_symmetric_and_sorted_diagonal_matrices(m, s)
@@ -171,7 +171,7 @@ def test_simultaneous_diagonalize_real_symmetric_matrix_vs_singulars(s, m):
         ([3, 2, 1], QFT, 'must be real symmetric'),
     ],
 )
-def test_simultaneous_diagonalize_real_symmetric_matrix_vs_singulars_fail(s, m, match: str):
+def test_simultaneous_diagonalize_real_symmetric_matrix_vs_singulars_fail(s, m, match: str) -> None:
     m = np.array(m)
     s = np.diag(s)
     with pytest.raises(ValueError, match=match):
@@ -199,7 +199,7 @@ def test_simultaneous_diagonalize_real_symmetric_matrix_vs_singulars_fail(s, m, 
     ]
     + [random_bi_diagonalizable_pair(k) for k in range(1, 10)],
 )
-def test_bidiagonalize_real_matrix_pair_with_symmetric_products(a, b):
+def test_bidiagonalize_real_matrix_pair_with_symmetric_products(a, b) -> None:
     a = np.array(a)
     b = np.array(b)
     p, q = cirq.bidiagonalize_real_matrix_pair_with_symmetric_products(a, b)
@@ -220,14 +220,14 @@ def test_bidiagonalize_real_matrix_pair_with_symmetric_products(a, b):
         [np.array([[1, 1], [1, 0]]), np.array([[1, 0], [1, 1]]), 'mat1 @ mat2.T must be symmetric'],
     ],
 )
-def test_bidiagonalize_real_fails(a, b, match: str):
+def test_bidiagonalize_real_fails(a, b, match: str) -> None:
     a = np.array(a)
     b = np.array(b)
     with pytest.raises(ValueError, match=match):
         cirq.bidiagonalize_real_matrix_pair_with_symmetric_products(a, b)
 
 
-def test_bidiagonalize__assertion_error():
+def test_bidiagonalize__assertion_error() -> None:
     with pytest.raises(AssertionError):
         a = np.diag([0, 1])
         assert_bidiagonalized_by(a, a, a)
@@ -261,7 +261,7 @@ def test_bidiagonalize__assertion_error():
     + [cirq.testing.random_unitary(4) for _ in range(10)]
     + [cirq.testing.random_unitary(k) for k in range(1, 10)],
 )
-def test_bidiagonalize_unitary_with_special_orthogonals(mat):
+def test_bidiagonalize_unitary_with_special_orthogonals(mat) -> None:
     p, d, q = cirq.bidiagonalize_unitary_with_special_orthogonals(mat)
     assert cirq.is_special_orthogonal(p)
     assert cirq.is_special_orthogonal(q)
@@ -273,6 +273,6 @@ def test_bidiagonalize_unitary_with_special_orthogonals(mat):
     'mat',
     [np.diag([0]), np.diag([0.5]), np.diag([1, 0]), np.diag([0.5, 2]), np.array([[0, 1], [0, 0]])],
 )
-def test_bidiagonalize_unitary_fails(mat):
+def test_bidiagonalize_unitary_fails(mat) -> None:
     with pytest.raises(ValueError):
         cirq.bidiagonalize_unitary_with_special_orthogonals(mat)

--- a/cirq-core/cirq/linalg/operator_spaces_test.py
+++ b/cirq-core/cirq/linalg/operator_spaces_test.py
@@ -84,7 +84,7 @@ def _one_hot_matrix(size: int, i: int, j: int) -> np.ndarray:
         ),
     ),
 )
-def test_kron_bases(basis1, basis2, expected_kron_basis):
+def test_kron_bases(basis1, basis2, expected_kron_basis) -> None:
     kron_basis = cirq.kron_bases(basis1, basis2)
     assert len(kron_basis) == 16
     assert set(kron_basis.keys()) == set(expected_kron_basis.keys())
@@ -115,14 +115,14 @@ def test_kron_bases(basis1, basis2, expected_kron_basis):
         ),
     ),
 )
-def test_kron_bases_consistency(basis1, basis2):
+def test_kron_bases_consistency(basis1, basis2) -> None:
     assert set(basis1.keys()) == set(basis2.keys())
     for name in basis1.keys():
         assert np.all(basis1[name] == basis2[name])
 
 
 @pytest.mark.parametrize('basis,repeat', itertools.product((PAULI_BASIS, STANDARD_BASIS), range(5)))
-def test_kron_bases_repeat_sanity_checks(basis, repeat):
+def test_kron_bases_repeat_sanity_checks(basis, repeat) -> None:
     product_basis = cirq.kron_bases(basis, repeat=repeat)
     assert len(product_basis) == 4**repeat
     for name1, matrix1 in product_basis.items():
@@ -138,7 +138,7 @@ def test_kron_bases_repeat_sanity_checks(basis, repeat):
     'm1,m2,expect_real',
     ((X, X, True), (X, Y, True), (X, H, True), (X, SQRT_X, False), (I, SQRT_Z, False)),
 )
-def test_hilbert_schmidt_inner_product_is_conjugate_symmetric(m1, m2, expect_real):
+def test_hilbert_schmidt_inner_product_is_conjugate_symmetric(m1, m2, expect_real) -> None:
     v1 = cirq.hilbert_schmidt_inner_product(m1, m2)
     v2 = cirq.hilbert_schmidt_inner_product(m2, m1)
     assert v1 == v2.conjugate()
@@ -149,7 +149,7 @@ def test_hilbert_schmidt_inner_product_is_conjugate_symmetric(m1, m2, expect_rea
 
 
 @pytest.mark.parametrize('a,m1,b,m2', ((1, X, 1, Z), (2, X, 3, Y), (2j, X, 3, I), (2, X, 3, X)))
-def test_hilbert_schmidt_inner_product_is_linear(a, m1, b, m2):
+def test_hilbert_schmidt_inner_product_is_linear(a, m1, b, m2) -> None:
     v1 = cirq.hilbert_schmidt_inner_product(H, (a * m1 + b * m2))
     v2 = a * cirq.hilbert_schmidt_inner_product(H, m1) + b * cirq.hilbert_schmidt_inner_product(
         H, m2
@@ -158,7 +158,7 @@ def test_hilbert_schmidt_inner_product_is_linear(a, m1, b, m2):
 
 
 @pytest.mark.parametrize('m', (I, X, Y, Z, H, SQRT_X, SQRT_Y, SQRT_Z))
-def test_hilbert_schmidt_inner_product_is_positive_definite(m):
+def test_hilbert_schmidt_inner_product_is_positive_definite(m) -> None:
     v = cirq.hilbert_schmidt_inner_product(m, m)
     # Cannot check using np.is_real due to bug in aarch64.
     # See https://github.com/quantumlib/Cirq/issues/4379
@@ -186,7 +186,7 @@ def test_hilbert_schmidt_inner_product_is_positive_definite(m):
         (SQRT_X, E11, np.sqrt(-0.5j)),
     ),
 )
-def test_hilbert_schmidt_inner_product_values(m1, m2, expected_value):
+def test_hilbert_schmidt_inner_product_values(m1, m2, expected_value) -> None:
     v = cirq.hilbert_schmidt_inner_product(m1, m2)
     assert np.isclose(v, expected_value)
 
@@ -195,7 +195,7 @@ def test_hilbert_schmidt_inner_product_values(m1, m2, expected_value):
     'm,basis',
     itertools.product((I, X, Y, Z, H, SQRT_X, SQRT_Y, SQRT_Z), (PAULI_BASIS, STANDARD_BASIS)),
 )
-def test_expand_matrix_in_orthogonal_basis(m, basis):
+def test_expand_matrix_in_orthogonal_basis(m, basis) -> None:
     expansion = cirq.expand_matrix_in_orthogonal_basis(m, basis)
 
     reconstructed = np.zeros(m.shape, dtype=complex)
@@ -216,7 +216,7 @@ def test_expand_matrix_in_orthogonal_basis(m, basis):
         {'I': 1, 'X': 2, 'Y': 3, 'Z': 4},
     ),
 )
-def test_matrix_from_basis_coefficients(expansion):
+def test_matrix_from_basis_coefficients(expansion) -> None:
     m = cirq.matrix_from_basis_coefficients(expansion, PAULI_BASIS)
 
     for name, coefficient in expansion.items():
@@ -236,7 +236,7 @@ def test_matrix_from_basis_coefficients(expansion):
         )
     ),
 )
-def test_expand_is_inverse_of_reconstruct(m1, basis):
+def test_expand_is_inverse_of_reconstruct(m1, basis) -> None:
     c1 = cirq.expand_matrix_in_orthogonal_basis(m1, basis)
     m2 = cirq.matrix_from_basis_coefficients(c1, basis)
     c2 = cirq.expand_matrix_in_orthogonal_basis(m2, basis)
@@ -299,7 +299,7 @@ def test_expand_is_inverse_of_reconstruct(m1, basis):
         (0, 1, 2, 3, 4, 5, 100, 101),
     ),
 )
-def test_pow_pauli_combination(coefficients, exponent):
+def test_pow_pauli_combination(coefficients, exponent) -> None:
     is_symbolic = any(isinstance(a, sympy.Basic) for a in coefficients)
     if is_symbolic and exponent > 2:
         return  # too slow

--- a/cirq-core/cirq/linalg/tolerance_test.py
+++ b/cirq-core/cirq/linalg/tolerance_test.py
@@ -15,7 +15,7 @@
 from cirq.linalg.tolerance import all_near_zero, all_near_zero_mod, near_zero, near_zero_mod
 
 
-def test_all_zero():
+def test_all_zero() -> None:
     atol = 5
     assert all_near_zero(0, atol=atol)
     assert all_near_zero(4.5, atol=atol)
@@ -25,7 +25,7 @@ def test_all_zero():
     assert not all_near_zero([-4.5, 0, 1, 4.5, 30], atol=atol)
 
 
-def test_all_zero_mod():
+def test_all_zero_mod() -> None:
     atol = 5
     assert all_near_zero_mod(0, 100, atol=atol)
     assert all_near_zero_mod(4.5, 100, atol=atol)
@@ -45,14 +45,14 @@ def test_all_zero_mod():
     assert not all_near_zero_mod([-4.5, 0, 1, 4.5, 30], 100, atol=atol)
 
 
-def test_near_zero():
+def test_near_zero() -> None:
     atol = 5
     assert near_zero(0, atol=atol)
     assert near_zero(4.5, atol=atol)
     assert not near_zero(5.5, atol=atol)
 
 
-def test_near_zero_mod():
+def test_near_zero_mod() -> None:
     atol = 5
     assert near_zero_mod(0, 100, atol=atol)
     assert near_zero_mod(4.5, 100, atol=atol)

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
@@ -43,7 +43,7 @@ Q, Q2, Q3 = cirq.LineQubit.range(3)
         (cirq.ZPowGate(exponent=0.5)(Q).controlled_by(Q2, Q3), False),
     ],
 )
-def test_gateset(op: cirq.Operation, expected: bool):
+def test_gateset(op: cirq.Operation, expected: bool) -> None:
     assert cirq.is_native_neutral_atom_op(op) == expected
     if op.gate is not None:
         assert cirq.is_native_neutral_atom_gate(op.gate) == expected

--- a/cirq-core/cirq/ops/arithmetic_operation_test.py
+++ b/cirq-core/cirq/ops/arithmetic_operation_test.py
@@ -36,7 +36,7 @@ def adder_matrix(target_width: int, source_width: int) -> np.ndarray:
     return result
 
 
-def test_the_tests():
+def test_the_tests() -> None:
     # fmt: off
     np.testing.assert_allclose(
         shift_matrix(4, 1),
@@ -85,7 +85,7 @@ def test_the_tests():
     )
 
 
-def test_arithmetic_gate_apply_unitary():
+def test_arithmetic_gate_apply_unitary() -> None:
     class Add(cirq.ArithmeticGate):
         def __init__(
             self,

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -56,7 +56,7 @@ def assert_mixtures_equal(actual, expected):
         np.testing.assert_almost_equal(a[1], e[1])
 
 
-def test_asymmetric_depolarizing_channel():
+def test_asymmetric_depolarizing_channel() -> None:
     d = cirq.asymmetric_depolarize(0.1, 0.2, 0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d),
@@ -68,17 +68,17 @@ def test_asymmetric_depolarizing_channel():
     assert cirq.AsymmetricDepolarizingChannel(p_x=0, p_y=0.1, p_z=0).num_qubits() == 1
 
 
-def test_asymmetric_depolarizing_mixture():
+def test_asymmetric_depolarizing_mixture() -> None:
     d = cirq.asymmetric_depolarize(0.1, 0.2, 0.3)
     assert_mixtures_equal(cirq.mixture(d), ((0.4, np.eye(2)), (0.1, X), (0.2, Y), (0.3, Z)))
     assert cirq.has_mixture(d)
 
 
-def test_asymmetric_depolarizing_channel_repr():
+def test_asymmetric_depolarizing_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.AsymmetricDepolarizingChannel(0.1, 0.2, 0.3))
 
 
-def test_asymmetric_depolarizing_channel_str():
+def test_asymmetric_depolarizing_channel_str() -> None:
     assert (
         str(cirq.asymmetric_depolarize(0.1, 0.2, 0.3))
         == "asymmetric_depolarize(error_probabilities={'I': 0.3999999999999999, "
@@ -86,7 +86,7 @@ def test_asymmetric_depolarizing_channel_str():
     )
 
 
-def test_asymmetric_depolarizing_channel_eq():
+def test_asymmetric_depolarizing_channel_eq() -> None:
     a = cirq.asymmetric_depolarize(0.0099999, 0.01)
     b = cirq.asymmetric_depolarize(0.01, 0.0099999)
     c = cirq.asymmetric_depolarize(0.0, 0.0, 0.0)
@@ -109,7 +109,7 @@ def test_asymmetric_depolarizing_channel_eq():
 @pytest.mark.parametrize(
     'p_x,p_y,p_z', ((-0.1, 0.0, 0.0), (0.0, -0.1, 0.0), (0.0, 0.0, -0.1), (0.1, -0.1, 0.1))
 )
-def test_asymmetric_depolarizing_channel_negative_probability(p_x, p_y, p_z):
+def test_asymmetric_depolarizing_channel_negative_probability(p_x, p_y, p_z) -> None:
     with pytest.raises(ValueError, match='was less than 0'):
         cirq.asymmetric_depolarize(p_x, p_y, p_z)
 
@@ -117,12 +117,12 @@ def test_asymmetric_depolarizing_channel_negative_probability(p_x, p_y, p_z):
 @pytest.mark.parametrize(
     'p_x,p_y,p_z', ((1.1, 0.0, 0.0), (0.0, 1.1, 0.0), (0.0, 0.0, 1.1), (0.1, 0.9, 0.1))
 )
-def test_asymmetric_depolarizing_channel_bigly_probability(p_x, p_y, p_z):
+def test_asymmetric_depolarizing_channel_bigly_probability(p_x, p_y, p_z) -> None:
     with pytest.raises(ValueError, match='was greater than 1'):
         cirq.asymmetric_depolarize(p_x, p_y, p_z)
 
 
-def test_asymmetric_depolarizing_channel_text_diagram():
+def test_asymmetric_depolarizing_channel_text_diagram() -> None:
     a = cirq.asymmetric_depolarize(1 / 9, 2 / 9, 3 / 9)
     assert cirq.circuit_diagram_info(a, args=no_precision) == cirq.CircuitDiagramInfo(
         wire_symbols=('A(0.1111111111111111,0.2222222222222222,' + '0.3333333333333333)',)
@@ -135,7 +135,7 @@ def test_asymmetric_depolarizing_channel_text_diagram():
     )
 
 
-def test_depolarizing_channel():
+def test_depolarizing_channel() -> None:
     d = cirq.depolarize(0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d),
@@ -145,7 +145,7 @@ def test_depolarizing_channel():
     cirq.testing.assert_consistent_mixture(d)
 
 
-def test_depolarizing_channel_two_qubits():
+def test_depolarizing_channel_two_qubits() -> None:
     d = cirq.depolarize(0.15, n_qubits=2)
     np.testing.assert_almost_equal(
         cirq.kraus(d),
@@ -182,13 +182,13 @@ def test_depolarizing_channel_two_qubits():
     )
 
 
-def test_depolarizing_mixture():
+def test_depolarizing_mixture() -> None:
     d = cirq.depolarize(0.3)
     assert_mixtures_equal(cirq.mixture(d), ((0.7, np.eye(2)), (0.1, X), (0.1, Y), (0.1, Z)))
     assert cirq.has_mixture(d)
 
 
-def test_depolarizing_mixture_two_qubits():
+def test_depolarizing_mixture_two_qubits() -> None:
     d = cirq.depolarize(0.15, n_qubits=2)
     assert_mixtures_equal(
         cirq.mixture(d),
@@ -214,23 +214,23 @@ def test_depolarizing_mixture_two_qubits():
     assert cirq.has_mixture(d)
 
 
-def test_depolarizing_channel_repr():
+def test_depolarizing_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.DepolarizingChannel(0.3))
 
 
-def test_depolarizing_channel_repr_two_qubits():
+def test_depolarizing_channel_repr_two_qubits() -> None:
     cirq.testing.assert_equivalent_repr(cirq.DepolarizingChannel(0.3, n_qubits=2))
 
 
-def test_depolarizing_channel_str():
+def test_depolarizing_channel_str() -> None:
     assert str(cirq.depolarize(0.3)) == 'depolarize(p=0.3)'
 
 
-def test_depolarizing_channel_str_two_qubits():
+def test_depolarizing_channel_str_two_qubits() -> None:
     assert str(cirq.depolarize(0.3, n_qubits=2)) == 'depolarize(p=0.3,n_qubits=2)'
 
 
-def test_deprecated_on_each_for_depolarizing_channel_one_qubit():
+def test_deprecated_on_each_for_depolarizing_channel_one_qubit() -> None:
     q0 = cirq.LineQubit.range(1)
     op = cirq.DepolarizingChannel(p=0.1, n_qubits=1)
 
@@ -240,7 +240,7 @@ def test_deprecated_on_each_for_depolarizing_channel_one_qubit():
         op.on_each('bogus object')
 
 
-def test_deprecated_on_each_for_depolarizing_channel_two_qubits():
+def test_deprecated_on_each_for_depolarizing_channel_two_qubits() -> None:
     q0, q1, q2, q3, q4, q5 = cirq.LineQubit.range(6)
     op = cirq.DepolarizingChannel(p=0.1, n_qubits=2)
 
@@ -259,19 +259,19 @@ def test_deprecated_on_each_for_depolarizing_channel_two_qubits():
         op.on_each([(False, None)])
 
 
-def test_depolarizing_channel_apply_two_qubits():
+def test_depolarizing_channel_apply_two_qubits() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     op = cirq.DepolarizingChannel(p=0.1, n_qubits=2)
     op(q0, q1)
 
 
-def test_asymmetric_depolarizing_channel_apply_two_qubits():
+def test_asymmetric_depolarizing_channel_apply_two_qubits() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     op = cirq.AsymmetricDepolarizingChannel(error_probabilities={'XX': 0.1})
     op(q0, q1)
 
 
-def test_depolarizing_channel_eq():
+def test_depolarizing_channel_eq() -> None:
     a = cirq.depolarize(p=0.0099999)
     b = cirq.depolarize(p=0.01)
     c = cirq.depolarize(0.0)
@@ -288,14 +288,14 @@ def test_depolarizing_channel_eq():
     et.add_equality_group(cirq.depolarize(1.0, n_qubits=2))
 
 
-def test_depolarizing_channel_invalid_probability():
+def test_depolarizing_channel_invalid_probability() -> None:
     with pytest.raises(ValueError, match=re.escape('p(I) was greater than 1.')):
         cirq.depolarize(-0.1)
     with pytest.raises(ValueError, match=re.escape('p(I) was less than 0.')):
         cirq.depolarize(1.1)
 
 
-def test_depolarizing_channel_text_diagram():
+def test_depolarizing_channel_text_diagram() -> None:
     d = cirq.depolarize(0.1234567)
     assert cirq.circuit_diagram_info(d, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('D(0.123457)',)
@@ -308,7 +308,7 @@ def test_depolarizing_channel_text_diagram():
     )
 
 
-def test_depolarizing_channel_text_diagram_two_qubits():
+def test_depolarizing_channel_text_diagram_two_qubits() -> None:
     d = cirq.depolarize(0.1234567, n_qubits=2)
     assert cirq.circuit_diagram_info(d, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('D(0.123457)', '#2')
@@ -321,7 +321,7 @@ def test_depolarizing_channel_text_diagram_two_qubits():
     )
 
 
-def test_generalized_amplitude_damping_channel():
+def test_generalized_amplitude_damping_channel() -> None:
     d = cirq.generalized_amplitude_damp(0.1, 0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d),
@@ -336,18 +336,18 @@ def test_generalized_amplitude_damping_channel():
     assert not cirq.has_mixture(d)
 
 
-def test_generalized_amplitude_damping_repr():
+def test_generalized_amplitude_damping_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.GeneralizedAmplitudeDampingChannel(0.1, 0.3))
 
 
-def test_generalized_amplitude_damping_str():
+def test_generalized_amplitude_damping_str() -> None:
     assert (
         str(cirq.generalized_amplitude_damp(0.1, 0.3))
         == 'generalized_amplitude_damp(p=0.1,gamma=0.3)'
     )
 
 
-def test_generalized_amplitude_damping_channel_eq():
+def test_generalized_amplitude_damping_channel_eq() -> None:
     a = cirq.generalized_amplitude_damp(0.0099999, 0.01)
     b = cirq.generalized_amplitude_damp(0.01, 0.0099999)
 
@@ -364,18 +364,18 @@ def test_generalized_amplitude_damping_channel_eq():
 
 
 @pytest.mark.parametrize('p, gamma', ((-0.1, 0.0), (0.0, -0.1), (0.1, -0.1), (-0.1, 0.1)))
-def test_generalized_amplitude_damping_channel_negative_probability(p, gamma):
+def test_generalized_amplitude_damping_channel_negative_probability(p, gamma) -> None:
     with pytest.raises(ValueError, match='was less than 0'):
         cirq.generalized_amplitude_damp(p, gamma)
 
 
 @pytest.mark.parametrize('p,gamma', ((1.1, 0.0), (0.0, 1.1), (1.1, 1.1)))
-def test_generalized_amplitude_damping_channel_bigly_probability(p, gamma):
+def test_generalized_amplitude_damping_channel_bigly_probability(p, gamma) -> None:
     with pytest.raises(ValueError, match='was greater than 1'):
         cirq.generalized_amplitude_damp(p, gamma)
 
 
-def test_generalized_amplitude_damping_channel_text_diagram():
+def test_generalized_amplitude_damping_channel_text_diagram() -> None:
     a = cirq.generalized_amplitude_damp(0.1, 0.39558391)
     assert cirq.circuit_diagram_info(a, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('GAD(0.1,0.395584)',)
@@ -388,7 +388,7 @@ def test_generalized_amplitude_damping_channel_text_diagram():
     )
 
 
-def test_amplitude_damping_channel():
+def test_amplitude_damping_channel() -> None:
     d = cirq.amplitude_damp(0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d),
@@ -401,15 +401,15 @@ def test_amplitude_damping_channel():
     assert not cirq.has_mixture(d)
 
 
-def test_amplitude_damping_channel_repr():
+def test_amplitude_damping_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.AmplitudeDampingChannel(0.3))
 
 
-def test_amplitude_damping_channel_str():
+def test_amplitude_damping_channel_str() -> None:
     assert str(cirq.amplitude_damp(0.3)) == 'amplitude_damp(gamma=0.3)'
 
 
-def test_amplitude_damping_channel_eq():
+def test_amplitude_damping_channel_eq() -> None:
     a = cirq.amplitude_damp(0.0099999)
     b = cirq.amplitude_damp(0.01)
     c = cirq.amplitude_damp(0.0)
@@ -425,14 +425,14 @@ def test_amplitude_damping_channel_eq():
     et.add_equality_group(cirq.amplitude_damp(0.8))
 
 
-def test_amplitude_damping_channel_invalid_probability():
+def test_amplitude_damping_channel_invalid_probability() -> None:
     with pytest.raises(ValueError, match='was less than 0'):
         cirq.amplitude_damp(-0.1)
     with pytest.raises(ValueError, match='was greater than 1'):
         cirq.amplitude_damp(1.1)
 
 
-def test_amplitude_damping_channel_text_diagram():
+def test_amplitude_damping_channel_text_diagram() -> None:
     ad = cirq.amplitude_damp(0.38059322)
     assert cirq.circuit_diagram_info(ad, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('AD(0.380593)',)
@@ -445,7 +445,7 @@ def test_amplitude_damping_channel_text_diagram():
     )
 
 
-def test_reset_channel():
+def test_reset_channel() -> None:
     r = cirq.reset(cirq.LineQubit(0))
     np.testing.assert_almost_equal(
         cirq.kraus(r), (np.array([[1.0, 0.0], [0.0, 0]]), np.array([[0.0, 1.0], [0.0, 0.0]]))
@@ -470,22 +470,22 @@ def test_reset_channel():
     assert cirq.qid_shape(r) == (3,)
 
 
-def test_reset_channel_equality():
+def test_reset_channel_equality() -> None:
     assert cirq.reset(cirq.LineQubit(0)).gate == cirq.ResetChannel()
     assert cirq.reset(cirq.LineQid(0, 3)).gate == cirq.ResetChannel(3)
 
 
-def test_reset_channel_repr():
+def test_reset_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.ResetChannel())
     cirq.testing.assert_equivalent_repr(cirq.ResetChannel(3))
 
 
-def test_reset_channel_str():
+def test_reset_channel_str() -> None:
     assert str(cirq.ResetChannel()) == 'reset'
     assert str(cirq.ResetChannel(3)) == 'reset'
 
 
-def test_reset_channel_text_diagram():
+def test_reset_channel_text_diagram() -> None:
     assert cirq.circuit_diagram_info(cirq.ResetChannel()) == cirq.CircuitDiagramInfo(
         wire_symbols=('R',)
     )
@@ -494,7 +494,7 @@ def test_reset_channel_text_diagram():
     )
 
 
-def test_reset_act_on():
+def test_reset_act_on() -> None:
     with pytest.raises(TypeError, match="Failed to act"):
         cirq.act_on(cirq.ResetChannel(), ExampleSimulationState(), qubits=())
 
@@ -523,7 +523,7 @@ def test_reset_act_on():
     )
 
 
-def test_reset_each():
+def test_reset_each() -> None:
     qubits = cirq.LineQubit.range(8)
     for n in range(len(qubits) + 1):
         ops = cirq.reset_each(*qubits[:n])
@@ -533,14 +533,14 @@ def test_reset_each():
             assert op.qubits == (qubits[i],)
 
 
-def test_reset_consistency():
+def test_reset_consistency() -> None:
     two_d_chan = cirq.ResetChannel()
     cirq.testing.assert_has_consistent_apply_channel(two_d_chan)
     three_d_chan = cirq.ResetChannel(dimension=3)
     cirq.testing.assert_has_consistent_apply_channel(three_d_chan)
 
 
-def test_phase_damping_channel():
+def test_phase_damping_channel() -> None:
     d = cirq.phase_damp(0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d),
@@ -553,15 +553,15 @@ def test_phase_damping_channel():
     assert not cirq.has_mixture(d)
 
 
-def test_phase_damping_channel_repr():
+def test_phase_damping_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.PhaseDampingChannel(0.3))
 
 
-def test_phase_damping_channel_str():
+def test_phase_damping_channel_str() -> None:
     assert str(cirq.phase_damp(0.3)) == 'phase_damp(gamma=0.3)'
 
 
-def test_phase_damping_channel_eq():
+def test_phase_damping_channel_eq() -> None:
     a = cirq.phase_damp(0.0099999)
     b = cirq.phase_damp(0.01)
     c = cirq.phase_damp(0.0)
@@ -577,14 +577,14 @@ def test_phase_damping_channel_eq():
     et.add_equality_group(cirq.phase_damp(0.8))
 
 
-def test_phase_damping_channel_invalid_probability():
+def test_phase_damping_channel_invalid_probability() -> None:
     with pytest.raises(ValueError, match='was less than 0'):
         cirq.phase_damp(-0.1)
     with pytest.raises(ValueError, match='was greater than 1'):
         cirq.phase_damp(1.1)
 
 
-def test_phase_damping_channel_text_diagram():
+def test_phase_damping_channel_text_diagram() -> None:
     pd = cirq.phase_damp(0.1000009)
     assert cirq.circuit_diagram_info(pd, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('PD(0.100001)',)
@@ -597,7 +597,7 @@ def test_phase_damping_channel_text_diagram():
     )
 
 
-def test_phase_damp_consistency():
+def test_phase_damp_consistency() -> None:
     full_damp = cirq.PhaseDampingChannel(gamma=1)
     cirq.testing.assert_has_consistent_apply_channel(full_damp)
     partial_damp = cirq.PhaseDampingChannel(gamma=0.5)
@@ -606,7 +606,7 @@ def test_phase_damp_consistency():
     cirq.testing.assert_has_consistent_apply_channel(no_damp)
 
 
-def test_phase_flip_channel():
+def test_phase_flip_channel() -> None:
     d = cirq.phase_flip(0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d), (np.sqrt(1.0 - 0.3) * np.eye(2), np.sqrt(0.3) * Z)
@@ -615,28 +615,28 @@ def test_phase_flip_channel():
     cirq.testing.assert_consistent_mixture(d)
 
 
-def test_phase_flip_mixture():
+def test_phase_flip_mixture() -> None:
     d = cirq.phase_flip(0.3)
     assert_mixtures_equal(cirq.mixture(d), ((0.7, np.eye(2)), (0.3, Z)))
     assert cirq.has_mixture(d)
 
 
-def test_phase_flip_overload():
+def test_phase_flip_overload() -> None:
     d = cirq.phase_flip()
     d2 = cirq.phase_flip(0.3)
     assert str(d) == 'Z'
     assert str(d2) == 'phase_flip(p=0.3)'
 
 
-def test_phase_flip_channel_repr():
+def test_phase_flip_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.PhaseFlipChannel(0.3))
 
 
-def test_phase_flip_channel_str():
+def test_phase_flip_channel_str() -> None:
     assert str(cirq.phase_flip(0.3)) == 'phase_flip(p=0.3)'
 
 
-def test_phase_flip_channel_eq():
+def test_phase_flip_channel_eq() -> None:
     a = cirq.phase_flip(0.0099999)
     b = cirq.phase_flip(0.01)
     c = cirq.phase_flip(0.0)
@@ -652,14 +652,14 @@ def test_phase_flip_channel_eq():
     et.add_equality_group(cirq.phase_flip(0.8))
 
 
-def test_phase_flip_channel_invalid_probability():
+def test_phase_flip_channel_invalid_probability() -> None:
     with pytest.raises(ValueError, match='was less than 0'):
         cirq.phase_flip(-0.1)
     with pytest.raises(ValueError, match='was greater than 1'):
         cirq.phase_flip(1.1)
 
 
-def test_phase_flip_channel_text_diagram():
+def test_phase_flip_channel_text_diagram() -> None:
     pf = cirq.phase_flip(0.987654)
     assert cirq.circuit_diagram_info(pf, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('PF(0.987654)',)
@@ -672,7 +672,7 @@ def test_phase_flip_channel_text_diagram():
     )
 
 
-def test_bit_flip_channel():
+def test_bit_flip_channel() -> None:
     d = cirq.bit_flip(0.3)
     np.testing.assert_almost_equal(
         cirq.kraus(d), (np.sqrt(1.0 - 0.3) * np.eye(2), np.sqrt(0.3) * X)
@@ -681,28 +681,28 @@ def test_bit_flip_channel():
     cirq.testing.assert_consistent_mixture(d)
 
 
-def test_bit_flip_mixture():
+def test_bit_flip_mixture() -> None:
     d = cirq.bit_flip(0.3)
     assert_mixtures_equal(cirq.mixture(d), ((0.7, np.eye(2)), (0.3, X)))
     assert cirq.has_mixture(d)
 
 
-def test_bit_flip_overload():
+def test_bit_flip_overload() -> None:
     d = cirq.bit_flip()
     d2 = cirq.bit_flip(0.3)
     assert str(d) == 'X'
     assert str(d2) == 'bit_flip(p=0.3)'
 
 
-def test_bit_flip_channel_repr():
+def test_bit_flip_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.BitFlipChannel(0.3))
 
 
-def test_bit_flip_channel_str():
+def test_bit_flip_channel_str() -> None:
     assert str(cirq.bit_flip(0.3)) == 'bit_flip(p=0.3)'
 
 
-def test_bit_flip_channel_eq():
+def test_bit_flip_channel_eq() -> None:
     a = cirq.bit_flip(0.0099999)
     b = cirq.bit_flip(0.01)
     c = cirq.bit_flip(0.0)
@@ -718,14 +718,14 @@ def test_bit_flip_channel_eq():
     et.add_equality_group(cirq.bit_flip(0.8))
 
 
-def test_bit_flip_channel_invalid_probability():
+def test_bit_flip_channel_invalid_probability() -> None:
     with pytest.raises(ValueError, match='was less than 0'):
         cirq.bit_flip(-0.1)
     with pytest.raises(ValueError, match='was greater than 1'):
         cirq.bit_flip(1.1)
 
 
-def test_bit_flip_channel_text_diagram():
+def test_bit_flip_channel_text_diagram() -> None:
     bf = cirq.bit_flip(0.1234567)
     assert cirq.circuit_diagram_info(bf, args=round_to_6_prec) == cirq.CircuitDiagramInfo(
         wire_symbols=('BF(0.123457)',)
@@ -738,7 +738,7 @@ def test_bit_flip_channel_text_diagram():
     )
 
 
-def test_stabilizer_supports_depolarize():
+def test_stabilizer_supports_depolarize() -> None:
     with pytest.raises(TypeError, match="act_on"):
         for _ in range(100):
             cirq.act_on(cirq.depolarize(3 / 4), ExampleSimulationState(), qubits=())
@@ -749,7 +749,7 @@ def test_stabilizer_supports_depolarize():
     assert 5 < m < 95
 
 
-def test_default_asymmetric_depolarizing_channel():
+def test_default_asymmetric_depolarizing_channel() -> None:
     d = cirq.asymmetric_depolarize()
     assert d.p_i == 1.0
     assert d.p_x == 0.0
@@ -758,28 +758,28 @@ def test_default_asymmetric_depolarizing_channel():
     assert d.num_qubits() == 1
 
 
-def test_bad_error_probabilities_gate():
+def test_bad_error_probabilities_gate() -> None:
     with pytest.raises(ValueError, match='AB is not made solely of I, X, Y, Z.'):
         cirq.asymmetric_depolarize(error_probabilities={'AB': 1.0})
     with pytest.raises(ValueError, match='Y must have 2 Pauli gates.'):
         cirq.asymmetric_depolarize(error_probabilities={'IX': 0.8, 'Y': 0.2})
 
 
-def test_bad_probs():
+def test_bad_probs() -> None:
     with pytest.raises(ValueError, match=re.escape('p(X) was greater than 1.')):
         cirq.asymmetric_depolarize(error_probabilities={'X': 1.1, 'Y': -0.1})
     with pytest.raises(ValueError, match=re.escape('Probabilities do not add up to 1')):
         cirq.asymmetric_depolarize(error_probabilities={'X': 0.7, 'Y': 0.6})
 
 
-def test_missing_prob_mass():
+def test_missing_prob_mass() -> None:
     with pytest.raises(ValueError, match='Probabilities do not add up to 1'):
         cirq.asymmetric_depolarize(error_probabilities={'X': 0.1, 'I': 0.2})
     d = cirq.asymmetric_depolarize(error_probabilities={'X': 0.1})
     np.testing.assert_almost_equal(d.error_probabilities['I'], 0.9)
 
 
-def test_multi_asymmetric_depolarizing_channel():
+def test_multi_asymmetric_depolarizing_channel() -> None:
     d = cirq.asymmetric_depolarize(error_probabilities={'II': 0.8, 'XX': 0.2})
     np.testing.assert_almost_equal(
         cirq.kraus(d), (np.sqrt(0.8) * np.eye(4), np.sqrt(0.2) * np.kron(X, X))
@@ -798,20 +798,20 @@ def test_multi_asymmetric_depolarizing_channel():
         assert d.p_z == 0.0
 
 
-def test_multi_asymmetric_depolarizing_mixture():
+def test_multi_asymmetric_depolarizing_mixture() -> None:
     d = cirq.asymmetric_depolarize(error_probabilities={'II': 0.8, 'XX': 0.2})
     assert_mixtures_equal(cirq.mixture(d), ((0.8, np.eye(4)), (0.2, np.kron(X, X))))
     assert cirq.has_mixture(d)
     np.testing.assert_equal(d._num_qubits_(), 2)
 
 
-def test_multi_asymmetric_depolarizing_channel_repr():
+def test_multi_asymmetric_depolarizing_channel_repr() -> None:
     cirq.testing.assert_equivalent_repr(
         cirq.AsymmetricDepolarizingChannel(error_probabilities={'II': 0.8, 'XX': 0.2})
     )
 
 
-def test_multi_asymmetric_depolarizing_eq():
+def test_multi_asymmetric_depolarizing_eq() -> None:
     a = cirq.asymmetric_depolarize(error_probabilities={'I': 0.8, 'X': 0.2})
     b = cirq.asymmetric_depolarize(error_probabilities={'II': 0.8, 'XX': 0.2})
 
@@ -845,13 +845,13 @@ def test_multi_asymmetric_depolarizing_eq():
     assert not cirq.approx_eq(a, cirq.X)
 
 
-def test_multi_asymmetric_depolarizing_channel_str():
+def test_multi_asymmetric_depolarizing_channel_str() -> None:
     assert str(cirq.asymmetric_depolarize(error_probabilities={'II': 0.8, 'XX': 0.2})) == (
         "asymmetric_depolarize(error_probabilities={'II': 0.8, 'XX': 0.2})"
     )
 
 
-def test_multi_asymmetric_depolarizing_channel_text_diagram():
+def test_multi_asymmetric_depolarizing_channel_text_diagram() -> None:
     a = cirq.asymmetric_depolarize(error_probabilities={'II': 2 / 3, 'XX': 1 / 3})
     assert cirq.circuit_diagram_info(a, args=no_precision) == cirq.CircuitDiagramInfo(
         wire_symbols=('A(II:0.6666666666666666, XX:0.3333333333333333)', '(1)')
@@ -867,5 +867,5 @@ def test_multi_asymmetric_depolarizing_channel_text_diagram():
     )
 
 
-def test_reset_stabilizer():
+def test_reset_stabilizer() -> None:
     assert cirq.has_stabilizer_effect(cirq.reset(cirq.LineQubit(0)))

--- a/cirq-core/cirq/ops/fsim_gate_test.py
+++ b/cirq-core/cirq/ops/fsim_gate_test.py
@@ -19,7 +19,7 @@ import sympy
 import cirq
 
 
-def test_fsim_init():
+def test_fsim_init() -> None:
     f = cirq.FSimGate(1, 2)
     assert f.theta == 1
     assert f.phi == 2
@@ -33,7 +33,7 @@ def test_fsim_init():
     assert f3.phi == -5 + 2 * np.pi
 
 
-def test_fsim_eq():
+def test_fsim_eq() -> None:
     eq = cirq.testing.EqualsTester()
     a, b = cirq.LineQubit.range(2)
 
@@ -45,7 +45,7 @@ def test_fsim_eq():
     eq.add_equality_group(cirq.FSimGate(np.pi, np.pi), cirq.FSimGate(-np.pi, -np.pi))
 
 
-def test_fsim_approx_eq():
+def test_fsim_approx_eq() -> None:
     assert cirq.approx_eq(cirq.FSimGate(1, 2), cirq.FSimGate(1.00001, 2.00001), atol=0.01)
 
 
@@ -60,12 +60,12 @@ def test_fsim_approx_eq():
         (np.pi / 2, 0.5),
     ],
 )
-def test_fsim_consistent(theta, phi):
+def test_fsim_consistent(theta, phi) -> None:
     gate = cirq.FSimGate(theta=theta, phi=phi)
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_fsim_circuit():
+def test_fsim_circuit() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(
         cirq.FSimGate(np.pi / 2, np.pi).on(a, b), cirq.FSimGate(-np.pi, np.pi / 2).on(a, b)
@@ -109,7 +109,7 @@ def test_fsim_circuit():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_fsim_resolve(resolve_fn):
+def test_fsim_resolve(resolve_fn) -> None:
     f = cirq.FSimGate(sympy.Symbol('a'), sympy.Symbol('b'))
     assert cirq.is_parameterized(f)
 
@@ -122,7 +122,7 @@ def test_fsim_resolve(resolve_fn):
     assert not cirq.is_parameterized(f)
 
 
-def test_fsim_unitary():
+def test_fsim_unitary() -> None:
     # fmt: off
     np.testing.assert_allclose(
         cirq.unitary(cirq.FSimGate(theta=0, phi=0)),
@@ -265,7 +265,7 @@ def test_fsim_unitary():
         (3.5 * np.pi, 4 * np.pi),
     ),
 )
-def test_fsim_iswap_cphase(theta, phi):
+def test_fsim_iswap_cphase(theta, phi) -> None:
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')
     iswap = cirq.ISWAP ** (-theta * 2 / np.pi)
     cphase = cirq.CZPowGate(exponent=-phi / np.pi)
@@ -274,16 +274,16 @@ def test_fsim_iswap_cphase(theta, phi):
     assert np.allclose(cirq.unitary(iswap_cphase), cirq.unitary(fsim))
 
 
-def test_fsim_repr():
+def test_fsim_repr() -> None:
     f = cirq.FSimGate(sympy.Symbol('a'), sympy.Symbol('b'))
     cirq.testing.assert_equivalent_repr(f)
 
 
-def test_fsim_json_dict():
+def test_fsim_json_dict() -> None:
     assert cirq.FSimGate(theta=0.123, phi=0.456)._json_dict_() == {'theta': 0.123, 'phi': 0.456}
 
 
-def test_phased_fsim_init():
+def test_phased_fsim_init() -> None:
     f = cirq.PhasedFSimGate(1, 2, 3, 4, 5)
     assert f.theta == 1
     assert f.zeta == 2
@@ -307,7 +307,7 @@ def test_phased_fsim_init():
         (np.pi / 5, np.pi / 6, (0.1, 0.2), (0.3, 0.5)),
     ),
 )
-def test_phased_fsim_from_fsim_rz(theta, phi, rz_angles_before, rz_angles_after):
+def test_phased_fsim_from_fsim_rz(theta, phi, rz_angles_before, rz_angles_after) -> None:
     f = cirq.PhasedFSimGate.from_fsim_rz(theta, phi, rz_angles_before, rz_angles_after)
     q0, q1 = cirq.LineQubit.range(2)
     c = cirq.Circuit(
@@ -330,7 +330,7 @@ def test_phased_fsim_from_fsim_rz(theta, phi, rz_angles_before, rz_angles_after)
         ((np.pi / 5, -np.pi / 3), (0, np.pi / 2)),
     ),
 )
-def test_phased_fsim_recreate_from_phase_angles(rz_angles_before, rz_angles_after):
+def test_phased_fsim_recreate_from_phase_angles(rz_angles_before, rz_angles_after) -> None:
     f = cirq.PhasedFSimGate.from_fsim_rz(np.pi / 3, np.pi / 5, rz_angles_before, rz_angles_after)
     f2 = cirq.PhasedFSimGate.from_fsim_rz(f.theta, f.phi, f.rz_angles_before, f.rz_angles_after)
     assert cirq.approx_eq(f, f2)
@@ -346,7 +346,7 @@ def test_phased_fsim_recreate_from_phase_angles(rz_angles_before, rz_angles_afte
         ((np.pi, np.pi / 6), (-np.pi / 2, 0)),
     ),
 )
-def test_phased_fsim_phase_angle_symmetry(rz_angles_before, rz_angles_after):
+def test_phased_fsim_phase_angle_symmetry(rz_angles_before, rz_angles_after) -> None:
     f = cirq.PhasedFSimGate.from_fsim_rz(np.pi / 3, np.pi / 5, rz_angles_before, rz_angles_after)
     for d in (-10, -7, -2 * np.pi, -0.2, 0, 0.1, 0.2, np.pi, 8, 20):
         rz_angles_before2 = (rz_angles_before[0] + d, rz_angles_before[1] + d)
@@ -357,7 +357,7 @@ def test_phased_fsim_phase_angle_symmetry(rz_angles_before, rz_angles_after):
         assert cirq.approx_eq(f, f2)
 
 
-def test_phased_fsim_eq():
+def test_phased_fsim_eq() -> None:
     eq = cirq.testing.EqualsTester()
     a, b = cirq.LineQubit.range(2)
     r, s = sympy.Symbol('r'), sympy.Symbol('s')
@@ -435,7 +435,7 @@ def test_phased_fsim_eq():
         (cirq.PhasedFSimGate(1, np.pi / 2, 0, 4, 5), False),
     ),
 )
-def test_qubit_interchangeability(gate, interchangeable):
+def test_qubit_interchangeability(gate, interchangeable) -> None:
     a, b = cirq.LineQubit.range(2)
     c1 = cirq.Circuit(gate.on(a, b))
     c2 = cirq.Circuit(cirq.SWAP(a, b), gate.on(a, b), cirq.SWAP(a, b))
@@ -444,7 +444,7 @@ def test_qubit_interchangeability(gate, interchangeable):
     assert np.all(u1 == u2) == interchangeable
 
 
-def test_phased_fsim_approx_eq():
+def test_phased_fsim_approx_eq() -> None:
     assert cirq.approx_eq(
         cirq.PhasedFSimGate(1, 2, 3, 4, 5),
         cirq.PhasedFSimGate(1.00001, 2.00001, 3.00001, 4.00004, 5.00005),
@@ -469,12 +469,12 @@ def test_phased_fsim_approx_eq():
         (np.pi, 0, 0, sympy.Symbol('a'), 0),
     ],
 )
-def test_phased_fsim_consistent(theta, zeta, chi, gamma, phi):
+def test_phased_fsim_consistent(theta, zeta, chi, gamma, phi) -> None:
     gate = cirq.PhasedFSimGate(theta=theta, zeta=zeta, chi=chi, gamma=gamma, phi=phi)
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_phased_fsim_circuit():
+def test_phased_fsim_circuit() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(
         cirq.PhasedFSimGate(np.pi / 2, np.pi, np.pi / 2, 0, -np.pi / 4).on(a, b),
@@ -529,7 +529,7 @@ def test_phased_fsim_circuit():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_phased_fsim_resolve(resolve_fn):
+def test_phased_fsim_resolve(resolve_fn) -> None:
     f = cirq.PhasedFSimGate(
         sympy.Symbol('a'),
         sympy.Symbol('b'),
@@ -562,7 +562,7 @@ def test_phased_fsim_resolve(resolve_fn):
     assert not cirq.is_parameterized(f)
 
 
-def test_phased_fsim_unitary():
+def test_phased_fsim_unitary() -> None:
     # fmt: off
     np.testing.assert_allclose(
         cirq.unitary(cirq.PhasedFSimGate(theta=0, phi=0)),
@@ -776,13 +776,13 @@ def test_phased_fsim_unitary():
         (3.5 * np.pi, 4 * np.pi),
     ),
 )
-def test_phased_fsim_vs_fsim(theta, phi):
+def test_phased_fsim_vs_fsim(theta, phi) -> None:
     g1 = cirq.FSimGate(theta, phi)
     g2 = cirq.PhasedFSimGate(theta, 0, 0, 0, phi)
     assert np.allclose(cirq.unitary(g1), cirq.unitary(g2))
 
 
-def test_phased_fsim_repr():
+def test_phased_fsim_repr() -> None:
     f = cirq.PhasedFSimGate(
         sympy.Symbol('a'),
         sympy.Symbol('b'),
@@ -793,7 +793,7 @@ def test_phased_fsim_repr():
     cirq.testing.assert_equivalent_repr(f)
 
 
-def test_phased_fsim_json_dict():
+def test_phased_fsim_json_dict() -> None:
     assert cirq.PhasedFSimGate(
         theta=0.12, zeta=0.34, chi=0.56, gamma=0.78, phi=0.9
     )._json_dict_() == {'theta': 0.12, 'zeta': 0.34, 'chi': 0.56, 'gamma': 0.78, 'phi': 0.9}
@@ -811,10 +811,10 @@ def test_phased_fsim_json_dict():
         cirq.CZ**0.2,
     ],
 )
-def test_phase_fsim_from_matrix(gate):
+def test_phase_fsim_from_matrix(gate) -> None:
     u = cirq.unitary(gate)
     np.testing.assert_allclose(cirq.unitary(cirq.PhasedFSimGate.from_matrix(u)), u, atol=1e-8)
 
 
-def test_phase_fsim_from_matrix_not_fsim_returns_none():
+def test_phase_fsim_from_matrix_not_fsim_returns_none() -> None:
     assert cirq.PhasedFSimGate.from_matrix(np.ones((4, 4))) is None

--- a/cirq-core/cirq/ops/gate_features_test.py
+++ b/cirq-core/cirq/ops/gate_features_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_qasm_output_args_validate():
+def test_qasm_output_args_validate() -> None:
     args = cirq.QasmArgs(version='2.0')
     args.validate_version('2.0')
 
@@ -25,7 +25,7 @@ def test_qasm_output_args_validate():
         args.validate_version('2.1')
 
 
-def test_qasm_output_args_format():
+def test_qasm_output_args_format() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     m_a = cirq.measure(a, key='meas_a')
@@ -52,7 +52,7 @@ def test_qasm_output_args_format():
     assert args.format('_{0}_', 'other') == '_other_'
 
 
-def test_multi_qubit_gate_validate():
+def test_multi_qubit_gate_validate() -> None:
     class Example(cirq.Gate):
         def _num_qubits_(self) -> int:
             return self._num_qubits

--- a/cirq-core/cirq/ops/greedy_qubit_manager_test.py
+++ b/cirq-core/cirq/ops/greedy_qubit_manager_test.py
@@ -30,7 +30,7 @@ class GateAllocInDecompose(cirq.Gate):
             qm.qfree([q])
 
 
-def test_greedy_qubit_manager():
+def test_greedy_qubit_manager() -> None:
     def make_circuit(qm: cirq.QubitManager):
         q = cirq.LineQubit.range(2)
         g = GateAllocInDecompose(1)
@@ -90,12 +90,12 @@ ancilla_1: ───X───X───
     )
 
 
-def test_empty_qubits():
+def test_empty_qubits() -> None:
     qm = cirq.GreedyQubitManager(prefix="anc")
     assert qm.qalloc(0) == []
 
 
-def test_greedy_qubit_manager_preserves_order():
+def test_greedy_qubit_manager_preserves_order() -> None:
     qm = cirq.GreedyQubitManager(prefix="anc")
     ancillae = [cirq.q(f"anc_{i}") for i in range(100)]
     assert qm.qalloc(100) == ancillae

--- a/cirq-core/cirq/ops/mixed_unitary_channel_test.py
+++ b/cirq-core/cirq/ops/mixed_unitary_channel_test.py
@@ -5,7 +5,7 @@ import pytest
 import cirq
 
 
-def test_matrix_mixture_from_mixture():
+def test_matrix_mixture_from_mixture() -> None:
     q0 = cirq.LineQubit(0)
     dp = cirq.depolarize(0.1)
     mm = cirq.MixedUnitaryChannel.from_mixture(dp, key='dp')
@@ -22,7 +22,7 @@ def test_matrix_mixture_from_mixture():
     assert results.measurements['dp'] in range(4)
 
 
-def test_matrix_mixture_equality():
+def test_matrix_mixture_equality() -> None:
     dp_pt1 = cirq.depolarize(0.1)
     dp_pt2 = cirq.depolarize(0.2)
     mm_a1 = cirq.MixedUnitaryChannel.from_mixture(dp_pt1, key='a')
@@ -45,7 +45,7 @@ def test_matrix_mixture_equality():
     assert half_flip != half_flip_inv
 
 
-def test_matrix_mixture_remap_keys():
+def test_matrix_mixture_remap_keys() -> None:
     dp = cirq.depolarize(0.1)
     mm = cirq.MixedUnitaryChannel.from_mixture(dp)
     with pytest.raises(TypeError):
@@ -63,7 +63,7 @@ def test_matrix_mixture_remap_keys():
     assert cirq.with_measurement_key_mapping(mm_a, {'a': 'b'}) == mm_b
 
 
-def test_matrix_mixture_from_unitaries():
+def test_matrix_mixture_from_unitaries() -> None:
     q0 = cirq.LineQubit(0)
     mix = [(0.5, np.array([[1, 0], [0, 1]])), (0.5, np.array([[0, 1], [1, 0]]))]
     half_flip = cirq.MixedUnitaryChannel(mix, key='flip')
@@ -77,7 +77,7 @@ def test_matrix_mixture_from_unitaries():
     assert results.measurements['flip'] == results.measurements['m']
 
 
-def test_matrix_mixture_str():
+def test_matrix_mixture_str() -> None:
     mix = [(0.5, np.array([[1, 0], [0, 1]])), (0.5, np.array([[0, 1], [1, 0]]))]
     half_flip = cirq.MixedUnitaryChannel(mix)
     assert (
@@ -95,7 +95,7 @@ def test_matrix_mixture_str():
     )
 
 
-def test_matrix_mixture_repr():
+def test_matrix_mixture_repr() -> None:
     mix = [
         (0.5, np.array([[1, 0], [0, 1]], dtype=np.dtype('complex64'))),
         (0.5, np.array([[0, 1], [1, 0]], dtype=np.dtype('complex64'))),
@@ -111,19 +111,19 @@ key='flip')"""
     )
 
 
-def test_mix_no_unitaries_fails():
+def test_mix_no_unitaries_fails() -> None:
     with pytest.raises(ValueError, match='must have at least one unitary'):
         _ = cirq.MixedUnitaryChannel(mixture=[], key='m')
 
 
-def test_mix_bad_prob_fails():
+def test_mix_bad_prob_fails() -> None:
     mix = [(0.5, np.array([[1, 0], [0, 0]]))]
 
     with pytest.raises(ValueError, match='Unitary probabilities must sum to 1'):
         _ = cirq.MixedUnitaryChannel(mixture=mix, key='m')
 
 
-def test_mix_mismatch_fails():
+def test_mix_mismatch_fails() -> None:
     op2 = np.zeros((4, 4))
     op2[1][1] = 1
     mix = [(0.5, np.array([[1, 0], [0, 0]])), (0.5, op2)]
@@ -132,14 +132,14 @@ def test_mix_mismatch_fails():
         _ = cirq.MixedUnitaryChannel(mixture=mix, key='m')
 
 
-def test_nonqubit_mixture_fails():
+def test_nonqubit_mixture_fails() -> None:
     mix = [(0.5, np.array([[1, 0, 0], [0, 1, 0]])), (0.5, np.array([[0, 1, 0], [1, 0, 0]]))]
 
     with pytest.raises(ValueError, match='Input mixture'):
         _ = cirq.MixedUnitaryChannel(mixture=mix, key='m')
 
 
-def test_validate():
+def test_validate() -> None:
     mix = [(0.5, np.array([[1, 0], [0, 0]])), (0.5, np.array([[0, 0], [0, 1]]))]
     with pytest.raises(ValueError, match='non-unitary'):
         _ = cirq.MixedUnitaryChannel(mixture=mix, key='m', validate=True)

--- a/cirq-core/cirq/ops/parallel_gate_test.py
+++ b/cirq-core/cirq/ops/parallel_gate_test.py
@@ -26,7 +26,7 @@ import cirq
         (cirq.X**0.5, 4, cirq.LineQubit.range(4)),
     ],
 )
-def test_parallel_gate_operation_init(gate, num_copies, qubits):
+def test_parallel_gate_operation_init(gate, num_copies, qubits) -> None:
     v = cirq.ParallelGate(gate, num_copies)
     assert v.sub_gate == gate
     assert v.num_copies == num_copies
@@ -52,7 +52,7 @@ def test_parallel_gate_operation_init(gate, num_copies, qubits):
         (cirq.testing.TwoQubitGate(), 2, cirq.LineQubit.range(4), "must be a single qubit gate"),
     ],
 )
-def test_invalid_parallel_gate_operation(gate, num_copies, qubits, error_msg):
+def test_invalid_parallel_gate_operation(gate, num_copies, qubits, error_msg) -> None:
     with pytest.raises(ValueError, match=error_msg):
         cirq.ParallelGate(gate, num_copies)(*qubits)
 
@@ -61,27 +61,27 @@ def test_invalid_parallel_gate_operation(gate, num_copies, qubits, error_msg):
     'gate, num_copies, qubits',
     [(cirq.X, 2, cirq.LineQubit.range(2)), (cirq.H**0.5, 4, cirq.LineQubit.range(4))],
 )
-def test_decompose(gate, num_copies, qubits):
+def test_decompose(gate, num_copies, qubits) -> None:
     g = cirq.ParallelGate(gate, num_copies)
     step = gate.num_qubits()
     qubit_lists = [qubits[i * step : (i + 1) * step] for i in range(num_copies)]
     assert set(cirq.decompose_once(g(*qubits))) == set(gate.on_each(qubit_lists))
 
 
-def test_decompose_raises():
+def test_decompose_raises() -> None:
     g = cirq.ParallelGate(cirq.X, 2)
     qubits = cirq.LineQubit.range(4)
     with pytest.raises(ValueError, match=r'len\(qubits\)=4 should be 2'):
         cirq.decompose_once_with_qubits(g, qubits)
 
 
-def test_with_num_copies():
+def test_with_num_copies() -> None:
     g = cirq.testing.SingleQubitGate()
     pg = cirq.ParallelGate(g, 3)
     assert pg.with_num_copies(5) == cirq.ParallelGate(g, 5)
 
 
-def test_extrapolate():
+def test_extrapolate() -> None:
     # If the gate isn't extrapolatable, you get a type error.
     g = cirq.ParallelGate(cirq.testing.SingleQubitGate(), 2)
     with pytest.raises(TypeError):
@@ -93,7 +93,7 @@ def test_extrapolate():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_parameterizable_gates(resolve_fn):
+def test_parameterizable_gates(resolve_fn) -> None:
     r = cirq.ParamResolver({'a': 0.5})
     g1 = cirq.ParallelGate(cirq.Z ** sympy.Symbol('a'), 2)
     assert cirq.is_parameterized(g1)
@@ -102,7 +102,7 @@ def test_parameterizable_gates(resolve_fn):
 
 
 @pytest.mark.parametrize('gate', [cirq.X ** sympy.Symbol("a"), cirq.testing.SingleQubitGate()])
-def test_no_unitary(gate):
+def test_no_unitary(gate) -> None:
     g = cirq.ParallelGate(gate, 2)
     assert not cirq.has_unitary(g)
     assert cirq.unitary(g, None) is None
@@ -115,7 +115,7 @@ def test_no_unitary(gate):
         (cirq.MatrixGate(cirq.unitary(cirq.H**0.25)), 6, cirq.LineQubit.range(6)),
     ],
 )
-def test_unitary(gate, num_copies, qubits):
+def test_unitary(gate, num_copies, qubits) -> None:
     g = cirq.ParallelGate(gate, num_copies)
     step = gate.num_qubits()
     qubit_lists = [qubits[i * step : (i + 1) * step] for i in range(num_copies)]
@@ -124,7 +124,7 @@ def test_unitary(gate, num_copies, qubits):
     )
 
 
-def test_not_implemented_diagram():
+def test_not_implemented_diagram() -> None:
     q = cirq.LineQubit.range(2)
     g = cirq.testing.SingleQubitGate()
     c = cirq.Circuit()
@@ -132,15 +132,15 @@ def test_not_implemented_diagram():
     assert 'cirq.testing.gate_features.SingleQubitGate ' in str(c)
 
 
-def test_repr():
+def test_repr() -> None:
     assert repr(cirq.ParallelGate(cirq.X, 2)) == 'cirq.ParallelGate(sub_gate=cirq.X, num_copies=2)'
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.ParallelGate(cirq.X**0.5, 10)) == 'X**0.5 x 10'
 
 
-def test_equivalent_circuit():
+def test_equivalent_circuit() -> None:
     qreg = cirq.LineQubit.range(4)
     oldc = cirq.Circuit()
     newc = cirq.Circuit()
@@ -154,11 +154,11 @@ def test_equivalent_circuit():
 
 
 @pytest.mark.parametrize('gate, num_copies', [(cirq.X, 1), (cirq.Y, 2), (cirq.Z, 3), (cirq.H, 4)])
-def test_parallel_gate_operation_is_consistent(gate, num_copies):
+def test_parallel_gate_operation_is_consistent(gate, num_copies) -> None:
     cirq.testing.assert_implements_consistent_protocols(cirq.ParallelGate(gate, num_copies))
 
 
-def test_trace_distance():
+def test_trace_distance() -> None:
     s = cirq.X**0.25
     two_g = cirq.ParallelGate(s, 2)
     three_g = cirq.ParallelGate(s, 3)
@@ -171,6 +171,6 @@ def test_trace_distance():
 
 
 @pytest.mark.parametrize('gate, num_copies', [(cirq.X, 1), (cirq.Y, 2), (cirq.Z, 3), (cirq.H, 4)])
-def test_parallel_gate_op(gate, num_copies):
+def test_parallel_gate_op(gate, num_copies) -> None:
     qubits = cirq.LineQubit.range(num_copies * gate.num_qubits())
     assert cirq.parallel_gate_op(gate, *qubits) == cirq.ParallelGate(gate, num_copies).on(*qubits)

--- a/cirq-core/cirq/ops/parity_gates_test.py
+++ b/cirq-core/cirq/ops/parity_gates_test.py
@@ -22,17 +22,17 @@ import cirq
 
 
 @pytest.mark.parametrize('eigen_gate_type', [cirq.XXPowGate, cirq.YYPowGate, cirq.ZZPowGate])
-def test_eigen_gates_consistent_protocols(eigen_gate_type):
+def test_eigen_gates_consistent_protocols(eigen_gate_type) -> None:
     cirq.testing.assert_eigengate_implements_consistent_protocols(eigen_gate_type)
 
 
-def test_xx_init():
+def test_xx_init() -> None:
     assert cirq.XXPowGate(exponent=1).exponent == 1
     v = cirq.XXPowGate(exponent=0.5)
     assert v.exponent == 0.5
 
 
-def test_xx_eq():
+def test_xx_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.XX,
@@ -49,24 +49,24 @@ def test_xx_eq():
     eq.add_equality_group(iXX**2.5, iXX**6.5)
 
 
-def test_xx_pow():
+def test_xx_pow() -> None:
     assert cirq.XX**0.5 != cirq.XX**-0.5
     assert cirq.XX**-1 == cirq.XX
     assert (cirq.XX**-1) ** 0.5 == cirq.XX**-0.5
 
 
-def test_xx_str():
+def test_xx_str() -> None:
     assert str(cirq.XX) == 'XX'
     assert str(cirq.XX**0.5) == 'XX**0.5'
     assert str(cirq.XXPowGate(global_shift=0.1)) == 'XX'
 
 
-def test_xx_repr():
+def test_xx_repr() -> None:
     assert repr(cirq.XXPowGate()) == 'cirq.XX'
     assert repr(cirq.XXPowGate(exponent=0.5)) == '(cirq.XX**0.5)'
 
 
-def test_xx_matrix():
+def test_xx_matrix() -> None:
     np.testing.assert_allclose(
         cirq.unitary(cirq.XX),
         np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]]),
@@ -82,7 +82,7 @@ def test_xx_matrix():
     )
 
 
-def test_xx_diagrams():
+def test_xx_diagrams() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     circuit = cirq.Circuit(cirq.XX(a, b), cirq.XX(a, b) ** 3, cirq.XX(a, b) ** 0.5)
@@ -96,13 +96,13 @@ b: ───XX───XX───XX^0.5───
     )
 
 
-def test_yy_init():
+def test_yy_init() -> None:
     assert cirq.YYPowGate(exponent=1).exponent == 1
     v = cirq.YYPowGate(exponent=0.5)
     assert v.exponent == 0.5
 
 
-def test_yy_eq():
+def test_yy_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.YY,
@@ -118,13 +118,13 @@ def test_yy_eq():
     eq.add_equality_group(iYY**2.5, iYY**6.5)
 
 
-def test_yy_pow():
+def test_yy_pow() -> None:
     assert cirq.YY**0.5 != cirq.YY**-0.5
     assert cirq.YY**-1 == cirq.YY
     assert (cirq.YY**-1) ** 0.5 == cirq.YY**-0.5
 
 
-def test_yy_str():
+def test_yy_str() -> None:
     assert str(cirq.YY) == 'YY'
     assert str(cirq.YY**0.5) == 'YY**0.5'
     assert str(cirq.YYPowGate(global_shift=0.1)) == 'YY'
@@ -133,12 +133,12 @@ def test_yy_str():
     assert str(iYY) == 'YY'
 
 
-def test_yy_repr():
+def test_yy_repr() -> None:
     assert repr(cirq.YYPowGate()) == 'cirq.YY'
     assert repr(cirq.YYPowGate(exponent=0.5)) == '(cirq.YY**0.5)'
 
 
-def test_yy_matrix():
+def test_yy_matrix() -> None:
     np.testing.assert_allclose(
         cirq.unitary(cirq.YY),
         np.array([[0, 0, 0, -1], [0, 0, 1, 0], [0, 1, 0, 0], [-1, 0, 0, 0]]),
@@ -154,7 +154,7 @@ def test_yy_matrix():
     )
 
 
-def test_yy_diagrams():
+def test_yy_diagrams() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     circuit = cirq.Circuit(cirq.YY(a, b), cirq.YY(a, b) ** 3, cirq.YY(a, b) ** 0.5)
@@ -168,13 +168,13 @@ b: ───YY───YY───YY^0.5───
     )
 
 
-def test_zz_init():
+def test_zz_init() -> None:
     assert cirq.ZZPowGate(exponent=1).exponent == 1
     v = cirq.ZZPowGate(exponent=0.5)
     assert v.exponent == 0.5
 
 
-def test_zz_eq():
+def test_zz_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.ZZ,
@@ -190,19 +190,19 @@ def test_zz_eq():
     eq.add_equality_group(iZZ**2.5, iZZ**6.5)
 
 
-def test_zz_pow():
+def test_zz_pow() -> None:
     assert cirq.ZZ**0.5 != cirq.ZZ**-0.5
     assert cirq.ZZ**-1 == cirq.ZZ
     assert (cirq.ZZ**-1) ** 0.5 == cirq.ZZ**-0.5
 
 
-def test_zz_phase_by():
+def test_zz_phase_by() -> None:
     assert cirq.phase_by(cirq.ZZ, 0.25, 0) == cirq.phase_by(cirq.ZZ, 0.25, 1) == cirq.ZZ
     assert cirq.phase_by(cirq.ZZ**0.5, 0.25, 0) == cirq.ZZ**0.5
     assert cirq.phase_by(cirq.ZZ**-0.5, 0.25, 1) == cirq.ZZ**-0.5
 
 
-def test_zz_str():
+def test_zz_str() -> None:
     assert str(cirq.ZZ) == 'ZZ'
     assert str(cirq.ZZ**0.5) == 'ZZ**0.5'
     assert str(cirq.ZZPowGate(global_shift=0.1)) == 'ZZ'
@@ -211,12 +211,12 @@ def test_zz_str():
     assert str(iZZ) == 'ZZ'
 
 
-def test_zz_repr():
+def test_zz_repr() -> None:
     assert repr(cirq.ZZPowGate()) == 'cirq.ZZ'
     assert repr(cirq.ZZPowGate(exponent=0.5)) == '(cirq.ZZ**0.5)'
 
 
-def test_zz_matrix():
+def test_zz_matrix() -> None:
     np.testing.assert_allclose(
         cirq.unitary(cirq.ZZ),
         np.array([[1, 0, 0, 0], [0, -1, 0, 0], [0, 0, -1, 0], [0, 0, 0, 1]]),
@@ -232,7 +232,7 @@ def test_zz_matrix():
     )
 
 
-def test_zz_diagrams():
+def test_zz_diagrams() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     circuit = cirq.Circuit(cirq.ZZ(a, b), cirq.ZZ(a, b) ** 3, cirq.ZZ(a, b) ** 0.5)
@@ -246,7 +246,7 @@ b: ───ZZ───ZZ───ZZ^0.5───
     )
 
 
-def test_trace_distance():
+def test_trace_distance() -> None:
     foo = sympy.Symbol('foo')
     assert cirq.trace_distance_bound(cirq.XX**foo) == 1.0
     assert cirq.trace_distance_bound(cirq.YY**foo) == 1.0
@@ -256,7 +256,7 @@ def test_trace_distance():
     assert cirq.approx_eq(cirq.trace_distance_bound(cirq.ZZ ** (1 / 3)), np.sin(np.pi / 6))
 
 
-def test_ms_arguments():
+def test_ms_arguments() -> None:
     eq_tester = cirq.testing.EqualsTester()
     eq_tester.add_equality_group(
         cirq.ms(np.pi / 2), cirq.MSGate(rads=np.pi / 2), cirq.XXPowGate(global_shift=-0.5)
@@ -268,7 +268,7 @@ def test_ms_arguments():
     eq_tester.add_equality_group(cirq.XX**0.5)
 
 
-def test_ms_equal_up_to_global_phase():
+def test_ms_equal_up_to_global_phase() -> None:
     assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 2), cirq.XX)
     assert cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX**0.5)
     assert not cirq.equal_up_to_global_phase(cirq.ms(np.pi / 4), cirq.XX)
@@ -278,7 +278,7 @@ def test_ms_equal_up_to_global_phase():
     assert cirq.ms(np.pi / 4) not in cirq.GateFamily(cirq.XX)
 
 
-def test_ms_str():
+def test_ms_str() -> None:
     ms = cirq.ms(np.pi / 2)
     assert str(ms) == 'MS(π/2)'
     assert str(cirq.ms(np.pi)) == 'MS(2.0π/2)'
@@ -287,7 +287,7 @@ def test_ms_str():
     assert str(ms**-1) == 'MS(-1.0π/2)'
 
 
-def test_ms_matrix():
+def test_ms_matrix() -> None:
     s = np.sqrt(0.5)
     # yapf: disable
     np.testing.assert_allclose(cirq.unitary(cirq.ms(np.pi/4)),
@@ -300,7 +300,7 @@ def test_ms_matrix():
     np.testing.assert_allclose(cirq.unitary(cirq.ms(np.pi)), np.diag([-1, -1, -1, -1]), atol=1e-8)
 
 
-def test_ms_repr():
+def test_ms_repr() -> None:
     assert repr(cirq.ms(np.pi / 2)) == 'cirq.ms(np.pi/2)'
     assert repr(cirq.ms(np.pi / 4)) == 'cirq.ms(0.5*np.pi/2)'
     cirq.testing.assert_equivalent_repr(cirq.ms(np.pi / 4))
@@ -309,7 +309,7 @@ def test_ms_repr():
     assert repr(ms**-0.5) == 'cirq.ms(-0.5*np.pi/2)'
 
 
-def test_ms_diagrams():
+def test_ms_diagrams() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     circuit = cirq.Circuit(cirq.SWAP(a, b), cirq.X(a), cirq.Y(a), cirq.ms(np.pi).on(a, b))
@@ -323,7 +323,7 @@ b: ───×───────────MS(π)───
     )
 
 
-def test_json_serialization():
+def test_json_serialization() -> None:
     assert cirq.read_json(json_text=cirq.to_json(cirq.ms(np.pi / 2))) == cirq.ms(np.pi / 2)
 
 
@@ -332,7 +332,9 @@ def test_json_serialization():
     'exponent,is_clifford',
     ((0, True), (0.5, True), (0.75, False), (1, True), (1.5, True), (-1.5, True)),
 )
-def test_clifford_protocols(gate_cls: type[cirq.EigenGate], exponent: float, is_clifford: bool):
+def test_clifford_protocols(
+    gate_cls: type[cirq.EigenGate], exponent: float, is_clifford: bool
+) -> None:
     gate = gate_cls(exponent=exponent)
     assert hasattr(gate, '_decompose_into_clifford_with_qubits_')
     if is_clifford:

--- a/cirq-core/cirq/ops/pauli_gates_test.py
+++ b/cirq-core/cirq/ops/pauli_gates_test.py
@@ -20,14 +20,14 @@ import pytest
 import cirq
 
 
-def test_equals():
+def test_equals() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.X, cirq.ops.pauli_gates.X, cirq.XPowGate())
     eq.add_equality_group(cirq.Y, cirq.ops.pauli_gates.Y, cirq.YPowGate())
     eq.add_equality_group(cirq.Z, cirq.ops.pauli_gates.Z, cirq.ZPowGate())
 
 
-def test_phased_pauli_product():
+def test_phased_pauli_product() -> None:
     assert cirq.X.phased_pauli_product(cirq.I) == (1, cirq.X)
     assert cirq.X.phased_pauli_product(cirq.X) == (1, cirq.I)
     assert cirq.X.phased_pauli_product(cirq.Y) == (1j, cirq.Z)
@@ -44,7 +44,7 @@ def test_phased_pauli_product():
     assert cirq.Z.phased_pauli_product(cirq.Z) == (1, cirq.I)
 
 
-def test_isinstance():
+def test_isinstance() -> None:
     assert isinstance(cirq.X, cirq.XPowGate)
     assert isinstance(cirq.Y, cirq.YPowGate)
     assert isinstance(cirq.Z, cirq.ZPowGate)
@@ -59,14 +59,14 @@ def test_isinstance():
     assert not isinstance(cirq.Z, cirq.YPowGate)
 
 
-def test_by_index():
+def test_by_index() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.X, *[cirq.Pauli.by_index(i) for i in (-3, 0, 3, 6)])
     eq.add_equality_group(cirq.Y, *[cirq.Pauli.by_index(i) for i in (-2, 1, 4, 7)])
     eq.add_equality_group(cirq.Z, *[cirq.Pauli.by_index(i) for i in (-1, 2, 5, 8)])
 
 
-def test_relative_index():
+def test_relative_index() -> None:
     assert cirq.X.relative_index(cirq.X) == 0
     assert cirq.X.relative_index(cirq.Y) == -1
     assert cirq.X.relative_index(cirq.Z) == 1
@@ -78,7 +78,7 @@ def test_relative_index():
     assert cirq.Z.relative_index(cirq.Z) == 0
 
 
-def test_by_relative_index():
+def test_by_relative_index() -> None:
     assert cirq.Pauli.by_relative_index(cirq.X, -1) == cirq.Z
     assert cirq.Pauli.by_relative_index(cirq.X, 0) == cirq.X
     assert cirq.Pauli.by_relative_index(cirq.X, 1) == cirq.Y
@@ -96,7 +96,7 @@ def test_by_relative_index():
     assert cirq.Pauli.by_relative_index(cirq.Z, 3) == cirq.Z
 
 
-def test_too_many_qubits():
+def test_too_many_qubits() -> None:
     a, b = cirq.LineQubit.range(2)
     with pytest.raises(ValueError, match='single qubit'):
         _ = cirq.X.on(a, b)
@@ -106,14 +106,14 @@ def test_too_many_qubits():
         _ = x.with_qubits(a, b)
 
 
-def test_relative_index_consistency():
+def test_relative_index_consistency() -> None:
     for pauli_1 in (cirq.X, cirq.Y, cirq.Z):
         for pauli_2 in (cirq.X, cirq.Y, cirq.Z):
             shift = pauli_2.relative_index(pauli_1)
             assert cirq.Pauli.by_relative_index(pauli_1, shift) == pauli_2
 
 
-def test_gt():
+def test_gt() -> None:
     assert not cirq.X > cirq.X
     assert not cirq.X > cirq.Y
     assert cirq.X > cirq.Z
@@ -125,12 +125,12 @@ def test_gt():
     assert not cirq.Z > cirq.Z
 
 
-def test_gt_other_type():
+def test_gt_other_type() -> None:
     with pytest.raises(TypeError):
         _ = cirq.X > object()
 
 
-def test_lt():
+def test_lt() -> None:
     assert not cirq.X < cirq.X
     assert cirq.X < cirq.Y
     assert not cirq.X < cirq.Z
@@ -142,24 +142,24 @@ def test_lt():
     assert not cirq.Z < cirq.Z
 
 
-def test_lt_other_type():
+def test_lt_other_type() -> None:
     with pytest.raises(TypeError):
         _ = cirq.X < object()
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.X) == 'X'
     assert str(cirq.Y) == 'Y'
     assert str(cirq.Z) == 'Z'
 
 
-def test_repr():
+def test_repr() -> None:
     assert repr(cirq.X) == 'cirq.X'
     assert repr(cirq.Y) == 'cirq.Y'
     assert repr(cirq.Z) == 'cirq.Z'
 
 
-def test_third():
+def test_third() -> None:
     assert cirq.X.third(cirq.Y) == cirq.Z
     assert cirq.Y.third(cirq.X) == cirq.Z
     assert cirq.Y.third(cirq.Z) == cirq.X
@@ -172,7 +172,7 @@ def test_third():
     assert cirq.Z.third(cirq.Z) == cirq.Z
 
 
-def test_commutes():
+def test_commutes() -> None:
     for A, B in itertools.product([cirq.X, cirq.Y, cirq.Z], repeat=2):
         assert cirq.commutes(A, B) == (A == B)
     with pytest.raises(TypeError):
@@ -181,19 +181,19 @@ def test_commutes():
     assert cirq.commutes(cirq.Z, cirq.read_json(json_text=cirq.to_json(cirq.Z)))
 
 
-def test_unitary():
+def test_unitary() -> None:
     np.testing.assert_equal(cirq.unitary(cirq.X), cirq.unitary(cirq.X))
     np.testing.assert_equal(cirq.unitary(cirq.Y), cirq.unitary(cirq.Y))
     np.testing.assert_equal(cirq.unitary(cirq.Z), cirq.unitary(cirq.Z))
 
 
-def test_apply_unitary():
+def test_apply_unitary() -> None:
     cirq.testing.assert_has_consistent_apply_unitary(cirq.X)
     cirq.testing.assert_has_consistent_apply_unitary(cirq.Y)
     cirq.testing.assert_has_consistent_apply_unitary(cirq.Z)
 
 
-def test_identity_multiplication():
+def test_identity_multiplication() -> None:
     a, b, c = cirq.LineQubit.range(3)
     assert cirq.X(a) * cirq.I(a) == cirq.X(a)
     assert cirq.X(a) * cirq.I(b) == cirq.X(a)
@@ -207,7 +207,7 @@ def test_identity_multiplication():
         _ = cirq.I(a) * str(cirq.Y(b))
 
 
-def test_powers():
+def test_powers() -> None:
     assert isinstance(cirq.X, cirq.Pauli)
     assert isinstance(cirq.Y, cirq.Pauli)
     assert isinstance(cirq.Z, cirq.Pauli)

--- a/cirq-core/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_interaction_gate_test.py
@@ -32,11 +32,11 @@ def _all_interaction_gates(exponents=(1,)):
 
 
 @pytest.mark.parametrize('gate', _all_interaction_gates())
-def test_pauli_interaction_gates_consistent_protocols(gate):
+def test_pauli_interaction_gates_consistent_protocols(gate) -> None:
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_eq_ne_and_hash():
+def test_eq_ne_and_hash() -> None:
     eq = cirq.testing.EqualsTester()
     for pauli0, invert0, pauli1, invert1, e in itertools.product(
         _paulis, _bools, _paulis, _bools, (0.125, -0.25, 1)
@@ -46,7 +46,7 @@ def test_eq_ne_and_hash():
         )
 
 
-def test_exponent_shifts_are_equal():
+def test_exponent_shifts_are_equal() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.PauliInteractionGate(cirq.X, False, cirq.X, False, exponent=e)
@@ -67,7 +67,7 @@ def test_exponent_shifts_are_equal():
 
 
 @pytest.mark.parametrize('gate', _all_interaction_gates(exponents=(0.1, -0.25, 0.5, 1)))
-def test_interchangeable_qubits(gate):
+def test_interchangeable_qubits(gate) -> None:
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')
     op0 = gate(q0, q1)
     op1 = gate(q1, q0)
@@ -78,7 +78,7 @@ def test_interchangeable_qubits(gate):
     assert same == same_check
 
 
-def test_exponent():
+def test_exponent() -> None:
     cnot = cirq.PauliInteractionGate(cirq.Z, False, cirq.X, False)
     np.testing.assert_almost_equal(
         cirq.unitary(cnot**0.5),
@@ -93,18 +93,18 @@ def test_exponent():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     cnot = cirq.PauliInteractionGate(cirq.Z, False, cirq.X, False)
     cirq.testing.assert_equivalent_repr(cnot)
 
 
-def test_decomposes_despite_symbol():
+def test_decomposes_despite_symbol() -> None:
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')
     gate = cirq.PauliInteractionGate(cirq.Z, False, cirq.X, False, exponent=sympy.Symbol('x'))
     assert cirq.decompose_once_with_qubits(gate, [q0, q1])
 
 
-def test_text_diagrams():
+def test_text_diagrams() -> None:
     q0, q1 = cirq.NamedQubit('q0'), cirq.NamedQubit('q1')
     circuit = cirq.Circuit(
         cirq.PauliInteractionGate(cirq.X, False, cirq.X, False)(q0, q1),

--- a/cirq-core/cirq/ops/pauli_sum_exponential_test.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential_test.py
@@ -22,12 +22,12 @@ import cirq.testing
 q0, q1, q2, q3 = cirq.LineQubit.range(4)
 
 
-def test_raises_for_non_commuting_paulis():
+def test_raises_for_non_commuting_paulis() -> None:
     with pytest.raises(ValueError, match='commuting'):
         cirq.PauliSumExponential(cirq.X(q0) + cirq.Z(q0), np.pi / 2)
 
 
-def test_raises_for_non_hermitian_pauli():
+def test_raises_for_non_hermitian_pauli() -> None:
     with pytest.raises(ValueError, match='hermitian'):
         cirq.PauliSumExponential(cirq.X(q0) + 1j * cirq.Z(q1), np.pi / 2)
 
@@ -46,7 +46,7 @@ def test_raises_for_non_hermitian_pauli():
         ),
     ),
 )
-def test_pauli_sum_exponential_qubits(psum_exp, expected_qubits):
+def test_pauli_sum_exponential_qubits(psum_exp, expected_qubits) -> None:
     assert psum_exp.qubits == expected_qubits
 
 
@@ -67,7 +67,7 @@ def test_pauli_sum_exponential_qubits(psum_exp, expected_qubits):
         ),
     ),
 )
-def test_pauli_sum_exponential_with_qubits(psum_exp, expected_psum_exp):
+def test_pauli_sum_exponential_with_qubits(psum_exp, expected_psum_exp) -> None:
     assert psum_exp.with_qubits(*expected_psum_exp.qubits) == expected_psum_exp
 
 
@@ -79,7 +79,7 @@ def test_pauli_sum_exponential_with_qubits(psum_exp, expected_psum_exp):
         (cirq.X(q0) * cirq.Y(q1) + cirq.Y(q1) * cirq.Z(q3), np.pi),
     ),
 )
-def test_with_parameters_resolved_by(psum, exp):
+def test_with_parameters_resolved_by(psum, exp) -> None:
     psum_exp = cirq.PauliSumExponential(psum, sympy.Symbol("theta"))
     resolver = cirq.ParamResolver({"theta": exp})
     actual = cirq.resolve_parameters(psum_exp, resolver)
@@ -87,7 +87,7 @@ def test_with_parameters_resolved_by(psum, exp):
     assert actual == expected
 
 
-def test_pauli_sum_exponential_parameterized_matrix_raises():
+def test_pauli_sum_exponential_parameterized_matrix_raises() -> None:
     with pytest.raises(ValueError, match='parameterized'):
         cirq.PauliSumExponential(cirq.X(q0) + cirq.Z(q1), sympy.Symbol("theta")).matrix()
 
@@ -102,7 +102,7 @@ def test_pauli_sum_exponential_parameterized_matrix_raises():
         ),
     ),
 )
-def test_pauli_sum_exponential_has_correct_unitary(psum_exp, expected_unitary):
+def test_pauli_sum_exponential_has_correct_unitary(psum_exp, expected_unitary) -> None:
     assert cirq.has_unitary(psum_exp)
     assert np.allclose(cirq.unitary(psum_exp), expected_unitary)
 
@@ -127,7 +127,7 @@ def test_pauli_sum_exponential_has_correct_unitary(psum_exp, expected_unitary):
         ),
     ),
 )
-def test_pauli_sum_exponential_pow(psum_exp, power, expected_psum):
+def test_pauli_sum_exponential_pow(psum_exp, power, expected_psum) -> None:
     assert psum_exp**power == expected_psum
 
 
@@ -138,7 +138,7 @@ def test_pauli_sum_exponential_pow(psum_exp, power, expected_psum):
         (cirq.PauliSumExponential(2j * cirq.X(q0) + 3j * cirq.Z(q1), np.pi / 2)),
     ),
 )
-def test_pauli_sum_exponential_repr(psum_exp):
+def test_pauli_sum_exponential_repr(psum_exp) -> None:
     cirq.testing.assert_equivalent_repr(psum_exp)
 
 
@@ -156,5 +156,5 @@ def test_pauli_sum_exponential_repr(psum_exp):
         ),
     ),
 )
-def test_pauli_sum_exponential_formatting(psum_exp, expected_str):
+def test_pauli_sum_exponential_formatting(psum_exp, expected_str) -> None:
     assert str(psum_exp) == expected_str

--- a/cirq-core/cirq/ops/permutation_gate_test.py
+++ b/cirq-core/cirq/ops/permutation_gate_test.py
@@ -19,7 +19,7 @@ import cirq
 from cirq.ops import QubitPermutationGate
 
 
-def test_permutation_gate_equality():
+def test_permutation_gate_equality() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(
         lambda: QubitPermutationGate([0, 1]), lambda: QubitPermutationGate((0, 1))
@@ -27,7 +27,7 @@ def test_permutation_gate_equality():
     eq.add_equality_group(QubitPermutationGate([1, 0]), QubitPermutationGate((1, 0)))
 
 
-def test_permutation_gate_repr():
+def test_permutation_gate_repr() -> None:
     cirq.testing.assert_equivalent_repr(QubitPermutationGate([0, 1]))
 
 
@@ -35,26 +35,26 @@ rs = np.random.RandomState(seed=1234)
 
 
 @pytest.mark.parametrize('permutation', [rs.permutation(i) for i in range(3, 7)])
-def test_permutation_gate_consistent_protocols(permutation):
+def test_permutation_gate_consistent_protocols(permutation) -> None:
     gate = QubitPermutationGate(list(permutation))
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_permutation_gate_invalid_indices():
+def test_permutation_gate_invalid_indices() -> None:
     with pytest.raises(ValueError, match="Invalid indices"):
         QubitPermutationGate([1, 0, 2, 4])
     with pytest.raises(ValueError, match="Invalid indices"):
         QubitPermutationGate([-1])
 
 
-def test_permutation_gate_invalid_permutation():
+def test_permutation_gate_invalid_permutation() -> None:
     with pytest.raises(ValueError, match="Invalid permutation"):
         QubitPermutationGate([1, 1])
     with pytest.raises(ValueError, match="Invalid permutation"):
         QubitPermutationGate([])
 
 
-def test_permutation_gate_diagram():
+def test_permutation_gate_diagram() -> None:
     q = cirq.LineQubit.range(6)
     cirq.testing.assert_has_diagram(
         cirq.Circuit(cirq.X(q[0]), cirq.X(q[5]), QubitPermutationGate([3, 2, 1, 0]).on(*q[1:5])),
@@ -74,7 +74,7 @@ def test_permutation_gate_diagram():
     )
 
 
-def test_permutation_gate_json_dict():
+def test_permutation_gate_json_dict() -> None:
     assert cirq.QubitPermutationGate([0, 1, 2])._json_dict_() == {'permutation': (0, 1, 2)}
 
 
@@ -96,7 +96,7 @@ def test_permutation_gate_json_dict():
         ],
     ],
 )
-def test_permutation_gate_maps(maps, permutation):
+def test_permutation_gate_maps(maps, permutation) -> None:
     qs = cirq.LineQubit.range(len(permutation))
     permutationOp = cirq.QubitPermutationGate(permutation).on(*qs)
     circuit = cirq.Circuit(permutationOp)

--- a/cirq-core/cirq/ops/phased_iswap_gate_test.py
+++ b/cirq-core/cirq/ops/phased_iswap_gate_test.py
@@ -22,7 +22,7 @@ import cirq
 np.set_printoptions(linewidth=300)
 
 
-def test_phased_iswap_init():
+def test_phased_iswap_init() -> None:
     p = -0.25
     t = 0.75
     s = 0.5
@@ -32,7 +32,7 @@ def test_phased_iswap_init():
     assert gate.global_shift == s
 
 
-def test_phased_iswap_equality():
+def test_phased_iswap_equality() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.PhasedISwapPowGate(phase_exponent=0, exponent=0.4))
     eq.add_equality_group(cirq.ISWAP**0.4)
@@ -40,7 +40,7 @@ def test_phased_iswap_equality():
     eq.add_equality_group(cirq.ISwapPowGate(global_shift=0.3) ** 0.4)
 
 
-def test_repr():
+def test_repr() -> None:
     p = -0.25
     t = 0.75
     s = 0.3
@@ -48,7 +48,7 @@ def test_repr():
     cirq.testing.assert_equivalent_repr(gate)
 
 
-def test_phased_iswap_unitary():
+def test_phased_iswap_unitary() -> None:
     p = 0.3
     t = 0.4
     actual = cirq.unitary(cirq.PhasedISwapPowGate(phase_exponent=p, exponent=t))
@@ -64,7 +64,7 @@ def test_phased_iswap_unitary():
     assert np.allclose(actual, expected)
 
 
-def test_phased_iswap_equivalent_circuit():
+def test_phased_iswap_equivalent_circuit() -> None:
     p = 0.7
     t = -0.4
     gate = cirq.PhasedISwapPowGate(phase_exponent=p, exponent=t)
@@ -81,7 +81,7 @@ def test_phased_iswap_equivalent_circuit():
     assert np.allclose(cirq.unitary(gate), cirq.unitary(equivalent_circuit))
 
 
-def test_phased_iswap_str():
+def test_phased_iswap_str() -> None:
     assert str(cirq.PhasedISwapPowGate(exponent=1)) == 'PhasedISWAP'
     assert str(cirq.PhasedISwapPowGate(exponent=0.5)) == 'PhasedISWAP**0.5'
     assert (
@@ -90,7 +90,7 @@ def test_phased_iswap_str():
     )
 
 
-def test_phased_iswap_pow():
+def test_phased_iswap_pow() -> None:
     gate1 = cirq.PhasedISwapPowGate(phase_exponent=0.1, exponent=0.25)
     gate2 = cirq.PhasedISwapPowGate(phase_exponent=0.1, exponent=0.5)
     assert gate1**2 == gate2
@@ -108,7 +108,7 @@ def test_phased_iswap_pow():
     assert np.allclose(u1 @ u1, u2)
 
 
-def test_decompose_invalid_qubits():
+def test_decompose_invalid_qubits() -> None:
     qs = cirq.LineQubit.range(3)
     with pytest.raises(ValueError):
         cirq.protocols.decompose_once_with_qubits(cirq.PhasedISwapPowGate(), qs)
@@ -134,7 +134,7 @@ def test_decompose_invalid_qubits():
         (sympy.Symbol('t'), sympy.Symbol('p'), 1),
     ],
 )
-def test_phased_iswap_has_consistent_protocols(phase_exponent, exponent, global_shift):
+def test_phased_iswap_has_consistent_protocols(phase_exponent, exponent, global_shift) -> None:
     cirq.testing.assert_implements_consistent_protocols(
         cirq.PhasedISwapPowGate(
             phase_exponent=phase_exponent, exponent=exponent, global_shift=global_shift
@@ -142,7 +142,7 @@ def test_phased_iswap_has_consistent_protocols(phase_exponent, exponent, global_
     )
 
 
-def test_diagram():
+def test_diagram() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     c = cirq.Circuit(
         cirq.PhasedISwapPowGate(phase_exponent=sympy.Symbol('p'), exponent=sympy.Symbol('t')).on(
@@ -165,7 +165,7 @@ def test_diagram():
 
 
 @pytest.mark.parametrize('angle_rads', (-np.pi, -np.pi / 3, -0.1, np.pi / 5))
-def test_givens_rotation_unitary(angle_rads):
+def test_givens_rotation_unitary(angle_rads) -> None:
     actual = cirq.unitary(cirq.givens(angle_rads))
     c = np.cos(angle_rads)
     s = np.sin(angle_rads)
@@ -179,7 +179,7 @@ def test_givens_rotation_unitary(angle_rads):
 
 
 @pytest.mark.parametrize('angle_rads', (-2 * np.pi / 3, -0.2, 0.4, np.pi / 4))
-def test_givens_rotation_hamiltonian(angle_rads):
+def test_givens_rotation_hamiltonian(angle_rads) -> None:
     actual = cirq.unitary(cirq.givens(angle_rads))
     x = np.array([[0, 1], [1, 0]])
     y = np.array([[0, -1j], [1j, 0]])
@@ -189,7 +189,7 @@ def test_givens_rotation_hamiltonian(angle_rads):
     assert np.allclose(actual, expected)
 
 
-def test_givens_rotation_equivalent_circuit():
+def test_givens_rotation_equivalent_circuit() -> None:
     angle_rads = 3 * np.pi / 7
     t = 2 * angle_rads / np.pi
     gate = cirq.givens(angle_rads)
@@ -201,11 +201,11 @@ def test_givens_rotation_equivalent_circuit():
 
 
 @pytest.mark.parametrize('angle_rads', (-np.pi / 5, 0.4, 2, np.pi))
-def test_givens_rotation_has_consistent_protocols(angle_rads):
+def test_givens_rotation_has_consistent_protocols(angle_rads) -> None:
     cirq.testing.assert_implements_consistent_protocols(cirq.givens(angle_rads))
 
 
-def test_approx_eq():
+def test_approx_eq() -> None:
     gate0 = cirq.PhasedISwapPowGate(phase_exponent=0)
     gate1 = cirq.PhasedISwapPowGate(phase_exponent=1e-12)
     gate2 = cirq.PhasedISwapPowGate(phase_exponent=2e-12)

--- a/cirq-core/cirq/ops/qubit_manager_test.py
+++ b/cirq-core/cirq/ops/qubit_manager_test.py
@@ -18,7 +18,7 @@ import cirq
 from cirq.ops import qubit_manager as cqi
 
 
-def test_clean_qubits():
+def test_clean_qubits() -> None:
     q = cqi.CleanQubit(1)
     assert q.id == 1
     assert q.dimension == 2
@@ -39,7 +39,7 @@ def test_clean_qubits():
     assert cqi.CleanQubit(1) < cqi.CleanQubit(2)
 
 
-def test_ancilla_qubits_prefix():
+def test_ancilla_qubits_prefix() -> None:
     assert cqi.CleanQubit(1, prefix="1") != cqi.CleanQubit(1, prefix="2")
     assert cqi.CleanQubit(1, prefix="1") < cqi.CleanQubit(1, prefix="2")
     assert cqi.CleanQubit(1, prefix="1") < cqi.CleanQubit(2, prefix="1")
@@ -49,7 +49,7 @@ def test_ancilla_qubits_prefix():
     assert cqi.CleanQubit(1, prefix="1") != cqi.BorrowableQubit(1, prefix="1")
 
 
-def test_borrow_qubits():
+def test_borrow_qubits() -> None:
     q = cqi.BorrowableQubit(10)
     assert q.id == 10
     assert q.dimension == 2
@@ -71,7 +71,7 @@ def test_borrow_qubits():
 
 
 @pytest.mark.parametrize('_', range(2))
-def test_simple_qubit_manager(_):
+def test_simple_qubit_manager(_) -> None:
     qm = cirq.ops.SimpleQubitManager()
     assert qm.qalloc(1) == [cqi.CleanQubit(0)]
     assert qm.qalloc(2) == [cqi.CleanQubit(1), cqi.CleanQubit(2)]

--- a/cirq-core/cirq/ops/random_gate_channel_test.py
+++ b/cirq-core/cirq/ops/random_gate_channel_test.py
@@ -18,7 +18,7 @@ import sympy
 import cirq
 
 
-def test_init():
+def test_init() -> None:
     p = cirq.RandomGateChannel(sub_gate=cirq.X, probability=0.5)
     assert p.sub_gate is cirq.X
     assert p.probability == 0.5
@@ -29,7 +29,7 @@ def test_init():
         _ = cirq.RandomGateChannel(sub_gate=cirq.X, probability=-1)
 
 
-def test_eq():
+def test_eq() -> None:
     eq = cirq.testing.EqualsTester()
     q = cirq.LineQubit(0)
 
@@ -67,7 +67,7 @@ def test_eq():
     )
 
 
-def test_consistent_protocols():
+def test_consistent_protocols() -> None:
     cirq.testing.assert_implements_consistent_protocols(
         cirq.RandomGateChannel(sub_gate=cirq.X, probability=1),
         ignore_decompose_to_default_gateset=True,
@@ -86,7 +86,7 @@ def test_consistent_protocols():
     )
 
 
-def test_diagram():
+def test_diagram() -> None:
     class NoDetailsGate(cirq.Gate):
         def num_qubits(self) -> int:
             raise NotImplementedError()
@@ -115,7 +115,7 @@ def test_diagram():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_parameterized(resolve_fn):
+def test_parameterized(resolve_fn) -> None:
     op = cirq.X.with_probability(sympy.Symbol('x'))
     assert cirq.is_parameterized(op)
     assert not cirq.has_kraus(op)
@@ -128,7 +128,7 @@ def test_parameterized(resolve_fn):
     assert cirq.has_mixture(op2)
 
 
-def test_mixture():
+def test_mixture() -> None:
     class NoDetailsGate(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -150,7 +150,7 @@ def test_mixture():
     assert {p for p, _ in m} == {7 / 8, 1 / 32, 3 / 32}
 
 
-def test_channel():
+def test_channel() -> None:
     class NoDetailsGate(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -192,7 +192,7 @@ def test_channel():
     np.testing.assert_allclose(m[2], cirq.unitary(cirq.I) * np.sqrt(0.75), atol=1e-8)
 
 
-def test_trace_distance():
+def test_trace_distance() -> None:
     t = cirq.trace_distance_bound
     assert 0.999 <= t(cirq.X.with_probability(sympy.Symbol('x')))
     assert t(cirq.X.with_probability(0)) == 0
@@ -201,18 +201,18 @@ def test_trace_distance():
     assert 0.35 <= t(cirq.S.with_probability(0.5)) <= 0.36
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.X.with_probability(0.5)) == 'X[prob=0.5]'
 
 
-def test_stabilizer_supports_probability():
+def test_stabilizer_supports_probability() -> None:
     q = cirq.LineQubit(0)
     c = cirq.Circuit(cirq.X(q).with_probability(0.5), cirq.measure(q, key='m'))
     m = np.sum(cirq.StabilizerSampler().sample(c, repetitions=100)['m'])
     assert 5 < m < 95
 
 
-def test_unsupported_stabilizer_safety():
+def test_unsupported_stabilizer_safety() -> None:
     from cirq.protocols.act_on_protocol_test import ExampleSimulationState
 
     with pytest.raises(TypeError, match="act_on"):

--- a/cirq-core/cirq/ops/state_preparation_channel_test.py
+++ b/cirq-core/cirq/ops/state_preparation_channel_test.py
@@ -36,7 +36,7 @@ import cirq
         ]
     ),
 )
-def test_state_prep_channel_kraus(state):
+def test_state_prep_channel_kraus(state) -> None:
     qubits = cirq.LineQubit.range(2)
     gate = cirq.StatePreparationChannel(state)(qubits[0], qubits[1])
     cirq.testing.assert_consistent_channel(gate)
@@ -53,7 +53,7 @@ def test_state_prep_channel_kraus(state):
     )
 
 
-def test_state_prep_channel_kraus_small():
+def test_state_prep_channel_kraus_small() -> None:
     gate = cirq.StatePreparationChannel(np.array([0.0, 1.0]))(cirq.LineQubit(0))
     np.testing.assert_almost_equal(
         cirq.kraus(gate), (np.array([[0.0, 0.0], [1.0, 0.0]]), np.array([[0.0, 0.0], [0.0, 1.0]]))
@@ -69,7 +69,7 @@ def test_state_prep_channel_kraus_small():
     assert not cirq.has_mixture(gate)
 
 
-def test_state_prep_gate_printing():
+def test_state_prep_gate_printing() -> None:
     circuit = cirq.Circuit()
     qubits = cirq.LineQubit.range(2)
     gate = cirq.StatePreparationChannel(np.array([1, 0, 0, 1]) / np.sqrt(2))
@@ -87,7 +87,7 @@ def test_state_prep_gate_printing():
 
 
 @pytest.mark.parametrize('name', ['Prep', 'S'])
-def test_state_prep_gate_printing_with_name(name):
+def test_state_prep_gate_printing_with_name(name) -> None:
     circuit = cirq.Circuit()
     qubits = cirq.LineQubit.range(2)
     gate = cirq.StatePreparationChannel(np.array([1, 0, 0, 1]) / np.sqrt(2), name=name)
@@ -104,7 +104,7 @@ def test_state_prep_gate_printing_with_name(name):
     )
 
 
-def test_gate_params():
+def test_gate_params() -> None:
     state = np.array([1, 0, 0, 0], dtype=np.complex64)
     gate = cirq.StatePreparationChannel(state)
     assert gate.num_qubits() == 2
@@ -114,14 +114,14 @@ def test_gate_params():
     cirq.testing.assert_equivalent_repr(gate)
 
 
-def test_gate_error_handling():
+def test_gate_error_handling() -> None:
     with pytest.raises(ValueError, match='`target_state` must be a 1d numpy array.'):
         cirq.StatePreparationChannel(np.eye(2))
     with pytest.raises(ValueError, match='Matrix width \\(5\\) is not a power of 2'):
         cirq.StatePreparationChannel(np.ones(shape=5))
 
 
-def test_equality_of_gates():
+def test_equality_of_gates() -> None:
     state = np.array([1, 0, 0, 0], dtype=np.complex64)
     gate_1 = cirq.StatePreparationChannel(state)
     gate_2 = cirq.StatePreparationChannel(state)
@@ -134,7 +134,7 @@ def test_equality_of_gates():
     assert gate_1 != gate_3, "Different states shouldn't lead to same gate"
 
 
-def test_approx_equality_of_gates():
+def test_approx_equality_of_gates() -> None:
     state = np.array([1, 0, 0, 0], dtype=np.complex64)
     gate_1 = cirq.StatePreparationChannel(state)
     gate_2 = cirq.StatePreparationChannel(state)

--- a/cirq-core/cirq/ops/swap_gates_test.py
+++ b/cirq-core/cirq/ops/swap_gates_test.py
@@ -21,11 +21,11 @@ import cirq
 
 
 @pytest.mark.parametrize('eigen_gate_type', [cirq.ISwapPowGate, cirq.SwapPowGate])
-def test_phase_sensitive_eigen_gates_consistent_protocols(eigen_gate_type):
+def test_phase_sensitive_eigen_gates_consistent_protocols(eigen_gate_type) -> None:
     cirq.testing.assert_eigengate_implements_consistent_protocols(eigen_gate_type)
 
 
-def test_interchangeable_qubit_eq():
+def test_interchangeable_qubit_eq() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
@@ -44,7 +44,7 @@ def test_interchangeable_qubit_eq():
     eq.add_equality_group(cirq.ISWAP(a, c) ** 0.3)
 
 
-def test_text_diagrams():
+def test_text_diagrams() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     circuit = cirq.Circuit(cirq.SWAP(a, b), cirq.ISWAP(a, b) ** -1)
@@ -69,14 +69,14 @@ b: ---Swap---iSwap^-1---
     )
 
 
-def test_swap_has_stabilizer_effect():
+def test_swap_has_stabilizer_effect() -> None:
     assert cirq.has_stabilizer_effect(cirq.SWAP)
     assert cirq.has_stabilizer_effect(cirq.SWAP**2)
     assert not cirq.has_stabilizer_effect(cirq.SWAP**0.5)
     assert not cirq.has_stabilizer_effect(cirq.SWAP ** sympy.Symbol('foo'))
 
 
-def test_swap_unitary():
+def test_swap_unitary() -> None:
     # yapf: disable
     np.testing.assert_almost_equal(
         cirq.unitary(cirq.SWAP**0.5),
@@ -89,7 +89,7 @@ def test_swap_unitary():
     # yapf: enable
 
 
-def test_iswap_unitary():
+def test_iswap_unitary() -> None:
     # yapf: disable
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(cirq.ISWAP),
@@ -103,7 +103,7 @@ def test_iswap_unitary():
     # yapf: enable
 
 
-def test_iswap_inv_unitary():
+def test_iswap_inv_unitary() -> None:
     # yapf: disable
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(cirq.ISWAP_INV),
@@ -117,7 +117,7 @@ def test_iswap_inv_unitary():
     # yapf: enable
 
 
-def test_sqrt_iswap_unitary():
+def test_sqrt_iswap_unitary() -> None:
     # yapf: disable
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(cirq.SQRT_ISWAP),
@@ -131,7 +131,7 @@ def test_sqrt_iswap_unitary():
     # yapf: enable
 
 
-def test_sqrt_iswap_inv_unitary():
+def test_sqrt_iswap_inv_unitary() -> None:
     # yapf: disable
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.unitary(cirq.SQRT_ISWAP_INV),
@@ -145,7 +145,7 @@ def test_sqrt_iswap_inv_unitary():
     # yapf: enable
 
 
-def test_repr():
+def test_repr() -> None:
     assert repr(cirq.SWAP) == 'cirq.SWAP'
     assert repr(cirq.SWAP**0.5) == '(cirq.SWAP**0.5)'
 
@@ -156,7 +156,7 @@ def test_repr():
     assert repr(cirq.ISWAP_INV**0.5) == '(cirq.ISWAP**-0.5)'
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.SWAP) == 'SWAP'
     assert str(cirq.SWAP**0.5) == 'SWAP**0.5'
 
@@ -167,7 +167,7 @@ def test_str():
     assert str(cirq.ISWAP_INV**0.5) == 'ISWAP**-0.5'
 
 
-def test_iswap_decompose_diagram():
+def test_iswap_decompose_diagram() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -182,7 +182,7 @@ b: ───X───────@───────@───────�
     )
 
 
-def test_trace_distance():
+def test_trace_distance() -> None:
     foo = sympy.Symbol('foo')
     sswap = cirq.SWAP**foo
     siswap = cirq.ISWAP**foo
@@ -194,14 +194,14 @@ def test_trace_distance():
     assert cirq.approx_eq(cirq.trace_distance_bound(cirq.ISWAP**0), 0.0)
 
 
-def test_trace_distance_over_range_of_exponents():
+def test_trace_distance_over_range_of_exponents() -> None:
     for exp in np.linspace(0, 4, 20):
         cirq.testing.assert_has_consistent_trace_distance_bound(cirq.SWAP**exp)
         cirq.testing.assert_has_consistent_trace_distance_bound(cirq.ISWAP**exp)
 
 
 @pytest.mark.parametrize('angle_rads', (-np.pi, -np.pi / 3, -0.1, np.pi / 5))
-def test_riswap_unitary(angle_rads):
+def test_riswap_unitary(angle_rads) -> None:
     actual = cirq.unitary(cirq.riswap(angle_rads))
     c = np.cos(angle_rads)
     s = 1j * np.sin(angle_rads)
@@ -215,7 +215,7 @@ def test_riswap_unitary(angle_rads):
 
 
 @pytest.mark.parametrize('angle_rads', (-2 * np.pi / 3, -0.2, 0.4, np.pi / 4))
-def test_riswap_hamiltonian(angle_rads):
+def test_riswap_hamiltonian(angle_rads) -> None:
     actual = cirq.unitary(cirq.riswap(angle_rads))
     x = np.array([[0, 1], [1, 0]])
     y = np.array([[0, -1j], [1j, 0]])
@@ -226,5 +226,5 @@ def test_riswap_hamiltonian(angle_rads):
 
 
 @pytest.mark.parametrize('angle_rads', (-np.pi / 5, 0.4, 2, np.pi))
-def test_riswap_has_consistent_protocols(angle_rads):
+def test_riswap_has_consistent_protocols(angle_rads) -> None:
     cirq.testing.assert_implements_consistent_protocols(cirq.riswap(angle_rads))

--- a/cirq-core/cirq/ops/tags_test.py
+++ b/cirq-core/cirq/ops/tags_test.py
@@ -15,7 +15,7 @@
 import cirq
 
 
-def test_virtual_tag():
+def test_virtual_tag() -> None:
     tag1 = cirq.ops.VirtualTag()
     tag2 = cirq.ops.VirtualTag()
 
@@ -26,7 +26,7 @@ def test_virtual_tag():
     cirq.testing.assert_equivalent_repr(tag2)
 
 
-def test_routing_swap_tag():
+def test_routing_swap_tag() -> None:
     tag1 = cirq.ops.RoutingSwapTag()
     tag2 = cirq.ops.RoutingSwapTag()
 

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -22,7 +22,7 @@ import cirq
 
 
 @pytest.mark.parametrize('eigen_gate_type', [cirq.CCXPowGate, cirq.CCZPowGate])
-def test_eigen_gates_consistent_protocols(eigen_gate_type):
+def test_eigen_gates_consistent_protocols(eigen_gate_type) -> None:
     cirq.testing.assert_eigengate_implements_consistent_protocols(eigen_gate_type)
 
 
@@ -36,18 +36,18 @@ def test_eigen_gates_consistent_protocols(eigen_gate_type):
         (cirq.CCZ),
     ),
 )
-def test_consistent_protocols(gate):
+def test_consistent_protocols(gate) -> None:
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_init():
+def test_init() -> None:
     assert (cirq.CCZ**0.5).exponent == 0.5
     assert (cirq.CCZ**0.25).exponent == 0.25
     assert (cirq.CCX**0.5).exponent == 0.5
     assert (cirq.CCX**0.25).exponent == 0.25
 
 
-def test_unitary():
+def test_unitary() -> None:
     assert cirq.has_unitary(cirq.CCX)
     np.testing.assert_allclose(
         cirq.unitary(cirq.CCX),
@@ -123,7 +123,7 @@ def test_unitary():
     )
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.CCX) == 'TOFFOLI'
     assert str(cirq.TOFFOLI) == 'TOFFOLI'
     assert str(cirq.CSWAP) == 'FREDKIN'
@@ -134,7 +134,7 @@ def test_str():
     assert str(cirq.CCZ**0.5) == 'CCZ**0.5'
 
 
-def test_repr():
+def test_repr() -> None:
     assert repr(cirq.CCX) == 'cirq.TOFFOLI'
     assert repr(cirq.TOFFOLI) == 'cirq.TOFFOLI'
     assert repr(cirq.CSWAP) == 'cirq.FREDKIN'
@@ -145,7 +145,7 @@ def test_repr():
     assert repr(cirq.CCZ**0.5) == '(cirq.CCZ**0.5)'
 
 
-def test_eq():
+def test_eq() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.CCZ(a, b, c), cirq.CCZ(a, c, b), cirq.CCZ(b, c, a))
@@ -163,7 +163,7 @@ def test_eq():
     eq.add_equality_group(cirq.CSWAP(b, a, c), cirq.CSWAP(b, c, a))
 
 
-def test_gate_equality():
+def test_gate_equality() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.CSwapGate(), cirq.CSwapGate())
     eq.add_equality_group(cirq.CZPowGate(), cirq.CZPowGate())
@@ -171,7 +171,7 @@ def test_gate_equality():
     eq.add_equality_group(cirq.CCZPowGate(), cirq.CCZPowGate())
 
 
-def test_identity_multiplication():
+def test_identity_multiplication() -> None:
     a, b, c = cirq.LineQubit.range(3)
     assert cirq.CCX(a, b, c) * cirq.I(a) == cirq.CCX(a, b, c)
     assert cirq.CCX(a, b, c) * cirq.I(b) == cirq.CCX(a, b, c)
@@ -197,7 +197,7 @@ def test_identity_multiplication():
         ),
     ],
 )
-def test_decomposition_cost(op: cirq.Operation, max_two_cost: int):
+def test_decomposition_cost(op: cirq.Operation, max_two_cost: int) -> None:
     ops = tuple(cirq.flatten_op_tree(cirq.decompose(op)))
     two_cost = len([e for e in ops if len(e.qubits) == 2])
     over_cost = len([e for e in ops if len(e.qubits) > 2])
@@ -205,12 +205,12 @@ def test_decomposition_cost(op: cirq.Operation, max_two_cost: int):
     assert two_cost == max_two_cost
 
 
-def test_parameterized_ccz_decompose_no_global_phase():
+def test_parameterized_ccz_decompose_no_global_phase() -> None:
     decomposed_ops = cirq.decompose(cirq.CCZ(*cirq.LineQubit.range(3)) ** sympy.Symbol("theta"))
     assert not any(isinstance(op.gate, cirq.GlobalPhaseGate) for op in decomposed_ops)
 
 
-def test_diagonal_gate_property():
+def test_diagonal_gate_property() -> None:
     assert cirq.ThreeQubitDiagonalGate([2, 3, 5, 7, 0, 0, 0, 1]).diag_angles_radians == (
         (2, 3, 5, 7, 0, 0, 0, 1)
     )
@@ -220,7 +220,7 @@ def test_diagonal_gate_property():
     'gate',
     [cirq.CCX, cirq.CSWAP, cirq.CCZ, cirq.ThreeQubitDiagonalGate([2, 3, 5, 7, 11, 13, 17, 19])],
 )
-def test_decomposition_respects_locality(gate):
+def test_decomposition_respects_locality(gate) -> None:
     a = cirq.GridQubit(0, 0)
     b = cirq.GridQubit(1, 0)
     c = cirq.GridQubit(0, 1)
@@ -231,7 +231,7 @@ def test_decomposition_respects_locality(gate):
         dev.validate_circuit(circuit)
 
 
-def test_diagram():
+def test_diagram() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
         cirq.TOFFOLI(a, b, c),
@@ -295,7 +295,7 @@ def test_diagram():
     )
 
 
-def test_diagonal_exponent():
+def test_diagonal_exponent() -> None:
     diagonal_angles = [2, 3, 5, 7, 11, 13, 17, 19]
     diagonal_gate = cirq.ThreeQubitDiagonalGate(diagonal_angles)
 
@@ -308,7 +308,7 @@ def test_diagonal_exponent():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_resolve(resolve_fn):
+def test_resolve(resolve_fn) -> None:
     diagonal_angles = [2, 3, 5, 7, 11, 13, 17, 19]
     diagonal_gate = cirq.ThreeQubitDiagonalGate(
         diagonal_angles[:6] + [sympy.Symbol('a'), sympy.Symbol('b')]
@@ -325,7 +325,7 @@ def test_resolve(resolve_fn):
 
 
 @pytest.mark.parametrize('gate', [cirq.CCX, cirq.CCZ, cirq.CSWAP])
-def test_controlled_ops_consistency(gate):
+def test_controlled_ops_consistency(gate) -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     assert gate.controlled(0) is gate
     assert gate(a, b, c).controlled_by(d) == gate(d, b, c).controlled_by(a)

--- a/cirq-core/cirq/ops/two_qubit_diagonal_gate_test.py
+++ b/cirq-core/cirq/ops/two_qubit_diagonal_gate_test.py
@@ -30,15 +30,15 @@ import cirq
         )
     ),
 )
-def test_consistent_protocols(gate):
+def test_consistent_protocols(gate) -> None:
     cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_property():
+def test_property() -> None:
     assert cirq.TwoQubitDiagonalGate([2, 3, 5, 7]).diag_angles_radians == (2, 3, 5, 7)
 
 
-def test_parameterized_decompose():
+def test_parameterized_decompose() -> None:
     angles = sympy.symbols('x0, x1, x2, x3')
     parameterized_op = cirq.TwoQubitDiagonalGate(angles).on(*cirq.LineQubit.range(2))
     decomposed_circuit = cirq.Circuit(cirq.decompose(parameterized_op))
@@ -54,7 +54,7 @@ def test_parameterized_decompose():
         )
 
 
-def test_unitary():
+def test_unitary() -> None:
     diagonal_angles = [2, 3, 5, 7]
     assert cirq.has_unitary(cirq.TwoQubitDiagonalGate(diagonal_angles))
     np.testing.assert_allclose(
@@ -64,7 +64,7 @@ def test_unitary():
     )
 
 
-def test_diagram():
+def test_diagram() -> None:
     a, b = cirq.LineQubit.range(2)
 
     diagonal_circuit = cirq.Circuit(cirq.TwoQubitDiagonalGate([2, 3, 5, 7])(a, b))
@@ -87,7 +87,7 @@ def test_diagram():
     )
 
 
-def test_diagonal_exponent():
+def test_diagonal_exponent() -> None:
     diagonal_angles = [2, 3, 5, 7]
     diagonal_gate = cirq.TwoQubitDiagonalGate(diagonal_angles)
 
@@ -99,7 +99,7 @@ def test_diagonal_exponent():
     assert cirq.pow(cirq.TwoQubitDiagonalGate(diagonal_angles), "test", None) is None
 
 
-def test_protocols_mul_not_implemented():
+def test_protocols_mul_not_implemented() -> None:
     diagonal_angles = [2, 3, None, 7]
     diagonal_gate = cirq.TwoQubitDiagonalGate(diagonal_angles)
     with pytest.raises(TypeError):
@@ -107,7 +107,7 @@ def test_protocols_mul_not_implemented():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_resolve(resolve_fn):
+def test_resolve(resolve_fn) -> None:
     diagonal_angles = [2, 3, 5, 7]
     diagonal_gate = cirq.TwoQubitDiagonalGate(
         diagonal_angles[:2] + [sympy.Symbol('a'), sympy.Symbol('b')]

--- a/cirq-core/cirq/ops/uniform_superposition_gate_test.py
+++ b/cirq-core/cirq/ops/uniform_superposition_gate_test.py
@@ -65,18 +65,18 @@ def test_incompatible_m_value_and_qubit_args(m: int, n: int) -> None:
             cirq.UniformSuperpositionGate(m, n)
 
 
-def test_repr():
+def test_repr() -> None:
     assert (
         repr(cirq.UniformSuperpositionGate(7, 3))
         == 'UniformSuperpositionGate(m_value=7, num_qubits=3)'
     )
 
 
-def test_uniform_superposition_gate_json_dict():
+def test_uniform_superposition_gate_json_dict() -> None:
     assert cirq.UniformSuperpositionGate(7, 3)._json_dict_() == {'m_value': 7, 'num_qubits': 3}
 
 
-def test_str():
+def test_str() -> None:
     assert (
         str(cirq.UniformSuperpositionGate(7, 3))
         == 'UniformSuperpositionGate(m_value=7, num_qubits=3)'

--- a/cirq-core/cirq/protocols/act_on_protocol_test.py
+++ b/cirq-core/cirq/protocols/act_on_protocol_test.py
@@ -45,24 +45,24 @@ class ExampleSimulationState(cirq.SimulationState):
 op = cirq.X(cirq.LineQubit(0))
 
 
-def test_act_on_fallback_succeeds():
+def test_act_on_fallback_succeeds() -> None:
     state = ExampleSimulationState(fallback_result=True)
     cirq.act_on(op, state)
 
 
-def test_act_on_fallback_fails():
+def test_act_on_fallback_fails() -> None:
     state = ExampleSimulationState(fallback_result=NotImplemented)
     with pytest.raises(TypeError, match='Failed to act'):
         cirq.act_on(op, state)
 
 
-def test_act_on_fallback_errors():
+def test_act_on_fallback_errors() -> None:
     state = ExampleSimulationState(fallback_result=False)
     with pytest.raises(ValueError, match='_act_on_fallback_ must return True or NotImplemented'):
         cirq.act_on(op, state)
 
 
-def test_act_on_errors():
+def test_act_on_errors() -> None:
     class Op(cirq.Operation):
         @property
         def qubits(self) -> Tuple[cirq.Qid, ...]:  # type: ignore[empty-body]
@@ -79,7 +79,7 @@ def test_act_on_errors():
         cirq.act_on(Op(), state)
 
 
-def test_qubits_not_allowed_for_operations():
+def test_qubits_not_allowed_for_operations() -> None:
     class Op(cirq.Operation):
         @property
         def qubits(self) -> Tuple[cirq.Qid, ...]:  # type: ignore[empty-body]
@@ -95,7 +95,7 @@ def test_qubits_not_allowed_for_operations():
         cirq.act_on(Op(), state, qubits=[])
 
 
-def test_qubits_should_be_defined_for_operations():
+def test_qubits_should_be_defined_for_operations() -> None:
     state = ExampleSimulationState()
     with pytest.raises(ValueError, match='Calls to act_on should'):
         cirq.act_on(cirq.KrausChannel([np.array([[1, 0], [0, 0]])]), state, qubits=None)

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
@@ -18,7 +18,7 @@ import sympy
 import cirq
 
 
-def test_circuit_diagram_info_value_wrapping():
+def test_circuit_diagram_info_value_wrapping() -> None:
     single_info = cirq.CircuitDiagramInfo(('Single',))
 
     class ReturnInfo:
@@ -67,20 +67,20 @@ def test_circuit_diagram_info_value_wrapping():
     )
 
 
-def test_circuit_diagram_info_init():
+def test_circuit_diagram_info_init() -> None:
     assert cirq.CircuitDiagramInfo(['a', 'b']).wire_symbols == ('a', 'b')
 
 
-def test_circuit_diagram_info_validate():
+def test_circuit_diagram_info_validate() -> None:
     with pytest.raises(ValueError):
         _ = cirq.CircuitDiagramInfo('X')
 
 
-def test_circuit_diagram_info_repr():
+def test_circuit_diagram_info_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.CircuitDiagramInfo(('X', 'Y'), 2))
 
 
-def test_circuit_diagram_info_eq():
+def test_circuit_diagram_info_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cirq.CircuitDiagramInfo(('X',)))
     eq.add_equality_group(
@@ -92,7 +92,7 @@ def test_circuit_diagram_info_eq():
     eq.add_equality_group(cirq.CircuitDiagramInfo(('Z',), 3, auto_exponent_parens=False))
 
 
-def test_circuit_diagram_info_pass_fail():
+def test_circuit_diagram_info_pass_fail() -> None:
     class C:
         pass
 
@@ -115,14 +115,14 @@ def test_circuit_diagram_info_pass_fail():
     assert cirq.circuit_diagram_info(E()) == cirq.CircuitDiagramInfo(('X',))
 
 
-def test_controlled_1x1_matrixgate_diagram_error():
+def test_controlled_1x1_matrixgate_diagram_error() -> None:
     q = cirq.LineQubit(0)
     g = cirq.MatrixGate(np.array([[1j]])).controlled()
     c = cirq.Circuit(g(q))
     assert str(c) == "0: ───C[[0.+1.j]]───"
 
 
-def test_circuit_diagram_info_args_eq():
+def test_circuit_diagram_info_args_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.CircuitDiagramInfoArgs.UNINFORMED_DEFAULT)
     eq.add_equality_group(
@@ -192,7 +192,7 @@ def test_circuit_diagram_info_args_eq():
     )
 
 
-def test_circuit_diagram_info_args_repr():
+def test_circuit_diagram_info_args_repr() -> None:
     cirq.testing.assert_equivalent_repr(
         cirq.CircuitDiagramInfoArgs(
             known_qubits=cirq.LineQubit.range(2),
@@ -206,7 +206,7 @@ def test_circuit_diagram_info_args_repr():
     )
 
 
-def test_format_real():
+def test_format_real() -> None:
     args = cirq.CircuitDiagramInfoArgs.UNINFORMED_DEFAULT.copy()
     assert args.format_real(1) == '1'
     assert args.format_real(1.1) == '1.1'
@@ -227,7 +227,7 @@ def test_format_real():
     assert args.format_real(sympy.Symbol('t') * 2 + 1) == '2*t + 1'
 
 
-def test_format_complex():
+def test_format_complex() -> None:
     args = cirq.CircuitDiagramInfoArgs.UNINFORMED_DEFAULT.copy()
     assert args.format_complex(1) == '1+0i'
     assert args.format_complex(1.1) == '1.1+0i'
@@ -250,7 +250,7 @@ def test_format_complex():
     assert args.format_complex(sympy.Symbol('t') * 2 + 1) == '2*t + 1'
 
 
-def test_format_radians_without_precision():
+def test_format_radians_without_precision() -> None:
     args = cirq.CircuitDiagramInfoArgs(
         known_qubits=None,
         known_qubit_count=None,
@@ -278,7 +278,7 @@ def test_format_radians_without_precision():
     assert args.format_radians(sympy.Symbol('t') * 2 + 1) == '2*t + 1'
 
 
-def test_format_radians_with_precision():
+def test_format_radians_with_precision() -> None:
     args = cirq.CircuitDiagramInfoArgs(
         known_qubits=None,
         known_qubit_count=None,

--- a/cirq-core/cirq/protocols/control_key_protocol_test.py
+++ b/cirq-core/cirq/protocols/control_key_protocol_test.py
@@ -15,7 +15,7 @@
 import cirq
 
 
-def test_control_key():
+def test_control_key() -> None:
     class Named:
         def _control_keys_(self):
             return frozenset([cirq.MeasurementKey('key')])

--- a/cirq-core/cirq/protocols/decompose_protocol_test.py
+++ b/cirq-core/cirq/protocols/decompose_protocol_test.py
@@ -64,7 +64,7 @@ class DecomposeQuditGate:
         yield cirq.identity_each(*qids)
 
 
-def test_decompose_once():
+def test_decompose_once() -> None:
     # No default value results in descriptive error.
     with pytest.raises(TypeError, match='no _decompose_with_context_ or _decompose_ method'):
         _ = cirq.decompose_once(NoMethod())
@@ -91,7 +91,7 @@ def test_decompose_once():
     ]
 
 
-def test_decompose_once_with_qubits():
+def test_decompose_once_with_qubits() -> None:
     qs = cirq.LineQubit.range(3)
 
     # No default value results in descriptive error.
@@ -137,7 +137,7 @@ def test_decompose_once_with_qubits():
     ) == list(cirq.X.on_each(*qs)) + list(cirq.Y.on_each(*qs))
 
 
-def test_decompose_general():
+def test_decompose_general() -> None:
     a, b, c = cirq.LineQubit.range(3)
     no_method = NoMethod()
     assert cirq.decompose(no_method) == [no_method]
@@ -152,7 +152,7 @@ def test_decompose_general():
     )
 
 
-def test_decompose_keep():
+def test_decompose_keep() -> None:
     a, b = cirq.LineQubit.range(2)
 
     # Recursion can be stopped.
@@ -180,7 +180,7 @@ def test_decompose_keep():
     assert cirq.decompose([[[cirq.SWAP(a, b)]]], keep=lambda _: True) == [cirq.SWAP(a, b)]
 
 
-def test_decompose_on_stuck_raise():
+def test_decompose_on_stuck_raise() -> None:
     a, b = cirq.LineQubit.range(2)
     no_method = NoMethod()
 
@@ -210,7 +210,7 @@ def test_decompose_on_stuck_raise():
         assert cirq.decompose([], on_stuck_raise=TypeError('x'))
 
 
-def test_decompose_intercept():
+def test_decompose_intercept() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -247,7 +247,7 @@ def test_decompose_intercept():
     assert actual == [cirq.X(a), cirq.X(cirq.ops.CleanQubit(0)), cirq.X(b)]
 
 
-def test_decompose_preserving_structure():
+def test_decompose_preserving_structure() -> None:
     a, b = cirq.LineQubit.range(2)
     fc1 = cirq.FrozenCircuit(cirq.SWAP(a, b), cirq.FSimGate(0.1, 0.2).on(a, b))
     cop1_1 = cirq.CircuitOperation(fc1).with_tags('test_tag')
@@ -275,7 +275,7 @@ def test_decompose_preserving_structure():
 
 # Test both intercepting and fallback decomposers.
 @pytest.mark.parametrize('decompose_mode', ['intercept', 'fallback'])
-def test_decompose_preserving_structure_forwards_args(decompose_mode):
+def test_decompose_preserving_structure_forwards_args(decompose_mode) -> None:
     a, b = cirq.LineQubit.range(2)
     fc1 = cirq.FrozenCircuit(cirq.SWAP(a, b), cirq.FSimGate(0.1, 0.2).on(a, b))
     cop1_1 = cirq.CircuitOperation(fc1).with_tags('test_tag')
@@ -322,7 +322,7 @@ def test_decompose_preserving_structure_forwards_args(decompose_mode):
     assert actual == expected
 
 
-def test_decompose_tagged_operation():
+def test_decompose_tagged_operation() -> None:
     op = cirq.TaggedOperation(
         cirq.CircuitOperation(
             circuit=cirq.FrozenCircuit(
@@ -377,7 +377,7 @@ class RecursiveDecompose(cirq.Gate):
 
 
 @pytest.mark.parametrize('with_context', [True, False])
-def test_decompose_recursive_dfs(with_context: bool):
+def test_decompose_recursive_dfs(with_context: bool) -> None:
     expected_calls = [
         mock.call.qalloc(True),
         mock.call.qalloc(False),
@@ -426,7 +426,7 @@ class G2(cirq.Gate):
 
 
 @mock.patch('cirq.protocols.decompose_protocol._CONTEXT_COUNTER', itertools.count())
-def test_successive_decompose_once_succeed():
+def test_successive_decompose_once_succeed() -> None:
     op = G2()(cirq.NamedQubit('q'))
     d1 = cirq.decompose_once(op)
     d2 = cirq.decompose_once(d1[0])
@@ -438,7 +438,7 @@ def test_successive_decompose_once_succeed():
     ]
 
 
-def test_decompose_without_context_succeed():
+def test_decompose_without_context_succeed() -> None:
     op = G2()(cirq.NamedQubit('q'))
     assert cirq.decompose(op, keep=lambda op: op.gate is cirq.CNOT) == [
         cirq.CNOT(

--- a/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import cirq
 
 
-def test_equal_up_to_global_phase_primitives():
+def test_equal_up_to_global_phase_primitives() -> None:
     assert cirq.equal_up_to_global_phase(1.0 + 1j, 1.0 + 1j, atol=1e-9)
     assert not cirq.equal_up_to_global_phase(2.0, 1.0 + 1j, atol=1e-9)
     assert cirq.equal_up_to_global_phase(1.0 + 1j, 1.0 - 1j, atol=1e-9)
@@ -34,7 +34,7 @@ def test_equal_up_to_global_phase_primitives():
     assert cirq.equal_up_to_global_phase(1.0 + 1e-10j, 1.0, atol=1e-15)
 
 
-def test_equal_up_to_global_numeric_iterables():
+def test_equal_up_to_global_numeric_iterables() -> None:
     assert cirq.equal_up_to_global_phase([], [], atol=1e-9)
     assert cirq.equal_up_to_global_phase([[]], [[]], atol=1e-9)
     assert cirq.equal_up_to_global_phase([1j, 1], [1j, 1], atol=1e-9)
@@ -49,7 +49,7 @@ def test_equal_up_to_global_numeric_iterables():
     assert not cirq.equal_up_to_global_phase((1j, 1), (1, 1j), atol=1e-09)
 
 
-def test_equal_up_to_global_numpy_array():
+def test_equal_up_to_global_numpy_array() -> None:
     assert cirq.equal_up_to_global_phase(
         np.asarray([1j, 1j]), np.asarray([1, 1], dtype=np.complex64)
     )
@@ -60,7 +60,7 @@ def test_equal_up_to_global_numpy_array():
     assert cirq.equal_up_to_global_phase(np.asarray([[]]), np.asarray([[]]))
 
 
-def test_equal_up_to_global_mixed_array_types():
+def test_equal_up_to_global_mixed_array_types() -> None:
     a = [1j, 1, -1j, -1]
     b = [-1, 1j, 1, -1j]
     c = [-1, 1, -1, 1]
@@ -108,7 +108,7 @@ class B:
         return cirq.equal_up_to_global_phase(self.val[0], other, atol=atol)
 
 
-def test_equal_up_to_global_phase_eq_supported():
+def test_equal_up_to_global_phase_eq_supported() -> None:
     assert cirq.equal_up_to_global_phase(A(0.1 + 0j), A(0.1j), atol=1e-2)
     assert not cirq.equal_up_to_global_phase(A(0.0 + 0j), A(0.1j), atol=0.0)
     assert not cirq.equal_up_to_global_phase(A(0.0 + 0j), 0.1j, atol=0.0)
@@ -120,7 +120,7 @@ def test_equal_up_to_global_phase_eq_supported():
     assert not cirq.equal_up_to_global_phase(1e-8j, B(0.0), atol=1e-10)
 
 
-def test_equal_up_to_global_phase_non_eigen_gates():
+def test_equal_up_to_global_phase_non_eigen_gates() -> None:
     gate1 = cirq.PhasedXPowGate(phase_exponent=1.5, exponent=1.0)
     gate2 = cirq.PhasedXPowGate(phase_exponent=0.5, exponent=1.0)
     assert cirq.equal_up_to_global_phase(gate1, gate2)

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -105,7 +105,7 @@ class GateDecomposes(cirq.Gate):
         yield YesOp(*qubits)
 
 
-def test_inconclusive():
+def test_inconclusive() -> None:
     assert not cirq.has_stabilizer_effect(object())
     assert not cirq.has_stabilizer_effect('boo')
     assert not cirq.has_stabilizer_effect(cirq.testing.SingleQubitGate())
@@ -113,21 +113,21 @@ def test_inconclusive():
     assert not cirq.has_stabilizer_effect(NoOp())
 
 
-def test_via_has_stabilizer_effect_method():
+def test_via_has_stabilizer_effect_method() -> None:
     assert not cirq.has_stabilizer_effect(No1())
     assert not cirq.has_stabilizer_effect(No2())
     assert not cirq.has_stabilizer_effect(No3())
     assert cirq.has_stabilizer_effect(Yes())
 
 
-def test_via_gate_of_op():
+def test_via_gate_of_op() -> None:
     assert cirq.has_stabilizer_effect(YesOp())
     assert not cirq.has_stabilizer_effect(NoOp1())
     assert not cirq.has_stabilizer_effect(NoOp2())
     assert not cirq.has_stabilizer_effect(NoOp3())
 
 
-def test_via_unitary():
+def test_via_unitary() -> None:
     op1 = OpWithUnitary(np.array([[0, 1], [1, 0]]))
     assert cirq.has_stabilizer_effect(op1)
 
@@ -148,7 +148,7 @@ def test_via_unitary():
     assert not cirq.has_stabilizer_effect(cirq.CCZ)
 
 
-def test_via_decompose():
+def test_via_decompose() -> None:
     assert cirq.has_stabilizer_effect(cirq.Circuit(cirq.H.on_each(cirq.LineQubit.range(4))))
     assert not cirq.has_stabilizer_effect(cirq.Circuit(cirq.T.on_each(cirq.LineQubit.range(4))))
     assert not cirq.has_stabilizer_effect(

--- a/cirq-core/cirq/protocols/has_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_unitary_protocol_test.py
@@ -18,7 +18,7 @@ import pytest
 import cirq
 
 
-def test_inconclusive():
+def test_inconclusive() -> None:
     class No:
         pass
 
@@ -30,7 +30,7 @@ def test_inconclusive():
 @pytest.mark.parametrize(
     'measurement_gate', (cirq.MeasurementGate(1, 'a'), cirq.PauliMeasurementGate([cirq.X], 'a'))
 )
-def test_fail_fast_measure(measurement_gate):
+def test_fail_fast_measure(measurement_gate) -> None:
     assert not cirq.has_unitary(measurement_gate)
 
     qubit = cirq.NamedQubit('q0')
@@ -40,13 +40,13 @@ def test_fail_fast_measure(measurement_gate):
     assert not cirq.has_unitary(circuit)
 
 
-def test_fail_fast_measure_large_memory():
+def test_fail_fast_measure_large_memory() -> None:
     num_qubits = 100
     measurement_op = cirq.MeasurementGate(num_qubits, 'a').on(*cirq.LineQubit.range(num_qubits))
     assert not cirq.has_unitary(measurement_op)
 
 
-def test_via_unitary():
+def test_via_unitary() -> None:
     class No1:
         def _unitary_(self):
             return NotImplemented
@@ -65,7 +65,7 @@ def test_via_unitary():
     assert cirq.has_unitary(Yes(), allow_decompose=False)
 
 
-def test_via_apply_unitary():
+def test_via_apply_unitary() -> None:
     class No1(EmptyOp):
         def _apply_unitary_(self, args):
             return None
@@ -100,7 +100,7 @@ def test_via_apply_unitary():
     assert not cirq.has_unitary(No4())
 
 
-def test_via_decompose():
+def test_via_decompose() -> None:
     class Yes1:
         def _decompose_(self):
             return []
@@ -132,7 +132,7 @@ def test_via_decompose():
     assert not cirq.has_unitary(No1(), allow_decompose=False)
 
 
-def test_via_has_unitary():
+def test_via_has_unitary() -> None:
     class No1:
         def _has_unitary_(self):
             return NotImplemented
@@ -150,7 +150,7 @@ def test_via_has_unitary():
     assert cirq.has_unitary(Yes())
 
 
-def test_order():
+def test_order() -> None:
     class Yes1(EmptyOp):
         def _has_unitary_(self):
             return True

--- a/cirq-core/cirq/protocols/hash_from_pickle_test.py
+++ b/cirq-core/cirq/protocols/hash_from_pickle_test.py
@@ -105,7 +105,7 @@ def test_exclude_json_files_has_valid_entries() -> None:
         if _is_included(f"{abs_path}.json")
     ],
 )
-def test_hash_from_pickle(json_filename: str, pool: multiprocessing.pool.Pool):
+def test_hash_from_pickle(json_filename: str, pool: multiprocessing.pool.Pool) -> None:
     obj_local = _read_json(json_filename)
     if not isinstance(obj_local, Hashable):
         return

--- a/cirq-core/cirq/protocols/inverse_protocol_test.py
+++ b/cirq-core/cirq/protocols/inverse_protocol_test.py
@@ -50,7 +50,7 @@ class IsIterable:
 @pytest.mark.parametrize(
     'val', (NoMethod(), 'text', object(), ReturnsNotImplemented(), [NoMethod(), 5])
 )
-def test_objects_with_no_inverse(val):
+def test_objects_with_no_inverse(val) -> None:
     with pytest.raises(TypeError, match="isn't invertible"):
         _ = cirq.inverse(val)
     assert cirq.inverse(val, None) is None
@@ -76,6 +76,6 @@ def test_objects_with_no_inverse(val):
         (IsIterable(), (0.5, 1)),
     ),
 )
-def test_objects_with_inverse(val, inv):
+def test_objects_with_inverse(val, inv) -> None:
     assert cirq.inverse(val) == inv
     assert cirq.inverse(val, 0) == inv

--- a/cirq-core/cirq/protocols/kraus_protocol_test.py
+++ b/cirq-core/cirq/protocols/kraus_protocol_test.py
@@ -24,7 +24,7 @@ import cirq
 LOCAL_DEFAULT: List[np.ndarray] = [np.array([])]
 
 
-def test_kraus_no_methods():
+def test_kraus_no_methods() -> None:
     class NoMethod:
         pass
 
@@ -51,7 +51,7 @@ def assert_not_implemented(val):
     assert not cirq.has_kraus(val)
 
 
-def test_kraus_returns_not_implemented():
+def test_kraus_returns_not_implemented() -> None:
     class ReturnsNotImplemented:
         def _kraus_(self):
             return NotImplemented
@@ -59,7 +59,7 @@ def test_kraus_returns_not_implemented():
     assert_not_implemented(ReturnsNotImplemented())
 
 
-def test_mixture_returns_not_implemented():
+def test_mixture_returns_not_implemented() -> None:
     class ReturnsNotImplemented:
         def _mixture_(self):
             return NotImplemented
@@ -67,7 +67,7 @@ def test_mixture_returns_not_implemented():
     assert_not_implemented(ReturnsNotImplemented())
 
 
-def test_unitary_returns_not_implemented():
+def test_unitary_returns_not_implemented() -> None:
     class ReturnsNotImplemented:
         def _unitary_(self):
             return NotImplemented
@@ -80,7 +80,7 @@ def test_unitary_returns_not_implemented():
     assert cirq.kraus(ReturnsNotImplemented(), LOCAL_DEFAULT) is LOCAL_DEFAULT
 
 
-def test_explicit_kraus():
+def test_explicit_kraus() -> None:
     a0 = np.array([[0, 0], [1, 0]])
     a1 = np.array([[1, 0], [0, 0]])
     c = (a0, a1)
@@ -98,7 +98,7 @@ def test_explicit_kraus():
     assert cirq.has_kraus(ReturnsKraus())
 
 
-def test_kraus_fallback_to_mixture():
+def test_kraus_fallback_to_mixture() -> None:
     m = ((0.3, cirq.unitary(cirq.X)), (0.4, cirq.unitary(cirq.Y)), (0.3, cirq.unitary(cirq.Z)))
 
     class ReturnsMixture:
@@ -120,7 +120,7 @@ def test_kraus_fallback_to_mixture():
     assert cirq.has_kraus(ReturnsMixture())
 
 
-def test_kraus_fallback_to_unitary():
+def test_kraus_fallback_to_unitary() -> None:
     u = np.array([[1, 0], [1, 0]])
 
     class ReturnsUnitary:
@@ -160,12 +160,12 @@ class HasKrausWhenDecomposed(cirq.testing.SingleQubitGate):
 
 
 @pytest.mark.parametrize('cls', [HasKraus, HasMixture, HasUnitary])
-def test_has_kraus(cls):
+def test_has_kraus(cls) -> None:
     assert cirq.has_kraus(cls())
 
 
 @pytest.mark.parametrize('decomposed_cls', [HasKraus, HasMixture, HasUnitary])
-def test_has_kraus_when_decomposed(decomposed_cls):
+def test_has_kraus_when_decomposed(decomposed_cls) -> None:
     op = HasKrausWhenDecomposed(decomposed_cls).on(cirq.NamedQubit('test'))
     assert cirq.has_kraus(op)
     assert not cirq.has_kraus(op, allow_decompose=False)

--- a/cirq-core/cirq/protocols/measurement_key_protocol_test.py
+++ b/cirq-core/cirq/protocols/measurement_key_protocol_test.py
@@ -28,7 +28,7 @@ class ReturnsObj:
 
 
 @pytest.mark.parametrize('gate', [ReturnsStr(), ReturnsObj()])
-def test_measurement_key_name(gate):
+def test_measurement_key_name(gate) -> None:
     assert isinstance(cirq.measurement_key_name(gate), str)
     assert cirq.measurement_key_name(gate) == 'door locker'
     assert cirq.measurement_key_obj(gate) == cirq.MeasurementKey(name='door locker')
@@ -39,7 +39,7 @@ def test_measurement_key_name(gate):
 
 
 @pytest.mark.parametrize('gate', [ReturnsStr(), ReturnsObj()])
-def test_measurement_key_obj(gate):
+def test_measurement_key_obj(gate) -> None:
     assert isinstance(cirq.measurement_key_obj(gate), cirq.MeasurementKey)
     assert cirq.measurement_key_obj(gate) == cirq.MeasurementKey(name='door locker')
     assert cirq.measurement_key_obj(gate) == 'door locker'
@@ -50,7 +50,7 @@ def test_measurement_key_obj(gate):
 
 
 @pytest.mark.parametrize('key_method', [cirq.measurement_key_name, cirq.measurement_key_obj])
-def test_measurement_key_no_method(key_method):
+def test_measurement_key_no_method(key_method) -> None:
     class NoMethod:
         pass
 
@@ -73,7 +73,7 @@ def test_measurement_key_no_method(key_method):
 
 
 @pytest.mark.parametrize('key_method', [cirq.measurement_key_name, cirq.measurement_key_obj])
-def test_measurement_key_not_implemented_default_behavior(key_method):
+def test_measurement_key_not_implemented_default_behavior(key_method) -> None:
     class ReturnsNotImplemented:
         def _measurement_key_name_(self):
             return NotImplemented
@@ -89,7 +89,7 @@ def test_measurement_key_not_implemented_default_behavior(key_method):
     assert key_method(ReturnsNotImplemented(), 'a') == 'a'
 
 
-def test_is_measurement():
+def test_is_measurement() -> None:
     q = cirq.NamedQubit('q')
     assert cirq.is_measurement(cirq.measure(q))
     assert cirq.is_measurement(cirq.MeasurementGate(num_qubits=1, key='b'))
@@ -109,7 +109,7 @@ def test_is_measurement():
     assert not cirq.is_measurement(NotImplementedOperation())
 
 
-def test_measurement_without_key():
+def test_measurement_without_key() -> None:
     class MeasurementWithoutKey:
         def _is_measurement_(self):
             return True
@@ -120,7 +120,7 @@ def test_measurement_without_key():
     assert cirq.is_measurement(MeasurementWithoutKey())
 
 
-def test_non_measurement_with_key():
+def test_non_measurement_with_key() -> None:
     class NonMeasurementGate(cirq.Gate):
         def _is_measurement_(self):
             return False  # pragma: no cover
@@ -155,7 +155,7 @@ def test_non_measurement_with_key():
     ('key_method', 'keys'),
     [(cirq.measurement_key_names, {'a', 'b'}), (cirq.measurement_key_objs, {'c', 'd'})],
 )
-def test_measurement_keys(key_method, keys):
+def test_measurement_keys(key_method, keys) -> None:
     class MeasurementKeysGate(cirq.Gate):
         def _measurement_key_names_(self):
             return frozenset(['a', 'b'])
@@ -180,7 +180,7 @@ def test_measurement_keys(key_method, keys):
     assert key_method(MeasurementKeysGate().on(a)) == keys
 
 
-def test_measurement_key_mapping():
+def test_measurement_key_mapping() -> None:
     class MultiKeyGate:
         def __init__(self, keys):
             self._keys = frozenset(keys)
@@ -217,7 +217,7 @@ def test_measurement_key_mapping():
     assert cirq.measurement_key_names(mkg_cdx) == {'c', 'd'}
 
 
-def test_measurement_key_path():
+def test_measurement_key_path() -> None:
     class MultiKeyGate:
         def __init__(self, keys):
             self._keys = frozenset(cirq.MeasurementKey.parse_serialized(key) for key in keys)

--- a/cirq-core/cirq/protocols/pauli_expansion_protocol_test.py
+++ b/cirq-core/cirq/protocols/pauli_expansion_protocol_test.py
@@ -54,7 +54,7 @@ class HasQuditUnitary:
 @pytest.mark.parametrize(
     'val', (NoMethod(), ReturnsNotImplemented(), HasQuditUnitary(), 123, np.eye(2), object(), cirq)
 )
-def test_raises_no_pauli_expansion(val):
+def test_raises_no_pauli_expansion(val) -> None:
     assert cirq.pauli_expansion(val, default=None) is None
     with pytest.raises(TypeError, match='No Pauli expansion'):
         cirq.pauli_expansion(val)
@@ -78,7 +78,7 @@ def test_raises_no_pauli_expansion(val):
         ),
     ),
 )
-def test_pauli_expansion(val, expected_expansion):
+def test_pauli_expansion(val, expected_expansion) -> None:
     actual_expansion = cirq.pauli_expansion(val)
     assert cirq.approx_eq(actual_expansion, expected_expansion, atol=1e-12)
     assert set(actual_expansion.keys()) == set(expected_expansion.keys())

--- a/cirq-core/cirq/protocols/phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/phase_protocol_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_phase_by():
+def test_phase_by() -> None:
     class NoMethod:
         pass
 

--- a/cirq-core/cirq/protocols/qasm_test.py
+++ b/cirq-core/cirq/protocols/qasm_test.py
@@ -40,7 +40,7 @@ class ExpectsArgsQubits:
         return 'text'
 
 
-def test_qasm():
+def test_qasm() -> None:
     assert cirq.qasm(NoMethod(), default=None) is None
     assert cirq.qasm(NoMethod(), default=5) == 5
     assert cirq.qasm(ReturnsText()) == 'text'
@@ -54,12 +54,12 @@ def test_qasm():
     assert cirq.qasm(ExpectsArgsQubits(), args=cirq.QasmArgs(), qubits=()) == 'text'
 
 
-def test_qasm_qubits_improperly_supplied():
+def test_qasm_qubits_improperly_supplied() -> None:
     with pytest.raises(TypeError, match="does not expect qubits or args to be specified"):
         _ = cirq.qasm(cirq.Circuit(), qubits=[cirq.LineQubit(1)])
 
 
-def test_qasm_args_formatting():
+def test_qasm_args_formatting() -> None:
     args = cirq.QasmArgs()
     assert args.format_field(0.01, '') == '0.01'
     assert args.format_field(0.01, 'half_turns') == 'pi*0.01'

--- a/cirq-core/cirq/protocols/qid_shape_protocol_test.py
+++ b/cirq-core/cirq/protocols/qid_shape_protocol_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_qid_shape():
+def test_qid_shape() -> None:
     class ShapeObj:
         def _qid_shape_(self):
             return (1, 2, 3)

--- a/cirq-core/cirq/protocols/resolve_parameters_test.py
+++ b/cirq-core/cirq/protocols/resolve_parameters_test.py
@@ -20,7 +20,7 @@ from cirq.study import ParamResolver
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_resolve_parameters(resolve_fn):
+def test_resolve_parameters(resolve_fn) -> None:
     class NoMethod:
         pass
 
@@ -74,7 +74,7 @@ def test_resolve_parameters(resolve_fn):
     assert resolve_fn(1j, resolver) == 1j
 
 
-def test_is_parameterized():
+def test_is_parameterized() -> None:
     a, b = tuple(sympy.Symbol(l) for l in 'ab')
     x, y = 0, 4
     assert not cirq.is_parameterized((x, y))
@@ -90,7 +90,7 @@ def test_is_parameterized():
     assert not cirq.is_parameterized(1j)
 
 
-def test_parameter_names():
+def test_parameter_names() -> None:
     a, b, c = tuple(sympy.Symbol(l) for l in 'abc')
     x, y, z = 0, 4, 7
     assert cirq.parameter_names((a, b, c)) == {'a', 'b', 'c'}
@@ -105,7 +105,7 @@ def test_parameter_names():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_skips_empty_resolution(resolve_fn):
+def test_skips_empty_resolution(resolve_fn) -> None:
     class Tester:
         def _resolve_parameters_(self, resolver, recursive):
             return 5
@@ -115,7 +115,7 @@ def test_skips_empty_resolution(resolve_fn):
     assert resolve_fn(t, {'x': 2}) == 5
 
 
-def test_recursive_resolve():
+def test_recursive_resolve() -> None:
     a, b, c = [sympy.Symbol(l) for l in 'abc']
     resolver = cirq.ParamResolver({a: b + 3, b: c + 2, c: 1})
     assert cirq.resolve_parameters_once(a, resolver) == b + 3

--- a/cirq-core/cirq/protocols/trace_distance_bound_test.py
+++ b/cirq-core/cirq/protocols/trace_distance_bound_test.py
@@ -17,7 +17,7 @@ import numpy as np
 import cirq
 
 
-def test_trace_distance_bound():
+def test_trace_distance_bound() -> None:
     class NoMethod:
         pass
 

--- a/cirq-core/cirq/qis/channels_test.py
+++ b/cirq-core/cirq/qis/channels_test.py
@@ -65,7 +65,7 @@ def compute_choi(channel: cirq.SupportsKraus) -> np.ndarray:
         ),
     ),
 )
-def test_kraus_to_choi(kraus_operators, expected_choi):
+def test_kraus_to_choi(kraus_operators, expected_choi) -> None:
     """Verifies that cirq.kraus_to_choi computes the correct Choi matrix."""
     assert np.allclose(cirq.kraus_to_choi(kraus_operators), expected_choi)
 
@@ -89,7 +89,7 @@ def test_kraus_to_choi(kraus_operators, expected_choi):
         ),
     ),
 )
-def test_choi_to_kraus_invalid_input(choi, error):
+def test_choi_to_kraus_invalid_input(choi, error) -> None:
     with pytest.raises(ValueError, match=error):
         _ = cirq.choi_to_kraus(choi)
 
@@ -143,7 +143,7 @@ def test_choi_to_kraus_invalid_input(choi, error):
         ),
     ),
 )
-def test_choi_to_kraus_fixed_values(choi, expected_kraus):
+def test_choi_to_kraus_fixed_values(choi, expected_kraus) -> None:
     """Verifies that cirq.choi_to_kraus gives correct results on a few fixed inputs."""
     actual_kraus = cirq.choi_to_kraus(choi)
     assert len(actual_kraus) == len(expected_kraus)
@@ -178,7 +178,7 @@ def test_choi_to_kraus_fixed_values(choi, expected_kraus):
         ),
     ),
 )
-def test_choi_to_kraus_action_on_operatorial_basis(choi):
+def test_choi_to_kraus_action_on_operatorial_basis(choi) -> None:
     """Verifies that cirq.choi_to_kraus computes a valid Kraus representation."""
     kraus_operators = cirq.choi_to_kraus(choi)
     c = np.reshape(choi, (2, 2, 2, 2))
@@ -217,14 +217,14 @@ def test_choi_to_kraus_action_on_operatorial_basis(choi):
         # fmt: on
     ),
 )
-def test_choi_to_kraus_inverse_of_kraus_to_choi(choi):
+def test_choi_to_kraus_inverse_of_kraus_to_choi(choi) -> None:
     """Verifies that cirq.kraus_to_choi(cirq.choi_to_kraus(.)) is identity on Choi matrices."""
     kraus = cirq.choi_to_kraus(choi)
     recovered_choi = cirq.kraus_to_choi(kraus)
     assert np.allclose(recovered_choi, choi)
 
 
-def test_choi_to_kraus_atol():
+def test_choi_to_kraus_atol() -> None:
     """Verifies that insignificant Kraus operators are omitted."""
     choi = cirq.kraus_to_choi(cirq.kraus(cirq.phase_damp(1e-6)))
     assert len(cirq.choi_to_kraus(choi, atol=1e-2)) == 1
@@ -242,7 +242,7 @@ def test_choi_to_kraus_atol():
         cirq.amplitude_damp(0.2),
     ),
 )
-def test_operation_to_choi(channel):
+def test_operation_to_choi(channel) -> None:
     """Verifies that cirq.operation_to_choi correctly computes the Choi matrix."""
     n_qubits = cirq.num_qubits(channel)
     actual = cirq.operation_to_choi(channel)
@@ -251,7 +251,7 @@ def test_operation_to_choi(channel):
     assert np.all(actual == expected)
 
 
-def test_choi_for_completely_dephasing_channel():
+def test_choi_for_completely_dephasing_channel() -> None:
     """Checks cirq.operation_to_choi on the completely dephasing channel."""
     assert np.all(cirq.operation_to_choi(cirq.phase_damp(1)) == np.diag([1, 0, 0, 1]))
 
@@ -268,7 +268,7 @@ def test_choi_for_completely_dephasing_channel():
         ),
     ),
 )
-def test_superoperator_to_kraus_fixed_values(superoperator, expected_kraus_operators):
+def test_superoperator_to_kraus_fixed_values(superoperator, expected_kraus_operators) -> None:
     """Verifies that cirq.kraus_to_superoperator computes the correct channel matrix."""
     actual_kraus_operators = cirq.superoperator_to_kraus(superoperator)
     for i in (0, 1):
@@ -306,14 +306,14 @@ def test_superoperator_to_kraus_fixed_values(superoperator, expected_kraus_opera
         # fmt: on
     ),
 )
-def test_superoperator_to_kraus_inverse_of_kraus_to_superoperator(superoperator):
+def test_superoperator_to_kraus_inverse_of_kraus_to_superoperator(superoperator) -> None:
     """Verifies that cirq.kraus_to_superoperator(cirq.superoperator_to_kraus(.)) is identity."""
     kraus = cirq.superoperator_to_kraus(superoperator)
     recovered_superoperator = cirq.kraus_to_superoperator(kraus)
     assert np.allclose(recovered_superoperator, superoperator)
 
 
-def test_superoperator_to_kraus_atol():
+def test_superoperator_to_kraus_atol() -> None:
     """Verifies that insignificant Kraus operators are omitted."""
     superop = cirq.kraus_to_superoperator(cirq.kraus(cirq.phase_damp(1e-6)))
     assert len(cirq.superoperator_to_kraus(superop, atol=1e-2)) == 1
@@ -338,7 +338,7 @@ def test_superoperator_to_kraus_atol():
         ),
     ),
 )
-def test_choi_to_superoperator_invalid_input(choi, error):
+def test_choi_to_superoperator_invalid_input(choi, error) -> None:
     with pytest.raises(ValueError, match=error):
         _ = cirq.choi_to_superoperator(choi)
 
@@ -346,7 +346,7 @@ def test_choi_to_superoperator_invalid_input(choi, error):
 @pytest.mark.parametrize(
     'superoperator, error', ((np.array([[1, 2, 3], [4, 5, 6]]), "shape"), (np.eye(2), "shape"))
 )
-def test_superoperator_to_choi_invalid_input(superoperator, error):
+def test_superoperator_to_choi_invalid_input(superoperator, error) -> None:
     with pytest.raises(ValueError, match=error):
         _ = cirq.superoperator_to_choi(superoperator)
 
@@ -402,7 +402,7 @@ def test_superoperator_to_choi_invalid_input(superoperator, error):
         ),
     ),
 )
-def test_superoperator_vs_choi_fixed_values(superoperator, choi):
+def test_superoperator_vs_choi_fixed_values(superoperator, choi) -> None:
     recovered_choi = cirq.superoperator_to_choi(superoperator)
     assert np.allclose(recovered_choi, choi)
 
@@ -436,7 +436,7 @@ def test_superoperator_vs_choi_fixed_values(superoperator, choi):
         # fmt: on
     ),
 )
-def test_choi_to_superoperator_inverse_of_superoperator_to_choi(choi):
+def test_choi_to_superoperator_inverse_of_superoperator_to_choi(choi) -> None:
     superoperator = cirq.choi_to_superoperator(choi)
     recovered_choi = cirq.superoperator_to_choi(superoperator)
     assert np.allclose(recovered_choi, choi)
@@ -445,6 +445,6 @@ def test_choi_to_superoperator_inverse_of_superoperator_to_choi(choi):
     assert np.allclose(recovered_superoperator, superoperator)
 
 
-def test_superoperator_for_completely_dephasing_channel():
+def test_superoperator_for_completely_dephasing_channel() -> None:
     """Checks cirq.operation_to_superoperator on the completely dephasing channel."""
     assert np.all(cirq.operation_to_superoperator(cirq.phase_damp(1)) == np.diag([1, 0, 0, 1]))

--- a/cirq-core/cirq/qis/measures_test.py
+++ b/cirq-core/cirq/qis/measures_test.py
@@ -25,7 +25,7 @@ MAT2 = cirq.testing.random_density_matrix(N)
 U = cirq.testing.random_unitary(N)
 
 
-def test_fidelity_symmetric():
+def test_fidelity_symmetric() -> None:
     np.testing.assert_allclose(cirq.fidelity(VEC1, VEC2), cirq.fidelity(VEC2, VEC1))
     np.testing.assert_allclose(cirq.fidelity(VEC1, MAT1), cirq.fidelity(MAT1, VEC1))
     np.testing.assert_allclose(
@@ -34,27 +34,27 @@ def test_fidelity_symmetric():
     )
 
 
-def test_bad_fidelity():
+def test_bad_fidelity() -> None:
     arr = np.asarray([[[1j, 0], [0, 0]], [[0, 0], [0, 0]]])
     assert arr.ndim > 2
     assert arr.dtype.kind == 'c'
     _ = cirq.fidelity(arr, arr)
 
 
-def test_fidelity_between_zero_and_one():
+def test_fidelity_between_zero_and_one() -> None:
     assert 0 <= cirq.fidelity(VEC1, VEC2) <= 1
     assert 0 <= cirq.fidelity(VEC1, MAT1) <= 1
     assert 0 <= cirq.fidelity(cirq.density_matrix(MAT1), MAT2) <= 1
 
 
-def test_fidelity_invariant_under_unitary_transformation():
+def test_fidelity_invariant_under_unitary_transformation() -> None:
     np.testing.assert_allclose(
         cirq.fidelity(cirq.density_matrix(MAT1), MAT2),
         cirq.fidelity(cirq.density_matrix(U @ MAT1 @ U.T.conj()), U @ MAT2 @ U.T.conj()),
     )
 
 
-def test_fidelity_commuting_matrices():
+def test_fidelity_commuting_matrices() -> None:
     d1 = np.random.uniform(size=N)
     d1 /= np.sum(d1)
     d2 = np.random.uniform(size=N)
@@ -67,7 +67,7 @@ def test_fidelity_commuting_matrices():
     )
 
 
-def test_fidelity_known_values():
+def test_fidelity_known_values() -> None:
     vec1 = np.array([1, 1j, -1, -1j]) * 0.5
     vec2 = np.array([1, -1, 1, -1], dtype=np.complex128) * 0.5
     vec3 = np.array([1, 0, 0, 0], dtype=np.complex128)
@@ -94,7 +94,7 @@ def test_fidelity_known_values():
     np.testing.assert_allclose(cirq.fidelity(mat3, vec2), 0.7)
 
 
-def test_fidelity_numpy_arrays():
+def test_fidelity_numpy_arrays() -> None:
     vec1 = np.array([1, 0, 0, 0, 0, 0, 0, 0], dtype=np.complex64)
     vec2 = np.array([1, 0, 0, 0], dtype=np.complex64)
     tensor1 = np.reshape(vec1, (2, 2, 2))
@@ -122,7 +122,7 @@ def test_fidelity_numpy_arrays():
         _ = cirq.fidelity(mat1, mat1)
 
 
-def test_fidelity_ints():
+def test_fidelity_ints() -> None:
     assert cirq.fidelity(3, 4) == 0.0
     assert cirq.fidelity(4, 4) == 1.0
 
@@ -134,7 +134,7 @@ def test_fidelity_ints():
         _ = cirq.fidelity(1, 4, qid_shape=(2,))
 
 
-def test_fidelity_product_states():
+def test_fidelity_product_states() -> None:
     a, b = cirq.LineQubit.range(2)
 
     np.testing.assert_allclose(
@@ -171,19 +171,19 @@ def test_fidelity_product_states():
         )
 
 
-def test_fidelity_fail_inference():
+def test_fidelity_fail_inference() -> None:
     state_vector = cirq.one_hot(shape=(4,), dtype=np.complex128)
     state_tensor = np.reshape(state_vector, (2, 2))
     with pytest.raises(ValueError, match='Please specify'):
         _ = cirq.fidelity(state_tensor, 4)
 
 
-def test_fidelity_bad_shape():
+def test_fidelity_bad_shape() -> None:
     with pytest.raises(ValueError, match='Invalid quantum state'):
         _ = cirq.fidelity(np.array([[[1.0]]]), np.array([[[1.0]]]), qid_shape=(1,))
 
 
-def test_von_neumann_entropy():
+def test_von_neumann_entropy() -> None:
     # 1x1 matrix
     assert cirq.von_neumann_entropy(np.array([[1]])) == 0
     # An EPR pair state (|00> + |11>)(<00| + <11|)
@@ -243,7 +243,7 @@ def test_von_neumann_entropy():
         (cirq.TOFFOLI, 9 / 16),
     ),
 )
-def test_entanglement_fidelity_of_unitary_channels(gate, expected_entanglement_fidelity):
+def test_entanglement_fidelity_of_unitary_channels(gate, expected_entanglement_fidelity) -> None:
     assert np.isclose(cirq.entanglement_fidelity(gate), expected_entanglement_fidelity)
 
 
@@ -261,7 +261,9 @@ def test_entanglement_fidelity_of_unitary_channels(gate, expected_entanglement_f
         (cirq.amplitude_damp, lambda gamma: 1 / 2 - gamma / 4 + np.sqrt(1 - gamma) / 2),
     ),
 )
-def test_entanglement_fidelity_of_noisy_channels(p, channel_factory, entanglement_fidelity_formula):
+def test_entanglement_fidelity_of_noisy_channels(
+    p, channel_factory, entanglement_fidelity_formula
+) -> None:
     channel = channel_factory(p)
     actual_entanglement_fidelity = cirq.entanglement_fidelity(channel)
     expected_entanglement_fidelity = entanglement_fidelity_formula(p)

--- a/cirq-core/cirq/qis/noise_utils_test.py
+++ b/cirq-core/cirq/qis/noise_utils_test.py
@@ -30,7 +30,7 @@ from cirq.qis.noise_utils import (
     'decay_constant,num_qubits,expected_output',
     [(0.01, 1, 1 - (0.99 * 1 / 2)), (0.05, 2, 1 - (0.95 * 3 / 4))],
 )
-def test_decay_constant_to_xeb_fidelity(decay_constant, num_qubits, expected_output):
+def test_decay_constant_to_xeb_fidelity(decay_constant, num_qubits, expected_output) -> None:
     val = decay_constant_to_xeb_fidelity(decay_constant, num_qubits)
     assert val == expected_output
 
@@ -39,7 +39,7 @@ def test_decay_constant_to_xeb_fidelity(decay_constant, num_qubits, expected_out
     'decay_constant,num_qubits,expected_output',
     [(0.01, 1, 0.99 * 3 / 4), (0.05, 2, 0.95 * 15 / 16)],
 )
-def test_decay_constant_to_pauli_error(decay_constant, num_qubits, expected_output):
+def test_decay_constant_to_pauli_error(decay_constant, num_qubits, expected_output) -> None:
     val = decay_constant_to_pauli_error(decay_constant, num_qubits)
     assert val == expected_output
 
@@ -48,7 +48,7 @@ def test_decay_constant_to_pauli_error(decay_constant, num_qubits, expected_outp
     'pauli_error,num_qubits,expected_output',
     [(0.01, 1, 1 - (0.01 / (3 / 4))), (0.05, 2, 1 - (0.05 / (15 / 16)))],
 )
-def test_pauli_error_to_decay_constant(pauli_error, num_qubits, expected_output):
+def test_pauli_error_to_decay_constant(pauli_error, num_qubits, expected_output) -> None:
     val = pauli_error_to_decay_constant(pauli_error, num_qubits)
     assert val == expected_output
 
@@ -57,7 +57,7 @@ def test_pauli_error_to_decay_constant(pauli_error, num_qubits, expected_output)
     'xeb_fidelity,num_qubits,expected_output',
     [(0.01, 1, 1 - 0.99 / (1 / 2)), (0.05, 2, 1 - 0.95 / (3 / 4))],
 )
-def test_xeb_fidelity_to_decay_constant(xeb_fidelity, num_qubits, expected_output):
+def test_xeb_fidelity_to_decay_constant(xeb_fidelity, num_qubits, expected_output) -> None:
     val = xeb_fidelity_to_decay_constant(xeb_fidelity, num_qubits)
     assert val == expected_output
 
@@ -69,7 +69,7 @@ def test_xeb_fidelity_to_decay_constant(xeb_fidelity, num_qubits, expected_outpu
         (4000, 1e4, (1 - np.exp(-4000 / 2e4)) / 2 + (1 - np.exp(-4000 / 1e4)) / 4),
     ],
 )
-def test_pauli_error_from_t1(t, t1_ns, expected_output):
+def test_pauli_error_from_t1(t, t1_ns, expected_output) -> None:
     val = pauli_error_from_t1(t, t1_ns)
     assert val == expected_output
 
@@ -77,7 +77,7 @@ def test_pauli_error_from_t1(t, t1_ns, expected_output):
 @pytest.mark.parametrize(
     'decay_constant,num_qubits,expected_output', [(0.01, 1, 0.99 * 1 / 2), (0.05, 2, 0.95 * 3 / 4)]
 )
-def test_average_error(decay_constant, num_qubits, expected_output):
+def test_average_error(decay_constant, num_qubits, expected_output) -> None:
     val = average_error(decay_constant, num_qubits)
     assert val == expected_output
 
@@ -85,7 +85,7 @@ def test_average_error(decay_constant, num_qubits, expected_output):
 @pytest.mark.parametrize(
     'T1_ns,Tphi_ns,gate_time_ns', [(1e4, 2e4, 25), (1e5, 2e3, 25), (1e4, 2e4, 4000)]
 )
-def test_decoherence_pauli_error(T1_ns, Tphi_ns, gate_time_ns):
+def test_decoherence_pauli_error(T1_ns, Tphi_ns, gate_time_ns) -> None:
     val = decoherence_pauli_error(T1_ns, Tphi_ns, gate_time_ns)
     # Expected value is of the form:
     #

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state_test.py
@@ -20,7 +20,7 @@ import pytest
 import cirq
 
 
-def test_unitary_fallback():
+def test_unitary_fallback() -> None:
     class UnitaryXGate(cirq.testing.SingleQubitGate):
         def _unitary_(self):
             return np.array([[0, 1], [1, 0]])
@@ -57,7 +57,7 @@ def test_unitary_fallback():
     assert args.tableau == expected_args.tableau
 
 
-def test_cannot_act():
+def test_cannot_act() -> None:
     class NoDetails:
         pass
 
@@ -77,7 +77,7 @@ def test_cannot_act():
         cirq.act_on(NoDetailsSingleQubitGate(), args, [cirq.LineQubit(1)])
 
 
-def test_copy():
+def test_copy() -> None:
     args = cirq.CliffordTableauSimulationState(
         tableau=cirq.CliffordTableau(num_qubits=3),
         qubits=cirq.LineQubit.range(3),

--- a/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state_test.py
@@ -18,14 +18,14 @@ import pytest
 import cirq
 
 
-def test_init_state():
+def test_init_state() -> None:
     args = cirq.StabilizerChFormSimulationState(qubits=cirq.LineQubit.range(1), initial_state=1)
     np.testing.assert_allclose(args.state.state_vector(), [0, 1])
     with pytest.raises(ValueError, match='Must specify qubits'):
         _ = cirq.StabilizerChFormSimulationState(initial_state=1)
 
 
-def test_cannot_act():
+def test_cannot_act() -> None:
     class NoDetails(cirq.testing.SingleQubitGate):
         pass
 
@@ -35,7 +35,7 @@ def test_cannot_act():
         cirq.act_on(NoDetails(), args, qubits=())
 
 
-def test_gate_with_act_on():
+def test_gate_with_act_on() -> None:
     class CustomGate(cirq.testing.SingleQubitGate):
         def _act_on_(self, sim_state, qubits):
             if isinstance(sim_state, cirq.StabilizerChFormSimulationState):
@@ -53,7 +53,7 @@ def test_gate_with_act_on():
     np.testing.assert_allclose(state.gamma, [0, 1, 0])
 
 
-def test_unitary_fallback_y():
+def test_unitary_fallback_y() -> None:
     class UnitaryYGate(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -72,7 +72,7 @@ def test_unitary_fallback_y():
     np.testing.assert_allclose(args.state.state_vector(), expected_args.state.state_vector())
 
 
-def test_unitary_fallback_h():
+def test_unitary_fallback_h() -> None:
     class UnitaryHGate(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -91,7 +91,7 @@ def test_unitary_fallback_h():
     np.testing.assert_allclose(args.state.state_vector(), expected_args.state.state_vector())
 
 
-def test_copy():
+def test_copy() -> None:
     args = cirq.StabilizerChFormSimulationState(
         qubits=cirq.LineQubit.range(3), prng=np.random.RandomState()
     )

--- a/cirq-core/cirq/sim/clifford/stabilizer_sampler_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_sampler_test.py
@@ -17,7 +17,7 @@ import numpy as np
 import cirq
 
 
-def test_produces_samples():
+def test_produces_samples() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.H(a), cirq.CNOT(a, b), cirq.measure(a, key='a'), cirq.measure(b, key='b'))
 
@@ -26,7 +26,7 @@ def test_produces_samples():
     assert np.all(result['a'] ^ result['b'] == 0)
 
 
-def test_reset():
+def test_reset() -> None:
     q = cirq.LineQubit(0)
     sampler = cirq.StabilizerSampler()
     c = cirq.Circuit(cirq.X(q), cirq.reset(q), cirq.measure(q))

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
@@ -20,7 +20,7 @@ import sympy
 import cirq
 
 
-def test_apply_gate():
+def test_apply_gate() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     state = mock.Mock()
     args = cirq.StabilizerSimulationState(state=state, qubits=[q0, q1])
@@ -89,7 +89,7 @@ def test_apply_gate():
     state.apply_x.assert_not_called()
 
 
-def test_apply_mixture():
+def test_apply_mixture() -> None:
     q0 = cirq.LineQubit(0)
     state = mock.Mock()
     args = cirq.StabilizerSimulationState(state=state, qubits=[q0])
@@ -100,7 +100,7 @@ def test_apply_mixture():
     assert 10 < state.apply_x.call_count < 90
 
 
-def test_act_from_single_qubit_decompose():
+def test_act_from_single_qubit_decompose() -> None:
     q0 = cirq.LineQubit(0)
     state = mock.Mock()
     args = cirq.StabilizerSimulationState(state=state, qubits=[q0])
@@ -113,7 +113,7 @@ def test_act_from_single_qubit_decompose():
     state.apply_x.assert_called_with(0, 1.0, 0.0)
 
 
-def test_decompose():
+def test_decompose() -> None:
     class XContainer(cirq.Gate):
         def _decompose_(self, qs):
             return [cirq.X(*qs)]

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form_test.py
@@ -22,7 +22,7 @@ import cirq.testing
 # Github issue: https://github.com/quantumlib/Cirq/issues/3021
 
 
-def test_initial_state():
+def test_initial_state() -> None:
     with pytest.raises(ValueError, match='Out of range'):
         _ = cirq.StabilizerStateChForm(initial_state=-31, num_qubits=5)
     with pytest.raises(ValueError, match='Out of range'):
@@ -33,7 +33,7 @@ def test_initial_state():
     np.testing.assert_allclose(state.state_vector(), expected_state_vector)
 
 
-def test_run():
+def test_run() -> None:
     (q0, q1, q2) = (cirq.LineQubit(0), cirq.LineQubit(1), cirq.LineQubit(2))
 
     """

--- a/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
@@ -18,7 +18,7 @@ import pytest
 import cirq
 
 
-def test_default_parameter():
+def test_default_parameter() -> None:
     qid_shape = (2,)
     tensor = cirq.to_valid_density_matrix(
         0, len(qid_shape), qid_shape=qid_shape, dtype=np.complex64
@@ -32,13 +32,13 @@ def test_default_parameter():
     assert args.qid_shape == qid_shape
 
 
-def test_shallow_copy_buffers():
+def test_shallow_copy_buffers() -> None:
     args = cirq.DensityMatrixSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
     copy = args.copy(deep_copy_buffers=False)
     assert copy.available_buffer is args.available_buffer
 
 
-def test_decomposed_fallback():
+def test_decomposed_fallback() -> None:
     class Composite(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -59,7 +59,7 @@ def test_decomposed_fallback():
     )
 
 
-def test_cannot_act():
+def test_cannot_act() -> None:
     class NoDetails:
         pass
 
@@ -73,12 +73,12 @@ def test_cannot_act():
         cirq.act_on(NoDetails(), args, qubits=())
 
 
-def test_qid_shape_error():
+def test_qid_shape_error() -> None:
     with pytest.raises(ValueError, match="qid_shape must be provided"):
         cirq.sim.density_matrix_simulation_state._BufferedDensityMatrix.create(initial_state=0)
 
 
-def test_initial_state_vector():
+def test_initial_state_vector() -> None:
     qubits = cirq.LineQubit.range(3)
     args = cirq.DensityMatrixSimulationState(
         qubits=qubits, initial_state=np.full((8,), 1 / np.sqrt(8)), dtype=np.complex64
@@ -91,7 +91,7 @@ def test_initial_state_vector():
     assert args2.target_tensor.shape == (2, 2, 2, 2, 2, 2)
 
 
-def test_initial_state_matrix():
+def test_initial_state_matrix() -> None:
     qubits = cirq.LineQubit.range(3)
     args = cirq.DensityMatrixSimulationState(
         qubits=qubits, initial_state=np.full((8, 8), 1 / 8), dtype=np.complex64
@@ -104,7 +104,7 @@ def test_initial_state_matrix():
     assert args2.target_tensor.shape == (2, 2, 2, 2, 2, 2)
 
 
-def test_initial_state_bad_shape():
+def test_initial_state_bad_shape() -> None:
     qubits = cirq.LineQubit.range(3)
     with pytest.raises(ValueError, match="Invalid quantum state"):
         cirq.DensityMatrixSimulationState(

--- a/cirq-core/cirq/sim/density_matrix_utils_test.py
+++ b/cirq-core/cirq/sim/density_matrix_utils_test.py
@@ -21,7 +21,7 @@ import cirq
 import cirq.testing
 
 
-def test_sample_density_matrix_big_endian():
+def test_sample_density_matrix_big_endian() -> None:
     results = []
     for x in range(8):
         matrix = cirq.to_valid_density_matrix(x, 3)
@@ -32,7 +32,7 @@ def test_sample_density_matrix_big_endian():
         np.testing.assert_equal(result, expected)
 
 
-def test_sample_density_matrix_partial_indices():
+def test_sample_density_matrix_partial_indices() -> None:
     for index in range(3):
         for x in range(8):
             matrix = cirq.to_valid_density_matrix(x, 3)
@@ -41,14 +41,14 @@ def test_sample_density_matrix_partial_indices():
             )
 
 
-def test_sample_density_matrix_partial_indices_oder():
+def test_sample_density_matrix_partial_indices_oder() -> None:
     for x in range(8):
         matrix = cirq.to_valid_density_matrix(x, 3)
         expected = [[bool(1 & (x >> 0)), bool(1 & (x >> 1))]]
         np.testing.assert_equal(cirq.sample_density_matrix(matrix, [2, 1]), expected)
 
 
-def test_sample_density_matrix_partial_indices_all_orders():
+def test_sample_density_matrix_partial_indices_all_orders() -> None:
     for perm in itertools.permutations([0, 1, 2]):
         for x in range(8):
             matrix = cirq.to_valid_density_matrix(x, 3)
@@ -56,7 +56,7 @@ def test_sample_density_matrix_partial_indices_all_orders():
             np.testing.assert_equal(cirq.sample_density_matrix(matrix, perm), expected)
 
 
-def test_sample_density_matrix():
+def test_sample_density_matrix() -> None:
     state = np.zeros(8, dtype=np.complex64)
     state[0] = 1 / np.sqrt(2)
     state[2] = 1 / np.sqrt(2)
@@ -72,7 +72,7 @@ def test_sample_density_matrix():
         np.testing.assert_equal(cirq.sample_density_matrix(matrix, [0]), [[False]])
 
 
-def test_sample_density_matrix_seed():
+def test_sample_density_matrix_seed() -> None:
     density_matrix = 0.5 * np.eye(2)
 
     samples = cirq.sample_density_matrix(density_matrix, [0], repetitions=10, seed=1234)
@@ -90,12 +90,12 @@ def test_sample_density_matrix_seed():
     )
 
 
-def test_sample_empty_density_matrix():
+def test_sample_empty_density_matrix() -> None:
     matrix = np.zeros(shape=())
     np.testing.assert_almost_equal(cirq.sample_density_matrix(matrix, []), [[]])
 
 
-def test_sample_density_matrix_no_repetitions():
+def test_sample_density_matrix_no_repetitions() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     np.testing.assert_almost_equal(
         cirq.sample_density_matrix(matrix, [1], repetitions=0), np.zeros(shape=(0, 1))
@@ -105,7 +105,7 @@ def test_sample_density_matrix_no_repetitions():
     )
 
 
-def test_sample_density_matrix_repetitions():
+def test_sample_density_matrix_repetitions() -> None:
     for perm in itertools.permutations([0, 1, 2]):
         for x in range(8):
             matrix = cirq.to_valid_density_matrix(x, 3)
@@ -115,30 +115,30 @@ def test_sample_density_matrix_repetitions():
             np.testing.assert_equal(result, expected)
 
 
-def test_sample_density_matrix_negative_repetitions():
+def test_sample_density_matrix_negative_repetitions() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     with pytest.raises(ValueError, match='-1'):
         cirq.sample_density_matrix(matrix, [1], repetitions=-1)
 
 
-def test_sample_density_matrix_not_square():
+def test_sample_density_matrix_not_square() -> None:
     with pytest.raises(ValueError, match='not square'):
         cirq.sample_density_matrix(np.array([1, 0, 0]), [1])
 
 
-def test_sample_density_matrix_not_power_of_two():
+def test_sample_density_matrix_not_power_of_two() -> None:
     with pytest.raises(ValueError, match='power of two'):
         cirq.sample_density_matrix(np.ones((3, 3)) / 3, [1])
     with pytest.raises(ValueError, match='power of two'):
         cirq.sample_density_matrix(np.ones((2, 3, 2, 3)) / 6, [1])
 
 
-def test_sample_density_matrix_higher_powers_of_two():
+def test_sample_density_matrix_higher_powers_of_two() -> None:
     with pytest.raises(ValueError, match='powers of two'):
         cirq.sample_density_matrix(np.ones((2, 4, 2, 4)) / 8, [1])
 
 
-def test_sample_density_matrix_out_of_range():
+def test_sample_density_matrix_out_of_range() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     with pytest.raises(IndexError, match='-2'):
         cirq.sample_density_matrix(matrix, [-2])
@@ -146,13 +146,13 @@ def test_sample_density_matrix_out_of_range():
         cirq.sample_density_matrix(matrix, [3])
 
 
-def test_sample_density_matrix_no_indices():
+def test_sample_density_matrix_no_indices() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     bits = cirq.sample_density_matrix(matrix, [])
     np.testing.assert_almost_equal(bits, np.zeros(shape=(1, 0)))
 
 
-def test_sample_density_matrix_validate_qid_shape():
+def test_sample_density_matrix_validate_qid_shape() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     cirq.sample_density_matrix(matrix, [], qid_shape=(2, 2, 2))
     with pytest.raises(ValueError, match='Matrix size does not match qid shape'):
@@ -163,7 +163,7 @@ def test_sample_density_matrix_validate_qid_shape():
         cirq.sample_density_matrix(matrix2, [], qid_shape=(2, 2, 2))
 
 
-def test_measure_density_matrix_computational_basis():
+def test_measure_density_matrix_computational_basis() -> None:
     results = []
     for x in range(8):
         matrix = cirq.to_valid_density_matrix(x, 3)
@@ -174,7 +174,7 @@ def test_measure_density_matrix_computational_basis():
     assert results == expected
 
 
-def test_measure_density_matrix_computational_basis_reversed():
+def test_measure_density_matrix_computational_basis_reversed() -> None:
     results = []
     for x in range(8):
         matrix = cirq.to_valid_density_matrix(x, 3)
@@ -185,7 +185,7 @@ def test_measure_density_matrix_computational_basis_reversed():
     assert results == expected
 
 
-def test_measure_density_matrix_computational_basis_reshaped():
+def test_measure_density_matrix_computational_basis_reshaped() -> None:
     results = []
     for x in range(8):
         matrix = np.reshape(cirq.to_valid_density_matrix(x, 3), (2,) * 6)
@@ -196,7 +196,7 @@ def test_measure_density_matrix_computational_basis_reshaped():
     assert results == expected
 
 
-def test_measure_density_matrix_partial_indices():
+def test_measure_density_matrix_partial_indices() -> None:
     for index in range(3):
         for x in range(8):
             matrix = cirq.to_valid_density_matrix(x, 3)
@@ -205,7 +205,7 @@ def test_measure_density_matrix_partial_indices():
             assert bits == [bool(1 & (x >> (2 - index)))]
 
 
-def test_measure_density_matrix_partial_indices_all_orders():
+def test_measure_density_matrix_partial_indices_all_orders() -> None:
     for perm in itertools.permutations([0, 1, 2]):
         for x in range(8):
             matrix = cirq.to_valid_density_matrix(x, 3)
@@ -221,7 +221,7 @@ def matrix_000_plus_010():
     return cirq.to_valid_density_matrix(state, num_qubits=3)
 
 
-def test_measure_density_matrix_collapse():
+def test_measure_density_matrix_collapse() -> None:
     matrix = matrix_000_plus_010()
     for _ in range(10):
         bits, out_matrix = cirq.measure_density_matrix(matrix, [2, 1, 0])
@@ -246,7 +246,7 @@ def test_measure_density_matrix_collapse():
         assert bits == [False]
 
 
-def test_measure_density_matrix_seed():
+def test_measure_density_matrix_seed() -> None:
     n = 5
     matrix = np.eye(2**n) / 2**n
 
@@ -261,7 +261,7 @@ def test_measure_density_matrix_seed():
     np.testing.assert_allclose(out_matrix1, out_matrix2)
 
 
-def test_measure_density_matrix_out_is_matrix():
+def test_measure_density_matrix_out_is_matrix() -> None:
     matrix = matrix_000_plus_010()
     bits, out_matrix = cirq.measure_density_matrix(matrix, [2, 1, 0], out=matrix)
     expected_state = np.zeros(8, dtype=np.complex64)
@@ -271,7 +271,7 @@ def test_measure_density_matrix_out_is_matrix():
     assert out_matrix is matrix
 
 
-def test_measure_state_out_is_not_matrix():
+def test_measure_state_out_is_not_matrix() -> None:
     matrix = matrix_000_plus_010()
     out = np.zeros_like(matrix)
     _, out_matrix = cirq.measure_density_matrix(matrix, [2, 1, 0], out=out)
@@ -279,7 +279,7 @@ def test_measure_state_out_is_not_matrix():
     assert out is out_matrix
 
 
-def test_measure_density_matrix_not_square():
+def test_measure_density_matrix_not_square() -> None:
     with pytest.raises(ValueError, match='not square'):
         cirq.measure_density_matrix(np.array([1, 0, 0]), [1])
     with pytest.raises(ValueError, match='not square'):
@@ -288,26 +288,26 @@ def test_measure_density_matrix_not_square():
         )
 
 
-def test_measure_density_matrix_not_power_of_two():
+def test_measure_density_matrix_not_power_of_two() -> None:
     with pytest.raises(ValueError, match='power of two'):
         cirq.measure_density_matrix(np.ones((3, 3)) / 3, [1])
     with pytest.raises(ValueError, match='power of two'):
         cirq.measure_density_matrix(np.ones((2, 3, 2, 3)) / 6, [1])
 
 
-def test_measure_density_matrix_higher_powers_of_two():
+def test_measure_density_matrix_higher_powers_of_two() -> None:
     with pytest.raises(ValueError, match='powers of two'):
         cirq.measure_density_matrix(np.ones((2, 4, 2, 4)) / 8, [1])
 
 
-def test_measure_density_matrix_tensor_different_left_right_shape():
+def test_measure_density_matrix_tensor_different_left_right_shape() -> None:
     with pytest.raises(ValueError, match='not equal'):
         cirq.measure_density_matrix(
             np.array([1, 0, 0, 0]).reshape((2, 2, 1, 1)), [1], qid_shape=(2, 1)
         )
 
 
-def test_measure_density_matrix_out_of_range():
+def test_measure_density_matrix_out_of_range() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     with pytest.raises(IndexError, match='-2'):
         cirq.measure_density_matrix(matrix, [-2])
@@ -315,14 +315,14 @@ def test_measure_density_matrix_out_of_range():
         cirq.measure_density_matrix(matrix, [3])
 
 
-def test_measure_state_no_indices():
+def test_measure_state_no_indices() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     bits, out_matrix = cirq.measure_density_matrix(matrix, [])
     assert [] == bits
     np.testing.assert_almost_equal(out_matrix, matrix)
 
 
-def test_measure_state_no_indices_out_is_matrix():
+def test_measure_state_no_indices_out_is_matrix() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     bits, out_matrix = cirq.measure_density_matrix(matrix, [], out=matrix)
     assert [] == bits
@@ -330,7 +330,7 @@ def test_measure_state_no_indices_out_is_matrix():
     assert out_matrix is matrix
 
 
-def test_measure_state_no_indices_out_is_not_matrix():
+def test_measure_state_no_indices_out_is_not_matrix() -> None:
     matrix = cirq.to_valid_density_matrix(0, 3)
     out = np.zeros_like(matrix)
     bits, out_matrix = cirq.measure_density_matrix(matrix, [], out=out)
@@ -340,7 +340,7 @@ def test_measure_state_no_indices_out_is_not_matrix():
     assert out is not matrix
 
 
-def test_measure_state_empty_density_matrix():
+def test_measure_state_empty_density_matrix() -> None:
     matrix = np.zeros(shape=())
     bits, out_matrix = cirq.measure_density_matrix(matrix, [])
     assert [] == bits
@@ -350,14 +350,14 @@ def test_measure_state_empty_density_matrix():
 @pytest.mark.parametrize('seed', [17, 35, 48])
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
 @pytest.mark.parametrize('split', [False, True])
-def test_to_valid_density_matrix_on_simulator_output(seed, dtype, split):
+def test_to_valid_density_matrix_on_simulator_output(seed, dtype, split) -> None:
     circuit = cirq.testing.random_circuit(qubits=5, n_moments=20, op_density=0.9, random_state=seed)
     simulator = cirq.DensityMatrixSimulator(split_untangled_states=split, dtype=dtype)
     result = simulator.simulate(circuit)
     _ = cirq.to_valid_density_matrix(result.final_density_matrix, num_qubits=5, atol=1e-6)
 
 
-def test_factor_validation():
+def test_factor_validation() -> None:
     args = cirq.DensityMatrixSimulator()._create_simulation_state(0, qubits=cirq.LineQubit.range(2))
     args.apply_operation(cirq.H(cirq.LineQubit(0)))
     t = args.create_merged_state().target_tensor

--- a/cirq-core/cirq/sim/simulation_product_state_test.py
+++ b/cirq-core/cirq/sim/simulation_product_state_test.py
@@ -70,7 +70,7 @@ def create_container(
     )
 
 
-def test_entanglement_causes_join():
+def test_entanglement_causes_join() -> None:
     state = create_container(qs2)
     assert len(set(state.values())) == 3
     state.apply_operation(cirq.CNOT(q0, q1))
@@ -79,7 +79,7 @@ def test_entanglement_causes_join():
     assert state[None] is not state[q0]
 
 
-def test_subcircuit_entanglement_causes_join():
+def test_subcircuit_entanglement_causes_join() -> None:
     state = create_container(qs2)
     assert len(set(state.values())) == 3
     state.apply_operation(cirq.CircuitOperation(cirq.FrozenCircuit(cirq.CNOT(q0, q1))))
@@ -87,7 +87,7 @@ def test_subcircuit_entanglement_causes_join():
     assert state[q0] is state[q1]
 
 
-def test_subcircuit_entanglement_causes_join_in_subset():
+def test_subcircuit_entanglement_causes_join_in_subset() -> None:
     state = create_container(qs3)
     assert len(set(state.values())) == 4
     state.apply_operation(cirq.CircuitOperation(cirq.FrozenCircuit(cirq.CNOT(q0, q1))))
@@ -98,7 +98,7 @@ def test_subcircuit_entanglement_causes_join_in_subset():
     assert state[q0] is state[q1] is state[q2]
 
 
-def test_identity_does_not_join():
+def test_identity_does_not_join() -> None:
     state = create_container(qs2)
     assert len(set(state.values())) == 3
     state.apply_operation(cirq.IdentityGate(2)(q0, q1))
@@ -107,7 +107,7 @@ def test_identity_does_not_join():
     assert state[q0] is not state[None]
 
 
-def test_identity_fallback_does_not_join():
+def test_identity_fallback_does_not_join() -> None:
     state = create_container(qs2)
     assert len(set(state.values())) == 3
     state._act_on_fallback_(cirq.I, (q0, q1))
@@ -116,7 +116,7 @@ def test_identity_fallback_does_not_join():
     assert state[q0] is not state[None]
 
 
-def test_subcircuit_identity_does_not_join():
+def test_subcircuit_identity_does_not_join() -> None:
     state = create_container(qs2)
     assert len(set(state.values())) == 3
     state.apply_operation(cirq.CircuitOperation(cirq.FrozenCircuit(cirq.IdentityGate(2)(q0, q1))))
@@ -124,7 +124,7 @@ def test_subcircuit_identity_does_not_join():
     assert state[q0] is not state[q1]
 
 
-def test_measurement_causes_split():
+def test_measurement_causes_split() -> None:
     state = create_container(qs2)
     state.apply_operation(cirq.CNOT(q0, q1))
     assert len(set(state.values())) == 2
@@ -134,7 +134,7 @@ def test_measurement_causes_split():
     assert state[q0] is not state[None]
 
 
-def test_subcircuit_measurement_causes_split():
+def test_subcircuit_measurement_causes_split() -> None:
     state = create_container(qs2)
     state.apply_operation(cirq.CNOT(q0, q1))
     assert len(set(state.values())) == 2
@@ -143,7 +143,7 @@ def test_subcircuit_measurement_causes_split():
     assert state[q0] is not state[q1]
 
 
-def test_subcircuit_measurement_causes_split_in_subset():
+def test_subcircuit_measurement_causes_split_in_subset() -> None:
     state = create_container(qs3)
     state.apply_operation(cirq.CNOT(q0, q1))
     state.apply_operation(cirq.CNOT(q0, q2))
@@ -158,7 +158,7 @@ def test_subcircuit_measurement_causes_split_in_subset():
     assert state[q1] is not state[q2]
 
 
-def test_reset_causes_split():
+def test_reset_causes_split() -> None:
     state = create_container(qs2)
     state.apply_operation(cirq.CNOT(q0, q1))
     assert len(set(state.values())) == 2
@@ -168,7 +168,7 @@ def test_reset_causes_split():
     assert state[q0] is not state[None]
 
 
-def test_measurement_does_not_split_if_disabled():
+def test_measurement_does_not_split_if_disabled() -> None:
     state = create_container(qs2, False)
     state.apply_operation(cirq.CNOT(q0, q1))
     assert len(set(state.values())) == 1
@@ -178,7 +178,7 @@ def test_measurement_does_not_split_if_disabled():
     assert state[None] is state[q0]
 
 
-def test_reset_does_not_split_if_disabled():
+def test_reset_does_not_split_if_disabled() -> None:
     state = create_container(qs2, False)
     state.apply_operation(cirq.CNOT(q0, q1))
     assert len(set(state.values())) == 1
@@ -188,7 +188,7 @@ def test_reset_does_not_split_if_disabled():
     assert state[None] is state[q0]
 
 
-def test_measurement_of_all_qubits_causes_split():
+def test_measurement_of_all_qubits_causes_split() -> None:
     state = create_container(qs2)
     state.apply_operation(cirq.CNOT(q0, q1))
     assert len(set(state.values())) == 2
@@ -198,7 +198,7 @@ def test_measurement_of_all_qubits_causes_split():
     assert state[q0] is not state[None]
 
 
-def test_measurement_in_single_qubit_circuit_passes():
+def test_measurement_in_single_qubit_circuit_passes() -> None:
     state = create_container([q0])
     assert len(set(state.values())) == 2
     state.apply_operation(cirq.measure(q0))
@@ -206,25 +206,25 @@ def test_measurement_in_single_qubit_circuit_passes():
     assert state[q0] is not state[None]
 
 
-def test_reorder_succeeds():
+def test_reorder_succeeds() -> None:
     state = create_container(qs2, False)
     reordered = state[q0].transpose_to_qubit_order([q1, q0])
     assert reordered.qubits == (q1, q0)
 
 
-def test_copy_succeeds():
+def test_copy_succeeds() -> None:
     state = create_container(qs2, False)
     copied = state[q0].copy()
     assert copied.qubits == (q0, q1)
 
 
-def test_merge_succeeds():
+def test_merge_succeeds() -> None:
     state = create_container(qs2, False)
     merged = state.create_merged_state()
     assert merged.qubits == (q0, q1)
 
 
-def test_swap_does_not_merge():
+def test_swap_does_not_merge() -> None:
     state = create_container(qs2)
     old_q0 = state[q0]
     old_q1 = state[q1]
@@ -238,14 +238,14 @@ def test_swap_does_not_merge():
     assert state[q1].qubits == (q1,)
 
 
-def test_half_swap_does_merge():
+def test_half_swap_does_merge() -> None:
     state = create_container(qs2)
     state.apply_operation(cirq.SWAP(q0, q1) ** 0.5)
     assert len(set(state.values())) == 2
     assert state[q0] is state[q1]
 
 
-def test_swap_after_entangle_reorders():
+def test_swap_after_entangle_reorders() -> None:
     state = create_container(qs2)
     state.apply_operation(cirq.CX(q0, q1))
     assert len(set(state.values())) == 2
@@ -256,7 +256,7 @@ def test_swap_after_entangle_reorders():
     assert state[q0].qubits == (q1, q0)
 
 
-def test_act_on_gate_does_not_join():
+def test_act_on_gate_does_not_join() -> None:
     state = create_container(qs2)
     assert len(set(state.values())) == 3
     cirq.act_on(cirq.X, state, [q0])
@@ -265,7 +265,7 @@ def test_act_on_gate_does_not_join():
     assert state[q0] is not state[None]
 
 
-def test_field_getters():
+def test_field_getters() -> None:
     state = create_container(qs2)
     assert state.sim_states.keys() == set(qs2) | {None}
     assert state.split_untangled_states

--- a/cirq-core/cirq/sim/simulation_state_test.py
+++ b/cirq-core/cirq/sim/simulation_state_test.py
@@ -72,20 +72,20 @@ class Composite(cirq.Gate):
         yield cirq.X(*qubits)
 
 
-def test_measurements():
+def test_measurements() -> None:
     args = ExampleSimulationState()
     args.measure([cirq.LineQubit(0)], "test", [False], {})
     assert args.log_of_measurement_results["test"] == [5]
 
 
-def test_decompose():
+def test_decompose() -> None:
     args = ExampleSimulationState()
     assert simulation_state.strat_act_on_from_apply_decompose(
         Composite(), args, [cirq.LineQubit(0)]
     )
 
 
-def test_decompose_for_gate_allocating_qubits_raises():
+def test_decompose_for_gate_allocating_qubits_raises() -> None:
     class Composite(cirq.testing.SingleQubitGate):
         def _decompose_(self, qubits):
             anc = cirq.NamedQubit("anc")
@@ -97,7 +97,7 @@ def test_decompose_for_gate_allocating_qubits_raises():
         simulation_state.strat_act_on_from_apply_decompose(Composite(), args, [cirq.LineQubit(0)])
 
 
-def test_mapping():
+def test_mapping() -> None:
     args = ExampleSimulationState()
     assert list(iter(args)) == cirq.LineQubit.range(2)
     r1 = args[cirq.LineQubit(0)]
@@ -106,7 +106,7 @@ def test_mapping():
         _ = args[cirq.LineQubit(2)]
 
 
-def test_swap_bad_dimensions():
+def test_swap_bad_dimensions() -> None:
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQid(1, 3)
     args = ExampleSimulationState()
@@ -114,7 +114,7 @@ def test_swap_bad_dimensions():
         args.swap(q0, q1)
 
 
-def test_rename_bad_dimensions():
+def test_rename_bad_dimensions() -> None:
     q0 = cirq.LineQubit(0)
     q1 = cirq.LineQid(1, 3)
     args = ExampleSimulationState()
@@ -122,7 +122,7 @@ def test_rename_bad_dimensions():
         args.rename(q0, q1)
 
 
-def test_transpose_qubits():
+def test_transpose_qubits() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     args = ExampleSimulationState()
     assert args.transpose_to_qubit_order((q1, q0)).qubits == (q1, q0)
@@ -132,14 +132,14 @@ def test_transpose_qubits():
         args.transpose_to_qubit_order((q0, q1, q1))
 
 
-def test_field_getters():
+def test_field_getters() -> None:
     args = ExampleSimulationState()
     assert args.prng is np.random
     assert args.qubit_map == {q: i for i, q in enumerate(cirq.LineQubit.range(2))}
 
 
 @pytest.mark.parametrize('exp', np.linspace(0, 2 * np.pi, 10))
-def test_delegating_gate_unitary(exp):
+def test_delegating_gate_unitary(exp) -> None:
     q = cirq.LineQubit(0)
 
     test_circuit = cirq.Circuit()
@@ -154,7 +154,7 @@ def test_delegating_gate_unitary(exp):
 
 
 @pytest.mark.parametrize('exp', np.linspace(0, 2 * np.pi, 10))
-def test_delegating_gate_channel(exp):
+def test_delegating_gate_channel(exp) -> None:
     q = cirq.LineQubit(0)
 
     test_circuit = cirq.Circuit()
@@ -169,7 +169,7 @@ def test_delegating_gate_channel(exp):
 
 
 @pytest.mark.parametrize('num_ancilla', [1, 2, 3])
-def test_phase_using_dirty_ancilla(num_ancilla: int):
+def test_phase_using_dirty_ancilla(num_ancilla: int) -> None:
     q = cirq.LineQubit(0)
     anc = cirq.NamedQubit.range(num_ancilla, prefix='anc')
 
@@ -184,7 +184,7 @@ def test_phase_using_dirty_ancilla(num_ancilla: int):
 
 @pytest.mark.parametrize('num_ancilla', [1, 2, 3])
 @pytest.mark.parametrize('theta', np.linspace(0, 2 * np.pi, 10))
-def test_phase_using_clean_ancilla(num_ancilla: int, theta: float):
+def test_phase_using_clean_ancilla(num_ancilla: int, theta: float) -> None:
     q = cirq.LineQubit(0)
     u = cirq.MatrixGate(cirq.testing.random_unitary(2))
     test_circuit = cirq.Circuit(

--- a/cirq-core/cirq/sim/simulation_utils_test.py
+++ b/cirq-core/cirq/sim/simulation_utils_test.py
@@ -19,7 +19,7 @@ from cirq.sim import simulation_utils
 
 
 @pytest.mark.parametrize('n,m', [(n, m) for n in range(1, 4) for m in range(1, n + 1)])
-def test_state_probabilities_by_indices(n: int, m: int):
+def test_state_probabilities_by_indices(n: int, m: int) -> None:
     np.random.seed(0)
     state = testing.random_superposition(1 << n)
     d = (state.conj() * state).real

--- a/cirq-core/cirq/sim/state_vector_simulation_state_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state_test.py
@@ -21,7 +21,7 @@ import pytest
 import cirq
 
 
-def test_default_parameter():
+def test_default_parameter() -> None:
     dtype = np.complex64
     tensor = cirq.one_hot(shape=(2, 2, 2), dtype=np.complex64)
     qubits = cirq.LineQubit.range(3)
@@ -33,7 +33,7 @@ def test_default_parameter():
     assert args.available_buffer.dtype == tensor.dtype
 
 
-def test_infer_target_tensor():
+def test_infer_target_tensor() -> None:
     dtype = np.complex64
     args = cirq.StateVectorSimulationState(
         qubits=cirq.LineQubit.range(2),
@@ -54,13 +54,13 @@ def test_infer_target_tensor():
     )
 
 
-def test_shallow_copy_buffers():
+def test_shallow_copy_buffers() -> None:
     args = cirq.StateVectorSimulationState(qubits=cirq.LineQubit.range(1), initial_state=0)
     copy = args.copy(deep_copy_buffers=False)
     assert copy.available_buffer is args.available_buffer
 
 
-def test_decomposed_fallback():
+def test_decomposed_fallback() -> None:
     class Composite(cirq.Gate):
         def num_qubits(self) -> int:
             return 1  # pragma: no cover
@@ -82,7 +82,7 @@ def test_decomposed_fallback():
     )
 
 
-def test_cannot_act():
+def test_cannot_act() -> None:
     class NoDetails:
         pass
 
@@ -98,7 +98,7 @@ def test_cannot_act():
         cirq.act_on(NoDetails(), args, qubits=())
 
 
-def test_act_using_probabilistic_single_qubit_channel():
+def test_act_using_probabilistic_single_qubit_channel() -> None:
     class ProbabilisticSorX(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -148,7 +148,7 @@ def test_act_using_probabilistic_single_qubit_channel():
     )
 
 
-def test_act_using_adaptive_two_qubit_channel():
+def test_act_using_adaptive_two_qubit_channel() -> None:
     class Decay11(cirq.Gate):
         def num_qubits(self) -> int:
             return 2
@@ -210,7 +210,7 @@ def test_act_using_adaptive_two_qubit_channel():
         assert_not_affected(projected_state, sample=3 / 4 + 1e-8)
 
 
-def test_probability_comes_up_short_results_in_fallback():
+def test_probability_comes_up_short_results_in_fallback() -> None:
     class Short(cirq.Gate):
         def num_qubits(self) -> int:
             return 1
@@ -234,7 +234,7 @@ def test_probability_comes_up_short_results_in_fallback():
     np.testing.assert_allclose(args.target_tensor, np.array([0, 1]))
 
 
-def test_random_channel_has_random_behavior():
+def test_random_channel_has_random_behavior() -> None:
     q = cirq.LineQubit(0)
     s = cirq.Simulator().sample(
         cirq.Circuit(cirq.X(q), cirq.amplitude_damp(0.4).on(q), cirq.measure(q, key='out')),
@@ -245,7 +245,7 @@ def test_random_channel_has_random_behavior():
     assert v[1] > 1
 
 
-def test_measured_channel():
+def test_measured_channel() -> None:
     # This behaves like an X-basis measurement.
     kc = cirq.KrausChannel(
         kraus_ops=(np.array([[1, 1], [1, 1]]) * 0.5, np.array([[1, -1], [-1, 1]]) * 0.5), key='m'
@@ -257,7 +257,7 @@ def test_measured_channel():
     assert results.histogram(key='m') == {0: 100}
 
 
-def test_measured_mixture():
+def test_measured_mixture() -> None:
     # This behaves like an X-basis measurement.
     mm = cirq.MixedUnitaryChannel(
         mixture=((0.5, np.array([[1, 0], [0, 1]])), (0.5, np.array([[0, 1], [1, 0]]))), key='flip'
@@ -269,6 +269,6 @@ def test_measured_mixture():
     assert results.histogram(key='flip') == results.histogram(key='m')
 
 
-def test_qid_shape_error():
+def test_qid_shape_error() -> None:
     with pytest.raises(ValueError, match="qid_shape must be provided"):
         cirq.sim.state_vector_simulation_state._BufferedStateVector.create(initial_state=0)

--- a/cirq-core/cirq/study/flatten_expressions_test.py
+++ b/cirq-core/cirq/study/flatten_expressions_test.py
@@ -23,14 +23,14 @@ from cirq.study import flatten_expressions
 # factor, is not consistent between sympy versions <1.4 and >=1.4.
 
 
-def test_expr_map_names():
+def test_expr_map_names() -> None:
     flattener = flatten_expressions._ParamFlattener({'collision': '<x + 2>'})
     expressions = [sympy.Symbol('x') + i for i in range(3)]
     syms = flattener.flatten(expressions)
     assert syms == [sympy.Symbol(name) for name in ('x', '<x + 1>', '<x + 2>_1')]
 
 
-def test_flattener_value_of():
+def test_flattener_value_of() -> None:
     flattener = flatten_expressions._ParamFlattener({'c': 5, 'x1': 'x1'})
     assert flattener.value_of(9) == 9
     assert flattener.value_of('c') == 5
@@ -54,18 +54,18 @@ def test_flattener_value_of():
     ]
 
 
-def test_flattener_repr():
+def test_flattener_repr() -> None:
     assert repr(flatten_expressions._ParamFlattener({'a': 1})) == ("_ParamFlattener({a: 1})")
     assert repr(
         flatten_expressions._ParamFlattener({'a': 1}, get_param_name=lambda expr: 'x')
     ).startswith("_ParamFlattener({a: 1}, get_param_name=<function ")
 
 
-def test_expression_map_repr():
+def test_expression_map_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.ExpressionMap({'a': 'b'}))
 
 
-def test_flatten_circuit():
+def test_flatten_circuit() -> None:
     qubit = cirq.LineQubit(0)
     a = sympy.Symbol('a')
     circuit = cirq.Circuit(cirq.X(qubit) ** a, cirq.X(qubit) ** (1 + a / 2))
@@ -78,7 +78,7 @@ def test_flatten_circuit():
     assert expr_map == {a: a, 1 + a / 2: sympy.Symbol('<a/2 + 1>')}
 
 
-def test_transform_params():
+def test_transform_params() -> None:
     qubit = cirq.LineQubit(0)
     a = sympy.Symbol('a')
     circuit = cirq.Circuit(cirq.X(qubit) ** (a / 4), cirq.X(qubit) ** (1 + a / 2))
@@ -90,7 +90,7 @@ def test_transform_params():
     assert new_params == expected_params
 
 
-def test_transform_sweep():
+def test_transform_sweep() -> None:
     qubit = cirq.LineQubit(0)
     a = sympy.Symbol('a')
     circuit = cirq.Circuit(cirq.X(qubit) ** (a / 4), cirq.X(qubit) ** (1 + a / 2))
@@ -109,20 +109,20 @@ def test_transform_sweep():
     assert resolvers == expected_resolvers
 
 
-def test_flattener_new():
+def test_flattener_new() -> None:
     flattener = flatten_expressions._ParamFlattener({'a': 'b'})
     flattener2 = flatten_expressions._ParamFlattener(flattener)
     assert isinstance(flattener2, flatten_expressions._ParamFlattener)
     assert flattener2.param_dict == flattener.param_dict
 
 
-def test_resolver_new():
+def test_resolver_new() -> None:
     flattener = flatten_expressions._ParamFlattener({'a': 'b'})
     flattener2 = cirq.ParamResolver(flattener)
     assert flattener2 is flattener
 
 
-def test_transformed_sweep():
+def test_transformed_sweep() -> None:
     a = sympy.Symbol('a')
     sweep = cirq.Linspace('a', start=0, stop=3, length=4)
     expr_map = cirq.ExpressionMap({a / 4: 'x0', 1 - a / 2: 'x1'})
@@ -134,7 +134,7 @@ def test_transformed_sweep():
     assert params[1] == (('x0', 1 / 4), ('x1', 1 - 1 / 2))
 
 
-def test_transformed_sweep_equality():
+def test_transformed_sweep_equality() -> None:
     a = sympy.Symbol('a')
     sweep = cirq.Linspace('a', start=0, stop=3, length=4)
     expr_map = cirq.ExpressionMap({a / 4: 'x0', 1 - a / 4: 'x1'})

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -39,7 +39,7 @@ import cirq
         fractions.Fraction(3, 2),
     ],
 )
-def test_value_of_pass_through_types(val):
+def test_value_of_pass_through_types(val) -> None:
     _assert_consistent_resolution(val, val)
 
 
@@ -47,12 +47,12 @@ def test_value_of_pass_through_types(val):
     'val,resolved',
     [(sympy.pi, np.pi), (sympy.S.NegativeOne, -1), (sympy.S.Half, 0.5), (sympy.S.One, 1)],
 )
-def test_value_of_transformed_types(val, resolved):
+def test_value_of_transformed_types(val, resolved) -> None:
     _assert_consistent_resolution(val, resolved)
 
 
 @pytest.mark.parametrize('val,resolved', [(sympy.I, 1j)])
-def test_value_of_substituted_types(val, resolved):
+def test_value_of_substituted_types(val, resolved) -> None:
     _assert_consistent_resolution(val, resolved)
 
 
@@ -112,11 +112,11 @@ def _assert_consistent_resolution(v, resolved):
     ), f"expected {type(resolved)} got {type(r.value_of(v))}"
 
 
-def test_value_of_strings():
+def test_value_of_strings() -> None:
     assert cirq.ParamResolver().value_of('x') == sympy.Symbol('x')
 
 
-def test_value_of_calculations():
+def test_value_of_calculations() -> None:
     assert not bool(cirq.ParamResolver())
 
     r = cirq.ParamResolver({'a': 0.5, 'b': 0.1, 'c': 1 + 1j})
@@ -129,34 +129,34 @@ def test_value_of_calculations():
     assert r.value_of(sympy.Symbol('b') / 0.1 - sympy.Symbol('a')) == 0.5
 
 
-def test_resolve_integer_division():
+def test_resolve_integer_division() -> None:
     r = cirq.ParamResolver({'a': 1, 'b': 2})
     resolved = r.value_of(sympy.Symbol('a') / sympy.Symbol('b'))
     assert resolved == 0.5
 
 
-def test_resolve_symbol_division():
+def test_resolve_symbol_division() -> None:
     B = sympy.Symbol('B')
     r = cirq.ParamResolver({'a': 1, 'b': B})
     resolved = r.value_of(sympy.Symbol('a') / sympy.Symbol('b'))
     assert resolved == sympy.core.power.Pow(B, -1)
 
 
-def test_param_dict():
+def test_param_dict() -> None:
     r = cirq.ParamResolver({'a': 0.5, 'b': 0.1})
     r2 = cirq.ParamResolver(r)
     assert r2 is r
     assert r.param_dict == {'a': 0.5, 'b': 0.1}
 
 
-def test_param_dict_iter():
+def test_param_dict_iter() -> None:
     r = cirq.ParamResolver({'a': 0.5, 'b': 0.1})
     assert [key for key in r] == ['a', 'b']
     assert [r.value_of(key) for key in r] == [0.5, 0.1]
     assert list(r) == ['a', 'b']
 
 
-def test_formulas_in_param_dict():
+def test_formulas_in_param_dict() -> None:
     """Tests that formula keys are rejected in a `param_dict`."""
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
@@ -166,7 +166,7 @@ def test_formulas_in_param_dict():
         _ = cirq.ParamResolver({a: b + 1, b: 2, b + c: 101, 'd': 2 * e})
 
 
-def test_recursive_evaluation():
+def test_recursive_evaluation() -> None:
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
     c = sympy.Symbol('c')
@@ -184,7 +184,7 @@ def test_recursive_evaluation():
     assert sympy.Eq(r.value_of(e), 0)
 
 
-def test_resolution_of_unknown_formulas():
+def test_resolution_of_unknown_formulas() -> None:
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
 
@@ -192,7 +192,7 @@ def test_resolution_of_unknown_formulas():
     assert r.value_of(sympy.sin(a), recursive=False) == sympy.sin(b - 2)
 
 
-def test_unbound_recursion_halted():
+def test_unbound_recursion_halted() -> None:
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
     c = sympy.Symbol('c')
@@ -223,14 +223,14 @@ def test_unbound_recursion_halted():
         _ = r.value_of(a)
 
 
-def test_resolve_unknown_type():
+def test_resolve_unknown_type() -> None:
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
     r = cirq.ParamResolver({a: b})
     assert r.value_of(cirq.X) == cirq.X
 
 
-def test_custom_resolved_value():
+def test_custom_resolved_value() -> None:
     class Foo:
         def _resolved_value_(self):
             return self
@@ -249,7 +249,7 @@ def test_custom_resolved_value():
     assert r.value_of(b) == 'Baz'
 
 
-def test_custom_value_not_implemented():
+def test_custom_value_not_implemented() -> None:
     class BarImplicit:
         pass
 
@@ -264,7 +264,7 @@ def test_custom_value_not_implemented():
         assert r.value_of(b) == b
 
 
-def test_compose():
+def test_compose() -> None:
     """Tests that cirq.resolve_parameters on a ParamResolver composes."""
     a = sympy.Symbol('a')
     b = sympy.Symbol('b')
@@ -301,7 +301,7 @@ def test_compose():
     ],
 )
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_compose_associative(p1, p2, p3, resolve_fn):
+def test_compose_associative(p1, p2, p3, resolve_fn) -> None:
     r1, r2, r3 = [
         cirq.ParamResolver(
             {sympy.Symbol(k): (sympy.Symbol(v) if isinstance(v, str) else v) for k, v in pd.items()}
@@ -313,7 +313,7 @@ def test_compose_associative(p1, p2, p3, resolve_fn):
     )
 
 
-def test_equals():
+def test_equals() -> None:
     et = cirq.testing.EqualsTester()
     et.add_equality_group(
         cirq.ParamResolver(),
@@ -329,7 +329,7 @@ def test_equals():
     et.add_equality_group(cirq.ParamResolver({'c': 0.1}))
 
 
-def test_repr():
+def test_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.ParamResolver())
     cirq.testing.assert_equivalent_repr(cirq.ParamResolver({'a': 2.0}))
     cirq.testing.assert_equivalent_repr(cirq.ParamResolver({'a': sympy.Symbol('a')}))

--- a/cirq-core/cirq/testing/consistent_act_on_test.py
+++ b/cirq-core/cirq/testing/consistent_act_on_test.py
@@ -55,7 +55,7 @@ class UnimplementedUnitaryGate(cirq.testing.TwoQubitGate):
         return np.array([[0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0], [1, 0, 0, 0]])
 
 
-def test_assert_act_on_clifford_tableau_effect_matches_unitary():
+def test_assert_act_on_clifford_tableau_effect_matches_unitary() -> None:
     cirq.testing.assert_all_implemented_act_on_effects_match_unitary(GoodGate())
     cirq.testing.assert_all_implemented_act_on_effects_match_unitary(
         GoodGate().on(cirq.LineQubit(1))

--- a/cirq-core/cirq/testing/consistent_channels_test.py
+++ b/cirq-core/cirq/testing/consistent_channels_test.py
@@ -18,12 +18,12 @@ import pytest
 import cirq
 
 
-def test_assert_consistent_channel_valid():
+def test_assert_consistent_channel_valid() -> None:
     channel = cirq.KrausChannel(kraus_ops=(np.array([[0, 1], [0, 0]]), np.array([[1, 0], [0, 0]])))
     cirq.testing.assert_consistent_channel(channel)
 
 
-def test_assert_consistent_channel_tolerances():
+def test_assert_consistent_channel_tolerances() -> None:
     # This channel is off by 1e-5 from the identity matrix in the consistency condition.
     channel = cirq.KrausChannel(
         kraus_ops=(np.array([[0, np.sqrt(1 - 1e-5)], [0, 0]]), np.array([[1, 0], [0, 0]]))
@@ -37,23 +37,23 @@ def test_assert_consistent_channel_tolerances():
         cirq.testing.assert_consistent_channel(channel, rtol=0, atol=1e-6)
 
 
-def test_assert_consistent_channel_invalid():
+def test_assert_consistent_channel_invalid() -> None:
     channel = cirq.KrausChannel(kraus_ops=(np.array([[1, 1], [0, 0]]), np.array([[1, 0], [0, 0]])))
     with pytest.raises(AssertionError, match=r"cirq.KrausChannel.*2 1"):
         cirq.testing.assert_consistent_channel(channel)
 
 
-def test_assert_consistent_channel_not_kraus():
+def test_assert_consistent_channel_not_kraus() -> None:
     with pytest.raises(AssertionError, match="12.*has_kraus"):
         cirq.testing.assert_consistent_channel(12)
 
 
-def test_assert_consistent_mixture_valid():
+def test_assert_consistent_mixture_valid() -> None:
     mixture = cirq.X.with_probability(0.1)
     cirq.testing.assert_consistent_mixture(mixture)
 
 
-def test_assert_consistent_mixture_not_mixture():
+def test_assert_consistent_mixture_not_mixture() -> None:
     not_mixture = cirq.amplitude_damp(0.1)
     with pytest.raises(AssertionError, match="has_mixture"):
         cirq.testing.assert_consistent_mixture(not_mixture)
@@ -69,7 +69,7 @@ class _MixtureGate(cirq.testing.SingleQubitGate):
         return (self._p, cirq.unitary(cirq.I)), (self._q, cirq.unitary(cirq.X))
 
 
-def test_assert_consistent_mixture_not_normalized():
+def test_assert_consistent_mixture_not_normalized() -> None:
     mixture = _MixtureGate(0.1, 0.85)
     with pytest.raises(AssertionError, match="sum to 1"):
         cirq.testing.assert_consistent_mixture(mixture)
@@ -79,7 +79,7 @@ def test_assert_consistent_mixture_not_normalized():
         cirq.testing.assert_consistent_mixture(mixture)
 
 
-def test_assert_consistent_mixture_tolerances():
+def test_assert_consistent_mixture_tolerances() -> None:
 
     # This gate is 1e-5 off being properly normalized.
     mixture = _MixtureGate(0.1, 0.9 - 1e-5)

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op_test.py
@@ -62,7 +62,7 @@ class BadGate(cirq.EigenGate, cirq.testing.SingleQubitGate):
         return ret
 
 
-def test_assert_controlled_and_controlled_by_identical():
+def test_assert_controlled_and_controlled_by_identical() -> None:
     cirq.testing.assert_controlled_and_controlled_by_identical(GoodGate())
 
     with pytest.raises(AssertionError):
@@ -79,7 +79,7 @@ def test_assert_controlled_and_controlled_by_identical():
         )
 
 
-def test_assert_controlled_unitary_consistent():
+def test_assert_controlled_unitary_consistent() -> None:
     cirq.testing.assert_controlled_and_controlled_by_identical(
         GoodGate(exponent=0.5, global_shift=1 / 3)
     )

--- a/cirq-core/cirq/testing/consistent_decomposition_test.py
+++ b/cirq-core/cirq/testing/consistent_decomposition_test.py
@@ -35,7 +35,7 @@ class BadGateDecompose(cirq.testing.SingleQubitGate):
         return np.array([[0, 1], [1, 0]])
 
 
-def test_assert_decompose_is_consistent_with_unitary():
+def test_assert_decompose_is_consistent_with_unitary() -> None:
     cirq.testing.assert_decompose_is_consistent_with_unitary(GoodGateDecompose())
 
     cirq.testing.assert_decompose_is_consistent_with_unitary(
@@ -89,7 +89,7 @@ class ParameterizedGate(cirq.Gate):
         yield cirq.Y(qubits[1]) ** sympy.Symbol("y")
 
 
-def test_assert_decompose_ends_at_default_gateset():
+def test_assert_decompose_ends_at_default_gateset() -> None:
     cirq.testing.assert_decompose_ends_at_default_gateset(GateDecomposesToDefaultGateset())
     cirq.testing.assert_decompose_ends_at_default_gateset(
         GateDecomposesToDefaultGateset().on(*cirq.LineQubit.range(2))

--- a/cirq-core/cirq/testing/consistent_pauli_expansion_test.py
+++ b/cirq-core/cirq/testing/consistent_pauli_expansion_test.py
@@ -52,7 +52,7 @@ class BadGateInconsistentPauliExpansion(cirq.testing.SingleQubitGate):
         return cirq.LinearDict({'X': np.sqrt(1 / 6), 'Y': np.sqrt(1 / 3), 'Z': np.sqrt(1 / 2)})
 
 
-def test_assert_pauli_expansion_is_consistent_with_unitary():
+def test_assert_pauli_expansion_is_consistent_with_unitary() -> None:
     cirq.testing.assert_pauli_expansion_is_consistent_with_unitary(GoodGateExplicitPauliExpansion())
     cirq.testing.assert_pauli_expansion_is_consistent_with_unitary(GoodGateNoPauliExpansion())
     cirq.testing.assert_pauli_expansion_is_consistent_with_unitary(GoodGateNoUnitary())

--- a/cirq-core/cirq/testing/consistent_phase_by_test.py
+++ b/cirq-core/cirq/testing/consistent_phase_by_test.py
@@ -89,7 +89,7 @@ class SemiBadPhaser:
         return SemiBadPhaser([resolver.value_of(val, recursive) for val in self.e])
 
 
-def test_assert_phase_by_is_consistent_with_unitary():
+def test_assert_phase_by_is_consistent_with_unitary() -> None:
     cirq.testing.assert_phase_by_is_consistent_with_unitary(GoodPhaser(0.5))
 
     cirq.testing.assert_phase_by_is_consistent_with_unitary(GoodQuditPhaser(0.5))

--- a/cirq-core/cirq/testing/consistent_qasm_test.py
+++ b/cirq-core/cirq/testing/consistent_qasm_test.py
@@ -51,7 +51,7 @@ class QuditGate(cirq.Gate):
         return NotImplemented
 
 
-def test_assert_qasm_is_consistent_with_unitary():
+def test_assert_qasm_is_consistent_with_unitary() -> None:
     try:
         import qiskit as _
     except ImportError:  # pragma: no cover

--- a/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
+++ b/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
@@ -18,7 +18,7 @@ import pytest
 import cirq
 
 
-def test_assert_specifies_has_unitary_if_unitary_from_matrix():
+def test_assert_specifies_has_unitary_if_unitary_from_matrix() -> None:
     class Bad:
         def _unitary_(self):
             return np.array([[1]])
@@ -28,7 +28,7 @@ def test_assert_specifies_has_unitary_if_unitary_from_matrix():
         cirq.testing.assert_specifies_has_unitary_if_unitary(Bad())
 
 
-def test_assert_specifies_has_unitary_if_unitary_from_apply():
+def test_assert_specifies_has_unitary_if_unitary_from_apply() -> None:
     class Bad(cirq.Operation):
         @property
         def qubits(self):
@@ -45,7 +45,7 @@ def test_assert_specifies_has_unitary_if_unitary_from_apply():
         cirq.testing.assert_specifies_has_unitary_if_unitary(Bad())
 
 
-def test_assert_specifies_has_unitary_if_unitary_from_decompose():
+def test_assert_specifies_has_unitary_if_unitary_from_decompose() -> None:
     class Bad:
         def _decompose_(self):
             return []
@@ -70,7 +70,7 @@ def test_assert_specifies_has_unitary_if_unitary_from_decompose():
     cirq.testing.assert_specifies_has_unitary_if_unitary(Okay())
 
 
-def test_assert_specifies_has_unitary_if_unitary_pass():
+def test_assert_specifies_has_unitary_if_unitary_pass() -> None:
     class Good:
         def _has_unitary_(self):
             return True

--- a/cirq-core/cirq/testing/consistent_unitary_test.py
+++ b/cirq-core/cirq/testing/consistent_unitary_test.py
@@ -78,7 +78,7 @@ class CleanCorrectButBorrowableIncorrectGate(cirq.Gate):
         (CleanCorrectButBorrowableIncorrectGate(use_clean_ancilla=False), False),
     ],
 )
-def test_assert_unitary_is_consistent(g, ignore_phase, is_consistent):
+def test_assert_unitary_is_consistent(g, ignore_phase, is_consistent) -> None:
     if is_consistent:
         cirq.testing.assert_unitary_is_consistent(g, ignore_phase)
         cirq.testing.assert_unitary_is_consistent(g.on(*cirq.LineQid.for_gate(g)), ignore_phase)
@@ -89,7 +89,7 @@ def test_assert_unitary_is_consistent(g, ignore_phase, is_consistent):
             cirq.testing.assert_unitary_is_consistent(g.on(*cirq.LineQid.for_gate(g)), ignore_phase)
 
 
-def test_failed_decomposition():
+def test_failed_decomposition() -> None:
     with pytest.raises(ValueError):
         cirq.testing.assert_unitary_is_consistent(FailsOnDecompostion())
 

--- a/cirq-core/cirq/testing/deprecation_test.py
+++ b/cirq-core/cirq/testing/deprecation_test.py
@@ -18,14 +18,14 @@ import pytest
 from cirq.testing import assert_deprecated
 
 
-def test_nested_assert_deprecation():
+def test_nested_assert_deprecation() -> None:
     with assert_deprecated(deadline="v1.2", count=1):
         with assert_deprecated(deadline="v1.2", count=1):
             with assert_deprecated(deadline="v1.2", count=1):
                 warnings.warn("hello, this is deprecated in v1.2")
 
 
-def test_assert_deprecated_log_handling():
+def test_assert_deprecated_log_handling() -> None:
     # correct deprecation message
     with assert_deprecated("hello", deadline="v1.2"):
         warnings.warn("hello, this is deprecated in v1.2")

--- a/cirq-core/cirq/testing/devices_test.py
+++ b/cirq-core/cirq/testing/devices_test.py
@@ -17,7 +17,7 @@ import cirq
 from cirq.testing.devices import ValidatingTestDevice
 
 
-def test_validating_types_and_qubits():
+def test_validating_types_and_qubits() -> None:
     dev = ValidatingTestDevice(
         allowed_qubit_types=(cirq.GridQubit,),
         allowed_gates=(cirq.XPowGate,),
@@ -37,7 +37,7 @@ def test_validating_types_and_qubits():
         dev.validate_operation(cirq.Y(cirq.GridQubit(0, 0)))
 
 
-def test_validating_locality():
+def test_validating_locality() -> None:
     dev = ValidatingTestDevice(
         allowed_qubit_types=(cirq.GridQubit,),
         allowed_gates=(cirq.CZPowGate, cirq.MeasurementGate),
@@ -62,7 +62,7 @@ def test_validating_locality():
         )
 
 
-def test_repr():
+def test_repr() -> None:
     dev = ValidatingTestDevice(
         allowed_qubit_types=(cirq.GridQubit,),
         allowed_gates=(cirq.CZPowGate, cirq.MeasurementGate),
@@ -73,7 +73,7 @@ def test_repr():
     assert repr(dev) == 'test'
 
 
-def test_defaults():
+def test_defaults() -> None:
     dev = ValidatingTestDevice(qubits={cirq.GridQubit(0, 0)})
     assert repr(dev) == 'ValidatingTestDevice'
     assert dev.allowed_qubit_types == (cirq.GridQubit,)

--- a/cirq-core/cirq/testing/equivalent_basis_map_test.py
+++ b/cirq-core/cirq/testing/equivalent_basis_map_test.py
@@ -17,7 +17,7 @@ import cirq
 from cirq import circuits
 
 
-def test_correct_mappings():
+def test_correct_mappings() -> None:
     a, b, c = cirq.LineQubit.range(3)
     cirq.testing.assert_equivalent_computational_basis_map(
         maps={0b01: 0b01, 0b10: 0b10},
@@ -30,7 +30,7 @@ def test_correct_mappings():
     )
 
 
-def test_incorrect_mappings():
+def test_incorrect_mappings() -> None:
     a, b, c = cirq.LineQubit.range(3)
     with pytest.raises(
         AssertionError,

--- a/cirq-core/cirq/testing/equivalent_repr_eval_test.py
+++ b/cirq-core/cirq/testing/equivalent_repr_eval_test.py
@@ -18,7 +18,7 @@ import pytest
 import cirq
 
 
-def test_external():
+def test_external() -> None:
     for t in ['a', 1j]:
         cirq.testing.assert_equivalent_repr(t)
         cirq.testing.assert_equivalent_repr(t, setup_code='')
@@ -29,7 +29,7 @@ def test_external():
         cirq.testing.assert_equivalent_repr(np.array([5]))
 
 
-def test_custom_class_repr():
+def test_custom_class_repr() -> None:
     class CustomRepr:  # pragma: no cover
         setup_code = """class CustomRepr:
             def __init__(self, eq_val):
@@ -81,5 +81,5 @@ def test_custom_class_repr():
         )
 
 
-def test_imports_cirq_by_default():
+def test_imports_cirq_by_default() -> None:
     cirq.testing.assert_equivalent_repr(cirq.NamedQubit('a'))

--- a/cirq-core/cirq/testing/gate_features_test.py
+++ b/cirq-core/cirq/testing/gate_features_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_two_qubit_gate_is_abstract_can_implement():
+def test_two_qubit_gate_is_abstract_can_implement() -> None:
     class Included(cirq.testing.TwoQubitGate):
         def matrix(self):
             pass
@@ -25,7 +25,7 @@ def test_two_qubit_gate_is_abstract_can_implement():
     assert isinstance(Included(), cirq.testing.TwoQubitGate)
 
 
-def test_two_qubit_gate_validate_pass():
+def test_two_qubit_gate_validate_pass() -> None:
     class Example(cirq.testing.TwoQubitGate):
         def matrix(self):
             pass
@@ -41,7 +41,7 @@ def test_two_qubit_gate_validate_pass():
     g.validate_args([q3, q2])
 
 
-def test_two_qubit_gate_validate_wrong_number():
+def test_two_qubit_gate_validate_wrong_number() -> None:
     class Example(cirq.testing.TwoQubitGate):
         def matrix(self):
             pass
@@ -59,7 +59,7 @@ def test_two_qubit_gate_validate_wrong_number():
         g.validate_args([q1, q2, q3])
 
 
-def test_three_qubit_gate_validate():
+def test_three_qubit_gate_validate() -> None:
     class Example(cirq.testing.ThreeQubitGate):
         def matrix(self):
             pass
@@ -80,6 +80,6 @@ def test_three_qubit_gate_validate():
         g.validate_args([a, b, c, d])
 
 
-def test_does_not_support_serialization_gate():
+def test_does_not_support_serialization_gate() -> None:
     g = cirq.testing.DoesNotSupportSerializationGate(n_qubits=4)
     assert g.num_qubits() == 4

--- a/cirq-core/cirq/testing/json_test.py
+++ b/cirq-core/cirq/testing/json_test.py
@@ -17,16 +17,16 @@ import pytest
 from cirq.testing.json import spec_for
 
 
-def test_module_missing_json_test_data():
+def test_module_missing_json_test_data() -> None:
     with pytest.raises(ValueError, match="json_test_data"):
         spec_for('cirq.testing.test_data.test_module_missing_json_test_data')
 
 
-def test_module_missing_testspec():
+def test_module_missing_testspec() -> None:
     with pytest.raises(ValueError, match="TestSpec"):
         spec_for('cirq.testing.test_data.test_module_missing_testspec')
 
 
-def test_missing_module():
+def test_missing_module() -> None:
     with pytest.raises(ModuleNotFoundError):
         spec_for('non_existent')

--- a/cirq-core/cirq/testing/lin_alg_utils_test.py
+++ b/cirq-core/cirq/testing/lin_alg_utils_test.py
@@ -28,14 +28,14 @@ from cirq.testing import (
 
 
 @pytest.mark.parametrize('dim', range(1, 10))
-def test_random_superposition(dim):
+def test_random_superposition(dim) -> None:
     state = random_superposition(dim)
 
     assert dim == len(state)
     assert np.isclose(np.linalg.norm(state), 1.0)
 
 
-def test_random_superposition_deterministic_given_seed():
+def test_random_superposition_deterministic_given_seed() -> None:
     state1 = random_superposition(10, random_state=1234)
     state2 = random_superposition(10, random_state=1234)
 
@@ -43,7 +43,7 @@ def test_random_superposition_deterministic_given_seed():
 
 
 @pytest.mark.parametrize('dim', range(1, 10))
-def test_random_density_matrix(dim):
+def test_random_density_matrix(dim) -> None:
     state = random_density_matrix(dim)
 
     assert state.shape == (dim, dim)
@@ -53,14 +53,14 @@ def test_random_density_matrix(dim):
     assert np.all(eigs >= 0)
 
 
-def test_random_density_matrix_deterministic_given_seed():
+def test_random_density_matrix_deterministic_given_seed() -> None:
     state1 = random_density_matrix(10, random_state=1234)
     state2 = random_density_matrix(10, random_state=1234)
 
     np.testing.assert_equal(state1, state2)
 
 
-def test_random_unitary():
+def test_random_unitary() -> None:
     u1 = random_unitary(2)
     u2 = random_unitary(2)
     assert is_unitary(u1)
@@ -68,7 +68,7 @@ def test_random_unitary():
     assert not np.allclose(u1, u2)
 
 
-def test_random_orthogonal():
+def test_random_orthogonal() -> None:
     o1 = random_orthogonal(2)
     o2 = random_orthogonal(2)
     assert is_orthogonal(o1)
@@ -76,14 +76,14 @@ def test_random_orthogonal():
     assert not np.allclose(o1, o2)
 
 
-def test_random_orthogonal_deterministic_given_seed():
+def test_random_orthogonal_deterministic_given_seed() -> None:
     o1 = random_orthogonal(2, random_state=1234)
     o2 = random_orthogonal(2, random_state=1234)
 
     np.testing.assert_equal(o1, o2)
 
 
-def test_random_special_unitary():
+def test_random_special_unitary() -> None:
     u1 = random_special_unitary(2)
     u2 = random_special_unitary(2)
     assert is_special_unitary(u1)
@@ -91,7 +91,7 @@ def test_random_special_unitary():
     assert not np.allclose(u1, u2)
 
 
-def test_seeded_special_unitary():
+def test_seeded_special_unitary() -> None:
     u1 = random_special_unitary(2, random_state=np.random.RandomState(1))
     u2 = random_special_unitary(2, random_state=np.random.RandomState(1))
     u3 = random_special_unitary(2, random_state=np.random.RandomState(2))
@@ -99,7 +99,7 @@ def test_seeded_special_unitary():
     assert not np.allclose(u1, u3)
 
 
-def test_random_special_orthogonal():
+def test_random_special_orthogonal() -> None:
     o1 = random_special_orthogonal(2)
     o2 = random_special_orthogonal(2)
     assert is_special_orthogonal(o1)
@@ -107,14 +107,14 @@ def test_random_special_orthogonal():
     assert not np.allclose(o1, o2)
 
 
-def test_random_special_orthogonal_deterministic_given_seed():
+def test_random_special_orthogonal_deterministic_given_seed() -> None:
     o1 = random_special_orthogonal(2, random_state=1234)
     o2 = random_special_orthogonal(2, random_state=1234)
 
     np.testing.assert_equal(o1, o2)
 
 
-def test_assert_allclose_up_to_global_phase():
+def test_assert_allclose_up_to_global_phase() -> None:
     assert_allclose_up_to_global_phase(np.array([[1]]), np.array([[1j]]), atol=0)
 
     with pytest.raises(AssertionError):

--- a/cirq-core/cirq/testing/logs_test.py
+++ b/cirq-core/cirq/testing/logs_test.py
@@ -20,7 +20,7 @@ import pytest
 import cirq.testing
 
 
-def test_assert_logs_valid_single_logs():
+def test_assert_logs_valid_single_logs() -> None:
     with cirq.testing.assert_logs('apple'):
         logging.error('orange apple fruit')
 
@@ -43,7 +43,7 @@ def test_assert_logs_valid_single_logs():
         warnings.warn('orange apple fruit')
 
 
-def test_assert_logs_invalid_single_logs():
+def test_assert_logs_invalid_single_logs() -> None:
     match = (
         '^dog expected to appear in log messages but it was not found. '
         'Log messages: \\[\'orange apple fruit\'\\].$'
@@ -57,7 +57,7 @@ def test_assert_logs_invalid_single_logs():
             logging.error('orange apple fruit')
 
 
-def test_assert_logs_valid_multiple_logs():
+def test_assert_logs_valid_multiple_logs() -> None:
     with cirq.testing.assert_logs('apple', count=2):
         logging.error('orange apple fruit')
         logging.error('other')
@@ -84,7 +84,7 @@ def test_assert_logs_valid_multiple_logs():
         logging.warning('other two')
 
 
-def test_assert_logs_invalid_multiple_logs():
+def test_assert_logs_invalid_multiple_logs() -> None:
     with pytest.raises(AssertionError, match='^Expected 1 log message but got 2. Log messages.*$'):
         with cirq.testing.assert_logs('dog'):
             logging.error('orange apple fruit')
@@ -107,7 +107,7 @@ def test_assert_logs_invalid_multiple_logs():
             logging.error('whatever')
 
 
-def test_assert_logs_log_level():
+def test_assert_logs_log_level() -> None:
     # Default minlevel is WARNING, max level CRITICAL
     with cirq.testing.assert_logs('apple'):
         logging.error('orange apple fruit')
@@ -131,7 +131,7 @@ def test_assert_logs_log_level():
             logging.warning("info warning 1")
 
 
-def test_invalid_levels():
+def test_invalid_levels() -> None:
     with pytest.raises(ValueError, match="min_level.*max_level"):
         with cirq.testing.assert_logs(
             "test", min_level=logging.CRITICAL, max_level=logging.WARNING
@@ -139,7 +139,7 @@ def test_invalid_levels():
             pass
 
 
-def test_assert_logs_warnings():
+def test_assert_logs_warnings() -> None:
     # Capture all warnings in one context, so that test cases that will
     # display a warning do not do so when the test is run.
     with warnings.catch_warnings(record=True):

--- a/cirq-core/cirq/testing/no_identifier_qubit_test.py
+++ b/cirq-core/cirq/testing/no_identifier_qubit_test.py
@@ -15,16 +15,16 @@
 import cirq
 
 
-def test_named_qubit_repr():
+def test_named_qubit_repr() -> None:
     q = cirq.testing.NoIdentifierQubit()
     assert repr(q) == "cirq.testing.NoIdentifierQubit()"
 
 
-def test_comparsion_key():
+def test_comparsion_key() -> None:
     q = cirq.testing.NoIdentifierQubit()
     p = cirq.testing.NoIdentifierQubit()
     assert p == q
 
 
-def test_to_json():
+def test_to_json() -> None:
     assert cirq.testing.NoIdentifierQubit()._json_dict_() == {}

--- a/cirq-core/cirq/testing/op_tree_test.py
+++ b/cirq-core/cirq/testing/op_tree_test.py
@@ -17,7 +17,7 @@ import cirq
 from cirq.testing import assert_equivalent_op_tree
 
 
-def test_assert_equivalent_op_tree():
+def test_assert_equivalent_op_tree() -> None:
     assert_equivalent_op_tree([], [])
     a = cirq.NamedQubit("a")
     assert_equivalent_op_tree([cirq.X(a)], [cirq.X(a)])

--- a/cirq-core/cirq/testing/order_tester_test.py
+++ b/cirq-core/cirq/testing/order_tester_test.py
@@ -62,7 +62,7 @@ class MockValue:
         return f'MockValue(val={self.val!r}, ...)'
 
 
-def test_add_ordering_group_correct():
+def test_add_ordering_group_correct() -> None:
     ot = cirq.testing.OrderTester()
     ot.add_ascending(-4, 0)
     ot.add_ascending(1, 2)
@@ -70,7 +70,7 @@ def test_add_ordering_group_correct():
     ot.add_ascending_equivalence_group(float('inf'), float('inf'))
 
 
-def test_add_ordering_group_incorrect():
+def test_add_ordering_group_incorrect() -> None:
     ot = cirq.testing.OrderTester()
     ot.add_ascending(0)
     with pytest.raises(AssertionError):
@@ -88,7 +88,7 @@ def test_add_ordering_group_incorrect():
         ot.add_ascending(0)
 
 
-def test_propagates_internal_errors():
+def test_propagates_internal_errors() -> None:
     class UnorderableClass:  # pragma: no cover
         def __eq__(self, other):
             return NotImplemented
@@ -113,7 +113,7 @@ def test_propagates_internal_errors():
         ot.add_ascending(UnorderableClass())
 
 
-def test_add_ascending_equivalence_group():
+def test_add_ascending_equivalence_group() -> None:
     ot = cirq.testing.OrderTester()
     with pytest.raises(AssertionError, match='Expected X=1 to equal Y=3'):
         ot.add_ascending_equivalence_group(1, 3)
@@ -127,7 +127,7 @@ def test_add_ascending_equivalence_group():
     ot.add_ascending_equivalence_group(5)
 
 
-def test_fails_to_return_not_implemented_vs_unknown():
+def test_fails_to_return_not_implemented_vs_unknown() -> None:
     def make_impls(bad_index: int, bad_result: bool):
         def make_impl(i, op):
             def impl(x, y):
@@ -153,7 +153,7 @@ def test_fails_to_return_not_implemented_vs_unknown():
     ot.add_ascending(MockValue(1, *good_impls))
 
 
-def test_fails_on_inconsistent_hashes():
+def test_fails_on_inconsistent_hashes() -> None:
     class ModifiedHash(tuple):
         def __hash__(self):
             return super().__hash__() ^ 1

--- a/cirq-core/cirq/testing/pytest_utils_test.py
+++ b/cirq-core/cirq/testing/pytest_utils_test.py
@@ -19,7 +19,7 @@ import pytest
 import cirq
 
 
-def test_retry_once_after_timeout():
+def test_retry_once_after_timeout() -> None:
     testfunc = Mock(side_effect=[TimeoutError("first call fails"), None])
     decoratedfunc = cirq.testing.retry_once_after_timeout(testfunc)
     with pytest.warns(UserWarning, match="Retrying.*transitive TimeoutError"):
@@ -27,7 +27,7 @@ def test_retry_once_after_timeout():
     assert testfunc.call_count == 2
 
 
-def test_retry_once_with_later_random_values():
+def test_retry_once_with_later_random_values() -> None:
     testfunc = Mock(side_effect=[AssertionError("first call fails"), None])
     decoratedfunc = cirq.testing.retry_once_with_later_random_values(testfunc)
     with pytest.warns(UserWarning, match="Retrying.*failing seed.*pytest-randomly"):

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -21,7 +21,7 @@ import cirq
 import cirq.testing
 
 
-def test_random_circuit_errors():
+def test_random_circuit_errors() -> None:
     with pytest.raises(ValueError, match='but was -1'):
         _ = cirq.testing.random_circuit(qubits=5, n_moments=5, op_density=-1)
 
@@ -92,7 +92,7 @@ def test_random_circuit(
 
 
 @pytest.mark.parametrize('seed', [random.randint(0, 2**32) for _ in range(10)])
-def test_random_circuit_reproducible_with_seed(seed):
+def test_random_circuit_reproducible_with_seed(seed) -> None:
     wrappers = (lambda s: s, np.random.RandomState)
     circuits = [
         cirq.testing.random_circuit(
@@ -105,7 +105,7 @@ def test_random_circuit_reproducible_with_seed(seed):
     eq.add_equality_group(*circuits)
 
 
-def test_random_circuit_not_expected_number_of_qubits():
+def test_random_circuit_not_expected_number_of_qubits() -> None:
     circuit = cirq.testing.random_circuit(
         qubits=3, n_moments=1, op_density=1.0, gate_domain={cirq.CNOT: 2}
     )
@@ -114,7 +114,7 @@ def test_random_circuit_not_expected_number_of_qubits():
     assert len(circuit.all_qubits()) == 2
 
 
-def test_random_circuit_reproducible_between_runs():
+def test_random_circuit_reproducible_between_runs() -> None:
     circuit = cirq.testing.random_circuit(5, 8, 0.5, random_state=77)
     expected_diagram = """
                   ┌──┐
@@ -132,7 +132,7 @@ def test_random_circuit_reproducible_between_runs():
     cirq.testing.assert_has_diagram(circuit, expected_diagram)
 
 
-def test_random_two_qubit_circuit_with_czs():
+def test_random_two_qubit_circuit_with_czs() -> None:
     num_czs = lambda circuit: len(
         [o for o in circuit.all_operations() if isinstance(o.gate, cirq.CZPowGate)]
     )

--- a/cirq-core/cirq/testing/repr_pretty_tester_test.py
+++ b/cirq-core/cirq/testing/repr_pretty_tester_test.py
@@ -15,7 +15,7 @@
 import cirq.testing
 
 
-def test_fake_printer():
+def test_fake_printer() -> None:
     p = cirq.testing.FakePrinter()
     assert p.text_pretty == ""
     p.text("stuff")
@@ -24,7 +24,7 @@ def test_fake_printer():
     assert p.text_pretty == "stuff more"
 
 
-def test_assert_repr_pretty():
+def test_assert_repr_pretty() -> None:
     class TestClass:
         def _repr_pretty_(self, p, cycle):
             p.text("TestClass" if cycle else "I'm so pretty")
@@ -44,7 +44,7 @@ def test_assert_repr_pretty():
     cirq.testing.assert_repr_pretty(TestClassMultipleTexts(), "TestClass", cycle=True)
 
 
-def test_assert_repr_pretty_contains():
+def test_assert_repr_pretty_contains() -> None:
     class TestClass:
         def _repr_pretty_(self, p, cycle):
             p.text("TestClass" if cycle else "I'm so pretty")

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_grid_device():
+def test_grid_device() -> None:
     rect_device = cirq.testing.construct_grid_device(5, 7)
     rect_device_graph = rect_device.metadata.nx_graph
     isomorphism_class = nx.Graph()
@@ -33,7 +33,7 @@ def test_grid_device():
     assert nx.is_isomorphic(isomorphism_class, rect_device_graph)
 
 
-def test_grid_op_validation():
+def test_grid_op_validation() -> None:
     device = cirq.testing.construct_grid_device(5, 7)
 
     with pytest.raises(ValueError, match="Qubits not on device"):
@@ -56,7 +56,7 @@ def test_grid_op_validation():
     device.validate_operation(cirq.CNOT(cirq.GridQubit(0, 0), cirq.GridQubit(1, 0)))
 
 
-def test_ring_device():
+def test_ring_device() -> None:
     undirected_device = cirq.testing.construct_ring_device(5)
     undirected_device_graph = undirected_device.metadata.nx_graph
     assert all(q in undirected_device_graph.nodes for q in cirq.LineQubit.range(5))
@@ -74,7 +74,7 @@ def test_ring_device():
     assert nx.is_isomorphic(isomorphism_class, directed_device_graph)
 
 
-def test_ring_op_validation():
+def test_ring_op_validation() -> None:
     directed_device = cirq.testing.construct_ring_device(5, directed=True)
     undirected_device = cirq.testing.construct_ring_device(5, directed=False)
 
@@ -93,7 +93,7 @@ def test_ring_op_validation():
     directed_device.validate_operation(cirq.CNOT(cirq.LineQubit(0), cirq.LineQubit(1)))
 
 
-def test_allowed_multi_qubit_gates():
+def test_allowed_multi_qubit_gates() -> None:
     device = cirq.testing.construct_ring_device(5)
 
     device.validate_operation(cirq.MeasurementGate(1).on(cirq.LineQubit(0)))
@@ -106,7 +106,7 @@ def test_allowed_multi_qubit_gates():
     device.validate_operation(cirq.CNOT(*cirq.LineQubit.range(2)))
 
 
-def test_namedqubit_device():
+def test_namedqubit_device() -> None:
     # 4-star graph
     nx_graph = nx.Graph([("a", "b"), ("a", "c"), ("a", "d")])
 

--- a/cirq-core/cirq/testing/sample_circuits_test.py
+++ b/cirq-core/cirq/testing/sample_circuits_test.py
@@ -15,7 +15,7 @@
 import cirq
 
 
-def test_nonoptimal_toffoli_circuit():
+def test_nonoptimal_toffoli_circuit() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     cirq.testing.assert_allclose_up_to_global_phase(
         cirq.testing.nonoptimal_toffoli_circuit(q0, q1, q2).unitary(),

--- a/cirq-core/cirq/testing/sample_gates_test.py
+++ b/cirq-core/cirq/testing/sample_gates_test.py
@@ -19,7 +19,7 @@ from cirq.testing import sample_gates
 
 
 @pytest.mark.parametrize('theta', np.linspace(0, 2 * np.pi, 20))
-def test_phase_using_clean_ancilla(theta: float):
+def test_phase_using_clean_ancilla(theta: float) -> None:
     g = sample_gates.PhaseUsingCleanAncilla(theta)
     q = cirq.LineQubit(0)
     qubit_order = cirq.QubitOrder.explicit([q], fallback=cirq.QubitOrder.DEFAULT)
@@ -45,7 +45,7 @@ def test_phase_using_clean_ancilla(theta: float):
     'target_bitsize, phase_state', [(1, 0), (1, 1), (2, 0), (2, 1), (2, 2), (2, 3)]
 )
 @pytest.mark.parametrize('ancilla_bitsize', [1, 4])
-def test_phase_using_dirty_ancilla(target_bitsize, phase_state, ancilla_bitsize):
+def test_phase_using_dirty_ancilla(target_bitsize, phase_state, ancilla_bitsize) -> None:
     g = sample_gates.PhaseUsingDirtyAncilla(phase_state, target_bitsize, ancilla_bitsize)
     q = cirq.LineQubit.range(target_bitsize)
     qubit_order = cirq.QubitOrder.explicit(q, fallback=cirq.QubitOrder.DEFAULT)

--- a/cirq-core/cirq/transformers/analytical_decompositions/pauli_string_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/pauli_string_decomposition_test.py
@@ -28,7 +28,7 @@ from cirq.transformers.analytical_decompositions import unitary_to_pauli_string
 @pytest.mark.parametrize(
     'pauli_string', [''.join(p) for p in itertools.product(['', 'I', 'X', 'Y', 'Z'], repeat=4)]
 )
-def test_unitary_to_pauli_string(pauli_string: str, phase: complex):
+def test_unitary_to_pauli_string(pauli_string: str, phase: complex) -> None:
     want = DensePauliString(pauli_string, coefficient=phase)
     got = unitary_to_pauli_string(protocols.unitary(want))
     assert got is not None
@@ -36,7 +36,7 @@ def test_unitary_to_pauli_string(pauli_string: str, phase: complex):
     assert np.isclose(cast(np.complex128, want.coefficient), cast(np.complex128, got.coefficient))
 
 
-def test_unitary_to_pauli_string_non_pauli_input():
+def test_unitary_to_pauli_string_non_pauli_input() -> None:
     got = unitary_to_pauli_string(protocols.unitary(T))
     assert got is None
 
@@ -50,7 +50,7 @@ def test_unitary_to_pauli_string_non_pauli_input():
     assert got is None
 
 
-def test_invalid_input():
+def test_invalid_input() -> None:
     with pytest.raises(ValueError, match='Input has a non-square shape.*'):
         _ = unitary_to_pauli_string(np.zeros((2, 3)))
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -52,7 +52,7 @@ def _skip_if_scipy(*, version_is_greater_than_1_5_0: bool) -> Callable[[Callable
         cirq.CCX._unitary_(),
     ],
 )
-def test_three_qubit_matrix_to_operations(u):
+def test_three_qubit_matrix_to_operations(u) -> None:
     a, b, c = cirq.LineQubit.range(3)
     operations = cirq.three_qubit_matrix_to_operations(a, b, c, u)
     final_circuit = cirq.Circuit(operations)
@@ -69,7 +69,7 @@ def test_three_qubit_matrix_to_operations(u):
 
 
 @_skip_if_scipy(version_is_greater_than_1_5_0=False)
-def test_three_qubit_matrix_to_operations_errors():
+def test_three_qubit_matrix_to_operations_errors() -> None:
     a, b, c = cirq.LineQubit.range(3)
     with pytest.raises(ValueError, match="(8,8)"):
         cirq.three_qubit_matrix_to_operations(a, b, c, np.eye(2))
@@ -82,7 +82,7 @@ def test_three_qubit_matrix_to_operations_errors():
 # environment like that, we'll need to ignore the coverage somehow conditionally on
 # the scipy version.
 @_skip_if_scipy(version_is_greater_than_1_5_0=True)
-def test_three_qubit_matrix_to_operations_scipy_error():  # pragma: no cover
+def test_three_qubit_matrix_to_operations_scipy_error() -> None:  # pragma: no cover
     a, b, c = cirq.LineQubit.range(3)
     with pytest.raises(ImportError, match="three_qubit.*1.5.0+"):
         cirq.three_qubit_matrix_to_operations(a, b, c, np.eye(8))
@@ -100,7 +100,7 @@ def test_three_qubit_matrix_to_operations_scipy_error():  # pragma: no cover
         (np.array([0.3, 0.3, -0.3, -0.3]), 2),
     ],
 )
-def test_cs_to_ops(theta, num_czs):
+def test_cs_to_ops(theta, num_czs) -> None:
     a, b, c = cirq.LineQubit.range(3)
     cs = _theta_to_cs(theta)
     circuit_cs = cirq.Circuit(_cs_to_ops(a, b, c, theta))
@@ -126,7 +126,7 @@ def _theta_to_cs(theta: np.ndarray) -> np.ndarray:
     return np.block([[c, -s], [s, c]])
 
 
-def test_multiplexed_angles():
+def test_multiplexed_angles() -> None:
     theta = [random() * np.pi, random() * np.pi, random() * np.pi, random() * np.pi]
 
     angles = _multiplexed_angles(theta)
@@ -190,7 +190,7 @@ def test_multiplexed_angles():
         [([-0.3, 0.3, -0.3, -0.3]), 4],
     ],
 )
-def test_middle_multiplexor(angles, num_cnots):
+def test_middle_multiplexor(angles, num_cnots) -> None:
     a, b, c = cirq.LineQubit.range(3)
     eigvals = np.exp(np.array(angles) * np.pi * 1j)
     d = np.diag(np.sqrt(eigvals))
@@ -212,7 +212,7 @@ def test_middle_multiplexor(angles, num_cnots):
 
 
 @pytest.mark.parametrize("shift_left", [True, False])
-def test_two_qubit_multiplexor_to_circuit(shift_left):
+def test_two_qubit_multiplexor_to_circuit(shift_left) -> None:
     a, b, c = cirq.LineQubit.range(3)
     u1 = cirq.testing.random_unitary(4)
     u2 = cirq.testing.random_unitary(4)

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz_test.py
@@ -52,7 +52,7 @@ from cirq.transformers.analytical_decompositions.two_qubit_to_cz import (
         ]
     )(1e-8 * 2 / 3, 1e-8 * 4 / 3),
 )
-def test_is_trivial_angle(rad, expected):
+def test_is_trivial_angle(rad, expected) -> None:
     tolerance = 1e-8
     out = _is_trivial_angle(rad, tolerance)
     assert out == expected, f'rad = {rad}'
@@ -163,7 +163,7 @@ def test_two_to_ops_equivalent_and_bounded_for_known_and_random(
     assert_cz_depth_below(operations_with_full, max_full_cz_depth, True)
 
 
-def test_trivial_parity_interaction_corner_case():
+def test_trivial_parity_interaction_corner_case() -> None:
     q0 = cirq.NamedQubit('q0')
     q1 = cirq.NamedQubit('q1')
     nearPi4 = np.pi / 4 * 0.99
@@ -172,7 +172,7 @@ def test_trivial_parity_interaction_corner_case():
     assert len(circuit) == 2
 
 
-def test_kak_decomposition_depth_full_cz():
+def test_kak_decomposition_depth_full_cz() -> None:
     a, b = cirq.LineQubit.range(2)
 
     # Random.
@@ -210,7 +210,7 @@ def test_kak_decomposition_depth_full_cz():
     assert len(c) <= 4
 
 
-def test_kak_decomposition_depth_partial_cz():
+def test_kak_decomposition_depth_partial_cz() -> None:
     a, b = cirq.LineQubit.range(2)
 
     # Random.
@@ -250,7 +250,7 @@ def test_kak_decomposition_depth_partial_cz():
         np.diag(np.exp(1j * np.pi * np.random.random(4))),
     ],
 )
-def test_decompose_to_diagonal_and_circuit(v):
+def test_decompose_to_diagonal_and_circuit(v) -> None:
     b, c = cirq.LineQubit.range(2)
     diagonal, ops = two_qubit_matrix_to_diagonal_and_cz_operations(b, c, v, atol=1e-8)
     assert cirq.is_diagonal(diagonal)
@@ -259,7 +259,7 @@ def test_decompose_to_diagonal_and_circuit(v):
     cirq.testing.assert_allclose_up_to_global_phase(circuit_unitary, v, atol=2e-6)
 
 
-def test_remove_partial_czs_or_fail():
+def test_remove_partial_czs_or_fail() -> None:
     CZ = cirq.CZ(*cirq.LineQubit.range(2))
     assert (
         cirq.transformers.analytical_decompositions.two_qubit_to_cz._remove_partial_czs_or_fail(

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_fsim_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_fsim_test.py
@@ -65,7 +65,7 @@ FEASIBLE_FSIM_GATES = [
 
 
 @pytest.mark.parametrize('obj', UNITARY_OBJS)
-def test_decompose_two_qubit_interaction_into_two_b_gates(obj: Any):
+def test_decompose_two_qubit_interaction_into_two_b_gates(obj: Any) -> None:
     circuit = cirq.Circuit(
         _decompose_two_qubit_interaction_into_two_b_gates(obj, qubits=cirq.LineQubit.range(2))
     )
@@ -75,7 +75,7 @@ def test_decompose_two_qubit_interaction_into_two_b_gates(obj: Any):
     np.testing.assert_allclose(cirq.unitary(circuit), desired_unitary, atol=1e-6)
 
 
-def test_decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops_fail():
+def test_decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops_fail() -> None:
     c = _decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops(
         qubits=cirq.LineQubit.range(2),
         fsim_gate=cirq.FSimGate(theta=np.pi / 2, phi=0),
@@ -108,7 +108,7 @@ def test_decompose_two_qubit_interaction_into_four_fsim_gates_equivalence(
     assert cirq.approx_eq(circuit.unitary(qubit_order=qubits), desired_unitary, atol=1e-4)
 
 
-def test_decompose_two_qubit_interaction_into_four_fsim_gates_validate():
+def test_decompose_two_qubit_interaction_into_four_fsim_gates_validate() -> None:
     iswap = cirq.FSimGate(theta=np.pi / 2, phi=0)
     with pytest.raises(ValueError, match='fsim_gate.theta'):
         cirq.decompose_two_qubit_interaction_into_four_fsim_gates(
@@ -127,7 +127,7 @@ def test_decompose_two_qubit_interaction_into_four_fsim_gates_validate():
         cirq.decompose_two_qubit_interaction_into_four_fsim_gates(np.eye(4), fsim_gate=fsim)
 
 
-def test_decompose_two_qubit_interaction_into_four_fsim_gates():
+def test_decompose_two_qubit_interaction_into_four_fsim_gates() -> None:
     iswap = cirq.FSimGate(theta=np.pi / 2, phi=0)
 
     # Defaults to line qubits.
@@ -153,7 +153,7 @@ def test_decompose_two_qubit_interaction_into_four_fsim_gates():
     assert set(c.all_qubits()) == set(cirq.LineQubit.range(10, 12))
 
 
-def test_sticky_0_to_1():
+def test_sticky_0_to_1() -> None:
     assert _sticky_0_to_1(-1, atol=1e-8) is None
 
     assert _sticky_0_to_1(-1e-6, atol=1e-8) is None

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms_test.py
@@ -130,7 +130,7 @@ def assert_ms_depth_below(operations, threshold):
     (2, _random_double_MS_effect()) for _ in range(10)
 ])
 # yapf: enable
-def test_two_to_ops(max_ms_depth: int, effect: np.ndarray):
+def test_two_to_ops(max_ms_depth: int, effect: np.ndarray) -> None:
     q0 = cirq.NamedQubit('q0')
     q1 = cirq.NamedQubit('q1')
 

--- a/cirq-core/cirq/transformers/drop_empty_moments_test.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments_test.py
@@ -15,7 +15,7 @@
 import cirq
 
 
-def test_drop():
+def test_drop() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     cirq.testing.assert_same_circuits(
@@ -28,7 +28,7 @@ def test_drop():
     )
 
 
-def test_drop_empty_moments():
+def test_drop_empty_moments() -> None:
     q1, q2 = cirq.LineQubit.range(2)
     c_nested = cirq.FrozenCircuit(
         cirq.Moment(), cirq.Moment(), cirq.Moment([cirq.CNOT(q1, q2)]), cirq.Moment()

--- a/cirq-core/cirq/transformers/eject_phased_paulis_test.py
+++ b/cirq-core/cirq/transformers/eject_phased_paulis_test.py
@@ -98,7 +98,7 @@ def quick_circuit(*moments: Iterable[cirq.OP_TREE]) -> cirq.Circuit:
     )
 
 
-def test_absorbs_z():
+def test_absorbs_z() -> None:
     q = cirq.NamedQubit('q')
     x = sympy.Symbol('x')
 
@@ -165,7 +165,7 @@ def test_absorbs_z():
     )
 
 
-def test_crosses_czs():
+def test_crosses_czs() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     x = sympy.Symbol('x')
@@ -232,7 +232,7 @@ def test_crosses_czs():
     )
 
 
-def test_toggles_measurements():
+def test_toggles_measurements() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     x = sympy.Symbol('x')
@@ -289,7 +289,7 @@ def test_toggles_measurements():
     )
 
 
-def test_eject_phased_xz():
+def test_eject_phased_xz() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.Circuit(
@@ -305,7 +305,7 @@ def test_eject_phased_xz():
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(c, c_expected, 1e-8)
 
 
-def test_cancels_other_full_w():
+def test_cancels_other_full_w() -> None:
     q = cirq.NamedQubit('q')
     x = sympy.Symbol('x')
     y = sympy.Symbol('y')
@@ -365,7 +365,7 @@ def test_cancels_other_full_w():
     )
 
 
-def test_phases_partial_ws():
+def test_phases_partial_ws() -> None:
     q = cirq.NamedQubit('q')
     x = sympy.Symbol('x')
     y = sympy.Symbol('y')
@@ -420,7 +420,7 @@ def test_phases_partial_ws():
 
 
 @pytest.mark.parametrize('sym', [sympy.Symbol('x'), sympy.Symbol('x') + 1])
-def test_blocked_by_unknown_and_symbols(sym):
+def test_blocked_by_unknown_and_symbols(sym) -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -442,7 +442,7 @@ def test_blocked_by_unknown_and_symbols(sym):
     )
 
 
-def test_blocked_by_nocompile_tag():
+def test_blocked_by_nocompile_tag() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -453,7 +453,7 @@ def test_blocked_by_nocompile_tag():
     )
 
 
-def test_zero_x_rotation():
+def test_zero_x_rotation() -> None:
     a = cirq.NamedQubit('a')
 
     assert_optimizes(before=quick_circuit([cirq.rx(0)(a)]), expected=quick_circuit([cirq.rx(0)(a)]))

--- a/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation_test.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation_test.py
@@ -41,7 +41,7 @@ _random_2Q_unitaries = np.array([random_special_unitary(4, random_state=_rng) fo
 
 @pytest.mark.parametrize('tabulation', [sycamore_tabulation, sqrt_iswap_tabulation])
 @pytest.mark.parametrize('target', _random_2Q_unitaries)
-def test_gate_compilation_matches_expected_max_infidelity(tabulation, target):
+def test_gate_compilation_matches_expected_max_infidelity(tabulation, target) -> None:
     result = tabulation.compile_two_qubit_gate(target)
 
     assert result.success
@@ -50,7 +50,7 @@ def test_gate_compilation_matches_expected_max_infidelity(tabulation, target):
 
 
 @pytest.mark.parametrize('tabulation', [sycamore_tabulation, sqrt_iswap_tabulation])
-def test_gate_compilation_on_base_gate_standard(tabulation):
+def test_gate_compilation_on_base_gate_standard(tabulation) -> None:
     base_gate = tabulation.base_gate
 
     result = tabulation.compile_two_qubit_gate(base_gate)
@@ -61,7 +61,7 @@ def test_gate_compilation_on_base_gate_standard(tabulation):
     assert fidelity > 0.99999
 
 
-def test_gate_compilation_on_base_gate_identity():
+def test_gate_compilation_on_base_gate_identity() -> None:
     tabulation = two_qubit_gate_product_tabulation(np.eye(4), 0.25)
     base_gate = tabulation.base_gate
 
@@ -73,7 +73,7 @@ def test_gate_compilation_on_base_gate_identity():
     assert fidelity > 0.99999
 
 
-def test_gate_compilation_missing_points_raises_error():
+def test_gate_compilation_missing_points_raises_error() -> None:
     with pytest.raises(ValueError, match='Failed to tabulate a'):
         two_qubit_gate_product_tabulation(
             np.eye(4), 0.4, allow_missed_points=False, random_state=_rng
@@ -81,7 +81,7 @@ def test_gate_compilation_missing_points_raises_error():
 
 
 @pytest.mark.parametrize('seed', [0, 1])
-def test_sycamore_gate_tabulation(seed):
+def test_sycamore_gate_tabulation(seed) -> None:
     base_gate = cirq.unitary(cirq.FSimGate(np.pi / 2, np.pi / 6))
     tab = two_qubit_gate_product_tabulation(
         base_gate, 0.1, sample_scaling=2, random_state=np.random.RandomState(seed)
@@ -90,7 +90,7 @@ def test_sycamore_gate_tabulation(seed):
     assert result.success
 
 
-def test_sycamore_gate_tabulation_repr():
+def test_sycamore_gate_tabulation_repr() -> None:
     simple_tabulation = TwoQubitGateTabulation(
         np.array([[(1 + 0j), 0j, 0j, 0j]], dtype=np.complex128),
         np.array([[(1 + 0j), 0j, 0j, 0j]], dtype=np.complex128),
@@ -102,7 +102,7 @@ def test_sycamore_gate_tabulation_repr():
     assert_equivalent_repr(simple_tabulation)
 
 
-def test_sycamore_gate_tabulation_eq():
+def test_sycamore_gate_tabulation_eq() -> None:
     assert sycamore_tabulation == sycamore_tabulation
     assert sycamore_tabulation != sqrt_iswap_tabulation
     assert sycamore_tabulation != 1

--- a/cirq-core/cirq/transformers/insertion_sort_test.py
+++ b/cirq-core/cirq/transformers/insertion_sort_test.py
@@ -16,7 +16,7 @@ import cirq
 import cirq.transformers
 
 
-def test_insertion_sort():
+def test_insertion_sort() -> None:
     c = cirq.Circuit(
         cirq.CZ(cirq.q(2), cirq.q(1)),
         cirq.CZ(cirq.q(2), cirq.q(4)),

--- a/cirq-core/cirq/transformers/merge_k_qubit_gates_test.py
+++ b/cirq-core/cirq/transformers/merge_k_qubit_gates_test.py
@@ -37,7 +37,7 @@ def assert_optimizes(optimized: cirq.AbstractCircuit, expected: cirq.AbstractCir
     cirq.testing.assert_same_circuits(optimized, expected)
 
 
-def test_merge_1q_unitaries():
+def test_merge_1q_unitaries() -> None:
     q, q2 = cirq.LineQubit.range(2)
     # 1. Combines trivial 1q sequence.
     c = cirq.Circuit(cirq.X(q) ** 0.5, cirq.Z(q) ** 0.5, cirq.X(q) ** -0.5)
@@ -57,7 +57,7 @@ def test_merge_1q_unitaries():
     assert isinstance(c[-1][q].gate, cirq.MatrixGate)
 
 
-def test_respects_nocompile_tags():
+def test_respects_nocompile_tags() -> None:
     q = cirq.NamedQubit("q")
     c = cirq.Circuit(
         [cirq.Z(q), cirq.H(q), cirq.X(q), cirq.H(q), cirq.X(q).with_tags("nocompile"), cirq.H(q)]
@@ -70,12 +70,12 @@ def test_respects_nocompile_tags():
     assert isinstance(c[-1][q].gate, cirq.MatrixGate)
 
 
-def test_ignores_2qubit_target():
+def test_ignores_2qubit_target() -> None:
     c = cirq.Circuit(cirq.CZ(*cirq.LineQubit.range(2)))
     assert_optimizes(optimized=cirq.merge_k_qubit_unitaries(c, k=1), expected=c)
 
 
-def test_ignore_unsupported_gate():
+def test_ignore_unsupported_gate() -> None:
     class UnsupportedExample(cirq.testing.SingleQubitGate):
         pass
 
@@ -83,7 +83,7 @@ def test_ignore_unsupported_gate():
     assert_optimizes(optimized=cirq.merge_k_qubit_unitaries(c, k=1), expected=c)
 
 
-def test_1q_rewrite():
+def test_1q_rewrite() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
         cirq.X(q0), cirq.Y(q0), cirq.X(q1), cirq.CZ(q0, q1), cirq.Y(q1), cirq.measure(q0, q1)
@@ -98,12 +98,12 @@ def test_1q_rewrite():
     )
 
 
-def test_merge_k_qubit_unitaries_raises():
+def test_merge_k_qubit_unitaries_raises() -> None:
     with pytest.raises(ValueError, match="k should be greater than or equal to 1"):
         _ = cirq.merge_k_qubit_unitaries(cirq.Circuit())
 
 
-def test_merge_complex_circuit_preserving_moment_structure():
+def test_merge_complex_circuit_preserving_moment_structure() -> None:
     q = cirq.LineQubit.range(3)
     c_orig = cirq.Circuit(
         cirq.Moment(cirq.H.on_each(*q)),
@@ -191,7 +191,7 @@ a: ═════════════════════════�
     )
 
 
-def test_merge_k_qubit_unitaries_deep():
+def test_merge_k_qubit_unitaries_deep() -> None:
     q = cirq.LineQubit.range(2)
     h_cz_y = [cirq.H(q[0]), cirq.CZ(*q), cirq.Y(q[1])]
     c_orig = cirq.Circuit(
@@ -253,7 +253,7 @@ def test_merge_k_qubit_unitaries_deep():
     cirq.testing.assert_same_circuits(c_new_matrix, c_expected_matrix)
 
 
-def test_merge_k_qubit_unitaries_deep_recurses_on_large_circuit_op():
+def test_merge_k_qubit_unitaries_deep_recurses_on_large_circuit_op() -> None:
     q = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q[0]), cirq.H(q[0]), cirq.CNOT(*q)))

--- a/cirq-core/cirq/transformers/qubit_management_transformers_test.py
+++ b/cirq-core/cirq/transformers/qubit_management_transformers_test.py
@@ -66,7 +66,7 @@ def get_decompose_func(gate_type, qm):
     return decompose_func
 
 
-def test_map_clean_and_borrowable_qubits_greedy_types():
+def test_map_clean_and_borrowable_qubits_greedy_types() -> None:
     qm = cirq.ops.SimpleQubitManager()
     q = cirq.LineQubit.range(2)
     g = GateAllocInDecompose(1)
@@ -130,7 +130,7 @@ ancilla_1: ───X───X───
     )
 
 
-def test_map_clean_and_borrowable_qubits_borrows():
+def test_map_clean_and_borrowable_qubits_borrows() -> None:
     qm = cirq.ops.SimpleQubitManager()
     op = GateAllocAndBorrowInDecompose(3).on(cirq.NamedQubit("original"))
     extra = cirq.LineQubit.range(3)
@@ -233,7 +233,7 @@ original: ────@───@───@───@─────@───@�
     )
 
 
-def test_map_clean_and_borrowable_qubits_deallocates_only_once():
+def test_map_clean_and_borrowable_qubits_deallocates_only_once() -> None:
     q = [cirq.ops.BorrowableQubit(i) for i in range(2)] + [cirq.q('q')]
     circuit = cirq.Circuit(cirq.X.on_each(*q), cirq.Y(q[1]), cirq.Z(q[1]))
     greedy_mm = cirq.GreedyQubitManager(prefix="a", size=2)

--- a/cirq-core/cirq/transformers/randomized_measurements_test.py
+++ b/cirq-core/cirq/transformers/randomized_measurements_test.py
@@ -18,7 +18,7 @@ import cirq
 import cirq.transformers.randomized_measurements as rand_meas
 
 
-def test_randomized_measurements_appends_two_moments_on_returned_circuit():
+def test_randomized_measurements_appends_two_moments_on_returned_circuit() -> None:
     # Create a 4-qubit circuit
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit_pre = cirq.Circuit(
@@ -34,7 +34,9 @@ def test_randomized_measurements_appends_two_moments_on_returned_circuit():
         assert num_moments_post == num_moments_pre + 2
 
 
-def test_append_randomized_measurements_leaves_qubits_not_in_specified_subsystem_unchanged():
+def test_append_randomized_measurements_leaves_qubits_not_in_specified_subsystem_unchanged() -> (
+    None
+):
     # Create a 4-qubit circuit
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit([cirq.H(q0), cirq.CNOT(q0, q1), cirq.CNOT(q1, q2), cirq.CNOT(q2, q3)])
@@ -46,7 +48,9 @@ def test_append_randomized_measurements_leaves_qubits_not_in_specified_subsystem
     assert circuit.operation_at(q3, 4) is None
 
 
-def test_append_randomized_measurements_leaves_qubits_not_in_noncontinuous_subsystem_unchanged():
+def test_append_random_measurements_leaves_qubits_not_in_noncontinuous_subsystem_unchanged() -> (
+    None
+):
     # Create a 4-qubit circuit
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit([cirq.H(q0), cirq.CNOT(q0, q1), cirq.CNOT(q1, q2), cirq.CNOT(q2, q3)])
@@ -59,7 +63,7 @@ def test_append_randomized_measurements_leaves_qubits_not_in_noncontinuous_subsy
     assert circuit.operation_at(q3, 4) is None
 
 
-def test_exception():
+def test_exception() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit([cirq.H(q0), cirq.CNOT(q0, q1), cirq.CNOT(q1, q2), cirq.CNOT(q2, q3)])
 

--- a/cirq-core/cirq/transformers/routing/line_initial_mapper_test.py
+++ b/cirq-core/cirq/transformers/routing/line_initial_mapper_test.py
@@ -66,7 +66,7 @@ def construct_valid_circuit():
     )
 
 
-def test_valid_circuit():
+def test_valid_circuit() -> None:
     # Any circuit with a (full connectivity) graph of disjoint lines should be directly
     # executable after mapping a a supporting device topology without the need for inserting
     # any swaps.
@@ -79,7 +79,7 @@ def test_valid_circuit():
     device.validate_circuit(mapped_circuit)
 
 
-def test_long_line_on_grid_device():
+def test_long_line_on_grid_device() -> None:
     # tests
     #   -if strategy is able to map a single long line onto the device whenever the device topology
     #   supports it (i.e. is Hamiltonian)
@@ -106,7 +106,7 @@ def test_long_line_on_grid_device():
         mapper.initial_mapping(step_circuit)
 
 
-def test_small_circuit_on_grid_device():
+def test_small_circuit_on_grid_device() -> None:
     circuit = construct_small_circuit()
     device_graph = cirq.testing.construct_grid_device(7, 7).metadata.nx_graph
     mapper = cirq.LineInitialMapper(device_graph)
@@ -126,7 +126,7 @@ def test_small_circuit_on_grid_device():
     cirq.testing.assert_same_circuits(circuit.transform_qubits(mapping), expected_circuit)
 
 
-def test_small_circuit_on_ring_device():
+def test_small_circuit_on_ring_device() -> None:
     circuit = construct_small_circuit()
     device_graph = cirq.testing.construct_ring_device(10, directed=True).metadata.nx_graph
 
@@ -187,7 +187,7 @@ def test_large_random_circuits_grid_device(
     assert nx.is_connected(nx.induced_subgraph(glob_device_graph, mapping.values()))
 
 
-def test_repr():
+def test_repr() -> None:
     device_graph = cirq.testing.construct_grid_device(7, 7).metadata.nx_graph
     mapper = cirq.LineInitialMapper(device_graph)
     cirq.testing.assert_equivalent_repr(mapper, setup_code='import cirq\nimport networkx as nx')

--- a/cirq-core/cirq/transformers/routing/route_circuit_cqc_test.py
+++ b/cirq-core/cirq/transformers/routing/route_circuit_cqc_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_directed_device():
+def test_directed_device() -> None:
     device = cirq.testing.construct_ring_device(10, directed=True)
     device_graph = device.metadata.nx_graph
     with pytest.raises(ValueError, match="Device graph must be undirected."):
@@ -33,7 +33,7 @@ def test_directed_device():
         for op_density in [0.3, 0.5, 0.7]
     ],
 )
-def test_route_small_circuit_random(n_qubits, n_moments, op_density, seed):
+def test_route_small_circuit_random(n_qubits, n_moments, op_density, seed) -> None:
     c_orig = cirq.testing.random_circuit(
         qubits=n_qubits, n_moments=n_moments, op_density=op_density, random_state=seed
     )
@@ -47,7 +47,7 @@ def test_route_small_circuit_random(n_qubits, n_moments, op_density, seed):
     )
 
 
-def test_high_qubit_count():
+def test_high_qubit_count() -> None:
     c_orig = cirq.testing.random_circuit(qubits=40, n_moments=350, op_density=0.4, random_state=0)
     device = cirq.testing.construct_grid_device(7, 7)
     device_graph = device.metadata.nx_graph
@@ -56,7 +56,7 @@ def test_high_qubit_count():
     device.validate_circuit(c_routed)
 
 
-def test_multi_qubit_gate_inputs():
+def test_multi_qubit_gate_inputs() -> None:
     device = cirq.testing.construct_grid_device(4, 4)
     device_graph = device.metadata.nx_graph
     router = cirq.RouteCQC(device_graph)
@@ -97,7 +97,7 @@ def test_multi_qubit_gate_inputs():
     device.validate_circuit(c_routed)
 
 
-def test_circuit_with_measurement_gates():
+def test_circuit_with_measurement_gates() -> None:
     device = cirq.testing.construct_ring_device(3)
     device_graph = device.metadata.nx_graph
     q = cirq.LineQubit.range(3)
@@ -108,7 +108,7 @@ def test_circuit_with_measurement_gates():
     cirq.testing.assert_same_circuits(routed_circuit, circuit)
 
 
-def test_circuit_with_two_qubit_intermediate_measurement_gate():
+def test_circuit_with_two_qubit_intermediate_measurement_gate() -> None:
     device = cirq.testing.construct_ring_device(2)
     device_graph = device.metadata.nx_graph
     router = cirq.RouteCQC(device_graph)
@@ -121,7 +121,7 @@ def test_circuit_with_two_qubit_intermediate_measurement_gate():
     device.validate_circuit(routed_circuit)
 
 
-def test_circuit_with_multi_qubit_intermediate_measurement_gate_and_with_default_key():
+def test_circuit_with_multi_qubit_intermediate_measurement_gate_and_with_default_key() -> None:
     device = cirq.testing.construct_ring_device(3)
     device_graph = device.metadata.nx_graph
     router = cirq.RouteCQC(device_graph)
@@ -135,7 +135,7 @@ def test_circuit_with_multi_qubit_intermediate_measurement_gate_and_with_default
     cirq.testing.assert_same_circuits(routed_circuit, expected)
 
 
-def test_circuit_with_multi_qubit_intermediate_measurement_gate_with_custom_key():
+def test_circuit_with_multi_qubit_intermediate_measurement_gate_with_custom_key() -> None:
     device = cirq.testing.construct_ring_device(3)
     device_graph = device.metadata.nx_graph
     router = cirq.RouteCQC(device_graph)
@@ -150,7 +150,7 @@ def test_circuit_with_multi_qubit_intermediate_measurement_gate_with_custom_key(
         )
 
 
-def test_circuit_with_non_unitary_and_global_phase():
+def test_circuit_with_non_unitary_and_global_phase() -> None:
     device = cirq.testing.construct_ring_device(4)
     device_graph = device.metadata.nx_graph
     q = cirq.LineQubit.range(3)
@@ -176,7 +176,7 @@ def test_circuit_with_non_unitary_and_global_phase():
     cirq.testing.assert_same_circuits(routed_circuit, expected)
 
 
-def test_circuit_with_tagged_ops():
+def test_circuit_with_tagged_ops() -> None:
     device = cirq.testing.construct_ring_device(4)
     device_graph = device.metadata.nx_graph
     q = cirq.LineQubit.range(3)
@@ -205,7 +205,7 @@ def test_circuit_with_tagged_ops():
     cirq.testing.assert_same_circuits(routed_circuit, expected)
 
 
-def test_already_valid_circuit():
+def test_already_valid_circuit() -> None:
     device = cirq.testing.construct_ring_device(10)
     device_graph = device.metadata.nx_graph
     circuit = cirq.Circuit(
@@ -222,7 +222,7 @@ def test_already_valid_circuit():
     cirq.testing.assert_same_circuits(routed_circuit, circuit)
 
 
-def test_empty_circuit():
+def test_empty_circuit() -> None:
     device = cirq.testing.construct_grid_device(5, 5)
     device_graph = device.metadata.nx_graph
     empty_circuit = cirq.Circuit()
@@ -235,7 +235,7 @@ def test_empty_circuit():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     device = cirq.testing.construct_ring_device(10)
     device_graph = device.metadata.nx_graph
     router = cirq.RouteCQC(device_graph)

--- a/cirq-core/cirq/transformers/routing/visualize_routed_circuit_test.py
+++ b/cirq-core/cirq/transformers/routing/visualize_routed_circuit_test.py
@@ -17,7 +17,7 @@ import pytest
 import cirq
 
 
-def test_routed_circuit_with_mapping_simple():
+def test_routed_circuit_with_mapping_simple() -> None:
     q = cirq.LineQubit.range(2)
     circuit = cirq.Circuit([cirq.Moment(cirq.SWAP(q[0], q[1]).with_tags(cirq.RoutingSwapTag()))])
     expected_diagram = """
@@ -57,7 +57,7 @@ def test_routed_circuit_with_mapping_simple():
         cirq.routed_circuit_with_mapping(circuit)
 
 
-def test_routed_circuit_with_mapping_multi_swaps():
+def test_routed_circuit_with_mapping_multi_swaps() -> None:
     q = cirq.LineQubit.range(6)
     circuit = cirq.Circuit(
         [

--- a/cirq-core/cirq/transformers/synchronize_terminal_measurements_test.py
+++ b/cirq-core/cirq/transformers/synchronize_terminal_measurements_test.py
@@ -48,14 +48,14 @@ def assert_optimizes(before, after, measure_only_moment=True, with_context=False
     cirq.testing.assert_same_circuits(transformed_circuit, c_expected)
 
 
-def test_no_move():
+def test_no_move() -> None:
     q1 = cirq.NamedQubit('q1')
     before = cirq.Circuit([cirq.Moment([cirq.H(q1)])])
     after = before
     assert_optimizes(before=before, after=after)
 
 
-def test_simple_align():
+def test_simple_align() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     before = cirq.Circuit(
@@ -76,7 +76,7 @@ def test_simple_align():
     assert_optimizes(before=before, after=before, with_context=True)
 
 
-def test_simple_partial_align():
+def test_simple_partial_align() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     before = cirq.Circuit(
@@ -96,7 +96,7 @@ def test_simple_partial_align():
     assert_optimizes(before=before, after=before, with_context=True)
 
 
-def test_slide_forward_one():
+def test_slide_forward_one() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     q3 = cirq.NamedQubit('q3')
@@ -119,7 +119,7 @@ def test_slide_forward_one():
     assert_optimizes(before=before, after=after_no_compile, with_context=True)
 
 
-def test_no_slide_forward_one():
+def test_no_slide_forward_one() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     q3 = cirq.NamedQubit('q3')
@@ -128,7 +128,7 @@ def test_no_slide_forward_one():
     assert_optimizes(before=before, after=after, measure_only_moment=False)
 
 
-def test_blocked_shift_one():
+def test_blocked_shift_one() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     before = cirq.Circuit(
@@ -150,7 +150,7 @@ def test_blocked_shift_one():
     assert_optimizes(before=before, after=before, with_context=True)
 
 
-def test_complex_move():
+def test_complex_move() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     q3 = cirq.NamedQubit('q3')
@@ -182,7 +182,7 @@ def test_complex_move():
     assert_optimizes(before=before, after=before, with_context=True)
 
 
-def test_complex_move_no_slide():
+def test_complex_move_no_slide() -> None:
     q1 = cirq.NamedQubit('q1')
     q2 = cirq.NamedQubit('q2')
     q3 = cirq.NamedQubit('q3')
@@ -208,13 +208,13 @@ def test_complex_move_no_slide():
     assert_optimizes(before=before, after=before, measure_only_moment=False, with_context=True)
 
 
-def test_multi_qubit():
+def test_multi_qubit() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.H(q1), cirq.measure(q0, q1, key='m'))
     assert_optimizes(before=circuit, after=circuit)
 
 
-def test_classically_controlled_op():
+def test_classically_controlled_op() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
         cirq.H(q0), cirq.measure(q0, key='m'), cirq.X(q1).with_classical_controls('m')

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset_test.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from cirq.protocols.decompose_protocol import DecomposeResult
 
 
-def test_compilation_target_gateset():
+def test_compilation_target_gateset() -> None:
     class ExampleTargetGateset(cirq.CompilationTargetGateset):
         def __init__(self):
             super().__init__(cirq.AnyUnitaryGateFamily(2))
@@ -94,7 +94,7 @@ class ExampleCXTargetGateset(cirq.TwoQubitCompilationTargetGateset):
         )
 
 
-def test_two_qubit_compilation_leaves_single_gates_in_gateset():
+def test_two_qubit_compilation_leaves_single_gates_in_gateset() -> None:
     q = cirq.LineQubit.range(2)
     gateset = ExampleCXTargetGateset()
 
@@ -105,7 +105,7 @@ def test_two_qubit_compilation_leaves_single_gates_in_gateset():
     cirq.testing.assert_same_circuits(cirq.optimize_for_target_gateset(c, gateset=gateset), c)
 
 
-def test_two_qubit_compilation_merges_runs_of_single_qubit_gates():
+def test_two_qubit_compilation_merges_runs_of_single_qubit_gates() -> None:
     q = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CNOT(*q), cirq.X(q[0]), cirq.Y(q[0]), cirq.CNOT(*q))
     cirq.testing.assert_same_circuits(
@@ -118,7 +118,7 @@ def test_two_qubit_compilation_merges_runs_of_single_qubit_gates():
     )
 
 
-def test_two_qubit_compilation_decompose_operation_not_implemented():
+def test_two_qubit_compilation_decompose_operation_not_implemented() -> None:
     gateset = ExampleCXTargetGateset()
     q = cirq.LineQubit.range(3)
     assert gateset.decompose_to_target_gateset(cirq.measure(q[0]), 1) is NotImplemented
@@ -130,7 +130,7 @@ def test_two_qubit_compilation_decompose_operation_not_implemented():
     assert gateset.decompose_to_target_gateset(cirq.CCZ(*q), 1) is NotImplemented
 
 
-def test_two_qubit_compilation_merge_and_replace_to_target_gateset():
+def test_two_qubit_compilation_merge_and_replace_to_target_gateset() -> None:
     q = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.Moment(cirq.Z(q[1]), cirq.X(q[0])),
@@ -164,7 +164,7 @@ def test_two_qubit_compilation_merge_and_replace_to_target_gateset():
     )
 
 
-def test_two_qubit_compilation_merge_and_replace_inefficient_component():
+def test_two_qubit_compilation_merge_and_replace_inefficient_component() -> None:
     q = cirq.LineQubit.range(2)
     c_orig = cirq.Circuit(
         cirq.Moment(cirq.X(q[0])),
@@ -208,7 +208,7 @@ m: ═════════════════════════�
     )
 
 
-def test_two_qubit_compilation_replaces_only_if_2q_gate_count_is_less():
+def test_two_qubit_compilation_replaces_only_if_2q_gate_count_is_less() -> None:
     class ExampleTargetGateset(cirq.TwoQubitCompilationTargetGateset):
         def __init__(self):
             super().__init__(cirq.X, cirq.CNOT)
@@ -228,7 +228,7 @@ def test_two_qubit_compilation_replaces_only_if_2q_gate_count_is_less():
     cirq.testing.assert_same_circuits(c_new, c_expected)
 
 
-def test_create_transformer_with_kwargs_raises():
+def test_create_transformer_with_kwargs_raises() -> None:
     with pytest.raises(SyntaxError, match="must not contain `context`"):
         cirq.create_transformer_with_kwargs(
             cirq.merge_k_qubit_unitaries, k=2, context=cirq.TransformerContext()

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
@@ -56,7 +56,7 @@ def assert_optimization_not_broken(circuit: cirq.Circuit):
     )
 
 
-def test_convert_to_cz_preserving_moment_structure():
+def test_convert_to_cz_preserving_moment_structure() -> None:
     q = cirq.LineQubit.range(5)
     op = lambda q0, q1: cirq.H(q1).controlled_by(q0)
     c_orig = cirq.Circuit(
@@ -100,7 +100,7 @@ def test_convert_to_cz_preserving_moment_structure():
     )
 
 
-def test_clears_paired_cnot():
+def test_clears_paired_cnot() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimizes(
         before=cirq.Circuit(cirq.Moment(cirq.CNOT(a, b)), cirq.Moment(cirq.CNOT(a, b))),
@@ -108,7 +108,7 @@ def test_clears_paired_cnot():
     )
 
 
-def test_ignores_czs_separated_by_parameterized():
+def test_ignores_czs_separated_by_parameterized() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimizes(
         before=cirq.Circuit(
@@ -129,19 +129,19 @@ def test_ignores_czs_separated_by_parameterized():
     )
 
 
-def test_cnots_separated_by_single_gates_correct():
+def test_cnots_separated_by_single_gates_correct() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimization_not_broken(cirq.Circuit(cirq.CNOT(a, b), cirq.H(b), cirq.CNOT(a, b)))
 
 
-def test_czs_separated_by_single_gates_correct():
+def test_czs_separated_by_single_gates_correct() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimization_not_broken(
         cirq.Circuit(cirq.CZ(a, b), cirq.X(b), cirq.X(b), cirq.X(b), cirq.CZ(a, b))
     )
 
 
-def test_inefficient_circuit_correct():
+def test_inefficient_circuit_correct() -> None:
     t = 0.1
     v = 0.11
     a, b = cirq.LineQubit.range(2)
@@ -166,7 +166,7 @@ def test_inefficient_circuit_correct():
     )
 
 
-def test_optimizes_single_iswap():
+def test_optimizes_single_iswap() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.ISWAP(a, b))
     assert_optimization_not_broken(c)
@@ -174,7 +174,7 @@ def test_optimizes_single_iswap():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
 
 
-def test_optimizes_tagged_partial_cz():
+def test_optimizes_tagged_partial_cz() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit((cirq.CZ**0.5)(a, b).with_tags('mytag'))
     assert_optimization_not_broken(c)
@@ -184,7 +184,7 @@ def test_optimizes_tagged_partial_cz():
     ), 'It should take 2 CZ gates to decompose a CZ**0.5 gate'
 
 
-def test_not_decompose_czs():
+def test_not_decompose_czs() -> None:
     circuit = cirq.Circuit(
         cirq.CZPowGate(exponent=1, global_shift=-0.5).on(*cirq.LineQubit.range(2))
     )
@@ -201,7 +201,7 @@ def test_not_decompose_czs():
         ),
     ),
 )
-def test_decompose_partial_czs(circuit):
+def test_decompose_partial_czs(circuit) -> None:
     circuit = cirq.optimize_for_target_gateset(
         circuit, gateset=cirq.CZTargetGateset(), ignore_failures=False
     )
@@ -216,7 +216,7 @@ def test_decompose_partial_czs(circuit):
     assert num_part_cz == 0
 
 
-def test_not_decompose_partial_czs():
+def test_not_decompose_partial_czs() -> None:
     circuit = cirq.Circuit(
         cirq.CZPowGate(exponent=0.1, global_shift=-0.5)(*cirq.LineQubit.range(2))
     )
@@ -232,7 +232,7 @@ def test_not_decompose_partial_czs():
     assert num_part_cz == 1
 
 
-def test_avoids_decompose_when_matrix_available():
+def test_avoids_decompose_when_matrix_available() -> None:
     class OtherXX(cirq.testing.TwoQubitGate):  # pragma: no cover
         def _has_unitary_(self) -> bool:
             return True
@@ -261,7 +261,7 @@ def test_avoids_decompose_when_matrix_available():
     assert len(c) == 0
 
 
-def test_composite_gates_without_matrix():
+def test_composite_gates_without_matrix() -> None:
     class CompositeExample(cirq.testing.SingleQubitGate):
         def _decompose_(self, qubits):
             yield cirq.X(qubits[0])
@@ -289,7 +289,7 @@ def test_composite_gates_without_matrix():
     )
 
 
-def test_unsupported_gate():
+def test_unsupported_gate() -> None:
     class UnsupportedExample(cirq.testing.TwoQubitGate):
         pass
 
@@ -319,11 +319,11 @@ def test_unsupported_gate():
         cirq.CZTargetGateset(additional_gates=()),
     ],
 )
-def test_repr(gateset):
+def test_repr(gateset) -> None:
     cirq.testing.assert_equivalent_repr(gateset)
 
 
-def test_with_commutation():
+def test_with_commutation() -> None:
     c = cirq.Circuit(
         cirq.CZ(cirq.q(0), cirq.q(1)), cirq.CZ(cirq.q(1), cirq.q(2)), cirq.CZ(cirq.q(0), cirq.q(1))
     )
@@ -335,7 +335,7 @@ def test_with_commutation():
     assert got == cirq.Circuit(cirq.CZ(cirq.q(1), cirq.q(2)))
 
 
-def test_reorder_operations_and_preserve_moment_structure_raises():
+def test_reorder_operations_and_preserve_moment_structure_raises() -> None:
     with pytest.raises(
         ValueError, match='reorder_operations and preserve_moment_structure can not both be True'
     ):

--- a/cirq-core/cirq/transformers/target_gatesets/sqrt_iswap_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/sqrt_iswap_gateset_test.py
@@ -60,7 +60,7 @@ def assert_optimization_not_broken(
     )
 
 
-def test_convert_to_sqrt_iswap_preserving_moment_structure():
+def test_convert_to_sqrt_iswap_preserving_moment_structure() -> None:
     q = cirq.LineQubit.range(5)
     op = lambda q0, q1: cirq.H(q1).controlled_by(q0)
     c_orig = cirq.Circuit(
@@ -112,7 +112,7 @@ def test_convert_to_sqrt_iswap_preserving_moment_structure():
     ],
 )
 @pytest.mark.parametrize('use_sqrt_iswap_inv', [True, False])
-def test_two_qubit_gates_with_symbols(gate: cirq.Gate, use_sqrt_iswap_inv: bool):
+def test_two_qubit_gates_with_symbols(gate: cirq.Gate, use_sqrt_iswap_inv: bool) -> None:
     # Note that even though these gates are not natively supported by
     # `cirq.parameterized_2q_op_to_sqrt_iswap_operations`, the transformation succeeds because
     # `cirq.optimize_for_target_gateset` also relies on `cirq.decompose` as a fallback.
@@ -142,12 +142,12 @@ def test_two_qubit_gates_with_symbols(gate: cirq.Gate, use_sqrt_iswap_inv: bool)
         )
 
 
-def test_sqrt_iswap_gateset_raises():
+def test_sqrt_iswap_gateset_raises() -> None:
     with pytest.raises(ValueError, match="`required_sqrt_iswap_count` must be 0, 1, 2, or 3"):
         _ = cirq.SqrtIswapTargetGateset(required_sqrt_iswap_count=4)
 
 
-def test_sqrt_iswap_gateset_eq():
+def test_sqrt_iswap_gateset_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.SqrtIswapTargetGateset(), cirq.SqrtIswapTargetGateset(use_sqrt_iswap_inv=False)
@@ -179,11 +179,11 @@ def test_sqrt_iswap_gateset_eq():
         cirq.SqrtIswapTargetGateset(additional_gates=()),
     ],
 )
-def test_sqrt_iswap_gateset_repr(gateset):
+def test_sqrt_iswap_gateset_repr(gateset) -> None:
     cirq.testing.assert_equivalent_repr(gateset)
 
 
-def test_simplifies_sqrt_iswap():
+def test_simplifies_sqrt_iswap() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimizes(
         before=cirq.Circuit(
@@ -204,7 +204,7 @@ def test_simplifies_sqrt_iswap():
     )
 
 
-def test_simplifies_sqrt_iswap_inv():
+def test_simplifies_sqrt_iswap_inv() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimizes(
         use_sqrt_iswap_inv=True,
@@ -226,7 +226,7 @@ def test_simplifies_sqrt_iswap_inv():
     )
 
 
-def test_works_with_tags():
+def test_works_with_tags() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimizes(
         before=cirq.Circuit(
@@ -240,7 +240,7 @@ def test_works_with_tags():
     )
 
 
-def test_no_touch_single_sqrt_iswap():
+def test_no_touch_single_sqrt_iswap() -> None:
     a, b = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
         [
@@ -252,7 +252,7 @@ def test_no_touch_single_sqrt_iswap():
     assert_optimizes(before=circuit, expected=circuit)
 
 
-def test_no_touch_single_sqrt_iswap_inv():
+def test_no_touch_single_sqrt_iswap_inv() -> None:
     a, b = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
         [
@@ -264,19 +264,19 @@ def test_no_touch_single_sqrt_iswap_inv():
     assert_optimizes(before=circuit, expected=circuit, use_sqrt_iswap_inv=True)
 
 
-def test_cnots_separated_by_single_gates_correct():
+def test_cnots_separated_by_single_gates_correct() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimization_not_broken(cirq.Circuit(cirq.CNOT(a, b), cirq.H(b), cirq.CNOT(a, b)))
 
 
-def test_czs_separated_by_single_gates_correct():
+def test_czs_separated_by_single_gates_correct() -> None:
     a, b = cirq.LineQubit.range(2)
     assert_optimization_not_broken(
         cirq.Circuit(cirq.CZ(a, b), cirq.X(b), cirq.X(b), cirq.X(b), cirq.CZ(a, b))
     )
 
 
-def test_inefficient_circuit_correct():
+def test_inefficient_circuit_correct() -> None:
     t = 0.1
     v = 0.11
     a, b = cirq.LineQubit.range(2)
@@ -301,7 +301,7 @@ def test_inefficient_circuit_correct():
     )
 
 
-def test_optimizes_single_iswap():
+def test_optimizes_single_iswap() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.ISWAP(a, b))
     assert_optimization_not_broken(c)
@@ -311,7 +311,7 @@ def test_optimizes_single_iswap():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
 
 
-def test_optimizes_single_inv_sqrt_iswap():
+def test_optimizes_single_inv_sqrt_iswap() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.SQRT_ISWAP_INV(a, b))
     assert_optimization_not_broken(c)
@@ -321,7 +321,7 @@ def test_optimizes_single_inv_sqrt_iswap():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 1
 
 
-def test_optimizes_single_iswap_require0():
+def test_optimizes_single_iswap_require0() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CNOT(a, b), cirq.CNOT(a, b))  # Minimum 0 sqrt-iSWAP
     assert_optimization_not_broken(c, required_sqrt_iswap_count=0)
@@ -331,7 +331,7 @@ def test_optimizes_single_iswap_require0():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 0
 
 
-def test_optimizes_single_iswap_require0_raises():
+def test_optimizes_single_iswap_require0_raises() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CNOT(a, b))  # Minimum 2 sqrt-iSWAP
     with pytest.raises(ValueError, match='cannot be decomposed into exactly 0 sqrt-iSWAP gates'):
@@ -342,7 +342,7 @@ def test_optimizes_single_iswap_require0_raises():
         )
 
 
-def test_optimizes_single_iswap_require1():
+def test_optimizes_single_iswap_require1() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.SQRT_ISWAP_INV(a, b))  # Minimum 1 sqrt-iSWAP
     assert_optimization_not_broken(c, required_sqrt_iswap_count=1)
@@ -352,7 +352,7 @@ def test_optimizes_single_iswap_require1():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 1
 
 
-def test_optimizes_single_iswap_require1_raises():
+def test_optimizes_single_iswap_require1_raises() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.CNOT(a, b))  # Minimum 2 sqrt-iSWAP
     with pytest.raises(ValueError, match='cannot be decomposed into exactly 1 sqrt-iSWAP gates'):
@@ -363,7 +363,7 @@ def test_optimizes_single_iswap_require1_raises():
         )
 
 
-def test_optimizes_single_iswap_require2():
+def test_optimizes_single_iswap_require2() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.SQRT_ISWAP_INV(a, b))  # Minimum 1 sqrt-iSWAP but 2 possible
     assert_optimization_not_broken(c, required_sqrt_iswap_count=2)
@@ -373,7 +373,7 @@ def test_optimizes_single_iswap_require2():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
 
 
-def test_optimizes_single_iswap_require2_raises():
+def test_optimizes_single_iswap_require2_raises() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.SWAP(a, b))  # Minimum 3 sqrt-iSWAP
     with pytest.raises(ValueError, match='cannot be decomposed into exactly 2 sqrt-iSWAP gates'):
@@ -384,7 +384,7 @@ def test_optimizes_single_iswap_require2_raises():
         )
 
 
-def test_optimizes_single_iswap_require3():
+def test_optimizes_single_iswap_require3() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.ISWAP(a, b))  # Minimum 2 sqrt-iSWAP but 3 possible
     assert_optimization_not_broken(c, required_sqrt_iswap_count=3)
@@ -394,7 +394,7 @@ def test_optimizes_single_iswap_require3():
     assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 3
 
 
-def test_optimizes_single_inv_sqrt_iswap_require3():
+def test_optimizes_single_inv_sqrt_iswap_require3() -> None:
     a, b = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.SQRT_ISWAP_INV(a, b))
     assert_optimization_not_broken(c, required_sqrt_iswap_count=3)

--- a/cirq-core/cirq/value/angle_test.py
+++ b/cirq-core/cirq/value/angle_test.py
@@ -19,7 +19,7 @@ import sympy
 import cirq
 
 
-def test_canonicalize_half_turns():
+def test_canonicalize_half_turns() -> None:
     assert cirq.canonicalize_half_turns(0) == 0
     assert cirq.canonicalize_half_turns(1) == +1
     assert cirq.canonicalize_half_turns(-1) == +1
@@ -34,7 +34,7 @@ def test_canonicalize_half_turns():
     assert cirq.canonicalize_half_turns(sympy.Symbol('a') * 0 + 3) == 1
 
 
-def test_chosen_angle_to_half_turns():
+def test_chosen_angle_to_half_turns() -> None:
     assert cirq.chosen_angle_to_half_turns() == 1
     assert cirq.chosen_angle_to_half_turns(default=0.5) == 0.5
     assert cirq.chosen_angle_to_half_turns(half_turns=0.25, default=0.75) == 0.25
@@ -54,7 +54,7 @@ def test_chosen_angle_to_half_turns():
         _ = cirq.chosen_angle_to_half_turns(half_turns=0, rads=0, degs=0)
 
 
-def test_chosen_angle_to_canonical_half_turns():
+def test_chosen_angle_to_canonical_half_turns() -> None:
     assert cirq.chosen_angle_to_canonical_half_turns() == 1
     assert cirq.chosen_angle_to_canonical_half_turns(default=0.5) == 0.5
     assert cirq.chosen_angle_to_canonical_half_turns(half_turns=0.25, default=0.75) == 0.25

--- a/cirq-core/cirq/value/classical_data_test.py
+++ b/cirq-core/cirq/value/classical_data_test.py
@@ -22,7 +22,7 @@ mkey_c = cirq.MeasurementKey('c')
 two_qubits = tuple(cirq.LineQubit.range(2))
 
 
-def test_init():
+def test_init() -> None:
     cd = cirq.ClassicalDataDictionaryStore()
     assert cd.records == {}
     assert cd.keys() == ()
@@ -44,7 +44,7 @@ def test_init():
     }
 
 
-def test_record_measurement():
+def test_record_measurement() -> None:
     cd = cirq.ClassicalDataDictionaryStore()
     cd.record_measurement(mkey_m, (0, 1), two_qubits)
     assert cd.records == {mkey_m: [(0, 1)]}
@@ -52,7 +52,7 @@ def test_record_measurement():
     assert cd.measured_qubits == {mkey_m: [two_qubits]}
 
 
-def test_record_measurement_errors():
+def test_record_measurement_errors() -> None:
     cd = cirq.ClassicalDataDictionaryStore()
     with pytest.raises(ValueError, match='3 measurements but 2 qubits'):
         cd.record_measurement(mkey_m, (0, 1, 2), two_qubits)
@@ -68,14 +68,14 @@ def test_record_measurement_errors():
         cd.record_measurement(mkey_m, (1, 0), tuple(cirq.LineQid.range(2, dimension=3)))
 
 
-def test_record_channel_measurement():
+def test_record_channel_measurement() -> None:
     cd = cirq.ClassicalDataDictionaryStore()
     cd.record_channel_measurement(mkey_m, 1)
     assert cd.channel_records == {mkey_m: [1]}
     assert cd.keys() == (mkey_m,)
 
 
-def test_record_channel_measurement_errors():
+def test_record_channel_measurement_errors() -> None:
     cd = cirq.ClassicalDataDictionaryStore()
     cd.record_channel_measurement(mkey_m, 1)
     cd.record_channel_measurement(mkey_m, 1)
@@ -88,7 +88,7 @@ def test_record_channel_measurement_errors():
         cd.record_channel_measurement(mkey_m, 1)
 
 
-def test_get_int():
+def test_get_int() -> None:
     cd = cirq.ClassicalDataDictionaryStore()
     cd.record_measurement(mkey_m, (0, 1), two_qubits)
     assert cd.get_int(mkey_m) == 1
@@ -106,7 +106,7 @@ def test_get_int():
         cd.get_int(mkey_m)
 
 
-def test_copy():
+def test_copy() -> None:
     cd = cirq.ClassicalDataDictionaryStore(
         _records={mkey_m: [(0, 1)]},
         _measured_qubits={mkey_m: [two_qubits]},
@@ -129,7 +129,7 @@ def test_copy():
     assert cd1.measurement_types == cd.measurement_types
 
 
-def test_repr():
+def test_repr() -> None:
     cd = cirq.ClassicalDataDictionaryStore(
         _records={mkey_m: [(0, 1)]},
         _measured_qubits={mkey_m: [two_qubits]},

--- a/cirq-core/cirq/value/periodic_value_test.py
+++ b/cirq-core/cirq/value/periodic_value_test.py
@@ -18,7 +18,7 @@ import sympy
 import cirq
 
 
-def test_periodic_value_equality():
+def test_periodic_value_equality() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.PeriodicValue(1, 2),
@@ -34,7 +34,7 @@ def test_periodic_value_equality():
     eq.add_equality_group(cirq.PeriodicValue(2, 4))
 
 
-def test_periodic_value_approx_eq_basic():
+def test_periodic_value_approx_eq_basic() -> None:
     assert cirq.approx_eq(cirq.PeriodicValue(1.0, 2.0), cirq.PeriodicValue(1.0, 2.0), atol=0.1)
     assert cirq.approx_eq(cirq.PeriodicValue(1.0, 2.0), cirq.PeriodicValue(1.2, 2.0), atol=0.3)
     assert not cirq.approx_eq(cirq.PeriodicValue(1.0, 2.0), cirq.PeriodicValue(1.2, 2.0), atol=0.1)
@@ -49,12 +49,12 @@ def test_periodic_value_approx_eq_basic():
     )
 
 
-def test_periodic_value_approx_eq_normalized():
+def test_periodic_value_approx_eq_normalized() -> None:
     assert cirq.approx_eq(cirq.PeriodicValue(1.0, 3.0), cirq.PeriodicValue(4.1, 3.0), atol=0.2)
     assert cirq.approx_eq(cirq.PeriodicValue(1.0, 3.0), cirq.PeriodicValue(-2.1, 3.0), atol=0.2)
 
 
-def test_periodic_value_approx_eq_boundary():
+def test_periodic_value_approx_eq_boundary() -> None:
     assert cirq.approx_eq(cirq.PeriodicValue(0.0, 2.0), cirq.PeriodicValue(1.9, 2.0), atol=0.2)
     assert cirq.approx_eq(cirq.PeriodicValue(0.1, 2.0), cirq.PeriodicValue(1.9, 2.0), atol=0.3)
     assert cirq.approx_eq(cirq.PeriodicValue(1.9, 2.0), cirq.PeriodicValue(0.1, 2.0), atol=0.3)
@@ -64,7 +64,7 @@ def test_periodic_value_approx_eq_boundary():
     assert cirq.approx_eq(cirq.PeriodicValue(0.4, 1.0), cirq.PeriodicValue(0.6, 1.0), atol=0.3)
 
 
-def test_periodic_value_types_mismatch():
+def test_periodic_value_types_mismatch() -> None:
     assert not cirq.approx_eq(cirq.PeriodicValue(0.0, 2.0), 0.0, atol=0.2)
     assert not cirq.approx_eq(0.0, cirq.PeriodicValue(0.0, 2.0), atol=0.2)
 
@@ -79,7 +79,9 @@ def test_periodic_value_types_mismatch():
     ],
 )
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_periodic_value_is_parameterized(value, is_parameterized, parameter_names, resolve_fn):
+def test_periodic_value_is_parameterized(
+    value, is_parameterized, parameter_names, resolve_fn
+) -> None:
     assert cirq.is_parameterized(value) == is_parameterized
     assert cirq.parameter_names(value) == parameter_names
     resolved = resolve_fn(value, {p: 1 for p in parameter_names})
@@ -98,5 +100,5 @@ def test_periodic_value_is_parameterized(value, is_parameterized, parameter_name
         cirq.PeriodicValue(sympy.Symbol('v'), 3),
     ],
 )
-def test_periodic_value_repr(val):
+def test_periodic_value_repr(val) -> None:
     cirq.testing.assert_equivalent_repr(val)

--- a/cirq-core/cirq/value/probability_test.py
+++ b/cirq-core/cirq/value/probability_test.py
@@ -18,11 +18,11 @@ import cirq
 
 
 @pytest.mark.parametrize('p', [0.0, 0.1, 0.6, 1.0])
-def test_validate_probability_valid(p):
+def test_validate_probability_valid(p) -> None:
     assert p == cirq.validate_probability(p, 'p')
 
 
 @pytest.mark.parametrize('p', [-0.1, 1.1])
-def test_validate_probability_invalid(p):
+def test_validate_probability_invalid(p) -> None:
     with pytest.raises(ValueError, match='p'):
         cirq.validate_probability(p, 'p')

--- a/cirq-core/cirq/value/value_equality_attr_test.py
+++ b/cirq-core/cirq/value/value_equality_attr_test.py
@@ -54,7 +54,7 @@ class BasicCb(BasicC):
     pass
 
 
-def test_value_equality_basic():
+def test_value_equality_basic() -> None:
 
     # Lookup works across equivalent types.
     v = {BasicC(1): 4, BasicCa(2): 5}
@@ -69,7 +69,7 @@ def test_value_equality_basic():
     eq.add_equality_group(BasicCa(3))
 
 
-def test_value_equality_manual():
+def test_value_equality_manual() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(MasqueradePositiveD(3), BasicD(3))
     eq.add_equality_group(MasqueradePositiveD(4), MasqueradePositiveD(4), BasicD(4))
@@ -105,7 +105,7 @@ class UnhashableCb(UnhashableC):
     pass
 
 
-def test_value_equality_unhashable():
+def test_value_equality_unhashable() -> None:
     # Not possible to use as a dictionary key.
     with pytest.raises(TypeError, match='unhashable'):
         _ = {UnhashableC(1): 4}
@@ -143,7 +143,7 @@ class DistinctCb(DistinctC):
     pass
 
 
-def test_value_equality_distinct_child_types():
+def test_value_equality_distinct_child_types() -> None:
     # Lookup is distinct across child types.
     v = {DistinctC(1): 4, DistinctCa(1): 5, DistinctCb(1): 6}
     assert v[DistinctC(1)] == 4
@@ -168,7 +168,7 @@ class ApproxE:
         return self.x
 
 
-def test_value_equality_approximate():
+def test_value_equality_approximate() -> None:
     assert cirq.approx_eq(ApproxE(0.0), ApproxE(0.0), atol=0.1)
     assert cirq.approx_eq(ApproxE(0.0), ApproxE(0.2), atol=0.3)
     assert not cirq.approx_eq(ApproxE(0.0), ApproxE(0.2), atol=0.1)
@@ -187,13 +187,13 @@ class PeriodicF:
         return self.x % self.n
 
 
-def test_value_equality_approximate_specialized():
+def test_value_equality_approximate_specialized() -> None:
     assert PeriodicF(1, 4) != PeriodicF(5, 4)
     assert cirq.approx_eq(PeriodicF(1, 4), PeriodicF(5, 4), atol=0.1)
     assert not cirq.approx_eq(PeriodicF(1, 4), PeriodicF(6, 4), atol=0.1)
 
 
-def test_value_equality_approximate_not_supported():
+def test_value_equality_approximate_not_supported() -> None:
     assert not cirq.approx_eq(BasicC(0.0), BasicC(0.1), atol=0.2)
 
 
@@ -222,7 +222,7 @@ class ApproxGb(ApproxG):
     pass
 
 
-def test_value_equality_approximate_typing():
+def test_value_equality_approximate_typing() -> None:
     assert not cirq.approx_eq(ApproxE(0.0), PeriodicF(0.0, 1.0), atol=0.1)
     assert cirq.approx_eq(ApproxEa(0.0), ApproxEb(0.0), atol=0.1)
     assert cirq.approx_eq(ApproxG(0.0), ApproxG(0.0), atol=0.1)
@@ -230,7 +230,7 @@ def test_value_equality_approximate_typing():
     assert not cirq.approx_eq(ApproxG(0.0), ApproxGb(0.0), atol=0.1)
 
 
-def test_value_equality_forgot_method():
+def test_value_equality_forgot_method() -> None:
     with pytest.raises(TypeError, match='_value_equality_values_'):
 
         @cirq.value_equality
@@ -238,7 +238,7 @@ def test_value_equality_forgot_method():
             pass
 
 
-def test_bad_manual_cls_incompatible_args():
+def test_bad_manual_cls_incompatible_args() -> None:
     with pytest.raises(ValueError, match='incompatible'):
 
         @cirq.value_equality(manual_cls=True, distinct_child_types=True)
@@ -246,7 +246,7 @@ def test_bad_manual_cls_incompatible_args():
             pass
 
 
-def test_bad_manual_cls_forgot_method():
+def test_bad_manual_cls_forgot_method() -> None:
     with pytest.raises(TypeError, match='_value_equality_values_cls_'):
 
         @cirq.value_equality(manual_cls=True)

--- a/cirq-core/cirq/vis/histogram_test.py
+++ b/cirq-core/cirq/vis/histogram_test.py
@@ -22,7 +22,7 @@ from cirq.vis import integrated_histogram
 
 @pytest.mark.usefixtures('closefigures')
 @pytest.mark.parametrize('data', [range(10), {f'key_{i}': i for i in range(10)}])
-def test_integrated_histogram(data):
+def test_integrated_histogram(data) -> None:
     ax = integrated_histogram(
         data,
         title='Test Plot',
@@ -40,7 +40,7 @@ def test_integrated_histogram(data):
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_multiple_plots():
+def test_multiple_plots() -> None:
     _, ax = plt.subplots(1, 1)
     n = 53
     data = np.random.random_sample((2, n))

--- a/cirq-core/cirq/vis/state_histogram_test.py
+++ b/cirq-core/cirq/vis/state_histogram_test.py
@@ -24,7 +24,7 @@ from cirq.devices import GridQubit
 from cirq.vis import state_histogram
 
 
-def test_get_state_histogram():
+def test_get_state_histogram() -> None:
     simulator = cirq.Simulator()
 
     q0 = GridQubit(0, 0)
@@ -40,7 +40,7 @@ def test_get_state_histogram():
     np.testing.assert_equal(values_to_plot, expected_values)
 
 
-def test_get_state_histogram_multi_1():
+def test_get_state_histogram_multi_1() -> None:
     qubits = cirq.LineQubit.range(4)
     c = cirq.Circuit(
         cirq.X.on_each(*qubits[1:]), cirq.measure(*qubits)  # One multi-qubit measurement
@@ -51,7 +51,7 @@ def test_get_state_histogram_multi_1():
     np.testing.assert_equal(values_to_plot, expected_values)
 
 
-def test_get_state_histogram_multi_2():
+def test_get_state_histogram_multi_2() -> None:
     qubits = cirq.LineQubit.range(4)
     c = cirq.Circuit(
         cirq.X.on_each(*qubits[1:]),
@@ -65,7 +65,7 @@ def test_get_state_histogram_multi_2():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_plot_state_histogram_result():
+def test_plot_state_histogram_result() -> None:
     qubits = cirq.LineQubit.range(4)
     c = cirq.Circuit(
         cirq.X.on_each(*qubits[1:]), cirq.measure(*qubits)  # One multi-qubit measurement
@@ -83,7 +83,7 @@ def test_plot_state_histogram_result():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_plot_state_histogram_collection():
+def test_plot_state_histogram_collection() -> None:
     qubits = cirq.LineQubit.range(4)
     c = cirq.Circuit(
         cirq.X.on_each(*qubits[1:]), cirq.measure(*qubits)  # One multi-qubit measurement

--- a/cirq-core/cirq/vis/vis_utils_test.py
+++ b/cirq-core/cirq/vis/vis_utils_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import cirq
 
 
-def test_relative_luminance():
+def test_relative_luminance() -> None:
     rl = cirq.vis.relative_luminance([100, 100, 100])
     assert np.isclose(rl, 55560.6360)
     rl = cirq.vis.relative_luminance([0, 1, 2])

--- a/cirq-core/cirq/work/observable_grouping_test.py
+++ b/cirq-core/cirq/work/observable_grouping_test.py
@@ -15,7 +15,7 @@
 import cirq
 
 
-def test_group_settings_greedy_one_group():
+def test_group_settings_greedy_one_group() -> None:
     qubits = cirq.LineQubit.range(2)
     q0, q1 = qubits
     terms = [cirq.X(q0), cirq.Y(q1)]
@@ -33,7 +33,7 @@ def test_group_settings_greedy_one_group():
     assert set(the_group) == set(settings)
 
 
-def test_group_settings_greedy_two_groups():
+def test_group_settings_greedy_two_groups() -> None:
     qubits = cirq.LineQubit.range(2)
     q0, q1 = qubits
     terms = [cirq.X(q0) * cirq.X(q1), cirq.Y(q0) * cirq.Y(q1)]
@@ -48,7 +48,7 @@ def test_group_settings_greedy_two_groups():
     assert set(grouped_settings.keys()) == set(group_max_settings_should_be)
 
 
-def test_group_settings_greedy_single_item():
+def test_group_settings_greedy_single_item() -> None:
     qubits = cirq.LineQubit.range(2)
     q0, q1 = qubits
     term = cirq.X(q0) * cirq.X(q1)
@@ -60,11 +60,11 @@ def test_group_settings_greedy_single_item():
     assert list(grouped_settings.values())[0][0] == settings[0]
 
 
-def test_group_settings_greedy_empty():
+def test_group_settings_greedy_empty() -> None:
     assert cirq.work.group_settings_greedy([]) == dict()
 
 
-def test_group_settings_greedy_init_state_compat():
+def test_group_settings_greedy_init_state_compat() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     settings = [
         cirq.work.InitObsSetting(
@@ -78,7 +78,7 @@ def test_group_settings_greedy_init_state_compat():
     assert len(grouped_settings) == 1
 
 
-def test_group_settings_greedy_init_state_compat_sparse():
+def test_group_settings_greedy_init_state_compat_sparse() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     settings = [
         cirq.work.InitObsSetting(init_state=cirq.KET_PLUS(q0), observable=cirq.X(q0)),
@@ -94,7 +94,7 @@ def test_group_settings_greedy_init_state_compat_sparse():
     assert grouped_settings == grouped_settings_should_be
 
 
-def test_group_settings_greedy_init_state_incompat():
+def test_group_settings_greedy_init_state_incompat() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     settings = [
         cirq.work.InitObsSetting(
@@ -106,7 +106,7 @@ def test_group_settings_greedy_init_state_incompat():
     assert len(grouped_settings) == 2
 
 
-def test_group_settings_greedy_hydrogen():
+def test_group_settings_greedy_hydrogen() -> None:
     qubits = cirq.LineQubit.range(4)
     q0, q1, q2, q3 = qubits
     terms = [

--- a/cirq-core/cirq/work/observable_readout_calibration_test.py
+++ b/cirq-core/cirq/work/observable_readout_calibration_test.py
@@ -33,7 +33,7 @@ class DepolarizingWithDampedReadoutNoiseModel(cirq.NoiseModel):
             return [moment, cirq.Moment(self.qubit_noise_gate(q) for q in system_qubits)]
 
 
-def test_calibrate_readout_error():
+def test_calibrate_readout_error() -> None:
     sampler = cirq.DensityMatrixSimulator(
         noise=DepolarizingWithDampedReadoutNoiseModel(
             depol_prob=1e-3, bitflip_prob=0.03, decay_prob=0.03

--- a/cirq-core/cirq/work/zeros_sampler_test.py
+++ b/cirq-core/cirq/work/zeros_sampler_test.py
@@ -21,7 +21,7 @@ import sympy
 import cirq
 
 
-def test_run_sweep():
+def test_run_sweep() -> None:
     a, b, c = [cirq.NamedQubit(s) for s in ['a', 'b', 'c']]
     circuit = cirq.Circuit([cirq.measure(a)], [cirq.measure(b, c)])
     sampler = cirq.ZerosSampler()
@@ -36,7 +36,7 @@ def test_run_sweep():
     assert np.all(result[0].measurements['b,c'] == 0)
 
 
-def test_sample():
+def test_sample() -> None:
     # Create a circuit whose measurements are always zeros, and check that
     # results of ZeroSampler on this circuit are identical to results of
     # actual simulation.
@@ -54,7 +54,7 @@ def test_sample():
     assert np.all(result1 == result2)
 
 
-def test_repeated_keys():
+def test_repeated_keys() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
 
     c = cirq.Circuit(
@@ -79,7 +79,7 @@ class OnlyMeasurementsDevice(cirq.Device):
             raise ValueError(f'{operation} is not a measurement and this device only measures!')
 
 
-def test_validate_device():
+def test_validate_device() -> None:
     device = OnlyMeasurementsDevice()
     sampler = cirq.ZerosSampler(device)
 


### PR DESCRIPTION
- Adds return type for tests as None.
- Looking at #4393, it occured we could automate a bunch of these errors with a simple script by adding "-> None" to tests.
- At first, I thought this was ridiculous, but actually, this enables mypy to check the tests for typing errors, of which there are many.
- These are the files that can be automatically changed that do not having typing errors.
- The only changes are adding "-> None" to the test functions.