### PR TITLE
Bump mypy to 1.16.0

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -469,7 +469,7 @@ def deprecate_attributes(module_name: str, deprecated_attributes: dict[str, tupl
         __dict__ = module.__dict__
 
         # Workaround for: https://github.com/python/mypy/issues/8083
-        __spec__ = _make_proxy_spec_property(module)  # type: ignore
+        __spec__ = _make_proxy_spec_property(module)
 
         def __getattr__(self, name):
             if name in deprecated_attributes:
@@ -770,7 +770,7 @@ def _setup_deprecated_submodule_attribute(
         __dict__ = parent_module.__dict__
 
         # Workaround for: https://github.com/python/mypy/issues/8083
-        __spec__ = _make_proxy_spec_property(parent_module)  # type: ignore
+        __spec__ = _make_proxy_spec_property(parent_module)
 
         def __getattr__(self, name):
             if name == old_child:

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -137,7 +137,7 @@ def sample_heavy_set(
     # Don't do a single large measurement gate because then the key will be one
     # large string. Instead, do a bunch of single-qubit measurement gates so we
     # preserve the qubit keys.
-    sorted_qubits = sorted(qubits, key=key)
+    sorted_qubits = sorted(qubits, key=key)  # type: ignore[arg-type]
     circuit_copy = circuit + [cirq.measure(q) for q in sorted_qubits]
 
     # Run the sampler to compare each output against the Heavy Set.

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-from typing import Any, Callable, cast, Container, Iterable, Iterator, Sequence, TYPE_CHECKING
+from typing import Any, Callable, Container, Iterable, Iterator, Sequence, TYPE_CHECKING
 
 import numpy as np
 
@@ -458,8 +458,7 @@ def _pairs_from_moment(moment: cirq.Moment) -> list[QidPairT]:
     for op in moment.operations:
         if len(op.qubits) != 2:
             raise ValueError("Layer circuit contains non-2-qubit operations.")
-        qpair = cast(QidPairT, op.qubits)
-        pairs.append(qpair)
+        pairs.append(op.qubits)
     return pairs
 
 

--- a/cirq-core/cirq/experiments/xeb_sampling.py
+++ b/cirq-core/cirq/experiments/xeb_sampling.py
@@ -341,8 +341,8 @@ def sample_2q_xeb_circuits(
     # Construct truncated-with-measurement circuits to run.
     tasks = _generate_sample_2q_xeb_tasks(zipped_circuits, cycle_depths)
     if shuffle is not None:
-        shuffle = value.parse_random_state(shuffle)
-        shuffle.shuffle(tasks)
+        prng = value.parse_random_state(shuffle)
+        prng.shuffle(tasks)  # type: ignore[arg-type]
 
     # Batch and run tasks.
     records = _execute_sample_2q_xeb_tasks_in_batches(

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import AbstractSet, Any, Mapping, Sequence, TYPE_CHECKING
+from typing import AbstractSet, Any, cast, Mapping, Sequence, TYPE_CHECKING
 
 import sympy
 
@@ -212,13 +212,17 @@ class ClassicallyControlledOperation(raw_types.Operation):
         conditions = [protocols.with_measurement_key_mapping(c, key_map) for c in self._conditions]
         sub_operation = protocols.with_measurement_key_mapping(self._sub_operation, key_map)
         sub_operation = self._sub_operation if sub_operation is NotImplemented else sub_operation
-        return sub_operation.with_classical_controls(*conditions)
+        return cast(
+            ClassicallyControlledOperation, sub_operation.with_classical_controls(*conditions)
+        )
 
     def _with_key_path_prefix_(self, prefix: tuple[str, ...]) -> ClassicallyControlledOperation:
         conditions = [protocols.with_key_path_prefix(c, prefix) for c in self._conditions]
         sub_operation = protocols.with_key_path_prefix(self._sub_operation, prefix)
         sub_operation = self._sub_operation if sub_operation is NotImplemented else sub_operation
-        return sub_operation.with_classical_controls(*conditions)
+        return cast(
+            ClassicallyControlledOperation, sub_operation.with_classical_controls(*conditions)
+        )
 
     def _with_rescoped_keys_(
         self, path: tuple[str, ...], bindable_keys: frozenset[cirq.MeasurementKey]

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -779,7 +779,6 @@ def test_simulate_moment_steps_qudits(dtype: type[np.complexfloating], split: bo
 def test_simulate_moment_steps_empty_circuit(dtype: type[np.complexfloating], split: bool):
     circuit = cirq.Circuit()
     simulator = cirq.DensityMatrixSimulator(dtype=dtype, split_untangled_states=split)
-    step = None
     for step in simulator.simulate_moment_steps(circuit):
         pass
     assert np.allclose(step.density_matrix(), np.array([[1]]))

--- a/cirq-core/cirq/sim/simulator_base.py
+++ b/cirq-core/cirq/sim/simulator_base.py
@@ -227,9 +227,10 @@ class SimulatorBase(
             if self._can_be_in_run_prefix(self.noise)
             else (resolved_circuit[0:0], resolved_circuit)
         )
-        step_result = None
+        step_result: TStepResultBase | None = None
         for step_result in self._core_iterator(circuit=prefix, sim_state=sim_state):
             pass
+        assert step_result is not None
 
         general_ops = list(general_suffix.all_operations())
         if all(isinstance(op.gate, ops.MeasurementGate) for op in general_ops):
@@ -310,9 +311,10 @@ class SimulatorBase(
             if self._can_be_in_run_prefix(self.noise)
             else (program[0:0], program)
         )
-        step_result = None
+        step_result: TStepResultBase | None = None
         for step_result in self._core_iterator(circuit=prefix, sim_state=sim_state):
             pass
+        assert step_result is not None
         sim_state = step_result._sim_state
         yield from super().simulate_sweep_iter(suffix, params, qubit_order, sim_state)
 

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -573,7 +573,6 @@ def test_simulate_moment_steps(dtype: type[np.complexfloating], split: bool):
 def test_simulate_moment_steps_empty_circuit(dtype: type[np.complexfloating], split: bool):
     circuit = cirq.Circuit()
     simulator = cirq.Simulator(dtype=dtype, split_untangled_states=split)
-    step = None
     for step in simulator.simulate_moment_steps(circuit):
         pass
     assert np.allclose(step.state_vector(copy=True), np.array([1]))

--- a/cirq-google/cirq_google/engine/asyncio_executor.py
+++ b/cirq-google/cirq_google/engine/asyncio_executor.py
@@ -17,10 +17,13 @@ from __future__ import annotations
 import asyncio
 import errno
 import threading
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, TYPE_CHECKING, TypeVar
 
 import duet
 from typing_extensions import ParamSpec
+
+if TYPE_CHECKING:
+    import concurrent
 
 R = TypeVar('R')
 P = ParamSpec("P")
@@ -66,7 +69,9 @@ class AsyncioExecutor:
             *args: Positional args to pass to func.
             **kwargs: Keyword args to pass to func.
         """
-        future = asyncio.run_coroutine_threadsafe(func(*args, **kwargs), self.loop)
+        future: concurrent.futures.Future = asyncio.run_coroutine_threadsafe(
+            func(*args, **kwargs), self.loop  # type: ignore[arg-type]
+        )
         return duet.AwaitableFuture.wrap(future)
 
     _instance: AsyncioExecutor | None = None

--- a/cirq-rigetti/cirq_rigetti/circuit_transformers.py
+++ b/cirq-rigetti/cirq_rigetti/circuit_transformers.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """A collection of `CircuitTransformer` s that the client may pass to `RigettiQCSService` or
 `RigettiQCSSampler` as `transformer`.
 """
-from typing import Callable, cast
+
+from typing import Callable
 
 from pyquil import Program
 from typing_extensions import Protocol
@@ -114,7 +116,7 @@ def build(
             post_transformation_hooks=post_transformation_hooks,
         )
 
-    return cast(CircuitTransformer, transformer)
+    return transformer
 
 
 @deprecated_cirq_rigetti_function()

--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -1,5 +1,5 @@
 # the mypy dependency file
-mypy==1.15.0
+mypy==1.16.0
 
 # packages with stub types for various libraries
 types-protobuf>=4.24


### PR DESCRIPTION
- Bump mypy to 1.16.0
- Remove redundant cast and ignore comments
- Add casts and ignores for typing flagged by mypy-1.16.0
- Fix annotations of simulator step results

Replaces #7404
