### PR TITLE
CODEOWNERS - remove owner specifications for cirq-rigetti

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,8 +16,6 @@ cirq-aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomol
 
 cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
-cirq-rigetti/**/*.* @erichulburd @kalzoo @dbanty @quantumlib/cirq-maintainers @vtomole
-
 ################################################
 # qcvv maintainers @mrwojtek + cirq maintainers
 ################################################
@@ -42,8 +40,6 @@ docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @aasfaw @
 docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
 
 docs/hardware/pasqal/**/*.* @HGSilveri @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
-
-docs/hardware/rigetti/**/*.* @erichulburd @kalzoo @dbanty @aasfaw @quantumlib/cirq-maintainers @vtomole
 
 docs/hardware/azure-quantum/**/*.* @guenp @anpaz @aasfaw @quantumlib/cirq-maintainers @vtomole
 


### PR DESCRIPTION
Follow-up to #7297
