### PR TITLE
Fix resolution of notebook paths when pytest is not at the repo root

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -142,7 +142,7 @@ def _partitioned_test_cases(notebooks):
 
 def _rewrite_and_run_notebook(notebook_path, cloned_env):
     notebook_file = os.path.basename(notebook_path)
-    notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))
+    notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, REPO_ROOT))
     out_path = f"out/{notebook_rel_dir}/{notebook_file[:-6]}.out.ipynb"
     notebook_env = cloned_env("isolated_notebook_tests", *PACKAGES)
 
@@ -150,17 +150,17 @@ def _rewrite_and_run_notebook(notebook_path, cloned_env):
 
     rewritten_notebook_path = rewrite_notebook(notebook_path)
 
+    REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
     cmd = f"""
-mkdir -p out/{notebook_rel_dir}
-cd {notebook_env}
 . ./bin/activate
 pip list
-papermill {rewritten_notebook_path} {os.getcwd()}/{out_path}"""
+papermill {rewritten_notebook_path} {REPO_ROOT/out_path}"""
     result = shell_tools.run(
         cmd,
         log_run_to_stderr=False,
         shell=True,
         check=False,
+        cwd=notebook_env,
         capture_output=True,
         # important to get rid of PYTHONPATH specifically, which contains
         # the Cirq repo path due to check/pytest

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -108,18 +108,19 @@ def test_notebooks_against_cirq_head(
     Lines in this file that do not have `->` are ignored.
     """
     notebook_file = os.path.basename(notebook_path)
-    notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, "."))
+    notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, REPO_ROOT))
     out_path = f"out/{notebook_rel_dir}/{notebook_file[:-6]}.out.ipynb"
     rewritten_notebook_path = rewrite_notebook(notebook_path)
     papermill_flags = "--no-request-save-on-cell-execute --autosave-cell-every 0"
-    cmd = f"""mkdir -p out/{notebook_rel_dir}
-papermill {rewritten_notebook_path} {out_path} {papermill_flags}"""
+    cmd = f"papermill {rewritten_notebook_path} {REPO_ROOT/out_path} {papermill_flags}"
 
+    REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
     result = shell_tools.run(
         cmd,
         log_run_to_stderr=False,
         shell=True,
         check=False,
+        cwd=REPO_ROOT,
         capture_output=True,
         env=env_with_temporary_pip_target,
     )


### PR DESCRIPTION
Create the `out` directory for notebook outputs at the repository
root regardless of the pytest execution directory.

Follow-up to #7481
