### PR TITLE
Treat classically controlled ops as non-Clifford in `dynamical_decoupling`

### DIFF
--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -119,7 +119,9 @@ def _is_single_qubit_gate_moment(moment: Moment) -> bool:
 
 
 def _is_clifford_op(op: ops.Operation) -> bool:
-    return has_unitary(op) and has_stabilizer_effect(op)
+    if op.gate:
+        return has_unitary(op.gate) and has_stabilizer_effect(op.gate)
+    return False
 
 
 def _calc_busy_moment_range_of_each_qubit(circuit: FrozenCircuit) -> dict[ops.Qid, list[int]]:

--- a/cirq-core/cirq/transformers/dynamical_decoupling_test.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling_test.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 
 import cirq
-from cirq import add_dynamical_decoupling, CNOT, CZ, CZPowGate, H, X, Y, Z
+from cirq import add_dynamical_decoupling, CNOT, CZ, CZPowGate, H, I, measure, X, Y, Z
 
 
 def assert_sim_eq(circuit1: cirq.AbstractCircuit, circuit2: cirq.AbstractCircuit):
@@ -51,6 +51,22 @@ def assert_dd(
         {q: q for q in input_circuit.all_qubits()},
     )
     assert_sim_eq(input_circuit, transformed_circuit)
+
+
+def test_classically_controlled_no_update_succeeds():
+    """Test case diagrams.
+    Input:
+    0: ───M───I───
+          ║   ║
+    c: ═══@═══^═══
+    """
+    a = cirq.NamedQubit('a')
+
+    add_dynamical_decoupling(
+        cirq.Circuit(
+            cirq.Moment(measure(a, key="a")), cirq.Moment(I(a).with_classical_controls("a"))
+        )
+    )
 
 
 def test_no_insertion():


### PR DESCRIPTION
Classically controlled operations were passing `_is_clifford_op`, which led `dynamical_decoupling` to synthesize/invert through them and crash. Mark them non-Clifford for DD so they act as boundaries. Add regression test `test_classically_controlled_no_update_succeeds`.

Fixes #7617