### PR TITLE
Replace importlib_metadata with builtin importlib.metadata

### DIFF
--- a/cirq-core/cirq/_compat_test.py
+++ b/cirq-core/cirq/_compat_test.py
@@ -757,7 +757,7 @@ def test_metadata_distributions_after_deprecated_submodule():
 
 
 def _test_metadata_distributions_after_deprecated_submodule():
-    # verify deprecated_submodule does not break importlib_metadata.distributions()
+    # verify deprecated_submodule does not break importlib.metadata.distributions()
     # See https://github.com/quantumlib/Cirq/issues/4729
     deprecated_submodule(
         new_module_name='cirq.neutral_atoms',
@@ -766,9 +766,7 @@ def _test_metadata_distributions_after_deprecated_submodule():
         deadline="v0.14",
         create_attribute=True,
     )
-    m = pytest.importorskip("importlib_metadata")
-    distlist = list(m.distributions())
-    assert all(isinstance(d.name, str) for d in distlist)
+    assert all(isinstance(d.name, str) for d in importlib.metadata.distributions())
 
 
 def test_parent_spec_after_deprecated_submodule():

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -10,9 +10,6 @@ coverage~=7.4
 pytest-xdist
 filelock~=3.1
 
-# For test_metadata_distributions_after_deprecated_submodule
-importlib-metadata
-
 # codeowners test dependency
 codeowners; platform_system != "Windows"
 


### PR DESCRIPTION
No need to use a backport of `importlib.metadata` if we have that
module already available.
