### PR TITLE
Fix a couple of typos in transformers

### DIFF
--- a/cirq-core/cirq/transformers/align.py
+++ b/cirq-core/cirq/transformers/align.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 def align_left(
     circuit: cirq.AbstractCircuit, *, context: cirq.TransformerContext | None = None
 ) -> cirq.Circuit:
-    """Align gates to the left of the circuit.
+    """Aligns gates to the left of the circuit.
 
     Note that tagged operations with tag in `context.tags_to_ignore` will continue to stay in their
     original position and will not be aligned.
@@ -62,7 +62,7 @@ def align_left(
 def align_right(
     circuit: cirq.AbstractCircuit, *, context: cirq.TransformerContext | None = None
 ) -> cirq.Circuit:
-    """Align gates to the right of the circuit.
+    """Aligns gates to the right of the circuit.
 
     Note that tagged operations with tag in `context.tags_to_ignore` will continue to stay in their
     original position and will not be aligned.

--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -61,7 +61,7 @@ def _pauli_up_to_global_phase(gate: ops.Gate) -> ops.Pauli | None:
 def _validate_dd_sequence(dd_sequence: tuple[ops.Gate, ...]) -> None:
     """Validates a given dynamical decoupling sequence.
 
-    The sequence should only consists of Pauli gates and is essentially an identity gate.
+    The sequence should only consist of Pauli gates and is essentially an identity gate.
 
     Args:
         dd_sequence: Input dynamical sequence to be validated.
@@ -82,7 +82,7 @@ def _validate_dd_sequence(dd_sequence: tuple[ops.Gate, ...]) -> None:
 
     if not protocols.equal_up_to_global_phase(product, np.eye(2)):
         raise ValueError(
-            'Invalid dynamical decoupling sequence. Expect sequence production equals'
+            'Invalid dynamical decoupling sequence. Expect sequence product equals'
             f' identity up to a global phase, got {product}.'.replace('\n', ' ')
         )
 
@@ -208,13 +208,13 @@ def add_dynamical_decoupling(
     single_qubit_gate_moments_only: bool = True,
 ) -> cirq.Circuit:
     """Adds dynamical decoupling gate operations to a given circuit.
-    This transformer might add new moments thus change structure of the original circuit.
+    This transformer might add new moments and thus change the structure of the original circuit.
 
     Args:
           circuit: Input circuit to transform.
           context: `cirq.TransformerContext` storing common configurable options for transformers.
           schema: Dynamical decoupling schema name or a dynamical decoupling sequence.
-            If a schema is specified, provided dynamical decouping sequence will be used.
+            If a schema is specified, the provided dynamical decoupling sequence will be used.
             Otherwise, customized dynamical decoupling sequence will be applied.
           single_qubit_gate_moments_only: If set True, dynamical decoupling operation will only be
             added in single-qubit gate moments.

--- a/cirq-core/cirq/transformers/dynamical_decoupling_test.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling_test.py
@@ -236,7 +236,7 @@ def test_pull_through_h_gate_case2(single_qubit_gate_moments_only: bool):
         ([X], 'Invalid dynamical decoupling sequence. Expect more than one gates.'),
         (
             [X, Y],
-            'Invalid dynamical decoupling sequence. Expect sequence production equals identity'
+            'Invalid dynamical decoupling sequence. Expect sequence product equals identity'
             ' up to a global phase, got',
         ),
         (

--- a/cirq-core/cirq/transformers/expand_composite_test.py
+++ b/cirq-core/cirq/transformers/expand_composite_test.py
@@ -191,7 +191,7 @@ def test_do_not_decompose_no_compile():
     assert_equal_mod_empty(c, cirq.expand_composite(c, context=context))
 
 
-def test_expands_composite_recursively_preserving_structur():
+def test_expands_composite_recursively_preserving_structure():
     q = cirq.LineQubit.range(2)
     c_nested = cirq.FrozenCircuit(
         cirq.SWAP(*q[:2]), cirq.SWAP(*q[:2]).with_tags("ignore"), cirq.SWAP(*q[:2])

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -172,7 +172,7 @@ def _all_possible_datastore_states(
     keys: Iterable[tuple[cirq.MeasurementKey, int]],
     measurement_qubits: dict[cirq.MeasurementKey, list[tuple[cirq.Qid, ...]]],
 ) -> Iterable[cirq.ClassicalDataStoreReader]:
-    """The cartesian product of all possible DataStore states for the given keys."""
+    """The Cartesian product of all possible DataStore states for the given keys."""
     # First we get the list of all possible values. So if we have a key mapped to qubits of shape
     # (2, 2) and a key mapped to a qutrit, the possible measurement values are:
     # [((0, 0), (0,)),

--- a/cirq-core/cirq/transformers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates.py
@@ -185,7 +185,7 @@ def _sweep_on_symbols(sweep: Sweep, symbols: set[sympy.Symbol]) -> Sweep:
 def _calc_phxz_sweeps(
     symbolized_circuit: cirq.Circuit, resolved_circuits: list[cirq.Circuit]
 ) -> Sweep:
-    """Return the phxz sweep of the symbolized_circuit on resolved_circuits.
+    """Returns the phxz sweep of the symbolized_circuit on resolved_circuits.
 
     Raises:
         ValueError: Structural mismatch: A `resolved_circuit` contains an unexpected gate type.
@@ -246,7 +246,7 @@ def merge_single_qubit_gates_to_phxz_symbolized(
     Args:
         circuit: Input circuit to transform. It will not be modified.
         context: `cirq.TransformerContext` storing common configurable options for transformers.
-        sweep: Sweep of the symbols in the input circuit, updated Sweep will be returned
+        sweep: Sweep of the symbols in the input circuit. An updated Sweep will be returned
             based on the transformation.
         atol: Absolute tolerance to angle error. Larger values allow more negligible gates to be
             dropped, smaller values increase accuracy.
@@ -280,7 +280,7 @@ def merge_single_qubit_gates_to_phxz_symbolized(
     remaining_symbols: set[sympy.Symbol] = set(
         protocols.parameter_symbols(circuit) - single_qubit_gate_symbols
     )
-    # If all single qubit gates are not parameterized, call the nonparamerized version of
+    # If all single qubit gates are not parameterized, call the non-parameterized version of
     # the transformer.
     if not single_qubit_gate_symbols:
         return (merge_single_qubit_gates_to_phxz(circuit, context=context, atol=atol), sweep)

--- a/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates_test.py
@@ -287,7 +287,7 @@ class TestMergeSingleQubitGatesSymbolized(TestCase):
         )
         assert_optimizes(output_circuit, expected)
 
-        # Check the unitaries are preserved for each set of sweep paramerization.
+        # Check the unitaries are preserved for each set of sweep parameterization.
         for old_resolver, new_resolver in zip(sweep, new_sweep):
             cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
                 cirq.resolve_parameters(input_circuit, old_resolver),
@@ -310,7 +310,7 @@ class TestMergeSingleQubitGatesSymbolized(TestCase):
         new_circuit, new_sweep = cirq.merge_single_qubit_gates_to_phxz_symbolized(
             old_circuit, sweep=old_sweep
         )
-        # Check the unitaries are preserved for each set of sweep paramerization.
+        # Check the unitaries are preserved for each set of sweep parameterization.
         for old_resolver, new_resolver in zip(old_sweep, new_sweep):
             cirq.testing.assert_circuits_have_same_unitary_given_final_permutation(
                 cirq.resolve_parameters(old_circuit[0:-1], old_resolver),

--- a/cirq-core/cirq/transformers/noise_adding.py
+++ b/cirq-core/cirq/transformers/noise_adding.py
@@ -36,7 +36,7 @@ class DepolarizingNoiseTransformer:
 
     Attrs:
         p: The probability with which to add noise.
-        target_gate: Add depolarizing nose after this type of gate
+        target_gate: Add depolarizing noise after this type of gate
     """
 
     def __init__(
@@ -88,7 +88,7 @@ class DepolarizingNoiseTransformer:
             rng = np.random.default_rng()
         target_gate = self.target_gate
 
-        # add random Pauli gates with probability p after each of the specified gate
+        # add random Pauli gates with probability p after each specified gate
         assert target_gate.num_qubits() == 2, "`target_gate` must be a two-qubit gate."
         paulis = [ops.I, ops.X, ops.Y, ops.Z]
         new_moments = []

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -46,9 +46,9 @@ def _decompose_operations_to_target_gateset(
     """Decomposes every operation to `gateset` using `cirq.decompose` and `decomposer`.
 
     This transformer attempts to decompose every operation `op` in the given circuit to `gateset`
-    using `cirq.decompose` protocol with `decomposer` used as an intercepting decomposer. This
-    ensures that `op` is recursively decomposed using implicitly defined known decompositions
-    (eg: in `_decompose_` magic method on the gaet class) till either `decomposer` knows how to
+    using the `cirq.decompose` protocol with `decomposer` used as an intercepting decomposer. This
+    ensures that `op` is recursively decomposed using implicitly defined known decompositions (e.g.
+    in the `_decompose_` magic method on the gate class) until either `decomposer` knows how to
     decompose the given operation or the given operation belongs to `gateset`.
 
     Args:

--- a/cirq-core/cirq/transformers/qubit_management_transformers.py
+++ b/cirq-core/cirq/transformers/qubit_management_transformers.py
@@ -58,7 +58,7 @@ def map_clean_and_borrowable_qubits(
     This transformer uses the `QubitManager` provided in the input to:
      - Allocate clean ancilla qubits by delegating to `qm.qalloc` for all `CleanQubit`s.
      - Allocate dirty qubits for all `BorrowableQubit` types via the following two steps:
-         1. First analyse the input circuit and check if there are any suitable system qubits
+         1. First analyze the input circuit and check if there are any suitable system qubits
             that can be borrowed, i.e. ones which do not have any overlapping operations
             between circuit[start_index : end_index] where `(start_index, end_index)` is the
             lifespan of temporary borrowable qubit under consideration. If yes, borrow the system
@@ -84,7 +84,7 @@ def map_clean_and_borrowable_qubits(
         circuit: Input `cirq.Circuit` containing temporarily allocated
             `CleanQubit`/`BorrowableQubit`s.
         qm: An instance of `cirq.QubitManager` specifying the strategy to use for allocating /
-            / deallocating new ancilla qubits to replace the temporary qubits.
+            deallocating new ancilla qubits to replace the temporary qubits.
 
     Returns:
         An updated `cirq.Circuit` with all `CleanQubit`/`BorrowableQubit` mapped to either existing

--- a/cirq-core/cirq/transformers/randomized_measurements.py
+++ b/cirq-core/cirq/transformers/randomized_measurements.py
@@ -34,8 +34,8 @@ class RandomizedMeasurements:
         For more details on the randomized measurement toolbox see https://arxiv.org/abs/2203.11374
 
         Args:
-            subsystem: The specific subsystem (e.g qubit index) to measure in random basis
-            rest of the qubits are measured in the computational basis
+            subsystem: The specific subsystem (e.g., qubit index) to measure in a random basis.
+                The rest of the qubits are measured in the computational basis.
         """
         self.subsystem = subsystem
 
@@ -48,9 +48,9 @@ class RandomizedMeasurements:
         context: transformer_api.TransformerContext | None = None,
     ) -> cirq.Circuit:
         """Apply the transformer to the given circuit. Given an input circuit returns
-        a new circuit with the pre-measurement unitaries and measurements gates added.
-        to the qubits in the subsystem provided.If no subsystem is specified in the
-        construction of this class it defaults to measuring all the qubits in the
+        a new circuit with the pre-measurement unitaries and measurement gates added
+        to the qubits in the subsystem provided. If no subsystem is specified in the
+        construction of this class, it defaults to measuring all the qubits in the
         randomized bases.
 
         Args:
@@ -138,7 +138,7 @@ def _pauli_basis_rotation(rng: np.random.Generator) -> cirq.Gate:
 
 
 def _single_qubit_clifford(rng: np.random.Generator) -> cirq.Gate:
-    """Randomly generate a single-qubit Clifford rotation.
+    """Randomly generates a single-qubit Clifford rotation.
 
     Args:
         rng: Random number generator
@@ -156,7 +156,7 @@ def _single_qubit_clifford(rng: np.random.Generator) -> cirq.Gate:
 
 
 def _single_qubit_cue(rng: np.random.Generator) -> cirq.Gate:
-    """Randomly generate a CUE gate.
+    """Randomly generates a CUE gate.
 
     Args:
         rng: Random number generator

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -164,7 +164,7 @@ def _stratify_circuit(
                 new_moments += [[] for _ in range(num_classes)]
             new_moments[time_index].append(op)
 
-            # Update qubit, measurment key, and control key moments.
+            # Update qubit, measurement key, and control key moments.
             for qubit in op.qubits:
                 qubit_time_index[qubit] = time_index
             for key in protocols.measurement_key_objs(op):

--- a/cirq-core/cirq/transformers/symbolize.py
+++ b/cirq-core/cirq/transformers/symbolize.py
@@ -75,7 +75,7 @@ def symbolize_single_qubit_gates_by_indexed_tags(
     """
 
     def _map_func(op: cirq.Operation, _):
-        """Maps an op with tag `{tag_prefix}_i` to a symbolzied `PhasedXZGate(xi,zi,ai)`."""
+        """Maps an op with tag `{tag_prefix}_i` to a symbolized `PhasedXZGate(xi,zi,ai)`."""
         tags: set[Hashable] = set(op.tags)
         tag_id: None | int = None
         for tag in tags:

--- a/cirq-core/cirq/transformers/tag_transformers.py
+++ b/cirq-core/cirq/transformers/tag_transformers.py
@@ -85,12 +85,12 @@ def remove_tags(
     target_tags = target_tags or set()
 
     def _map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
-        remaing_tags = set()
+        remaining_tags = set()
         for tag in op.tags:
             if not remove_if(tag) and tag not in target_tags:
-                remaing_tags.add(tag)
+                remaining_tags.add(tag)
 
-        return op.untagged.with_tags(*remaing_tags)
+        return op.untagged.with_tags(*remaining_tags)
 
     return transformer_primitives.map_operations(
         circuit, _map_func, deep=context.deep if context else False

--- a/cirq-core/cirq/transformers/transformer_api.py
+++ b/cirq-core/cirq/transformers/transformer_api.py
@@ -88,8 +88,8 @@ class TransformerLogger:
 
     The logger assumes that
         - Transformers are run sequentially.
-        - Nested transformers are allowed, in which case the behavior would be similar to a
-          doing a depth first search on the graph of transformers -- i.e. the top level transformer
+        - Nested transformers are allowed, in which case the behavior would be similar to
+          doing a depth-first search on the graph of transformers -- i.e. the top level transformer
           would end (i.e. receive a `register_final` call) once all nested transformers (i.e. all
           `register_initial` calls received while the top level transformer was active) have
           finished (i.e. corresponding `register_final` calls have also been received).

--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -125,7 +125,7 @@ def _map_operations_impl(
             resulting optree spans more than 1 moment, it's either wrapped in a tagged circuit
             operation and inserted in-place in the same moment (if  `wrap_in_circuit_op` is True)
             OR the mapped operations are inserted directly in the circuit, preserving moment
-            strucutre. The effect is equivalent to (but much faster) a two-step approach of first
+            structure. The effect is equivalent to (but much faster) a two-step approach of first
             wrapping the operations in a circuit operation and then calling `cirq.unroll_circuit_op`
             to unroll the corresponding circuit ops.
         deep: If true, `map_func` will be recursively applied to circuits wrapped inside
@@ -364,13 +364,13 @@ def merge_operations(
     """Merges operations in a circuit by calling `merge_func` iteratively on operations.
 
     Two operations op1 and op2 are merge-able if
-        - There is no other operations between op1 and op2 in the circuit
+        - There is no other operation between op1 and op2 in the circuit
         - is_subset(op1.qubits, op2.qubits) or is_subset(op2.qubits, op1.qubits)
 
     The `merge_func` is a callable which, given two merge-able operations
     op1 and op2, decides whether they should be merged into a single operation
     or not. If not, it should return None, else it should return the single merged
-    operations `op`.
+    operation `op`.
 
     The method iterates on the input circuit moment-by-moment from left to right and attempts
     to repeatedly merge each operation in the latest moment with all the corresponding merge-able
@@ -383,7 +383,7 @@ def merge_operations(
 
     The number of calls to `merge_func` is O(N), where N = Total no. of operations, because:
         - Every time the `merge_func` returns a new operation, the number of operations in the
-            circuit reduce by 1 and hence this can happen at most O(N) times
+            circuit reduces by 1 and hence this can happen at most O(N) times
         - Every time the `merge_func` returns None, the current operation is inserted into the
             frontier and we go on to process the next operation, which can also happen at-most
             O(N) times.
@@ -501,7 +501,7 @@ def merge_operations_to_circuit_op(
     Args:
         circuit: Input circuit to apply the transformations on. The input circuit is not mutated.
         can_merge: Callable to determine whether a new operation `right_op` can be merged into an
-            existing connected component of operations `left_ops` based on boolen returned by
+            existing connected component of operations `left_ops` based on boolean returned by
             `can_merge(left_ops, right_op)`.
         tags_to_ignore: Tagged operations marked any of `tags_to_ignore` will not be considered as
             potential candidates for any connected component.
@@ -771,7 +771,7 @@ def unroll_circuit_op_greedy_frontier(
 def toggle_tags(circuit: CIRCUIT_TYPE, tags: Sequence[Hashable], *, deep: bool = False):
     """Toggles tags applied on each operation in the circuit, via `op.tags ^= tags`
 
-    For every operations `op` in the input circuit, the tags on `op` are replaced by a symmetric
+    For every operation `op` in the input circuit, the tags on `op` are replaced by a symmetric
     difference of `op.tags` and `tags` -- this is useful in scenarios where you mark a small subset
     of operations with a specific tag and then toggle the set of marked operations s.t. every
     marked operation is now unmarked and vice versa.

--- a/docs/build/classical_control.ipynb
+++ b/docs/build/classical_control.ipynb
@@ -278,7 +278,7 @@
     "\n",
     "Cirq supports evaluating complex boolean functions on multiqubit measurement keys throught Sympy's [indexed objects](https://docs.sympy.org/latest/modules/tensor/indexed.html#sympy.tensor.indexed.Indexed.base).\n",
     "\n",
-    "In this example, `X` will be applied to $q_2$ if and only if the result of the two-qubit measurment of $q_0, q_1$ has two different bits. "
+    "In this example, `X` will be applied to $q_2$ if and only if the result of the two-qubit measurement of $q_0, q_1$ has two different bits. "
    ]
   },
   {


### PR DESCRIPTION
I came across a couple of typos in transformers, so I ask the code assistant to help identify more of them and update all here.