### PR TITLE
Add option and set the default float encoding as float32

### DIFF
--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -18,7 +18,6 @@ import gzip
 import numbers
 from typing import Any, Callable, cast, TYPE_CHECKING
 
-import numpy as np
 import sympy
 import tunits
 
@@ -40,7 +39,8 @@ def _build_sweep_const(value: Any, use_float64: bool = False) -> run_context_pb2
         if use_float64:
             return run_context_pb2.ConstValue(double_value=float(value))
         else:
-            return run_context_pb2.ConstValue(float_value=np.float32(value))
+            # Note: A loss of precision for floating-point numbers may occur here.
+            return run_context_pb2.ConstValue(float_value=float(value))
     elif isinstance(value, str):
         return run_context_pb2.ConstValue(string_value=value)
     elif isinstance(value, tunits.Value):
@@ -139,6 +139,7 @@ def sweep_to_proto(
                 out.single_sweep.linspace.first_point_double = sweep.start[unit]
                 out.single_sweep.linspace.last_point_double = sweep.stop[unit]
             else:
+                # Note: A loss of precision for floating-point numbers may occur here.
                 out.single_sweep.linspace.first_point = sweep.start[unit]
                 out.single_sweep.linspace.last_point = sweep.stop[unit]
             out.single_sweep.linspace.num_points = sweep.length
@@ -148,6 +149,7 @@ def sweep_to_proto(
                 out.single_sweep.linspace.first_point_double = sweep.start
                 out.single_sweep.linspace.last_point_double = sweep.stop
             else:
+                # Note: A loss of precision for floating-point numbers may occur here.
                 out.single_sweep.linspace.first_point = sweep.start
                 out.single_sweep.linspace.last_point = sweep.stop
 
@@ -174,12 +176,14 @@ def sweep_to_proto(
                 if use_float64:
                     out.single_sweep.points.points_double.extend(p[unit] for p in sweep.points)
                 else:
+                    # Note: A loss of precision for floating-point numbers may occur here.
                     out.single_sweep.points.points.extend(p[unit] for p in sweep.points)
                 unit.to_proto(out.single_sweep.points.unit)
             else:
                 if use_float64:
                     out.single_sweep.points.points_double.extend(sweep.points)
                 else:
+                    # Note: A loss of precision for floating-point numbers may occur here.
                     out.single_sweep.points.points.extend(sweep.points)
 
         # Encode the metadata if present

--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -18,6 +18,7 @@ import gzip
 import numbers
 from typing import Any, Callable, cast, TYPE_CHECKING
 
+import numpy as np
 import sympy
 import tunits
 
@@ -39,7 +40,7 @@ def _build_sweep_const(value: Any, use_float64: bool = False) -> run_context_pb2
         if use_float64:
             return run_context_pb2.ConstValue(double_value=float(value))
         else:
-            return run_context_pb2.ConstValue(float_value=float(value))
+            return run_context_pb2.ConstValue(float_value=np.float32(value))
     elif isinstance(value, str):
         return run_context_pb2.ConstValue(string_value=value)
     elif isinstance(value, tunits.Value):

--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -29,15 +29,17 @@ if TYPE_CHECKING:
     from cirq.study import sweeps
 
 
-def _build_sweep_const(value: Any) -> run_context_pb2.ConstValue:
+def _build_sweep_const(value: Any, use_float64: bool = False) -> run_context_pb2.ConstValue:
     """Build the sweep const message from a value."""
     if value is None:
         return run_context_pb2.ConstValue(is_none=True)
     elif isinstance(value, numbers.Integral):
         return run_context_pb2.ConstValue(int_value=int(value))
     elif isinstance(value, numbers.Real):
-        # TODO Switch to double_value when server is rolled out.
-        return run_context_pb2.ConstValue(float_value=float(value))
+        if use_float64:
+            return run_context_pb2.ConstValue(double_value=float(value))
+        else:
+            return run_context_pb2.ConstValue(float_value=float(value))
     elif isinstance(value, str):
         return run_context_pb2.ConstValue(string_value=value)
     elif isinstance(value, tunits.Value):
@@ -69,6 +71,7 @@ def sweep_to_proto(
     *,
     out: run_context_pb2.Sweep | None = None,
     sweep_transformer: Callable[[sweeps.SingleSweep], sweeps.SingleSweep] = lambda x: x,
+    use_float64: bool = False,
 ) -> run_context_pb2.Sweep:
     """Converts a Sweep to v2 protobuf message.
 
@@ -77,6 +80,8 @@ def sweep_to_proto(
         out: Optional message to be populated. If not given, a new message will
             be created.
         sweep_transformer: A function called on Linspace, Points.
+        use_float64: If true, float64 is used to encode the floating value. If false,
+            float32 is used instead. Default: False.
 
     Returns:
         Populated sweep protobuf message.
@@ -92,45 +97,58 @@ def sweep_to_proto(
         out.sweep_function.function_type = run_context_pb2.SweepFunction.PRODUCT
         for factor in sweep.factors:
             sweep_to_proto(
-                factor, out=out.sweep_function.sweeps.add(), sweep_transformer=sweep_transformer
+                factor,
+                out=out.sweep_function.sweeps.add(),
+                sweep_transformer=sweep_transformer,
+                use_float64=use_float64,
             )
     elif isinstance(sweep, cirq.ZipLongest):
         out.sweep_function.function_type = run_context_pb2.SweepFunction.ZIP_LONGEST
         for s in sweep.sweeps:
             sweep_to_proto(
-                s, out=out.sweep_function.sweeps.add(), sweep_transformer=sweep_transformer
+                s,
+                out=out.sweep_function.sweeps.add(),
+                sweep_transformer=sweep_transformer,
+                use_float64=use_float64,
             )
     elif isinstance(sweep, cirq.Zip):
         out.sweep_function.function_type = run_context_pb2.SweepFunction.ZIP
         for s in sweep.sweeps:
             sweep_to_proto(
-                s, out=out.sweep_function.sweeps.add(), sweep_transformer=sweep_transformer
+                s,
+                out=out.sweep_function.sweeps.add(),
+                sweep_transformer=sweep_transformer,
+                use_float64=use_float64,
             )
     elif isinstance(sweep, cirq.Concat):
         out.sweep_function.function_type = run_context_pb2.SweepFunction.CONCAT
         for s in sweep.sweeps:
             sweep_to_proto(
-                s, out=out.sweep_function.sweeps.add(), sweep_transformer=sweep_transformer
+                s,
+                out=out.sweep_function.sweeps.add(),
+                sweep_transformer=sweep_transformer,
+                use_float64=use_float64,
             )
     elif isinstance(sweep, cirq.Linspace) and not isinstance(sweep.key, sympy.Expr):
         sweep = cast(cirq.Linspace, sweep_transformer(sweep))
         out.single_sweep.parameter_key = sweep.key
         if isinstance(sweep.start, tunits.Value):
             unit = sweep.start.unit
-            out.single_sweep.linspace.first_point = sweep.start[unit]
-            out.single_sweep.linspace.last_point = sweep.stop[unit]
-            # Dual write for float32 to float64 migration
-            out.single_sweep.linspace.first_point_double = sweep.start[unit]
-            out.single_sweep.linspace.last_point_double = sweep.stop[unit]
-
+            if use_float64:
+                out.single_sweep.linspace.first_point_double = sweep.start[unit]
+                out.single_sweep.linspace.last_point_double = sweep.stop[unit]
+            else:
+                out.single_sweep.linspace.first_point = sweep.start[unit]
+                out.single_sweep.linspace.last_point = sweep.stop[unit]
             out.single_sweep.linspace.num_points = sweep.length
             unit.to_proto(out.single_sweep.linspace.unit)
         else:
-            out.single_sweep.linspace.first_point = sweep.start
-            out.single_sweep.linspace.last_point = sweep.stop
-            # Dual write for float32 to float64 migration
-            out.single_sweep.linspace.first_point_double = sweep.start
-            out.single_sweep.linspace.last_point_double = sweep.stop
+            if use_float64:
+                out.single_sweep.linspace.first_point_double = sweep.start
+                out.single_sweep.linspace.last_point_double = sweep.stop
+            else:
+                out.single_sweep.linspace.first_point = sweep.start
+                out.single_sweep.linspace.last_point = sweep.stop
 
             out.single_sweep.linspace.num_points = sweep.length
         # Encode the metadata if present
@@ -148,18 +166,21 @@ def sweep_to_proto(
         sweep = cast(cirq.Points, sweep_transformer(sweep))
         out.single_sweep.parameter_key = sweep.key
         if len(sweep.points) == 1:
-            out.single_sweep.const_value.MergeFrom(_build_sweep_const(sweep.points[0]))
+            out.single_sweep.const_value.MergeFrom(_build_sweep_const(sweep.points[0], use_float64))
         else:
             if isinstance(sweep.points[0], tunits.Value):
                 unit = sweep.points[0].unit
-                # Dual-write to both points and points_double for temporary compatibility.
-                out.single_sweep.points.points.extend(p[unit] for p in sweep.points)
-                out.single_sweep.points.points_double.extend(p[unit] for p in sweep.points)
+                if use_float64:
+                    out.single_sweep.points.points_double.extend(p[unit] for p in sweep.points)
+                else:
+                    out.single_sweep.points.points.extend(p[unit] for p in sweep.points)
                 unit.to_proto(out.single_sweep.points.unit)
             else:
-                # Dual-write to both points and points_double for temporary compatibility.
-                out.single_sweep.points.points.extend(sweep.points)
-                out.single_sweep.points.points_double.extend(sweep.points)
+                if use_float64:
+                    out.single_sweep.points.points_double.extend(sweep.points)
+                else:
+                    out.single_sweep.points.points.extend(sweep.points)
+
         # Encode the metadata if present
         if isinstance(sweep.metadata, Metadata):
             out.single_sweep.metadata.MergeFrom(metadata_to_proto(sweep.metadata))
@@ -184,6 +205,7 @@ def sweep_to_proto(
                 cirq.Points(key, sweep_dict[key]),
                 out=out.sweep_function.sweeps.add(),
                 sweep_transformer=sweep_transformer,
+                use_float64=use_float64,
             )
     else:
         raise ValueError(f'cannot convert to v2 Sweep proto: {sweep}')
@@ -327,6 +349,7 @@ def run_context_to_proto(
     *,
     out: run_context_pb2.RunContext | None = None,
     compress_proto: bool = False,
+    use_float64: bool = False,
 ) -> run_context_pb2.RunContext:
     """Populates a RunContext protobuf message.
 
@@ -337,6 +360,8 @@ def run_context_to_proto(
             be created.
         compress_proto: If set to `True` the function will gzip the proto and
             store the contents in the bytes field.
+        use_float64: If true, float64 is used to encode the floating value. If false,
+            float32 is used instead. Default: False.
 
     Returns:
         Populated RunContext protobuf message.
@@ -349,7 +374,7 @@ def run_context_to_proto(
     for sweep in cirq.to_sweeps(sweepable):
         sweep_proto = out.parameter_sweeps.add()
         sweep_proto.repetitions = repetitions
-        sweep_to_proto(sweep, out=sweep_proto.sweep)
+        sweep_to_proto(sweep, out=sweep_proto.sweep, use_float64=use_float64)
     if compress_proto:
         raw_bytes = out.SerializeToString()
         uncompressed_wrapper.compressed_run_context = gzip.compress(raw_bytes)

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -370,25 +370,24 @@ def test_sweep_from_proto_with_func_on_resursive_sweep_succeeds(expected_sweep):
     assert round_trip_sweep == expected_sweep
 
 
-def test_sweep_with_list_sweep():
+@pytest.mark.parametrize("use_float64", [True, False])
+def test_sweep_with_list_sweep(use_float64):
     ls = cirq.study.to_sweep([{'a': 1, 'b': 2}, {'a': 3, 'b': 4}])
-    proto = v2.sweep_to_proto(ls)
+    proto = v2.sweep_to_proto(ls, use_float64=use_float64)
     expected = v2.run_context_pb2.Sweep()
     expected.sweep_function.function_type = v2.run_context_pb2.SweepFunction.ZIP
     p1 = expected.sweep_function.sweeps.add()
     p1.single_sweep.parameter_key = 'a'
-    p1.single_sweep.points.points.extend([1, 3])
+
     p2 = expected.sweep_function.sweeps.add()
     p2.single_sweep.parameter_key = 'b'
-    p2.single_sweep.points.points.extend([2, 4])
-    assert proto == expected
 
-    # Encode into float64 isntead
-    proto = v2.sweep_to_proto(ls, use_float64=True)
-    p1.single_sweep.points.ClearField('points')
-    p1.single_sweep.points.points_double.extend([1.0, 3.0])
-    p2.single_sweep.points.ClearField('points')
-    p2.single_sweep.points.points_double.extend([2, 4])
+    if use_float64:
+        p1.single_sweep.points.points_double.extend([1, 3])
+        p2.single_sweep.points.points_double.extend([2, 4])
+    else:
+        p1.single_sweep.points.points.extend([1, 3])
+        p2.single_sweep.points.points.extend([2, 4])
     assert proto == expected
 
 

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -444,8 +444,9 @@ def test_run_context_to_proto_with_compression() -> None:
         (cirq.Points('tunits_const', [tunits.MHz])),  # type: ignore[list-item]
     ],
 )
-def test_tunits_round_trip(sweep):
-    msg = v2.sweep_to_proto(sweep)
+@pytest.mark.parametrize('use_float64', [True, False])
+def test_tunits_round_trip(sweep, use_float64):
+    msg = v2.sweep_to_proto(sweep, use_float64=use_float64)
     recovered = v2.sweep_from_proto(msg)
     assert sweep == recovered
 


### PR DESCRIPTION
Adding an option in the `run_context_to_proto` so that only one of the float32 or float64 will be written into proto. Default to be float 32 so that the behavior is unchanged. 

When we update the Cirq version internally to include this CL, we need to make sure all  swithcing into `v2.run_context_to_proto(.., use_float64=True)`

