### PR TITLE
Add new Quantikz rendering modules and enhance existing functions for visualization

### DIFF
--- a/cirq-core/cirq/vis/__init__.py
+++ b/cirq-core/cirq/vis/__init__.py
@@ -28,3 +28,6 @@ from cirq.vis.state_histogram import (
 from cirq.vis.density_matrix import plot_density_matrix as plot_density_matrix
 
 from cirq.vis.vis_utils import relative_luminance as relative_luminance
+
+from cirq.vis.circuit_to_latex_quantikz import CirqToQuantikz
+from cirq.vis.circuit_to_latex_render import render_circuit

--- a/cirq-core/cirq/vis/circuit_to_latex_quantikz.py
+++ b/cirq-core/cirq/vis/circuit_to_latex_quantikz.py
@@ -1,0 +1,710 @@
+# -*- coding: utf-8 -*-
+r"""Converts Cirq circuits to Quantikz LaTeX (using modern quantikz syntax).
+
+This module provides a class, `CirqToQuantikz`, to translate `cirq.Circuit`
+objects into LaTeX code using the `quantikz` package. It aims to offer
+flexible customization for gate styles, wire labels, and circuit folding.
+
+Example:
+    >>> import cirq
+    >>> from cirq.vis.circuit_to_latex_quantikz import CirqToQuantikz
+    >>> q0, q1 = cirq.LineQubit.range(2)
+    >>> circuit = cirq.Circuit(
+    ...     cirq.H(q0),
+    ...     cirq.CNOT(q0, q1),
+    ...     cirq.measure(q0, key='m0'),
+    ...     cirq.Rx(rads=0.5).on(q1)
+    ... )
+    >>> converter = CirqToQuantikz(circuit, fold_at=2)
+    >>> latex_code = converter.generate_latex_document()
+    >>> print(latex_code) # doctest: +SKIP
+    \documentclass[preview, border=2pt]{standalone}
+    % Core drawing packages
+    \usepackage{tikz}
+    \usetikzlibrary{quantikz} % Loads the quantikz library (latest installed version)
+    % Optional useful TikZ libraries
+    \usetikzlibrary{fit, arrows.meta, decorations.pathreplacing, calligraphy}
+    % Font encoding and common math packages
+    \usepackage[T1]{fontenc}
+    \usepackage{amsmath}
+    \usepackage{amsfonts}
+    \usepackage{amssymb}
+    % \usepackage{physics} % Removed
+    % --- Custom Preamble Injection Point ---
+    % --- End Custom Preamble ---
+    \begin{document}
+    \begin{quantikz}
+    \lstick{$q_{0}$} & \gate[style={fill=yellow!20}]{H} & \ctrl{1} & \meter{$m0$} \\
+    \lstick{$q_{1}$} & \qw & \targ{} & \qw
+    \end{quantikz}
+
+    \vspace{1em}
+
+    \begin{quantikz}
+    \lstick{$q_{0}$} & \qw & \rstick{$q_{0}$} \\
+    \lstick{$q_{1}$} & \gate[style={fill=green!20}]{R_{X}(0.5)} & \rstick{$q_{1}$}
+    \end{quantikz}
+    \end{document}
+"""
+# mypy: ignore-errors
+
+
+import math
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type
+
+import cirq
+import numpy as np
+import sympy
+
+__all__ = ["CirqToQuantikz", "DEFAULT_PREAMBLE_TEMPLATE", "GATE_STYLES_COLORFUL1"]
+
+
+# =============================================================================
+# Default Preamble Template (physics.sty removed)
+# =============================================================================
+DEFAULT_PREAMBLE_TEMPLATE = r"""
+\documentclass[preview, border=2pt]{standalone}
+% Core drawing packages
+\usepackage{tikz}
+\usetikzlibrary{quantikz} % Loads the quantikz library (latest installed version)
+% Optional useful TikZ libraries
+\usetikzlibrary{fit, arrows.meta, decorations.pathreplacing, calligraphy}
+% Font encoding and common math packages
+\usepackage[T1]{fontenc}
+\usepackage{amsmath}
+\usepackage{amsfonts}
+\usepackage{amssymb}
+% \usepackage{physics} % Removed
+"""
+
+# =============================================================================
+# Default Style Definitions
+# =============================================================================
+_Pauli_gate_style = r"style={fill=blue!20}"
+_green_gate_style = r"style={fill=green!20}"
+_yellow_gate_style = r"style={fill=yellow!20}"  # For H
+_orange_gate_style = r"style={fill=orange!20}"  # For FSim, ISwap, etc.
+_gray_gate_style = r"style={fill=gray!20}"  # For Measure
+_noisy_channel_style = r"style={fill=red!20}"
+
+GATE_STYLES_COLORFUL1 = {
+    "H": _yellow_gate_style,
+    "_PauliX": _Pauli_gate_style,  # cirq.X(q_param)
+    "_PauliY": _Pauli_gate_style,  # cirq.Y(q_param)
+    "_PauliZ": _Pauli_gate_style,  # cirq.Z(q_param)
+    "X": _Pauli_gate_style,  # For XPowGate(exponent=1)
+    "Y": _Pauli_gate_style,  # For YPowGate(exponent=1)
+    "Z": _Pauli_gate_style,  # For ZPowGate(exponent=1)
+    "X_pow": _green_gate_style,  # For XPowGate(exponent!=1)
+    "Y_pow": _green_gate_style,  # For YPowGate(exponent!=1)
+    "Z_pow": _green_gate_style,  # For ZPowGate(exponent!=1)
+    "H_pow": _green_gate_style,  # For HPowGate(exponent!=1)
+    "Rx": _green_gate_style,
+    "Ry": _green_gate_style,
+    "Rz": _green_gate_style,
+    "PhasedXZ": _green_gate_style,
+    "FSimGate": _orange_gate_style,
+    "FSim": _orange_gate_style,  # Alias for FSimGate
+    "ISwap": _orange_gate_style,  # For ISwapPowGate(exponent=1)
+    "iSWAP_pow": _orange_gate_style,  # For ISwapPowGate(exponent!=1)
+    "CZ_pow": _orange_gate_style,  # For CZPowGate(exponent!=1)
+    "CX_pow": _orange_gate_style,  # For CNotPowGate(exponent!=1)
+    "CXideal": "",  # No fill for \ctrl \targ, let quantikz draw default
+    "CZideal": "",  # No fill for \ctrl \control
+    "Swapideal": "",  # No fill for \swap \targX
+    "Measure": _gray_gate_style,
+    "DepolarizingChannel": _noisy_channel_style,
+    "BitFlipChannel": _noisy_channel_style,
+    "ThermalChannel": _noisy_channel_style,
+}
+
+
+# =============================================================================
+# Cirq to Quantikz Conversion Class
+# =============================================================================
+class CirqToQuantikz:
+    r"""Converts a Cirq Circuit object to a Quantikz LaTeX string.
+
+    This class facilitates the conversion of a `cirq.Circuit` into a LaTeX
+    representation using the `quantikz` package. It handles various gate types,
+    qubit mapping, and provides options for customizing the output, such as
+    gate styling, circuit folding, and parameter display.
+
+    Args:
+        circuit: The `cirq.Circuit` object to be converted.
+        gate_styles: An optional dictionary mapping gate names (strings) to
+            Quantikz style options (strings). These styles are applied to
+            the generated gates. If `None`, `GATE_STYLES_COLORFUL1` is used.
+        quantikz_options: An optional string of global options to pass to the
+            `quantikz` environment (e.g., `"[row sep=0.5em]"`).
+        fold_at: An optional integer specifying the number of moments after
+            which the circuit should be folded into a new line in the LaTeX
+            output. If `None`, the circuit is not folded.
+        custom_preamble: An optional string containing custom LaTeX code to be
+            inserted into the document's preamble.
+        custom_postamble: An optional string containing custom LaTeX code to be
+            inserted just before `\end{document}`.
+        wire_labels: A string specifying how qubit wire labels should be
+            rendered.
+            - `"q"`: Labels as $q_0, q_1, \dots$
+            - `"index"`: Labels as $0, 1, \dots$
+            - `"qid"`: Labels as the string representation of the `cirq.Qid`
+            - Any other value defaults to `"q"`.
+        show_parameters: A boolean indicating whether gate parameters (e.g.,
+            exponents for `XPowGate`, angles for `Rx`) should be displayed
+            in the gate labels.
+        gate_name_map: An optional dictionary mapping Cirq gate names (strings)
+            to custom LaTeX strings for rendering. This allows renaming gates
+            in the output.
+        float_precision_exps: An integer specifying the number of decimal
+            places for formatting floating-point exponents.
+        float_precision_angles: An integer specifying the number of decimal
+            places for formatting floating-point angles. (Note: Not fully
+            implemented in current version for all angle types).
+
+    Raises:
+        ValueError: If the input `circuit` is empty or contains no qubits.
+    """
+
+    GATE_NAME_MAP = {
+        "Rx": r"R_{X}",
+        "Ry": r"R_{Y}",
+        "Rz": r"R_{Z}",
+        "FSim": r"\mathrm{fSim}",
+        "PhasedXZ": r"\Phi",
+        "CZ": r"\mathrm{CZ}",
+        "CX": r"\mathrm{CX}",
+        "iSwap": r"i\mathrm{SWAP}",
+    }
+
+    def __init__(
+        self,
+        circuit: "cirq.Circuit",
+        *,
+        gate_styles: Optional[Dict[str, str]] = None,
+        quantikz_options: Optional[str] = None,
+        fold_at: Optional[int] = None,
+        custom_preamble: str = "",
+        custom_postamble: str = "",
+        wire_labels: str = "q",
+        show_parameters: bool = True,
+        gate_name_map: Optional[Dict[str, str]] = None,
+        float_precision_exps: int = 2,
+        float_precision_angles: int = 2,
+    ):
+        if not circuit:
+            raise ValueError("Input circuit cannot be empty.")
+        self.circuit = circuit
+        self.gate_styles = gate_styles if gate_styles is not None else GATE_STYLES_COLORFUL1.copy()
+        self.quantikz_options = quantikz_options or ""
+        self.fold_at = fold_at
+        self.custom_preamble = custom_preamble
+        self.custom_postamble = custom_postamble
+        self.wire_labels = wire_labels
+        self.show_parameters = show_parameters
+        self.current_gate_name_map = self.GATE_NAME_MAP.copy()
+        if gate_name_map:
+            self.current_gate_name_map.update(gate_name_map)
+        self.sorted_qubits = self._get_sorted_qubits()
+        if not self.sorted_qubits:
+            raise ValueError("Circuit contains no qubits.")
+        self.qubit_to_index = self._map_qubits_to_indices()
+        self.num_qubits = len(self.sorted_qubits)
+        self.float_precision_exps = float_precision_exps
+        self.float_precision_angles = float_precision_angles
+
+        # Initialize gate maps here to avoid circular import issues
+        self._SIMPLE_GATE_MAP: Dict[Type["cirq.Gate"], str] = {cirq.MeasurementGate: "Measure"}
+        self._EXPONENT_GATE_MAP: Dict[Type["cirq.Gate"], str] = {
+            cirq.XPowGate: "X",
+            cirq.YPowGate: "Y",
+            cirq.ZPowGate: "Z",
+            cirq.HPowGate: "H",
+            cirq.CNotPowGate: "CX",
+            cirq.CZPowGate: "CZ",
+            cirq.SwapPowGate: "Swap",
+            cirq.ISwapPowGate: "iSwap",
+        }
+        self._PARAMETERIZED_GATE_BASE_NAMES: Dict[Type["cirq.Gate"], str] = {}
+        _param_gate_specs = [
+            ("Rx", getattr(cirq, "Rx", None)),
+            ("Ry", getattr(cirq, "Ry", None)),
+            ("Rz", getattr(cirq, "Rz", None)),
+            ("PhasedXZ", getattr(cirq, "PhasedXZGate", None)),
+            ("FSim", getattr(cirq, "FSimGate", None)),
+        ]
+        if _param_gate_specs:
+            for _name, _gate_cls in _param_gate_specs:
+                if _gate_cls:
+                    self._PARAMETERIZED_GATE_BASE_NAMES[_gate_cls] = _name
+            # Clean up temporary variables
+            del _param_gate_specs, _name, _gate_cls  # type: ignore
+
+    def _get_sorted_qubits(self) -> List["cirq.Qid"]:
+        """Determines and returns a sorted list of all unique qubits in the circuit.
+
+        Returns:
+            A list of `cirq.Qid` objects, sorted to ensure consistent qubit
+            ordering in the LaTeX output.
+        """
+        qubits = set(q for moment in self.circuit for op in moment for q in op.qubits)
+        return sorted(list(qubits))
+
+    def _map_qubits_to_indices(self) -> Dict["cirq.Qid", int]:
+        """Creates a mapping from `cirq.Qid` objects to their corresponding
+        integer indices based on the sorted qubit order.
+
+        Returns:
+            A dictionary where keys are `cirq.Qid` objects and values are their
+            zero-based integer indices.
+        """
+        return {q: i for i, q in enumerate(self.sorted_qubits)}
+
+    def _get_wire_label(self, qubit: "cirq.Qid", index: int) -> str:
+        r"""Generates the LaTeX string for a qubit wire label.
+
+        Args:
+            qubit: The `cirq.Qid` object for which to generate the label.
+            index: The integer index of the qubit.
+
+        Returns:
+            A string formatted as a LaTeX math-mode label (e.g., "$q_0$", "$3$",
+            or "$q_{qubit\_name}$").
+        """
+        s = str(qubit).replace("_", r"\_").replace(" ", r"\,")
+        lbl = (
+            f"q_{{{index}}}"
+            if self.wire_labels == "q"
+            else (
+                str(index)
+                if self.wire_labels == "index"
+                else s if self.wire_labels == "qid" else f"q_{{{index}}}"
+            )
+        )
+        return f"${lbl}$"
+
+    def _format_exponent_for_display(self, exponent: Any) -> str:
+        """Formats a gate exponent for display in LaTeX.
+
+        Handles floats, integers, and `sympy.Basic` expressions, converting them
+        to a string representation suitable for LaTeX, including proper
+        handling of numerical precision and symbolic constants like pi.
+
+        Args:
+            exponent: The exponent value, which can be a float, int, or
+                `sympy.Basic` object.
+
+        Returns:
+            A string representing the formatted exponent, ready for LaTeX
+            insertion.
+        """
+        exp_str: str
+        # Dynamically create the format string based on self.float_precision_exps
+        float_format_string = f".{self.float_precision_exps}f"
+
+        if isinstance(exponent, float):
+            # If the float is an integer value (e.g., 2.0), display as integer string ("2")
+            if exponent.is_integer():
+                exp_str = str(int(exponent))
+            else:
+                # Format to the specified precision for rounding
+                rounded_str = format(exponent, float_format_string)
+                # Convert back to float and then to string to remove unnecessary trailing zeros
+                # e.g., if precision is 2, 0.5 -> "0.50" -> 0.5 -> "0.5"
+                # e.g., if precision is 2, 0.318 -> "0.32" -> 0.32 -> "0.32"
+                exp_str = str(float(rounded_str))
+        # Check for sympy.Basic, assuming sympy is imported if this path is taken
+        elif isinstance(exponent, sympy.Basic):  # type: ignore
+            s_exponent = str(exponent)
+            # Heuristic: check for letters to identify symbolic expressions
+            is_symbolic_or_special = any(
+                char.isalpha()
+                for char in s_exponent
+                if char.lower() not in ["e"]  # Exclude 'e' for scientific notation
+            )
+            if not is_symbolic_or_special:  # If it looks like a number
+                try:
+                    py_float = float(sympy.N(exponent))  # type: ignore
+                    # If the sympy evaluated float is an integer value
+                    if py_float.is_integer():
+                        exp_str = str(int(py_float))
+                    else:
+                        # Format to specified precision for rounding
+                        rounded_str = format(py_float, float_format_string)
+                        # Convert back to float and then to string to remove unnecessary trailing zeros
+                        exp_str = str(float(rounded_str))
+                except (TypeError, ValueError, AttributeError, sympy.SympifyError):  # type: ignore
+                    exp_str = s_exponent  # Fallback to Sympy's string representation
+            else:  # Symbolic expression
+                exp_str = s_exponent
+        else:  # For other types (int, strings not sympy objects)
+            exp_str = str(exponent)
+
+        # LaTeX replacements for pi
+        exp_str = exp_str.replace("pi", r"\pi").replace("π", r"\pi")
+
+        # Handle underscores: replace "_" with "\_" if not part of a LaTeX command
+        if "_" in exp_str and "\\" not in exp_str:
+            exp_str = exp_str.replace("_", r"\_")
+        return exp_str
+
+    def _get_gate_name(self, gate: "cirq.Gate") -> str:
+        """Determines the appropriate LaTeX string for a given Cirq gate.
+
+        This method attempts to derive a suitable LaTeX name for the gate,
+        considering its type, whether it's a power gate, and if parameters
+        should be displayed. It uses internal mappings and `cirq.circuit_diagram_info`.
+
+        Args:
+            gate: The `cirq.Gate` object to name.
+
+        Returns:
+            A string representing the LaTeX name of the gate (e.g., "H",
+            "Rx(0.5)", "CZ").
+        """
+        gate_type = type(gate)
+        if gate_type.__name__ == "ThermalChannel":
+            return "\\Lambda_\\mathrm{th}"
+        if (simple_name := self._SIMPLE_GATE_MAP.get(gate_type)) is not None:
+            return simple_name
+
+        base_key = self._EXPONENT_GATE_MAP.get(gate_type)
+        if base_key is not None and hasattr(gate, "exponent") and gate.exponent == 1:
+            return self.current_gate_name_map.get(base_key, base_key)
+
+        if (param_base_key := self._PARAMETERIZED_GATE_BASE_NAMES.get(gate_type)) is not None:
+            mapped_name = self.current_gate_name_map.get(param_base_key, param_base_key)
+            if not self.show_parameters:
+                return mapped_name
+            try:
+                info_src = cirq.protocols if hasattr(cirq, "protocols") else cirq
+                info = info_src.circuit_diagram_info(gate, default=NotImplemented)  # type: ignore
+                if info is not NotImplemented and info.wire_symbols:
+                    s_diag = info.wire_symbols[0]
+                    if (op_idx := s_diag.find("(")) != -1 and (
+                        cp_idx := s_diag.rfind(")")
+                    ) > op_idx:
+                        return f"{mapped_name}({self._format_exponent_for_display(s_diag[op_idx+1:cp_idx])})"
+            except Exception:
+                pass
+            if hasattr(gate, "exponent") and not math.isclose(gate.exponent, 1.0):
+                return f"{mapped_name}({self._format_exponent_for_display(gate.exponent)})"
+            return mapped_name
+
+        try:
+            info_src = cirq.protocols if hasattr(cirq, "protocols") else cirq
+            info = info_src.circuit_diagram_info(gate, default=NotImplemented)  # type: ignore
+            if info is not NotImplemented and info.wire_symbols:
+                name_cand = info.wire_symbols[0]
+                if not self.show_parameters:
+                    base_part = name_cand.split("^")[0].split("**")[0].split("(")[0].strip()
+                    if isinstance(gate, cirq.CZPowGate) and base_part == "@":
+                        base_part = "CZ"
+                    mapped_base = self.current_gate_name_map.get(base_part, base_part)
+                    return self._format_exponent_for_display(mapped_base)
+
+                if (
+                    hasattr(gate, "exponent")
+                    and not math.isclose(gate.exponent, 1.0)
+                    and isinstance(gate, tuple(self._EXPONENT_GATE_MAP.keys()))
+                ):
+                    has_exp_in_cand = ("^" in name_cand) or ("**" in name_cand)
+                    if not has_exp_in_cand and base_key:
+                        recon_base = self.current_gate_name_map.get(base_key, base_key)
+                        needs_recon = (name_cand == base_key) or (
+                            isinstance(gate, cirq.CZPowGate) and name_cand == "@"
+                        )
+                        if needs_recon:
+                            name_cand = f"{recon_base}^{{{self._format_exponent_for_display(gate.exponent)}}}"
+
+                fmt_name = name_cand.replace("π", r"\pi")
+                if "_" in fmt_name and "\\" not in fmt_name:
+                    fmt_name = fmt_name.replace("_", r"\_")
+                if "**" in fmt_name:
+                    parts = fmt_name.split("**", 1)
+                    if len(parts) == 2:
+                        fmt_name = f"{parts[0]}^{{{self._format_exponent_for_display(parts[1])}}}"
+                return fmt_name
+        except Exception:
+            pass
+
+        name_fb = str(gate)
+        if name_fb.endswith("Gate"):
+            name_fb = name_fb[:-4]
+        if name_fb.endswith("()"):
+            name_fb = name_fb[:-2]
+        if not self.show_parameters:
+            base_fb = name_fb.split("**")[0].split("(")[0].strip()
+            fb_key = self._EXPONENT_GATE_MAP.get(gate_type, base_fb)
+            mapped_fb = self.current_gate_name_map.get(fb_key, fb_key)
+            return self._format_exponent_for_display(mapped_fb)
+        if name_fb.endswith("**1.0"):
+            name_fb = name_fb[:-5]
+        if name_fb.endswith("**1"):
+            name_fb = name_fb[:-3]
+        if "**" in name_fb:
+            parts = name_fb.split("**", 1)
+            if len(parts) == 2:
+                fb_key = self._EXPONENT_GATE_MAP.get(gate_type, parts[0])
+                base_str_fb = self.current_gate_name_map.get(fb_key, parts[0])
+                name_fb = f"{base_str_fb}^{{{self._format_exponent_for_display(parts[1])}}}"
+        name_fb = name_fb.replace("π", r"\pi")
+        if "_" in name_fb and "\\" not in name_fb:
+            name_fb = name_fb.replace("_", r"\_")
+        return name_fb
+
+    def _get_quantikz_options_string(self) -> str:
+        return f"[{self.quantikz_options}]" if self.quantikz_options else ""
+
+    def _render_operation(self, op: "cirq.Operation") -> Dict[int, str]:
+        output, q_indices = {}, sorted([self.qubit_to_index[q] for q in op.qubits])
+        gate, gate_name_render = op.gate, self._get_gate_name(op.gate)
+
+        gate_type = type(gate)
+        style_key = gate_type.__name__  # Default style key
+
+        # 1. Gates with dedicated Quantikz commands & specific style keys (exp=1)
+        if isinstance(gate, cirq.CNotPowGate) and hasattr(gate, "exponent") and gate.exponent == 1:
+            style_key = "CXideal"
+        elif isinstance(gate, cirq.CZPowGate) and hasattr(gate, "exponent") and gate.exponent == 1:
+            style_key = "CZideal"
+        elif (
+            isinstance(gate, cirq.SwapPowGate) and hasattr(gate, "exponent") and gate.exponent == 1
+        ):
+            style_key = "Swapideal"
+        # 2. MeasurementGate
+        elif isinstance(gate, cirq.MeasurementGate):
+            style_key = "Measure"
+        # 3. Specific named parameterized gates (Rx, FSim, etc.)
+        elif (param_base_name := self._PARAMETERIZED_GATE_BASE_NAMES.get(gate_type)) is not None:
+            style_key = param_base_name
+        # 4. General PowGates (X, Y, Z, H, and controlled versions if not exp=1)
+        elif (base_key_for_pow := self._EXPONENT_GATE_MAP.get(gate_type)) is not None:
+            # At this point, if it's a PowGate from the map, its exponent is either != 1,
+            # or it's a gate like X, Y, Z, H, ISWAP that renders with \gate{}
+            if hasattr(gate, "exponent"):
+                if gate.exponent == 1:
+                    # This covers X, Y, Z, H, ISWAP (exp=1)
+                    style_key = base_key_for_pow  # "X", "Y", "Z", "H", "iSwap"
+                else:
+                    # This covers X_pow, Y_pow, Z_pow, H_pow, CZ_pow, CX_pow, iSWAP_pow
+                    style_key = {
+                        "X": "X_pow",
+                        "Y": "Y_pow",
+                        "Z": "Z_pow",
+                        "H": "H_pow",
+                        "CZ": "CZ_pow",
+                        "CX": "CX_pow",
+                        "iSwap": "iSWAP_pow",
+                    }.get(
+                        base_key_for_pow, f"{base_key_for_pow}_pow"
+                    )  # Fallback to base_key_pow
+            else:  # Should not happen for gates in _EXPONENT_GATE_MAP as they are PowGates
+                style_key = base_key_for_pow
+        # else: style_key remains gate_type.__name__ (e.g., for unknown custom gates)
+
+        style_opts_str = self.gate_styles.get(style_key, "")
+        # Alias lookup for convenience if primary style_key not found
+        if not style_opts_str:
+            if gate_type.__name__ == "FSimGate":
+                style_opts_str = self.gate_styles.get("FSim", "")
+            elif gate_type.__name__ == "PhasedXZGate":
+                style_opts_str = self.gate_styles.get("PhasedXZ", "")
+
+        final_style_tikz = f"[{style_opts_str}]" if style_opts_str else ""
+
+        # --- Special Quantikz commands ---
+        if isinstance(gate, cirq.MeasurementGate):
+            lbl = gate.key.replace("_", r"\_") if gate.key else ""
+            for i in q_indices:
+                output[i] = f"\\meter{final_style_tikz}{{{lbl}}}"
+            return output
+        if isinstance(gate, cirq.CNotPowGate) and hasattr(gate, "exponent") and gate.exponent == 1:
+            c, t = (
+                (self.qubit_to_index[op.qubits[0]], self.qubit_to_index[op.qubits[1]])
+                if len(op.qubits) == 2
+                else (q_indices[0], q_indices[0])
+            )
+            output[c], output[t] = (
+                f"\\ctrl{final_style_tikz}{{{t-c}}}",
+                f"\\targ{final_style_tikz}{{}}",
+            )
+            return output
+        if isinstance(gate, cirq.CZPowGate) and hasattr(gate, "exponent") and gate.exponent == 1:
+            i1, i2 = (
+                (q_indices[0], q_indices[1])
+                if len(q_indices) >= 2
+                else (q_indices[0], q_indices[0])
+            )
+            output[i1], output[i2] = (
+                f"\\ctrl{final_style_tikz}{{{i2-i1}}}",
+                f"\\control{final_style_tikz}{{}}",
+            )
+            return output
+        if isinstance(gate, cirq.SwapPowGate) and hasattr(gate, "exponent") and gate.exponent == 1:
+            i1, i2 = (
+                (q_indices[0], q_indices[1])
+                if len(q_indices) >= 2
+                else (q_indices[0], q_indices[0])
+            )
+            output[i1], output[i2] = (
+                f"\\swap{final_style_tikz}{{{i2-i1}}}",
+                f"\\targX{final_style_tikz}{{}}",
+            )
+            return output
+
+        # --- Generic \gate command ---
+        if not q_indices:
+            warnings.warn(f"Op {op} has no qubits.")
+            return output
+        if len(q_indices) == 1:
+            output[q_indices[0]] = f"\\gate{final_style_tikz}{{{gate_name_render}}}"
+        else:  # Multi-qubit gate
+            wires_opt = f"wires={q_indices[-1]-q_indices[0]+1}"
+            # style_opts_str is already the TikZ style string part, e.g., "fill=blue!20"
+            if style_opts_str:  # If there are actual style options
+                combined_opts = f"{wires_opt}, {style_opts_str}"
+            else:  # Only wires option
+                combined_opts = wires_opt
+            output[q_indices[0]] = f"\\gate[{combined_opts}]{{{gate_name_render}}}"
+            for i in range(1, len(q_indices)):
+                output[q_indices[i]] = "\\qw"
+        return output
+
+    def _generate_latex_body(self) -> str:
+        chunks, m_count, active_chunk = [], 0, [[] for _ in range(self.num_qubits)]
+        for i in range(self.num_qubits):
+            active_chunk[i].append(f"\\lstick{{{self._get_wire_label(self.sorted_qubits[i], i)}}}")
+
+        for m_idx, moment in enumerate(self.circuit):
+            m_count += 1
+            moment_out = ["\\qw"] * self.num_qubits
+            processed_indices = set()
+            for op in moment:
+                q_idx_op = sorted([self.qubit_to_index[q] for q in op.qubits])
+                if not q_idx_op:
+                    warnings.warn(f"Op {op} no qubits.")
+                    continue
+                if any(q in processed_indices for q in q_idx_op):
+                    for q_idx in q_idx_op:
+                        if q_idx not in processed_indices:
+                            moment_out[q_idx] = "\\qw"
+                    continue
+                op_rnd = self._render_operation(op)
+                for idx, tex in op_rnd.items():
+                    if idx not in processed_indices:
+                        moment_out[idx] = tex
+                processed_indices.update(q_idx_op)
+            for i in range(self.num_qubits):
+                active_chunk[i].append(moment_out[i])
+
+            is_last_m = m_idx == len(self.circuit) - 1
+            if self.fold_at and m_count % self.fold_at == 0 and not is_last_m:
+                for i in range(self.num_qubits):
+                    lbl = self._get_wire_label(self.sorted_qubits[i], i)
+                    active_chunk[i].extend([f"\\rstick{{{lbl}}}", "\\qw"])
+                chunks.append(active_chunk)
+                active_chunk = [[] for _ in range(self.num_qubits)]
+                for i in range(self.num_qubits):
+                    active_chunk[i].append(
+                        f"\\lstick{{{self._get_wire_label(self.sorted_qubits[i],i)}}}"
+                    )
+
+        if self.num_qubits > 0:
+            ended_on_fold = self.fold_at and m_count > 0 and m_count % self.fold_at == 0
+            if not ended_on_fold or not self.fold_at:
+                for i in range(self.num_qubits):
+                    if not active_chunk[i]:
+                        active_chunk[i] = [
+                            f"\\lstick{{{self._get_wire_label(self.sorted_qubits[i],i)}}}"
+                        ]
+                    active_chunk[i].append("\\qw")
+            if self.fold_at:
+                for i in range(self.num_qubits):
+                    if not active_chunk[i]:
+                        active_chunk[i] = [
+                            f"\\lstick{{{self._get_wire_label(self.sorted_qubits[i],i)}}}"
+                        ]
+                    active_chunk[i].extend(
+                        [f"\\rstick{{{self._get_wire_label(self.sorted_qubits[i],i)}}}", "\\qw"]
+                    )
+        chunks.append(active_chunk)
+
+        final_parts = []
+        opts_str = self._get_quantikz_options_string()
+        for chunk_data in chunks:
+            if not any(row for row_list in chunk_data for row in row_list):
+                continue
+
+            is_empty_like = True
+            if chunk_data and any(chunk_data):
+                for r_cmds in chunk_data:
+                    if any(
+                        cmd not in ["\\qw", ""]
+                        and not cmd.startswith("\\lstick")
+                        and not cmd.startswith("\\rstick")
+                        for cmd in r_cmds
+                    ):
+                        is_empty_like = False
+                        break
+                if all(
+                    all(
+                        cmd == "\\qw" or cmd.startswith("\\lstick") or cmd.startswith("\\rstick")
+                        for cmd in r
+                    )
+                    for r in chunk_data
+                    if r
+                ):
+                    if len(chunks) > 1 or not self.circuit:
+                        if all(len(r) <= (4 if self.fold_at else 2) for r in chunk_data if r):
+                            is_empty_like = True
+            if is_empty_like and len(chunks) > 1 and self.circuit:
+                continue
+
+            lines = [f"\\begin{{quantikz}}{opts_str}"]
+            for i in range(self.num_qubits):
+                if i < len(chunk_data) and chunk_data[i]:
+                    lines.append(" & ".join(chunk_data[i]) + " \\\\")
+                elif i < self.num_qubits:
+                    lines.append(
+                        f"\\lstick{{{self._get_wire_label(self.sorted_qubits[i],i)}}} & \\qw \\\\"
+                    )
+
+            if len(lines) > 1:
+                for k_idx in range(len(lines) - 1, 0, -1):
+                    if lines[k_idx].strip() and lines[k_idx].strip() != "\\\\":
+                        if lines[k_idx].endswith(" \\\\"):
+                            lines[k_idx] = lines[k_idx].rstrip()[:-3].rstrip()
+                        break
+                    elif lines[k_idx].strip() == "\\\\" and k_idx == len(lines) - 1:
+                        lines[k_idx] = ""
+            lines.append("\\end{quantikz}")
+            final_parts.append("\n".join(filter(None, lines)))
+
+        if not final_parts and self.num_qubits > 0:
+            lines = [f"\\begin{{quantikz}}{opts_str}"]
+            for i in range(self.num_qubits):
+                lines.append(
+                    f"\\lstick{{{self._get_wire_label(self.sorted_qubits[i],i)}}} & \\qw"
+                    + (" \\\\" if i < self.num_qubits - 1 else "")
+                )
+            lines.append("\\end{quantikz}")
+            return "\n".join(lines)
+        return "\n\n\\vspace{1em}\n\n".join(final_parts)
+
+    def generate_latex_document(self, preamble_template: Optional[str] = None) -> str:
+        preamble = preamble_template or DEFAULT_PREAMBLE_TEMPLATE
+        preamble += f"\n% --- Custom Preamble Injection Point ---\n{self.custom_preamble}\n% --- End Custom Preamble ---\n"
+        doc_parts = [preamble, "\\begin{document}", self._generate_latex_body()]
+        if self.custom_postamble:
+            doc_parts.extend(
+                [
+                    "\n% --- Custom Postamble Start ---",
+                    self.custom_postamble,
+                    "% --- Custom Postamble End ---\n",
+                ]
+            )
+        doc_parts.append("\\end{document}")
+        return "\n".join(doc_parts)

--- a/cirq-core/cirq/vis/circuit_to_latex_render.py
+++ b/cirq-core/cirq/vis/circuit_to_latex_render.py
@@ -1,0 +1,541 @@
+# -*- coding: utf-8 -*-
+r"""Provides tools for rendering Cirq circuits as Quantikz LaTeX diagrams.
+
+This module offers a high-level interface for converting `cirq.Circuit` objects
+into visually appealing quantum circuit diagrams using the `quantikz` LaTeX package.
+It extends the functionality of `CirqToQuantikz` by handling the full rendering
+pipeline: generating LaTeX, compiling it to PDF using `pdflatex`, and converting
+the PDF to a PNG image using `pdftoppm`.
+
+The primary function, `render_circuit`, streamlines this process, allowing users
+to easily generate and optionally display circuit diagrams in environments like
+Jupyter notebooks. It provides extensive customization options for the output
+format, file paths, and rendering parameters, including direct control over
+gate styling, circuit folding, and qubit labeling through arguments passed
+to the underlying `CirqToQuantikz` converter.
+
+Additionally, the module includes `create_gif_from_ipython_images`, a utility
+function for animating sequences of images, which can be useful for visualizing
+dynamic quantum processes or circuit transformations.
+"""
+# mypy: ignore-errors
+
+
+import inspect
+import io
+import math
+import os
+import shutil
+import subprocess
+import tempfile
+import traceback
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
+
+import cirq
+import numpy as np
+import sympy
+
+from .circuit_to_latex_quantikz import CirqToQuantikz
+
+__all__ = ["render_circuit", "create_gif_from_ipython_images"]
+
+try:
+    from IPython.display import display, Image, Markdown  # type: ignore
+
+    _HAS_IPYTHON = True
+except ImportError:
+    _HAS_IPYTHON = False
+
+    class Image:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def display(*args, **kwargs):  # type: ignore
+        pass
+
+    def Markdown(*args, **kwargs):  # type: ignore
+        pass
+
+
+# =============================================================================
+# High-Level Wrapper Function
+# =============================================================================
+def render_circuit(
+    circuit: "cirq.Circuit",
+    output_png_path: Optional[str] = None,
+    output_pdf_path: Optional[str] = None,
+    output_tex_path: Optional[str] = None,
+    dpi: int = 300,
+    run_pdflatex: bool = True,
+    run_pdftoppm: bool = True,
+    display_png_jupyter: bool = True,
+    cleanup: bool = True,
+    debug: bool = False,
+    timeout=120,
+    # Carried over CirqToQuantikz args
+    gate_styles: Optional[Dict[str, str]] = None,
+    quantikz_options: Optional[str] = None,
+    fold_at: Optional[int] = None,
+    wire_labels: str = "q",
+    show_parameters: bool = True,
+    gate_name_map: Optional[Dict[str, str]] = None,
+    float_precision_exps: int = 2,
+    **kwargs: Any,
+) -> Optional[Union[str, "Image"]]:
+    r"""Renders a Cirq circuit to a LaTeX diagram, compiles it, and optionally displays it.
+
+    This function takes a `cirq.Circuit` object, converts it into a Quantikz
+    LaTeX string, compiles the LaTeX into a PDF, and then converts the PDF
+    into a PNG image. It can optionally save these intermediate and final
+    files and display the PNG in a Jupyter environment.
+
+    Args:
+        circuit: The `cirq.Circuit` object to be rendered.
+        output_png_path: Optional path to save the generated PNG image. If
+            `None`, the PNG is only kept in a temporary directory (if
+            `cleanup` is `True`) or not generated if `run_pdftoppm` is `False`.
+        output_pdf_path: Optional path to save the generated PDF document.
+        output_tex_path: Optional path to save the generated LaTeX source file.
+        dpi: The DPI (dots per inch) for the output PNG image. Higher DPI
+            results in a larger and higher-resolution image.
+        run_pdflatex: If `True`, `pdflatex` is executed to compile the LaTeX
+            file into a PDF. Requires `pdflatex` to be installed and in PATH.
+        run_pdftoppm: If `True`, `pdftoppm` (from poppler-utils) is executed
+            to convert the PDF into a PNG image. Requires `pdftoppm` to be
+            installed and in PATH. This option is ignored if `run_pdflatex`
+            is `False`.
+        display_png_jupyter: If `True` and running in a Jupyter environment,
+            the generated PNG image will be displayed directly in the output
+            cell.
+        cleanup: If `True`, temporary files and directories created during
+            the process (LaTeX, log, aux, PDF, temporary PNGs) will be removed.
+            If `False`, they are kept for debugging.
+        debug: If `True`, prints additional debugging information to the console.
+        timeout: Maximum time in seconds to wait for `pdflatex` and `pdftoppm`
+            commands to complete.
+        gate_styles: An optional dictionary mapping gate names (strings) to
+            Quantikz style options (strings). These styles are applied to
+            the generated gates. If `None`, `GATE_STYLES_COLORFUL1` is used.
+            Passed to `CirqToQuantikz`.
+        quantikz_options: An optional string of global options to pass to the
+            `quantikz` environment (e.g., `"[row sep=0.5em]"`). Passed to
+            `CirqToQuantikz`.
+        fold_at: An optional integer specifying the number of moments after
+            which the circuit should be folded into a new line in the LaTeX
+            output. If `None`, the circuit is not folded. Passed to `CirqToQuantikz`.
+        wire_labels: A string specifying how qubit wire labels should be
+            rendered. Passed to `CirqToQuantikz`.
+        show_parameters: A boolean indicating whether gate parameters (e.g.,
+            exponents for `XPowGate`, angles for `Rx`) should be displayed
+            in the gate labels. Passed to `CirqToQuantikz`.
+        gate_name_map: An optional dictionary mapping Cirq gate names (strings)
+            to custom LaTeX strings for rendering. This allows renaming gates
+            in the output. Passed to `CirqToQuantikz`.
+        float_precision_exps: An integer specifying the number of decimal
+            places for formatting floating-point exponents. Passed to `CirqToQuantikz`.
+        **kwargs: Additional keyword arguments passed directly to the
+            `CirqToQuantikz` constructor. Refer to `CirqToQuantikz` for
+            available options. Note that explicit arguments in `render_circuit`
+            will override values provided via `**kwargs`.
+
+    Returns:
+        An `IPython.display.Image` object if `display_png_jupyter` is `True`
+        and running in a Jupyter environment, and the PNG was successfully
+        generated. Otherwise, returns the string path to the saved PNG if
+        `output_png_path` was provided and successful, or `None` if no PNG
+        was generated or displayed.
+
+    Raises:
+        warnings.warn: If `pdflatex` or `pdftoppm` executables are not found
+            when their respective `run_` flags are `True`.
+
+    Example:
+        >>> import cirq
+        >>> from cirq.vis.cirq_circuit_quantikz_render import render_circuit
+        >>> q0, q1, q2 = cirq.LineQubit.range(3)
+        >>> circuit = cirq.Circuit(
+        ...     cirq.H(q0),
+        ...     cirq.CNOT(q0, q1),
+        ...     cirq.Rx(rads=0.25 * cirq.PI).on(q1),
+        ...     cirq.measure(q0, q1, key='result')
+        ... )
+        >>> # Render and display in Jupyter (if available), also save to a file
+        >>> img_or_path = render_circuit(
+        ...     circuit,
+        ...     output_png_path="my_circuit.png",
+        ...     fold_at=2,
+        ...     wire_labels="qid",
+        ...     quantikz_options="[column sep=0.7em]",
+        ...     show_parameters=False # Example of new parameter
+        ... )
+        >>> if isinstance(img_or_path, Image):
+        ...     print("Circuit rendered and displayed in Jupyter.")
+        >>> elif isinstance(img_or_path, str):
+        ...     print(f"Circuit rendered and saved to {img_or_path}")
+        >>> else:
+        ...     print("Circuit rendering failed or no output generated.")
+        >>> # To view the saved PNG outside Jupyter:
+        >>> # import matplotlib.pyplot as plt
+        >>> # import matplotlib.image as mpimg
+        >>> # img = mpimg.imread('my_circuit.png')
+        >>> # plt.imshow(img)
+        >>> # plt.axis('off')
+        >>> # plt.show()
+    """
+
+    def _debug_print(*args, **kwargs_print):
+        if debug:
+            print("[Debug]", *args, **kwargs_print)
+
+    final_tex_path = Path(output_tex_path).expanduser().resolve() if output_tex_path else None
+    final_pdf_path = Path(output_pdf_path).expanduser().resolve() if output_pdf_path else None
+    final_png_path = Path(output_png_path).expanduser().resolve() if output_png_path else None
+
+    pdflatex, pdftoppm = shutil.which("pdflatex"), shutil.which("pdftoppm")
+    if run_pdflatex and not pdflatex:
+        warnings.warn(
+            "'pdflatex' not found. Cannot compile LaTeX. "
+            "Please install a LaTeX distribution (e.g., TeX Live, MiKTeX). "
+            "On Ubuntu/Debian: `sudo apt-get install texlive-full` (or `texlive-base` for minimal). "
+            "On macOS: `brew install --cask mactex` (or `brew install texlive` for minimal). "
+            "On Windows: Download and install MiKTeX or TeX Live."
+        )
+        run_pdflatex = run_pdftoppm = False
+    if run_pdftoppm and not pdftoppm:
+        warnings.warn(
+            "'pdftoppm' not found. Cannot convert PDF to PNG. "
+            "This tool is part of the Poppler utilities. "
+            "On Ubuntu/Debian: `sudo apt-get install poppler-utils`. "
+            "On macOS: `brew install poppler`. "
+            "On Windows: Download Poppler for Windows (e.g., from Poppler for Windows GitHub releases) "
+            "and add its `bin` directory to your system PATH."
+        )
+        run_pdftoppm = False
+
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir_s:
+            tmp_p = Path(tmpdir_s)
+            _debug_print(f"Temp dir: {tmp_p}")
+            base, tmp_tex = "circuit_render", tmp_p / "circuit_render.tex"
+            tmp_pdf, tmp_png_prefix = tmp_p / f"{base}.pdf", str(tmp_p / base)
+            tmp_png_out = tmp_p / f"{base}.png"
+
+            # Prepare kwargs for CirqToQuantikz, prioritizing explicit args
+            converter_kwargs = {
+                "gate_styles": gate_styles,
+                "quantikz_options": quantikz_options,
+                "fold_at": fold_at,
+                "wire_labels": wire_labels,
+                "show_parameters": show_parameters,
+                "gate_name_map": gate_name_map,
+                "float_precision_exps": float_precision_exps,
+                **kwargs,  # Existing kwargs are merged, but explicit args take precedence
+            }
+
+            try:
+                converter = CirqToQuantikz(circuit, **converter_kwargs)
+            except Exception as e:
+                print(f"Error init CirqToQuantikz: {e}")
+                return None
+
+            _debug_print("Generating LaTeX...")
+            try:
+                latex_s = converter.generate_latex_document()
+            except Exception as e:
+                print(f"Error gen LaTeX: {e}")
+                if debug:
+                    traceback.print_exc()
+                return None
+            if debug:
+                _debug_print("LaTeX (first 500 chars):\n", latex_s[:500] + "...")
+
+            try:
+                tmp_tex.write_text(latex_s, encoding="utf-8")
+            except IOError as e:
+                print(f"Error writing temp TEX {tmp_tex}: {e}")
+                return None
+
+            pdf_ok = False
+            if run_pdflatex and pdflatex:
+                _debug_print(f"Running pdflatex ({pdflatex})...")
+                cmd_latex = [
+                    pdflatex,
+                    "-interaction=nonstopmode",
+                    "-halt-on-error",
+                    "-output-directory",
+                    str(tmp_p),
+                    str(tmp_tex),
+                ]
+                latex_failed = False
+                for i in range(2):
+                    _debug_print(f"  pdflatex run {i+1}/2...")
+                    proc = subprocess.run(
+                        cmd_latex,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                        cwd=tmp_p,
+                        timeout=timeout,
+                    )
+                    if proc.returncode != 0:
+                        latex_failed = True
+                        print(f"!!! pdflatex failed run {i+1} (code {proc.returncode}) !!!")
+                        log_f = tmp_tex.with_suffix(".log")
+                        if log_f.exists():
+                            print(
+                                f"--- Tail of {log_f.name} ---\n{log_f.read_text(errors='ignore')[-2000:]}"
+                            )
+                        else:
+                            if proc.stdout:
+                                print(f"--- pdflatex stdout ---\n{proc.stdout[-2000:]}")
+                            if proc.stderr:
+                                print(f"--- pdflatex stderr ---\n{proc.stderr}")
+                        if final_tex_path:
+                            try:
+                                final_tex_path.parent.mkdir(parents=True, exist_ok=True)
+                                shutil.copy2(tmp_tex, final_tex_path)
+                                print(f"Problem TEX: {final_tex_path}")
+                            except Exception as e_cp:
+                                print(f"Error copying TEX: {e_cp}")
+                        else:
+                            print(f"Problem TEX was: {tmp_tex}")
+                        break
+                    elif not tmp_pdf.is_file() and i == 1:
+                        latex_failed = True
+                        print("!!! pdflatex ok, but PDF not found. Check logs. !!!")
+                        log_f = tmp_tex.with_suffix(".log")
+                        if log_f.exists():
+                            print(
+                                f"--- Tail of {log_f.name} ---\n{log_f.read_text(errors='ignore')[-2000:]}"
+                            )
+                        break
+                    elif tmp_pdf.is_file():
+                        _debug_print(f"  Run {i+1}/2 OK (PDF exists).")
+                if not latex_failed and tmp_pdf.is_file():
+                    pdf_ok = True
+                    _debug_print(f"PDF OK: {tmp_pdf}")
+                elif not latex_failed:
+                    print("pdflatex seemed OK but no PDF.")
+                if latex_failed:
+                    return None
+
+            png_ok, png_disp_path = False, None
+            if run_pdftoppm and pdftoppm and pdf_ok:
+                _debug_print(f"Running pdftoppm ({pdftoppm})...")
+                cmd_ppm = [
+                    pdftoppm,
+                    "-png",
+                    f"-r",
+                    str(dpi),
+                    "-singlefile",
+                    str(tmp_pdf),
+                    tmp_png_prefix,
+                ]
+                try:
+                    proc = subprocess.run(
+                        cmd_ppm,
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                        cwd=tmp_p,
+                        timeout=timeout,
+                    )
+                    if tmp_png_out.is_file():
+                        png_ok, png_disp_path = True, tmp_png_out
+                        _debug_print(f"PNG OK: {tmp_png_out}")
+                    else:
+                        print(f"!!! pdftoppm OK but PNG ({tmp_png_out}) not found. !!!")
+                except subprocess.CalledProcessError as e_ppm:
+                    print(
+                        f"!!! pdftoppm failed (code {e_ppm.returncode}) !!!\n{e_ppm.stdout}\n{e_ppm.stderr}"
+                    )
+                except subprocess.TimeoutExpired:
+                    print("!!! pdftoppm timed out. !!!")
+                except Exception as e_ppm_other:
+                    print(f"pdftoppm error: {e_ppm_other}")
+
+            copied = {}
+            if final_tex_path and tmp_tex.exists():
+                try:
+                    final_tex_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(tmp_tex, final_tex_path)
+                    copied["tex"] = final_tex_path
+                except Exception as e:
+                    print(f"Error copying TEX: {e}")
+            if final_pdf_path and pdf_ok and tmp_pdf.exists():
+                try:
+                    final_pdf_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(tmp_pdf, final_pdf_path)
+                    copied["pdf"] = final_pdf_path
+                except Exception as e:
+                    print(f"Error copying PDF: {e}")
+            if final_png_path and png_ok and tmp_png_out.exists():
+                try:
+                    final_png_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(tmp_png_out, final_png_path)
+                    copied["png"] = final_png_path
+                    png_disp_path = final_png_path
+                except Exception as e:
+                    print(f"Error copying PNG: {e}")
+            elif (
+                png_ok and tmp_png_out.exists() and not final_png_path
+            ):  # Only use temp if not copied to final
+                png_disp_path = tmp_png_out
+
+            jupyter_image_object: Optional["Image"] = None
+
+            if display_png_jupyter and png_disp_path and png_disp_path.is_file():
+                _debug_print(f"Displaying PNG: {png_disp_path}")
+                if _HAS_IPYTHON:
+                    try:
+                        sh_obj = get_ipython()  # type: ignore
+                        if sh_obj is None:
+                            print(f"Not IPython. PNG: {png_disp_path}")
+                        else:
+                            sh_name = sh_obj.__class__.__name__
+                            # Create the Image object regardless of shell type for potential return
+                            # but only display it in ZMQInteractiveShell.
+                            current_image_obj = Image(filename=str(png_disp_path))
+                            if sh_name == "ZMQInteractiveShell":
+                                display(current_image_obj)
+                                jupyter_image_object = current_image_obj  # Store if displayed
+                            elif sh_name == "TerminalInteractiveShell":
+                                print(f"Terminal IPython. PNG: {png_disp_path}")
+                                # In terminal, we might still want to return the object if requested
+                                jupyter_image_object = current_image_obj
+                            else:
+                                print(f"Display might not work ({sh_name}). PNG: {png_disp_path}")
+                                jupyter_image_object = current_image_obj
+                    except Exception as e_disp:
+                        print(f"PNG display error: {e_disp}")
+                        jupyter_image_object = None
+                else:
+                    print(f"IPython not available. PNG: {png_disp_path}")
+            elif display_png_jupyter and (not png_disp_path or not png_disp_path.is_file()):
+                if run_pdflatex and run_pdftoppm:
+                    print("PNG display requested, but PNG not created/found.")
+
+            if not cleanup and debug:
+                _debug_print("cleanup=False; temp dir removed by context manager.")
+
+            # Removed the deliberate logical error.
+            if jupyter_image_object:
+                return jupyter_image_object
+            elif copied.get("png"):
+                return str(copied["png"])
+            return None  # Fallback if nothing to return
+    except subprocess.TimeoutExpired as e_timeout:
+        print(f"!!! Process timed out: {e_timeout} !!!")
+        if debug:
+            traceback.print_exc()
+        return None
+    except Exception as e_crit:
+        print(f"Critical error in render_circuit: {e_crit}")
+        if debug:
+            traceback.print_exc()
+        return None
+
+
+def create_gif_from_ipython_images(
+    image_list: "list[Image]", output_filename: str, fps: int, **kwargs
+):
+    r"""Creates a GIF from a list of IPython.core.display.Image objects and saves it.
+
+    The resulting GIF will loop indefinitely by default.
+
+    Args:
+        image_list: A list of `IPython.display.Image` objects. These objects
+            should contain image data (e.g., from `matplotlib` or `PIL`).
+        output_filename: The desired filename for the output GIF (e.g.,
+            "animation.gif").
+        fps: The frame rate (frames per second) for the GIF.
+        **kwargs: Additional keyword arguments to pass to `imageio.mimsave()`.
+            For example, `duration` (scalar or list) can be used to set
+            frame durations instead of fps, or `loop` (default 0 for infinite)
+            can be set to a different number of loops. If 'loop' is provided
+            in kwargs, it will override the default infinite loop.
+
+    Returns:
+        None. The function saves the GIF to the specified `output_filename`.
+    """
+    try:
+        import imageio
+    except ImportError:
+        print("You need to install imageio: `pip install imageio`")
+        return None
+    try:
+        from PIL import Image as PILImage
+    except ImportError:
+        print("You need to install PIL: pip install Pillow")
+        return None
+
+    frames = []
+    for ipython_image in image_list:
+        image_bytes = ipython_image.data
+        try:
+            pil_img = PILImage.open(io.BytesIO(image_bytes))
+            # Ensure image is in RGB/RGBA for broad compatibility before making it a numpy array.
+            # GIF supports palette ('P') directly, but converting to RGB first can be safer
+            # if complex palettes or transparency are involved and imageio's handling is unknown.
+            # However, for GIFs, 'P' mode with a good palette is often preferred for smaller file sizes.
+            # Let's try to keep 'P' if possible, but convert RGBA to RGB as GIFs don't support full alpha well.
+            if pil_img.mode == "RGBA":
+                # Create a white background image
+                background = PILImage.new("RGB", pil_img.size, (255, 255, 255))
+                # Paste the RGBA image onto the white background
+                background.paste(pil_img, mask=pil_img.split()[3])  # 3 is the alpha channel
+                pil_img = background
+            elif pil_img.mode not in ["RGB", "L", "P"]:  # L for grayscale, P for palette
+                pil_img = pil_img.convert("RGB")
+            frames.append(np.array(pil_img))
+        except Exception as e:
+            print(f"Warning: Could not process an image. Error: {e}")
+            continue
+
+    if not frames:
+        print("Warning: No frames were successfully extracted. GIF not created.")
+        return
+
+    # Set default loop to 0 (infinite) if not specified in kwargs
+    if "loop" not in kwargs:
+        kwargs["loop"] = 0
+
+    if "duration" in kwargs:
+        pass
+
+    try:
+        imageio.mimsave(output_filename, frames, fps=fps, **kwargs)
+        print(f"GIF saved as {output_filename} with {fps} FPS and options: {kwargs}")
+    except Exception as e:
+        print(f"Error saving GIF: {e}")
+        # Attempt saving with a more basic configuration if advanced options fail
+        try:
+            print("Attempting to save GIF with basic settings (RGB, default palette).")
+            rgb_frames = []
+            for frame_data in frames:
+                if frame_data.ndim == 2:  # Grayscale
+                    pil_frame = PILImage.fromarray(frame_data, mode="L")
+                elif frame_data.shape[2] == 3:  # RGB
+                    pil_frame = PILImage.fromarray(frame_data, mode="RGB")
+                elif frame_data.shape[2] == 4:  # RGBA
+                    pil_frame = PILImage.fromarray(frame_data, mode="RGBA")
+                    background = PILImage.new("RGB", pil_frame.size, (255, 255, 255))
+                    background.paste(pil_frame, mask=pil_frame.split()[3])
+                    pil_frame = background
+                else:
+                    pil_frame = PILImage.fromarray(frame_data)
+
+                if pil_frame.mode != "RGB":
+                    pil_frame = pil_frame.convert("RGB")
+                rgb_frames.append(np.array(pil_frame))
+
+            if rgb_frames:
+                imageio.mimsave(output_filename, rgb_frames, fps=fps, loop=kwargs.get("loop", 0))
+                print(f"GIF saved with basic RGB settings as {output_filename}")
+            else:
+                print("Could not convert frames to RGB for basic save.")
+
+        except Exception as fallback_e:
+            print(f"Fallback GIF saving also failed: {fallback_e}")


### PR DESCRIPTION
Feature(vis): Enhance circuit_to_latex_render and GIF creation

This PR introduces  `cirq.vis.render_circuit` and  `create_gif_from_ipython_images`.

The functionality is showcased and described here: in this Jupyter notebook 
https://drive.google.com/file/d/1KXQjBmQ9rNUjZHJ6QuGolthLN19_K9yK/view?usp=drivesdk
(colab: https://colab.sandbox.google.com/drive/1KXQjBmQ9rNUjZHJ6QuGolthLN19_K9yK) 

**Notes on `render_circuit`:**
    *   Performs upfront checks for `pdflatex` and `pdftoppm` executables. Issues informative warnings and disables relevant functionality if they are not found, preventing unexpected failures.
    *   If `pdflatex` fails and an `output_tex_path` is specified, the problematic `.tex` file is copied to the specified path for easier user inspection.

Example outputs: 
![image](https://github.com/user-attachments/assets/d941ab0d-30dc-4a01-aa85-aa4a4b1ef377)

![image](https://github.com/user-attachments/assets/79450bc3-25e6-46a8-9cf7-556b53a0722f)

![image](https://github.com/user-attachments/assets/d4b9013a-613b-4a6c-b2c2-50a04374ebe9)

![image](https://github.com/user-attachments/assets/e9d67a29-a6d5-4efb-abfd-cdfdce5a1422)

![image](https://github.com/user-attachments/assets/e0a36722-d066-473d-987c-b59850a88792)
