### PR TITLE
approx_eq - ensure set-sorting of the first argument is tested

### DIFF
--- a/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
+++ b/cirq-core/cirq/protocols/approximate_equality_protocol_test.py
@@ -176,6 +176,7 @@ def test_approx_eq_set() -> None:
 
     # here sij, sji are equal, but have a different order
     assert cirq.approx_eq(sij, sji)
+    assert cirq.approx_eq(sji, sij)
     assert cirq.approx_eq(sij, frozenset(sji))
     assert cirq.approx_eq(frozenset(sij), frozenset(sji))
 


### PR DESCRIPTION
Problem: Internal mutants test showed that tests pass if the first
set-like argument to approx_eq is not sorted.  That is because
the first argument in test cases happens to have sorted order.

Solution: Also test with the first argument of unsorted order.

Related to #6376 and #7792
