### PR TITLE
CI - store test report for Pytest Ubuntu 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,9 @@ jobs:
       - name: Pytest check
         run: check/pytest -n auto --durations=20 --junit-xml=pytest-ubuntu-report.xml
       - name: Persist the test report
-        if: matrix.python-version == '3.11'
+        if: >-
+          (github.event_name == 'merge_group' || github.event_name == 'schedule') &&
+          matrix.python-version == '3.11'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: pytest-ubuntu-report


### PR DESCRIPTION
Save test report for scheduled and merge-queue runs.

To be used for tracking unit test durations.

Related to b/467133647
