### PR TITLE
Handle non-2D arrays in cirq.unitary

### DIFF
--- a/cirq-core/cirq/linalg/predicates.py
+++ b/cirq-core/cirq/linalg/predicates.py
@@ -115,8 +115,12 @@ def is_unitary(matrix: np.ndarray, *, rtol: float = 1e-5, atol: float = 1e-8) ->
     Returns:
         Whether the matrix is unitary within the given tolerance.
     """
-    return matrix.shape[0] == matrix.shape[1] and np.allclose(
-        matrix.dot(np.conj(matrix.T)), np.eye(matrix.shape[0]), rtol=rtol, atol=atol
+    return (
+        matrix.ndim == 2
+        and matrix.shape[0] == matrix.shape[1]
+        and np.allclose(
+            matrix.dot(np.conj(matrix.T)), np.eye(matrix.shape[0]), rtol=rtol, atol=atol
+        )
     )
 
 

--- a/cirq-core/cirq/linalg/predicates_test.py
+++ b/cirq-core/cirq/linalg/predicates_test.py
@@ -103,10 +103,13 @@ def test_is_hermitian_tolerance():
 
 
 def test_is_unitary():
+    assert not cirq.is_unitary(np.empty((0,)))
     assert cirq.is_unitary(np.empty((0, 0)))
     assert not cirq.is_unitary(np.empty((1, 0)))
     assert not cirq.is_unitary(np.empty((0, 1)))
+    assert not cirq.is_unitary(np.empty((0, 0, 0)))
 
+    assert not cirq.is_unitary(np.array(1))
     assert cirq.is_unitary(np.array([[1]]))
     assert cirq.is_unitary(np.array([[-1]]))
     assert cirq.is_unitary(np.array([[1j]]))


### PR DESCRIPTION
Return False rather than raising IndexError for vector and scalar arrays.
