### PR TITLE
Expand product sweep parameters iteratively rather than recursively

### DIFF
--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -232,7 +232,7 @@ class Product(Sweep):
     def param_tuples(self) -> Iterator[Params]:
         yield from map(
             lambda values: tuple(itertools.chain.from_iterable(values)),
-            itertools.product(*(factor.param_tuples() for factor in self.factors))
+            itertools.product(*(factor.param_tuples() for factor in self.factors)),
         )
 
     def __repr__(self) -> str:

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -230,16 +230,10 @@ class Product(Sweep):
         return length
 
     def param_tuples(self) -> Iterator[Params]:
-        def _gen(factors):
-            if not factors:
-                yield ()
-            else:
-                first, rest = factors[0], factors[1:]
-                for first_values in first.param_tuples():
-                    for rest_values in _gen(rest):
-                        yield first_values + rest_values
-
-        return _gen(self.factors)
+        yield from map(
+            lambda values: tuple(itertools.chain.from_iterable(values)),
+            itertools.product(*(factor.param_tuples() for factor in self.factors))
+        )
 
     def __repr__(self) -> str:
         factors_repr = ', '.join(repr(f) for f in self.factors)

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -158,6 +158,29 @@ def test_product():
     assert _values(sweep, 'b') == [3, 3, 4, 4, 3, 3, 4, 4]
     assert _values(sweep, 'c') == [5, 6, 5, 6, 5, 6, 5, 6]
 
+    sweep = cirq.Points('a', [1, 2]) * (cirq.Points('b', [3, 4, 5]))
+    assert list(map(list, sweep.param_tuples())) == [
+        [('a', 1), ('b', 3)],
+        [('a', 1), ('b', 4)],
+        [('a', 1), ('b', 5)],
+        [('a', 2), ('b', 3)],
+        [('a', 2), ('b', 4)],
+        [('a', 2), ('b', 5)],
+    ]
+
+    sweep = cirq.Product(*[cirq.Points(str(i), [0]) for i in range(1025)])
+    assert list(map(list, sweep.param_tuples())) == [[(str(i), 0) for i in range(1025)]]
+
+def test_nested_product_zip():
+    sweep = cirq.Product(
+        cirq.Product(cirq.Points('a', [0]), cirq.Points('b', [0])),
+        cirq.Zip(cirq.Points('c', [0, 1]), cirq.Points('d', [0, 1]))
+    )
+    assert list(map(list, sweep.param_tuples())) == [
+        [('a', 0), ('b', 0), ('c', 0), ('d', 0)],
+        [('a', 0), ('b', 0), ('c', 1), ('d', 1)],
+    ]
+
 
 def test_zip_addition():
     zip_sweep = cirq.Zip(cirq.Points('a', [1, 2]), cirq.Points('b', [3, 4]))
@@ -172,6 +195,7 @@ def test_empty_product():
     sweep = cirq.Product()
     assert len(sweep) == len(list(sweep)) == 1
     assert str(sweep) == 'Product()'
+    assert list(map(list, sweep.param_tuples())) == [[]]
 
 
 def test_slice_access_error():

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -171,10 +171,11 @@ def test_product():
     sweep = cirq.Product(*[cirq.Points(str(i), [0]) for i in range(1025)])
     assert list(map(list, sweep.param_tuples())) == [[(str(i), 0) for i in range(1025)]]
 
+
 def test_nested_product_zip():
     sweep = cirq.Product(
         cirq.Product(cirq.Points('a', [0]), cirq.Points('b', [0])),
-        cirq.Zip(cirq.Points('c', [0, 1]), cirq.Points('d', [0, 1]))
+        cirq.Zip(cirq.Points('c', [0, 1]), cirq.Points('d', [0, 1])),
     )
     assert list(map(list, sweep.param_tuples())) == [
         [('a', 0), ('b', 0), ('c', 0), ('d', 0)],


### PR DESCRIPTION
The new unit test assertion involving a product of 1025 sweeps crashes the current implementation with a "max recursion depth exceeded" error, but passes with the new implementation. This is particularly relevant when dict_to_product_sweep is called with a large input dictionary.

This re-introduces the change reverted in https://github.com/quantumlib/Cirq/pull/7522 and addresses the issue which caused the failure:

`itertools.chain.from_iterable` produces an `Iterator` as its output, meaning the output object can only be iterated through once before it is exhausted. However, `Params` is a type alias for `Iterable[tuple['cirq.TParamKey', 'cirq.TParamVal']]`, meaning it is expected for a given `Params` to be iterated through repeatedly. This is also necessary in order for the `Params` produced by a `Product` sweep to function correctly, as the `Params` yielded by the individual factors' `param_tuples()` can appear multiple times in the compound `Params` of the product's `param_tuples()`. To properly allow the yielded `Params` to be iterated through repeatedly, we now use `lambda values: tuple(itertools.chain.from_iterable(values)` on line 234 of sweeps.py whereas the previous implementation effectively had `lambda values: itertools.chain.from_iterables(values)`. Collecting into a `tuple` guarantees that we yield a repeatedly-iterable `Params` object.

In addition to the new test `test_nested_product_zip()` which reproduced the error in the previous implementation, this change has also been tested against the internal library tests which were broken by the previous implementation.