### PR TITLE
ci - avoid overlapping artifact names from notebook tests

### DIFF
--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -33,7 +33,8 @@ jobs:
         run: pip install -r dev_tools/requirements/isolated-base.env.txt
       - name: Notebook tests
         run: check/pytest -n auto -m weekly dev_tools/notebooks/isolated_notebook_test.py -k ${{matrix.partition}}
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - name: Persist the outputs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: notebook-outputs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
-          name: notebook-outputs
+          name: notebook-outputs-${{ matrix.partition }}
           path: out
   notebooks-branch:
     if: github.repository_owner == 'quantumlib'


### PR DESCRIPTION
Each CI job (including partitions) needs to use a unique artifact name
otherwise the output is not saved.

Also use common naming for the upload-artifacts step in ci-weekly.

No change in the effective tests.
