### PR TITLE
Bail out of shell scripts on failure to determine repository root

### DIFF
--- a/check/all
+++ b/check/all
@@ -31,8 +31,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 errors=()

--- a/check/all
+++ b/check/all
@@ -32,8 +32,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 errors=()
 

--- a/check/all
+++ b/check/all
@@ -31,7 +31,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/asv_run
+++ b/check/asv_run
@@ -9,7 +9,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 asv run "$@"

--- a/check/asv_run
+++ b/check/asv_run
@@ -8,8 +8,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 asv run "$@"

--- a/check/asv_run
+++ b/check/asv_run
@@ -8,7 +8,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/doctest
+++ b/check/doctest
@@ -14,7 +14,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/doctest
+++ b/check/doctest
@@ -14,8 +14,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 source dev_tools/pypath || exit $?

--- a/check/doctest
+++ b/check/doctest
@@ -15,8 +15,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 source dev_tools/pypath || exit $?
 

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -31,8 +31,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 
@@ -72,7 +72,7 @@ if (( only_changed == 1 )); then
             exit 1
         fi
     fi
-    base="$(git merge-base "${rev}" HEAD)"
+    base=$(git merge-base "${rev}" HEAD)
     if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
         echo -e "Comparing against revision '${rev}'." >&2
     else
@@ -109,7 +109,7 @@ if [[ -t 1 || "${CI}" == true ]]; then
     arg_color=("--color")
 fi
 
-ISORTVERSION="$(isort --version-number)"
+ISORTVERSION=$(isort --version-number)
 
 echo "Sorting imports with isort... (version: $ISORTVERSION)"
 
@@ -124,7 +124,7 @@ if (( "${#isort_files[@]}" )); then
     ISORTSTATUS=$?
 fi
 
-BLACKVERSION="$(black --version | head -1)"
+BLACKVERSION=$(black --version | head -1)
 
 echo "Running the black formatter... (version: $BLACKVERSION)"
 

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -31,7 +31,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/format-incremental
+++ b/check/format-incremental
@@ -32,8 +32,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 
 # Parse arguments.

--- a/check/misc
+++ b/check/misc
@@ -9,8 +9,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # Check for non-contrib references to contrib.
 results=$(grep -Rl "\bcirq\.contrib\b" cirq-core | grep -v "cirq/contrib" | grep -v "__")

--- a/check/misc
+++ b/check/misc
@@ -8,8 +8,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 # Check for non-contrib references to contrib.

--- a/check/misc
+++ b/check/misc
@@ -8,7 +8,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/mypy
+++ b/check/mypy
@@ -8,8 +8,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 CONFIG_FILE='mypy.ini'

--- a/check/mypy
+++ b/check/mypy
@@ -9,8 +9,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 CONFIG_FILE='mypy.ini'
 

--- a/check/mypy
+++ b/check/mypy
@@ -8,7 +8,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/nbformat
+++ b/check/nbformat
@@ -26,8 +26,8 @@ done
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # check if the nbfmt tool in tensorflow-docs is installed and working
 if ! python3 -c "import tensorflow_docs.tools.nbfmt"; then

--- a/check/nbformat
+++ b/check/nbformat
@@ -25,7 +25,7 @@ for arg in "$@"; do
 done
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/nbformat
+++ b/check/nbformat
@@ -25,8 +25,8 @@ for arg in "$@"; do
 done
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 # check if the nbfmt tool in tensorflow-docs is installed and working

--- a/check/npm
+++ b/check/npm
@@ -23,8 +23,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 npm --prefix 'cirq-web/cirq_web' "$@"

--- a/check/npm
+++ b/check/npm
@@ -24,7 +24,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 npm --prefix 'cirq-web/cirq_web' "$@"

--- a/check/npm
+++ b/check/npm
@@ -23,7 +23,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/npx
+++ b/check/npx
@@ -23,7 +23,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 
-cd "${topdir}/cirq-web/cirq_web" || exit $?
+cd "${repo_dir}/cirq-web/cirq_web" || exit $?
 npx "$@"

--- a/check/npx
+++ b/check/npx
@@ -22,7 +22,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 
 cd "${topdir}/cirq-web/cirq_web" || exit $?

--- a/check/npx
+++ b/check/npx
@@ -22,8 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 
 cd "${topdir}/cirq-web/cirq_web" || exit $?
 npx "$@"

--- a/check/protos-up-to-date
+++ b/check/protos-up-to-date
@@ -7,7 +7,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/protos-up-to-date
+++ b/check/protos-up-to-date
@@ -8,8 +8,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 git_status=$(git status --short)
 if [[ -n "${git_status}" ]]; then

--- a/check/protos-up-to-date
+++ b/check/protos-up-to-date
@@ -7,11 +7,11 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
-git_status="$(git status --short)"
+git_status=$(git status --short)
 if [[ -n "${git_status}" ]]; then
     echo "$0 requires a pristine worktree, but 'git status' shows"
     echo "some changes or untracked files."
@@ -33,7 +33,7 @@ echo
 
 dev_tools/build-protos.sh
 
-git_status="$(git status --short)"
+git_status=$(git status --short)
 
 if [[ -n "${git_status}" ]]; then
     echo

--- a/check/pylint
+++ b/check/pylint
@@ -8,8 +8,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 read -r -a CIRQ_MODULES < \

--- a/check/pylint
+++ b/check/pylint
@@ -9,8 +9,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 read -r -a CIRQ_MODULES < \
     <(env PYTHONPATH=. python dev_tools/modules.py list --mode package-path)

--- a/check/pylint
+++ b/check/pylint
@@ -8,7 +8,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -25,7 +25,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -26,8 +26,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # Figure out which revision to compare against.
 if [ -n "$1" ] && [[ $1 != -* ]]; then

--- a/check/pylint-changed-files
+++ b/check/pylint-changed-files
@@ -25,8 +25,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 # Figure out which revision to compare against.
@@ -46,7 +46,7 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/main' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base "${rev}" HEAD)"
+base=$(git merge-base "${rev}" HEAD)
 if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else

--- a/check/pytest
+++ b/check/pytest
@@ -12,8 +12,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 # Run in parallel by default.  Pass the `-n0` option for a single-process run.

--- a/check/pytest
+++ b/check/pytest
@@ -13,8 +13,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # Run in parallel by default.  Pass the `-n0` option for a single-process run.
 # (the last `-n` option wins)

--- a/check/pytest
+++ b/check/pytest
@@ -12,7 +12,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -60,7 +60,7 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/main' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base "${rev}" HEAD)"
+base=$(git merge-base "${rev}" HEAD)
 if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -23,8 +23,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-cd "$(git rev-parse --show-toplevel)" || exit 1
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 PYTEST_ARGS=()
 ANALYZE_COV=1

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -28,8 +28,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 # Figure out which branch to compare against.

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -29,8 +29,8 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # Figure out which branch to compare against.
 rest=( "$@" )

--- a/check/pytest-changed-files
+++ b/check/pytest-changed-files
@@ -28,7 +28,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -49,7 +49,7 @@ else
     echo -e "\033[31mNo default revision found to compare against. Argument #1 must be what to diff against (e.g. 'origin/main' or 'HEAD~1').\033[0m" >&2
     exit 1
 fi
-base="$(git merge-base "${rev}" HEAD)"
+base=$(git merge-base "${rev}" HEAD)
 if [ "$(git rev-parse "${rev}")" == "${base}" ]; then
     echo -e "Comparing against revision '${rev}'." >&2
 else

--- a/check/pytest-changed-files-and-incremental-coverage
+++ b/check/pytest-changed-files-and-incremental-coverage
@@ -29,8 +29,9 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-cd "$(git rev-parse --show-toplevel)" || exit 1
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # Figure out which revision to compare against.
 if [ -n "$1" ] && [[ $1 != -* ]]; then

--- a/check/shellcheck
+++ b/check/shellcheck
@@ -13,8 +13,8 @@
 
 # Change working directory to the repository root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 # Process command line arguments
 opt_dry_run=0

--- a/check/shellcheck
+++ b/check/shellcheck
@@ -12,7 +12,7 @@
 ################################################################################
 
 # Change working directory to the repository root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/shellcheck
+++ b/check/shellcheck
@@ -12,8 +12,8 @@
 ################################################################################
 
 # Change working directory to the repository root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 # Process command line arguments
@@ -51,9 +51,9 @@ required_shell_scripts=(
     dev_tools/pypath
 )
 
-scripts_not_found="$(comm -13 \
+scripts_not_found=$(comm -13 \
     <(printf "%s\n" "${our_shell_scripts[@]}") \
-    <(printf "%s\n" "${required_shell_scripts[@]}") )"
+    <(printf "%s\n" "${required_shell_scripts[@]}") )
 
 if [[ -n "${scripts_not_found}" ]]; then
     echo "Identification of shell scripts failed - files not found:" >&2

--- a/check/ts-build
+++ b/check/ts-build
@@ -22,7 +22,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/ts-build
+++ b/check/ts-build
@@ -22,8 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 check/npx webpack --mode production "$@"

--- a/check/ts-build
+++ b/check/ts-build
@@ -23,7 +23,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 check/npx webpack --mode production "$@"

--- a/check/ts-coverage
+++ b/check/ts-coverage
@@ -23,7 +23,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 check/npm run coverage "$@"

--- a/check/ts-coverage
+++ b/check/ts-coverage
@@ -22,7 +22,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/ts-coverage
+++ b/check/ts-coverage
@@ -22,8 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 check/npm run coverage "$@"

--- a/check/ts-lint
+++ b/check/ts-lint
@@ -22,8 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 check/npm run lint "$@"

--- a/check/ts-lint
+++ b/check/ts-lint
@@ -22,7 +22,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/ts-lint
+++ b/check/ts-lint
@@ -23,7 +23,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 check/npm run lint "$@"

--- a/check/ts-lint-and-format
+++ b/check/ts-lint-and-format
@@ -23,7 +23,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 check/npm run fix "$@"

--- a/check/ts-lint-and-format
+++ b/check/ts-lint-and-format
@@ -22,8 +22,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 check/npm run fix "$@"

--- a/check/ts-lint-and-format
+++ b/check/ts-lint-and-format
@@ -22,7 +22,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/ts-test
+++ b/check/ts-test
@@ -24,7 +24,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/ts-test
+++ b/check/ts-test
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ################################################################################
-# Runs the test files 
+# Runs the test files
 #
 # Usage:
 #     check/ts-test
@@ -24,8 +24,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 check/npm run test "$@"

--- a/check/ts-test
+++ b/check/ts-test
@@ -25,7 +25,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 check/npm run test "$@"

--- a/check/ts-test-e2e
+++ b/check/ts-test-e2e
@@ -24,7 +24,7 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
 topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 

--- a/check/ts-test-e2e
+++ b/check/ts-test-e2e
@@ -24,8 +24,8 @@
 ################################################################################
 
 # Get the working directory to the repo root.
-thisdir="$(dirname "${BASH_SOURCE[0]}")" || exit $?
-topdir="$(git -C "${thisdir}" rev-parse --show-toplevel)" || exit $?
+thisdir=$(dirname "${BASH_SOURCE[0]}") || exit $?
+topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
 cd "${topdir}" || exit $?
 
 check/npm run test-e2e "$@"

--- a/check/ts-test-e2e
+++ b/check/ts-test-e2e
@@ -25,7 +25,7 @@
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?
-topdir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
-cd "${topdir}" || exit $?
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel) || exit $?
+cd "${repo_dir}" || exit $?
 
 check/npm run test-e2e "$@"

--- a/dev_tools/build-protos.sh
+++ b/dev_tools/build-protos.sh
@@ -25,10 +25,10 @@ set -e
 trap "{ echo -e '\033[31mFAILED\033[0m'; }" ERR
 
 # Get the working directory to the repo root.
-cd "$(dirname "${BASH_SOURCE[0]}")"
-cd "$(git rev-parse --show-toplevel)"
+thisdir=$(dirname "${BASH_SOURCE[0]:?}")
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel)
 
-cd cirq-google || exit $?
+cd "${repo_dir}/cirq-google"
 
 TUNITS_PROTO_PATH=$(python -c "import importlib.resources; print(importlib.resources.files('tunits').parent)")
 

--- a/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
+++ b/dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
@@ -17,8 +17,9 @@
 set -e
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-cd "$(git rev-parse --show-toplevel)"
+thisdir=$(dirname "${BASH_SOURCE[0]:?}")
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel)
+cd "${repo_dir}"
 
 reqs=(
     -r dev_tools/requirements/pytest-minimal.env.txt

--- a/dev_tools/packaging/generate-dev-version-id.sh
+++ b/dev_tools/packaging/generate-dev-version-id.sh
@@ -35,8 +35,8 @@
 set -e
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-repo_dir=$(git rev-parse --show-toplevel)
+thisdir=$(dirname "${BASH_SOURCE[0]:?}")
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel)
 cd "${repo_dir}"
 
 PROJECT_NAME=cirq-core/cirq

--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -44,8 +44,8 @@ my_dev_tools_modules() {
 }
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-repo_dir=$(git rev-parse --show-toplevel)
+thisdir=$(dirname "${BASH_SOURCE[0]:?}")
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel)
 cd "${repo_dir}"
 
 # Make a clean copy of HEAD, without files ignored by git (but potentially kept by setup.py).

--- a/dev_tools/packaging/publish-dev-package.sh
+++ b/dev_tools/packaging/publish-dev-package.sh
@@ -104,8 +104,9 @@ UPLOAD_VERSION="${EXPECTED_VERSION}$(date "+%Y%m%d%H%M%S")"
 echo -e "Producing package with version \033[33m\033[100m${UPLOAD_VERSION}\033[0m to upload to \033[33m\033[100m${PYPI_REPO_NAME}\033[0m pypi repository"
 
 # Get the working directory to the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-cd "$(git rev-parse --show-toplevel)"
+thisdir=$(dirname "${BASH_SOURCE[0]:?}")
+repo_dir=$(git -C "${thisdir}" rev-parse --show-toplevel)
+cd "${repo_dir}"
 
 # Temporary workspace.
 tmp_package_dir=$(mktemp -d "/tmp/publish-dev-package_package.XXXXXXXXXXXXXXXX")

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -59,7 +59,7 @@ fi
 
 # Find the repo root.
 cd "$( dirname "${BASH_SOURCE[0]}" )"
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # Temporary workspace.
 tmp_dir=$(mktemp -d "/tmp/verify-published-package.XXXXXXXXXXXXXXXX")

--- a/dev_tools/packaging/verify-published-package.sh
+++ b/dev_tools/packaging/verify-published-package.sh
@@ -58,8 +58,8 @@ else
 fi
 
 # Find the repo root.
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-REPO_ROOT=$(git rev-parse --show-toplevel)
+thisdir=$(dirname "${BASH_SOURCE[0]:?}")
+REPO_ROOT=$(git -C "${thisdir}" rev-parse --show-toplevel)
 
 # Temporary workspace.
 tmp_dir=$(mktemp -d "/tmp/verify-published-package.XXXXXXXXXXXXXXXX")

--- a/dev_tools/pypath
+++ b/dev_tools/pypath
@@ -26,7 +26,7 @@ if [ -n "${ZSH_VERSION}" ]; then
     # shellcheck disable=2296,2298
     _PYPATH_BASE_DIR="${${(%):-%x}:a:h:h}"
 else
-    _PYPATH_BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    _PYPATH_BASE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 fi
 
 if ! python --version | grep -q -F "Python 3."; then

--- a/dev_tools/pypath
+++ b/dev_tools/pypath
@@ -26,7 +26,7 @@ if [ -n "${ZSH_VERSION}" ]; then
     # shellcheck disable=2296,2298
     _PYPATH_BASE_DIR="${${(%):-%x}:a:h:h}"
 else
-    _PYPATH_BASE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+    _PYPATH_BASE_DIR=$(d=$(dirname "${BASH_SOURCE[0]:?}") && cd "${d}/.." && pwd)
 fi
 
 if ! python --version | grep -q -F "Python 3."; then


### PR DESCRIPTION
- Remove unnecessary quotes `x="$(command)"` --> `x=$(command)`
- Fail shell scripts on failure to get the repository root
- Fail shell scripts if `${BASH_SOURCE[0]}` is empty or undefined
- Rename `topdir` --> `repo_dir` for the sake of uniformity
