### PR TITLE
Tighten the search for actual version sources

### DIFF
--- a/dev_tools/modules.py
+++ b/dev_tools/modules.py
@@ -56,7 +56,7 @@ _FOLDER = 'folder'
 _PACKAGE_PATH = 'package-path'
 _PACKAGE = 'package'
 
-_DEFAULT_SEARCH_DIR: Path = Path(".")
+_DEFAULT_SEARCH_DIR: Path = Path(__file__).absolute().parent.parent
 
 
 @dataclasses.dataclass

--- a/dev_tools/modules.py
+++ b/dev_tools/modules.py
@@ -160,7 +160,7 @@ def replace_version(search_dir: Path = _DEFAULT_SEARCH_DIR, *, old: str, new: st
 
     _validate_version(new)
 
-    for m in list_modules(search_dir=search_dir, include_parent=True):
+    for m in list_modules(search_dir=search_dir):
         version_file = _find_version_file(search_dir / m.root)
         _rewrite_version(version_file, old, new)
         version_test = version_file.parent / "_version_test.py"

--- a/dev_tools/modules.py
+++ b/dev_tools/modules.py
@@ -181,9 +181,8 @@ def _rewrite_version(version_file: Path, old: str, new: str) -> None:
 
 
 def _find_version_file(top: Path) -> Path:
-    for root, _, files in os.walk(str(top)):
-        if "_version.py" in files:
-            return Path(root) / "_version.py"
+    for version_path in top.glob("*/_version.py"):
+        return version_path
     raise FileNotFoundError(f"Can't find _version.py in {top}.")
 
 


### PR DESCRIPTION
- Resolve `_DEFAULT_SEARCH_DIR` from the `dev_tools/modules.py` location

- Skip the top Cirq metapackage in `_version.py` search as it has none.

- Look for `_version.py` files only in immediated subdirectories of
  Cirq's sub-packages.  This excludes `_version.py` copy in temporary
  build directories created by setuptools.

Fixes #7602
