### PR TITLE
Optimize multiplication of Pauli operations

### DIFF
--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -1095,6 +1095,9 @@ def _try_interpret_as_pauli_string(op: Any) -> PauliString | None:
     if not isinstance(op, raw_types.Operation):
         return None
 
+    if isinstance(op, PauliString):
+        return op
+
     pauli_expansion_op = protocols.pauli_expansion(op, default=None)
     if pauli_expansion_op is None or len(pauli_expansion_op) != 1:
         return None
@@ -1132,6 +1135,12 @@ class SingleQubitPauliStringGateOperation(  # type: ignore
     def qubit(self) -> raw_types.Qid:
         assert len(self.qubits) == 1
         return self.qubits[0]
+
+    def __mul__(self, other):
+        return PauliString.__mul__(self, other)
+
+    def __rmul__(self, other):
+        return PauliString.__rmul__(self, other)
 
     def _json_dict_(self) -> dict[str, Any]:
         return protocols.obj_to_dict_helper(self, ['pauli', 'qubit'])

--- a/t7603/t00-base-cedd002c.txt
+++ b/t7603/t00-base-cedd002c.txt
@@ -1,0 +1,10 @@
+x**2 * x * x * x
+71.5 μs ± 2.68 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x * x**2 * x * x
+68.2 μs ± 2.36 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**1 * x**4
+40.2 μs ± 685 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**4 * x**1
+43.8 μs ± 790 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x1 * x2
+21.8 μs ± 159 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

--- a/t7603/t01-pr-f3680d05.txt
+++ b/t7603/t01-pr-f3680d05.txt
@@ -1,0 +1,10 @@
+x**2 * x * x * x
+169 μs ± 4.76 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x * x**2 * x * x
+172 μs ± 1.68 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**1 * x**4
+88 μs ± 1.58 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**4 * x**1
+85.6 μs ± 2.08 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x1 * x2
+78.4 μs ± 1.66 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

--- a/t7603/t02-amend-49c9b2a1.txt
+++ b/t7603/t02-amend-49c9b2a1.txt
@@ -1,0 +1,10 @@
+x**2 * x * x * x
+67.7 μs ± 775 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x * x**2 * x * x
+69.3 μs ± 1.56 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**1 * x**4
+61.1 μs ± 2.96 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**4 * x**1
+64.5 μs ± 1.68 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x1 * x2
+12.5 μs ± 545 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

--- a/t7603/t03-amend-4e804857.txt
+++ b/t7603/t03-amend-4e804857.txt
@@ -1,0 +1,10 @@
+x**2 * x * x * x
+47.9 μs ± 2.31 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x * x**2 * x * x
+45.8 μs ± 2.02 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**1 * x**4
+42.4 μs ± 3.49 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x**4 * x**1
+42.5 μs ± 2.74 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
+x1 * x2
+13 μs ± 659 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

--- a/t7603/timing.ipy
+++ b/t7603/timing.ipy
@@ -1,0 +1,21 @@
+import cirq
+q = cirq.q(0)
+x = cirq.X(q)
+
+print("x**2 * x * x * x")
+%timeit x**2 * x * x * x
+
+print("x * x**2 * x * x")
+%timeit x * x**2 * x * x
+
+print("x**1 * x**4")
+%timeit x**1 * x**4
+
+print("x**4 * x**1")
+%timeit x**4 * x**1
+
+q1, q2 = cirq.q(1), cirq.q(2)
+x1 = cirq.X(q1)
+x2 = cirq.X(q2)
+print("x1 * x2")
+%timeit x1 * x2


### PR DESCRIPTION
- `Delegate SingleQubitPauliStringGateOperation.__mul__`, `__rmul__` to
  its PauliString base
- Put back faster to-PauliString conversion of Pauli gates

Follow-up to #7603
Related to #7588
