### PR TITLE
Fix unexpected markdown syntax in docstring

### DIFF
--- a/cirq-core/cirq/ops/arithmetic_operation.py
+++ b/cirq-core/cirq/ops/arithmetic_operation.py
@@ -130,9 +130,9 @@ class ArithmeticGate(Gate, metaclass=abc.ABCMeta):
         1. The `apply` method is permitted to return values that have more bits
             than the registers they will be stored into. The extra bits are
             simply dropped. For example, if the value 5 is returned for a 2
-            qubit register then 5 % 2^2 = 1 will be used instead. Negative
+            qubit register then ``5 % 2**2 = 1`` will be used instead. Negative
             values are also permitted. For example, for a 3 qubit register the
-            value -2 becomes -2 % 2^3 = 6.
+            value -2 becomes ``-2 % 2**3 = 6``.
         2. When the value of the last `k` registers is not changed by the
             gate, the `apply` method is permitted to omit these values
             from the result. That is to say, when the length of the output is

--- a/cirq-core/cirq/ops/arithmetic_operation.py
+++ b/cirq-core/cirq/ops/arithmetic_operation.py
@@ -130,9 +130,9 @@ class ArithmeticGate(Gate, metaclass=abc.ABCMeta):
         1. The `apply` method is permitted to return values that have more bits
             than the registers they will be stored into. The extra bits are
             simply dropped. For example, if the value 5 is returned for a 2
-            qubit register then 5 % 2**2 = 1 will be used instead. Negative
+            qubit register then 5 % 2^2 = 1 will be used instead. Negative
             values are also permitted. For example, for a 3 qubit register the
-            value -2 becomes -2 % 2**3 = 6.
+            value -2 becomes -2 % 2^3 = 6.
         2. When the value of the last `k` registers is not changed by the
             gate, the `apply` method is permitted to omit these values
             from the result. That is to say, when the length of the output is

--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -391,7 +391,7 @@ class YPowGate(eigen_gate.EigenGate):
     Unlike `cirq.XPowGate` and `cirq.ZPowGate`, this gate has no generalization
     to qudits and hence does not take the dimension argument. Ignoring the
     global phase all generalized Pauli operators on a d-level system may be
-    written as X**a Z**b for a,b=0,1,...,d-1. For a qubit, there is only one
+    written as ``X**a Z**b`` for a,b=0,1,...,d-1. For a qubit, there is only one
     "mixed" operator: XZ, conventionally denoted -iY. However, when d > 2 there
     are (d-1)*(d-1) > 1 such "mixed" operators (still ignoring the global phase).
     Due to this ambiguity, qudit Y gate is not well defined. The "mixed" operators

--- a/cirq-core/cirq/ops/pauli_string_phasor.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor.py
@@ -73,9 +73,9 @@ class PauliStringPhasor(gate_operation.GateOperation):
                 `pauli_string` are acted upon by identity. The order of
                 these qubits must match the order in `pauli_string`.
             exponent_neg: How much to phase vectors in the negative eigenspace,
-                in the form of the t in (-1)**t = exp(i pi t).
+                in the form of the t in ``(-1)**t = exp(i*pi*t)``.
             exponent_pos: How much to phase vectors in the positive eigenspace,
-                in the form of the t in (-1)**t = exp(i pi t).
+                in the form of the t in ``(-1)**t = exp(i*pi*t)``.
 
         Raises:
             ValueError: If coefficient is not 1 or -1 or the qubits of


### PR DESCRIPTION
In the docstring of [ArithmeticGate.apply](https://quantumai.google/reference/python/cirq/ArithmeticGate),
two exponentiation `**` accidentally combine to a bold text syntax.
Here we add backtick quotes to avoid this, and also fix a few other
similar instances.
