### PR TITLE
Update branches from master to main for ReCirq and qsim

### DIFF
--- a/cirq-google/cirq_google/engine/runtime_estimator.py
+++ b/cirq-google/cirq_google/engine/runtime_estimator.py
@@ -24,7 +24,7 @@ Your experience may vary based on many factors not captured here.
 Parameters were calculated using a variety of width/depth/sweeps from
 the rep rate calculator, see:
 
-[https://github.com/quantumlib/ReCirq/blob/master/recirq/benchmarks/rep_rate/](https://github.com/quantumlib/ReCirq/blob/master/recirq/benchmarks/rep_rate/){:.external}
+[https://github.com/quantumlib/ReCirq/blob/main/recirq/benchmarks/rep_rate/](https://github.com/quantumlib/ReCirq/blob/main/recirq/benchmarks/rep_rate/){:.external}
 
 Model was then fitted by hand, correcting for anomalies and outliers
 when possible.

--- a/docs/simulate/simulation.ipynb
+++ b/docs/simulate/simulation.ipynb
@@ -672,7 +672,7 @@
     "| Project name | PyPI package | Description |\n",
     "| --- | --- | --- |\n",
     "| [qsim](https://github.com/quantumlib/qsim) | qsimcirq | Implements `cirq.SimulatesAmplitudes`, `cirq.SimulatesFinalState`, and `cirq.SimulatesExpectationValues`. Recommended for deep circuits with up to 30 qubits (consumes 8GB RAM). Larger circuits are possible, but RAM usage doubles with each additional qubit. |\n",
-    "| [qsimh](https://github.com/quantumlib/qsim/blob/master/qsimcirq/qsimh_simulator.py) | qsimcirq | Implements `cirq.SimulatesAmplitudes`. Intended for heavy parallelization across several computers; Cirq users should generally prefer qsim. |\n",
+    "| [qsimh](https://github.com/quantumlib/qsim/blob/main/qsimcirq/qsimh_simulator.py) | qsimcirq | Implements `cirq.SimulatesAmplitudes`. Intended for heavy parallelization across several computers; Cirq users should generally prefer qsim. |\n",
     "| [quimb](https://quimb.readthedocs.io/en/latest/) | quimb | Not based on `cirq.Simulator`; instead uses a Cirq-to-quimb translation layer provided in `contrib/quimb`. In addition to circuit simulation, this allows the use of quimb circuit-analysis tools on Cirq circuits. |\n",
     "| [qFlex](https://github.com/ngnrsaa/qflex) | qflexcirq | Implements `cirq.SimulatesAmplitudes`. RAM usage is highly dependent on the number of two-qubit gates in the circuit. Not recommended - prefer qsim or quimb. |\n"
    ]


### PR DESCRIPTION
This updates default branch names in a couple of references to the ReCirq and qsim repositories on GitHub.