### PR TITLE
NEP-29 - require minimum Python version 3.11

### DIFF
--- a/cirq-aqt/setup.py
+++ b/cirq-aqt/setup.py
@@ -46,8 +46,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 """Define version number here, read it from setup.py automatically,
-and warn users that the latest version of cirq uses python 3.11+"""
+and warn users that the latest version of Cirq uses Python 3.11+"""
 
 import sys
 
 if sys.version_info < (3, 11, 0):  # pragma: no cover
     raise SystemError(
-        "You installed the latest version of cirq but aren't on python 3.11+.\n"
+        "You installed the latest version of Cirq but aren't on Python 3.11+.\n"
         'To fix this error, you need to either:\n'
         '\n'
-        'A) Update to python 3.11 or later.\n'
+        'A) Update to Python 3.11 or later.\n'
         '- OR -\n'
         'B) Explicitly install an older deprecated-but-compatible version '
-        'of cirq (e.g. "python -m pip install cirq==1.5.0")'
+        'of Cirq (e.g. "python -m pip install cirq==1.5.0")'
     )
 
 __version__ = "1.6.0.dev0"

--- a/cirq-core/cirq/_version.py
+++ b/cirq-core/cirq/_version.py
@@ -17,8 +17,7 @@ and warn users that the latest version of cirq uses python 3.11+"""
 
 import sys
 
-# TODO: #6648 - update when internal docs build supports python3.11
-if sys.version_info < (3, 11 - 1, 0):  # pragma: no cover
+if sys.version_info < (3, 11, 0):  # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.11+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -49,7 +49,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="The Quantum AI open-source software maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires=('>=3.11.0'),
+    python_requires='>=3.11.0',
     install_requires=requirements,
     extras_require={'contrib': contrib_requirements},
     license='Apache 2',

--- a/cirq-core/setup.py
+++ b/cirq-core/setup.py
@@ -49,8 +49,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="The Quantum AI open-source software maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires=('>=3.11.0'),
     install_requires=requirements,
     extras_require={'contrib': contrib_requirements},
     license='Apache 2',

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 """Define version number here, read it from setup.py automatically,
-and warn users that the latest version of cirq uses python 3.11+"""
+and warn users that the latest version of Cirq uses Python 3.11+"""
 
 import sys
 
 if sys.version_info < (3, 11, 0):  # pragma: no cover
     raise SystemError(
-        "You installed the latest version of cirq but aren't on python 3.11+.\n"
+        "You installed the latest version of Cirq but aren't on Python 3.11+.\n"
         'To fix this error, you need to either:\n'
         '\n'
-        'A) Update to python 3.11 or later.\n'
+        'A) Update to Python 3.11 or later.\n'
         '- OR -\n'
         'B) Explicitly install an older deprecated-but-compatible version '
-        'of cirq (e.g. "python -m pip install cirq==1.5.0")'
+        'of Cirq (e.g. "python -m pip install cirq==1.5.0")'
     )
 
 __version__ = "1.6.0.dev0"

--- a/cirq-google/cirq_google/_version.py
+++ b/cirq-google/cirq_google/_version.py
@@ -17,8 +17,7 @@ and warn users that the latest version of cirq uses python 3.11+"""
 
 import sys
 
-# TODO: #6648 - update when internal docs build supports python3.11
-if sys.version_info < (3, 11 - 1, 0):  # pragma: no cover
+if sys.version_info < (3, 11, 0):  # pragma: no cover
     raise SystemError(
         "You installed the latest version of cirq but aren't on python 3.11+.\n"
         'To fix this error, you need to either:\n'

--- a/cirq-google/setup.py
+++ b/cirq-google/setup.py
@@ -47,8 +47,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-ionq/setup.py
+++ b/cirq-ionq/setup.py
@@ -45,8 +45,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-pasqal/setup.py
+++ b/cirq-pasqal/setup.py
@@ -44,8 +44,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -42,8 +42,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     description=description,

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="The Quantum AI open-source software maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires='>=3.11.0',
+    python_requires=('>=3.11.0'),
     install_requires=requirements,
     license='Apache 2',
     packages=pack1_packages,

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="The Quantum AI open-source software maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    python_requires=('>=3.11.0'),
+    python_requires='>=3.11.0',
     install_requires=requirements,
     license='Apache 2',
     packages=pack1_packages,

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,7 @@ setup(
     author_email='cirq-dev@googlegroups.com',
     maintainer="Google Quantum AI open-source maintainers",
     maintainer_email="quantum-oss-maintainers@google.com",
-    # TODO: #6648 - update when internal docs build supports python3.11
-    python_requires='>=3.10.0',
+    python_requires='>=3.11.0',
     install_requires=requirements,
     extras_require={'dev_env': dev_requirements},
     license='Apache 2',


### PR DESCRIPTION
NEP-29 require minimum Python version 3.11

Roll forward of #7338 because internal documentation build can now
run with Python 3.11.  A few capitalization fixups are here too.

Revert "Permit installation for Python 3.10 (docs build only) (#7445)"

This reverts commit 609d93dbc51a6608a0d0c3f5d50d51325052e027.

Fixes #6648
