### PR TITLE
Generate reproducible dev-versions from the last commit time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python environment
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -50,6 +50,8 @@ echo =======================================
 echo Testing that all modules are installed
 echo =======================================
 
+exit_code=0
+
 python_test_template="\
 import @p
 print(@p)
@@ -61,5 +63,12 @@ CIRQ_PACKAGES=$(env PYTHONPATH=. python dev_tools/modules.py list --mode package
 for p in $CIRQ_PACKAGES; do
   echo "--- Testing $p -----"
   python_test="${python_test_template//@p/$p}"
-  env PYTHONPATH='' "${tmp_dir}/env/bin/python" -c "$python_test" && echo -e "\033[32mPASS\033[0m"  || echo -e "\033[31mFAIL\033[0m"
+  if env PYTHONPATH='' "${tmp_dir}/env/bin/python" -c "$python_test"; then
+    echo -e "\033[32mPASS\033[0m"
+  else
+    echo -e "\033[31mFAIL\033[0m"
+    exit_code=1
+  fi
 done
+
+exit ${exit_code}

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -36,11 +36,9 @@ out_dir=$(realpath "${1}")
 
 SPECIFIED_VERSION="${2}"
 
-# Helper to run dev_tools/modules.py without CIRQ_PRE_RELEASE_VERSION
-# to avoid environment version override in setup.py.
+# Helper to isolate dev_tools/modules.py from Python environment variables
 my_dev_tools_modules() {
-    env -u CIRQ_PRE_RELEASE_VERSION PYTHONPATH=. \
-        python3 dev_tools/modules.py "$@"
+    python3 -E dev_tools/modules.py "$@"
 }
 
 # Get the working directory to the repo root.


### PR DESCRIPTION
Produce timestamp string with respect to the UTC time zone.
Also ensure the working repository is in a pristine state.

Partially implements #6502
