### PR TITLE
Combine cirq-web dependabot updates

### DIFF
--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -178,24 +178,6 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, 'cirq.TParamValComple
         snapshot = self.copy().clean(atol=0)
         return snapshot._terms.items()
 
-    @overload
-    def update(
-        self, other: Mapping[TVector, cirq.TParamValComplex], **kwargs: cirq.TParamValComplex
-    ) -> None:
-        pass
-
-    @overload
-    def update(
-        self,
-        other: Iterable[tuple[TVector, cirq.TParamValComplex]],
-        **kwargs: cirq.TParamValComplex,
-    ) -> None:
-        pass
-
-    @overload
-    def update(self, *args: Any, **kwargs: cirq.TParamValComplex) -> None:
-        pass
-
     def update(self, *args, **kwargs):
         terms = dict()
         terms.update(*args, **kwargs)

--- a/dev_tools/requirements/deps/mypy.txt
+++ b/dev_tools/requirements/deps/mypy.txt
@@ -1,5 +1,5 @@
 # the mypy dependency file
-mypy==1.16.1
+mypy==1.17.1
 
 # packages with stub types for various libraries
 types-protobuf>=5.26.1, <6.0dev


### PR DESCRIPTION
Bumps [on-headers](https://github.com/jshttp/on-headers), [morgan](https://github.com/expressjs/morgan) and [compression](https://github.com/expressjs/compression). These dependencies needed to be updated together.

Updates `on-headers` from 1.0.2 to 1.1.0
- [Release notes](https://github.com/jshttp/on-headers/releases)
- [Changelog](https://github.com/jshttp/on-headers/blob/master/HISTORY.md)
- [Commits](https://github.com/jshttp/on-headers/compare/v1.0.2...v1.1.0)

Updates `morgan` from 1.10.0 to 1.10.1
- [Release notes](https://github.com/expressjs/morgan/releases)
- [Changelog](https://github.com/expressjs/morgan/blob/master/HISTORY.md)
- [Commits](https://github.com/expressjs/morgan/compare/1.10.0...1.10.1)

Updates `compression` from 1.7.5 to 1.8.1
- [Release notes](https://github.com/expressjs/compression/releases)
- [Changelog](https://github.com/expressjs/compression/blob/master/HISTORY.md)
- [Commits](https://github.com/expressjs/compression/compare/1.7.5...v1.8.1)

---
updated-dependencies:
- dependency-name: on-headers
  dependency-version: 1.1.0
  dependency-type: indirect
- dependency-name: morgan
  dependency-version: 1.10.1
  dependency-type: indirect
- dependency-name: compression
  dependency-version: 1.8.1
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>