### PR TITLE
CI - fix type checking complains that arise with numpy-2.4.2

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -147,14 +147,14 @@ class AQTNoiseModel(cirq.NoiseModel):
         gate = cast(cirq.EigenGate, gate_dict[op_str])
 
         if len(operation.qubits) == 1:
-            for idx in xtlk_arr.nonzero()[0]:
+            for idx in cast(Sequence[int], xtlk_arr.nonzero()[0]):
                 exponent = operation.gate.exponent  # type: ignore
                 exponent = exponent * xtlk_arr[idx]
                 xtlk_op = operation.gate.on(system_qubits[idx]) ** exponent  # type: ignore
                 xtlk_op_list.append(xtlk_op)
         elif len(operation.qubits) == 2:
             for op_qubit in operation.qubits:
-                for idx in xtlk_arr.nonzero()[0]:
+                for idx in cast(Sequence[int], xtlk_arr.nonzero()[0]):
                     exponent = operation.gate.exponent  # type: ignore
                     exponent = exponent * xtlk_arr[idx]
                     xtlk_op = gate.on(op_qubit, system_qubits[idx]) ** exponent

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -125,10 +125,11 @@ def _pad_tableau(
             "num_qubits_after_padding."
         )
     padded_tableau = qis.CliffordTableau(num_qubits_after_padding)
-    v_index = np.concatenate((np.asarray(axes), num_qubits_after_padding + np.asarray(axes)))
+    axes_a = np.asarray(axes)
+    v_index = np.concatenate((axes_a, num_qubits_after_padding + axes_a))
 
-    padded_tableau.xs[np.ix_(v_index, axes)] = clifford_tableau.xs
-    padded_tableau.zs[np.ix_(v_index, axes)] = clifford_tableau.zs
+    padded_tableau.xs[np.ix_(v_index, axes_a)] = clifford_tableau.xs
+    padded_tableau.zs[np.ix_(v_index, axes_a)] = clifford_tableau.zs
     padded_tableau.rs[v_index] = clifford_tableau.rs
     return padded_tableau
 


### PR DESCRIPTION
After updating from numpy-2.3.5 to numpy-2.4.x the mypy started flagging

1. for-loop of int variable over a numpy integer array.
   (Seems incorrect, reported at
   https://github.com/numpy/numpy/issues/30848)

2. `np.ix_` called with arguments of non-uniform type
   (i.e, `np.array` and `list`)

Here is the fix.
