### PR TITLE
Support serializing sweeps with numpy values

### DIFF
--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import numbers
 from typing import Any, Callable, cast, TYPE_CHECKING
 
 import sympy
@@ -31,10 +32,10 @@ def _build_sweep_const(value: Any) -> run_context_pb2.ConstValue:
     """Build the sweep const message from a value."""
     if value is None:
         return run_context_pb2.ConstValue(is_none=True)
-    elif isinstance(value, float):
-        return run_context_pb2.ConstValue(float_value=value)
-    elif isinstance(value, int):
-        return run_context_pb2.ConstValue(int_value=value)
+    elif isinstance(value, numbers.Integral):
+        return run_context_pb2.ConstValue(int_value=int(value))
+    elif isinstance(value, numbers.Real):
+        return run_context_pb2.ConstValue(float_value=float(value))
     elif isinstance(value, str):
         return run_context_pb2.ConstValue(string_value=value)
     elif isinstance(value, tunits.Value):

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -18,6 +18,7 @@ import math
 from copy import deepcopy
 from typing import Iterator
 
+import numpy as np
 import pytest
 import sympy
 import tunits
@@ -418,3 +419,9 @@ def test_tunits_round_trip(sweep):
     msg = v2.sweep_to_proto(sweep)
     recovered = v2.sweep_from_proto(msg)
     assert sweep == recovered
+
+
+@pytest.mark.parametrize('value', [np.float32(3.14), np.int64(5)])
+def test_const_sweep_with_numpy_types_roundtrip(value):
+    sweep = cirq.Points('const', [value])
+    assert v2.sweep_from_proto(v2.sweep_to_proto(sweep)) == sweep


### PR DESCRIPTION
- **Update `_NPY_MAXDIMS` (#7167)**
- **Try again to format messages more nicely (#7180)**
- **Filter out harmless quimb-related warnings in check/doctest (#7179)**
- **Fix np.einsum type annotations (#7184)**
- **Fix flakes in pauli_string_measurement_with_readout_mitigation_test (#7185)**
- **Simplify python package description (#7187)**
- **Fix WaitGate for multiple qubits in cirq_google proto (#7189)**
- **Avoid frequent test failure in greedy_test.py by increasing timeout (#7188)**
- **Add isort for import linting (#7181)**
- **CI - skip sorting of imports with isort (#7190)**
- **Fix isort invocation in format-incremental (#7194)**
- **Update Zenodo info & correct a small typo (#7191)**
- **Improve check of expected shell commands in check/format-incremental (#7196)**
- **Sort import statements - no change in the effective code (#7195)**
- **Ignore isort code formatting in git blame (#7197)**
- **Update and make minor additions to docs/ in time for Cirq 1.5 (#7175)**
- **fix typos in docstrings (#7200)**
- **Create a new condition that allows easy control by bitmasks and Add a new classical Update the notebook for 'Classical control' to reflect new features" (#7166)**
- **Remove debug printouts from the test (#7202)**
- **Fix #5497: update IonQ docs to remove decompose_operation (#7198)**
- **Revise Community section (#7199)**
- **Add bytes to cirq_google proto (#7201)**
- **Format typescript sources at max_line_length=100 (#7205)**
- **Change a list of if statements into match (#7204)**
- **Resolve issue #7000 by adding PR labeler workflow (#7203)**
- **Bump actions/setup-python from 5.4.0 to 5.5.0 (#7207)**
- **Bump actions/cache from 4.2.2 to 4.2.3 (#7208)**
- **Bump actions/upload-artifact from 4.6.1 to 4.6.2 (#7209)**
- **Bump the non-security group in /cirq-web/cirq_ts with 5 updates (#7210)**
- **Better stimcirq serialization (#7192)**
- **Improve cirq-dev installation command (#7213)**
- **Fix gitignore to track maintained sources in docs/build (#7216)**
- **Clarify docstring of `is_parameterized` (#7215)**
- **Recommend use of unquoted annotations in coding style guide (#7222)**
- **Use a different action for size labeler GHA (#7219)**
- **Fix ALL THE COVERAGE (#7220)**
- **Update clifford_gate.py (#7223)**
- **Try using a PAT (#7225)**
- **Switch to unquoted type annotations part 1 (#7193)**
- **Test qcircuit pdf generation without extra `prepare_only` argument (#7227)**
- **Fix issue #6934 (#7230)**
- **ci-daily - explicitly install cirq-rigetti for the tests (#7229)**
- **Remove previously deprecated fields in cirq_google proto (#7183)**
- **Compensate for global phase in MatrixGate decomposition (#7118)**
- **Fix EigenGate equality (#7057)**
- **Allow '_mixture_' to return gates instead of just raw unitary matrices (#7048)**
- **Address warning about node_link_data, node_link_graph defaults (#7234)**
- **Ignore spurious PollerCompletionQueue errors in AsyncioExecutor (#6492)**
- **Add tuples, ndarrays, and complex numbers to cirq_google proto (#7226)**
- **Assume PhasedXPowGate is different from XPowGate and YPowGate (#7070)**
- **Address pandas warning about deprecated DataFrameGroupBy.apply default (#7235)**
- **Fix docker installation for cirq_pre_release image (#7240)**
- **Flip back to default `use_repetition_ids=True` in CircuitOperation (#7237)**
- **Fix a few capitalization typos (#7244)**
- **Fix failing CI tests due to old setuptools (#7249)**
- **Switch notebooks from dev to stable cirq where possible (#7247)**
- **CI - fix failing pre-release workflow (#7252)**
- **Fix issue #7245: update docs referring to calibration_api.ipynb (#7253)**
- **Correct minor typo in BitMaskKeyCondition (#7251)**
- **Do mild editing for grammar, consistency, and Markdown (#7246)**
- **Fix typos in XEB (#7254)**
- **Drop temporary warnings about changed data promotion in numpy-2 (#7258)**
- **Avoid using NotImplemented as a boolean (#7259)**
- **Fix serialization error in cirq_google. (#7260)**
- **Add classical conditions to cirq_google proto (#7250)**
- **Bump cirq version to 1.6.0 (#7261)**
- **Cite Cirq release 1.5.0 (#7263)**
- **Test all notebooks vs stable cirq after the release (#7255)**
- **Roll forward #6910 - CircuitOperation: change use_repetition_ids default to False (#7265)**
- **Remove USE_CONSTANTS flags and make them the default (#7262)**
- **Clarify instructions for release process (#7266)**
- **Remove pytest-debug.yaml workflow (#7274)**
- **Remove first-interction.yaml workflow (#7273)**
- **Replace PR labeler with better & safer version (#7271)**
- **Flip test names to match expected warnings (#7275)**
- **Put back the issues-write permission for pr-labeler (#7277)**
- **Remove pr_monitor (#7214)**
- **Update cirq resolver to check sympy singletons with `is` instead of `==` (#7279)**
- **Switch to unquoted type annotations part 2 (#7278)**
- **Fix YAML quotation error (#7286)**
- **Fixed visual bug and unit test (#7293)**
- **Fix minor README glitches, update Cirq logo to respond to dark/light mode, and add QAI logo (#7186)**
- **Switch to unquoted type annotations part 3 (#7295)**
- **Clarify error message for `decompose_once(X(q))` (#7281)**
- **Switch to unquoted type annotations part 4 (#7298)**
- **Improve reporting of errors & efficiency of pr-size-labeler (#7288)**
- **Bump http-proxy-middleware from 2.0.7 to 2.0.9 in /cirq-web/cirq_ts (#7300)**
- **Make cirq.Zip twenty times faster (#7303)**
- **Update documentation about num_qubits protocol (#7299)**
- **Add Willow gate (#7301)**
- **CI - replace actions/cache with setup-python package caching (#7305)**
- **Bump actions/setup-python from 5.5.0 to 5.6.0 (#7311)**
- **Bump actions/setup-node from 4.3.0 to 4.4.0 (#7312)**
- **Bump codecov/codecov-action from 5.4.0 to 5.4.2 (#7310)**
- **Bump typescript from 5.8.2 to 5.8.3 in /cirq-web/cirq_ts (#7315)**
- **Bump the non-security group in /cirq-web/cirq_ts with 7 updates (#7314)**
- **Switch to unquoted type annotations part 5 (#7317)**
- **Add the capability to accept group Paulis that can be measured using same measurement results (#7236)**
- **Group updates for GitHub Actions (#7318)**
- **Rewrite inefficient `sum(..., [])` and `sum(..., ())` (#7304)**
- **CI - fix type check with a temporary pin to numpy-1 (#7324)**
- **Create a new implementation of parallel XEB and its methods (#6940)**
- **Switch to unquoted type annotations part 6 (#7325)**
- **Starts deprecating pass_operations_over for PauliString and PauliStringPhasor (#7294)**
- **Add tag_transformers remove_tags, index_tags. (#7306)**
- **Fix qubit metadata in identifying_hardware_changes (#7308)**
- **Add WillowGate to cirq_google serialization (#7309)**
- **Disable all GitHub Actions jobs in forks (#7326)**
- **Add return type for tests (#7327)**
- **Pin Cotengra version (#7335)**
- **Add few more return-type annotations to tests (#7331)**
- **Fix identifying hardware changes notebook (#7328)**
- **Add CXSWAP and CZSWAP gates (#7334)**
- **Adjust type annotations for numpy-2 (#7333)**
- **Unpin cotengra requirement (#7340)**
- **Update .git-blame-ignore-revs for test return types. (#7332)**
- **Optimize the HHL algorithm using amplitude amplification (#7141)**
- **Remove documentation references to optimized_for_sycamore (#7329)**
- **NEP-29 - require minimum Python version 3.11 (#7338)**
- **Switch to unquoted type annotations part 7 (#7343)**
- **Fix another round of typing issues (#7341)**
- **Add a symbolize transformer (#7307)**
- **Remove Dockerfile and associated files and documentation (#7347)**
- **Support Reset gate in GridDevice and device specification proto (#7349)**
- **Switch to unquoted type annotations part 8 (#7345)**
- **Update Type Hints (#7348)**
- **Add QVM helper `extract_gate_times_ns_from_device` (#7350)**
- **Switch to unquoted type annotations part 9 (#7356)**
- **Bump codecov/codecov-action in the actions-version-updates group (#7351)**
- **Bump the non-security group in /cirq-web/cirq_ts with 5 updates (#7353)**
- **Update types for standard collections (#7355)**
- **Fix Linear dict scalar division test (#7361)**
- **Finalize switch to unquoted type annotations (part 10) (#7357)**
- **Added QASM Import Support for rzz, rxx, ryy, crx, cry, and iswap Gates (#7290)**
- **Unpin upper bound on setuptools requirement (#7359)**
- **Ignore typing PR for git blame. (#7363)**
- **Attempt canonicalization first when decomposing controlled gates (#7269)**
- **Update type annotations (#7364)**
- **Finalize switch to PEP 585 style type annotations (#7367)**
- **Flatten controlled-CZ and controlled-CX more consistently (#7365)**
- **Add QVM factory function load_device_noise_properties (#7369)**
- **Add new "willow_pink" processor to the QVM factory (#7366)**
- **Decompose controlled 1x1 unitary gates generically, not just GlobalPhaseGate (#7283)**
- **Add `list_virtual_processors` function to the QVM factory (#7375)**
- **Fix: Allow subtraction of IdentityGate in PauliSum.__sub__ (#7276)**
- **Bump networkx to minimum version 3.4 (#7378)**
- **Move cirq-ts files to cirq-web (#7362)**
- **CI - add ruff check of the code (#7372)**
- **Update format-incremental script to format notebooks (#7342)**
- **Format all notebooks (no change in the code) (#7386)**
- **pylint - sync with rules used in internal codes (#7387)**
- **Take care of leftover conversions to PEP 585 style (#7382)**
- **Fix more typing issues (#7388)**
- **support serializing sweeps with numpy values**
