### PR TITLE
Add return-type to public functions, mostly tests part 2

### DIFF
--- a/cirq-core/cirq/contrib/noise_models/noise_models.py
+++ b/cirq-core/cirq/contrib/noise_models/noise_models.py
@@ -45,7 +45,7 @@ class DepolarizingNoiseModel(devices.NoiseModel):
         self._prepend = prepend
 
     @property
-    def depol_prob(self):
+    def depol_prob(self) -> float:
         """The depolarizing probability."""
         return self._depol_prob
 
@@ -100,7 +100,7 @@ class ReadoutNoiseModel(devices.NoiseModel):
         self._prepend = prepend
 
     @property
-    def bitflip_prob(self):
+    def bitflip_prob(self) -> float:
         """The probability of a bit-flip during measurement."""
         return self._bitflip_prob
 
@@ -154,7 +154,7 @@ class DampedReadoutNoiseModel(devices.NoiseModel):
         self._prepend = prepend
 
     @property
-    def decay_prob(self):
+    def decay_prob(self) -> float:
         """The probability of T1 decay during measurement."""
         return self._decay_prob
 
@@ -207,12 +207,12 @@ class DepolarizingWithReadoutNoiseModel(devices.NoiseModel):
         self.readout_noise_gate = ops.BitFlipChannel(bitflip_prob)
 
     @property
-    def depol_prob(self):
+    def depol_prob(self) -> float:
         """The depolarizing probability."""
         return self._depol_prob
 
     @property
-    def bitflip_prob(self):
+    def bitflip_prob(self) -> float:
         """The probability of a bit-flip during measurement."""
         return self._bitflip_prob
 
@@ -262,17 +262,17 @@ class DepolarizingWithDampedReadoutNoiseModel(devices.NoiseModel):
         self.readout_decay_gate = ops.AmplitudeDampingChannel(decay_prob)
 
     @property
-    def depol_prob(self):
+    def depol_prob(self) -> float:
         """The depolarizing probability."""
         return self._depol_prob
 
     @property
-    def bitflip_prob(self):
+    def bitflip_prob(self) -> float:
         """Probability of a bit-flip during measurement."""
         return self._bitflip_prob
 
     @property
-    def decay_prob(self):
+    def decay_prob(self) -> float:
         """The probability of T1 decay during measurement."""
         return self._decay_prob
 

--- a/cirq-core/cirq/contrib/quimb/grid_circuits.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits.py
@@ -105,7 +105,7 @@ def get_grid_moments(
     )
 
 
-def simplify_expectation_value_circuit(circuit_sand: cirq.Circuit):
+def simplify_expectation_value_circuit(circuit_sand: cirq.Circuit) -> None:
     """For low weight operators on low-degree circuits, we can simplify
     the circuit representation of an expectation value.
 

--- a/cirq-core/cirq/contrib/quimb/grid_circuits_test.py
+++ b/cirq-core/cirq/contrib/quimb/grid_circuits_test.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -26,12 +28,13 @@ def _get_circuit(width, height, rs, p=2):
     return circuit, qubits
 
 
-def test_simplify_sandwich():
+def test_simplify_sandwich() -> None:
     rs = np.random.RandomState(52)
     for width in [2, 3]:
         for height in [1, 3]:
             for p in [1, 2]:
                 circuit, qubits = _get_circuit(width=width, height=height, p=p, rs=rs)
+                operator: cirq.PauliString
                 operator = cirq.PauliString(
                     {q: cirq.Z for q in rs.choice(qubits, size=2, replace=False)}
                 )
@@ -47,11 +50,12 @@ def test_simplify_sandwich():
 
 
 @pytest.mark.parametrize('simplify', [False, True])
-def test_circuit_to_tensors(simplify):
-    rs = np.random.RandomState(52)
+def test_circuit_to_tensors(simplify) -> None:
+    qubits: Sequence[cirq.Qid]
     qubits = cirq.LineQubit.range(2)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=10, op_density=0.8)
-    operator = cirq.PauliString({q: cirq.Z for q in rs.choice(qubits, size=2, replace=False)})
+    operator: cirq.PauliString
+    operator = cirq.PauliString(dict.fromkeys(qubits, cirq.Z))
 
     circuit_sand = ccq.circuit_for_expectation_value(circuit, operator)
     if simplify:
@@ -62,13 +66,14 @@ def test_circuit_to_tensors(simplify):
     np.testing.assert_allclose(u_tn, u_cirq, atol=1e-6)
 
 
-def test_tensor_expectation_value():
+def test_tensor_expectation_value() -> None:
     for _ in range(10):
         for width in [2, 3]:
             for height in [1, 3]:
                 for p in [1, 2]:
                     rs = np.random.RandomState(52)
                     circuit, qubits = _get_circuit(width=width, height=height, p=p, rs=rs)
+                    operator: cirq.PauliString
                     operator = cirq.PauliString(
                         {q: cirq.Z for q in rs.choice(qubits, size=2, replace=False)},
                         coefficient=rs.uniform(-1, 1),

--- a/cirq-core/cirq/contrib/quimb/mps_simulator.py
+++ b/cirq-core/cirq/contrib/quimb/mps_simulator.py
@@ -183,7 +183,7 @@ class MPSSimulatorStepResult(simulator_base.StepResultBase['MPSState']):
         super().__init__(sim_state)
 
     @property
-    def state(self):
+    def state(self) -> MPSState:
         return self._merged_sim_state
 
     def __str__(self) -> str:
@@ -646,10 +646,10 @@ class MPSState(SimulationState[_MPSHandler]):
         """Delegates the action to self.apply_op"""
         return self._state.apply_op(action, self.get_axes(qubits), self.prng)
 
-    def estimation_stats(self):
+    def estimation_stats(self) -> dict[str, float]:
         """Returns some statistics about the memory usage and quality of the approximation."""
         return self._state.estimation_stats()
 
     @property
-    def M(self):
+    def M(self) -> list[qtn.Tensor]:
         return self._state._M

--- a/cirq-core/cirq/contrib/quimb/mps_simulator_test.py
+++ b/cirq-core/cirq/contrib/quimb/mps_simulator_test.py
@@ -15,7 +15,7 @@ import cirq.testing
 from cirq import value
 
 
-def assert_same_output_as_dense(circuit, qubit_order, initial_state=0, grouping=None):
+def assert_same_output_as_dense(circuit, qubit_order, initial_state=0, grouping=None) -> None:
     mps_simulator = ccq.mps_simulator.MPSSimulator(grouping=grouping)
     ref_simulator = cirq.Simulator()
 
@@ -27,7 +27,7 @@ def assert_same_output_as_dense(circuit, qubit_order, initial_state=0, grouping=
     assert len(actual.measurements) == 0
 
 
-def test_various_gates_1d():
+def test_various_gates_1d() -> None:
     gate_op_cls = [cirq.I, cirq.H, cirq.X, cirq.Y, cirq.Z, cirq.T]
     cross_gate_op_cls = [cirq.CNOT, cirq.SWAP]
 
@@ -43,7 +43,7 @@ def test_various_gates_1d():
                     )
 
 
-def test_various_gates_1d_flip():
+def test_various_gates_1d_flip() -> None:
     q0, q1 = cirq.LineQubit.range(2)
 
     circuit = cirq.Circuit(cirq.H(q1), cirq.CNOT(q1, q0))
@@ -52,7 +52,7 @@ def test_various_gates_1d_flip():
     assert_same_output_as_dense(circuit=circuit, qubit_order=[q1, q0])
 
 
-def test_various_gates_2d():
+def test_various_gates_2d() -> None:
     gate_op_cls = [cirq.I, cirq.H]
     cross_gate_op_cls = [cirq.CNOT, cirq.SWAP]
 
@@ -77,7 +77,7 @@ def test_various_gates_2d():
                             )
 
 
-def test_grouping():
+def test_grouping() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
 
     circuit = cirq.Circuit(
@@ -107,7 +107,7 @@ def test_grouping():
             )
 
 
-def test_grouping_does_not_overlap():
+def test_grouping_does_not_overlap() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     mps_simulator = ccq.mps_simulator.MPSSimulator(grouping={q0: 0})
 
@@ -115,7 +115,7 @@ def test_grouping_does_not_overlap():
         mps_simulator.simulate(cirq.Circuit(), qubit_order={q0: 0, q1: 1})
 
 
-def test_same_partial_trace():
+def test_same_partial_trace() -> None:
     qubit_order = cirq.LineQubit.range(2)
     q0, q1 = qubit_order
 
@@ -134,14 +134,14 @@ def test_same_partial_trace():
             final_state = mps_simulator.simulate(
                 circuit, qubit_order=qubit_order, initial_state=initial_state
             ).final_state
-            actual_density_matrix = final_state.partial_trace([q0, q1])
-            actual_partial_trace = final_state.partial_trace([q0])
+            actual_density_matrix = final_state.partial_trace({q0, q1})
+            actual_partial_trace = final_state.partial_trace({q0})
 
             np.testing.assert_allclose(actual_density_matrix, expected_density_matrix, atol=1e-4)
             np.testing.assert_allclose(actual_partial_trace, expected_partial_trace, atol=1e-4)
 
 
-def test_probs_dont_sum_up_to_one():
+def test_probs_dont_sum_up_to_one() -> None:
     q0 = cirq.NamedQid('q0', dimension=2)
     circuit = cirq.Circuit(cirq.measure(q0))
 
@@ -153,7 +153,7 @@ def test_probs_dont_sum_up_to_one():
         simulator.run(circuit, repetitions=1)
 
 
-def test_empty():
+def test_empty() -> None:
     q0 = cirq.NamedQid('q0', dimension=2)
     q1 = cirq.NamedQid('q1', dimension=3)
     q2 = cirq.NamedQid('q2', dimension=5)
@@ -165,7 +165,7 @@ def test_empty():
         )
 
 
-def test_cnot():
+def test_cnot() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.CNOT(q0, q1))
 
@@ -175,7 +175,7 @@ def test_cnot():
         )
 
 
-def test_cnot_flipped():
+def test_cnot_flipped() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.CNOT(q1, q0))
 
@@ -185,7 +185,7 @@ def test_cnot_flipped():
         )
 
 
-def test_simulation_state():
+def test_simulation_state() -> None:
     q0, q1 = qubit_order = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.CNOT(q1, q0))
     mps_simulator = ccq.mps_simulator.MPSSimulator()
@@ -202,7 +202,7 @@ def test_simulation_state():
         assert len(actual.measurements) == 0
 
 
-def test_three_qubits():
+def test_three_qubits() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     circuit = cirq.Circuit(cirq.CCX(q0, q1, q2))
 
@@ -210,7 +210,7 @@ def test_three_qubits():
         assert_same_output_as_dense(circuit=circuit, qubit_order=[q0, q1, q2])
 
 
-def test_measurement_1qubit():
+def test_measurement_1qubit() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.X(q0), cirq.H(q1), cirq.measure(q1))
 
@@ -221,7 +221,7 @@ def test_measurement_1qubit():
     assert sum(result.measurements['q(1)'])[0] > 20
 
 
-def test_reset():
+def test_reset() -> None:
     q = cirq.LineQubit(0)
     simulator = ccq.mps_simulator.MPSSimulator()
     c = cirq.Circuit(cirq.X(q), cirq.reset(q), cirq.measure(q))
@@ -232,7 +232,7 @@ def test_reset():
     assert simulator.sample(c)['q(0)'][0] == 0
 
 
-def test_measurement_2qubits():
+def test_measurement_2qubits() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     circuit = cirq.Circuit(cirq.H(q0), cirq.H(q1), cirq.H(q2), cirq.measure(q0, q2))
 
@@ -252,7 +252,7 @@ def test_measurement_2qubits():
         assert result_count < repetitions * 0.35
 
 
-def test_measurement_str():
+def test_measurement_str() -> None:
     q0 = cirq.NamedQid('q0', dimension=3)
     circuit = cirq.Circuit(cirq.measure(q0))
 
@@ -262,7 +262,7 @@ def test_measurement_str():
     assert str(result) == "q0 (d=3)=0000000"
 
 
-def test_trial_result_str():
+def test_trial_result_str() -> None:
     q0 = cirq.LineQubit(0)
     final_simulator_state = ccq.mps_simulator.MPSState(
         qubits=(q0,),
@@ -277,7 +277,7 @@ def test_trial_result_str():
     assert 'output state: TensorNetwork' in str(result)
 
 
-def test_trial_result_repr_pretty():
+def test_trial_result_repr_pretty() -> None:
     q0 = cirq.LineQubit(0)
     final_simulator_state = ccq.mps_simulator.MPSState(
         qubits=(q0,),
@@ -293,14 +293,14 @@ def test_trial_result_repr_pretty():
     cirq.testing.assert_repr_pretty(result, "cirq.MPSTrialResult(...)", cycle=True)
 
 
-def test_empty_step_result():
+def test_empty_step_result() -> None:
     q0 = cirq.LineQubit(0)
     sim = ccq.mps_simulator.MPSSimulator()
     step_result = next(sim.simulate_moment_steps(cirq.Circuit(cirq.measure(q0))))
     assert 'TensorNetwork' in str(step_result)
 
 
-def test_step_result_repr_pretty():
+def test_step_result_repr_pretty() -> None:
     q0 = cirq.LineQubit(0)
     sim = ccq.mps_simulator.MPSSimulator()
     step_result = next(sim.simulate_moment_steps(cirq.Circuit(cirq.measure(q0))))
@@ -308,7 +308,7 @@ def test_step_result_repr_pretty():
     cirq.testing.assert_repr_pretty(step_result, "cirq.MPSSimulatorStepResult(...)", cycle=True)
 
 
-def test_state_equal():
+def test_state_equal() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     state0 = ccq.mps_simulator.MPSState(
         qubits=(q0,),
@@ -330,7 +330,7 @@ def test_state_equal():
     assert state1a != state1b
 
 
-def test_random_circuits_equal_more_rows():
+def test_random_circuits_equal_more_rows() -> None:
     circuit = cirq.testing.random_circuit(
         qubits=cirq.GridQubit.rect(3, 2), n_moments=6, op_density=1.0
     )
@@ -338,7 +338,7 @@ def test_random_circuits_equal_more_rows():
     assert_same_output_as_dense(circuit, qubits)
 
 
-def test_random_circuits_equal_more_cols():
+def test_random_circuits_equal_more_cols() -> None:
     circuit = cirq.testing.random_circuit(
         qubits=cirq.GridQubit.rect(2, 3), n_moments=6, op_density=1.0
     )
@@ -346,10 +346,9 @@ def test_random_circuits_equal_more_cols():
     assert_same_output_as_dense(circuit, qubits)
 
 
-def test_tensor_index_names():
+def test_tensor_index_names() -> None:
     qubits = cirq.LineQubit.range(12)
-    qubit_map = {qubit: i for i, qubit in enumerate(qubits)}
-    state = ccq.mps_simulator.MPSState(qubits=qubit_map, prng=value.parse_random_state(0))
+    state = ccq.mps_simulator.MPSState(qubits=qubits, prng=value.parse_random_state(0))
 
     assert state.i_str(0) == "i_00"
     assert state.i_str(11) == "i_11"
@@ -357,7 +356,7 @@ def test_tensor_index_names():
     assert state.mu_str(3, 0) == "mu_0_3"
 
 
-def test_simulate_moment_steps_sample():
+def test_simulate_moment_steps_sample() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1))
 
@@ -366,7 +365,7 @@ def test_simulate_moment_steps_sample():
     for i, step in enumerate(simulator.simulate_moment_steps(circuit)):
         if i == 0:
             np.testing.assert_almost_equal(
-                step._simulator_state().to_numpy(),
+                step._simulator_state().to_numpy(),  # type: ignore[attr-defined]
                 np.asarray([1.0 / math.sqrt(2), 0.0, 1.0 / math.sqrt(2), 0.0]),
             )
             # There are two "Tensor()" copies in the string.
@@ -377,12 +376,12 @@ def test_simulate_moment_steps_sample():
                     sample, [False, False]
                 )
             np.testing.assert_almost_equal(
-                step._simulator_state().to_numpy(),
+                step._simulator_state().to_numpy(),  # type: ignore[attr-defined]
                 np.asarray([1.0 / math.sqrt(2), 0.0, 1.0 / math.sqrt(2), 0.0]),
             )
         else:
             np.testing.assert_almost_equal(
-                step._simulator_state().to_numpy(),
+                step._simulator_state().to_numpy(),  # type: ignore[attr-defined]
                 np.asarray([1.0 / math.sqrt(2), 0.0, 0.0, 1.0 / math.sqrt(2)]),
             )
             # There are two "Tensor()" copies in the string.
@@ -394,7 +393,7 @@ def test_simulate_moment_steps_sample():
                 )
 
 
-def test_sample_seed():
+def test_sample_seed() -> None:
     q = cirq.NamedQubit('q')
     circuit = cirq.Circuit(cirq.H(q), cirq.measure(q))
     simulator = ccq.mps_simulator.MPSSimulator(seed=1234)
@@ -404,7 +403,7 @@ def test_sample_seed():
     assert result_string == '01011001110111011011'
 
 
-def test_run_no_repetitions():
+def test_run_no_repetitions() -> None:
     q0 = cirq.LineQubit(0)
     simulator = ccq.mps_simulator.MPSSimulator()
     circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
@@ -412,7 +411,7 @@ def test_run_no_repetitions():
     assert len(result.measurements['q(0)']) == 0
 
 
-def test_run_parameters_not_resolved():
+def test_run_parameters_not_resolved() -> None:
     a = cirq.LineQubit(0)
     simulator = ccq.mps_simulator.MPSSimulator()
     circuit = cirq.Circuit(cirq.XPowGate(exponent=sympy.Symbol('a'))(a), cirq.measure(a))
@@ -420,7 +419,7 @@ def test_run_parameters_not_resolved():
         _ = simulator.run_sweep(circuit, cirq.ParamResolver({}))
 
 
-def test_deterministic_gate_noise():
+def test_deterministic_gate_noise() -> None:
     q = cirq.LineQubit(0)
     circuit = cirq.Circuit(cirq.I(q), cirq.measure(q))
 
@@ -438,7 +437,7 @@ def test_deterministic_gate_noise():
     assert result1 != result3
 
 
-def test_nondeterministic_mixture_noise():
+def test_nondeterministic_mixture_noise() -> None:
     q = cirq.LineQubit(0)
     circuit = cirq.Circuit(cirq.I(q), cirq.measure(q))
 
@@ -451,12 +450,12 @@ def test_nondeterministic_mixture_noise():
     assert result1 != result2
 
 
-def test_unsupported_noise_fails():
+def test_unsupported_noise_fails() -> None:
     with pytest.raises(ValueError, match='noise must be unitary or mixture but was'):
         ccq.mps_simulator.MPSSimulator(noise=cirq.amplitude_damp(0.5))
 
 
-def test_state_copy():
+def test_state_copy() -> None:
     sim = ccq.mps_simulator.MPSSimulator()
 
     q = cirq.LineQubit(0)
@@ -471,7 +470,7 @@ def test_state_copy():
             assert not np.shares_memory(x[i], y[i])
 
 
-def test_simulation_state_initializer():
+def test_simulation_state_initializer() -> None:
     expected_classical_data = cirq.ClassicalDataDictionaryStore(
         _records={cirq.MeasurementKey('test'): [(4,)]}
     )
@@ -489,7 +488,7 @@ def test_simulation_state_initializer():
     }
 
 
-def test_act_on_gate():
+def test_act_on_gate() -> None:
     args = ccq.mps_simulator.MPSState(qubits=cirq.LineQubit.range(3), prng=np.random.RandomState(0))
 
     cirq.act_on(cirq.X, args, [cirq.LineQubit(1)])

--- a/cirq-core/cirq/contrib/quimb/state_vector_test.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector_test.py
@@ -12,7 +12,7 @@ import cirq
 import cirq.contrib.quimb as ccq
 
 
-def test_tensor_state_vector_1():
+def test_tensor_state_vector_1() -> None:
     q = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.YPowGate(exponent=0.25).on(q[0]))
 
@@ -21,7 +21,7 @@ def test_tensor_state_vector_1():
     np.testing.assert_allclose(psi1, psi2, atol=1e-15)
 
 
-def test_tensor_state_vector_implicit_qubits():
+def test_tensor_state_vector_implicit_qubits() -> None:
     q = cirq.LineQubit.range(2)
     c = cirq.Circuit(cirq.YPowGate(exponent=0.25).on(q[0]))
 
@@ -30,7 +30,7 @@ def test_tensor_state_vector_implicit_qubits():
     np.testing.assert_allclose(psi1, psi2, atol=1e-15)
 
 
-def test_tensor_state_vector_2():
+def test_tensor_state_vector_2() -> None:
     q = cirq.LineQubit.range(2)
     rs = np.random.RandomState(52)
     for _ in range(10):
@@ -41,7 +41,7 @@ def test_tensor_state_vector_2():
         np.testing.assert_allclose(psi1, psi2, atol=1e-8)
 
 
-def test_tensor_state_vector_3():
+def test_tensor_state_vector_3() -> None:
     qubits = cirq.LineQubit.range(10)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=10, op_density=0.8)
     psi1 = cirq.final_state_vector(circuit, dtype=np.complex128)
@@ -49,7 +49,7 @@ def test_tensor_state_vector_3():
     np.testing.assert_allclose(psi1, psi2, atol=1e-8)
 
 
-def test_tensor_state_vector_4():
+def test_tensor_state_vector_4() -> None:
     qubits = cirq.LineQubit.range(4)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=100, op_density=0.8)
     psi1 = cirq.final_state_vector(circuit, dtype=np.complex128)
@@ -57,7 +57,7 @@ def test_tensor_state_vector_4():
     np.testing.assert_allclose(psi1, psi2, atol=1e-8)
 
 
-def test_sandwich_operator_identity():
+def test_sandwich_operator_identity() -> None:
     qubits = cirq.LineQubit.range(6)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=10, op_density=0.8)
     tot_c = ccq.circuit_for_expectation_value(circuit, cirq.PauliString({}))
@@ -74,7 +74,7 @@ def _random_pauli_string(qubits, rs, coefficients=False):
     return ps
 
 
-def test_sandwich_operator_expect_val():
+def test_sandwich_operator_expect_val() -> None:
     rs = np.random.RandomState(52)
     qubits = cirq.LineQubit.range(5)
     for _ in range(10):  # try a bunch of different ones
@@ -89,7 +89,7 @@ def test_sandwich_operator_expect_val():
         np.testing.assert_allclose(eval_sandwich, eval_normal, atol=1e-5)
 
 
-def test_tensor_unitary():
+def test_tensor_unitary() -> None:
     rs = np.random.RandomState(52)
     for _ in range(10):
         qubits = cirq.LineQubit.range(5)
@@ -104,7 +104,7 @@ def test_tensor_unitary():
         np.testing.assert_allclose(u_tn, u_cirq, atol=1e-6)
 
 
-def test_tensor_unitary_implicit_qubits():
+def test_tensor_unitary_implicit_qubits() -> None:
     rs = np.random.RandomState(52)
     for _ in range(10):
         qubits = cirq.LineQubit.range(5)
@@ -119,7 +119,7 @@ def test_tensor_unitary_implicit_qubits():
         np.testing.assert_allclose(u_tn, u_cirq, atol=1e-6)
 
 
-def test_tensor_expectation_value():
+def test_tensor_expectation_value() -> None:
     rs = np.random.RandomState(52)
     for _ in range(10):
         for n_qubit in [2, 7]:
@@ -140,17 +140,18 @@ def test_tensor_expectation_value():
                 np.testing.assert_allclose(eval_tn, eval_normal, atol=1e-3)
 
 
-def test_bad_init_state():
+def test_bad_init_state() -> None:
     qubits = cirq.LineQubit.range(5)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=10, op_density=0.8)
     with pytest.raises(ValueError):
         ccq.circuit_to_tensors(circuit=circuit, qubits=qubits, initial_state=1)
 
 
-def test_too_much_ram():
+def test_too_much_ram() -> None:
     qubits = cirq.LineQubit.range(30)
     circuit = cirq.testing.random_circuit(qubits=qubits, n_moments=20, op_density=0.8)
-    op = functools.reduce(operator.mul, [cirq.Z(q) for q in qubits], 1)
+    op: cirq.PauliString
+    op = functools.reduce(operator.mul, [cirq.Z(q) for q in qubits], cirq.PauliString())
     with pytest.raises(MemoryError) as e:
         ccq.tensor_expectation_value(circuit=circuit, pauli_string=op)
 

--- a/cirq-core/cirq/contrib/quirk/export_to_quirk_test.py
+++ b/cirq-core/cirq/contrib/quirk/export_to_quirk_test.py
@@ -172,10 +172,10 @@ class MysteryOperation(cirq.Operation):
         self._qubits = qubits
 
     @property
-    def qubits(self):
+    def qubits(self) -> tuple[cirq.Qid, ...]:
         return self._qubits
 
-    def with_qubits(self, *new_qubits):
+    def with_qubits(self, *new_qubits) -> MysteryOperation:
         return MysteryOperation(*new_qubits)
 
 

--- a/cirq-core/cirq/contrib/quirk/linearize_circuit.py
+++ b/cirq-core/cirq/contrib/quirk/linearize_circuit.py
@@ -29,7 +29,7 @@ class QubitMapper:
     def map_moment(self, moment: circuits.Moment) -> circuits.Moment:
         return circuits.Moment(self.map_operation(op) for op in moment.operations)
 
-    def optimize_circuit(self, circuit: circuits.Circuit):
+    def optimize_circuit(self, circuit: circuits.Circuit) -> None:
         circuit[:] = (self.map_moment(m) for m in circuit)
 
 

--- a/cirq-core/cirq/contrib/routing/device.py
+++ b/cirq-core/cirq/contrib/routing/device.py
@@ -36,7 +36,7 @@ def get_grid_device_graph(*args, **kwargs) -> nx.Graph:
     return gridqubits_to_graph_device(cirq.GridQubit.rect(*args, **kwargs))
 
 
-def gridqubits_to_graph_device(qubits: Iterable[cirq.GridQubit]):
+def gridqubits_to_graph_device(qubits: Iterable[cirq.GridQubit]) -> nx.Graph:
     """Gets the graph of a set of grid qubits."""
     return nx.Graph(
         pair for pair in itertools.combinations(qubits, 2) if _manhattan_distance(*pair) == 1

--- a/cirq-core/cirq/contrib/routing/device_test.py
+++ b/cirq-core/cirq/contrib/routing/device_test.py
@@ -22,33 +22,35 @@ import cirq.contrib.routing as ccr
 
 
 @pytest.mark.parametrize('n_qubits', (2, 5, 11))
-def test_get_linear_device_graph(n_qubits):
+def test_get_linear_device_graph(n_qubits) -> None:
     graph = ccr.get_linear_device_graph(n_qubits)
     assert sorted(graph) == cirq.LineQubit.range(n_qubits)
     assert len(graph.edges()) == n_qubits - 1
     assert all(abs(a.x - b.x) == 1 for a, b in graph.edges())
 
 
-def test_nx_qubit_layout():
+def test_nx_qubit_layout() -> None:
     grid_qubit_graph = ccr.gridqubits_to_graph_device(cirq.GridQubit.rect(5, 5))
     pos = ccr.nx_qubit_layout(grid_qubit_graph)
     assert len(pos) == len(grid_qubit_graph)
     for k, (x, y) in pos.items():
+        assert isinstance(k, cirq.GridQubit)
         assert x == k.col
         assert y == -k.row
 
 
-def test_nx_qubit_layout_2():
+def test_nx_qubit_layout_2() -> None:
     g = nx.from_edgelist(
         [(cirq.LineQubit(0), cirq.LineQubit(1)), (cirq.LineQubit(1), cirq.LineQubit(2))]
     )
     pos = ccr.nx_qubit_layout(g)
     for k, (x, y) in pos.items():
+        assert isinstance(k, cirq.LineQubit)
         assert x == k.x
         assert y == 0.5
 
 
-def test_nx_qubit_layout_3():
+def test_nx_qubit_layout_3() -> None:
     g = nx.from_edgelist(
         [(cirq.NamedQubit('a'), cirq.NamedQubit('b')), (cirq.NamedQubit('b'), cirq.NamedQubit('c'))]
     )
@@ -57,4 +59,4 @@ def test_nx_qubit_layout_3():
     pos = ccr.nx_qubit_layout(g)
     for k, (x, y) in pos.items():
         assert x == 0.5
-        assert y == node_to_i[k] + 1
+        assert y == node_to_i[k] + 1  # type: ignore[index]

--- a/cirq-core/cirq/contrib/routing/greedy_test.py
+++ b/cirq-core/cirq/contrib/routing/greedy_test.py
@@ -15,12 +15,16 @@
 from __future__ import annotations
 
 from multiprocessing import Process
+from typing import TYPE_CHECKING
 
 import pytest
 
 import cirq
 import cirq.contrib.routing as ccr
 from cirq.contrib.routing.greedy import route_circuit_greedily
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 
 def test_bad_args() -> None:
@@ -34,18 +38,19 @@ def test_bad_args() -> None:
         route_circuit_greedily(circuit, device_graph, max_num_empty_steps=0)
 
 
-def create_circuit_and_device():
+def create_circuit_and_device() -> tuple[cirq.Circuit, nx.Graph]:
     """Construct a small circuit and a device with line connectivity
     to test the greedy router. This instance hangs router in Cirq 8.2.
     """
     num_qubits = 6
+    gate_domain: dict[cirq.Gate, int]
     gate_domain = {cirq.ops.CNOT: 2}
     circuit = cirq.testing.random_circuit(num_qubits, 15, 0.5, gate_domain, random_state=37)
     device_graph = ccr.get_linear_device_graph(num_qubits)
     return circuit, device_graph
 
 
-def create_hanging_routing_instance(circuit, device_graph):
+def create_hanging_routing_instance(circuit, device_graph) -> None:
     """Create a test problem instance."""
     route_circuit_greedily(  # pragma: no cover
         circuit, device_graph, max_search_radius=2, random_state=1

--- a/cirq-core/cirq/contrib/routing/initialization_test.py
+++ b/cirq-core/cirq/contrib/routing/initialization_test.py
@@ -24,7 +24,7 @@ import cirq
 import cirq.contrib.routing as ccr
 
 
-def get_seeded_initial_mapping(graph_seed, init_seed):
+def get_seeded_initial_mapping(graph_seed, init_seed) -> dict[cirq.Qid, cirq.Qid]:
     logical_graph = nx.erdos_renyi_graph(10, 0.5, seed=graph_seed)
     logical_graph = nx.relabel_nodes(logical_graph, cirq.LineQubit)
     device_graph = ccr.get_grid_device_graph(4, 4)

--- a/cirq-core/cirq/contrib/routing/router_test.py
+++ b/cirq-core/cirq/contrib/routing/router_test.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import itertools
 import random
 
 import numpy as np
@@ -25,7 +24,7 @@ import cirq.contrib.acquaintance as cca
 import cirq.contrib.routing as ccr
 
 
-def random_seed():
+def random_seed() -> int:
     return random.randint(0, 2**32)
 
 
@@ -35,7 +34,7 @@ def random_seed():
     + [(0, 'greedy', random_seed(), random_seed())]
     + [(10, 'greedy', random_seed(), None)],
 )
-def test_route_circuit(n_moments, algo, circuit_seed, routing_seed):
+def test_route_circuit(n_moments, algo, circuit_seed, routing_seed) -> None:
     circuit = cirq.testing.random_circuit(10, n_moments, 0.5, random_state=circuit_seed)
     device_graph = ccr.get_grid_device_graph(4, 3)
     swap_network = ccr.route_circuit(
@@ -52,15 +51,15 @@ def test_route_circuit(n_moments, algo, circuit_seed, routing_seed):
 @pytest.mark.parametrize(
     'algo,seed', [(algo, random_seed()) for algo in ccr.ROUTERS for _ in range(3)]
 )
-def test_route_circuit_reproducible_with_seed(algo, seed):
+def test_route_circuit_reproducible_with_seed(algo, seed) -> None:
     circuit = cirq.testing.random_circuit(8, 20, 0.5, random_state=seed)
     device_graph = ccr.get_grid_device_graph(4, 3)
-    wrappers = (lambda s: s, np.random.RandomState)
+    random_states = [seed, seed, seed] + [np.random.RandomState(seed) for _ in range(3)]
 
     swap_networks = []
-    for wrapper, _ in itertools.product(wrappers, range(3)):
+    for random_state in random_states:
         swap_network = ccr.route_circuit(
-            circuit, device_graph, algo_name=algo, random_state=wrapper(seed)
+            circuit, device_graph, algo_name=algo, random_state=random_state
         )
         swap_networks.append(swap_network)
 
@@ -69,7 +68,7 @@ def test_route_circuit_reproducible_with_seed(algo, seed):
 
 
 @pytest.mark.parametrize('algo', ccr.ROUTERS.keys())
-def test_route_circuit_reproducible_between_runs(algo):
+def test_route_circuit_reproducible_between_runs(algo) -> None:
     seed = 23
     circuit = cirq.testing.random_circuit(6, 5, 0.5, random_state=seed)
     device_graph = ccr.get_grid_device_graph(2, 3)
@@ -106,7 +105,7 @@ def test_route_circuit_reproducible_between_runs(algo):
     ]
     + [(0, 'greedy', random_seed(), False)],
 )
-def test_route_circuit_via_unitaries(n_moments, algo, seed, make_bad):
+def test_route_circuit_via_unitaries(n_moments, algo, seed, make_bad) -> None:
     circuit = cirq.testing.random_circuit(4, n_moments, 0.5, random_state=seed)
     device_graph = ccr.get_grid_device_graph(3, 2)
 
@@ -132,7 +131,7 @@ def test_route_circuit_via_unitaries(n_moments, algo, seed, make_bad):
     assert np.allclose(physical_unitary, logical_unitary) == (not make_bad)
 
 
-def test_router_bad_args():
+def test_router_bad_args() -> None:
     circuit = cirq.Circuit()
     device_graph = ccr.get_linear_device_graph(5)
     with pytest.raises(ValueError):

--- a/cirq-core/cirq/contrib/routing/swap_network_test.py
+++ b/cirq-core/cirq/contrib/routing/swap_network_test.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import itertools
+from typing import Any
 
 import pytest
 
@@ -23,9 +24,10 @@ import cirq.contrib.acquaintance as cca
 import cirq.contrib.routing as ccr
 
 
-def test_final_mapping():
+def test_final_mapping() -> None:
     n_qubits = 10
     qubits = cirq.LineQubit.range(n_qubits)
+    initial_mapping: dict[cirq.Qid, cirq.Qid]
     initial_mapping = dict(zip(qubits, qubits))
     expected_final_mapping = dict(zip(qubits, reversed(qubits)))
     SWAP = cca.SwapPermutationGate()
@@ -37,10 +39,11 @@ def test_final_mapping():
     assert swap_network.final_mapping() == expected_final_mapping
 
 
-def test_swap_network_bad_args():
+def test_swap_network_bad_args() -> None:
     n_qubits = 10
     qubits = cirq.LineQubit.range(n_qubits)
     circuit = cirq.Circuit()
+    initial_mapping: dict[Any, Any]
     with pytest.raises(ValueError):
         initial_mapping = dict(zip(qubits, range(n_qubits)))
         ccr.SwapNetwork(circuit, initial_mapping)
@@ -50,7 +53,8 @@ def test_swap_network_bad_args():
 
 
 @pytest.mark.parametrize('circuits', [[cirq.testing.random_circuit(10, 10, 0.5) for _ in range(3)]])
-def test_swap_network_equality(circuits):
+def test_swap_network_equality(circuits) -> None:
+    mapping: dict[cirq.Qid, cirq.Qid]
     et = cirq.testing.EqualsTester()
     for circuit in circuits:  # NB: tiny prob. that circuits aren't unique
         qubits = sorted(circuit.all_qubits())
@@ -59,11 +63,13 @@ def test_swap_network_equality(circuits):
             et.add_equality_group(ccr.SwapNetwork(circuit, mapping))
 
 
-def test_swap_network_str():
+def test_swap_network_str() -> None:
     n_qubits = 5
     phys_qubits = cirq.GridQubit.rect(n_qubits, 1)
     log_qubits = cirq.LineQubit.range(n_qubits)
 
+    gates: dict[tuple[cirq.Qid, cirq.Qid], cirq.Gate]
+    initial_mapping: dict[cirq.Qid, cirq.Qid]
     gates = {(l, ll): cirq.ZZ for l, ll in itertools.combinations(log_qubits, 2)}
     initial_mapping = {p: l for p, l in zip(phys_qubits, log_qubits)}
     execution_strategy = cca.GreedyExecutionStrategy(gates, initial_mapping)

--- a/cirq-core/cirq/contrib/routing/utils_test.py
+++ b/cirq-core/cirq/contrib/routing/utils_test.py
@@ -21,7 +21,7 @@ import cirq
 import cirq.contrib.routing as ccr
 
 
-def test_ops_are_consistent_with_device_graph():
+def test_ops_are_consistent_with_device_graph() -> None:
     device_graph = ccr.get_linear_device_graph(3)
     qubits = cirq.LineQubit.range(3)
     circuit = cirq.Circuit(cirq.ZZ(qubits[0], qubits[2]))
@@ -31,7 +31,7 @@ def test_ops_are_consistent_with_device_graph():
     )
 
 
-def test_get_circuit_connectivity():
+def test_get_circuit_connectivity() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(cirq.CZ(a, b), cirq.CZ(b, c), cirq.CZ(c, d), cirq.CZ(d, a))
     graph = ccr.get_circuit_connectivity(circuit)
@@ -41,12 +41,12 @@ def test_get_circuit_connectivity():
     assert is_planar
 
 
-def test_is_valid_routing_with_bad_args():
+def test_is_valid_routing_with_bad_args() -> None:
     p, q, r = cirq.LineQubit.range(3)
     x, y = cirq.NamedQubit('x'), cirq.NamedQubit('y')
     circuit = cirq.Circuit([cirq.CNOT(x, y), cirq.CZ(x, y)])
     routed_circuit = cirq.Circuit([cirq.CNOT(p, q), cirq.CZ(q, r)])
-    initial_mapping = {p: x, q: y}
+    initial_mapping: dict[cirq.Qid, cirq.Qid] = {p: x, q: y}
     swap_network = ccr.SwapNetwork(routed_circuit, initial_mapping)
     assert not ccr.is_valid_routing(circuit, swap_network)
 

--- a/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking.py
+++ b/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import time
-from typing import Optional, Sequence, TYPE_CHECKING
+from typing import Sequence, TYPE_CHECKING
 
 import attrs
 import numpy as np
@@ -64,7 +64,7 @@ class ReadoutBenchmarkingParams:
 def _validate_experiment_input(
     input_circuits: Sequence[circuits.Circuit],
     circuit_repetitions: int | list[int],
-    rng_or_seed: Optional[np.random.Generator | int] = None,
+    rng_or_seed: np.random.Generator | int | None = None,
 ):
     if not input_circuits:
         raise ValueError("Input circuits must not be empty.")
@@ -84,7 +84,7 @@ def _validate_experiment_input_with_sweep(
     input_circuits: Sequence[circuits.Circuit],
     sweep_params: Sequence[study.Sweepable],
     circuit_repetitions: int | list[int],
-    rng_or_seed: Optional[np.random.Generator | int] = None,
+    rng_or_seed: np.random.Generator | int | None = None,
 ):
     """Validates the input for the run_sweep_with_readout_benchmarking function."""
     if not sweep_params:
@@ -183,7 +183,7 @@ def _generate_all_readout_calibration_circuits(
 
 def _determine_qubits_to_measure(
     input_circuits: Sequence[circuits.Circuit],
-    qubits: Optional[Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]]],
+    qubits: Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]] | None,
 ) -> list[list[ops.Qid]]:
     """Determine the qubits to measure based on the input circuits and provided qubits."""
     # If input qubits is None, extract qubits from input circuits
@@ -280,7 +280,7 @@ def run_shuffled_with_readout_benchmarking(
     rng_or_seed: np.random.Generator | int,
     num_random_bitstrings: int = 100,
     readout_repetitions: int = 1000,
-    qubits: Optional[Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]]] = None,
+    qubits: Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]] | None = None,
 ) -> tuple[Sequence[ResultDict], dict[tuple[ops.Qid, ...], SingleQubitReadoutCalibrationResult]]:
     """Run the circuits in a shuffled order with readout error benchmarking.
 
@@ -373,8 +373,8 @@ def run_shuffled_circuits_with_readout_benchmarking(
     sampler: work.Sampler,
     input_circuits: list[circuits.Circuit],
     parameters: ReadoutBenchmarkingParams,
-    qubits: Optional[Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]]] = None,
-    rng_or_seed: Optional[np.random.Generator | int] = None,
+    qubits: Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]] | None = None,
+    rng_or_seed: np.random.Generator | int | None = None,
 ) -> tuple[Sequence[ResultDict], dict[tuple[ops.Qid, ...], SingleQubitReadoutCalibrationResult]]:
     """Run the circuits in a shuffled order with readout error benchmarking.
 
@@ -458,8 +458,8 @@ def run_sweep_with_readout_benchmarking(
     input_circuits: list[circuits.Circuit],
     sweep_params: Sequence[study.Sweepable],
     parameters: ReadoutBenchmarkingParams,
-    qubits: Optional[Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]]] = None,
-    rng_or_seed: Optional[np.random.Generator | int] = None,
+    qubits: Sequence[ops.Qid] | Sequence[Sequence[ops.Qid]] | None = None,
+    rng_or_seed: np.random.Generator | int | None = None,
 ) -> tuple[
     Sequence[Sequence[study.Result]], dict[tuple[ops.Qid, ...], SingleQubitReadoutCalibrationResult]
 ]:

--- a/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking_test.py
+++ b/cirq-core/cirq/contrib/shuffle_circuits/shuffle_circuits_with_readout_benchmarking_test.py
@@ -124,7 +124,7 @@ def _circuits_with_readout_benchmarking_errors_sweep(
 
 
 @pytest.mark.parametrize("mode", ["shuffled", "sweep"])
-def test_circuits_with_readout_benchmarking_errors_no_noise(mode: str):
+def test_circuits_with_readout_benchmarking_errors_no_noise(mode: str) -> None:
     """Test shuffled/sweep circuits with readout benchmarking with no noise from sampler."""
     qubits = cirq.LineQubit.range(5)
 
@@ -166,7 +166,7 @@ def test_circuits_with_readout_benchmarking_errors_no_noise(mode: str):
 
 
 @pytest.mark.parametrize("mode", ["shuffled", "sweep"])
-def test_circuits_with_readout_benchmarking_errors_with_noise(mode: str):
+def test_circuits_with_readout_benchmarking_errors_with_noise(mode: str) -> None:
     """Test shuffled/sweep circuits with readout benchmarking with noise from sampler."""
     qubits = cirq.LineQubit.range(6)
     sampler = NoisySingleQubitReadoutSampler(p0=0.1, p1=0.2, seed=1234)
@@ -209,7 +209,7 @@ def test_circuits_with_readout_benchmarking_errors_with_noise(mode: str):
 
 
 @pytest.mark.parametrize("mode", ["shuffled", "sweep"])
-def test_circuits_with_readout_benchmarking_errors_with_noise_and_input_qubits(mode: str):
+def test_circuits_with_readout_benchmarking_errors_with_noise_and_input_qubits(mode: str) -> None:
     """Test shuffled/sweep circuits with readout benchmarking with
     noise from sampler and input qubits."""
     qubits = cirq.LineQubit.range(6)
@@ -255,7 +255,9 @@ def test_circuits_with_readout_benchmarking_errors_with_noise_and_input_qubits(m
 
 
 @pytest.mark.parametrize("mode", ["shuffled", "sweep"])
-def test_circuits_with_readout_benchmarking_errors_with_noise_and_lists_input_qubits(mode: str):
+def test_circuits_with_readout_benchmarking_errors_with_noise_and_lists_input_qubits(
+    mode: str,
+) -> None:
     """Test shuffled/sweep circuits with readout benchmarking with noise
     from sampler and input qubits."""
     qubits_1 = cirq.LineQubit.range(3)
@@ -305,7 +307,7 @@ def test_circuits_with_readout_benchmarking_errors_with_noise_and_lists_input_qu
 
 
 @pytest.mark.parametrize("mode", ["shuffled", "sweep"])
-def test_can_handle_zero_random_bitstring(mode: str):
+def test_can_handle_zero_random_bitstring(mode: str) -> None:
     """Test shuffled/sweep circuits without readout benchmarking."""
     qubits_1 = cirq.LineQubit.range(3)
     qubits_2 = cirq.LineQubit.range(4)
@@ -345,7 +347,7 @@ def test_can_handle_zero_random_bitstring(mode: str):
 
 
 @pytest.mark.parametrize("mode", ["shuffled", "sweep"])
-def test_circuits_with_readout_benchmarking_no_qubits_arg_empty_rng(mode: str):
+def test_circuits_with_readout_benchmarking_no_qubits_arg_empty_rng(mode: str) -> None:
     """Test benchmarking when the `qubits` argument is not provided."""
     qubits = cirq.LineQubit.range(3)
     sampler = NoisySingleQubitReadoutSampler(p0=0.1, p1=0.2, seed=1234)
@@ -389,7 +391,7 @@ def test_circuits_with_readout_benchmarking_no_qubits_arg_empty_rng(mode: str):
     assert result.repetitions == readout_repetitions
 
 
-def test_deprecated_run_shuffled_with_readout_benchmarking():
+def test_deprecated_run_shuffled_with_readout_benchmarking() -> None:
     """Test that the deprecated function works correctly and is covered."""
     qubits = cirq.LineQubit.range(3)
     input_circuits = _create_test_circuits(qubits, 3)
@@ -470,7 +472,7 @@ def test_deprecated_run_shuffled_with_readout_benchmarking():
             )
 
 
-def test_empty_input_circuits():
+def test_empty_input_circuits() -> None:
     """Test that the input circuits are empty."""
     readout_benchmarking_params = sc_readout.ReadoutBenchmarkingParams(
         circuit_repetitions=10, num_random_bitstrings=5, readout_repetitions=100
@@ -484,7 +486,7 @@ def test_empty_input_circuits():
         )
 
 
-def test_non_circuit_input():
+def test_non_circuit_input() -> None:
     """Test that the input circuits are not of type cirq.Circuit."""
     q = cirq.LineQubit(0)
     readout_benchmarking_params = sc_readout.ReadoutBenchmarkingParams(
@@ -493,13 +495,13 @@ def test_non_circuit_input():
     with pytest.raises(ValueError, match="Input circuits must be of type cirq.Circuit."):
         sc_readout.run_shuffled_circuits_with_readout_benchmarking(
             cirq.ZerosSampler(),
-            [q],
+            [q],  # type: ignore[list-item]
             readout_benchmarking_params,
             rng_or_seed=np.random.default_rng(456),
         )
 
 
-def test_no_measurements():
+def test_no_measurements() -> None:
     """Test that the input circuits don't have measurements."""
     q = cirq.LineQubit(0)
     circuit = cirq.Circuit(cirq.H(q))
@@ -515,7 +517,7 @@ def test_no_measurements():
         )
 
 
-def test_zero_circuit_repetitions():
+def test_zero_circuit_repetitions() -> None:
     """Test that the circuit repetitions are zero."""
     with pytest.raises(ValueError, match="Must provide non-zero circuit_repetitions."):
         sc_readout.ReadoutBenchmarkingParams(
@@ -523,7 +525,7 @@ def test_zero_circuit_repetitions():
         )
 
 
-def test_mismatch_circuit_repetitions():
+def test_mismatch_circuit_repetitions() -> None:
     """Test that the number of circuit repetitions don't match the number of input circuits."""
     q = cirq.LineQubit(0)
     circuit = cirq.Circuit(cirq.H(q), cirq.measure(q))
@@ -542,7 +544,7 @@ def test_mismatch_circuit_repetitions():
         )
 
 
-def test_zero_num_random_bitstrings():
+def test_zero_num_random_bitstrings() -> None:
     """Test that the number of random bitstrings is smaller than zero."""
     with pytest.raises(ValueError, match="Must provide zero or more num_random_bitstrings."):
         sc_readout.ReadoutBenchmarkingParams(
@@ -550,7 +552,7 @@ def test_zero_num_random_bitstrings():
         )
 
 
-def test_zero_readout_repetitions():
+def test_zero_readout_repetitions() -> None:
     """Test that the readout repetitions is zero."""
     with pytest.raises(
         ValueError, match="Must provide non-zero readout_repetitions for readout" + " calibration."
@@ -560,7 +562,7 @@ def test_zero_readout_repetitions():
         )
 
 
-def test_empty_sweep_params():
+def test_empty_sweep_params() -> None:
     """Test that the sweep params are empty."""
     q = cirq.LineQubit(5)
     circuit = cirq.Circuit(cirq.H(q))

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -15,7 +15,7 @@ FONT = matplotlib.font_manager.FontProperties()
 EMPTY_MOMENT_COLWIDTH = float(21)  # assumed default column width
 
 
-def fixup_text(text: str):
+def fixup_text(text: str) -> str:
     if '\n' in text:
         # https://github.com/quantumlib/Cirq/issues/4499
         # TODO: Visualize Custom MatrixGate

--- a/cirq-core/cirq/devices/grid_device_metadata_test.py
+++ b/cirq-core/cirq/devices/grid_device_metadata_test.py
@@ -22,15 +22,15 @@ import pytest
 import cirq
 
 
-def test_griddevice_metadata():
+def test_griddevice_metadata() -> None:
     qubits = cirq.GridQubit.rect(2, 3)
     qubit_pairs = [(a, b) for a in qubits for b in qubits if a != b and a.is_adjacent(b)]
     isolated_qubits = [cirq.GridQubit(9, 9), cirq.GridQubit(10, 10)]
     gateset = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZ)
     gate_durations = {
-        cirq.GateFamily(cirq.XPowGate): 1_000,
-        cirq.GateFamily(cirq.YPowGate): 1_000,
-        cirq.GateFamily(cirq.ZPowGate): 1_000,
+        cirq.GateFamily(cirq.XPowGate): cirq.Duration(nanos=10),
+        cirq.GateFamily(cirq.YPowGate): cirq.Duration(nanos=10),
+        cirq.GateFamily(cirq.ZPowGate): cirq.Duration(nanos=10),
         # omitting cirq.CZ
     }
     target_gatesets = (cirq.CZTargetGateset(),)
@@ -65,8 +65,8 @@ def test_griddevice_metadata():
     assert metadata.compilation_target_gatesets == target_gatesets
 
 
-def test_griddevice_metadata_bad_durations():
-    qubits = tuple(cirq.GridQubit.rect(1, 2))
+def test_griddevice_metadata_bad_durations() -> None:
+    qubits: tuple[cirq.GridQubit, cirq.GridQubit] = (cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))
 
     gateset = cirq.Gateset(cirq.XPowGate, cirq.YPowGate)
     invalid_duration = {
@@ -77,7 +77,7 @@ def test_griddevice_metadata_bad_durations():
         cirq.GridDeviceMetadata([qubits], gateset, gate_durations=invalid_duration)
 
 
-def test_griddevice_metadata_bad_isolated():
+def test_griddevice_metadata_bad_isolated() -> None:
     qubits = cirq.GridQubit.rect(2, 3)
     qubit_pairs = [(a, b) for a in qubits for b in qubits if a != b and a.is_adjacent(b)]
     fewer_qubits = [cirq.GridQubit(0, 0)]
@@ -86,7 +86,7 @@ def test_griddevice_metadata_bad_isolated():
         _ = cirq.GridDeviceMetadata(qubit_pairs, gateset, all_qubits=fewer_qubits)
 
 
-def test_griddevice_self_loop():
+def test_griddevice_self_loop() -> None:
     bad_pairs = [
         (cirq.GridQubit(0, 0), cirq.GridQubit(0, 0)),
         (cirq.GridQubit(1, 0), cirq.GridQubit(1, 1)),
@@ -95,7 +95,7 @@ def test_griddevice_self_loop():
         _ = cirq.GridDeviceMetadata(bad_pairs, cirq.Gateset(cirq.XPowGate))
 
 
-def test_griddevice_json_load():
+def test_griddevice_json_load() -> None:
     qubits = cirq.GridQubit.rect(2, 3)
     qubit_pairs = [(a, b) for a in qubits for b in qubits if a != b and a.is_adjacent(b)]
     gateset = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZ)
@@ -118,7 +118,7 @@ def test_griddevice_json_load():
     assert metadata == cirq.read_json(json_text=rep_str)
 
 
-def test_griddevice_json_load_with_defaults():
+def test_griddevice_json_load_with_defaults() -> None:
     qubits = cirq.GridQubit.rect(2, 3)
     qubit_pairs = [(a, b) for a in qubits for b in qubits if a != b and a.is_adjacent(b)]
     gateset = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZ)
@@ -130,7 +130,7 @@ def test_griddevice_json_load_with_defaults():
     assert metadata == cirq.read_json(json_text=rep_str)
 
 
-def test_griddevice_metadata_equality():
+def test_griddevice_metadata_equality() -> None:
     qubits = cirq.GridQubit.rect(2, 3)
     qubit_pairs = [(a, b) for a in qubits for b in qubits if a != b and a.is_adjacent(b)]
     gateset = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZ, cirq.SQRT_ISWAP)
@@ -182,7 +182,7 @@ def test_griddevice_metadata_equality():
     assert metadata == metadata5
 
 
-def test_repr():
+def test_repr() -> None:
     qubits = cirq.GridQubit.rect(2, 3)
     qubit_pairs = [(a, b) for a in qubits for b in qubits if a != b and a.is_adjacent(b)]
     gateset = cirq.Gateset(cirq.XPowGate, cirq.YPowGate, cirq.ZPowGate, cirq.CZ)

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -24,18 +24,18 @@ import pytest
 import cirq
 
 
-def test_init():
+def test_init() -> None:
     q = cirq.GridQubit(3, 4)
     assert q.row == 3
     assert q.col == 4
 
-    q = cirq.GridQid(1, 2, dimension=3)
-    assert q.row == 1
-    assert q.col == 2
-    assert q.dimension == 3
+    qid = cirq.GridQid(1, 2, dimension=3)
+    assert qid.row == 1
+    assert qid.col == 2
+    assert qid.dimension == 3
 
 
-def test_eq():
+def test_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cirq.GridQubit(0, 0), lambda: cirq.GridQid(0, 0, dimension=2))
     eq.make_equality_group(lambda: cirq.GridQubit(1, 0), lambda: cirq.GridQid(1, 0, dimension=2))
@@ -43,7 +43,7 @@ def test_eq():
     eq.make_equality_group(lambda: cirq.GridQid(0, 0, dimension=3))
 
 
-def test_grid_qubit_pickled_hash():
+def test_grid_qubit_pickled_hash() -> None:
     # Use a large number that is unlikely to be used by any other tests.
     row, col = 123456789, 2345678910
     q_bad = cirq.GridQubit(row, col)
@@ -52,7 +52,7 @@ def test_grid_qubit_pickled_hash():
     _test_qid_pickled_hash(q, q_bad)
 
 
-def test_grid_qid_pickled_hash():
+def test_grid_qid_pickled_hash() -> None:
     # Use a large number that is unlikely to be used by any other tests.
     row, col = 123456789, 2345678910
     q_bad = cirq.GridQid(row, col, dimension=3)
@@ -74,12 +74,12 @@ def _test_qid_pickled_hash(q: cirq.Qid, q_bad: cirq.Qid) -> None:
     assert hash(q_ok) == hash(q)
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.GridQubit(5, 2)) == 'q(5, 2)'
     assert str(cirq.GridQid(5, 2, dimension=3)) == 'q(5, 2) (d=3)'
 
 
-def test_circuit_info():
+def test_circuit_info() -> None:
     assert cirq.circuit_diagram_info(cirq.GridQubit(5, 2)) == cirq.CircuitDiagramInfo(
         wire_symbols=('(5, 2)',)
     )
@@ -88,12 +88,12 @@ def test_circuit_info():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.GridQubit(5, 2))
     cirq.testing.assert_equivalent_repr(cirq.GridQid(5, 2, dimension=3))
 
 
-def test_cmp():
+def test_cmp() -> None:
     order = cirq.testing.OrderTester()
     order.add_ascending_equivalence_group(cirq.GridQubit(0, 0), cirq.GridQid(0, 0, dimension=2))
     order.add_ascending(
@@ -110,7 +110,7 @@ def test_cmp():
     )
 
 
-def test_cmp_failure():
+def test_cmp_failure() -> None:
     with pytest.raises(TypeError, match='not supported between instances'):
         _ = 0 < cirq.GridQubit(0, 0)
     with pytest.raises(TypeError, match='not supported between instances'):
@@ -121,7 +121,7 @@ def test_cmp_failure():
         _ = cirq.GridQid(1, 1, dimension=3) < 0
 
 
-def test_is_adjacent():
+def test_is_adjacent() -> None:
     assert cirq.GridQubit(0, 0).is_adjacent(cirq.GridQubit(0, 1))
     assert cirq.GridQubit(0, 0).is_adjacent(cirq.GridQubit(0, -1))
     assert cirq.GridQubit(0, 0).is_adjacent(cirq.GridQubit(1, 0))
@@ -138,7 +138,7 @@ def test_is_adjacent():
     assert not cirq.GridQubit(500, 999).is_adjacent(cirq.GridQubit(5034, 999))
 
 
-def test_neighbors():
+def test_neighbors() -> None:
     assert cirq.GridQubit(1, 1).neighbors() == {
         cirq.GridQubit(1, 2),
         cirq.GridQubit(2, 1),
@@ -151,7 +151,7 @@ def test_neighbors():
     assert cirq.GridQubit(1, 1).neighbors(restricted_qubits) == {cirq.GridQubit(2, 1)}
 
 
-def test_square():
+def test_square() -> None:
     assert cirq.GridQubit.square(2, top=1, left=1) == [
         cirq.GridQubit(1, 1),
         cirq.GridQubit(1, 2),
@@ -179,7 +179,7 @@ def test_square():
     ]
 
 
-def test_rect():
+def test_rect() -> None:
     assert cirq.GridQubit.rect(1, 2, top=5, left=6) == [cirq.GridQubit(5, 6), cirq.GridQubit(5, 7)]
     assert cirq.GridQubit.rect(2, 2) == [
         cirq.GridQubit(0, 0),
@@ -200,7 +200,7 @@ def test_rect():
     ]
 
 
-def test_diagram():
+def test_diagram() -> None:
     s = """
 -----AB-----
 ----ABCD----
@@ -237,7 +237,7 @@ BA"""
         cirq.GridQubit.from_diagram('@')
 
 
-def test_addition_subtraction():
+def test_addition_subtraction() -> None:
     # GridQubits
     assert cirq.GridQubit(1, 2) + (2, 5) == cirq.GridQubit(3, 7)
     assert cirq.GridQubit(1, 2) + (0, 0) == cirq.GridQubit(1, 2)
@@ -276,7 +276,7 @@ def test_addition_subtraction():
 
 
 @pytest.mark.parametrize('dtype', (np.int8, np.int16, np.int32, np.int64, int))
-def test_addition_subtraction_numpy_array(dtype):
+def test_addition_subtraction_numpy_array(dtype) -> None:
     assert cirq.GridQubit(1, 2) + np.array([1, 2], dtype=dtype) == cirq.GridQubit(2, 4)
     assert cirq.GridQubit(1, 2) + np.array([0, 0], dtype=dtype) == cirq.GridQubit(1, 2)
     assert cirq.GridQubit(1, 2) + np.array([-1, 0], dtype=dtype) == cirq.GridQubit(0, 2)
@@ -306,18 +306,18 @@ def test_addition_subtraction_numpy_array(dtype):
     )
 
 
-def test_unsupported_add():
+def test_unsupported_add() -> None:
     with pytest.raises(TypeError, match='1'):
-        _ = cirq.GridQubit(1, 1) + 1
+        _ = cirq.GridQubit(1, 1) + 1  # type: ignore[operator]
     with pytest.raises(TypeError, match='(1,)'):
-        _ = cirq.GridQubit(1, 1) + (1,)
+        _ = cirq.GridQubit(1, 1) + (1,)  # type: ignore[operator]
     with pytest.raises(TypeError, match='(1, 2, 3)'):
-        _ = cirq.GridQubit(1, 1) + (1, 2, 3)
+        _ = cirq.GridQubit(1, 1) + (1, 2, 3)  # type: ignore[operator]
     with pytest.raises(TypeError, match='(1, 2.0)'):
-        _ = cirq.GridQubit(1, 1) + (1, 2.0)
+        _ = cirq.GridQubit(1, 1) + (1, 2.0)  # type: ignore[operator]
 
     with pytest.raises(TypeError, match='1'):
-        _ = cirq.GridQubit(1, 1) - 1
+        _ = cirq.GridQubit(1, 1) - 1  # type: ignore[operator]
 
     with pytest.raises(TypeError, match='[1., 2.]'):
         _ = cirq.GridQubit(1, 1) + np.array([1.0, 2.0])
@@ -325,16 +325,16 @@ def test_unsupported_add():
         _ = cirq.GridQubit(1, 1) + np.array([1, 2, 3], dtype=int)
 
 
-def test_addition_subtraction_type_error():
+def test_addition_subtraction_type_error() -> None:
     with pytest.raises(TypeError, match="bort"):
-        _ = cirq.GridQubit(5, 3) + "bort"
+        _ = cirq.GridQubit(5, 3) + "bort"  # type: ignore[operator]
     with pytest.raises(TypeError, match="bort"):
-        _ = cirq.GridQubit(5, 3) - "bort"
+        _ = cirq.GridQubit(5, 3) - "bort"  # type: ignore[operator]
 
     with pytest.raises(TypeError, match="bort"):
-        _ = cirq.GridQid(5, 3, dimension=3) + "bort"
+        _ = cirq.GridQid(5, 3, dimension=3) + "bort"  # type: ignore[operator]
     with pytest.raises(TypeError, match="bort"):
-        _ = cirq.GridQid(5, 3, dimension=3) - "bort"
+        _ = cirq.GridQid(5, 3, dimension=3) - "bort"  # type: ignore[operator]
 
     with pytest.raises(TypeError, match="Can only add GridQids with identical dimension."):
         _ = cirq.GridQid(5, 3, dimension=3) + cirq.GridQid(3, 5, dimension=4)
@@ -342,62 +342,62 @@ def test_addition_subtraction_type_error():
         _ = cirq.GridQid(5, 3, dimension=3) - cirq.GridQid(3, 5, dimension=4)
 
 
-def test_neg():
+def test_neg() -> None:
     assert -cirq.GridQubit(1, 2) == cirq.GridQubit(-1, -2)
     assert -cirq.GridQid(1, 2, dimension=3) == cirq.GridQid(-1, -2, dimension=3)
 
 
-def test_to_json():
+def test_to_json() -> None:
     assert cirq.GridQubit(5, 6)._json_dict_() == {'row': 5, 'col': 6}
 
     assert cirq.GridQid(5, 6, dimension=3)._json_dict_() == {'row': 5, 'col': 6, 'dimension': 3}
 
 
-def test_immutable():
+def test_immutable() -> None:
     # Match one of two strings. The second one is message returned since python 3.11.
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'col' of 'GridQubit' object has no setter)",
     ):
         q = cirq.GridQubit(1, 2)
-        q.col = 3
+        q.col = 3  # type: ignore[misc]
 
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'row' of 'GridQubit' object has no setter)",
     ):
         q = cirq.GridQubit(1, 2)
-        q.row = 3
+        q.row = 3  # type: ignore[misc]
 
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'col' of 'GridQid' object has no setter)",
     ):
-        q = cirq.GridQid(1, 2, dimension=3)
-        q.col = 3
+        qid = cirq.GridQid(1, 2, dimension=3)
+        qid.col = 3  # type: ignore[misc]
 
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'row' of 'GridQid' object has no setter)",
     ):
-        q = cirq.GridQid(1, 2, dimension=3)
-        q.row = 3
+        qid = cirq.GridQid(1, 2, dimension=3)
+        qid.row = 3  # type: ignore[misc]
 
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'dimension' of 'GridQid' object has no setter)",
     ):
-        q = cirq.GridQid(1, 2, dimension=3)
-        q.dimension = 3
+        qid = cirq.GridQid(1, 2, dimension=3)
+        qid.dimension = 3  # type: ignore[misc]
 
 
-def test_complex():
+def test_complex() -> None:
     assert complex(cirq.GridQubit(row=1, col=2)) == 2 + 1j
     assert isinstance(complex(cirq.GridQubit(row=1, col=2)), complex)
 
 
 @pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float64))
-def test_numpy_index(dtype):
+def test_numpy_index(dtype) -> None:
     np5, np6, np3 = [dtype(i) for i in [5, 6, 3]]
     q = cirq.GridQubit(np5, np6)
     assert hash(q) == hash(cirq.GridQubit(5, 6))
@@ -406,19 +406,19 @@ def test_numpy_index(dtype):
     assert q.dimension == 2
     assert isinstance(q.dimension, int)
 
-    q = cirq.GridQid(np5, np6, dimension=np3)
-    assert hash(q) == hash(cirq.GridQid(5, 6, dimension=3))
-    assert q.row == 5
-    assert q.col == 6
-    assert q.dimension == 3
-    assert isinstance(q.dimension, int)
+    qid = cirq.GridQid(np5, np6, dimension=np3)
+    assert hash(qid) == hash(cirq.GridQid(5, 6, dimension=3))
+    assert qid.row == 5
+    assert qid.col == 6
+    assert qid.dimension == 3
+    assert isinstance(qid.dimension, int)
 
 
 @pytest.mark.parametrize('dtype', (float, np.float64))
-def test_non_integer_index(dtype):
+def test_non_integer_index(dtype) -> None:
     # Not supported type-wise, but is used in practice, so behavior needs to be preserved.
     q = cirq.GridQubit(dtype(5.5), dtype(6.5))
-    assert hash(q) == hash(cirq.GridQubit(5.5, 6.5))
+    assert hash(q) == hash(cirq.GridQubit(5.5, 6.5))  # type: ignore[arg-type]
     assert q.row == 5.5
     assert q.col == 6.5
     assert isinstance(q.row, dtype)

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -21,16 +21,16 @@ import cirq
 from cirq.devices.grid_qubit_test import _test_qid_pickled_hash
 
 
-def test_init():
+def test_init() -> None:
     q = cirq.LineQubit(1)
     assert q.x == 1
 
-    q = cirq.LineQid(1, dimension=3)
-    assert q.x == 1
-    assert q.dimension == 3
+    qid = cirq.LineQid(1, dimension=3)
+    assert qid.x == 1
+    assert qid.dimension == 3
 
 
-def test_eq():
+def test_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cirq.LineQubit(1), lambda: cirq.LineQid(1, dimension=2))
     eq.add_equality_group(cirq.LineQubit(2))
@@ -38,17 +38,17 @@ def test_eq():
     eq.add_equality_group(cirq.LineQid(1, dimension=3))
 
 
-def test_str():
+def test_str() -> None:
     assert str(cirq.LineQubit(5)) == 'q(5)'
     assert str(cirq.LineQid(5, dimension=3)) == 'q(5) (d=3)'
 
 
-def test_repr():
+def test_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.LineQubit(5))
     cirq.testing.assert_equivalent_repr(cirq.LineQid(5, dimension=3))
 
 
-def test_cmp():
+def test_cmp() -> None:
     order = cirq.testing.OrderTester()
     order.add_ascending_equivalence_group(cirq.LineQubit(0), cirq.LineQid(0, 2))
     order.add_ascending(
@@ -60,7 +60,7 @@ def test_cmp():
     )
 
 
-def test_cmp_failure():
+def test_cmp_failure() -> None:
     with pytest.raises(TypeError, match='not supported between instances'):
         _ = 0 < cirq.LineQubit(1)
     with pytest.raises(TypeError, match='not supported between instances'):
@@ -71,7 +71,7 @@ def test_cmp_failure():
         _ = cirq.LineQid(1, 3) < 0
 
 
-def test_line_qubit_pickled_hash():
+def test_line_qubit_pickled_hash() -> None:
     # Use a large number that is unlikely to be used by any other tests.
     x = 1234567891011
     q_bad = cirq.LineQubit(x)
@@ -80,7 +80,7 @@ def test_line_qubit_pickled_hash():
     _test_qid_pickled_hash(q, q_bad)
 
 
-def test_line_qid_pickled_hash():
+def test_line_qid_pickled_hash() -> None:
     # Use a large number that is unlikely to be used by any other tests.
     x = 1234567891011
     q_bad = cirq.LineQid(x, dimension=3)
@@ -89,7 +89,7 @@ def test_line_qid_pickled_hash():
     _test_qid_pickled_hash(q, q_bad)
 
 
-def test_is_adjacent():
+def test_is_adjacent() -> None:
     assert cirq.LineQubit(1).is_adjacent(cirq.LineQubit(2))
     assert cirq.LineQubit(1).is_adjacent(cirq.LineQubit(0))
     assert cirq.LineQubit(2).is_adjacent(cirq.LineQubit(3))
@@ -100,13 +100,13 @@ def test_is_adjacent():
     assert not cirq.LineQubit(2).is_adjacent(cirq.LineQid(0, 3))
 
 
-def test_neighborhood():
+def test_neighborhood() -> None:
     assert cirq.LineQubit(1).neighbors() == {cirq.LineQubit(0), cirq.LineQubit(2)}
     restricted_qubits = [cirq.LineQubit(2), cirq.LineQubit(3)]
     assert cirq.LineQubit(1).neighbors(restricted_qubits) == {cirq.LineQubit(2)}
 
 
-def test_range():
+def test_range() -> None:
     assert cirq.LineQubit.range(0) == []
     assert cirq.LineQubit.range(1) == [cirq.LineQubit(0)]
     assert cirq.LineQubit.range(2) == [cirq.LineQubit(0), cirq.LineQubit(1)]
@@ -127,7 +127,7 @@ def test_range():
     assert cirq.LineQubit.range(1, 5, 2) == [cirq.LineQubit(1), cirq.LineQubit(3)]
 
 
-def test_qid_range():
+def test_qid_range() -> None:
     assert cirq.LineQid.range(0, dimension=3) == []
     assert cirq.LineQid.range(1, dimension=3) == [cirq.LineQid(0, 3)]
     assert cirq.LineQid.range(2, dimension=3) == [cirq.LineQid(0, 3), cirq.LineQid(1, 3)]
@@ -152,7 +152,7 @@ def test_qid_range():
     assert cirq.LineQid.range(1, 5, 2, dimension=2) == [cirq.LineQid(1, 2), cirq.LineQid(3, 2)]
 
 
-def test_for_qid_shape():
+def test_for_qid_shape() -> None:
     assert cirq.LineQid.for_qid_shape(()) == []
     assert cirq.LineQid.for_qid_shape((4, 2, 3, 1)) == [
         cirq.LineQid(0, 4),
@@ -180,7 +180,7 @@ def test_for_qid_shape():
     ]
 
 
-def test_addition_subtraction():
+def test_addition_subtraction() -> None:
     assert cirq.LineQubit(1) + 2 == cirq.LineQubit(3)
     assert cirq.LineQubit(3) - 1 == cirq.LineQubit(2)
     assert 1 + cirq.LineQubit(4) == cirq.LineQubit(5)
@@ -199,16 +199,16 @@ def test_addition_subtraction():
     )
 
 
-def test_addition_subtraction_type_error():
+def test_addition_subtraction_type_error() -> None:
     with pytest.raises(TypeError, match='dave'):
-        _ = cirq.LineQubit(1) + 'dave'
+        _ = cirq.LineQubit(1) + 'dave'  # type: ignore[operator]
     with pytest.raises(TypeError, match='dave'):
-        _ = cirq.LineQubit(1) - 'dave'
+        _ = cirq.LineQubit(1) - 'dave'  # type: ignore[operator]
 
     with pytest.raises(TypeError, match='dave'):
-        _ = cirq.LineQid(1, 3) + 'dave'
+        _ = cirq.LineQid(1, 3) + 'dave'  # type: ignore[operator]
     with pytest.raises(TypeError, match='dave'):
-        _ = cirq.LineQid(1, 3) - 'dave'
+        _ = cirq.LineQid(1, 3) - 'dave'  # type: ignore[operator]
 
     with pytest.raises(TypeError, match="Can only add LineQids with identical dimension."):
         _ = cirq.LineQid(5, dimension=3) + cirq.LineQid(3, dimension=4)
@@ -217,17 +217,17 @@ def test_addition_subtraction_type_error():
         _ = cirq.LineQid(5, dimension=3) - cirq.LineQid(3, dimension=4)
 
 
-def test_neg():
+def test_neg() -> None:
     assert -cirq.LineQubit(1) == cirq.LineQubit(-1)
     assert -cirq.LineQid(1, dimension=3) == cirq.LineQid(-1, dimension=3)
 
 
-def test_json_dict():
+def test_json_dict() -> None:
     assert cirq.LineQubit(5)._json_dict_() == {'x': 5}
     assert cirq.LineQid(5, 3)._json_dict_() == {'x': 5, 'dimension': 3}
 
 
-def test_for_gate():
+def test_for_gate() -> None:
     class NoQidGate:
         def _qid_shape_(self):
             return ()
@@ -263,24 +263,24 @@ def test_for_gate():
     ]
 
 
-def test_immutable():
+def test_immutable() -> None:
     # Match one of two strings. The second one is message returned since python 3.11.
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'x' of 'LineQubit' object has no setter)",
     ):
         q = cirq.LineQubit(5)
-        q.x = 6
+        q.x = 6  # type: ignore[misc]
 
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'x' of 'LineQid' object has no setter)",
     ):
-        q = cirq.LineQid(5, dimension=4)
-        q.x = 6
+        qid = cirq.LineQid(5, dimension=4)
+        qid.x = 6  # type: ignore[misc]
 
 
-def test_numeric():
+def test_numeric() -> None:
     assert int(cirq.LineQubit(x=5)) == 5
     assert float(cirq.LineQubit(x=5)) == 5
     assert complex(cirq.LineQubit(x=5)) == 5 + 0j
@@ -290,7 +290,7 @@ def test_numeric():
 
 
 @pytest.mark.parametrize('dtype', (np.int8, np.int64, float, np.float64))
-def test_numpy_index(dtype):
+def test_numpy_index(dtype) -> None:
     np5 = dtype(5)
     q = cirq.LineQubit(np5)
     assert hash(q) == 5
@@ -298,15 +298,15 @@ def test_numpy_index(dtype):
     assert q.dimension == 2
     assert isinstance(q.dimension, int)
 
-    q = cirq.LineQid(np5, dtype(3))
-    hash(q)  # doesn't throw
-    assert q.x == 5
-    assert q.dimension == 3
-    assert isinstance(q.dimension, int)
+    qid = cirq.LineQid(np5, dtype(3))
+    hash(qid)  # doesn't throw
+    assert qid.x == 5
+    assert qid.dimension == 3
+    assert isinstance(qid.dimension, int)
 
 
 @pytest.mark.parametrize('dtype', (float, np.float64))
-def test_non_integer_index(dtype):
+def test_non_integer_index(dtype) -> None:
     # Not supported type-wise, but is used in practice, so behavior needs to be preserved.
     q = cirq.LineQubit(dtype(5.5))
     assert q.x == 5.5

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -66,7 +66,7 @@ def _node_and_coordinates(
 
 def draw_gridlike(
     graph: nx.Graph, ax: plt.Axes | None = None, tilted: bool = True, **kwargs
-) -> dict[Any, tuple[int, int]]:
+) -> dict[_GRIDLIKE_NODE, tuple[int, int]]:
     """Draw a grid-like graph using Matplotlib.
 
     This wraps nx.draw_networkx to produce a matplotlib drawing of the graph. Nodes
@@ -220,7 +220,7 @@ class TiltedSquareLattice(NamedTopology):
         n_nodes += ((self.width + 1) // 2) * ((self.height + 1) // 2)
         object.__setattr__(self, 'n_nodes', n_nodes)
 
-    def draw(self, ax=None, tilted=True, **kwargs):
+    def draw(self, ax=None, tilted=True, **kwargs) -> dict[_GRIDLIKE_NODE, tuple[int, int]]:
         """Draw this graph using Matplotlib.
 
         Args:
@@ -301,7 +301,7 @@ def get_placements(
 
 def _is_valid_placement_helper(
     big_graph: nx.Graph, small_mapped: nx.Graph, small_to_big_mapping: dict
-):
+) -> bool:
     """Helper function for `is_valid_placement` that assumes the mapping of `small_graph` has
     already occurred.
 
@@ -311,7 +311,9 @@ def _is_valid_placement_helper(
     return (subgraph.nodes == small_mapped.nodes) and (subgraph.edges == small_mapped.edges)
 
 
-def is_valid_placement(big_graph: nx.Graph, small_graph: nx.Graph, small_to_big_mapping: dict):
+def is_valid_placement(
+    big_graph: nx.Graph, small_graph: nx.Graph, small_to_big_mapping: dict
+) -> bool:
     """Return whether the given placement is a valid placement of small_graph onto big_graph.
 
     This is done by making sure all the nodes and edges on the mapped version of `small_graph`
@@ -338,7 +340,7 @@ def draw_placements(
     axes: Sequence[plt.Axes] | None = None,
     tilted: bool = True,
     bad_placement_callback: Callable[[plt.Axes, int], None] | None = None,
-):
+) -> None:
     """Draw a visualization of placements from small_graph onto big_graph using Matplotlib.
 
     The entire `big_graph` will be drawn with default blue colored nodes. `small_graph` nodes

--- a/cirq-core/cirq/devices/named_topologies_test.py
+++ b/cirq-core/cirq/devices/named_topologies_test.py
@@ -108,7 +108,7 @@ def test_draw_gridlike(tilted) -> None:
     ax = MagicMock()
     pos = draw_gridlike(graph, tilted=tilted, ax=ax)
     ax.scatter.assert_called()
-    for (row, column), _ in pos.items():
+    for row, column in pos.keys():  # type: ignore[misc]
         assert 0 <= row < 3
         assert 0 <= column < 3
 
@@ -120,7 +120,8 @@ def test_draw_gridlike_qubits(tilted) -> None:
     ax = MagicMock()
     pos = draw_gridlike(graph, tilted=tilted, ax=ax)
     ax.scatter.assert_called()
-    for q, _ in pos.items():
+    for q in pos.keys():
+        assert isinstance(q, cirq.GridQubit)
         assert 0 <= q.row < 3
         assert 0 <= q.col < 3
 

--- a/cirq-core/cirq/devices/noise_model.py
+++ b/cirq-core/cirq/devices/noise_model.py
@@ -235,7 +235,7 @@ class ConstantQubitNoiseModel(NoiseModel):
     def __repr__(self) -> str:
         return f'cirq.ConstantQubitNoiseModel({self.qubit_noise_gate!r})'
 
-    def noisy_moment(self, moment: cirq.Moment, system_qubits: Sequence[cirq.Qid]):
+    def noisy_moment(self, moment: cirq.Moment, system_qubits: Sequence[cirq.Qid]) -> cirq.OP_TREE:
         # Noise should not be appended to previously-added noise.
         if self.is_virtual_moment(moment):
             return moment

--- a/cirq-core/cirq/devices/noise_properties_test.py
+++ b/cirq-core/cirq/devices/noise_properties_test.py
@@ -34,7 +34,7 @@ class SampleNoiseProperties(NoiseProperties):
         self.qubits = system_qubits
         self.qubit_pairs = qubit_pairs
 
-    def build_noise_models(self):
+    def build_noise_models(self) -> list[cirq.NoiseModel]:
         add_h = InsertionNoiseModel({OpIdentifier(cirq.Gate, q): cirq.H(q) for q in self.qubits})
         add_iswap = InsertionNoiseModel(
             {OpIdentifier(cirq.Gate, *qs): cirq.ISWAP(*qs) for qs in self.qubit_pairs}

--- a/cirq-core/cirq/devices/noise_utils.py
+++ b/cirq-core/cirq/devices/noise_utils.py
@@ -48,7 +48,7 @@ class OpIdentifier:
     def _predicate(self, *args, **kwargs):
         return self._gate_family._predicate(*args, **kwargs)
 
-    def is_proper_subtype_of(self, op_id: OpIdentifier):
+    def is_proper_subtype_of(self, op_id: OpIdentifier) -> bool:
         """Returns true if this is contained within op_id, but not equal to it.
 
         If this returns true, (x in self) implies (x in op_id), but the reverse

--- a/cirq-core/cirq/devices/noise_utils_test.py
+++ b/cirq-core/cirq/devices/noise_utils_test.py
@@ -18,13 +18,13 @@ import cirq
 from cirq.devices.noise_utils import OpIdentifier
 
 
-def test_op_identifier():
+def test_op_identifier() -> None:
     op_id = OpIdentifier(cirq.XPowGate)
     assert cirq.X(cirq.LineQubit(1)) in op_id
     assert cirq.Rx(rads=1) in op_id
 
 
-def test_op_identifier_subtypes():
+def test_op_identifier_subtypes() -> None:
     gate_id = OpIdentifier(cirq.Gate)
     xpow_id = OpIdentifier(cirq.XPowGate)
     x_on_q0_id = OpIdentifier(cirq.XPowGate, cirq.LineQubit(0))
@@ -34,7 +34,7 @@ def test_op_identifier_subtypes():
     assert not xpow_id.is_proper_subtype_of(xpow_id)
 
 
-def test_op_id_str():
+def test_op_id_str() -> None:
     op_id = OpIdentifier(cirq.XPowGate, cirq.LineQubit(0))
     assert str(op_id) == "<class 'cirq.ops.common_gates.XPowGate'>(cirq.LineQubit(0),)"
     assert repr(op_id) == (
@@ -42,7 +42,7 @@ def test_op_id_str():
     )
 
 
-def test_op_id_swap():
+def test_op_id_swap() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     base_id = OpIdentifier(cirq.CZPowGate, q0, q1)
     swap_id = OpIdentifier(base_id.gate_type, *base_id.qubits[::-1])
@@ -52,8 +52,8 @@ def test_op_id_swap():
     assert cirq.CZ(q1, q0) in swap_id
 
 
-def test_op_id_instance():
+def test_op_id_instance() -> None:
     q0 = cirq.LineQubit.range(1)[0]
     gate = cirq.SingleQubitCliffordGate.from_xz_map((cirq.X, False), (cirq.Z, False))
-    op_id = OpIdentifier(gate, q0)
+    op_id = OpIdentifier(type(gate), q0)
     cirq.testing.assert_equivalent_repr(op_id)

--- a/cirq-core/cirq/devices/superconducting_qubits_noise_properties_test.py
+++ b/cirq-core/cirq/devices/superconducting_qubits_noise_properties_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Any, Sequence
+
 import numpy as np
 import pytest
 
@@ -37,7 +39,9 @@ DEFAULT_GATE_NS: dict[type, float] = {
 }
 
 
-def default_props(system_qubits: list[cirq.Qid], qubit_pairs: list[tuple[cirq.Qid, cirq.Qid]]):
+def default_props(
+    system_qubits: Sequence[cirq.Qid], qubit_pairs: Sequence[tuple[cirq.Qid, cirq.Qid]]
+) -> dict[str, Any]:
     return {
         'gate_times_ns': DEFAULT_GATE_NS,
         't1_ns': {q: 1e5 for q in system_qubits},
@@ -75,7 +79,7 @@ class ExampleNoiseProperties(SuperconductingQubitsNoiseProperties):
         return set()
 
 
-def test_init_validation():
+def test_init_validation() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     with pytest.raises(ValueError, match='Keys specified for T1 and Tphi are not identical.'):
         _ = ExampleNoiseProperties(
@@ -92,7 +96,7 @@ def test_init_validation():
             t1_ns={q0: 1},
             tphi_ns={q0: 1},
             readout_errors={q0: [0.1, 0.2]},
-            gate_pauli_errors={OpIdentifier(cirq.CCNOT, q0, q1, q2): 0.1},
+            gate_pauli_errors={OpIdentifier(type(cirq.CCNOT), q0, q1, q2): 0.1},
         )
 
     with pytest.raises(ValueError, match='does not appear in the symmetric or asymmetric'):
@@ -102,8 +106,8 @@ def test_init_validation():
             tphi_ns={q0: 1},
             readout_errors={q0: [0.1, 0.2]},
             gate_pauli_errors={
-                OpIdentifier(cirq.CNOT, q0, q1): 0.1,
-                OpIdentifier(cirq.CNOT, q1, q0): 0.1,
+                OpIdentifier(cirq.CNotPowGate, q0, q1): 0.1,
+                OpIdentifier(cirq.CNotPowGate, q1, q0): 0.1,
             },
         )
 
@@ -136,18 +140,19 @@ def test_init_validation():
     # All errors are ignored if validation is disabled.
     _ = ExampleNoiseProperties(
         gate_times_ns=DEFAULT_GATE_NS,
-        t1_ns={},
+        # t1_ns={},
+        t1_ns={q0: 1},
         tphi_ns={q0: 1},
         readout_errors={q0: [0.1, 0.2]},
         gate_pauli_errors={
-            OpIdentifier(cirq.CCNOT, q0, q1, q2): 0.1,
-            OpIdentifier(cirq.CNOT, q0, q1): 0.1,
+            OpIdentifier(type(cirq.CCNOT), q0, q1, q2): 0.1,
+            OpIdentifier(type(cirq.CNOT), q0, q1): 0.1,
         },
         validate=False,
     )
 
 
-def test_qubits():
+def test_qubits() -> None:
     q0 = cirq.LineQubit(0)
     props = ExampleNoiseProperties(**default_props([q0], []))
     assert props.qubits == [q0]
@@ -155,7 +160,7 @@ def test_qubits():
     assert props.qubits == [q0]
 
 
-def test_depol_memoization():
+def test_depol_memoization() -> None:
     # Verify that depolarizing error is memoized.
     q0 = cirq.LineQubit(0)
     props = ExampleNoiseProperties(**default_props([q0], []))
@@ -165,7 +170,7 @@ def test_depol_memoization():
     assert depol_error_a is depol_error_b
 
 
-def test_depol_validation():
+def test_depol_validation() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     # Create unvalidated properties with too many qubits on a Z gate.
     z_2q_props = ExampleNoiseProperties(
@@ -213,7 +218,7 @@ def test_depol_validation():
         ),
     ],
 )
-def test_single_qubit_gates(op):
+def test_single_qubit_gates(op) -> None:
     q0 = cirq.LineQubit(0)
     props = ExampleNoiseProperties(**default_props([q0], []))
     model = NoiseModelFromNoiseProperties(props)
@@ -237,10 +242,10 @@ def test_single_qubit_gates(op):
     assert np.allclose(
         thermal_choi,
         [
-            [1, 0, 0, 9.99750031e-01],
-            [0, 2.49968753e-04, 0, 0],
-            [0, 0, 0, 0],
-            [9.99750031e-01, 0, 0, 9.99750031e-01],
+            [1.0, 0.0, 0.0, 9.99750031e-01],
+            [0.0, 2.49968753e-04, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [9.99750031e-01, 0.0, 0.0, 9.99750031e-01],
         ],
     )
 
@@ -248,7 +253,7 @@ def test_single_qubit_gates(op):
 @pytest.mark.parametrize(
     'op', [cirq.ISWAP(*cirq.LineQubit.range(2)) ** 0.6, cirq.CZ(*cirq.LineQubit.range(2)) ** 0.3]
 )
-def test_two_qubit_gates(op):
+def test_two_qubit_gates(op) -> None:
     q0, q1 = cirq.LineQubit.range(2)
     props = ExampleNoiseProperties(**default_props([q0, q1], [(q0, q1), (q1, q0)]))
     model = NoiseModelFromNoiseProperties(props)
@@ -268,6 +273,8 @@ def test_two_qubit_gates(op):
     assert len(noisy_circuit.moments[2].operations) == 2
     thermal_op_0 = noisy_circuit.moments[2].operation_at(q0)
     thermal_op_1 = noisy_circuit.moments[2].operation_at(q1)
+    assert thermal_op_0 is not None
+    assert thermal_op_1 is not None
     assert isinstance(thermal_op_0.gate, cirq.KrausChannel)
     assert isinstance(thermal_op_1.gate, cirq.KrausChannel)
     thermal_choi_0 = cirq.kraus_to_choi(cirq.kraus(thermal_op_0))
@@ -284,7 +291,7 @@ def test_two_qubit_gates(op):
     assert np.allclose(thermal_choi_1, expected_thermal_choi)
 
 
-def test_measure_gates():
+def test_measure_gates() -> None:
     q00, q01, q10, q11 = cirq.GridQubit.rect(2, 2)
     qubits = [q00, q01, q10, q11]
     props = ExampleNoiseProperties(
@@ -311,7 +318,7 @@ def test_measure_gates():
     # Amplitude damping before measurement
     assert len(noisy_circuit.moments[0].operations) == 4
     for q in qubits:
-        op = noisy_circuit.moments[0].operation_at(q)
+        op = noisy_circuit.moments[0].operation_at(q)  # type: ignore[assignment]
         assert isinstance(op.gate, cirq.GeneralizedAmplitudeDampingChannel), q
         assert np.isclose(op.gate.p, 0.90909090), q
         assert np.isclose(op.gate.gamma, 0.011), q
@@ -322,7 +329,7 @@ def test_measure_gates():
     assert noisy_circuit.moments[1] == circuit.moments[0]
 
 
-def test_wait_gates():
+def test_wait_gates() -> None:
     q0 = cirq.LineQubit(0)
     props = ExampleNoiseProperties(**default_props([q0], []))
     model = NoiseModelFromNoiseProperties(props)
@@ -341,9 +348,9 @@ def test_wait_gates():
     assert np.allclose(
         thermal_choi,
         [
-            [1, 0, 0, 9.990005e-01],
-            [0, 9.99500167e-04, 0, 0],
-            [0, 0, 0, 0],
-            [9.990005e-01, 0, 0, 9.990005e-01],
+            [1.0, 0.0, 0.0, 9.990005e-01],
+            [0.0, 9.99500167e-04, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [9.990005e-01, 0.0, 0.0, 9.990005e-01],
         ],
     )

--- a/cirq-core/cirq/devices/thermal_noise_model_test.py
+++ b/cirq-core/cirq/devices/thermal_noise_model_test.py
@@ -28,7 +28,7 @@ from cirq.devices.thermal_noise_model import (
 )
 
 
-def test_helper_method_errors():
+def test_helper_method_errors() -> None:
     with pytest.raises(ValueError, match='_left_mul only accepts square matrices'):
         _ = _left_mul(np.array([[1, 2, 3], [4, 5, 6]]))
 
@@ -49,12 +49,12 @@ def test_helper_method_errors():
         _validate_rates({q0}, {q0: np.array([[0.001, 0.01, 0.1], [0.002, 0.02, 0.2]])})
 
 
-def test_create_thermal_noise_per_qubit():
+def test_create_thermal_noise_per_qubit() -> None:
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {cirq.PhasedXZGate: 25.0}
-    heat_rate_GHz = {q0: 1e-5, q1: 2e-5}
-    cool_rate_GHz = {q0: 1e-4, q1: 2e-4}
-    dephase_rate_GHz = {q0: 3e-4, q1: 4e-4}
+    gate_durations: dict[type, float] = {cirq.PhasedXZGate: 25.0}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-5, q1: 2e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4, q1: 2e-4}
+    dephase_rate_GHz: dict[cirq.Qid, float] = {q0: 3e-4, q1: 4e-4}
     model = ThermalNoiseModel(
         qubits={q0, q1},
         gate_durations_ns=gate_durations,
@@ -69,11 +69,11 @@ def test_create_thermal_noise_per_qubit():
     assert np.allclose(model.rate_matrix_GHz[q1], np.array([[0, 2e-4], [2e-5, 4e-4]]))
 
 
-def test_create_thermal_noise_mixed_type():
+def test_create_thermal_noise_mixed_type() -> None:
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {cirq.PhasedXZGate: 25.0}
+    gate_durations: dict[type, float] = {cirq.PhasedXZGate: 25.0}
     heat_rate_GHz = None
-    cool_rate_GHz = {q0: 1e-4, q1: 2e-4}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4, q1: 2e-4}
     dephase_rate_GHz = 3e-4
     model = ThermalNoiseModel(
         qubits={q0, q1},
@@ -89,11 +89,11 @@ def test_create_thermal_noise_mixed_type():
     assert np.allclose(model.rate_matrix_GHz[q1], np.array([[0, 2e-4], [0, 3e-4]]))
 
 
-def test_incomplete_rates():
+def test_incomplete_rates() -> None:
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {cirq.PhasedXZGate: 25.0}
-    heat_rate_GHz = {q1: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {cirq.PhasedXZGate: 25.0}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q1: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0, q1},
         gate_durations_ns=gate_durations,
@@ -108,12 +108,12 @@ def test_incomplete_rates():
     assert np.allclose(model.rate_matrix_GHz[q1], np.array([[0, 0], [1e-5, 0]]))
 
 
-def test_noise_from_empty_moment():
+def test_noise_from_empty_moment() -> None:
     # Verify that a moment with no duration has no noise.
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {}
-    heat_rate_GHz = {q1: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q1: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0, q1},
         gate_durations_ns=gate_durations,
@@ -127,12 +127,12 @@ def test_noise_from_empty_moment():
     assert model.noisy_moment(moment, system_qubits=[q0, q1]) == [moment]
 
 
-def test_noise_from_zero_duration():
+def test_noise_from_zero_duration() -> None:
     # Verify that a moment with no duration has no noise.
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {}
-    heat_rate_GHz = {q1: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q1: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0, q1},
         gate_durations_ns=gate_durations,
@@ -146,13 +146,13 @@ def test_noise_from_zero_duration():
     assert model.noisy_moment(moment, system_qubits=[q0, q1]) == [moment]
 
 
-def test_noise_from_virtual_gates():
+def test_noise_from_virtual_gates() -> None:
     # Verify that a moment with only virtual gates has no noise if
     # require_physical_tag is True.
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {cirq.ZPowGate: 25.0}
-    heat_rate_GHz = {q1: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {cirq.ZPowGate: 25.0}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q1: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0, q1},
         gate_durations_ns=gate_durations,
@@ -170,16 +170,16 @@ def test_noise_from_virtual_gates():
         _ = model.noisy_moment(part_virtual_moment, system_qubits=[q0, q1])
 
     model.require_physical_tag = False
-    assert len(model.noisy_moment(moment, system_qubits=[q0, q1])) == 2
+    assert len(model.noisy_moment(moment, system_qubits=[q0, q1])) == 2  # type: ignore[arg-type]
 
 
-def test_noise_from_measurement():
+def test_noise_from_measurement() -> None:
     # Verify that a moment with only measurement gates has no noise if
     # skip_measurements is True.
     q0, q1 = cirq.LineQubit.range(2)
-    gate_durations = {cirq.ZPowGate: 25.0, cirq.MeasurementGate: 4000.0}
-    heat_rate_GHz = {q1: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {cirq.ZPowGate: 25.0, cirq.MeasurementGate: 4000.0}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q1: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0, q1},
         gate_durations_ns=gate_durations,
@@ -193,13 +193,13 @@ def test_noise_from_measurement():
     assert model.noisy_moment(moment, system_qubits=[q0, q1]) == [moment]
 
     part_measure_moment = cirq.Moment(cirq.measure(q0, key='m'), cirq.Z(q1))
-    assert len(model.noisy_moment(part_measure_moment, system_qubits=[q0, q1])) == 2
+    assert len(model.noisy_moment(part_measure_moment, system_qubits=[q0, q1])) == 2  # type: ignore[arg-type]
 
     model.skip_measurements = False
-    assert len(model.noisy_moment(moment, system_qubits=[q0, q1])) == 2
+    assert len(model.noisy_moment(moment, system_qubits=[q0, q1])) == 2  # type: ignore[arg-type]
 
 
-def test_noisy_moment_one_qubit():
+def test_noisy_moment_one_qubit() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     model = ThermalNoiseModel(
         qubits={q0, q1},
@@ -212,6 +212,7 @@ def test_noisy_moment_one_qubit():
     gate = cirq.PhasedXZGate(x_exponent=1, z_exponent=0.5, axis_phase_exponent=0.25)
     moment = cirq.Moment(gate.on(q0))
     noisy_moment = model.noisy_moment(moment, system_qubits=[q0, q1])
+    assert isinstance(noisy_moment, list)
     assert noisy_moment[0] == moment
     # Noise applies to both qubits, even if only one is acted upon.
     assert len(noisy_moment[1]) == 2
@@ -227,7 +228,7 @@ def test_noisy_moment_one_qubit():
     )
 
 
-def test_noisy_moment_one_qubit_prepend():
+def test_noisy_moment_one_qubit_prepend() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     model = ThermalNoiseModel(
         qubits={q0, q1},
@@ -241,6 +242,7 @@ def test_noisy_moment_one_qubit_prepend():
     gate = cirq.PhasedXZGate(x_exponent=1, z_exponent=0.5, axis_phase_exponent=0.25)
     moment = cirq.Moment(gate.on(q0))
     noisy_moment = model.noisy_moment(moment, system_qubits=[q0, q1])
+    assert isinstance(noisy_moment, list)
     # Noise applies to both qubits, even if only one is acted upon.
     assert len(noisy_moment[0]) == 2
     noisy_choi = cirq.kraus_to_choi(cirq.kraus(noisy_moment[0].operations[0]))
@@ -257,12 +259,12 @@ def test_noisy_moment_one_qubit_prepend():
     assert noisy_moment[1] == moment
 
 
-def test_noise_from_wait():
+def test_noise_from_wait() -> None:
     # Verify that wait-gate noise is duration-dependent.
     q0 = cirq.LineQubit(0)
-    gate_durations = {cirq.ZPowGate: 25.0}
-    heat_rate_GHz = {q0: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {cirq.ZPowGate: 25.0}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0},
         gate_durations_ns=gate_durations,
@@ -274,6 +276,7 @@ def test_noise_from_wait():
     )
     moment = cirq.Moment(cirq.wait(q0, nanos=100))
     noisy_moment = model.noisy_moment(moment, system_qubits=[q0])
+    assert isinstance(noisy_moment, list)
     assert noisy_moment[0] == moment
     assert len(noisy_moment[1]) == 1
     noisy_choi = cirq.kraus_to_choi(cirq.kraus(noisy_moment[1].operations[0]))
@@ -288,11 +291,11 @@ def test_noise_from_wait():
     )
 
 
-def test_symbolic_times_for_wait_gate():
+def test_symbolic_times_for_wait_gate() -> None:
     q0 = cirq.LineQubit(0)
-    gate_durations = {cirq.ZPowGate: 25.0}
-    heat_rate_GHz = {q0: 1e-5}
-    cool_rate_GHz = {q0: 1e-4}
+    gate_durations: dict[type, float] = {cirq.ZPowGate: 25.0}
+    heat_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-5}
+    cool_rate_GHz: dict[cirq.Qid, float] = {q0: 1e-4}
     model = ThermalNoiseModel(
         qubits={q0},
         gate_durations_ns=gate_durations,
@@ -307,7 +310,7 @@ def test_symbolic_times_for_wait_gate():
         _ = model.noisy_moment(moment, system_qubits=[q0])
 
 
-def test_noisy_moment_two_qubit():
+def test_noisy_moment_two_qubit() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     model = ThermalNoiseModel(
         qubits={q0, q1},
@@ -320,6 +323,7 @@ def test_noisy_moment_two_qubit():
     gate = cirq.CZ**0.5
     moment = cirq.Moment(gate.on(q0, q1))
     noisy_moment = model.noisy_moment(moment, system_qubits=[q0, q1])
+    assert isinstance(noisy_moment, list)
     assert noisy_moment[0] == moment
     assert len(noisy_moment[1]) == 2
     noisy_choi_0 = cirq.kraus_to_choi(cirq.kraus(noisy_moment[1].operations[0]))
@@ -344,7 +348,7 @@ def test_noisy_moment_two_qubit():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     q0 = cirq.LineQubit(0)
     model = ThermalNoiseModel(
         qubits={q0},

--- a/cirq-core/cirq/devices/unconstrained_device.py
+++ b/cirq-core/cirq/devices/unconstrained_device.py
@@ -47,5 +47,5 @@ class _UnconstrainedDevice(device.Device):
         return protocols.obj_to_dict_helper(self, [])
 
 
-UNCONSTRAINED_DEVICE: device.Device = _UnconstrainedDevice()
+UNCONSTRAINED_DEVICE = _UnconstrainedDevice()
 document(UNCONSTRAINED_DEVICE, """A device with no constraints on operations or qubits.""")

--- a/cirq-core/cirq/devices/unconstrained_device_test.py
+++ b/cirq-core/cirq/devices/unconstrained_device_test.py
@@ -17,17 +17,17 @@ from __future__ import annotations
 import cirq
 
 
-def test_repr():
+def test_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.UNCONSTRAINED_DEVICE)
 
 
-def test_infinitely_fast():
+def test_infinitely_fast() -> None:
     assert cirq.UNCONSTRAINED_DEVICE.duration_of(cirq.X(cirq.NamedQubit('a'))) == cirq.Duration(
         picos=0
     )
 
 
-def test_any_qubit_works():
+def test_any_qubit_works() -> None:
     moment = cirq.Moment([cirq.X(cirq.LineQubit(987654321))])
     cirq.UNCONSTRAINED_DEVICE.validate_moment(moment)
     cirq.UNCONSTRAINED_DEVICE.validate_circuit(cirq.Circuit(moment))

--- a/cirq-core/cirq/experiments/benchmarking/parallel_xeb_test.py
+++ b/cirq-core/cirq/experiments/benchmarking/parallel_xeb_test.py
@@ -288,13 +288,11 @@ def test_estimate_fidelities() -> None:
         ],
     )
 
-    assert result == [
-        xeb.XEBFidelity(
-            pair=_PAIRS[0],
-            cycle_depth=1,
-            fidelity=pytest.approx(0.785, abs=2e-4),  # type: ignore[arg-type]
-        )
-    ]
+    assert len(result) == 1
+    xeb_fidelity = result[0]
+    assert xeb_fidelity.pair == _PAIRS[0]
+    assert xeb_fidelity.cycle_depth == 1
+    assert xeb_fidelity.fidelity == pytest.approx(0.785, abs=2e-4)
 
 
 def test_estimate_fidelities_with_dict_target() -> None:
@@ -323,13 +321,11 @@ def test_estimate_fidelities_with_dict_target() -> None:
         ],
     )
 
-    assert result == [
-        xeb.XEBFidelity(
-            pair=_PAIRS[0],
-            cycle_depth=1,
-            fidelity=pytest.approx(0.785, abs=2e-4),  # type: ignore[arg-type]
-        )
-    ]
+    assert len(result) == 1
+    xeb_fidelity = result[0]
+    assert xeb_fidelity.pair == _PAIRS[0]
+    assert xeb_fidelity.cycle_depth == 1
+    assert xeb_fidelity.fidelity == pytest.approx(0.785, abs=2e-4)
 
 
 def _assert_fidelities_approx_equal(fids, expected: float, atol: float):

--- a/cirq-core/cirq/experiments/benchmarking/parallel_xeb_test.py
+++ b/cirq-core/cirq/experiments/benchmarking/parallel_xeb_test.py
@@ -37,8 +37,8 @@ _PAIRS = ((cirq.q(0, 0), cirq.q(0, 1)), (cirq.q(0, 2), cirq.q(0, 3)), (cirq.q(0,
 
 class TestXEBWideCircuitInfo:
 
-    def test_from_circuit(self):
-        permutation = [1, 2, 0]
+    def test_from_circuit(self) -> None:
+        permutation = np.array([1, 2, 0])
         target = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.CNOT(*_QUBITS)))
         wide_circuit = xeb.XEBWideCircuitInfo.from_narrow_circuits(
             _CIRCUIT_TEMPLATES, permutation=permutation, pairs=_PAIRS, target=target
@@ -65,7 +65,7 @@ class TestXEBWideCircuitInfo:
             narrow_template_indices=permutation,
         )
 
-    def test_sliced_circuit(self):
+    def test_sliced_circuit(self) -> None:
         wid_circuit = xeb.XEBWideCircuitInfo(
             wide_circuit=cirq.Circuit.from_moments(
                 [
@@ -114,10 +114,14 @@ class TestXEBWideCircuitInfo:
         assert wid_circuit.sliced_circuits([1]) == [sliced_circuit]
 
 
-def test_create_combination_circuits():
+def test_create_combination_circuits() -> None:
     wide_circuits_info = xeb.create_combination_circuits(
         _CIRCUIT_TEMPLATES,
-        [rqcg.CircuitLibraryCombination(layer=None, combinations=[[1, 2, 0]], pairs=_PAIRS)],
+        [
+            rqcg.CircuitLibraryCombination(
+                layer=None, combinations=np.array([[1, 2, 0]]), pairs=_PAIRS
+            )
+        ],
         target=cirq.CNOT(*_QUBITS),
     )
 
@@ -142,10 +146,14 @@ def test_create_combination_circuits():
     ]
 
 
-def test_create_combination_circuits_with_target_dict():
+def test_create_combination_circuits_with_target_dict() -> None:
     wide_circuits_info = xeb.create_combination_circuits(
         _CIRCUIT_TEMPLATES,
-        [rqcg.CircuitLibraryCombination(layer=None, combinations=[[1, 2, 0]], pairs=_PAIRS)],
+        [
+            rqcg.CircuitLibraryCombination(
+                layer=None, combinations=np.array([[1, 2, 0]]), pairs=_PAIRS
+            )
+        ],
         target={_PAIRS[0]: cirq.CNOT(*_QUBITS), _PAIRS[1]: cirq.CZ(*_QUBITS)},
     )
 
@@ -164,7 +172,7 @@ def test_create_combination_circuits_with_target_dict():
     ]
 
 
-def test_simulate_circuit():
+def test_simulate_circuit() -> None:
     sim = cirq.Simulator(seed=0)
     circuit = cirq.Circuit.from_moments(
         cirq.X.on_each(_QUBITS),
@@ -180,7 +188,7 @@ def test_simulate_circuit():
     np.testing.assert_allclose(result, [[0, 1, 0, 0], [1, 0, 0, 0]])  # |01>  # |00>
 
 
-def test_simulate_circuit_library():
+def test_simulate_circuit_library() -> None:
     circuit_templates = [
         cirq.Circuit.from_moments(
             cirq.X.on_each(_QUBITS),
@@ -199,7 +207,7 @@ def test_simulate_circuit_library():
     np.testing.assert_allclose(result, [[[0, 1, 0, 0], [1, 0, 0, 0]]])  # |01>  # |00>
 
 
-def test_simulate_circuit_library_with_target_dict():
+def test_simulate_circuit_library_with_target_dict() -> None:
     circuit_templates = [
         cirq.Circuit.from_moments(
             [cirq.H(_QUBITS[0]), cirq.X(_QUBITS[1])],
@@ -219,13 +227,15 @@ def test_simulate_circuit_library_with_target_dict():
     )
 
     # First pair result.
-    np.testing.assert_allclose(result[_PAIRS[0]], [[[0.25, 0.25, 0.25, 0.25], [0, 1, 0, 0]]])
+    np.testing.assert_allclose(
+        result[_PAIRS[0]], [[[0.25, 0.25, 0.25, 0.25], [0.0, 1.0, 0.0, 0.0]]]
+    )
 
     # Second pair result.
     np.testing.assert_allclose(result[_PAIRS[1]], [[[0, 0, 1, 0], [1, 0, 0, 0]]])  # |10>  # |00>
 
 
-def test_sample_all_circuits():
+def test_sample_all_circuits() -> None:
     wide_circuits = [
         cirq.Circuit.from_moments(
             [cirq.Y.on_each(*_PAIRS[0]), cirq.Z.on_each(*_PAIRS[1]), cirq.X.on_each(*_PAIRS[2])],
@@ -252,7 +262,7 @@ def test_sample_all_circuits():
     )  # |01>
 
 
-def test_estimate_fidelities():
+def test_estimate_fidelities() -> None:
     sampling_result = [{str(_PAIRS[0]): np.array([0.15, 0.15, 0.35, 0.35])}]
 
     simulation_results = [[np.array([0.1, 0.2, 0.3, 0.4])]]
@@ -279,11 +289,15 @@ def test_estimate_fidelities():
     )
 
     assert result == [
-        xeb.XEBFidelity(pair=_PAIRS[0], cycle_depth=1, fidelity=pytest.approx(0.785, abs=2e-4))
+        xeb.XEBFidelity(
+            pair=_PAIRS[0],
+            cycle_depth=1,
+            fidelity=pytest.approx(0.785, abs=2e-4),  # type: ignore[arg-type]
+        )
     ]
 
 
-def test_estimate_fidelities_with_dict_target():
+def test_estimate_fidelities_with_dict_target() -> None:
     sampling_result = [{str(_PAIRS[0]): np.array([0.15, 0.15, 0.35, 0.35])}]
 
     simulation_results = {_PAIRS[0]: [[np.array([0.1, 0.2, 0.3, 0.4])]]}
@@ -310,7 +324,11 @@ def test_estimate_fidelities_with_dict_target():
     )
 
     assert result == [
-        xeb.XEBFidelity(pair=_PAIRS[0], cycle_depth=1, fidelity=pytest.approx(0.785, abs=2e-4))
+        xeb.XEBFidelity(
+            pair=_PAIRS[0],
+            cycle_depth=1,
+            fidelity=pytest.approx(0.785, abs=2e-4),  # type: ignore[arg-type]
+        )
     ]
 
 
@@ -323,7 +341,7 @@ def _assert_fidelities_approx_equal(fids, expected: float, atol: float):
 
 @pytest.mark.parametrize('target', [cirq.CZ, cirq.Circuit(cirq.CZ(*_QUBITS)), cirq.CZ(*_QUBITS)])
 @pytest.mark.parametrize('pairs', [_PAIRS[:1], _PAIRS[:2]])
-def test_parallel_two_qubit_xeb(target, pairs):
+def test_parallel_two_qubit_xeb(target, pairs) -> None:
     sampler = cirq.DensityMatrixSimulator(noise=cirq.depolarize(0.03), seed=0)
     result = xeb.parallel_two_qubit_xeb(
         sampler=sampler,
@@ -349,17 +367,17 @@ class ExampleDevice(cirq.Device):
 
 
 class ExampleProcessor:
-    def get_device(self):
+    def get_device(self) -> ExampleDevice:
         return ExampleDevice()
 
 
 class DensityMatrixSimulatorWithProcessor(cirq.DensityMatrixSimulator):
     @property
-    def processor(self):
+    def processor(self) -> ExampleProcessor:
         return ExampleProcessor()
 
 
-def test_parallel_two_qubit_xeb_with_device():
+def test_parallel_two_qubit_xeb_with_device() -> None:
     target = cirq.CZ
     sampler = DensityMatrixSimulatorWithProcessor(noise=cirq.depolarize(0.03), seed=0)
     result = xeb.parallel_two_qubit_xeb(
@@ -380,7 +398,7 @@ def test_parallel_two_qubit_xeb_with_device():
     assert result.all_qubit_pairs == pairs
 
 
-def test_parallel_two_qubit_xeb_with_dict_target():
+def test_parallel_two_qubit_xeb_with_dict_target() -> None:
     target = {p: cirq.Circuit(cirq.CZ(*_QUBITS)) for p in _PAIRS[:2]}
     target[_PAIRS[2]] = cirq.CZ(*_QUBITS)
     sampler = cirq.DensityMatrixSimulator(noise=cirq.depolarize(0.03), seed=0)
@@ -395,7 +413,7 @@ def test_parallel_two_qubit_xeb_with_dict_target():
     assert result.all_qubit_pairs == _PAIRS
 
 
-def test_parallel_two_qubit_xeb_with_ideal_target():
+def test_parallel_two_qubit_xeb_with_ideal_target() -> None:
     target = {p: cirq.Circuit(cirq.CZ(*_QUBITS)) for p in _PAIRS[:2]}
     target[_PAIRS[2]] = cirq.CZ(*_QUBITS)
     sampler = cirq.DensityMatrixSimulator(noise=cirq.depolarize(0.03), seed=0)
@@ -417,7 +435,7 @@ def threading_pool() -> Iterator[futures.Executor]:
         yield pool
 
 
-def test_parallel_two_qubit_xeb_with_dict_target_and_pool(threading_pool):
+def test_parallel_two_qubit_xeb_with_dict_target_and_pool(threading_pool) -> None:
     target = {p: cirq.Circuit(cirq.CZ(*_QUBITS)) for p in _PAIRS}
     sampler = cirq.DensityMatrixSimulator(noise=cirq.depolarize(0.03), seed=0)
     result = xeb.parallel_two_qubit_xeb(
@@ -432,7 +450,7 @@ def test_parallel_two_qubit_xeb_with_dict_target_and_pool(threading_pool):
     assert result.all_qubit_pairs == _PAIRS
 
 
-def test_parallel_two_qubit_xeb_with_invalid_input_raises():
+def test_parallel_two_qubit_xeb_with_invalid_input_raises() -> None:
     with pytest.raises(AssertionError):
         _ = xeb.parallel_two_qubit_xeb(
             sampler=cirq.Simulator(seed=0), target={_PAIRS[0]: cirq.CZ}, pairs=_PAIRS

--- a/cirq-core/cirq/experiments/fidelity_estimation.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Mapping, Sequence, TYPE_CHECKING
+from typing import Callable, Sequence, TYPE_CHECKING
 
 import numpy as np
 
@@ -141,7 +141,7 @@ def xeb_fidelity(
     circuit: cirq.Circuit,
     bitstrings: Sequence[int],
     qubit_order: QubitOrderOrList = QubitOrder.DEFAULT,
-    amplitudes: Mapping[int, complex] | None = None,
+    amplitudes: np.ndarray | None = None,
     estimator: Callable[[int, Sequence[float]], float] = linear_xeb_fidelity_from_probabilities,
 ) -> float:
     """Estimates XEB fidelity from one circuit using user-supplied estimator.
@@ -169,7 +169,7 @@ def xeb_fidelity(
             `cirq.final_state_vector`.
         qubit_order: Qubit order used to construct bitstrings enumerating
             qubits starting with the most significant qubit.
-        amplitudes: Optional mapping from bitstring to output amplitude.
+        amplitudes: Optional array of output amplitudes at bitstring indices.
             If provided, simulation is skipped. Useful for large circuits
             when an offline simulation had already been performed.
         estimator: Fidelity estimator to use, see above. Defaults to the
@@ -206,7 +206,7 @@ def linear_xeb_fidelity(
     circuit: cirq.Circuit,
     bitstrings: Sequence[int],
     qubit_order: QubitOrderOrList = QubitOrder.DEFAULT,
-    amplitudes: Mapping[int, complex] | None = None,
+    amplitudes: np.ndarray | None = None,
 ) -> float:
     """Estimates XEB fidelity from one circuit using linear estimator."""
     return xeb_fidelity(
@@ -222,7 +222,7 @@ def log_xeb_fidelity(
     circuit: cirq.Circuit,
     bitstrings: Sequence[int],
     qubit_order: QubitOrderOrList = QubitOrder.DEFAULT,
-    amplitudes: Mapping[int, complex] | None = None,
+    amplitudes: np.ndarray | None = None,
 ) -> float:
     """Estimates XEB fidelity from one circuit using logarithmic estimator."""
     return xeb_fidelity(

--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -25,7 +25,7 @@ import cirq
 
 def sample_noisy_bitstrings(
     circuit: cirq.Circuit, qubit_order: Sequence[cirq.Qid], depolarization: float, repetitions: int
-) -> np.ndarray:
+) -> Sequence[int]:
     assert 0 <= depolarization <= 1
     dim = np.prod(circuit.qid_shape(), dtype=np.int64)
     n_incoherent = int(depolarization * repetitions)
@@ -34,7 +34,7 @@ def sample_noisy_bitstrings(
     circuit_with_measurements = cirq.Circuit(circuit, cirq.measure(*qubit_order, key='m'))
     r = cirq.sample(circuit_with_measurements, repetitions=n_coherent)
     coherent_samples = r.data['m'].to_numpy()
-    return np.concatenate((coherent_samples, incoherent_samples))
+    return np.concatenate((coherent_samples, incoherent_samples)).tolist()
 
 
 def make_random_quantum_circuit(qubits: Sequence[cirq.Qid], depth: int) -> cirq.Circuit:
@@ -69,7 +69,7 @@ def make_random_quantum_circuit(qubits: Sequence[cirq.Qid], depth: int) -> cirq.
         ),
     ),
 )
-def test_xeb_fidelity(depolarization, estimator):
+def test_xeb_fidelity(depolarization, estimator) -> None:
     prng_state = np.random.get_state()
     np.random.seed(0)
 
@@ -95,7 +95,7 @@ def test_xeb_fidelity(depolarization, estimator):
     np.random.set_state(prng_state)
 
 
-def test_linear_and_log_xeb_fidelity():
+def test_linear_and_log_xeb_fidelity() -> None:
     prng_state = np.random.get_state()
     np.random.seed(0)
 
@@ -122,7 +122,7 @@ def test_linear_and_log_xeb_fidelity():
     np.random.set_state(prng_state)
 
 
-def test_xeb_fidelity_invalid_qubits():
+def test_xeb_fidelity_invalid_qubits() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     circuit = cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1))
     bitstrings = sample_noisy_bitstrings(circuit, (q0, q1, q2), 0.9, 10)
@@ -130,7 +130,7 @@ def test_xeb_fidelity_invalid_qubits():
         cirq.xeb_fidelity(circuit, bitstrings, (q0, q2))
 
 
-def test_xeb_fidelity_invalid_bitstrings():
+def test_xeb_fidelity_invalid_bitstrings() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1))
     bitstrings = [0, 1, 2, 3, 4]
@@ -138,7 +138,7 @@ def test_xeb_fidelity_invalid_bitstrings():
         cirq.xeb_fidelity(circuit, bitstrings, (q0, q1))
 
 
-def test_xeb_fidelity_tuple_input():
+def test_xeb_fidelity_tuple_input() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1))
     bitstrings = [0, 1, 2]

--- a/cirq-core/cirq/experiments/purity_estimation.py
+++ b/cirq-core/cirq/experiments/purity_estimation.py
@@ -20,7 +20,7 @@ import numpy as np
 
 
 def purity_from_probabilities(
-    hilbert_space_dimension: int, probabilities: Sequence[float]
+    hilbert_space_dimension: int, probabilities: np.ndarray | Sequence[float]
 ) -> float:
     """Purity estimator from speckle purity benchmarking.
 

--- a/cirq-core/cirq/experiments/purity_estimation_test.py
+++ b/cirq-core/cirq/experiments/purity_estimation_test.py
@@ -19,7 +19,7 @@ import numpy as np
 from cirq.experiments import purity_from_probabilities
 
 
-def test_purity_from_probabilities():
+def test_purity_from_probabilities() -> None:
     probabilities = np.random.uniform(0, 1, size=4)
     probabilities /= np.sum(probabilities)
     purity = purity_from_probabilities(4, probabilities)

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -33,7 +33,7 @@ from cirq.experiments import (
 )
 
 
-def test_single_qubit_cliffords():
+def test_single_qubit_cliffords() -> None:
     I = np.eye(2)
     X = np.array([[0, 1], [1, 0]])
     Y = np.array([[0, -1j], [1j, 0]])
@@ -108,7 +108,7 @@ def test_single_qubit_cliffords():
 
 
 @mock.patch.dict(os.environ, clear='CIRQ_TESTING')
-def test_single_qubit_randomized_benchmarking():
+def test_single_qubit_randomized_benchmarking() -> None:
     # Check that the ground state population at the end of the Clifford
     # sequences is always unity.
     simulator = sim.Simulator()
@@ -121,7 +121,7 @@ def test_single_qubit_randomized_benchmarking():
 
 
 @mock.patch.dict(os.environ, clear='CIRQ_TESTING')
-def test_parallel_single_qubit_parallel_single_qubit_randomized_benchmarking():
+def test_parallel_single_qubit_parallel_single_qubit_randomized_benchmarking() -> None:
     # Check that the ground state population at the end of the Clifford
     # sequences is always unity.
     simulator = sim.Simulator()
@@ -140,7 +140,7 @@ def test_parallel_single_qubit_parallel_single_qubit_randomized_benchmarking():
     _ = results.plot_integrated_histogram()
 
 
-def test_two_qubit_randomized_benchmarking():
+def test_two_qubit_randomized_benchmarking() -> None:
     # Check that the ground state population at the end of the Clifford
     # sequences is always unity.
     simulator = sim.Simulator()
@@ -154,7 +154,7 @@ def test_two_qubit_randomized_benchmarking():
     assert np.isclose(np.mean(g_pops), 1.0)
 
 
-def test_single_qubit_state_tomography():
+def test_single_qubit_state_tomography() -> None:
     # Check that the density matrices of the output states of X/2, Y/2 and
     # H + Y gates closely match the ideal cases.
     # Checks that unique tomography keys are generated
@@ -187,7 +187,7 @@ def test_single_qubit_state_tomography():
     np.testing.assert_almost_equal(act_rho_5, tar_rho_5, decimal=1)
 
 
-def test_two_qubit_state_tomography():
+def test_two_qubit_state_tomography() -> None:
     # Check that the density matrices of the four Bell states closely match
     # the ideal cases. In addition, check that the output states of
     # single-qubit rotations (H, H), (X/2, Y/2), (Y/2, X/2) have the correct
@@ -231,14 +231,14 @@ def test_two_qubit_state_tomography():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_tomography_plot_raises_for_incorrect_number_of_axes():
+def test_tomography_plot_raises_for_incorrect_number_of_axes() -> None:
     simulator = sim.Simulator()
     qubit = GridQubit(0, 0)
     circuit = circuits.Circuit(ops.X(qubit) ** 0.5)
     result = single_qubit_state_tomography(simulator, qubit, circuit, 1000)
     with pytest.raises(TypeError):  # ax is not a list[plt.Axes]
         ax = plt.subplot()
-        result.plot(ax)
+        result.plot(ax)  # type: ignore[arg-type]
     with pytest.raises(ValueError):
         _, axes = plt.subplots(1, 3)
         result.plot(axes)
@@ -247,7 +247,7 @@ def test_tomography_plot_raises_for_incorrect_number_of_axes():
 @pytest.mark.parametrize('num_cliffords', range(5, 10))
 @pytest.mark.parametrize('use_xy_basis', [False, True])
 @pytest.mark.parametrize('strict_basis', [False, True])
-def test_single_qubit_cliffords_gateset(num_cliffords, use_xy_basis, strict_basis):
+def test_single_qubit_cliffords_gateset(num_cliffords, use_xy_basis, strict_basis) -> None:
     qubits = [GridQubit(0, i) for i in range(4)]
     c1_in_xy = cirq.experiments.qubit_characterizations.RBParameters(
         use_xy_basis=use_xy_basis, strict_basis=strict_basis
@@ -260,7 +260,7 @@ def test_single_qubit_cliffords_gateset(num_cliffords, use_xy_basis, strict_basi
         qubits, num_cliffords, c1_in_xy
     )
     device = cirq.testing.ValidatingTestDevice(
-        qubits=qubits, allowed_gates=(cirq.ops.PhasedXZGate, cirq.MeasurementGate)
+        qubits=set(qubits), allowed_gates=(cirq.ops.PhasedXZGate, cirq.MeasurementGate)
     )
     device.validate_circuit(c)
 

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
@@ -297,7 +297,7 @@ class CircuitLibraryCombination:
 
     layer: Any | None
     combinations: np.ndarray
-    pairs: list[QidPairT]
+    pairs: Sequence[QidPairT]
 
 
 def _get_random_combinations(

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -38,7 +38,7 @@ from cirq.experiments.random_quantum_circuit_generation import (
 SINGLE_QUBIT_LAYER = dict[cirq.GridQubit, cirq.Gate | None]
 
 
-def test_random_rotation_between_two_qubit_circuit():
+def test_random_rotation_between_two_qubit_circuit() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = random_rotations_between_two_qubit_circuit(q0, q1, 4, seed=52)
     assert len(circuit) == 4 * 2 + 1
@@ -75,7 +75,7 @@ X^0.5         PhX(0.25)^0.5
     )
 
 
-def test_generate_library_of_2q_circuits():
+def test_generate_library_of_2q_circuits() -> None:
     circuits = generate_library_of_2q_circuits(
         n_library_circuits=5, two_qubit_gate=cirq.CNOT, max_cycle_depth=13, random_state=9
     )
@@ -89,7 +89,7 @@ def test_generate_library_of_2q_circuits():
             assert m2.operations[0].gate == cirq.CNOT
 
 
-def test_generate_library_of_2q_circuits_custom_qubits():
+def test_generate_library_of_2q_circuits_custom_qubits() -> None:
     circuits = generate_library_of_2q_circuits(
         n_library_circuits=5,
         two_qubit_gate=cirq.ISWAP**0.5,
@@ -117,7 +117,7 @@ def _gridqubits_to_graph_device(qubits: Iterable[cirq.GridQubit]):
     )
 
 
-def test_get_random_combinations_for_device():
+def test_get_random_combinations_for_device() -> None:
     graph = _gridqubits_to_graph_device(cirq.GridQubit.rect(3, 3))
     n_combinations = 4
     combinations = get_random_combinations_for_device(
@@ -136,7 +136,7 @@ def test_get_random_combinations_for_device():
         assert cirq.experiments.HALF_GRID_STAGGERED_PATTERN[i] == comb.layer
 
 
-def test_get_random_combinations_for_small_device():
+def test_get_random_combinations_for_small_device() -> None:
     graph = _gridqubits_to_graph_device(cirq.GridQubit.rect(3, 1))
     n_combinations = 4
     combinations = get_random_combinations_for_device(
@@ -145,7 +145,8 @@ def test_get_random_combinations_for_small_device():
     assert len(combinations) == 2  # 3x1 device only fits two layers
 
 
-def test_get_random_combinations_for_pairs():
+def test_get_random_combinations_for_pairs() -> None:
+    all_pairs: list[list[tuple[cirq.Qid, cirq.Qid]]]
     all_pairs = [
         [(cirq.LineQubit(0), cirq.LineQubit(1)), (cirq.LineQubit(2), cirq.LineQubit(3))],
         [(cirq.LineQubit(1), cirq.LineQubit(2))],
@@ -167,7 +168,11 @@ def test_get_random_combinations_for_pairs():
         assert comb.pairs == all_pairs[i]
 
 
-def test_get_random_combinations_for_layer_circuit():
+def test_get_random_combinations_for_layer_circuit() -> None:
+    q0: cirq.Qid
+    q1: cirq.Qid
+    q2: cirq.Qid
+    q3: cirq.Qid
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(cirq.CNOT(q0, q1), cirq.CNOT(q2, q3), cirq.CNOT(q1, q2))
     combinations = get_random_combinations_for_layer_circuit(
@@ -186,7 +191,7 @@ def test_get_random_combinations_for_layer_circuit():
         assert comb.layer == circuit.moments[i]
 
 
-def test_get_random_combinations_for_bad_layer_circuit():
+def test_get_random_combinations_for_bad_layer_circuit() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
         cirq.H.on_each(q0, q1, q2, q3), cirq.CNOT(q0, q1), cirq.CNOT(q2, q3), cirq.CNOT(q1, q2)
@@ -198,7 +203,7 @@ def test_get_random_combinations_for_bad_layer_circuit():
         )
 
 
-def test_get_grid_interaction_layer_circuit():
+def test_get_grid_interaction_layer_circuit() -> None:
     graph = _gridqubits_to_graph_device(cirq.GridQubit.rect(3, 3))
     layer_circuit = get_grid_interaction_layer_circuit(graph)
 
@@ -225,7 +230,7 @@ def test_get_grid_interaction_layer_circuit():
     assert layer_circuit == should_be
 
 
-def test_random_combinations_layer_circuit_vs_device():
+def test_random_combinations_layer_circuit_vs_device() -> None:
     # Random combinations from layer circuit is the same as getting it directly from graph
     graph = _gridqubits_to_graph_device(cirq.GridQubit.rect(3, 3))
     layer_circuit = get_grid_interaction_layer_circuit(graph)
@@ -373,7 +378,7 @@ def test_random_rotations_between_grid_interaction_layers(
     expected_circuit_length: int,
     single_qubit_layers_slice: slice,
     two_qubit_layers_slice: slice,
-):
+) -> None:
     qubits = set(qubits)
     circuit = random_rotations_between_grid_interaction_layers_circuit(
         qubits,
@@ -396,7 +401,7 @@ def test_random_rotations_between_grid_interaction_layers(
     )
 
 
-def test_grid_interaction_layer_repr():
+def test_grid_interaction_layer_repr() -> None:
     layer = GridInteractionLayer(col_offset=0, vertical=True, stagger=False)
     assert repr(layer) == (
         'cirq.experiments.GridInteractionLayer(col_offset=0, vertical=True, stagger=False)'
@@ -462,7 +467,7 @@ def _coupled_qubit_pairs(
     return pairs
 
 
-def test_generate_library_of_2q_circuits_with_tags():
+def test_generate_library_of_2q_circuits_with_tags() -> None:
     circuits = generate_library_of_2q_circuits(
         n_library_circuits=5,
         two_qubit_gate=cirq.FSimGate(3, 4),

--- a/cirq-core/cirq/experiments/readout_confusion_matrix_test.py
+++ b/cirq-core/cirq/experiments/readout_confusion_matrix_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 import numpy as np
 import pytest
 
@@ -49,7 +51,7 @@ def add_readout_error(
     return noisy_measurements.astype(int)
 
 
-def get_expected_cm(num_qubits: int, p0: float, p1: float):
+def get_expected_cm(num_qubits: int, p0: float, p1: float) -> np.ndarray:
     expected_cm = np.zeros((2**num_qubits,) * 2)
     for i in range(2**num_qubits):
         for j in range(2**num_qubits):
@@ -66,7 +68,7 @@ def get_expected_cm(num_qubits: int, p0: float, p1: float):
 
 
 @pytest.mark.parametrize('p0, p1', [(0, 0), (0.2, 0.4), (0.5, 0.5), (0.6, 0.3), (1.0, 1.0)])
-def test_measure_confusion_matrix_with_noise(p0, p1):
+def test_measure_confusion_matrix_with_noise(p0, p1) -> None:
     sampler = NoisySingleQubitReadoutSampler(p0, p1, seed=1234)
     num_qubits = 4
     qubits = cirq.LineQubit.range(num_qubits)
@@ -113,8 +115,8 @@ def test_measure_confusion_matrix_with_noise(p0, p1):
     assert l2norm(corrected_result) <= l2norm(sampled_result)
 
 
-def test_from_measurement():
-    qubits = cirq.LineQubit.range(3)
+def test_from_measurement() -> None:
+    qubits: Sequence[cirq.Qid] = cirq.LineQubit.range(3)
     confuse_02 = np.array([[0, 1, 0, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 0, 1, 0]])
     confuse_1 = np.array([[0, 1], [1, 0]])
     op = cirq.measure(
@@ -123,6 +125,7 @@ def test_from_measurement():
         invert_mask=(True, False),
         confusion_map={(0, 2): confuse_02, (1,): confuse_1},
     )
+    assert isinstance(op.gate, cirq.MeasurementGate)
     tcm = cirq.TensoredConfusionMatrices.from_measurement(op.gate, op.qubits)
     expected_tcm = cirq.TensoredConfusionMatrices(
         [confuse_02, confuse_1], ((qubits[0], qubits[2]), (qubits[1],)), repetitions=0, timestamp=0
@@ -130,11 +133,12 @@ def test_from_measurement():
     assert tcm == expected_tcm
 
     no_cm_op = cirq.measure(*qubits, key='a')
+    assert isinstance(no_cm_op.gate, cirq.MeasurementGate)
     with pytest.raises(ValueError, match="Measurement has no confusion matrices"):
         _ = cirq.TensoredConfusionMatrices.from_measurement(no_cm_op.gate, no_cm_op.qubits)
 
 
-def test_readout_confusion_matrix_raises():
+def test_readout_confusion_matrix_raises() -> None:
     num_qubits = 2
     confusion_matrix = get_expected_cm(num_qubits, 0.1, 0.2)
     qubits = cirq.LineQubit.range(4)
@@ -174,7 +178,7 @@ def test_readout_confusion_matrix_raises():
         _ = readout_cm.apply(np.asarray([1 / 16] * 16), method='l1norm')
 
 
-def test_readout_confusion_matrix_repr_and_equality():
+def test_readout_confusion_matrix_repr_and_equality() -> None:
     mat1 = cirq.testing.random_orthogonal(4, random_state=1234)
     mat2 = cirq.testing.random_orthogonal(2, random_state=1234)
     q = cirq.LineQubit.range(3)
@@ -245,8 +249,8 @@ def _add_noise_and_mitigate_ghz(
     return (*tcm.readout_mitigation_pauli_uncorrelated(qubits, noisy_measurements), z, dz)
 
 
-def test_uncorrelated_readout_mitigation_pauli():
-    n_all = np.arange(2, 35)
+def test_uncorrelated_readout_mitigation_pauli() -> None:
+    n_all = list(range(2, 35))
     z_all_mit = []
     dz_all_mit = []
     z_all_raw = []

--- a/cirq-core/cirq/experiments/single_qubit_readout_calibration_test.py
+++ b/cirq-core/cirq/experiments/single_qubit_readout_calibration_test.py
@@ -22,7 +22,7 @@ import pytest
 import cirq
 
 
-def test_single_qubit_readout_result_repr():
+def test_single_qubit_readout_result_repr() -> None:
     result = cirq.experiments.SingleQubitReadoutCalibrationResult(
         zero_state_errors={cirq.LineQubit(0): 0.1},
         one_state_errors={cirq.LineQubit(0): 0.2},
@@ -61,7 +61,7 @@ class NoisySingleQubitReadoutSampler(cirq.Sampler):
         return results
 
 
-def test_estimate_single_qubit_readout_errors_no_noise():
+def test_estimate_single_qubit_readout_errors_no_noise() -> None:
     qubits = cirq.LineQubit.range(10)
     sampler = cirq.Simulator()
     repetitions = 1000
@@ -74,7 +74,7 @@ def test_estimate_single_qubit_readout_errors_no_noise():
     assert isinstance(result.timestamp, float)
 
 
-def test_estimate_single_qubit_readout_errors_with_noise():
+def test_estimate_single_qubit_readout_errors_with_noise() -> None:
     qubits = cirq.LineQubit.range(5)
     sampler = NoisySingleQubitReadoutSampler(p0=0.1, p1=0.2, seed=1234)
     repetitions = 1000
@@ -89,7 +89,7 @@ def test_estimate_single_qubit_readout_errors_with_noise():
     assert isinstance(result.timestamp, float)
 
 
-def test_estimate_parallel_readout_errors_no_noise():
+def test_estimate_parallel_readout_errors_no_noise() -> None:
     qubits = [cirq.GridQubit(i, 0) for i in range(10)]
     sampler = cirq.Simulator()
     repetitions = 1000
@@ -104,7 +104,7 @@ def test_estimate_parallel_readout_errors_no_noise():
     _, _ = result.plot_heatmap()
 
 
-def test_estimate_parallel_readout_errors_all_zeros():
+def test_estimate_parallel_readout_errors_all_zeros() -> None:
     qubits = cirq.LineQubit.range(10)
     sampler = cirq.ZerosSampler()
     repetitions = 1000
@@ -117,7 +117,7 @@ def test_estimate_parallel_readout_errors_all_zeros():
     assert isinstance(result.timestamp, float)
 
 
-def test_estimate_parallel_readout_errors_bad_bit_string():
+def test_estimate_parallel_readout_errors_bad_bit_string() -> None:
     qubits = cirq.LineQubit.range(4)
     with pytest.raises(ValueError, match='but was None'):
         _ = cirq.estimate_parallel_single_qubit_readout_errors(
@@ -126,7 +126,7 @@ def test_estimate_parallel_readout_errors_bad_bit_string():
             repetitions=1000,
             trials=35,
             trials_per_batch=10,
-            bit_strings=[[1] * 4],
+            bit_strings=[[1] * 4],  # type: ignore[arg-type]
         )
     with pytest.raises(ValueError, match='0 or 1'):
         _ = cirq.estimate_parallel_single_qubit_readout_errors(
@@ -138,7 +138,7 @@ def test_estimate_parallel_readout_errors_bad_bit_string():
         )
 
 
-def test_estimate_parallel_readout_errors_zero_reps():
+def test_estimate_parallel_readout_errors_zero_reps() -> None:
     qubits = cirq.LineQubit.range(10)
     with pytest.raises(ValueError, match='non-zero repetition'):
         _ = cirq.estimate_parallel_single_qubit_readout_errors(
@@ -146,7 +146,7 @@ def test_estimate_parallel_readout_errors_zero_reps():
         )
 
 
-def test_estimate_parallel_readout_errors_zero_trials():
+def test_estimate_parallel_readout_errors_zero_trials() -> None:
     qubits = cirq.LineQubit.range(10)
     with pytest.raises(ValueError, match='non-zero trials'):
         _ = cirq.estimate_parallel_single_qubit_readout_errors(
@@ -154,7 +154,7 @@ def test_estimate_parallel_readout_errors_zero_trials():
         )
 
 
-def test_estimate_parallel_readout_errors_zero_batch():
+def test_estimate_parallel_readout_errors_zero_batch() -> None:
     qubits = cirq.LineQubit.range(10)
     with pytest.raises(ValueError, match='non-zero trials_per_batch'):
         _ = cirq.estimate_parallel_single_qubit_readout_errors(
@@ -162,7 +162,7 @@ def test_estimate_parallel_readout_errors_zero_batch():
         )
 
 
-def test_estimate_parallel_readout_errors_batching():
+def test_estimate_parallel_readout_errors_batching() -> None:
     qubits = cirq.LineQubit.range(5)
     sampler = cirq.ZerosSampler()
     repetitions = 1000
@@ -175,7 +175,7 @@ def test_estimate_parallel_readout_errors_batching():
     assert isinstance(result.timestamp, float)
 
 
-def test_estimate_parallel_readout_errors_with_noise():
+def test_estimate_parallel_readout_errors_with_noise() -> None:
     qubits = cirq.LineQubit.range(5)
     sampler = NoisySingleQubitReadoutSampler(p0=0.1, p1=0.2, seed=1234)
     repetitions = 1000
@@ -190,7 +190,7 @@ def test_estimate_parallel_readout_errors_with_noise():
     assert isinstance(result.timestamp, float)
 
 
-def test_estimate_parallel_readout_errors_missing_qubits():
+def test_estimate_parallel_readout_errors_missing_qubits() -> None:
     qubits = cirq.LineQubit.range(4)
 
     result = cirq.estimate_parallel_single_qubit_readout_errors(

--- a/cirq-core/cirq/experiments/t2_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment.py
@@ -48,7 +48,7 @@ def t2_decay(
     repetitions: int = 1000,
     delay_sweep: study.Sweep | None = None,
     num_pulses: list[int] | None = None,
-) -> cirq.experiments.T2DecayResult | list[cirq.experiments.T2DecayResult]:
+) -> cirq.experiments.T2DecayResult:
     """Runs a t2 transverse relaxation experiment.
 
     Initializes a qubit into a superposition state, evolves the system using

--- a/cirq-core/cirq/experiments/t2_decay_experiment_test.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment_test.py
@@ -22,7 +22,7 @@ import cirq
 import cirq.experiments.t2_decay_experiment as t2
 
 
-def test_init_t2_decay_result():
+def test_init_t2_decay_result() -> None:
     x_data = pd.DataFrame(
         columns=['delay_ns', 0, 1], index=range(2), data=[[100.0, 0, 10], [1000.0, 10, 0]]
     )
@@ -42,7 +42,7 @@ def test_init_t2_decay_result():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_plot_does_not_raise_error():
+def test_plot_does_not_raise_error() -> None:
     class _TimeDependentDecay(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):
             duration = max(
@@ -67,7 +67,7 @@ def test_plot_does_not_raise_error():
     results.plot_bloch_vector()
 
 
-def test_result_eq():
+def test_result_eq() -> None:
     example_data = pd.DataFrame(
         columns=['delay_ns', 0, 1],
         index=range(5),
@@ -85,7 +85,7 @@ def test_result_eq():
     eq.add_equality_group(cirq.experiments.T2DecayResult(example_data, other_data))
 
 
-def test_sudden_decay_results():
+def test_sudden_decay_results() -> None:
     class _SuddenDecay(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):
             duration = max(
@@ -117,7 +117,7 @@ def test_sudden_decay_results():
 
 
 @pytest.mark.parametrize('experiment_type', [t2.ExperimentType.HAHN_ECHO, t2.ExperimentType.CPMG])
-def test_spin_echo_cancels_out_constant_rate_phase(experiment_type):
+def test_spin_echo_cancels_out_constant_rate_phase(experiment_type) -> None:
     class _TimeDependentPhase(cirq.NoiseModel):
         def noisy_moment(self, moment, system_qubits):
             duration = max(
@@ -151,7 +151,7 @@ def test_spin_echo_cancels_out_constant_rate_phase(experiment_type):
     'experiment_type',
     [t2.ExperimentType.RAMSEY, t2.ExperimentType.HAHN_ECHO, t2.ExperimentType.CPMG],
 )
-def test_all_on_results(experiment_type):
+def test_all_on_results(experiment_type) -> None:
     pulses = [1] if experiment_type == t2.ExperimentType.CPMG else None
     results = t2.t2_decay(
         sampler=cirq.Simulator(),
@@ -174,7 +174,7 @@ def test_all_on_results(experiment_type):
     'experiment_type',
     [t2.ExperimentType.RAMSEY, t2.ExperimentType.HAHN_ECHO, t2.ExperimentType.CPMG],
 )
-def test_all_off_results(experiment_type):
+def test_all_off_results(experiment_type) -> None:
     pulses = [1] if experiment_type == t2.ExperimentType.CPMG else None
     results = t2.t2_decay(
         sampler=cirq.DensityMatrixSimulator(noise=cirq.amplitude_damp(1)),
@@ -204,7 +204,7 @@ def test_all_off_results(experiment_type):
     'experiment_type',
     [t2.ExperimentType.RAMSEY, t2.ExperimentType.HAHN_ECHO, t2.ExperimentType.CPMG],
 )
-def test_custom_delay_sweep(experiment_type):
+def test_custom_delay_sweep(experiment_type) -> None:
     pulses = [1] if experiment_type == t2.ExperimentType.CPMG else None
     results = t2.t2_decay(
         sampler=cirq.DensityMatrixSimulator(noise=cirq.amplitude_damp(1)),
@@ -231,7 +231,7 @@ def test_custom_delay_sweep(experiment_type):
     )
 
 
-def test_multiple_pulses():
+def test_multiple_pulses() -> None:
     results = t2.t2_decay(
         sampler=cirq.DensityMatrixSimulator(noise=cirq.amplitude_damp(1)),
         qubit=cirq.GridQubit(0, 0),
@@ -302,7 +302,7 @@ def test_multiple_pulses():
     assert results.expectation_pauli_x.equals(expected)
 
 
-def test_bad_args():
+def test_bad_args() -> None:
     with pytest.raises(ValueError, match='repetitions <= 0'):
         _ = cirq.experiments.t2_decay(
             sampler=cirq.Simulator(),
@@ -388,7 +388,7 @@ def test_bad_args():
         )
 
 
-def test_cpmg_circuit():
+def test_cpmg_circuit() -> None:
     """Tests sub-component to make sure CPMG circuit is generated correctly."""
     q = cirq.GridQubit(1, 1)
     t = sympy.Symbol('t')
@@ -406,7 +406,7 @@ def test_cpmg_circuit():
     assert circuit == expected
 
 
-def test_cpmg_sweep():
+def test_cpmg_sweep() -> None:
     sweep = t2._cpmg_sweep([1, 3, 5])
     expected = cirq.Zip(
         cirq.Points('pulse_0', [1, 1, 1]),
@@ -418,7 +418,7 @@ def test_cpmg_sweep():
     assert sweep == expected
 
 
-def test_str():
+def test_str() -> None:
     x_data = pd.DataFrame(
         columns=['delay_ns', 0, 1], index=range(2), data=[[100.0, 0, 10], [1000.0, 10, 0]]
     )

--- a/cirq-core/cirq/experiments/two_qubit_xeb_test.py
+++ b/cirq-core/cirq/experiments/two_qubit_xeb_test.py
@@ -36,7 +36,7 @@ def _manhattan_distance(qubit1: cirq.GridQubit, qubit2: cirq.GridQubit) -> int:
 
 class MockDevice(cirq.Device):
     @property
-    def metadata(self):
+    def metadata(self) -> cirq.DeviceMetadata:
         qubits = cirq.GridQubit.rect(3, 2, 4, 3)
         graph = nx.Graph(
             pair for pair in itertools.combinations(qubits, 2) if _manhattan_distance(*pair) == 1
@@ -45,21 +45,19 @@ class MockDevice(cirq.Device):
 
 
 class MockProcessor:
-    def get_device(self):
+    def get_device(self) -> MockDevice:
         return MockDevice()
 
 
 class DensityMatrixSimulatorWithProcessor(cirq.DensityMatrixSimulator):
     @property
-    def processor(self):
+    def processor(self) -> MockProcessor:
         return MockProcessor()
 
 
-def test_parallel_two_qubit_xeb_simulator_without_processor_fails():
-    sampler = (
-        cirq.DensityMatrixSimulator(
-            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
-        ),
+def test_parallel_two_qubit_xeb_simulator_without_processor_fails() -> None:
+    sampler = cirq.DensityMatrixSimulator(
+        seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
     )
 
     with pytest.raises(ValueError):
@@ -90,7 +88,9 @@ def test_parallel_two_qubit_xeb_simulator_without_processor_fails():
         ),
     ],
 )
-def test_parallel_two_qubit_xeb(sampler: cirq.Sampler, qubits: Sequence[cirq.GridQubit] | None):
+def test_parallel_two_qubit_xeb(
+    sampler: cirq.Sampler, qubits: Sequence[cirq.GridQubit] | None
+) -> None:
     res = cirq.experiments.parallel_two_qubit_xeb(
         sampler=sampler,
         qubits=qubits,
@@ -114,7 +114,7 @@ def test_parallel_two_qubit_xeb(sampler: cirq.Sampler, qubits: Sequence[cirq.Gri
     ],
 )
 @pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
-def test_plotting(sampler, qubits, ax):
+def test_plotting(sampler, qubits, ax) -> None:
     res = cirq.experiments.parallel_two_qubit_xeb(
         sampler=sampler,
         qubits=qubits,
@@ -157,7 +157,7 @@ _TEST_RESULT = cirq.experiments.TwoQubitXEBResult(
         (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 0.46875),
     ],
 )
-def test_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
+def test_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float) -> None:
     assert _TEST_RESULT.pauli_error()[(q0, q1)] == pytest.approx(pauli)
 
 
@@ -183,7 +183,7 @@ class MockParallelRandomizedBenchmarkingResult(ParallelRandomizedBenchmarkingRes
         (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 0.46875 - 0.13),
     ],
 )
-def test_inferred_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
+def test_inferred_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float) -> None:
     combined_results = cirq.experiments.InferredXEBResult(
         rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
     )
@@ -200,7 +200,7 @@ def test_inferred_pauli_error(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: flo
         (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 0.2709999999999999),
     ],
 )
-def test_inferred_xeb_error(q0: cirq.GridQubit, q1: cirq.GridQubit, xeb: float):
+def test_inferred_xeb_error(q0: cirq.GridQubit, q1: cirq.GridQubit, xeb: float) -> None:
     combined_results = cirq.experiments.InferredXEBResult(
         rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
     )
@@ -208,7 +208,7 @@ def test_inferred_xeb_error(q0: cirq.GridQubit, q1: cirq.GridQubit, xeb: float):
     assert combined_results.inferred_xeb_error()[(q0, q1)] == pytest.approx(xeb)
 
 
-def test_inferred_single_qubit_pauli():
+def test_inferred_single_qubit_pauli() -> None:
     combined_results = cirq.experiments.InferredXEBResult(
         rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
     )
@@ -233,7 +233,7 @@ def test_inferred_single_qubit_pauli():
         (cirq.GridQubit(6, 3), cirq.GridQubit(6, 4), 0.46875),
     ],
 )
-def test_inferred_two_qubit_pauli(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float):
+def test_inferred_two_qubit_pauli(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli: float) -> None:
     combined_results = cirq.experiments.InferredXEBResult(
         rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
     )
@@ -243,7 +243,7 @@ def test_inferred_two_qubit_pauli(q0: cirq.GridQubit, q1: cirq.GridQubit, pauli:
 @pytest.mark.parametrize('ax', [None, plt.subplots(1, 1, figsize=(8, 8))[1]])
 @pytest.mark.parametrize('target_error', ['pauli', 'xeb', 'decay_constant'])
 @pytest.mark.parametrize('kind', ['single_qubit', 'two_qubit', 'both', ''])
-def test_inferred_plots(ax, target_error, kind):
+def test_inferred_plots(ax, target_error, kind) -> None:
     combined_results = cirq.experiments.InferredXEBResult(
         rb_result=MockParallelRandomizedBenchmarkingResult({}), xeb_result=_TEST_RESULT
     )
@@ -296,7 +296,7 @@ def test_run_rb_and_xeb(
     sampler: cirq.Sampler,
     qubits: Sequence[cirq.GridQubit] | None,
     pairs: Sequence[tuple[cirq.GridQubit, cirq.GridQubit]] | None,
-):
+) -> None:
     res = cirq.experiments.run_rb_and_xeb(
         sampler=sampler,
         qubits=qubits,
@@ -313,11 +313,9 @@ def test_run_rb_and_xeb(
     )
 
 
-def test_run_rb_and_xeb_without_processor_fails():
-    sampler = (
-        cirq.DensityMatrixSimulator(
-            seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
-        ),
+def test_run_rb_and_xeb_without_processor_fails() -> None:
+    sampler = cirq.DensityMatrixSimulator(
+        seed=0, noise=cirq.ConstantQubitNoiseModel(cirq.amplitude_damp(0.1))
     )
 
     with pytest.raises(ValueError):

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -342,7 +342,7 @@ class XEBPhasedFSimCharacterizationOptions(XEBCharacterizationOptions):
 
         return np.asarray(initial_simplex), names
 
-    def get_parameterized_gate(self):
+    def get_parameterized_gate(self) -> cirq.PhasedFSimGate:
         theta = THETA_SYMBOL if self.characterize_theta else self.theta_default
         zeta = ZETA_SYMBOL if self.characterize_zeta else self.zeta_default
         chi = CHI_SYMBOL if self.characterize_chi else self.chi_default
@@ -374,7 +374,7 @@ class XEBPhasedFSimCharacterizationOptions(XEBCharacterizationOptions):
 
     def with_defaults_from_gate(
         self, gate: cirq.Gate, gate_to_angles_func=phased_fsim_angles_from_gate
-    ):
+    ) -> XEBPhasedFSimCharacterizationOptions:
         """A new Options class with {angle}_defaults inferred from `gate`.
 
         This keeps the same settings for the characterize_{angle} booleans, but will disregard
@@ -393,7 +393,7 @@ class XEBPhasedFSimCharacterizationOptions(XEBCharacterizationOptions):
         return protocols.dataclass_json_dict(self)
 
 
-def SqrtISwapXEBOptions(*args, **kwargs):
+def SqrtISwapXEBOptions(*args, **kwargs) -> XEBPhasedFSimCharacterizationOptions:
     """Options for calibrating a sqrt(ISWAP) gate using XEB."""
     return XEBPhasedFSimCharacterizationOptions(*args, **kwargs).with_defaults_from_gate(
         ops.SQRT_ISWAP

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -342,7 +342,7 @@ class XEBPhasedFSimCharacterizationOptions(XEBCharacterizationOptions):
 
         return np.asarray(initial_simplex), names
 
-    def get_parameterized_gate(self) -> cirq.PhasedFSimGate:
+    def get_parameterized_gate(self) -> cirq.Gate:
         theta = THETA_SYMBOL if self.characterize_theta else self.theta_default
         zeta = ZETA_SYMBOL if self.characterize_zeta else self.zeta_default
         chi = CHI_SYMBOL if self.characterize_chi else self.chi_default

--- a/cirq-core/cirq/experiments/xeb_fitting_test.py
+++ b/cirq-core/cirq/experiments/xeb_fitting_test.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import itertools
 import multiprocessing
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, Sequence
 
 import networkx as nx
 import numpy as np
@@ -50,7 +50,7 @@ def pool() -> Iterator[multiprocessing.pool.Pool]:
 
 
 @pytest.fixture(scope='module')
-def circuits_cycle_depths_sampled_df():
+def circuits_cycle_depths_sampled_df() -> tuple[list[cirq.Circuit], Sequence[int], pd.DataFrame]:
     q0, q1 = cirq.LineQubit.range(2)
     circuits = [
         rqcg.random_rotations_between_two_qubit_circuit(
@@ -58,7 +58,7 @@ def circuits_cycle_depths_sampled_df():
         )
         for _ in range(2)
     ]
-    cycle_depths = np.arange(10, 40 + 1, 10)
+    cycle_depths = list(range(10, 40 + 1, 10))
 
     sampled_df = sample_2q_xeb_circuits(
         sampler=cirq.Simulator(seed=53), circuits=circuits, cycle_depths=cycle_depths
@@ -67,7 +67,7 @@ def circuits_cycle_depths_sampled_df():
 
 
 @pytest.mark.parametrize('pass_cycle_depths', (True, False))
-def test_benchmark_2q_xeb_fidelities(circuits_cycle_depths_sampled_df, pass_cycle_depths):
+def test_benchmark_2q_xeb_fidelities(circuits_cycle_depths_sampled_df, pass_cycle_depths) -> None:
     circuits, cycle_depths, sampled_df = circuits_cycle_depths_sampled_df
 
     if pass_cycle_depths:
@@ -75,7 +75,7 @@ def test_benchmark_2q_xeb_fidelities(circuits_cycle_depths_sampled_df, pass_cycl
     else:
         fid_df = benchmark_2q_xeb_fidelities(sampled_df, circuits)
     assert len(fid_df) == len(cycle_depths)
-    assert sorted(fid_df['cycle_depth'].unique()) == cycle_depths.tolist()
+    assert sorted(fid_df['cycle_depth'].unique()) == cycle_depths
     assert np.all(fid_df['fidelity'] > 0.98)
 
     fit_df = fit_exponential_decays(fid_df)
@@ -84,7 +84,7 @@ def test_benchmark_2q_xeb_fidelities(circuits_cycle_depths_sampled_df, pass_cycl
         assert len(row['fidelities']) == len(cycle_depths)
 
 
-def test_benchmark_2q_xeb_subsample_depths(circuits_cycle_depths_sampled_df):
+def test_benchmark_2q_xeb_subsample_depths(circuits_cycle_depths_sampled_df) -> None:
     circuits, _, sampled_df = circuits_cycle_depths_sampled_df
     cycle_depths = [10, 20]
     fid_df = benchmark_2q_xeb_fidelities(sampled_df, circuits, cycle_depths)
@@ -114,7 +114,7 @@ def _gridqubits_to_graph_device(qubits: Iterable[cirq.GridQubit]):
     )
 
 
-def test_benchmark_2q_xeb_fidelities_parallel():
+def test_benchmark_2q_xeb_fidelities_parallel() -> None:
     circuits = rqcg.generate_library_of_2q_circuits(
         n_library_circuits=5, two_qubit_gate=cirq.ISWAP**0.5, max_cycle_depth=4
     )
@@ -140,7 +140,7 @@ def test_benchmark_2q_xeb_fidelities_parallel():
         assert len(row['fidelities']) == len(cycle_depths)
 
 
-def test_benchmark_2q_xeb_fidelities_vectorized():
+def test_benchmark_2q_xeb_fidelities_vectorized() -> None:
     rs = np.random.RandomState(52)
     mock_records = [{'pure_probs': rs.rand(4), 'sampled_probs': rs.rand(4)} for _ in range(100)]
     df = pd.DataFrame(mock_records)
@@ -177,7 +177,7 @@ def test_benchmark_2q_xeb_fidelities_vectorized():
 
 
 @pytest.mark.parametrize('gate', [cirq.SQRT_ISWAP, cirq.FSimGate(np.pi / 4, 0)])
-def test_parameterize_phased_fsim_circuit(gate):
+def test_parameterize_phased_fsim_circuit(gate) -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuit = rqcg.random_rotations_between_two_qubit_circuit(
         q0, q1, depth=3, two_qubit_op_factory=lambda a, b, _: gate(a, b), seed=52
@@ -208,7 +208,7 @@ X^0.5                                PhX(0.25)^0.5
     )
 
 
-def test_get_initial_simplex():
+def test_get_initial_simplex() -> None:
     options = SqrtISwapXEBOptions()
     simplex, names = options.get_initial_simplex_and_names()
     assert names == ['theta', 'zeta', 'chi', 'gamma', 'phi']
@@ -216,7 +216,7 @@ def test_get_initial_simplex():
     assert simplex.shape[1] == len(names)
 
 
-def test_characterize_phased_fsim_parameters_with_xeb(pool):
+def test_characterize_phased_fsim_parameters_with_xeb(pool) -> None:
     q0, q1 = cirq.LineQubit.range(2)
     rs = np.random.RandomState(52)
     circuits = [
@@ -225,7 +225,7 @@ def test_characterize_phased_fsim_parameters_with_xeb(pool):
         )
         for _ in range(2)
     ]
-    cycle_depths = np.arange(3, 20, 6)
+    cycle_depths = list(range(3, 20, 6))
     sampled_df = sample_2q_xeb_circuits(
         sampler=cirq.Simulator(seed=rs),
         circuits=circuits,
@@ -260,7 +260,7 @@ def test_characterize_phased_fsim_parameters_with_xeb(pool):
 
 
 @pytest.mark.parametrize('use_pool', (True, False))
-def test_parallel_full_workflow(request, use_pool):
+def test_parallel_full_workflow(request, use_pool) -> None:
     circuits = rqcg.generate_library_of_2q_circuits(
         n_library_circuits=5,
         two_qubit_gate=cirq.ISWAP**0.5,
@@ -320,7 +320,7 @@ def test_parallel_full_workflow(request, use_pool):
         assert 0 <= row['layer_fid_c'] <= 1
 
 
-def test_fit_exponential_decays():
+def test_fit_exponential_decays() -> None:
     rs = np.random.RandomState(999)
     cycle_depths = np.arange(3, 100, 11)
     fidelities = 0.95 * 0.98**cycle_depths + rs.normal(0, 0.2)
@@ -330,7 +330,7 @@ def test_fit_exponential_decays():
     assert 0 < layer_fid_std < 1e-3
 
 
-def test_fit_exponential_decays_negative_fids():
+def test_fit_exponential_decays_negative_fids() -> None:
     rs = np.random.RandomState(999)
     cycle_depths = np.arange(3, 100, 11)
     fidelities = 0.5 * 0.5**cycle_depths + rs.normal(0, 0.2) - 0.5
@@ -342,10 +342,12 @@ def test_fit_exponential_decays_negative_fids():
     assert layer_fid_std == np.inf
 
 
-def test_options_with_defaults_from_gate():
+def test_options_with_defaults_from_gate() -> None:
     options = XEBPhasedFSimCharacterizationOptions().with_defaults_from_gate(cirq.ISWAP**0.5)
+    assert options.theta_default is not None
     np.testing.assert_allclose(options.theta_default, -np.pi / 4)
     options = XEBPhasedFSimCharacterizationOptions().with_defaults_from_gate(cirq.ISWAP**-0.5)
+    assert options.theta_default is not None
     np.testing.assert_allclose(options.theta_default, np.pi / 4)
 
     options = XEBPhasedFSimCharacterizationOptions().with_defaults_from_gate(
@@ -365,7 +367,7 @@ def test_options_with_defaults_from_gate():
         _ = XEBPhasedFSimCharacterizationOptions().with_defaults_from_gate(cirq.XX)
 
 
-def test_options_defaults_set():
+def test_options_defaults_set() -> None:
     o1 = XEBPhasedFSimCharacterizationOptions(
         characterize_zeta=True,
         characterize_chi=True,
@@ -424,13 +426,13 @@ def _random_angles(n, seed):
     ]
     + [cirq.PhasedFSimGate(*r) for r in _random_angles(10, 0)],
 )
-def test_phased_fsim_angles_from_gate(gate):
+def test_phased_fsim_angles_from_gate(gate) -> None:
     angles = phased_fsim_angles_from_gate(gate)
     angles = {k.removesuffix('_default'): v for k, v in angles.items()}
     phasedfsim = cirq.PhasedFSimGate(**angles)
     np.testing.assert_allclose(cirq.unitary(phasedfsim), cirq.unitary(gate), atol=1e-9)
 
 
-def test_phased_fsim_angles_from_gate_unsupporet_gate():
+def test_phased_fsim_angles_from_gate_unsupporet_gate() -> None:
     with pytest.raises(ValueError, match='Unknown default angles'):
         _ = phased_fsim_angles_from_gate(cirq.testing.TwoQubitGate())

--- a/cirq-core/cirq/experiments/xeb_sampling.py
+++ b/cirq-core/cirq/experiments/xeb_sampling.py
@@ -159,7 +159,7 @@ class _ZippedCircuit:
     """
 
     wide_circuit: cirq.Circuit
-    pairs: list[tuple[cirq.Qid, cirq.Qid]]
+    pairs: Sequence[tuple[cirq.Qid, cirq.Qid]]
     combination: list[int]
     layer_i: int
     combination_i: int
@@ -291,7 +291,7 @@ def sample_2q_xeb_circuits(
     combinations_by_layer: list[CircuitLibraryCombination] | None = None,
     shuffle: cirq.RANDOM_STATE_OR_SEED_LIKE | None = None,
     dataset_directory: str | None = None,
-):
+) -> pd.DataFrame:
     """Sample two-qubit XEB circuits given a sampler.
 
     Args:

--- a/cirq-core/cirq/experiments/xeb_sampling_test.py
+++ b/cirq-core/cirq/experiments/xeb_sampling_test.py
@@ -28,7 +28,7 @@ import cirq.experiments.random_quantum_circuit_generation as rqcg
 from cirq.experiments.xeb_sampling import sample_2q_xeb_circuits
 
 
-def test_sample_2q_xeb_circuits():
+def test_sample_2q_xeb_circuits() -> None:
     q0 = cirq.NamedQubit('a')
     q1 = cirq.NamedQubit('b')
     circuits = [
@@ -37,7 +37,7 @@ def test_sample_2q_xeb_circuits():
         )
         for _ in range(2)
     ]
-    cycle_depths = np.arange(3, 20, 6)
+    cycle_depths = list(range(3, 20, 6))
 
     df = sample_2q_xeb_circuits(
         sampler=cirq.Simulator(),
@@ -53,20 +53,20 @@ def test_sample_2q_xeb_circuits():
         assert np.isclose(np.sum(row['sampled_probs']), 1)
 
 
-def test_sample_2q_xeb_circuits_error():
+def test_sample_2q_xeb_circuits_error() -> None:
     qubits = cirq.LineQubit.range(3)
     circuits = [cirq.testing.random_circuit(qubits, n_moments=5, op_density=0.8, random_state=52)]
-    cycle_depths = np.arange(3, 50, 9)
+    cycle_depths = list(range(3, 50, 9))
     with pytest.raises(ValueError):  # three qubit circuits
         _ = sample_2q_xeb_circuits(
             sampler=cirq.Simulator(), circuits=circuits, cycle_depths=cycle_depths
         )
 
 
-def test_sample_2q_xeb_circuits_no_progress(capsys):
+def test_sample_2q_xeb_circuits_no_progress(capsys) -> None:
     qubits = cirq.LineQubit.range(2)
     circuits = [cirq.testing.random_circuit(qubits, n_moments=7, op_density=0.8, random_state=52)]
-    cycle_depths = np.arange(3, 4)
+    cycle_depths = [3]
     _ = sample_2q_xeb_circuits(
         sampler=cirq.Simulator(), circuits=circuits, cycle_depths=cycle_depths, progress_bar=None
     )
@@ -98,7 +98,7 @@ def _assert_frame_approx_equal(df, df2, *, atol):
                 assert v1 == v2, k
 
 
-def test_sample_2q_parallel_xeb_circuits(tmpdir):
+def test_sample_2q_parallel_xeb_circuits(tmpdir) -> None:
     circuits = rqcg.generate_library_of_2q_circuits(
         n_library_circuits=5, two_qubit_gate=cirq.ISWAP**0.5, max_cycle_depth=10
     )
@@ -139,7 +139,7 @@ def test_sample_2q_parallel_xeb_circuits(tmpdir):
     )
 
 
-def test_sample_2q_parallel_xeb_circuits_bad_circuit_library():
+def test_sample_2q_parallel_xeb_circuits_bad_circuit_library() -> None:
     circuits = rqcg.generate_library_of_2q_circuits(
         n_library_circuits=5, two_qubit_gate=cirq.ISWAP**0.5, max_cycle_depth=10
     )
@@ -161,7 +161,7 @@ def test_sample_2q_parallel_xeb_circuits_bad_circuit_library():
         )
 
 
-def test_sample_2q_parallel_xeb_circuits_error_bad_qubits():
+def test_sample_2q_parallel_xeb_circuits_error_bad_qubits() -> None:
     circuits = rqcg.generate_library_of_2q_circuits(
         n_library_circuits=5,
         two_qubit_gate=cirq.ISWAP**0.5,

--- a/cirq-core/cirq/experiments/xeb_simulation.py
+++ b/cirq-core/cirq/experiments/xeb_simulation.py
@@ -86,7 +86,7 @@ def simulate_2q_xeb_circuits(
     param_resolver: cirq.ParamResolverOrSimilarType = None,
     pool: multiprocessing.pool.Pool | None = None,
     simulator: cirq.SimulatesIntermediateState | None = None,
-):
+) -> pd.DataFrame:
     """Simulate two-qubit XEB circuits.
 
     These ideal probabilities can be benchmarked against potentially noisy

--- a/cirq-core/cirq/experiments/xeb_simulation_test.py
+++ b/cirq-core/cirq/experiments/xeb_simulation_test.py
@@ -35,7 +35,7 @@ def pool() -> Iterator[multiprocessing.pool.Pool]:
         yield pool
 
 
-def test_simulate_2q_xeb_circuits(pool):
+def test_simulate_2q_xeb_circuits(pool) -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuits = [
         rqcg.random_rotations_between_two_qubit_circuit(
@@ -43,7 +43,7 @@ def test_simulate_2q_xeb_circuits(pool):
         )
         for _ in range(2)
     ]
-    cycle_depths = np.arange(3, 50, 9)
+    cycle_depths = list(range(3, 50, 9))
 
     df = simulate_2q_xeb_circuits(circuits=circuits, cycle_depths=cycle_depths)
     assert len(df) == len(cycle_depths) * len(circuits)
@@ -58,7 +58,7 @@ def test_simulate_2q_xeb_circuits(pool):
     pd.testing.assert_frame_equal(df, df2)
 
 
-def test_simulate_circuit_length_validation():
+def test_simulate_circuit_length_validation() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuits = [
         rqcg.random_rotations_between_two_qubit_circuit(
@@ -69,7 +69,7 @@ def test_simulate_circuit_length_validation():
         )
         for _ in range(2)
     ]
-    cycle_depths = np.arange(3, 50, 9, dtype=np.int64)
+    cycle_depths = list(range(3, 50, 9))
     with pytest.raises(ValueError, match='.*not long enough.*'):
         _ = simulate_2q_xeb_circuits(circuits=circuits, cycle_depths=cycle_depths)
 
@@ -129,7 +129,7 @@ def _ref_simulate_2q_xeb_circuits(
 
 
 @pytest.mark.parametrize('use_pool', (True, False))
-def test_incremental_simulate(request, use_pool):
+def test_incremental_simulate(request, use_pool) -> None:
     q0, q1 = cirq.LineQubit.range(2)
     circuits = [
         rqcg.random_rotations_between_two_qubit_circuit(
@@ -137,7 +137,7 @@ def test_incremental_simulate(request, use_pool):
         )
         for _ in range(20)
     ]
-    cycle_depths = np.arange(3, 100, 9, dtype=np.int64)
+    cycle_depths = list(range(3, 100, 9))
 
     # avoid starting worker pool if it is not needed
     pool = request.getfixturevalue("pool") if use_pool else None

--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -95,6 +95,7 @@ def measure(
     *target: raw_types.Qid,
     key: str | cirq.MeasurementKey | None = None,
     invert_mask: tuple[bool, ...] = (),
+    confusion_map: dict[tuple[int, ...], np.ndarray] | None = None,
 ) -> raw_types.Operation:
     pass
 
@@ -105,6 +106,7 @@ def measure(
     *,
     key: str | cirq.MeasurementKey | None = None,
     invert_mask: tuple[bool, ...] = (),
+    confusion_map: dict[tuple[int, ...], np.ndarray] | None = None,
 ) -> raw_types.Operation:
     pass
 


### PR DESCRIPTION
Add return-type to public functions, mostly tests part 2

No change in the effective code.  A batch of ~50 files.

Modified files pass  ruff check --select=ANN201

Partially implements #4393
