### PR TITLE
Advise to use `git ls-remote --branches` instead of `--heads`

### DIFF
--- a/dev_tools/bash_scripts_test.py
+++ b/dev_tools/bash_scripts_test.py
@@ -321,7 +321,7 @@ def test_pytest_changed_files_branch_selection(tmpdir_factory) -> None:
         'git init --quiet --initial-branch main\n'
         'git config --local user.name \'Me\'\n'
         'git config --local user.email \'<>\'\n'
-        'git commit -m tes --quiet --allow-empty --no-gpg-sign\n'
+        'git commit -m test --quiet --allow-empty --no-gpg-sign\n'
         'cd ..\n'
         'git remote add origin alt\n'
         'git fetch origin main --quiet 2> /dev/null\n',

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -54,7 +54,7 @@ This remote can be used to merge changes from Cirq's main repository into your l
     ```
 
     You can check the branches that are on the ```upstream``` remote by
-    running `git ls-remote --heads upstream` or `git branch -r`.
+    running `git ls-remote --branches upstream` or `git branch -r`.
 Most importantly you should see ```upstream/main``` listed.
 1. Merge the upstream main into your local main so that it is up to date.
 


### PR DESCRIPTION
The `--heads` option is a deprecated synonym of `--branches`.
Also fix unrelated typo.
