### PR TITLE
Add return-type to public functions, mostly tests part 3

### DIFF
--- a/cirq-core/cirq/experiments/z_phase_calibration_test.py
+++ b/cirq-core/cirq/experiments/z_phase_calibration_test.py
@@ -88,7 +88,7 @@ class _TestSimulator(cirq.Simulator):
 @pytest.mark.parametrize(
     ['angles', 'error', 'characterization_flags'], _create_tests(n=10, with_options=True)
 )
-def test_calibrate_z_phases(angles, error, characterization_flags):
+def test_calibrate_z_phases(angles, error, characterization_flags) -> None:
 
     original_gate = cirq.PhasedFSimGate(**{k: v for k, v in zip(_ANGLES, angles)})
     actual_gate = cirq.PhasedFSimGate(**{k: v + e for k, v, e in zip(_ANGLES, angles, error)})
@@ -127,7 +127,7 @@ def test_calibrate_z_phases(angles, error, characterization_flags):
 
 
 @pytest.mark.parametrize(['angles', 'error'], _create_tests(n=3))
-def test_calibrate_z_phases_no_options(angles, error):
+def test_calibrate_z_phases_no_options(angles, error) -> None:
 
     original_gate = cirq.PhasedFSimGate(**{k: v for k, v in zip(_ANGLES, angles)})
     actual_gate = cirq.PhasedFSimGate(**{k: v + e for k, v, e in zip(_ANGLES, angles, error)})
@@ -162,7 +162,7 @@ def test_calibrate_z_phases_no_options(angles, error):
 
 
 @pytest.mark.parametrize(['angles', 'error'], _create_tests(n=3))
-def test_calibrate_z_phases_workflow_no_options(angles, error):
+def test_calibrate_z_phases_workflow_no_options(angles, error) -> None:
 
     original_gate = cirq.PhasedFSimGate(**{k: v for k, v in zip(_ANGLES, angles)})
     actual_gate = cirq.PhasedFSimGate(**{k: v + e for k, v, e in zip(_ANGLES, angles, error)})
@@ -189,7 +189,7 @@ def test_calibrate_z_phases_workflow_no_options(angles, error):
         assert 'theta' not in params
 
 
-def test_plot_z_phase_calibration_result():
+def test_plot_z_phase_calibration_result() -> None:
     df = pd.DataFrame()
     qs = cirq.q(0, 0), cirq.q(0, 1), cirq.q(0, 2)
     df.index = [qs[:2], qs[-2:]]
@@ -211,13 +211,14 @@ def test_plot_z_phase_calibration_result():
 
 
 @pytest.mark.parametrize('angles', 2 * np.pi * np.random.random((10, 10)))
-def test_transform_circuit(angles):
+def test_transform_circuit(angles) -> None:
     theta, phi = angles[:2]
     old_zs = angles[2:6]
     new_zs = angles[6:]
     gate = cirq.PhasedFSimGate.from_fsim_rz(theta, phi, old_zs[:2], old_zs[2:])
     fsim = cirq.PhasedFSimGate.from_fsim_rz(theta, phi, new_zs[:2], new_zs[2:])
     c = cirq.Circuit(gate(cirq.q(0), cirq.q(1)))
+    replacement_map: dict[tuple[cirq.Qid, cirq.Qid], cirq.PhasedFSimGate]
     replacement_map = {(cirq.q(1), cirq.q(0)): fsim}
 
     new_circuit = CalibrationTransformer(gate, replacement_map)(c)
@@ -230,11 +231,11 @@ def test_transform_circuit(angles):
     np.testing.assert_allclose(cirq.unitary(circuit_with_replacement_gate), cirq.unitary(c))
 
 
-def test_transform_circuit_invalid_gate_raises():
+def test_transform_circuit_invalid_gate_raises() -> None:
     with pytest.raises(ValueError, match="is not equivalent to a PhasedFSimGate"):
         _ = CalibrationTransformer(cirq.XX, {})
 
 
-def test_transform_circuit_uncalibrated_gates_pass():
+def test_transform_circuit_uncalibrated_gates_pass() -> None:
     c = cirq.Circuit(cirq.CZ(cirq.q(0), cirq.q(1)), cirq.measure(cirq.q(0)))
     assert c == CalibrationTransformer(cirq.CZ, {})(c)

--- a/cirq-core/cirq/interop/quirk/cells/arithmetic_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/arithmetic_cells.py
@@ -205,7 +205,7 @@ class ArithmeticCell(Cell):
         )
 
     @property
-    def operation(self):
+    def operation(self) -> _QuirkArithmeticCallable:
         return ARITHMETIC_OP_TABLE[self.identifier]
 
     def with_input(self, letter: str, register: Sequence[cirq.Qid] | int) -> ArithmeticCell:

--- a/cirq-core/cirq/interop/quirk/cells/cell_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/cell_test.py
@@ -20,7 +20,7 @@ import cirq
 from cirq.interop.quirk.cells.cell import Cell, ExplicitOperationsCell
 
 
-def test_cell_defaults():
+def test_cell_defaults() -> None:
     class BasicCell(Cell):
         def with_line_qubits_mapped_to(self, qubits):
             raise NotImplementedError()
@@ -32,12 +32,12 @@ def test_cell_defaults():
     assert c.operations() == ()
     assert c.basis_change() == ()
     assert c.controlled_by(cirq.LineQubit(0)) is c
-    x = []
+    x: list[Cell | None] = []
     c.modify_column(x)
     assert x == []
 
 
-def test_cell_replace_utils():
+def test_cell_replace_utils() -> None:
     a, b, c = cirq.NamedQubit.range(3, prefix='q')
     assert Cell._replace_qubit(cirq.LineQubit(1), [a, b, c]) == b
     with pytest.raises(ValueError, match='only map from line qubits'):
@@ -48,7 +48,7 @@ def test_cell_replace_utils():
         _ = Cell._replace_qubit(cirq.LineQubit(999), [a, b, c])
 
 
-def test_explicit_operations_cell_equality():
+def test_explicit_operations_cell_equality() -> None:
     a = cirq.LineQubit(0)
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(ExplicitOperationsCell([], []), ExplicitOperationsCell([]))
@@ -56,7 +56,7 @@ def test_explicit_operations_cell_equality():
     eq.add_equality_group(ExplicitOperationsCell([], [cirq.Y(a)]))
 
 
-def test_explicit_operations_cell():
+def test_explicit_operations_cell() -> None:
     a, b = cirq.LineQubit.range(2)
     v = ExplicitOperationsCell([cirq.X(a)], [cirq.S(a)])
     assert v.operations() == (cirq.X(a),)

--- a/cirq-core/cirq/interop/quirk/cells/composite_cell_test.py
+++ b/cirq-core/cirq/interop/quirk/cells/composite_cell_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+from typing import Iterable
+
 import pytest
 
 import cirq
@@ -22,7 +24,7 @@ from cirq.interop.quirk.cells.composite_cell import _iterator_to_iterable
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_iterator_to_iterable():
+def test_iterator_to_iterable() -> None:
     k = 0
 
     def counter():
@@ -32,7 +34,7 @@ def test_iterator_to_iterable():
 
     # Normal iterator usage.
     k = 0
-    generator = (counter() for _ in range(10))
+    generator: Iterable[int] = (counter() for _ in range(10))
     assert k == 0
     assert list(generator) == list(range(10))
     assert k == 10
@@ -73,7 +75,7 @@ def test_iterator_to_iterable():
     assert k == 10
 
 
-def test_custom_circuit_gate():
+def test_custom_circuit_gate() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
 
     # Without name.

--- a/cirq-core/cirq/interop/quirk/cells/control_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/control_cells.py
@@ -53,7 +53,7 @@ class ControlCell(Cell):
             ),
         )
 
-    def modify_column(self, column: list[Cell | None]):
+    def modify_column(self, column: list[Cell | None]) -> None:
         for i in range(len(column)):
             gate = column[i]
             if gate is not None:
@@ -97,7 +97,7 @@ class ParityControlCell(Cell):
             ),
         )
 
-    def modify_column(self, column: list[Cell | None]):
+    def modify_column(self, column: list[Cell | None]) -> None:
         for i in range(len(column)):
             gate = column[i]
             if gate is self:

--- a/cirq-core/cirq/interop/quirk/cells/input_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_cells.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Iterator, TYPE_CHECKING
+from typing import Callable, Iterable, Iterator, TYPE_CHECKING
 
 from cirq.interop.quirk.cells.cell import Cell, CELL_SIZES, CellMaker
 
@@ -35,7 +35,7 @@ class InputCell(Cell):
     def with_line_qubits_mapped_to(self, qubits: list[cirq.Qid]) -> Cell:
         return InputCell(qubits=Cell._replace_qubits(self.qubits, qubits), letter=self.letter)
 
-    def modify_column(self, column: list[Cell | None]):
+    def modify_column(self, column: list[Cell | None]) -> None:
         for i in range(len(column)):
             cell = column[i]
             if cell is not None:
@@ -55,7 +55,7 @@ class SetDefaultInputCell(Cell):
     def with_line_qubits_mapped_to(self, qubits: list[cirq.Qid]) -> Cell:
         return self
 
-    def persistent_modifiers(self):
+    def persistent_modifiers(self) -> dict[str, Callable[[Cell], Cell]]:
         return {f'set_default_{self.letter}': lambda cell: cell.with_input(self.letter, self.value)}
 
 

--- a/cirq-core/cirq/interop/quirk/cells/input_rotation_cells.py
+++ b/cirq-core/cirq/interop/quirk/cells/input_rotation_cells.py
@@ -77,7 +77,7 @@ class InputRotationCell(Cell):
             )
         return self
 
-    def controlled_by(self, qubit: cirq.Qid):
+    def controlled_by(self, qubit: cirq.Qid) -> InputRotationCell:
         return InputRotationCell(
             self.identifier,
             self.register,
@@ -118,7 +118,7 @@ class QuirkInputRotationOperation(ops.Operation):
     def qubits(self) -> tuple[cirq.Qid, ...]:
         return tuple(self.base_operation.qubits) + self.register
 
-    def with_qubits(self, *new_qubits):
+    def with_qubits(self, *new_qubits) -> QuirkInputRotationOperation:
         k = len(self.base_operation.qubits)
         new_op_qubits = new_qubits[:k]
         new_register = new_qubits[k:]

--- a/cirq-core/cirq/interop/quirk/cells/swap_cell.py
+++ b/cirq-core/cirq/interop/quirk/cells/swap_cell.py
@@ -38,7 +38,7 @@ class SwapCell(Cell):
             controls=Cell._replace_qubits(self._controls, qubits),
         )
 
-    def modify_column(self, column: list[Cell | None]):
+    def modify_column(self, column: list[Cell | None]) -> None:
         # Swallow other swap cells.
         for i in range(len(column)):
             gate = column[i]
@@ -52,7 +52,7 @@ class SwapCell(Cell):
             raise ValueError('Wrong number of swap gates in a column.')
         return ops.SWAP(*self._qubits).controlled_by(*self._controls)
 
-    def controlled_by(self, qubit: cirq.Qid):
+    def controlled_by(self, qubit: cirq.Qid) -> SwapCell:
         return SwapCell(self._qubits, self._controls + [qubit])
 
     def _value_equality_values_(self) -> Any:

--- a/cirq-core/cirq/interop/quirk/cells/testing.py
+++ b/cirq-core/cirq/interop/quirk/cells/testing.py
@@ -28,7 +28,7 @@ def assert_url_to_circuit_returns(
     diagram: str | None = None,
     output_amplitudes_from_quirk: list[dict[str, float]] | None = None,
     maps: dict[int, int] | None = None,
-):
+) -> None:
     """Assert that `quirk_url_to_circuit` functions correctly.
 
     Args:

--- a/cirq-core/cirq/interop/quirk/url_to_circuit.py
+++ b/cirq-core/cirq/interop/quirk/url_to_circuit.py
@@ -39,7 +39,7 @@ def quirk_url_to_circuit(
     quirk_url: str,
     *,
     qubits: Sequence[cirq.Qid] | None = None,
-    extra_cell_makers: dict[str, cirq.Gate] | Iterable[cirq.interop.quirk.cells.CellMaker] = (),
+    extra_cell_makers: Mapping[str, cirq.Gate] | Iterable[cirq.interop.quirk.cells.CellMaker] = (),
     max_operation_count: int = 10**6,
 ) -> cirq.Circuit:
     """Parses a Cirq circuit out of a Quirk URL.
@@ -140,7 +140,7 @@ def quirk_json_to_circuit(
     data: dict,
     *,
     qubits: Sequence[cirq.Qid] | None = None,
-    extra_cell_makers: dict[str, cirq.Gate] | Iterable[cirq.interop.quirk.cells.CellMaker] = (),
+    extra_cell_makers: Mapping[str, cirq.Gate] | Iterable[cirq.interop.quirk.cells.CellMaker] = (),
     quirk_url: str | None = None,
     max_operation_count: int = 10**6,
 ) -> cirq.Circuit:

--- a/cirq-core/cirq/interop/quirk/url_to_circuit_test.py
+++ b/cirq-core/cirq/interop/quirk/url_to_circuit_test.py
@@ -25,7 +25,7 @@ from cirq import quirk_json_to_circuit, quirk_url_to_circuit
 from cirq.interop.quirk.cells.testing import assert_url_to_circuit_returns
 
 
-def test_parse_simple_cases():
+def test_parse_simple_cases() -> None:
     a, b = cirq.LineQubit.range(2)
 
     assert quirk_url_to_circuit('http://algassert.com/quirk') == cirq.Circuit()
@@ -47,7 +47,7 @@ def test_parse_simple_cases():
         ('http://algassert.com/quirk#circuit=', json.JSONDecodeError, None),
     ],
 )
-def test_parse_url_failures(url, error_cls, msg):
+def test_parse_url_failures(url, error_cls, msg) -> None:
     with pytest.raises(error_cls, match=msg):
         _ = quirk_url_to_circuit(url)
 
@@ -70,7 +70,7 @@ def test_parse_url_failures(url, error_cls, msg):
         ),
     ],
 )
-def test_parse_failures(url, msg):
+def test_parse_failures(url, msg) -> None:
     parsed_url = urllib.parse.urlparse(url)
     data = json.loads(parsed_url.fragment[len('circuit=') :])
 
@@ -81,7 +81,7 @@ def test_parse_failures(url, msg):
         _ = quirk_json_to_circuit(data)
 
 
-def test_parse_with_qubits():
+def test_parse_with_qubits() -> None:
     a = cirq.GridQubit(0, 0)
     b = cirq.GridQubit(0, 1)
     c = cirq.GridQubit(0, 2)
@@ -103,7 +103,7 @@ def test_parse_with_qubits():
         )
 
 
-def test_extra_cell_makers():
+def test_extra_cell_makers() -> None:
     assert cirq.quirk_url_to_circuit(
         'http://algassert.com/quirk#circuit={"cols":[["iswap"]]}',
         extra_cell_makers=[
@@ -140,7 +140,7 @@ def test_extra_cell_makers():
     )
 
 
-def test_init():
+def test_init() -> None:
     b, c, d, e, f = cirq.LineQubit.range(1, 6)
     assert_url_to_circuit_returns(
         '{"cols":[],"init":[0,1,"+","-","i","-i"]}',
@@ -176,7 +176,7 @@ def test_init():
         _ = cirq.quirk_url_to_circuit('http://algassert.com/quirk#circuit={"cols":[],"init":[2]}')
 
 
-def test_custom_gate_parse_failures():
+def test_custom_gate_parse_failures() -> None:
     with pytest.raises(ValueError, match='must be a list'):
         _ = quirk_url_to_circuit('https://algassert.com/quirk#circuit={"cols":[],"gates":5}')
 
@@ -229,7 +229,7 @@ def test_custom_gate_parse_failures():
         )
 
 
-def test_custom_matrix_gate():
+def test_custom_matrix_gate() -> None:
     a, b = cirq.LineQubit.range(2)
 
     # Without name.
@@ -259,7 +259,7 @@ def test_custom_matrix_gate():
     )
 
 
-def test_survives_a_billion_laughs():
+def test_survives_a_billion_laughs() -> None:
     # If this test is timing out, it means you made a change that accidentally
     # iterated over the circuit contents before they were counted and checked
     # against the maximum. It is not possible to test for the billion laughs
@@ -301,7 +301,7 @@ def test_survives_a_billion_laughs():
         )
 
 
-def test_completes_weight_zero_billion_laughs():
+def test_completes_weight_zero_billion_laughs() -> None:
     circuit = cirq.quirk_url_to_circuit(
         'https://algassert.com/quirk#circuit={'
         '"cols":[["~z"]],'
@@ -339,7 +339,7 @@ def test_completes_weight_zero_billion_laughs():
     assert circuit == cirq.Circuit()
 
 
-def test_example_qft_circuit():
+def test_example_qft_circuit() -> None:
     qft_example_diagram = """
 0: ───×───────────────H───@───────────@────────────────────@──────────────────────────────@─────────────────────────────────────────@───────────────────────────────────────────────────@─────────────────────────────────────────────────────────────@───────────────────────────────────────────────────────────────────────
       │                   │           │                    │                              │                                         │                                                   │                                                             │

--- a/cirq-core/cirq/linalg/decompositions.py
+++ b/cirq-core/cirq/linalg/decompositions.py
@@ -518,7 +518,7 @@ def scatter_plot_normalized_kak_interaction_coefficients(
     include_frame: bool = True,
     ax: mplot3d.axes3d.Axes3D | None = None,
     **kwargs,
-):
+) -> mplot3d.axes3d.Axes3D:
     r"""Plots the interaction coefficients of many two-qubit operations.
 
     Plots:

--- a/cirq-core/cirq/linalg/decompositions_test.py
+++ b/cirq-core/cirq/linalg/decompositions_test.py
@@ -35,19 +35,19 @@ CNOT = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
 CZ = np.diag([1, 1, 1, -1])
 
 
-def assert_kronecker_factorization_within_tolerance(matrix, g, f1, f2):
+def assert_kronecker_factorization_within_tolerance(matrix, g, f1, f2) -> None:
     restored = g * cirq.linalg.combinators.kron(f1, f2)
     assert not np.any(np.isnan(restored)), "NaN in kronecker product."
     assert np.allclose(restored, matrix), "Can't factor kronecker product."
 
 
-def assert_magic_su2_within_tolerance(mat, a, b):
+def assert_magic_su2_within_tolerance(mat, a, b) -> None:
     recon = cirq.linalg.combinators.dot(MAGIC_CONJ_T, cirq.linalg.combinators.kron(a, b), MAGIC)
     assert np.allclose(recon, mat), "Failed to decompose within tolerance."
 
 
 @pytest.mark.parametrize('matrix', [X, cirq.kron(X, X), cirq.kron(X, Y), cirq.kron(X, np.eye(2))])
-def test_map_eigenvalues_identity(matrix):
+def test_map_eigenvalues_identity(matrix) -> None:
     identity_mapped = cirq.map_eigenvalues(matrix, lambda e: e)
     assert np.allclose(matrix, identity_mapped)
 
@@ -63,7 +63,7 @@ def test_map_eigenvalues_identity(matrix):
         [X, 0.5, np.array([[1j, 1], [1, 1j]]) * (1 - 1j) / 2],
     ],
 )
-def test_map_eigenvalues_raise(matrix, exponent, desired):
+def test_map_eigenvalues_raise(matrix, exponent, desired) -> None:
     exp_mapped = cirq.map_eigenvalues(matrix, lambda e: complex(e) ** exponent)
     assert np.allclose(desired, exp_mapped)
 
@@ -88,7 +88,7 @@ def _random_unitary_with_close_eigenvalues():
         _random_unitary_with_close_eigenvalues(),
     ],
 )
-def test_unitary_eig(matrix):
+def test_unitary_eig(matrix) -> None:
     # np.linalg.eig(matrix) won't work for the perturbed matrix
     d, vecs = unitary_eig(matrix)
 
@@ -96,7 +96,7 @@ def test_unitary_eig(matrix):
     np.testing.assert_allclose(matrix, vecs @ np.diag(d) @ vecs.conj().T, atol=1e-14)
 
 
-def test_non_unitary_eig():
+def test_non_unitary_eig() -> None:
     with pytest.raises(Exception):
         unitary_eig(np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 0, 1, 2], [3, 4, 5, 6]]))
 
@@ -118,7 +118,7 @@ def test_non_unitary_eig():
     ]
     + [(cirq.testing.random_unitary(2), cirq.testing.random_unitary(2)) for _ in range(10)],
 )
-def test_kron_factor(f1, f2):
+def test_kron_factor(f1, f2) -> None:
     p = cirq.kron(f1, f2)
     g, g1, g2 = cirq.kron_factor_4x4_to_2x2s(p)
     assert abs(np.linalg.det(g1) - 1) < 0.00001
@@ -134,7 +134,7 @@ def test_kron_factor(f1, f2):
         for _ in range(10)
     ],
 )
-def test_kron_factor_special_unitaries(f1, f2):
+def test_kron_factor_special_unitaries(f1, f2) -> None:
     p = cirq.kron(f1, f2)
     g, g1, g2 = cirq.kron_factor_4x4_to_2x2s(p)
     assert np.allclose(cirq.kron(g1, g2), p)
@@ -144,7 +144,7 @@ def test_kron_factor_special_unitaries(f1, f2):
     assert_kronecker_factorization_within_tolerance(p, g, g1, g2)
 
 
-def test_kron_factor_invalid_input():
+def test_kron_factor_invalid_input() -> None:
     mats = [
         cirq.kron_with_controls(cirq.CONTROL_TAG, X),
         np.array([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 2, 3, 4]]),
@@ -167,7 +167,7 @@ def recompose_so4(a: np.ndarray, b: np.ndarray) -> np.ndarray:
 
 
 @pytest.mark.parametrize('m', [cirq.testing.random_special_orthogonal(4) for _ in range(10)])
-def test_so4_to_magic_su2s(m):
+def test_so4_to_magic_su2s(m) -> None:
     a, b = cirq.so4_to_magic_su2s(m)
     m2 = recompose_so4(a, b)
     assert_magic_su2_within_tolerance(m2, a, b)
@@ -181,7 +181,7 @@ def test_so4_to_magic_su2s(m):
         for _ in range(10)
     ],
 )
-def test_so4_to_magic_su2s_known_factors(a, b):
+def test_so4_to_magic_su2s_known_factors(a, b) -> None:
     m = recompose_so4(a, b)
     a2, b2 = cirq.so4_to_magic_su2s(m)
     m2 = recompose_so4(a2, b2)
@@ -206,7 +206,7 @@ def test_so4_to_magic_su2s_known_factors(a, b):
         np.diag([1, 1, 1, -1]),
     ],
 )
-def test_so4_to_magic_su2s_fail(mat):
+def test_so4_to_magic_su2s_fail(mat) -> None:
     with pytest.raises(ValueError):
         _ = cirq.so4_to_magic_su2s(mat)
 
@@ -214,7 +214,7 @@ def test_so4_to_magic_su2s_fail(mat):
 @pytest.mark.parametrize(
     'x,y,z', [[(random.random() * 2 - 1) * np.pi * 2 for _ in range(3)] for _ in range(10)]
 )
-def test_kak_canonicalize_vector(x, y, z):
+def test_kak_canonicalize_vector(x, y, z) -> None:
     i = np.eye(2)
     m = cirq.unitary(
         cirq.KakDecomposition(
@@ -243,12 +243,12 @@ def test_kak_canonicalize_vector(x, y, z):
     assert np.allclose(m, m2)
 
 
-def test_kak_vector_empty():
+def test_kak_vector_empty() -> None:
     assert len(cirq.kak_vector([])) == 0
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_kak_plot_empty():
+def test_kak_plot_empty() -> None:
     cirq.scatter_plot_normalized_kak_interaction_coefficients([])
 
 
@@ -257,21 +257,21 @@ def test_kak_plot_empty():
     [np.eye(4), SWAP, SWAP * 1j, CZ, CNOT, SWAP @ CZ]
     + [cirq.testing.random_unitary(4) for _ in range(10)],
 )
-def test_kak_decomposition(target):
+def test_kak_decomposition(target) -> None:
     kak = cirq.kak_decomposition(target)
     np.testing.assert_allclose(cirq.unitary(kak), target, atol=1e-8)
 
 
-def test_kak_decomposition_unitary_object():
+def test_kak_decomposition_unitary_object() -> None:
     op = cirq.ISWAP(*cirq.LineQubit.range(2)) ** 0.5
     kak = cirq.kak_decomposition(op)
     np.testing.assert_allclose(cirq.unitary(kak), cirq.unitary(op), atol=1e-8)
     assert cirq.kak_decomposition(kak) is kak
 
 
-def test_kak_decomposition_invalid_object():
+def test_kak_decomposition_invalid_object() -> None:
     with pytest.raises(TypeError, match='unitary effect'):
-        _ = cirq.kak_decomposition('test')
+        _ = cirq.kak_decomposition('test')  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match='4x4 unitary matrix'):
         _ = cirq.kak_decomposition(np.eye(3))
@@ -289,7 +289,7 @@ def test_kak_decomposition_invalid_object():
     np.testing.assert_allclose(cirq.unitary(nil), np.eye(4), atol=1e-8)
 
 
-def test_kak_decomposition_eq():
+def test_kak_decomposition_eq() -> None:
     eq = cirq.testing.EqualsTester()
 
     eq.make_equality_group(
@@ -339,7 +339,7 @@ def test_kak_decomposition_eq():
     )
 
 
-def test_kak_repr():
+def test_kak_repr() -> None:
     cirq.testing.assert_equivalent_repr(
         cirq.KakDecomposition(
             global_phase=1j,
@@ -374,7 +374,7 @@ cirq.KakDecomposition(
     )
 
 
-def test_kak_str():
+def test_kak_str() -> None:
     v = cirq.KakDecomposition(
         interaction_coefficients=(0.3 * np.pi / 4, 0.2 * np.pi / 4, 0.1 * np.pi / 4),
         single_qubit_operations_before=(cirq.unitary(cirq.I), cirq.unitary(cirq.X)),
@@ -391,7 +391,7 @@ def test_kak_str():
     )
 
 
-def test_axis_angle_decomposition_eq():
+def test_axis_angle_decomposition_eq() -> None:
     eq = cirq.testing.EqualsTester()
 
     eq.make_equality_group(
@@ -402,13 +402,13 @@ def test_axis_angle_decomposition_eq():
     eq.add_equality_group(cirq.AxisAngleDecomposition(angle=1, axis=(0.8, 0.6, 0), global_phase=1))
 
 
-def test_axis_angle_decomposition_repr():
+def test_axis_angle_decomposition_repr() -> None:
     cirq.testing.assert_equivalent_repr(
         cirq.AxisAngleDecomposition(angle=1, axis=(0, 0.6, 0.8), global_phase=-1)
     )
 
 
-def test_axis_angle_decomposition_str():
+def test_axis_angle_decomposition_str() -> None:
     assert str(cirq.axis_angle(cirq.unitary(cirq.X))) == '1*π around X'
     assert str(cirq.axis_angle(cirq.unitary(cirq.Y))) == '1*π around Y'
     assert str(cirq.axis_angle(cirq.unitary(cirq.Z))) == '1*π around Z'
@@ -424,14 +424,14 @@ def test_axis_angle_decomposition_str():
     )
 
 
-def test_axis_angle_decomposition_unitary():
+def test_axis_angle_decomposition_unitary() -> None:
     u = cirq.testing.random_unitary(2)
     u = cirq.unitary(cirq.T)
     a = cirq.axis_angle(u)
     np.testing.assert_allclose(u, cirq.unitary(a), atol=1e-8)
 
 
-def test_axis_angle():
+def test_axis_angle() -> None:
     assert cirq.approx_eq(
         cirq.axis_angle(cirq.unitary(cirq.ry(1e-10))),
         cirq.AxisAngleDecomposition(angle=0, axis=(1, 0, 0), global_phase=1),
@@ -492,7 +492,7 @@ def test_axis_angle():
     )
 
 
-def test_axis_angle_canonicalize():
+def test_axis_angle_canonicalize() -> None:
     a = cirq.AxisAngleDecomposition(
         angle=np.pi * 2.3, axis=(1, 0, 0), global_phase=1j
     ).canonicalize()
@@ -522,7 +522,7 @@ def test_axis_angle_canonicalize():
     assert np.isclose(a.angle, -np.pi + 0.01)
 
 
-def test_axis_angle_canonicalize_approx_equal():
+def test_axis_angle_canonicalize_approx_equal() -> None:
     a1 = cirq.AxisAngleDecomposition(angle=np.pi, axis=(1, 0, 0), global_phase=1)
     a2 = cirq.AxisAngleDecomposition(angle=-np.pi, axis=(1, 0, 0), global_phase=-1)
     b1 = cirq.AxisAngleDecomposition(angle=np.pi, axis=(1, 0, 0), global_phase=-1)
@@ -530,7 +530,7 @@ def test_axis_angle_canonicalize_approx_equal():
     assert not cirq.approx_eq(a1, b1, atol=1e-8)
 
 
-def test_axis_angle_init():
+def test_axis_angle_init() -> None:
     a = cirq.AxisAngleDecomposition(angle=1, axis=(0, 1, 0), global_phase=1j)
     assert a.angle == 1
     assert a.axis == (0, 1, 0)
@@ -541,14 +541,14 @@ def test_axis_angle_init():
 
 
 @pytest.mark.usefixtures('closefigures')
-def test_scatter_plot_normalized_kak_interaction_coefficients():
+def test_scatter_plot_normalized_kak_interaction_coefficients() -> None:
     a, b = cirq.LineQubit.range(2)
-    data = [
+    data = (
         cirq.kak_decomposition(cirq.unitary(cirq.CZ)),
         cirq.unitary(cirq.CZ),
         cirq.CZ,
         cirq.Circuit(cirq.H(a), cirq.CNOT(a, b)),
-    ]
+    )
     ax = cirq.scatter_plot_normalized_kak_interaction_coefficients(data)
     assert ax is not None
     ax2 = cirq.scatter_plot_normalized_kak_interaction_coefficients(
@@ -645,33 +645,35 @@ def _local_invariants_from_kak(vector: np.ndarray) -> np.ndarray:
 _random_unitaries, _kak_vecs = _random_two_qubit_unitaries(100, random_state=11)
 
 
-def test_kak_vector_matches_vectorized():
+def test_kak_vector_matches_vectorized() -> None:
     actual = cirq.kak_vector(_random_unitaries)
     expected = np.array([cirq.kak_vector(u) for u in _random_unitaries])
     np.testing.assert_almost_equal(actual, expected)
 
 
-def test_kak_vector_local_invariants_random_input():
+def test_kak_vector_local_invariants_random_input() -> None:
     actual = _local_invariants_from_kak(cirq.kak_vector(_random_unitaries))
     expected = _local_invariants_from_kak(_kak_vecs)
 
     np.testing.assert_almost_equal(actual, expected)
 
 
-def test_kak_vector_on_weyl_chamber_face():
+def test_kak_vector_on_weyl_chamber_face() -> None:
     # unitaries with KAK vectors from I to ISWAP
     theta_swap = np.linspace(0, np.pi / 4, 10)
     k_vecs = np.zeros((10, 3))
     k_vecs[:, (0, 1)] = theta_swap[:, np.newaxis]
 
-    kwargs = dict(
-        global_phase=1j,
-        single_qubit_operations_before=(X, Y),
-        single_qubit_operations_after=(Z, 1j * X),
-    )
     unitaries = np.array(
         [
-            cirq.unitary(cirq.KakDecomposition(interaction_coefficients=(t, t, 0), **kwargs))
+            cirq.unitary(
+                cirq.KakDecomposition(
+                    interaction_coefficients=(t, t, 0),
+                    global_phase=1j,
+                    single_qubit_operations_before=(X, Y),
+                    single_qubit_operations_after=(Z, 1j * X),
+                )
+            )
             for t in theta_swap
         ]
     )
@@ -692,7 +694,7 @@ def test_kak_vector_on_weyl_chamber_face():
         (np.kron(X, X), (0, 0, 0)),
     ),
 )
-def test_kak_vector_weyl_chamber_vertices(unitary, expected):
+def test_kak_vector_weyl_chamber_vertices(unitary, expected) -> None:
     actual = cirq.kak_vector(unitary)
     np.testing.assert_almost_equal(actual, expected)
 
@@ -701,17 +703,17 @@ cases = [np.eye(3), SWAP.reshape((2, 8)), SWAP.ravel()]
 
 
 @pytest.mark.parametrize('bad_input', cases)
-def test_kak_vector_wrong_matrix_shape(bad_input):
+def test_kak_vector_wrong_matrix_shape(bad_input) -> None:
     with pytest.raises(ValueError, match='to have shape'):
         cirq.kak_vector(bad_input)
 
 
-def test_kak_vector_negative_atol():
+def test_kak_vector_negative_atol() -> None:
     with pytest.raises(ValueError, match='must be positive'):
         cirq.kak_vector(np.eye(4), atol=-1.0)
 
 
-def test_kak_vector_input_not_unitary():
+def test_kak_vector_input_not_unitary() -> None:
     with pytest.raises(ValueError, match='must correspond to'):
         cirq.kak_vector(np.zeros((4, 4)))
 
@@ -728,7 +730,7 @@ def test_kak_vector_input_not_unitary():
         cirq.unitary(cirq.CZ),
     ],
 )
-def test_kak_decompose(unitary: np.ndarray):
+def test_kak_decompose(unitary: np.ndarray) -> None:
     kak = cirq.kak_decomposition(unitary)
     circuit = cirq.Circuit(kak._decompose_(cirq.LineQubit.range(2)))
     np.testing.assert_allclose(cirq.unitary(circuit), unitary, atol=1e-6)
@@ -737,7 +739,7 @@ def test_kak_decompose(unitary: np.ndarray):
 
 
 @cirq.testing.retry_once_with_later_random_values
-def test_num_two_qubit_gates_required():
+def test_num_two_qubit_gates_required() -> None:
     for i in range(4):
         assert (
             cirq.num_cnots_required(
@@ -749,7 +751,7 @@ def test_num_two_qubit_gates_required():
     assert cirq.num_cnots_required(np.eye(4)) == 0
 
 
-def test_num_two_qubit_gates_required_invalid():
+def test_num_two_qubit_gates_required_invalid() -> None:
     with pytest.raises(ValueError, match="(4,4)"):
         cirq.num_cnots_required(np.array([[1]]))
 
@@ -772,7 +774,7 @@ def test_num_two_qubit_gates_required_invalid():
         ),
     ],
 )
-def test_extract_right_diag(u):
+def test_extract_right_diag(u) -> None:
     assert cirq.num_cnots_required(u) == 3
     diag = cirq.linalg.extract_right_diag(u)
     assert cirq.is_diagonal(diag)

--- a/cirq-core/cirq/linalg/diagonalize_test.py
+++ b/cirq-core/cirq/linalg/diagonalize_test.py
@@ -67,7 +67,7 @@ def _get_assert_diagonalized_by_str(m, p, d):
     )
 
 
-def assert_diagonalized_by(m, p, atol: float = 1e-8):
+def assert_diagonalized_by(m, p, atol: float = 1e-8) -> None:
     d = p.T.dot(m).dot(p)
 
     assert cirq.is_orthogonal(p) and cirq.is_diagonal(
@@ -82,7 +82,7 @@ def _get_assert_bidiagonalized_by_str(m, p, q, d):
     )
 
 
-def assert_bidiagonalized_by(m, p, q, rtol: float = 1e-5, atol: float = 1e-8):
+def assert_bidiagonalized_by(m, p, q, rtol: float = 1e-5, atol: float = 1e-8) -> None:
     d = p.dot(m).dot(q)
 
     assert (

--- a/cirq-core/cirq/linalg/predicates.py
+++ b/cirq-core/cirq/linalg/predicates.py
@@ -160,7 +160,7 @@ def is_normal(matrix: np.ndarray, *, rtol: float = 1e-5, atol: float = 1e-8) -> 
     return matrix_commutes(matrix, matrix.T.conj(), rtol=rtol, atol=atol)
 
 
-def is_cptp(*, kraus_ops: Sequence[np.ndarray], rtol: float = 1e-5, atol: float = 1e-8):
+def is_cptp(*, kraus_ops: Sequence[np.ndarray], rtol: float = 1e-5, atol: float = 1e-8) -> bool:
     """Determines if a channel is completely positive trace preserving (CPTP).
 
     A channel composed of Kraus operators K[0:n] is a CPTP map if the sum of

--- a/cirq-core/cirq/linalg/predicates_test.py
+++ b/cirq-core/cirq/linalg/predicates_test.py
@@ -23,7 +23,7 @@ import cirq
 from cirq.linalg import matrix_commutes
 
 
-def test_is_diagonal():
+def test_is_diagonal() -> None:
     assert cirq.is_diagonal(np.empty((0, 0)))
     assert cirq.is_diagonal(np.empty((1, 0)))
     assert cirq.is_diagonal(np.empty((0, 1)))
@@ -48,7 +48,7 @@ def test_is_diagonal():
     assert cirq.is_diagonal(np.array([[1, 1e-11], [1e-10, 1]]))
 
 
-def test_is_diagonal_tolerance():
+def test_is_diagonal_tolerance() -> None:
     atol = 0.5
 
     # Pays attention to specified tolerance.
@@ -60,7 +60,7 @@ def test_is_diagonal_tolerance():
     assert not cirq.is_diagonal(np.array([[1, 0.5], [-0.6, 1]]), atol=atol)
 
 
-def test_is_hermitian():
+def test_is_hermitian() -> None:
     assert cirq.is_hermitian(np.empty((0, 0)))
     assert not cirq.is_hermitian(np.empty((1, 0)))
     assert not cirq.is_hermitian(np.empty((0, 1)))
@@ -87,7 +87,7 @@ def test_is_hermitian():
     assert cirq.is_hermitian(np.array([[1, 1j + 1e-11], [-1j, 1 + 1j * 1e-9]]))
 
 
-def test_is_hermitian_tolerance():
+def test_is_hermitian_tolerance() -> None:
     atol = 0.5
 
     # Pays attention to specified tolerance.
@@ -102,7 +102,7 @@ def test_is_hermitian_tolerance():
     assert not cirq.is_hermitian(np.array([[1, 0, 0.6], [0, 1, 0], [0, 0, 1]]), atol=atol)
 
 
-def test_is_unitary():
+def test_is_unitary() -> None:
     assert not cirq.is_unitary(np.empty((0,)))
     assert cirq.is_unitary(np.empty((0, 0)))
     assert not cirq.is_unitary(np.empty((1, 0)))
@@ -133,7 +133,7 @@ def test_is_unitary():
     assert cirq.is_unitary(np.array([[1, 1j + 1e-11], [1j, 1 + 1j * 1e-9]]) * np.sqrt(0.5))
 
 
-def test_is_unitary_tolerance():
+def test_is_unitary_tolerance() -> None:
     atol = 0.5
 
     # Pays attention to specified tolerance.
@@ -145,7 +145,7 @@ def test_is_unitary_tolerance():
     assert not cirq.is_unitary(np.array([[1.2, 0, 0], [0, 1.3, 0], [0, 0, 1.2]]), atol=atol)
 
 
-def test_is_orthogonal():
+def test_is_orthogonal() -> None:
     assert cirq.is_orthogonal(np.empty((0, 0)))
     assert not cirq.is_orthogonal(np.empty((1, 0)))
     assert not cirq.is_orthogonal(np.empty((0, 1)))
@@ -173,7 +173,7 @@ def test_is_orthogonal():
     assert cirq.is_orthogonal(np.array([[1, 1e-11], [0, 1 + 1e-11]]))
 
 
-def test_is_orthogonal_tolerance():
+def test_is_orthogonal_tolerance() -> None:
     atol = 0.5
 
     # Pays attention to specified tolerance.
@@ -185,7 +185,7 @@ def test_is_orthogonal_tolerance():
     assert not cirq.is_orthogonal(np.array([[1.2, 0, 0], [0, 1.3, 0], [0, 0, 1.2]]), atol=atol)
 
 
-def test_is_special_orthogonal():
+def test_is_special_orthogonal() -> None:
     assert cirq.is_special_orthogonal(np.empty((0, 0)))
     assert not cirq.is_special_orthogonal(np.empty((1, 0)))
     assert not cirq.is_special_orthogonal(np.empty((0, 1)))
@@ -215,7 +215,7 @@ def test_is_special_orthogonal():
     assert cirq.is_special_orthogonal(np.array([[1, 1e-11], [0, 1 + 1e-11]]))
 
 
-def test_is_special_orthogonal_tolerance():
+def test_is_special_orthogonal_tolerance() -> None:
     atol = 0.5
 
     # Pays attention to specified tolerance.
@@ -234,7 +234,7 @@ def test_is_special_orthogonal_tolerance():
     )
 
 
-def test_is_special_unitary():
+def test_is_special_unitary() -> None:
     assert cirq.is_special_unitary(np.empty((0, 0)))
     assert not cirq.is_special_unitary(np.empty((1, 0)))
     assert not cirq.is_special_unitary(np.empty((0, 1)))
@@ -260,7 +260,7 @@ def test_is_special_unitary():
     assert cirq.is_special_unitary(np.array([[1, 1j + 1e-11], [1j, 1 + 1j * 1e-9]]) * np.sqrt(0.5))
 
 
-def test_is_special_unitary_tolerance():
+def test_is_special_unitary_tolerance() -> None:
     atol = 0.5
 
     # Pays attention to specified tolerance.
@@ -277,7 +277,7 @@ def test_is_special_unitary_tolerance():
     )
 
 
-def test_is_normal():
+def test_is_normal() -> None:
     assert cirq.is_normal(np.array([[1]]))
     assert cirq.is_normal(np.array([[3j]]))
     assert cirq.is_normal(cirq.testing.random_density_matrix(4))
@@ -286,7 +286,7 @@ def test_is_normal():
     assert not cirq.is_normal(np.zeros((1, 0)))
 
 
-def test_is_normal_tolerance():
+def test_is_normal_tolerance() -> None:
     atol = 0.25
 
     # Pays attention to specified tolerance.
@@ -298,7 +298,7 @@ def test_is_normal_tolerance():
     assert not cirq.is_normal(np.array([[0, 0.5, 0], [0, 0, 0.6], [0, 0, 0]]), atol=atol)
 
 
-def test_is_cptp():
+def test_is_cptp() -> None:
     rt2 = np.sqrt(0.5)
     # Amplitude damping with gamma=0.5.
     assert cirq.is_cptp(kraus_ops=[np.array([[1, 0], [0, rt2]]), np.array([[0, rt2], [0, 0]])])
@@ -325,15 +325,15 @@ def test_is_cptp():
     # Makes 4 2x2 kraus ops.
     one_qubit_u = cirq.testing.random_unitary(8)
     one_qubit_kraus = np.reshape(one_qubit_u[:, :2], (-1, 2, 2))
-    assert cirq.is_cptp(kraus_ops=one_qubit_kraus)
+    assert cirq.is_cptp(kraus_ops=one_qubit_kraus)  # type: ignore[arg-type]
 
     # Makes 16 4x4 kraus ops.
     two_qubit_u = cirq.testing.random_unitary(64)
     two_qubit_kraus = np.reshape(two_qubit_u[:, :4], (-1, 4, 4))
-    assert cirq.is_cptp(kraus_ops=two_qubit_kraus)
+    assert cirq.is_cptp(kraus_ops=two_qubit_kraus)  # type: ignore[arg-type]
 
 
-def test_is_cptp_tolerance():
+def test_is_cptp_tolerance() -> None:
     rt2_ish = np.sqrt(0.5) - 0.01
     atol = 0.25
     # Moderately-incorrect amplitude damping with gamma=0.5.
@@ -345,7 +345,7 @@ def test_is_cptp_tolerance():
     )
 
 
-def test_commutes():
+def test_commutes() -> None:
     assert matrix_commutes(np.empty((0, 0)), np.empty((0, 0)))
     assert not matrix_commutes(np.empty((1, 0)), np.empty((0, 1)))
     assert not matrix_commutes(np.empty((0, 1)), np.empty((1, 0)))
@@ -372,7 +372,7 @@ def test_commutes():
     assert matrix_commutes(xx, np.diag([1, -1, -1, 1 + 1e-9]))
 
 
-def test_commutes_tolerance():
+def test_commutes_tolerance() -> None:
     atol = 0.5
 
     x = np.array([[0, 1], [1, 0]])
@@ -383,7 +383,7 @@ def test_commutes_tolerance():
     assert not matrix_commutes(x, x + z * 0.5, atol=atol)
 
 
-def test_allclose_up_to_global_phase():
+def test_allclose_up_to_global_phase() -> None:
     assert cirq.allclose_up_to_global_phase(np.array([1]), np.array([1j]))
 
     assert not cirq.allclose_up_to_global_phase(np.array([[[1]]]), np.array([1]))
@@ -402,7 +402,7 @@ def test_allclose_up_to_global_phase():
     assert not cirq.allclose_up_to_global_phase(np.array([[1]]), np.array([[2]]))
 
 
-def test_binary_sub_tensor_slice():
+def test_binary_sub_tensor_slice() -> None:
     a = slice(None)
     e = Ellipsis
 
@@ -437,7 +437,7 @@ def test_binary_sub_tensor_slice():
     assert cirq.slice_for_qubits_equal_to([2], 0b0, num_qubits=3) == (a, a, 0)
 
 
-def test_binary_sub_tensor_slice_big_endian():
+def test_binary_sub_tensor_slice_big_endian() -> None:
     a = slice(None)
     e = Ellipsis
     sfqet = cirq.slice_for_qubits_equal_to
@@ -473,7 +473,7 @@ def test_binary_sub_tensor_slice_big_endian():
     assert sfqet([2], big_endian_qureg_value=0b0, num_qubits=3) == (a, a, 0)
 
 
-def test_qudit_sub_tensor_slice():
+def test_qudit_sub_tensor_slice() -> None:
     a = slice(None)
     sfqet = cirq.slice_for_qubits_equal_to
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -34,7 +34,7 @@ from cirq.linalg import predicates
 RaiseValueErrorIfNotProvided: np.ndarray = np.array([])
 
 
-def reflection_matrix_pow(reflection_matrix: np.ndarray, exponent: float):
+def reflection_matrix_pow(reflection_matrix: np.ndarray, exponent: float) -> np.ndarray:
     """Raises a matrix with two opposing eigenvalues to a power.
 
     Args:
@@ -720,7 +720,7 @@ def factor_density_matrix(
     return extracted, remainder
 
 
-def transpose_state_vector_to_axis_order(t: np.ndarray, axes: Sequence[int]):
+def transpose_state_vector_to_axis_order(t: np.ndarray, axes: Sequence[int]) -> np.ndarray:
     """Transposes the axes of a state vector to a specified order.
 
     Args:
@@ -733,7 +733,7 @@ def transpose_state_vector_to_axis_order(t: np.ndarray, axes: Sequence[int]):
     return np.moveaxis(t, axes, range(len(axes)))
 
 
-def transpose_density_matrix_to_axis_order(t: np.ndarray, axes: Sequence[int]):
+def transpose_density_matrix_to_axis_order(t: np.ndarray, axes: Sequence[int]) -> np.ndarray:
     """Transposes the axes of a density matrix to a specified order.
 
     Args:
@@ -780,7 +780,9 @@ def _index_from_coordinates(s: Sequence[int], volume: Sequence[int]) -> int:
     return np.dot(s, volume)
 
 
-def transpose_flattened_array(t: np.ndarray, shape: Sequence[int], axes: Sequence[int]):
+def transpose_flattened_array(
+    t: np.ndarray, shape: Sequence[int], axes: Sequence[int]
+) -> np.ndarray:
     """Transposes a flattened array.
 
     Equivalent to np.transpose(t.reshape(shape), axes).reshape((-1,)).

--- a/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
+++ b/cirq-core/cirq/neutral_atoms/neutral_atom_devices.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from cirq import ops
 
 
-def neutral_atom_gateset(max_parallel_z=None, max_parallel_xy=None):
+def neutral_atom_gateset(max_parallel_z=None, max_parallel_xy=None) -> ops.Gateset:
     return ops.Gateset(
         ops.AnyIntegerPowerGateFamily(ops.CNotPowGate),
         ops.AnyIntegerPowerGateFamily(ops.CCNotPowGate),

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -117,10 +117,10 @@ class ClassicallyControlledOperation(raw_types.Operation):
         return self._sub_operation.without_classical_controls()
 
     @property
-    def qubits(self):
+    def qubits(self) -> tuple[cirq.Qid, ...]:
         return self._sub_operation.qubits
 
-    def with_qubits(self, *new_qubits):
+    def with_qubits(self, *new_qubits) -> cirq.Operation:
         return self._sub_operation.with_qubits(*new_qubits).with_classical_controls(
             *self._conditions
         )

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -374,7 +374,7 @@ class CliffordGate(raw_types.Gate, CommonCliffordGates):
         object.__setattr__(self, '_clifford_tableau', _clifford_tableau.copy())
 
     @property
-    def clifford_tableau(self):
+    def clifford_tableau(self) -> qis.CliffordTableau:
         return self._clifford_tableau
 
     def _json_dict_(self) -> dict[str, Any]:

--- a/cirq-core/cirq/ops/common_channels_test.py
+++ b/cirq-core/cirq/ops/common_channels_test.py
@@ -51,7 +51,7 @@ round_to_2_prec = cirq.CircuitDiagramInfoArgs(
 )
 
 
-def assert_mixtures_equal(actual, expected):
+def assert_mixtures_equal(actual, expected) -> None:
     """Assert equal for tuple of mixed scalar and array types."""
     for a, e in zip(actual, expected):
         np.testing.assert_almost_equal(a[0], e[0])

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -274,7 +274,7 @@ class XPowGate(eigen_gate.EigenGate):
         return args.format('rx({0:half_turns}) {1};\n', self._exponent, qubits[0])
 
     @property
-    def phase_exponent(self):
+    def phase_exponent(self) -> float:
         return 0.0
 
     def _phase_by_(self, phase_turns, qubit_index):
@@ -467,7 +467,7 @@ class YPowGate(eigen_gate.EigenGate):
         return args.format('ry({0:half_turns}) {1};\n', self._exponent, qubits[0])
 
     @property
-    def phase_exponent(self):
+    def phase_exponent(self) -> float:
         return 0.5
 
     def _phase_by_(self, phase_turns, qubit_index):

--- a/cirq-core/cirq/ops/controlled_operation.py
+++ b/cirq-core/cirq/ops/controlled_operation.py
@@ -124,10 +124,10 @@ class ControlledOperation(raw_types.Operation):
         )
 
     @property
-    def qubits(self):
+    def qubits(self) -> tuple[cirq.Qid, ...]:
         return self.controls + self.sub_operation.qubits
 
-    def with_qubits(self, *new_qubits):
+    def with_qubits(self, *new_qubits) -> ControlledOperation:
         n = len(self.controls)
         return ControlledOperation(
             new_qubits[:n], self.sub_operation.with_qubits(*new_qubits[n:]), self.control_values

--- a/cirq-core/cirq/ops/controlled_operation_test.py
+++ b/cirq-core/cirq/ops/controlled_operation_test.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import itertools
 import re
 from types import EllipsisType, NotImplementedType
-from typing import cast
+from typing import cast, Sequence
 
 import numpy as np
 import pytest
@@ -74,7 +74,7 @@ class GateAllocatingNewSpaceForResult(cirq.testing.SingleQubitGate):
         return 'cirq.ops.controlled_operation_test.GateAllocatingNewSpaceForResult()'
 
 
-def test_controlled_operation_init():
+def test_controlled_operation_init() -> None:
     class G(cirq.testing.SingleQubitGate):
         def _has_mixture_(self):
             return True
@@ -123,7 +123,7 @@ def test_controlled_operation_init():
         _ = cirq.ControlledOperation([cb], cirq.PhaseDampingChannel(1)(q))
 
 
-def test_controlled_operation_eq():
+def test_controlled_operation_eq() -> None:
     c1 = cirq.NamedQubit('c1')
     q1 = cirq.NamedQubit('q1')
     c2 = cirq.NamedQubit('c2')
@@ -148,7 +148,7 @@ def test_controlled_operation_eq():
     )
 
 
-def test_str():
+def test_str() -> None:
     c1 = cirq.NamedQubit('c1')
     c2 = cirq.NamedQubit('c2')
     q2 = cirq.NamedQubit('q2')
@@ -190,7 +190,7 @@ def test_str():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
 
     ch = cirq.H(a).controlled_by(b)
@@ -231,7 +231,8 @@ class MultiH(cirq.Gate):
         return True
 
 
-def test_circuit_diagram():
+def test_circuit_diagram() -> None:
+    qubits: Sequence[cirq.Qid]
     qubits = cirq.LineQubit.range(3)
     c = cirq.Circuit()
     c.append(cirq.ControlledOperation(qubits[:1], MultiH(2)(*qubits[1:])))
@@ -302,7 +303,7 @@ class MockGate(cirq.testing.TwoQubitGate):
         return True
 
 
-def test_controlled_diagram_exponent():
+def test_controlled_diagram_exponent() -> None:
     for q in itertools.permutations(cirq.LineQubit.range(5)):
         for idx in [None, 0, 1]:
             op = MockGate(idx)(*q[:2]).controlled_by(*q[2:])
@@ -310,7 +311,7 @@ def test_controlled_diagram_exponent():
             assert cirq.circuit_diagram_info(op).exponent_qubit_index == len(q[2:]) + add
 
 
-def test_uninformed_circuit_diagram_info():
+def test_uninformed_circuit_diagram_info() -> None:
     qbits = cirq.LineQubit.range(3)
     mock_gate = MockGate()
     c_op = cirq.ControlledOperation(qbits[:1], mock_gate(*qbits[1:]))
@@ -323,7 +324,7 @@ def test_uninformed_circuit_diagram_info():
     assert mock_gate.captured_diagram_args == args
 
 
-def test_non_diagrammable_subop():
+def test_non_diagrammable_subop() -> None:
     qbits = cirq.LineQubit.range(2)
 
     class UndiagrammableGate(cirq.testing.SingleQubitGate):
@@ -369,7 +370,7 @@ def test_non_diagrammable_subop():
 )
 def test_controlled_operation_is_consistent(
     gate: cirq.GateOperation, should_decompose_to_target: bool
-):
+) -> None:
     cb = cirq.NamedQubit('ctr')
     cgate = cirq.ControlledOperation([cb], gate)
     cirq.testing.assert_implements_consistent_protocols(cgate)
@@ -395,7 +396,7 @@ def test_controlled_operation_is_consistent(
     cirq.testing.assert_decompose_ends_at_default_gateset(cgate)
 
 
-def test_controlled_circuit_operation_is_consistent():
+def test_controlled_circuit_operation_is_consistent() -> None:
     op = cirq.CircuitOperation(
         cirq.FrozenCircuit(
             cirq.XXPowGate(exponent=0.25, global_shift=-0.5).on(*cirq.LineQubit.range(2))
@@ -416,7 +417,7 @@ def test_controlled_circuit_operation_is_consistent():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_parameterizable(resolve_fn):
+def test_parameterizable(resolve_fn) -> None:
     a = sympy.Symbol('a')
     qubits = cirq.LineQubit.range(3)
 
@@ -434,7 +435,7 @@ def test_parameterizable(resolve_fn):
         resolve_fn(cchan, cirq.ParamResolver({'a': 0.1}))
 
 
-def test_bounded_effect():
+def test_bounded_effect() -> None:
     qubits = cirq.LineQubit.range(3)
     cy = cirq.ControlledOperation(qubits[:1], cirq.Y(qubits[1]))
     assert cirq.trace_distance_bound(cy**0.001) < 0.01
@@ -444,8 +445,8 @@ def test_bounded_effect():
     assert cirq.approx_eq(cirq.trace_distance_bound(cy), 1.0)
 
 
-def test_controlled_operation_gate():
-    gate = cirq.X.controlled(control_values=[0, 1], control_qid_shape=[2, 3])
+def test_controlled_operation_gate() -> None:
+    gate = cirq.X.controlled(control_values=[0, 1], control_qid_shape=(2, 3))
     op = gate.on(cirq.LineQubit(0), cirq.LineQid(1, 3), cirq.LineQubit(2))
     assert op.gate == gate
 
@@ -464,7 +465,7 @@ def test_controlled_operation_gate():
     assert op.gate is None
 
 
-def test_controlled_mixture():
+def test_controlled_mixture() -> None:
     a, b = cirq.LineQubit.range(2)
     c_yes = cirq.ControlledOperation(controls=[b], sub_operation=cirq.phase_flip(0.25).on(a))
     assert cirq.has_mixture(c_yes)

--- a/cirq-core/cirq/ops/dense_pauli_string_test.py
+++ b/cirq-core/cirq/ops/dense_pauli_string_test.py
@@ -24,7 +24,7 @@ import cirq
 from cirq.ops.dense_pauli_string import _vectorized_pauli_mul_phase
 
 
-def test_init():
+def test_init() -> None:
     mask = np.array([0, 3, 1, 2], dtype=np.uint8)
     p = cirq.DensePauliString(coefficient=2, pauli_mask=mask)
     m = cirq.MutableDensePauliString(coefficient=3, pauli_mask=mask)
@@ -50,10 +50,10 @@ def test_init():
     assert cirq.DensePauliString([1, 'X', cirq.X]) == cirq.DensePauliString('XXX')
     assert list(cirq.DensePauliString('XXX')) == [cirq.X, cirq.X, cirq.X]
     with pytest.raises(TypeError, match='Expected a cirq.PAULI_GATE_LIKE'):
-        _ = cirq.DensePauliString([object()])
+        _ = cirq.DensePauliString([object()])  # type: ignore[list-item]
 
 
-def test_value_to_char_correspondence():
+def test_value_to_char_correspondence() -> None:
     d = cirq.DensePauliString
     assert [d.I_VAL, d.X_VAL, d.Y_VAL, d.Z_VAL] == [0, 1, 2, 3]
     assert list(d([cirq.I, cirq.X, cirq.Y, cirq.Z]).pauli_mask) == [0, 1, 2, 3]
@@ -69,7 +69,7 @@ def test_value_to_char_correspondence():
     assert d('Z') * d('Y') == -1j * d('X')
 
 
-def test_from_text():
+def test_from_text() -> None:
     d = cirq.DensePauliString
     m = cirq.MutableDensePauliString
 
@@ -86,7 +86,7 @@ def test_from_text():
         _ = d('2')
 
 
-def test_immutable_eq():
+def test_immutable_eq() -> None:
     eq = cirq.testing.EqualsTester()
 
     # Immutables
@@ -103,7 +103,7 @@ def test_immutable_eq():
     eq.make_equality_group(lambda: cirq.MutableDensePauliString(coefficient=2, pauli_mask=[2]))
 
 
-def test_eye():
+def test_eye() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
     assert cirq.BaseDensePauliString.eye(4) == f('IIII')
@@ -111,7 +111,7 @@ def test_eye():
     assert cirq.MutableDensePauliString.eye(4) == m('IIII')
 
 
-def test_sparse():
+def test_sparse() -> None:
     a, b, c = cirq.LineQubit.range(3)
     p = -cirq.DensePauliString('XYZ')
     assert p.sparse() == cirq.PauliString(-1, cirq.X(a), cirq.Y(b), cirq.Z(c))
@@ -122,12 +122,14 @@ def test_sparse():
         _ = p.sparse(cirq.GridQubit.rect(2, 2))
 
 
-def test_mul_vectorized_pauli_mul_phase():
+def test_mul_vectorized_pauli_mul_phase() -> None:
     f = _vectorized_pauli_mul_phase
     paulis = [cirq.I, cirq.X, cirq.Y, cirq.Z]
     q = cirq.LineQubit(0)
 
     # Check single qubit cases.
+    sparse1: cirq.PauliString
+    sparse2: cirq.PauliString
     for i in range(4):
         for j in range(4):
             sparse1 = cirq.PauliString(paulis[i].on(q))
@@ -146,7 +148,7 @@ def test_mul_vectorized_pauli_mul_phase():
     )
 
 
-def test_mul():
+def test_mul() -> None:
     f = cirq.DensePauliString
 
     # Scalar.
@@ -193,22 +195,23 @@ def test_mul():
 
     # Unknown number type
     class UnknownNumber(numbers.Number):
-        pass
+        def __hash__(self):
+            return hash(complex(self))
 
     with pytest.raises(TypeError):
         _ = UnknownNumber() * f('I')
 
 
-def test_imul():
+def test_imul() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
 
     # Immutable not modified by imul.
-    p = f('III')
-    p2 = p
-    p2 *= 2
-    assert p.coefficient == 1
-    assert p is not p2
+    pf = f('III')
+    pf2 = pf
+    pf2 *= 2
+    assert pf.coefficient == 1
+    assert pf is not pf2
 
     # Mutable is modified by imul.
     p = m('III')
@@ -239,19 +242,20 @@ def test_imul():
 
     # Unknown number type
     class UnknownNumber(numbers.Number):
-        pass
+        def __hash__(self):
+            return hash(complex(self))
 
     with pytest.raises(TypeError):
         p *= UnknownNumber()
 
 
-def test_pos_neg():
+def test_pos_neg() -> None:
     p = 1j * cirq.DensePauliString('XYZ')
     assert +p == p
     assert -p == -1 * p
 
 
-def test_abs():
+def test_abs() -> None:
     f = cirq.DensePauliString
     m = cirq.DensePauliString
     assert abs(-f('XX')) == f('XX')
@@ -259,7 +263,7 @@ def test_abs():
     assert abs(2j * m('XX')) == 2 * f('XX')
 
 
-def test_approx_eq():
+def test_approx_eq() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
 
@@ -278,7 +282,7 @@ def test_approx_eq():
     assert not cirq.approx_eq(f('X'), f('Y'), atol=500)
 
 
-def test_pow():
+def test_pow() -> None:
     f = cirq.DensePauliString
     m = cirq.DensePauliString
     p = 1j * f('IXYZ')
@@ -314,7 +318,7 @@ def test_pow():
     assert m('X') ** 3 == f('X')
 
 
-def test_div():
+def test_div() -> None:
     f = cirq.DensePauliString
     t = sympy.Symbol('t')
     assert f('X') / 2 == 0.5 * f('X')
@@ -323,7 +327,7 @@ def test_div():
         _ = f('X') / object()
 
 
-def test_str():
+def test_str() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
 
@@ -338,7 +342,7 @@ def test_str():
     assert str(f('XX', coefficient=sympy.Symbol('t'))) == 't*XX'
 
 
-def test_repr():
+def test_repr() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
     cirq.testing.assert_equivalent_repr(f(''))
@@ -351,7 +355,7 @@ def test_repr():
     cirq.testing.assert_equivalent_repr(m(coefficient=sympy.Symbol('c'), pauli_mask=[0, 3, 2, 1]))
 
 
-def test_one_hot():
+def test_one_hot() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
 
@@ -374,7 +378,7 @@ def test_one_hot():
         _ = cirq.BaseDensePauliString.one_hot(index=0, length=0, pauli=cirq.X)
 
 
-def test_protocols():
+def test_protocols() -> None:
     t = sympy.Symbol('t')
     cirq.testing.assert_implements_consistent_protocols(cirq.DensePauliString('Y'))
     cirq.testing.assert_implements_consistent_protocols(-cirq.DensePauliString('Z'))
@@ -400,7 +404,7 @@ def test_protocols():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_parameterizable(resolve_fn):
+def test_parameterizable(resolve_fn) -> None:
     t = sympy.Symbol('t')
     x = cirq.DensePauliString('X')
     xt = x * t
@@ -415,7 +419,7 @@ def test_parameterizable(resolve_fn):
     assert resolve_fn(xt(q).gate, {'t': 2}) == x2
 
 
-def test_item_immutable():
+def test_item_immutable() -> None:
     p = -cirq.DensePauliString('XYIZ')
     assert p[-1] == cirq.Z
     assert p[0] == cirq.X
@@ -437,7 +441,7 @@ def test_item_immutable():
     assert p[::2] == cirq.DensePauliString('XI')
 
 
-def test_item_mutable():
+def test_item_mutable() -> None:
     m = cirq.MutableDensePauliString
     p = m('XYIZ', coefficient=-1)
     assert p[-1] == cirq.Z
@@ -448,9 +452,9 @@ def test_item_mutable():
     with pytest.raises(IndexError):
         _ = p[4]
     with pytest.raises(TypeError):
-        _ = p["test"]
+        _ = p["test"]  # type: ignore[call-overload]
     with pytest.raises(TypeError):
-        p["test"] = 'X'
+        p["test"] = 'X'  # type: ignore[call-overload]
 
     p[2] = cirq.X
     assert p == m('XYXZ', coefficient=-1)
@@ -482,7 +486,7 @@ def test_item_mutable():
     assert p == m('ZYXX', coefficient=-1)
 
 
-def test_tensor_product():
+def test_tensor_product() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
     assert (2 * f('XX')).tensor_product(-f('XI')) == -2 * f('XXXI')
@@ -491,7 +495,7 @@ def test_tensor_product():
     assert m('XX', coefficient=2).tensor_product(m('XI', coefficient=-1)) == -2 * m('XXXI')
 
 
-def test_commutes():
+def test_commutes() -> None:
     f = cirq.DensePauliString
     m = cirq.MutableDensePauliString
 
@@ -507,7 +511,7 @@ def test_commutes():
     assert cirq.commutes(f('XX'), "test", default=NotImplemented) is NotImplemented
 
 
-def test_copy():
+def test_copy() -> None:
     p = -cirq.DensePauliString('XYZ')
     m = cirq.MutableDensePauliString('XYZ', coefficient=-1)
 
@@ -545,7 +549,7 @@ def test_copy():
     assert cirq.MutableDensePauliString('XYZ').copy(pauli_mask=mask).pauli_mask is mask
 
 
-def test_gaussian_elimination():
+def test_gaussian_elimination() -> None:
     def table(*rows: str) -> list[cirq.MutableDensePauliString]:
         coefs = {'i': 1j, '-': -1, '+': 1}
         return [
@@ -626,7 +630,7 @@ def test_gaussian_elimination():
     )
 
 
-def test_idiv():
+def test_idiv() -> None:
     p = cirq.MutableDensePauliString('XYZ', coefficient=2)
     p /= 2
     assert p == cirq.MutableDensePauliString('XYZ')
@@ -635,7 +639,7 @@ def test_idiv():
         p /= object()
 
 
-def test_symbolic():
+def test_symbolic() -> None:
     t = sympy.Symbol('t')
     r = sympy.Symbol('r')
     m = cirq.MutableDensePauliString('XYZ', coefficient=t)

--- a/cirq-core/cirq/ops/dense_pauli_string_test.py
+++ b/cirq-core/cirq/ops/dense_pauli_string_test.py
@@ -196,7 +196,7 @@ def test_mul() -> None:
     # Unknown number type
     class UnknownNumber(numbers.Number):
         def __hash__(self):
-            return hash(complex(self))
+            return hash(complex(self))  # pragma: no cover
 
     with pytest.raises(TypeError):
         _ = UnknownNumber() * f('I')
@@ -243,7 +243,7 @@ def test_imul() -> None:
     # Unknown number type
     class UnknownNumber(numbers.Number):
         def __hash__(self):
-            return hash(complex(self))
+            return hash(complex(self))  # pragma: no cover
 
     with pytest.raises(TypeError):
         p *= UnknownNumber()

--- a/cirq-core/cirq/ops/eigen_gate_test.py
+++ b/cirq-core/cirq/ops/eigen_gate_test.py
@@ -34,10 +34,6 @@ class CExpZinGate(cirq.EigenGate, cirq.testing.TwoQubitGate):
     def __init__(self, quarter_turns: value.TParamVal) -> None:
         super().__init__(exponent=quarter_turns)
 
-    @property
-    def exponent(self):
-        return self._exponent
-
     def _with_exponent(self, exponent):
         return CExpZinGate(exponent)
 
@@ -50,9 +46,6 @@ class CExpZinGate(cirq.EigenGate, cirq.testing.TwoQubitGate):
 
 
 class ZGateDef(cirq.EigenGate, cirq.testing.SingleQubitGate):
-    @property
-    def exponent(self):
-        return self._exponent
 
     def _eigen_components(self) -> list[tuple[float, np.ndarray]]:
         return [(0, np.diag([1, 0])), (1, np.diag([0, 1]))]

--- a/cirq-core/cirq/ops/gateset.py
+++ b/cirq-core/cirq/ops/gateset.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, cast, Hashable, Sequence, TYPE_CHECKING
+from typing import Any, Callable, cast, Hashable, Iterable, TYPE_CHECKING
 
 from cirq import protocols, value
 from cirq.ops import global_phase_op, op_tree, raw_types
@@ -105,8 +105,8 @@ class GateFamily:
         name: str | None = None,
         description: str | None = None,
         ignore_global_phase: bool = True,
-        tags_to_accept: Sequence[Hashable] = (),
-        tags_to_ignore: Sequence[Hashable] = (),
+        tags_to_accept: Iterable[Hashable] = (),
+        tags_to_ignore: Iterable[Hashable] = (),
     ) -> None:
         """Init GateFamily.
 

--- a/cirq-core/cirq/ops/gateset_test.py
+++ b/cirq-core/cirq/ops/gateset_test.py
@@ -56,7 +56,7 @@ q = cirq.NamedQubit("q")
 
 
 @pytest.mark.parametrize('gate', [CustomX, CustomXPowGate])
-def test_gate_family_init(gate):
+def test_gate_family_init(gate) -> None:
     name = 'test_name'
     description = 'test_description'
     g = cirq.GateFamily(gate=gate, name=name, description=description)
@@ -75,7 +75,7 @@ def test_gate_family_init(gate):
         (CustomXPowGate, [], []),
     ],
 )
-def test_gate_family_default_name_and_description(gate, tags_to_accept, tags_to_ignore):
+def test_gate_family_default_name_and_description(gate, tags_to_accept, tags_to_ignore) -> None:
     g = cirq.GateFamily(gate, tags_to_accept=tags_to_accept, tags_to_ignore=tags_to_ignore)
     assert re.match('.*GateFamily.*CustomX.*', g.name)
     assert re.match('Accepts.*instances.*CustomX.*', g.description)
@@ -97,7 +97,7 @@ def test_gate_family_default_name_and_description(gate, tags_to_accept, tags_to_
 )
 def test_gate_family_equality_with_tags(
     tags_to_accept_fam1, tags_to_ignore_fam1, tags_to_accept_fam2, tags_to_ignore_fam2
-):
+) -> None:
     gate_fam1 = cirq.GateFamily(
         cirq.X, tags_to_accept=tags_to_accept_fam1, tags_to_ignore=tags_to_ignore_fam1
     )
@@ -108,9 +108,9 @@ def test_gate_family_equality_with_tags(
     assert gate_fam1 == gate_fam2
 
 
-def test_invalid_gate_family():
+def test_invalid_gate_family() -> None:
     with pytest.raises(ValueError, match='instance or subclass of `cirq.Gate`'):
-        _ = cirq.GateFamily(gate=cirq.Operation)
+        _ = cirq.GateFamily(gate=cirq.Operation)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match='non-parameterized instance of `cirq.Gate`'):
         _ = cirq.GateFamily(gate=CustomX ** sympy.Symbol('theta'))
@@ -119,31 +119,31 @@ def test_invalid_gate_family():
         _ = cirq.GateFamily(gate=cirq.H, tags_to_accept={'a', 'b'}, tags_to_ignore={'b', 'c'})
 
 
-def test_gate_family_immutable():
+def test_gate_family_immutable() -> None:
     g = cirq.GateFamily(CustomX)
     # Match one of two strings. The second one is message returned since python 3.11.
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'gate' of 'GateFamily' object has no setter)",
     ):
-        g.gate = CustomXPowGate
+        g.gate = CustomXPowGate  # type: ignore[misc]
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'name' of 'GateFamily' object has no setter)",
     ):
-        g.name = 'new name'
+        g.name = 'new name'  # type: ignore[misc]
     with pytest.raises(
         AttributeError,
         match="(can't set attribute)|(property 'description' of 'GateFamily' object has no setter)",
     ):
-        g.description = 'new description'
+        g.description = 'new description'  # type: ignore[misc]
 
 
 @pytest.mark.parametrize(
     'gate', [CustomX, CustomXPowGate(exponent=0.5, global_shift=0.1), CustomXPowGate]
 )
 @pytest.mark.parametrize('name, description', [(None, None), ('custom_name', 'custom_description')])
-def test_gate_family_repr_and_str(gate, name, description):
+def test_gate_family_repr_and_str(gate, name, description) -> None:
     g = cirq.GateFamily(gate, name=name, description=description)
     cirq.testing.assert_equivalent_repr(g)
     assert g.name in str(g)
@@ -152,13 +152,13 @@ def test_gate_family_repr_and_str(gate, name, description):
 
 @pytest.mark.parametrize('gate', [cirq.X, cirq.XPowGate(), cirq.XPowGate])
 @pytest.mark.parametrize('name, description', [(None, None), ('custom_name', 'custom_description')])
-def test_gate_family_json(gate, name, description):
+def test_gate_family_json(gate, name, description) -> None:
     g = cirq.GateFamily(gate, name=name, description=description)
     g_json = cirq.to_json(g)
     assert cirq.read_json(json_text=g_json) == g
 
 
-def test_gate_family_eq():
+def test_gate_family_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.GateFamily(CustomX))
     eq.add_equality_group(cirq.GateFamily(CustomX**3))
@@ -206,7 +206,7 @@ def test_gate_family_eq():
         ),
     ],
 )
-def test_gate_family_predicate_and_containment(gate_family, gates_to_check):
+def test_gate_family_predicate_and_containment(gate_family, gates_to_check) -> None:
     for gate, result in gates_to_check:
         assert gate_family._predicate(gate) == result
         assert (gate in gate_family) == result
@@ -265,7 +265,7 @@ def test_gate_family_predicate_and_containment(gate_family, gates_to_check):
         ),
     ],
 )
-def test_gate_family_tagged_operations(gate_family, gates_to_check):
+def test_gate_family_tagged_operations(gate_family, gates_to_check) -> None:
     for gate, result in gates_to_check:
         assert (gate in gate_family) == result
 
@@ -296,7 +296,7 @@ gateset = cirq.Gateset(
 )
 
 
-def test_gateset_init():
+def test_gateset_init() -> None:
     assert gateset.name == 'custom gateset'
     assert gateset.gates == frozenset(
         [
@@ -308,7 +308,7 @@ def test_gateset_init():
 
 
 @pytest.mark.parametrize('g', [gateset, cirq.Gateset(name='empty gateset')])
-def test_gateset_repr_and_str(g):
+def test_gateset_repr_and_str(g) -> None:
     cirq.testing.assert_equivalent_repr(g)
     assert g.name in str(g)
     for gate_family in g.gates:
@@ -328,7 +328,7 @@ def test_gateset_repr_and_str(g):
         (cirq.testing.TwoQubitGate(), True),
     ],
 )
-def test_gateset_contains(gate, result):
+def test_gateset_contains(gate, result) -> None:
     assert (gate in gateset) is result
     op = gate(*cirq.LineQubit.range(gate.num_qubits()))
     assert (op in gateset) is result
@@ -339,7 +339,7 @@ def test_gateset_contains(gate, result):
 
 
 @pytest.mark.parametrize('use_circuit_op', [True, False])
-def test_gateset_validate(use_circuit_op):
+def test_gateset_validate(use_circuit_op) -> None:
     def optree_and_circuit(optree):
         yield optree
         yield cirq.Circuit(optree)
@@ -374,14 +374,14 @@ def test_gateset_validate(use_circuit_op):
         )
 
 
-def test_gateset_validate_circuit_op_negative_reps():
+def test_gateset_validate_circuit_op_negative_reps() -> None:
     gate = CustomXPowGate(exponent=0.5)
     op = cirq.CircuitOperation(cirq.FrozenCircuit(gate.on(cirq.LineQubit(0))), repetitions=-1)
     assert op not in cirq.Gateset(gate)
     assert op**-1 in cirq.Gateset(gate)
 
 
-def test_with_params():
+def test_with_params() -> None:
     assert gateset.with_params() is gateset
     assert (
         gateset.with_params(name=gateset.name, unroll_circuit_op=gateset._unroll_circuit_op)
@@ -392,7 +392,7 @@ def test_with_params():
     assert gateset_with_params._unroll_circuit_op is False
 
 
-def test_gateset_eq():
+def test_gateset_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.Gateset(CustomX))
     eq.add_equality_group(cirq.Gateset(CustomX**3))
@@ -427,7 +427,7 @@ def test_gateset_eq():
     )
 
 
-def test_gateset_contains_with_tags():
+def test_gateset_contains_with_tags() -> None:
     tag = "PhysicalZTag"
     gf_accept = cirq.GateFamily(cirq.ZPowGate, tags_to_accept=[tag])
     gf_ignore = cirq.GateFamily(cirq.ZPowGate, tags_to_ignore=[tag])
@@ -447,7 +447,7 @@ def test_gateset_contains_with_tags():
     assert op_with_tag in cirq.Gateset(gf_accept, gf_ignore)
 
 
-def test_gateset_contains_op_with_no_gate():
+def test_gateset_contains_op_with_no_gate() -> None:
     gf = cirq.GateFamily(cirq.ZPowGate)
     op = cirq.X(cirq.q(1)).with_classical_controls('a')
     assert op.gate is None

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -473,7 +473,7 @@ class PauliSum:
 
     @classmethod
     def from_boolean_expression(
-        cls, boolean_expr: sympy.Expr, qubit_map: dict[str, cirq.Qid]
+        cls, boolean_expr: sympy.Expr, qubit_map: Mapping[str, cirq.Qid]
     ) -> PauliSum:
         """Builds the Hamiltonian representation of a Boolean expression.
 

--- a/cirq-core/cirq/ops/linear_combinations_test.py
+++ b/cirq-core/cirq/ops/linear_combinations_test.py
@@ -36,7 +36,7 @@ q0, q1, q2, q3 = cirq.LineQubit.range(4)
         {cirq.TOFFOLI: 0.5j, cirq.FREDKIN: 0.5},
     ),
 )
-def test_linear_combination_of_gates_accepts_consistent_gates(terms):
+def test_linear_combination_of_gates_accepts_consistent_gates(terms) -> None:
     combination_1 = cirq.LinearCombinationOfGates(terms)
 
     combination_2 = cirq.LinearCombinationOfGates({})
@@ -57,7 +57,7 @@ def test_linear_combination_of_gates_accepts_consistent_gates(terms):
         {cirq.TOFFOLI: 0.5j, cirq.S: 0.5},
     ),
 )
-def test_linear_combination_of_gates_rejects_inconsistent_gates(terms):
+def test_linear_combination_of_gates_rejects_inconsistent_gates(terms) -> None:
     with pytest.raises(ValueError):
         cirq.LinearCombinationOfGates(terms)
 
@@ -72,7 +72,7 @@ def test_linear_combination_of_gates_rejects_inconsistent_gates(terms):
 
 
 @pytest.mark.parametrize('gate', (cirq.X, cirq.Y, cirq.XX, cirq.CZ, cirq.CSWAP, cirq.FREDKIN))
-def test_empty_linear_combination_of_gates_accepts_all_gates(gate):
+def test_empty_linear_combination_of_gates_accepts_all_gates(gate) -> None:
     combination = cirq.LinearCombinationOfGates({})
     combination[gate] = -0.5j
     assert len(combination) == 1
@@ -87,12 +87,12 @@ def test_empty_linear_combination_of_gates_accepts_all_gates(gate):
         ({cirq.CCZ: 0.1, cirq.CSWAP: 0.2}, 3),
     ),
 )
-def test_linear_combination_of_gates_has_correct_num_qubits(terms, expected_num_qubits):
+def test_linear_combination_of_gates_has_correct_num_qubits(terms, expected_num_qubits) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     assert combination.num_qubits() == expected_num_qubits
 
 
-def test_empty_linear_combination_of_gates_has_no_matrix():
+def test_empty_linear_combination_of_gates_has_no_matrix() -> None:
     empty = cirq.LinearCombinationOfGates({})
     assert empty.num_qubits() is None
     with pytest.raises(ValueError):
@@ -110,7 +110,7 @@ def test_empty_linear_combination_of_gates_has_no_matrix():
         ({cirq.CCZ: 3j}, np.diag([3j, 3j, 3j, 3j, 3j, 3j, 3j, -3j])),
     ),
 )
-def test_linear_combination_of_gates_has_correct_matrix(terms, expected_matrix):
+def test_linear_combination_of_gates_has_correct_matrix(terms, expected_matrix) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     assert np.all(combination.matrix() == expected_matrix)
 
@@ -128,7 +128,7 @@ def test_linear_combination_of_gates_has_correct_matrix(terms, expected_matrix):
         ),
     ),
 )
-def test_unitary_linear_combination_of_gates_has_correct_unitary(terms, expected_unitary):
+def test_unitary_linear_combination_of_gates_has_correct_unitary(terms, expected_unitary) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     assert cirq.has_unitary(combination)
     assert np.allclose(cirq.unitary(combination), expected_unitary)
@@ -137,7 +137,7 @@ def test_unitary_linear_combination_of_gates_has_correct_unitary(terms, expected
 @pytest.mark.parametrize(
     'terms', ({cirq.X: 2}, {cirq.Y ** sympy.Symbol('t'): 1}, {cirq.X: 1, cirq.S: 1})
 )
-def test_non_unitary_linear_combination_of_gates_has_no_unitary(terms):
+def test_non_unitary_linear_combination_of_gates_has_no_unitary(terms) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     assert not cirq.has_unitary(combination)
     with pytest.raises((TypeError, ValueError)):
@@ -160,7 +160,7 @@ def test_non_unitary_linear_combination_of_gates_has_no_unitary(terms):
         ),
     ),
 )
-def test_linear_combination_of_gates_has_correct_pauli_expansion(terms, expected_expansion):
+def test_linear_combination_of_gates_has_correct_pauli_expansion(terms, expected_expansion) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     actual_expansion = cirq.pauli_expansion(combination)
     assert set(actual_expansion.keys()) == set(expected_expansion.keys())
@@ -184,7 +184,7 @@ def test_linear_combination_of_gates_has_correct_pauli_expansion(terms, expected
         ({cirq.X: 0.4, cirq.Y: 0.4}, 0, {cirq.I: 1}),
     ),
 )
-def test_linear_combinations_of_gates_valid_powers(terms, exponent, expected_terms):
+def test_linear_combinations_of_gates_valid_powers(terms, exponent, expected_terms) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     actual_result = combination**exponent
     expected_result = cirq.LinearCombinationOfGates(expected_terms)
@@ -203,7 +203,7 @@ def test_linear_combinations_of_gates_valid_powers(terms, exponent, expected_ter
         ({cirq.Y: 1}, sympy.Symbol('k')),
     ),
 )
-def test_linear_combinations_of_gates_invalid_powers(terms, exponent):
+def test_linear_combinations_of_gates_invalid_powers(terms, exponent) -> None:
     combination = cirq.LinearCombinationOfGates(terms)
     with pytest.raises(TypeError):
         _ = combination**exponent
@@ -220,7 +220,7 @@ def test_linear_combinations_of_gates_invalid_powers(terms, exponent):
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
 def test_parameterized_linear_combination_of_gates(
     terms, is_parameterized, parameter_names, resolve_fn
-):
+) -> None:
     gate = cirq.LinearCombinationOfGates(terms)
     assert cirq.is_parameterized(gate) == is_parameterized
     assert cirq.parameter_names(gate) == parameter_names
@@ -292,7 +292,7 @@ def assert_linear_combinations_are_equal(
         ((cirq.X + cirq.Z) * sympy.Symbol('s') / np.sqrt(2), cirq.H * sympy.Symbol('s')),
     ),
 )
-def test_gate_expressions(expression, expected_result):
+def test_gate_expressions(expression, expected_result) -> None:
     assert_linear_combinations_are_equal(expression, expected_result)
 
 
@@ -304,7 +304,7 @@ def test_gate_expressions(expression, expected_result):
         (cirq.TOFFOLI, cirq.TOFFOLI, cirq.FREDKIN),
     ),
 )
-def test_in_place_manipulations_of_linear_combination_of_gates(gates):
+def test_in_place_manipulations_of_linear_combination_of_gates(gates) -> None:
     a = cirq.LinearCombinationOfGates({})
     b = cirq.LinearCombinationOfGates({})
 
@@ -333,7 +333,7 @@ def test_in_place_manipulations_of_linear_combination_of_gates(gates):
         cirq.PauliString({q0: cirq.X, q1: cirq.Y, q2: cirq.Z}),
     ),
 )
-def test_empty_linear_combination_of_operations_accepts_all_operations(op):
+def test_empty_linear_combination_of_operations_accepts_all_operations(op) -> None:
     combination = cirq.LinearCombinationOfOperations({})
     combination[op] = -0.5j
     assert len(combination) == 1
@@ -348,7 +348,7 @@ def test_empty_linear_combination_of_operations_accepts_all_operations(op):
         {cirq.X(q0): 1 + 1j, cirq.CZ(q1, q2): 0.5},
     ),
 )
-def test_linear_combination_of_operations_is_consistent(terms):
+def test_linear_combination_of_operations_is_consistent(terms) -> None:
     combination_1 = cirq.LinearCombinationOfOperations(terms)
 
     combination_2 = cirq.LinearCombinationOfOperations({})
@@ -371,7 +371,7 @@ def test_linear_combination_of_operations_is_consistent(terms):
         ({cirq.Z(q0): -1j, cirq.CNOT(q1, q2): 0.25}, (q0, q1, q2)),
     ),
 )
-def test_linear_combination_of_operations_has_correct_qubits(terms, expected_qubits):
+def test_linear_combination_of_operations_has_correct_qubits(terms, expected_qubits) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     assert combination.qubits == expected_qubits
 
@@ -590,7 +590,7 @@ def test_linear_combination_of_operations_has_correct_qubits(terms, expected_qub
         ),
     ),
 )
-def test_linear_combination_of_operations_has_correct_matrix(terms, expected_matrix):
+def test_linear_combination_of_operations_has_correct_matrix(terms, expected_matrix) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     assert np.allclose(combination.matrix(), expected_matrix)
 
@@ -622,7 +622,9 @@ def test_linear_combination_of_operations_has_correct_matrix(terms, expected_mat
         ),
     ),
 )
-def test_unitary_linear_combination_of_operations_has_correct_unitary(terms, expected_unitary):
+def test_unitary_linear_combination_of_operations_has_correct_unitary(
+    terms, expected_unitary
+) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     assert cirq.has_unitary(combination)
     assert np.allclose(cirq.unitary(combination), expected_unitary)
@@ -636,7 +638,7 @@ def test_unitary_linear_combination_of_operations_has_correct_unitary(terms, exp
         {cirq.X(q0): 1, cirq.S(q0): 1},
     ),
 )
-def test_non_unitary_linear_combination_of_operations_has_no_unitary(terms):
+def test_non_unitary_linear_combination_of_operations_has_no_unitary(terms) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     assert not cirq.has_unitary(combination)
     with pytest.raises((TypeError, ValueError)):
@@ -676,7 +678,9 @@ def test_non_unitary_linear_combination_of_operations_has_no_unitary(terms):
         ),
     ),
 )
-def test_linear_combination_of_operations_has_correct_pauli_expansion(terms, expected_expansion):
+def test_linear_combination_of_operations_has_correct_pauli_expansion(
+    terms, expected_expansion
+) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     actual_expansion = cirq.pauli_expansion(combination)
     assert set(actual_expansion.keys()) == set(expected_expansion.keys())
@@ -700,7 +704,7 @@ def test_linear_combination_of_operations_has_correct_pauli_expansion(terms, exp
         ({cirq.Y(q1): 2, cirq.Z(q1): 3}, 0, {cirq.I(q1): 1}),
     ),
 )
-def test_linear_combinations_of_operations_valid_powers(terms, exponent, expected_terms):
+def test_linear_combinations_of_operations_valid_powers(terms, exponent, expected_terms) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     actual_result = combination**exponent
     expected_result = cirq.LinearCombinationOfOperations(expected_terms)
@@ -720,7 +724,7 @@ def test_linear_combinations_of_operations_valid_powers(terms, exponent, expecte
         ({cirq.X(q0): 1}, sympy.Symbol('k')),
     ),
 )
-def test_linear_combinations_of_operations_invalid_powers(terms, exponent):
+def test_linear_combinations_of_operations_invalid_powers(terms, exponent) -> None:
     combination = cirq.LinearCombinationOfOperations(terms)
     with pytest.raises(TypeError):
         _ = combination**exponent
@@ -737,7 +741,7 @@ def test_linear_combinations_of_operations_invalid_powers(terms, exponent):
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
 def test_parameterized_linear_combination_of_ops(
     terms, is_parameterized, parameter_names, resolve_fn
-):
+) -> None:
     op = cirq.LinearCombinationOfOperations(terms)
     assert cirq.is_parameterized(op) == is_parameterized
     assert cirq.parameter_names(op) == parameter_names
@@ -810,11 +814,11 @@ def test_parameterized_linear_combination_of_ops(
         ),
     ),
 )
-def test_operation_expressions(expression, expected_result):
+def test_operation_expressions(expression, expected_result) -> None:
     assert_linear_combinations_are_equal(expression, expected_result)
 
 
-def test_pauli_sum_construction():
+def test_pauli_sum_construction() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.Y(q[0]) * cirq.Y(q[1])
@@ -839,7 +843,7 @@ def test_pauli_sum_construction():
         ),
     ),
 )
-def test_unitary_pauli_sum_has_correct_unitary(psum, expected_unitary):
+def test_unitary_pauli_sum_has_correct_unitary(psum, expected_unitary) -> None:
     assert cirq.has_unitary(psum)
     assert np.allclose(cirq.unitary(psum), expected_unitary)
 
@@ -852,7 +856,7 @@ def test_unitary_pauli_sum_has_correct_unitary(psum, expected_unitary):
         cirq.X(q0) * cirq.Z(q1) - cirq.Z(q1) * cirq.X(q0),
     ),
 )
-def test_non_pauli_sum_has_no_unitary(psum):
+def test_non_pauli_sum_has_no_unitary(psum) -> None:
     assert isinstance(psum, cirq.PauliSum)
     assert not cirq.has_unitary(psum)
     with pytest.raises(ValueError):
@@ -869,7 +873,7 @@ def test_non_pauli_sum_has_no_unitary(psum):
         (cirq.X(q0) * cirq.Y(q1) + cirq.Y(q1) * cirq.Z(q3), (q0, q1, q3)),
     ),
 )
-def test_pauli_sum_qubits(psum, expected_qubits):
+def test_pauli_sum_qubits(psum, expected_qubits) -> None:
     assert psum.qubits == expected_qubits
 
 
@@ -884,7 +888,7 @@ def test_pauli_sum_qubits(psum, expected_qubits):
         ),
     ),
 )
-def test_pauli_sum_with_qubits(psum, expected_psum):
+def test_pauli_sum_with_qubits(psum, expected_psum) -> None:
     if len(expected_psum.qubits) == len(psum.qubits):
         assert psum.with_qubits(*expected_psum.qubits) == expected_psum
     else:
@@ -892,7 +896,7 @@ def test_pauli_sum_with_qubits(psum, expected_psum):
             psum.with_qubits(*expected_psum.qubits)
 
 
-def test_pauli_sum_from_single_pauli():
+def test_pauli_sum_from_single_pauli() -> None:
     q = cirq.LineQubit.range(2)
     psum1 = cirq.X(q[0]) + cirq.Y(q[1])
     assert psum1 == cirq.PauliSum.from_pauli_strings([cirq.X(q[0]) * 1, cirq.Y(q[1]) * 1])
@@ -906,7 +910,7 @@ def test_pauli_sum_from_single_pauli():
     assert psum3 == psum2
 
 
-def test_pauli_sub():
+def test_pauli_sub() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.Y(q[0]) * cirq.Y(q[1])
@@ -916,7 +920,7 @@ def test_pauli_sub():
     assert psum == psum2
 
 
-def test_pauli_sub_simplify():
+def test_pauli_sub_simplify() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.X(q[0]) * cirq.X(q[1])
@@ -926,7 +930,7 @@ def test_pauli_sub_simplify():
     assert psum == psum2
 
 
-def test_pauli_sum_neg():
+def test_pauli_sum_neg() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.Y(q[0]) * cirq.Y(q[1])
@@ -941,12 +945,12 @@ def test_pauli_sum_neg():
     assert psum1 == -psum2
 
 
-def test_paulisum_validation():
+def test_paulisum_validation() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.Y(q[0]) * cirq.Y(q[1])
     with pytest.raises(ValueError) as e:
-        cirq.PauliSum([pstr1, pstr2])
+        cirq.PauliSum([pstr1, pstr2])  # type: ignore[arg-type]
     assert e.match("Consider using")
 
     with pytest.raises(ValueError):
@@ -959,12 +963,12 @@ def test_paulisum_validation():
         cirq.PauliSum(ld)
 
     with pytest.raises(ValueError):
-        key = frozenset([(q[0], cirq.H)])
-        ld = cirq.LinearDict({key: 2.0})
+        key1 = frozenset([(q[0], cirq.H)])
+        ld = cirq.LinearDict({key1: 2.0})
         cirq.PauliSum(ld)
 
-    key = frozenset([(q[0], cirq.X)])
-    ld = cirq.LinearDict({key: 2.0})
+    key2 = frozenset([(q[0], cirq.X)])
+    ld = cirq.LinearDict({key2: 2.0})
     assert cirq.PauliSum(ld) == cirq.PauliSum.from_pauli_strings([2 * cirq.X(q[0])])
 
     ps = cirq.PauliSum()
@@ -976,14 +980,14 @@ def test_paulisum_validation():
     assert ps == cirq.PauliSum(cirq.LinearDict({frozenset(): complex(-1)}))
 
 
-def test_add_number_paulisum():
+def test_add_number_paulisum() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     psum = cirq.PauliSum.from_pauli_strings([pstr1]) + 1.3
     assert psum == cirq.PauliSum.from_pauli_strings([pstr1, cirq.PauliString({}, 1.3)])
 
 
-def test_add_number_paulistring():
+def test_add_number_paulistring() -> None:
     a, b = cirq.LineQubit.range(2)
     pstr1 = cirq.X(a) * cirq.X(b)
     psum = pstr1 + 1.3
@@ -1005,7 +1009,7 @@ def test_add_number_paulistring():
     )
 
 
-def test_pauli_sum_formatting():
+def test_pauli_sum_formatting() -> None:
     q = cirq.LineQubit.range(2)
     pauli = cirq.X(q[0])
     assert str(pauli) == 'X(q(0))'
@@ -1023,7 +1027,7 @@ def test_pauli_sum_formatting():
     assert str(empty) == "0.000"
 
 
-def test_pauli_sum_matrix():
+def test_pauli_sum_matrix() -> None:
     q = cirq.LineQubit.range(3)
     paulisum = cirq.X(q[0]) * cirq.X(q[1]) + cirq.Z(q[0])
     H1 = np.array(
@@ -1052,7 +1056,7 @@ def test_pauli_sum_matrix():
     assert np.allclose(H3, paulisum.matrix([q[1], q[2], q[0]]))
 
 
-def test_pauli_sum_repr():
+def test_pauli_sum_repr() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.Y(q[0]) * cirq.Y(q[1])
@@ -1060,7 +1064,7 @@ def test_pauli_sum_repr():
     cirq.testing.assert_equivalent_repr(psum)
 
 
-def test_bad_arithmetic():
+def test_bad_arithmetic() -> None:
     q = cirq.LineQubit.range(2)
     pstr1 = cirq.X(q[0]) * cirq.X(q[1])
     pstr2 = cirq.Y(q[0]) * cirq.Y(q[1])
@@ -1099,9 +1103,11 @@ def test_bad_arithmetic():
         _ = psum ** "string"
 
 
-def test_paulisum_mul_paulistring():
+def test_paulisum_mul_paulistring() -> None:
     q0, q1 = cirq.LineQubit.range(2)
 
+    x0: cirq.PauliString[cirq.LineQubit]
+    y1: cirq.PauliString[cirq.LineQubit]
     psum1 = cirq.X(q0) + 2 * cirq.Y(q0) + 3 * cirq.Z(q0)
     x0 = cirq.PauliString(cirq.X(q0))
     y1 = cirq.PauliString(cirq.Y(q1))
@@ -1121,7 +1127,7 @@ def test_paulisum_mul_paulistring():
     assert psum1 == -1j * cirq.Y(q0) + 2j * cirq.X(q0) + 3
 
 
-def test_paulisum_mul_paulisum():
+def test_paulisum_mul_paulisum() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
 
     psum1 = cirq.X(q0) + 2 * cirq.Y(q0) * cirq.Y(q1)
@@ -1158,7 +1164,7 @@ def test_paulisum_mul_paulisum():
     )
 
 
-def test_pauli_sum_pow():
+def test_pauli_sum_pow() -> None:
     identity = cirq.PauliSum.from_pauli_strings([cirq.PauliString(coefficient=1)])
     psum1 = cirq.X(q0) + cirq.Y(q0)
     assert psum1**2 == psum1 * psum1
@@ -1215,7 +1221,7 @@ def test_pauli_sum_pow():
         ('x0 ^ x1 ^ x2', ['(-0.5+0j)*Z(x0)*Z(x1)*Z(x2)', '(0.5+0j)*I']),
     ],
 )
-def test_from_boolean_expression(boolean_expr, expected_pauli_sum):
+def test_from_boolean_expression(boolean_expr, expected_pauli_sum) -> None:
     boolean = sympy_parser.parse_expr(boolean_expr)
     qubit_map = {name: cirq.NamedQubit(name) for name in sorted(cirq.parameter_names(boolean))}
     actual = cirq.PauliSum.from_boolean_expression(boolean, qubit_map)
@@ -1226,14 +1232,14 @@ def test_from_boolean_expression(boolean_expr, expected_pauli_sum):
     assert expected_pauli_sum == actual_items
 
 
-def test_unsupported_op():
+def test_unsupported_op() -> None:
     not_a_boolean = sympy_parser.parse_expr('x * x')
     qubit_map = {name: cirq.NamedQubit(name) for name in cirq.parameter_names(not_a_boolean)}
     with pytest.raises(ValueError, match='Unsupported type'):
         cirq.PauliSum.from_boolean_expression(not_a_boolean, qubit_map)
 
 
-def test_imul_aliasing():
+def test_imul_aliasing() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     psum1 = cirq.X(q0) + cirq.Y(q1)
     psum2 = psum1
@@ -1242,7 +1248,7 @@ def test_imul_aliasing():
     assert psum1 == psum2
 
 
-def test_expectation_from_state_vector_invalid_input():
+def test_expectation_from_state_vector_invalid_input() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     psum = cirq.X(q0) + 2 * cirq.Y(q1) + 3 * cirq.Z(q3)
     q_map = {q0: 0, q1: 1, q3: 2}
@@ -1285,7 +1291,7 @@ def test_expectation_from_state_vector_invalid_input():
         psum.expectation_from_state_vector(wf.reshape((4, 4, 1)), q_map_2)
 
 
-def test_expectation_from_state_vector_check_preconditions():
+def test_expectation_from_state_vector_check_preconditions() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     psum = cirq.X(q0) + 2 * cirq.Y(q1) + 3 * cirq.Z(q3)
     q_map = {q0: 0, q1: 1, q2: 2, q3: 3}
@@ -1298,7 +1304,7 @@ def test_expectation_from_state_vector_check_preconditions():
     )
 
 
-def test_expectation_from_state_vector_basis_states():
+def test_expectation_from_state_vector_basis_states() -> None:
     q = cirq.LineQubit.range(2)
     psum = cirq.X(q[0]) + 2 * cirq.Y(q[0]) + 3 * cirq.Z(q[0])
     q_map = {x: i for i, x in enumerate(q)}
@@ -1335,7 +1341,7 @@ def test_expectation_from_state_vector_basis_states():
     )
 
 
-def test_expectation_from_state_vector_two_qubit_states():
+def test_expectation_from_state_vector_two_qubit_states() -> None:
     q = cirq.LineQubit.range(2)
     q_map = {x: i for i, x in enumerate(q)}
 
@@ -1371,7 +1377,7 @@ def test_expectation_from_state_vector_two_qubit_states():
         )
 
 
-def test_expectation_from_density_matrix_invalid_input():
+def test_expectation_from_density_matrix_invalid_input() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
     psum = cirq.X(q0) + 2 * cirq.Y(q1) + 3 * cirq.Z(q3)
     q_map = {q0: 0, q1: 1, q3: 2}
@@ -1427,7 +1433,7 @@ def test_expectation_from_density_matrix_invalid_input():
         psum.expectation_from_density_matrix(rho.reshape((-1)), q_map)
 
 
-def test_expectation_from_density_matrix_check_preconditions():
+def test_expectation_from_density_matrix_check_preconditions() -> None:
     q0, q1, _, q3 = cirq.LineQubit.range(4)
     psum = cirq.X(q0) + 2 * cirq.Y(q1) + 3 * cirq.Z(q3)
     q_map = {q0: 0, q1: 1, q3: 2}
@@ -1441,7 +1447,7 @@ def test_expectation_from_density_matrix_check_preconditions():
     _ = psum.expectation_from_density_matrix(not_psd, q_map, check_preconditions=False)
 
 
-def test_expectation_from_density_matrix_basis_states():
+def test_expectation_from_density_matrix_basis_states() -> None:
     q = cirq.LineQubit.range(2)
     psum = cirq.X(q[0]) + 2 * cirq.Y(q[0]) + 3 * cirq.Z(q[0])
     q_map = {x: i for i, x in enumerate(q)}
@@ -1476,7 +1482,7 @@ def test_expectation_from_density_matrix_basis_states():
     )
 
 
-def test_expectation_from_density_matrix_two_qubit_states():
+def test_expectation_from_density_matrix_two_qubit_states() -> None:
     q = cirq.LineQubit.range(2)
     q_map = {x: i for i, x in enumerate(q)}
 
@@ -1507,7 +1513,7 @@ def test_expectation_from_density_matrix_two_qubit_states():
         )
 
 
-def test_projector_sum_expectations_matrix():
+def test_projector_sum_expectations_matrix() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(
@@ -1524,7 +1530,7 @@ def test_projector_sum_expectations_matrix():
     )
 
 
-def test_projector_sum_expectations_from_state_vector():
+def test_projector_sum_expectations_from_state_vector() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(
@@ -1545,7 +1551,7 @@ def test_projector_sum_expectations_from_state_vector():
     )
 
 
-def test_projector_sum_expectations_from_density_matrix():
+def test_projector_sum_expectations_from_density_matrix() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(
@@ -1567,7 +1573,7 @@ def test_projector_sum_expectations_from_density_matrix():
     )
 
 
-def test_projector_sum_accessor():
+def test_projector_sum_accessor() -> None:
     q0 = cirq.NamedQubit('q0')
 
     projector_string_1 = cirq.ProjectorString({q0: 0}, 0.2016)
@@ -1582,7 +1588,7 @@ def test_projector_sum_accessor():
     assert expanded_projector_strings == [projector_string_1, projector_string_2]
 
 
-def test_projector_bool_operation():
+def test_projector_bool_operation() -> None:
     q0 = cirq.NamedQubit('q0')
 
     empty_projector_sum = cirq.ProjectorSum.from_projector_strings([])
@@ -1594,7 +1600,7 @@ def test_projector_bool_operation():
     assert non_empty_projector_sum
 
 
-def test_projector_sum_addition():
+def test_projector_sum_addition() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1612,10 +1618,10 @@ def test_projector_sum_addition():
     np.testing.assert_allclose(one_projector_sum.matrix().toarray(), [[0.0, 0.0], [0.0, 1.0]])
 
     with pytest.raises(TypeError):
-        _ = zero_projector_sum + 0.20160913
+        _ = zero_projector_sum + 0.20160913  # type: ignore[operator]
 
 
-def test_projector_sum_subtraction():
+def test_projector_sum_subtraction() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1633,10 +1639,10 @@ def test_projector_sum_subtraction():
     np.testing.assert_allclose(one_projector_sum.matrix().toarray(), [[0.0, 0.0], [0.0, 1.0]])
 
     with pytest.raises(TypeError):
-        _ = zero_projector_sum - 0.87539319
+        _ = zero_projector_sum - 0.87539319  # type: ignore[operator]
 
 
-def test_projector_sum_negation():
+def test_projector_sum_negation() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1648,7 +1654,7 @@ def test_projector_sum_negation():
     np.testing.assert_allclose(zero_projector_sum.matrix().toarray(), [[1.0, 0.0], [0.0, 0.0]])
 
 
-def test_projector_sum_incrementation():
+def test_projector_sum_incrementation() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1668,10 +1674,10 @@ def test_projector_sum_incrementation():
     np.testing.assert_allclose(one_projector_sum.matrix().toarray(), [[0.0, 0.0], [0.0, 1.0]])
 
     with pytest.raises(TypeError):
-        zero_projector_sum += 0.6963472309248
+        zero_projector_sum += 0.6963472309248  # type: ignore[arg-type]
 
 
-def test_projector_sum_decrementation():
+def test_projector_sum_decrementation() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1691,10 +1697,10 @@ def test_projector_sum_decrementation():
     np.testing.assert_allclose(one_projector_sum.matrix().toarray(), [[0.0, 0.0], [0.0, 1.0]])
 
     with pytest.raises(TypeError):
-        zero_projector_sum -= 0.12345
+        zero_projector_sum -= 0.12345  # type: ignore[arg-type]
 
 
-def test_projector_sum_multiplication_left():
+def test_projector_sum_multiplication_left() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1706,16 +1712,18 @@ def test_projector_sum_multiplication_left():
     np.testing.assert_allclose(multiplication_int.matrix().toarray(), [[2.0, 0.0], [0.0, 0.0]])
 
     multiplication_complex = 2j * zero_projector_sum
-    np.testing.assert_allclose(multiplication_complex.matrix().toarray(), [[2.0j, 0.0], [0.0, 0.0]])
+    np.testing.assert_allclose(
+        multiplication_complex.matrix().toarray(), [[2.0j, 0.0j], [0.0j, 0.0j]]
+    )
 
     # Check that the input is not changed:
     np.testing.assert_allclose(zero_projector_sum.matrix().toarray(), [[1.0, 0.0], [0.0, 0.0]])
 
     with pytest.raises(TypeError):
-        _ = 'not_the_correct_type' * zero_projector_sum
+        _ = 'not_the_correct_type' * zero_projector_sum  # type: ignore[operator]
 
 
-def test_projector_sum_multiplication_right():
+def test_projector_sum_multiplication_right() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1727,16 +1735,18 @@ def test_projector_sum_multiplication_right():
     np.testing.assert_allclose(multiplication_int.matrix().toarray(), [[2.0, 0.0], [0.0, 0.0]])
 
     multiplication_complex = zero_projector_sum * 2j
-    np.testing.assert_allclose(multiplication_complex.matrix().toarray(), [[2.0j, 0.0], [0.0, 0.0]])
+    np.testing.assert_allclose(
+        multiplication_complex.matrix().toarray(), [[2.0j, 0.0j], [0.0j, 0.0j]]
+    )
 
     # Check that the input is not changed:
-    np.testing.assert_allclose(zero_projector_sum.matrix().toarray(), [[1.0, 0.0], [0.0, 0.0]])
+    np.testing.assert_allclose(zero_projector_sum.matrix().toarray(), [[1.0, 0.0j], [0.0j, 0.0j]])
 
     with pytest.raises(TypeError):
-        _ = zero_projector_sum * 'not_the_correct_type'
+        _ = zero_projector_sum * 'not_the_correct_type'  # type: ignore[operator]
 
 
-def test_projector_sum_self_multiplication():
+def test_projector_sum_self_multiplication() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1751,13 +1761,15 @@ def test_projector_sum_self_multiplication():
 
     multiplication_complex = zero_projector_sum.copy()
     multiplication_complex *= 2j
-    np.testing.assert_allclose(multiplication_complex.matrix().toarray(), [[2.0j, 0.0], [0.0, 0.0]])
+    np.testing.assert_allclose(
+        multiplication_complex.matrix().toarray(), [[2.0j, 0.0j], [0.0j, 0.0j]]
+    )
 
     with pytest.raises(TypeError):
-        zero_projector_sum *= 'not_the_correct_type'
+        zero_projector_sum *= 'not_the_correct_type'  # type: ignore[arg-type]
 
 
-def test_projector_sum_weighted_sum():
+def test_projector_sum_weighted_sum() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1771,7 +1783,7 @@ def test_projector_sum_weighted_sum():
     np.testing.assert_allclose(one_projector_sum.matrix().toarray(), [[0.0, 0.0], [0.0, 1.0]])
 
 
-def test_projector_sum_division():
+def test_projector_sum_division() -> None:
     q0 = cirq.NamedQubit('q0')
 
     zero_projector_sum = cirq.ProjectorSum.from_projector_strings(cirq.ProjectorString({q0: 0}))
@@ -1783,13 +1795,15 @@ def test_projector_sum_division():
     np.testing.assert_allclose(true_division_int.matrix().toarray(), [[0.5, 0.0], [0.0, 0.0]])
 
     true_division_complex = zero_projector_sum / 2j
-    np.testing.assert_allclose(true_division_complex.matrix().toarray(), [[-0.5j, 0.0], [0.0, 0.0]])
+    np.testing.assert_allclose(
+        true_division_complex.matrix().toarray(), [[-0.5j, 0.0j], [0.0j, 0.0j]]
+    )
 
     # Check that the input is not changed:
     np.testing.assert_allclose(zero_projector_sum.matrix().toarray(), [[1.0, 0.0], [0.0, 0.0]])
 
     with pytest.raises(TypeError):
-        _ = zero_projector_sum / 'not_the_correct_type'
+        _ = zero_projector_sum / 'not_the_correct_type'  # type: ignore[operator]
 
 
 @pytest.mark.parametrize(
@@ -1801,6 +1815,6 @@ def test_projector_sum_division():
         ([cirq.ProjectorString({q0: 0, q1: 1})], (q0, q1)),
     ),
 )
-def test_projector_sum_has_correct_qubits(terms, expected_qubits):
+def test_projector_sum_has_correct_qubits(terms, expected_qubits) -> None:
     combination = cirq.ProjectorSum.from_projector_strings(terms)
     assert combination.qubits == expected_qubits

--- a/cirq-core/cirq/ops/matrix_gates_test.py
+++ b/cirq-core/cirq/ops/matrix_gates_test.py
@@ -28,7 +28,7 @@ QFT2 = np.array([[1, 1, 1, 1], [1, 1j, -1, -1j], [1, -1, 1, -1], [1, -1j, -1, 1j
 PLUS_ONE = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]])
 
 
-def test_single_qubit_init():
+def test_single_qubit_init() -> None:
     m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
     x2 = cirq.MatrixGate(m)
     assert cirq.has_unitary(x2)
@@ -50,7 +50,7 @@ def test_single_qubit_init():
         cirq.MatrixGate(np.ones((2, 2, 2)))
 
 
-def test_single_qubit_eq():
+def test_single_qubit_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cirq.MatrixGate(np.eye(2)))
     eq.make_equality_group(lambda: cirq.MatrixGate(np.array([[0, 1], [1, 0]])))
@@ -59,14 +59,14 @@ def test_single_qubit_eq():
     eq.add_equality_group(cirq.MatrixGate(PLUS_ONE, qid_shape=(3,)))
 
 
-def test_single_qubit_trace_distance_bound():
+def test_single_qubit_trace_distance_bound() -> None:
     x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
     x2 = cirq.MatrixGate(np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5))
     assert cirq.trace_distance_bound(x) >= 1
     assert cirq.trace_distance_bound(x2) >= 0.5
 
 
-def test_single_qubit_approx_eq():
+def test_single_qubit_approx_eq() -> None:
     x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
     i = cirq.MatrixGate(np.array([[1, 0], [0, 1]]))
     i_ish = cirq.MatrixGate(np.array([[1, 0.000000000000001], [0, 1]]))
@@ -76,7 +76,7 @@ def test_single_qubit_approx_eq():
     assert not cirq.approx_eq(i, '', atol=1e-9)
 
 
-def test_single_qubit_extrapolate():
+def test_single_qubit_extrapolate() -> None:
     i = cirq.MatrixGate(np.eye(2))
     x = cirq.MatrixGate(np.array([[0, 1], [1, 0]]))
     x2 = cirq.MatrixGate(np.array([[1, 1j], [1j, 1]]) * (1 - 1j) / 2)
@@ -97,20 +97,20 @@ def test_single_qubit_extrapolate():
         _ = x ** sympy.Symbol('a')
 
 
-def test_two_qubit_init():
+def test_two_qubit_init() -> None:
     x2 = cirq.MatrixGate(QFT2)
     assert cirq.has_unitary(x2)
     assert np.all(cirq.unitary(x2) == QFT2)
 
 
-def test_two_qubit_eq():
+def test_two_qubit_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(lambda: cirq.MatrixGate(np.eye(4)))
     eq.make_equality_group(lambda: cirq.MatrixGate(QFT2))
     eq.make_equality_group(lambda: cirq.MatrixGate(HH))
 
 
-def test_two_qubit_approx_eq():
+def test_two_qubit_approx_eq() -> None:
     f = cirq.MatrixGate(QFT2)
     perturb = np.zeros(shape=QFT2.shape, dtype=np.float64)
     perturb[1, 2] = 1e-8
@@ -123,7 +123,7 @@ def test_two_qubit_approx_eq():
     assert not cirq.approx_eq(f, cirq.MatrixGate(HH), atol=1e-9)
 
 
-def test_two_qubit_extrapolate():
+def test_two_qubit_extrapolate() -> None:
     cz2 = cirq.MatrixGate(np.diag([1, 1, 1, 1j]))
     cz4 = cirq.MatrixGate(np.diag([1, 1, 1, (1 + 1j) * np.sqrt(0.5)]))
     i = cirq.MatrixGate(np.eye(4))
@@ -135,7 +135,7 @@ def test_two_qubit_extrapolate():
         _ = cz2 ** sympy.Symbol('a')
 
 
-def test_single_qubit_diagram():
+def test_single_qubit_diagram() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
@@ -169,11 +169,11 @@ a[          ]+  b
     )
 
 
-def test_two_qubit_diagram():
+def test_two_qubit_diagram() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
-    c = cirq.Circuit(
+    circuit = cirq.Circuit(
         cirq.MatrixGate(cirq.unitary(cirq.CZ)).on(a, b),
         cirq.MatrixGate(cirq.unitary(cirq.CZ)).on(c, a),
     )
@@ -195,7 +195,7 @@ c: ────[──────────]+────│[0-9\.+\-j ]+│�
        [          ]+    │[0-9\.+\-j ]+│
        [          ]+    └[          ]+┘
     """.strip(),
-        c.to_text_diagram().strip(),
+        circuit.to_text_diagram().strip(),
     )
 
     assert re.match(
@@ -217,11 +217,11 @@ a[          ]+  b  c
 │[          ]+  │  └[          ]+┘
 │[          ]+  │  │
     """.strip(),
-        c.to_text_diagram(transpose=True).strip(),
+        circuit.to_text_diagram(transpose=True).strip(),
     )
 
 
-def test_named_single_qubit_diagram():
+def test_named_single_qubit_diagram() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     m = np.array([[1, 1j], [1j, 1]]) * np.sqrt(0.5)
@@ -245,11 +245,11 @@ Foo │
     assert expected_vertical == c.to_text_diagram(transpose=True).strip()
 
 
-def test_named_two_qubit_diagram():
+def test_named_two_qubit_diagram() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
-    c = cirq.Circuit(
+    circuit = cirq.Circuit(
         cirq.MatrixGate(cirq.unitary(cirq.CZ), name='Foo').on(a, b),
         cirq.MatrixGate(cirq.unitary(cirq.CZ), name='Bar').on(c, a),
     )
@@ -261,7 +261,7 @@ b: ───Foo[2]───┼────────
                │
 c: ────────────Bar[1]───
     """.strip()
-    assert expected_horizontal == c.to_text_diagram().strip()
+    assert expected_horizontal == circuit.to_text_diagram().strip()
 
     expected_vertical = """
 a      b      c
@@ -271,10 +271,10 @@ Foo[1]─Foo[2] │
 Bar[2]─┼──────Bar[1]
 │      │      │
     """.strip()
-    assert expected_vertical == c.to_text_diagram(transpose=True).strip()
+    assert expected_vertical == circuit.to_text_diagram(transpose=True).strip()
 
 
-def test_with_name():
+def test_with_name() -> None:
     gate = cirq.MatrixGate(cirq.unitary(cirq.Z**0.25))
     T = gate.with_name('T')
     S = (T**2).with_name('S')
@@ -284,13 +284,13 @@ def test_with_name():
     np.testing.assert_allclose(cirq.unitary(S), cirq.unitary(T**2))
 
 
-def test_str_executes():
+def test_str_executes() -> None:
     assert '1' in str(cirq.MatrixGate(np.eye(2)))
     assert '0' in str(cirq.MatrixGate(np.eye(4)))
 
 
 @pytest.mark.parametrize('n', [1, 2, 3, 4, 5])
-def test_implements_consistent_protocols(n):
+def test_implements_consistent_protocols(n) -> None:
     u = cirq.testing.random_unitary(2**n)
     g1 = cirq.MatrixGate(u)
     cirq.testing.assert_implements_consistent_protocols(g1, ignoring_global_phase=True)
@@ -304,12 +304,12 @@ def test_implements_consistent_protocols(n):
     cirq.testing.assert_decompose_ends_at_default_gateset(g2)
 
 
-def test_repr():
+def test_repr() -> None:
     cirq.testing.assert_equivalent_repr(cirq.MatrixGate(cirq.testing.random_unitary(2)))
     cirq.testing.assert_equivalent_repr(cirq.MatrixGate(cirq.testing.random_unitary(4)))
 
 
-def test_matrix_gate_init_validation():
+def test_matrix_gate_init_validation() -> None:
     with pytest.raises(ValueError, match='square 2d numpy array'):
         _ = cirq.MatrixGate(np.ones(shape=(1, 1, 1)))
     with pytest.raises(ValueError, match='square 2d numpy array'):
@@ -322,7 +322,7 @@ def test_matrix_gate_init_validation():
         _ = cirq.MatrixGate(np.eye(3), qid_shape=(4,))
 
 
-def test_matrix_gate_eq():
+def test_matrix_gate_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(cirq.MatrixGate(np.eye(1)))
     eq.add_equality_group(cirq.MatrixGate(-np.eye(1)))
@@ -330,7 +330,7 @@ def test_matrix_gate_eq():
     eq.add_equality_group(cirq.MatrixGate(np.diag([1, 1, 1, 1, 1, -1]), qid_shape=(3, 2)))
 
 
-def test_matrix_gate_pow():
+def test_matrix_gate_pow() -> None:
     t = sympy.Symbol('t')
     assert cirq.pow(cirq.MatrixGate(1j * np.eye(1)), t, default=None) is None
     assert cirq.pow(cirq.MatrixGate(1j * np.eye(1)), 2) == cirq.MatrixGate(-np.eye(1))
@@ -339,7 +339,7 @@ def test_matrix_gate_pow():
     assert m**3 == cirq.MatrixGate(np.diag([1, -1j, -1]), qid_shape=(3,))
 
 
-def test_phase_by():
+def test_phase_by() -> None:
     # Single qubit case.
     x = cirq.MatrixGate(cirq.unitary(cirq.X))
     y = cirq.phase_by(x, 0.25, 0)
@@ -363,14 +363,14 @@ def test_phase_by():
         _ = cirq.phase_by(m, 0.25, 0)
 
 
-def test_protocols_and_repr():
+def test_protocols_and_repr() -> None:
     cirq.testing.assert_implements_consistent_protocols(cirq.MatrixGate(np.diag([1, 1j, 1, -1])))
     cirq.testing.assert_implements_consistent_protocols(
         cirq.MatrixGate(np.diag([1, 1j, -1]), qid_shape=(3,))
     )
 
 
-def test_matrixgate_unitary_tolerance():
+def test_matrixgate_unitary_tolerance() -> None:
     ## non-unitary matrix
     with pytest.raises(ValueError):
         _ = cirq.MatrixGate(np.array([[1, 0], [0, -0.6]]), unitary_check_atol=0.5)
@@ -393,7 +393,7 @@ def test_matrixgate_unitary_tolerance():
         _ = cirq.MatrixGate(np.array([[0.707, 0.707], [-0.707, 0.707]]), unitary_check_rtol=1e-10)
 
 
-def test_matrixgate_name_serialization():
+def test_matrixgate_name_serialization() -> None:
     # https://github.com/quantumlib/Cirq/issues/5999
 
     # Test name serialization
@@ -415,7 +415,7 @@ def test_matrixgate_name_serialization():
     assert gate_after_serialization3._name == ''
 
 
-def test_decompose_when_qubits_not_in_ascending_order():
+def test_decompose_when_qubits_not_in_ascending_order() -> None:
     # Previous code for preserving global phase would misorder qubits
     q0, q1 = cirq.LineQubit.range(2)
     circuit1 = cirq.Circuit()

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -20,7 +20,7 @@ import pytest
 import cirq
 
 
-def test_measure_qubits():
+def test_measure_qubits() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -48,6 +48,7 @@ def test_measure_qubits():
     assert cirq.measure(cirq.LineQid.for_qid_shape((1, 2, 3)), key='a') == cirq.MeasurementGate(
         num_qubits=3, key='a', qid_shape=(1, 2, 3)
     ).on(*cirq.LineQid.for_qid_shape((1, 2, 3)))
+    cmap: dict[tuple[int, ...], np.ndarray]
     cmap = {(0,): np.array([[0, 1], [1, 0]])}
     assert cirq.measure(a, confusion_map=cmap) == cirq.MeasurementGate(
         num_qubits=1, key='a', confusion_map=cmap
@@ -57,16 +58,16 @@ def test_measure_qubits():
         _ = cirq.measure(np.array([1, 0]))
 
     with pytest.raises(ValueError, match='Qid'):
-        _ = cirq.measure("bork")
+        _ = cirq.measure("bork")  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match='Qid'):
-        _ = cirq.measure([a, [b]])
+        _ = cirq.measure([a, [b]])  # type: ignore[list-item]
 
     with pytest.raises(ValueError, match='Qid'):
-        _ = cirq.measure([a], [b])
+        _ = cirq.measure([a], [b])  # type: ignore
 
 
-def test_measure_each():
+def test_measure_each() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
 
@@ -83,13 +84,13 @@ def test_measure_each():
         cirq.measure(b.with_dimension(3)),
     ]
 
-    assert cirq.measure_each(a, b, key_func=lambda e: e.name + '!') == [
+    assert cirq.measure_each(a, b, key_func=lambda e: e.name + '!') == [  # type: ignore[attr-defined]
         cirq.measure(a, key='a!'),
         cirq.measure(b, key='b!'),
     ]
 
 
-def test_measure_single_paulistring():
+def test_measure_single_paulistring() -> None:
     # Correct application
     q = cirq.LineQubit.range(3)
     ps = cirq.X(q[0]) * cirq.Y(q[1]) * cirq.Z(q[2])
@@ -109,14 +110,14 @@ def test_measure_single_paulistring():
 
     # Wrong type
     with pytest.raises(ValueError, match='should be an instance of cirq.PauliString'):
-        _ = cirq.measure_single_paulistring(q)
+        _ = cirq.measure_single_paulistring(q)  # type: ignore[arg-type]
 
     # Coefficient != +1 or -1
     with pytest.raises(ValueError, match='must have a coefficient'):
         _ = cirq.measure_single_paulistring(-2 * ps)
 
 
-def test_measure_paulistring_terms():
+def test_measure_paulistring_terms() -> None:
     # Correct application
     q = cirq.LineQubit.range(3)
     ps = cirq.X(q[0]) * cirq.Y(q[1]) * cirq.Z(q[2])
@@ -132,4 +133,4 @@ def test_measure_paulistring_terms():
 
     # Wrong type
     with pytest.raises(ValueError, match='should be an instance of cirq.PauliString'):
-        _ = cirq.measure_paulistring_terms(q)
+        _ = cirq.measure_paulistring_terms(q)  # type: ignore[arg-type]

--- a/cirq-core/cirq/ops/measurement_gate_test.py
+++ b/cirq-core/cirq/ops/measurement_gate_test.py
@@ -26,14 +26,14 @@ import cirq
     'key',
     ['q0_1_0', cirq.MeasurementKey(name='q0_1_0'), cirq.MeasurementKey(path=('a', 'b'), name='c')],
 )
-def test_eval_repr(key):
+def test_eval_repr(key) -> None:
     # Basic safeguard against repr-inequality.
     op = cirq.GateOperation(gate=cirq.MeasurementGate(1, key), qubits=[cirq.GridQubit(0, 1)])
     cirq.testing.assert_equivalent_repr(op)
 
 
 @pytest.mark.parametrize('num_qubits', [1, 2, 4])
-def test_measure_init(num_qubits):
+def test_measure_init(num_qubits) -> None:
     assert cirq.MeasurementGate(num_qubits, 'a').num_qubits() == num_qubits
     assert cirq.MeasurementGate(num_qubits, key='a').key == 'a'
     assert cirq.MeasurementGate(num_qubits, key='a').mkey == cirq.MeasurementKey('a')
@@ -43,11 +43,12 @@ def test_measure_init(num_qubits):
     )
     assert cirq.MeasurementGate(num_qubits, 'a', invert_mask=(True,)).invert_mask == (True,)
     assert cirq.qid_shape(cirq.MeasurementGate(num_qubits, 'a')) == (2,) * num_qubits
+    cmap: dict[tuple[int, ...], np.ndarray]
     cmap = {(0,): np.array([[0, 1], [1, 0]])}
     assert cirq.MeasurementGate(num_qubits, 'a', confusion_map=cmap).confusion_map == cmap
 
 
-def test_measure_init_num_qubit_agnostic():
+def test_measure_init_num_qubit_agnostic() -> None:
     assert cirq.qid_shape(cirq.MeasurementGate(3, 'a', qid_shape=(1, 2, 3))) == (1, 2, 3)
     assert cirq.qid_shape(cirq.MeasurementGate(key='a', qid_shape=(1, 2, 3))) == (1, 2, 3)
     with pytest.raises(ValueError, match='len.* >'):
@@ -55,24 +56,24 @@ def test_measure_init_num_qubit_agnostic():
     with pytest.raises(ValueError, match='len.* !='):
         cirq.MeasurementGate(5, 'a', qid_shape=(1, 2))
     with pytest.raises(ValueError, match='valid string'):
-        cirq.MeasurementGate(2, qid_shape=(1, 2), key=None)
+        cirq.MeasurementGate(2, qid_shape=(1, 2), key=None)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match='Confusion matrices have index out of bounds'):
         cirq.MeasurementGate(1, 'a', confusion_map={(1,): np.array([[0, 1], [1, 0]])})
     with pytest.raises(ValueError, match='Specify either'):
         cirq.MeasurementGate()
 
 
-def test_measurement_has_unitary_returns_false():
+def test_measurement_has_unitary_returns_false() -> None:
     gate = cirq.MeasurementGate(1, 'a')
     assert not cirq.has_unitary(gate)
 
 
 @pytest.mark.parametrize('num_qubits', [1, 2, 4])
-def test_has_stabilizer_effect(num_qubits):
+def test_has_stabilizer_effect(num_qubits) -> None:
     assert cirq.has_stabilizer_effect(cirq.MeasurementGate(num_qubits, 'a'))
 
 
-def test_measurement_eq():
+def test_measurement_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(
         lambda: cirq.MeasurementGate(1, 'a'),
@@ -93,7 +94,7 @@ def test_measurement_eq():
     eq.add_equality_group(cirq.MeasurementGate(3, 'a', qid_shape=(1, 2, 3)))
 
 
-def test_measurement_full_invert_mask():
+def test_measurement_full_invert_mask() -> None:
     assert cirq.MeasurementGate(1, 'a').full_invert_mask() == (False,)
     assert cirq.MeasurementGate(2, 'a', invert_mask=(False, True)).full_invert_mask() == (
         False,
@@ -112,7 +113,7 @@ def test_measurement_full_invert_mask():
         cirq.MeasurementGate(2, 'a', invert_mask=(True, False), qid_shape=(2, 3)),
     ],
 )
-def test_measurement_with_key(use_protocol, gate):
+def test_measurement_with_key(use_protocol, gate) -> None:
     if use_protocol:
         gate1 = cirq.with_measurement_key_mapping(gate, {'a': 'b'})
     else:
@@ -136,7 +137,7 @@ def test_measurement_with_key(use_protocol, gate):
         (3, (False, False), [0, 2], (True, False, True)),
     ],
 )
-def test_measurement_with_bits_flipped(num_qubits, mask, bits, flipped):
+def test_measurement_with_bits_flipped(num_qubits, mask, bits, flipped) -> None:
     gate = cirq.MeasurementGate(num_qubits, key='a', invert_mask=mask, qid_shape=(3,) * num_qubits)
 
     gate1 = gate.with_bits_flipped(*bits)
@@ -150,7 +151,7 @@ def test_measurement_with_bits_flipped(num_qubits, mask, bits, flipped):
     assert gate2.full_invert_mask() == gate.full_invert_mask()
 
 
-def test_qudit_measure_qasm():
+def test_qudit_measure_qasm() -> None:
     assert (
         cirq.qasm(
             cirq.measure(cirq.LineQid(0, 3), key='a'),
@@ -161,7 +162,7 @@ def test_qudit_measure_qasm():
     )
 
 
-def test_confused_measure_qasm():
+def test_confused_measure_qasm() -> None:
     q0 = cirq.LineQubit(0)
     assert (
         cirq.qasm(
@@ -173,7 +174,7 @@ def test_confused_measure_qasm():
     )
 
 
-def test_measurement_gate_diagram():
+def test_measurement_gate_diagram() -> None:
     # Shows key.
     assert cirq.circuit_diagram_info(
         cirq.MeasurementGate(1, key='test')
@@ -245,7 +246,7 @@ b: ───M───────────
     )
 
 
-def test_measurement_channel():
+def test_measurement_channel() -> None:
     np.testing.assert_allclose(
         cirq.kraus(cirq.MeasurementGate(1, 'a')),
         (np.array([[1, 0], [0, 0]]), np.array([[0, 0], [0, 1]])),
@@ -282,7 +283,7 @@ def test_measurement_channel():
     # yapf: enable
 
 
-def test_measurement_qubit_count_vs_mask_length():
+def test_measurement_qubit_count_vs_mask_length() -> None:
     a = cirq.NamedQubit('a')
     b = cirq.NamedQubit('b')
     c = cirq.NamedQubit('c')
@@ -296,7 +297,7 @@ def test_measurement_qubit_count_vs_mask_length():
         _ = cirq.MeasurementGate(num_qubits=3, key='a', invert_mask=(True, False, True)).on(a, b)
 
 
-def test_consistent_protocols():
+def test_consistent_protocols() -> None:
     for n in range(1, 5):
         gate = cirq.MeasurementGate(num_qubits=n, key='a')
         cirq.testing.assert_implements_consistent_protocols(gate)
@@ -305,7 +306,7 @@ def test_consistent_protocols():
         cirq.testing.assert_implements_consistent_protocols(gate)
 
 
-def test_op_repr():
+def test_op_repr() -> None:
     a, b = cirq.LineQubit.range(2)
     assert repr(cirq.measure(a)) == 'cirq.measure(cirq.LineQubit(0))'
     assert repr(cirq.measure(a, b)) == ('cirq.measure(cirq.LineQubit(0), cirq.LineQubit(1))')
@@ -330,7 +331,7 @@ def test_op_repr():
     )
 
 
-def test_repr():
+def test_repr() -> None:
     gate = cirq.MeasurementGate(
         3,
         'a',
@@ -345,7 +346,7 @@ def test_repr():
     )
 
 
-def test_act_on_state_vector():
+def test_act_on_state_vector() -> None:
     a, b = [cirq.LineQubit(3), cirq.LineQubit(1)]
     m = cirq.measure(
         a, b, key='out', invert_mask=(True,), confusion_map={(1,): np.array([[0, 1], [1, 0]])}
@@ -392,7 +393,7 @@ def test_act_on_state_vector():
     assert datastore.records[out] == [(0, 0), (0, 0)]
 
 
-def test_act_on_clifford_tableau():
+def test_act_on_clifford_tableau() -> None:
     a, b = [cirq.LineQubit(3), cirq.LineQubit(1)]
     m = cirq.measure(
         a, b, key='out', invert_mask=(True,), confusion_map={(1,): np.array([[0, 1], [1, 0]])}
@@ -432,7 +433,7 @@ def test_act_on_clifford_tableau():
     assert datastore.records[out] == [(0, 0), (0, 0)]
 
 
-def test_act_on_stabilizer_ch_form():
+def test_act_on_stabilizer_ch_form() -> None:
     a, b = [cirq.LineQubit(3), cirq.LineQubit(1)]
     m = cirq.measure(
         a, b, key='out', invert_mask=(True,), confusion_map={(1,): np.array([[0, 1], [1, 0]])}
@@ -466,7 +467,7 @@ def test_act_on_stabilizer_ch_form():
     assert datastore.records[out] == [(0, 0), (0, 0)]
 
 
-def test_act_on_qutrit():
+def test_act_on_qutrit() -> None:
     a, b = [cirq.LineQid(3, dimension=3), cirq.LineQid(1, dimension=3)]
     m = cirq.measure(
         a,

--- a/cirq-core/cirq/ops/pauli_gates.py
+++ b/cirq-core/cirq/ops/pauli_gates.py
@@ -56,7 +56,7 @@ class Pauli(raw_types.Gate, metaclass=abc.ABCMeta):
         self._index = index
         self._name = name
 
-    def num_qubits(self):
+    def num_qubits(self) -> int:
         return 1
 
     def _commutes_(self, other: Any, *, atol: float = 1e-8) -> bool | NotImplementedType | None:

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -23,7 +23,7 @@ import cirq
     'key',
     ['q0_1_0', cirq.MeasurementKey(name='q0_1_0'), cirq.MeasurementKey(path=('a', 'b'), name='c')],
 )
-def test_eval_repr(key):
+def test_eval_repr(key) -> None:
     # Basic safeguard against repr-inequality.
     op = cirq.GateOperation(
         gate=cirq.PauliMeasurementGate([cirq.X, cirq.Y], key),
@@ -36,7 +36,7 @@ def test_eval_repr(key):
 
 @pytest.mark.parametrize('observable', [[cirq.X], [cirq.Y, cirq.Z], cirq.DensePauliString('XYZ')])
 @pytest.mark.parametrize('key', ['a', cirq.MeasurementKey('a')])
-def test_init(observable, key):
+def test_init(observable, key) -> None:
     g = cirq.PauliMeasurementGate(observable, key)
     assert g.num_qubits() == len(observable)
     assert g.key == 'a'
@@ -45,12 +45,12 @@ def test_init(observable, key):
     assert cirq.qid_shape(g) == (2,) * len(observable)
 
 
-def test_measurement_has_unitary_returns_false():
+def test_measurement_has_unitary_returns_false() -> None:
     gate = cirq.PauliMeasurementGate([cirq.X], 'a')
     assert not cirq.has_unitary(gate)
 
 
-def test_measurement_eq():
+def test_measurement_eq() -> None:
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(
         lambda: cirq.PauliMeasurementGate([cirq.X, cirq.Y], 'a'),
@@ -76,7 +76,7 @@ def test_measurement_eq():
         cirq.PauliMeasurementGate([cirq.X, cirq.Y, cirq.Z], 'a'),
     ],
 )
-def test_measurement_with_key(protocol, args, key, gate):
+def test_measurement_with_key(protocol, args, key, gate) -> None:
     if protocol:
         gate_with_key = protocol(gate, args)
     else:
@@ -92,7 +92,7 @@ def test_measurement_with_key(protocol, args, key, gate):
     assert same_gate == gate
 
 
-def test_measurement_gate_diagram():
+def test_measurement_gate_diagram() -> None:
     # Shows observable & key.
     assert cirq.circuit_diagram_info(
         cirq.PauliMeasurementGate([cirq.X], key='test')
@@ -129,14 +129,14 @@ b: ───M(Y)───────────
     'key',
     ['q0_1_0', cirq.MeasurementKey(name='q0_1_0'), cirq.MeasurementKey(path=('a', 'b'), name='c')],
 )
-def test_consistent_protocols(observable, key):
+def test_consistent_protocols(observable, key) -> None:
     gate = cirq.PauliMeasurementGate(observable, key=key)
     cirq.testing.assert_implements_consistent_protocols(gate)
     assert cirq.is_measurement(gate)
     assert cirq.measurement_key_name(gate) == str(key)
 
 
-def test_op_repr():
+def test_op_repr() -> None:
     a, b, c = cirq.LineQubit.range(3)
     ps = cirq.X(a) * cirq.Y(b) * cirq.Z(c)
     assert (
@@ -152,12 +152,12 @@ def test_op_repr():
     )
 
 
-def test_bad_observable_raises():
+def test_bad_observable_raises() -> None:
     with pytest.raises(ValueError, match='Pauli observable .* is empty'):
         _ = cirq.PauliMeasurementGate([])
 
     with pytest.raises(ValueError, match=r'Pauli observable .* must be Iterable\[`cirq.Pauli`\]'):
-        _ = cirq.PauliMeasurementGate([cirq.I, cirq.X, cirq.Y])
+        _ = cirq.PauliMeasurementGate([cirq.I, cirq.X, cirq.Y])  # type: ignore[list-item]
 
     with pytest.raises(ValueError, match=r'Pauli observable .* must be Iterable\[`cirq.Pauli`\]'):
         _ = cirq.PauliMeasurementGate(cirq.DensePauliString('XYZI'))
@@ -166,7 +166,7 @@ def test_bad_observable_raises():
         _ = cirq.PauliMeasurementGate(cirq.DensePauliString('XYZ', coefficient=1j))
 
 
-def test_with_observable():
+def test_with_observable() -> None:
     o1 = [cirq.Z, cirq.Y, cirq.X]
     o2 = [cirq.X, cirq.Y, cirq.Z]
     g1 = cirq.PauliMeasurementGate(o1, key='a')
@@ -186,7 +186,7 @@ def test_with_observable():
         (cirq.X**-0.5, cirq.DensePauliString("Y", coefficient=-1), 1),
     ],
 )
-def test_pauli_measurement_gate_samples(rot, obs, out):
+def test_pauli_measurement_gate_samples(rot, obs, out) -> None:
     q = cirq.NamedQubit("q")
     c = cirq.Circuit(rot(q), cirq.PauliMeasurementGate(obs, key='out').on(q))
     assert cirq.Simulator().sample(c)['out'][0] == out

--- a/cirq-core/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor_test.py
@@ -31,11 +31,11 @@ dps_xyz = cirq.DensePauliString('XYZ')
 dps_zyx = cirq.DensePauliString('ZYX')
 
 
-def _make_qubits(n):
+def _make_qubits(n) -> list[cirq.Qid]:
     return [cirq.NamedQubit(f'q{i}') for i in range(n)]
 
 
-def test_init():
+def test_init() -> None:
     a = cirq.LineQubit(0)
     with pytest.raises(ValueError, match='eigenvalues'):
         _ = cirq.PauliStringPhasor(1j * cirq.X(a))
@@ -50,7 +50,7 @@ def test_init():
     assert v2.exponent_pos == -0.125
 
 
-def test_qubit_order_mismatch():
+def test_qubit_order_mismatch() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     with pytest.raises(ValueError, match='are not an ordered subset'):
         _ = cirq.PauliStringPhasor(1j * cirq.X(q0), qubits=[q1])
@@ -62,7 +62,7 @@ def test_qubit_order_mismatch():
         _ = cirq.PauliStringPhasor(1j * cirq.X(q0) * cirq.X(q1), qubits=[q1, q0])
 
 
-def test_eq_ne_hash():
+def test_eq_ne_hash() -> None:
     q0, q1, q2, q3 = _make_qubits(4)
     eq = cirq.testing.EqualsTester()
     ps1 = cirq.X(q0) * cirq.Y(q1) * cirq.Z(q2)
@@ -83,7 +83,7 @@ def test_eq_ne_hash():
     eq.add_equality_group(cirq.PauliStringPhasor(ps1, qubits=[q0, q1, q2, q3]))
 
 
-def test_equal_up_to_global_phase():
+def test_equal_up_to_global_phase() -> None:
     a, b, c = cirq.LineQubit.range(3)
     groups = [
         [
@@ -106,13 +106,13 @@ def test_equal_up_to_global_phase():
     ]
     for g1 in groups:
         for e1 in g1:
-            assert not e1.equal_up_to_global_phase("not even close")
+            assert not e1.equal_up_to_global_phase("not even close")  # type: ignore[arg-type]
             for g2 in groups:
                 for e2 in g2:
                     assert e1.equal_up_to_global_phase(e2) == (g1 is g2)
 
 
-def test_map_qubits():
+def test_map_qubits() -> None:
     q0, q1, q2, q3, q4, q5 = _make_qubits(6)
     qubit_map = {q1: q2, q0: q3}
     before = cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Z, q1: cirq.Y}), exponent_neg=0.1)
@@ -129,7 +129,7 @@ def test_map_qubits():
     assert before.map_qubits(qubit_map) == after
 
 
-def test_map_qubits_missing_qubits():
+def test_map_qubits_missing_qubits() -> None:
     q0, q1, q2 = _make_qubits(3)
     qubit_map = {q1: q2}
     before = cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Z, q1: cirq.Y}), exponent_neg=0.1)
@@ -137,7 +137,8 @@ def test_map_qubits_missing_qubits():
         _ = before.map_qubits(qubit_map)
 
 
-def test_pow():
+def test_pow() -> None:
+    s: cirq.PauliString[cirq.Qid]
     a = cirq.LineQubit(0)
     s = cirq.PauliString({a: cirq.X})
     p = cirq.PauliStringPhasor(s, exponent_neg=0.25, exponent_pos=0.5)
@@ -149,7 +150,7 @@ def test_pow():
     assert p**0.5 == cirq.PauliStringPhasor(s, exponent_neg=0.125, exponent_pos=0.25)
 
 
-def test_consistent():
+def test_consistent() -> None:
     a, b = cirq.LineQubit.range(2)
     op = np.exp(1j * np.pi / 2 * cirq.X(a) * cirq.X(b))
     cirq.testing.assert_implements_consistent_protocols(op)
@@ -157,11 +158,13 @@ def test_consistent():
     cirq.testing.assert_implements_consistent_protocols(p)
 
 
-def test_conjugated_by():
+def test_conjugated_by() -> None:
     q0, q1 = _make_qubits(2)
     op = cirq.SingleQubitCliffordGate.from_double_map(
         {cirq.Z: (cirq.X, False), cirq.X: (cirq.Z, False)}
     )(q0)
+    ps_before: cirq.PauliString[cirq.Qid]
+    ps_after: cirq.PauliString[cirq.Qid]
     ps_before = cirq.PauliString({q0: cirq.X, q1: cirq.Y}, -1)
     ps_after = cirq.PauliString({q0: cirq.Z, q1: cirq.Y}, -1)
     before = cirq.PauliStringPhasor(ps_before, exponent_neg=0.1)
@@ -169,7 +172,7 @@ def test_conjugated_by():
     assert before.conjugated_by(op).pauli_string == after.pauli_string
 
 
-def test_extrapolate_effect():
+def test_extrapolate_effect() -> None:
     op1 = cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=0.5)
     op2 = cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=1.5)
     op3 = cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=0.125)
@@ -177,7 +180,7 @@ def test_extrapolate_effect():
     assert op1**0.25 == op3
 
 
-def test_extrapolate_effect_with_symbol():
+def test_extrapolate_effect_with_symbol() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=sympy.Symbol('a')),
@@ -196,7 +199,8 @@ def test_extrapolate_effect_with_symbol():
     )
 
 
-def test_inverse():
+def test_inverse() -> None:
+    i: cirq.PauliString
     i = cirq.PauliString({})
     op1 = cirq.PauliStringPhasor(i, exponent_neg=0.25)
     op2 = cirq.PauliStringPhasor(i, exponent_neg=-0.25)
@@ -206,7 +210,7 @@ def test_inverse():
     assert cirq.inverse(op3, None) == op4
 
 
-def test_can_merge_with():
+def test_can_merge_with() -> None:
     q0, q1 = _make_qubits(2)
 
     op1 = cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=0.25)
@@ -228,7 +232,7 @@ def test_can_merge_with():
     assert not op1.can_merge_with(op2)
 
 
-def test_merge_with():
+def test_merge_with() -> None:
     (q0,) = _make_qubits(1)
 
     op1 = cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=0.25)
@@ -262,7 +266,7 @@ def test_merge_with():
         op1.merged_with(op2)
 
 
-def test_is_parameterized():
+def test_is_parameterized() -> None:
     op = cirq.PauliStringPhasor(cirq.PauliString({}))
     assert not cirq.is_parameterized(op)
     assert not cirq.is_parameterized(op**0.1)
@@ -270,7 +274,7 @@ def test_is_parameterized():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_with_parameters_resolved_by(resolve_fn):
+def test_with_parameters_resolved_by(resolve_fn) -> None:
     op = cirq.PauliStringPhasor(cirq.PauliString({}), exponent_neg=sympy.Symbol('a'))
     resolver = cirq.ParamResolver({'a': 0.1})
     actual = resolve_fn(op, resolver)
@@ -284,7 +288,7 @@ def test_with_parameters_resolved_by(resolve_fn):
         resolve_fn(op, cirq.ParamResolver({'a': 0.1j}))
 
 
-def test_drop_negligible():
+def test_drop_negligible() -> None:
     (q0,) = _make_qubits(1)
     sym = sympy.Symbol('a')
     circuit = cirq.Circuit(
@@ -301,7 +305,7 @@ def test_drop_negligible():
     assert circuit == expected
 
 
-def test_manual_default_decompose():
+def test_manual_default_decompose() -> None:
     q0, q1, q2 = _make_qubits(3)
 
     mat = cirq.Circuit(
@@ -352,7 +356,7 @@ def test_manual_default_decompose():
         (+1, -1),
     ),
 )
-def test_default_decompose(paulis, phase_exponent_negative: float, sign: int):
+def test_default_decompose(paulis, phase_exponent_negative: float, sign: int) -> None:
     paulis = [pauli for pauli in paulis if pauli is not None]
     qubits = _make_qubits(len(paulis))
 
@@ -380,8 +384,9 @@ def test_default_decompose(paulis, phase_exponent_negative: float, sign: int):
     cirq.testing.assert_allclose_up_to_global_phase(actual, expected, rtol=1e-7, atol=1e-7)
 
 
-def test_decompose_with_symbol():
+def test_decompose_with_symbol() -> None:
     (q0,) = _make_qubits(1)
+    ps: cirq.PauliString[cirq.Qid]
     ps = cirq.PauliString({q0: cirq.Y})
     op = cirq.PauliStringPhasor(ps, exponent_neg=sympy.Symbol('a'))
     circuit = cirq.Circuit(op)
@@ -395,7 +400,7 @@ def test_decompose_with_symbol():
     cirq.testing.assert_has_diagram(circuit, "q0: ───X^0.5───X───Z^a───X───X^-0.5───")
 
 
-def test_text_diagram():
+def test_text_diagram() -> None:
     q0, q1, q2 = _make_qubits(3)
     circuit = cirq.Circuit(
         cirq.PauliStringPhasor(cirq.PauliString({q0: cirq.Z})),
@@ -424,14 +429,14 @@ q2: ────────────────────[Z]───[X]^
     )
 
 
-def test_empty_phasor_diagram():
+def test_empty_phasor_diagram() -> None:
     q = cirq.LineQubit(0)
     op = cirq.PauliSumExponential(cirq.I(q))
     circuit = cirq.Circuit(op)
     cirq.testing.assert_has_diagram(circuit, '    (I)**-0.6366197723675815')
 
 
-def test_repr():
+def test_repr() -> None:
     q0, q1, q2 = _make_qubits(3)
     cirq.testing.assert_equivalent_repr(
         cirq.PauliStringPhasor(
@@ -447,7 +452,7 @@ def test_repr():
     )
 
 
-def test_str():
+def test_str() -> None:
     q0, q1, q2 = _make_qubits(3)
     ps = cirq.PauliStringPhasor(cirq.PauliString({q2: cirq.Z, q1: cirq.Y, q0: cirq.X}, +1)) ** 0.5
     assert str(ps) == '(X(q0)*Y(q1)*Z(q2))**0.5'
@@ -466,7 +471,7 @@ def test_str():
     assert str(ps) == '(X(q0))**0.5'
 
 
-def test_old_json():
+def test_old_json() -> None:
     """Older versions of PauliStringPhasor did not have a qubit field."""
     old_json = """
     {
@@ -532,7 +537,7 @@ def test_old_json():
     )
 
 
-def test_gate_init():
+def test_gate_init() -> None:
     a = cirq.LineQubit(0)
     with pytest.raises(ValueError, match='eigenvalues'):
         _ = cirq.PauliStringPhasorGate(1j * cirq.X(a))
@@ -550,7 +555,7 @@ def test_gate_init():
     assert v2.exponent_pos == -0.125
 
 
-def test_gate_on():
+def test_gate_on() -> None:
     q = cirq.LineQubit(0)
     g1 = cirq.PauliStringPhasorGate(
         cirq.DensePauliString('X', coefficient=-1), exponent_neg=0.25, exponent_pos=-0.5
@@ -574,7 +579,7 @@ def test_gate_on():
     assert op2.exponent_pos == -0.125
 
 
-def test_gate_eq_ne_hash():
+def test_gate_eq_ne_hash() -> None:
     eq = cirq.testing.EqualsTester()
     dps_xyx = cirq.DensePauliString('XYX')
     eq.make_equality_group(
@@ -602,7 +607,7 @@ def test_gate_eq_ne_hash():
     eq.add_equality_group(cirq.PauliStringPhasorGate(dps_xyz, exponent_neg=sympy.Symbol('a')))
 
 
-def test_gate_equal_up_to_global_phase():
+def test_gate_equal_up_to_global_phase() -> None:
     groups = [
         [
             cirq.PauliStringPhasorGate(dps_x, exponent_neg=0.25),
@@ -615,13 +620,13 @@ def test_gate_equal_up_to_global_phase():
     ]
     for g1 in groups:
         for e1 in g1:
-            assert not e1.equal_up_to_global_phase("not even close")
+            assert not e1.equal_up_to_global_phase("not even close")  # type: ignore[arg-type]
             for g2 in groups:
                 for e2 in g2:
                     assert e1.equal_up_to_global_phase(e2) == (g1 is g2)
 
 
-def test_gate_pow():
+def test_gate_pow() -> None:
     s = dps_x
     p = cirq.PauliStringPhasorGate(s, exponent_neg=0.25, exponent_pos=0.5)
     assert p**0.5 == cirq.PauliStringPhasorGate(s, exponent_neg=0.125, exponent_pos=0.25)
@@ -630,7 +635,7 @@ def test_gate_pow():
     assert p**1 == p
 
 
-def test_gate_extrapolate_effect():
+def test_gate_extrapolate_effect() -> None:
     gate1 = cirq.PauliStringPhasorGate(dps_empty, exponent_neg=0.5)
     gate2 = cirq.PauliStringPhasorGate(dps_empty, exponent_neg=1.5)
     gate3 = cirq.PauliStringPhasorGate(dps_empty, exponent_neg=0.125)
@@ -638,7 +643,7 @@ def test_gate_extrapolate_effect():
     assert gate1**0.25 == gate3
 
 
-def test_gate_extrapolate_effect_with_symbol():
+def test_gate_extrapolate_effect_with_symbol() -> None:
     eq = cirq.testing.EqualsTester()
     eq.add_equality_group(
         cirq.PauliStringPhasorGate(dps_empty, exponent_neg=sympy.Symbol('a')),
@@ -656,7 +661,7 @@ def test_gate_extrapolate_effect_with_symbol():
     )
 
 
-def test_gate_inverse():
+def test_gate_inverse() -> None:
     i = dps_empty
     gate1 = cirq.PauliStringPhasorGate(i, exponent_neg=0.25)
     gate2 = cirq.PauliStringPhasorGate(i, exponent_neg=-0.25)
@@ -666,7 +671,7 @@ def test_gate_inverse():
     assert cirq.inverse(gate3, None) == gate4
 
 
-def test_gate_is_parameterized():
+def test_gate_is_parameterized() -> None:
     gate = cirq.PauliStringPhasorGate(dps_empty)
     assert not cirq.is_parameterized(gate)
     assert not cirq.is_parameterized(gate**0.1)
@@ -674,7 +679,7 @@ def test_gate_is_parameterized():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_gate_with_parameters_resolved_by(resolve_fn):
+def test_gate_with_parameters_resolved_by(resolve_fn) -> None:
     gate = cirq.PauliStringPhasorGate(dps_empty, exponent_neg=sympy.Symbol('a'))
     resolver = cirq.ParamResolver({'a': 0.1})
     actual = resolve_fn(gate, resolver)
@@ -682,7 +687,7 @@ def test_gate_with_parameters_resolved_by(resolve_fn):
     assert actual == expected
 
 
-def test_gate_repr():
+def test_gate_repr() -> None:
     cirq.testing.assert_equivalent_repr(
         cirq.PauliStringPhasorGate(dps_zyx, exponent_neg=0.5, exponent_pos=0.25)
     )
@@ -691,7 +696,7 @@ def test_gate_repr():
     )
 
 
-def test_gate_str():
+def test_gate_str() -> None:
     gate = cirq.PauliStringPhasorGate(cirq.DensePauliString('ZYX', coefficient=+1)) ** 0.5
     assert str(gate) == '(+ZYX)**0.5'
 

--- a/cirq-core/cirq/ops/pauli_string_raw_types_test.py
+++ b/cirq-core/cirq/ops/pauli_string_raw_types_test.py
@@ -19,11 +19,11 @@ import pytest
 import cirq
 
 
-def _make_qubits(n):
+def _make_qubits(n) -> list[cirq.Qid]:
     return [cirq.NamedQubit(f'q{i}') for i in range(n)]
 
 
-def test_op_calls_validate():
+def test_op_calls_validate() -> None:
     q0, q1, q2 = _make_qubits(3)
     bad_qubit = cirq.NamedQubit('bad')
 
@@ -47,7 +47,7 @@ def test_op_calls_validate():
         _ = g.with_qubits(q0, q1, bad_qubit)
 
 
-def test_on_wrong_number_qubits():
+def test_on_wrong_number_qubits() -> None:
     q0, q1, q2 = _make_qubits(3)
 
     class ExampleGate(cirq.PauliStringGateOperation):
@@ -66,7 +66,7 @@ def test_on_wrong_number_qubits():
         _ = g.with_qubits(q0, q1, q2)
 
 
-def test_default_text_diagram():
+def test_default_text_diagram() -> None:
     class DiagramGate(cirq.PauliStringGateOperation):
         def map_qubits(self, qubit_map):
             pass
@@ -76,6 +76,7 @@ def test_default_text_diagram():
         ) -> cirq.CircuitDiagramInfo:
             return self._pauli_string_diagram_info(args)
 
+    ps: cirq.PauliString[cirq.Qid]
     q0, q1, q2 = _make_qubits(3)
     ps = cirq.PauliString({q0: cirq.X, q1: cirq.Y, q2: cirq.Z})
 

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import itertools
 import math
+from typing import Iterator
 
 import numpy as np
 import pytest
@@ -25,11 +26,11 @@ import cirq
 import cirq.testing
 
 
-def _make_qubits(n):
+def _make_qubits(n) -> list[cirq.NamedQubit]:
     return [cirq.NamedQubit(f'q{i}') for i in range(n)]
 
 
-def _sample_qubit_pauli_maps():
+def _sample_qubit_pauli_maps() -> Iterator[dict[cirq.NamedQubit, cirq.Pauli]]:
     """All combinations of having a Pauli or nothing on 3 qubits.
     Yields 64 qubit pauli maps
     """
@@ -39,7 +40,7 @@ def _sample_qubit_pauli_maps():
         yield {qubit: pauli for qubit, pauli in zip(qubits, paulis) if pauli is not None}
 
 
-def _small_sample_qubit_pauli_maps():
+def _small_sample_qubit_pauli_maps() -> Iterator[dict[cirq.NamedQubit, cirq.Pauli]]:
     """A few representative samples of qubit maps.
 
     Only tests 10 combinations of Paulis to speed up testing.
@@ -63,7 +64,7 @@ def assert_conjugation(
     op: cirq.Operation,
     expected: cirq.PauliString | None = None,
     force_checking_unitary=True,
-):
+) -> None:
     """Verifies that conjugating `input_ps` by `op` results in `expected`.
 
     Also ensures that the unitary representation of the Pauli string is
@@ -96,7 +97,7 @@ def assert_conjugation(
 
 def assert_conjugation_multi_ops(
     input_ps: cirq.PauliString, ops: list[cirq.Operation], expected: cirq.PauliString | None = None
-):
+) -> None:
     conjugation = input_ps.conjugated_by(ops)
     if expected is not None:
         assert conjugation == expected
@@ -108,7 +109,7 @@ def assert_conjugation_multi_ops(
     assert conjugation == conj_in_order
 
 
-def test_eq_ne_hash():
+def test_eq_ne_hash() -> None:
     q0, q1, q2 = _make_qubits(3)
     eq = cirq.testing.EqualsTester()
     eq.make_equality_group(
@@ -126,7 +127,7 @@ def test_eq_ne_hash():
         eq.add_equality_group(cirq.PauliString(qubit_pauli_map={q: p0, q2: p1}, coefficient=+1))
 
 
-def test_equal_up_to_coefficient():
+def test_equal_up_to_coefficient() -> None:
     (q0,) = _make_qubits(1)
     assert cirq.PauliString({}, +1).equal_up_to_coefficient(cirq.PauliString({}, +1))
     assert cirq.PauliString({}, -1).equal_up_to_coefficient(cirq.PauliString({}, -1))
@@ -161,8 +162,9 @@ def test_equal_up_to_coefficient():
     assert not cirq.PauliString({q0: cirq.X}, +1).equal_up_to_coefficient(cirq.PauliString({}, -1))
 
 
-def test_exponentiation_as_exponent():
+def test_exponentiation_as_exponent() -> None:
     a, b = cirq.LineQubit.range(2)
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString({a: cirq.X, b: cirq.Y})
 
     with pytest.raises(NotImplementedError, match='non-Hermitian'):
@@ -194,7 +196,7 @@ def test_exponentiation_as_exponent():
     )
 
 
-def test_exponentiate_single_value_as_exponent():
+def test_exponentiate_single_value_as_exponent() -> None:
     q = cirq.LineQubit(0)
 
     assert cirq.approx_eq(math.e ** (-0.125j * math.pi * cirq.X(q)), cirq.rx(0.25 * math.pi).on(q))
@@ -212,8 +214,9 @@ def test_exponentiate_single_value_as_exponent():
     assert cirq.approx_eq(cirq.Z(q) ** 0.5, cirq.ZPowGate(exponent=0.5).on(q))
 
 
-def test_exponentiation_as_base():
+def test_exponentiation_as_base() -> None:
     a, b = cirq.LineQubit.range(2)
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString({a: cirq.X, b: cirq.Y})
 
     with pytest.raises(TypeError, match='unsupported'):
@@ -256,7 +259,7 @@ def test_exponentiation_as_base():
 
 
 @pytest.mark.parametrize('pauli', (cirq.X, cirq.Y, cirq.Z))
-def test_list_op_constructor_matches_mapping(pauli):
+def test_list_op_constructor_matches_mapping(pauli) -> None:
     (q0,) = _make_qubits(1)
     op = pauli.on(q0)
     assert cirq.PauliString([op]) == cirq.PauliString({q0: pauli})
@@ -264,7 +267,7 @@ def test_list_op_constructor_matches_mapping(pauli):
 
 @pytest.mark.parametrize('pauli1', (cirq.X, cirq.Y, cirq.Z))
 @pytest.mark.parametrize('pauli2', (cirq.X, cirq.Y, cirq.Z))
-def test_exponent_mul_consistency(pauli1, pauli2):
+def test_exponent_mul_consistency(pauli1, pauli2) -> None:
     a, b = cirq.LineQubit.range(2)
     op_a, op_b = pauli1(a), pauli2(b)
 
@@ -285,14 +288,14 @@ def test_exponent_mul_consistency(pauli1, pauli2):
     assert op_b**3 * op_a == op_b * op_b * op_b * op_a
 
 
-def test_constructor_flexibility():
+def test_constructor_flexibility() -> None:
     a, b = cirq.LineQubit.range(2)
     with pytest.raises(TypeError, match='cirq.PAULI_STRING_LIKE'):
         _ = cirq.PauliString(cirq.CZ(a, b))
     with pytest.raises(TypeError, match='cirq.PAULI_STRING_LIKE'):
         _ = cirq.PauliString('test')
     with pytest.raises(TypeError, match='S is not a Pauli'):
-        _ = cirq.PauliString(qubit_pauli_map={a: cirq.S})
+        _ = cirq.PauliString(qubit_pauli_map={a: cirq.S})  # type: ignore[dict-item]
     with pytest.raises(TypeError, match="cirq.PAULI_STRING_LIKE"):
         _ = cirq.PauliString(cirq.Z(a) + cirq.Z(b))
 
@@ -318,7 +321,7 @@ def test_constructor_flexibility():
 
 
 @pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_getitem(qubit_pauli_map):
+def test_getitem(qubit_pauli_map) -> None:
     other = cirq.NamedQubit('other')
     pauli_string = cirq.PauliString(qubit_pauli_map=qubit_pauli_map)
     for key in qubit_pauli_map:
@@ -330,8 +333,9 @@ def test_getitem(qubit_pauli_map):
 
 
 @pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_get(qubit_pauli_map):
+def test_get(qubit_pauli_map) -> None:
     other = cirq.NamedQubit('other')
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString(qubit_pauli_map)
     for key in qubit_pauli_map:
         assert qubit_pauli_map.get(key) == pauli_string.get(key)
@@ -341,8 +345,9 @@ def test_get(qubit_pauli_map):
 
 
 @pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_contains(qubit_pauli_map):
+def test_contains(qubit_pauli_map) -> None:
     other = cirq.NamedQubit('other')
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString(qubit_pauli_map)
     for key in qubit_pauli_map:
         assert key in pauli_string
@@ -350,7 +355,8 @@ def test_contains(qubit_pauli_map):
 
 
 @pytest.mark.parametrize('qubit_pauli_map', _sample_qubit_pauli_maps())
-def test_basic_functionality(qubit_pauli_map):
+def test_basic_functionality(qubit_pauli_map) -> None:
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString(qubit_pauli_map)
     # Test items
     assert len(qubit_pauli_map.items()) == len(pauli_string.items())
@@ -372,8 +378,9 @@ def test_basic_functionality(qubit_pauli_map):
     assert set(tuple(qubit_pauli_map)) == set(tuple(pauli_string))
 
 
-def test_repr():
+def test_repr() -> None:
     q0, q1, q2 = _make_qubits(3)
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString({q2: cirq.X, q1: cirq.Y, q0: cirq.Z})
     cirq.testing.assert_equivalent_repr(pauli_string)
     cirq.testing.assert_equivalent_repr(-pauli_string)
@@ -382,8 +389,9 @@ def test_repr():
     cirq.testing.assert_equivalent_repr(cirq.PauliString())
 
 
-def test_repr_preserves_qubit_order():
+def test_repr_preserves_qubit_order() -> None:
     q0, q1, q2 = _make_qubits(3)
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString({q2: cirq.X, q1: cirq.Y, q0: cirq.Z})
     assert eval(repr(pauli_string)).qubits == pauli_string.qubits
 
@@ -394,14 +402,15 @@ def test_repr_preserves_qubit_order():
     assert eval(repr(pauli_string)).qubits == pauli_string.qubits
 
 
-def test_repr_coefficient_of_one():
+def test_repr_coefficient_of_one() -> None:
     pauli_string = cirq.Z(cirq.LineQubit(0)) * 1
     assert type(pauli_string) == type(eval(repr(pauli_string)))
     cirq.testing.assert_equivalent_repr(pauli_string)
 
 
-def test_str():
+def test_str() -> None:
     q0, q1, q2 = _make_qubits(3)
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString({q2: cirq.X, q1: cirq.Y, q0: cirq.Z})
     assert str(cirq.PauliString({})) == 'I'
     assert str(-cirq.PauliString({})) == '-I'
@@ -426,9 +435,13 @@ def test_str():
                 {q0: (cirq.X, cirq.Y), q1: (cirq.Y, cirq.Z)},
             ),
         )
-    )(*_make_qubits(3)),
+    )(
+        *_make_qubits(3)  # type: ignore[arg-type]
+    ),
 )
-def test_zip_items(map1, map2, out):
+def test_zip_items(map1, map2, out) -> None:
+    ps1: cirq.PauliString[cirq.NamedQubit]
+    ps2: cirq.PauliString[cirq.NamedQubit]
     ps1 = cirq.PauliString(map1)
     ps2 = cirq.PauliString(map2)
     out_actual = tuple(ps1.zip_items(ps2))
@@ -452,9 +465,13 @@ def test_zip_items(map1, map2, out):
                 ((cirq.X, cirq.Y), (cirq.Y, cirq.Z)),
             ),
         )
-    )(*_make_qubits(3)),
+    )(
+        *_make_qubits(3)  # type: ignore[arg-type]
+    ),
 )
-def test_zip_paulis(map1, map2, out):
+def test_zip_paulis(map1, map2, out) -> None:
+    ps1: cirq.PauliString[cirq.NamedQubit]
+    ps2: cirq.PauliString[cirq.NamedQubit]
     ps1 = cirq.PauliString(map1)
     ps2 = cirq.PauliString(map2)
     out_actual = tuple(ps1.zip_paulis(ps2))
@@ -464,9 +481,10 @@ def test_zip_paulis(map1, map2, out):
     assert set(out_actual) == set(out)  # Ignore output order
 
 
-def test_commutes():
+def test_commutes() -> None:
     qubits = _make_qubits(3)
 
+    ps1: cirq.PauliString[cirq.NamedQubit]
     ps1 = cirq.PauliString([cirq.X(qubits[0])])
     with pytest.raises(TypeError):
         cirq.commutes(ps1, 'X')
@@ -487,6 +505,7 @@ def test_commutes():
         (cirq.Y, cirq.X, cirq.Z): True,
         (cirq.Y, cirq.Z, cirq.X): True,
     }.items():
+        ps2: cirq.PauliString[cirq.NamedQubit]
         ps2 = cirq.PauliString(dict(zip(qubits, paulis)))
         assert cirq.commutes(ps1, ps2) == commutes
 
@@ -500,9 +519,11 @@ def test_commutes():
         assert cirq.commutes(ps1, ps2) == commutes
 
 
-def test_negate():
+def test_negate() -> None:
     q0, q1 = _make_qubits(2)
     qubit_pauli_map = {q0: cirq.X, q1: cirq.Y}
+    ps1: cirq.PauliString[cirq.NamedQubit]
+    ps2: cirq.PauliString[cirq.NamedQubit]
     ps1 = cirq.PauliString(qubit_pauli_map)
     ps2 = cirq.PauliString(qubit_pauli_map, -1)
     assert -ps1 == ps2
@@ -516,8 +537,9 @@ def test_negate():
     assert isinstance(-m, cirq.MutablePauliString)
 
 
-def test_mul_scalar():
+def test_mul_scalar() -> None:
     a, b = cirq.LineQubit.range(2)
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString({a: cirq.X, b: cirq.Y})
     assert -p == -1 * p == -1.0 * p == p * -1 == p * complex(-1)
     assert -p != 1j * p
@@ -532,8 +554,9 @@ def test_mul_scalar():
         _ = 'test' * p
 
 
-def test_div_scalar():
+def test_div_scalar() -> None:
     a, b = cirq.LineQubit.range(2)
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString({a: cirq.X, b: cirq.Y})
     assert -p == p / -1 == p / -1.0 == p / (-1 + 0j)
     assert -p != p / 1j
@@ -543,11 +566,13 @@ def test_div_scalar():
         _ = p / 'test'
     with pytest.raises(TypeError):
         # noinspection PyUnresolvedReferences
-        _ = 'test' / p
+        _ = 'test' / p  # type: ignore[operator]
 
 
-def test_mul_strings():
+def test_mul_strings() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
+    p1: cirq.PauliString[cirq.LineQubit]
+    p2: cirq.PauliString[cirq.LineQubit]
     p1 = cirq.PauliString({a: cirq.X, b: cirq.Y, c: cirq.Z})
     p2 = cirq.PauliString({b: cirq.X, c: cirq.Y, d: cirq.Z})
     assert p1 * p2 == -cirq.PauliString({a: cirq.X, b: cirq.Z, c: cirq.X, d: cirq.Z})
@@ -565,7 +590,7 @@ def test_mul_strings():
     assert -cirq.X(a) == -cirq.PauliString({a: cirq.X})
 
 
-def test_op_equivalence():
+def test_op_equivalence() -> None:
     a, b = cirq.LineQubit.range(2)
     various_x = [
         cirq.X(a),
@@ -586,7 +611,7 @@ def test_op_equivalence():
     eq.add_equality_group(cirq.Z(b), cirq.PauliString({b: cirq.Z}))
 
 
-def test_op_product():
+def test_op_product() -> None:
     a, b = cirq.LineQubit.range(2)
 
     assert cirq.X(a) * cirq.X(b) == cirq.PauliString({a: cirq.X, b: cirq.X})
@@ -598,9 +623,10 @@ def test_op_product():
     assert cirq.Y(a) * cirq.Z(b) * cirq.X(a) == -1j * cirq.PauliString({a: cirq.Z, b: cirq.Z})
 
 
-def test_pos():
+def test_pos() -> None:
     q0, q1 = _make_qubits(2)
     qubit_pauli_map = {q0: cirq.X, q1: cirq.Y}
+    ps1: cirq.PauliString[cirq.NamedQubit]
     ps1 = cirq.PauliString(qubit_pauli_map)
     assert ps1 == +ps1
 
@@ -610,13 +636,14 @@ def test_pos():
     assert isinstance(+m, cirq.MutablePauliString)
 
 
-def test_pow():
+def test_pow() -> None:
     a, b = cirq.LineQubit.range(2)
 
     assert cirq.PauliString({a: cirq.X}) ** 0.25 == cirq.X(a) ** 0.25
     assert cirq.PauliString({a: cirq.Y}) ** 0.25 == cirq.Y(a) ** 0.25
     assert cirq.PauliString({a: cirq.Z}) ** 0.25 == cirq.Z(a) ** 0.25
 
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString({a: cirq.X, b: cirq.Y})
     assert p**1 == p
     assert p**-1 == p
@@ -626,7 +653,7 @@ def test_pow():
     assert (1j * p) ** -1 == -1j * p
 
 
-def test_rpow():
+def test_rpow() -> None:
     a, b = cirq.LineQubit.range(2)
 
     u = cirq.unitary(np.exp(1j * np.pi / 2 * cirq.Z(a) * cirq.Z(b)))
@@ -639,7 +666,7 @@ def test_rpow():
     np.testing.assert_allclose(u, np.diag([-1, -1, -1, -1]), atol=1e-8)
 
 
-def test_numpy_ufunc():
+def test_numpy_ufunc() -> None:
     with pytest.raises(TypeError, match="returned NotImplemented"):
         _ = np.sin(cirq.PauliString())
     with pytest.raises(NotImplementedError, match="non-Hermitian"):
@@ -650,25 +677,27 @@ def test_numpy_ufunc():
     assert x == 2 * cirq.PauliString()
 
 
-def test_map_qubits():
+def test_map_qubits() -> None:
     a, b = (cirq.NamedQubit(name) for name in 'ab')
     q0, q1 = _make_qubits(2)
     qubit_pauli_map1 = {a: cirq.X, b: cirq.Y}
     qubit_pauli_map2 = {q0: cirq.X, q1: cirq.Y}
     qubit_map = {a: q0, b: q1}
+    ps1: cirq.PauliString[cirq.NamedQubit]
+    ps2: cirq.PauliString[cirq.NamedQubit]
     ps1 = cirq.PauliString(qubit_pauli_map1)
     ps2 = cirq.PauliString(qubit_pauli_map2)
     assert ps1.map_qubits(qubit_map) == ps2
 
 
-def test_map_qubits_raises():
+def test_map_qubits_raises() -> None:
     q = cirq.LineQubit.range(3)
     pauli_string = cirq.X(q[0]) * cirq.Y(q[1]) * cirq.Z(q[2])
     with pytest.raises(ValueError, match='must have a key for every qubit'):
         pauli_string.map_qubits({q[0]: q[1]})
 
 
-def test_to_z_basis_ops():
+def test_to_z_basis_ops() -> None:
     x0 = np.array([1, 1]) / np.sqrt(2)
     x1 = np.array([1, -1]) / np.sqrt(2)
     y0 = np.array([1, 1j]) / np.sqrt(2)
@@ -677,6 +706,7 @@ def test_to_z_basis_ops():
     z1 = np.array([0, 1])
 
     q0, q1, q2, q3, q4, q5 = _make_qubits(6)
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString(
         {q0: cirq.X, q1: cirq.X, q2: cirq.Y, q3: cirq.Y, q4: cirq.Z, q5: cirq.Z}
     )
@@ -695,8 +725,9 @@ def test_to_z_basis_ops():
     )
 
 
-def test_to_z_basis_ops_product_state():
+def test_to_z_basis_ops_product_state() -> None:
     q0, q1, q2, q3, q4, q5 = _make_qubits(6)
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString(
         {q0: cirq.X, q1: cirq.X, q2: cirq.Y, q3: cirq.Y, q4: cirq.Z, q5: cirq.Z}
     )
@@ -722,10 +753,11 @@ def test_to_z_basis_ops_product_state():
     )
 
 
-def test_with_qubits():
+def test_with_qubits() -> None:
     old_qubits = cirq.LineQubit.range(9)
     new_qubits = cirq.LineQubit.range(9, 18)
     qubit_pauli_map = {q: cirq.Pauli.by_index(q.x) for q in old_qubits}
+    pauli_string: cirq.PauliString[cirq.LineQubit]
     pauli_string = cirq.PauliString(qubit_pauli_map, -1)
     new_pauli_string = pauli_string.with_qubits(*new_qubits)
 
@@ -735,16 +767,17 @@ def test_with_qubits():
     assert new_pauli_string.coefficient == -1
 
 
-def test_with_qubits_raises():
+def test_with_qubits_raises() -> None:
     q = cirq.LineQubit.range(3)
     pauli_string = cirq.X(q[0]) * cirq.Y(q[1]) * cirq.Z(q[2])
     with pytest.raises(ValueError, match='does not match'):
         pauli_string.with_qubits(q[:2])
 
 
-def test_with_coefficient():
+def test_with_coefficient() -> None:
     qubits = cirq.LineQubit.range(4)
     qubit_pauli_map = {q: cirq.Pauli.by_index(q.x) for q in qubits}
+    pauli_string: cirq.PauliString[cirq.LineQubit]
     pauli_string = cirq.PauliString(qubit_pauli_map, 1.23)
     ps2 = pauli_string.with_coefficient(1.0)
     assert ps2.coefficient == 1.0
@@ -754,18 +787,19 @@ def test_with_coefficient():
 
 
 @pytest.mark.parametrize('qubit_pauli_map', _small_sample_qubit_pauli_maps())
-def test_consistency(qubit_pauli_map):
+def test_consistency(qubit_pauli_map) -> None:
+    pauli_string: cirq.PauliString[cirq.NamedQubit]
     pauli_string = cirq.PauliString(qubit_pauli_map)
     cirq.testing.assert_implements_consistent_protocols(pauli_string)
 
 
-def test_scaled_unitary_consistency():
+def test_scaled_unitary_consistency() -> None:
     a, b = cirq.LineQubit.range(2)
     cirq.testing.assert_implements_consistent_protocols(2 * cirq.X(a) * cirq.Y(b))
     cirq.testing.assert_implements_consistent_protocols(1j * cirq.X(a) * cirq.Y(b))
 
 
-def test_bool():
+def test_bool() -> None:
     a = cirq.LineQubit(0)
     assert not bool(cirq.PauliString({}))
     assert bool(cirq.PauliString({a: cirq.X}))
@@ -818,11 +852,11 @@ def _pauli_string_matrix_cases():
 
 
 @pytest.mark.parametrize('pauli_string, qubits, expected_matrix', _pauli_string_matrix_cases())
-def test_matrix(pauli_string, qubits, expected_matrix):
+def test_matrix(pauli_string, qubits, expected_matrix) -> None:
     assert np.allclose(pauli_string.matrix(qubits), expected_matrix)
 
 
-def test_unitary_matrix():
+def test_unitary_matrix() -> None:
     a, b = cirq.LineQubit.range(2)
     assert not cirq.has_unitary(2 * cirq.X(a) * cirq.Z(b))
     assert cirq.unitary(2 * cirq.X(a) * cirq.Z(b), default=None) is None
@@ -852,7 +886,7 @@ def test_unitary_matrix():
     # fmt: on
 
 
-def test_decompose():
+def test_decompose() -> None:
     a, b = cirq.LineQubit.range(2)
     assert cirq.decompose_once(2 * cirq.X(a) * cirq.Z(b), default=None) is None
     assert cirq.decompose_once(1j * cirq.X(a) * cirq.Z(b)) == [
@@ -863,13 +897,13 @@ def test_decompose():
     assert cirq.decompose_once(cirq.Y(b) * cirq.Z(a)) == [cirq.Y(b), cirq.Z(a)]
 
 
-def test_rejects_non_paulis():
+def test_rejects_non_paulis() -> None:
     q = cirq.NamedQubit('q')
     with pytest.raises(TypeError):
         _ = cirq.PauliString({q: cirq.S})
 
 
-def test_cannot_multiply_by_non_paulis():
+def test_cannot_multiply_by_non_paulis() -> None:
     q = cirq.NamedQubit('q')
     with pytest.raises(TypeError):
         _ = cirq.X(q) * cirq.Z(q) ** 0.5
@@ -879,13 +913,14 @@ def test_cannot_multiply_by_non_paulis():
         _ = cirq.Y(q) * cirq.S(q)
 
 
-def test_filters_identities():
+def test_filters_identities() -> None:
     q1, q2 = cirq.LineQubit.range(2)
     assert cirq.PauliString({q1: cirq.I, q2: cirq.X}) == cirq.PauliString({q2: cirq.X})
 
 
-def test_expectation_from_state_vector_invalid_input():
+def test_expectation_from_state_vector_invalid_input() -> None:
     q0, q1, q2, q3 = _make_qubits(4)
+    ps: cirq.PauliString[cirq.NamedQubit]
     ps = cirq.PauliString({q0: cirq.X, q1: cirq.Y})
     wf = np.array([1, 0, 0, 0], dtype=np.complex64)
     q_map = {q0: 0, q1: 1}
@@ -899,13 +934,13 @@ def test_expectation_from_state_vector_invalid_input():
 
     with pytest.raises(TypeError, match='mapping'):
         # noinspection PyTypeChecker
-        ps.expectation_from_state_vector(wf, "bad type")
+        ps.expectation_from_state_vector(wf, "bad type")  # type: ignore[arg-type]
     with pytest.raises(TypeError, match='mapping'):
         # noinspection PyTypeChecker
-        ps.expectation_from_state_vector(wf, {"bad key": 1})
+        ps.expectation_from_state_vector(wf, {"bad key": 1})  # type: ignore[dict-item]
     with pytest.raises(TypeError, match='mapping'):
         # noinspection PyTypeChecker
-        ps.expectation_from_state_vector(wf, {q0: "bad value"})
+        ps.expectation_from_state_vector(wf, {q0: "bad value"})  # type: ignore[dict-item]
     with pytest.raises(ValueError, match='complete'):
         ps.expectation_from_state_vector(wf, {q0: 0})
     with pytest.raises(ValueError, match='complete'):
@@ -937,8 +972,9 @@ def test_expectation_from_state_vector_invalid_input():
         ps.expectation_from_state_vector(wf.reshape((4, 4, 1)), q_map_2)
 
 
-def test_expectation_from_state_vector_check_preconditions():
+def test_expectation_from_state_vector_check_preconditions() -> None:
     q0, q1, q2, q3 = _make_qubits(4)
+    ps: cirq.PauliString[cirq.NamedQubit]
     ps = cirq.PauliString({q0: cirq.X, q1: cirq.Y})
     q_map = {q0: 0, q1: 1, q2: 2, q3: 3}
 
@@ -950,8 +986,9 @@ def test_expectation_from_state_vector_check_preconditions():
     )
 
 
-def test_expectation_from_state_vector_basis_states():
+def test_expectation_from_state_vector_basis_states() -> None:
     q0 = cirq.LineQubit(0)
+    x0: cirq.PauliString[cirq.LineQubit]
     x0 = cirq.PauliString({q0: cirq.X})
     q_map = {q0: 0}
 
@@ -972,6 +1009,7 @@ def test_expectation_from_state_vector_basis_states():
         atol=1e-7,
     )
 
+    y0: cirq.PauliString[cirq.LineQubit]
     y0 = cirq.PauliString({q0: cirq.Y})
     np.testing.assert_allclose(
         y0.expectation_from_state_vector(np.array([1, 1j], dtype=complex) / np.sqrt(2), q_map),
@@ -995,11 +1033,13 @@ def test_expectation_from_state_vector_basis_states():
     )
 
 
-def test_expectation_from_state_vector_entangled_states():
+def test_expectation_from_state_vector_entangled_states() -> None:
     q0, q1 = _make_qubits(2)
     z0z1_pauli_map = {q0: cirq.Z, q1: cirq.Z}
+    z0z1: cirq.PauliString[cirq.NamedQubit]
     z0z1 = cirq.PauliString(z0z1_pauli_map)
     x0x1_pauli_map = {q0: cirq.X, q1: cirq.X}
+    x0x1: cirq.PauliString[cirq.NamedQubit]
     x0x1 = cirq.PauliString(x0x1_pauli_map)
     q_map = {q0: 0, q1: 1}
     wf1 = np.array([0, 1, 1, 0], dtype=complex) / np.sqrt(2)
@@ -1018,8 +1058,9 @@ def test_expectation_from_state_vector_entangled_states():
         np.testing.assert_allclose(x0x1.expectation_from_state_vector(state, q_map), 1)
 
 
-def test_expectation_from_state_vector_qubit_map():
+def test_expectation_from_state_vector_qubit_map() -> None:
     q0, q1, q2 = _make_qubits(3)
+    z: cirq.PauliString[cirq.NamedQubit]
     z = cirq.PauliString({q0: cirq.Z})
     wf = np.array([0, 1, 0, 1, 0, 0, 0, 0], dtype=complex) / np.sqrt(2)
     for state in [wf, wf.reshape((2, 2, 2))]:
@@ -1043,7 +1084,7 @@ def test_expectation_from_state_vector_qubit_map():
         )
 
 
-def test_pauli_string_expectation_from_state_vector_pure_state():
+def test_pauli_string_expectation_from_state_vector_pure_state() -> None:
     qubits = cirq.LineQubit.range(4)
     q_map = {q: i for i, q in enumerate(qubits)}
 
@@ -1054,13 +1095,13 @@ def test_pauli_string_expectation_from_state_vector_pure_state():
         qubit_order=qubits, ignore_terminal_measurements=False, dtype=np.complex128
     )
 
-    z0z1 = cirq.PauliString({qubits[0]: cirq.Z, qubits[1]: cirq.Z})
-    z0z2 = cirq.PauliString({qubits[0]: cirq.Z, qubits[2]: cirq.Z})
-    z0z3 = cirq.PauliString({qubits[0]: cirq.Z, qubits[3]: cirq.Z})
-    z0x1 = cirq.PauliString({qubits[0]: cirq.Z, qubits[1]: cirq.X})
-    z1x2 = cirq.PauliString({qubits[1]: cirq.Z, qubits[2]: cirq.X})
-    x0z1 = cirq.PauliString({qubits[0]: cirq.X, qubits[1]: cirq.Z})
-    x3 = cirq.PauliString({qubits[3]: cirq.X})
+    z0z1: cirq.PauliString = cirq.PauliString({qubits[0]: cirq.Z, qubits[1]: cirq.Z})
+    z0z2: cirq.PauliString = cirq.PauliString({qubits[0]: cirq.Z, qubits[2]: cirq.Z})
+    z0z3: cirq.PauliString = cirq.PauliString({qubits[0]: cirq.Z, qubits[3]: cirq.Z})
+    z0x1: cirq.PauliString = cirq.PauliString({qubits[0]: cirq.Z, qubits[1]: cirq.X})
+    z1x2: cirq.PauliString = cirq.PauliString({qubits[1]: cirq.Z, qubits[2]: cirq.X})
+    x0z1: cirq.PauliString = cirq.PauliString({qubits[0]: cirq.X, qubits[1]: cirq.Z})
+    x3: cirq.PauliString = cirq.PauliString({qubits[3]: cirq.X})
 
     for state in [wf, wf.reshape((2, 2, 2, 2))]:
         np.testing.assert_allclose(z0z1.expectation_from_state_vector(state, q_map), -1, atol=1e-8)
@@ -1072,7 +1113,7 @@ def test_pauli_string_expectation_from_state_vector_pure_state():
         np.testing.assert_allclose(x3.expectation_from_state_vector(state, q_map), -1, atol=1e-8)
 
 
-def test_pauli_string_expectation_from_state_vector_pure_state_with_coef():
+def test_pauli_string_expectation_from_state_vector_pure_state_with_coef() -> None:
     qs = cirq.LineQubit.range(4)
     q_map = {q: i for i, q in enumerate(qs)}
 
@@ -1093,8 +1134,9 @@ def test_pauli_string_expectation_from_state_vector_pure_state_with_coef():
         np.testing.assert_allclose(z1x2.expectation_from_state_vector(state, q_map), 1, atol=1e-8)
 
 
-def test_expectation_from_density_matrix_invalid_input():
+def test_expectation_from_density_matrix_invalid_input() -> None:
     q0, q1, q2, q3 = _make_qubits(4)
+    ps: cirq.PauliString[cirq.NamedQubit]
     ps = cirq.PauliString({q0: cirq.X, q1: cirq.Y})
     wf = cirq.testing.random_superposition(4)
     rho = np.kron(wf.conjugate().T, wf).reshape((4, 4))
@@ -1109,13 +1151,13 @@ def test_expectation_from_density_matrix_invalid_input():
 
     with pytest.raises(TypeError, match='mapping'):
         # noinspection PyTypeChecker
-        ps.expectation_from_density_matrix(rho, "bad type")
+        ps.expectation_from_density_matrix(rho, "bad type")  # type: ignore[arg-type]
     with pytest.raises(TypeError, match='mapping'):
         # noinspection PyTypeChecker
-        ps.expectation_from_density_matrix(rho, {"bad key": 1})
+        ps.expectation_from_density_matrix(rho, {"bad key": 1})  # type: ignore[dict-item]
     with pytest.raises(TypeError, match='mapping'):
         # noinspection PyTypeChecker
-        ps.expectation_from_density_matrix(rho, {q0: "bad value"})
+        ps.expectation_from_density_matrix(rho, {q0: "bad value"})  # type: ignore[dict-item]
     with pytest.raises(ValueError, match='complete'):
         ps.expectation_from_density_matrix(rho, {q0: 0})
     with pytest.raises(ValueError, match='complete'):
@@ -1162,8 +1204,9 @@ def test_expectation_from_density_matrix_invalid_input():
     _ = ps.expectation_from_density_matrix(rho_or_wf, q_map)
 
 
-def test_expectation_from_density_matrix_check_preconditions():
+def test_expectation_from_density_matrix_check_preconditions() -> None:
     q0, q1 = _make_qubits(2)
+    ps: cirq.PauliString[cirq.NamedQubit]
     ps = cirq.PauliString({q0: cirq.X, q1: cirq.Y})
     q_map = {q0: 0, q1: 1}
 
@@ -1182,9 +1225,10 @@ def test_expectation_from_density_matrix_check_preconditions():
     )
 
 
-def test_expectation_from_density_matrix_basis_states():
+def test_expectation_from_density_matrix_basis_states() -> None:
     q0 = cirq.LineQubit(0)
     x0_pauli_map = {q0: cirq.X}
+    x0: cirq.PauliString[cirq.LineQubit]
     x0 = cirq.PauliString(x0_pauli_map)
     q_map = {q0: 0}
     np.testing.assert_allclose(
@@ -1202,11 +1246,13 @@ def test_expectation_from_density_matrix_basis_states():
     )
 
 
-def test_expectation_from_density_matrix_entangled_states():
+def test_expectation_from_density_matrix_entangled_states() -> None:
     q0, q1 = _make_qubits(2)
     z0z1_pauli_map = {q0: cirq.Z, q1: cirq.Z}
+    z0z1: cirq.PauliString[cirq.NamedQubit]
     z0z1 = cirq.PauliString(z0z1_pauli_map)
     x0x1_pauli_map = {q0: cirq.X, q1: cirq.X}
+    x0x1: cirq.PauliString[cirq.NamedQubit]
     x0x1 = cirq.PauliString(x0x1_pauli_map)
     q_map = {q0: 0, q1: 1}
 
@@ -1229,8 +1275,9 @@ def test_expectation_from_density_matrix_entangled_states():
         np.testing.assert_allclose(x0x1.expectation_from_density_matrix(state, q_map), 1)
 
 
-def test_expectation_from_density_matrix_qubit_map():
+def test_expectation_from_density_matrix_qubit_map() -> None:
     q0, q1, q2 = _make_qubits(3)
+    z: cirq.PauliString[cirq.NamedQubit]
     z = cirq.PauliString({q0: cirq.Z})
     wf = np.array([0, 1, 0, 1, 0, 0, 0, 0], dtype=complex) / np.sqrt(2)
     rho = np.kron(wf, wf).reshape((8, 8))
@@ -1256,8 +1303,9 @@ def test_expectation_from_density_matrix_qubit_map():
         )
 
 
-def test_pauli_string_expectation_from_density_matrix_pure_state():
+def test_pauli_string_expectation_from_density_matrix_pure_state() -> None:
     qubits = cirq.LineQubit.range(4)
+    q_map: dict[cirq.Qid, int]
     q_map = {q: i for i, q in enumerate(qubits)}
 
     circuit = cirq.Circuit(
@@ -1267,6 +1315,14 @@ def test_pauli_string_expectation_from_density_matrix_pure_state():
         qubit_order=qubits, ignore_terminal_measurements=False, dtype=np.complex128
     )
     rho = np.outer(state_vector, np.conj(state_vector))
+
+    z0z1: cirq.PauliString[cirq.Qid]
+    z0z2: cirq.PauliString[cirq.Qid]
+    z0z3: cirq.PauliString[cirq.Qid]
+    z0x1: cirq.PauliString[cirq.Qid]
+    z1x2: cirq.PauliString[cirq.Qid]
+    x0z1: cirq.PauliString[cirq.Qid]
+    x3: cirq.PauliString[cirq.Qid]
 
     z0z1 = cirq.PauliString({qubits[0]: cirq.Z, qubits[1]: cirq.Z})
     z0z2 = cirq.PauliString({qubits[0]: cirq.Z, qubits[2]: cirq.Z})
@@ -1286,7 +1342,7 @@ def test_pauli_string_expectation_from_density_matrix_pure_state():
         np.testing.assert_allclose(x3.expectation_from_density_matrix(state, q_map), -1)
 
 
-def test_pauli_string_expectation_from_density_matrix_pure_state_with_coef():
+def test_pauli_string_expectation_from_density_matrix_pure_state_with_coef() -> None:
     qs = cirq.LineQubit.range(4)
     q_map = {q: i for i, q in enumerate(qs)}
 
@@ -1306,7 +1362,7 @@ def test_pauli_string_expectation_from_density_matrix_pure_state_with_coef():
         np.testing.assert_allclose(z1x2.expectation_from_density_matrix(state, q_map), 1)
 
 
-def test_pauli_string_expectation_from_state_vector_mixed_state_linearity():
+def test_pauli_string_expectation_from_state_vector_mixed_state_linearity() -> None:
     n_qubits = 6
 
     state_vector1 = cirq.testing.random_superposition(2**n_qubits)
@@ -1316,9 +1372,11 @@ def test_pauli_string_expectation_from_state_vector_mixed_state_linearity():
     density_matrix = rho1 / 2 + rho2 / 2
 
     qubits = cirq.LineQubit.range(n_qubits)
+    q_map: dict[cirq.Qid, int]
     q_map = {q: i for i, q in enumerate(qubits)}
     paulis = [cirq.X, cirq.Y, cirq.Z]
-    pauli_string = cirq.PauliString({q: np.random.choice(paulis) for q in qubits})
+    pauli_string: cirq.PauliString[cirq.Qid]
+    pauli_string = cirq.PauliString({q: np.random.choice(paulis) for q in qubits})  # type: ignore[arg-type]
 
     a = pauli_string.expectation_from_state_vector(state_vector1, q_map)
     b = pauli_string.expectation_from_state_vector(state_vector2, q_map)
@@ -1326,7 +1384,7 @@ def test_pauli_string_expectation_from_state_vector_mixed_state_linearity():
     np.testing.assert_allclose(0.5 * (a + b), c)
 
 
-def test_conjugated_by_normal_gates():
+def test_conjugated_by_normal_gates() -> None:
     a = cirq.LineQubit(0)
 
     assert_conjugation(cirq.X(a), cirq.H(a), cirq.Z(a))
@@ -1343,14 +1401,15 @@ def test_conjugated_by_normal_gates():
     assert_conjugation(cirq.Z(a), clifford_op, -cirq.Z(a))
 
 
-def test_conjugated_by_op_gate_of_clifford_gate_type():
+def test_conjugated_by_op_gate_of_clifford_gate_type() -> None:
     a = cirq.LineQubit(0)
 
     assert_conjugation(cirq.X(a), cirq.CliffordGate.from_op_list([cirq.H(a)], [a]).on(a), cirq.Z(a))
 
 
-def test_dense():
+def test_dense() -> None:
     a, b, c, d, e = cirq.LineQubit.range(5)
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString([cirq.X(a), cirq.Y(b), cirq.Z(c)])
     assert p.dense([a, b, c, d]) == cirq.DensePauliString('XYZI')
     assert p.dense([d, e, a, b, c]) == cirq.DensePauliString('IIXYZ')
@@ -1363,7 +1422,7 @@ def test_dense():
 
 
 @pytest.mark.parametrize('qubits', [*itertools.permutations(cirq.LineQubit.range(3))])
-def test_gate_consistent(qubits):
+def test_gate_consistent(qubits) -> None:
     g = cirq.DensePauliString('XYZ')
     assert g == g(*qubits).gate
     a, b, c = cirq.GridQubit.rect(1, 3)
@@ -1371,8 +1430,9 @@ def test_gate_consistent(qubits):
     assert ps.gate == ps.with_qubits(*qubits).gate
 
 
-def test_conjugated_by_incorrectly_powered_cliffords():
+def test_conjugated_by_incorrectly_powered_cliffords() -> None:
     a, b = cirq.LineQubit.range(2)
+    p: cirq.PauliString[cirq.LineQubit]
     p = cirq.PauliString([cirq.X(a), cirq.Z(b)])
     cliffords = [
         cirq.H(a),
@@ -1403,7 +1463,7 @@ def test_conjugated_by_incorrectly_powered_cliffords():
             _ = p.conjugated_by(c ** sympy.Symbol('t'))
 
 
-def test_conjugated_by_global_phase():
+def test_conjugated_by_global_phase() -> None:
     """Global phase gate preserves PauliString."""
     a = cirq.LineQubit(0)
     assert_conjugation(cirq.X(a), cirq.global_phase_operation(1j), cirq.X(a))
@@ -1419,7 +1479,7 @@ def test_conjugated_by_global_phase():
     assert_conjugation(cirq.X(a), DecomposeGlobal().on(a), cirq.X(a))
 
 
-def test_conjugated_by_composite_with_disjoint_sub_gates():
+def test_conjugated_by_composite_with_disjoint_sub_gates() -> None:
     a, b = cirq.LineQubit.range(2)
 
     class DecomposeDisjoint(cirq.Gate):
@@ -1435,7 +1495,7 @@ def test_conjugated_by_composite_with_disjoint_sub_gates():
             assert ps.conjugated_by(DecomposeDisjoint().on(a, b)) == ps.conjugated_by(cirq.H(b))
 
 
-def test_conjugated_by_clifford_composite():
+def test_conjugated_by_clifford_composite() -> None:
     class UnknownGate(cirq.Gate):
         def num_qubits(self) -> int:
             return 4
@@ -1452,14 +1512,14 @@ def test_conjugated_by_clifford_composite():
     assert_conjugation(ps, u(a, b, c, d), cirq.Z(a) * cirq.X(b))
 
 
-def test_conjugated_by_move_into_uninvolved():
+def test_conjugated_by_move_into_uninvolved() -> None:
     a, b, c, d = cirq.LineQubit.range(4)
     ps = cirq.X(a) * cirq.Z(b)
     assert_conjugation_multi_ops(ps, [cirq.SWAP(c, d), cirq.SWAP(b, c)], cirq.X(a) * cirq.Z(d))
     assert_conjugation_multi_ops(ps, [cirq.SWAP(b, c), cirq.SWAP(c, d)], cirq.X(a) * cirq.Z(c))
 
 
-def test_conjugated_by_common_single_qubit_gates():
+def test_conjugated_by_common_single_qubit_gates() -> None:
     a, b = cirq.LineQubit.range(2)
 
     base_single_qubit_gates = [
@@ -1484,7 +1544,7 @@ def test_conjugated_by_common_single_qubit_gates():
             assert_conjugation(p(a), g(a))
 
 
-def test_conjugated_by_common_two_qubit_gates():
+def test_conjugated_by_common_two_qubit_gates() -> None:
 
     a, b, c, d = cirq.LineQubit.range(4)
     two_qubit_gates = [
@@ -1505,7 +1565,7 @@ def test_conjugated_by_common_two_qubit_gates():
     ]
     for p1 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
         for p2 in [cirq.I, cirq.X, cirq.Y, cirq.Z]:
-            pd = cirq.DensePauliString([p1, p2])
+            pd: cirq.DensePauliString = cirq.DensePauliString([p1, p2])  # type: ignore[list-item]
             p = pd.sparse([a, b])
             for g in two_qubit_gates:
                 # pauli_string on (a,b), clifford on (c,d): pauli_string preserves.
@@ -1515,7 +1575,7 @@ def test_conjugated_by_common_two_qubit_gates():
                 assert_conjugation(p, g.on(a, b))
 
 
-def test_conjugated_by_ordering():
+def test_conjugated_by_ordering() -> None:
     """Tests .conjugated_by([op1, op2]) == .conjugated_by(op2).conjugated_by(op1)"""
     a, b = cirq.LineQubit.range(2)
     inp = cirq.Z(b)
@@ -1524,8 +1584,9 @@ def test_conjugated_by_ordering():
     assert out1 == out2 == cirq.X(a) * cirq.Z(b)
 
 
-def test_pretty_print():
+def test_pretty_print() -> None:
     a, b, c = cirq.LineQubit.range(3)
+    result: cirq.PauliString[cirq.LineQubit]
     result = cirq.PauliString({a: 'x', b: 'y', c: 'z'})
 
     # Test Jupyter console output from
@@ -1546,7 +1607,7 @@ def test_pretty_print():
     assert p.text_pretty == 'cirq.PauliString(...)'
 
 
-def test_circuit_diagram_info():
+def test_circuit_diagram_info() -> None:
     a, b, c = cirq.LineQubit.range(3)
 
     assert cirq.circuit_diagram_info(cirq.PauliString(), default=None) is None
@@ -1570,13 +1631,13 @@ def test_circuit_diagram_info():
     )
 
 
-def test_mutable_pauli_string_init_raises():
+def test_mutable_pauli_string_init_raises() -> None:
     q = cirq.LineQubit.range(3)
     with pytest.raises(ValueError, match='must be between 1 and 3'):
         _ = cirq.MutablePauliString(pauli_int_dict={q[0]: 0, q[1]: 1, q[2]: 2})
 
 
-def test_mutable_pauli_string_equality():
+def test_mutable_pauli_string_equality() -> None:
     eq = cirq.testing.EqualsTester()
     a, b, c = cirq.LineQubit.range(3)
 
@@ -1624,11 +1685,12 @@ def test_mutable_pauli_string_equality():
         _ = cirq.MutablePauliString("test")
     with pytest.raises(TypeError, match="cirq.PAULI_STRING_LIKE"):
         # noinspection PyTypeChecker
-        _ = cirq.MutablePauliString(object())
+        _ = cirq.MutablePauliString(object())  # type: ignore[arg-type]
 
 
-def test_mutable_pauli_string_inplace_multiplication():
+def test_mutable_pauli_string_inplace_multiplication() -> None:
     a, b, c = cirq.LineQubit.range(3)
+    p: cirq.MutablePauliString[cirq.LineQubit]
     p = cirq.MutablePauliString()
     original = p
 
@@ -1676,7 +1738,7 @@ def test_mutable_pauli_string_inplace_multiplication():
     assert p == -cirq.X(b) and p is original
 
 
-def test_mutable_frozen_copy():
+def test_mutable_frozen_copy() -> None:
     a, b, c = cirq.LineQubit.range(3)
     p = -cirq.X(a) * cirq.Y(b) * cirq.Z(c)
 
@@ -1696,8 +1758,9 @@ def test_mutable_frozen_copy():
     assert p == pf == pm == pmm == pmf
 
 
-def test_mutable_pauli_string_inplace_conjugate_by():
+def test_mutable_pauli_string_inplace_conjugate_by() -> None:
     a, b, c = cirq.LineQubit.range(3)
+    p: cirq.MutablePauliString[cirq.LineQubit]
     p = cirq.MutablePauliString(cirq.X(a))
 
     class NoOp(cirq.Operation):
@@ -1828,15 +1891,15 @@ def test_mutable_pauli_string_inplace_conjugate_by():
     assert p2 is p and p == cirq.X(a) * cirq.Y(b)
 
 
-def test_mps_inplace_after_clifford_gate_type():
+def test_mps_inplace_after_clifford_gate_type() -> None:
     q = cirq.LineQubit(0)
 
-    mps = cirq.MutablePauliString(cirq.X(q))
+    mps: cirq.MutablePauliString = cirq.MutablePauliString(cirq.X(q))
     mps2 = mps.inplace_after(cirq.CliffordGate.from_op_list([cirq.H(q)], [q]).on(q))
     assert mps2 is mps and mps == cirq.Z(q)
 
 
-def test_after_before_vs_conjugate_by():
+def test_after_before_vs_conjugate_by() -> None:
     a, b, c = cirq.LineQubit.range(3)
     p = cirq.X(a) * cirq.Y(b) * cirq.Z(c)
     assert p.before(cirq.S(b)) == p.conjugated_by(cirq.S(b))
@@ -1846,8 +1909,9 @@ def test_after_before_vs_conjugate_by():
     )
 
 
-def test_mutable_pauli_string_dict_functionality():
+def test_mutable_pauli_string_dict_functionality() -> None:
     a, b, c = cirq.LineQubit.range(3)
+    p: cirq.MutablePauliString[cirq.LineQubit]
     p = cirq.MutablePauliString()
     with pytest.raises(KeyError):
         _ = p[a]
@@ -1886,27 +1950,30 @@ def test_mutable_pauli_string_dict_functionality():
 @pytest.mark.parametrize(
     'pauli', (cirq.X, cirq.Y, cirq.Z, cirq.I, "I", "X", "Y", "Z", "i", "x", "y", "z", 0, 1, 2, 3)
 )
-def test_mutable_pauli_string_dict_pauli_like(pauli):
+def test_mutable_pauli_string_dict_pauli_like(pauli) -> None:
+    p: cirq.MutablePauliString
     p = cirq.MutablePauliString()
     # Check that is successfully converts.
     p[0] = pauli
 
 
-def test_mutable_pauli_string_dict_pauli_like_not_pauli_like():
+def test_mutable_pauli_string_dict_pauli_like_not_pauli_like() -> None:
+    p: cirq.MutablePauliString[cirq.Qid]
     p = cirq.MutablePauliString()
     # Check error string includes terms like "X" in error message.
     with pytest.raises(TypeError, match="PAULI_GATE_LIKE.*X"):
-        p[0] = 1.2
+        p[0] = 1.2  # type: ignore
 
 
-def test_mutable_pauli_string_text():
+def test_mutable_pauli_string_text() -> None:
+    p: cirq.MutablePauliString
     p = cirq.MutablePauliString(cirq.X(cirq.LineQubit(0)) * cirq.Y(cirq.LineQubit(1)))
     assert str(cirq.MutablePauliString()) == "mutable I"
     assert str(p) == "mutable X(q(0))*Y(q(1))"
     cirq.testing.assert_equivalent_repr(p)
 
 
-def test_mutable_pauli_string_mul():
+def test_mutable_pauli_string_mul() -> None:
     a, b = cirq.LineQubit.range(2)
     p = cirq.X(a).mutable_copy()
     q = cirq.Y(b).mutable_copy()
@@ -1918,7 +1985,7 @@ def test_mutable_pauli_string_mul():
     assert isinstance(2 * p, cirq.PauliString)
 
 
-def test_mutable_can_override_mul():
+def test_mutable_can_override_mul() -> None:
     class LMul:
         def __mul__(self, other):
             return "Yay!"
@@ -1931,15 +1998,17 @@ def test_mutable_can_override_mul():
     assert LMul() * cirq.MutablePauliString() == "Yay!"
 
 
-def test_coefficient_precision():
+def test_coefficient_precision() -> None:
     qs = cirq.LineQubit.range(4 * 10**3)
+    r: cirq.MutablePauliString[cirq.LineQubit]
+    r2: cirq.MutablePauliString[cirq.LineQubit]
     r = cirq.MutablePauliString({q: cirq.X for q in qs})
     r2 = cirq.MutablePauliString({q: cirq.Y for q in qs})
     r2 *= r
     assert r2.coefficient == 1
 
 
-def test_transform_qubits():
+def test_transform_qubits() -> None:
     a, b, c = cirq.LineQubit.range(3)
     p = cirq.X(a) * cirq.Z(b)
     p2 = cirq.X(b) * cirq.Z(c)
@@ -1960,9 +2029,10 @@ def test_transform_qubits():
     assert m2 == p2
 
 
-def test_parameterization():
+def test_parameterization() -> None:
     t = sympy.Symbol('t')
     q = cirq.LineQubit(0)
+    pst: cirq.PauliString[cirq.LineQubit]
     pst = cirq.PauliString({q: 'x'}, coefficient=t)
     assert cirq.is_parameterized(pst)
     assert cirq.parameter_names(pst) == {'t'}
@@ -1991,9 +2061,11 @@ def test_parameterization():
 
 
 @pytest.mark.parametrize('resolve_fn', [cirq.resolve_parameters, cirq.resolve_parameters_once])
-def test_resolve(resolve_fn):
+def test_resolve(resolve_fn) -> None:
     t = sympy.Symbol('t')
     q = cirq.LineQubit(0)
+    pst: cirq.PauliString[cirq.LineQubit]
+    ps1: cirq.PauliString[cirq.LineQubit]
     pst = cirq.PauliString({q: 'x'}, coefficient=t)
     ps1 = cirq.PauliString({q: 'x'}, coefficient=1j)
     assert resolve_fn(pst, {'t': 1j}) == ps1

--- a/cirq-core/cirq/ops/permutation_gate.py
+++ b/cirq-core/cirq/ops/permutation_gate.py
@@ -69,7 +69,7 @@ class QubitPermutationGate(raw_types.Gate):
     def _value_equality_values_(self):
         return self.permutation
 
-    def num_qubits(self):
+    def num_qubits(self) -> int:
         return len(self.permutation)
 
     def _has_unitary_(self):

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -33,7 +33,6 @@ from typing import (
 )
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import protocols, value
 from cirq._compat import __cirq_debug__, _method_cache_name, cached_method
@@ -521,7 +520,7 @@ class Operation(metaclass=abc.ABCMeta):
         return protocols.qid_shape(self.qubits)
 
     @abc.abstractmethod
-    def with_qubits(self, *new_qubits: cirq.Qid) -> Self:
+    def with_qubits(self, *new_qubits: cirq.Qid) -> cirq.Operation:
         """Returns the same operation, but applied to different qubits.
 
         Args:
@@ -567,7 +566,7 @@ class Operation(metaclass=abc.ABCMeta):
 
     def transform_qubits(
         self, qubit_map: dict[cirq.Qid, cirq.Qid] | Callable[[cirq.Qid], cirq.Qid]
-    ) -> Self:
+    ) -> cirq.Operation:
         """Returns the same operation, but with different qubits.
 
         This function will return a new operation with the same gate but
@@ -769,7 +768,7 @@ class TaggedOperation(Operation):
     def gate(self) -> cirq.Gate | None:
         return self.sub_operation.gate
 
-    def with_qubits(self, *new_qubits: cirq.Qid):
+    def with_qubits(self, *new_qubits: cirq.Qid) -> TaggedOperation:
         return TaggedOperation(self.sub_operation.with_qubits(*new_qubits), *self._tags)
 
     def _with_measurement_key_mapping_(self, key_map: Mapping[str, str]):

--- a/cirq-core/cirq/ops/raw_types_test.py
+++ b/cirq-core/cirq/ops/raw_types_test.py
@@ -48,7 +48,7 @@ class ValidQid(cirq.Qid):
         self.validate_dimension(dimension)
 
     @property
-    def dimension(self):
+    def dimension(self) -> int:
         return self._dimension
 
     def with_dimension(self, dimension) -> ValidQid:

--- a/cirq-core/cirq/ops/three_qubit_gates.py
+++ b/cirq-core/cirq/ops/three_qubit_gates.py
@@ -423,8 +423,8 @@ class CCXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
             }
         )
 
-    def qubit_index_to_equivalence_group_key(self, index):
-        return index < 2
+    def qubit_index_to_equivalence_group_key(self, index) -> int:
+        return 1 if index < 2 else 0
 
     def _apply_unitary_(self, args: protocols.ApplyUnitaryArgs) -> np.ndarray:
         if protocols.is_parameterized(self):
@@ -508,7 +508,7 @@ class CCXPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
 class CSwapGate(gate_features.InterchangeableQubitsGate, raw_types.Gate):
     """A controlled swap gate. The Fredkin gate."""
 
-    def qubit_index_to_equivalence_group_key(self, index):
+    def qubit_index_to_equivalence_group_key(self, index) -> int:
         return 0 if index == 0 else 1
 
     def _pauli_expansion_(self) -> value.LinearDict[str]:

--- a/cirq-core/cirq/protocols/act_on_protocol.py
+++ b/cirq-core/cirq/protocols/act_on_protocol.py
@@ -94,7 +94,7 @@ def act_on(
     qubits: Sequence[cirq.Qid] | None = None,
     *,
     allow_decompose: bool = True,
-):
+) -> None:
     """Applies an action to a state argument.
 
     For example, the action may be a `cirq.Operation` and the state argument may

--- a/cirq-core/cirq/protocols/act_on_protocol_test.py
+++ b/cirq-core/cirq/protocols/act_on_protocol_test.py
@@ -25,10 +25,10 @@ import cirq
 
 class ExampleQuantumState(cirq.QuantumStateRepresentation):
     def copy(self, deep_copy_buffers=True) -> Self:
-        return self.__class__()
+        return self.__class__()  # pragma: no cover
 
     def measure(self, axes, seed=None) -> list[int]:
-        return []
+        return []  # pragma: no cover
 
 
 class ExampleSimulationState(cirq.SimulationState):

--- a/cirq-core/cirq/protocols/act_on_protocol_test.py
+++ b/cirq-core/cirq/protocols/act_on_protocol_test.py
@@ -24,11 +24,11 @@ import cirq
 
 
 class ExampleQuantumState(cirq.QuantumStateRepresentation):
-    def copy(self, deep_copy_buffers=True):
-        pass
+    def copy(self, deep_copy_buffers=True) -> Self:
+        return self.__class__()
 
-    def measure(self, axes, seed=None):
-        pass
+    def measure(self, axes, seed=None) -> list[int]:
+        return []
 
 
 class ExampleSimulationState(cirq.SimulationState):

--- a/cirq-core/cirq/protocols/apply_channel_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_channel_protocol_test.py
@@ -20,7 +20,7 @@ import pytest
 import cirq
 
 
-def make_buffers(shape, dtype):
+def make_buffers(shape, dtype) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     return (
         np.empty(shape, dtype=dtype),
         np.empty(shape, dtype=dtype),
@@ -28,7 +28,7 @@ def make_buffers(shape, dtype):
     )
 
 
-def apply_channel(val, rho, left_axes, right_axes, assert_result_is_out_buf=False):
+def apply_channel(val, rho, left_axes, right_axes, assert_result_is_out_buf=False) -> np.ndarray:
     out_buf, buf0, buf1 = make_buffers(rho.shape, rho.dtype)
     result = cirq.apply_channel(
         val,
@@ -48,7 +48,7 @@ def apply_channel(val, rho, left_axes, right_axes, assert_result_is_out_buf=Fals
     return result
 
 
-def test_apply_channel_bad_args():
+def test_apply_channel_bad_args() -> None:
     target = np.zeros((3,) + (1, 2, 3) + (3, 1, 2) + (3,))
     with pytest.raises(ValueError, match='Invalid target_tensor shape'):
         cirq.apply_channel(
@@ -77,7 +77,7 @@ def test_apply_channel_bad_args():
         )
 
 
-def test_apply_channel_simple():
+def test_apply_channel_simple() -> None:
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     class HasApplyChannel:
@@ -108,7 +108,7 @@ def test_apply_channel_simple():
     np.testing.assert_almost_equal(result, x)
 
 
-def test_apply_channel_inline():
+def test_apply_channel_inline() -> None:
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     class HasApplyChannel:
@@ -123,7 +123,7 @@ def test_apply_channel_inline():
     np.testing.assert_almost_equal(result, x)
 
 
-def test_apply_channel_returns_aux_buffer():
+def test_apply_channel_returns_aux_buffer() -> None:
     rho = np.array([[1, 0], [0, 0]], dtype=np.complex128)
 
     class ReturnsAuxBuffer0:
@@ -141,7 +141,7 @@ def test_apply_channel_returns_aux_buffer():
         _ = apply_channel(ReturnsAuxBuffer1(), rho, [0], [1])
 
 
-def test_apply_channel_channel_fallback_simple():
+def test_apply_channel_channel_fallback_simple() -> None:
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     class HasChannel:
@@ -153,7 +153,7 @@ def test_apply_channel_channel_fallback_simple():
     np.testing.assert_almost_equal(result, x)
 
 
-def test_apply_channel_channel_fallback_one_qubit_random_on_qubit():
+def test_apply_channel_channel_fallback_one_qubit_random_on_qubit() -> None:
     for _ in range(25):
         state = cirq.testing.random_superposition(2)
         rho = np.outer(np.conjugate(state), state)
@@ -171,7 +171,7 @@ def test_apply_channel_channel_fallback_one_qubit_random_on_qubit():
         np.testing.assert_almost_equal(result, expected)
 
 
-def test_apply_channel_channel_fallback_one_qubit_random_on_two_qubits():
+def test_apply_channel_channel_fallback_one_qubit_random_on_two_qubits() -> None:
     for _ in range(25):
         state = cirq.testing.random_superposition(4)
         rho = np.outer(np.conjugate(state), state)
@@ -193,7 +193,7 @@ def test_apply_channel_channel_fallback_one_qubit_random_on_two_qubits():
         np.testing.assert_almost_equal(result, expected)
 
 
-def test_apply_channel_channel_fallback_two_qubit_random():
+def test_apply_channel_channel_fallback_two_qubit_random() -> None:
     for _ in range(25):
         state = cirq.testing.random_superposition(4)
         rho = np.outer(np.conjugate(state), state)
@@ -214,7 +214,7 @@ def test_apply_channel_channel_fallback_two_qubit_random():
         np.testing.assert_almost_equal(result, expected)
 
 
-def test_apply_channel_no_protocols_implemented():
+def test_apply_channel_no_protocols_implemented() -> None:
     class NoProtocols:
         pass
 
@@ -224,23 +224,24 @@ def test_apply_channel_no_protocols_implemented():
         apply_channel(NoProtocols(), rho, left_axes=[1], right_axes=[1])
 
 
-def test_apply_channel_no_protocols_implemented_default():
+def test_apply_channel_no_protocols_implemented_default() -> None:
     class NoProtocols:
         pass
 
+    out_buffer, auxiliary_buffer0, auxiliary_buffer1 = make_buffers((2, 2), float)
     args = cirq.ApplyChannelArgs(
         target_tensor=np.eye(2),
         left_axes=[0],
         right_axes=[1],
-        out_buffer=None,
-        auxiliary_buffer0=None,
-        auxiliary_buffer1=None,
+        out_buffer=out_buffer,
+        auxiliary_buffer0=auxiliary_buffer0,
+        auxiliary_buffer1=auxiliary_buffer1,
     )
     result = cirq.apply_channel(NoProtocols(), args, 'cirq')
     assert result == 'cirq'
 
 
-def test_apply_channel_unitary():
+def test_apply_channel_unitary() -> None:
     m = np.diag([1, 1j])
 
     shape = (2, 2, 2, 2)
@@ -263,7 +264,7 @@ def test_apply_channel_unitary():
         )
 
 
-def test_apply_channel_apply_unitary():
+def test_apply_channel_apply_unitary() -> None:
     shape = (2, 2, 2, 2)
     rho = np.ones(shape, dtype=np.complex128)
 
@@ -291,7 +292,7 @@ def test_apply_channel_apply_unitary():
         )
 
 
-def test_apply_channel_apply_unitary_not_implemented():
+def test_apply_channel_apply_unitary_not_implemented() -> None:
     class ApplyUnitaryNotImplemented:
         def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs):
             return NotImplemented

--- a/cirq-core/cirq/protocols/apply_mixture_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_mixture_protocol_test.py
@@ -21,7 +21,7 @@ import pytest
 import cirq
 
 
-def make_buffers(shape, dtype):
+def make_buffers(shape, dtype) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     return (
         np.empty(shape, dtype=dtype),
         np.empty(shape, dtype=dtype),
@@ -36,7 +36,7 @@ def assert_apply_mixture_returns(
     right_axes: Iterable[int] | None,
     assert_result_is_out_buf: bool = False,
     expected_result: np.ndarray | None = None,
-):
+) -> None:
     out_buf, buf0, buf1 = make_buffers(rho.shape, rho.dtype)
     result = cirq.apply_mixture(
         val,
@@ -58,7 +58,7 @@ def assert_apply_mixture_returns(
     np.testing.assert_array_almost_equal(result, expected_result)
 
 
-def test_apply_mixture_bad_args():
+def test_apply_mixture_bad_args() -> None:
     target = np.zeros((3,) + (1, 2, 3) + (3, 1, 2) + (3,))
     with pytest.raises(ValueError, match='Invalid target_tensor shape'):
         cirq.apply_mixture(
@@ -89,7 +89,7 @@ def test_apply_mixture_bad_args():
         )
 
 
-def test_apply_mixture_simple():
+def test_apply_mixture_simple() -> None:
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     class HasApplyMixture:
@@ -121,7 +121,7 @@ def test_apply_mixture_simple():
     )
 
 
-def test_apply_mixture_inline():
+def test_apply_mixture_inline() -> None:
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     class HasApplyMixture:
@@ -135,7 +135,7 @@ def test_apply_mixture_inline():
     assert_apply_mixture_returns(HasApplyMixture(), rho, [0], [1], expected_result=x)
 
 
-def test_apply_mixture_returns_aux_buffer():
+def test_apply_mixture_returns_aux_buffer() -> None:
     rho = np.array([[1, 0], [0, 0]], dtype=np.complex128)
 
     class ReturnsAuxBuffer0:
@@ -153,7 +153,7 @@ def test_apply_mixture_returns_aux_buffer():
         assert_apply_mixture_returns(ReturnsAuxBuffer1(), rho, [0], [1])
 
 
-def test_apply_mixture_simple_state_vector():
+def test_apply_mixture_simple_state_vector() -> None:
     for _ in range(25):
         state = cirq.testing.random_superposition(2)
         u1 = cirq.testing.random_unitary(2)
@@ -172,7 +172,7 @@ def test_apply_mixture_simple_state_vector():
         )
 
 
-def test_apply_mixture_simple_split_fallback():
+def test_apply_mixture_simple_split_fallback() -> None:
     x = np.array([[0, 1], [1, 0]], dtype=np.complex128)
 
     class HasMixture:
@@ -185,7 +185,7 @@ def test_apply_mixture_simple_split_fallback():
     )
 
 
-def test_apply_mixture_fallback_one_qubit_random_on_qubit():
+def test_apply_mixture_fallback_one_qubit_random_on_qubit() -> None:
     for _ in range(25):
         state = cirq.testing.random_superposition(2)
         rho = np.outer(np.conjugate(state), state)
@@ -203,7 +203,7 @@ def test_apply_mixture_fallback_one_qubit_random_on_qubit():
         )
 
 
-def test_apply_mixture_fallback_two_qubit_random():
+def test_apply_mixture_fallback_two_qubit_random() -> None:
     for _ in range(25):
         state = cirq.testing.random_superposition(4)
         rho = np.outer(np.conjugate(state), state)
@@ -229,7 +229,7 @@ def test_apply_mixture_fallback_two_qubit_random():
         )
 
 
-def test_apply_mixture_no_protocols_implemented():
+def test_apply_mixture_no_protocols_implemented() -> None:
     class NoProtocols:
         pass
 
@@ -239,7 +239,7 @@ def test_apply_mixture_no_protocols_implemented():
         assert_apply_mixture_returns(NoProtocols(), rho, left_axes=[1], right_axes=[1])
 
 
-def test_apply_mixture_mixture_returns_not_implemented():
+def test_apply_mixture_mixture_returns_not_implemented() -> None:
     class NoMixture:
         def _mixture_(self):
             return NotImplemented
@@ -250,23 +250,24 @@ def test_apply_mixture_mixture_returns_not_implemented():
         assert_apply_mixture_returns(NoMixture(), rho, left_axes=[1], right_axes=[1])
 
 
-def test_apply_mixture_no_protocols_implemented_default():
+def test_apply_mixture_no_protocols_implemented_default() -> None:
     class NoProtocols:
         pass
 
+    out_buffer, auxiliary_buffer0, auxiliary_buffer1 = make_buffers((2, 2), float)
     args = cirq.ApplyMixtureArgs(
         target_tensor=np.eye(2),
         left_axes=[0],
         right_axes=[1],
-        out_buffer=None,
-        auxiliary_buffer0=None,
-        auxiliary_buffer1=None,
+        out_buffer=out_buffer,
+        auxiliary_buffer0=auxiliary_buffer0,
+        auxiliary_buffer1=auxiliary_buffer1,
     )
     result = cirq.apply_mixture(NoProtocols(), args, default='cirq')
     assert result == 'cirq'
 
 
-def test_apply_mixture_unitary():
+def test_apply_mixture_unitary() -> None:
     m = np.diag([1, 1j])
 
     shape = (2, 2, 2, 2)
@@ -291,7 +292,7 @@ def test_apply_mixture_unitary():
         )
 
 
-def test_apply_mixture_apply_unitary():
+def test_apply_mixture_apply_unitary() -> None:
     shape = (2, 2, 2, 2)
     rho = np.ones(shape, dtype=np.complex128)
 
@@ -320,7 +321,7 @@ def test_apply_mixture_apply_unitary():
         )
 
 
-def test_apply_mixture_apply_unitary_not_implemented():
+def test_apply_mixture_apply_unitary_not_implemented() -> None:
     class ApplyUnitaryNotImplemented:
         def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs):
             return NotImplemented

--- a/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol_test.py
@@ -21,7 +21,7 @@ import cirq
 from cirq.protocols.apply_unitary_protocol import _incorporate_result_into_target
 
 
-def test_apply_unitary_presence_absence():
+def test_apply_unitary_presence_absence() -> None:
     m = np.diag([1, -1])
 
     class NoUnitaryEffect:
@@ -102,7 +102,7 @@ def test_apply_unitary_presence_absence():
         )
 
 
-def test_apply_unitary_args_tensor_manipulation():
+def test_apply_unitary_args_tensor_manipulation() -> None:
     # All below are qubit swap operations with 1j global phase
 
     class ModifyTargetTensor:
@@ -215,7 +215,7 @@ def test_apply_unitary_args_tensor_manipulation():
             args.available_buffer[...] = 98
             return ret
 
-    operations = [
+    operations: list[cirq.SupportsConsistentApplyUnitary] = [
         ModifyTargetTensor(),
         TransposeTargetTensor(),
         ReshapeTargetTensor(),
@@ -266,7 +266,7 @@ def test_apply_unitary_args_tensor_manipulation():
         assert_is_swap(op)
 
 
-def test_big_endian_subspace_index():
+def test_big_endian_subspace_index() -> None:
     state = np.zeros(shape=(2, 3, 4, 5, 1, 6, 1, 1))
     args = cirq.ApplyUnitaryArgs(state, np.empty_like(state), [1, 3])
     s = slice(None)
@@ -274,12 +274,13 @@ def test_big_endian_subspace_index():
     assert args.subspace_index(big_endian_bits_int=1) == (s, 0, s, 1, s, s, s, s)
 
 
-def test_apply_unitaries():
+def test_apply_unitaries() -> None:
     a, b, c = cirq.LineQubit.range(3)
 
     result = cirq.apply_unitaries(
         unitary_values=[cirq.H(a), cirq.CNOT(a, b), cirq.H(c).controlled_by(b)], qubits=[a, b, c]
     )
+    assert result is not None
     np.testing.assert_allclose(
         result.reshape(8), [np.sqrt(0.5), 0, 0, 0, 0, 0, 0.5, 0.5], atol=1e-8
     )
@@ -288,6 +289,7 @@ def test_apply_unitaries():
     result = cirq.apply_unitaries(
         unitary_values=[cirq.H(a), cirq.CNOT(a, b), cirq.H(c).controlled_by(b)], qubits=[a, c, b]
     )
+    assert result is not None
     np.testing.assert_allclose(
         result.reshape(8), [np.sqrt(0.5), 0, 0, 0, 0, 0.5, 0, 0.5], atol=1e-8
     )
@@ -298,14 +300,17 @@ def test_apply_unitaries():
         qubits=[a, b, c],
         args=cirq.ApplyUnitaryArgs.default(num_qubits=3),
     )
+    assert result is not None
     np.testing.assert_allclose(
         result.reshape(8), [np.sqrt(0.5), 0, 0, 0, 0, 0, 0.5, 0.5], atol=1e-8
     )
 
     # Empty.
     result = cirq.apply_unitaries(unitary_values=[], qubits=[])
+    assert result is not None
     np.testing.assert_allclose(result, [1])
     result = cirq.apply_unitaries(unitary_values=[], qubits=[], default=None)
+    assert result is not None
     np.testing.assert_allclose(result, [1])
 
     # Non-unitary operation.
@@ -327,7 +332,7 @@ def test_apply_unitaries():
         )
 
 
-def test_apply_unitaries_mixed_qid_shapes():
+def test_apply_unitaries_mixed_qid_shapes() -> None:
     class PlusOneMod3Gate(cirq.testing.SingleQubitGate):
         def _qid_shape_(self):
             return (3,)
@@ -358,6 +363,7 @@ def test_apply_unitaries_mixed_qid_shapes():
         ],
         qubits=[a, b],
     )
+    assert result is not None
     np.testing.assert_allclose(result.reshape(12), [1] + [0] * 11, atol=1e-8)
 
     result = cirq.apply_unitaries(
@@ -377,6 +383,7 @@ def test_apply_unitaries_mixed_qid_shapes():
             axes=(0, 1),
         ),
     )
+    assert result is not None
     np.testing.assert_allclose(result.reshape(12, 12), np.eye(12), atol=1e-8)
 
     result = cirq.apply_unitaries(
@@ -403,6 +410,7 @@ def test_apply_unitaries_mixed_qid_shapes():
             axes=(0, 1),
         ),
     )
+    assert result is not None
     np.testing.assert_allclose(
         result.reshape(12, 12),
         np.array(
@@ -426,7 +434,7 @@ def test_apply_unitaries_mixed_qid_shapes():
 
 
 # fmt: off
-def test_subspace_size_2():
+def test_subspace_size_2() -> None:
     result = cirq.apply_unitary(
         unitary_value=cirq.X,
         args=cirq.ApplyUnitaryArgs(
@@ -513,7 +521,7 @@ def test_subspace_size_2():
     )
 
 
-def test_subspaces_size_3():
+def test_subspaces_size_3() -> None:
     plus_one_mod_3_gate = cirq.XPowGate(dimension=3)
 
     result = cirq.apply_unitary(
@@ -581,7 +589,7 @@ def test_subspaces_size_3():
     )
 
 
-def test_subspaces_size_1():
+def test_subspaces_size_1() -> None:
     phase_gate = cirq.MatrixGate(np.array([[1j]]))
 
     result = cirq.apply_unitary(
@@ -646,7 +654,7 @@ def test_subspaces_size_1():
 # fmt: on
 
 
-def test_invalid_subspaces():
+def test_invalid_subspaces() -> None:
     with pytest.raises(ValueError, match='Subspace specified does not exist in axis'):
         _ = cirq.ApplyUnitaryArgs(
             target_tensor=cirq.eye_tensor((2,), dtype=np.complex64),
@@ -677,7 +685,7 @@ def test_invalid_subspaces():
         )
 
 
-def test_incorporate_result_not_view():
+def test_incorporate_result_not_view() -> None:
     tensor = np.zeros((2, 2))
     tensor2 = np.zeros((2, 2))
     buffer = np.empty_like(tensor)
@@ -687,12 +695,12 @@ def test_incorporate_result_not_view():
         _incorporate_result_into_target(args, not_sub_args, tensor2)
 
 
-def test_default_method_arguments():
+def test_default_method_arguments() -> None:
     with pytest.raises(TypeError, match='exactly one of'):
         cirq.ApplyUnitaryArgs.default(1, qid_shape=(2,))
 
 
-def test_apply_unitary_args_with_axes_transposed_to_start():
+def test_apply_unitary_args_with_axes_transposed_to_start() -> None:
     target = np.zeros((2, 3, 4, 5))
     buffer = np.zeros((2, 3, 4, 5))
     args = cirq.ApplyUnitaryArgs(target, buffer, [1, 3])
@@ -709,7 +717,8 @@ def test_apply_unitary_args_with_axes_transposed_to_start():
     assert args.available_buffer[1, 2, 3, 4] == 2
 
 
-def test_cast_to_complex():
+def test_cast_to_complex() -> None:
+    y0: cirq.PauliString[cirq.LineQubit]
     y0 = cirq.PauliString({cirq.LineQubit(0): cirq.Y})
     state = 0.5 * np.eye(2)
     args = cirq.ApplyUnitaryArgs(
@@ -724,7 +733,7 @@ def test_cast_to_complex():
 
 
 class NotDecomposableGate(cirq.Gate):
-    def num_qubits(self):
+    def num_qubits(self) -> int:
         return 1
 
 
@@ -734,7 +743,7 @@ class DecomposableGate(cirq.Gate):
         self._sub_gate = sub_gate
         self._allocate_ancilla = allocate_ancilla
 
-    def num_qubits(self):
+    def num_qubits(self) -> int:
         return 1
 
     def _decompose_(self, qubits):
@@ -743,17 +752,16 @@ class DecomposableGate(cirq.Gate):
         yield self._sub_gate(qubits[0])
 
 
-def test_strat_apply_unitary_from_decompose():
+def test_strat_apply_unitary_from_decompose() -> None:
     state = np.eye(2, dtype=np.complex128)
     args = cirq.ApplyUnitaryArgs(
         target_tensor=state, available_buffer=np.zeros_like(state), axes=(0,)
     )
-    np.testing.assert_allclose(
-        cirq.apply_unitaries(
-            [DecomposableGate(cirq.X, False)(cirq.LineQubit(0))], [cirq.LineQubit(0)], args
-        ),
-        [[0, 1], [1, 0]],
+    result = cirq.apply_unitaries(
+        [DecomposableGate(cirq.X, False)(cirq.LineQubit(0))], [cirq.LineQubit(0)], args
     )
+    assert result is not None
+    np.testing.assert_allclose(result, [[0, 1], [1, 0]])
 
     with pytest.raises(TypeError):
         _ = cirq.apply_unitaries(
@@ -763,7 +771,7 @@ def test_strat_apply_unitary_from_decompose():
         )
 
 
-def test_unitary_construction():
+def test_unitary_construction() -> None:
     with pytest.raises(TypeError):
         _ = cirq.ApplyUnitaryArgs.for_unitary()
 

--- a/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
+++ b/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
@@ -124,7 +124,7 @@ class X(Number):
         return self.val == other.val
 
     def __hash__(self):
-        return hash(self.val)
+        return hash(self.val)  # pragma: no cover
 
 
 class Y(Number):
@@ -134,7 +134,7 @@ class Y(Number):
         pass
 
     def __hash__(self):
-        return hash(complex(self))
+        return hash(complex(self))  # pragma: no cover
 
 
 def test_approx_eq_number_uses__eq__() -> None:

--- a/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
+++ b/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
@@ -25,7 +25,7 @@ import sympy
 import cirq
 
 
-def test_approx_eq_primitives():
+def test_approx_eq_primitives() -> None:
     assert not cirq.approx_eq(1, 2, atol=1e-01)
     assert cirq.approx_eq(1.0, 1.0 + 1e-10, atol=1e-09)
     assert not cirq.approx_eq(1.0, 1.0 + 1e-10, atol=1e-11)
@@ -40,7 +40,7 @@ def test_approx_eq_primitives():
     assert not cirq.approx_eq('1', 1, atol=1e-3)
 
 
-def test_approx_eq_mixed_primitives():
+def test_approx_eq_mixed_primitives() -> None:
     assert cirq.approx_eq(complex(1, 1e-10), 1, atol=1e-09)
     assert not cirq.approx_eq(complex(1, 1e-4), 1, atol=1e-09)
     assert cirq.approx_eq(complex(1, 1e-10), 1.0, atol=1e-09)
@@ -49,7 +49,7 @@ def test_approx_eq_mixed_primitives():
     assert not cirq.approx_eq(1, 1.0 + 1e-10, atol=1e-11)
 
 
-def test_numpy_dtype_compatibility():
+def test_numpy_dtype_compatibility() -> None:
     i_a, i_b, i_c = 0, 1, 2
     i_types = [np.intc, np.intp, np.int8, np.int16, np.int32, np.int64]
     for i_type in i_types:
@@ -77,18 +77,18 @@ def test_numpy_dtype_compatibility():
         assert not cirq.approx_eq(c_type(c_a), c_type(c_c), atol=1e-8)
 
 
-def test_fractions_compatibility():
+def test_fractions_compatibility() -> None:
     assert cirq.approx_eq(Fraction(0), Fraction(1, int(1e10)), atol=1e-9)
     assert not cirq.approx_eq(Fraction(0), Fraction(1, int(1e7)), atol=1e-9)
 
 
-def test_decimal_compatibility():
+def test_decimal_compatibility() -> None:
     assert cirq.approx_eq(Decimal('0'), Decimal('0.0000000001'), atol=1e-9)
     assert not cirq.approx_eq(Decimal('0'), Decimal('0.00000001'), atol=1e-9)
     assert not cirq.approx_eq(Decimal('NaN'), Decimal('-Infinity'), atol=1e-9)
 
 
-def test_approx_eq_mixed_types():
+def test_approx_eq_mixed_types() -> None:
     assert cirq.approx_eq(np.float32(1), 1.0 + 1e-10, atol=1e-9)
     assert cirq.approx_eq(np.float64(1), np.complex64(1 + 1e-8j), atol=1e-4)
     assert cirq.approx_eq(np.uint8(1), np.complex64(1 + 1e-8j), atol=1e-4)
@@ -103,7 +103,7 @@ def test_approx_eq_mixed_types():
     assert not cirq.approx_eq(np.complex64(1e-5j), Decimal('0.001'), atol=1e-4)
 
 
-def test_approx_eq_special_numerics():
+def test_approx_eq_special_numerics() -> None:
     assert not cirq.approx_eq(float('nan'), 0, atol=0.0)
     assert not cirq.approx_eq(float('nan'), float('nan'), atol=0.0)
     assert not cirq.approx_eq(float('inf'), float('-inf'), atol=0.0)
@@ -123,6 +123,9 @@ class X(Number):
             return NotImplemented
         return self.val == other.val
 
+    def __hash__(self):
+        return hash(self.val)
+
 
 class Y(Number):
     """Subtype of Number that cannot fallback to __eq__"""
@@ -130,15 +133,18 @@ class Y(Number):
     def __init__(self):
         pass
 
+    def __hash__(self):
+        return hash(complex(self))
 
-def test_approx_eq_number_uses__eq__():
+
+def test_approx_eq_number_uses__eq__() -> None:
     assert cirq.approx_eq(C(0), C(0), atol=0.0)
     assert not cirq.approx_eq(X(0), X(1), atol=0.0)
     assert not cirq.approx_eq(X(0), 0, atol=0.0)
     assert not cirq.approx_eq(Y(), 1, atol=0.0)
 
 
-def test_approx_eq_tuple():
+def test_approx_eq_tuple() -> None:
     assert cirq.approx_eq((1, 1), (1, 1), atol=0.0)
     assert not cirq.approx_eq((1, 1), (1, 1, 1), atol=0.0)
     assert not cirq.approx_eq((1, 1), (1,), atol=0.0)
@@ -146,7 +152,7 @@ def test_approx_eq_tuple():
     assert not cirq.approx_eq((1.1, 1.2, 1.3), (1, 1, 1), atol=0.2)
 
 
-def test_approx_eq_list():
+def test_approx_eq_list() -> None:
     assert cirq.approx_eq([], [], atol=0.0)
     assert not cirq.approx_eq([], [[]], atol=0.0)
     assert cirq.approx_eq([1, 1], [1, 1], atol=0.0)
@@ -156,7 +162,7 @@ def test_approx_eq_list():
     assert not cirq.approx_eq([1.1, 1.2, 1.3], [1, 1, 1], atol=0.2)
 
 
-def test_approx_eq_symbol():
+def test_approx_eq_symbol() -> None:
     q = cirq.GridQubit(0, 0)
     s = sympy.Symbol("s")
     t = sympy.Symbol("t")
@@ -184,14 +190,14 @@ def test_approx_eq_symbol():
         cirq.approx_eq(symbol_1, symbol_3, atol=0.2)
 
 
-def test_approx_eq_default():
+def test_approx_eq_default() -> None:
     assert cirq.approx_eq(1.0, 1.0 + 1e-9)
     assert cirq.approx_eq(1.0, 1.0 - 1e-9)
     assert not cirq.approx_eq(1.0, 1.0 + 1e-7)
     assert not cirq.approx_eq(1.0, 1.0 - 1e-7)
 
 
-def test_approx_eq_iterables():
+def test_approx_eq_iterables() -> None:
     def gen_1_1():
         yield 1
         yield 1
@@ -221,7 +227,7 @@ class B:
         return cirq.approx_eq(self.val, other, atol=atol)
 
 
-def test_approx_eq_supported():
+def test_approx_eq_supported() -> None:
     assert cirq.approx_eq(A(0.0), A(0.1), atol=0.1)
     assert not cirq.approx_eq(A(0.0), A(0.1), atol=0.0)
     assert cirq.approx_eq(B(0.0), 0.1, atol=0.1)
@@ -238,7 +244,7 @@ class C:
         return self.val == other.val
 
 
-def test_approx_eq_uses__eq__():
+def test_approx_eq_uses__eq__() -> None:
     assert cirq.approx_eq(C(0), C(0), atol=0.0)
     assert not cirq.approx_eq(C(1), C(2), atol=0.0)
     assert cirq.approx_eq([C(0)], [C(0)], atol=0.0)
@@ -247,7 +253,7 @@ def test_approx_eq_uses__eq__():
     assert cirq.approx_eq(0, complex(0, 0), atol=0.0)
 
 
-def test_approx_eq_types_mismatch():
+def test_approx_eq_types_mismatch() -> None:
     assert not cirq.approx_eq(0, A(0), atol=0.0)
     assert not cirq.approx_eq(A(0), 0, atol=0.0)
     assert not cirq.approx_eq(B(0), A(0), atol=0.0)

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 from fractions import Fraction
-from typing import Any, Iterable, overload, Sequence, TYPE_CHECKING, TypeVar, Union
+from typing import Any, Iterable, overload, Self, Sequence, TYPE_CHECKING, TypeVar, Union
 
 import numpy as np
 import sympy
@@ -76,7 +76,7 @@ class CircuitDiagramInfo:
         self.exponent_qubit_index = exponent_qubit_index
         self.auto_exponent_parens = auto_exponent_parens
 
-    def with_wire_symbols(self, new_wire_symbols: Iterable[str]):
+    def with_wire_symbols(self, new_wire_symbols: Iterable[str]) -> CircuitDiagramInfo:
         return CircuitDiagramInfo(
             wire_symbols=new_wire_symbols,
             exponent=self.exponent,
@@ -300,7 +300,7 @@ class CircuitDiagramInfoArgs:
             return str(radians)
         return repr(radians)
 
-    def copy(self):
+    def copy(self) -> Self:
         return self.__class__(
             known_qubits=self.known_qubits,
             known_qubit_count=self.known_qubit_count,
@@ -311,7 +311,7 @@ class CircuitDiagramInfoArgs:
             transpose=self.transpose,
         )
 
-    def with_args(self, **kwargs):
+    def with_args(self, **kwargs) -> Self:
         args = self.copy()
         for arg_name, val in kwargs.items():
             setattr(args, arg_name, val)

--- a/cirq-core/cirq/protocols/commutes_protocol_test.py
+++ b/cirq-core/cirq/protocols/commutes_protocol_test.py
@@ -21,7 +21,7 @@ import sympy
 import cirq
 
 
-def test_commutes_on_matrices():
+def test_commutes_on_matrices() -> None:
     I, X, Y, Z = (cirq.unitary(A) for A in (cirq.I, cirq.X, cirq.Y, cirq.Z))
     IX, IY = (np.kron(I, A) for A in (X, Y))
     XI, YI, ZI = (np.kron(A, I) for A in (X, Y, Z))
@@ -38,14 +38,14 @@ def test_commutes_on_matrices():
         assert cirq.commutes(A, B)
 
 
-def test_commutes_on_gates_and_gate_operations():
+def test_commutes_on_gates_and_gate_operations() -> None:
     X, Y, Z = tuple(cirq.unitary(A) for A in (cirq.X, cirq.Y, cirq.Z))
     XGate, YGate, ZGate = (cirq.MatrixGate(A) for A in (X, Y, Z))
     XXGate, YYGate, ZZGate = (cirq.MatrixGate(cirq.kron(A, A)) for A in (X, Y, Z))
     a, b = cirq.LineQubit.range(2)
     for A in (XGate, YGate, ZGate):
         assert cirq.commutes(A, A)
-        assert A._commutes_on_qids_(a, A, atol=1e-8) is NotImplemented
+        assert A._commutes_on_qids_([a], A, atol=1e-8) is NotImplemented
         with pytest.raises(TypeError):
             cirq.commutes(A(a), A)
         with pytest.raises(TypeError):
@@ -91,7 +91,7 @@ def test_commutes_on_gates_and_gate_operations():
     assert cirq.commutes(XGate(a), 'Gate', default='default') == 'default'
 
 
-def test_operation_commutes_using_overlap_and_unitary():
+def test_operation_commutes_using_overlap_and_unitary() -> None:
     class CustomCnotGate(cirq.Gate):
         def num_qubits(self) -> int:
             return 2


### PR DESCRIPTION
No change in the effective code.  A batch of ~50 files.

Modified files pass  ruff check --select=ANN201

Partially implements #4393
