### PR TITLE
Link to Willow and Weber data sheets

### DIFF
--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -129,7 +129,7 @@
     "\n",
     "### Choose a processor to virtualize\n",
     "\n",
-    "Currently, the necessary data is publicly accessible only for the Weber and Rainbow processors. Read more about Google's processors [here](../hardware)."
+    "Currently, the necessary data is publicly accessible for the [Willow](https://quantumai.google/static/site-assets/downloads/willow-spec-sheet.pdf) processor as well as the older [Weber](https://quantumai.google/hardware/datasheet/weber.pdf) and Rainbow processors. "
    ]
   },
   {


### PR DESCRIPTION
- This links to the Willow and Weber data spec sheets instead of the hardware landing page for the QVM documentation.

Fixes: #7559