### PR TITLE
Implement structure preserving dynamical decoupling (dd-v2)

### DIFF
--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -277,7 +277,7 @@ class _Grid:
 
     def __str__(self) -> str:
         if not self.gate_types:
-            return "CircuitRepr(empty)"
+            return "Grid(empty)"
 
         qubits = sorted(list(self.gate_types.keys()))
         num_moments = len(self.gate_types[qubits[0]])
@@ -291,7 +291,7 @@ class _Grid:
         separator = f"{'-' * max_qubit_len}-+"
         separator += '-----+' * num_moments
 
-        lines = ["Labeled Circuit:", header, separator]
+        lines = ["Grid Repr:", header, separator]
 
         for q in qubits:
             row_str = f"{str(q):>{max_qubit_len}} |"

--- a/cirq-core/cirq/transformers/dynamical_decoupling_test.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling_test.py
@@ -832,7 +832,7 @@ def test_labeled_circuit_str():
     )
     labeled_circuit = _Grid.from_circuit(input_circuit, single_qubit_gate_moments_only=True)
     assert str(labeled_circuit) == (
-        """Labeled Circuit:
+        """Grid Repr:
      |  0  |  1  |  2  |  3  |  4  |
 -----+-----+-----+-----+-----+-----+
 q(0) |  d  |  i  | i,s |  d  |  w  |
@@ -846,7 +846,7 @@ def test_labeled_circuit_str_empty():
     # Test case for an empty circuit (no moments, no qubits)
     empty_circuit = cirq.Circuit()
     labeled_empty = _Grid.from_circuit(empty_circuit, single_qubit_gate_moments_only=True)
-    assert str(labeled_empty) == "CircuitRepr(empty)"
+    assert str(labeled_empty) == "Grid(empty)"
 
 
 def test_add_dynamical_decoupling_with_deep_context_raises_error():
@@ -868,4 +868,3 @@ def test_context_logger():
 
     mock_logger.log.assert_called_once()
     assert "Preprocessed input circuit grid repr:" in mock_logger.log.call_args[0][0]
-    assert isinstance(mock_logger.log.call_args[0][1], _Grid)


### PR DESCRIPTION
Previous version of dd allows adding new moments to the circuit in the transformer. In some use cases, we might see a lot of new moments in the transformed circuits. This PR will fix the issues.

First, it captures the circuit's structure. Second, it inserts elements based on the structural information gathered in the initial step: [the design](https://docs.google.com/document/d/1FhPwRRazCKKpEG2L3P8CvN5Eqd_3s-MGJSVU6xLxv44/edit?tab=t.0#heading=h.xgjl2srtytjt).