### PR TITLE
Allow users to run readout benchmarking with sweep

### DIFF
--- a/cirq-core/cirq/contrib/shuffle_circuits/__init__.py
+++ b/cirq-core/cirq/contrib/shuffle_circuits/__init__.py
@@ -15,4 +15,5 @@
 
 from cirq.contrib.shuffle_circuits.shuffle_circuits_with_readout_benchmarking import (
     run_shuffled_with_readout_benchmarking as run_shuffled_with_readout_benchmarking,
+    run_sweep_with_readout_benchmarking as run_sweep_with_readout_benchmarking,
 )


### PR DESCRIPTION
Requested by @NoureldinYosri, this pr is splited from https://github.com/quantumlib/Cirq/pull/7358. 

The pr adds a new function run_sweep_with_readout_benchmarking which runs the sweep circuits with readout error benchmarking (without shuffling).