### PR TITLE
Fix `Circuit._control_keys_` to respect control-measurement order

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1666,8 +1666,14 @@ class AbstractCircuit(abc.ABC):
         )
 
     def _control_keys_(self) -> frozenset[cirq.MeasurementKey]:
-        controls = frozenset(k for op in self.all_operations() for k in protocols.control_keys(op))
-        return controls - protocols.measurement_key_objs(self)
+        measures = set()
+        controls = set()
+        for op in self.all_operations():
+            # Only require keys that haven't already been measured earlier
+            controls.update(k for k in protocols.control_keys(op) if k not in measures)
+            # Record any measurement keys produced by this op
+            measures.update(protocols.measurement_key_objs(op))
+        return frozenset(controls)
 
 
 def _overlap_collision_time(

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -1324,3 +1324,17 @@ def test_has_unitary_protocol_returns_true_if_all_params_resolve() -> None:
     exp = sympy.Symbol('exp')
     op = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q) ** exp), param_resolver={exp: 0.5})
     assert protocols.has_unitary(op)
+
+
+def test_control_keys_respects_internal_measurement_order() -> None:
+    q = cirq.LineQubit(0)
+
+    # Control BEFORE measurement inside the subcircuit: external key required
+    fc_before = cirq.FrozenCircuit(cirq.X(q).with_classical_controls('a'), cirq.measure(q, key='a'))
+    op_before = cirq.CircuitOperation(fc_before)
+    assert cirq.control_keys(op_before) == {cirq.MeasurementKey('a')}
+
+    # Measurement BEFORE control inside the subcircuit: no external key required
+    fc_after = cirq.FrozenCircuit(cirq.measure(q, key='a'), cirq.X(q).with_classical_controls('a'))
+    op_after = cirq.CircuitOperation(fc_after)
+    assert cirq.control_keys(op_after) == set()

--- a/cirq-core/cirq/protocols/control_key_protocol.py
+++ b/cirq-core/cirq/protocols/control_key_protocol.py
@@ -53,6 +53,13 @@ def control_keys(val: Any) -> frozenset[cirq.MeasurementKey]:
     Returns:
         The measurement keys the value is controlled by. If the value is not
         classically controlled, the result is the empty tuple.
+
+    Notes:
+        For composite operations (e.g. CircuitOperation), only control keys that
+        have not already been measured earlier in the subcircuit are returned.
+        Control keys that are satisfied by measurements **after** their use in
+        the subcircuit are still required externally and thus appear in the
+        result.
     """
     getter = getattr(val, '_control_keys_', None)
     result = NotImplemented if getter is None else getter()


### PR DESCRIPTION
Previously, `Circuit._control_keys_` excluded any key that was measured inside the subcircuit. This caused keys to be omitted even when they were still required externally.

This change iterates through operations in order, only treating a key as satisfied internally if it has already been measured earlier in the subcircuit.

Also updates the `control_keys` protocol docstring to explicitly document this and adds regression tests to ensure correct behavior for simple CircuitOperations.

Fixes #7632