### PR TITLE
Switch to unquoted type annotations part 7

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -24,6 +24,8 @@ arbitrary connectivity. For more information see:
 The native gate set consists of the local gates: X, Y, and XX entangling gates
 """
 
+from __future__ import annotations
+
 import json
 from enum import Enum
 from typing import Any, cast, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union

--- a/cirq-aqt/cirq_aqt/aqt_device_metadata.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata.py
@@ -14,6 +14,8 @@
 
 """DeviceMetadata for ion trap device with mutually linked qubits placed on a line."""
 
+from __future__ import annotations
+
 from typing import Any, Iterable, Mapping
 
 import networkx as nx

--- a/cirq-aqt/cirq_aqt/aqt_device_metadata_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_device_metadata_test.py
@@ -14,6 +14,8 @@
 
 """Tests for AQTDeviceMetadata."""
 
+from __future__ import annotations
+
 from typing import List
 
 import pytest

--- a/cirq-aqt/cirq_aqt/aqt_sampler.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler.py
@@ -22,6 +22,8 @@ API keys for classical simulators and quantum devices can be obtained at:
 
 """
 
+from __future__ import annotations
+
 import json
 import time
 import uuid

--- a/cirq-aqt/cirq_aqt/aqt_sampler_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from unittest import mock
 

--- a/cirq-aqt/cirq_aqt/aqt_simulator_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_simulator_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-aqt/cirq_aqt/aqt_target_gateset.py
+++ b/cirq-aqt/cirq_aqt/aqt_target_gateset.py
@@ -14,6 +14,8 @@
 
 """Target gateset for ion trap device with mutually linked qubits placed on a line."""
 
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/cirq-aqt/cirq_aqt/aqt_target_gateset_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_target_gateset_test.py
@@ -14,6 +14,8 @@
 
 """Tests for AQTTargetGateset."""
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-aqt/cirq_aqt/json_resolver_cache.py
+++ b/cirq-aqt/cirq_aqt/json_resolver_cache.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 from typing import Dict
 

--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Workarounds for compatibility issues between versions and libraries."""
+
+from __future__ import annotations
+
 import contextlib
 import contextvars
 import dataclasses

--- a/cirq-core/cirq/_doc.py
+++ b/cirq-core/cirq/_doc.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Workaround for associating docstrings with public constants."""
 
+from __future__ import annotations
+
 from typing import Any, Dict
 
 RECORDED_CONST_DOCS: Dict[int, str] = {}

--- a/cirq-core/cirq/_import.py
+++ b/cirq-core/cirq/_import.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import importlib
 import sys
 from contextlib import contextmanager

--- a/cirq-core/cirq/_import_test.py
+++ b/cirq-core/cirq/_import_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from cirq import _import
 
 

--- a/cirq-core/cirq/circuits/_block_diagram_drawer.py
+++ b/cirq-core/cirq/circuits/_block_diagram_drawer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import collections
 from typing import Dict, List, Optional, Tuple
 

--- a/cirq-core/cirq/circuits/_block_diagram_drawer_test.py
+++ b/cirq-core/cirq/circuits/_block_diagram_drawer_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import pytest

--- a/cirq-core/cirq/circuits/_box_drawing_character_data.py
+++ b/cirq-core/cirq/circuits/_box_drawing_character_data.py
@@ -14,6 +14,8 @@
 
 """Exposes structured data about unicode/ascii box drawing characters."""
 
+from __future__ import annotations
+
 from typing import List, NamedTuple, Optional
 
 _BoxDrawCharacterSet = NamedTuple(

--- a/cirq-core/cirq/circuits/_box_drawing_character_data_test.py
+++ b/cirq-core/cirq/circuits/_box_drawing_character_data_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from cirq.circuits._box_drawing_character_data import (
     BOLD_BOX_CHARS,
     box_draw_character,

--- a/cirq-core/cirq/circuits/_bucket_priority_queue.py
+++ b/cirq-core/cirq/circuits/_bucket_priority_queue.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Generic, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar
 
 TItem = TypeVar('TItem')

--- a/cirq-core/cirq/circuits/_bucket_priority_queue_test.py
+++ b/cirq-core/cirq/circuits/_bucket_priority_queue_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import unittest.mock as mock
 from typing import Optional
 

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import os
 import time

--- a/cirq-core/cirq/circuits/frozen_circuit_test.py
+++ b/cirq-core/cirq/circuits/frozen_circuit_test.py
@@ -16,6 +16,8 @@
 Behavior shared with Circuit is tested with parameters in circuit_test.py.
 """
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/circuits/insert_strategy_test.py
+++ b/cirq-core/cirq/circuits/insert_strategy_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pickle
 
 import pytest

--- a/cirq-core/cirq/circuits/moment_test.py
+++ b/cirq-core/cirq/circuits/moment_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/circuits/optimization_pass_test.py
+++ b/cirq-core/cirq/circuits/optimization_pass_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List, Optional, Set
 
 import pytest

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import os
 import re
 

--- a/cirq-core/cirq/circuits/text_diagram_drawer_test.py
+++ b/cirq-core/cirq/circuits/text_diagram_drawer_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/cirq-core/cirq/contrib/acquaintance/bipartite_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/bipartite_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import pytest

--- a/cirq-core/cirq/contrib/acquaintance/devices_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/devices_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/contrib/acquaintance/executor_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/executor_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from itertools import combinations
 from string import ascii_lowercase
 from typing import Dict, Sequence, Tuple

--- a/cirq-core/cirq/contrib/acquaintance/inspection_utils_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/inspection_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from itertools import combinations, product
 
 import pytest

--- a/cirq-core/cirq/contrib/acquaintance/mutation_utils_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/mutation_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from string import ascii_lowercase as alphabet
 
 import pytest

--- a/cirq-core/cirq/contrib/acquaintance/optimizers_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/optimizers_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import cirq
 import cirq.contrib.acquaintance as cca
 import cirq.testing as ct

--- a/cirq-core/cirq/contrib/acquaintance/permutation_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/permutation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 
 import pytest

--- a/cirq-core/cirq/contrib/acquaintance/shift_swap_network_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/shift_swap_network_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import random
 

--- a/cirq-core/cirq/contrib/acquaintance/shift_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/shift_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 import cirq.contrib.acquaintance as cca
 

--- a/cirq-core/cirq/contrib/acquaintance/strategies/cubic_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/strategies/cubic_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import pytest

--- a/cirq-core/cirq/contrib/acquaintance/strategies/quartic_paired_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/strategies/quartic_paired_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import random
 

--- a/cirq-core/cirq/contrib/acquaintance/testing.py
+++ b/cirq-core/cirq/contrib/acquaintance/testing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import cast, Sequence, TYPE_CHECKING
 
 from cirq import devices, ops, protocols

--- a/cirq-core/cirq/contrib/acquaintance/topological_sort_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/topological_sort_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/contrib/bayesian_network/bayesian_network_gate_test.py
+++ b/cirq-core/cirq/contrib/bayesian_network/bayesian_network_gate_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/contrib/circuitdag/circuit_dag_test.py
+++ b/cirq-core/cirq/contrib/circuitdag/circuit_dag_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import random
 

--- a/cirq-core/cirq/contrib/graph_device/graph_device_test.py
+++ b/cirq-core/cirq/contrib/graph_device/graph_device_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/contrib/graph_device/hypergraph_test.py
+++ b/cirq-core/cirq/contrib/graph_device/hypergraph_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 
 import pytest

--- a/cirq-core/cirq/contrib/graph_device/uniform_graph_device.py
+++ b/cirq-core/cirq/contrib/graph_device/uniform_graph_device.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, Hashable, Iterable, Mapping, Optional
 
 from cirq import devices, ops

--- a/cirq-core/cirq/contrib/graph_device/uniform_graph_device_test.py
+++ b/cirq-core/cirq/contrib/graph_device/uniform_graph_device_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/contrib/hacks/disable_validation.py
+++ b/cirq-core/cirq/contrib/hacks/disable_validation.py
@@ -14,6 +14,8 @@
 
 """Tools for disabling validation in circuit construction."""
 
+from __future__ import annotations
+
 import contextlib
 
 

--- a/cirq-core/cirq/contrib/hacks/disable_validation_test.py
+++ b/cirq-core/cirq/contrib/hacks/disable_validation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/contrib/json.py
+++ b/cirq-core/cirq/contrib/json.py
@@ -1,6 +1,8 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
 """Functions for JSON serialization and de-serialization for classes in Contrib."""
 
+from __future__ import annotations
+
 from cirq.protocols.json_serialization import DEFAULT_RESOLVERS
 
 

--- a/cirq-core/cirq/contrib/json_test.py
+++ b/cirq-core/cirq/contrib/json_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.acquaintance import SwapPermutationGate
 from cirq.contrib.bayesian_network import BayesianNetworkGate

--- a/cirq-core/cirq/contrib/noise_models/noise_models_test.py
+++ b/cirq-core/cirq/contrib/noise_models/noise_models_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 import cirq.contrib.noise_models as ccn
 from cirq import ops

--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import cast, Tuple
 
 from cirq import circuits, ops, protocols, transformers

--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.paulistring import clifford_optimized_circuit, CliffordTargetGateset
 

--- a/cirq-core/cirq/contrib/paulistring/clifford_target_gateset_test.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_target_gateset_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/contrib/paulistring/optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/optimize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Callable
 
 from cirq import circuits, ops, transformers

--- a/cirq-core/cirq/contrib/paulistring/optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/optimize_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.paulistring import optimized_circuit
 

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_dag.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_dag.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import cast
 
 from cirq import circuits, ops, protocols

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_dag_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_dag_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.paulistring import convert_and_separate_circuit, pauli_string_dag_from_circuit
 

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_optimize.py
@@ -14,14 +14,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import networkx
 
 from cirq import circuits, linalg
-from cirq.contrib import circuitdag
 from cirq.contrib.paulistring.pauli_string_dag import pauli_string_dag_from_circuit
 from cirq.contrib.paulistring.recombine import move_pauli_strings_into_circuit
 from cirq.contrib.paulistring.separate import convert_and_separate_circuit
 from cirq.ops import PauliStringGateOperation
+
+if TYPE_CHECKING:
+    from cirq.contrib import circuitdag
 
 
 def pauli_string_optimized_circuit(

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_optimize_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_optimize_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.paulistring import CliffordTargetGateset, pauli_string_optimized_circuit
 

--- a/cirq-core/cirq/contrib/paulistring/recombine.py
+++ b/cirq-core/cirq/contrib/paulistring/recombine.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Callable, cast, Iterable, List, Sequence, Tuple, Union
 
 from cirq import circuits, ops, protocols

--- a/cirq-core/cirq/contrib/paulistring/recombine_test.py
+++ b/cirq-core/cirq/contrib/paulistring/recombine_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.paulistring import (
     convert_and_separate_circuit,

--- a/cirq-core/cirq/contrib/paulistring/separate.py
+++ b/cirq-core/cirq/contrib/paulistring/separate.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Iterator, Tuple
 
 from cirq import circuits, ops, transformers

--- a/cirq-core/cirq/contrib/paulistring/separate_test.py
+++ b/cirq-core/cirq/contrib/paulistring/separate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.contrib.paulistring import convert_and_separate_circuit
 

--- a/cirq-core/cirq/contrib/qasm_import/_lexer.py
+++ b/cirq-core/cirq/contrib/qasm_import/_lexer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 from typing import Optional
 

--- a/cirq-core/cirq/contrib/qasm_import/_lexer_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_lexer_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from cirq.contrib.qasm_import import QasmException

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 import functools
 import operator

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 import textwrap
 from typing import Callable

--- a/cirq-core/cirq/contrib/qasm_import/exception.py
+++ b/cirq-core/cirq/contrib/qasm_import/exception.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 
 class QasmException(Exception):
     def __init__(self, message: str) -> None:

--- a/cirq-core/cirq/contrib/qasm_import/qasm.py
+++ b/cirq-core/cirq/contrib/qasm_import/qasm.py
@@ -14,11 +14,15 @@
 
 from __future__ import annotations
 
-from cirq import circuits
+from typing import TYPE_CHECKING
+
 from cirq.contrib.qasm_import._parser import QasmParser
 
+if TYPE_CHECKING:
+    import cirq
 
-def circuit_from_qasm(qasm: str) -> circuits.Circuit:
+
+def circuit_from_qasm(qasm: str) -> cirq.Circuit:
     """Parses an OpenQASM string to `cirq.Circuit`.
 
     Args:

--- a/cirq-core/cirq/contrib/qasm_import/qasm_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/qasm_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_diagram_info.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_diagram_info.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 from cirq import ops, protocols

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_diagram_info_test.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_diagram_info_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 import cirq.contrib.qcircuit as ccq
 

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf.py
@@ -13,17 +13,22 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import errno
 import os
+from typing import TYPE_CHECKING
 
 from pylatex import Document, NoEscape, Package
 
-from cirq import circuits
 from cirq.contrib.qcircuit.qcircuit_diagram import circuit_to_latex_using_qcircuit
+
+if TYPE_CHECKING:
+    import cirq
 
 
 def circuit_to_pdf_using_qcircuit_via_tex(
-    circuit: circuits.Circuit,
+    circuit: cirq.Circuit,
     filepath: str,
     pdf_kwargs=None,
     qcircuit_kwargs=None,

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf_test.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_pdf_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from unittest import mock
 
 import pylatex

--- a/cirq-core/cirq/contrib/qcircuit/qcircuit_test.py
+++ b/cirq-core/cirq/contrib/qcircuit/qcircuit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 import cirq.contrib.qcircuit as ccq
 import cirq.testing as ct

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -3,6 +3,8 @@
 https://arxiv.org/abs/1811.12926.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Set, Tuple
 

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume_test.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume_test.py
@@ -1,6 +1,8 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
 """Tests for the Quantum Volume utilities."""
 
+from __future__ import annotations
+
 import io
 from unittest.mock import MagicMock, Mock
 

--- a/cirq-core/cirq/contrib/quimb/density_matrix_test.py
+++ b/cirq-core/cirq/contrib/quimb/density_matrix_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/contrib/quimb/grid_circuits.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Iterator
 
 import networkx as nx

--- a/cirq-core/cirq/contrib/quimb/grid_circuits_test.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import networkx as nx
 import numpy as np
 import pytest

--- a/cirq-core/cirq/contrib/quimb/mps_simulator_test.py
+++ b/cirq-core/cirq/contrib/quimb/mps_simulator_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import itertools
 import math
 

--- a/cirq-core/cirq/contrib/quimb/state_vector_test.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import functools
 import operator
 

--- a/cirq-core/cirq/contrib/quirk/export_to_quirk.py
+++ b/cirq-core/cirq/contrib/quirk/export_to_quirk.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import urllib.parse
 from typing import Any, cast, Iterable, List, Tuple

--- a/cirq-core/cirq/contrib/quirk/export_to_quirk_test.py
+++ b/cirq-core/cirq/contrib/quirk/export_to_quirk_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/contrib/quirk/linearize_circuit.py
+++ b/cirq-core/cirq/contrib/quirk/linearize_circuit.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Callable
 
 from cirq import circuits, devices, ops

--- a/cirq-core/cirq/contrib/routing/device.py
+++ b/cirq-core/cirq/contrib/routing/device.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 from typing import Dict, Iterable, Tuple
 

--- a/cirq-core/cirq/contrib/routing/device_test.py
+++ b/cirq-core/cirq/contrib/routing/device_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import networkx as nx
 import pytest
 

--- a/cirq-core/cirq/contrib/routing/greedy_test.py
+++ b/cirq-core/cirq/contrib/routing/greedy_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from multiprocessing import Process
 
 import pytest

--- a/cirq-core/cirq/contrib/routing/initialization_test.py
+++ b/cirq-core/cirq/contrib/routing/initialization_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 
 import networkx as nx

--- a/cirq-core/cirq/contrib/routing/router.py
+++ b/cirq-core/cirq/contrib/routing/router.py
@@ -14,13 +14,15 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 
 import networkx as nx
 
 from cirq import circuits, protocols
 from cirq.contrib.routing.greedy import route_circuit_greedily
-from cirq.contrib.routing.swap_network import SwapNetwork
+
+if TYPE_CHECKING:
+    from cirq.contrib.routing.swap_network import SwapNetwork
 
 ROUTERS = {'greedy': route_circuit_greedily}
 

--- a/cirq-core/cirq/contrib/routing/router_test.py
+++ b/cirq-core/cirq/contrib/routing/router_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import random
 

--- a/cirq-core/cirq/contrib/routing/swap_network_test.py
+++ b/cirq-core/cirq/contrib/routing/swap_network_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import pytest

--- a/cirq-core/cirq/contrib/routing/utils_test.py
+++ b/cirq-core/cirq/contrib/routing/utils_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import networkx as nx
 import pytest
 

--- a/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking.py
+++ b/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking.py
@@ -17,13 +17,15 @@
 from __future__ import annotations
 
 import time
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 
 from cirq import circuits, ops, protocols, work
 from cirq.experiments import SingleQubitReadoutCalibrationResult
-from cirq.study import ResultDict
+
+if TYPE_CHECKING:
+    from cirq.study import ResultDict
 
 
 def _validate_input(

--- a/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking_test.py
+++ b/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import IPython.display
 import numpy as np
 import pytest

--- a/cirq-core/cirq/devices/device_test.py
+++ b/cirq-core/cirq/devices/device_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import networkx as nx
 
 import cirq

--- a/cirq-core/cirq/devices/grid_device_metadata_test.py
+++ b/cirq-core/cirq/devices/grid_device_metadata_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for GridDevicemetadata."""
+
+from __future__ import annotations
 
 import networkx as nx
 import pytest

--- a/cirq-core/cirq/ops/pauli_string_phasor.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor.py
@@ -199,7 +199,7 @@ class PauliStringPhasor(gate_operation.GateOperation):
         syms = tuple(sym(qubit) for qubit in qubits)
         return protocols.CircuitDiagramInfo(wire_symbols=syms, exponent=self.exponent_relative)
 
-    def conjugated_by(self, clifford: 'cirq.OP_TREE') -> 'PauliStringPhasor':
+    def conjugated_by(self, clifford: cirq.OP_TREE) -> PauliStringPhasor:
         r"""Returns the Pauli string conjugated by a clifford operation.
 
         The PauliStringPhasor $P$ conjugated by the Clifford operation $C$ is


### PR DESCRIPTION
No change in the effective code.  A batch of 100 files (~700 to go).
Added future import of annotations to detect typing-only imports.

Passes  ruff check --target-version=py311 --select=UP037,TC001

Partially implements #1999
