### PR TITLE
Bump networkx to minimum version 3.4

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -3,7 +3,7 @@
 attrs>=21.3.0
 duet>=0.2.8
 matplotlib~=3.7
-networkx~=3.1
+networkx~=3.4
 numpy>=1.25
 pandas~=2.0
 sortedcontainers~=2.0


### PR DESCRIPTION
As of #7234 we use the `edges` argument to `node_link_data` which
was added in networkx-3.4.
