### PR TITLE
Improve hashing of PhasedXZGate for symbolic values

### DIFF
--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -140,6 +140,10 @@ class PhasedXZGate(raw_types.Gate):
         return self._axis_phase_exponent
 
     def _value_equality_values_(self):
+        if self._is_parameterized_():
+            # If this is parameterized, do not try to calculate the canonical exponents
+            # as this results in some slow sympy operations.
+            return (self._x_exponent, self._z_exponent, self._axis_phase_exponent)
         c = self._canonical()
         return (
             value.PeriodicValue(c._x_exponent, 2),


### PR DESCRIPTION
- hashing symbolic values is slow, since they create lots of sympy formulas like sympy.Mod(sympy.Symbol('t'), 2), etc.
- if the gate is parametrized, skip this.

This improves the following function from 1.5 seconds to 0.003 seconds:

```
def test_hash():
   gates = [cirq.PhasedXZGate(x_exponent=sympy.Symbol(f'x{t}'),
                              z_exponent=sympy.Symbol(f'z{t}'),
                              axis_phase_exponent=sympy.Symbol(f'a{t}'))
                              for t in range(2000)]
   t0 = time.time()
   for g in gates:
       hash(g)
   print(time.time()-t0)
```

(If performancing testing this, take care that hashes are saved after the first call)