### PR TITLE
Increase np.isclose tolerance for mitigated expectation value assertion

### DIFF
--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -107,6 +107,7 @@ def _ideal_expectation_based_on_pauli_string(
     )
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_pauli_string_measurement_errors_no_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string"""
@@ -155,6 +156,7 @@ def test_pauli_string_measurement_errors_no_noise() -> None:
             }
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_pauli_string_measurement_errors_with_coefficient_no_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string"""
@@ -203,6 +205,7 @@ def test_pauli_string_measurement_errors_with_coefficient_no_noise() -> None:
             }
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_group_pauli_string_measurement_errors_no_noise_with_coefficient() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the group of Pauli strings"""
@@ -257,6 +260,7 @@ def test_group_pauli_string_measurement_errors_no_noise_with_coefficient() -> No
             }
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_pauli_string_measurement_errors_with_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string"""
@@ -304,6 +308,7 @@ def test_pauli_string_measurement_errors_with_noise() -> None:
                 assert 0.0045 < error < 0.0055
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_group_pauli_string_measurement_errors_with_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the group Pauli strings"""
@@ -355,6 +360,7 @@ def test_group_pauli_string_measurement_errors_with_noise() -> None:
                 assert 0.0045 < error < 0.0055
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_many_circuits_input_measurement_with_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string for multiple circuits"""
@@ -414,6 +420,7 @@ def test_many_circuits_input_measurement_with_noise() -> None:
                 assert 0.0045 < error < 0.0055
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_allow_measurement_without_readout_mitigation() -> None:
     """Test that the function allows to measure without error mitigation"""
     qubits = cirq.LineQubit.range(7)
@@ -444,6 +451,7 @@ def test_allow_measurement_without_readout_mitigation() -> None:
             assert pauli_string_measurement_results.calibration_result is None
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_allow_group_pauli_measurement_without_readout_mitigation() -> None:
     """Test that the function allows to measure without error mitigation"""
     qubits = cirq.LineQubit.range(7)
@@ -474,6 +482,7 @@ def test_allow_group_pauli_measurement_without_readout_mitigation() -> None:
             assert pauli_string_measurement_results.calibration_result is None
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_many_circuits_with_coefficient() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string for multiple circuits"""
@@ -533,6 +542,7 @@ def test_many_circuits_with_coefficient() -> None:
                 assert 0.0045 < error < 0.0055
 
 
+@cirq.testing.retry_once_with_later_random_values
 def test_many_group_pauli_in_circuits_with_coefficient() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string for multiple circuits"""

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -107,7 +107,6 @@ def _ideal_expectation_based_on_pauli_string(
     )
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_pauli_string_measurement_errors_no_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string"""
@@ -156,7 +155,6 @@ def test_pauli_string_measurement_errors_no_noise() -> None:
             }
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_pauli_string_measurement_errors_with_coefficient_no_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string"""
@@ -205,7 +203,6 @@ def test_pauli_string_measurement_errors_with_coefficient_no_noise() -> None:
             }
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_group_pauli_string_measurement_errors_no_noise_with_coefficient() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the group of Pauli strings"""
@@ -260,7 +257,6 @@ def test_group_pauli_string_measurement_errors_no_noise_with_coefficient() -> No
             }
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_pauli_string_measurement_errors_with_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string"""
@@ -308,7 +304,6 @@ def test_pauli_string_measurement_errors_with_noise() -> None:
                 assert 0.0045 < error < 0.0055
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_group_pauli_string_measurement_errors_with_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the group Pauli strings"""
@@ -360,7 +355,6 @@ def test_group_pauli_string_measurement_errors_with_noise() -> None:
                 assert 0.0045 < error < 0.0055
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_many_circuits_input_measurement_with_noise() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string for multiple circuits"""
@@ -420,7 +414,6 @@ def test_many_circuits_input_measurement_with_noise() -> None:
                 assert 0.0045 < error < 0.0055
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_allow_measurement_without_readout_mitigation() -> None:
     """Test that the function allows to measure without error mitigation"""
     qubits = cirq.LineQubit.range(7)
@@ -451,7 +444,6 @@ def test_allow_measurement_without_readout_mitigation() -> None:
             assert pauli_string_measurement_results.calibration_result is None
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_allow_group_pauli_measurement_without_readout_mitigation() -> None:
     """Test that the function allows to measure without error mitigation"""
     qubits = cirq.LineQubit.range(7)
@@ -482,7 +474,6 @@ def test_allow_group_pauli_measurement_without_readout_mitigation() -> None:
             assert pauli_string_measurement_results.calibration_result is None
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_many_circuits_with_coefficient() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string for multiple circuits"""
@@ -542,7 +533,6 @@ def test_many_circuits_with_coefficient() -> None:
                 assert 0.0045 < error < 0.0055
 
 
-@cirq.testing.retry_once_with_later_random_values
 def test_many_group_pauli_in_circuits_with_coefficient() -> None:
     """Test that the mitigated expectation is close to the ideal expectation
     based on the Pauli string for multiple circuits"""

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -141,7 +141,7 @@ def test_pauli_string_measurement_errors_no_noise() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
             assert isinstance(
                 pauli_string_measurement_results.calibration_result,
@@ -189,7 +189,7 @@ def test_pauli_string_measurement_errors_with_coefficient_no_noise() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
             assert isinstance(
                 pauli_string_measurement_results.calibration_result,
@@ -243,7 +243,7 @@ def test_group_pauli_string_measurement_errors_no_noise_with_coefficient() -> No
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
             assert isinstance(
                 pauli_string_measurement_results.calibration_result,
@@ -286,7 +286,7 @@ def test_pauli_string_measurement_errors_with_noise() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
 
             assert isinstance(
@@ -337,7 +337,7 @@ def test_group_pauli_string_measurement_errors_with_noise() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
 
             assert isinstance(
@@ -398,7 +398,7 @@ def test_many_circuits_input_measurement_with_noise() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
             assert isinstance(
                 pauli_string_measurement_results.calibration_result,
@@ -517,7 +517,7 @@ def test_many_circuits_with_coefficient() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
             assert isinstance(
                 pauli_string_measurement_results.calibration_result,
@@ -588,7 +588,7 @@ def test_many_group_pauli_in_circuits_with_coefficient() -> None:
                 _ideal_expectation_based_on_pauli_string(
                     pauli_string_measurement_results.pauli_string, final_state_vector
                 ),
-                atol=max(4 * pauli_string_measurement_results.mitigated_stddev, 0.1),
+                atol=10 * pauli_string_measurement_results.mitigated_stddev,
             )
             assert isinstance(
                 pauli_string_measurement_results.calibration_result,


### PR DESCRIPTION
This PR updates the tolerance of the np.isclose assertion used to validate the mitigated expectation value against its ideal value. The tolerance is being increased from 4 * mitigated_stddev to 10 * mitigated_stddev. 
The nature of calculating a Pauli expectation is to statistically estimate the value by sampling from measurement outcomes a finite number of times, which by chance can lead to a small probability of the result deviate from the ideal value by > 4 * standard deviations. Increasing the tolerance to 10  * mitigated_stddev can makes the test much more robust against these statistical fluctuations.

Fixes #7612 