### PR TITLE
Use list for GoogleNoiseProperties.readout_errors values

### DIFF
--- a/cirq-core/cirq/devices/superconducting_qubits_noise_properties.py
+++ b/cirq-core/cirq/devices/superconducting_qubits_noise_properties.py
@@ -38,7 +38,7 @@ class SuperconductingQubitsNoiseProperties(devices.NoiseProperties, abc.ABC):
             quantum hardware. Used with t(1|phi)_ns to specify thermal noise.
         t1_ns: dict[cirq.Qid, float] of qubits to their T_1 time, in ns.
         tphi_ns: dict[cirq.Qid, float] of qubits to their T_phi time, in ns.
-        readout_errors: dict[cirq.Qid, np.ndarray] of qubits to their readout
+        readout_errors: dict[cirq.Qid, list[float]] of qubits to their readout
             errors in matrix form: [P(read |1> from |0>), P(read |0> from |1>)].
             Used to prepend amplitude damping errors to measurements.
         gate_pauli_errors: dict of noise_utils.OpIdentifiers (a gate and the qubits it

--- a/cirq-google/cirq_google/devices/google_noise_properties.py
+++ b/cirq-google/cirq_google/devices/google_noise_properties.py
@@ -54,7 +54,7 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
             thermal noise.
         t1_ns: dict[`cirq.Qid`, float] of qubits to their T_1 time, in ns.
         tphi_ns: dict[`cirq.Qid`, float] of qubits to their T_phi time, in ns.
-        readout_errors: dict[`cirq.Qid`, np.ndarray] of qubits to their readout
+        readout_errors: dict[`cirq.Qid`, list[float]] of qubits to their readout
             errors in matrix form: [P(read |1> from |0>), P(read |0> from |1>)].
             Used to prepend amplitude damping errors to measurements.
         gate_pauli_errors: dict of `noise_utils.OpIdentifiers` (a gate and the
@@ -129,7 +129,7 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
         t1_ns: float or dict[`cirq.Qid`, float].
         tphi_ns: float or dict[`cirq.Qid`, float].
         readout_errors: Sequence or dict[`cirq.Qid`, Sequence]. Converted to
-            np.ndarray if not provided in that format.
+            list[float] if not provided in that format.
         gate_pauli_errors: float or dict[`cirq.OpIdentifier`, float].
             Dict key can also be type[`cirq.Gate`]; this will apply the given
             error to all placements of that gate that appear in the original
@@ -150,11 +150,11 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
         if readout_errors is not None:
             if isinstance(readout_errors, dict):
                 replace_args['readout_errors'] = _with_values(
-                    self.readout_errors, {k: np.array(v) for k, v in readout_errors.items()}
+                    self.readout_errors, {k: list(v) for k, v in readout_errors.items()}
                 )
             else:
                 replace_args['readout_errors'] = _with_values(
-                    self.readout_errors, np.array(readout_errors)
+                    self.readout_errors, list(readout_errors)
                 )
         if gate_pauli_errors is not None:
             if isinstance(gate_pauli_errors, dict):
@@ -274,7 +274,7 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
             'gate_times_ns': tuple(storage_gate_times.items()),
             't1_ns': tuple(self.t1_ns.items()),
             'tphi_ns': tuple(self.tphi_ns.items()),
-            'readout_errors': tuple((k, v.tolist()) for k, v in self.readout_errors.items()),
+            'readout_errors': tuple(self.readout_errors.items()),
             'gate_pauli_errors': tuple(self.gate_pauli_errors.items()),
             'fsim_errors': tuple(self.fsim_errors.items()),
             'validate': self.validate,
@@ -298,7 +298,7 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
             gate_times_ns=gate_type_times,
             t1_ns=dict(t1_ns),
             tphi_ns=dict(tphi_ns),
-            readout_errors={k: np.array(v) for k, v in readout_errors},
+            readout_errors=dict(readout_errors),
             gate_pauli_errors=dict(gate_pauli_errors),
             fsim_errors=dict(fsim_errors),
             validate=validate,

--- a/cirq-google/cirq_google/engine/calibration_to_noise_properties_test.py
+++ b/cirq-google/cirq_google/engine/calibration_to_noise_properties_test.py
@@ -329,6 +329,56 @@ def test_zphase_data():
             assert prop.fsim_errors[OpIdentifier(gate, *qs[::-1])] == values[i]
 
 
+def test_json_serde_works():
+    qubits = [cirq.GridQubit(0, 0), cirq.GridQubit(0, 1), cirq.GridQubit(1, 0)]
+    pauli_error = [0.001, 0.002, 0.003]
+    incoherent_error = [0.0001, 0.0002, 0.0003]
+    p00_error = [0.004, 0.005, 0.006]
+    p11_error = [0.007, 0.008, 0.009]
+    t1_micros = [10, 20, 30]
+    syc_pauli = [0.01, 0.02]
+    iswap_pauli = [0.03, 0.04]
+    syc_angles = [
+        cirq.PhasedFSimGate(theta=0.011, phi=-0.021, zeta=-0.031, gamma=0.043),
+        cirq.PhasedFSimGate(theta=-0.012, phi=0.022, zeta=0.032, gamma=-0.044),
+    ]
+    iswap_angles = [
+        cirq.PhasedFSimGate(theta=-0.013, phi=0.023, zeta=0.031, gamma=-0.043),
+        cirq.PhasedFSimGate(theta=0.014, phi=-0.024, zeta=-0.032, gamma=0.044),
+    ]
+
+    # Create NoiseProperties object from Calibration
+    calibration = get_mock_calibration(
+        pauli_error,
+        incoherent_error,
+        p00_error,
+        p11_error,
+        t1_micros,
+        syc_pauli,
+        iswap_pauli,
+        syc_angles,
+        iswap_angles,
+    )
+
+    qubit_pairs = [(qubits[0], qubits[1]), (qubits[0], qubits[2])]
+    zphase_data = {
+        "syc": {
+            "zeta": {qubit_pairs[0]: syc_angles[0].zeta, qubit_pairs[1]: syc_angles[1].zeta},
+            "gamma": {qubit_pairs[0]: syc_angles[0].gamma, qubit_pairs[1]: syc_angles[1].gamma},
+        },
+        "sqrt_iswap": {
+            "zeta": {qubit_pairs[0]: iswap_angles[0].zeta, qubit_pairs[1]: iswap_angles[1].zeta},
+            "gamma": {qubit_pairs[0]: iswap_angles[0].gamma, qubit_pairs[1]: iswap_angles[1].gamma},
+        },
+    }
+
+    prop = cirq_google.noise_properties_from_calibration(calibration, zphase_data)
+
+    json_text = cirq.to_json(prop)
+    prop1 = cirq.read_json(json_text=json_text)
+    assert prop1 == prop
+
+
 def test_incomplete_calibration():
     pauli_error = [0.001, 0.002, 0.003]
     p00_error = [0.004, 0.005, 0.006]


### PR DESCRIPTION
Problem: The values in `SuperconductingQubitsNoiseProperties.readout_errors`
and `GoogleNoiseProperties.readout_errors` dictionaries are declared as
`np.ndarray` in docstrings, but annotated as`list[float]` in the code,
and can be set to either type.  JSON serialization fails when assigned a list.

Solution: Always convert to `list[float]` following the type annotation.

This fixes serialization failure for `GoogleNoiseProperties` objects created
with `noise_properties_from_calibration`.
