### PR TITLE
Fix typos in reference docs

### DIFF
--- a/cirq-core/cirq/ops/fsim_gate.py
+++ b/cirq-core/cirq/ops/fsim_gate.py
@@ -350,7 +350,7 @@ class PhasedFSimGate(gate_features.InterchangeableQubitsGate, raw_types.Gate):
 
     @staticmethod
     def from_matrix(u: np.ndarray) -> PhasedFSimGate | None:
-        """Contruct a PhasedFSimGate from unitary.
+        """Constructs a PhasedFSimGate from unitary.
 
         Args:
             u: A unitary matrix representing a PhasedFSimGate.

--- a/cirq-core/cirq/value/condition.py
+++ b/cirq-core/cirq/value/condition.py
@@ -154,7 +154,7 @@ class BitMaskKeyCondition(Condition):
         - BitMaskKeyCondition.create_not_equal_mask('a', 13) -> (a & 13) != 13
 
     The bits in the bitmask have the same order as the qubits passed to `cirq.measure(...)`. That's
-    the most significant bit corresponds to the the first (left most) qubit.
+    the most significant bit corresponds to the first (left most) qubit.
 
     Attributes:
         - key: Measurement key.

--- a/cirq-google/cirq_google/line/placement/anneal.py
+++ b/cirq-google/cirq_google/line/placement/anneal.py
@@ -327,7 +327,7 @@ class AnnealSequenceSearchStrategy(place_strategy.LinePlacementStrategy):
 
     TODO: This line search strategy is still work in progress and requires
     efficiency improvements.
-    Github issue: https://github.com/quantumlib/Cirq/issues/2217
+    GitHub issue: https://github.com/quantumlib/Cirq/issues/2217
     """
 
     def __init__(

--- a/cirq-google/cirq_google/ops/analog_detune_gates.py
+++ b/cirq-google/cirq_google/ops/analog_detune_gates.py
@@ -64,8 +64,8 @@ class AnalogDetuneQubit(cirq.ops.Gate):
         Args:
             length: The duration of gate.
             w: Width of the step envelope raising edge.
-            target_freq: The target frequecy for the qubit at end of detune gate.
-            prev_freq: Previous detuning frequecy to compensate beginning of detune gate.
+            target_freq: The target frequency for the qubit at end of detune gate.
+            prev_freq: Previous detuning frequency to compensate beginning of detune gate.
             neighbor_coupler_g_dict: A dictionary has coupler name like "c_q0_0_q1_0"
                 as key and the coupling strength `g` as the value.
             prev_neighbor_coupler_g_dict: A dictionary has the same format as
@@ -231,7 +231,7 @@ class AnalogDetuneCouplerOnly(cirq.ops.Gate):
             interpolate_coupling_cal: If true, find the required amp for the coupling strength
                 through interpolation. If not true, require all coupling strength has associated
                 amp calibrated in the registry.
-            analog_cal_for_pulseshaping: If ture, using the analog model instead of
+            analog_cal_for_pulseshaping: If true, using the analog model instead of
                 standard transmon model to find the amp of pulse.
         """
         self.length = length

--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -532,7 +532,7 @@ def internal_gate_from_proto(msg: v2.program_pb2.InternalGate) -> InternalGate:
 def clifford_tableau_arg_to_proto(
     value: CliffordTableau, *, out: v2.program_pb2.CliffordTableau | None = None
 ):
-    """Writes an CliffordTableau object into an CliffordTableau proto.
+    """Writes a CliffordTableau object into a CliffordTableau proto.
     Args:
         value: The gate to encode.
         out: The proto to write the result into. Defaults to a new instance.

--- a/cirq-ionq/cirq_ionq/results.py
+++ b/cirq-ionq/cirq_ionq/results.py
@@ -115,7 +115,7 @@ class QPUResult:
         `cirq.Result` contains a less dense representation of results than that returned by
         the IonQ API.  Typically these results are also ordered by when they were run, though
         that contract is implicit.  Because the IonQ API does not retain that ordering information,
-        the order of these `cirq.Result` objects should *not* be interpetted as representing the
+        the order of these `cirq.Result` objects should *not* be interpreted as representing the
         order in which the circuit was repeated. Correlations between measurements keys are
         preserved.
 


### PR DESCRIPTION
- These are typos identified by running the CommonTypos internal tool on api reference docs for cirq.