### PR TITLE
Fix #7556: update isolated_notebook_test.py

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -48,6 +48,8 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = [
     'docs/simulate/noisy_simulation.ipynb',
     'docs/simulate/quantum_virtual_machine.ipynb',
     'docs/simulate/qvm_basic_example.ipynb',
+    'docs/simulate/qvm_builder_code.ipynb',
+    'docs/simulate/qvm_stabilizer_example.ipynb',
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule


### PR DESCRIPTION
Update `NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES` to reflect changes in the contents of the `docs/simulate` directory. This addresses issue #7556 and follows the procedure described in [`docs/dev/notebooks.md`](https://github.com/quantumlib/Cirq/blob/main/docs/dev/notebooks.md).