### PR TITLE
Adding tags to Moments

### DIFF
--- a/cirq-core/cirq/circuits/moment_test.py
+++ b/cirq-core/cirq/circuits/moment_test.py
@@ -929,3 +929,96 @@ def test_superoperator():
     assert m._has_superoperator_()
     s = m._superoperator_()
     assert np.allclose(s, np.array([[1, 0, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 1]]) / 2)
+
+
+def test_moment_with_tags() -> None:
+    q0 = cirq.LineQubit(0)
+    q1 = cirq.LineQubit(1)
+    op1 = cirq.X(q0)
+    op2 = cirq.Y(q1)
+
+    # Test initialization with no tags
+    moment_no_tags = cirq.Moment(op1)
+    assert moment_no_tags.tags == ()
+
+    # Test initialization with tags
+    moment_with_tags = cirq.Moment(op1, op2, tags=("initial_tag_1", "initial_tag_2"))
+    assert moment_with_tags.tags == ("initial_tag_1", "initial_tag_2")
+
+    # Test with_tags method to add new tags
+    new_moment = moment_with_tags.with_tags("new_tag_1", "new_tag_2")
+
+    # Ensure the original moment's tags are unchanged
+    assert moment_with_tags.tags == ("initial_tag_1", "initial_tag_2")
+
+    # Ensure the new moment has both old and new tags
+    assert new_moment.tags == ("initial_tag_1", "initial_tag_2", "new_tag_1", "new_tag_2")
+
+    # Test with_tags on a moment that initially had no tags
+    new_moment_from_no_tags = moment_no_tags.with_tags("single_new_tag")
+    assert new_moment_from_no_tags.tags == ("single_new_tag",)
+
+    # Test adding no new tags
+    same_moment_tags = moment_with_tags.with_tags()
+    assert same_moment_tags.tags == ("initial_tag_1", "initial_tag_2")
+
+    class CustomTag:
+        """Example Hashable Tag"""
+
+        def __init__(self, value):
+            self.value = value
+
+        def __hash__(self):
+            return hash(self.value)  # pragma: nocover
+
+        def __eq__(self, other):
+            return isinstance(other, CustomTag) and self.value == other.value  # pragma: nocover
+
+        def __repr__(self):
+            return f"CustomTag({self.value})"  # pragma: nocover
+
+    tag_obj = CustomTag("complex_tag")
+    moment_with_custom_tag = cirq.Moment(op1, tags=("string_tag", 123, tag_obj))
+    assert moment_with_custom_tag.tags == ("string_tag", 123, tag_obj)
+
+    new_moment_with_custom_tag = moment_with_custom_tag.with_tags(456)
+    assert new_moment_with_custom_tag.tags == ("string_tag", 123, tag_obj, 456)
+
+
+def test_adding_moments_with_tags() -> None:
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    op1 = cirq.X(q0)
+    op2 = cirq.Y(q1)
+    op3 = cirq.Z(q2)
+
+    moment_a = cirq.Moment(op1, tags=("tag_a1", "tag_a2"))
+    moment_b = cirq.Moment(op2, op3, tags=("tag_b1", "tag_b2"))
+
+    combined_moment = moment_a + moment_b
+    assert combined_moment.operations == (op1, op2, op3)
+    assert combined_moment.tags == ("tag_a1", "tag_a2", "tag_b1", "tag_b2")
+
+    # Test adding a moment to a moment with no tags
+    moment_c = cirq.Moment(op1)
+    moment_d = cirq.Moment(op2, tags=("tag_d1",))
+    combined_no_tags = moment_c + moment_d
+    assert combined_no_tags.tags == ("tag_d1",)
+
+    # Test adding a moment with no tags to a moment
+    moment_e = cirq.Moment(op1, tags=("tag_e1",))
+    moment_f = cirq.Moment(op2)
+    combined_no_tags_reversed = moment_e + moment_f
+    assert combined_no_tags_reversed.tags == ("tag_e1",)
+
+
+def test_subtracting_moments_with_tags() -> None:
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    op1 = cirq.X(q0)
+    op2 = cirq.Y(q1)
+    op3 = cirq.Z(q2)
+    moment_a = cirq.Moment(op1, op2, tags=("tag_a1", "tag_a2"))
+    moment_b = cirq.Moment(op2, tags=("tag_a1", "tag_b2"))
+
+    subtracted_moment = moment_a - moment_b
+    assert subtracted_moment.operations == (op1,)
+    assert subtracted_moment.tags == ("tag_a2",)

--- a/cirq-core/cirq/protocols/json_test_data/Moment.json
+++ b/cirq-core/cirq/protocols/json_test_data/Moment.json
@@ -39,5 +39,26 @@
         }
       }
     ]
+  },
+  {
+	  "cirq_type": "Moment",
+	  "operations": [
+	      	  {
+		    	  "cirq_type": "SingleQubitPauliStringGateOperation",
+		    	  "pauli": {
+			  	  "cirq_type": "_PauliX",
+			  	  "exponent": 1.0,
+			  	  "global_shift": 0.0
+		    	  },
+		    	  "qubit": {
+			  	  "cirq_type": "LineQubit",
+			  	  "x": 0
+		    	  }
+	      	  }
+	  ],
+	  "tags": {
+	      	  "cirq_type": "Duration",
+	      	  "picos": 25000
+	  }
   }
 ]

--- a/cirq-core/cirq/protocols/json_test_data/Moment.repr
+++ b/cirq-core/cirq/protocols/json_test_data/Moment.repr
@@ -2,4 +2,9 @@
     cirq.X(cirq.LineQubit(0)),
     cirq.Y(cirq.LineQubit(1)),
     cirq.Z(cirq.LineQubit(2)),
-)]
+),
+cirq.Moment(
+    cirq.X(cirq.LineQubit(0)),
+    tags=cirq.Duration(nanos=25)
+)
+]


### PR DESCRIPTION
- This PR adds the ability to add tags to Moment objects.
- tags in Moments function similar to tags in operations, in that they can be any hashable object and are lost if the circuit undergoes transformation, such as by a transformer.