### PR TITLE
Combine mypy version updates

### DIFF
--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -3,4 +3,4 @@ mypy==1.16.1
 
 # packages with stub types for various libraries
 types-protobuf>=4.24
-types-requests~=2.32.4.20250611
+types-requests~=2.32


### PR DESCRIPTION
- Bump mypy from 1.16.0 to 1.16.1 in /dev_tools/requirements/deps
- Let us unify version specs for types-requests and requests
