### PR TITLE
ruff - enable and fix RUF027 - missing-f-string-syntax

### DIFF
--- a/cirq-core/cirq/interop/quirk/cells/parse.py
+++ b/cirq-core/cirq/interop/quirk/cells/parse.py
@@ -147,7 +147,7 @@ def _parse_formula_using_token_map(
     def apply(op: str | _HangingNode) -> None:
         assert isinstance(op, _HangingNode)
         if len(vals) < 2:
-            raise ValueError("Bad expression: operated on nothing.\ntext={text!r}")
+            raise ValueError(f"Bad expression: operated on nothing.\ntext={text!r}")
         b = vals.pop()
         a = vals.pop()
         # Note: vals seems to be _HangingToken
@@ -157,7 +157,7 @@ def _parse_formula_using_token_map(
     def close_paren() -> None:
         while True:
             if len(ops) == 0:
-                raise ValueError("Bad expression: unmatched ')'.\ntext={text!r}")
+                raise ValueError(f"Bad expression: unmatched ')'.\ntext={text!r}")
             op = ops.pop()
             if op == "(":
                 break
@@ -193,7 +193,7 @@ def _parse_formula_using_token_map(
                 token_unary_action = token.unary_action
                 ops.append(_HangingNode(func=lambda _, b: token_unary_action(b), weight=np.inf))
             elif token.binary_action is not None:
-                raise ValueError("Bad expression: binary op in bad spot.\ntext={text!r}")
+                raise ValueError(f"Bad expression: binary op in bad spot.\ntext={text!r}")
 
     was_valid_end_token = False
     for token in tokens:

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -202,7 +202,7 @@ class ParamResolver:
         if value in self._deep_eval_map:
             v = self._deep_eval_map[value]
             if v is _RECURSION_FLAG:
-                raise RecursionError('Evaluation of {value} indirectly contains itself.')
+                raise RecursionError(f'Evaluation of {value} indirectly contains itself.')
             return v
 
         # There isn't a full evaluation for 'value' yet. Until it's ready,

--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -400,7 +400,7 @@ def arg_from_proto(
                             return set(values)
                         case v2.program_pb2.Tuple.SequenceType.FROZENSET:
                             return frozenset(values)
-                    raise ValueError('Unrecognized type: {sequence_type}')  # pragma: no cover
+                    raise ValueError(f'Unrecognized type: {sequence_type}')  # pragma: no cover
 
                 case 'ndarray_value':
                     return _ndarray_from_proto(arg_value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 line-length = 100
+preview = true
 target-version = "py311"
 extend-exclude = ["*_pb2.py*"]
 
@@ -86,6 +87,7 @@ select = [
     "PLE0100",  # yield-in-init, pylint init-is-generator
     "PLE0101",  # return-in-init, pylint return-in-init
     "PLE0116",  # continue-in-finally, pylint continue-in-finally
+    "RUF027",  # missing-f-string-syntax
     "RUF100",  # unused-noqa
     "SIM101",  # duplicate-isinstance-call, pylint consider-merging-isinstance
     "SIM201",  # negate-equal-op, pylint unneeded-not, unnecessary-negation


### PR DESCRIPTION
- enable rule RUF027 - missing-f-string-syntax
- fix f-strings without the f-prefix

Partially implements #7505
