### PR TITLE
Remove obsolete check from circuit.earliest_available_moment.

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2129,7 +2129,7 @@ class Circuit(AbstractCircuit):
             Index of the earliest matching moment. Returns `end_moment_index` if no moment on left
             is available.
         """
-        if end_moment_index is None:
+        if end_moment_index is None or end_moment_index > len(self.moments):
             end_moment_index = len(self.moments)
         last_available = end_moment_index
         k = end_moment_index
@@ -2148,10 +2148,7 @@ class Circuit(AbstractCircuit):
                 or not moment._control_keys_().isdisjoint(op_measurement_keys)
             ):
                 return last_available
-            if self._can_add_op_at(k, op):
-                # Note: Remove the if condition after `self._device` is gone and move the method to
-                # `cirq.AbstractDevice`.
-                last_available = k
+            last_available = k
         return last_available
 
     def _can_add_op_at(self, moment_index: int, operation: cirq.Operation) -> bool:

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -1243,6 +1243,7 @@ def test_earliest_available_moment() -> None:
         c.earliest_available_moment(cirq.Y(q[1]).with_classical_controls("m"), end_moment_index=1)
         == 1
     )
+    assert c.earliest_available_moment(cirq.Y(q[1]), end_moment_index=4) == 2
 
 
 @pytest.mark.parametrize('circuit_cls', [cirq.Circuit, cirq.FrozenCircuit])


### PR DESCRIPTION
The conditions in `_can_add_op_at` are already checked in the while loop. There is no `AbstractDevice` so I removed the check and the note.

I also handled the case when `end_moment_index > len(self._moments)`. `earliest_available_moment` references from `insert` are guaranteed to have `end_moment_index` between `0` and `len(self._moments)`, but `earliest_available_moment` is also exposed publicly.