### PR TITLE
Performance Improvement for Circuit.has_measurements()

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -844,7 +844,12 @@ class AbstractCircuit(abc.ABC):
         return protocols.is_measurement(self)
 
     def _is_measurement_(self) -> bool:
-        return any(protocols.is_measurement(op) for op in self.all_operations())
+        # Measurements are most likely at the end of the circuit,
+        # so iterate from the end of the circuit
+        for idx in range(len(self) - 1, -1, -1):
+            if any(protocols.is_measurement(op) for op in self[idx]):
+                return True
+        return False
 
     def are_all_measurements_terminal(self) -> bool:
         """Whether all measurement gates are at the end of the circuit.


### PR DESCRIPTION
- Circuits are likely to have terminal measurements, or at least measurements towards the end of the circuit.
- This iterates from the last moment backwards, rather than starting at the first moment and going forwards.
- For a 25 qubit circuit with 400 moments and terminal measurements, this speeds up Circuit.has_measurements() from 7 milliseconds to 0.01 milliseconds.

(This is in the critical path for executing circuits since it is part of validation of user circuits.)