### PR TITLE
Switch to unquoted type annotations part 8

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for grid_qubit."""
+
+from __future__ import annotations
 
 import pickle
 

--- a/cirq-core/cirq/devices/insertion_noise_model_test.py
+++ b/cirq-core/cirq/devices/insertion_noise_model_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.devices.insertion_noise_model import InsertionNoiseModel
 from cirq.devices.noise_utils import OpIdentifier, PHYSICAL_GATE_TAG

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/devices/named_topologies_test.py
+++ b/cirq-core/cirq/devices/named_topologies_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 from unittest.mock import MagicMock
 

--- a/cirq-core/cirq/devices/noise_properties_test.py
+++ b/cirq-core/cirq/devices/noise_properties_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List, Tuple
 
 import cirq

--- a/cirq-core/cirq/devices/noise_utils_test.py
+++ b/cirq-core/cirq/devices/noise_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.devices.noise_utils import OpIdentifier
 

--- a/cirq-core/cirq/devices/superconducting_qubits_noise_properties_test.py
+++ b/cirq-core/cirq/devices/superconducting_qubits_noise_properties_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, List, Set, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/devices/thermal_noise_model_test.py
+++ b/cirq-core/cirq/devices/thermal_noise_model_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/devices/unconstrained_device_test.py
+++ b/cirq-core/cirq/devices/unconstrained_device_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/experiments/benchmarking/parallel_xeb_test.py
+++ b/cirq-core/cirq/experiments/benchmarking/parallel_xeb_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 from concurrent import futures
 from typing import Iterator

--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 from typing import Sequence
 

--- a/cirq-core/cirq/experiments/n_qubit_tomography_test.py
+++ b/cirq-core/cirq/experiments/n_qubit_tomography_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Sequence
 
 import numpy as np

--- a/cirq-core/cirq/experiments/purity_estimation.py
+++ b/cirq-core/cirq/experiments/purity_estimation.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Sequence
 
 import numpy as np

--- a/cirq-core/cirq/experiments/purity_estimation_test.py
+++ b/cirq-core/cirq/experiments/purity_estimation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 from cirq.experiments import purity_from_probabilities

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/cirq-core/cirq/experiments/readout_confusion_matrix_test.py
+++ b/cirq-core/cirq/experiments/readout_confusion_matrix_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/cirq-core/cirq/experiments/t2_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pandas as pd
 import pytest
 import sympy

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Wraps Parallel Two Qubit XEB into a few convenience methods."""
+
+from __future__ import annotations
+
 import io
 import itertools
 from typing import Dict, Optional, Sequence

--- a/cirq-core/cirq/experiments/xeb_sampling_test.py
+++ b/cirq-core/cirq/experiments/xeb_sampling_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import glob
 import itertools
 from typing import Iterable

--- a/cirq-core/cirq/experiments/z_phase_calibration_test.py
+++ b/cirq-core/cirq/experiments/z_phase_calibration_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/cirq-core/cirq/interop/quirk/cells/all_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/all_cells.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Iterator
+
+from __future__ import annotations
+
+from typing import Iterator, TYPE_CHECKING
 
 from cirq.interop.quirk.cells.arithmetic_cells import generate_all_arithmetic_cell_makers
-from cirq.interop.quirk.cells.cell import CellMaker
 from cirq.interop.quirk.cells.control_cells import generate_all_control_cell_makers
 from cirq.interop.quirk.cells.frequency_space_cells import generate_all_frequency_space_cell_makers
 from cirq.interop.quirk.cells.ignored_cells import generate_all_ignored_cell_makers
@@ -30,6 +32,9 @@ from cirq.interop.quirk.cells.single_qubit_rotation_cells import (
 )
 from cirq.interop.quirk.cells.swap_cell import generate_all_swap_cell_makers
 from cirq.interop.quirk.cells.unsupported_cells import generate_all_unsupported_cell_makers
+
+if TYPE_CHECKING:
+    from cirq.interop.quirk.cells.cell import CellMaker
 
 
 def generate_all_quirk_cell_makers() -> Iterator[CellMaker]:

--- a/cirq-core/cirq/interop/quirk/cells/arithmetic_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/arithmetic_cells_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import cast
 
 import numpy as np

--- a/cirq-core/cirq/interop/quirk/cells/cell_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/cell_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/interop/quirk/cells/composite_cell_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/composite_cell_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/interop/quirk/cells/control_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/control_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 

--- a/cirq-core/cirq/interop/quirk/cells/frequency_space_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/frequency_space_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import sympy
 
 import cirq

--- a/cirq-core/cirq/interop/quirk/cells/ignored_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/ignored_cells.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Iterator
 
 from cirq.interop.quirk.cells.cell import CELL_SIZES, CellMaker

--- a/cirq-core/cirq/interop/quirk/cells/ignored_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/ignored_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 

--- a/cirq-core/cirq/interop/quirk/cells/input_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from cirq import quirk_url_to_circuit

--- a/cirq-core/cirq/interop/quirk/cells/input_rotation_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_rotation_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/interop/quirk/cells/measurement_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/measurement_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 

--- a/cirq-core/cirq/interop/quirk/cells/parse.py
+++ b/cirq-core/cirq/interop/quirk/cells/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cmath
 import re
 from typing import (

--- a/cirq-core/cirq/interop/quirk/cells/parse_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/parse_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/interop/quirk/cells/qubit_permutation_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/qubit_permutation_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.interop.quirk.cells.qubit_permutation_cells import QuirkQubitPermutationGate
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns

--- a/cirq-core/cirq/interop/quirk/cells/scalar_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/scalar_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 

--- a/cirq-core/cirq/interop/quirk/cells/single_qubit_rotation_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/single_qubit_rotation_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import sympy
 
 import cirq

--- a/cirq-core/cirq/interop/quirk/cells/swap_cell_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/swap_cell_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/interop/quirk/cells/testing.py
+++ b/cirq-core/cirq/interop/quirk/cells/testing.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, List, Optional
 
 import numpy as np

--- a/cirq-core/cirq/interop/quirk/cells/testing_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/testing_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/interop/quirk/cells/unsupported_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/unsupported_cells.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Iterator
 
 from cirq.interop.quirk.cells.cell import CELL_SIZES, CellMaker

--- a/cirq-core/cirq/interop/quirk/cells/unsupported_cells_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/unsupported_cells_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from cirq import quirk_url_to_circuit

--- a/cirq-core/cirq/interop/quirk/url_to_circuit_test.py
+++ b/cirq-core/cirq/interop/quirk/url_to_circuit_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import json
 import urllib
 

--- a/cirq-core/cirq/linalg/combinators_test.py
+++ b/cirq-core/cirq/linalg/combinators_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/linalg/decompositions_test.py
+++ b/cirq-core/cirq/linalg/decompositions_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 
 import numpy as np

--- a/cirq-core/cirq/linalg/diagonalize.py
+++ b/cirq-core/cirq/linalg/diagonalize.py
@@ -14,6 +14,8 @@
 
 """Utility methods for diagonalizing matrices."""
 
+from __future__ import annotations
+
 from typing import Callable, List, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/linalg/diagonalize_test.py
+++ b/cirq-core/cirq/linalg/diagonalize_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 from typing import Optional, Tuple
 

--- a/cirq-core/cirq/linalg/operator_spaces_test.py
+++ b/cirq-core/cirq/linalg/operator_spaces_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/linalg/predicates_test.py
+++ b/cirq-core/cirq/linalg/predicates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cmath
 
 import numpy as np

--- a/cirq-core/cirq/linalg/tolerance_test.py
+++ b/cirq-core/cirq/linalg/tolerance_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from cirq.linalg.tolerance import all_near_zero, all_near_zero_mod, near_zero, near_zero_mod
 
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -14,8 +14,11 @@
 
 """Utility methods for transforming matrices or vectors."""
 
+from __future__ import annotations
+
 import dataclasses
 import functools
+from types import EllipsisType
 from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -298,7 +301,7 @@ def targeted_conjugate_about(
     return targeted_left_multiply(np.conjugate(tensor), first_multiply, conj_indices, out=out)
 
 
-_TSliceAtom = Union[int, slice, 'ellipsis']
+_TSliceAtom = Union[int, slice, EllipsisType]
 _TSlice = Union[_TSliceAtom, Sequence[_TSliceAtom]]
 
 

--- a/cirq-core/cirq/linalg/transformations_test.py
+++ b/cirq-core/cirq/linalg/transformations_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from cirq import ops
 
 

--- a/cirq-core/cirq/ops/arithmetic_operation_test.py
+++ b/cirq-core/cirq/ops/arithmetic_operation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Sequence, Union
 
 import numpy as np

--- a/cirq-core/cirq/ops/boolean_hamiltonian_test.py
+++ b/cirq-core/cirq/ops/boolean_hamiltonian_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import functools
 import itertools
 import math

--- a/cirq-core/cirq/ops/classically_controlled_operation_test.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 
 import numpy as np

--- a/cirq-core/cirq/ops/common_gate_families.py
+++ b/cirq-core/cirq/ops/common_gate_families.py
@@ -14,6 +14,8 @@
 
 """Common Gate Families used in cirq-core"""
 
+from __future__ import annotations
+
 from typing import Any, cast, Optional, Type, Union
 
 from cirq import protocols

--- a/cirq-core/cirq/ops/common_gate_families_test.py
+++ b/cirq-core/cirq/ops/common_gate_families_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/control_values_test.py
+++ b/cirq-core/cirq/ops/control_values_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/controlled_gate_test.py
+++ b/cirq-core/cirq/ops/controlled_gate_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import NotImplementedType
+from __future__ import annotations
+
+from types import EllipsisType, NotImplementedType
 from typing import Any, cast, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -45,7 +47,7 @@ class GateAllocatingNewSpaceForResult(cirq.testing.SingleQubitGate):
     def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> Union[np.ndarray, NotImplementedType]:
         assert len(args.axes) == 1
         a = args.axes[0]
-        seed = cast(Tuple[Union[int, slice, 'ellipsis'], ...], (slice(None),))
+        seed = cast(Tuple[Union[int, slice, EllipsisType], ...], (slice(None),))
         zero = seed * a + (0, Ellipsis)
         one = seed * a + (1, Ellipsis)
         result = np.zeros(args.target_tensor.shape, args.target_tensor.dtype)

--- a/cirq-core/cirq/ops/controlled_operation_test.py
+++ b/cirq-core/cirq/ops/controlled_operation_test.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import re
-from types import NotImplementedType
+from types import EllipsisType, NotImplementedType
 from typing import cast, Tuple, Union
 
 import numpy as np
@@ -48,7 +50,7 @@ class GateAllocatingNewSpaceForResult(cirq.testing.SingleQubitGate):
     def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> Union[np.ndarray, NotImplementedType]:
         assert len(args.axes) == 1
         a = args.axes[0]
-        seed = cast(Tuple[Union[int, slice, 'ellipsis'], ...], (slice(None),))
+        seed = cast(Tuple[Union[int, slice, EllipsisType], ...], (slice(None),))
         zero = seed * a + (0, Ellipsis)
         one = seed * a + (1, Ellipsis)
         result = np.zeros(args.target_tensor.shape, args.target_tensor.dtype)

--- a/cirq-core/cirq/ops/dense_pauli_string_test.py
+++ b/cirq-core/cirq/ops/dense_pauli_string_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numbers
 from typing import List
 

--- a/cirq-core/cirq/ops/diagonal_gate_test.py
+++ b/cirq-core/cirq/ops/diagonal_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/cirq-core/cirq/ops/eigen_gate_test.py
+++ b/cirq-core/cirq/ops/eigen_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/ops/fourier_transform_test.py
+++ b/cirq-core/cirq/ops/fourier_transform_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/fsim_gate_test.py
+++ b/cirq-core/cirq/ops/fsim_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/gate_features.py
+++ b/cirq-core/cirq/ops/gate_features.py
@@ -17,6 +17,8 @@
 For example: some gates are reversible, some have known matrices, etc.
 """
 
+from __future__ import annotations
+
 import abc
 
 

--- a/cirq-core/cirq/ops/gate_features_test.py
+++ b/cirq-core/cirq/ops/gate_features_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/gate_operation_test.py
+++ b/cirq-core/cirq/ops/gate_operation_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import collections.abc
 import pathlib
 

--- a/cirq-core/cirq/ops/gateset_test.py
+++ b/cirq-core/cirq/ops/gateset_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 from typing import cast, List, Tuple
 

--- a/cirq-core/cirq/ops/global_phase_op_test.py
+++ b/cirq-core/cirq/ops/global_phase_op_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/greedy_qubit_manager_test.py
+++ b/cirq-core/cirq/ops/greedy_qubit_manager_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/ops/identity_test.py
+++ b/cirq-core/cirq/ops/identity_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 from typing import Any
 from unittest import mock

--- a/cirq-core/cirq/ops/kraus_channel_test.py
+++ b/cirq-core/cirq/ops/kraus_channel_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/linear_combinations_test.py
+++ b/cirq-core/cirq/ops/linear_combinations_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import collections
 from typing import Union
 

--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import re
 
 import numpy as np

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/measurement_gate_test.py
+++ b/cirq-core/cirq/ops/measurement_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import cast
 
 import numpy as np

--- a/cirq-core/cirq/ops/mixed_unitary_channel_test.py
+++ b/cirq-core/cirq/ops/mixed_unitary_channel_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/named_qubit_test.py
+++ b/cirq-core/cirq/ops/named_qubit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.devices.grid_qubit_test import _test_qid_pickled_hash
 from cirq.ops.named_qubit import _pad_digits

--- a/cirq-core/cirq/ops/op_tree_test.py
+++ b/cirq-core/cirq/ops/op_tree_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import cast
 
 import pytest

--- a/cirq-core/cirq/ops/parallel_gate_test.py
+++ b/cirq-core/cirq/ops/parallel_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/parity_gates_test.py
+++ b/cirq-core/cirq/ops/parity_gates_test.py
@@ -14,6 +14,8 @@
 
 """Tests for `parity_gates.py`."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/pauli_gates_test.py
+++ b/cirq-core/cirq/ops/pauli_gates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_interaction_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/ops/pauli_string_raw_types_test.py
+++ b/cirq-core/cirq/ops/pauli_string_raw_types_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import math
 

--- a/cirq-core/cirq/ops/pauli_sum_exponential_test.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/permutation_gate_test.py
+++ b/cirq-core/cirq/ops/permutation_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/phased_iswap_gate_test.py
+++ b/cirq-core/cirq/ops/phased_iswap_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import scipy

--- a/cirq-core/cirq/ops/phased_x_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import random
 
 import numpy as np

--- a/cirq-core/cirq/ops/projector_test.py
+++ b/cirq-core/cirq/ops/projector_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/qid_util_test.py
+++ b/cirq-core/cirq/ops/qid_util_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/qubit_manager_test.py
+++ b/cirq-core/cirq/ops/qubit_manager_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/qubit_order.py
+++ b/cirq-core/cirq/ops/qubit_order.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 from typing import Any, Callable, Iterable, Optional, Tuple, TYPE_CHECKING, TypeVar
 
-from cirq.ops import raw_types
-
 if TYPE_CHECKING:
-    from cirq.ops import qubit_order_or_list
+    import cirq
 
 
 TInternalQubit = TypeVar('TInternalQubit')
@@ -28,12 +28,10 @@ TExternalQubit = TypeVar('TExternalQubit')
 class QubitOrder:
     """Defines the kronecker product order of qubits."""
 
-    def __init__(
-        self, explicit_func: Callable[[Iterable[raw_types.Qid]], Tuple[raw_types.Qid, ...]]
-    ) -> None:
+    def __init__(self, explicit_func: Callable[[Iterable[cirq.Qid]], Tuple[cirq.Qid, ...]]) -> None:
         self._explicit_func = explicit_func
 
-    DEFAULT: 'QubitOrder'
+    DEFAULT: QubitOrder
     """A basis that orders qubits in the same way that calling `sorted` does.
 
     Specifically, qubits are ordered first by their type name and then by
@@ -43,8 +41,8 @@ class QubitOrder:
 
     @staticmethod
     def explicit(
-        fixed_qubits: Iterable[raw_types.Qid], fallback: Optional['QubitOrder'] = None
-    ) -> 'QubitOrder':
+        fixed_qubits: Iterable[cirq.Qid], fallback: Optional[QubitOrder] = None
+    ) -> QubitOrder:
         """A basis that contains exactly the given qubits in the given order.
 
         Args:
@@ -77,7 +75,7 @@ class QubitOrder:
         return QubitOrder(func)
 
     @staticmethod
-    def sorted_by(key: Callable[[raw_types.Qid], Any]) -> 'QubitOrder':
+    def sorted_by(key: Callable[[cirq.Qid], Any]) -> QubitOrder:
         """A basis that orders qubits ascending based on a key function.
 
         Args:
@@ -89,7 +87,7 @@ class QubitOrder:
         """
         return QubitOrder(lambda qubits: tuple(sorted(qubits, key=key)))
 
-    def order_for(self, qubits: Iterable[raw_types.Qid]) -> Tuple[raw_types.Qid, ...]:
+    def order_for(self, qubits: Iterable[cirq.Qid]) -> Tuple[cirq.Qid, ...]:
         """Returns a qubit tuple ordered corresponding to the basis.
 
         Args:
@@ -104,7 +102,7 @@ class QubitOrder:
         return self._explicit_func(qubits)
 
     @staticmethod
-    def as_qubit_order(val: 'qubit_order_or_list.QubitOrderOrList') -> 'QubitOrder':
+    def as_qubit_order(val: cirq.QubitOrderOrList) -> QubitOrder:
         """Converts a value into a basis.
 
         Args:
@@ -126,7 +124,7 @@ class QubitOrder:
         self,
         internalize: Callable[[TExternalQubit], TInternalQubit],
         externalize: Callable[[TInternalQubit], TExternalQubit],
-    ) -> 'QubitOrder':
+    ) -> QubitOrder:
         """Transforms the Basis so that it applies to wrapped qubits.
 
         Args:

--- a/cirq-core/cirq/ops/qubit_order_or_list.py
+++ b/cirq-core/cirq/ops/qubit_order_or_list.py
@@ -18,6 +18,8 @@ This type is defined in its own file to work around an "invalid type" bug in
 mypy.
 """
 
+from __future__ import annotations
+
 from typing import Iterable, Union
 
 from cirq._doc import document

--- a/cirq-core/cirq/ops/qubit_order_test.py
+++ b/cirq-core/cirq/ops/qubit_order_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/ops/random_gate_channel_test.py
+++ b/cirq-core/cirq/ops/random_gate_channel_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/state_preparation_channel_test.py
+++ b/cirq-core/cirq/ops/state_preparation_channel_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/swap_gates_test.py
+++ b/cirq-core/cirq/ops/swap_gates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/tags.py
+++ b/cirq-core/cirq/ops/tags.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Canonical tags for the TaggedOperation class."""
+
+from __future__ import annotations
+
 from typing import Dict
 
 

--- a/cirq-core/cirq/ops/tags_test.py
+++ b/cirq-core/cirq/ops/tags_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/ops/two_qubit_diagonal_gate_test.py
+++ b/cirq-core/cirq/ops/two_qubit_diagonal_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/ops/uniform_superposition_gate_test.py
+++ b/cirq-core/cirq/ops/uniform_superposition_gate_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/ops/wait_gate_test.py
+++ b/cirq-core/cirq/ops/wait_gate_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/cirq-core/cirq/protocols/apply_channel_protocol.py
+++ b/cirq-core/cirq/protocols/apply_channel_protocol.py
@@ -14,6 +14,8 @@
 
 """A protocol for implementing high performance channel evolutions."""
 
+from __future__ import annotations
+
 from types import NotImplementedType
 from typing import Any, Iterable, Optional, Sequence, Tuple, TypeVar, Union
 
@@ -273,7 +275,7 @@ def apply_channel(
     )
 
 
-def _apply_unitary(val: Any, args: 'ApplyChannelArgs') -> Optional[np.ndarray]:
+def _apply_unitary(val: Any, args: ApplyChannelArgs) -> Optional[np.ndarray]:
     """Attempt to use `apply_unitary` and return the result.
 
     If `val` does not support `apply_unitary` returns None.
@@ -297,7 +299,7 @@ def _apply_unitary(val: Any, args: 'ApplyChannelArgs') -> Optional[np.ndarray]:
 
 
 def _apply_kraus(
-    kraus: Union[Tuple[np.ndarray], Sequence[Any]], args: 'ApplyChannelArgs'
+    kraus: Union[Tuple[np.ndarray], Sequence[Any]], args: ApplyChannelArgs
 ) -> np.ndarray:
     """Directly apply the kraus operators to the target tensor."""
     # Initialize output.
@@ -313,7 +315,7 @@ def _apply_kraus(
 
 
 def _apply_kraus_single_qubit(
-    kraus: Union[Tuple[Any], Sequence[Any]], args: 'ApplyChannelArgs'
+    kraus: Union[Tuple[Any], Sequence[Any]], args: ApplyChannelArgs
 ) -> np.ndarray:
     """Use slicing to apply single qubit channel.  Only for two-level qubits."""
     zero_left = linalg.slice_for_qubits_equal_to(args.left_axes, 0)
@@ -338,7 +340,7 @@ def _apply_kraus_single_qubit(
 
 
 def _apply_kraus_multi_qubit(
-    kraus: Union[Tuple[Any], Sequence[Any]], args: 'ApplyChannelArgs'
+    kraus: Union[Tuple[Any], Sequence[Any]], args: ApplyChannelArgs
 ) -> np.ndarray:
     """Use numpy's einsum to apply a multi-qubit channel."""
     qid_shape = tuple(args.target_tensor.shape[i] for i in args.left_axes)

--- a/cirq-core/cirq/protocols/apply_channel_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_channel_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/protocols/apply_mixture_protocol.py
+++ b/cirq-core/cirq/protocols/apply_mixture_protocol.py
@@ -14,6 +14,8 @@
 
 """A protocol for implementing high performance mixture evolutions."""
 
+from __future__ import annotations
+
 from types import NotImplementedType
 from typing import Any, cast, Iterable, Optional, Tuple, TypeVar, Union
 
@@ -273,7 +275,7 @@ def apply_mixture(
     )
 
 
-def _validate_input(val: Any, args: 'ApplyMixtureArgs') -> Tuple[Any, 'ApplyMixtureArgs', bool]:
+def _validate_input(val: Any, args: ApplyMixtureArgs) -> Tuple[Any, ApplyMixtureArgs, bool]:
     """Validate args input and determine if we are operating on a
     density matrix or a state vector.
     """
@@ -303,7 +305,7 @@ def _validate_input(val: Any, args: 'ApplyMixtureArgs') -> Tuple[Any, 'ApplyMixt
 
 
 def _apply_unitary_strat(
-    val: Any, args: 'ApplyMixtureArgs', is_density_matrix: bool
+    val: Any, args: ApplyMixtureArgs, is_density_matrix: bool
 ) -> Optional[np.ndarray]:
     """Attempt to use `apply_unitary` and return the result.
 
@@ -333,7 +335,7 @@ def _apply_unitary_strat(
 
 
 def _apply_unitary_from_matrix_strat(
-    val: np.ndarray, args: 'ApplyMixtureArgs', is_density_matrix: bool
+    val: np.ndarray, args: ApplyMixtureArgs, is_density_matrix: bool
 ) -> Optional[np.ndarray]:
     """Used to enact mixture tuples that are given as (probability, np.ndarray)
 
@@ -359,7 +361,7 @@ def _apply_unitary_from_matrix_strat(
 
 
 def _apply_mixture_from_mixture_strat(
-    val: Any, args: 'ApplyMixtureArgs', is_density_matrix: bool
+    val: Any, args: ApplyMixtureArgs, is_density_matrix: bool
 ) -> Optional[np.ndarray]:
     """Attempt to use unitary matrices in _mixture_ and return the result."""
     method = getattr(val, '_mixture_', None)

--- a/cirq-core/cirq/protocols/apply_mixture_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_mixture_protocol_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Any, cast, Iterable, Optional, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/protocols/approximate_equality_protocol.py
+++ b/cirq-core/cirq/protocols/approximate_equality_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numbers
 from decimal import Decimal
 from fractions import Fraction

--- a/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
+++ b/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from decimal import Decimal
 from fractions import Fraction
 from numbers import Number

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/protocols/commutes_protocol.py
+++ b/cirq-core/cirq/protocols/commutes_protocol.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Protocol for determining commutativity."""
+
+from __future__ import annotations
 
 from types import NotImplementedType
 from typing import Any, overload, TypeVar, Union

--- a/cirq-core/cirq/protocols/commutes_protocol_test.py
+++ b/cirq-core/cirq/protocols/commutes_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/protocols/control_key_protocol_test.py
+++ b/cirq-core/cirq/protocols/control_key_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol.py
+++ b/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numbers
 from collections.abc import Iterable
 from typing import Any

--- a/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Optional
 
 import cirq.protocols.decompose_protocol as decompose_protocol

--- a/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_stabilizer_effect_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/protocols/has_unitary_protocol.py
+++ b/cirq-core/cirq/protocols/has_unitary_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Optional, TypeVar
 
 import numpy as np

--- a/cirq-core/cirq/protocols/has_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/has_unitary_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/protocols/inverse_protocol_test.py
+++ b/cirq-core/cirq/protocols/inverse_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq
@@ -32,7 +34,7 @@ class ReturnsFive:
 
 
 class SelfInverse:
-    def __pow__(self, exponent) -> 'SelfInverse':
+    def __pow__(self, exponent) -> SelfInverse:
         return self
 
 

--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import dataclasses
 import datetime
 import gzip

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import contextlib
 import dataclasses
 import datetime

--- a/cirq-core/cirq/protocols/json_test_data/spec.py
+++ b/cirq-core/cirq/protocols/json_test_data/spec.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pathlib
 
 import cirq

--- a/cirq-core/cirq/protocols/kraus_protocol.py
+++ b/cirq-core/cirq/protocols/kraus_protocol.py
@@ -14,6 +14,8 @@
 
 """Protocol and methods for obtaining Kraus representation of quantum channels."""
 
+from __future__ import annotations
+
 import warnings
 from types import NotImplementedType
 from typing import Any, Sequence, Tuple, TypeVar, Union

--- a/cirq-core/cirq/protocols/kraus_protocol_test.py
+++ b/cirq-core/cirq/protocols/kraus_protocol_test.py
@@ -14,6 +14,8 @@
 
 """Tests for kraus_protocol.py."""
 
+from __future__ import annotations
+
 from typing import Iterable, List, Sequence, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/protocols/measurement_key_protocol_test.py
+++ b/cirq-core/cirq/protocols/measurement_key_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq
@@ -99,7 +101,8 @@ def test_is_measurement() -> None:
     assert not cirq.is_measurement(cirq.bit_flip(1))
 
     class NotImplementedOperation(cirq.Operation):
-        def with_qubits(self, *new_qubits) -> 'NotImplementedOperation':
+        # pylint: disable=undefined-variable
+        def with_qubits(self, *new_qubits) -> NotImplementedOperation:
             raise NotImplementedError()
 
         @property

--- a/cirq-core/cirq/protocols/mixture_protocol.py
+++ b/cirq-core/cirq/protocols/mixture_protocol.py
@@ -14,6 +14,8 @@
 
 """Protocol for objects that are mixtures (probabilistic combinations)."""
 
+from __future__ import annotations
+
 from types import NotImplementedType
 from typing import Any, Sequence, Tuple, Union
 

--- a/cirq-core/cirq/protocols/mixture_protocol_test.py
+++ b/cirq-core/cirq/protocols/mixture_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/protocols/mul_protocol.py
+++ b/cirq-core/cirq/protocols/mul_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 from cirq.protocols.resolve_parameters import is_parameterized

--- a/cirq-core/cirq/protocols/mul_protocol_test.py
+++ b/cirq-core/cirq/protocols/mul_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/protocols/pauli_expansion_protocol.py
+++ b/cirq-core/cirq/protocols/pauli_expansion_protocol.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Protocol for obtaining expansion of linear operators in Pauli basis."""
+
+from __future__ import annotations
 
 from typing import Any, TypeVar, Union
 

--- a/cirq-core/cirq/protocols/pauli_expansion_protocol_test.py
+++ b/cirq-core/cirq/protocols/pauli_expansion_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/protocols/phase_protocol.py
+++ b/cirq-core/cirq/protocols/phase_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, TypeVar
 
 from typing_extensions import Protocol

--- a/cirq-core/cirq/protocols/phase_protocol_test.py
+++ b/cirq-core/cirq/protocols/phase_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/protocols/pow_protocol_test.py
+++ b/cirq-core/cirq/protocols/pow_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/protocols/qasm_test.py
+++ b/cirq-core/cirq/protocols/qasm_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/protocols/qid_shape_protocol.py
+++ b/cirq-core/cirq/protocols/qid_shape_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from types import NotImplementedType
 from typing import Any, Sequence, Tuple, TypeVar, Union
 

--- a/cirq-core/cirq/protocols/qid_shape_protocol_test.py
+++ b/cirq-core/cirq/protocols/qid_shape_protocol_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/protocols/resolve_parameters_test.py
+++ b/cirq-core/cirq/protocols/resolve_parameters_test.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 
 import cirq
-from cirq.study import ParamResolver
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
@@ -38,7 +39,7 @@ def test_resolve_parameters(resolve_fn) -> None:
         def _is_parameterized_(self) -> bool:
             return self.parameter != 0
 
-        def _resolve_parameters_(self, resolver: ParamResolver, recursive: bool):
+        def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool):
             self.parameter = resolver.value_of(self.parameter, recursive)
             return self
 

--- a/cirq-core/cirq/protocols/trace_distance_bound.py
+++ b/cirq-core/cirq/protocols/trace_distance_bound.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Optional, Sequence, TypeVar, Union
 
 import numpy as np

--- a/cirq-core/cirq/protocols/trace_distance_bound_test.py
+++ b/cirq-core/cirq/protocols/trace_distance_bound_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/protocols/unitary_protocol.py
+++ b/cirq-core/cirq/protocols/unitary_protocol.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from types import NotImplementedType
 from typing import Any, Optional, TypeVar, Union
 

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/cirq-core/cirq/qis/channels.py
+++ b/cirq-core/cirq/qis/channels.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tools for analyzing and manipulating quantum channels."""
+
+from __future__ import annotations
+
 from typing import Sequence
 
 import numpy as np
@@ -280,7 +284,7 @@ def superoperator_to_choi(superoperator: np.ndarray) -> np.ndarray:
     return np.reshape(c, (d * d, d * d))
 
 
-def operation_to_choi(operation: 'protocols.SupportsKraus') -> np.ndarray:
+def operation_to_choi(operation: protocols.SupportsKraus) -> np.ndarray:
     r"""Returns the unique Choi matrix associated with an operation .
 
     Choi matrix J(E) of a linear map E: L(H1) -> L(H2) which takes linear operators
@@ -302,7 +306,7 @@ def operation_to_choi(operation: 'protocols.SupportsKraus') -> np.ndarray:
     return kraus_to_choi(protocols.kraus(operation))
 
 
-def operation_to_superoperator(operation: 'protocols.SupportsKraus') -> np.ndarray:
+def operation_to_superoperator(operation: protocols.SupportsKraus) -> np.ndarray:
     """Returns the matrix representation of an operation in standard basis.
 
     Let E: L(H1) -> L(H2) denote a linear map which takes linear operators on Hilbert space H1

--- a/cirq-core/cirq/qis/channels_test.py
+++ b/cirq-core/cirq/qis/channels_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for channels."""
+
+from __future__ import annotations
+
 from typing import Iterable, Sequence
 
 import numpy as np

--- a/cirq-core/cirq/qis/clifford_tableau_test.py
+++ b/cirq-core/cirq/qis/clifford_tableau_test.py
@@ -14,6 +14,8 @@
 
 """Tests for clifford tableau."""
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/qis/entropy.py
+++ b/cirq-core/cirq/qis/entropy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from itertools import product

--- a/cirq-core/cirq/qis/entropy_test.py
+++ b/cirq-core/cirq/qis/entropy_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np

--- a/cirq-core/cirq/qis/measures_test.py
+++ b/cirq-core/cirq/qis/measures_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for measures."""
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/qis/noise_utils.py
+++ b/cirq-core/cirq/qis/noise_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/cirq-core/cirq/qis/noise_utils_test.py
+++ b/cirq-core/cirq/qis/noise_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/qis/states_test.py
+++ b/cirq-core/cirq/qis/states_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/sim/classical_simulator_test.py
+++ b/cirq-core/cirq/sim/classical_simulator_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from itertools import product
 
 import numpy as np

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/sim/clifford/stabilizer_sampler_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_sampler_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest.mock as mock
 
 import numpy as np

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulation_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 import random
 from typing import Type, Union

--- a/cirq-core/cirq/sim/density_matrix_utils_test.py
+++ b/cirq-core/cirq/sim/density_matrix_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/sim/mux_test.py
+++ b/cirq-core/cirq/sim/mux_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Tests sampling/simulation methods that delegate to appropriate simulators."""
+
+from __future__ import annotations
+
 import collections
 
 import numpy as np

--- a/cirq-core/cirq/sim/simulation_product_state_test.py
+++ b/cirq-core/cirq/sim/simulation_product_state_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Any, Dict, Optional, Sequence
 
 import cirq

--- a/cirq-core/cirq/sim/simulation_state_test.py
+++ b/cirq-core/cirq/sim/simulation_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Sequence
 
 import numpy as np

--- a/cirq-core/cirq/sim/simulation_utils.py
+++ b/cirq-core/cirq/sim/simulation_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Sequence, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/sim/simulation_utils_test.py
+++ b/cirq-core/cirq/sim/simulation_utils_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import itertools
 import random
 from typing import Type, Union

--- a/cirq-core/cirq/sim/state_vector_simulation_state_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import cast, Type
 from unittest import mock
 

--- a/cirq-core/cirq/sim/state_vector_simulator_test.py
+++ b/cirq-core/cirq/sim/state_vector_simulator_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/sim/state_vector_test.py
+++ b/cirq-core/cirq/sim/state_vector_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for state_vector.py"""
+
+from __future__ import annotations
 
 import itertools
 from typing import Iterator, Optional

--- a/cirq-core/cirq/study/flatten_expressions_test.py
+++ b/cirq-core/cirq/study/flatten_expressions_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import sympy
 
 import cirq

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -14,6 +14,8 @@
 
 """Tests for parameter resolvers."""
 
+from __future__ import annotations
+
 import fractions
 
 import numpy as np

--- a/cirq-core/cirq/study/result_test.py
+++ b/cirq-core/cirq/study/result_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import collections
 
 import numpy as np

--- a/cirq-core/cirq/study/sweepable.py
+++ b/cirq-core/cirq/study/sweepable.py
@@ -14,6 +14,8 @@
 
 """Defines which types are Sweepable."""
 
+from __future__ import annotations
+
 import warnings
 from typing import cast, Iterable, Iterator, List, Optional, Sequence, Union
 
@@ -31,7 +33,7 @@ class _Sweepable(Protocol):
     """An intermediate class allowing for recursive definition of Sweepable,
     since recursive union definitions are not yet supported in mypy."""
 
-    def __iter__(self) -> Iterator[Union[SweepLike, '_Sweepable']]:
+    def __iter__(self) -> Iterator[Union[SweepLike, _Sweepable]]:
         pass
 
 
@@ -72,9 +74,9 @@ def to_sweeps(sweepable: Sweepable, metadata: Optional[dict] = None) -> List[Swe
 
 def to_sweep(
     sweep_or_resolver_list: Union[
-        'Sweep', ParamResolverOrSimilarType, Iterable[ParamResolverOrSimilarType]
+        Sweep, ParamResolverOrSimilarType, Iterable[ParamResolverOrSimilarType]
     ],
-) -> 'Sweep':
+) -> Sweep:
     """Converts the argument into a ``cirq.Sweep``.
 
     Args:

--- a/cirq-core/cirq/study/sweepable_test.py
+++ b/cirq-core/cirq/study/sweepable_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for sweepable.py."""
+
+from __future__ import annotations
 
 import itertools
 

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/testing/circuit_compare.py
+++ b/cirq-core/cirq/testing/circuit_compare.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import random
 from collections import defaultdict

--- a/cirq-core/cirq/testing/circuit_compare_test.py
+++ b/cirq-core/cirq/testing/circuit_compare_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/consistent_act_on.py
+++ b/cirq-core/cirq/testing/consistent_act_on.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, cast, Optional, Type
+from __future__ import annotations
+
+from typing import Any, cast, Optional, Type, TYPE_CHECKING
 
 import numpy as np
 
@@ -20,7 +22,6 @@ from cirq import protocols
 from cirq.circuits.circuit import Circuit
 from cirq.devices import LineQubit
 from cirq.ops import common_gates
-from cirq.ops.dense_pauli_string import DensePauliString
 from cirq.qis import clifford_tableau
 from cirq.sim import final_state_vector, state_vector_simulation_state
 from cirq.sim.clifford import (
@@ -29,8 +30,13 @@ from cirq.sim.clifford import (
     stabilizer_state_ch_form,
 )
 
+if TYPE_CHECKING:
+    import cirq
 
-def state_vector_has_stabilizer(state_vector: np.ndarray, stabilizer: DensePauliString) -> bool:
+
+def state_vector_has_stabilizer(
+    state_vector: np.ndarray, stabilizer: cirq.DensePauliString
+) -> bool:
     """Checks that the state_vector is stabilized by the given stabilizer.
 
     The stabilizer should not modify the value of the state_vector, up to the

--- a/cirq-core/cirq/testing/consistent_act_on_test.py
+++ b/cirq-core/cirq/testing/consistent_act_on_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Sequence
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_channels.py
+++ b/cirq-core/cirq/testing/consistent_channels.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_channels_test.py
+++ b/cirq-core/cirq/testing/consistent_channels_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/consistent_controlled_gate_op.py
+++ b/cirq-core/cirq/testing/consistent_controlled_gate_op.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Collection, Optional, Sequence, Union
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_decomposition.py
+++ b/cirq-core/cirq/testing/consistent_decomposition.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_decomposition_test.py
+++ b/cirq-core/cirq/testing/consistent_decomposition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/testing/consistent_pauli_expansion.py
+++ b/cirq-core/cirq/testing/consistent_pauli_expansion.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_pauli_expansion_test.py
+++ b/cirq-core/cirq/testing/consistent_pauli_expansion_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/consistent_phase_by.py
+++ b/cirq-core/cirq/testing/consistent_phase_by.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_phase_by_test.py
+++ b/cirq-core/cirq/testing/consistent_phase_by_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 


### PR DESCRIPTION
No change in the effective code.  A batch of 200 files (~400 to go).
Added future import of annotations to detect typing-only imports.

Passes  ruff check --target-version=py311 --select=UP037,TC001

Partially implements #1999
