### PR TITLE
Multi-moment CZ, CPhase GaugeTransformers.

### DIFF
--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -211,6 +211,7 @@ def add_dynamical_decoupling(
     context: Optional[cirq.TransformerContext] = None,
     schema: Union[str, Tuple[ops.Gate, ...]] = 'DEFAULT',
     single_qubit_gate_moments_only: bool = True,
+    # pulling_through_mode = "through_all_cliffords" | "stop_at_non_clifford_moments",
 ) -> cirq.Circuit:
     """Adds dynamical decoupling gate operations to a given circuit.
     This transformer might add new moments thus change structure of the original circuit.
@@ -266,6 +267,8 @@ def add_dynamical_decoupling(
         # unitary representation (e.g., measure gates). If there are remaining pulled through ops,
         # insert into a new moment before current moment.
         stop_pulling_through_qubits: set[ops.Qid] = _get_stop_qubits(moment)
+        if stop_pulling_through_qubits:
+            stop_pulling_through_qubits = orig_circuit.all_qubits()
         new_moment_ops = []
         for q in stop_pulling_through_qubits:
             # Insert the remaining pulled_through

--- a/cirq-core/cirq/transformers/gauge_compiling/__init__.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/__init__.py
@@ -42,4 +42,7 @@ from cirq.transformers.gauge_compiling.sqrt_iswap_gauge import (
     SqrtISWAPGaugeTransformer as SqrtISWAPGaugeTransformer,
 )
 
-from cirq.transformers.gauge_compiling.cphase_gauge import CPhaseGaugeTransformer
+from cirq.transformers.gauge_compiling.cphase_gauge import (
+    CPhaseGaugeTransformer as CPhaseGaugeTransformer,
+    CPhaseGaugeTransformerMM as CPhaseGaugeTransformerMM,
+)

--- a/cirq-core/cirq/transformers/gauge_compiling/__init__.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/__init__.py
@@ -29,7 +29,10 @@ from cirq.transformers.gauge_compiling.spin_inversion_gauge import (
     SpinInversionGaugeTransformer as SpinInversionGaugeTransformer,
 )
 
-from cirq.transformers.gauge_compiling.cz_gauge import CZGaugeTransformer as CZGaugeTransformer
+from cirq.transformers.gauge_compiling.cz_gauge import (
+    CZGaugeTransformer as CZGaugeTransformer,
+    CZGaugeTransformerML as CZGaugeTransformerML,
+)
 
 from cirq.transformers.gauge_compiling.iswap_gauge import (
     ISWAPGaugeTransformer as ISWAPGaugeTransformer,

--- a/cirq-core/cirq/transformers/gauge_compiling/__init__.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/__init__.py
@@ -31,7 +31,7 @@ from cirq.transformers.gauge_compiling.spin_inversion_gauge import (
 
 from cirq.transformers.gauge_compiling.cz_gauge import (
     CZGaugeTransformer as CZGaugeTransformer,
-    CZGaugeTransformerML as CZGaugeTransformerML,
+    CZGaugeTransformerMM as CZGaugeTransformerMM,
 )
 
 from cirq.transformers.gauge_compiling.iswap_gauge import (

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -379,7 +379,8 @@ def _multi_moment_gauge_fn(
             if q not in pulled:
                 pulled[q] = prev[q]
         prev = pulled
-        new_moments.append(circuits.Moment(new_moment))
+        if new_moment:
+            new_moments.append(circuits.Moment(new_moment))
 
     last_moment = circuits.Moment([pulled[q].to_single_gate().on(q) for q in all_qubits])
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge.py
@@ -16,10 +16,12 @@
 
 from __future__ import annotations
 
+from typing import List
+
 import numpy as np
 
 import cirq.transformers.gauge_compiling.sqrt_cz_gauge as sqrt_cz_gauge
-from cirq import ops
+from cirq import circuits, ops
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     ConstantGauge,
     Gauge,
@@ -145,4 +147,239 @@ CPhaseGaugeTransformer = GaugeTransformer(
     two_qubit_gate_symbolizer=TwoQubitGateSymbolizer(
         symbolizer_fn=sqrt_cz_gauge._symbolize_as_cz_pow, n_symbols=1
     ),
+)
+
+
+class _PhasedXYAndRz:
+    """In pulling through, one qubit gate can be represented by a Pauli and an Rz gate.
+
+    The order is --(X|Y|I)--Rz(rad)--phase--.
+    """
+
+    pauli: ops.X | ops.Y | ops.I
+    rz_rads: float
+    phase_exp: float  # phase of the qubit is e^{i*phase_exp*pi}
+
+    def __init__(
+        self, pauli: ops.Pauli | ops.I = ops.I, rz_rads: float = 0, phase_exp: float = 0
+    ) -> None:
+        if pauli == ops.Z:  # Merge Z gates to Rz where Z = Rz(π) * e^{iπ/2}
+            self.pauli = ops.I
+            self.rz_rads = rz_rads + np.pi
+            self.phase_exp = phase_exp + 0.5
+        else:
+            self.pauli = pauli
+            self.rz_rads = rz_rads
+            self.phase_exp = phase_exp
+
+    def _merge_left_rz(self, rads: float):
+        """Merges Rz(rad) from left."""
+        if self.pauli == ops.I:
+            self.rz_rads += rads
+        else:
+            self.rz_rads -= rads
+
+    def _merge_right_rz(self, rads: float):
+        """Merges Rz(rads) from right."""
+        self.rz_rads += rads
+
+    def _merge_left_xy(self, other: ops.X | ops.Y):
+        """Merges --(X|Y)--self--."""
+        if self.pauli == other:
+            self.pauli = ops.I
+            return
+        if self.pauli == ops.I:
+            self.pauli = other
+            return
+        if (other, self.pauli) == (ops.X, ops.Y):
+            # -X--Y-  ==>  --Rz(pi)--
+            self.pauli = ops.I
+            self.rz_rads += np.pi
+            return
+        if (other, self.pauli) == (ops.Y, ops.X):
+            # -Y--X-  ==>  --Rz(-pi)--
+            self.pauli = ops.I
+            self.rz_rads -= np.pi
+            return
+
+    def _merge_right_xy(self, other: ops.X | ops.Y):
+        """Merges --self--(X|Y)--."""
+        self.rz_rads *= -1
+        if self.pauli == other:
+            self.pauli = ops.I
+            return
+        if self.pauli == ops.I:
+            self.pauli = other
+            return
+        if (self.pauli, other) == (ops.X, ops.Y):
+            # -X--Y-  ==>  --Rz(pi)--
+            self.pauli = ops.I
+            self.rz_rads += np.pi
+            return
+        if (self.pauli, other) == (ops.Y, ops.X):
+            # -X--Y-  ==>  --Rz(-pi)--
+            self.pauli = ops.I
+            self.rz_rads -= np.pi
+            return
+
+    def merge_left(self, other: _PhasedXYAndRz) -> None:
+        """Inplace merge other from left."""
+        self._merge_left_rz(other.rz_rads)
+        self.phase_exp += other.phase_exp
+        if other.pauli != ops.I:
+            self._merge_left_xy(other.pauli)
+
+    def merge_right(self, other: _PhasedXYAndRz) -> None:
+        """Inplace merge other from right."""
+        self.phase_exp += other.phase_exp
+        if other.pauli != ops.I:
+            self._merge_right_xy(other.pauli)
+        self._merge_right_rz(other.rz_rads)
+
+    def after_cphase(
+        self, cphase: ops.CZPowGate
+    ) -> tuple[ops.CZPowGate, _PhasedXYAndRz, _PhasedXYAndRz]:
+        """Pull self through cphase.
+
+        Returns:
+            updated cphase gate, pull_through of this qubit, pull_through of the other qubit.
+        """
+        match self.pauli:
+            case ops.I:
+                return cphase, self, _PhasedXYAndRz()
+            case _:  # ops.X | ops.Y:
+                # Taking input0 with X gate as an example:
+                # 0: ─X─Rz(t)─phase─@──────      0: ─X──@─────Rz(t)──phase─
+                #                   │       ==>         │
+                # 1: ───────────────@^exp──      1: ────@^exp──────────────
+                #      0: ─@──────X────Rz(t)───phase─────────
+                # ==>      │
+                #      1: ─@^-exp─Rz(exp pi)─e^{-exp pi/2 i}─
+                # where rad = -exp * pi.
+                # Similarly for X|Y on qubit 0/1, the result is always flipping cphase and
+                # add an extra Rz rotation on the other qubit.
+                return (
+                    cphase**-1,
+                    self,
+                    _PhasedXYAndRz(rz_rads=cphase.exponent * np.pi, phase_exp=-cphase.exponent / 2),
+                )
+
+    def __str__(self) -> str:
+        return f"─{self.pauli}──Rz({self.rz_rads})──phase(e^{{i{self.phase_exp}π}})─"
+
+    def __eq__(self, other: _PhasedXYAndRz) -> bool:
+        return (
+            self.pauli == other.pauli
+            and np.isclose(self.rz_rads, other.rz_rads, atol=1e-10)
+            and np.isclose(self.phase_exp, other.phase_exp, atol=1e-10)
+        )
+
+    def to_single_gate(self) -> ops.PhasedXZGate | ops.ZPowGate:
+        if self.pauli == ops.I:
+            rz_rads = self.rz_rads
+            if np.isclose(self.rz_rads, 0, atol=1e-2):
+                rz_rads = self.rz_rads + 4 * np.pi
+            return ops.ZPowGate(
+                exponent=rz_rads / np.pi, global_shift=np.pi * self.phase_exp / rz_rads - 0.5
+            )
+        if self.pauli == ops.X:
+            return ops.PhasedXZGate(
+                x_exponent=1,
+                z_exponent=2 * self.phase_exp,
+                axis_phase_exponent=self.rz_rads / 2 / np.pi - self.phase_exp,
+            )
+        if self.pauli == ops.Y:
+            return ops.PhasedXZGate(
+                x_exponent=1,
+                z_exponent=2 * self.phase_exp,
+                axis_phase_exponent=1 / 2 - self.phase_exp + self.rz_rads / 2 / np.pi,
+            )
+
+
+def _pull_through_single_cphase(
+    cphase: ops.CZPowGate, input0: _PhasedXYAndRz, input1: _PhasedXYAndRz
+) -> tuple[ops.CZPowGate, _PhasedXYAndRz, _PhasedXYAndRz]:
+    """Pulls input0 and input1 through a CZPowGate.
+    Input:
+    0: ─(input0=P0──Rz0──phase0)─@─────
+                                 │
+    1: ─(input1=P1──Rz1──phase1)─@^exp─
+    Output:
+    0: ─@────────(output0=P0'──Rz0'──phase0')─
+        │
+    1: ─@^+/-exp─(output1=P1'──Rz1'──phase1')─
+    """
+
+    # Step 1; pull input0 through CZPowGate.
+    # 0: ─input0─@─────     0: ────────@─────────output0─
+    #            │      ==>            │
+    # 1: ─input1─@^exp─     1: ─input1─@^+/-exp──output1─
+    output_cphase, output0, output1 = input0.after_cphase(cphase)
+
+    # Step 2; similar to step 1, pull input1 through CZPowGate.
+    #      0: ─@──────────pulled0────output0─     0: ─@────────output0─
+    #  ==>     │                              ==>     │
+    #      1: ─@^+/-exp───pulled1────output1─     1: ─@^+/-exp─output1─
+    output_cphase, pulled1, pulled0 = input1.after_cphase(output_cphase)
+    output0.merge_left(pulled0)
+    output1.merge_left(pulled1)
+
+    return output_cphase, output0, output1
+
+
+def _multi_moment_pull_through(
+    moments: List[circuits.Moment], rng: np.random.Generator
+) -> List[circuits.Moment]:
+    """TO FILL."""
+    all_qubits = [q for q in circuits.Circuit(moments).all_qubits()]
+    if not all_qubits:
+        return moments
+    if not any(isinstance(op.gate, ops.CZPowGate) for moment in moments for op in moment):
+        return moments
+
+    left_moment = circuits.Moment(
+        [rng.choice([ops.I, ops.X, ops.Y, ops.Z]).on(q) for q in all_qubits]
+    )
+    prev: map[ops.Qid, ops.Gate] = {
+        op.qubits[0]: _PhasedXYAndRz(pauli=op.gate) for op in left_moment
+    }
+
+    new_moments: List[circuits.Moment] = [left_moment]
+
+    pulled: map[ops.Qid, ops.Gate]
+    for moment in moments:
+        pulled = {}
+        new_moment: List[ops.Operation] = []
+        for op in moment:
+            if op.gate and (isinstance(op.gate, ops.CZPowGate)):
+                q0, q1 = op.qubits
+                cphase_gate, pulled[q0], pulled[q1] = _pull_through_single_cphase(
+                    op.gate, prev[q0], prev[q1]
+                )
+                new_moment.append(cphase_gate.on(q0, q1))
+            elif op.gate and isinstance(op.gate, ops.ZPowGate):
+                q = op.qubits[0]
+                pulled[q] = prev[q]
+                pulled[q].merge_right(_PhasedXYAndRz(rz_rads=op.gate.exponent * np.pi))
+                # Don't need to add the op in the new_moment as it is already merged into pulled.
+            else:
+                new_moment.append(op)
+        for q in all_qubits:
+            if q not in pulled:
+                pulled[q] = prev[q]
+        prev = pulled
+        new_moments.append(new_moment)
+
+    last_moment = circuits.Moment([pulled[q].to_single_gate().on(q) for q in all_qubits])
+
+    new_moments.append(last_moment)
+
+    return new_moments
+
+
+# Multi-moments pull through version of CZGaugeTransformer
+CPhaseGaugeTransformerMM = GaugeTransformer(
+    target=ops.Gateset(ops.CZPowGate, ops.ZPowGate),
+    gauge_selector=CPhaseGaugeSelector,
+    multi_moment_pull_thourgh_fn=_multi_moment_pull_through,
 )

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
+import numpy as np
+
 import cirq
-from cirq.transformers.gauge_compiling.cphase_gauge import CPhaseGaugeTransformer
+from cirq.transformers.gauge_compiling.cphase_gauge import (
+    CPhaseGaugeTransformer,
+    CPhaseGaugeTransformerMM,
+    _PhasedXYAndRz,
+)
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester
 
 
@@ -40,3 +47,150 @@ class TestCPhaseGauge_m0_1(GaugeTester):
 class TestCPhaseGauge_0_7(GaugeTester):
     two_qubit_gate = cirq.CZ**0.7
     gauge_transformer = CPhaseGaugeTransformer
+
+
+def test_single_cphase():
+    """Test case.
+    Input:
+    0: ───@───────
+          │
+    1: ───@^0.2───
+    Example output:
+    0: ───X───@────────PhXZ(a=0,x=1,z=0)───
+              │
+    1: ───I───@^-0.2───Z^0.2───────────────
+    """
+    q0, q1 = cirq.LineQubit.range(2)
+    input_circuit = cirq.Circuit(cirq.Moment(cirq.CZ(q0, q1) ** 0.2))
+    transformer = CPhaseGaugeTransformerMM
+
+    output_circuit = transformer(input_circuit, prng=np.random.default_rng())
+
+    cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
+        input_circuit, output_circuit, {q: q for q in input_circuit.all_qubits()}
+    )
+
+
+def test_multi_layer_pull_through_all_czs():
+    """Test case.
+    Input:
+                  ┌──┐
+    0: ───@────@─────H───────@───@───
+          │    │             │   │
+    1: ───@────┼@────────────@───@───
+               ││
+    2: ───@────@┼────────@───@───@───
+          │     │        │   │   │
+    3: ───@─────@────────@───@───@───
+              └──┘
+    Example output:
+                  ┌──┐
+    0: ───X───@────@─────PhXZ(a=0,x=1,z=1)──────H───X───────@───@───PhXZ(a=0,x=1,z=2)────
+              │    │                                        │   │
+    1: ───I───@────┼@────Z──────────────────────────X───────@───@───PhXZ(a=2,x=1,z=-2)───
+                   ││
+    2: ───Y───@────@┼────PhXZ(a=1.5,x=1,z=-1)───────Z───@───@───@───Z────────────────────
+              │     │                                   │   │   │
+    3: ───Z───@─────@────Z^0────────────────────────I───@───@───@───Z^0──────────────────
+                  └──┘
+    """
+    q0, q1, q2, q3 = cirq.LineQubit.range(4)
+    input_circuit = cirq.Circuit(
+        cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
+        cirq.Moment(cirq.CZ(q0, q2), cirq.CZ(q1, q3)),
+        cirq.Moment(cirq.H(q0)),
+        cirq.Moment(cirq.CZ(q2, q3)),
+        cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
+        cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
+    )
+    transformer = CPhaseGaugeTransformerMM
+
+    output_circuit = transformer(input_circuit, prng=np.random.default_rng())
+    cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
+        input_circuit, output_circuit, {q: q for q in input_circuit.all_qubits()}
+    )
+
+
+def test_multi_layer_pull_through():
+    """Test case.
+    Input:
+                  ┌──┐
+    0: ───@────────@─────H───────────@───────@───────
+          │        │                 │       │
+    1: ───@^0.2────┼@────────────────@^0.1───@───────
+                   ││
+    2: ───@────────@┼────────@───────@───────@───────
+          │         │        │       │       │
+    3: ───@─────────@────────@^0.2───@───────@^0.2───
+                  └──┘
+    Example output:
+                       ┌──┐
+    0: ───Y───@─────────@─────PhXZ(a=0.5,x=1,z=0)───H───Y────────────@────────@────────PhXZ(a=0.5,x=1,z=0)───
+              │         │                                            │        │
+    1: ───Z───@^-0.2────┼@────Z^-0.8────────────────────I────────────@^-0.1───@────────Z^-0.9────────────────
+                        ││
+    2: ───Z───@─────────@┼────Z^0───────────────────────Y───@────────@────────@────────PhXZ(a=0.5,x=1,z=0)───
+              │          │                                  │        │        │
+    3: ───I───@──────────@────Z^0───────────────────────I───@^-0.2───@────────@^-0.2───Z^-0.6────────────────
+                       └──┘
+    """
+    q0, q1, q2, q3 = cirq.LineQubit.range(4)
+    for _ in range(10):
+        input_circuit = cirq.Circuit(
+            cirq.Moment(cirq.CZ(q0, q1) ** 0.2, cirq.CZ(q2, q3)),
+            cirq.Moment(cirq.CZ(q0, q2), cirq.CZ(q1, q3)),
+            cirq.Moment(cirq.H(q0)),
+            cirq.Moment(cirq.CZ(q2, q3) ** 0.2),
+            cirq.Moment(cirq.CZ(q0, q1) ** 0.1, cirq.CZ(q2, q3)),
+            cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3) ** 0.2),
+        )
+        transformer = CPhaseGaugeTransformerMM
+
+        output_circuit = transformer(input_circuit, prng=np.random.default_rng())
+        cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
+            input_circuit, output_circuit, {q: q for q in input_circuit.all_qubits()}
+        )
+
+
+def test_phxyrz_str():
+    phxyrz = _PhasedXYAndRz(pauli=cirq.X, phase_exp=0.1)
+    assert str(phxyrz) == "─X──Rz(0)──phase(e^{i0.1π})─"
+
+
+def test_phxyrz_to_single_gate():
+    q = cirq.LineQubit(0)
+    for pauli in [cirq.X, cirq.Y, cirq.Z, cirq.I]:
+        for rz_rads in [0.0, np.random.uniform(0, 2 * np.pi)]:
+            for phase_exp in [0.0, np.random.uniform(0, 1)]:
+                phxyrz = _PhasedXYAndRz(pauli=pauli, rz_rads=rz_rads, phase_exp=phase_exp)
+                assert np.allclose(
+                    cirq.unitary(phxyrz.to_single_gate()),
+                    cirq.unitary(
+                        cirq.Circuit(
+                            pauli(q),
+                            cirq.Rz(rads=rz_rads).on(q),
+                            cirq.global_phase_operation(coefficient=np.exp(1j * phase_exp * np.pi)),
+                        )
+                    ),
+                )
+
+
+def test_phxyrz_merge():
+    for left_pauli in [cirq.X, cirq.Y, cirq.Z, cirq.I]:
+        for right_pauli in [cirq.X, cirq.Y, cirq.Z, cirq.I]:
+            left = _PhasedXYAndRz(pauli=left_pauli, rz_rads=0.1, phase_exp=0.2)
+            right = _PhasedXYAndRz(pauli=right_pauli, rz_rads=0.3, phase_exp=0.4)
+            merge1 = deepcopy(right)
+            merge1.merge_left(left)
+            merge2 = deepcopy(left)
+            merge2.merge_right(right)
+
+            assert merge1 == merge2
+            q = cirq.LineQubit(0)
+            assert np.allclose(
+                cirq.unitary(
+                    cirq.Circuit(left.to_single_gate().on(q), right.to_single_gate().on(q))
+                ),
+                cirq.unitary(merge1.to_single_gate()),
+                atol=1e-10,
+            )

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -195,3 +195,15 @@ def test_phxyrz_merge():
                 cirq.unitary(merge1.to_single_gate()),
                 atol=1e-10,
             )
+
+
+def test_rz_mix_with_cphase():
+    q0, q1 = cirq.LineQubit.range(2)
+    input_circuit = cirq.Circuit(
+        cirq.Moment(cirq.CZ(q0, q1) ** 0.2), cirq.Moment(cirq.Rz(rads=0.1).on(q0))
+    )
+    output_circuit = CPhaseGaugeTransformerMM(input_circuit)
+    cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
+        input_circuit, output_circuit, {q: q for q in input_circuit.all_qubits()}
+    )
+    assert len(output_circuit) == 3

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
@@ -50,8 +50,8 @@ def _multi_layer_pull_through_cz(
     left: List[circuits.Moment], moments: List[circuits.Moment]
 ) -> List[circuits.Moment]:
     # Check all the ops are CZ first
-    if not all(op.gate is CZ for moment in moments for op in moment):
-        raise ValueError("Input moments must only contains CZ gates.")
+    if not all(op.gate == CZ for moment in moments for op in moment):
+        raise ValueError(f"Input moments must only contain CZ gates:\nmoments = {moments}.")
     if len(left) > 1:
         raise ValueError("CZ's gauge only has one pre_q0 gate, and one pre_q1 gate.")
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
@@ -48,7 +48,7 @@ CZGaugeSelector = GaugeSelector(
 )
 
 
-def _multi_moment_pull_through(
+def _multi_moment_gauge_fn(
     moments: List[circuits.Moment], rng: np.random.Generator
 ) -> List[circuits.Moment]:
     # Check all the ops are CZ first
@@ -56,7 +56,9 @@ def _multi_moment_pull_through(
         raise ValueError(f"Input moments must only contain CZ gates:\nmoments = {moments}.")
 
     left: List[ops.Operation] = [
-        rng.choice([ops.I, ops.X, ops.Y, ops.Z]).on(q)
+        rng.choice(
+            np.array([ops.I, ops.X, ops.Y, ops.Z], dtype=ops.Gate), p=[0.25, 0.25, 0.25, 0.25]
+        ).on(q)
         for q in circuits.Circuit(moments).all_qubits()
     ]
     if not left:
@@ -73,7 +75,5 @@ CZGaugeTransformer = GaugeTransformer(target=CZ, gauge_selector=CZGaugeSelector)
 
 # Multi-moments pull through version of CZGaugeTransformer
 CZGaugeTransformerMM = GaugeTransformer(
-    target=CZ,
-    gauge_selector=CZGaugeSelector,
-    multi_moment_pull_thourgh_fn=_multi_moment_pull_through,
+    target=CZ, gauge_selector=CZGaugeSelector, multi_moment_gauge_fn=_multi_moment_gauge_fn
 )

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
@@ -48,7 +48,7 @@ CZGaugeSelector = GaugeSelector(
 )
 
 
-def _multi_layer_pull_through_cz(
+def _multi_moment_pull_through(
     moments: List[circuits.Moment], rng: np.random.Generator
 ) -> List[circuits.Moment]:
     # Check all the ops are CZ first
@@ -71,9 +71,9 @@ def _multi_layer_pull_through_cz(
 
 CZGaugeTransformer = GaugeTransformer(target=CZ, gauge_selector=CZGaugeSelector)
 
-# Multi-layer pull through version of CZGaugeTransformer
-CZGaugeTransformerML = GaugeTransformer(
+# Multi-moments pull through version of CZGaugeTransformer
+CZGaugeTransformerMM = GaugeTransformer(
     target=CZ,
     gauge_selector=CZGaugeSelector,
-    multi_layer_pull_thourgh_fn=_multi_layer_pull_through_cz,
+    multi_moment_pull_thourgh_fn=_multi_moment_pull_through,
 )

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -27,24 +27,24 @@ class TestCZGauge(GaugeTester):
 def test_multi_layer_pull_through():
     """Test case.
     Input:
-             ┌──┐
-    0: ───@────@─────H───@───@───@───
-          │    │         │   │   │
-    1: ───@────┼@────────@───@───@───
+              ┌──┐
+    0: ───@────@─────H───────@───@───
+          │    │             │   │
+    1: ───@────┼@────────────@───@───
                ││
     2: ───@────@┼────────@───@───@───
           │     │        │   │   │
     3: ───@─────@────────@───@───@───
               └──┘
-    An example output:
+        An example output:
                   ┌──┐
-    0: ───X───@────@─────X───H───Z───@───@───@───────
-              │    │                 │   │   │
-    1: ───I───@────┼@────Z───────Y───@───@───@───Y───
+    0: ───Z───@────@─────Z───H───X───────@───@───X───
+              │    │                     │   │
+    1: ───Y───@────┼@────X───────I───────@───@───────
                    ││
-    2: ───I───@────@┼────Z───────Y───@───@───@───Y───
+    2: ───Y───@────@┼────X───────I───@───@───@───────
               │     │                │   │   │
-    3: ───I───@─────@────────────Z───@───@───@───────
+    3: ───X───@─────@────X───────I───@───@───@───────
                   └──┘
     """
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
@@ -52,13 +52,13 @@ def test_multi_layer_pull_through():
         cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
         cirq.Moment(cirq.CZ(q0, q2), cirq.CZ(q1, q3)),
         cirq.Moment(cirq.H(q0)),
-        cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
+        cirq.Moment(cirq.CZ(q2, q3)),
         cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
         cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
     )
     transformer = CZGaugeTransformerML
 
-    output_circuit = transformer(input_circuit, prng=np.random.default_rng(0))
+    output_circuit = transformer(input_circuit, prng=np.random.default_rng())
     cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
         input_circuit, output_circuit, {q: q for q in input_circuit.all_qubits()}
     )

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -15,7 +15,7 @@
 import numpy as np
 
 import cirq
-from cirq.transformers.gauge_compiling import CZGaugeTransformer, CZGaugeTransformerML
+from cirq.transformers.gauge_compiling import CZGaugeTransformer, CZGaugeTransformerMM
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester
 
 
@@ -56,7 +56,7 @@ def test_multi_layer_pull_through():
         cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
         cirq.Moment(cirq.CZ(q0, q1), cirq.CZ(q2, q3)),
     )
-    transformer = CZGaugeTransformerML
+    transformer = CZGaugeTransformerMM
 
     output_circuit = transformer(input_circuit, prng=np.random.default_rng())
     cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -24,7 +24,7 @@ class TestCZGauge(GaugeTester):
     gauge_transformer = CZGaugeTransformer
 
 
-def test_multi_player_pull_through():
+def test_multi_layer_pull_through():
     """Test case.
     Input:
              ┌──┐

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling.py
@@ -196,7 +196,7 @@ class GaugeTransformer:
         target: Union[ops.Gate, ops.Gateset, ops.GateFamily],
         gauge_selector: Callable[[np.random.Generator], Gauge],
         two_qubit_gate_symbolizer: Optional[TwoQubitGateSymbolizer] = None,
-        multi_layer_pull_thourgh_fn: Optional[
+        multi_moment_pull_thourgh_fn: Optional[
             Callable[[List[circuits.Moment], List[circuits.Moment]], List[circuits.Moment]]
         ] = None,
     ) -> None:
@@ -211,7 +211,7 @@ class GaugeTransformer:
         self.target = ops.GateFamily(target) if isinstance(target, ops.Gate) else target
         self.gauge_selector = gauge_selector
         self.two_qubit_gate_symbolizer = two_qubit_gate_symbolizer
-        self.multi_layer_pull_thourgh_fn = multi_layer_pull_thourgh_fn
+        self.multi_moment_pull_thourgh_fn = multi_moment_pull_thourgh_fn
 
     def __call__(
         self,
@@ -231,7 +231,7 @@ class GaugeTransformer:
         all_target_moments: List[circuits.Moment] = []
 
         for moment in circuit:
-            if self.multi_layer_pull_thourgh_fn and all(
+            if self.multi_moment_pull_thourgh_fn and all(
                 [
                     op in self.target and not set(op.tags).intersection(context.tags_to_ignore)
                     for op in moment
@@ -240,7 +240,7 @@ class GaugeTransformer:
                 all_target_moments.append(moment)
                 continue
             if all_target_moments:
-                new_moments.extend(self.multi_layer_pull_thourgh_fn(all_target_moments, rng))
+                new_moments.extend(self.multi_moment_pull_thourgh_fn(all_target_moments, rng))
                 all_target_moments.clear()
 
             left.clear()
@@ -266,7 +266,7 @@ class GaugeTransformer:
             if right:
                 new_moments.extend(_build_moments(right))
         if all_target_moments:
-            new_moments.extend(self.multi_layer_pull_thourgh_fn(all_target_moments, rng))
+            new_moments.extend(self.multi_moment_pull_thourgh_fn(all_target_moments, rng))
         return circuits.Circuit.from_moments(*new_moments)
 
     def as_sweep(


### PR DESCRIPTION
Usage: use CZGaugeTransformerMM (CZ only) / CPhaseGaugeTransformerMM (CZ+CPhase)

Example:

```
    Input:
             ┌──┐
    0: ───@────@─────H───@───@───@───
          │    │         │   │   │
    1: ───@────┼@────────@───@───@───
               ││
    2: ───@────@┼────────@───@───@───
          │     │        │   │   │
    3: ───@─────@────────@───@───@───
              └──┘
    An example output:
                  ┌──┐
    0: ───X───@────@─────X───H───Z───@───@───@───────
              │    │                 │   │   │
    1: ───I───@────┼@────Z───────Y───@───@───@───Y───
                   ││
    2: ───I───@────@┼────Z───────Y───@───@───@───Y───
              │     │                │   │   │
    3: ───I───@─────@────────────Z───@───@───@───────
                  └──┘
```