### PR TITLE
Add parameter sweep support for Pauli string measurements with readout mitigation

### DIFF
--- a/cirq-core/cirq/contrib/shuffle_circuits/__init__.py
+++ b/cirq-core/cirq/contrib/shuffle_circuits/__init__.py
@@ -15,4 +15,5 @@
 
 from cirq.contrib.shuffle_circuits.shuffle_circuits_with_readout_benchmarking import (
     run_shuffled_with_readout_benchmarking as run_shuffled_with_readout_benchmarking,
+    run_sweep_with_readout_benchmarking as run_sweep_with_readout_benchmarking,
 )


### PR DESCRIPTION
https://github.com/quantumlib/Cirq/pull/7236 and https://github.com/quantumlib/Cirq/pull/7067 builds a tool for measuring expectation values of Pauli strings with readout error mitigation. This pr enhances the tool by providing option for sweep-based execution. The new sweep mode could make it faster for external users since for them sweep operations can be more efficient than run_batch with large circuit lists. 
The changes include:
1. Adding a new function `run_sweep_with_readout_benchmarking` which runs the sweep circuits with readout error benchmarking (without shuffling).
2. Allow user to run measuring_pauli_strings in sweep mode. In this mode, the function uses parameterized circuits and sweeps parameters for both Pauli measurements and readout benchmarking