### PR TITLE
Replace typing_extensions with builtin typing module

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -39,6 +39,7 @@ from typing import (
     Mapping,
     MutableSequence,
     overload,
+    Self,
     Sequence,
     TYPE_CHECKING,
     TypeVar,
@@ -47,7 +48,6 @@ from typing import (
 
 import networkx
 import numpy as np
-from typing_extensions import Self
 
 import cirq._version
 from cirq import _compat, devices, ops, protocols, qis

--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -29,12 +29,12 @@ from typing import (
     Iterator,
     Mapping,
     overload,
+    Self,
     Sequence,
     TYPE_CHECKING,
 )
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import _compat, ops, protocols, qis
 from cirq._import import LazyLoader

--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 import abc
 import functools
 import weakref
-from typing import Any, Iterable, TYPE_CHECKING
+from typing import Any, Iterable, Self, TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import ops, protocols
 

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -17,9 +17,7 @@ from __future__ import annotations
 import abc
 import functools
 import weakref
-from typing import Any, Iterable, Sequence, TYPE_CHECKING
-
-from typing_extensions import Self
+from typing import Any, Iterable, Self, Sequence, TYPE_CHECKING
 
 from cirq import ops, protocols
 

--- a/cirq-core/cirq/ops/arithmetic_operation.py
+++ b/cirq-core/cirq/ops/arithmetic_operation.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 
 import abc
 import itertools
-from typing import cast, Iterable, Sequence, TYPE_CHECKING
+from typing import cast, Iterable, Self, Sequence, TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq.ops.raw_types import Gate
 

--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -25,13 +25,13 @@ from typing import (
     Iterable,
     Iterator,
     overload,
+    Self,
     Sequence,
     TYPE_CHECKING,
 )
 
 import numpy as np
 import sympy
-from typing_extensions import Self
 
 from cirq import linalg, protocols, value
 from cirq._compat import proper_repr

--- a/cirq-core/cirq/ops/gate_operation.py
+++ b/cirq-core/cirq/ops/gate_operation.py
@@ -19,9 +19,17 @@ from __future__ import annotations
 import re
 import warnings
 from types import NotImplementedType
-from typing import AbstractSet, Any, cast, Collection, Mapping, Sequence, TYPE_CHECKING, TypeVar
-
-from typing_extensions import Self
+from typing import (
+    AbstractSet,
+    Any,
+    cast,
+    Collection,
+    Mapping,
+    Self,
+    Sequence,
+    TYPE_CHECKING,
+    TypeVar,
+)
 
 from cirq import ops, protocols, value
 from cirq.ops import control_values as cv, gate_features, raw_types

--- a/cirq-core/cirq/ops/parity_gates.py
+++ b/cirq-core/cirq/ops/parity_gates.py
@@ -16,10 +16,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator, Sequence, TYPE_CHECKING
+from typing import Any, Iterator, Self, Sequence, TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import protocols, value
 from cirq._compat import proper_repr

--- a/cirq-core/cirq/ops/pauli_string_raw_types.py
+++ b/cirq-core/cirq/ops/pauli_string_raw_types.py
@@ -15,9 +15,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Sequence, TYPE_CHECKING
-
-from typing_extensions import Self
+from typing import Any, Self, Sequence, TYPE_CHECKING
 
 from cirq import protocols
 from cirq.ops import pauli_string as ps, raw_types

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -28,7 +28,6 @@ from typing import (
     Hashable,
     Iterable,
     Mapping,
-    Self,
     Sequence,
     TYPE_CHECKING,
 )

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -28,12 +28,12 @@ from typing import (
     Hashable,
     Iterable,
     Mapping,
+    Self,
     Sequence,
     TYPE_CHECKING,
 )
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import protocols, value
 from cirq._compat import __cirq_debug__, _method_cache_name, cached_method

--- a/cirq-core/cirq/protocols/act_on_protocol.py
+++ b/cirq-core/cirq/protocols/act_on_protocol.py
@@ -15,9 +15,7 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, Sequence, TYPE_CHECKING
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, Sequence, TYPE_CHECKING
 
 from cirq import ops
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/act_on_protocol_test.py
+++ b/cirq-core/cirq/protocols/act_on_protocol_test.py
@@ -14,11 +14,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any, Self, Sequence
 
 import numpy as np
 import pytest
-from typing_extensions import Self
 
 import cirq
 

--- a/cirq-core/cirq/protocols/apply_channel_protocol.py
+++ b/cirq-core/cirq/protocols/apply_channel_protocol.py
@@ -17,10 +17,9 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, Iterable, Sequence, TypeVar
+from typing import Any, Iterable, Protocol, Sequence, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import linalg
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/apply_mixture_protocol.py
+++ b/cirq-core/cirq/protocols/apply_mixture_protocol.py
@@ -17,10 +17,9 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, cast, Iterable, TypeVar
+from typing import Any, cast, Iterable, Protocol, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq._doc import doc_private
 from cirq.protocols import qid_shape_protocol

--- a/cirq-core/cirq/protocols/apply_unitary_protocol.py
+++ b/cirq-core/cirq/protocols/apply_unitary_protocol.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 
 import warnings
 from types import EllipsisType, NotImplementedType
-from typing import Any, cast, Iterable, Sequence, TYPE_CHECKING, TypeVar
+from typing import Any, cast, Iterable, Protocol, Sequence, TYPE_CHECKING, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import linalg, qis
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/approximate_equality_protocol.py
+++ b/cirq-core/cirq/protocols/approximate_equality_protocol.py
@@ -17,11 +17,10 @@ from __future__ import annotations
 import numbers
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Iterable
+from typing import Any, Iterable, Protocol
 
 import numpy as np
 import sympy
-from typing_extensions import Protocol
 
 from cirq._doc import doc_private
 

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
@@ -16,11 +16,10 @@ from __future__ import annotations
 
 import re
 from fractions import Fraction
-from typing import Any, Iterable, overload, Sequence, TYPE_CHECKING, TypeVar, Union
+from typing import Any, Iterable, overload, Protocol, Sequence, TYPE_CHECKING, TypeVar, Union
 
 import numpy as np
 import sympy
-from typing_extensions import Protocol
 
 from cirq import protocols, value
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/commutes_protocol.py
+++ b/cirq-core/cirq/protocols/commutes_protocol.py
@@ -17,10 +17,9 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, overload, TypeVar
+from typing import Any, overload, Protocol, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import linalg
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/control_key_protocol.py
+++ b/cirq-core/cirq/protocols/control_key_protocol.py
@@ -16,9 +16,7 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, TYPE_CHECKING
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, TYPE_CHECKING
 
 from cirq._doc import doc_private
 from cirq.protocols import measurement_key_protocol

--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -25,13 +25,12 @@ from typing import (
     Iterable,
     Iterator,
     overload,
+    Protocol,
     Sequence,
     TYPE_CHECKING,
     TypeVar,
     Union,
 )
-
-from typing_extensions import Protocol
 
 from cirq import devices, ops
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol.py
+++ b/cirq-core/cirq/protocols/equal_up_to_global_phase_protocol.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 
 import numbers
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Protocol
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import linalg
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/has_unitary_protocol.py
+++ b/cirq-core/cirq/protocols/has_unitary_protocol.py
@@ -14,10 +14,9 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import linalg, qis
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -21,13 +21,12 @@ import json
 import numbers
 import pathlib
 from types import NotImplementedType
-from typing import Any, Callable, cast, IO, Iterable, overload, Sequence
+from typing import Any, Callable, cast, IO, Iterable, overload, Protocol, Sequence
 
 import attrs
 import numpy as np
 import pandas as pd
 import sympy
-from typing_extensions import Protocol
 
 from cirq._doc import doc_private
 

--- a/cirq-core/cirq/protocols/kraus_protocol.py
+++ b/cirq-core/cirq/protocols/kraus_protocol.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 
 import warnings
 from types import NotImplementedType
-from typing import Any, Sequence, TypeVar
+from typing import Any, Protocol, Sequence, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import protocols, qis
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/measurement_key_protocol.py
+++ b/cirq-core/cirq/protocols/measurement_key_protocol.py
@@ -17,9 +17,7 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, Mapping, TYPE_CHECKING
-
-from typing_extensions import Protocol
+from typing import Any, Mapping, Protocol, TYPE_CHECKING
 
 from cirq import value
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/mixture_protocol.py
+++ b/cirq-core/cirq/protocols/mixture_protocol.py
@@ -17,10 +17,9 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, Sequence
+from typing import Any, Protocol, Sequence
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq._doc import doc_private
 from cirq.protocols.decompose_protocol import _try_decompose_into_operations_and_qubits

--- a/cirq-core/cirq/protocols/pauli_expansion_protocol.py
+++ b/cirq-core/cirq/protocols/pauli_expansion_protocol.py
@@ -16,9 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, TypeVar
 
 from cirq import value
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/phase_protocol.py
+++ b/cirq-core/cirq/protocols/phase_protocol.py
@@ -14,9 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, TypeVar
 
 # This is a special value to indicate that a type error should be returned.
 # This is used within phase_by to raise an error if no underlying

--- a/cirq-core/cirq/protocols/qasm.py
+++ b/cirq-core/cirq/protocols/qasm.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 
 import string
 from types import NotImplementedType
-from typing import Any, Iterable, Mapping, TYPE_CHECKING, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, Iterable, Mapping, Protocol, TYPE_CHECKING, TypeVar
 
 from cirq import ops
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/qid_shape_protocol.py
+++ b/cirq-core/cirq/protocols/qid_shape_protocol.py
@@ -15,9 +15,7 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, Sequence, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, Sequence, TypeVar
 
 from cirq import ops
 from cirq._doc import doc_private, document

--- a/cirq-core/cirq/protocols/resolve_parameters.py
+++ b/cirq-core/cirq/protocols/resolve_parameters.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import numbers
-from typing import AbstractSet, Any, cast, TYPE_CHECKING, TypeVar
+from typing import AbstractSet, Any, cast, Protocol, Self, TYPE_CHECKING, TypeVar
 
 import sympy
-from typing_extensions import Protocol, Self
 
 from cirq import study
 from cirq._doc import doc_private

--- a/cirq-core/cirq/protocols/trace_distance_bound.py
+++ b/cirq-core/cirq/protocols/trace_distance_bound.py
@@ -14,10 +14,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, TypeVar
+from typing import Any, Protocol, Sequence, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq._doc import doc_private
 from cirq.protocols import unitary_protocol

--- a/cirq-core/cirq/protocols/unitary_protocol.py
+++ b/cirq-core/cirq/protocols/unitary_protocol.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 from types import NotImplementedType
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import linalg
 from cirq._doc import doc_private

--- a/cirq-core/cirq/qis/quantum_state_representation.py
+++ b/cirq-core/cirq/qis/quantum_state_representation.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import abc
-from typing import Sequence, TYPE_CHECKING
+from typing import Self, Sequence, TYPE_CHECKING
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import value
 

--- a/cirq-core/cirq/sim/simulation_state.py
+++ b/cirq-core/cirq/sim/simulation_state.py
@@ -18,10 +18,9 @@ from __future__ import annotations
 
 import abc
 import copy
-from typing import Any, cast, Generic, Iterator, Sequence, TYPE_CHECKING, TypeVar
+from typing import Any, cast, Generic, Iterator, Self, Sequence, TYPE_CHECKING, TypeVar
 
 import numpy as np
-from typing_extensions import Self
 
 from cirq import ops, protocols, value
 from cirq.sim.simulation_state_base import SimulationStateBase

--- a/cirq-core/cirq/sim/simulation_state_base.py
+++ b/cirq-core/cirq/sim/simulation_state_base.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 
 import abc
 from types import NotImplementedType
-from typing import Any, Generic, Iterator, Mapping, Sequence, TYPE_CHECKING, TypeVar
-
-from typing_extensions import Self
+from typing import Any, Generic, Iterator, Mapping, Self, Sequence, TYPE_CHECKING, TypeVar
 
 from cirq import protocols, value
 

--- a/cirq-core/cirq/study/sweepable.py
+++ b/cirq-core/cirq/study/sweepable.py
@@ -17,9 +17,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import cast, Iterable, Iterator, Sequence
-
-from typing_extensions import Protocol
+from typing import cast, Iterable, Iterator, Protocol, Sequence
 
 from cirq._doc import document
 from cirq.study.resolver import ParamResolver, ParamResolverOrSimilarType

--- a/cirq-core/cirq/transformers/transformer_api.py
+++ b/cirq-core/cirq/transformers/transformer_api.py
@@ -21,9 +21,7 @@ import enum
 import functools
 import inspect
 import textwrap
-from typing import Any, Callable, cast, Hashable, overload, TYPE_CHECKING, TypeVar
-
-from typing_extensions import Protocol
+from typing import Any, Callable, cast, Hashable, overload, Protocol, TYPE_CHECKING, TypeVar
 
 from cirq import circuits
 

--- a/cirq-core/cirq/value/classical_data.py
+++ b/cirq-core/cirq/value/classical_data.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 
 import abc
 import enum
-from typing import Mapping, Sequence, TYPE_CHECKING
-
-from typing_extensions import Self
+from typing import Mapping, Self, Sequence, TYPE_CHECKING
 
 from cirq.value import digits, value_equality_attr
 

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -28,6 +28,7 @@ from typing import (
     Mapping,
     MutableMapping,
     overload,
+    Self,
     TYPE_CHECKING,
     TypeVar,
     ValuesView,
@@ -35,7 +36,6 @@ from typing import (
 
 import numpy as np
 import sympy
-from typing_extensions import Self
 
 from cirq import protocols
 

--- a/cirq-core/cirq/value/value_equality_attr.py
+++ b/cirq-core/cirq/value/value_equality_attr.py
@@ -16,9 +16,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, overload
-
-from typing_extensions import Protocol
+from typing import Any, Callable, overload, Protocol
 
 from cirq import _compat, protocols
 

--- a/cirq-core/cirq/work/collector.py
+++ b/cirq-core/cirq/work/collector.py
@@ -15,11 +15,10 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Iterator, TYPE_CHECKING
+from typing import Any, Iterator, Protocol, TYPE_CHECKING
 
 import duet
 import numpy as np
-from typing_extensions import Protocol
 
 from cirq import study, value
 

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -9,5 +9,4 @@ pandas~=2.1
 sortedcontainers~=2.0
 scipy~=1.12
 sympy
-typing_extensions>=4.2
 tqdm>=4.12

--- a/cirq-google/cirq_google/engine/asyncio_executor.py
+++ b/cirq-google/cirq_google/engine/asyncio_executor.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 import asyncio
 import errno
 import threading
-from typing import Awaitable, Callable, TYPE_CHECKING, TypeVar
+from typing import Awaitable, Callable, ParamSpec, TYPE_CHECKING, TypeVar
 
 import duet
-from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     import concurrent

--- a/cirq-google/cirq_google/study/device_parameter.py
+++ b/cirq-google/cirq_google/study/device_parameter.py
@@ -15,9 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Sequence
-
-from typing_extensions import Protocol
+from typing import Any, Protocol, Sequence
 
 import cirq
 


### PR DESCRIPTION
Cirq requires Python >= 3.11 which provides all used types
from `typing_extensions` in the builtin `typing` module.
This removes dependency on the `typing_extensions` package.
