### PR TITLE
Add cirq.symbol function to create a sympy.Symbol.

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -520,6 +520,7 @@ from cirq.study import (
     Product as Product,
     Sweep as Sweep,
     Sweepable as Sweepable,
+    symbol as symbol,
     to_resolvers as to_resolvers,
     to_sweep as to_sweep,
     to_sweeps as to_sweeps,

--- a/cirq-core/cirq/study/__init__.py
+++ b/cirq-core/cirq/study/__init__.py
@@ -26,6 +26,7 @@ from cirq.study.resolver import (
     ParamMappingType as ParamMappingType,
     ParamResolver as ParamResolver,
     ParamResolverOrSimilarType as ParamResolverOrSimilarType,
+    symbol as symbol,
 )
 
 from cirq.study.sweepable import (

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -48,6 +48,15 @@ _NOT_FOUND = object()
 _RECURSION_FLAG = object()
 
 
+def symbol(name: str) -> sympy.Symbol:
+    """Creates a sympy Symbol for use in sweeps.
+
+    We export this from cirq to allow constructing basic parametrizable objects
+    without additional imports beyond cirq itself.
+    """
+    return sympy.Symbol(name)
+
+
 class ParamResolver:
     """Resolves parameters to actual values.
 

--- a/cirq-core/cirq/study/resolver_test.py
+++ b/cirq-core/cirq/study/resolver_test.py
@@ -25,6 +25,12 @@ import sympy
 import cirq
 
 
+def test_symbol() -> None:
+    x = cirq.symbol("x")
+    assert isinstance(x, sympy.Symbol)
+    assert str(x) == "x"
+
+
 @pytest.mark.parametrize(
     'val',
     [


### PR DESCRIPTION
It is very common in "hello world" examples of sweeps to use symbols to parameterize a circuit, for example I often do something like a rabi circuit:

    cirq.Circuit(cirq.X(q)**sympy.Symbol("x"), cirq.M(q))

With this change, such a circuit can be constructed after importing cirq only, without also needing to import sympy:

    cirq.Circuit(cirq.X(q)**cirq.symbol("x"), cirq.M(q))

Note that for this particular case, we could also change gate and op exponentiation to accept a str and convert to symbol, but having a `symbol` helper function covers any symbol use, not just this particular case.