### PR TITLE
Update Scientific Python dependencies per NEP-29 and SPEC-0

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -2,10 +2,10 @@
 
 attrs>=21.3.0
 duet>=0.2.8
-matplotlib~=3.8
+matplotlib~=3.9
 networkx~=3.4
-numpy>=1.26
-pandas~=2.1
+numpy~=2.0
+pandas~=2.2
 sortedcontainers~=2.0
 scipy~=1.12
 sympy

--- a/dev_tools/requirements/deps/ipython.txt
+++ b/dev_tools/requirements/deps/ipython.txt
@@ -1,1 +1,1 @@
-ipython>=8.15
+ipython>=8.17


### PR DESCRIPTION
* drop numpy-1 per NEP-29 and SPEC-0
* drop matplotlib-3.8 per SPEC-0
* drop pandas-2.2 per SPEC-0
* drop ipython-8.16 per SPEC-0

Refs:

* https://numpy.org/neps/nep-0029-deprecation_policy.html
* https://scientific-python.org/specs/spec-0000

Resolves b/432284080
