### PR TITLE
CI - add manual trigger for daily and weekly workflows

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -5,6 +5,9 @@ on:
     # Checks out main by default.
     - cron: '0 0 * * *'
 
+  # Allow manual invocation.
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -5,6 +5,9 @@ on:
     # Checks out main by default.
     - cron: '0 0 * * 0'
 
+  # Allow manual invocation.
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Allow manual execution for debugging or as an extra check before release.
