### PR TITLE
Fix test flake in pauli_string_measurement_with_readout_mitigation_test

### DIFF
--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation.py
@@ -304,10 +304,11 @@ def _process_pauli_measurement_results(
 
     Args:
         qubits: Qubits to build confusion matrices for. In a sorted order.
-        pauli_strings: The lists of QWC Pauli string groups that are measured.
+        pauli_string_groups: The lists of QWC Pauli string groups that are measured.
         circuit_results: A list of ResultDict obtained
             from running the Pauli measurement circuits.
-        confusion_matrices: A list of confusion matrices from calibration results.
+        calibration_results: A dictionary of SingleQubitReadoutCalibrationResult
+            for tuples of qubits present in `pauli_string_groups`.
         pauli_repetitions: The number of repetitions used for Pauli string measurements.
         timestamp: The timestamp of the calibration results.
         disable_readout_mitigation: If set to True, returns no error-mitigated error
@@ -326,7 +327,7 @@ def _process_pauli_measurement_results(
 
         calibration_result = (
             calibration_results[tuple(pauli_readout_qubits)]
-            if disable_readout_mitigation is False
+            if not disable_readout_mitigation
             else None
         )
 
@@ -458,7 +459,7 @@ def measure_pauli_strings(
     qubits_list = sorted(unique_qubit_tuples)
 
     # Build the basis-change circuits for each Pauli string group
-    pauli_measurement_circuits = list[circuits.Circuit]()
+    pauli_measurement_circuits: list[circuits.Circuit] = []
     for input_circuit, pauli_string_groups in normalized_circuits_to_pauli.items():
         qid_list = sorted(input_circuit.all_qubits())
         basis_change_circuits = []

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation.py
@@ -286,7 +286,7 @@ def _build_many_one_qubits_empty_confusion_matrix(qubits_length: int) -> list[np
 
 
 def _process_pauli_measurement_results(
-    qubits: list[ops.Qid],
+    qubits: Sequence[ops.Qid],
     pauli_string_groups: list[list[ops.PauliString]],
     circuit_results: list[ResultDict],
     calibration_results: dict[tuple[ops.Qid, ...], SingleQubitReadoutCalibrationResult],
@@ -460,7 +460,7 @@ def measure_pauli_strings(
     # Build the basis-change circuits for each Pauli string group
     pauli_measurement_circuits = list[circuits.Circuit]()
     for input_circuit, pauli_string_groups in normalized_circuits_to_pauli.items():
-        qid_list = list(sorted(input_circuit.all_qubits()))
+        qid_list = sorted(input_circuit.all_qubits())
         basis_change_circuits = []
         input_circuit_unfrozen = input_circuit.unfreeze()
         for pauli_strings in pauli_string_groups:

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -874,7 +874,7 @@ def test_group_paulis_type_mismatch() -> None:
 
 def test_process_pauli_measurement_results_raises_error_on_missing_calibration() -> None:
     """Test that the function raises an error if the calibration result is missing."""
-    qubits: list[cirq.Qid] = [q for q in cirq.LineQubit.range(5)]
+    qubits: Sequence[cirq.Qid] = cirq.LineQubit.range(5)
 
     measurement_op = cirq.measure(*qubits, key='m')
     test_circuits = list[cirq.Circuit]()

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -890,7 +890,10 @@ def test_process_pauli_measurement_results_raises_error_on_missing_calibration()
 
     circuit_results = sampler.run_batch(test_circuits, repetitions=1000)
 
-    empty_calibration_result_dict = {tuple(qubits): None}
+    pauli_strings_qubits = sorted(
+        set(itertools.chain.from_iterable(ps.qubits for ps in pauli_strings))
+    )
+    empty_calibration_result_dict = {tuple(pauli_strings_qubits): None}
 
     with pytest.raises(
         ValueError,

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -877,13 +877,7 @@ def test_process_pauli_measurement_results_raises_error_on_missing_calibration()
     qubits: Sequence[cirq.Qid] = cirq.LineQubit.range(5)
 
     measurement_op = cirq.measure(*qubits, key='m')
-    test_circuits = list[cirq.Circuit]()
-    for _ in range(3):
-        circuit_list = []
-
-        circuit = _create_ghz(5, qubits) + measurement_op
-        circuit_list.append(circuit)
-    test_circuits.extend(circuit_list)
+    test_circuits: list[cirq.Circuit] = [_create_ghz(5, qubits) + measurement_op for _ in range(3)]
 
     pauli_strings = [_generate_random_pauli_string(qubits, True) for _ in range(3)]
     sampler = cirq.Simulator()


### PR DESCRIPTION
Avoid possible KeyError in `test_process_pauli_measurement_results_raises_error_on_missing_calibration`

Problem: Random Pauli strings generated in the test may not contain all qubits
as is assumed in the `empty_calibration_result_dict` key.

Solution: Make dictionary with the qubits present in Pauli strings.

Fixes spurious test failure

```
pytest --randomly-seed=532866775 \
  cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py \
  -k test_process_pauli_measurement_results_raises_error_on_missing_calibration
```

Also fix

- unnecessarily repeated list construction
- unintentional dropping of circuits in a loop
- Nit - sync docstring with function arguments
