### PR TITLE
fix sympy and t-unit comparison

### DIFF
--- a/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit.py
+++ b/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit.py
@@ -14,6 +14,7 @@
 
 import functools
 import re
+from typing import Any
 
 import cirq
 from cirq_google.experimental.analog_experiments import analog_trajectory_util as atu
@@ -51,6 +52,16 @@ def _get_neighbor_coupler_freqs(
         for pair, g in coupler_g_dict.items()
         if qubit_name in pair
     }
+
+
+def is_same_value_or_symbol(val1, val2) -> bool:
+    """Check two values are same value or same symbols."""
+    try:
+        # If we run "sympy.Symbol('t') == 2*tu.ns", it will
+        # throw the dimension issue.
+        return val1 == val2
+    except:
+        return False
 
 
 class GenericAnalogCircuitBuilder:
@@ -125,7 +136,7 @@ class GenericAnalogCircuitBuilder:
         for p, g_max in freq_map.couplings.items():
             # Currently skipping the step if these are the same.
             # However, change in neighbor qubit freq could potentially change coupler amp
-            if g_max == prev_freq_map.couplings[p]:
+            if is_same_value_or_symbol(g_max, prev_freq_map.couplings.get(p)):
                 continue
 
             coupler_gates.append(

--- a/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit.py
+++ b/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit.py
@@ -54,7 +54,7 @@ def _get_neighbor_coupler_freqs(
     }
 
 
-def is_same_value_or_symbol(val1, val2) -> bool:
+def is_same_value_or_symbol(val1: Any, val2: Any) -> bool:
     """Check two values are same value or same symbols."""
     try:
         # If we run "sympy.Symbol('t') == 2*tu.ns", it will

--- a/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit_test.py
+++ b/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit_test.py
@@ -39,6 +39,16 @@ def test_to_grid_qubit() -> None:
         gac._to_grid_qubit("q1")
 
 
+def test_is_same_value_or_symbol() -> None:
+    assert gac.is_same_value_or_symbol(sympy.Symbol("a"), sympy.Symbol("a"))
+    assert gac.is_same_value_or_symbol(1, 1)
+    assert gac.is_same_value_or_symbol(1 * tu.ns, 1 * tu.ns)
+
+    assert not gac.is_same_value_or_symbol(sympy.Symbol("a"), sympy.Symbol("b"))
+    assert not gac.is_same_value_or_symbol(1 * tu.ns, sympy.Symbol("a"))
+    assert not gac.is_same_value_or_symbol(1 * tu.ns, None)
+
+
 def test_coupler_name_from_qubit_pair() -> None:
     pair = ("q0_0", "q0_1")
     coupler_name = gac._coupler_name_from_qubit_pair(pair)


### PR DESCRIPTION
!!!UPDATE!!!!

We do not need this after updating the Sympy version from 1.9 => 1.14.