### PR TITLE
Switch to unquoted type annotations part 9

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_target_gateset.py
+++ b/cirq-aqt/cirq_aqt/aqt_target_gateset.py
@@ -16,10 +16,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 import cirq
-from cirq.protocols.decompose_protocol import DecomposeResult
+
+if TYPE_CHECKING:
+    from cirq.protocols.decompose_protocol import DecomposeResult
 
 
 class AQTTargetGateset(cirq.TwoQubitCompilationTargetGateset):

--- a/cirq-aqt/cirq_aqt/json_resolver_cache.py
+++ b/cirq-aqt/cirq_aqt/json_resolver_cache.py
@@ -15,8 +15,10 @@
 from __future__ import annotations
 
 import functools
+from typing import TYPE_CHECKING
 
-from cirq.protocols.json_serialization import ObjectFactory
+if TYPE_CHECKING:
+    from cirq.protocols.json_serialization import ObjectFactory
 
 
 @functools.lru_cache()

--- a/cirq-core/cirq/circuits/frozen_circuit.py
+++ b/cirq-core/cirq/circuits/frozen_circuit.py
@@ -30,13 +30,13 @@ from typing import (
     Union,
 )
 
-import numpy as np
-
 from cirq import _compat, protocols
 from cirq.circuits import AbstractCircuit, Alignment, Circuit
 from cirq.circuits.insert_strategy import InsertStrategy
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/contrib/acquaintance/topological_sort.py
+++ b/cirq-core/cirq/contrib/acquaintance/topological_sort.py
@@ -18,11 +18,11 @@ import operator
 import random
 from typing import Any, Callable, cast, Iterable, TYPE_CHECKING
 
-import networkx
-
 from cirq import ops
 
 if TYPE_CHECKING:
+    import networkx
+
     import cirq
 
 

--- a/cirq-core/cirq/contrib/custom_simulators/custom_state_simulator.py
+++ b/cirq-core/cirq/contrib/custom_simulators/custom_state_simulator.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 
 from typing import Any, Dict, Generic, Sequence, Type, TYPE_CHECKING
 
-import numpy as np
-
 from cirq import sim
 from cirq.sim.simulation_state import TSimulationState
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/contrib/paulistring/clifford_target_gateset.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_target_gateset.py
@@ -18,11 +18,11 @@ from enum import Enum
 from types import NotImplementedType
 from typing import cast, List, Type, TYPE_CHECKING, Union
 
-import numpy as np
-
 from cirq import linalg, ops, protocols, transformers
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -6,14 +6,16 @@ https://arxiv.org/abs/1811.12926.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple, TYPE_CHECKING
 
-import networkx as nx
 import numpy as np
-import pandas as pd
 
 import cirq
 import cirq.contrib.routing as ccr
+
+if TYPE_CHECKING:
+    import networkx as nx
+    import pandas as pd
 
 
 def generate_model_circuit(

--- a/cirq-core/cirq/contrib/quimb/grid_circuits.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits.py
@@ -14,11 +14,12 @@
 
 from __future__ import annotations
 
-from typing import Iterator
-
-import networkx as nx
+from typing import Iterator, TYPE_CHECKING
 
 import cirq
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 def get_grid_moments(

--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import warnings
-from typing import cast, Dict, List, Optional, Sequence, Tuple, Union
+from typing import cast, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
-import numpy as np
 import quimb
 import quimb.tensor as qtn
 
 import cirq
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def _get_quimb_version():

--- a/cirq-core/cirq/contrib/routing/router.py
+++ b/cirq-core/cirq/contrib/routing/router.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 
 from typing import Callable, Optional, TYPE_CHECKING
 
-import networkx as nx
-
 from cirq import circuits, protocols
 from cirq.contrib.routing.greedy import route_circuit_greedily
 
 if TYPE_CHECKING:
+    import networkx as nx
+
     from cirq.contrib.routing.swap_network import SwapNetwork
 
 ROUTERS = {'greedy': route_circuit_greedily}

--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -34,7 +34,6 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 # this is for older systems with matplotlib <3.2 otherwise 3d projections fail
-from mpl_toolkits import mplot3d
 from scipy.optimize import curve_fit
 
 import cirq.vis.heatmap as cirq_heatmap
@@ -43,6 +42,8 @@ from cirq import circuits, ops, protocols
 from cirq.devices import grid_qubit
 
 if TYPE_CHECKING:
+    from mpl_toolkits import mplot3d
+
     import cirq
 
 

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
@@ -33,13 +33,14 @@ from typing import (
     Union,
 )
 
-import networkx as nx
 import numpy as np
 
 from cirq import circuits, devices, ops, protocols, value
 from cirq._doc import document
 
 if TYPE_CHECKING:
+    import networkx as nx
+
     import cirq
 
 QidPairT = Tuple['cirq.Qid', 'cirq.Qid']

--- a/cirq-core/cirq/experiments/two_qubit_xeb.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb.py
@@ -24,7 +24,6 @@ from typing import Any, cast, Dict, Mapping, Optional, Sequence, Tuple, TYPE_CHE
 
 import networkx as nx
 import numpy as np
-import pandas as pd
 from matplotlib import pyplot as plt
 
 from cirq import ops, value, vis
@@ -44,6 +43,8 @@ from cirq.qis import noise_utils
 
 if TYPE_CHECKING:
     import multiprocessing
+
+    import pandas as pd
 
     import cirq
 

--- a/cirq-core/cirq/linalg/predicates.py
+++ b/cirq-core/cirq/linalg/predicates.py
@@ -302,7 +302,7 @@ def slice_for_qubits_equal_to(
     out_size = (
         cast(int, num_qubits) if out_size_specified else max(target_qubit_axes, default=-1) + 1
     )
-    result = cast(List[Union[slice, int, 'ellipsis']], [slice(None)] * out_size)
+    result = cast(List[Union[slice, int, EllipsisType]], [slice(None)] * out_size)
     if not out_size_specified:
         result.append(Ellipsis)
     if qid_shape is None:

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -36,13 +36,14 @@ from typing import (
     Union,
 )
 
-import numpy as np
 from typing_extensions import Self
 
 from cirq import ops, protocols, value
 from cirq.ops import control_values as cv, gate_features, raw_types
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -32,9 +32,7 @@ from typing import (
 )
 
 import numpy as np
-from scipy.sparse import csr_matrix
-from sympy.core.expr import Expr
-from sympy.core.symbol import Symbol
+import sympy
 from sympy.logic.boolalg import And, Not, Or, Xor
 
 from cirq import linalg, protocols, qis, value
@@ -46,6 +44,8 @@ from cirq.ops.projector import ProjectorString
 from cirq.value.linear_dict import _format_terms
 
 if TYPE_CHECKING:
+    from scipy.sparse import csr_matrix
+
     import cirq
 
 UnitPauliStringT = FrozenSet[Tuple[raw_types.Qid, pauli_gates.Pauli]]
@@ -490,7 +490,7 @@ class PauliSum:
 
     @classmethod
     def from_boolean_expression(
-        cls, boolean_expr: Expr, qubit_map: Dict[str, cirq.Qid]
+        cls, boolean_expr: sympy.Expr, qubit_map: Dict[str, cirq.Qid]
     ) -> PauliSum:
         """Builds the Hamiltonian representation of a Boolean expression.
 
@@ -507,7 +507,7 @@ class PauliSum:
         Raises:
             ValueError: If `boolean_expr` is of an unsupported type.
         """
-        if isinstance(boolean_expr, Symbol):
+        if isinstance(boolean_expr, sympy.Symbol):
             # In table 1, the entry for 'x' is '1/2.I - 1/2.Z'
             return cls.from_pauli_strings(
                 [

--- a/cirq-core/cirq/ops/pauli_string_phasor.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor.py
@@ -27,8 +27,6 @@ from typing import (
     Union,
 )
 
-import sympy
-
 from cirq import protocols, value
 from cirq._compat import deprecated, proper_repr
 from cirq.ops import (
@@ -42,6 +40,8 @@ from cirq.ops import (
 )
 
 if TYPE_CHECKING:
+    import sympy
+
     import cirq
 
 

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -39,7 +39,6 @@ from typing import (
 )
 
 import numpy as np
-import sympy
 from typing_extensions import Self
 
 from cirq import protocols, value
@@ -52,6 +51,8 @@ line_qubit = LazyLoader("line_qubit", globals(), "cirq.devices.line_qubit")
 
 
 if TYPE_CHECKING:
+    import sympy
+
     import cirq
     from cirq.ops import control_values as cv
 

--- a/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/clifford_tableau_simulation_state.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 from typing import Optional, Sequence, TYPE_CHECKING
 
-import numpy as np
-
 from cirq.qis import clifford_tableau
 from cirq.sim.clifford.stabilizer_simulation_state import StabilizerSimulationState
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_ch_form_simulation_state.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 from typing import Optional, Sequence, TYPE_CHECKING, Union
 
-import numpy as np
-
 from cirq._compat import proper_repr
 from cirq.sim.clifford import stabilizer_state_ch_form
 from cirq.sim.clifford.stabilizer_simulation_state import StabilizerSimulationState
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state.py
@@ -18,7 +18,6 @@ import abc
 from types import NotImplementedType
 from typing import Any, cast, Generic, Optional, Sequence, TYPE_CHECKING, TypeVar, Union
 
-import numpy as np
 import sympy
 
 from cirq import linalg, ops, protocols
@@ -28,6 +27,8 @@ from cirq.protocols import has_unitary, num_qubits, unitary
 from cirq.sim.simulation_state import SimulationState
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/sim/simulation_state_base.py
+++ b/cirq-core/cirq/sim/simulation_state_base.py
@@ -33,12 +33,13 @@ from typing import (
     Union,
 )
 
-import numpy as np
 from typing_extensions import Self
 
 from cirq import protocols, value
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/testing/consistent_protocols.py
+++ b/cirq-core/cirq/testing/consistent_protocols.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 from typing import Any, Dict, Optional, Sequence, Type
 

--- a/cirq-core/cirq/testing/consistent_protocols_test.py
+++ b/cirq-core/cirq/testing/consistent_protocols_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from types import NotImplementedType
 from typing import AbstractSet, List, Sequence, Tuple, Union
 
@@ -83,7 +85,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
             exponent=self.exponent, phase_exponent=self.phase_exponent + phase_turns * 2
         )
 
-    def __pow__(self, exponent: Union[float, sympy.Expr]) -> 'GoodGate':
+    def __pow__(self, exponent: Union[float, sympy.Expr]) -> GoodGate:
         new_exponent = cirq.mul(self.exponent, exponent, NotImplemented)
         if new_exponent is NotImplemented:
             return NotImplemented  # pragma: no cover
@@ -101,7 +103,7 @@ class GoodGate(cirq.testing.SingleQubitGate):
     def _parameter_names_(self) -> AbstractSet[str]:
         return cirq.parameter_names(self.exponent) | cirq.parameter_names(self.phase_exponent)
 
-    def _resolve_parameters_(self, resolver, recursive) -> 'GoodGate':
+    def _resolve_parameters_(self, resolver, recursive) -> GoodGate:
         return GoodGate(
             phase_exponent=resolver.value_of(self.phase_exponent, recursive),
             exponent=resolver.value_of(self.exponent, recursive),

--- a/cirq-core/cirq/testing/consistent_qasm.py
+++ b/cirq-core/cirq/testing/consistent_qasm.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import warnings
 from typing import Any, List, Optional, Sequence
 

--- a/cirq-core/cirq/testing/consistent_qasm_test.py
+++ b/cirq-core/cirq/testing/consistent_qasm_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import warnings
 from typing import Tuple
 

--- a/cirq-core/cirq/testing/consistent_resolve_parameters.py
+++ b/cirq-core/cirq/testing/consistent_resolve_parameters.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 import sympy

--- a/cirq-core/cirq/testing/consistent_specified_has_unitary.py
+++ b/cirq-core/cirq/testing/consistent_specified_has_unitary.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 from cirq import protocols

--- a/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
+++ b/cirq-core/cirq/testing/consistent_specified_has_unitary_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/consistent_unitary.py
+++ b/cirq-core/cirq/testing/consistent_unitary.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/cirq-core/cirq/testing/consistent_unitary_test.py
+++ b/cirq-core/cirq/testing/consistent_unitary_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/deprecation.py
+++ b/cirq-core/cirq/testing/deprecation.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import contextlib
 import logging
 import os

--- a/cirq-core/cirq/testing/deprecation_test.py
+++ b/cirq-core/cirq/testing/deprecation_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import warnings
 
 import pytest

--- a/cirq-core/cirq/testing/devices.py
+++ b/cirq-core/cirq/testing/devices.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Provides test devices that can validate circuits."""
+
+from __future__ import annotations
+
 from typing import AbstractSet, cast, Tuple
 
 from cirq import devices, ops

--- a/cirq-core/cirq/testing/devices_test.py
+++ b/cirq-core/cirq/testing/devices_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/testing/equals_tester.py
+++ b/cirq-core/cirq/testing/equals_tester.py
@@ -20,6 +20,8 @@ group are all equal to each other, but that items between each group are never
 equal to each other. It will also check that a==b implies hash(a)==hash(b).
 """
 
+from __future__ import annotations
+
 import collections
 import itertools
 from typing import Any, Callable, List, Tuple, Union

--- a/cirq-core/cirq/testing/equals_tester_test.py
+++ b/cirq-core/cirq/testing/equals_tester_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import fractions
 
 import pytest

--- a/cirq-core/cirq/testing/equivalent_basis_map.py
+++ b/cirq-core/cirq/testing/equivalent_basis_map.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, Optional, Sequence
 
 import numpy as np

--- a/cirq-core/cirq/testing/equivalent_basis_map_test.py
+++ b/cirq-core/cirq/testing/equivalent_basis_map_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/testing/equivalent_repr_eval.py
+++ b/cirq-core/cirq/testing/equivalent_repr_eval.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
 
 

--- a/cirq-core/cirq/testing/equivalent_repr_eval_test.py
+++ b/cirq-core/cirq/testing/equivalent_repr_eval_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/gate_features.py
+++ b/cirq-core/cirq/testing/gate_features.py
@@ -14,6 +14,8 @@
 
 """Simple gates used for testing purposes."""
 
+from __future__ import annotations
+
 from cirq.ops import raw_types
 
 

--- a/cirq-core/cirq/testing/gate_features_test.py
+++ b/cirq-core/cirq/testing/gate_features_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/testing/json.py
+++ b/cirq-core/cirq/testing/json.py
@@ -12,19 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 import inspect
 import io
 import pathlib
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Dict, Iterator, List, Set, Tuple, Type
+from typing import Dict, Iterator, List, Set, Tuple, Type, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 
 import cirq
-from cirq.protocols.json_serialization import ObjectFactory
+
+if TYPE_CHECKING:
+    from cirq.protocols.json_serialization import ObjectFactory
 
 # This is the testing framework for json serialization
 # The actual tests live in cirq.protocols.json_serialization_test.py.

--- a/cirq-core/cirq/testing/json_test.py
+++ b/cirq-core/cirq/testing/json_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 from cirq.testing.json import spec_for

--- a/cirq-core/cirq/testing/lin_alg_utils_test.py
+++ b/cirq-core/cirq/testing/lin_alg_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/testing/logs.py
+++ b/cirq-core/cirq/testing/logs.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Helper for testing python logging statements."""
+
+from __future__ import annotations
+
 import contextlib
 import logging
 from typing import Iterator, List, Optional

--- a/cirq-core/cirq/testing/logs_test.py
+++ b/cirq-core/cirq/testing/logs_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 import warnings
 

--- a/cirq-core/cirq/testing/no_identifier_qubit.py
+++ b/cirq-core/cirq/testing/no_identifier_qubit.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Any, Dict
 
 from cirq import protocols

--- a/cirq-core/cirq/testing/no_identifier_qubit_test.py
+++ b/cirq-core/cirq/testing/no_identifier_qubit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/testing/op_tree.py
+++ b/cirq-core/cirq/testing/op_tree.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from cirq import ops
 
 

--- a/cirq-core/cirq/testing/op_tree_test.py
+++ b/cirq-core/cirq/testing/op_tree_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/testing/order_tester.py
+++ b/cirq-core/cirq/testing/order_tester.py
@@ -23,6 +23,8 @@ added items or groups.
 It will also check that a==b implies hash(a)==hash(b).
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 from cirq.testing.equals_tester import EqualsTester

--- a/cirq-core/cirq/testing/order_tester_test.py
+++ b/cirq-core/cirq/testing/order_tester_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import fractions
 
 import pytest

--- a/cirq-core/cirq/testing/pytest_utils.py
+++ b/cirq-core/cirq/testing/pytest_utils.py
@@ -14,6 +14,8 @@
 
 """Support one retry of tests that fail for a specific seed from pytest-randomly."""
 
+from __future__ import annotations
+
 import functools
 import warnings
 from typing import Any, Callable

--- a/cirq-core/cirq/testing/pytest_utils_test.py
+++ b/cirq-core/cirq/testing/pytest_utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from unittest.mock import Mock
 
 import pytest

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import random
 from typing import cast, Dict, Optional, Sequence, Union
 

--- a/cirq-core/cirq/testing/repr_pretty_tester.py
+++ b/cirq-core/cirq/testing/repr_pretty_tester.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from typing import Any
 

--- a/cirq-core/cirq/testing/repr_pretty_tester_test.py
+++ b/cirq-core/cirq/testing/repr_pretty_tester_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq.testing
 
 

--- a/cirq-core/cirq/testing/routing_devices_test.py
+++ b/cirq-core/cirq/testing/routing_devices_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import networkx as nx
 import pytest
 

--- a/cirq-core/cirq/testing/sample_circuits_test.py
+++ b/cirq-core/cirq/testing/sample_circuits_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/testing/sample_gates.py
+++ b/cirq-core/cirq/testing/sample_gates.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import dataclasses
 
 import numpy as np

--- a/cirq-core/cirq/testing/sample_gates_test.py
+++ b/cirq-core/cirq/testing/sample_gates_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/transformers/align_test.py
+++ b/cirq-core/cirq/transformers/align_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/clifford_decomposition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/controlled_gate_decomposition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import scipy.stats
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 from typing import List, Sequence, Tuple
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/pauli_string_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/pauli_string_decomposition.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import cast, Optional, Tuple
 
 import numpy as np

--- a/cirq-core/cirq/transformers/analytical_decompositions/pauli_string_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/pauli_string_decomposition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cmath
 import itertools
 from typing import cast

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from scipy.stats import unitary_group

--- a/cirq-core/cirq/transformers/analytical_decompositions/single_qubit_decompositions.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/single_qubit_decompositions.py
@@ -14,6 +14,8 @@
 
 """Utility methods related to optimizing quantum circuits."""
 
+from __future__ import annotations
+
 import math
 from typing import List, Optional, Tuple
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/single_qubit_decompositions_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/single_qubit_decompositions_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 from typing import Sequence
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/single_to_two_qubit_isometry_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/single_to_two_qubit_isometry_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
@@ -14,6 +14,8 @@
 
 """Utility methods for decomposing three-qubit unitaries."""
 
+from __future__ import annotations
+
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from random import random
 from typing import Callable
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_state_preparation_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_state_preparation_test.py
@@ -14,6 +14,8 @@
 
 """Tests for efficient two qubit state preparation methods."""
 
+from __future__ import annotations
+
 import copy
 
 import numpy as np

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cmath
 import random
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_fsim_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_fsim_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 import random
 from typing import Any

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 from typing import cast, Iterable, List, Optional, Tuple, TYPE_CHECKING
 
-import numpy as np
-
 from cirq import linalg, ops, protocols
 from cirq.transformers.analytical_decompositions import single_qubit_decompositions, two_qubit_to_cz
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_ms_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import random
 
 import numpy as np

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_sqrt_iswap_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_sqrt_iswap_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 
 import numpy as np

--- a/cirq-core/cirq/transformers/drop_empty_moments_test.py
+++ b/cirq-core/cirq/transformers/drop_empty_moments_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/transformers/drop_negligible_operations_test.py
+++ b/cirq-core/cirq/transformers/drop_negligible_operations_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 NO_COMPILE_TAG = "no_compile_tag"

--- a/cirq-core/cirq/transformers/eject_phased_paulis_test.py
+++ b/cirq-core/cirq/transformers/eject_phased_paulis_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import dataclasses
 from typing import cast, Iterable
 

--- a/cirq-core/cirq/transformers/eject_z_test.py
+++ b/cirq-core/cirq/transformers/eject_z_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 
 import numpy as np

--- a/cirq-core/cirq/transformers/expand_composite_test.py
+++ b/cirq-core/cirq/transformers/expand_composite_test.py
@@ -14,6 +14,8 @@
 
 """Tests for the expand composite transformer pass."""
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cphase_gauge_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.transformers.gauge_compiling.cphase_gauge import CPhaseGaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge.py
@@ -14,6 +14,8 @@
 
 """A Gauge Transformer for the CZ gate."""
 
+from __future__ import annotations
+
 from cirq import ops
 from cirq.ops.common_gates import CZ
 from cirq.transformers.gauge_compiling.gauge_compiling import (

--- a/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/cz_gauge_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 import cirq
 from cirq.transformers.gauge_compiling import CZGaugeTransformer

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling.py
@@ -14,12 +14,14 @@
 
 """Creates the abstraction for gauge compiling as a cirq transformer."""
 
+from __future__ import annotations
+
 import abc
 import functools
 import itertools
 from dataclasses import dataclass
 from numbers import Real
-from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sympy
@@ -28,10 +30,12 @@ from attrs import field, frozen
 from cirq import circuits, ops
 from cirq.protocols import unitary_protocol
 from cirq.protocols.has_unitary_protocol import has_unitary
-from cirq.study import sweepable
 from cirq.study.sweeps import Points, Zip
 from cirq.transformers import transformer_api
 from cirq.transformers.analytical_decompositions import single_qubit_decompositions
+
+if TYPE_CHECKING:
+    import cirq
 
 
 class Gauge(abc.ABC):
@@ -49,7 +53,7 @@ class Gauge(abc.ABC):
         return 1.0
 
     @abc.abstractmethod
-    def sample(self, gate: ops.Gate, prng: np.random.Generator) -> "ConstantGauge":
+    def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:
         """Returns a ConstantGauge sampled from a family of gauges.
 
         Args:
@@ -80,7 +84,7 @@ class ConstantGauge(Gauge):
     )
     swap_qubits: bool = False
 
-    def sample(self, gate: ops.Gate, prng: np.random.Generator) -> "ConstantGauge":
+    def sample(self, gate: ops.Gate, prng: np.random.Generator) -> ConstantGauge:
         return self
 
     @property
@@ -256,7 +260,7 @@ class GaugeTransformer:
         N: int,
         context: Optional[transformer_api.TransformerContext] = None,
         prng: Optional[np.random.Generator] = None,
-    ) -> Tuple[circuits.AbstractCircuit, sweepable.Sweepable]:
+    ) -> Tuple[circuits.AbstractCircuit, cirq.Sweepable]:
         """Generates a parameterized circuit with *N* sets of sweepable parameters.
 
         Args:

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest.mock
 
 import numpy as np

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
 
 from unittest.mock import patch
 

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling_test_utils_test.py
@@ -13,11 +13,16 @@
 # limitations under the License.
 
 
-import numpy as np
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import cirq
 from cirq.transformers import ConstantGauge, GaugeSelector, GaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class ExampleGate(cirq.testing.TwoQubitGate):

--- a/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge.py
@@ -14,6 +14,8 @@
 
 """A Gauge transformer for ISWAP gate."""
 
+from __future__ import annotations
+
 import numpy as np
 
 from cirq import ops

--- a/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from __future__ import annotations
+
 import cirq
 from cirq.transformers.gauge_compiling import ISWAPGaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester

--- a/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge.py
@@ -14,6 +14,8 @@
 
 """The spin inversion gauge transformer."""
 
+from __future__ import annotations
+
 from cirq import ops
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     GaugeSelector,

--- a/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/spin_inversion_gauge_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.transformers.gauge_compiling import SpinInversionGaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_cz_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_cz_gauge.py
@@ -20,9 +20,6 @@ from __future__ import annotations
 from numbers import Real
 from typing import Dict, Sequence, Tuple, TYPE_CHECKING
 
-import numpy as np
-import sympy
-
 from cirq.ops import CZ, CZPowGate, Gate, Gateset, S, X
 from cirq.transformers.gauge_compiling.gauge_compiling import (
     ConstantGauge,
@@ -33,6 +30,9 @@ from cirq.transformers.gauge_compiling.gauge_compiling import (
 )
 
 if TYPE_CHECKING:
+    import numpy as np
+    import sympy
+
     import cirq
 
 _SQRT_CZ = CZ**0.5

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_cz_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_cz_gauge_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.transformers.gauge_compiling import SqrtCZGaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge.py
@@ -14,6 +14,8 @@
 
 """A Gauge transformer for SQRT_ISWAP gate."""
 
+from __future__ import annotations
+
 import numpy as np
 
 from cirq import ops

--- a/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge_test.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/sqrt_iswap_gauge_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 from cirq.transformers.gauge_compiling import SqrtISWAPGaugeTransformer
 from cirq.transformers.gauge_compiling.gauge_compiling_test_utils import GaugeTester

--- a/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import itertools
 from typing import Optional, Sequence, Union
 

--- a/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils_test.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/gate_tabulation_math_utils_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation_test.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/transformers/insertion_sort_test.py
+++ b/cirq-core/cirq/transformers/insertion_sort_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 import cirq.transformers
 

--- a/cirq-core/cirq/transformers/measurement_transformers_test.py
+++ b/cirq-core/cirq/transformers/measurement_transformers_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import List
 
 import cirq

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import cast
 

--- a/cirq-core/cirq/transformers/noise_adding_test.py
+++ b/cirq-core/cirq/transformers/noise_adding_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 import cirq.transformers.noise_adding as na

--- a/cirq-core/cirq/transformers/qubit_management_transformers_test.py
+++ b/cirq-core/cirq/transformers/qubit_management_transformers_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/transformers/randomized_measurements_test.py
+++ b/cirq-core/cirq/transformers/randomized_measurements_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/transformers/routing/initial_mapper_test.py
+++ b/cirq-core/cirq/transformers/routing/initial_mapper_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/transformers/routing/line_initial_mapper_test.py
+++ b/cirq-core/cirq/transformers/routing/line_initial_mapper_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import networkx as nx
 import pytest
 

--- a/cirq-core/cirq/transformers/routing/mapping_manager_test.py
+++ b/cirq-core/cirq/transformers/routing/mapping_manager_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import networkx as nx
 import pytest
 from networkx.utils.misc import graphs_equal

--- a/cirq-core/cirq/transformers/routing/route_circuit_cqc_test.py
+++ b/cirq-core/cirq/transformers/routing/route_circuit_cqc_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/transformers/routing/visualize_routed_circuit_test.py
+++ b/cirq-core/cirq/transformers/routing/visualize_routed_circuit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/transformers/stratify_test.py
+++ b/cirq-core/cirq/transformers/stratify_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/transformers/synchronize_terminal_measurements_test.py
+++ b/cirq-core/cirq/transformers/synchronize_terminal_measurements_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 NO_COMPILE_TAG = "no_compile_tag"

--- a/cirq-core/cirq/transformers/tag_transformers.py
+++ b/cirq-core/cirq/transformers/tag_transformers.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import itertools
 from typing import Callable, Hashable, Optional, TYPE_CHECKING
 
@@ -23,11 +25,11 @@ if TYPE_CHECKING:
 
 @transformer_api.transformer
 def index_tags(
-    circuit: 'cirq.AbstractCircuit',
+    circuit: cirq.AbstractCircuit,
     *,
-    context: Optional['cirq.TransformerContext'] = None,
+    context: Optional[cirq.TransformerContext] = None,
     target_tags: Optional[set[Hashable]] = None,
-) -> 'cirq.Circuit':
+) -> cirq.Circuit:
     """Indexes tags in target_tags as tag_0, tag_1, ... per tag.
 
     Args:
@@ -44,7 +46,7 @@ def index_tags(
         return circuit.unfreeze(copy=False)
     tag_iter_by_tags = {tag: itertools.count(start=0, step=1) for tag in target_tags}
 
-    def _map_func(op: 'cirq.Operation', _) -> 'cirq.OP_TREE':
+    def _map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
         tag_set = set(op.tags)
         nonlocal tag_iter_by_tags
         for tag in target_tags.intersection(op.tags):
@@ -60,12 +62,12 @@ def index_tags(
 
 @transformer_api.transformer
 def remove_tags(
-    circuit: 'cirq.AbstractCircuit',
+    circuit: cirq.AbstractCircuit,
     *,
-    context: Optional['cirq.TransformerContext'] = None,
+    context: Optional[cirq.TransformerContext] = None,
     target_tags: Optional[set[Hashable]] = None,
     remove_if: Callable[[Hashable], bool] = lambda _: False,
-) -> 'cirq.Circuit':
+) -> cirq.Circuit:
     """Removes tags from the operations based on the input args.
 
     Args:
@@ -82,7 +84,7 @@ def remove_tags(
         raise ValueError("remove_tags doesn't support tags_to_ignore, use function args instead.")
     target_tags = target_tags or set()
 
-    def _map_func(op: 'cirq.Operation', _) -> 'cirq.OP_TREE':
+    def _map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
         remaing_tags = set()
         for tag in op.tags:
             if not remove_if(tag) and tag not in target_tags:

--- a/cirq-core/cirq/transformers/tag_transformers_test.py
+++ b/cirq-core/cirq/transformers/tag_transformers_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional, Sequence, Type
 
 import numpy as np

--- a/cirq-core/cirq/transformers/target_gatesets/sqrt_iswap_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/sqrt_iswap_gateset_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np

--- a/cirq-core/cirq/transformers/transformer_api_test.py
+++ b/cirq-core/cirq/transformers/transformer_api_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Optional
 from unittest import mock
 

--- a/cirq-core/cirq/value/abc_alt.py
+++ b/cirq-core/cirq/value/abc_alt.py
@@ -14,6 +14,8 @@
 
 """A more flexible abstract base class metaclass ABCMetaImplementAnyOneOf."""
 
+from __future__ import annotations
+
 import abc
 import functools
 from typing import Callable, cast, Set, TypeVar

--- a/cirq-core/cirq/value/abc_alt_test.py
+++ b/cirq-core/cirq/value/abc_alt_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import abc
 from typing import NoReturn, Optional
 

--- a/cirq-core/cirq/value/angle.py
+++ b/cirq-core/cirq/value/angle.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, overload
+from __future__ import annotations
+
+from typing import Optional, overload, TYPE_CHECKING
 
 import numpy as np
 import sympy
 
-from cirq.value import type_alias
+if TYPE_CHECKING:
+    from cirq.value import type_alias
 
 
 def chosen_angle_to_half_turns(

--- a/cirq-core/cirq/value/angle_test.py
+++ b/cirq-core/cirq/value/angle_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/value/classical_data_test.py
+++ b/cirq-core/cirq/value/classical_data_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/cirq-core/cirq/value/condition_test.py
+++ b/cirq-core/cirq/value/condition_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/cirq-core/cirq/value/digits.py
+++ b/cirq-core/cirq/value/digits.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Iterable, List, Optional, overload, Union
 
 

--- a/cirq-core/cirq/value/digits_test.py
+++ b/cirq-core/cirq/value/digits_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/value/duration_test.py
+++ b/cirq-core/cirq/value/duration_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from datetime import timedelta
 
 import numpy as np

--- a/cirq-core/cirq/value/linear_dict_test.py
+++ b/cirq-core/cirq/value/linear_dict_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-core/cirq/value/measurement_key.py
+++ b/cirq-core/cirq/value/measurement_key.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import dataclasses
 from typing import Any, Dict, FrozenSet, Mapping, Optional, Tuple
 
@@ -49,7 +51,7 @@ class MeasurementKey:
                 '`MeasurementKey.parse_serialized` for correct behavior.'
             )
 
-    def replace(self, **changes) -> 'MeasurementKey':
+    def replace(self, **changes) -> MeasurementKey:
         """Returns a copy of this MeasurementKey with the specified changes."""
         return dataclasses.replace(self, **changes)
 
@@ -102,7 +104,7 @@ class MeasurementKey:
         return cls(name=name, path=tuple(path))
 
     @classmethod
-    def parse_serialized(cls, key_str: str) -> 'MeasurementKey':
+    def parse_serialized(cls, key_str: str) -> MeasurementKey:
         """Parses the serialized string representation of `Measurementkey` into a `MeasurementKey`.
 
         This is the only way to construct a `MeasurementKey` from a nested string representation
@@ -124,9 +126,7 @@ class MeasurementKey:
         """
         return self.replace(path=path_component + self.path)
 
-    def _with_rescoped_keys_(
-        self, path: Tuple[str, ...], bindable_keys: FrozenSet['MeasurementKey']
-    ):
+    def _with_rescoped_keys_(self, path: Tuple[str, ...], bindable_keys: FrozenSet[MeasurementKey]):
         return self.replace(path=path + self.path)
 
     def _with_measurement_key_mapping_(self, key_map: Mapping[str, str]):

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/value/periodic_value_test.py
+++ b/cirq-core/cirq/value/periodic_value_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/value/probability_test.py
+++ b/cirq-core/cirq/value/probability_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/value/product_state_test.py
+++ b/cirq-core/cirq/value/product_state_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-core/cirq/value/random_state.py
+++ b/cirq-core/cirq/value/random_state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, cast
 
 import numpy as np

--- a/cirq-core/cirq/value/random_state_test.py
+++ b/cirq-core/cirq/value/random_state_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/value/timestamp.py
+++ b/cirq-core/cirq/value/timestamp.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A typed location in time that supports picosecond accuracy."""
+
+from __future__ import annotations
 
 from datetime import timedelta
 from typing import overload
@@ -45,27 +48,27 @@ class Timestamp:
         """The timestamp's location in picoseconds from arbitrary time zero."""
         return self._picos
 
-    def __add__(self, other) -> 'Timestamp':
+    def __add__(self, other) -> Timestamp:
         if isinstance(other, timedelta):
             return Timestamp(picos=self._picos + other.total_seconds() * 10**12)
         if not isinstance(other, Duration):
             return NotImplemented
         return Timestamp(picos=self._picos + other.total_picos())
 
-    def __radd__(self, other) -> 'Timestamp':
+    def __radd__(self, other) -> Timestamp:
         return self.__add__(other)
 
     # pylint: disable=function-redefined
     @overload
-    def __sub__(self, other: 'Timestamp') -> Duration:
+    def __sub__(self, other: Timestamp) -> Duration:
         pass
 
     @overload
-    def __sub__(self, other: Duration) -> 'Timestamp':
+    def __sub__(self, other: Duration) -> Timestamp:
         pass
 
     @overload
-    def __sub__(self, other: timedelta) -> 'Timestamp':
+    def __sub__(self, other: timedelta) -> Timestamp:
         pass
 
     def __sub__(self, other):

--- a/cirq-core/cirq/value/timestamp_test.py
+++ b/cirq-core/cirq/value/timestamp_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from datetime import timedelta
 
 import pytest

--- a/cirq-core/cirq/value/type_alias.py
+++ b/cirq-core/cirq/value/type_alias.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Union
 
 import numpy as np

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Defines `@cirq.value_equality`, for easy __eq__/__hash__ methods."""
+
+from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, overload, Union
 

--- a/cirq-core/cirq/value/value_equality_attr_test.py
+++ b/cirq-core/cirq/value/value_equality_attr_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-core/cirq/vis/density_matrix.py
+++ b/cirq-core/cirq/vis/density_matrix.py
@@ -14,6 +14,8 @@
 
 """Tool to visualize the magnitudes and phases in the density matrix"""
 
+from __future__ import annotations
+
 from typing import Optional
 
 import matplotlib.pyplot as plt

--- a/cirq-core/cirq/vis/density_matrix_test.py
+++ b/cirq-core/cirq/vis/density_matrix_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for Density Matrix Plotter."""
+
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/cirq-core/cirq/vis/heatmap_test.py
+++ b/cirq-core/cirq/vis/heatmap_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for Heatmap."""
+
+from __future__ import annotations
 
 import pathlib
 import shutil

--- a/cirq-core/cirq/vis/histogram.py
+++ b/cirq-core/cirq/vis/histogram.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Any, Mapping, Optional, Sequence, SupportsFloat, Union
 
 import numpy as np

--- a/cirq-core/cirq/vis/histogram_test.py
+++ b/cirq-core/cirq/vis/histogram_test.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for Histogram."""
+
+from __future__ import annotations
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/cirq-core/cirq/vis/state_histogram.py
+++ b/cirq-core/cirq/vis/state_histogram.py
@@ -14,6 +14,8 @@
 
 """Tool to visualize the results of a study."""
 
+from __future__ import annotations
+
 import collections
 from typing import Optional, Sequence, SupportsFloat, Union
 
@@ -23,7 +25,7 @@ import numpy as np
 import cirq.study.result as result
 
 
-def get_state_histogram(result: 'result.Result') -> np.ndarray:
+def get_state_histogram(result: result.Result) -> np.ndarray:
     """Computes a state histogram from a single result with repetitions.
 
     Args:
@@ -52,7 +54,7 @@ def get_state_histogram(result: 'result.Result') -> np.ndarray:
 
 
 def plot_state_histogram(
-    data: Union['result.Result', collections.Counter, Sequence[SupportsFloat]],
+    data: Union[result.Result, collections.Counter, Sequence[SupportsFloat]],
     ax: Optional[plt.Axes] = None,
     *,
     tick_label: Optional[Sequence[str]] = None,

--- a/cirq-core/cirq/vis/state_histogram_test.py
+++ b/cirq-core/cirq/vis/state_histogram_test.py
@@ -14,6 +14,8 @@
 
 """Tests for state_histogram."""
 
+from __future__ import annotations
+
 import matplotlib as mpl
 import numpy as np
 import pytest

--- a/cirq-core/cirq/vis/vis_utils.py
+++ b/cirq-core/cirq/vis/vis_utils.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -19,7 +22,7 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
 
-def relative_luminance(color: 'ArrayLike') -> float:
+def relative_luminance(color: ArrayLike) -> float:
     """Returns the relative luminance according to W3C specification.
 
     Spec: https://www.w3.org/TR/WCAG21/#dfn-relative-luminance.

--- a/cirq-core/cirq/vis/vis_utils_test.py
+++ b/cirq-core/cirq/vis/vis_utils_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 
 import cirq

--- a/cirq-core/cirq/work/collector_test.py
+++ b/cirq-core/cirq/work/collector_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import duet
 import pytest
 

--- a/cirq-core/cirq/work/observable_grouping.py
+++ b/cirq-core/cirq/work/observable_grouping.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Callable, cast, Dict, Iterable, List, TYPE_CHECKING
 
 from cirq import ops, value

--- a/cirq-core/cirq/work/observable_grouping_test.py
+++ b/cirq-core/cirq/work/observable_grouping_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import cirq
 
 

--- a/cirq-core/cirq/work/observable_measurement_data_test.py
+++ b/cirq-core/cirq/work/observable_measurement_data_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import dataclasses
 import datetime
 import time
@@ -113,7 +116,7 @@ def test_observable_measured_result():
 
 
 @pytest.fixture
-def example_bsa() -> 'cw.BitstringAccumulator':
+def example_bsa() -> cw.BitstringAccumulator:
     """Test fixture to create an (empty) example BitstringAccumulator"""
     q0, q1 = cirq.LineQubit.range(2)
     setting = cw.InitObsSetting(

--- a/cirq-core/cirq/work/observable_measurement_test.py
+++ b/cirq-core/cirq/work/observable_measurement_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import tempfile
 from typing import Dict, Iterable, List
 

--- a/cirq-core/cirq/work/observable_settings_test.py
+++ b/cirq-core/cirq/work/observable_settings_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-core/cirq/work/pauli_sum_collector_test.py
+++ b/cirq-core/cirq/work/pauli_sum_collector_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import duet
 
 import cirq

--- a/cirq-google/cirq_google/api/v1/params.py
+++ b/cirq-google/cirq_google/api/v1/params.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import cast
 
 import sympy

--- a/cirq-google/cirq_google/api/v1/params_test.py
+++ b/cirq-google/cirq_google/api/v1/params_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-google/cirq_google/api/v1/programs.py
+++ b/cirq-google/cirq_google/api/v1/programs.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from typing import Any, cast, Dict, Iterator, Optional, Sequence, Tuple, TYPE_CHECKING
 

--- a/cirq-google/cirq_google/api/v1/programs_test.py
+++ b/cirq-google/cirq_google/api/v1/programs_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-google/cirq_google/api/v1/proto_test.py
+++ b/cirq-google/cirq_google/api/v1/proto_test.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Check protobuf modules initialize successfully."""
 
 # pylint: disable=unused-import
+
+from __future__ import annotations
+
 from cirq_google.api.v1 import operations_pb2, params_pb2, program_pb2
 
 # pylint: enable=unused-import

--- a/cirq-google/cirq_google/api/v2/ndarrays_test.py
+++ b/cirq-google/cirq_google/api/v2/ndarrays_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import functools
 import math
 from collections.abc import Sequence

--- a/cirq-google/cirq_google/api/v2/program.py
+++ b/cirq-google/cirq_google/api/v2/program.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import re
 
 import cirq

--- a/cirq-google/cirq_google/api/v2/program_test.py
+++ b/cirq-google/cirq_google/api/v2/program_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-google/cirq_google/api/v2/proto_test.py
+++ b/cirq-google/cirq_google/api/v2/proto_test.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Check protobuf modules initialize successfully."""
 
 # pylint: disable=unused-import
+
+from __future__ import annotations
+
 from cirq_google.api.v2 import metrics_pb2, program_pb2, result_pb2, run_context_pb2
 
 # pylint: enable=unused-import

--- a/cirq-google/cirq_google/api/v2/results.py
+++ b/cirq-google/cirq_google/api/v2/results.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import dataclasses
 from collections import OrderedDict
 from typing import cast, Dict, Hashable, Iterable, List, Optional, Sequence

--- a/cirq-google/cirq_google/api/v2/results_test.py
+++ b/cirq-google/cirq_google/api/v2/results_test.py
@@ -1,4 +1,7 @@
 # pylint: disable=wrong-or-nonexistent-copyright-notice
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-google/cirq_google/api/v2/run_context.py
+++ b/cirq-google/cirq_google/api/v2/run_context.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 from typing import Sequence
 

--- a/cirq-google/cirq_google/api/v2/run_context_test.py
+++ b/cirq-google/cirq_google/api/v2/run_context_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import google.protobuf.text_format as text_format
 
 import cirq_google.api.v2.run_context as run_context

--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, cast, Dict, List, Optional
+from __future__ import annotations
+
+from typing import Any, Callable, cast, Dict, List, Optional, TYPE_CHECKING
 
 import sympy
 import tunits
 
 import cirq
-from cirq.study import sweeps
 from cirq_google.api.v2 import run_context_pb2
 from cirq_google.study.device_parameter import DeviceParameter, Metadata
+
+if TYPE_CHECKING:
+    from cirq.study import sweeps
 
 
 def _build_sweep_const(value: Any) -> run_context_pb2.ConstValue:

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import math
 from copy import deepcopy
 from typing import Iterator

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/async_client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/async_client.py
@@ -14,18 +14,33 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import importlib.metadata
-from typing import AsyncIterable, AsyncIterator, Awaitable, Optional, Sequence, Tuple, Union
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Optional,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 
 from google.api_core import gapic_v1, retry as retries
-from google.api_core.client_options import ClientOptions
-from google.auth import credentials as ga_credentials
 
 from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service import pagers
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 
 from .client import QuantumEngineServiceClient
-from .transports.base import DEFAULT_CLIENT_INFO, QuantumEngineServiceTransport
+from .transports.base import DEFAULT_CLIENT_INFO
+
+if TYPE_CHECKING:
+    from google.api_core.client_options import ClientOptions
+    from google.auth import credentials as ga_credentials
+
+    from .transports.base import QuantumEngineServiceTransport
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
@@ -13,14 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import importlib.metadata
 import os
 import re
 from collections import OrderedDict
-from typing import Dict, Iterable, Iterator, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, Iterable, Iterator, Optional, Sequence, Tuple, Type, TYPE_CHECKING, Union
 
 from google.api_core import client_options as client_options_lib, gapic_v1, retry as retries
-from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.auth.transport import mtls
 from google.oauth2 import service_account
@@ -31,6 +33,9 @@ from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 from .transports.base import DEFAULT_CLIENT_INFO, QuantumEngineServiceTransport
 from .transports.grpc import QuantumEngineServiceGrpcTransport
 from .transports.grpc_asyncio import QuantumEngineServiceGrpcAsyncIOTransport
+
+if TYPE_CHECKING:
+    from google.auth import credentials as ga_credentials
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/pagers.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/pagers.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 from typing import Any, AsyncIterator, Awaitable, Callable, Iterator, Optional, Sequence, Tuple
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/base.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/base.py
@@ -13,18 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import abc
 import importlib.metadata
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, TYPE_CHECKING, Union
 
 import google.api_core
 import google.auth
 from google.api_core import exceptions as core_exceptions, gapic_v1
-from google.auth import credentials as ga_credentials
 from google.oauth2 import service_account
-from google.protobuf import empty_pb2
 
-from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
+if TYPE_CHECKING:
+    from google.auth import credentials as ga_credentials
+    from google.protobuf import empty_pb2
+
+    from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc.py
@@ -13,19 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import warnings
-from typing import Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import google.auth
 import grpc  # type: ignore
 from google.api_core import gapic_v1, grpc_helpers
-from google.auth import credentials as ga_credentials
 from google.auth.transport.grpc import SslCredentials
 from google.protobuf import empty_pb2
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 
 from .base import DEFAULT_CLIENT_INFO, QuantumEngineServiceTransport
+
+if TYPE_CHECKING:
+    from google.auth import credentials as ga_credentials
 
 
 class QuantumEngineServiceGrpcTransport(QuantumEngineServiceTransport):

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc_asyncio.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc_asyncio.py
@@ -13,20 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import warnings
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import grpc  # type: ignore
 from google.api_core import gapic_v1, grpc_helpers_async
-from google.auth import credentials as ga_credentials
 from google.auth.transport.grpc import SslCredentials
 from google.protobuf import empty_pb2
-from grpc.experimental import aio  # type: ignore
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 
 from .base import DEFAULT_CLIENT_INFO, QuantumEngineServiceTransport
 from .grpc import QuantumEngineServiceGrpcTransport
+
+if TYPE_CHECKING:
+    from google.auth import credentials as ga_credentials
+    from grpc.experimental import aio  # type: ignore
 
 
 class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/engine.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/engine.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import proto
 from google.protobuf import duration_pb2, field_mask_pb2
 

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/quantum.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/quantum.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import proto
 from google.protobuf import any_pb2, duration_pb2, field_mask_pb2, timestamp_pb2
 

--- a/cirq-google/cirq_google/devices/google_noise_properties_test.py
+++ b/cirq-google/cirq_google/devices/google_noise_properties_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, List, Tuple
 
 import numpy as np

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -14,6 +14,8 @@
 
 """Device object representing Google devices with a grid qubit layout."""
 
+from __future__ import annotations
+
 import re
 import warnings
 from dataclasses import dataclass
@@ -447,7 +449,7 @@ class GridDevice(cirq.Device):
         self._metadata = metadata
 
     @classmethod
-    def from_proto(cls, proto: v2.device_pb2.DeviceSpecification) -> 'GridDevice':
+    def from_proto(cls, proto: v2.device_pb2.DeviceSpecification) -> GridDevice:
         """Deserializes the `DeviceSpecification` to a `GridDevice`.
 
         Args:
@@ -538,7 +540,7 @@ class GridDevice(cirq.Device):
         gateset: cirq.Gateset,
         gate_durations: Optional[Mapping[cirq.GateFamily, cirq.Duration]] = None,
         all_qubits: Optional[Collection[cirq.GridQubit]] = None,
-    ) -> 'GridDevice':
+    ) -> GridDevice:
         """Constructs a GridDevice using the device information provided.
 
         EXPERIMENTAL: this method may have changes which are not backward compatible in the future.

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import unittest.mock as mock
 from dataclasses import dataclass
 from typing import Dict, List, Tuple

--- a/cirq-google/cirq_google/devices/known_devices_test.py
+++ b/cirq-google/cirq_google/devices/known_devices_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/cirq-google/cirq_google/engine/abstract_engine.py
+++ b/cirq-google/cirq_google/engine/abstract_engine.py
@@ -17,13 +17,16 @@ This class is an abstract class which all Engine implementations
 (production API or locally simulated) should follow.
 """
 
+from __future__ import annotations
+
 import abc
 import datetime
-from typing import Dict, List, Optional, Sequence, Set, Union
+from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
 
-import cirq
-from cirq_google.cloud import quantum
-from cirq_google.engine import abstract_job, abstract_processor, abstract_program
+if TYPE_CHECKING:
+    import cirq
+    from cirq_google.cloud import quantum
+    from cirq_google.engine import abstract_job, abstract_processor, abstract_program
 
 VALID_DATE_TYPE = Union[datetime.datetime, datetime.date]
 

--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -11,24 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A helper for jobs that have been created on the Quantum Engine."""
+
+from __future__ import annotations
 
 import abc
 from typing import Dict, Iterator, List, Optional, overload, Sequence, Tuple, TYPE_CHECKING
 
 import duet
 
-import cirq
-from cirq_google.cloud import quantum
-from cirq_google.engine.engine_result import EngineResult
-
 if TYPE_CHECKING:
     import datetime
 
+    import cirq
+    import cirq_google.cloud.quantum as quantum
     import cirq_google.engine.abstract_engine as abstract_engine
     import cirq_google.engine.abstract_processor as abstract_processor
     import cirq_google.engine.abstract_program as abstract_program
     import cirq_google.engine.calibration as calibration
+    from cirq_google.engine.engine_result import EngineResult
 
 
 class AbstractJob(abc.ABC):
@@ -54,7 +56,7 @@ class AbstractJob(abc.ABC):
     """
 
     @abc.abstractmethod
-    def engine(self) -> 'abstract_engine.AbstractEngine':
+    def engine(self) -> abstract_engine.AbstractEngine:
         """Returns the parent `AbstractEngine` object."""
 
     @abc.abstractmethod
@@ -62,15 +64,15 @@ class AbstractJob(abc.ABC):
         """Returns the id of this job."""
 
     @abc.abstractmethod
-    def program(self) -> 'abstract_program.AbstractProgram':
+    def program(self) -> abstract_program.AbstractProgram:
         """Returns the parent `AbstractProgram`object."""
 
     @abc.abstractmethod
-    def create_time(self) -> 'datetime.datetime':
+    def create_time(self) -> datetime.datetime:
         """Returns when the job was created."""
 
     @abc.abstractmethod
-    def update_time(self) -> 'datetime.datetime':
+    def update_time(self) -> datetime.datetime:
         """Returns when the job was last updated."""
 
     @abc.abstractmethod
@@ -78,7 +80,7 @@ class AbstractJob(abc.ABC):
         """Returns the description of the job."""
 
     @abc.abstractmethod
-    def set_description(self, description: str) -> 'AbstractJob':
+    def set_description(self, description: str) -> AbstractJob:
         """Sets the description of the job.
 
         Params:
@@ -93,7 +95,7 @@ class AbstractJob(abc.ABC):
         """Returns the labels of the job."""
 
     @abc.abstractmethod
-    def set_labels(self, labels: Dict[str, str]) -> 'AbstractJob':
+    def set_labels(self, labels: Dict[str, str]) -> AbstractJob:
         """Sets (overwriting) the labels for a previously created quantum job.
 
         Params:
@@ -104,7 +106,7 @@ class AbstractJob(abc.ABC):
         """
 
     @abc.abstractmethod
-    def add_labels(self, labels: Dict[str, str]) -> 'AbstractJob':
+    def add_labels(self, labels: Dict[str, str]) -> AbstractJob:
         """Adds new labels to a previously created quantum job.
 
         Params:
@@ -115,7 +117,7 @@ class AbstractJob(abc.ABC):
         """
 
     @abc.abstractmethod
-    def remove_labels(self, keys: List[str]) -> 'AbstractJob':
+    def remove_labels(self, keys: List[str]) -> AbstractJob:
         """Removes labels with given keys.
 
         Params:
@@ -146,12 +148,12 @@ class AbstractJob(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_processor(self) -> Optional['abstract_processor.AbstractProcessor']:
+    def get_processor(self) -> Optional[abstract_processor.AbstractProcessor]:
         """Returns the AbstractProcessor for the processor the job is/was run on,
         if available, else None."""
 
     @abc.abstractmethod
-    def get_calibration(self) -> Optional['calibration.Calibration']:
+    def get_calibration(self) -> Optional[calibration.Calibration]:
         """Returns the recorded calibration at the time when the job was run, if
         one was captured, else None."""
 

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Dict, List, TYPE_CHECKING
 
 import numpy as np
@@ -27,37 +30,37 @@ if TYPE_CHECKING:
 
 
 class MockJob(AbstractJob):
-    def engine(self) -> 'abstract_engine.AbstractEngine':  # type: ignore[empty-body]
+    def engine(self) -> abstract_engine.AbstractEngine:  # type: ignore[empty-body]
         pass
 
     def id(self) -> str:  # type: ignore[empty-body]
         pass
 
-    def program(self) -> 'abstract_program.AbstractProgram':  # type: ignore[empty-body]
+    def program(self) -> abstract_program.AbstractProgram:  # type: ignore[empty-body]
         pass
 
-    def create_time(self) -> 'datetime.datetime':  # type: ignore[empty-body]
+    def create_time(self) -> datetime.datetime:  # type: ignore[empty-body]
         pass
 
-    def update_time(self) -> 'datetime.datetime':  # type: ignore[empty-body]
+    def update_time(self) -> datetime.datetime:  # type: ignore[empty-body]
         pass
 
     def description(self) -> str:  # type: ignore[empty-body]
         pass
 
-    def set_description(self, description: str) -> 'AbstractJob':  # type: ignore[empty-body]
+    def set_description(self, description: str) -> AbstractJob:  # type: ignore[empty-body]
         pass
 
     def labels(self) -> Dict[str, str]:  # type: ignore[empty-body]
         pass
 
-    def set_labels(self, labels: Dict[str, str]) -> 'AbstractJob':  # type: ignore[empty-body]
+    def set_labels(self, labels: Dict[str, str]) -> AbstractJob:  # type: ignore[empty-body]
         pass
 
-    def add_labels(self, labels: Dict[str, str]) -> 'AbstractJob':  # type: ignore[empty-body]
+    def add_labels(self, labels: Dict[str, str]) -> AbstractJob:  # type: ignore[empty-body]
         pass
 
-    def remove_labels(self, keys: List[str]) -> 'AbstractJob':  # type: ignore[empty-body]
+    def remove_labels(self, keys: List[str]) -> AbstractJob:  # type: ignore[empty-body]
         pass
 
     def processor_ids(self):

--- a/cirq-google/cirq_google/engine/abstract_local_engine.py
+++ b/cirq-google/cirq_google/engine/abstract_local_engine.py
@@ -11,15 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import datetime
-from typing import Dict, List, Optional, Sequence, Set, Union
 
-import cirq
-from cirq_google.cloud import quantum
+from __future__ import annotations
+
+import datetime
+from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
+
 from cirq_google.engine.abstract_engine import AbstractEngine
-from cirq_google.engine.abstract_job import AbstractJob
-from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
-from cirq_google.engine.abstract_program import AbstractProgram
+
+if TYPE_CHECKING:
+    import cirq
+    import cirq_google.cloud.quantum as quantum
+    from cirq_google.engine.abstract_job import AbstractJob
+    from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
+    from cirq_google.engine.abstract_program import AbstractProgram
 
 
 class AbstractLocalEngine(AbstractEngine):

--- a/cirq-google/cirq_google/engine/abstract_local_engine_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_engine_test.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
 import pytest
 
@@ -22,7 +25,9 @@ from cirq_google.engine.abstract_local_engine import AbstractLocalEngine
 from cirq_google.engine.abstract_local_job_test import NothingJob
 from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
 from cirq_google.engine.abstract_local_program_test import NothingProgram
-from cirq_google.engine.abstract_program import AbstractProgram
+
+if TYPE_CHECKING:
+    from cirq_google.engine.abstract_program import AbstractProgram
 
 
 class ProgramDictProcessor(AbstractLocalProcessor):

--- a/cirq-google/cirq_google/engine/abstract_local_job.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job.py
@@ -11,16 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A helper for jobs that have been created on the Quantum Engine."""
+
+from __future__ import annotations
+
 import copy
 import datetime
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
-import cirq
-from cirq_google.engine import calibration
 from cirq_google.engine.abstract_job import AbstractJob
 
 if TYPE_CHECKING:
+    import cirq
+    import cirq_google.engine.calibration as calibration
     from cirq_google.engine.abstract_local_engine import AbstractLocalEngine
     from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
     from cirq_google.engine.abstract_local_program import AbstractLocalProgram
@@ -51,7 +55,7 @@ class AbstractLocalJob(AbstractJob):
         self,
         *,
         job_id: str,
-        parent_program: 'AbstractLocalProgram',
+        parent_program: AbstractLocalProgram,
         repetitions: int,
         sweeps: List[cirq.Sweep],
         processor_id: str = '',
@@ -66,7 +70,7 @@ class AbstractLocalJob(AbstractJob):
         self._description = ''
         self._labels: Dict[str, str] = {}
 
-    def engine(self) -> 'AbstractLocalEngine':
+    def engine(self) -> AbstractLocalEngine:
         """Returns the parent program's `AbstractEngine` object."""
         return self._parent_program.engine()
 
@@ -74,15 +78,15 @@ class AbstractLocalJob(AbstractJob):
         """Returns the identifier of this job."""
         return self._id
 
-    def program(self) -> 'AbstractLocalProgram':
+    def program(self) -> AbstractLocalProgram:
         """Returns the parent `AbstractLocalProgram` object."""
         return self._parent_program
 
-    def create_time(self) -> 'datetime.datetime':
+    def create_time(self) -> datetime.datetime:
         """Returns when the job was created."""
         return self._create_time
 
-    def update_time(self) -> 'datetime.datetime':
+    def update_time(self) -> datetime.datetime:
         """Returns when the job was last updated."""
         return self._update_time
 
@@ -90,7 +94,7 @@ class AbstractLocalJob(AbstractJob):
         """Returns the description of the job."""
         return self._description
 
-    def set_description(self, description: str) -> 'AbstractJob':
+    def set_description(self, description: str) -> AbstractJob:
         """Sets the description of the job.
 
         Params:
@@ -107,7 +111,7 @@ class AbstractLocalJob(AbstractJob):
         """Returns the labels of the job."""
         return copy.copy(self._labels)
 
-    def set_labels(self, labels: Dict[str, str]) -> 'AbstractJob':
+    def set_labels(self, labels: Dict[str, str]) -> AbstractJob:
         """Sets (overwriting) the labels for a previously created quantum job.
 
         Params:
@@ -120,7 +124,7 @@ class AbstractLocalJob(AbstractJob):
         self._update_time = datetime.datetime.now()
         return self
 
-    def add_labels(self, labels: Dict[str, str]) -> 'AbstractJob':
+    def add_labels(self, labels: Dict[str, str]) -> AbstractJob:
         """Adds new labels to a previously created quantum job.
 
         Params:
@@ -134,7 +138,7 @@ class AbstractLocalJob(AbstractJob):
             self._labels[key] = labels[key]
         return self
 
-    def remove_labels(self, keys: List[str]) -> 'AbstractJob':
+    def remove_labels(self, keys: List[str]) -> AbstractJob:
         """Removes labels with given keys from the labels of a previously
         created quantum job.
 
@@ -161,7 +165,7 @@ class AbstractLocalJob(AbstractJob):
         """
         return (self._repetitions, self._sweeps)
 
-    def get_processor(self) -> 'AbstractLocalProcessor':
+    def get_processor(self) -> AbstractLocalProcessor:
         """Returns the AbstractProcessor for the processor the job is/was run on,
         if available, else None."""
         return self.engine().get_processor(self._processor_id)

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -11,14 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A helper for jobs that have been created on the Quantum Engine."""
+
+from __future__ import annotations
+
 import datetime
-from typing import Optional, Sequence, Tuple
+from typing import Optional, Sequence, Tuple, TYPE_CHECKING
 
 import cirq
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_local_job import AbstractLocalJob
-from cirq_google.engine.engine_result import EngineResult
+
+if TYPE_CHECKING:
+    from cirq_google.engine.engine_result import EngineResult
 
 
 class NothingJob(AbstractLocalJob):

--- a/cirq-google/cirq_google/engine/abstract_local_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_local_processor.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import abc
 import datetime
 from typing import Dict, List, Optional, overload, TYPE_CHECKING, Union
@@ -18,13 +21,13 @@ from typing import Dict, List, Optional, overload, TYPE_CHECKING, Union
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from cirq_google.cloud import quantum
-from cirq_google.engine import calibration
 from cirq_google.engine.abstract_processor import AbstractProcessor
-from cirq_google.engine.abstract_program import AbstractProgram
 
 if TYPE_CHECKING:
+    import cirq_google.engine.calibration as calibration
     from cirq_google.engine.abstract_engine import AbstractEngine
     from cirq_google.engine.abstract_local_program import AbstractLocalProgram
+    from cirq_google.engine.abstract_program import AbstractProgram
 
 
 @overload
@@ -67,7 +70,7 @@ class AbstractLocalProcessor(AbstractProcessor):
         self,
         *,
         processor_id: str,
-        engine: Optional['AbstractEngine'] = None,
+        engine: Optional[AbstractEngine] = None,
         expected_down_time: Optional[datetime.datetime] = None,
         expected_recovery_time: Optional[datetime.datetime] = None,
         schedule: Optional[List[quantum.QuantumTimeSlot]] = None,
@@ -107,7 +110,7 @@ class AbstractLocalProcessor(AbstractProcessor):
         """Unique string id of the processor."""
         return self._processor_id
 
-    def engine(self) -> Optional['AbstractEngine']:
+    def engine(self) -> Optional[AbstractEngine]:
         """Returns the parent Engine object.
 
         Returns:
@@ -122,12 +125,12 @@ class AbstractLocalProcessor(AbstractProcessor):
         """Sets the parent processor."""
         self._engine = engine
 
-    def expected_down_time(self) -> 'Optional[datetime.datetime]':
+    def expected_down_time(self) -> Optional[datetime.datetime]:
         """Returns the start of the next expected down time of the processor, if
         set."""
         return self._expected_down_time
 
-    def expected_recovery_time(self) -> 'Optional[datetime.datetime]':
+    def expected_recovery_time(self) -> Optional[datetime.datetime]:
         """Returns the expected the processor should be available, if set."""
         return self._expected_recovery_time
 
@@ -413,7 +416,7 @@ class AbstractLocalProcessor(AbstractProcessor):
         created_before: Optional[Union[datetime.datetime, datetime.date]] = None,
         created_after: Optional[Union[datetime.datetime, datetime.date]] = None,
         has_labels: Optional[Dict[str, str]] = None,
-    ) -> List['AbstractLocalProgram']:
+    ) -> List[AbstractLocalProgram]:
         """Returns a list of previously executed quantum programs.
 
         Args:

--- a/cirq-google/cirq_google/engine/abstract_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_processor_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/cirq-google/cirq_google/engine/abstract_local_program.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import copy
 import datetime
 from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
 
-import cirq
-from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_program import AbstractProgram
 
 if TYPE_CHECKING:
+    import cirq
+    import cirq_google.cloud.quantum as quantum
     from cirq_google.engine.abstract_local_engine import AbstractLocalEngine
     from cirq_google.engine.abstract_local_job import AbstractLocalJob
 
@@ -35,7 +38,7 @@ class AbstractLocalProgram(AbstractProgram):
     need to implement abstract methods.
     """
 
-    def __init__(self, circuits: List[cirq.Circuit], engine: 'AbstractLocalEngine'):
+    def __init__(self, circuits: List[cirq.Circuit], engine: AbstractLocalEngine):
         if not circuits:
             raise ValueError('No circuits provided to program.')
         self._create_time = datetime.datetime.now()
@@ -46,7 +49,7 @@ class AbstractLocalProgram(AbstractProgram):
         self._jobs: Dict[str, AbstractLocalJob] = {}
         self._circuits = circuits
 
-    def engine(self) -> 'AbstractLocalEngine':
+    def engine(self) -> AbstractLocalEngine:
         """Returns the parent Engine object.
 
         Returns:
@@ -54,10 +57,10 @@ class AbstractLocalProgram(AbstractProgram):
         """
         return self._engine
 
-    def add_job(self, job_id: str, job: 'AbstractLocalJob') -> None:
+    def add_job(self, job_id: str, job: AbstractLocalJob) -> None:
         self._jobs[job_id] = job
 
-    def get_job(self, job_id: str) -> 'AbstractLocalJob':
+    def get_job(self, job_id: str) -> AbstractLocalJob:
         """Returns an AbstractLocalJob for an existing Quantum Engine job.
 
         Args:
@@ -79,7 +82,7 @@ class AbstractLocalProgram(AbstractProgram):
         created_after: Optional[Union[datetime.datetime, datetime.date]] = None,
         has_labels: Optional[Dict[str, str]] = None,
         execution_states: Optional[Set[quantum.ExecutionStatus.State]] = None,
-    ) -> Sequence['AbstractLocalJob']:
+    ) -> Sequence[AbstractLocalJob]:
         """Returns the list of jobs for this program.
 
         Args:
@@ -118,11 +121,11 @@ class AbstractLocalProgram(AbstractProgram):
             job_list.append(job)
         return job_list
 
-    def create_time(self) -> 'datetime.datetime':
+    def create_time(self) -> datetime.datetime:
         """Returns when the program was created."""
         return self._create_time
 
-    def update_time(self) -> 'datetime.datetime':
+    def update_time(self) -> datetime.datetime:
         """Returns when the program was last updated."""
         return self._update_time
 
@@ -130,7 +133,7 @@ class AbstractLocalProgram(AbstractProgram):
         """Returns the description of the program."""
         return self._description
 
-    def set_description(self, description: str) -> 'AbstractProgram':
+    def set_description(self, description: str) -> AbstractProgram:
         """Sets the description of the program.
 
         Params:
@@ -146,7 +149,7 @@ class AbstractLocalProgram(AbstractProgram):
         """Returns the labels of the program."""
         return copy.copy(self._labels)
 
-    def set_labels(self, labels: Dict[str, str]) -> 'AbstractProgram':
+    def set_labels(self, labels: Dict[str, str]) -> AbstractProgram:
         """Sets (overwriting) the labels for a previously created quantum
         program.
 
@@ -159,7 +162,7 @@ class AbstractLocalProgram(AbstractProgram):
         self._labels = copy.copy(labels)
         return self
 
-    def add_labels(self, labels: Dict[str, str]) -> 'AbstractProgram':
+    def add_labels(self, labels: Dict[str, str]) -> AbstractProgram:
         """Adds new labels to a previously created quantum program.
 
         Params:
@@ -172,7 +175,7 @@ class AbstractLocalProgram(AbstractProgram):
             self._labels[key] = labels[key]
         return self
 
-    def remove_labels(self, keys: List[str]) -> 'AbstractProgram':
+    def remove_labels(self, keys: List[str]) -> AbstractProgram:
         """Removes labels with given keys from the labels of a previously
         created quantum program.
 

--- a/cirq-google/cirq_google/engine/abstract_local_program_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import datetime
 
 import pytest

--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -18,6 +18,8 @@ requests.  Inheritors of this interface should implement all
 methods.
 """
 
+from __future__ import annotations
+
 import abc
 import datetime
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
@@ -25,14 +27,14 @@ from typing import Dict, List, Optional, TYPE_CHECKING, Union
 import duet
 
 import cirq
-from cirq_google.api import v2
-from cirq_google.cloud import quantum
-from cirq_google.engine import calibration
 
 if TYPE_CHECKING:
     import cirq_google as cg
+    import cirq_google.api.v2 as v2
+    import cirq_google.cloud.quantum as quantum
     import cirq_google.engine.abstract_engine as abstract_engine
     import cirq_google.engine.abstract_job as abstract_job
+    import cirq_google.engine.calibration as calibration
     import cirq_google.serialization.serializer as serializer
 
 
@@ -138,7 +140,7 @@ class AbstractProcessor(abc.ABC):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-    ) -> 'abstract_job.AbstractJob':
+    ) -> abstract_job.AbstractJob:
         """Runs the supplied Circuit on this processor.
 
         In contrast to run, this runs across multiple parameter sweeps, and
@@ -179,9 +181,7 @@ class AbstractProcessor(abc.ABC):
     run_sweep = duet.sync(run_sweep_async)
 
     @abc.abstractmethod
-    def get_sampler(
-        self, run_name: str = "", device_config_name: str = ""
-    ) -> 'cg.ProcessorSampler':
+    def get_sampler(self, run_name: str = "", device_config_name: str = "") -> cg.ProcessorSampler:
         """Returns a sampler backed by the processor.
 
         Args:
@@ -194,7 +194,7 @@ class AbstractProcessor(abc.ABC):
         """
 
     @abc.abstractmethod
-    def engine(self) -> Optional['abstract_engine.AbstractEngine']:
+    def engine(self) -> Optional[abstract_engine.AbstractEngine]:
         """Returns the parent Engine object.
 
         Returns:
@@ -206,12 +206,12 @@ class AbstractProcessor(abc.ABC):
         """Returns the current health of processor."""
 
     @abc.abstractmethod
-    def expected_down_time(self) -> 'Optional[datetime.datetime]':
+    def expected_down_time(self) -> Optional[datetime.datetime]:
         """Returns the start of the next expected down time of the processor, if
         set."""
 
     @abc.abstractmethod
-    def expected_recovery_time(self) -> 'Optional[datetime.datetime]':
+    def expected_recovery_time(self) -> Optional[datetime.datetime]:
         """Returns the expected the processor should be available, if set."""
 
     @abc.abstractmethod

--- a/cirq-google/cirq_google/engine/abstract_program.py
+++ b/cirq-google/cirq_google/engine/abstract_program.py
@@ -18,14 +18,15 @@ when combined with a run context, will become a quantum job.
 """
 
 
+from __future__ import annotations
+
 import abc
 import datetime
 from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
 
-import cirq
-from cirq_google.cloud import quantum
-
 if TYPE_CHECKING:
+    import cirq
+    import cirq_google.cloud.quantum as quantum
     import cirq_google.engine.abstract_engine as abstract_engine
     import cirq_google.engine.abstract_job as abstract_job
 
@@ -43,7 +44,7 @@ class AbstractProgram(abc.ABC):
     """
 
     @abc.abstractmethod
-    def engine(self) -> 'abstract_engine.AbstractEngine':
+    def engine(self) -> abstract_engine.AbstractEngine:
         """Returns the parent Engine object.
 
         Returns:
@@ -51,7 +52,7 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_job(self, job_id: str) -> 'abstract_job.AbstractJob':
+    def get_job(self, job_id: str) -> abstract_job.AbstractJob:
         """Returns an AbstractJob for an existing id.
 
         Args:
@@ -68,7 +69,7 @@ class AbstractProgram(abc.ABC):
         created_after: Optional[Union[datetime.datetime, datetime.date]] = None,
         has_labels: Optional[Dict[str, str]] = None,
         execution_states: Optional[Set[quantum.ExecutionStatus.State]] = None,
-    ) -> Sequence['abstract_job.AbstractJob']:
+    ) -> Sequence[abstract_job.AbstractJob]:
         """Returns the list of jobs for this program.
 
         Args:
@@ -95,11 +96,11 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def create_time(self) -> 'datetime.datetime':
+    def create_time(self) -> datetime.datetime:
         """Returns when the program was created."""
 
     @abc.abstractmethod
-    def update_time(self) -> 'datetime.datetime':
+    def update_time(self) -> datetime.datetime:
         """Returns when the program was last updated."""
 
     @abc.abstractmethod
@@ -107,7 +108,7 @@ class AbstractProgram(abc.ABC):
         """Returns the description of the program."""
 
     @abc.abstractmethod
-    def set_description(self, description: str) -> 'AbstractProgram':
+    def set_description(self, description: str) -> AbstractProgram:
         """Sets the description of the program.
 
         Params:
@@ -122,7 +123,7 @@ class AbstractProgram(abc.ABC):
         """Returns the labels of the program."""
 
     @abc.abstractmethod
-    def set_labels(self, labels: Dict[str, str]) -> 'AbstractProgram':
+    def set_labels(self, labels: Dict[str, str]) -> AbstractProgram:
         """Sets (overwriting) the labels for a previously created quantum program.
 
         Params:
@@ -133,7 +134,7 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def add_labels(self, labels: Dict[str, str]) -> 'AbstractProgram':
+    def add_labels(self, labels: Dict[str, str]) -> AbstractProgram:
         """Adds new labels to a previously created quantum program.
 
         Params:
@@ -144,7 +145,7 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def remove_labels(self, keys: List[str]) -> 'AbstractProgram':
+    def remove_labels(self, keys: List[str]) -> AbstractProgram:
         """Removes labels with given keys from the labels of a previously
         created quantum program.
 

--- a/cirq-google/cirq_google/engine/asyncio_executor.py
+++ b/cirq-google/cirq_google/engine/asyncio_executor.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import asyncio
 import errno
 import threading
@@ -67,10 +69,10 @@ class AsyncioExecutor:
         future = asyncio.run_coroutine_threadsafe(func(*args, **kwargs), self.loop)
         return duet.AwaitableFuture.wrap(future)
 
-    _instance: Optional['AsyncioExecutor'] = None
+    _instance: Optional[AsyncioExecutor] = None
 
     @classmethod
-    def instance(cls) -> 'AsyncioExecutor':
+    def instance(cls) -> AsyncioExecutor:
         """Returns a singleton AsyncioExecutor shared globally."""
         if cls._instance is None:
             cls._instance = cls()

--- a/cirq-google/cirq_google/engine/calibration.py
+++ b/cirq-google/cirq_google/engine/calibration.py
@@ -14,6 +14,8 @@
 
 """Calibration wrapper for calibrations returned from the Quantum Engine."""
 
+from __future__ import annotations
+
 import datetime
 from collections import abc, defaultdict
 from itertools import cycle
@@ -147,7 +149,7 @@ class Calibration(abc.Mapping):
         return proto
 
     @classmethod
-    def _from_json_dict_(cls, metrics: str, **kwargs) -> 'Calibration':
+    def _from_json_dict_(cls, metrics: str, **kwargs) -> Calibration:
         """Magic method for the JSON serialization protocol."""
         metric_proto = v2.metrics_pb2.MetricsSnapshot()
         return cls(json_format.ParseDict(metrics, metric_proto))

--- a/cirq-google/cirq_google/engine/calibration_layer.py
+++ b/cirq-google/cirq_google/engine/calibration_layer.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import dataclasses
 from typing import Any, Dict, Union
 

--- a/cirq-google/cirq_google/engine/calibration_result.py
+++ b/cirq-google/cirq_google/engine/calibration_result.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import annotations
+
 import dataclasses
 import datetime
 from typing import Any, Dict, Optional, TYPE_CHECKING
@@ -38,7 +41,7 @@ class CalibrationResult:
     error_message: Optional[str]
     token: Optional[str]
     valid_until: Optional[datetime.datetime]
-    metrics: 'cirq_google.Calibration'
+    metrics: cirq_google.Calibration
 
     @classmethod
     def _from_json_dict_(
@@ -47,9 +50,9 @@ class CalibrationResult:
         error_message: Optional[str],
         token: Optional[str],
         utc_valid_until: float,
-        metrics: 'cirq_google.Calibration',
+        metrics: cirq_google.Calibration,
         **kwargs,
-    ) -> 'CalibrationResult':
+    ) -> CalibrationResult:
         """Magic method for the JSON serialization protocol."""
         valid_until = (
             datetime.datetime.utcfromtimestamp(utc_valid_until)

--- a/cirq-google/cirq_google/engine/calibration_test.py
+++ b/cirq-google/cirq_google/engine/calibration_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 
 import matplotlib as mpl

--- a/cirq-google/cirq_google/engine/calibration_to_noise_properties_test.py
+++ b/cirq-google/cirq_google/engine/calibration_to_noise_properties_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from google.protobuf.text_format import Merge

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -33,7 +33,6 @@ from typing import Dict, List, Optional, Set, TYPE_CHECKING, TypeVar, Union
 
 import duet
 import google.auth
-from google.protobuf import any_pb2
 
 import cirq
 from cirq_google.api import v2
@@ -50,6 +49,7 @@ from cirq_google.serialization import CIRCUIT_SERIALIZER, Serializer
 
 if TYPE_CHECKING:
     import google.protobuf
+    from google.protobuf import any_pb2
 
     import cirq_google
     from cirq_google.cloud import quantum

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 import sys
 import warnings

--- a/cirq-google/cirq_google/engine/engine_client_test.py
+++ b/cirq-google/cirq_google/engine/engine_client_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for EngineClient."""
+
+from __future__ import annotations
+
 import asyncio
 import datetime
 import os

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A helper for jobs that have been created on the Quantum Engine."""
+
+from __future__ import annotations
+
 import datetime
 from typing import Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import duet
-from google.protobuf import any_pb2
 
 import cirq
 from cirq_google.api import v1, v2
@@ -25,6 +28,8 @@ from cirq_google.engine import abstract_job, calibration, engine_client
 from cirq_google.engine.engine_result import EngineResult
 
 if TYPE_CHECKING:
+    from google.protobuf import any_pb2
+
     import cirq_google.engine.engine as engine_base
     from cirq_google.engine.calibration_result import CalibrationResult
     from cirq_google.engine.engine import engine_processor, engine_program
@@ -62,7 +67,7 @@ class EngineJob(abstract_job.AbstractJob):
         project_id: str,
         program_id: str,
         job_id: str,
-        context: 'engine_base.EngineContext',
+        context: engine_base.EngineContext,
         _job: Optional[quantum.QuantumJob] = None,
         job_result_future: Optional[
             duet.AwaitableFuture[Union[quantum.QuantumResult, quantum.QuantumJob]]
@@ -94,13 +99,13 @@ class EngineJob(abstract_job.AbstractJob):
         """Returns the job id."""
         return self.job_id
 
-    def engine(self) -> 'engine_base.Engine':
+    def engine(self) -> engine_base.Engine:
         """Returns the parent Engine object."""
         import cirq_google.engine.engine as engine_base
 
         return engine_base.Engine(self.project_id, context=self.context)
 
-    def program(self) -> 'engine_program.EngineProgram':
+    def program(self) -> engine_program.EngineProgram:
         """Returns the parent EngineProgram object."""
         import cirq_google.engine.engine_program as engine_program
 
@@ -138,7 +143,7 @@ class EngineJob(abstract_job.AbstractJob):
         """Returns the description of the job."""
         return self._inner_job().description
 
-    def set_description(self, description: str) -> 'EngineJob':
+    def set_description(self, description: str) -> EngineJob:
         """Sets the description of the job.
 
         Params:
@@ -156,7 +161,7 @@ class EngineJob(abstract_job.AbstractJob):
         """Returns the labels of the job."""
         return self._inner_job().labels
 
-    def set_labels(self, labels: Dict[str, str]) -> 'EngineJob':
+    def set_labels(self, labels: Dict[str, str]) -> EngineJob:
         """Sets (overwriting) the labels for a previously created quantum job.
 
         Params:
@@ -170,7 +175,7 @@ class EngineJob(abstract_job.AbstractJob):
         )
         return self
 
-    def add_labels(self, labels: Dict[str, str]) -> 'EngineJob':
+    def add_labels(self, labels: Dict[str, str]) -> EngineJob:
         """Adds new labels to a previously created quantum job.
 
         Params:
@@ -184,7 +189,7 @@ class EngineJob(abstract_job.AbstractJob):
         )
         return self
 
-    def remove_labels(self, keys: List[str]) -> 'EngineJob':
+    def remove_labels(self, keys: List[str]) -> EngineJob:
         """Removes labels with given keys from the labels of a previously
         created quantum job.
 
@@ -231,7 +236,7 @@ class EngineJob(abstract_job.AbstractJob):
             self._job = self._get_job(return_run_context=True)
         return _deserialize_run_context(self._job.run_context)
 
-    def get_processor(self) -> 'Optional[engine_processor.EngineProcessor]':
+    def get_processor(self) -> Optional[engine_processor.EngineProcessor]:
         """Returns the EngineProcessor for the processor the job is/was run on,
         if available, else None."""
         status = self._inner_job().execution_status

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from unittest import mock
 

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
-from google.protobuf import any_pb2
-
-import cirq
 from cirq_google.api import v2
-from cirq_google.cloud import quantum
 from cirq_google.devices import grid_device
 from cirq_google.engine import abstract_processor, calibration, processor_sampler, util
 
 if TYPE_CHECKING:
+    from google.protobuf import any_pb2
+
+    import cirq
     import cirq_google as cg
+    import cirq_google.cloud.quantum as quantum
     import cirq_google.engine.abstract_job as abstract_job
     import cirq_google.engine.engine as engine_base
 
@@ -53,7 +55,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         self,
         project_id: str,
         processor_id: str,
-        context: 'engine_base.EngineContext',
+        context: engine_base.EngineContext,
         _processor: Optional[quantum.QuantumProcessor] = None,
     ) -> None:
         """A processor available via the engine.
@@ -75,7 +77,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             f'project_id={self.project_id!r}>'
         )
 
-    def engine(self) -> 'engine_base.Engine':
+    def engine(self) -> engine_base.Engine:
         """Returns the parent Engine object.
 
         Returns:
@@ -91,7 +93,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         device_config_name: str = "",
         snapshot_id: str = "",
         max_concurrent_jobs: int = 10,
-    ) -> 'cg.engine.ProcessorSampler':
+    ) -> cg.engine.ProcessorSampler:
         """Returns a sampler backed by the engine.
         Args:
             run_name: A unique identifier representing an automation run for the
@@ -153,7 +155,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         program_labels: Optional[Dict[str, str]] = None,
         job_description: Optional[str] = None,
         job_labels: Optional[Dict[str, str]] = None,
-    ) -> 'abstract_job.AbstractJob':
+    ) -> abstract_job.AbstractJob:
         """Runs the supplied Circuit on this processor.
 
         In contrast to run, this runs across multiple parameter sweeps, and
@@ -222,12 +224,12 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         self._processor = self.context.client.get_processor(self.project_id, self.processor_id)
         return self._processor.health.name
 
-    def expected_down_time(self) -> 'Optional[datetime.datetime]':
+    def expected_down_time(self) -> Optional[datetime.datetime]:
         """Returns the start of the next expected down time of the processor, if
         set."""
         return self._inner_processor().expected_down_time
 
-    def expected_recovery_time(self) -> 'Optional[datetime.datetime]':
+    def expected_recovery_time(self) -> Optional[datetime.datetime]:
         """Returns the expected the processor should be available, if set."""
         return self._inner_processor().expected_recovery_time
 

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from unittest import mock
 

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -12,19 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING, Union
 
 import duet
-from google.protobuf import any_pb2
 
 import cirq
 from cirq_google.api import v2
-from cirq_google.cloud import quantum
 from cirq_google.engine import abstract_program, engine_client, engine_job
 from cirq_google.serialization import circuit_serializer
 
 if TYPE_CHECKING:
+    from google.protobuf import any_pb2
+
+    import cirq_google.cloud.quantum as quantum
     import cirq_google.engine.engine as engine_base
 
 
@@ -43,7 +46,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         self,
         project_id: str,
         program_id: str,
-        context: 'engine_base.EngineContext',
+        context: engine_base.EngineContext,
         _program: Optional[quantum.QuantumProgram] = None,
     ) -> None:
         """A job submitted to the engine.
@@ -191,7 +194,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     run = duet.sync(run_async)
 
-    def engine(self) -> 'engine_base.Engine':
+    def engine(self) -> engine_base.Engine:
         """Returns the parent Engine object.
 
         Returns:
@@ -267,11 +270,11 @@ class EngineProgram(abstract_program.AbstractProgram):
             self._program = self.context.client.get_program(self.project_id, self.program_id, False)
         return self._program
 
-    def create_time(self) -> 'datetime.datetime':
+    def create_time(self) -> datetime.datetime:
         """Returns when the program was created."""
         return self._inner_program().create_time
 
-    def update_time(self) -> 'datetime.datetime':
+    def update_time(self) -> datetime.datetime:
         """Returns when the program was last updated."""
         self._program = self.context.client.get_program(self.project_id, self.program_id, False)
         return self._program.update_time
@@ -280,7 +283,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         """Returns the description of the program."""
         return self._inner_program().description
 
-    async def set_description_async(self, description: str) -> 'EngineProgram':
+    async def set_description_async(self, description: str) -> EngineProgram:
         """Sets the description of the program.
 
         Params:
@@ -300,7 +303,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         """Returns the labels of the program."""
         return self._inner_program().labels
 
-    async def set_labels_async(self, labels: Dict[str, str]) -> 'EngineProgram':
+    async def set_labels_async(self, labels: Dict[str, str]) -> EngineProgram:
         """Sets (overwriting) the labels for a previously created quantum
         program.
 
@@ -317,7 +320,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     set_labels = duet.sync(set_labels_async)
 
-    async def add_labels_async(self, labels: Dict[str, str]) -> 'EngineProgram':
+    async def add_labels_async(self, labels: Dict[str, str]) -> EngineProgram:
         """Adds new labels to a previously created quantum program.
 
         Params:
@@ -333,7 +336,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     add_labels = duet.sync(add_labels_async)
 
-    async def remove_labels_async(self, keys: List[str]) -> 'EngineProgram':
+    async def remove_labels_async(self, keys: List[str]) -> EngineProgram:
         """Removes labels with given keys from the labels of a previously
         created quantum program.
 

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
 from unittest import mock
 

--- a/cirq-google/cirq_google/engine/engine_result.py
+++ b/cirq-google/cirq_google/engine/engine_result.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 import datetime
 from typing import Any, Dict, Mapping, Optional, TYPE_CHECKING
 
-import numpy as np
-
 from cirq import study
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq
 
 

--- a/cirq-google/cirq_google/engine/engine_result_test.py
+++ b/cirq-google/cirq_google/engine/engine_result_test.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import datetime
-from typing import Mapping
+from typing import Mapping, TYPE_CHECKING
 
 import numpy as np
-import pandas as pd
 
 import cirq
 import cirq_google as cg
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 _DT = datetime.datetime(2022, 4, 1, 1, 23, 45, tzinfo=datetime.timezone.utc)
 
@@ -82,7 +86,7 @@ def test_engine_result_eq():
 
 class MyResult(cirq.Result):
     @property
-    def params(self) -> 'cirq.ParamResolver':
+    def params(self) -> cirq.ParamResolver:
         return cirq.ParamResolver()
 
     @property

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Tests for engine."""
+
+from __future__ import annotations
+
 import datetime
 import time
 from unittest import mock

--- a/cirq-google/cirq_google/engine/engine_validator.py
+++ b/cirq-google/cirq_google/engine/engine_validator.py
@@ -11,13 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Sequence, Union
+
+from __future__ import annotations
+
+from typing import Callable, Sequence, TYPE_CHECKING, Union
 
 from google.protobuf import any_pb2
 
 import cirq
-from cirq_google.engine.validating_sampler import VALIDATOR_TYPE
-from cirq_google.serialization.serializer import Serializer
+
+if TYPE_CHECKING:
+    from cirq_google import Serializer
+    from cirq_google.engine.validating_sampler import VALIDATOR_TYPE
 
 MAX_MESSAGE_SIZE = 10_000_000
 MAX_MOMENTS = 10000

--- a/cirq-google/cirq_google/engine/engine_validator_test.py
+++ b/cirq-google/cirq_google/engine/engine_validator_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 
 import cirq

--- a/cirq-google/cirq_google/engine/local_simulation_type.py
+++ b/cirq-google/cirq_google/engine/local_simulation_type.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import enum
 
 

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from unittest import mock
 
 import duet

--- a/cirq-google/cirq_google/engine/qcs_notebook.py
+++ b/cirq-google/cirq_google/engine/qcs_notebook.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
-from typing import cast, Optional, Sequence, Union
+from __future__ import annotations
 
-import cirq
+import dataclasses
+from typing import cast, Optional, Sequence, TYPE_CHECKING, Union
+
 from cirq_google import get_engine, ProcessorSampler
 from cirq_google.engine import (
     AbstractEngine,
@@ -24,6 +25,9 @@ from cirq_google.engine import (
     create_noiseless_virtual_engine_from_latest_templates,
     EngineProcessor,
 )
+
+if TYPE_CHECKING:
+    import cirq
 
 
 @dataclasses.dataclass

--- a/cirq-google/cirq_google/engine/qcs_notebook_test.py
+++ b/cirq-google/cirq_google/engine/qcs_notebook_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import sys
 import unittest.mock as mock
 

--- a/cirq-google/cirq_google/engine/runtime_estimator.py
+++ b/cirq-google/cirq_google/engine/runtime_estimator.py
@@ -30,6 +30,8 @@ Model was then fitted by hand, correcting for anomalies and outliers
 when possible.
 """
 
+from __future__ import annotations
+
 from typing import List, Optional, Sequence
 
 import cirq

--- a/cirq-google/cirq_google/engine/runtime_estimator_test.py
+++ b/cirq-google/cirq_google/engine/runtime_estimator_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-google/cirq_google/engine/simulated_local_engine.py
+++ b/cirq-google/cirq_google/engine/simulated_local_engine.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Classes for running against Google's Quantum Cloud Service.
 
 As an example, to run a circuit against the xmon simulator on the cloud,
@@ -22,10 +23,15 @@ As an example, to run a circuit against the xmon simulator on the cloud,
 In order to run on must have access to the Quantum Engine API. Access to this
 API is (as of June 22, 2018) restricted to invitation only.
 """
-from typing import List
+
+from __future__ import annotations
+
+from typing import List, TYPE_CHECKING
 
 from cirq_google.engine.abstract_local_engine import AbstractLocalEngine
-from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
+
+if TYPE_CHECKING:
+    from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
 
 
 class SimulatedLocalEngine(AbstractLocalEngine):

--- a/cirq-google/cirq_google/engine/simulated_local_engine_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_engine_test.py
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import datetime
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, TYPE_CHECKING, Union
 
 import numpy as np
 import pytest
@@ -24,9 +27,11 @@ from cirq_google.api import v2
 from cirq_google.engine.abstract_local_job_test import NothingJob
 from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
 from cirq_google.engine.abstract_local_program_test import NothingProgram
-from cirq_google.engine.abstract_program import AbstractProgram
 from cirq_google.engine.simulated_local_engine import SimulatedLocalEngine
 from cirq_google.engine.simulated_local_processor import SimulatedLocalProcessor
+
+if TYPE_CHECKING:
+    from cirq_google.engine.abstract_program import AbstractProgram
 
 
 class ProgramDictProcessor(AbstractLocalProcessor):

--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for SimulatedLocalJob."""
+
+from __future__ import annotations
+
 import numpy as np
 import pytest
 import sympy

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -11,20 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 
 import cirq
-from cirq_google.api import v2
 from cirq_google.engine import calibration, engine_validator, validating_sampler
 from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
-from cirq_google.engine.abstract_local_program import AbstractLocalProgram
-from cirq_google.engine.abstract_program import AbstractProgram
 from cirq_google.engine.local_simulation_type import LocalSimulationType
 from cirq_google.engine.processor_sampler import ProcessorSampler
 from cirq_google.engine.simulated_local_job import SimulatedLocalJob
 from cirq_google.engine.simulated_local_program import SimulatedLocalProgram
 from cirq_google.serialization.circuit_serializer import CIRCUIT_SERIALIZER
+
+if TYPE_CHECKING:
+    from cirq_google.api import v2
+    from cirq_google.engine.abstract_local_program import AbstractLocalProgram
+    from cirq_google.engine.abstract_program import AbstractProgram
 
 VALID_LANGUAGES = ['type.googleapis.com/cirq.google.api.v2.Program']
 

--- a/cirq-google/cirq_google/engine/simulated_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor_test.py
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Tests for SimulatedLocalProcessor"""
+
+from __future__ import annotations
+
 import datetime
 from typing import List
 

--- a/cirq-google/cirq_google/engine/simulated_local_program.py
+++ b/cirq-google/cirq_google/engine/simulated_local_program.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Optional, TYPE_CHECKING
 
 from cirq_google.engine.abstract_local_program import AbstractLocalProgram
@@ -34,7 +37,7 @@ class SimulatedLocalProgram(AbstractLocalProgram):
         *args,
         program_id: str,
         simulation_type: LocalSimulationType = LocalSimulationType.SYNCHRONOUS,
-        processor: Optional['SimulatedLocalProcessor'] = None,
+        processor: Optional[SimulatedLocalProcessor] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)

--- a/cirq-google/cirq_google/engine/simulated_local_program_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_program_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import cirq
 from cirq_google.engine.simulated_local_job import SimulatedLocalJob
 from cirq_google.engine.simulated_local_program import SimulatedLocalProgram

--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-from typing import AsyncIterator, Dict, Optional, Union
+from __future__ import annotations
 
-import duet
+import asyncio
+from typing import AsyncIterator, Dict, Optional, TYPE_CHECKING, Union
+
 import google.api_core.exceptions as google_exceptions
 
 from cirq_google.cloud import quantum
 from cirq_google.engine.asyncio_executor import AsyncioExecutor
+
+if TYPE_CHECKING:
+    import duet
 
 Code = quantum.StreamError.Code
 

--- a/cirq-google/cirq_google/engine/stream_manager_test.py
+++ b/cirq-google/cirq_google/engine/stream_manager_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import asyncio
 import concurrent
 from typing import AsyncIterable, AsyncIterator, Awaitable, List, Sequence, Union

--- a/cirq-google/cirq_google/engine/util.py
+++ b/cirq-google/cirq_google/engine/util.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Dict, Tuple, TypeVar
 
 from google.protobuf import any_pb2

--- a/cirq-google/cirq_google/engine/validating_sampler.py
+++ b/cirq-google/cirq_google/engine/validating_sampler.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import Callable, Optional, Sequence, Union
 
 import duet

--- a/cirq-google/cirq_google/engine/validating_sampler_test.py
+++ b/cirq-google/cirq_google/engine/validating_sampler_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/cirq-google/cirq_google/engine/virtual_engine_factory_test.py
+++ b/cirq-google/cirq_google/engine/virtual_engine_factory_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import google.protobuf.text_format as text_format
 import numpy as np
 import pytest

--- a/cirq-google/cirq_google/experimental/noise_models/noise_models.py
+++ b/cirq-google/cirq_google/experimental/noise_models/noise_models.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from math import exp
 from typing import Dict, Optional, Sequence, TYPE_CHECKING
 
@@ -96,7 +98,7 @@ class PerQubitDepolarizingWithDampedReadoutNoiseModel(cirq.NoiseModel):
 
 
 def simple_noise_from_calibration_metrics(
-    calibration: 'calibration.Calibration',
+    calibration: calibration.Calibration,
     depol_noise: bool = False,
     damping_noise: bool = False,
     readout_decay_noise: bool = False,

--- a/cirq-google/cirq_google/experimental/noise_models/noise_models_test.py
+++ b/cirq-google/cirq_google/experimental/noise_models/noise_models_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from math import exp
 
 import pytest

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import AbstractSet, Any, Optional, Tuple
+from __future__ import annotations
 
-import numpy as np
+from typing import AbstractSet, Any, Optional, Tuple, TYPE_CHECKING
 
 import cirq
 from cirq._compat import proper_repr
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @cirq.value_equality(approximate=True)
@@ -127,7 +130,7 @@ class CouplerPulse(cirq.ops.Gate):
 
     def _resolve_parameters_(
         self, resolver: cirq.ParamResolverOrSimilarType, recursive: bool
-    ) -> 'CouplerPulse':
+    ) -> CouplerPulse:
         return CouplerPulse(
             hold_time=cirq.resolve_parameters(self.hold_time, resolver, recursive=recursive),
             coupling_mhz=cirq.resolve_parameters(self.coupling_mhz, resolver, recursive=recursive),

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
+
 import pytest
 import sympy
 

--- a/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset.py
+++ b/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset.py
@@ -17,12 +17,14 @@
 from __future__ import annotations
 
 import itertools
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
 
 import cirq
-from cirq.protocols.decompose_protocol import DecomposeResult
 from cirq_google import ops
 from cirq_google.transformers.analytical_decompositions import two_qubit_to_sycamore
+
+if TYPE_CHECKING:
+    from cirq.protocols.decompose_protocol import DecomposeResult
 
 
 @cirq.transformer

--- a/cirq-google/cirq_google/workflow/_device_shim.py
+++ b/cirq-google/cirq_google/workflow/_device_shim.py
@@ -15,11 +15,12 @@
 from __future__ import annotations
 
 import itertools
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
 import networkx as nx
 
-import cirq
+if TYPE_CHECKING:
+    import cirq
 
 
 def _gridqubits_to_graph_device(qubits: Iterable[cirq.GridQubit]):

--- a/cirq-google/cirq_google/workflow/qubit_placement.py
+++ b/cirq-google/cirq_google/workflow/qubit_placement.py
@@ -21,8 +21,6 @@ import dataclasses
 from functools import lru_cache
 from typing import Any, Callable, Dict, Hashable, List, Tuple, TYPE_CHECKING
 
-import numpy as np
-
 import cirq
 from cirq import _compat
 from cirq.devices.named_topologies import get_placements, NamedTopology
@@ -30,6 +28,8 @@ from cirq.protocols import obj_to_dict_helper
 from cirq_google.workflow._device_shim import _Device_dot_get_nx_graph
 
 if TYPE_CHECKING:
+    import numpy as np
+
     import cirq_google as cg
 
 

--- a/cirq-ionq/cirq_ionq/serializer.py
+++ b/cirq-ionq/cirq_ionq/serializer.py
@@ -29,16 +29,19 @@ from typing import (
     Optional,
     Sequence,
     Type,
+    TYPE_CHECKING,
     Union,
 )
 
 import numpy as np
-import sympy
 
 import cirq
 from cirq.devices import line_qubit
 from cirq_ionq.ionq_exceptions import IonQSerializerMixedGatesetsException
 from cirq_ionq.ionq_native_gates import GPI2Gate, GPIGate, MSGate, ZZGate
+
+if TYPE_CHECKING:
+    import sympy
 
 _NATIVE_GATES = cirq.Gateset(
     GPIGate, GPI2Gate, MSGate, ZZGate, cirq.MeasurementGate, unroll_circuit_op=False

--- a/cirq-pasqal/cirq_pasqal/pasqal_gateset.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_gateset.py
@@ -14,10 +14,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Dict, List, Type, TYPE_CHECKING, Union
 
 import cirq
-from cirq.protocols.decompose_protocol import DecomposeResult
+
+if TYPE_CHECKING:
+    from cirq.protocols.decompose_protocol import DecomposeResult
 
 
 class PasqalGateset(cirq.CompilationTargetGateset):

--- a/dev_tools/pylint_copyright_checker.py
+++ b/dev_tools/pylint_copyright_checker.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from astroid import nodes
 from pylint.checkers import BaseRawFileChecker
 
 if TYPE_CHECKING:
+    from astroid import nodes
     from pylint.lint import PyLinter
 
 


### PR DESCRIPTION
No change in the effective code.  A batch of 250 files (~200 to go).
Added future import of annotations to detect typing-only imports.

Passes  ruff check --target-version=py311 --select=UP037,TC001,TC002

Partially implements #1999
