### PR TITLE
doctest - improve loading of doctest examples

### DIFF
--- a/dev_tools/docs/run_doctest.py
+++ b/dev_tools/docs/run_doctest.py
@@ -246,6 +246,7 @@ def main():
     assert file_names
     excluded = (
         'cirq-core/cirq/testing/_compat_test_data/',
+        'cirq-core/cirq/testing/deprecation.py',
         'cirq-google/cirq_google/api/',
         'cirq-google/cirq_google/cloud/',
         'cirq-web/cirq_web/node_modules/',


### PR DESCRIPTION
Switch to standard import of tested sources to detect doc tests
in decorated functions.

Problem: Custom import code in `run_doctest.py` does not find doctest
in functions decorated with `@transformer_api.transformer`.
    
Solution: Use standard Python import instead.  Skip `_compat_test_data`
files which have no doctest examples (and fail standard import).

Also skip doctest of `cirq.testing.deprecation.assert_deprecated` which
would need a code to raises the expected DeprecationWarning.

This increases number of detected doctests from 335 to 349.