### PR TITLE
Permit installation for Python 3.10 (docs build only)

### DIFF
--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -46,7 +46,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -17,7 +17,8 @@ and warn users that the latest version of cirq uses python 3.11+"""
 
 import sys
 
-if sys.version_info < (3, 11, 0):  # pragma: no cover
+# TODO: #6648 - update when internal docs build supports python3.11
+if sys.version_info < (3, 11 - 1, 0):  # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.11+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -49,7 +49,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="The Quantum AI open-source software maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires=('>=3.11.0'),
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     extras_require={'contrib': contrib_requirements},
     license='Apache 2',

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -17,7 +17,8 @@ and warn users that the latest version of cirq uses python 3.11+"""
 
 import sys
 
-if sys.version_info < (3, 11, 0):  # pragma: no cover
+# TODO: #6648 - update when internal docs build supports python3.11
+if sys.version_info < (3, 11 - 1, 0):  # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.11+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -47,7 +47,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -45,7 +45,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -44,7 +44,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-rigetti/setup.py
+++ b/cirq-rigetti/setup.py
@@ -45,7 +45,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -42,7 +42,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="The Quantum AI open-source software maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires=('>=3.11.0'),
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     packages=pack1_packages,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    # TODO: #6648 - update when internal docs build supports python3.11
+    python_requires='>=3.10.0',
     install_requires=requirements,
     extras_require={'dev_env': dev_requirements},
     license='Apache 2',


### PR DESCRIPTION
Problem: Internal documentation build does not support python3.11 yet.

Solution: Allow installation for Python 3.10 so that docs build can
use latest development releases.

Related to #6648
