### PR TITLE
Fix test assertion in raw_types_test.py.

### DIFF
--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -652,7 +652,7 @@ def test_tagged_operation_forwards_protocols() -> None:
     np.testing.assert_equal(cirq.unitary(tagged_h), cirq.unitary(h))
     assert cirq.has_unitary(tagged_h)
     assert cirq.decompose(tagged_h) == cirq.decompose(h)
-    assert [*tagged_h._decompose_()] == cirq.decompose(h)
+    assert [*tagged_h._decompose_()] == cirq.decompose_once(h)
     assert cirq.pauli_expansion(tagged_h) == cirq.pauli_expansion(h)
     assert cirq.equal_up_to_global_phase(h, tagged_h)
     assert np.isclose(cirq.kraus(h), cirq.kraus(tagged_h)).all()


### PR DESCRIPTION
This fixes a small issue that I found while working on #7291 

TaggedOperation `_decompose` calls `protocols.decompose_once` (see [here](https://github.com/quantumlib/Cirq/blob/e27d883d20d4acea97bd96d795170ae984b3dba9/cirq-core/cirq/ops/raw_types.py#L837)). So it must be compared against `cirq.decompose_once`.