### PR TITLE
Fix typo and numbered list in variational algo doc

### DIFF
--- a/docs/experiments/variational_algorithm.ipynb
+++ b/docs/experiments/variational_algorithm.ipynb
@@ -281,7 +281,7 @@
     "\n",
     "Given this definition of the problem instance, we can now introduce our ansatz. It will consist of one step of a circuit made up of:\n",
     "\n",
-    "0. Apply an initial mixing step that puts all the qubits into the $|+\\rangle=\\frac{1}{\\sqrt{2}}(|0\\rangle+|1\\rangle)$ state.\n"
+    "0\\. Apply an initial mixing step that puts all the qubits into the $|+\\rangle=\\frac{1}{\\sqrt{2}}(|0\\rangle+|1\\rangle)$ state.\n"
    ]
   },
   {
@@ -304,7 +304,7 @@
     "id": "49482d550033"
    },
    "source": [
-    "1. Apply a `cirq.ZPowGate` for the same parameter for all qubits where the transverse field term $h$ is $+1$."
+    "1\\. Apply a `cirq.ZPowGate` for the same parameter for all qubits where the transverse field term $h$ is $+1$."
    ]
   },
   {
@@ -330,7 +330,7 @@
     "id": "iSizAkjE_5pq"
    },
    "source": [
-    "2. Apply a `cirq.CZPowGate` for the same parameter between all qubits where the coupling field term $J$ is $+1$. If the field is $-1$, apply `cirq.CZPowGate` conjugated by $X$ gates on all qubits."
+    "2\\. Apply a `cirq.CZPowGate` for the same parameter between all qubits where the coupling field term $J$ is $+1$. If the field is $-1$, apply `cirq.CZPowGate` conjugated by $X$ gates on all qubits."
    ]
   },
   {
@@ -375,7 +375,7 @@
     "id": "DI7wQure_5ps"
    },
    "source": [
-    "3. Apply an `cirq.XPowGate` for the same parameter for all qubits. This is the method `rot_x_layer` we have written above.\n",
+    "3\\. Apply an `cirq.XPowGate` for the same parameter for all qubits. This is the method `rot_x_layer` we have written above.\n",
     "\n",
     "Putting all together, we can create a step that uses just three parameters. Below is the code, which uses the generator for each of the layers (note to advanced Python users: this code does not contain a bug in using `yield` due to the auto flattening of the `OP_TREE concept`. Typically, one would want to use `yield` from here, but this is not necessary):"
    ]
@@ -523,7 +523,7 @@
     "\n",
     "Now that we have constructed a variational ansatz and shown how to simulate it using Cirq, we can think about optimizing the value. \n",
     "\n",
-    "On quantum hardware, one would most likely want to have the optimization code as close to the hardware as possible. As the classical hardware that is allowed to inter-operate with the quantum hardware becomes better specified, this language will be better defined. Without this specification, however, Cirq also provides a useful concept for optimizing the looping in many optimization algorithms. This is the fact that many of the value in the gate sets can, instead of being specified by a float, be specified by a `symply.Symbol`, and this `sympy.Symbol` can be substituted for a value specified at execution time.\n",
+    "On quantum hardware, one would most likely want to have the optimization code as close to the hardware as possible. As the classical hardware that is allowed to inter-operate with the quantum hardware becomes better specified, this language will be better defined. Without this specification, however, Cirq also provides a useful concept for optimizing the looping in many optimization algorithms. This is the fact that many of the value in the gate sets can, instead of being specified by a float, be specified by a `sympy.Symbol`, and this `sympy.Symbol` can be substituted for a value specified at execution time.\n",
     "\n",
     "Luckily for us, we have written our code so that using parameterized values is as simple as passing `sympy.Symbol` objects where we previously passed float values."
    ]


### PR DESCRIPTION
1. The numbered list in official doc isn't displaying as expected
2. Typo in sympy.Symbol