### PR TITLE
Deflake the status test of an asynchronous SimulatedLocalJob

### DIFF
--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -107,6 +107,9 @@ def test_run_async():
         sweeps=[{}],
         simulation_type=LocalSimulationType.ASYNCHRONOUS,
     )
-    assert job.execution_status() == quantum.ExecutionStatus.State.RUNNING
+    assert job.execution_status() in (
+        quantum.ExecutionStatus.State.READY,
+        quantum.ExecutionStatus.State.RUNNING,
+    )
     _ = job.results()
     assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS


### PR DESCRIPTION
When SimulatedLocalJob runs asynchronously it may report the initial
READY state right after its creation because the scheduling of the job
and test threads is undefined.
Accept READY as a valid job status.

This avoids flaky test failure on Windows.
