### PR TITLE
Add clarification to GridQubit neighbors function

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -125,7 +125,7 @@ class _BaseGridQid(ops.Qid):
         layout.
 
         If you want to take into account the device layout, you must pass in the
-        device's qubit set as the `qid` parameter.
+        device's qubit set as the `qids` parameter.
 
         Args:
             qids: optional Iterable of qubits to constrain neighbors to.

--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -117,7 +117,15 @@ class _BaseGridQid(ops.Qid):
         )
 
     def neighbors(self, qids: Iterable[ops.Qid] | None = None) -> set[_BaseGridQid]:
-        """Returns qubits that are potential neighbors to this GridQid
+        """Returns qubits that are potential neighbors to this GridQid.
+
+        Note that this returns _potential_ neighbors.  That is, if no arguments
+        are given, this returns the qubits above, below, to the right and left of
+        the Qid in the grid.  It does not take into account any hardware device
+        layout.
+
+        If you want to take into account the device layout, you must pass in the
+        device's qubit set as the `qid` parameter.
 
         Args:
             qids: optional Iterable of qubits to constrain neighbors to.


### PR DESCRIPTION
- An internal bug noted that there could be confusion if you assumed that GridQubit.neighbors() returned only the neighbors on a specific device layout.
- This changes only the documentation to point out that this function is device-agnostic.