### PR TITLE
CI - add dedicated workflow to monitor performance of Pytest Ubuntu

### DIFF
--- a/.github/workflows/ci-monitoring.yml
+++ b/.github/workflows/ci-monitoring.yml
@@ -14,6 +14,9 @@ on:
   # Allow manual invocation.
   workflow_dispatch:
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   pytest:
     # Run only with the minimum-supported Python version, otherwise


### PR DESCRIPTION
Collect test durations for PR merges to `main` and release tags.
Running on the `push` event ensures commit already exists and
allows test reports with failed flaky tests.

Related to b/467133647
