### PR TITLE
pylint - sync with rules used in internal codes

### DIFF
--- a/cirq-core/cirq/ops/control_values_test.py
+++ b/cirq-core/cirq/ops/control_values_test.py
@@ -239,14 +239,14 @@ def test_sum_of_products_repr(data):
 def test_sum_of_products_validate():
     control_val = cirq.SumOfProducts(((1, 2), (0, 1)))
 
-    _ = control_val.validate([2, 3])
+    control_val.validate([2, 3])
 
     with pytest.raises(ValueError):
-        _ = control_val.validate([2, 2])
+        control_val.validate([2, 2])
 
     # number of qubits != number of control values.
     with pytest.raises(ValueError):
-        _ = control_val.validate([2])
+        control_val.validate([2])
 
 
 @pytest.mark.parametrize('data', [((1,),), ((0, 1),), ((0, 0), (0, 1), (1, 0))])

--- a/cirq-core/cirq/ops/pauli_gates_test.py
+++ b/cirq-core/cirq/ops/pauli_gates_test.py
@@ -116,6 +116,7 @@ def test_relative_index_consistency() -> None:
 
 
 def test_gt() -> None:
+    # pylint: disable=unnecessary-negation
     assert not cirq.X > cirq.X
     assert not cirq.X > cirq.Y
     assert cirq.X > cirq.Z
@@ -133,6 +134,7 @@ def test_gt_other_type() -> None:
 
 
 def test_lt() -> None:
+    # pylint: disable=unnecessary-negation
     assert not cirq.X < cirq.X
     assert cirq.X < cirq.Y
     assert not cirq.X < cirq.Z

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -79,6 +79,7 @@ def test_wrapped_qid():
         'dimension': 3,
     }
 
+    # pylint: disable=unnecessary-negation
     assert not ValidQubit('zz') == 4
     assert ValidQubit('zz') != 4
     assert ValidQubit('zz') > ValidQubit('aa')

--- a/cirq-core/cirq/ops/state_preparation_channel_test.py
+++ b/cirq-core/cirq/ops/state_preparation_channel_test.py
@@ -124,6 +124,7 @@ def test_gate_error_handling() -> None:
 
 
 def test_equality_of_gates() -> None:
+    # pylint: disable=unnecessary-negation
     state = np.array([1, 0, 0, 0], dtype=np.complex64)
     gate_1 = cirq.StatePreparationChannel(state)
     gate_2 = cirq.StatePreparationChannel(state)

--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -64,7 +64,7 @@ class QasmArgs(string.Formatter):
     def _format_number(self, value) -> str:
         """OpenQASM 2.0 does not support '1e-5' and wants '1.0e-5'"""
         s = f'{value}'
-        if 'e' in s and not '.' in s:
+        if 'e' in s and '.' not in s:
             return s.replace('e', '.0e')
         return s
 

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -570,7 +570,7 @@ def test_valid_apply_measurement():
     q0 = cirq.LineQubit(0)
     state = cirq.CliffordState(qubit_map={q0: 0}, initial_state=1)
     measurements = {}
-    _ = state.apply_measurement(
+    state.apply_measurement(
         cirq.measure(q0), measurements, np.random.RandomState(), collapse_state_vector=False
     )
     assert measurements == {'q(0)': [1]}

--- a/cirq-core/cirq/sim/simulator_test.py
+++ b/cirq-core/cirq/sim/simulator_test.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Generic, Sequence
+from typing import Any, Generic, Iterator, Sequence
 from unittest import mock
 
 import duet
@@ -72,6 +72,11 @@ class SimulatesIntermediateStateImpl(
     metaclass=abc.ABCMeta,
 ):
     """A SimulatesIntermediateState that uses the default SimulationTrialResult type."""
+
+    def _base_iterator(
+        self, circuit: cirq.AbstractCircuit, qubits: tuple[cirq.Qid, ...], initial_state: Any
+    ) -> Iterator[TStepResult]:
+        raise NotImplementedError
 
     def _create_simulator_trial_result(
         self,

--- a/cirq-core/cirq/value/abc_alt.py
+++ b/cirq-core/cirq/value/abc_alt.py
@@ -82,8 +82,8 @@ class ABCMetaImplementAnyOneOf(abc.ABCMeta):
     `@alternative(...)` may be used.
     """
 
-    def __new__(mcls, name, bases, namespace, **kwargs):
-        cls = super().__new__(mcls, name, bases, namespace, **kwargs)
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
         implemented_by = {}
 
         def has_some_implementation(name: str) -> bool:

--- a/cirq-core/cirq/value/linear_dict_test.py
+++ b/cirq-core/cirq/value/linear_dict_test.py
@@ -29,7 +29,7 @@ def test_empty_init():
 
 sym = sympy.Symbol('sym')
 expr = sym * -(2 + 3j)
-symval = expr.subs({'sym': 5})
+symval = expr.subs({'sym': 5})  # pylint: disable=assignment-from-no-return
 symvalresolved = -10 - 15j
 
 

--- a/cirq-core/cirq/value/linear_dict_test.py
+++ b/cirq-core/cirq/value/linear_dict_test.py
@@ -433,6 +433,7 @@ def test_bool(terms, bool_value):
     ),
 )
 def test_equal(terms_1, terms_2):
+    # pylint: disable=unnecessary-negation
     linear_dict_1 = cirq.LinearDict(terms_1)
     linear_dict_2 = cirq.LinearDict(terms_2)
     assert linear_dict_1 == linear_dict_2
@@ -452,6 +453,7 @@ def test_equal(terms_1, terms_2):
     ),
 )
 def test_unequal(terms_1, terms_2):
+    # pylint: disable=unnecessary-negation
     linear_dict_1 = cirq.LinearDict(terms_1)
     linear_dict_2 = cirq.LinearDict(terms_2)
     assert linear_dict_1 != linear_dict_2

--- a/cirq-core/cirq/value/measurement_key_test.py
+++ b/cirq-core/cirq/value/measurement_key_test.py
@@ -103,6 +103,7 @@ def test_with_measurement_key_mapping():
 
 
 def test_compare():
+    # pylint: disable=unnecessary-negation
     assert cirq.MeasurementKey('a') < cirq.MeasurementKey('b')
     assert cirq.MeasurementKey('a') <= cirq.MeasurementKey('b')
     assert cirq.MeasurementKey('a') <= cirq.MeasurementKey('a')

--- a/cirq-core/cirq/value/timestamp_test.py
+++ b/cirq-core/cirq/value/timestamp_test.py
@@ -77,6 +77,7 @@ def test_cmp() -> None:
             assert (i >= j) == (a >= b)
             assert (i > j) == (a > b)
 
+    # pylint: disable=unnecessary-negation
     assert not (Timestamp() == 0)
     assert Timestamp() != 0
     assert not (Timestamp() == Duration())

--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -8,9 +8,14 @@ output-format=colorized
 score=no
 reports=no
 enable=
+    abstract-class-instantiated,
     anomalous-backslash-in-string,
     assert-on-tuple,
+    assignment-from-no-return,
+    bad-chained-comparison,
     bad-indentation,
+    bad-mcs-classmethod-argument,
+    bad-mcs-method-argument,
     bad-option-value,
     bad-reversed-sequence,
     bad-super-call,
@@ -18,6 +23,7 @@ enable=
     consider-using-f-string,
     continue-in-finally,
     dangerous-default-value,
+    deprecated-decorator,
     docstyle,
     duplicate-argument-name,
     expression-not-assigned,
@@ -27,6 +33,7 @@ enable=
     init-is-generator,
     line-too-long,
     lost-exception,
+    method-hidden,
     missing-kwoa,
     missing-param-doc,
     missing-raises-doc,
@@ -35,10 +42,16 @@ enable=
     nonexistent-operator,
     not-in-loop,
     pointless-statement,
+    raising-bad-type,
+    raising-format-tuple,
     redefined-builtin,
+    redefined-slots-in-subclass,
     return-arg-in-generator,
     return-in-init,
     return-outside-function,
+    self-cls-assignment,
+    shadowed-import,
+    simplifiable-condition,
     simplifiable-if-statement,
     singleton-comparison,
     syntax-error,
@@ -48,30 +61,20 @@ enable=
     unexpected-keyword-arg,
     unhashable-dict-key,
     unnecessary-pass,
+    unnecessary-semicolon,
+    unneeded-not,
     unreachable,
     unrecognized-inline-option,
     unused-import,
-    unnecessary-semicolon,
     unused-variable,
     unused-wildcard-import,
+    use-maxsplit-arg,
+    using-constant-test,
     wildcard-import,
-    wrong-or-nonexistent-copyright-notice,
     wrong-import-order,
     wrong-import-position,
+    wrong-or-nonexistent-copyright-notice,
     yield-outside-function
 
 # Ignore long lines containing urls or pylint directives.
 ignore-long-lines=^(.*#\w*pylint: disable.*|\s*(# )?[<\[\(]?https?://\S+[>\]\)]?)$
-
-[TYPECHECK]
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=numpy.*
-
-
-[IMPORTS]
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=cirq,cirq_google,cirq_aqt,cirq_ionq


### PR DESCRIPTION
Activate pylint rules used in pyle and fix flagged issues.

Added pylint rules:

- abstract-class-instantiated
- assignment-from-no-return
- bad-chained-comparison
- bad-mcs-classmethod-argument
- bad-mcs-method-argument
- deprecated-decorator
- method-hidden
- raising-bad-type
- raising-format-tuple
- redefined-slots-in-subclass
- self-cls-assignment
- shadowed-import
- simplifiable-condition
- unneeded-not
- use-maxsplit-arg
- using-constant-test

Related to #7371
