### PR TITLE
Change order of checking containment within a gateset

### DIFF
--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -416,16 +416,13 @@ class Gateset:
         g = item if isinstance(item, raw_types.Gate) else item.gate
         assert g is not None, f'`item`: {item} must be a gate or have a valid `item.gate`'
 
-        failed_family = None
-
         for gate_mro_type in type(g).mro():
             if gate_mro_type in self._type_gate_families:
-                if item in self._type_gate_families[gate_mro_type]:
-                    return True
-                assert item in failed_family, (
+                assert item in self._type_gate_families[gate_mro_type], (
                     f"{g} type {gate_mro_type} matches Type GateFamily:"
                     f"{self._type_gate_families[gate_mro_type]} but is not accepted by it."
                 )
+                return True
 
         if g in self._instance_gate_families:
             assert item in self._instance_gate_families[g], (

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -416,20 +416,23 @@ class Gateset:
         g = item if isinstance(item, raw_types.Gate) else item.gate
         assert g is not None, f'`item`: {item} must be a gate or have a valid `item.gate`'
 
+        failed_family = None
+
+        for gate_mro_type in type(g).mro():
+            if gate_mro_type in self._type_gate_families:
+                if item in self._type_gate_families[gate_mro_type]:
+                    return True
+                assert item in failed_family, (
+                    f"{g} type {gate_mro_type} matches Type GateFamily:"
+                    f"{self._type_gate_families[gate_mro_type]} but is not accepted by it."
+                )
+
         if g in self._instance_gate_families:
             assert item in self._instance_gate_families[g], (
                 f"{item} instance matches {self._instance_gate_families[g]} but "
                 f"is not accepted by it."
             )
             return True
-
-        for gate_mro_type in type(g).mro():
-            if gate_mro_type in self._type_gate_families:
-                assert item in self._type_gate_families[gate_mro_type], (
-                    f"{g} type {gate_mro_type} matches Type GateFamily:"
-                    f"{self._type_gate_families[gate_mro_type]} but is not accepted by it."
-                )
-                return True
 
         return any(item in gate_family for gate_family in self._gates)
 

--- a/cirq-core/cirq/ops/gateset_test.py
+++ b/cirq-core/cirq/ops/gateset_test.py
@@ -452,3 +452,25 @@ def test_gateset_contains_op_with_no_gate():
     op = cirq.X(cirq.q(1)).with_classical_controls('a')
     assert op.gate is None
     assert op not in gf
+
+
+def test_overlapping_gate_families() -> None:
+    """Tests if a gate belongs both to an instance and type family
+    but is rejected by the type family it can still be accepted."""
+
+    # The following gateset should accept ZPowGates only with the tag
+    # except it lets in cirq.Z with no tag
+    tag = "PhysicalZTag"
+    gf_accept = cirq.GateFamily(cirq.ZPowGate, tags_to_accept=[tag])
+    instance_accept = cirq.GateFamily(cirq.Z)
+    gs = cirq.Gateset(gf_accept, instance_accept)
+
+    instance_op = cirq.Z(q)
+    instance_op_with_tag = cirq.Z(q).with_tags(tag)
+    type_op_no_tag = cirq.ZPowGate(exponent=0.5)(q)
+    type_op_with_tag = cirq.ZPowGate(exponent=0.5)(q).with_tags(tag)
+
+    assert instance_op in gs
+    assert instance_op_with_tag in gs
+    assert type_op_no_tag not in gs
+    assert type_op_with_tag in gs


### PR DESCRIPTION
Gate Families have two main modes of operations: 'type' gate families that check containment versus a type of gate and 'instance' gate families which check whether the operation matches a specific instantiation of the gate.  'instance' checking is much slower.

- This PR switches the order of checking gate families.  It now checks "type" gate families before "instance" gate families.
- Type gate family checks are simple `isinstance` checks and should be fast.
- Instance gate families check instance equality, which is a lot slower, since it has to compare value equality for every operation for containment.

This speeds up the validation of a sample circuit with 400 moments of 18 single-qubit operations from 1.5 seconds to 0.11 seconds.