### PR TITLE
Add linting and type checking overrides for cirq-google/cirq_google/cloud, which contains only generated code

### DIFF
--- a/cirq-google/cirq_google/cloud/README.md
+++ b/cirq-google/cirq_google/cloud/README.md
@@ -1,0 +1,2 @@
+# DO NOT EDIT MANUALLY (except to fix linting and type checking errors)
+This directory and all of its sub-directories contain only generated RPC clients for the `QuantumEngineService` and the associated request/response objects. The only manual edits made to these files should be to fix linter and type checker complaints.

--- a/cirq-google/cirq_google/cloud/README.md
+++ b/cirq-google/cirq_google/cloud/README.md
@@ -1,4 +1,9 @@
-# DO NOT EDIT MANUALLY (except to fix linting and type checking errors)
+# DO NOT EDIT MANUALLY (except to fix formatting errors)
 This directory and all of its sub-directories contain only generated RPC clients for the
-`QuantumEngineService` and the associated request/response objects. The only manual edits made to
-these files should be to fix formatter and type checker complaints.
+`QuantumEngineService` and the associated request/response objects. The only edits made to the
+generated code should be to fix fix formatting issues, which can be done by running the following
+command from from the Cirq root:
+
+```
+./check/format-incremental --apply
+```

--- a/cirq-google/cirq_google/cloud/README.md
+++ b/cirq-google/cirq_google/cloud/README.md
@@ -1,2 +1,4 @@
 # DO NOT EDIT MANUALLY (except to fix linting and type checking errors)
-This directory and all of its sub-directories contain only generated RPC clients for the `QuantumEngineService` and the associated request/response objects. The only manual edits made to these files should be to fix linter and type checker complaints.
+This directory and all of its sub-directories contain only generated RPC clients for the
+`QuantumEngineService` and the associated request/response objects. The only manual edits made to
+these files should be to fix formatter and type checker complaints.

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -20,6 +20,10 @@ ignore_missing_imports = true
 follow_imports = silent
 ignore_missing_imports = true
 
+# Cirq-Google
+[mypy-cirq_google.cloud.quantum_v1alpha1.*]
+warn_unused_ignores = false
+
 # Non-Google
 [mypy-IPython.*,sympy.*,matplotlib.*,proto.*,pandas.*,scipy.*,freezegun.*,mpl_toolkits.*,networkx.*,ply.*,astroid.*,pytest.*,_pytest.*,pylint.*,setuptools.*,qiskit.*,quimb.*,pylatex.*,filelock.*,sortedcontainers.*,tqdm.*,ruamel.*,absl.*,tensorflow_docs.*,ipywidgets.*,cachetools.*,stimcirq.*]
 follow_imports = silent

--- a/dev_tools/conf/mypy.ini
+++ b/dev_tools/conf/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = /setup\.py
+exclude = (/setup\.py|cirq-google/cirq_google/cloud/.+\.py)
 show_error_codes = true
 plugins = duet.typing
 warn_unused_ignores = true
@@ -19,10 +19,6 @@ ignore_missing_imports = true
 [mypy-google.api_core.*,google.auth.*,google.colab.*,google.cloud.*,google.oauth2.*,qsimcirq]
 follow_imports = silent
 ignore_missing_imports = true
-
-# Cirq-Google
-[mypy-cirq_google.cloud.quantum_v1alpha1.*]
-warn_unused_ignores = false
 
 # Non-Google
 [mypy-IPython.*,sympy.*,matplotlib.*,proto.*,pandas.*,scipy.*,freezegun.*,mpl_toolkits.*,networkx.*,ply.*,astroid.*,pytest.*,_pytest.*,pylint.*,setuptools.*,qiskit.*,quimb.*,pylatex.*,filelock.*,sortedcontainers.*,tqdm.*,ruamel.*,absl.*,tensorflow_docs.*,ipywidgets.*,cachetools.*,stimcirq.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ asyncio_default_fixture_loop_scope = "function"
 line-length = 100
 preview = true
 target-version = "py311"
-extend-exclude = ["*_pb2.py*"]
+extend-exclude = [
+    "*_pb2.py*",
+    "cirq-google/cirq_google/cloud/*.py",  # contains only generated code
+]
 
 [tool.ruff.lint]
 select = [
@@ -142,10 +145,3 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402"]
-"cirq-google/cirq_google/cloud/*" = [
-    "E402",  # module-import-not-at-top-of-file
-    "E501",  # line-too-long
-    "F401",  # unused-import
-    "RUF100", # unused-noqa
-    "UP007",  # non-pep604-annotation-union
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,5 +146,6 @@ select = [
     "E402",  # module-import-not-at-top-of-file
     "E501",  # line-too-long
     "F401",  # unused-import
+    "RUF100", # unused-noqa
     "UP007",  # non-pep604-annotation-union
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,3 +142,9 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "*.ipynb" = ["E402"]
+"cirq-google/cirq_google/cloud/*" = [
+    "E402",  # module-import-not-at-top-of-file
+    "E501",  # line-too-long
+    "F401",  # unused-import
+    "UP007",  # non-pep604-annotation-union
+]


### PR DESCRIPTION
The cirq-google/cirq_google/cloud contains only generated code.