### PR TITLE
Add a new transformer that performs random pauli insertion

### DIFF
--- a/cirq-core/cirq/transformers/__init__.py
+++ b/cirq-core/cirq/transformers/__init__.py
@@ -160,3 +160,6 @@ from cirq.transformers.randomized_measurements import (
 from cirq.transformers.insertion_sort import (
     insertion_sort_transformer as insertion_sort_transformer,
 )
+
+
+from cirq.transformers.pauli_insertion import PauliInsertionTransformer as PauliInsertionTransformer

--- a/cirq-core/cirq/transformers/pauli_insertion.py
+++ b/cirq-core/cirq/transformers/pauli_insertion.py
@@ -1,0 +1,120 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A pauli insertion transformer."""
+
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from cirq import circuits, ops
+from cirq.transformers import transformer_api
+
+_PAULIS = [ops.I, ops.X, ops.Y, ops.Z]
+
+
+def _is_target(
+    op: ops.Operation,
+    target: ops.Gate | ops.GateFamily | ops.Gateset | type[ops.Gate | ops.Operation],
+):
+    if inspect.isclass(target):
+        if issubclass(target, ops.Operation):
+            return isinstance(op, target)
+        if not hasattr(op, 'gate'):
+            return False
+        return isinstance(op.gate, target)
+    if isinstance(target, ops.Gate):
+        if not hasattr(op, 'gate') or op.gate is None:
+            return False
+        return op.gate == target
+    return op in target
+
+
+@transformer_api.transformer
+class PauliInsertionTransformer:
+    r"""Creates a pauli insertion transformer.
+
+    A pauli insertion operation samples paulis from $\{I, X, Y, Z\}^2$ with the given
+    probabilities and adds it before the target 2Q gate/operation. This procedure is commonly
+    used in zero noise extrapolation (ZNE), see appendix D of https://arxiv.org/abs/2503.20870.
+    """
+
+    def __init__(
+        self,
+        target: ops.Gate | ops.GateFamily | ops.Gateset | type[ops.Gate | ops.Operation],
+        probabilities: np.ndarray | None = None,
+    ):
+        """Creates a pauli insertion transformer that samples 2Q paulis with the given probabilities.
+
+        Args:
+            target: The target gate, gatefamily, gateset, or type (e.g. PauliSumExponential).
+            probabilities: Optional ndarray representing the probabilities of sampling 2Q paulis.
+                The order of the paulis is IXYZ. If None, assume uniform distribution.
+        Returns:
+            A gauge transformer.
+        """
+        if probabilities is None:
+            probabilities = np.ones((4, 4)) / 16
+        probabilities = np.asarray(probabilities)
+        assert probabilities.shape == (4, 4)
+        assert np.isclose(probabilities.sum(), 1)
+
+        self.target = target
+        self._flat_probs = probabilities.reshape(-1)
+
+    def __call__(
+        self,
+        circuit: circuits.AbstractCircuit,
+        *,
+        rng_or_seed: np.random.Generator | int | None = None,
+        context: transformer_api.TransformerContext | None = None,
+    ):
+        context = (
+            context
+            if isinstance(context, transformer_api.TransformerContext)
+            else transformer_api.TransformerContext()
+        )
+        rng = (
+            rng_or_seed
+            if isinstance(rng_or_seed, np.random.Generator)
+            else np.random.default_rng(rng_or_seed)
+        )
+
+        if context.deep:
+            raise ValueError(f"this transformer doesn't support deep {context=}")
+
+        tags_to_ignore = frozenset(context.tags_to_ignore)
+        new_circuit: list[circuits.Moment] = []
+        for moment in circuit:
+            if any(tag in tags_to_ignore for tag in moment.tags):
+                continue
+            new_moment = []
+            for op in moment:
+                if any(tag in tags_to_ignore for tag in op.tags):
+                    continue
+                if not _is_target(op, self.target):
+                    continue
+                pair = np.unravel_index(rng.choice(16, p=self._flat_probs), (4, 4))
+                for pauli_index, q in zip(pair, op.qubits):
+                    if new_circuit and (q not in new_circuit[-1].qubits):
+                        new_circuit[-1] += _PAULIS[pauli_index](q)
+                    else:
+                        new_moment.append(_PAULIS[pauli_index](q))
+            if new_moment:
+                new_circuit.append(circuits.Moment(new_moment))
+            new_circuit.append(moment)
+        return circuits.Circuit.from_moments(*new_circuit)

--- a/cirq-core/cirq/transformers/pauli_insertion_test.py
+++ b/cirq-core/cirq/transformers/pauli_insertion_test.py
@@ -1,0 +1,60 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+import cirq
+
+_PAULIS = [cirq.I, cirq.X, cirq.Y, cirq.Z]
+
+
+def _random_probs(n: int, seed: int | None = None):
+    rng = np.random.default_rng(seed)
+    for _ in range(n):
+        probs = rng.random((4, 4))
+        probs /= probs.sum()
+        yield probs
+
+
+@pytest.mark.parametrize('probs', _random_probs(3, 0))
+def test_pauli_insertion_with_probabilities(probs):
+    c = cirq.Circuit(cirq.ZZ(*cirq.LineQubit.range(2)) ** 0.324)
+    transformer = cirq.transformers.PauliInsertionTransformer(cirq.ZZPowGate, probs)
+    count = np.zeros((4, 4))
+    for _ in range(100):
+        nc = transformer(c)
+        assert len(nc) == 2
+        u, v = nc[0]
+        i = _PAULIS.index(u.gate)
+        j = _PAULIS.index(v.gate)
+        count[i, j] += 1
+    count = count / count.sum()
+    np.testing.assert_allclose(count, probs, atol=0.1)
+
+
+@pytest.mark.parametrize('probs', _random_probs(3, 0))
+def test_pauli_insertion_with_probabilities_doesnot_create_moment(probs):
+    c = cirq.Circuit.from_moments([], [cirq.ZZ(*cirq.LineQubit.range(2)) ** 0.324])
+    transformer = cirq.transformers.PauliInsertionTransformer(cirq.ZZPowGate, probs)
+    count = np.zeros((4, 4))
+    for _ in range(100):
+        nc = transformer(c)
+        assert len(nc) == 2
+        u, v = nc[0]
+        i = _PAULIS.index(u.gate)
+        j = _PAULIS.index(v.gate)
+        count[i, j] += 1
+    count = count / count.sum()
+    np.testing.assert_allclose(count, probs, atol=0.1)


### PR DESCRIPTION
- **Update `_NPY_MAXDIMS` (#7167)**
- **Try again to format messages more nicely (#7180)**
- **Filter out harmless quimb-related warnings in check/doctest (#7179)**
- **Fix np.einsum type annotations (#7184)**
- **Fix flakes in pauli_string_measurement_with_readout_mitigation_test (#7185)**
- **Simplify python package description (#7187)**
- **Fix WaitGate for multiple qubits in cirq_google proto (#7189)**
- **Avoid frequent test failure in greedy_test.py by increasing timeout (#7188)**
- **Add isort for import linting (#7181)**
- **CI - skip sorting of imports with isort (#7190)**
- **Fix isort invocation in format-incremental (#7194)**
- **Update Zenodo info & correct a small typo (#7191)**
- **Improve check of expected shell commands in check/format-incremental (#7196)**
- **Sort import statements - no change in the effective code (#7195)**
- **Ignore isort code formatting in git blame (#7197)**
- **Update and make minor additions to docs/ in time for Cirq 1.5 (#7175)**
- **fix typos in docstrings (#7200)**
- **Create a new condition that allows easy control by bitmasks and Add a new classical Update the notebook for 'Classical control' to reflect new features" (#7166)**
- **Remove debug printouts from the test (#7202)**
- **Fix #5497: update IonQ docs to remove decompose_operation (#7198)**
- **Revise Community section (#7199)**
- **Add bytes to cirq_google proto (#7201)**
- **Format typescript sources at max_line_length=100 (#7205)**
- **Change a list of if statements into match (#7204)**
- **Resolve issue #7000 by adding PR labeler workflow (#7203)**
- **Bump actions/setup-python from 5.4.0 to 5.5.0 (#7207)**
- **Bump actions/cache from 4.2.2 to 4.2.3 (#7208)**
- **Bump actions/upload-artifact from 4.6.1 to 4.6.2 (#7209)**
- **Bump the non-security group in /cirq-web/cirq_ts with 5 updates (#7210)**
- **Better stimcirq serialization (#7192)**
- **Improve cirq-dev installation command (#7213)**
- **Fix gitignore to track maintained sources in docs/build (#7216)**
- **Clarify docstring of `is_parameterized` (#7215)**
- **Recommend use of unquoted annotations in coding style guide (#7222)**
- **Use a different action for size labeler GHA (#7219)**
- **Fix ALL THE COVERAGE (#7220)**
- **Update clifford_gate.py (#7223)**
- **Try using a PAT (#7225)**
- **Switch to unquoted type annotations part 1 (#7193)**
- **Test qcircuit pdf generation without extra `prepare_only` argument (#7227)**
- **Fix issue #6934 (#7230)**
- **ci-daily - explicitly install cirq-rigetti for the tests (#7229)**
- **Remove previously deprecated fields in cirq_google proto (#7183)**
- **Compensate for global phase in MatrixGate decomposition (#7118)**
- **Fix EigenGate equality (#7057)**
- **Allow '_mixture_' to return gates instead of just raw unitary matrices (#7048)**
- **Address warning about node_link_data, node_link_graph defaults (#7234)**
- **Ignore spurious PollerCompletionQueue errors in AsyncioExecutor (#6492)**
- **Add tuples, ndarrays, and complex numbers to cirq_google proto (#7226)**
- **Assume PhasedXPowGate is different from XPowGate and YPowGate (#7070)**
- **Address pandas warning about deprecated DataFrameGroupBy.apply default (#7235)**
- **Fix docker installation for cirq_pre_release image (#7240)**
- **Flip back to default `use_repetition_ids=True` in CircuitOperation (#7237)**
- **Fix a few capitalization typos (#7244)**
- **Fix failing CI tests due to old setuptools (#7249)**
- **Switch notebooks from dev to stable cirq where possible (#7247)**
- **CI - fix failing pre-release workflow (#7252)**
- **Fix issue #7245: update docs referring to calibration_api.ipynb (#7253)**
- **Correct minor typo in BitMaskKeyCondition (#7251)**
- **Do mild editing for grammar, consistency, and Markdown (#7246)**
- **Fix typos in XEB (#7254)**
- **Drop temporary warnings about changed data promotion in numpy-2 (#7258)**
- **Avoid using NotImplemented as a boolean (#7259)**
- **Fix serialization error in cirq_google. (#7260)**
- **Add classical conditions to cirq_google proto (#7250)**
- **Bump cirq version to 1.6.0 (#7261)**
- **Cite Cirq release 1.5.0 (#7263)**
- **Test all notebooks vs stable cirq after the release (#7255)**
- **Roll forward #6910 - CircuitOperation: change use_repetition_ids default to False (#7265)**
- **Remove USE_CONSTANTS flags and make them the default (#7262)**
- **Clarify instructions for release process (#7266)**
- **Remove pytest-debug.yaml workflow (#7274)**
- **Remove first-interction.yaml workflow (#7273)**
- **Replace PR labeler with better & safer version (#7271)**
- **Flip test names to match expected warnings (#7275)**
- **Put back the issues-write permission for pr-labeler (#7277)**
- **Remove pr_monitor (#7214)**
- **Update cirq resolver to check sympy singletons with `is` instead of `==` (#7279)**
- **Switch to unquoted type annotations part 2 (#7278)**
- **Fix YAML quotation error (#7286)**
- **Fixed visual bug and unit test (#7293)**
- **Fix minor README glitches, update Cirq logo to respond to dark/light mode, and add QAI logo (#7186)**
- **Switch to unquoted type annotations part 3 (#7295)**
- **Clarify error message for `decompose_once(X(q))` (#7281)**
- **Switch to unquoted type annotations part 4 (#7298)**
- **Improve reporting of errors & efficiency of pr-size-labeler (#7288)**
- **Bump http-proxy-middleware from 2.0.7 to 2.0.9 in /cirq-web/cirq_ts (#7300)**
- **Make cirq.Zip twenty times faster (#7303)**
- **Update documentation about num_qubits protocol (#7299)**
- **Add Willow gate (#7301)**
- **CI - replace actions/cache with setup-python package caching (#7305)**
- **Bump actions/setup-python from 5.5.0 to 5.6.0 (#7311)**
- **Bump actions/setup-node from 4.3.0 to 4.4.0 (#7312)**
- **Bump codecov/codecov-action from 5.4.0 to 5.4.2 (#7310)**
- **Bump typescript from 5.8.2 to 5.8.3 in /cirq-web/cirq_ts (#7315)**
- **Bump the non-security group in /cirq-web/cirq_ts with 7 updates (#7314)**
- **Switch to unquoted type annotations part 5 (#7317)**
- **Add the capability to accept group Paulis that can be measured using same measurement results (#7236)**
- **Group updates for GitHub Actions (#7318)**
- **Rewrite inefficient `sum(..., [])` and `sum(..., ())` (#7304)**
- **CI - fix type check with a temporary pin to numpy-1 (#7324)**
- **Create a new implementation of parallel XEB and its methods (#6940)**
- **Switch to unquoted type annotations part 6 (#7325)**
- **Starts deprecating pass_operations_over for PauliString and PauliStringPhasor (#7294)**
- **Add tag_transformers remove_tags, index_tags. (#7306)**
- **Fix qubit metadata in identifying_hardware_changes (#7308)**
- **Add WillowGate to cirq_google serialization (#7309)**
- **Disable all GitHub Actions jobs in forks (#7326)**
- **Add return type for tests (#7327)**
- **Pin Cotengra version (#7335)**
- **Add few more return-type annotations to tests (#7331)**
- **Fix identifying hardware changes notebook (#7328)**
- **Add CXSWAP and CZSWAP gates (#7334)**
- **Adjust type annotations for numpy-2 (#7333)**
- **Unpin cotengra requirement (#7340)**
- **Update .git-blame-ignore-revs for test return types. (#7332)**
- **Optimize the HHL algorithm using amplitude amplification (#7141)**
- **Remove documentation references to optimized_for_sycamore (#7329)**
- **NEP-29 - require minimum Python version 3.11 (#7338)**
- **Switch to unquoted type annotations part 7 (#7343)**
- **Fix another round of typing issues (#7341)**
- **Add a symbolize transformer (#7307)**
- **Remove Dockerfile and associated files and documentation (#7347)**
- **Support Reset gate in GridDevice and device specification proto (#7349)**
- **Switch to unquoted type annotations part 8 (#7345)**
- **Update Type Hints (#7348)**
- **Add QVM helper `extract_gate_times_ns_from_device` (#7350)**
- **Switch to unquoted type annotations part 9 (#7356)**
- **Bump codecov/codecov-action in the actions-version-updates group (#7351)**
- **Bump the non-security group in /cirq-web/cirq_ts with 5 updates (#7353)**
- **Update types for standard collections (#7355)**
- **Fix Linear dict scalar division test (#7361)**
- **Finalize switch to unquoted type annotations (part 10) (#7357)**
- **Added QASM Import Support for rzz, rxx, ryy, crx, cry, and iswap Gates (#7290)**
- **Unpin upper bound on setuptools requirement (#7359)**
- **Ignore typing PR for git blame. (#7363)**
- **Attempt canonicalization first when decomposing controlled gates (#7269)**
- **Update type annotations (#7364)**
- **Finalize switch to PEP 585 style type annotations (#7367)**
- **Flatten controlled-CZ and controlled-CX more consistently (#7365)**
- **Add QVM factory function load_device_noise_properties (#7369)**
- **Add new "willow_pink" processor to the QVM factory (#7366)**
- **Decompose controlled 1x1 unitary gates generically, not just GlobalPhaseGate (#7283)**
- **Add `list_virtual_processors` function to the QVM factory (#7375)**
- **Fix: Allow subtraction of IdentityGate in PauliSum.__sub__ (#7276)**
- **Bump networkx to minimum version 3.4 (#7378)**
- **Move cirq-ts files to cirq-web (#7362)**
- **CI - add ruff check of the code (#7372)**
- **Update format-incremental script to format notebooks (#7342)**
- **Format all notebooks (no change in the code) (#7386)**
- **pylint - sync with rules used in internal codes (#7387)**
- **Take care of leftover conversions to PEP 585 style (#7382)**
- **Fix more typing issues (#7388)**
- **Ignore notebook formatting in git blame (#7389)**
- **Support serializing sweeps with numpy values (#7398)**
- **QVM - deprecate default gate_times_ns in noise_properties_from_calibration (#7399)**
- **Use list for GoogleNoiseProperties.readout_errors values (#7392)**
- **Bump ossf/scorecard-action from 2.4.1 to 2.4.2 in the actions-version-updates group (#7402)**
- **Bump the non-security group in /cirq-web/cirq_web with 6 updates (#7403)**
- **Fix test case names. (#7406)**
- **Prefer load_device_noise_properties in example notebooks (#7408)**
- **Bump mypy to 1.16.0 (#7407)**
- **Remove dead code for scipy<=1.5 (#7410)**
- **Enable pylint and ruff check for unused suppression comments (#7412)**
- **Cirq x exponent symbol (#7400)**
- **ruff - enable and fix rules F401, F601 (#7413)**
- **Update dd at "pulled-throughs meet non-cliffords" (#7409)**
- **Fixes #7072: Support more OpenQASM 2.0 gates from qelib1.inc (#7377)**
- **Cirq Exponent exception for str only (#7422)**
- **ruff - enable and fix pylint-equivalent rules (#7420)**
- **Deselect ruff-covered pylint rules (#7424)**
- **CI - bump GHA windows runner to windows-2022 (#7423)**
- **Extend include_tags to support by-type selection (#7425)**
- **Fix typo in notebook example (#7426)**
- **Change merge_single_qubit_moments_to_phxz to support global phase. (#7405)**
- **Handle non-2D arrays in cirq.unitary (#7427)**
- **Modify apply_unitary and unitary to take in numpy unitary matrix. (#7419)**
- **Fix test assertion in raw_types_test.py. (#7401)**
- **Update dd with faster circuit construction (#7431)**
- **Combining readout circuits for QWC pauli strings in the ```measure_pauli_strings``` method (#7416)**
- **Support merge symbolized 1 qubit gate transformer (#7393)**
- **Ensure QVM notebooks use development version of cirq (#7436)**
- **Simplify decomposition of controlled eigengates with global phase (#7383)**
- **Implements optimizations A.1 and A.2 for Quantum Shannon Decomposition (#7390)**
- **Add AnalogDetuneQubit cirq google version (#7430)**
- **Update QVM demo notebooks to use willow_pink (#7428)**
- **Add AnalogTrajectory and FreqMap (#7437)**
- **Make QVM notebooks use development version of cirq_google (#7439)**
- **Address review comments for PR #7390 (#7441)**
- **Permit installation for Python 3.10 (docs build only) (#7445)**
- **Update ruff requirement from ~=0.11.11 to ~=0.12.1 in /dev_tools/requirements/deps (#7451)**
- **Bump github/codeql-action from 3.28.11 to 3.29.2 in the actions-version-updates group (#7449)**
- **CI - disable cirq-rigetti tests (#7433)**
- **Combine cirq-web updates (#7456)**
- **Combine mypy version updates (#7457)**
- **Fix test flake in pauli_string_measurement_with_readout_mitigation_test (#7459)**
- **Add return-type to public functions, mostly tests part 1 (#7440)**
- **Fix a couple of typos in transformers (#7471)**
- **Add AnalogDetuneCouplerOnly (#7444)**
- **Add `max_concurrent_jobs` to `Engine.get_sampler()`. (#7442)**
- **Adding tags to Moments (#7467)**
- **Add noise gates to cirq_google serialization (#7443)**
- **Update RB to reduce the size of the generated circuits (#7411)**
- **Promote FrozenCircuit.tags to AbstractCircuit (#7476)**
- **Fixing MS gate inverse is not implemented correctly (Issue 7432) (#7466)**
- **Add proto serialization support for circuit tags (#7478)**
- **Make isolated_notebook_test work from any directory (#7481)**
- **Standardize serialization of CalibrationTag (#7480)**
- **Cache the result of CircuitOperation.has_unitary (#7483)**
- **ci - avoid overlapping artifact names from notebook tests (#7486)**
- **Remove cirq-rigetti vendor module (#7488)**
- **Fix missing None types on test functions (#7494)**
- **Fix resolution of notebook paths when pytest is not at the repo root (#7487)**
- **CODEOWNERS - remove owner specifications for cirq-rigetti (#7497)**
- **Update Scientific Python dependencies per NEP-29 and SPEC-0 (#7496)**
- **NEP-29 - require minimum Python version 3.11 (#7499)**
- **Bump up grpcio-tools-1.71.2 (#7495)**
- **CI - activate Python 3.13 tests for all platforms (#7489)**
- **Expand parameters for product sweeps iteratively instead of recursively (#7490)**
- **Serialize tags on moments in cirq_google protos (#7493)**
- **Make the points in cirq_google v2 proto to be double (#7498)**
- **Implementation of support for IonQ pauliexp gates (#7374)**
- **Adjust example notebooks for the change of the use_repetion_ids default to false (#7504)**
- **Update link to qelib1.inc file (#7508)**
- **Remove documentation links to nonexistent documents and pages (#7506)**
- **Add num_qubits to DepolarizingChannel cirq_google serialization (#7502)**
- **ruff - enable and fix ISC, implicit string concatenation (#7511)**
- **Don't attempt to make the logo light/dark responsive (#7512)**
- **Revert "Expand parameters for product sweeps iteratively instead of recursively" (#7522)**
- **Add clarification to GridQubit neighbors function (#7521)**
- **Add JSON serialization support for NoiseModel classes (#7396)**
- **Expand product sweep parameters iteratively rather than recursively (#7523)**
- **Fix global phase computation in matrix gate decomposition (#7482)**
- **Derive _kraus_ from _apply_channel_ (#7434)**
- **Fix sidepanel contents for section on noise (#7518)**
- **Regenerate QuantumEngineService gRPC client libraries with GAPIC (#7500)**
- **Fix #7510: remove outdated notebook about XEB (#7519)**
- **Change use of measurements to records in tomography [continued] (#7477)**
- **Bump cirq version to 1.7.0 (#7526)**
- **Indicate that `docs/simulate/virtual_engine_interface.ipynb` depends on unreleased features (#7528)**
- **Cite Cirq release 1.6.0 (#7530)**
- **Restore behavior which persists `quantum_run_stream`s indefinitely (#7527)**
- **Include cirq.contrib test JSON files in cirq-core package (#7529)**
- **Fix two typos (#7533)**
- **Adds option to compress the size of RunContext (#7532)**
- **Add generic analog circuit builder class (#7491)**
- **Fix kraus channels for fallbacks to super-operators (#7537)**
- **Fix typos in reference docs (#7539)**
- **Remove the merge moments logic in dd (#7545)**
- **Bump github/codeql-action from 3.29.2 to 3.29.5 in the actions-version-updates group (#7548)**
- **Add option and set the default float encoding as float32 (#7554)**
- **Allow users to run readout benchmarking with sweep (#7435)**
- **Add CompressDurationTag (#7543)**
- **Add a new transformer that performs random pauli insertion**
