### PR TITLE
pylint - fail for unnecessary pylint-disable comments

### DIFF
--- a/dev_tools/conf/.pylintrc
+++ b/dev_tools/conf/.pylintrc
@@ -2,6 +2,7 @@
 load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams,pylint_copyright_checker
 max-line-length=100
 disable=all
+fail-on=I
 ignore-paths=cirq-google/cirq_google/cloud/.*
 ignore-patterns=.*_pb2\.py
 output-format=colorized


### PR DESCRIPTION
By default pylint only reports on `useless-suppression` instances,
but does not return an error exit code.  Here we make it exit with
failure so that useless-suppression-s are caught by the CI.

Ref: https://pylint.readthedocs.io/en/stable/user_guide/messages/information/useless-suppression.html
