### PR TITLE
Revert "Expand parameters for product sweeps iteratively instead of recursively"

### DIFF
--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -230,10 +230,16 @@ class Product(Sweep):
         return length
 
     def param_tuples(self) -> Iterator[Params]:
-        yield from map(
-            itertools.chain.from_iterable,
-            itertools.product(*(factor.param_tuples() for factor in self.factors)),
-        )
+        def _gen(factors):
+            if not factors:
+                yield ()
+            else:
+                first, rest = factors[0], factors[1:]
+                for first_values in first.param_tuples():
+                    for rest_values in _gen(rest):
+                        yield first_values + rest_values
+
+        return _gen(self.factors)
 
     def __repr__(self) -> str:
         factors_repr = ', '.join(repr(f) for f in self.factors)

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -158,19 +158,6 @@ def test_product():
     assert _values(sweep, 'b') == [3, 3, 4, 4, 3, 3, 4, 4]
     assert _values(sweep, 'c') == [5, 6, 5, 6, 5, 6, 5, 6]
 
-    sweep = cirq.Points('a', [1, 2]) * (cirq.Points('b', [3, 4, 5]))
-    assert list(map(list, sweep.param_tuples())) == [
-        [('a', 1), ('b', 3)],
-        [('a', 1), ('b', 4)],
-        [('a', 1), ('b', 5)],
-        [('a', 2), ('b', 3)],
-        [('a', 2), ('b', 4)],
-        [('a', 2), ('b', 5)],
-    ]
-
-    sweep = cirq.Product(*[cirq.Points(str(i), [0]) for i in range(1025)])
-    assert list(map(list, sweep.param_tuples())) == [[(str(i), 0) for i in range(1025)]]
-
 
 def test_zip_addition():
     zip_sweep = cirq.Zip(cirq.Points('a', [1, 2]), cirq.Points('b', [3, 4]))
@@ -185,7 +172,6 @@ def test_empty_product():
     sweep = cirq.Product()
     assert len(sweep) == len(list(sweep)) == 1
     assert str(sweep) == 'Product()'
-    assert list(map(list, sweep.param_tuples())) == [[]]
 
 
 def test_slice_access_error():


### PR DESCRIPTION
Reverts quantumlib/Cirq#7490

See b/433265888