### PR TITLE
Use an efficient representation for merged components of operations

### DIFF
--- a/cirq-core/cirq/transformers/connected_component.py
+++ b/cirq-core/cirq/transformers/connected_component.py
@@ -1,0 +1,272 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Defines a connected component of operations, to be used in merge transformers."""
+
+from __future__ import annotations
+
+from typing import Callable, cast, Sequence, TYPE_CHECKING
+
+from cirq import ops, protocols
+
+if TYPE_CHECKING:
+    import cirq
+
+class Component:
+    """Internal representation for a connected component of operations.
+
+    It uses the disjoint-set data structure to implement merge efficiently.
+    Additional merge conditions can be added by deriving from the Component
+    class and overriding the merge function (see ComponentWithOps and
+    ComponentWithCircuitOp) below.
+    """
+
+    # Properties for the disjoint set data structure
+    parent: Component|None = None
+    rank: int = 0
+
+    # True if the component can be merged
+    is_mergeable: bool
+
+    # Circuit moment containing the component
+    moment: int
+    # Union of all op qubits in the component
+    qubits: frozenset[cirq.Qid]
+    # Union of all measurement keys in the component
+    mkeys: frozenset[cirq.MeasurementKey]
+    # Union of all control keys in the component
+    ckeys: frozenset[cirq.MeasurementKey]
+    # Initial operation in the component
+    op: cirq.Operation
+
+    def __init__(self, op: cirq.Operation, moment: int, is_mergeable = True):
+        """Initializes a singleton component."""
+        self.is_mergeable = is_mergeable
+        self.moment = moment
+        self.qubits = frozenset(op.qubits)
+        self.mkeys = protocols.measurement_key_objs(op)
+        self.ckeys = protocols.control_keys(op)
+        self.op = op
+
+    def find(self) -> Component:
+        """Finds the component representative."""
+
+        root = self
+        while root.parent != None:
+            root = root.parent
+        x = self
+        while x != root:
+            parent = x.parent
+            x.parent = root
+            x = cast(Component, parent)
+        return root
+
+    def merge(self, c: Component, merge_left = True) -> Component|None:
+        """Attempts to merge two components.
+
+        We assume the following is true whenever merge is called:
+            - if merge_left = True then c.qubits are a subset of self.qubits
+            - if merge_left = False then self.qubits are a subset of c.qubits
+
+        If merge_left is True, c is merged into this component, and the representative
+        will keep this moment and qubits. If merge_left is False, this component is
+        merged into c, and the representative will keep c's moment and qubits.
+
+        Args:
+            c: other component to merge
+            merge_left: True to keep self's data for the merged component, False to
+                keep c's data for the merged component.
+
+        Returns:
+            None, if the components can't be merged.
+            Otherwise the new component representative.
+        """
+        x = self.find()
+        y = c.find()
+
+        if not x.is_mergeable or not y.is_mergeable:
+            return None
+
+        if x == y:
+            return x
+
+        if x.rank < y.rank:
+            if merge_left:
+                # As y will be the new representative, copy moment and qubits from x
+                y.moment = x.moment
+                y.qubits = x.qubits
+            x, y = y, x
+        elif not merge_left:
+            # As x will be the new representative, copy moment and qubits from y
+            x.moment = y.moment
+            x.qubits = y.qubits
+
+        y.parent = x
+        if x.rank == y.rank:
+            x.rank += 1
+
+        x.mkeys = x.mkeys.union(y.mkeys)
+        x.ckeys = x.ckeys.union(y.ckeys)
+        return x
+
+
+class ComponentWithOps(Component):
+    """Component that keeps track of operations.
+
+    Encapsulates a method can_merge that is used to decide if two components
+    can be merged.
+    """
+
+    # List of all operations in the component
+    ops: list[cirq.Operation]
+
+    # Method to decide if two components can be merged based on their operations
+    can_merge: Callable[[Sequence[cirq.Operation], Sequence[cirq.Operation]], bool]
+
+    def __init__(self, op: cirq.Operation, moment: int,
+                 can_merge: Callable[[Sequence[cirq.Operation], Sequence[cirq.Operation]], bool],
+                 is_mergeable = True):
+        super().__init__(op, moment, is_mergeable)
+        self.ops = [op]
+        self.can_merge = can_merge
+
+    def merge(self, c: Component, merge_left = True) -> Component|None:
+        """Attempts to merge two components.
+
+        Returns:
+            None if can_merge is False, otherwise the new representative.
+                The representative will have ops = a.ops + b.ops.
+        """
+        x = cast(ComponentWithOps, self.find())
+        y = cast(ComponentWithOps, c.find())
+
+        if x == y:
+            return x
+
+        if not x.is_mergeable or not y.is_mergeable or not x.can_merge(x.ops, y.ops):
+            return None
+
+        root = cast(ComponentWithOps, super(ComponentWithOps, x).merge(y, merge_left))
+        if not root:
+            return None
+        root.ops = x.ops + y.ops
+        # Clear the ops list in the non-representative set to avoid memory consumption
+        if x != root:
+            x.ops = []
+        else:
+            y.ops = []
+        return root
+
+
+class ComponentWithCircuitOp(Component):
+    """Component that keeps track of operations as a CircuitOperation.
+
+    Encapsulates a method merge_func that is used to merge two components.
+    """
+
+    # CircuitOperation containing all the operations in the component,
+    # or a single Operation if the component is a singleton
+    circuit_op: cirq.Operation
+
+    merge_func: Callable[[ops.Operation, ops.Operation], ops.Operation | None]
+
+    def __init__(self, op: cirq.Operation, moment: int,
+                 merge_func: Callable[[ops.Operation, ops.Operation], ops.Operation | None],
+                 is_mergeable = True):
+        super().__init__(op, moment, is_mergeable)
+        self.circuit_op = op
+        self.merge_func = merge_func
+
+    def merge(self, c: Component, merge_left = True) -> Component|None:
+        """Attempts to merge two components.
+
+        Returns:
+            None if merge_func returns None, otherwise the new representative.
+        """
+        x = cast(ComponentWithCircuitOp, self.find())
+        y = cast(ComponentWithCircuitOp, c.find())
+
+        if x == y:
+            return x
+
+        if not x.is_mergeable or not y.is_mergeable:
+            return None
+
+        new_op = x.merge_func(x.circuit_op, y.circuit_op)
+        if not new_op:
+            return None
+
+        root = cast(ComponentWithCircuitOp, super(ComponentWithCircuitOp, x).merge(y, merge_left))
+        if not root:
+            return None
+
+        root.circuit_op = new_op
+        # The merge_func can be arbitrary, so we need to recompute the component properties
+        root.qubits = frozenset(new_op.qubits)
+        root.mkeys = protocols.measurement_key_objs(new_op)
+        root.ckeys = protocols.control_keys(new_op)
+
+        # Clear the circuit op in the non-representative set to avoid memory consumption
+        if x != root:
+            del x.circuit_op
+        else:
+            del y.circuit_op
+        return root
+
+
+class ComponentFactory:
+    """Factory for components."""
+
+    is_mergeable: Callable[[cirq.Operation], bool]
+
+    def __init__(self,
+                 is_mergeable: Callable[[cirq.Operation], bool]):
+        self.is_mergeable = is_mergeable
+
+    def new_component(self, op: cirq.Operation, moment: int, is_mergeable = True) -> Component:
+        return Component(op, moment, self.is_mergeable(op) and is_mergeable)
+
+
+class ComponentWithOpsFactory(ComponentFactory):
+    """Factory for components with operations."""
+
+    can_merge: Callable[[Sequence[cirq.Operation], Sequence[cirq.Operation]], bool]
+
+    def __init__(self,
+                 is_mergeable: Callable[[cirq.Operation], bool],
+                 can_merge: Callable[[Sequence[cirq.Operation], Sequence[cirq.Operation]], bool]):
+        super().__init__(is_mergeable)
+        self.can_merge = can_merge
+
+    def new_component(self, op: cirq.Operation, moment: int, is_mergeable = True) -> Component:
+        return ComponentWithOps(op, moment, self.can_merge, self.is_mergeable(op) and is_mergeable)
+
+
+class ComponentWithCircuitOpFactory(ComponentFactory):
+    """Factory for components with operations as CircuitOperation."""
+
+    merge_func: Callable[[ops.Operation, ops.Operation], ops.Operation | None]
+
+    def __init__(self,
+                 is_mergeable: Callable[[cirq.Operation], bool],
+                 merge_func: Callable[[ops.Operation, ops.Operation], ops.Operation | None]):
+        super().__init__(is_mergeable)
+        self.merge_func = merge_func
+
+    def new_component(self, op: cirq.Operation, moment: int, is_mergeable=True) -> Component:
+        return ComponentWithCircuitOp(op, moment, self.merge_func, self.is_mergeable(op) and is_mergeable)
+
+
+
+

--- a/cirq-core/cirq/transformers/connected_component_test.py
+++ b/cirq-core/cirq/transformers/connected_component_test.py
@@ -1,0 +1,212 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import cirq
+from cirq.transformers.connected_component import (
+    Component, ComponentWithOps, ComponentWithCircuitOp, ComponentFactory, ComponentWithOpsFactory, ComponentWithCircuitOpFactory
+)
+
+
+def test_find_returns_itself_for_singleton():
+    q = cirq.NamedQubit('x')
+    c = Component(op=cirq.X(q), moment=0)
+    assert c.find() == c
+
+
+def test_merge_components():
+    q = cirq.NamedQubit('x')
+    c = [Component(op=cirq.X(q), moment=i) for i in range(5)]
+    c[1].merge(c[0])
+    c[2].merge(c[1])
+    c[4].merge(c[3])
+    c[3].merge(c[0])
+    # Disjoint set structure:
+    #         c[4]
+    #        /  \
+    #     c[1] c[3]
+    #    /  \
+    # c[0]  c[2]
+    assert c[0].parent == c[1]
+    assert c[2].parent == c[1]
+    assert c[1].parent == c[4]
+    assert c[3].parent == c[4]
+
+    for i in range(5):
+        assert c[i].find() == c[4]
+    # Find() compressed all paths
+    for i in range(4):
+        assert c[i].parent == c[4]
+
+
+def test_merge_returns_None_if_one_component_is_not_mergeable():
+    q = cirq.NamedQubit('x')
+    c0 = Component(op=cirq.X(q), moment=0, is_mergeable=True)
+    c1 = Component(op=cirq.X(q), moment=1, is_mergeable=False)
+    assert c0.merge(c1) == None
+
+
+def test_factory_merge_returns_None_if_is_mergeable_is_false():
+    q = cirq.NamedQubit('x')
+
+    def is_mergeable(op: cirq.Operation) -> bool:
+        del op
+        return False
+
+    factory = ComponentFactory(is_mergeable=is_mergeable)
+    c0 = factory.new_component(op=cirq.X(q), moment=0, is_mergeable=True)
+    c1 = factory.new_component(op=cirq.X(q), moment=1, is_mergeable=True)
+    assert c0.merge(c1) == None
+
+
+def test_merge_qubits_with_merge_left_true():
+    q0 = cirq.NamedQubit('x')
+    q1 = cirq.NamedQubit('y')
+    c0 = Component(op=cirq.X(q0), moment=0)
+    c1 = Component(op=cirq.X(q1), moment=0)
+    c2 = Component(op=cirq.X(q1), moment=1)
+    c1.merge(c2)
+    c0.merge(c1, merge_left=True)
+    assert c0.find() == c1
+    # c1 is the set representative but kept c0's qubits
+    assert c1.qubits == frozenset([q0])
+
+
+def test_merge_qubits_with_merge_left_false():
+    q0 = cirq.NamedQubit('x')
+    q1 = cirq.NamedQubit('y')
+    c0 = Component(op=cirq.X(q0), moment=0)
+    c1 = Component(op=cirq.X(q0), moment=0)
+    c2 = Component(op=cirq.X(q1), moment=1)
+    c0.merge(c1)
+    c1.merge(c2, merge_left=False)
+    assert c2.find() == c0
+    # c0 is the set representative but kept c2's qubits
+    assert c0.qubits == frozenset([q1])
+
+
+def test_merge_moment_with_merge_left_true():
+    q0 = cirq.NamedQubit('x')
+    q1 = cirq.NamedQubit('y')
+    c0 = Component(op=cirq.X(q0), moment=0)
+    c1 = Component(op=cirq.X(q1), moment=1)
+    c2 = Component(op=cirq.X(q1), moment=1)
+    c1.merge(c2)
+    c0.merge(c1, merge_left=True)
+    assert c0.find() == c1
+    # c1 is the set representative but kept c0's moment
+    assert c1.moment == 0
+
+
+def test_merge_moment_with_merge_left_false():
+    q0 = cirq.NamedQubit('x')
+    q1 = cirq.NamedQubit('y')
+    c0 = Component(op=cirq.X(q0), moment=0)
+    c1 = Component(op=cirq.X(q0), moment=0)
+    c2 = Component(op=cirq.X(q1), moment=1)
+    c0.merge(c1)
+    c1.merge(c2, merge_left=False)
+    assert c2.find() == c0
+    # c0 is the set representative but kept c2's moment
+    assert c0.moment == 1
+
+
+def test_component_with_ops_merge():
+    def is_mergeable(op: cirq.Operation) -> bool:
+        del op
+        return True
+
+    def can_merge(ops1: list[cirq.Operation], ops2: list[cirq.Operation]) -> bool:
+        del ops1, ops2
+        return True
+
+    factory = ComponentWithOpsFactory(is_mergeable, can_merge)
+
+    q = cirq.LineQubit.range(3)
+    ops = [cirq.X(q[i]) for i in range(3)]
+    c = [factory.new_component(op=ops[i], moment=i) for i in range(3)]
+
+    c[0].merge(c[1])
+    c[1].merge(c[2])
+    assert c[0].find().ops == ops
+
+
+def test_component_with_ops_merge_when_merge_fails():
+    def is_mergeable(op: cirq.Operation) -> bool:
+        del op
+        return True
+
+    def can_merge(ops1: list[cirq.Operation], ops2: list[cirq.Operation]) -> bool:
+        del ops1, ops2
+        return False
+
+    factory = ComponentWithOpsFactory(is_mergeable, can_merge)
+
+    q = cirq.LineQubit.range(3)
+    ops = [cirq.X(q[i]) for i in range(3)]
+    c = [factory.new_component(op=ops[i], moment=i) for i in range(3)]
+
+    c[0].merge(c[1])
+    c[1].merge(c[2])
+    # No merge happened
+    for i in range(3):
+        assert c[i].find() == c[i]
+
+
+def test_component_with_circuit_op_merge():
+    def is_mergeable(op: cirq.Operation) -> bool:
+        del op
+        return True
+
+    def merge_func(op1: cirq.Operation, op2: cirq.Operation) -> cirq.Operation:
+        del op2
+        return op1
+
+    factory = ComponentWithCircuitOpFactory(is_mergeable, merge_func)
+
+    q = cirq.LineQubit.range(3)
+    ops = [cirq.X(q[i]) for i in range(3)]
+    c = [factory.new_component(op=ops[i], moment=i) for i in range(3)]
+
+    c[0].merge(c[1])
+    c[1].merge(c[2])
+    for i in range(3):
+        assert c[i].find().circuit_op == ops[0]
+
+
+def test_component_with_circuit_op_merge_func_is_none():
+    def is_mergeable(op: cirq.Operation) -> bool:
+        del op
+        return True
+
+    def merge_func(op1: cirq.Operation, op2: cirq.Operation) -> None:
+        del op1, op2
+        return None
+
+    factory = ComponentWithCircuitOpFactory(is_mergeable, merge_func)
+
+    q = cirq.LineQubit.range(3)
+    ops = [cirq.X(q[i]) for i in range(3)]
+    c = [factory.new_component(op=ops[i], moment=i) for i in range(3)]
+
+    c[0].merge(c[1])
+    c[1].merge(c[2])
+    # No merge happened
+    for i in range(3):
+        assert c[i].find() == c[i]
+
+
+
+

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -877,3 +877,187 @@ def test_merge_operations_does_not_merge_measurements_behind_ccos():
     cirq.testing.assert_same_circuits(
         cirq.align_left(cirq.merge_operations(circuit, merge_func)), expected_circuit
     )
+
+
+def test_merge_3q_unitaries_to_circuit_op_3q_gate_absorbs_overlapping_2q_gates():
+    q = cirq.LineQubit.range(3)
+    c_orig = cirq.Circuit(
+        cirq.Moment(
+            cirq.H(q[0]).with_tags("ignore"),
+            cirq.H(q[1]).with_tags("ignore"),
+            cirq.H(q[2]).with_tags("ignore"),
+        ),
+        cirq.Moment(cirq.CNOT(q[0], q[2]), cirq.X(q[1]).with_tags("ignore")),
+        cirq.CNOT(q[0], q[1]),
+        cirq.CNOT(q[1], q[2]),
+        cirq.CCZ(*q),
+        strategy=cirq.InsertStrategy.NEW,
+    )
+    cirq.testing.assert_has_diagram(
+        c_orig,
+        '''
+                  ┌──────────┐
+0: ───H[ignore]────@─────────────@───────@───
+                   │             │       │
+1: ───H[ignore]────┼X[ignore]────X───@───@───
+                   │                 │   │
+2: ───H[ignore]────X─────────────────X───@───
+                  └──────────┘
+''',
+    )
+
+    c_new = cirq.merge_k_qubit_unitaries_to_circuit_op(
+        c_orig, k=3, merged_circuit_op_tag="merged", tags_to_ignore=["ignore"]
+    )
+    cirq.testing.assert_has_diagram(
+        cirq.drop_empty_moments(c_new),
+        '''
+                              [ 0: ───@───@───────@─── ]
+                              [       │   │       │    ]
+0: ───H[ignore]───────────────[ 1: ───┼───X───@───@─── ]───────────
+                              [       │       │   │    ]
+                              [ 2: ───X───────X───@─── ][merged]
+                              │
+1: ───H[ignore]───X[ignore]───#2───────────────────────────────────
+                              │
+2: ───H[ignore]───────────────#3───────────────────────────────────
+''',
+    )
+
+
+def test_merge_3q_unitaries_to_circuit_op_3q_gate_absorbs_disjoint_gates():
+    q = cirq.LineQubit.range(3)
+    c_orig = cirq.Circuit(
+        cirq.Moment(cirq.CNOT(q[0], q[1]), cirq.X(q[2])),
+        cirq.CCZ(*q),
+        strategy=cirq.InsertStrategy.NEW,
+    )
+    cirq.testing.assert_has_diagram(
+        c_orig,
+        '''
+0: ───@───@───
+      │   │
+1: ───X───@───
+          │
+2: ───X───@───
+''',
+    )
+
+    c_new = cirq.merge_k_qubit_unitaries_to_circuit_op(
+        c_orig, k=3, merged_circuit_op_tag="merged", tags_to_ignore=["ignore"]
+    )
+    cirq.testing.assert_has_diagram(
+        cirq.drop_empty_moments(c_new),
+        '''
+      [ 0: ───@───@─── ]
+      [       │   │    ]
+0: ───[ 1: ───X───@─── ]───────────
+      [           │    ]
+      [ 2: ───X───@─── ][merged]
+      │
+1: ───#2───────────────────────────
+      │
+2: ───#3───────────────────────────
+''',
+    )
+
+
+def test_merge_3q_unitaries_to_circuit_op_3q_gate_doesnt_absorb_unmergeable_gate():
+    q = cirq.LineQubit.range(3)
+    c_orig = cirq.Circuit(
+        cirq.CCZ(*q),
+        cirq.Moment(cirq.CNOT(q[0], q[1]), cirq.X(q[2]).with_tags("ignore")),
+        cirq.CCZ(*q),
+        strategy=cirq.InsertStrategy.NEW,
+    )
+    cirq.testing.assert_has_diagram(
+        c_orig,
+        '''
+0: ───@───@───────────@───
+      │   │           │
+1: ───@───X───────────@───
+      │               │
+2: ───@───X[ignore]───@───
+''',
+    )
+
+    c_new = cirq.merge_k_qubit_unitaries_to_circuit_op(
+        c_orig, k=3, merged_circuit_op_tag="merged", tags_to_ignore=["ignore"]
+    )
+    cirq.testing.assert_has_diagram(
+        cirq.drop_empty_moments(c_new),
+        '''
+      [ 0: ───@───@─── ]
+      [       │   │    ]
+0: ───[ 1: ───@───X─── ]───────────────────────@───
+      [       │        ]                       │
+      [ 2: ───@─────── ][merged]               │
+      │                                        │
+1: ───#2───────────────────────────────────────@───
+      │                                        │
+2: ───#3───────────────────────────X[ignore]───@───
+''',
+    )
+
+
+def test_merge_3q_unitaries_to_circuit_op_prefer_to_merge_into_earlier_op():
+    q = cirq.LineQubit.range(6)
+    c_orig = cirq.Circuit(
+        cirq.Moment(
+            cirq.CCZ(*q[0:3]), cirq.X(q[3]), cirq.H(q[4]), cirq.H(q[5]).with_tags("ignore")
+        ),
+        cirq.Moment(cirq.CNOT(q[0], q[1]), cirq.X(q[2]).with_tags("ignore"), cirq.CCZ(*q[3:6])),
+        cirq.Moment(
+            cirq.X(q[0]),
+            cirq.X(q[1]),
+            cirq.X(q[2]),
+            cirq.X(q[3]).with_tags("ignore"),
+            cirq.CNOT(*q[4:6]),
+        ),
+        cirq.Moment(cirq.CCZ(*q[0:3]), cirq.CCZ(*q[3:6])),
+        strategy=cirq.InsertStrategy.NEW,
+    )
+    cirq.testing.assert_has_diagram(
+        c_orig,
+        '''
+0: ───@───────────@───────────X───────────@───
+      │           │                       │
+1: ───@───────────X───────────X───────────@───
+      │                                   │
+2: ───@───────────X[ignore]───X───────────@───
+
+3: ───X───────────@───────────X[ignore]───@───
+                  │                       │
+4: ───H───────────@───────────@───────────@───
+                  │           │           │
+5: ───H[ignore]───@───────────X───────────@───
+''',
+    )
+
+    c_new = cirq.merge_k_qubit_unitaries_to_circuit_op(
+        c_orig, k=3, merged_circuit_op_tag="merged", tags_to_ignore=["ignore"]
+    )
+    cirq.testing.assert_has_diagram(
+        cirq.drop_empty_moments(c_new),
+        '''
+      [ 0: ───@───@───X─── ]                                                        [ 0: ───────@─── ]
+      [       │   │        ]                                                        [           │    ]
+0: ───[ 1: ───@───X───X─── ]────────────────────────────────────────────────────────[ 1: ───────@─── ]───────────
+      [       │            ]                                                        [           │    ]
+      [ 2: ───@─────────── ][merged]                                                [ 2: ───X───@─── ][merged]
+      │                                                                             │
+1: ───#2────────────────────────────────────────────────────────────────────────────#2───────────────────────────
+      │                                                                             │
+2: ───#3───────────────────────────────X[ignore]────────────────────────────────────#3───────────────────────────
+
+                                       [ 3: ───X───@─────── ]
+                                       [           │        ]
+3: ────────────────────────────────────[ 4: ───H───@───@─── ]───────────X[ignore]───@────────────────────────────
+                                       [           │   │    ]                       │
+                                       [ 5: ───────@───X─── ][merged]               │
+                                       │                                            │
+4: ────────────────────────────────────#2───────────────────────────────────────────@────────────────────────────
+                                       │                                            │
+5: ───H[ignore]────────────────────────#3───────────────────────────────────────────@────────────────────────────
+''',
+    )


### PR DESCRIPTION
Currently [`merge_operations`](https://github.com/quantumlib/Cirq/blob/a89f5b9f0875dcae419efc13790af078075fcb6b/cirq-core/cirq/transformers/transformer_primitives.py#L357) represents merged components as a `CircuitOperation`. This means in a merge of `n` operations, `n-1` `CircuitOperations` are created, with a complexity of `O(n^2)`.
I use a disjont-set data structure to reduce the complexity to `O(n)` for `merge_k_qubit_unitaries_to_circuit_op`. `merge_operations` itself can't be improved because it uses a `merge_func` that requires creating a `CircuitOperation` at every step.