### PR TITLE
Remove trailing empty ListSweep from merged sweep

### DIFF
--- a/cirq-core/cirq/transformers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates.py
@@ -324,7 +324,7 @@ def merge_single_qubit_gates_to_phxz_symbolized(
 
     # Step 3, get N sets of parameterizations as new_sweep.
     if remaining_symbols:
-        new_sweep = Zip(
+        new_sweep: Sweep = Zip(
             _calc_phxz_sweeps(new_circuit, merged_circuits),  # phxz sweeps
             _sweep_on_symbols(sweep, remaining_symbols),  # remaining sweeps
         )


### PR DESCRIPTION
- when calling merge_single_qubit_gates_to_phxz_symbolized, if remaining symbols is empty, then an empty ListSweep is added to the end of the sweep.
- This empty ListSweep confuses parsers, which then interpret this as a sweep of zero length and return an empty list.
- This now only adds this ListSweep if there is something to add.