### PR TITLE
Fix comments in routing_transformer.ipynb

### DIFF
--- a/docs/transform/routing_transformer.ipynb
+++ b/docs/transform/routing_transformer.ipynb
@@ -251,7 +251,7 @@
    "outputs": [],
    "source": [
     "# Use a hard-coded initial mapping strategy of logical to physical that places q0, q1, q2, q3 onto\n",
-    "# Grid(3, 5), Grid(3, 6), Grid(4, 5), Grid(4, 6), respectively\n",
+    "# Grid(3, 5), Grid(3, 4), Grid(2, 5), Grid(2, 4), respectively\n",
     "gq = cirq.GridQubit(3, 5)\n",
     "hc_initial_mapper = cirq.HardCodedInitialMapper(\n",
     "    {q[0]: gq, q[1]: gq + (0, -1), q[2]: gq + (-1, 0), q[3]: gq + (-1, -1)}\n",
@@ -370,7 +370,7 @@
     "id": "RccNfl947CyV"
    },
    "source": [
-    "**Note**: the decomposition of the `SwapPermutationGate` is a series of SWAP gates that may be applied on qubits that are not physically adjacent. \n",
+    "**Note**: the decomposition of the `QubitPermutationGate` is a series of SWAP gates that may be applied on qubits that are not physically adjacent. \n",
     "\n",
     "In practice, the user would seldom need to undo the permutation due to inserted SWAP gates as they are often just doing some measurement at the end. Instead, this can be done correctly by just keeping track of the qubit with terminal measurement gate using *measurement keys* (which are unaffected by routing) or by looking at `initial_mapping` and `swap_mapping` to manually trace the permutation of the qubit in question."
    ]


### PR DESCRIPTION
While reading the [Qubit Routing](https://quantumai.google/cirq/transform/routing_transformer) doc, I found some comments that might need update:

1. The GridQubit indexes mismatch with the output
2. From the context, the gate using in the example should be `QubitPermutationGate`.

Please check if my understanding is correct. Thanks!