### PR TITLE
change use of measurements to records in tomography

### DIFF
--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -25,15 +25,15 @@ from matplotlib import pyplot as plt
 # this is for older systems with matplotlib <3.2 otherwise 3d projections fail
 from scipy.optimize import curve_fit
 
+
 import cirq.vis.heatmap as cirq_heatmap
 import cirq.vis.histogram as cirq_histogram
 from cirq import circuits, ops, protocols
 from cirq.devices import grid_qubit
-from cirq.protocols import measurement_key_names
 
 if TYPE_CHECKING:
     from mpl_toolkits import mplot3d
-    
+
     import cirq
 
 
@@ -528,7 +528,7 @@ def single_qubit_state_tomography(
     Returns:
         A TomographyResult object that stores and plots the density matrix.
     """
-    keys = measurement_key_names(circuit)
+    keys = protocols.measurement_key_names(circuit)
     tomo_key = "tomo_key"
     while tomo_key in keys:
         tomo_key = f"tomo_key{uuid.uuid4().hex}"

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -152,40 +152,32 @@ def test_two_qubit_randomized_benchmarking():
 def test_single_qubit_state_tomography():
     # Check that the density matrices of the output states of X/2, Y/2 and
     # H + Y gates closely match the ideal cases.
+    # checks that unique tomography keys are generated
     simulator = sim.Simulator()
-    qubit = GridQubit(0, 0)
+    q_0 = GridQubit(0, 0)
+    q_1 = GridQubit(0, 1)
 
-    circuit_1 = circuits.Circuit(ops.X(qubit) ** 0.5)
-    circuit_2 = circuits.Circuit(ops.Y(qubit) ** 0.5)
-    circuit_3 = circuits.Circuit(ops.H(qubit), ops.Y(qubit))
+    circuit_1 = circuits.Circuit(ops.X(q_0) ** 0.5)
+    circuit_2 = circuits.Circuit(ops.Y(q_0) ** 0.5)
+    circuit_3 = circuits.Circuit(ops.H(q_0), ops.Y(q_0))
+    circuit_4 = circuits.Circuit(
+        ops.H(q_0), ops.Y(q_0), cirq.measure(q_1, key='z')
+    )
 
-    act_rho_1 = single_qubit_state_tomography(simulator, qubit, circuit_1, 1000).data
-    act_rho_2 = single_qubit_state_tomography(simulator, qubit, circuit_2, 1000).data
-    act_rho_3 = single_qubit_state_tomography(simulator, qubit, circuit_3, 1000).data
+    act_rho_1 = single_qubit_state_tomography(simulator, q_0, circuit_1, 1000).data
+    act_rho_2 = single_qubit_state_tomography(simulator, q_0, circuit_2, 1000).data
+    act_rho_3 = single_qubit_state_tomography(simulator, q_0, circuit_3, 1000).data
+    act_rho_4 = single_qubit_state_tomography(simulator, q_0, circuit_4, 1000).data
 
     tar_rho_1 = np.array([[0.5, 0.5j], [-0.5j, 0.5]])
     tar_rho_2 = np.array([[0.5, 0.5], [0.5, 0.5]])
     tar_rho_3 = np.array([[0.5, -0.5], [-0.5, 0.5]])
+    tar_rho_4 = np.array([[0.5, -0.5], [-0.5, 0.5]])
 
     np.testing.assert_almost_equal(act_rho_1, tar_rho_1, decimal=1)
     np.testing.assert_almost_equal(act_rho_2, tar_rho_2, decimal=1)
     np.testing.assert_almost_equal(act_rho_3, tar_rho_3, decimal=1)
-
-
-def test_single_qubit_state_tomography_unique_key():
-    # Checks if the key 'z' is already being used in the circuit, and if so picks a unique key
-    sim = cirq.Simulator()
-    qubits = cirq.LineQubit.range(2)
-
-    circuit_1 = cirq.Circuit(
-        cirq.H(qubits[0]), cirq.H(qubits[1]), cirq.measure(qubits[0], qubits[1], key='z')
-    )
-
-    result = single_qubit_state_tomography(sim, qubits[0], circuit_1, repetitions=1000)
-    act_rho_1 = result.data
-    tar_rho_1 = np.array([[0.527 + 0.0j, -0.001 - 0.02j], [-0.001 + 0.02j, 0.473 + 0.0j]])
-
-    np.testing.assert_almost_equal(act_rho_1, tar_rho_1, decimal=1)
+    np.testing.assert_almost_equal(act_rho_4, tar_rho_4, decimal=1)
 
 
 def test_two_qubit_state_tomography():


### PR DESCRIPTION
In the file qubit_characterizations.py, in the function definition of single_qubit_state_tomography, changing the use of measurements to records allows for circuits with multiple key measurements to be supported without throwing an error for having repeated keys

@sgavi4 
@abyssaldragonz 
@thomasasha

closes #7417