### PR TITLE
Pass numpy arrays in cirq.unitary unchecked

### DIFF
--- a/cirq-core/cirq/protocols/unitary_protocol.py
+++ b/cirq-core/cirq/protocols/unitary_protocol.py
@@ -20,7 +20,6 @@ from typing import Any, TypeVar
 import numpy as np
 from typing_extensions import Protocol
 
-from cirq import linalg
 from cirq._doc import doc_private
 from cirq.protocols import qid_shape_protocol
 from cirq.protocols.apply_unitary_protocol import apply_unitaries, ApplyUnitaryArgs
@@ -112,11 +111,8 @@ def unitary(
     Raises:
         TypeError: `val` doesn't have a unitary effect and no default value was
             specified.
-        ValueError: `val` is a numpy array that is not unitary.
     """
     if isinstance(val, np.ndarray):
-        if not linalg.is_unitary(val):
-            raise ValueError("The provided numpy array is not unitary.")
         return val
 
     strats = [

--- a/cirq-core/cirq/protocols/unitary_protocol_test.py
+++ b/cirq-core/cirq/protocols/unitary_protocol_test.py
@@ -163,12 +163,9 @@ def test_unitary():
 
     # Test that numpy arrays are handled directly
     test_matrix = np.array([[1, 0], [0, 1]])
-    assert cirq.unitary(test_matrix, NotImplemented) is test_matrix
-
-    # Test that non-unitary numpy arrays raise ValueError
+    assert cirq.unitary(test_matrix) is test_matrix
     non_unitary_matrix = np.array([[1, 1], [0, 1]])
-    with pytest.raises(ValueError, match="The provided numpy array is not unitary"):
-        _ = cirq.unitary(non_unitary_matrix)
+    assert cirq.unitary(non_unitary_matrix) is non_unitary_matrix
 
     assert cirq.unitary(NoMethod(), None) is None
     assert cirq.unitary(ReturnsNotImplemented(), None) is None


### PR DESCRIPTION
The unitary_protocol returns `val._unitary_()` unchecked and thus
does not guarantee the output of `cirq.unitary(val)` is unitary.
Here we lift an extra check for `cirq.unitary(np_array)` so that
`unitary(unitary(val))` does not fail if `unitary(val)` works.

Resolves #7572
Follow-up to #7419
