### PR TITLE
Update OpenQASM compatibility table

### DIFF
--- a/docs/build/interop.ipynb
+++ b/docs/build/interop.ipynb
@@ -313,15 +313,15 @@
     "|`qreg name[size];`| supported (see mapping qubits)| Declare a named register of qubits|`qreg q[5];`|\n",
     "|`creg name[size];`|supported (see mapping classical register to measurement keys)|  Declare a named register of bits|`creg c[5];`|\n",
     "|`include \"filename\";`| supported ONLY to include the standard \"qelib1.inc\" lib for compatibility| Open and parse another source file|`include \"qelib1.inc\";`|\n",
-    "|`gate name(params) qargs;`|NOT supported| Declare a unitary gate||\n",
+    "|`gate name(params) qargs;`| supported| Declare a unitary gate|`gate g(p0, p1) q0, q1 { rx(p0) q0; ry(p0+p1) q0, rz(p1) q1; }`|\n",
     "|`opaque name(params) qargs;`| NOT supported| Declare an opaque gate||\n",
     "|`// comment text`| supported|Comment a line of text|`// supported!`|\n",
     "|`U(θ,φ,λ) qubit/qreg;`|  supported| Apply built-in single qubit gate(s)|``U(pi/2,2*pi/3,0) q[0];``|\n",
     "|`CX qubit/qreg,qubit/qreg;`| supported|Apply built-in CNOT gate(s)|`CX q[0],q[1];`|\n",
     "|measure qubit/qreg|supported|Make measurements in Z basis||\n",
-    "|`reset qubit/qreg;`| NOT supported|Prepare qubit(s) in <code>&#124;0></code>|`reset q[0];`| \n",
+    "|`reset qubit/qreg;`| supported|Prepare qubit(s) in <code>&#124;0></code>|`reset q[0];`| \n",
     "|`gatename(params) qargs;`|  supported for ONLY the supported subset of standard gates defined in \"qelib1.inc\"|Apply a user-defined unitary gate|`rz(pi/2) q[0];`|\n",
-    "|`if(creg==int) qop;`| NOT supported| Conditionally apply quantum operation|`if(c==5) CX q[0],q[1];`|\n",
+    "|`if(creg==int) qop;`| supported| Conditionally apply quantum operation|`if(c==5) CX q[0],q[1];`|\n",
     "|`barrier qargs;`| NOT supported| Prevent transformations across this source line|`barrier q[0],q[1];`|\n"
    ]
   },


### PR DESCRIPTION
Since recent changes have added supports for multiple statements, update the description in the OpenQASM compatibility table accordingly. 

#6917: added "gate" support
#6710: added "reset" support
#4738: added "if" support

Fixes: #7525 