### PR TITLE
First pass at updating CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,49 +1,40 @@
-####################
-# cirq maintainers
-####################
+################################################################################
+# GitHub CODEOWNERS file for Cirq.
+#
+# People listed here as code owners must have write permissions for the repo.
+# Patterns are matched such that the last matching pattern takes precedence, so
+# earlier rules in this file should be broader and later rules more specific.
+################################################################################
+
+# Overall Cirq maintainers.
 
 * @quantumlib/cirq-maintainers @vtomole
 
-####################
-# vendor maintainers
-####################
 
-cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult
+# Docs maintainers.
 
-cirq-ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
+/docs/**/*.* @quantumlib/cirq-maintainers @vtomole
+/docs/tutorials/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult
+/docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
 
-cirq-aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomole
 
-cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
+# Hardware module maintainers.
 
-################################################
-# qcvv maintainers @mrwojtek + cirq maintainers
-################################################
+/cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult
+/docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult
 
-cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
+/cirq-ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
+/docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 
-#####################################################
-# docs maintainers: maintainers + @aasfaw + @rmlarose
-#####################################################
+/cirq-aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomole
+/docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomole
 
-docs/**/*.* @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
+/cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
+/docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
-###################################################################
-# vendor docs maintainers: vendor maintainers + @aasfaw + @rmlarose
-###################################################################
+/docs/hardware/azure-quantum/**/*.* @guenp @anpaz @quantumlib/cirq-maintainers @vtomole
 
-docs/google/**/*.* @wcourtney @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole @verult
-docs/tutorials/google/**/*.* @wcourtney @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole @verult
 
-docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @aasfaw @rmlarose @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
+# Experiments maintainers.
 
-docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
-
-docs/hardware/pasqal/**/*.* @HGSilveri @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
-
-docs/hardware/azure-quantum/**/*.* @guenp @anpaz @aasfaw @quantumlib/cirq-maintainers @vtomole
-
-#############################################################
-# qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw
-#############################################################
-docs/noise/qcvv/**/*.* @mrwojtek @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
+/cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole


### PR DESCRIPTION
This reorganizes the file slightly to

- try to make it easier to find things (e.g., by not splitting up docs and code in completely separate sections)

- put the rule for docs/** higher, because the way it was before, it would have overwritten the more specific settings

- use rooted paths, to avoid accidentally matching subdirectories (e.g., because there's a docs in dev_tools/ too)

I also removed a couple of users who either have left Google or have not been involved for a long time.