### PR TITLE
Promote FrozenCircuit.tags to AbstractCircuit

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -40,7 +40,6 @@ from typing import (
     MutableSequence,
     overload,
     Sequence,
-    Tuple,
     TYPE_CHECKING,
     TypeVar,
     Union,
@@ -205,7 +204,7 @@ class AbstractCircuit(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def tags(self) -> Tuple[Hashable, ...]:
+    def tags(self) -> tuple[Hashable, ...]:
         """Returns a tuple of the Circuit's tags."""
 
     def __bool__(self) -> bool:
@@ -2491,7 +2490,7 @@ class Circuit(AbstractCircuit):
         return self._moments
 
     @property
-    def tags(self) -> Tuple[Hashable, ...]:
+    def tags(self) -> tuple[Hashable, ...]:
         return self._tags
 
     def with_noise(self, noise: cirq.NOISE_MODEL_LIKE) -> cirq.Circuit:

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1579,9 +1579,7 @@ class AbstractCircuit(abc.ABC):
         for k in range(1, len(circuits)):
             offset, n_acc = _concat_ragged_helper(offset, n_acc, buffer, circuits[k].moments, align)
 
-        return cirq.Circuit(
-            buffer[offset : offset + n_acc], tags=circuits[0].tags if circuits else ()
-        )
+        return cirq.Circuit(buffer[offset : offset + n_acc], tags=circuits[0].tags)
 
     def get_independent_qubit_sets(self) -> list[set[cirq.Qid]]:
         """Divide circuit's qubits into independent qubit sets.
@@ -1956,7 +1954,7 @@ class Circuit(AbstractCircuit):
     def copy(self) -> Circuit:
         """Return a copy of this circuit."""
         copied_circuit = Circuit()
-        copied_circuit._moments[:] = self._moments[:]
+        copied_circuit._moments[:] = self._moments
         copied_circuit._placement_cache = None
         copied_circuit._tags = self.tags
         return copied_circuit

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4924,11 +4924,11 @@ def test_append_speed() -> None:
 def test_tagged_circuits() -> None:
     q = cirq.LineQubit(0)
     ops = [cirq.X(q), cirq.H(q)]
-    tags = [sympy.Symbol("a"), "b"]
+    tags = (sympy.Symbol("a"), "b")
     circuit = cirq.Circuit(ops)
     tagged_circuit = cirq.Circuit(ops, tags=tags)
     # Test equality
-    assert tagged_circuit.tags == tuple(tags)
+    assert tagged_circuit.tags == tags
     assert circuit != tagged_circuit
     assert not cirq.approx_eq(circuit, tagged_circuit)
     # Test _repr_ and _json_ round trips.
@@ -4940,9 +4940,31 @@ def test_tagged_circuits() -> None:
     assert tagged_circuit.with_tags("c") == cirq.Circuit(ops, tags=[*tags, "c"])
     assert tagged_circuit.untagged == circuit
     assert circuit.untagged is circuit
+    assert tagged_circuit.freeze().tags == tags
+    assert tagged_circuit.unfreeze(copy=True).tags == tags
+    assert tagged_circuit.unfreeze(copy=False).tags == tags
     # Test parameterized protocols
     assert cirq.is_parameterized(circuit) is False
     assert cirq.is_parameterized(tagged_circuit) is True
     assert cirq.parameter_names(tagged_circuit) == {"a"}
+    assert cirq.resolve_parameters(tagged_circuit, {"a": 1}).tags == (1, "b")
     # Tags are not propagated to diagrams yet.
     assert str(circuit) == str(tagged_circuit)
+    # Test tags are preserved through operations
+    assert (tagged_circuit + circuit).tags == tags
+    assert (circuit + tagged_circuit).tags == ()  # We only preserve the tags for the first one
+    assert (2 * tagged_circuit).tags == tags
+    assert (tagged_circuit * 2).tags == tags
+    assert (tagged_circuit**-1).tags == tags
+    assert tagged_circuit.with_noise(cirq.X).tags == tags
+    for c in tagged_circuit.factorize():
+        assert tagged_circuit.tags == tags
+
+    q2 = cirq.LineQubit(1)
+    circuit2 = cirq.Circuit(cirq.X(q2), cirq.H(q2))
+    assert tagged_circuit.zip(circuit2).tags == tags
+    assert circuit2.zip(tagged_circuit).tags == ()  # We only preserve the tags for the first one
+    assert tagged_circuit.concat_ragged(circuit2).tags == tags
+    assert (
+        circuit2.concat_ragged(tagged_circuit).tags == ()
+    )  # We only preserve the tags for the first one

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4919,3 +4919,24 @@ def test_append_speed() -> None:
     duration = time.perf_counter() - t
     assert len(c) == moments
     assert duration < 5
+
+
+def test_tagged_circuits() -> None:
+    q = cirq.LineQubit(0)
+    ops = [cirq.X(q), cirq.H(q)]
+    tags = [sympy.Symbol("a"), "b"]
+    circuit = cirq.Circuit(ops)
+    tagged_circuit = cirq.Circuit(ops, tags=tags)
+    # Test equality
+    assert tagged_circuit.tags == tuple(tags)
+    assert circuit != tagged_circuit
+    assert cirq.approx_eq(circuit, tagged_circuit)
+    # Test _repr_ and _json_ round trips.
+    cirq.testing.assert_equivalent_repr(tagged_circuit)
+    cirq.testing.assert_json_roundtrip_works(tagged_circuit)
+    # Test parameterized protocols
+    assert cirq.is_parameterized(circuit) is False
+    assert cirq.is_parameterized(tagged_circuit) is True
+    assert cirq.parameter_names(tagged_circuit) == {"a"}
+    # Tags are not propagated to diagrams yet.
+    assert str(circuit) == str(tagged_circuit)

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -4930,10 +4930,16 @@ def test_tagged_circuits() -> None:
     # Test equality
     assert tagged_circuit.tags == tuple(tags)
     assert circuit != tagged_circuit
-    assert cirq.approx_eq(circuit, tagged_circuit)
+    assert not cirq.approx_eq(circuit, tagged_circuit)
     # Test _repr_ and _json_ round trips.
     cirq.testing.assert_equivalent_repr(tagged_circuit)
     cirq.testing.assert_json_roundtrip_works(tagged_circuit)
+    # Test utility methods and constructors
+    assert tagged_circuit.with_tags() is tagged_circuit
+    assert circuit.with_tags(*tags) == tagged_circuit
+    assert tagged_circuit.with_tags("c") == cirq.Circuit(ops, tags=[*tags, "c"])
+    assert tagged_circuit.untagged == circuit
+    assert circuit.untagged is circuit
     # Test parameterized protocols
     assert cirq.is_parameterized(circuit) is False
     assert cirq.is_parameterized(tagged_circuit) is True

--- a/cirq-core/cirq/circuits/frozen_circuit_test.py
+++ b/cirq-core/cirq/circuits/frozen_circuit_test.py
@@ -103,8 +103,8 @@ def test_tagged_circuits() -> None:
     # Test equality
     assert tagged_circuit.tags == tuple(tags)
     assert circuit == frozen_circuit != tagged_circuit
+    assert not cirq.approx_eq(frozen_circuit, tagged_circuit)
     assert cirq.approx_eq(circuit, frozen_circuit)
-    assert cirq.approx_eq(frozen_circuit, tagged_circuit)
     # Test hash
     assert hash(frozen_circuit) != hash(tagged_circuit)
     # Test _repr_ and _json_ round trips.

--- a/cirq-core/cirq/circuits/frozen_circuit_test.py
+++ b/cirq-core/cirq/circuits/frozen_circuit_test.py
@@ -96,12 +96,12 @@ def test_immutable() -> None:
 def test_tagged_circuits() -> None:
     q = cirq.LineQubit(0)
     ops = [cirq.X(q), cirq.H(q)]
-    tags = [sympy.Symbol("a"), "b"]
+    tags = (sympy.Symbol("a"), "b")
     circuit = cirq.Circuit(ops)
     frozen_circuit = cirq.FrozenCircuit(ops)
     tagged_circuit = cirq.FrozenCircuit(ops, tags=tags)
     # Test equality
-    assert tagged_circuit.tags == tuple(tags)
+    assert tagged_circuit.tags == tags
     assert circuit == frozen_circuit != tagged_circuit
     assert not cirq.approx_eq(frozen_circuit, tagged_circuit)
     assert cirq.approx_eq(circuit, frozen_circuit)
@@ -116,9 +116,29 @@ def test_tagged_circuits() -> None:
     assert tagged_circuit.with_tags("c") == cirq.FrozenCircuit(ops, tags=[*tags, "c"])
     assert tagged_circuit.untagged == frozen_circuit
     assert frozen_circuit.untagged is frozen_circuit
+    assert tagged_circuit.unfreeze(copy=True).tags == tags
+    assert tagged_circuit.unfreeze(copy=False).tags == tags
     # Test parameterized protocols
     assert cirq.is_parameterized(frozen_circuit) is False
     assert cirq.is_parameterized(tagged_circuit) is True
     assert cirq.parameter_names(tagged_circuit) == {"a"}
+    assert cirq.resolve_parameters(tagged_circuit, {"a": 1}).tags == (1, "b")
     # Tags are not propagated to diagrams yet.
     assert str(frozen_circuit) == str(tagged_circuit)
+    # Test tags are preserved through operations
+    assert (tagged_circuit + circuit).tags == tags
+    assert (circuit + tagged_circuit).tags == ()  # We only preserve the tags for the first one
+    assert (2 * tagged_circuit).tags == tags
+    assert (tagged_circuit * 2).tags == tags
+    assert (tagged_circuit**-1).tags == tags
+    for c in tagged_circuit.factorize():
+        assert tagged_circuit.tags == tags
+
+    q2 = cirq.LineQubit(1)
+    circuit2 = cirq.Circuit(cirq.X(q2), cirq.H(q2))
+    assert tagged_circuit.zip(circuit2).tags == tags
+    assert circuit2.zip(tagged_circuit).tags == ()  # We only preserve the tags for the first one
+    assert tagged_circuit.concat_ragged(circuit2).tags == tags
+    assert (
+        circuit2.concat_ragged(tagged_circuit).tags == ()
+    )  # We only preserve the tags for the first one


### PR DESCRIPTION
First step towards fixing https://github.com/quantumlib/Cirq/issues/7454. This PR just adds the `tags` attribute to `AbstractCircuit`, along with some of the logic (e.g. `__eq__`, `_json_dict_`, etc). After this we have to add support in the proto serialization itself.

Partially implements #7454