### PR TITLE
Remove dead code for scipy<=1.5

### DIFF
--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Sequence
 
 import numpy as np
+import scipy.linalg
 
 import cirq
 from cirq import ops, transformers as opt
@@ -47,24 +48,13 @@ def three_qubit_matrix_to_operations(
 
     Raises:
         ValueError: If the u matrix is non-unitary or not of shape (8,8).
-        ImportError: If the decomposition cannot be done because the SciPy version is less than
-            1.5.0 and so does not contain the required `cossin` method.
     """
     if np.shape(u) != (8, 8):
         raise ValueError(f"Expected unitary matrix with shape (8,8) got {np.shape(u)}")
     if not cirq.is_unitary(u, atol=atol):
         raise ValueError(f"Matrix is not unitary: {u}")
 
-    try:
-        from scipy.linalg import cossin
-    except ImportError:  # pragma: no cover
-        raise ImportError(
-            "cirq.three_qubit_unitary_to_operations requires "
-            "SciPy 1.5.0+, as it uses the cossin function. Please"
-            " upgrade scipy in your environment to use this "
-            "function!"
-        )
-    (u1, u2), theta, (v1h, v2h) = cossin(u, 4, 4, separate=True)
+    (u1, u2), theta, (v1h, v2h) = scipy.linalg.cossin(u, 4, 4, separate=True)
 
     cs_ops = _cs_to_ops(q0, q1, q2, theta)
     if len(cs_ops) > 0 and cs_ops[-1] == cirq.CZ(q2, q0):

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from random import random
-from typing import Callable
 
 import numpy as np
 import pytest
@@ -31,20 +30,6 @@ from cirq.transformers.analytical_decompositions.three_qubit_decomposition impor
 )
 
 
-def _skip_if_scipy(*, version_is_greater_than_1_5_0: bool) -> Callable[[Callable], Callable]:
-    def decorator(func):  # pragma: no cover
-        try:
-            # pylint: disable=unused-import
-            from scipy.linalg import cossin
-
-            return None if version_is_greater_than_1_5_0 else func
-        except ImportError:
-            return func if version_is_greater_than_1_5_0 else None
-
-    return decorator
-
-
-@_skip_if_scipy(version_is_greater_than_1_5_0=False)
 @pytest.mark.parametrize(
     "u",
     [
@@ -70,24 +55,12 @@ def test_three_qubit_matrix_to_operations(u) -> None:
     assert num_two_qubit_gates <= 20, f"expected at most 20 CZ/CNOTs got {num_two_qubit_gates}"
 
 
-@_skip_if_scipy(version_is_greater_than_1_5_0=False)
 def test_three_qubit_matrix_to_operations_errors() -> None:
     a, b, c = cirq.LineQubit.range(3)
     with pytest.raises(ValueError, match="(8,8)"):
         cirq.three_qubit_matrix_to_operations(a, b, c, np.eye(2))
     with pytest.raises(ValueError, match="not unitary"):
         cirq.three_qubit_matrix_to_operations(a, b, c, cirq.unitary(cirq.CCX) * 2)
-
-
-# on environments with scipy <1.5.0 this will not be sufficient to cover the
-# full three_qubit_matrix_to_operations method. In case we ever introduce a CI
-# environment like that, we'll need to ignore the coverage somehow conditionally on
-# the scipy version.
-@_skip_if_scipy(version_is_greater_than_1_5_0=True)
-def test_three_qubit_matrix_to_operations_scipy_error() -> None:  # pragma: no cover
-    a, b, c = cirq.LineQubit.range(3)
-    with pytest.raises(ImportError, match="three_qubit.*1.5.0+"):
-        cirq.three_qubit_matrix_to_operations(a, b, c, np.eye(8))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We require scipy>=1.11 so any special code for earlier scipy is dead.
