### PR TITLE
CI - bump GHA windows runner to windows-2022

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Check out source repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
The windows-2019 runner is deprecated per GitHub Actions notice.
Follow their update recommendation.
