### PR TITLE
Micro-optimizations to WaitGate

### DIFF
--- a/cirq-core/cirq/ops/wait_gate.py
+++ b/cirq-core/cirq/ops/wait_gate.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import AbstractSet, Any, TYPE_CHECKING
 
+import sympy
+
 from cirq import protocols, value
 from cirq.ops import raw_types
 
@@ -54,7 +56,8 @@ class WaitGate(raw_types.Gate):
         self._duration = (
             duration if isinstance(duration, value.Duration) else value.Duration(duration)
         )
-        if not self.duration._is_parameterized_() and self.duration.total_picos() < 0:
+        total_picos = self.duration.total_picos()
+        if not isinstance(total_picos, sympy.Basic) and self.duration.total_picos() < 0:
             raise ValueError('duration < 0')
         if qid_shape is None:
             if num_qubits is None:

--- a/cirq-core/cirq/ops/wait_gate.py
+++ b/cirq-core/cirq/ops/wait_gate.py
@@ -55,7 +55,6 @@ class WaitGate(raw_types.Gate):
             duration if isinstance(duration, value.Duration) else value.Duration(duration)
         )
         if not self.duration._is_parameterized_() and self.duration.total_picos() < 0:
-            # if not protocols.is_parameterized(self.duration) and self.duration.total_picos() < 0:
             raise ValueError('duration < 0')
         if qid_shape is None:
             if num_qubits is None:

--- a/cirq-core/cirq/ops/wait_gate.py
+++ b/cirq-core/cirq/ops/wait_gate.py
@@ -51,8 +51,11 @@ class WaitGate(raw_types.Gate):
             ValueError: If the `qid_shape` provided is empty or `num_qubits` contradicts
                 `qid_shape`.
         """
-        self._duration = value.Duration(duration)
-        if not protocols.is_parameterized(self.duration) and self.duration < 0:
+        self._duration = (
+            duration if isinstance(duration, value.Duration) else value.Duration(duration)
+        )
+        if not self.duration._is_parameterized_() and self.duration.total_picos() < 0:
+            # if not protocols.is_parameterized(self.duration) and self.duration.total_picos() < 0:
             raise ValueError('duration < 0')
         if qid_shape is None:
             if num_qubits is None:

--- a/cirq-core/cirq/ops/wait_gate.py
+++ b/cirq-core/cirq/ops/wait_gate.py
@@ -57,7 +57,7 @@ class WaitGate(raw_types.Gate):
             duration if isinstance(duration, value.Duration) else value.Duration(duration)
         )
         total_picos = self.duration.total_picos()
-        if not isinstance(total_picos, sympy.Basic) and self.duration.total_picos() < 0:
+        if not isinstance(total_picos, sympy.Basic) and total_picos < 0:
             raise ValueError('duration < 0')
         if qid_shape is None:
             if num_qubits is None:

--- a/cirq-core/cirq/value/duration.py
+++ b/cirq-core/cirq/value/duration.py
@@ -84,19 +84,19 @@ class Duration:
         """
         self._time_vals: list[_NUMERIC_INPUT_TYPE] = [0, 0, 0, 0]
         self._multipliers = [1, 1000, 1000_000, 1000_000_000]
-        if value is not None and value != 0:
+        if value is not None:
             if isinstance(value, datetime.timedelta):
                 # timedelta has microsecond resolution.
                 self._time_vals[2] = int(value / datetime.timedelta(microseconds=1))
             elif isinstance(value, Duration):
                 self._time_vals = value._time_vals
-            else:
+            elif value != 0:
                 raise TypeError(f'Not a `cirq.DURATION_LIKE`: {repr(value)}.')
         input_vals = [picos, nanos, micros, millis]
         self._time_vals = _add_time_vals(self._time_vals, input_vals)
 
     def _is_parameterized_(self) -> bool:
-        return protocols.is_parameterized(self._time_vals)
+        return any(isinstance(val, sympy.Expr) for val in self._time_vals)
 
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self._time_vals)

--- a/cirq-core/cirq/value/duration.py
+++ b/cirq-core/cirq/value/duration.py
@@ -96,7 +96,7 @@ class Duration:
         self._time_vals = _add_time_vals(self._time_vals, input_vals)
 
     def _is_parameterized_(self) -> bool:
-        return any(isinstance(val, sympy.Expr) for val in self._time_vals)
+        return any(isinstance(val, sympy.Basic) for val in self._time_vals)
 
     def _parameter_names_(self) -> AbstractSet[str]:
         return protocols.parameter_names(self._time_vals)


### PR DESCRIPTION
- Noticed some inefficiencies in the creation of WaitGate where it is doing unnecessary object boxing.
- This removes (slow) comparisons between Duration objects.

This improves creation of WaitGate objects (e.g. from cirq.wait(nanos=10)) from about 27 micros to about 16 micros. While not a huge effect, this could have measurable savings for certain T1 and similar experiments that involve creation of lots of wait gates.