### PR TITLE
Fix stabilizer effect detection for floating-point exponents

### DIFF
--- a/cirq-core/cirq/ops/common_gates.py
+++ b/cirq-core/cirq/ops/common_gates.py
@@ -285,7 +285,7 @@ class XPowGate(eigen_gate.EigenGate):
     def _has_stabilizer_effect_(self) -> bool | None:
         if self._is_parameterized_() or self._dimension != 2:
             return None
-        return self.exponent % 0.5 == 0
+        return abs(self.exponent % 0.5) < 1e-8
 
     def __str__(self) -> str:
         if self._global_shift == 0:
@@ -480,7 +480,7 @@ class YPowGate(eigen_gate.EigenGate):
     def _has_stabilizer_effect_(self) -> bool | None:
         if self._is_parameterized_():
             return None
-        return self.exponent % 0.5 == 0
+        return abs(self.exponent % 0.5) < 1e-8
 
     def __str__(self) -> str:
         if self._global_shift == 0:
@@ -760,7 +760,7 @@ class ZPowGate(eigen_gate.EigenGate):
     def _has_stabilizer_effect_(self) -> bool | None:
         if self._is_parameterized_() or self._dimension != 2:
             return None
-        return self.exponent % 0.5 == 0
+        return abs(self.exponent % 0.5) < 1e-8
 
     def _circuit_diagram_info_(
         self, args: cirq.CircuitDiagramInfoArgs


### PR DESCRIPTION
#7750 

If this feature is deemed necessary, the fixes have been made: added tolerance for stabilizer effect for XPowGate, YPowGate, and ZPowGate using abs(). A similar change can be made for other gates if desired. 

I am a beginner, and this is for a university class assignment to contribute to open-source software, so please let me know if this was not the intended change or something else must be fixed! I apologize in advance if that is the case.