### PR TITLE
Convert cirq_google proto_test-s to actual unit tests

### DIFF
--- a/cirq-google/cirq_google/api/v1/proto_test.py
+++ b/cirq-google/cirq_google/api/v1/proto_test.py
@@ -16,4 +16,10 @@
 
 from __future__ import annotations
 
-from cirq_google.api.v1 import operations_pb2, params_pb2, program_pb2  # noqa: F401
+from cirq_google.api.v1 import operations_pb2, params_pb2, program_pb2
+
+
+def test_api_v1_import_works() -> None:
+    assert operations_pb2
+    assert params_pb2
+    assert program_pb2

--- a/cirq-google/cirq_google/api/v2/proto_test.py
+++ b/cirq-google/cirq_google/api/v2/proto_test.py
@@ -16,4 +16,11 @@
 
 from __future__ import annotations
 
-from cirq_google.api.v2 import metrics_pb2, program_pb2, result_pb2, run_context_pb2  # noqa: F401
+from cirq_google.api.v2 import metrics_pb2, program_pb2, result_pb2, run_context_pb2
+
+
+def test_api_v2_import_works() -> None:
+    assert metrics_pb2
+    assert program_pb2
+    assert result_pb2
+    assert run_context_pb2


### PR DESCRIPTION
Add minimum test methods so these files contain pytest tests.
This simplifies test specification at the internal test framework.

Related to b/465462872
