### PR TITLE
Fix type-checking issues for numpy-2.3.3

### DIFF
--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -82,7 +82,7 @@ def match_global_phase(a: np.ndarray, b: np.ndarray) -> tuple[np.ndarray, np.nda
         return np.copy(a), np.copy(b)
 
     # Find the entry with the largest magnitude in one of the matrices.
-    k = max(np.ndindex(*a.shape), key=lambda t: abs(b[t]))
+    k = max(np.ndindex(*a.shape), key=lambda t: abs(b[t].item()))
 
     def dephase(v):
         r = np.real(v)

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -639,7 +639,7 @@ class SingleQubitCliffordGate(CliffordGate):
             return None
         # Find the entry with the largest magnitude in the input unitary, to find
         # the global phase difference between the input unitary and the gate unitary.
-        k = max(np.ndindex(*u.shape), key=lambda t: abs(u[t]))
+        k = max(np.ndindex(*u.shape), key=lambda t: abs(u[t].item()))
         return gate, u[k] / protocols.unitary(gate)[k]
 
     def pauli_tuple(self, pauli: Pauli) -> tuple[Pauli, bool]:

--- a/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_state_ch_form.py
@@ -288,10 +288,10 @@ class StabilizerStateChForm(qis.StabilizerState):
         copy = StabilizerStateChForm(self.n)
         copy.G = self.G[axes][:, axes]
         copy.F = self.F[axes][:, axes]
-        copy.M = self.M[axes][:, axes]  # type: ignore[assignment]
-        copy.gamma = self.gamma[axes]  # type: ignore[assignment]
-        copy.v = self.v[axes]  # type: ignore[assignment]
-        copy.s = self.s[axes]  # type: ignore[assignment]
+        copy.M = self.M[axes][:, axes]
+        copy.gamma = self.gamma[axes]
+        copy.v = self.v[axes]
+        copy.s = self.s[axes]
         copy.omega = self.omega
         return copy
 

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -55,7 +55,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
         *,
         initial_state: np.ndarray | cirq.STATE_VECTOR_LIKE = 0,
         qid_shape: tuple[int, ...] | None = None,
-        dtype: type[np.complexfloating] | None = None,
+        dtype: type[np.complexfloating] | np.dtype[np.complexfloating] | None = None,
         buffer: np.ndarray | None = None,
     ):
         """Initializes the object with the inputs.
@@ -324,7 +324,7 @@ class StateVectorSimulationState(SimulationState[_BufferedStateVector]):
         prng: np.random.RandomState | None = None,
         qubits: Sequence[cirq.Qid] | None = None,
         initial_state: np.ndarray | cirq.STATE_VECTOR_LIKE = 0,
-        dtype: type[np.complexfloating] = np.complex64,
+        dtype: type[np.complexfloating] | np.dtype[np.complexfloating] = np.complex64,
         classical_data: cirq.ClassicalDataStore | None = None,
     ):
         """Inits StateVectorSimulationState.

--- a/cirq-core/cirq/testing/lin_alg_utils.py
+++ b/cirq-core/cirq/testing/lin_alg_utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 def random_superposition(
     dim: int, *, random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None
-) -> np.ndarray:
+) -> np.ndarray[tuple[int], np.dtype[np.complex128]]:
     """Returns a random unit-length vector from the uniform distribution.
 
     Args:

--- a/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation.py
+++ b/cirq-core/cirq/transformers/heuristic_decompositions/two_qubit_gate_tabulation.py
@@ -109,7 +109,7 @@ class TwoQubitGateTabulation:
         success = infidelities[nearest_ind] < self.max_expected_infidelity
 
         # shape (n,2,2,2)
-        inner_gates = np.array(self.single_qubit_gates[nearest_ind])
+        inner_gates: np.ndarray = np.array(self.single_qubit_gates[nearest_ind])
 
         if inner_gates.size == 0:  # Only need base gate
             kR, kL, actual = _outer_locals_for_unitary(unitary, self.base_gate)

--- a/dev_tools/requirements/mypy.env.txt
+++ b/dev_tools/requirements/mypy.env.txt
@@ -4,6 +4,3 @@
 
 -r deps/cirq-all.txt
 -r deps/mypy.txt
-
-# TODO: #7657 - remove after fixing type annotations for NumPy-2.3
-numpy<2.3


### PR DESCRIPTION
- revert "CI - unblock type check with a temporary pin to numpy-2.2 (#7658)"
- purge unused "type: ignore" comments
- fix small issues showing for numpy-2.3.3
- allow convertible types for the dtype argument of `StateVectorSimulationState`

Fixes #7657
