### PR TITLE
Prefer load_device_noise_properties in example notebooks

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -42,7 +42,13 @@ from dev_tools.notebooks import filter_notebooks, list_all_notebooks, rewrite_no
 # note that these notebooks are still tested in dev_tools/notebook_test.py
 # Please, always indicate in comments the feature used for easier bookkeeping.
 
-NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = []
+NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = [
+    # Requires `load_device_noise_properties` from #7369
+    'docs/hardware/qubit_picking.ipynb',
+    'docs/simulate/noisy_simulation.ipynb',
+    'docs/simulate/quantum_virtual_machine.ipynb',
+    'docs/simulate/qvm_basic_example.ipynb',
+]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule
 # please always add a reason for skipping.

--- a/docs/hardware/qubit_picking.ipynb
+++ b/docs/hardware/qubit_picking.ipynb
@@ -72,6 +72,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cb67ae611d34"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -85,7 +96,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --upgrade --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "\n",

--- a/docs/hardware/qubit_picking.ipynb
+++ b/docs/hardware/qubit_picking.ipynb
@@ -120,8 +120,7 @@
    "outputs": [],
    "source": [
     "processor_id = \"rainbow\"\n",
-    "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
-    "noise_props = cirq_google.noise_properties_from_calibration(cal)"
+    "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)"
    ]
   },
   {

--- a/docs/simulate/noisy_simulation.ipynb
+++ b/docs/simulate/noisy_simulation.ipynb
@@ -63,6 +63,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "f9c6fb06ebbf"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -74,7 +85,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install --upgrade --quiet cirq~=1.0.dev\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/simulate/noisy_simulation.ipynb
+++ b/docs/simulate/noisy_simulation.ipynb
@@ -988,10 +988,8 @@
     "import cirq_google\n",
     "\n",
     "processor_id = \"rainbow\"  # or \"weber\"\n",
-    "# Load the calibration data\n",
-    "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
-    "# Turn calibration data into a noise properties object\n",
-    "noise_props = cirq_google.noise_properties_from_calibration(cal)\n",
+    "# Load the noise properties for the processor\n",
+    "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)\n",
     "# Build a noise model from the noise properties\n",
     "noise_model = cirq_google.NoiseModelFromGoogleNoiseProperties(noise_props)"
    ]

--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -79,7 +79,9 @@
     "id": "p31cCK_T1ylm"
    },
    "source": [
-    "## Setup"
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
    ]
   },
   {
@@ -98,7 +100,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq-google\n",
+    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",

--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -161,8 +161,8 @@
    "source": [
     "# Load the median device noise calibration for your selected processor.\n",
     "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
-    "# Create the noise properties object.\n",
-    "noise_props = cirq_google.noise_properties_from_calibration(cal)\n",
+    "# Load the noise properties for the processor.\n",
+    "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)\n",
     "# Create a noise model from the noise properties.\n",
     "noise_model = cirq_google.NoiseModelFromGoogleNoiseProperties(noise_props)\n",
     "# Prepare a qsim simulator using the noise model.\n",

--- a/docs/simulate/qvm_basic_example.ipynb
+++ b/docs/simulate/qvm_basic_example.ipynb
@@ -145,7 +145,7 @@
     "\n",
     "# Construct a simulator with a noise model based on the specified processor.\n",
     "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
-    "noise_props = cirq_google.noise_properties_from_calibration(cal)\n",
+    "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)\n",
     "noise_model = cirq_google.NoiseModelFromGoogleNoiseProperties(noise_props)\n",
     "sim = qsimcirq.QSimSimulator(noise=noise_model)\n",
     "\n",

--- a/docs/simulate/qvm_basic_example.ipynb
+++ b/docs/simulate/qvm_basic_example.ipynb
@@ -81,6 +81,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8e3ded3ff3d1"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -96,7 +107,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq-google\n",
+    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",


### PR DESCRIPTION
Replace calls of `noise_properties_from_calibration` with
`load_device_noise_properties` so users do not need to pass
the `gate_times_ns` argument.

Updated notebooks need to install development cirq and be listed in
`NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES`.

Related to b/395705720
