### PR TITLE
Clean up unused environment variable CIRQ_PRE_RELEASE_VERSION

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -33,7 +33,7 @@ jobs:
           envsubst < dev_tools/packaging/pypirc_template > $HOME/.pypirc
       - name: Build and publish
         run: |
-          export CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
+          CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
           [[ "$CIRQ_PRE_RELEASE_VERSION" =~ .*dev.* ]] && echo "Deploying dev version '$CIRQ_PRE_RELEASE_VERSION'" || (echo "not dev version"; exit 1)
           out_dir="${PWD}/dist"
           dev_tools/packaging/produce-package.sh ${out_dir} $CIRQ_PRE_RELEASE_VERSION

--- a/dev_tools/packaging/packaging_test.sh
+++ b/dev_tools/packaging/packaging_test.sh
@@ -30,7 +30,6 @@ trap '{ rm -rf "${tmp_dir}"; }' EXIT
 echo "Working in a fresh virtualenv at ${tmp_dir}/env"
 python3.11 -m venv "${tmp_dir}/env"
 
-export CIRQ_PRE_RELEASE_VERSION
 CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
 out_dir=${tmp_dir}/dist
 dev_tools/packaging/produce-package.sh "${out_dir}" "$CIRQ_PRE_RELEASE_VERSION"


### PR DESCRIPTION
As of #7187 setup.py files do not need CIRQ_PRE_RELEASE_VERSION
as an environment variable.  Here we scrub it from the environment.
