### PR TITLE
Remove documentation references to optimized_for_sycamore

### DIFF
--- a/docs/google/concepts.ipynb
+++ b/docs/google/concepts.ipynb
@@ -153,7 +153,7 @@
    "source": [
     "### Quantum Programs\n",
     "\n",
-    "In Cirq, one creates a `Circuit` in Python.  If one then wants to run it using Quantum Engine, one must then upload this Circuit to the Quantum Engine API.  The uploaded version of the Circuit is called a Program.  Programs are not the Python code itself, but a representation of the Circuit suitable for running on hardware.  The `Engine` class and its corresponding `sampler` will translate the circuit into the format needed by the API for you.  You will need to make sure that your circuit uses only gates and qubits compatible with the hardware (see `cirq_google.optimized_for_sycamore()` to help with this).\n",
+    "In Cirq, one creates a `Circuit` in Python.  If one then wants to run it using Quantum Engine, one must then upload this Circuit to the Quantum Engine API.  The uploaded version of the Circuit is called a Program.  Programs are not the Python code itself, but a representation of the Circuit suitable for running on hardware.  The `Engine` class and its corresponding `sampler` will translate the circuit into the format needed by the API for you.  You will need to make sure that your circuit uses only gates and qubits compatible with the hardware.\n",
     "\n",
     "![Quantum Program Conceptual Diagram](https://github.com/quantumlib/Cirq/blob/main/docs/images/engine_program.png?raw=1)\n",
     "\n",

--- a/docs/google/devices.md
+++ b/docs/google/devices.md
@@ -295,10 +295,9 @@ It can be accessed by using `cirq_google.Sycamore`. This device has two possible
 two-qubits gates that can be used.
 
 *  Square root of ISWAP. The gate `cirq.ISWAP ** 0.5` or `cirq.ISWAP ** -0.5` can be
-used on `cirq_google.optimized_for_sycamore` with optimizer type `sqrt_iswap`
+used on this device.
 *  Sycamore gate. This gate, equivalent to FSimGate(π/2, π/6) can be used as `cirq_google.SYC`
-or by using `cirq.FsimGate(numpy.pi/2,numpy.pi/6)`. Circuits can be compiled to use this gate
-by using `cirq_google.optimized_for_sycamore` with optimizer type `sycamore`
+or by using `cirq.FsimGate(numpy.pi/2,numpy.pi/6)`. 
 
 
 ### Sycamore23

--- a/docs/tutorials/google/spin_echoes.ipynb
+++ b/docs/tutorials/google/spin_echoes.ipynb
@@ -81,15 +81,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "S0OPIhmnv5AO"
-   },
-   "source": [
-    "Note: The function `cirq_google.optimized_for_sycamore` implements some of the optimizations shown here. This tutorial provides more detail for finer control."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "BRfLi9YSMg4v"
    },
    "source": [


### PR DESCRIPTION
- The function cirq_google.optimized_for_sycamore has been replaced by the transformer paradigm and can be implemented using the appropriate CompilationTargetGateset for the device.
- This PR removes the last references to them in the documentation.