### PR TITLE
Add OSSF Scorecard configuration file

### DIFF
--- a/.github/scorecard.yaml
+++ b/.github/scorecard.yaml
@@ -1,0 +1,25 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Summary: configure OSSF Scorecard for some nuances of this project.
+# For more info about Scorecard options, see https://scorecard.dev/.
+
+checks:
+  # TODO: remove this rule after pinned dependencies are introduced to Cirq.
+  - name: Pinned-Dependencies
+    reason: >-
+      Unpinned dependencies in the CI workflow are a known concern. They will
+      be addressed in a future update.
+    ignored-paths:
+      - ".github/workflows/**"


### PR DESCRIPTION
This configuration file tells the scanner to ignore unpinned dependencies in the CI workflows. They are a known concern and are judged to be relatively low risk for the time being. They will be addressed in future work. Until then, it is not useful to keep seeing the same warnings repeatedly.