### PR TITLE
Fixes #7384 : Made DecompositionContext non-optional in _decompose_with_context_ me…

### DIFF
--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -125,9 +125,6 @@ class ClassicallyControlledOperation(raw_types.Operation):
             *self._conditions
         )
 
-    def _decompose_(self):
-        return self._decompose_with_context_()
-
     def _decompose_with_context_(self, *, context: cirq.DecompositionContext):
         result = protocols.decompose_once(
             self._sub_operation, NotImplemented, flatten=False, context=context

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -128,7 +128,7 @@ class ClassicallyControlledOperation(raw_types.Operation):
     def _decompose_(self):
         return self._decompose_with_context_()
 
-    def _decompose_with_context_(self, context: cirq.DecompositionContext | None = None):
+    def _decompose_with_context_(self, *, context: cirq.DecompositionContext):
         result = protocols.decompose_once(
             self._sub_operation, NotImplemented, flatten=False, context=context
         )

--- a/cirq-core/cirq/ops/controlled_gate.py
+++ b/cirq-core/cirq/ops/controlled_gate.py
@@ -143,7 +143,7 @@ class ControlledGate(raw_types.Gate):
         return self._decompose_with_context_(qubits)
 
     def _decompose_with_context_(
-        self, qubits: tuple[cirq.Qid, ...], context: cirq.DecompositionContext | None = None
+        self, qubits: tuple[cirq.Qid, ...], *, context: cirq.DecompositionContext
     ) -> None | NotImplementedType | cirq.OP_TREE:
         control_qubits = list(qubits[: self.num_controls()])
         controlled_sub_gate = self.sub_gate.controlled(

--- a/cirq-core/cirq/ops/controlled_gate.py
+++ b/cirq-core/cirq/ops/controlled_gate.py
@@ -139,9 +139,6 @@ class ControlledGate(raw_types.Gate):
     def _qid_shape_(self) -> tuple[int, ...]:
         return self.control_qid_shape + protocols.qid_shape(self.sub_gate)
 
-    def _decompose_(self, qubits: tuple[cirq.Qid, ...]) -> None | NotImplementedType | cirq.OP_TREE:
-        return self._decompose_with_context_(qubits)
-
     def _decompose_with_context_(
         self, qubits: tuple[cirq.Qid, ...], *, context: cirq.DecompositionContext
     ) -> None | NotImplementedType | cirq.OP_TREE:

--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -134,9 +134,6 @@ class ControlledOperation(raw_types.Operation):
             new_qubits[:n], self.sub_operation.with_qubits(*new_qubits[n:]), self.control_values
         )
 
-    def _decompose_(self):
-        return self._decompose_with_context_()
-
     def _decompose_with_context_(self, *, context: cirq.DecompositionContext):
         result = protocols.decompose_once_with_qubits(
             self.gate, self.qubits, NotImplemented, flatten=False, context=context

--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -137,7 +137,7 @@ class ControlledOperation(raw_types.Operation):
     def _decompose_(self):
         return self._decompose_with_context_()
 
-    def _decompose_with_context_(self, context: cirq.DecompositionContext | None = None):
+    def _decompose_with_context_(self, *, context: cirq.DecompositionContext):
         result = protocols.decompose_once_with_qubits(
             self.gate, self.qubits, NotImplemented, flatten=False, context=context
         )

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -152,7 +152,7 @@ class GateOperation(raw_types.Operation):
         return self._decompose_with_context_()
 
     def _decompose_with_context_(
-        self, context: cirq.DecompositionContext | None = None
+        self, *, context: cirq.DecompositionContext
     ) -> cirq.OP_TREE:
         return protocols.decompose_once_with_qubits(
             self.gate, self.qubits, NotImplemented, flatten=False, context=context

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -148,9 +148,6 @@ class GateOperation(raw_types.Operation):
     def _num_qubits_(self):
         return len(self._qubits)
 
-    def _decompose_(self) -> cirq.OP_TREE:
-        return self._decompose_with_context_()
-
     def _decompose_with_context_(
         self, *, context: cirq.DecompositionContext
     ) -> cirq.OP_TREE:

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -832,7 +832,7 @@ class TaggedOperation(Operation):
         return self._decompose_with_context_()
 
     def _decompose_with_context_(
-        self, context: cirq.DecompositionContext | None = None
+        self, *, context: cirq.DecompositionContext
     ) -> cirq.OP_TREE:
         return protocols.decompose_once(
             self.sub_operation, default=None, flatten=False, context=context
@@ -986,7 +986,7 @@ class _InverseCompositeGate(Gate):
         return self._decompose_with_context_(qubits)
 
     def _decompose_with_context_(
-        self, qubits: Sequence[cirq.Qid], context: cirq.DecompositionContext | None = None
+        self, qubits: Sequence[cirq.Qid], *, context: cirq.DecompositionContext
     ) -> cirq.OP_TREE:
         return protocols.inverse(
             protocols.decompose_once_with_qubits(self._original, qubits, context=context)

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -828,9 +828,6 @@ class TaggedOperation(Operation):
     def _json_dict_(self) -> dict[str, Any]:
         return protocols.obj_to_dict_helper(self, ['sub_operation', 'tags'])
 
-    def _decompose_(self) -> cirq.OP_TREE:
-        return self._decompose_with_context_()
-
     def _decompose_with_context_(
         self, *, context: cirq.DecompositionContext
     ) -> cirq.OP_TREE:

--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -126,7 +126,7 @@ class SupportsDecompose(Protocol):
         pass
 
     def _decompose_with_context_(
-        self, *, context: DecompositionContext | None = None
+        self, *, context: DecompositionContext
     ) -> DecomposeResult:
         pass
 
@@ -154,7 +154,7 @@ class SupportsDecomposeWithQubits(Protocol):
         pass
 
     def _decompose_with_context_(
-        self, qubits: tuple[cirq.Qid, ...], *, context: DecompositionContext | None = None
+        self, qubits: tuple[cirq.Qid, ...], *, context: DecompositionContext
     ) -> DecomposeResult:
         pass
 


### PR DESCRIPTION
 Fixes https://github.com/quantumlib/Cirq/issues/7384#issue-3099241575
- Updated type annotations in SupportsDecompose and SupportsDecomposeWithQubits protocols
- Made context parameter non-optional in all _decompose_with_context_ implementations
- Kept context optional in top-level decompose functions (decompose, decompose_once, decompose_once_with_qubits)
- This change reflects that _decompose_with_context_ is never called without a valid DecompositionContext