### PR TITLE
QVM - require gate_times_ns argument in noise_properties_from_calibration

### DIFF
--- a/cirq-google/cirq_google/engine/calibration_to_noise_properties.py
+++ b/cirq-google/cirq_google/engine/calibration_to_noise_properties.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from typing import Literal, TYPE_CHECKING
 
-from cirq import _compat, ops
+from cirq import ops
 from cirq.devices import noise_utils
 from cirq_google import engine, ops as cg_ops
 from cirq_google.devices import google_noise_properties
@@ -93,7 +93,7 @@ def _unpack_2q_from_calibration(
 def noise_properties_from_calibration(
     calibration: engine.Calibration,
     *,
-    gate_times_ns: dict[type[cirq.Gate], float] | Literal['legacy'] | None = None,
+    gate_times_ns: dict[type[cirq.Gate], float] | Literal['legacy'],
     zphase_data: util.ZPhaseDataType | None = None,
 ) -> google_noise_properties.GoogleNoiseProperties:
     """Translates between `cirq_google.Calibration` and NoiseProperties.
@@ -126,15 +126,7 @@ def noise_properties_from_calibration(
         A `cirq_google.GoogleNoiseProperties` which represents the error
         present in the given Calibration object.
     """
-    if gate_times_ns is None:
-        _compat._warn_or_error(
-            'Function noise_properties_from_calibration was called without the '
-            'gate_times_ns argument.\n'
-            'This argument will become mandatory in cirq_google v1.7.\n'
-            'To continue using the old gate times default, please pass the "legacy" value.'
-        )
-        gate_times_ns = DEFAULT_GATE_NS
-    elif gate_times_ns == 'legacy':
+    if gate_times_ns == 'legacy':
         gate_times_ns = DEFAULT_GATE_NS
     if not isinstance(gate_times_ns, dict):
         raise TypeError(

--- a/cirq-google/cirq_google/engine/calibration_to_noise_properties_test.py
+++ b/cirq-google/cirq_google/engine/calibration_to_noise_properties_test.py
@@ -237,13 +237,11 @@ def test_noise_properties_from_calibration():
         syc_angles,
         iswap_angles,
     )
-    with cirq.testing.assert_deprecated(
-        "noise_properties_from_calibration was called without the gate_times_ns", deadline="v1.7"
-    ):
-        prop = cirq_google.noise_properties_from_calibration(calibration)
-    assert prop == cirq_google.noise_properties_from_calibration(
-        calibration, gate_times_ns="legacy"
-    )
+    prop = cirq_google.noise_properties_from_calibration(calibration, gate_times_ns="legacy")
+
+    assert prop.gate_times_ns[cirq.ZPowGate] == 25
+    assert prop.gate_times_ns[cirq.ResetChannel] == 250
+    assert prop.gate_times_ns[cirq.FSimGate] == 32
 
     for i, q in enumerate(qubits):
         assert np.isclose(


### PR DESCRIPTION
The default value for the `gate_times_ns` argument of
`noise_properties_from_calibration` was deprecated in #7399.
Here we make the argument mandatory.

Note the literal "legacy" value, i.e., `gate_times_ns="legacy"`,
can be used as a stand-in for the old default.

Related to b/395705720
