### PR TITLE
Fix test case names.

### DIFF
--- a/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
@@ -221,13 +221,13 @@ def test_merge_single_qubit_moments_to_phxz_deep():
     )
 
 
-def test_merge_single_qubit_moments_to_phxz_global_phase():
+def test_merge_single_qubit_gates_to_phxz_global_phase():
     c = cirq.Circuit(cirq.GlobalPhaseGate(1j).on())
     c2 = cirq.merge_single_qubit_gates_to_phxz(c)
     assert c == c2
 
 
-def test_merge_single_qubit_moments_to_phased_x_and_z_global_phase():
+def test_merge_single_qubit_gates_to_phased_x_and_z_global_phase():
     c = cirq.Circuit(cirq.GlobalPhaseGate(1j).on())
     c2 = cirq.merge_single_qubit_gates_to_phased_x_and_z(c)
     assert c == c2


### PR DESCRIPTION
This fixes a minor issue I found while working on #7291 

The test case names don't match the method being tested. This is confusing because there is another method called `merge_single_qubit_moments_to_phxz`, but it's not the one tested here.