### PR TITLE
Fix missing None types on test functions

### DIFF
--- a/cirq-google/cirq_google/experimental/analog_experiments/analog_trajectory_util_test.py
+++ b/cirq-google/cirq_google/experimental/analog_experiments/analog_trajectory_util_test.py
@@ -115,7 +115,7 @@ def test_get_full_trajectory_with_resolved_idles(sparse_trajectory: list[FreqMap
     )
 
 
-def test_plot_with_unresolved_parameters():
+def test_plot_with_unresolved_parameters() -> None:
     traj1: FreqMapType = (20 * tu.ns, {"q0_1": sympy.Symbol("qf")}, {})
     traj2: FreqMapType = (sympy.Symbol("t"), {"q0_2": 8 * tu.GHz}, {})
     analog_traj = atu.AnalogTrajectory.from_sparse_trajectory([traj1, traj2])
@@ -124,7 +124,7 @@ def test_plot_with_unresolved_parameters():
         analog_traj.plot()
 
 
-def test_analog_traj_plot():
+def test_analog_traj_plot() -> None:
     traj1: FreqMapType = (5 * tu.ns, {"q0_1": sympy.Symbol("qf")}, {("q0_0", "q0_1"): 2 * tu.MHz})
     traj2: FreqMapType = (sympy.Symbol("t"), {"q0_2": 8 * tu.GHz}, {})
     analog_traj = atu.AnalogTrajectory.from_sparse_trajectory([traj1, traj2])


### PR DESCRIPTION
- Noticed that these functions were throwing warnings since there are type annotations defined but the return type was not defined.