### PR TITLE
Update Scientific Python dependencies per NEP-29 and SPEC-0

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -5,8 +5,8 @@ duet>=0.2.8
 matplotlib~=3.9
 networkx~=3.4
 numpy~=2.0
-pandas~=2.2
+pandas~=2.3
 sortedcontainers~=2.0
-scipy~=1.12
+scipy~=1.13
 sympy
 tqdm>=4.12

--- a/dev_tools/requirements/deps/ipython.txt
+++ b/dev_tools/requirements/deps/ipython.txt
@@ -1,1 +1,1 @@
-ipython>=8.17
+ipython>=8.21,<10.0dev


### PR DESCRIPTION
* drop scipy-1.12 per SPEC-0
* drop pandas-2.2 per SPEC-0
* drop ipython-8.20 and allow ipython-9 per SPEC-0

No changes needed for NEP-29.

Refs:

* https://numpy.org/neps/nep-0029-deprecation_policy.html
* https://scientific-python.org/specs/spec-0000

Resolves b/448132744
