### PR TITLE
Fail check/ts-build-current when bundle files cannot be built

### DIFF
--- a/check/ts-build-current
+++ b/check/ts-build-current
@@ -21,7 +21,7 @@
 #     check/ts-build-changes
 ################################################################################
 
-check/ts-build 
+check/ts-build || exit $?
 
 # Find the changed bundle.js files, if any
 untracked=$(git diff --name-only HEAD -- "*.bundle.js" "*.bundle.js.*txt")


### PR DESCRIPTION
The `check/ts-build-current` CI job could pass if `check/ts-build`
failed before writing the bundle files.
