### PR TITLE
fix: Raise TypeError for string exponents in EigenGate and add test

### DIFF
--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -1322,3 +1322,8 @@ def test_parameterized_pauli_expansion(gate_type, exponent):
     gate_resolved = cirq.resolve_parameters(gate, {'s': 0.5})
     pauli_resolved = cirq.resolve_parameters(pauli, {'s': 0.5})
     assert cirq.approx_eq(pauli_resolved, cirq.pauli_expansion(gate_resolved))
+
+
+def test_xpowgate_string_exponent_raises():
+    with pytest.raises(TypeError, match="Exponent must be a float or sympy expression, not str"):
+        _ = cirq.X ** "text"

--- a/cirq-core/cirq/ops/eigen_gate.py
+++ b/cirq-core/cirq/ops/eigen_gate.py
@@ -289,6 +289,8 @@ class EigenGate(raw_types.Gate):
         return _approximate_common_period(real_periods)
 
     def __pow__(self, exponent: float | sympy.Symbol) -> EigenGate:
+        if isinstance(exponent, str):
+            raise TypeError("Exponent must be a float or sympy expression, not str. String exponents are not supported.")
         new_exponent = protocols.mul(self._exponent, exponent, NotImplemented)
         if new_exponent is NotImplemented:
             return NotImplemented  # pragma: no cover


### PR DESCRIPTION
This PR updates Cirq’s parameterized gate logic to **disallow using strings as exponents** (e.g., `cirq.X**"text"`).  
- If a string is passed as an exponent to any gate inheriting from `EigenGate`, a `TypeError` is now raised with a clear message.
- A test is added to ensure this behavior is enforced.

#### Changes - 
- Added a type check in `EigenGate.__pow__` to raise a `TypeError` if the exponent is a string.
- Added a test in `common_gates_test.py` to verify that `cirq.X**"text"` raises the expected error.

Closes - #2936
Solved Under unitaryhack