### PR TITLE
Update QVM demo notebooks to use willow_pink

### DIFF
--- a/docs/simulate/noisy_simulation.ipynb
+++ b/docs/simulate/noisy_simulation.ipynb
@@ -998,7 +998,8 @@
    "source": [
     "import cirq_google\n",
     "\n",
-    "processor_id = \"rainbow\"  # or \"weber\"\n",
+    "# See cirq_google.engine.list_virtual_processors() for available processor names\n",
+    "processor_id = \"rainbow\"  # or \"weber\" or \"willow_pink\"\n",
     "# Load the noise properties for the processor\n",
     "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)\n",
     "# Build a noise model from the noise properties\n",

--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -135,8 +135,10 @@
    },
    "outputs": [],
    "source": [
-    "# Choose a processor (\"rainbow\" or \"weber\")\n",
-    "processor_id = \"weber\""
+    "# Choose a processor (\"willow_pink\" or \"rainbow\" or \"weber\")\n",
+    "# (see cirq_google.engine.list_virtual_processors() for available names)\n",
+    "\n",
+    "processor_id = \"willow_pink\""
    ]
   },
   {
@@ -161,8 +163,6 @@
    },
    "outputs": [],
    "source": [
-    "# Load the median device noise calibration for your selected processor.\n",
-    "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
     "# Load the noise properties for the processor.\n",
     "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)\n",
     "# Create a noise model from the noise properties.\n",
@@ -197,6 +197,8 @@
     "# Package the simulator and device in an Engine.\n",
     "# The device object\n",
     "device = cirq_google.engine.create_device_from_processor_id(processor_id)\n",
+    "# Load the median device noise calibration for your processor.\n",
+    "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
     "# The simulated processor object\n",
     "sim_processor = cirq_google.engine.SimulatedLocalProcessor(\n",
     "    processor_id=processor_id, sampler=sim, device=device, calibrations={cal.timestamp // 1000: cal}\n",
@@ -233,7 +235,13 @@
    "source": [
     "q0 = cirq.GridQubit(4, 4)\n",
     "q1 = cirq.GridQubit(4, 5)\n",
-    "circuit = cirq.Circuit(cirq.X(q0), cirq.SQRT_ISWAP(q0, q1), cirq.measure([q0, q1], key=\"measure\"))\n",
+    "circuit = cirq.Circuit(\n",
+    "    cirq.X(q0),\n",
+    "    cirq.X(q1) ** 0.5,\n",
+    "    cirq.CZ(q0, q1),\n",
+    "    cirq.X(q1) ** 0.5,\n",
+    "    cirq.measure([q0, q1], key=\"measure\"),\n",
+    ")\n",
     "\n",
     "results = sim_engine.get_sampler(processor_id).run(circuit, repetitions=3000)\n",
     "\n",

--- a/docs/simulate/qvm_basic_example.ipynb
+++ b/docs/simulate/qvm_basic_example.ipynb
@@ -133,7 +133,7 @@
    "source": [
     "## Create a **Quantum Virtual Machine**\n",
     "\n",
-    "The following cell builds a Quantum Virtual Machine that mimics a particular Google quantum hardware device (currently Rainbow or Weber) using the following customizable steps: \n",
+    "The following cell builds a Quantum Virtual Machine that mimics a particular Google quantum hardware device (currently Willow-pink, Rainbow or Weber) using the following customizable steps: \n",
     "- Constructing a `cirq.NoiseModel` object from device calibration data saved in Cirq. See [Representing Noise](../noise/representing_noise.ipynb) for more on noise models. \n",
     "- Building a `qsimcirq.QsimSimulator` that uses this noise model. See [Noisy Simulation](./noisy_simulation.ipynb) and [Noise simulation with qsim](/qsim/tutorials/noisy_qsimcirq) for more. \n",
     "- Creating a `cirq.Device` that imposes the same constraints on circuits that the original device would. See [Devices](../hardware/devices.ipynb) for more on these constraint objects. \n",
@@ -151,17 +151,18 @@
    },
    "outputs": [],
    "source": [
-    "# @title Choose a processor (\"rainbow\" or \"weber\")\n",
-    "processor_id = \"weber\"  # @param {type:\"string\"}\n",
+    "# @title Choose a processor (\"willow_pink\" or \"rainbow\" or \"weber\")\n",
+    "# (see cirq_google.engine.list_virtual_processors() for available names)\n",
+    "processor_id = \"willow_pink\"  # @param {type:\"string\"}\n",
     "\n",
     "# Construct a simulator with a noise model based on the specified processor.\n",
-    "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
     "noise_props = cirq_google.engine.load_device_noise_properties(processor_id)\n",
     "noise_model = cirq_google.NoiseModelFromGoogleNoiseProperties(noise_props)\n",
     "sim = qsimcirq.QSimSimulator(noise=noise_model)\n",
     "\n",
     "# Create a device from the public device description\n",
     "device = cirq_google.engine.create_device_from_processor_id(processor_id)\n",
+    "cal = cirq_google.engine.load_median_device_calibration(processor_id)\n",
     "# Build the simulated local processor from the simulator and device.\n",
     "sim_processor = cirq_google.engine.SimulatedLocalProcessor(\n",
     "    processor_id=processor_id, sampler=sim, device=device, calibrations={cal.timestamp // 1000: cal}\n",
@@ -190,7 +191,7 @@
     "- Is applied to qubits that exist on the device. \n",
     "- Respects the connectivity of qubits on the device.\n",
     "\n",
-    "Below is an example of a circuit that has the correct topology to be placed on the Weber device, and how it is prepared to be run on the QVM."
+    "Below is an example of a circuit that has the correct topology to be placed on the Willow-pink device, and how it is prepared to be run on the QVM."
    ]
   },
   {
@@ -242,7 +243,7 @@
    "source": [
     "### Transform the circuit \n",
     "\n",
-    "Before executing a circuit on (virtual) quantum hardware, the operations in the circuit need to be translated to use the types of gates the device supports. The `cirq.optimize_for_target_gateset` function does this for you, transforming the operations to use the `cirq.SqrtIswapTargetGateset`, which is supported by the Weber processor that this QVM is based on. Learn more about the gate set constraints of Google hardware at the [Hardware](../hardware) page."
+    "Before executing a circuit on (virtual) quantum hardware, the operations in the circuit need to be translated to use the types of gates the device supports. The `cirq.optimize_for_target_gateset` function does this for you, transforming the operations to use the `cirq.CZTargetGateset`, which is supported by the Willow-pink processor that this QVM is based on. Learn more about the gate set constraints of Google hardware at the [Hardware](../hardware) page."
    ]
   },
   {
@@ -253,9 +254,9 @@
    },
    "outputs": [],
    "source": [
-    "# Convert the gates in the GHZ circuit to the \"SqrtIswap\" gateset, which the device uses.\n",
+    "# Convert the gates in the GHZ circuit to the \"CZ\" gateset, which the device uses.\n",
     "translated_ghz_circuit = cirq.optimize_for_target_gateset(\n",
-    "    ghz_circuit, context=cirq.TransformerContext(deep=True), gateset=cirq.SqrtIswapTargetGateset()\n",
+    "    ghz_circuit, context=cirq.TransformerContext(deep=True), gateset=cirq.CZTargetGateset()\n",
     ")\n",
     "print(translated_ghz_circuit)"
    ]
@@ -268,7 +269,7 @@
    "source": [
     "### Choose qubits on the virtual device\n",
     "\n",
-    "Choose qubits on the device to execute your device ready circuit on. Look at the device map (as above) and choose a set of qubits that fit your circuit (eg a line or a block). The Rainbow and Weber devices have different topologies, some qubit maps may be possible on only one of these devices. As noted, the GHZ example circuit as constructed will fit on a 17 qubit chain of adjacent qubits on the device, so you only need to find this consecutive line of qubits. See [Qubit Picking](../hardware/qubit_picking.ipynb) for more advice and methods for selecting qubits. "
+    "Choose qubits on the device to execute your device ready circuit on. Look at the device map (as above) and choose a set of qubits that fit your circuit (eg a line or a block). The Willow-pink, Rainbow and Weber devices have different topologies, some qubit maps may be possible on only one of these devices. As noted, the GHZ example circuit as constructed will fit on a 17 qubit chain of adjacent qubits on the device, so you only need to find this consecutive line of qubits. See [Qubit Picking](../hardware/qubit_picking.ipynb) for more advice and methods for selecting qubits. "
    ]
   },
   {
@@ -281,39 +282,39 @@
    "source": [
     "# Choose qubits on the virtual device\n",
     "device_qubit_chain = [\n",
-    "    cirq.GridQubit(5, 2),\n",
-    "    cirq.GridQubit(5, 3),\n",
-    "    cirq.GridQubit(4, 3),\n",
-    "    cirq.GridQubit(4, 2),\n",
-    "    cirq.GridQubit(4, 1),\n",
-    "    cirq.GridQubit(5, 1),\n",
-    "    cirq.GridQubit(6, 1),\n",
-    "    cirq.GridQubit(6, 2),\n",
-    "    cirq.GridQubit(6, 3),\n",
-    "    cirq.GridQubit(6, 4),\n",
+    "    cirq.GridQubit(5, 6),\n",
+    "    cirq.GridQubit(5, 7),\n",
+    "    cirq.GridQubit(4, 7),\n",
+    "    cirq.GridQubit(4, 6),\n",
+    "    cirq.GridQubit(4, 5),\n",
+    "    cirq.GridQubit(5, 5),\n",
     "    cirq.GridQubit(6, 5),\n",
-    "    cirq.GridQubit(7, 5),\n",
-    "    cirq.GridQubit(8, 5),\n",
-    "    cirq.GridQubit(8, 4),\n",
-    "    cirq.GridQubit(8, 3),\n",
-    "    cirq.GridQubit(7, 3),\n",
-    "    cirq.GridQubit(7, 4),\n",
+    "    cirq.GridQubit(6, 6),\n",
+    "    cirq.GridQubit(6, 7),\n",
+    "    cirq.GridQubit(6, 8),\n",
+    "    cirq.GridQubit(6, 9),\n",
+    "    cirq.GridQubit(7, 9),\n",
+    "    cirq.GridQubit(8, 9),\n",
+    "    cirq.GridQubit(8, 8),\n",
+    "    cirq.GridQubit(8, 7),\n",
+    "    cirq.GridQubit(7, 7),\n",
+    "    cirq.GridQubit(7, 8),\n",
     "]\n",
     "# Layout:\n",
     "#\n",
-    "# q(4, 1)───q(4, 2)───q(4, 3)\n",
+    "# q(4, 5)───q(4, 6)───q(4, 7)\n",
     "# │                   │\n",
     "# │                   │\n",
-    "# q(5, 1)   q(5, 2)───q(5, 3)\n",
+    "# q(5, 5)   q(5, 6)───q(5, 7)\n",
     "# │\n",
     "# │\n",
-    "# q(6, 1)───q(6, 2)───q(6, 3)───q(6, 4)───q(6, 5)\n",
+    "# q(6, 5)───q(6, 6)───q(6, 7)───q(6, 8)───q(6, 9)\n",
     "#                                         │\n",
     "#                                         │\n",
-    "#                     q(7, 3)───q(7, 4)   q(7, 5)\n",
+    "#                     q(7, 7)───q(7, 8)   q(7, 9)\n",
     "#                     │                   │\n",
     "#                     │                   │\n",
-    "#                     q(8, 3)───q(8, 4)───q(8, 5)"
+    "#                     q(8, 7)───q(8, 8)───q(8, 9)"
    ]
   },
   {

--- a/docs/simulate/qvm_builder_code.ipynb
+++ b/docs/simulate/qvm_builder_code.ipynb
@@ -81,6 +81,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3f2687e48726"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -96,7 +107,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq-google\n",
+    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",
@@ -132,8 +143,9 @@
    },
    "outputs": [],
    "source": [
-    "# @title Choose a processor (\"rainbow\" or \"weber\")\n",
-    "processor_id = \"rainbow\"  # @param {type:\"string\"}\n",
+    "# @title Choose a processor (\"willow_pink\" or \"rainbow\" or \"weber\")\n",
+    "# (see cirq_google.engine.list_virtual_processors() for available names)\n",
+    "processor_id = \"willow_pink\"  # @param {type:\"string\"}\n",
     "\n",
     "# Instantiate an engine.\n",
     "sim_engine = cirq_google.engine.create_default_noisy_quantum_virtual_machine(\n",
@@ -175,7 +187,7 @@
    "outputs": [],
    "source": [
     "# create your device ready circuit here!\n",
-    "q0 = cirq.GridQubit(4, 1)\n",
+    "q0 = cirq.GridQubit(6, 3)\n",
     "your_circuit = cirq.Circuit([(cirq.X**0.5)(q0), cirq.measure(q0)])\n",
     "print(your_circuit)"
    ]
@@ -209,6 +221,17 @@
     "print('Circuit successfully executed on your quantum virtual machine', processor_id)\n",
     "print(f'QVM runtime: {elapsed:.04g}s ({reps} reps)')\n",
     "print('You can now print or plot \"results\"')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "98bf142f5be6"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"measurements: {results.histogram(key=q0)}\")"
    ]
   }
  ],

--- a/docs/simulate/qvm_stabilizer_example.ipynb
+++ b/docs/simulate/qvm_stabilizer_example.ipynb
@@ -81,6 +81,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3f2687e48726"
+   },
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -96,7 +107,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq-google\n",
+    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",
@@ -124,8 +135,9 @@
    },
    "outputs": [],
    "source": [
-    "# @title Create Quantum Virtual Machine: Choose a processor (\"rainbow\" or \"weber\")\n",
-    "processor_id = \"rainbow\"  # @param {type:\"string\"}\n",
+    "# @title Create Quantum Virtual Machine: Choose a processor (\"willow_pink\", \"rainbow\" or \"weber\")\n",
+    "# (see cirq_google.engine.list_virtual_processors() for available names)\n",
+    "processor_id = \"willow_pink\"  # @param {type:\"string\"}\n",
     "\n",
     "# Instantiate the engine.\n",
     "sim_engine = cirq_google.engine.create_default_noisy_quantum_virtual_machine(\n",
@@ -214,8 +226,7 @@
    "source": [
     "simulator = cirq.Simulator()\n",
     "result = simulator.run(stabilizer_circuit, repetitions=100)\n",
-    "ax = cirq.plot_state_histogram(result)\n",
-    "plt.show(ax)"
+    "cirq.plot_state_histogram(result)"
    ]
   },
   {
@@ -254,8 +265,7 @@
    "outputs": [],
    "source": [
     "result = simulator.run(stabilizer_circuit_with_error, repetitions=100)\n",
-    "ax = cirq.plot_state_histogram(result)\n",
-    "plt.show(ax)"
+    "cirq.plot_state_histogram(result)"
    ]
   },
   {
@@ -313,11 +323,16 @@
     "    cirq.GridQubit(6, 3),\n",
     "]\n",
     "\n",
+    "if processor_id == \"willow_pink\":\n",
+    "    target_gateset = cirq.CZTargetGateset()\n",
+    "else:\n",
+    "    target_gateset = cirq.SqrtIswapTargetGateset()\n",
+    "\n",
     "# Translate the circuit to a suitable gate set.\n",
     "test_stabilizer_circuit = cirq.optimize_for_target_gateset(\n",
     "    stabilizer_circuit_for_hardware,\n",
     "    context=cirq.TransformerContext(deep=True),\n",
-    "    gateset=cirq.SqrtIswapTargetGateset(),\n",
+    "    gateset=target_gateset,\n",
     ")\n",
     "# Map circuit qubits to hardware ones.\n",
     "qubit_map = dict(zip([measure_qubit] + data_qubits, device_stabilizer_plaquette))\n",
@@ -378,8 +393,7 @@
     "\n",
     "print(\"Results (<meas>_<data>)\")\n",
     "ax = cirq.plot_state_histogram(hist)\n",
-    "plt.setp(ax.get_xticklabels(), rotation=30, horizontalalignment='right')\n",
-    "plt.show(ax)"
+    "plt.setp(ax.get_xticklabels(), rotation=30, horizontalalignment='right');"
    ]
   },
   {
@@ -406,7 +420,7 @@
     "}\n",
     "\n",
     "heatmap = cirq.Heatmap({**meas_map, **data_map})\n",
-    "heatmap.plot()"
+    "heatmap.plot();"
    ]
   },
   {
@@ -560,7 +574,7 @@
     "}\n",
     "\n",
     "heatmap = cirq.Heatmap({**meas_map, **data_map})\n",
-    "heatmap.plot()"
+    "heatmap.plot();"
    ]
   },
   {
@@ -587,7 +601,7 @@
     "test_stabilizer_grid_circuit = cirq.optimize_for_target_gateset(\n",
     "    cirq.Circuit(cirq.decompose(stabilizer_grid_circuit)),\n",
     "    context=cirq.TransformerContext(deep=True),\n",
-    "    gateset=cirq.SqrtIswapTargetGateset(),\n",
+    "    gateset=target_gateset,\n",
     ")\n",
     "print(test_stabilizer_grid_circuit)"
    ]
@@ -628,7 +642,7 @@
     "}\n",
     "\n",
     "heatmap = cirq.Heatmap({**meas_map, **data_map})\n",
-    "heatmap.plot()"
+    "heatmap.plot();"
    ]
   }
  ],

--- a/docs/simulate/virtual_engine_interface.ipynb
+++ b/docs/simulate/virtual_engine_interface.ipynb
@@ -216,15 +216,6 @@
     "try:\n",
     "    sampler.run(cirq.Circuit(cirq.measure(cirq.GridQubit(7, 1))), repetitions=10)\n",
     "except ValueError as e:\n",
-    "    print(e)\n",
-    "\n",
-    "# Weber does not support the H gate on qubit (7, 2).\n",
-    "try:\n",
-    "    sampler.run(\n",
-    "        cirq.Circuit(cirq.H(cirq.GridQubit(7, 2)), cirq.measure(cirq.GridQubit(7, 2))),\n",
-    "        repetitions=10,\n",
-    "    )\n",
-    "except ValueError as e:\n",
     "    print(e)"
    ]
   },
@@ -271,7 +262,7 @@
    "source": [
     "## Reservations and scheduling\n",
     "\n",
-    "Other functions are available to `Engine` classes that are part of using the `Engine` as a service. These include reservations, scheduling, downtime, and others. Thes functions are also available with the virtual processors, though all of them will generally succeed since there are no other users using the virtual service."
+    "Other functions are available to `Engine` classes that are part of using the `Engine` as a service. These include reservations, scheduling, downtime, and others. These functions are also available with the virtual processors, though all of them will generally succeed since there are no other users using the virtual service."
    ]
   },
   {
@@ -397,7 +388,7 @@
     "    iter(cirq_google.engine.virtual_engine_factory.MOST_RECENT_TEMPLATES.items())\n",
     ")\n",
     "# Read the protobuf template.\n",
-    "device_str = importlib.resources.read_text(specifications, template_name)\n",
+    "device_str = importlib.resources.files(specifications).joinpath(template_name).read_text()\n",
     "# Print just the first 10 lines of the very long protobuf specification.\n",
     "print(f'Processor: {processor_id}')\n",
     "print('\\n'.join(device_str.splitlines()[:10]))\n",

--- a/docs/tutorials/google/colab.ipynb
+++ b/docs/tutorials/google/colab.ipynb
@@ -121,7 +121,7 @@
     "You can also retrieve the entire Cirq repository by running the following command in a terminal that has `git` installed:\n",
     "\n",
     "```\n",
-    "git checkout https://github.com/quantumlib/Cirq.git\n",
+    "git clone https://github.com/quantumlib/Cirq.git\n",
     "```"
    ]
   },

--- a/docs/tutorials/google/echoes.ipynb
+++ b/docs/tutorials/google/echoes.ipynb
@@ -205,7 +205,7 @@
     "    pause: cirq.Duration | None = None,\n",
     "    seed: int | None = None,\n",
     ") -> cirq.Circuit:\n",
-    "    \"\"\"Returns a Loschmidt echo circuit using a random unitary U.\n",
+    "    r\"\"\"Returns a Loschmidt echo circuit using a random unitary U.\n",
     "\n",
     "    Args:\n",
     "        qubits: Qubits to use.\n",

--- a/examples/advanced/quantum_volume_errors.ipynb
+++ b/examples/advanced/quantum_volume_errors.ipynb
@@ -123,29 +123,11 @@
  "metadata": {
   "colab": {
    "name": "quantum_volume_errors.ipynb",
-   "provenance": []
+   "toc_visible": true
   },
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('cirq-py39')",
-   "language": "python",
+   "display_name": "Python 3",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.12"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "3db3b90ce1706c237bee38396dbe8ac1e0f0d31a71caf46d5ee7d6851b595260"
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The following quantum virtual machine notebooks were updated to use
the new `willow_pink` processor by default:

- quantum_virtual_machine.ipynb
- qvm_basic_example.ipynb
- qvm_builder_code.ipynb
- qvm_stabilizer_example.ipynb

Small fixups in other reviewed notebooks.

Related to b/395705720
