### PR TITLE
Update Scientific Python dependencies per NEP-29 and SPEC-0

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -2,12 +2,12 @@
 
 attrs>=21.3.0
 duet>=0.2.8
-matplotlib~=3.7
+matplotlib~=3.8
 networkx~=3.4
-numpy>=1.25
-pandas~=2.0
+numpy>=1.26
+pandas~=2.1
 sortedcontainers~=2.0
-scipy~=1.11
+scipy~=1.12
 sympy
 typing_extensions>=4.2
 tqdm>=4.12

--- a/dev_tools/requirements/deps/ipython.txt
+++ b/dev_tools/requirements/deps/ipython.txt
@@ -1,1 +1,1 @@
-ipython~=8.10
+ipython>=8.15


### PR DESCRIPTION
* drop numpy-1.25 per NEP-29 and SPEC-0
* drop scipy-1.11 per SPEC-0
* drop matplotlib-3.7 per SPEC-0
* drop pandas-2.0 per SPEC-0
* drop ipython-8.14 and allow ipython-9 per SPEC-0

Refs:

* https://numpy.org/neps/nep-0029-deprecation_policy.html
* https://scientific-python.org/specs/spec-0000

Resolves b/392641425
