### PR TITLE
asv - adjust build_command for making the cirq-core wheel

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,6 +4,9 @@
     "project_url": "https://quantumai.google/cirq",
     "repo": ".",
     "repo_subdir": "cirq-core/",
+    "build_command": [
+        "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
     "branches": ["main"],
     "dvcs": "git",
     "environment_type": "virtualenv",


### PR DESCRIPTION
Fixes `asv run` failure when building the cirq-core wheel for benchmarking.

Related to b/393456969
