### PR TITLE
Unpin cotengra requirement

### DIFF
--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -5,5 +5,4 @@ pylatex~=1.4
 
 # quimb
 quimb>=1.8
-cotengra==0.7.0
 opt_einsum


### PR DESCRIPTION
- The cotengra developer has quickly fixed the bug in 0.7.3 and released 0.7.4, so we should be okay to unpin this requirement.