### PR TITLE
Fix sidepanel contents for section on noise

### DIFF
--- a/docs/_book.yaml
+++ b/docs/_book.yaml
@@ -167,18 +167,15 @@ upper_tabs:
         path: /cirq/noise/representing_noise
       ####  CHARACTERIZATION AND COMPENSATION  ####
       - heading: "Characterization and compensation"
-      - title: "Cross-Entropy Benchmarking (XEB)"
-        style: accordion
-        section:
-        - title: "Cross-Entropy Benchmarking Theory"
-          path: /cirq/noise/qcvv/xeb_theory
-        - title: "Coherent vs incoherent noise with XEB"
-          path: /cirq/noise/qcvv/coherent_vs_incoherent_xeb
-        - title: "Parallel XEB"
-          path: /cirq/noise/qcvv/parallel_xeb
-        - title: "XEB calibration: Example and Benchmark"
-          path: /cirq/noise/qcvv/xeb_calibration_example
-      ####  VISUALIZING NOISE  ####
+      - title: "Cross-Entropy Benchmarking (XEB) Theory"
+        path: /cirq/noise/qcvv/xeb_theory
+      - title: "Coherent vs incoherent noise with XEB"
+        path: /cirq/noise/qcvv/coherent_vs_incoherent_xeb
+      - title: "Parallel XEB"
+        path: /cirq/noise/qcvv/parallel_xeb
+      - title: "XEB calibration: Example and Benchmark"
+        path: /cirq/noise/qcvv/xeb_calibration_example
+    ####  VISUALIZING NOISE  ####
       - heading: "Visualizing noise"
       - title: "Heatmaps"
         path: /cirq/noise/heatmaps


### PR DESCRIPTION
The removal of some documents in a previous PR left the left-side TOC panel with an extra heading. Now, it also turns out that none of the other sections in the Cirq docs use an accordion, so we can feed two birds with one scone by getting rid of the accordion and moving the contents up one level. This should result in a properly-structured panel.

<div align="center">
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/fd90fb7e-4085-448f-8e09-016df4348212" />
 
</div>
