### PR TITLE
Fix kraus channels for fallbacks to super-operators

### DIFF
--- a/cirq-core/cirq/circuits/moment_test.py
+++ b/cirq-core/cirq/circuits/moment_test.py
@@ -885,7 +885,7 @@ def test_kraus() -> None:
 
 
 def test_kraus_too_big() -> None:
-    m = cirq.Moment(cirq.IdentityGate(11).on(*cirq.LineQubit.range(11)))
+    m = cirq.Moment(cirq.IdentityGate(11).with_probability(0.5).on(*cirq.LineQubit.range(11)))
     assert not cirq.has_kraus(m)
     assert not m._has_superoperator_()
     assert m._kraus_() is NotImplemented

--- a/cirq-core/cirq/protocols/kraus_protocol.py
+++ b/cirq-core/cirq/protocols/kraus_protocol.py
@@ -98,7 +98,12 @@ class SupportsKraus(Protocol):
 
 def _strat_kraus_from_apply_channel(val: Any, atol: float) -> tuple[np.ndarray, ...] | None:
     """Attempts to compute a value's Kraus operators via its _apply_channel_ method.
-    This is very expensive (O(16^N)), so only do this as a last resort."""
+    This is very expensive (O(16^N)), so only do this as a last resort.
+
+    Args:
+        val: value to calculate kraus channels from.
+        atol: Absolute tolerance for super-operator calculation.
+            Matrices with all entries less than this will be dropped."""
     method = getattr(val, '_apply_channel_', None)
     if method is None:
         return None
@@ -153,7 +158,7 @@ def kraus(
         default: Determines the fallback behavior when `val` doesn't have
             a channel. If `default` is not set, a TypeError is raised. If
             default is set to a value, that value is returned.
-        atol: If calculating kraus channels from channels, use this tolerance
+        atol: If calculating Kraus channels from channels, use this tolerance
             for determining whether a super-operator is all zeros.
 
     Returns:

--- a/cirq-core/cirq/protocols/kraus_protocol.py
+++ b/cirq-core/cirq/protocols/kraus_protocol.py
@@ -193,7 +193,7 @@ def kraus(
     if unitary_result is not NotImplemented and unitary_result is not None:
         return (unitary_result,)
 
-    if protocols.has_unitary(val):
+    if has_unitary(val):
         return (unitary(val),)
 
     channel_result = NotImplemented if channel_getter is None else channel_getter()

--- a/cirq-core/cirq/protocols/kraus_protocol_test.py
+++ b/cirq-core/cirq/protocols/kraus_protocol_test.py
@@ -249,7 +249,7 @@ def test_reset_channel_kraus_apply_channel_consistency():
 
 
 def test_kraus_channel_with_has_unitary():
-    """CZSWAP is a gate with no unitary but has a unitary."""
+    """CZSWAP has no unitary dunder method but has_unitary returns True."""
     op = cirq.CZSWAP.on(cirq.q(1), cirq.q(2))
     channels = cirq.kraus(op)
     assert len(channels) == 1

--- a/cirq-core/cirq/protocols/kraus_protocol_test.py
+++ b/cirq-core/cirq/protocols/kraus_protocol_test.py
@@ -153,9 +153,6 @@ class HasUnitary(cirq.testing.SingleQubitGate):
     def _has_unitary_(self) -> bool:
         return True
 
-    def _unitary_(self) -> np.ndarray:
-        return np.asarray([[1, 0], [0, 1]])
-
 
 class HasKrausWhenDecomposed(cirq.testing.SingleQubitGate):
     def __init__(self, decomposed_cls):

--- a/cirq-core/cirq/protocols/kraus_protocol_test.py
+++ b/cirq-core/cirq/protocols/kraus_protocol_test.py
@@ -153,6 +153,9 @@ class HasUnitary(cirq.testing.SingleQubitGate):
     def _has_unitary_(self) -> bool:
         return True
 
+    def _unitary_(self) -> np.ndarray:
+        return np.asarray([[1, 0], [0, 1]])
+
 
 class HasKrausWhenDecomposed(cirq.testing.SingleQubitGate):
     def __init__(self, decomposed_cls):
@@ -167,7 +170,7 @@ def test_has_kraus(cls) -> None:
     assert cirq.has_kraus(cls())
 
 
-@pytest.mark.parametrize('decomposed_cls', [HasKraus, HasMixture, HasUnitary])
+@pytest.mark.parametrize('decomposed_cls', [HasKraus, HasMixture])
 def test_has_kraus_when_decomposed(decomposed_cls) -> None:
     op = HasKrausWhenDecomposed(decomposed_cls).on(cirq.NamedQubit('test'))
     assert cirq.has_kraus(op)
@@ -243,3 +246,11 @@ def test_reset_channel_kraus_apply_channel_consistency():
     gate_no_kraus = NoKrausReset()
     # Should still match the original superoperator
     np.testing.assert_allclose(cirq.kraus(gate), cirq.kraus(gate_no_kraus), atol=1e-8)
+
+
+def test_kraus_channel_with_has_unitary():
+    """CZSWAP is a gate with no unitary but has a unitary."""
+    op = cirq.CZSWAP.on(cirq.q(1), cirq.q(2))
+    channels = cirq.kraus(op)
+    assert len(channels) == 1
+    np.testing.assert_allclose(channels[0], cirq.unitary(op))


### PR DESCRIPTION
- There were a few issues with the new strategy to fall back to super-operator calculations using apply_channels.
- First, the super_operator_to_kraus function is generally not precise or numerically stable enough to support an atol of 1e-10 so loosened this to 1e-6 and also allowed the ability to specify this as a parameter.
- Next, some operators define decomposition, so cirq.kraus should try to decompose and get a unitary before falling back to using apply_channel.

Fixes: #7536