### PR TITLE
Generalize DensePauliString.mul to handle multi-qubit ops

### DIFF
--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -35,13 +35,10 @@ import sympy
 
 from cirq import linalg, protocols, value
 from cirq._compat import proper_repr
-from cirq._import import LazyLoader
 from cirq.ops import global_phase_op, identity, pauli_gates, pauli_string, raw_types
 
 if TYPE_CHECKING:
     import cirq
-
-devices = LazyLoader("devices", globals(), "cirq.devices")
 
 # Order is important! Index equals numeric value.
 PAULI_CHARS = 'IXYZ'
@@ -173,6 +170,7 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
     def _apply_unitary_(self, args) -> np.ndarray | None | NotImplementedType:
         if not self._has_unitary_():
             return NotImplemented
+        from cirq import devices
 
         qubits = devices.LineQubit.range(len(self))
         decomposed_ops = cast(Iterable['cirq.OP_TREE'], self._decompose_(qubits))
@@ -323,6 +321,8 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
                 this instance.
         """
         if qubits is None:
+            from cirq import devices
+
             qubits = devices.LineQubit.range(len(self))
 
         if len(qubits) != len(self):
@@ -591,6 +591,8 @@ def _try_coerce_to_dps(v: cirq.Operation) -> BaseDensePauliString | None:
 
     if (ps := pauli_string._try_interpret_as_pauli_string(v)) is None:
         return None
+
+    from cirq import devices
 
     if not all(isinstance(q, devices.LineQubit) for q in ps.qubits):
         raise ValueError(

--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -247,13 +247,8 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
 
     def __mul__(self, other):
         concrete_class = type(self)
-        if isinstance(other, (sympy.Basic, numbers.Number)):
-            new_coef = protocols.mul(self.coefficient, other, default=None)
-            if new_coef is None:
-                return NotImplemented
-            return concrete_class(pauli_mask=self.pauli_mask, coefficient=new_coef)
-
-        if (other := self._attempt_value_to_dps(other)) is not None:
+        other = self._try_coerce_to_dps(other) or other
+        if isinstance(other, BaseDensePauliString):
             if isinstance(other, MutableDensePauliString):
                 concrete_class = MutableDensePauliString
             max_len = max(len(self.pauli_mask), len(other.pauli_mask))
@@ -268,13 +263,19 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
                 pauli_mask=new_mask, coefficient=self.coefficient * other.coefficient * tweak
             )
 
+        if isinstance(other, (sympy.Basic, numbers.Number)):
+            new_coef = protocols.mul(self.coefficient, other, default=None)
+            if new_coef is None:
+                return NotImplemented
+            return concrete_class(pauli_mask=self.pauli_mask, coefficient=new_coef)
+
         return NotImplemented
 
     def __rmul__(self, other):
         if isinstance(other, (sympy.Basic, numbers.Number)):
             return self.__mul__(other)
 
-        if (other := self._attempt_value_to_dps(other)) is not None:
+        if (other := self._try_coerce_to_dps(other)) is not None:
             return other.__mul__(self)
 
         return NotImplemented
@@ -352,7 +353,8 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
         )
 
     def _commutes_(self, other: Any, *, atol: float = 1e-8) -> bool | NotImplementedType | None:
-        if (other := self._attempt_value_to_dps(other)) is not None:
+        other = self._try_coerce_to_dps(other) or other
+        if isinstance(other, BaseDensePauliString):
             n = min(len(self.pauli_mask), len(other.pauli_mask))
             phase = _vectorized_pauli_mul_phase(self.pauli_mask[:n], other.pauli_mask[:n])
             return phase == 1 or phase == -1
@@ -388,7 +390,7 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
         """
 
     @classmethod
-    def _attempt_value_to_dps(cls, v: Any) -> BaseDensePauliString | None:
+    def _try_coerce_to_dps(cls, v: Any) -> BaseDensePauliString | None:
         if isinstance(v, BaseDensePauliString):
             return v
 
@@ -517,14 +519,8 @@ class MutableDensePauliString(BaseDensePauliString):
         return NotImplemented
 
     def __imul__(self, other):
-        if isinstance(other, (sympy.Basic, numbers.Number)):
-            new_coef = protocols.mul(self.coefficient, other, default=None)
-            if new_coef is None:
-                return NotImplemented
-            self._coefficient = new_coef if isinstance(new_coef, sympy.Basic) else complex(new_coef)
-            return self
-
-        if (other := self._attempt_value_to_dps(other)) is not None:
+        other = self._try_coerce_to_dps(other) or other
+        if isinstance(other, BaseDensePauliString):
             if len(other) > len(self):
                 raise ValueError(
                     "The receiving dense pauli string is smaller than "
@@ -536,6 +532,13 @@ class MutableDensePauliString(BaseDensePauliString):
             self._coefficient *= _vectorized_pauli_mul_phase(self_mask, other.pauli_mask)
             self._coefficient *= other.coefficient
             self_mask ^= other.pauli_mask
+            return self
+
+        if isinstance(other, (sympy.Basic, numbers.Number)):
+            new_coef = protocols.mul(self.coefficient, other, default=None)
+            if new_coef is None:
+                return NotImplemented
+            self._coefficient = new_coef if isinstance(new_coef, sympy.Basic) else complex(new_coef)
             return self
 
         return NotImplemented

--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -585,7 +585,7 @@ def _as_pauli_mask(val: Iterable[cirq.PAULI_GATE_LIKE] | np.ndarray) -> np.ndarr
     return np.array([_pauli_index(v) for v in val], dtype=np.uint8)
 
 
-def _try_coerce_to_dps(v: Any) -> BaseDensePauliString | None:
+def _try_coerce_to_dps(v: cirq.Operation) -> BaseDensePauliString | None:
     if isinstance(v, BaseDensePauliString):
         return v
 

--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -35,10 +35,13 @@ import sympy
 
 from cirq import linalg, protocols, value
 from cirq._compat import proper_repr
+from cirq._import import LazyLoader
 from cirq.ops import global_phase_op, identity, pauli_gates, pauli_string, raw_types
 
 if TYPE_CHECKING:
     import cirq
+
+devices = LazyLoader("devices", globals(), "cirq.devices")
 
 # Order is important! Index equals numeric value.
 PAULI_CHARS = 'IXYZ'
@@ -170,7 +173,6 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
     def _apply_unitary_(self, args) -> np.ndarray | None | NotImplementedType:
         if not self._has_unitary_():
             return NotImplemented
-        from cirq import devices
 
         qubits = devices.LineQubit.range(len(self))
         decomposed_ops = cast(Iterable['cirq.OP_TREE'], self._decompose_(qubits))
@@ -321,8 +323,6 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
                 this instance.
         """
         if qubits is None:
-            from cirq import devices
-
             qubits = devices.LineQubit.range(len(self))
 
         if len(qubits) != len(self):
@@ -591,8 +591,6 @@ def _try_coerce_to_dps(v: cirq.Operation) -> BaseDensePauliString | None:
 
     if (ps := pauli_string._try_interpret_as_pauli_string(v)) is None:
         return None
-
-    from cirq import devices
 
     if not all(isinstance(q, devices.LineQubit) for q in ps.qubits):
         raise ValueError(

--- a/cirq-core/cirq/ops/dense_pauli_string_test.py
+++ b/cirq-core/cirq/ops/dense_pauli_string_test.py
@@ -173,6 +173,10 @@ def test_mul() -> None:
     with pytest.raises(ValueError, match='other than `cirq.LineQubit'):
         _ = f('III') * cirq.X(cirq.NamedQubit('tmp'))
 
+    # Parity operations.
+    assert f('IXYZ') * cirq.XX(*cirq.LineQubit.range(1, 3)) == -1j * f('IIZZ')
+    assert cirq.XX(*cirq.LineQubit.range(1, 3)) * f('IXYZ') == 1j * f('IIZZ')
+
     # Mixed types.
     m = cirq.MutableDensePauliString
     assert m('X') * m('Z') == -1j * m('Y')
@@ -187,6 +191,10 @@ def test_mul() -> None:
     assert f('I') * f('III') == f('III')
     assert f('X') * f('XXX') == f('IXX')
     assert f('XXX') * f('X') == f('IXX')
+    assert f('X') * cirq.Y(cirq.LineQubit(2)) == f('XIY')
+    assert f('XY') * cirq.YY(*cirq.LineQubit.range(1, 3)) == f('XIY')
+    assert cirq.X(cirq.LineQubit(2)) * f('Y') == f('YIX')
+    assert cirq.XX(*cirq.LineQubit.range(1, 3)) * f('YX') == f('YIX')
 
     with pytest.raises(TypeError):
         _ = f('I') * object()
@@ -235,8 +243,15 @@ def test_imul() -> None:
     p *= cirq.X(cirq.LineQubit(1))
     assert p == m('IZI')
 
+    p *= cirq.ZZ(*cirq.LineQubit.range(1, 3))
+    assert p == m('IIZ')
+
     with pytest.raises(ValueError, match='smaller than'):
         p *= f('XXXXXXXXXXXX')
+    with pytest.raises(ValueError, match='smaller than'):
+        p *= cirq.X(cirq.LineQubit(3))
+    with pytest.raises(ValueError, match='smaller than'):
+        p *= cirq.XX(*cirq.LineQubit.range(2, 4))
     with pytest.raises(TypeError):
         p *= object()
 
@@ -511,6 +526,8 @@ def test_commutes() -> None:
     assert cirq.commutes(f('IIIXII'), cirq.X(cirq.LineQubit(2)) ** 3)
     assert not cirq.commutes(f('IIIXII'), cirq.Z(cirq.LineQubit(3)) ** 3)
     assert cirq.commutes(f('IIIXII'), cirq.Z(cirq.LineQubit(2)) ** 3)
+    assert cirq.commutes(f('X'), cirq.Z(cirq.LineQubit(10)))
+    assert cirq.commutes(cirq.Z(cirq.LineQubit(10)), f('X'))
 
     assert cirq.commutes(f('XX'), "test", default=NotImplemented) is NotImplemented
 


### PR DESCRIPTION
Instead of a special block to handle paulis on linequbits in mul, rmul, imul, and commutes, this PR just converts those paulis to DensePauliString up-front. That allows removal of the special handling blocks, plus generalizes to multi-qubit paulis and eliminates out-of-bounds errors.

Fixes #7640