### PR TITLE
Extend pandas compatibility window to include pandas-2.2

### DIFF
--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -5,7 +5,7 @@ duet>=0.2.8
 matplotlib~=3.9
 networkx~=3.4
 numpy~=2.0
-pandas~=2.3
+pandas~=2.2
 sortedcontainers~=2.0
 scipy~=1.13
 sympy


### PR DESCRIPTION
Avoid version conflict with internal software which requires pandas-2.2.

Fixes b/477048850
Partially reverts #7834
