### PR TITLE
Fix Linear dict scalar division test

### DIFF
--- a/cirq-core/cirq/value/linear_dict_test.py
+++ b/cirq-core/cirq/value/linear_dict_test.py
@@ -393,8 +393,8 @@ def test_scalar_division(scalar, terms, terms_expected):
     linear_dict = cirq.LinearDict(terms)
     actual = linear_dict / scalar
     expected = cirq.LinearDict(terms_expected)
-    assert actual == pytest.approx(expected)
-    assert expected == pytest.approx(actual)
+    assert cirq.approx_eq(actual, expected)
+    assert cirq.approx_eq(expected, actual)
 
 
 @pytest.mark.parametrize(

--- a/cirq-core/cirq/value/linear_dict_test.py
+++ b/cirq-core/cirq/value/linear_dict_test.py
@@ -393,8 +393,8 @@ def test_scalar_division(scalar, terms, terms_expected):
     linear_dict = cirq.LinearDict(terms)
     actual = linear_dict / scalar
     expected = cirq.LinearDict(terms_expected)
-    assert actual == expected
-    assert expected == actual
+    assert actual == pytest.approx(expected)
+    assert expected == pytest.approx(actual)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes a failing test in `LinearDict` by using `cirq.approx_eq` for floating-point comparisons. The test was failing due to precision issues when comparing complex numbers in Python 3.11.

The failing test case was:

(-10.0 - 15.0*I, {'X': 2}, {'X': (-0.061538461538461535+0.0923076923076923j)})

Using `cirq.approx_eq` ensures that small floating-point differences are ignored, making the test more robust while maintaining the same functionality.