### PR TITLE
Unpin upper bound on setuptools requirement

### DIFF
--- a/dev_tools/requirements/deps/packaging.txt
+++ b/dev_tools/requirements/deps/packaging.txt
@@ -2,8 +2,7 @@
 virtualenv
 
 # for creating packages
-# TODO (juhas) - remove when pyquil allows packaging-24
-setuptools>=70,<77
+setuptools>=70
 wheel
 
 # for uploading packages to pypi


### PR DESCRIPTION
This was added as a workaround in #7168, but the problem
appears to be fixed upstream in pyquil.
