### PR TITLE
Fix CircuitDag constructor to match its networkx.DiGraph base

### DIFF
--- a/cirq-core/cirq/contrib/circuitdag/circuit_dag.py
+++ b/cirq-core/cirq/contrib/circuitdag/circuit_dag.py
@@ -73,8 +73,9 @@ class CircuitDag(networkx.DiGraph):
 
     def __init__(
         self,
-        can_reorder: Callable[[cirq.Operation, cirq.Operation], bool] = _disjoint_qubits,
         incoming_graph_data: Any = None,
+        *,
+        can_reorder: Callable[[cirq.Operation, cirq.Operation], bool] = _disjoint_qubits,
     ) -> None:
         """Initializes a CircuitDag.
 

--- a/cirq-core/cirq/contrib/paulistring/recombine.py
+++ b/cirq-core/cirq/contrib/paulistring/recombine.py
@@ -70,7 +70,9 @@ def move_pauli_strings_into_circuit(
     circuit_left: circuits.Circuit | circuitdag.CircuitDag, circuit_right: circuits.Circuit
 ) -> circuits.Circuit:
     if isinstance(circuit_left, circuitdag.CircuitDag):
-        string_dag = circuitdag.CircuitDag(pauli_string_reorder_pred, circuit_left)
+        string_dag = circuitdag.CircuitDag(
+            incoming_graph_data=circuit_left, can_reorder=pauli_string_reorder_pred
+        )
     else:
         string_dag = pauli_string_dag_from_circuit(cast(circuits.Circuit, circuit_left))
     output_ops = list(circuit_right.all_operations())


### PR DESCRIPTION
Problem: `CircuitDag` had a different number (2 vs 1) and a different
order of positional arguments than its `networkx.DiGraph` base.
This caused failure for networkx-3.6 which added `DiGraph.__new__`
as it was receiving incompatible arguments.

Solution: Change `CircuitDag` arguments so they are compatible with
its superclass, i.e., make `incoming_graph_data` the first argument
as in the base and change `can_reorder` to a keyword-only argument.

This breaks the `CircuitDag` interface, but that should be acceptable
for a `contrib` function.
