### PR TITLE
pr-size-labeler - fetch change info for the maximum number of files

### DIFF
--- a/dev_tools/ci/size-labeler.sh
+++ b/dev_tools/ci/size-labeler.sh
@@ -114,7 +114,7 @@ function compute_changes() {
     local response
     local change_info
     local -r keys_filter='with_entries(select([.key] | inside(["changes", "filename"])))'
-    response="$(api_call "pulls/${pr}/files")"
+    response="$(api_call "pulls/${pr}/files?per_page=100")"
     change_info="$(jq_stdin "map(${keys_filter})" <<<"${response}")"
 
     local files total_changes


### PR DESCRIPTION
By default the GHA endpoint `pulls/PULL_NUMBER/files` retrieves
change data for up to 30 files which is insufficient for PRs that
touch more files.  Here we increase the count to the maximum
`per_page` limit of 100.

It does not seem worthwhile to add pagination processing as
in the last year only 1% of PRs touched more than 100 files.

Ref: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
