### PR TITLE
Use "uv pip compile" to check consistency of requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,10 +230,10 @@ jobs:
           python-version: '3.11'
           architecture: 'x64'
       - name: Install requirements
-        run: pip install pip-tools
-      - name: Test dependencies with pip-compile
+        run: pip install uv
+      - name: Test dependencies with uv pip compile
         run: |
-          pip-compile --resolver=backtracking dev_tools/requirements/deps/cirq-all.txt -o-
+          uv pip compile dev_tools/requirements/deps/cirq-all.txt
   build_protos:
     if: github.repository_owner == 'quantumlib'
     name: Build protos


### PR DESCRIPTION
Problem: pip-tools is compatible with pip-25.3 causing spurious
CI failures (https://github.com/jazzband/pip-tools/issues/2252)

Solution: use `uv` instead which is self-contained and faster.
