### PR TITLE
Improve serialization of Sweepable objects

### DIFF
--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import gzip
 import numbers
-from typing import Any, Callable, cast, TYPE_CHECKING
+from typing import Any, Callable, cast, Iterable, TYPE_CHECKING
 
 import sympy
 import tunits
@@ -31,18 +31,32 @@ if TYPE_CHECKING:
 
 def _build_sweep_const(value: Any, use_float64: bool = False) -> run_context_pb2.ConstValue:
     """Build the sweep const message from a value."""
-    if value is None:
+    if isinstance(value, float):
+        # comparing to float is ~5x than testing numbers.Real
+        # if modifying the below, also modify the block below for numbers.Real
+        if use_float64:
+            return run_context_pb2.ConstValue(double_value=value)
+        else:
+            # Note: A loss of precision for floating-point numbers may occur here.
+            return run_context_pb2.ConstValue(float_value=value)
+    elif isinstance(value, int):
+        # comparing to int is ~5x than testing numbers.Integral
+        # if modifying the below, also modify the block below for numbers.Integral
+        return run_context_pb2.ConstValue(int_value=value)
+    elif value is None:
         return run_context_pb2.ConstValue(is_none=True)
+    elif isinstance(value, str):
+        return run_context_pb2.ConstValue(string_value=value)
     elif isinstance(value, numbers.Integral):
+        # more general than isinstance(int) but also slower
         return run_context_pb2.ConstValue(int_value=int(value))
     elif isinstance(value, numbers.Real):
+        # more general than isinstance(float) but also slower
         if use_float64:
             return run_context_pb2.ConstValue(double_value=float(value))
         else:
             # Note: A loss of precision for floating-point numbers may occur here.
             return run_context_pb2.ConstValue(float_value=float(value))
-    elif isinstance(value, str):
-        return run_context_pb2.ConstValue(string_value=value)
     elif isinstance(value, tunits.Value):
         return run_context_pb2.ConstValue(with_unit_value=value.to_proto())
     else:
@@ -348,6 +362,39 @@ def metadata_from_proto(metadata_pb: run_context_pb2.Metadata) -> Metadata:
     )
 
 
+def sweepable_to_proto(
+    sweepable: cirq.Sweepable,
+    repetitions: int,
+    *,
+    out: run_context_pb2.RunContext,
+    use_float64: bool = False,
+) -> run_context_pb2.RunContext:
+    if sweepable is None:
+        sweepable = cirq.UnitSweep
+    if isinstance(sweepable, cirq.ParamResolver):
+        sweepable = sweepable.param_dict or cirq.UnitSweep
+    if isinstance(sweepable, cirq.Sweep):
+        sweep_proto = out.parameter_sweeps.add()
+        sweep_proto.repetitions = repetitions
+        sweep_to_proto(sweepable, out=sweep_proto.sweep, use_float64=use_float64)
+        return out
+    if isinstance(sweepable, dict):
+        sweep_proto = out.parameter_sweeps.add()
+        sweep_proto.repetitions = repetitions
+        zip_proto = sweep_proto.sweep.sweep_function
+        zip_proto.function_type = run_context_pb2.SweepFunction.ZIP
+        for key, val in sweepable.items():
+            single_sweep = zip_proto.sweeps.add().single_sweep
+            single_sweep.parameter_key = key
+            single_sweep.const_value.MergeFrom(_build_sweep_const(val, use_float64))
+        return out
+    if isinstance(sweepable, Iterable):
+        for sweepable_element in sweepable:
+            sweepable_to_proto(sweepable_element, repetitions, out=out, use_float64=use_float64)
+        return out
+    raise TypeError(f'Unrecognized sweepable type: {type(sweepable)}.\nsweepable: {sweepable}')
+
+
 def run_context_to_proto(
     sweepable: cirq.Sweepable,
     repetitions: int,
@@ -376,10 +423,7 @@ def run_context_to_proto(
     if compress_proto:
         uncompressed_wrapper = out
         out = run_context_pb2.RunContext()
-    for sweep in cirq.to_sweeps(sweepable):
-        sweep_proto = out.parameter_sweeps.add()
-        sweep_proto.repetitions = repetitions
-        sweep_to_proto(sweep, out=sweep_proto.sweep, use_float64=use_float64)
+    sweepable_to_proto(sweepable, repetitions, out=out, use_float64=use_float64)
     if compress_proto:
         raw_bytes = out.SerializeToString()
         uncompressed_wrapper.compressed_run_context = gzip.compress(raw_bytes)

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -455,3 +455,36 @@ def test_tunits_round_trip(sweep, use_float64):
 def test_const_sweep_with_numpy_types_roundtrip(value):
     sweep = cirq.Points('const', [value])
     assert v2.sweep_from_proto(v2.sweep_to_proto(sweep)) == sweep
+
+
+@pytest.mark.parametrize(
+    'sweepable', [{'a': 4}, {'a': 2, 'b': 8}, [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}]]
+)
+@pytest.mark.parametrize('use_resolver', [True, False])
+def test_sweepable(sweepable: cirq.Sweepable, use_resolver: bool) -> None:
+    """Sweepable objects are accepted by run_context_to_proto.
+
+    These, like lists of dictionaries and ParamResolvers should be
+    converted to sweeps by the serializer.
+
+    This test ensures that the sweepable is serialized the same
+    as the corresponding sweep.
+    """
+    if use_resolver:
+        if isinstance(sweepable, list):
+            sweepable = [cirq.ParamResolver(element) for element in sweepable]
+        else:
+            sweepable = cirq.ParamResolver(sweepable)
+    sweeps = cirq.to_sweeps(sweepable)
+    expected_sweep = v2.run_context_pb2.RunContext()
+    for sweep in sweeps:
+        sweep_proto = expected_sweep.parameter_sweeps.add()
+        sweep_proto.repetitions = 1000
+        v2.sweep_to_proto(sweep, out=sweep_proto.sweep)
+    actual_sweep = v2.run_context_to_proto(sweepable, 1000, compress_proto=False)
+    assert expected_sweep == actual_sweep
+
+
+def test_invalid_sweepable():
+    with pytest.raises(TypeError):
+        _ = v2.run_context_to_proto(cirq.X, 1000, compress_proto=False)


### PR DESCRIPTION
- Sweepable objects (such as lists of dicts or ParamResolvers) get serialized into cirq_google run_contexts by converting them to sweeps first then converts the sweeps.  This is hugely inefficient as compared to directly serializing the dictionary directly.
- This changes run_context_to_sweep to directly serialize Sweepable objects.
- It adds a check to verify the serialization is equivalent to the old way of doing things.
- This PR also reorders some isinstance checks to make it more efficient.

For the following:
```
    sweepable = [{f'x_{i}':i+t for i in range(500)} for t in range(500)]
    _ = v2.run_context_to_proto(sweepable, 1000, compress_proto=False)
```

This change speeds the code from 2.4 seconds to 0.5 seconds.