### PR TITLE
CI - unblock type check with a temporary pin to numpy-2.2

### DIFF
--- a/dev_tools/requirements/mypy.env.txt
+++ b/dev_tools/requirements/mypy.env.txt
@@ -4,3 +4,6 @@
 
 -r deps/cirq-all.txt
 -r deps/mypy.txt
+
+# TODO: #7657 - remove after fixing type annotations for NumPy-2.3
+numpy<2.3


### PR DESCRIPTION
Type check fails for numpy-2.3.3.  Add temporary pin
to numpy-2.2.x to let it pass.

Workaround for #7657
