### PR TITLE
Test all notebooks vs stable Cirq after the release

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -43,16 +43,9 @@ from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT,
 # Please, always indicate in comments the feature used for easier bookkeeping.
 
 NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = [
-    # Requires `load_device_noise_properties` from #7369
-    'docs/hardware/qubit_picking.ipynb',
-    'docs/simulate/noisy_simulation.ipynb',
-    'docs/simulate/quantum_virtual_machine.ipynb',
-    'docs/simulate/qvm_basic_example.ipynb',
-    'docs/simulate/qvm_builder_code.ipynb',
-    'docs/simulate/qvm_stabilizer_example.ipynb',
     # Remove once the renaming of `whitelisted_users` -> `allowlisted_users`
     # throughout cirq_google is released.
-    'docs/simulate/virtual_engine_interface.ipynb',
+    'docs/simulate/virtual_engine_interface.ipynb'
 ]
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -48,6 +48,8 @@ NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = [
     'docs/simulate/noisy_simulation.ipynb',
     'docs/simulate/quantum_virtual_machine.ipynb',
     'docs/simulate/qvm_basic_example.ipynb',
+    'docs/simulate/qvm_builder_code.ipynb',
+    'docs/simulate/qvm_stabilizer_example.ipynb',
     # Remove once the renaming of `whitelisted_users` -> `allowlisted_users`
     # throughout cirq_google is released.
     'docs/simulate/virtual_engine_interface.ipynb',

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -42,11 +42,7 @@ from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT,
 # note that these notebooks are still tested in dev_tools/notebook_test.py
 # Please, always indicate in comments the feature used for easier bookkeeping.
 
-NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = [
-    # Remove once the renaming of `whitelisted_users` -> `allowlisted_users`
-    # throughout cirq_google is released.
-    'docs/simulate/virtual_engine_interface.ipynb'
-]
+NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = []
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule
 # please always add a reason for skipping.

--- a/docs/hardware/qubit_picking.ipynb
+++ b/docs/hardware/qubit_picking.ipynb
@@ -72,17 +72,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cb67ae611d34"
-   },
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -94,13 +83,9 @@
     "# @title Setup\n",
     "try:\n",
     "    import cirq\n",
-    "\n",
-    "    # raise ImportError when cirq is not new enough\n",
-    "    if cirq.__version__ == \"1.5.0\":\n",
-    "        raise ImportError(\"This notebook requires the development version of Cirq\")\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq~=1.0.dev\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "\n",

--- a/docs/simulate/noisy_simulation.ipynb
+++ b/docs/simulate/noisy_simulation.ipynb
@@ -63,17 +63,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "f9c6fb06ebbf"
-   },
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -83,13 +72,9 @@
    "source": [
     "try:\n",
     "    import cirq\n",
-    "\n",
-    "    # raise ImportError when cirq is not new enough\n",
-    "    if cirq.__version__ == \"1.5.0\":\n",
-    "        raise ImportError(\"This notebook requires the development version of Cirq\")\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq~=1.0.dev\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")"
    ]
   },

--- a/docs/simulate/quantum_virtual_machine.ipynb
+++ b/docs/simulate/quantum_virtual_machine.ipynb
@@ -79,9 +79,7 @@
     "id": "p31cCK_T1ylm"
    },
    "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
+    "## Setup"
    ]
   },
   {
@@ -97,15 +95,10 @@
     "\n",
     "try:\n",
     "    import cirq\n",
-    "\n",
-    "    # raise ImportError when cirq is not new enough\n",
-    "    if cirq.__version__ == \"1.5.0\":\n",
-    "        raise ImportError(\"This notebook requires the development version of Cirq\")\n",
-    "\n",
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
+    "    !pip install --quiet cirq-google\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",

--- a/docs/simulate/qvm_basic_example.ipynb
+++ b/docs/simulate/qvm_basic_example.ipynb
@@ -81,17 +81,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "8e3ded3ff3d1"
-   },
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -104,15 +93,10 @@
     "\n",
     "try:\n",
     "    import cirq\n",
-    "\n",
-    "    # raise ImportError when cirq is not new enough\n",
-    "    if cirq.__version__ == \"1.5.0\":\n",
-    "        raise ImportError(\"This notebook requires the development version of Cirq\")\n",
-    "\n",
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
+    "    !pip install --quiet cirq-google\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",

--- a/docs/simulate/qvm_builder_code.ipynb
+++ b/docs/simulate/qvm_builder_code.ipynb
@@ -81,17 +81,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3f2687e48726"
-   },
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -107,7 +96,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
+    "    !pip install --quiet cirq-google\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",

--- a/docs/simulate/qvm_stabilizer_example.ipynb
+++ b/docs/simulate/qvm_stabilizer_example.ipynb
@@ -81,17 +81,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3f2687e48726"
-   },
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -107,7 +96,7 @@
     "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq-google~=1.0.dev\n",
+    "    !pip install --quiet cirq-google\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "    import cirq_google\n",

--- a/docs/simulate/virtual_engine_interface.ipynb
+++ b/docs/simulate/virtual_engine_interface.ipynb
@@ -34,15 +34,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "ff0101ac0724"
-   },
-   "source": [
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq-google via `pip install --upgrade cirq-google~=1.0.dev`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "5v5kLs-DU9qp"
    },
    "source": [
@@ -103,14 +94,13 @@
    "source": [
     "try:\n",
     "    import cirq\n",
-    "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq~=1.0.dev cirq-google~=1.0.dev\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
-    "    import cirq_google\n",
     "\n",
+    "import cirq_google\n",
     "import sympy"
    ]
   },

--- a/docs/simulate/virtual_engine_interface.ipynb
+++ b/docs/simulate/virtual_engine_interface.ipynb
@@ -94,13 +94,14 @@
    "source": [
     "try:\n",
     "    import cirq\n",
+    "    import cirq_google\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
     "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
+    "    import cirq_google\n",
     "\n",
-    "import cirq_google\n",
     "import sympy"
    ]
   },


### PR DESCRIPTION
Make all notebook tests use stable cirq after the 1.6.0 release.

Ref: https://github.com/quantumlib/Cirq/blob/main/docs/dev/notebooks.md#lifecycle

Fixes #7556