### PR TITLE
Performance improvement in _check_duplicate_keys

### DIFF
--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -34,10 +34,15 @@ ProductOrZipSweepLike = dict['cirq.TParamKey', Union['cirq.TParamVal', Sequence[
 
 def _check_duplicate_keys(sweeps):
     keys = set()
+    key_count = 0
     for sweep in sweeps:
-        if any(key in keys for key in sweep.keys):
-            raise ValueError('duplicate keys')
+        key_count += len(sweep.keys)
         keys.update(sweep.keys)
+    # If the total length of the sweep keys
+    # is not the same as the size of the set,
+    # then there is a duplicate key.
+    if key_count != len(keys):
+        raise ValueError('duplicate keys')
 
 
 class Sweep(metaclass=abc.ABCMeta):

--- a/cirq-core/cirq/study/sweeps.py
+++ b/cirq-core/cirq/study/sweeps.py
@@ -33,11 +33,8 @@ ProductOrZipSweepLike = dict['cirq.TParamKey', Union['cirq.TParamVal', Sequence[
 
 
 def _check_duplicate_keys(sweeps):
-    keys = set()
-    key_count = 0
-    for sweep in sweeps:
-        key_count += len(sweep.keys)
-        keys.update(sweep.keys)
+    keys = set(itertools.chain.from_iterable(sweep.keys for sweep in sweeps))
+    key_count = sum(len(sweep.keys) for sweep in sweeps)
     # If the total length of the sweep keys
     # is not the same as the size of the set,
     # then there is a duplicate key.


### PR DESCRIPTION
- This change improves the performance of _check_duplicate_keys.
- Rather than check each sweep individually, this adds the keys of all the sweeps to the set and checks the total size. The total size of the set should be the sum of the sizes of the sweep, otherwise there are duplicates.
- This is a relatively minor performance improvement, but I saw it while trying to optimize something else, and it is self-contained.

This speeds checking a large sweep (the example I have is a Zip of 700k sweeps) from 300ms to 150ms.