### PR TITLE
Restore behavior which persists `quantum_run_stream`s indefinitely

### DIFF
--- a/cirq-google/cirq_google/engine/stream_manager.py
+++ b/cirq-google/cirq_google/engine/stream_manager.py
@@ -205,9 +205,9 @@ class StreamManager:
         """
         while True:
             try:
-                # The default gRPC client timeout is used.
                 response_iterable = await self._grpc_client.quantum_run_stream(
-                    _request_iterator(request_queue)
+                    _request_iterator(request_queue),
+                    timeout=None,  # Persist the stream indefinitely.
                 )
                 async for response in response_iterable:
                     self._response_demux.publish(response)


### PR DESCRIPTION
https://github.com/quantumlib/Cirq/pull/7500 modified the `quantum_run_stream` method definition by changing the `timeout` argument from `timeout: float | None = None` to `timeout: float | object = gapic_v1.method.DEFAULT`. Setting `timeout=None` is interpreted as having no timeout at all, whereas `timeout=gapic_v1.method.DEFAULT` uses the framework-supplied default value of 60s. For bidirectional streams, the `timeout` is used to set the lifetime of the entire stream, causing batches of jobs which cumulatively take more than 60s to fail with `DEADLINE_EXCEEDED` errors. This change sets `timout=None` explicitly, restoring the behavior previously obtained via the default argument.