### PR TITLE
Increase default max_concurrent_jobs to 100

### DIFF
--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -595,7 +595,7 @@ class Engine(abstract_engine.AbstractEngine):
         run_name: str = "",
         device_config_name: str = "",
         snapshot_id: str = "",
-        max_concurrent_jobs: int = 10,
+        max_concurrent_jobs: int = 100,
     ) -> cirq_google.ProcessorSampler:
         """Returns a sampler backed by the engine.
 

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -98,7 +98,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         run_name: str = "",
         device_config_name: str = "",
         snapshot_id: str = "",
-        max_concurrent_jobs: int = 10,
+        max_concurrent_jobs: int = 100,
     ) -> cg.engine.ProcessorSampler:
         """Returns a sampler backed by the engine.
         Args:

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -34,7 +34,7 @@ class ProcessorSampler(cirq.Sampler):
         run_name: str = "",
         snapshot_id: str = "",
         device_config_name: str = "",
-        max_concurrent_jobs: int = 10,
+        max_concurrent_jobs: int = 100,
     ):
         """Inits ProcessorSampler.
 


### PR DESCRIPTION
Increases default throughput for Quantum Engine users.