### PR TITLE
Combine cirq-web dependabot updates

### DIFF
--- a/cirq-web/cirq_web/package-lock.json
+++ b/cirq-web/cirq_web/package-lock.json
@@ -24,7 +24,7 @@
         "@types/pngjs": "^6.0.0",
         "@types/puppeteer": "^7.0.4",
         "@types/temp": "^0.9.0",
-        "@types/three": "^0.176.0",
+        "@types/three": "^0.179.0",
         "canvas": "^3.1.0",
         "chai": "^4.3.4",
         "concurrently": "^9.1.2",
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
-      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.7.tgz",
+      "integrity": "sha512-wHWLkQWBjHtajZeqCB74nsa/X70KheyOhySYBRmVQDJiNj0zjZR/naPCvdWjMhcG1LmjaMV/9WtTo5mpe8qWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1330,9 +1330,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1476,19 +1476,19 @@
       }
     },
     "node_modules/@types/three": {
-      "version": "0.176.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.176.0.tgz",
-      "integrity": "sha512-FwfPXxCqOtP7EdYMagCFePNKoG1AGBDUEVKtluv2BTVRpSt7b+X27xNsirPCTCqY1pGYsPUzaM3jgWP7dXSxlw==",
+      "version": "0.179.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.179.0.tgz",
+      "integrity": "sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@dimforge/rapier3d-compat": "^0.12.0",
+        "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
         "@webgpu/types": "*",
         "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "meshoptimizer": "~0.22.0"
       }
     },
     "node_modules/@types/tough-cookie": {
@@ -3024,9 +3024,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canvas": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.2.tgz",
-      "integrity": "sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3168,9 +3168,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.3.1.tgz",
-      "integrity": "sha512-i+BMGluhZZc4Jic9L1aHJBTfaopxmCqQxGklyMcqFx4fvF3nI4BJ3bCe1ad474nvYRIo/ZN/VrdA4eOaRZua4Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
+      "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7269,9 +7269,9 @@
       }
     },
     "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -11665,18 +11665,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.16.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.16.1.tgz",
-      "integrity": "sha512-3jrx2BrOBb8yr3+KE7OyxVtI2fjPNZi46/SQGxFvlKZX4/56i2LbdArEhNvlQw/xxmsZfpjFRbGtkMavgh3I+g==",
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.17.0.tgz",
+      "integrity": "sha512-CGrmJ8WgilK3nyE73k+pbxHggETPpEvL6AQ9H5JSK1RgZRGMQVJ+iO3MocGm9yBQXQJ9U5xijyLvkYXFeb0/+g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.3.1",
+        "@puppeteer/browsers": "2.10.7",
+        "chromium-bidi": "8.0.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1475386",
-        "puppeteer-core": "24.16.1",
+        "puppeteer-core": "24.17.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -11687,14 +11687,14 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.16.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.16.1.tgz",
-      "integrity": "sha512-0dGD2kxoH9jqj/xiz4KZLcPKpqWygs+VSEBzvuVbU3KoT2cCw4HnMT9r/7NvYl1lIa+JCa5yIyRqi+4R3UyYfQ==",
+      "version": "24.17.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.17.0.tgz",
+      "integrity": "sha512-RYOBKFiF+3RdwIZTEacqNpD567gaFcBAOKTT7742FdB1icXudrPI7BlZbYTYWK2wgGQUXt9Zi1Yn+D5PmCs4CA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.3.1",
+        "@puppeteer/browsers": "2.10.7",
+        "chromium-bidi": "8.0.0",
         "debug": "^4.4.1",
         "devtools-protocol": "0.0.1475386",
         "typed-query-selector": "^2.12.0",
@@ -14624,9 +14624,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.101.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.1.tgz",
-      "integrity": "sha512-rHY3vHXRbkSfhG6fH8zYQdth/BtDgXXuR2pHF++1f/EBkI8zkgM5XWfsC3BvOoW9pr1CvZ1qQCxhCEsbNgT50g==",
+      "version": "5.101.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
+      "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/cirq-web/cirq_web/package.json
+++ b/cirq-web/cirq_web/package.json
@@ -20,7 +20,7 @@
     "@types/pngjs": "^6.0.0",
     "@types/puppeteer": "^7.0.4",
     "@types/temp": "^0.9.0",
-    "@types/three": "^0.176.0",
+    "@types/three": "^0.179.0",
     "canvas": "^3.1.0",
     "chai": "^4.3.4",
     "concurrently": "^9.1.2",


### PR DESCRIPTION
Bump the non-security group across 1 directory with 5 updates, #7591

- Updates `@types/node` from 24.2.1 to 24.3.0
- Updates `@types/three` from 0.176.0 to 0.179.0
- Updates `canvas` from 3.1.2 to 3.2.0
- Updates `puppeteer` from 24.16.1 to 24.17.0
- Updates `webpack` from 5.101.1 to 5.101.3

Bump tsc-watch from 6.2.1 to 7.1.1, #7381

- Updates `tsc-watch` from 6.2.1 to 7.1.1.
