### PR TITLE
Change ParamResolver keys to be strings

### DIFF
--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -75,16 +75,17 @@ class ParamResolver:
 
         self._param_hash: int | None = None
         self._param_dict = cast(ParamDictType, {} if param_dict is None else param_dict)
-        remake = False
+        self._param_dict_with_str_keys = self._param_dict
+        generate_str_keys = False
         for key in self._param_dict:
             if isinstance(key, sympy.Expr):
                 if isinstance(key, sympy.Symbol):
-                    remake = True
+                    generate_str_keys = True
                 else:
                     raise TypeError(f'ParamResolver keys cannot be (non-symbol) formulas ({key})')
-        if remake:
+        if generate_str_keys:
             # Remake dictionary with string keys for faster access
-            self._param_dict = {
+            self._param_dict_with_str_keys = {
                 (key.name if isinstance(key, sympy.Symbol) else key): value
                 for key, value in self._param_dict.items()
             }
@@ -133,7 +134,7 @@ class ParamResolver:
         if isinstance(value, sympy.Symbol):
             value = value.name
         if isinstance(value, str):
-            param_value = self._param_dict.get(value, _NOT_FOUND)
+            param_value = self._param_dict_with_str_keys.get(value, _NOT_FOUND)
             if isinstance(param_value, float):
                 return param_value
             if param_value is _NOT_FOUND:


### PR DESCRIPTION
- This PR changes ParamResolvers to only use string keys.
- Previously, ParamResolver keys could be strings or symbols.
- If a symbol is detected, the ParamResolver will remake the dictionary using only strings.
- This simplifies the logic and improves performance since sympy Symbols can be slower to create and hash.

Performance implications:
- Creation speed is unchanged unless you have symbols as keys, then creation takes about twice as long.  (For 1000 parameters, this is a change from about 0.6ms to 1.3ms).
- Lookup speed is now about ~120-130ns
- Before it was: -- ~200ns for string lookup with string keys
-- ~250ns for symbol lookup with string keys
-- ~850ns for string lookup with symbol keys
-- ~350ns for symbol lookup with symbol keys