### PR TITLE
Add support for QASM 3.0

### DIFF
--- a/cirq-core/cirq/contrib/qasm_import/_lexer3.py
+++ b/cirq-core/cirq/contrib/qasm_import/_lexer3.py
@@ -1,0 +1,128 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+import numpy as np
+
+import ply.lex as lex
+
+from cirq.contrib.qasm_import.exception import QasmException
+
+
+class Qasm3Lexer:
+    def __init__(self):
+        self.lex = lex.lex(object=self, debug=False, nowarn=True)
+
+    literals = "{}[]();,+/*-^="
+
+    reserved = {
+        'qubit': 'QUBIT',
+        'qreg': 'QREG',
+        'bit': 'BIT',
+        'angle': 'ANGLE',
+        'creg': 'CREG',
+        'measure': 'MEASURE',
+        'reset': 'RESET',
+        'gate': 'GATE',
+        'gphase': 'GPHASE',
+        'ctrl': 'CTRL',
+        'pi': 'PI',
+    }
+
+    tokens = [
+        'FORMAT_SPEC',
+        'NUMBER',
+        'NATURAL_NUMBER',
+        'STDGATESINC',
+        'ID',
+        'ARROW',
+        'DOUBLE_ASTERISK',
+        'AT',
+        'SEMI',
+    ] + list(reserved.values())
+
+    def t_newline(self, t):
+        r"""\n+"""
+        t.lexer.lineno += len(t.value)
+
+    t_ignore = ' \t'
+
+    # all numbers except NATURAL_NUMBERs:
+    # it's useful to have this separation to be able to handle indices
+    # separately. In case of the parameter expressions, we are "OR"-ing
+    # them together (see p_term in _parser.py)
+    def t_NUMBER(self, t):
+        r"""(
+        (
+        [0-9]+\.?|
+        [0-9]?\.[0-9]+
+        )
+        [eE][+-]?[0-9]+
+        )|
+        (
+        ([0-9]+)?\.[0-9]+|
+        [0-9]+\.)"""
+        t.value = float(t.value)
+        return t
+
+    def t_NATURAL_NUMBER(self, t):
+        r"""\d+"""
+        t.value = int(t.value)
+        return t
+
+    def t_FORMAT_SPEC(self, t):
+        r"""OPENQASM(\s+)([^\s\t\;]*);"""
+        match = re.match(r"""OPENQASM(\s+)([^\s\t;]*);""", t.value)
+        t.value = match.groups()[1]
+        return t
+
+    def t_STDGATESINC(self, t):
+        r"""include(\s+)"stdgates.inc";"""
+        return t
+
+    def t_ARROW(self, t):
+        """->"""
+        return t
+
+    def t_DOUBLE_ASTERISK(self, t):
+        r"""\*\*"""
+        return t
+    
+    def t_AT(self, t):
+        r"""\@"""
+        return t
+
+    def t_SEMI(self, t):
+        """;"""
+        return t
+
+    def t_ID(self, t):
+        r"""[a-zA-Z_][a-zA-Z\d_]*"""
+        if t.value in Qasm3Lexer.reserved:
+            t.type = Qasm3Lexer.reserved[t.value]
+        return t
+
+    def t_COMMENT(self, t):
+        r"""//.*"""
+
+    def t_error(self, t):
+        raise QasmException(f"Illegal character '{t.value[0]}' at line {t.lineno}")
+
+    def input(self, qasm):
+        self.lex.input(qasm)
+
+    def token(self) -> lex.Token | None:
+        return self.lex.token()

--- a/cirq-core/cirq/contrib/qasm_import/_lexer3_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_lexer3_test.py
@@ -1,0 +1,316 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from cirq.contrib.qasm_import import QasmException
+from cirq.contrib.qasm_import._lexer3 import Qasm3Lexer
+
+
+def test_empty_circuit() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input("")
+    assert lexer.token() is None
+
+
+@pytest.mark.parametrize('number', ["00000", "03", "3", "0045", "21"])
+def test_natural_numbers(number: str) -> None:
+    lexer = Qasm3Lexer()
+    lexer.input(number)
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "NATURAL_NUMBER"
+    assert token.value == int(number)
+
+
+def test_supported_format() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input("OPENQASM 3.0;")
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "FORMAT_SPEC"
+    assert token.value == '3.0'
+
+
+def test_stdgates_inc() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input('include "stdgates.inc";')
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "STDGATESINC"
+    assert token.value == 'include "stdgates.inc";'
+
+
+def test_measurement() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input("measure q -> c;")
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "MEASURE"
+    assert token.value == 'measure'
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == 'q'
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ARROW"
+    assert token.value == '->'
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == 'c'
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "SEMI"
+    assert token.value == ';'
+
+
+@pytest.mark.parametrize(
+    'identifier', ['b', 'CX', 'abc', '_abc', 'aXY03', 'a_valid_name_with_02_digits_and_underscores']
+)
+def test_valid_ids(identifier: str) -> None:
+    lexer = Qasm3Lexer()
+    lexer.input(identifier)
+    token = lexer.token()
+
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == identifier
+
+
+@pytest.mark.parametrize(
+    'number',
+    ['1e2', '1e0', '3.', '4.e10', '.333', '1.0', '0.1', '2.0e-05', '1.2E+05', '123123.2132312'],
+)
+def test_numbers(number: str) -> None:
+    lexer = Qasm3Lexer()
+    lexer.input(number)
+    token = lexer.token()
+
+    assert token is not None
+    assert token.type == "NUMBER"
+    assert token.value == float(number)
+
+
+@pytest.mark.parametrize('token', Qasm3Lexer.reserved.keys())
+def test_keywords(token) -> None:
+    lexer = Qasm3Lexer()
+    identifier = f'{token} {token}'
+    lexer.input(identifier)
+    t = lexer.token()
+    assert t is not None
+    assert t.type == Qasm3Lexer.reserved[token]
+    assert t.value == token
+    t2 = lexer.token()
+    assert t2 is not None
+    assert t2.type == Qasm3Lexer.reserved[token]
+    assert t2.value == token
+
+
+@pytest.mark.parametrize('token', Qasm3Lexer.reserved.keys())
+@pytest.mark.parametrize('separator', ['', '_'])
+def test_identifier_starts_or_ends_with_keyword(token, separator) -> None:
+    lexer = Qasm3Lexer()
+    identifier = f'{token}{separator}{token}'
+    lexer.input(identifier)
+    t = lexer.token()
+    assert t is not None
+    assert t.type == "ID"
+    assert t.value == identifier
+
+
+def test_qreg() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input('qreg [5];')
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "QREG"
+    assert token.value == "qreg"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "["
+    assert token.value == "["
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "NATURAL_NUMBER"
+    assert token.value == 5
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "]"
+    assert token.value == "]"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "SEMI"
+    assert token.value == ";"
+
+
+def test_creg() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input('creg [8];')
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "CREG"
+    assert token.value == "creg"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "["
+    assert token.value == "["
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "NATURAL_NUMBER"
+    assert token.value == 8
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "]"
+    assert token.value == "]"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "SEMI"
+    assert token.value == ";"
+
+
+def test_custom_gate() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input('gate ctrl @ name(param1,param2) q1, q2 {X(q1)}')
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "GATE"
+    assert token.value == "gate"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "CTRL"
+    assert token.value == "ctrl"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "AT"
+    assert token.value == "@"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "name"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "("
+    assert token.value == "("
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "param1"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == ","
+    assert token.value == ","
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "param2"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == ")"
+    assert token.value == ")"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "q1"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == ","
+    assert token.value == ","
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "q2"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "{"
+    assert token.value == "{"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "X"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "("
+    assert token.value == "("
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "ID"
+    assert token.value == "q1"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == ")"
+    assert token.value == ")"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "}"
+    assert token.value == "}"
+
+
+def test_expression() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input('3 ** 5')
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "NATURAL_NUMBER"
+    assert token.value == 3
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "DOUBLE_ASTERISK"
+    assert token.value == "**"
+
+    token = lexer.token()
+    assert token is not None
+    assert token.type == "NATURAL_NUMBER"
+    assert token.value == 5
+
+
+def test_error() -> None:
+    lexer = Qasm3Lexer()
+    lexer.input('θ')
+
+    with pytest.raises(QasmException, match="Illegal character 'θ' at line 1"):
+        lexer.token()

--- a/cirq-core/cirq/contrib/qasm_import/_parser3.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser3.py
@@ -1,0 +1,846 @@
+# Copyright 2018 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+import operator
+from typing import Callable, TYPE_CHECKING
+from enum import StrEnum
+
+import numpy as np
+import sympy
+from ply import yacc
+
+from cirq import Circuit, CircuitOperation, CX, FrozenCircuit, NamedQubit, ops, value, global_phase_operation
+from cirq.circuits.qasm_output import QasmUGate
+from cirq.contrib.qasm_import._lexer3 import Qasm3Lexer
+from cirq.contrib.qasm_import.exception import QasmException
+from cirq.contrib.qasm_import._parser import _generate_op_qubits
+
+if TYPE_CHECKING:
+    import cirq
+
+
+class Qasm:
+    """Qasm stores the final result of the Qasm parsing."""
+
+    def __init__(
+        self, supported_format: bool, std_gates_include: bool, regs: QasmRegisters, c: Circuit
+    ):
+        # defines whether the Quantum Experience standard header
+        # is present or not
+        self.std_gates_included = std_gates_include
+        # defines if it has a supported format or not
+        self.supportedFormat = supported_format
+        # circuit
+        self.regs = regs
+        self.circuit = c
+
+def _global_phase_operation(phase):
+    if isinstance(phase, sympy.Expr):
+        return ops.global_phase_operation(sympy.exp(1j * phase))
+    return ops.global_phase_operation(np.exp(1j* phase))
+
+class Qasm3UGate(QasmUGate):
+    def _decompose_(self, qubits):
+        gates: list = super()._decompose_(qubits)
+        # add the additional phase introduced in QASM 3
+        gates.append(_global_phase_operation(np.pi*self.theta/2))
+        return gates
+
+class QasmGateStatement:
+    """Specifies how to convert a call to an OpenQASM gate
+    to a list of `cirq.GateOperation`s.
+
+    Has the responsibility to validate the arguments
+    and parameters of the call and to generate a list of corresponding
+    `cirq.GateOperation`s in the `on` method.
+    """
+
+    def __init__(
+        self,
+        qasm_gate: str,
+        cirq_gate: ops.Gate | Callable[[list[float]], ops.Gate],
+        num_params: int,
+        num_args: int,
+    ):
+        """Initializes a Qasm gate statement.
+
+        Args:
+            qasm_gate: The symbol of the QASM gate.
+            cirq_gate: The gate class on the cirq side.
+            num_params: The number of params taken by this gate.
+            num_args: The number of qubits (used in validation) this
+                gate takes.
+        """
+        self.qasm_gate = qasm_gate
+        self.cirq_gate = cirq_gate
+        self.num_params = num_params
+
+        # at least one quantum argument is mandatory for gates to act on
+        assert num_args >= 1
+        self.num_args = num_args
+
+    def _validate_params(self, params: list[value.TParamVal], lineno: int):
+        if len(params) != self.num_params:
+            raise QasmException(
+                f"{self.qasm_gate} takes {self.num_params} parameter(s), "
+                f"got: {len(params)}, at line {lineno}"
+            )
+        
+    def resolve(self, params: list[value.TParamVal], lineno:int):
+        self._validate_params(params, lineno)
+        # the actual gate we'll apply the arguments to might be a parameterized
+        # or non-parameterized gate
+        final_gate: ops.Gate = (
+            self.cirq_gate if isinstance(self.cirq_gate, ops.Gate) else self.cirq_gate(params)
+        )
+        return final_gate
+
+
+class CustomGate:
+    """Represents an invocation of a user-defined gate.
+
+    The custom gate definition is encoded here as a `FrozenCircuit`, and the
+    arguments (params and qubits) of the specific invocation of that gate are
+    stored here too. When `on` is called, we create a CircuitOperation, mapping
+    the qubits and params to the values provided."""
+
+    name: str
+    circuit: FrozenCircuit
+    params: tuple[str, ...]
+    qubits: tuple[ops.Qid, ...]
+
+    class CustomQasmGate(ops.Gate):
+        def __init__(self, name:str, sub_circuit: ops.CircuitOperation):
+            self.sub_circuit = sub_circuit
+            self.name = name
+
+        def _num_qubits_(self):
+            return self.sub_circuit._num_qubits_()
+
+        def _decompose_(self, qubits):
+            return self.sub_circuit.with_qubits(*qubits)
+
+        def __repr__(self):
+            return f"<CustomQasmGate.{self.name}>"
+
+    def __init__(self, name, circuit, params, qubits):
+        self.name = name
+        self.circuit = circuit
+        self.params = params
+        self.qubits = qubits
+        super(CustomGate, self)
+
+    def resolve(
+        self, params: list[value.TParamVal], lineno: int
+    ) -> ops.Gate:
+        if len(params) != len(self.params):
+            raise QasmException(f"Wrong number of params for '{self.name}' at line {lineno}")
+        rescircuit = CircuitOperation(
+            self.circuit,
+            param_resolver=dict(zip(self.params, params)),
+        )
+        return CustomGate.CustomQasmGate(self.name, rescircuit)
+
+
+class RegisterType(StrEnum):
+    QUBIT = 'qubit'
+    BIT = 'bit'
+    ANGLE = 'angle'
+
+
+@dataclasses.dataclass
+class Register:
+    name: str
+    type_: RegisterType
+    length: int
+
+
+@dataclasses.dataclass
+class QasmRegisters:
+    qubits: dict[str, int] = dataclasses.field(default_factory=dict)
+    bits: dict[str, int] = dataclasses.field(default_factory=dict)
+    angles: dict[str, int] = dataclasses.field(default_factory=dict)
+
+    @property
+    def defined_regs(self) -> list[str]:
+        return self.classical_regs + self.quantum_regs
+        
+    @property
+    def classical_regs(self) -> list[str]:
+        return list(self.bits.keys()) +\
+        list(self.angles.keys())
+    
+    @property
+    def quantum_regs(self) -> list[str]:
+        return list(self.qubits.keys())
+    
+    def add_register(self, register: Register, lineno):
+        if register.name in self.defined_regs:
+            raise QasmException(f"{register.name} is already defined at line {lineno}")
+        if register.length == 0:
+            raise QasmException(f"Illegal, zero-length register '{register.name}' at line {lineno}")
+        match register.type_:
+            case RegisterType.QUBIT:
+                registers = self.qubits
+            case RegisterType.BIT:
+                registers = self.bits
+            case RegisterType.ANGLE:
+                registers = self.angles
+        registers[register.name] = register.length
+
+    def __getitem__(self, name:str)-> Register | None:
+        if name in self.qubits:
+            type_ = RegisterType.QUBIT
+            registers = self.qubits
+        elif name in self.bits:
+            type_ = RegisterType.BIT
+            registers = self.bits
+        elif name in self.angles:
+            type_ = RegisterType.ANGLE
+            registers = self.angles
+        else:
+            return
+        return Register(name, type_, registers[name])
+
+
+class Qasm3Parser:
+    """Parser for QASM3 strings.
+
+    Example:
+
+        qasm = "OPENQASM 2.0; qreg q1[2]; CX q1[0], q1[1];"
+        parsedQasm = QasmParser().parse(qasm)
+    """
+
+    def __init__(self) -> None:
+        self.circuit_stack: list[Circuit] = [Circuit()]
+        self.register_stack: list[QasmRegisters] = [QasmRegisters()]
+        self.in_global_scope: bool = True
+        self.in_gate_or_function_scope: bool = False
+        self.gate_set: dict[str, CustomGate | QasmGateStatement] = {**self.basic_gates}
+        self.parser = yacc.yacc(module=self, debug=False, write_tables=False)
+        self.lexer = Qasm3Lexer()
+        self.stdgatesinc = False
+        self.supported_format = False
+        self.parsedQasm: Qasm | None = None
+        self.qubits: dict[str, ops.Qid] = {} # TODO could move into regs
+
+        self.binary_operators = {
+            '+': operator.add,
+            '-': operator.sub,
+            '*': operator.mul,
+            '/': operator.truediv,
+            '**': operator.pow,
+        }
+        self.functions = {
+            'sin': np.sin,
+            'cos': np.cos,
+            'tan': np.tan,
+            'exp': np.exp,
+            'log': np.log,
+            'sqrt': np.sqrt,
+            'arccos': np.acos,
+            'arctan': np.atan,
+            'arcsin': np.asin,
+            'ceiling': np.ceil,
+            'floor': np.floor,
+            'mod': np.mod,
+        }
+
+    basic_gates: dict[str, QasmGateStatement] = {
+        'U': QasmGateStatement(
+            qasm_gate='U',
+            num_params=3,
+            num_args=1,
+            # QasmUGate expects half turns
+            cirq_gate=(lambda params: Qasm3UGate(*[p / np.pi for p in params])),
+        ),
+    }
+
+    std_gates = {
+        'p': QasmGateStatement(
+            qasm_gate='p',
+            cirq_gate=(lambda params: ops.ZPowGate(exponent=params[0] / np.pi)),
+            num_params=1,
+            num_args=1,
+        ),
+        'x': QasmGateStatement(qasm_gate='x', num_params=0, num_args=1, cirq_gate=ops.X),
+        'y': QasmGateStatement(qasm_gate='y', num_params=0, num_args=1, cirq_gate=ops.Y),
+        'z': QasmGateStatement(qasm_gate='z', num_params=0, num_args=1, cirq_gate=ops.Z),
+        'h': QasmGateStatement(qasm_gate='h', num_params=0, num_args=1, cirq_gate=ops.H),
+        's': QasmGateStatement(qasm_gate='s', num_params=0, num_args=1, cirq_gate=ops.S),
+        'sdg': QasmGateStatement(qasm_gate='sdg', num_params=0, num_args=1, cirq_gate=ops.S**-1),
+        't': QasmGateStatement(qasm_gate='t', num_params=0, num_args=1, cirq_gate=ops.T),
+        'tdg': QasmGateStatement(qasm_gate='tdg', num_params=0, num_args=1, cirq_gate=ops.T**-1),
+        'sx': QasmGateStatement(
+            qasm_gate='sx', num_params=0, num_args=1, cirq_gate=ops.XPowGate(exponent=0.5)
+        ),
+        'rx': QasmGateStatement(
+            qasm_gate='rx', cirq_gate=(lambda params: ops.rx(params[0])), num_params=1, num_args=1
+        ),
+        'ry': QasmGateStatement(
+            qasm_gate='ry', cirq_gate=(lambda params: ops.ry(params[0])), num_params=1, num_args=1
+        ),
+        'rz': QasmGateStatement(
+            qasm_gate='rz', cirq_gate=(lambda params: ops.rz(params[0])), num_params=1, num_args=1
+        ),
+        'cx': QasmGateStatement(qasm_gate='cx', cirq_gate=CX, num_params=0, num_args=2),
+        'cy': QasmGateStatement(qasm_gate='cy', cirq_gate=ops.CY, num_params=0, num_args=2),
+        'cz': QasmGateStatement(qasm_gate='cz', cirq_gate=ops.CZ, num_params=0, num_args=2),
+        'cp': QasmGateStatement(
+            qasm_gate='cp',
+            num_params=1,
+            num_args=2,
+            cirq_gate=(lambda params: ops.ControlledGate(ops.ZPowGate(exponent=params[0] / np.pi))),
+        ),
+        'crx': QasmGateStatement(
+            qasm_gate='crx',
+            num_params=1,
+            num_args=2,
+            cirq_gate=(lambda params: ops.ControlledGate(ops.rx(params[0]))),
+        ),
+        'cry': QasmGateStatement(
+            qasm_gate='cry',
+            num_params=1,
+            num_args=2,
+            cirq_gate=(lambda params: ops.ControlledGate(ops.ry(params[0]))),
+        ),
+        'crz': QasmGateStatement(
+            qasm_gate='crz',
+            num_params=1,
+            num_args=2,
+            cirq_gate=(lambda params: ops.ControlledGate(ops.rz(params[0]))),
+        ),
+        'ch': QasmGateStatement(
+            qasm_gate='ch', cirq_gate=ops.ControlledGate(ops.H), num_params=0, num_args=2
+        ),
+        'swap': QasmGateStatement(qasm_gate='swap', cirq_gate=ops.SWAP, num_params=0, num_args=2),
+        'ccx': QasmGateStatement(qasm_gate='ccx', num_params=0, num_args=3, cirq_gate=ops.CCX),
+        'cswap': QasmGateStatement(
+            qasm_gate='cswap', num_params=0, num_args=3, cirq_gate=ops.CSWAP
+        ),
+        'cu': QasmGateStatement(
+            qasm_gate='cu',
+            num_params=4,
+            num_args=2,
+            cirq_gate=(
+                lambda params: ops.ControlledGate(
+                    ops.MatrixGate((QasmUGate(params[0]/np.pi, params[1]/np.pi, params[2]/np.pi)*np.exp(1j*params[3])).matrix())
+                )
+            ),
+        ),
+        'CX': QasmGateStatement(
+            qasm_gate='CX',
+            num_params=0,
+            num_args=2,
+            cirq_gate=ops.ControlledGate(Qasm3UGate(*[np.pi, 0, np.pi])),
+        ),
+        'phase': QasmGateStatement(
+            qasm_gate='phase',
+            num_params=1,
+            num_args=1,
+            cirq_gate=(lambda params: Qasm3UGate(*[0, 0, params[0]])),
+        ),
+        'cphase': QasmGateStatement(
+            qasm_gate='cphase',
+            num_params=1,
+            num_args=2,
+            cirq_gate=(lambda params: ops.ControlledGate(Qasm3UGate(*[0, 0, params[0]]))),
+        ),
+        'id': QasmGateStatement(
+            qasm_gate='id', cirq_gate=ops.IdentityGate(1), num_params=0, num_args=1
+        ),
+        'u1': QasmGateStatement(
+            qasm_gate='u1',
+            cirq_gate=(lambda params: QasmUGate(0, 0, params[0] / np.pi)),
+            num_params=1,
+            num_args=1,
+        ),
+        'u2': QasmGateStatement(
+            qasm_gate='u2',
+            cirq_gate=(lambda params: QasmUGate(0.5, params[0] / np.pi, params[1] / np.pi)),
+            num_params=2,
+            num_args=1,
+        ),
+        'u3': QasmGateStatement(
+            qasm_gate='u3',
+            num_params=3,
+            num_args=1,
+            cirq_gate=(lambda params: QasmUGate(*[p / np.pi for p in params])),
+        ),
+    }
+
+    tokens = Qasm3Lexer.tokens
+    start = 'start'
+
+    precedence = (
+        ('left', '+', '-'), 
+        ('left', '*', '/'), 
+        ('right', 'DOUBLE_ASTERISK'),
+    )
+
+    @property
+    def regs(self) -> QasmRegisters:
+        return self.register_stack[-1]
+    
+    @property
+    def circuit(self) -> Circuit:
+        return self.circuit_stack[-1]
+
+    def p_start(self, p):
+        """start : version qasm
+        | version
+        """
+        p[0] = Qasm(self.supported_format, self.stdgatesinc, self.regs, self.circuit)
+
+    def p_version(self, p):
+        """version : FORMAT_SPEC"""
+        if p[1] not in ["3.0"]:
+            raise QasmException(
+                f"Unsupported OpenQASM version: {p[1]}, "
+                "only 3.0 is supported currently by Cirq"
+            )
+        self.supported_format = True
+
+    def p_no_format_specified_error(self, p):
+        """version : qasm"""
+        if self.supported_format is False:
+            raise QasmException("Missing 'OPENQASM 3.0;' statement")
+    
+    def p_scope_full(self, p):
+        """scope : '{' qasm '}'
+        """
+        p[0] = p[2]
+
+    def p_scope_empty(self, p):
+        """scope : '{' '}'
+        """
+
+    def p_qasm(self, p):
+        """qasm : statementOrScope qasm
+        | statementOrScope
+        """
+        if len(p) == 2:
+            p[0] = [p[1]]
+        else:
+            p[0] = [p[1]] + p[2]
+
+    def p_statementOrScope_statement(self, p):
+        """statementOrScope : statement
+        """
+        p[0] = p[1]
+
+    def p_statement_qasm(self, p):
+        """statement : classicalDeclarationStatement
+        | gateStatement
+        | includeStatement
+        | oldStyleDeclarationStatement
+        | quantumDeclarationStatement
+        | empty
+        """
+        p[0] = p[1]
+
+    def p_statement_circuit(self, p):
+        """statement : gateCallStatement
+        | measureArrowAssignmentStatement
+        | measureAssignmentStatement
+        | resetStatement 
+        """
+        self.circuit.append(p[1])
+        p[0] = p[1]
+
+    def p_includeStatement_stdgates(self, p):
+        """includeStatement : STDGATESINC
+        """
+        self.stdgatesinc = True
+        self.gate_set.update(self.std_gates)
+
+    def p_resetStatement(self, p):
+        """resetStatement : RESET gateOperand SEMI"""
+        qreg = p[2]
+        p[0] = [ops.ResetChannel().on(qreg[i]) for i in range(len(qreg))]
+
+    def p_gateCall_base(self, p):
+        """gateCall : ID '(' expressionList ')'
+        | ID
+        """
+        gate_name = p[1]
+        params = [] if len(p) != 5 else p[3]
+        if gate_name not in self.gate_set:
+            tip = ", did you forget to include stdgates.inc?" if not self.stdgatesinc else ""
+            msg = f'Unknown gate "{gate_name}" at line {p.lineno(1)}{tip}'
+            raise QasmException(msg)
+        gate = self.gate_set[gate_name].resolve(params=params, lineno=p.lineno(1))
+        p[0] = (gate_name, gate)
+
+    def p_gateCall_modified(self, p):
+        """gateCall : gateModifier gateCall
+        """
+        p[0] = (p[2][0], p[1](p[2][1]))
+
+    def p_gateCallStatement(self, p):
+        """gateCallStatement : gateCall gateOperandList SEMI
+        """
+        args = p[2]
+        gate = p[1][1]
+        gate_name = p[1][0]
+        if len(args) != gate.num_qubits():
+            raise QasmException(
+                f"{gate_name} only takes {gate.num_qubits()} arg(s) (qubits and/or registers), "
+                f"got: {len(args)}, at line {p.lineno(3)}"
+            )
+        p[0] = (gate.on(*qubits) for qubits in _generate_op_qubits(args, p.lineno(3)))
+    
+    def p_gateCallStatement_gphase(self, p):
+        """gateCallStatement : GPHASE '(' expressionList ')' SEMI
+        | GPHASE expressionList SEMI
+        """
+        args = p[2] if len(p) == 4 else p[3]
+        if len(args) != 1:
+            raise QasmException(
+                f"gphase takes 1 parameter, "
+                f"got: {len(args)}, at line {p.lineno(1)}"
+            )
+        phase = args[0]
+        p[0] = _global_phase_operation(phase)
+
+    def p_gateCall_ctrl_gphase(self, p):
+        """gateCall : CTRL AT GPHASE '(' expressionList ')'
+        """
+        args = p[5]
+        if len(args) != 1:
+            raise QasmException(
+                f"gphase takes 1 parameter, "
+                f"got: {len(args)}, at line {p.lineno(1)}"
+            )
+        phase = args[0]
+        p[0] = ('gphase', ops.ZPowGate(exponent=phase / np.pi))
+
+    def p_measureArrowAssignmentStatement(self, p):
+        """measureArrowAssignmentStatement : measureExpression ARROW indexedIdentifier SEMI
+        | measureExpression SEMI 
+        """
+        p[0] = self._measure(p[3], p[1], p.lineno(2))
+    
+    def p_classicalDeclarationStatement_scalar(self, p):
+        """classicalDeclarationStatement : scalarType ID SEMI
+        """
+        reg = Register(p[2], *p[1])
+        self.regs.add_register(reg,  p.lineno(2))
+        p[0] = reg
+
+    def p_oldStyleDeclarationStatement(self, p):
+        """oldStyleDeclarationStatement : CREG ID designator SEMI
+        | CREG ID SEMI
+        | QREG ID designator SEMI
+        | QREG ID SEMI
+        """
+        name = p[2]
+        length = 1 if len(p) == 4 else p[3]
+        if p[1] == 'qreg':
+            if not self.in_global_scope:
+                raise QasmException(
+                    f"Qubits cannot be declared in non global scope at line {p.lineno(1)}"
+                )
+            type_ = RegisterType.QUBIT
+        else:
+            type_ = RegisterType.BIT
+        reg = Register(name, type_, length)
+        self.regs.add_register(reg,  p.lineno(2))
+        p[0] = reg
+
+    def p_quantumDeclarationStatement(self, p):
+        """quantumDeclarationStatement : qubitType ID SEMI"""
+        if not self.in_global_scope:
+            raise QasmException(
+                f"Qubits cannot be declared in non global scope at line {p.lineno(2)}"
+            )
+        type_, length = p[1]
+        name = p[2]
+        reg = Register(name, type_, length)
+        self.regs.add_register(reg,  p.lineno(2))
+        p[0] = reg
+
+    def p_gateParams_identifierList(self, p):
+        """gateParams_identifierList : identifierList"""
+        for reg in p[1]:
+            self.regs.add_register(Register(reg, RegisterType.ANGLE, 1),  p.lineno(1))
+        p[0] = p[1]
+
+    def p_gateQubits_identifierList(self, p):
+        """gateQubits_identifierList : identifierList"""
+        for reg in p[1]:
+            self.regs.add_register(Register(reg, RegisterType.QUBIT, 1), p.lineno(1))
+        p[0] = p[1]
+
+    def _gate_def(self, name: str, gate_params: list, gate_qubits: list, lineno: int):
+        circuit = Circuit(self.circuit).freeze()
+        gate_def = CustomGate(name, circuit, gate_params, gate_qubits)
+        self.gate_set[name] = gate_def
+        self.register_stack.pop()
+        self.circuit_stack.pop()
+        self.in_global_scope = True
+        self.in_gate_or_function_scope = False
+        return gate_def
+    
+    def p_enter_custom_gate_scope(self, p):
+        """enter_custom_gate_scope : GATE"""
+        if not self.in_global_scope:
+            raise QasmException(f"Custom gates cannot be defined in non global scope at line {p.lineno(1)}")
+        self.in_global_scope = False
+        self.in_gate_or_function_scope = True
+        self.register_stack.append(QasmRegisters())
+        self.circuit_stack.append(Circuit())
+
+    def p_gateStatement_params(self, p):
+        """gateStatement : enter_custom_gate_scope ID '(' gateParams_identifierList ')' gateQubits_identifierList scope
+        """
+        self._gate_def(p[2], p[4], p[6], p.lineno(1))
+
+    def p_gateStatement_no_params(self, p):
+        """gateStatement : enter_custom_gate_scope ID '(' ')' gateQubits_identifierList scope
+        | enter_custom_gate_scope ID gateQubits_identifierList scope
+        """
+        offset = len(p) - 6
+        self._gate_def(p[2], [], p[3+offset], p.lineno(1))   
+
+    def p_assignmentStatement_measure(self, p):
+        """measureAssignmentStatement : indexedIdentifier '=' measureExpression SEMI
+        """
+        p[0] = self._measure(p[1], p[3], p.lineno(2))
+
+    def _measure(self, cregs: tuple[Register, list[int]], qregs:list[ops.Qid], lineno):
+        creg_type = cregs[0].type_
+        if  creg_type != RegisterType.BIT:
+            raise QasmException(
+                f"Illegal use of `{creg_type}` type register for measurement results at line {lineno}"
+            )
+        if len(qregs) != len(cregs[1]):
+            raise QasmException(
+                f'mismatched register sizes {len(qregs)} -> {len(cregs[1])} for measurement '
+                f'at line {lineno}'
+            )
+        creg = [self.make_name(i, cregs[0].name) for i in cregs[1]]
+        return [
+            ops.MeasurementGate(num_qubits=1, key=creg[i]).on(qregs[i]) for i in range(len(qregs))
+        ]
+
+    # Second level defs
+
+    def p_expression_binary_operator(self, p):
+        """expression : expression '+' expression
+        | expression '-' expression
+        | expression '*' expression
+        | expression '/' expression
+        | expression DOUBLE_ASTERISK expression
+        """
+        p[0] = self.binary_operators[p[2]](p[1], p[3])
+
+    def p_expression_call(self, p):
+        """expression : ID '(' expressionList ')'
+        """
+        func = p[1]
+        args = p[3]
+        if func not in self.functions:
+            raise QasmException(
+                f"Function not recognized: '{func}' at line {p.lineno(1)}"
+            )
+        if any( not isinstance(exp, (int, float)) for exp in args):
+            raise QasmException(
+                f"Non contant input for built-in function `{func}` at line {p.lineno(1)}"
+            )
+        p[0] = self.functions[func](*args)
+
+    def p_parenExp(self, p):
+        """expression : '(' expression ')'"""
+        p[0] = p[2]
+
+    def p_unaryExp(self, p):
+        """expression : '-' expression
+        """
+        p[0] = -p[2]
+
+    def p_literalExp_number(self, p):
+        """expression : NUMBER
+        | NATURAL_NUMBER
+        """
+        p[0] = p[1]
+
+    def p_literalExp_id(self, p):
+        """expression : ID
+        """
+        if p[1] not in self.regs.defined_regs:
+            raise QasmException(f"Undefined parameter '{p[1]}' in line {p.lineno(1)}")
+        p[0] = sympy.Symbol(p[1])
+    
+    def p_pi(self, p):
+        """expression : PI"""
+        p[0] = np.pi
+    
+    def p_measureExpression(self, p):
+        """measureExpression : MEASURE gateOperand"""
+        p[0] = p[2]
+
+    def p_indexOperator(self, p):
+        """indexOperator : '[' NATURAL_NUMBER ']'"""
+        p[0] = [p[2]]
+
+    def p_indexedIdentifier(self, p):
+        """indexedIdentifier : ID indexOperator
+        | ID
+        """
+        reg = p[1]
+        if reg not in self.regs.defined_regs:
+            raise QasmException(f"Undefined register '{reg}' at line {p.lineno(1)}")
+        reg =  self.regs[reg]
+        size = reg.length
+        idxs = list(range(size))
+        if len(p) == 3:
+            if reg.type_ == RegisterType.QUBIT and self.in_gate_or_function_scope:
+                raise QasmException(
+                    f"Cannot index into qubit while defining a custom gate at line {p.lineno(1)}"
+                )
+            for idx in p[2]:
+                if idx >= size:
+                    raise QasmException(
+                        f'Out of bounds index {idx} '
+                        f'on register {reg.name} of size {size} '
+                        f'at line {p.lineno(1)}'
+                    )
+            idxs = p[2]
+        p[0] = (reg, idxs)
+
+#####
+
+    def p_gateModifier_ctrl(self, p):
+        """gateModifier : CTRL AT
+        | CTRL '(' expression ')' AT
+        """
+        n_controls = 1 
+        if len(p) == 6:
+            if not isinstance(p[3], int):
+                raise QasmException(f"Number of control qubits must be an integer known at compile time at line {p.lineno(1)}")
+            n_controls = p[3]
+        def ctrl(gate:ops.Gate) -> ops.ControlledGate:
+            return ops.ControlledGate(gate, n_controls)
+        p[0] = ctrl
+
+    def p_scalarType_bit(self, p):
+        """scalarType : BIT designator
+        | BIT
+        """
+        length = 1 if len(p) != 3 else p[2]
+        p[0] = (RegisterType.BIT, length)
+
+    def p_scalarType_angle(self, p):
+        """scalarType : ANGLE designator
+        | ANGLE
+        """
+        length = 1 if len(p) != 3 else p[2]
+        p[0] = (RegisterType.ANGLE, length)
+
+    def p_qubitType(self, p):
+        """qubitType : QUBIT
+        | QUBIT designator
+        """
+        length = 1 if len(p) != 3 else p[2]
+        p[0] = (RegisterType.QUBIT, length)
+
+    def p_designator(self, p):
+        """designator : '[' NATURAL_NUMBER ']'"""
+        p[0] = p[2]
+
+    def p_gateOperand(self, p):
+        """gateOperand : indexedIdentifier"""
+        reg: Register = p[1][0]
+        if  reg.type_ != RegisterType.QUBIT:
+            raise QasmException(
+                f"Illegal use of {reg.type_} register where qubit required at line {p.lineno(1)}"
+            )
+        qubits = []
+        for idx in p[1][1]:
+            arg_name = self.make_name(idx, reg.name)
+            if arg_name not in self.qubits.keys():
+                self.qubits[arg_name] = NamedQubit(arg_name)
+            qubits.append(self.qubits[arg_name])
+        p[0] = qubits
+
+    def make_name(self, idx, reg):
+        return str(reg) + "_" + str(idx)
+
+    def p_expressionList(self, p):
+        """expressionList : expression ',' expressionList
+        | expression
+        """
+        if len(p) == 2:
+            p[0] = [p[1]]
+        else:
+            p[0] = [p[1]] + p[3] 
+
+    def p_identifierList(self, p):
+        """identifierList : ID ',' identifierList
+        | ID
+        """
+        if len(p) == 2:
+            p[0] = [p[1]]
+        else:
+            p[0] = [p[1]] + p[3] 
+
+    def p_gateOperandList(self, p):
+        """gateOperandList : gateOperand ',' gateOperandList
+        | gateOperand
+        """
+        if len(p) == 2:
+            p[0] = [p[1]]
+        else:
+            p[0] = [p[1]] + p[3] 
+    
+#####################
+
+    def p_error(self, p):
+        if p is None:
+            raise QasmException('Unexpected end of file')
+
+        raise QasmException(f"""Syntax error: '{p.value}'
+{self.debug_context(p)}
+at line {p.lineno}, column {self.find_column(p)}""")
+
+    def find_column(self, p):
+        line_start = self.qasm.rfind('\n', 0, p.lexpos) + 1
+        return (p.lexpos - line_start) + 1
+
+    def p_empty(self, p):
+        """empty :"""
+
+    def parse(self, qasm: str) -> Qasm:
+        if self.parsedQasm is None:
+            self.qasm = qasm
+            self.lexer.input(self.qasm)
+            self.parsedQasm = self.parser.parse(lexer=self.lexer)
+        return self.parsedQasm
+
+    def debug_context(self, p):
+        debug_start = max(self.qasm.rfind('\n', 0, p.lexpos) + 1, p.lexpos - 5)
+        debug_end = min(self.qasm.find('\n', p.lexpos, p.lexpos + 5), p.lexpos + 5)
+
+        return (
+            "..."
+            + self.qasm[debug_start:debug_end]
+            + "\n"
+            + (" " * (3 + p.lexpos - debug_start))
+            + "^"
+        )

--- a/cirq-core/cirq/contrib/qasm_import/_parser3_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser3_test.py
@@ -1,0 +1,1970 @@
+# Copyright 2021 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import re
+import textwrap
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+import sympy
+
+import cirq
+import cirq.testing as ct
+from cirq import Circuit
+from cirq.circuits.qasm_output import QasmUGate
+from cirq.contrib.qasm_import import QasmException
+from cirq.contrib.qasm_import._parser3 import Qasm3Parser, Qasm3UGate
+from cirq.testing import consistent_qasm as cq
+
+
+def test_format_header_circuit() -> None:
+    parser = Qasm3Parser()
+
+    parsed_qasm = parser.parse("OPENQASM 3.0;")
+
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.std_gates_included
+    ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
+
+
+def test_unsupported_format() -> None:
+    qasm = "OPENQASM 2.0;"
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match="Unsupported.*2.0.*3.0.*supported.*"):
+        parser.parse(qasm)
+
+
+def test_format_header_with_quelibinc_circuit() -> None:
+    qasm = """OPENQASM 3.0;
+include "stdgates.inc";
+"""
+    parser = Qasm3Parser()
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+    ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
+
+
+@pytest.mark.parametrize('qasm', ["include \"stdgates.inc\";", "", "qreg q[3];"])
+def test_error_not_starting_with_format(qasm: str) -> None:
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match="Missing 'OPENQASM 3.0;' statement"):
+        parser.parse(qasm)
+
+
+def test_comments() -> None:
+    parser = Qasm3Parser()
+
+    parsed_qasm = parser.parse("""
+    //this is the format
+    OPENQASM 3.0;
+    // this is some other comment
+    include "stdgates.inc";
+    // and something at the end of the file
+    // multiline
+    """)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+    ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
+
+
+def test_multiple_qreg_declaration() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg a_quantum_register [ 1337 ];
+     qreg q[42];
+"""
+    parser = Qasm3Parser()
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+    ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
+    assert parsed_qasm.regs.qubits == {'a_quantum_register': 1337, 'q': 42}
+
+
+@pytest.mark.parametrize(
+    'qasm',
+    [
+        """OPENQASM 3.0;
+           qreg q[2];
+           creg q[3];
+               """,
+        """OPENQASM 3.0;
+           creg q[2];
+           qreg q[3];
+               """,
+        """OPENQASM 3.0;
+           bit[2] q;
+           qubit[3] q;
+               """,
+        """OPENQASM 3.0;
+           bit[2] q;
+           angle[3] q;
+               """,
+    ],
+)
+def test_already_defined_error(qasm: str) -> None:
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"q.*already defined.* line 3"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize(
+    'qasm',
+    [
+        """OPENQASM 3.0;
+           qreg q[0];
+               """,
+        """OPENQASM 3.0;
+           creg q[0];
+               """,
+        """OPENQASM 3.0;
+            bit[0] q;
+               """, 
+        """OPENQASM 3.0;
+            qubit[0] q;
+               """,   
+        """OPENQASM 3.0;
+            angle[0] q;
+               """, 
+    ],
+)
+def test_zero_length_register(qasm: str) -> None:
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=".* zero-length.*'q'.*line 2"):
+        parser.parse(qasm)
+
+
+def test_unexpected_end_of_file() -> None:
+    qasm = """OPENQASM 3.0;
+              include "stdgates.inc";
+              creg
+           """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match="Unexpected end of file"):
+        parser.parse(qasm)
+
+
+def test_multiple_creg_declaration() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     creg a_classical_register [1337];
+     qreg a_quantum_register [1337];
+     creg c[42];
+"""
+    parser = Qasm3Parser()
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+    ct.assert_same_circuits(parsed_qasm.circuit, Circuit())
+    assert parsed_qasm.regs.qubits == {'a_quantum_register': 1337}
+    assert parsed_qasm.regs.bits == {'a_classical_register': 1337, 'c': 42}
+
+
+def test_syntax_error() -> None:
+    qasm = """OPENQASM 3.0;
+         qreg q[2] bla;
+         foobar q[0];
+    """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Syntax error: 'bla'.*"""):
+        parser.parse(qasm)
+
+
+def test_cx_gate() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qubit[2] q1;
+     qubit[2] q2;
+     cx q1[0], q1[1];
+     cx q1, q2[0];
+     cx q2, q1;
+"""
+    parser = Qasm3Parser()
+
+    q1_0 = cirq.NamedQubit('q1_0')
+    q1_1 = cirq.NamedQubit('q1_1')
+    q2_0 = cirq.NamedQubit('q2_0')
+    q2_1 = cirq.NamedQubit('q2_1')
+
+    expected_circuit = Circuit()
+    # CX q1[0], q1[1];
+    expected_circuit.append(cirq.CNOT(q1_0, q1_1))
+    # CX q1, q2[0];
+    expected_circuit.append(cirq.CNOT(q1_0, q2_0))
+    expected_circuit.append(cirq.CNOT(q1_1, q2_0))
+    # CX q2, q1;
+    expected_circuit.append(cirq.CNOT(q2_0, q1_0))
+    expected_circuit.append(cirq.CNOT(q2_1, q1_1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q1': 2, 'q2': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_cx_gate_not_enough_args() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     cx q[0];
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"cx.*takes.*got.*1.*line 4"):
+        parser.parse(qasm)
+
+
+def test_cx_gate_mismatched_registers() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q1[2];
+     qreg q2[3];
+     cx q1, q2;
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"Non matching.*length \[2 3\].*line 5"):
+        parser.parse(qasm)
+
+
+def test_cx_gate_bounds() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qubit[2] q1;
+     qubit[3] q2;
+     cx q1[4], q2[0];
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"Out of bounds.*4.*q1.*2.*line 5"):
+        parser.parse(qasm)
+
+
+def test_cx_gate_arg_overlap() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q1[2];
+     qreg q2[3];
+     CX q1[1], q1[1];
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"Overlapping.*at line 5"):
+        parser.parse(qasm)
+
+
+def test_U_gate() -> None:
+    qasm = """
+     OPENQASM 3.0;
+     qubit[2] q;
+     U(pi, 2.3, 3) q[0];
+     U(3.14, -pi, (8)) q;
+"""
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(
+        cirq.Moment(
+            [
+                QasmUGate(1.0, 2.3 / np.pi, 3 / np.pi)(q0),
+                QasmUGate(3.14 / np.pi, -1.0, 8 / np.pi)(q1),
+            ]
+        )
+    )
+
+    expected_circuit.append(cirq.Moment([QasmUGate(3.14 / np.pi, -1.0, 8 / np.pi)(q0)]))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_U_angles() -> None:
+    qasm = """
+    OPENQASM 3.0;
+    qreg q[1];
+    U(pi/2,0,pi) q[0];
+    """
+
+    c = Qasm3Parser().parse(qasm).circuit
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(c), cirq.unitary(cirq.H), atol=1e-7
+    )
+
+
+def test_U_gate_zero_params_error() -> None:
+    qasm = """OPENQASM 3.0;
+     qreg q[2];
+     U q[1];"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"U takes 3.*got.*0.*line 3"):
+        parser.parse(qasm)
+
+
+def test_U_gate_too_much_params_error() -> None:
+    qasm = """OPENQASM 3.0;
+     qreg q[2];
+     U(pi, pi, pi, pi) q[1];"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"U takes 3.*got.*4.*line 3"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize(
+    'expr',
+    [
+        '.333 + 4',
+        '1.0 * 2',
+        '0.1 / pi',
+        '1.2E+05 * (3 + 2)',
+        '3 - 4 * 2',  # precedence of *
+        '3 * 4 + 2',  # precedence of *
+        '(-1) * pi',
+        '-3 * 5 + 2',
+    ],
+)
+def test_expressions(expr: str) -> None:
+    qasm = f"""OPENQASM 3.0;
+     qreg q[1];
+     U({expr}, 2 * pi, pi / 2.0) q[0];
+"""
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(Qasm3UGate(float(sympy.sympify(expr)) / np.pi, 2.0, 1 / 2.0)(q0))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.std_gates_included
+
+    ct.assert_allclose_up_to_global_phase(
+        cirq.unitary(parsed_qasm.circuit), cirq.unitary(expected_circuit), atol=1e-10
+    )
+    assert parsed_qasm.regs.qubits == {'q': 1}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize(
+    'expr',
+    [
+        '0.1 ** pi',
+        '2.0e-05 ** (1/2)',
+        '123123.2132312 * cos(pi)',
+        '123123.2132312 * sin(2 * pi)',
+        '3 - 4 * 2',  # precedence of *
+        '3 * 4 + 2',  # precedence of *
+        '3 * 4 ** 2',  # precedence of **
+        '3 - 4 ** 2',  # precedence of **
+        '3**2**(-2)',  # right associativity of **
+        '(4 * (-3) ** 5 - 2)',
+        'tan(123123.2132312)',
+        'log(pi)',
+        'exp(2*pi)',
+        'sqrt(4)',
+        'arccos(1)',
+        'arctan(0.2)',
+        'mod(10, 2)',
+        'ceiling(0.3)',
+        'floor(1.7)',
+    ],
+)
+def test_expressions_no_qiskit_support(expr: str) -> None:
+    qasm = f"""OPENQASM 3.0;
+     qreg q[1];
+     U({expr}, 2 * pi, pi / 2.0) q[0];
+"""
+    # The qiskit qasm3 parser doesnt support ** or function calls
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit()
+    expr = expr.replace('mod', 'Mod') # sympy uses differnt name
+    expr = expr.replace('arccos', 'acos') # sympy uses differnt name
+    expr = expr.replace('arcsin', 'asin') # sympy uses differnt name
+    expr = expr.replace('arctan', 'atan') # sympy uses differnt name
+    expected_circuit.append(Qasm3UGate(float(sympy.sympify(expr)) / np.pi, 2.0, 1 / 2.0)(q0))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.std_gates_included
+
+    ct.assert_allclose_up_to_global_phase(
+        cirq.unitary(parsed_qasm.circuit), cirq.unitary(expected_circuit), atol=1e-10
+    )
+    assert parsed_qasm.regs.qubits == {'q': 1}
+
+
+@pytest.mark.parametrize(
+    'expr',
+    [
+        'phi',
+        '3 * phi',
+    ],
+)
+def test_expressions_with_identifier(expr: str) -> None:
+    symbol_name = "phi"
+    qasm = f"""OPENQASM 3.0;
+     qreg q[1];
+     angle[64] {symbol_name};
+     U({expr}, 2 * pi, pi / 2.0) q[0];
+"""
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    ns = {symbol_name:sympy.Symbol(symbol_name)}
+    expected_circuit = Circuit()
+    expected_circuit.append(QasmUGate(sympy.sympify(expr, locals=ns) / np.pi, 2.0, 1 / 2.0)(q0))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert not parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+
+    parsed_qasm_circuit_resolved = cirq.resolve_parameters(parsed_qasm.circuit, {symbol_name: 10})
+    expected_circuit_resolved = cirq.resolve_parameters(expected_circuit, {symbol_name: 10})
+
+    ct.assert_allclose_up_to_global_phase(
+        cirq.unitary(parsed_qasm_circuit_resolved), cirq.unitary(expected_circuit_resolved), atol=1e-10
+    )
+    assert parsed_qasm.regs.qubits == {'q': 1}
+    assert parsed_qasm.regs.angles == {symbol_name: 64}
+
+
+def test_gphase_with_identifier() -> None:
+    qasm = f"""OPENQASM 3.0;
+    include "stdgates.inc";
+     qreg q[1];
+     angle[64] phi;
+     gphase(phi);
+     x q[0];
+    """
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit([cirq.global_phase_operation(sympy.exp(1j*sympy.Symbol('phi'))), cirq.X(q0)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+
+    parsed_qasm_circuit_resolved = cirq.resolve_parameters(parsed_qasm.circuit, {'phi': 10})
+    expected_circuit_resolved = cirq.resolve_parameters(expected_circuit, {'phi': 10})
+
+    ct.assert_allclose_up_to_global_phase(
+        cirq.unitary(parsed_qasm_circuit_resolved), cirq.unitary(expected_circuit_resolved), atol=1e-10
+    )
+    assert parsed_qasm.regs.qubits == {'q': 1}
+    assert parsed_qasm.regs.angles == {'phi': 64}
+
+
+def test_identifier_in_function_error() -> None:
+    qasm = """OPENQASM 3.0;
+     qreg q[1];
+     angle[64] phi;
+     U(floor(phi), 2 * pi, pi / 3.0) q[0];
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"Non contant .* function .* line 4"):
+        parser.parse(qasm)
+
+
+def test_unknown_function() -> None:
+    qasm = """OPENQASM 3.0;
+     qreg q[1];
+     U(nonexistent(3), 2 * pi, pi / 3.0) q[0];
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r".*not recognized.*'nonexistent'.*line 3"):
+        parser.parse(qasm)
+
+
+rotation_gates = [('rx', cirq.rx), ('ry', cirq.ry), ('rz', cirq.rz)]
+
+
+single_qubit_gates = [
+    ('id', cirq.I),
+    ('x', cirq.X),
+    ('y', cirq.Y),
+    ('z', cirq.Z),
+    ('h', cirq.H),
+    ('s', cirq.S),
+    ('t', cirq.T),
+    ('sdg', cirq.S**-1),
+    ('tdg', cirq.T**-1),
+    ('sx', cirq.XPowGate(exponent=0.5)),
+]
+
+
+@pytest.mark.parametrize('qasm_gate,cirq_gate', rotation_gates)
+def test_rotation_gates(qasm_gate: str, cirq_gate: Callable[[float], cirq.Gate]) -> None:
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate}(pi/2) q[0];
+     {qasm_gate}(pi) q;
+    """
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq.Moment([cirq_gate(np.pi / 2).on(q0), cirq_gate(np.pi).on(q1)]))
+    expected_circuit.append(cirq.Moment([cirq_gate(np.pi).on(q0)]))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
+def test_rotation_gates_wrong_number_of_args(qasm_gate: str) -> None:
+    qasm = f"""
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate}(pi) q[0], q[1];
+"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=f".*{qasm_gate}.* takes 1.*got.*2.*line 5"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in rotation_gates])
+def test_rotation_gates_zero_params_error(qasm_gate: str) -> None:
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate} q[1];
+"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=f".*{qasm_gate}.* takes 1.*got.*0.*line 4"):
+        parser.parse(qasm)
+
+
+def test_std_gate_without_include_statement() -> None:
+    qasm = """OPENQASM 3.0;
+         qreg q[2];
+         x q[0];
+    """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Unknown gate "x".* line 3.*forget.*\?"""):
+        parser.parse(qasm)
+
+
+def test_undefined_register_from_qubit_arg() -> None:
+    qasm = """OPENQASM 3.0;
+            include "stdgates.inc";
+            qreg q[2];
+            CX q[0], q2[1];
+       """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Undefined.*register.*q2.*"""):
+        parser.parse(qasm)
+
+
+def test_undefined_register_from_register_arg() -> None:
+    qasm = """OPENQASM 3.0;
+            include "stdgates.inc";
+            qreg q[2];
+            qreg q2[2];
+            CX q1, q2;
+       """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Undefined.*register.*q.*"""):
+        parser.parse(qasm)
+
+
+def test_measure_individual_bits() -> None:
+    qasm = """
+         OPENQASM 3.0;
+         include "stdgates.inc";
+         qreg q1[2];
+         creg c1[2];
+         measure q1[0] -> c1[0];
+         measure q1[1] -> c1[1];
+    """
+    parser = Qasm3Parser()
+
+    q1_0 = cirq.NamedQubit('q1_0')
+    q1_1 = cirq.NamedQubit('q1_1')
+
+    expected_circuit = Circuit()
+
+    expected_circuit.append(cirq.MeasurementGate(num_qubits=1, key='c1_0').on(q1_0))
+    expected_circuit.append(cirq.MeasurementGate(num_qubits=1, key='c1_1').on(q1_1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q1': 2}
+    assert parsed_qasm.regs.bits == {'c1': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_measure_registers() -> None:
+    qasm = """OPENQASM 3.0;
+         include "stdgates.inc";
+         qreg q1[3];
+         creg c1[3];
+         measure q1 -> c1;
+    """
+    parser = Qasm3Parser()
+
+    q1_0 = cirq.NamedQubit('q1_0')
+    q1_1 = cirq.NamedQubit('q1_1')
+    q1_2 = cirq.NamedQubit('q1_2')
+
+    expected_circuit = Circuit()
+
+    expected_circuit.append(cirq.MeasurementGate(num_qubits=1, key='c1_0').on(q1_0))
+    expected_circuit.append(cirq.MeasurementGate(num_qubits=1, key='c1_1').on(q1_1))
+    expected_circuit.append(cirq.MeasurementGate(num_qubits=1, key='c1_2').on(q1_2))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q1': 3}
+    assert parsed_qasm.regs.bits == {'c1': 3}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_measure_mismatched_register_size() -> None:
+    qasm = """OPENQASM 3.0;
+         include "stdgates.inc";
+         qreg q1[2];
+         creg c1[3];
+         measure q1 -> c1;
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r""".*mismatched .* 2 -> 3.*line 5"""):
+        parser.parse(qasm)
+
+
+def test_measure_to_quantum_register() -> None:
+    qasm = """OPENQASM 3.0;
+         include "stdgates.inc";
+         qreg q1[3];
+         qreg q2[3];
+         creg c1[3];
+         measure q2 -> q1;
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Illegal .*`qubit` .*measurement .*line 6"""):
+        parser.parse(qasm)
+
+
+def test_measure_undefined_classical_bit() -> None:
+    qasm = """OPENQASM 3.0;
+         include "stdgates.inc";
+         qreg q1[3];
+         creg c1[3];
+         measure q1[1] -> c2[1];
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Undefined register.*c2.*line 5"""):
+        parser.parse(qasm)
+
+
+def test_measure_from_classical_register() -> None:
+    qasm = """OPENQASM 3.0;
+         include "stdgates.inc";
+         qreg q1[2];
+         creg c1[3];
+         creg c2[3];
+         measure c1 -> c2;
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"""Illegal .* bit .* line 0"""):
+        parser.parse(qasm)
+
+
+def test_measurement_bounds() -> None:
+    qasm = """OPENQASM 3.0;
+     qreg q1[3];
+     creg c1[3];
+     measure q1[0] -> c1[4];
+"""
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r"Out of bounds index.*4.*c1.*size 3.*line 4"):
+        parser.parse(qasm)
+
+
+def test_reset() -> None:
+    qasm = """OPENQASM 3.0;
+    include "stdgates.inc";
+    qreg q[1];
+    creg c[1];
+    x q[0];
+    reset q[0];
+    measure q[0] -> c[0];
+"""
+
+    parser = Qasm3Parser()
+
+    q_0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit([cirq.X(q_0), cirq.reset(q_0), cirq.measure(q_0, key='c_0')])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+    assert parsed_qasm.regs.bits == {'c': 1}
+
+
+def test_u1_gate() -> None:
+    qasm = """
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     u1(pi / 3.0) q[0];
+"""
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(QasmUGate(0, 0, 1.0 / 3.0)(q0))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_p_gate() -> None:
+    qasm = """
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     p(pi / 3.0) q[0];
+"""
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq.ZPowGate(exponent=1.0 / 3.0)(q0))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_u2_gate() -> None:
+    qasm = """
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     u2(2 * pi, pi / 3.0) q[0];
+"""
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(QasmUGate(0.5, 2.0, 1.0 / 3.0)(q0))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_id_gate() -> None:
+    qasm = """
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     id q;
+"""
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq.IdentityGate(num_qubits=1)(q0))
+    expected_circuit.append(cirq.IdentityGate(num_qubits=1)(q1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_u3_gate() -> None:
+    qasm = """
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     u3(pi, 2.3, 3) q[0];
+     u3(3.14, -pi, (8)) q;
+"""
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(
+        cirq.Moment(
+            [
+                QasmUGate(1.0, 2.3 / np.pi, 3 / np.pi)(q0),
+                QasmUGate(3.14 / np.pi, -1.0, 8 / np.pi)(q1),
+            ]
+        )
+    )
+
+    expected_circuit.append(cirq.Moment([QasmUGate(3.14 / np.pi, -1.0, 8 / np.pi)(q0)]))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize(
+    'qasm_gate',
+    ['p', 'u1', 'u2', 'u3']
+    + [g[0] for g in rotation_gates]
+    + [g[0] for g in single_qubit_gates],
+)
+def test_standard_single_qubit_gates_wrong_number_of_args(qasm_gate) -> None:
+    qasm = f"""
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate} q[0], q[1];
+"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=r".* takes .*got.*line 5"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize(
+    ['qasm_gate', 'num_params'],
+    [
+        ['rx', 1],
+        ['ry', 1],
+        ['rz', 1],
+        ['p', 1],
+        ['u1', 1],
+        ['u2', 2],
+        ['u3', 3],
+    ]
+    + [[g[0], 0] for g in single_qubit_gates],
+)
+def test_standard_gates_wrong_params_error(qasm_gate: str, num_params: int) -> None:
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate}(pi, 2*pi, 3*pi, 4*pi, 5*pi) q[1];
+"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=f".*{qasm_gate}.* takes {num_params}.*got.*5.*line 4"):
+        parser.parse(qasm)
+
+    if num_params == 0:
+        return
+
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate} q[1];
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=f".*{qasm_gate}.* takes {num_params}.*got.*0.*line 4"):
+        parser.parse(qasm)
+
+
+two_qubit_gates = [
+    ('cx', cirq.CNOT),
+    # BUG? CX has non standard phase in QASM3 but qiskit yeilds standard phase?
+    # ('CX', cirq.ControlledGate(Qasm3UGate(*[np.pi, 0, np.pi]))),
+    ('cz', cirq.CZ),
+    ('cy', cirq.CY),
+    ('swap', cirq.SWAP),
+    ('ch', cirq.ControlledGate(cirq.H)),
+]
+
+
+# Mapping of two-qubit gates and `num_params`
+two_qubit_param_gates = {
+    ('cu', cirq.ControlledGate(cirq.MatrixGate((QasmUGate(0.1/np.pi, 0.2/np.pi, 0.3/np.pi)*np.exp(1j*0.4)).matrix()))): 4,
+    ('crx', cirq.ControlledGate(cirq.rx(0.1))): 1,
+    ('cry', cirq.ControlledGate(cirq.ry(0.1))): 1,
+    ('crz', cirq.ControlledGate(cirq.rz(0.1))): 1,
+    ('cp', cirq.ControlledGate(cirq.ZPowGate(exponent=0.1 / np.pi))): 1,
+}
+
+
+@pytest.mark.parametrize('qasm_gate,cirq_gate', two_qubit_gates)
+def test_two_qubit_gates(qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate) -> None:
+    qasm = f"""
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qreg q1[2];
+    qreg q2[2];
+    {qasm_gate} q1[0], q1[1];
+    {qasm_gate} q1, q2[0];
+    {qasm_gate} q2, q1;
+"""
+    parser = Qasm3Parser()
+
+    q1_0 = cirq.NamedQubit('q1_0')
+    q1_1 = cirq.NamedQubit('q1_1')
+    q2_0 = cirq.NamedQubit('q2_0')
+    q2_1 = cirq.NamedQubit('q2_1')
+
+    expected_circuit = Circuit()
+    # CX q1[0], q1[1];
+    expected_circuit.append(cirq_gate(q1_0, q1_1))
+    # CX q1, q2[0];
+    expected_circuit.append(cirq_gate(q1_0, q2_0))
+    expected_circuit.append(cirq_gate(q1_1, q2_0))
+    # CX q2, q1;
+    expected_circuit.append(cirq_gate(q2_0, q1_0))
+    expected_circuit.append(cirq_gate(q2_1, q1_1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q1': 2, 'q2': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize(
+    'qasm_gate, cirq_gate, num_params',
+    [
+        (gate_map[0], gate_map[1], num_param)
+        for gate_map, num_param in two_qubit_param_gates.items()
+    ],
+)
+def test_two_qubit_param_gates(
+    qasm_gate: str, cirq_gate: cirq.testing.TwoQubitGate, num_params: int
+) -> None:
+    params = f"({', '.join(f'{0.1 * (x + 1):g}' for x in range(num_params))})"
+
+    qasm = f"""
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qreg q1[2];
+    qreg q2[2];
+    {qasm_gate}{params} q1[0], q1[1];
+    {qasm_gate}{params} q1, q2[0];
+    {qasm_gate}{params} q2, q1;
+    """
+    parser = Qasm3Parser()
+
+    q1_0 = cirq.NamedQubit('q1_0')
+    q1_1 = cirq.NamedQubit('q1_1')
+    q2_0 = cirq.NamedQubit('q2_0')
+    q2_1 = cirq.NamedQubit('q2_1')
+
+    expected_circuit = cirq.Circuit()
+    expected_circuit.append(cirq_gate.on(q1_0, q1_1))
+    expected_circuit.append(cirq_gate.on(q1_0, q2_0))
+    expected_circuit.append(cirq_gate.on(q1_1, q2_0))
+    expected_circuit.append(cirq_gate.on(q2_0, q1_0))
+    expected_circuit.append(cirq_gate.on(q2_1, q1_1))
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q1': 2, 'q2': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize(
+    'qasm_gate', [g[0] for g in two_qubit_gates] + [g[0] for g in two_qubit_param_gates.keys()]
+)
+def test_two_qubit_gates_not_enough_qubits(qasm_gate: str) -> None:
+    gate_mapping = {
+        'crx': '(0.1)',
+        'cry': '(0.1)',
+        'crz': '(0.1)',
+        'cp': '(0.1)',
+        'cu1': '(0.1)',
+        'cu3': '(0.1, 0.2, 0.3)',
+        'cu': '(0.1, 0.2, 0.3, 0.4)',
+    }
+
+    qasm_param = gate_mapping.get(qasm_gate, '')
+
+    qasm = f"""
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qreg q[2];
+        {qasm_gate}{qasm_param} q[0];
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=rf".*{qasm_gate}.* takes 2 arg\(s\).*got.*1.*line 5"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize('qasm_gate, n_params', [(k[0], v) for k, v in two_qubit_param_gates.items()])
+def test_two_qubit_gates_not_enough_args(qasm_gate: str, n_params: int) -> None:
+    qasm = f"""
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate}({','.join(["0.1"]*n_params)}) q[0];
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=rf".*{qasm_gate}.* takes 2 arg\(s\).*got.*1.*line 5"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize(
+    'qasm_gate', [g[0] for g in two_qubit_gates] + [g[0] for g in two_qubit_param_gates.keys()]
+)
+def test_two_qubit_gates_with_too_much_parameters(qasm_gate: str) -> None:
+    params_mapping = {'crx': 1, 'cry': 1, 'crz': 1, 'cp': 1, 'cu1': 1, 'cu3': 3, 'cu': 4}
+
+    num_params_needed = params_mapping.get(qasm_gate, 0)
+
+    qasm = f"""
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qreg q[2];
+        {qasm_gate}(pi, pi/2, pi/3, pi/4, pi/5) q[0],q[1];
+    """
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(
+        QasmException,
+        match=rf".*{qasm_gate}*. takes {num_params_needed} parameter\(s\).*got.*5.*line 5",
+    ):
+        parser.parse(qasm)
+
+
+three_qubit_gates = [
+    ('ccx', cirq.TOFFOLI),
+    ('cswap', cirq.CSWAP),
+]
+
+
+@pytest.mark.parametrize('qasm_gate,cirq_gate', three_qubit_gates)
+def test_three_qubit_gates(qasm_gate: str, cirq_gate: cirq.Gate) -> None:
+    qasm = f"""
+     OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q1[2];
+     qreg q2[2];
+     qreg q3[2];
+     {qasm_gate} q1[0], q1[1], q2[0];
+     {qasm_gate} q1, q2[0], q3[0];
+     {qasm_gate} q1, q2, q3;
+"""
+    parser = Qasm3Parser()
+
+    q1_0 = cirq.NamedQubit('q1_0')
+    q1_1 = cirq.NamedQubit('q1_1')
+    q2_0 = cirq.NamedQubit('q2_0')
+    q2_1 = cirq.NamedQubit('q2_1')
+    q3_0 = cirq.NamedQubit('q3_0')
+    q3_1 = cirq.NamedQubit('q3_1')
+
+    expected_circuit = Circuit()
+
+    expected_circuit.append(cirq_gate(q1_0, q1_1, q2_0))
+
+    expected_circuit.append(cirq_gate(q1_0, q2_0, q3_0))
+    expected_circuit.append(cirq_gate(q1_1, q2_0, q3_0))
+
+    expected_circuit.append(cirq_gate(q1_0, q2_0, q3_0))
+    expected_circuit.append(cirq_gate(q1_1, q2_1, q3_1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q1': 2, 'q2': 2, 'q3': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in three_qubit_gates])
+def test_three_qubit_gates_not_enough_args(qasm_gate: str) -> None:
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate} q[0];
+"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=rf".*{qasm_gate}.* takes 3 arg\(s\).*got.*1.*line 4"):
+        parser.parse(qasm)
+
+
+@pytest.mark.parametrize('qasm_gate', [g[0] for g in three_qubit_gates])
+def test_three_qubit_gates_with_too_much_parameters(qasm_gate: str) -> None:
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[3];
+     {qasm_gate}(pi) q[0],q[1],q[2];
+"""
+
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=f".*{qasm_gate}.*parameter.*line 4.*"):
+        parser.parse(qasm)
+
+@pytest.mark.parametrize('qasm_gate,cirq_gate', single_qubit_gates)
+def test_single_qubit_gates(qasm_gate: str, cirq_gate: cirq.Gate) -> None:
+    qasm = f"""OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     {qasm_gate} q[0];
+     {qasm_gate} q;
+    """
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit([cirq_gate.on(q0), cirq_gate.on(q0), cirq_gate.on(q1)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_gphase_gate_with_too_many_parameters() -> None:
+    qasm = f"""OPENQASM 3.0;
+     qreg q[2];
+     gphase(pi/2, 1.0);
+    """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=rf".*gphase takes 1 .*got.*2.*line 3"):
+        parser.parse(qasm)
+
+
+def test_ctrl_gphase_gate_with_too_many_parameters() -> None:
+    qasm = f"""OPENQASM 3.0;
+     qreg q[2];
+     ctrl @ gphase(pi/2, 1.0);
+    """
+    parser = Qasm3Parser()
+
+    with pytest.raises(QasmException, match=rf".*gphase takes 1 .*got.*2.*line 3"):
+        parser.parse(qasm)
+
+
+def test_gphase_gate() -> None:
+    qasm = f"""OPENQASM 3.0;
+    include "stdgates.inc";
+     qreg q[1];
+     gphase(pi/2);
+     x q[0];
+    """
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit([cirq.global_phase_operation(np.exp(1j*np.pi/2)), cirq.X(q0)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_gphase_gate_with_control() -> None:
+    qasm = f"""OPENQASM 3.0;
+     qreg q[1];
+     ctrl @ gphase(3 / pi) q[0];
+    """
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit([cirq.ZPowGate(exponent=3 / np.pi**2)(q0)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_gphase_gate_inside_custom_gate() -> None:
+    qasm = """OPENQASM 3.0;
+     qreg q[2];
+     gate X q {
+        U(pi, 0, pi) q;
+        gphase(-pi/2);
+     }
+     gate CX c, t {
+        ctrl @ X c, t;
+     }
+     CX q[0], q[1];
+    """
+
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+    q1 = cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit([cirq.CNOT(q0, q1)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    np.testing.assert_allclose(cirq.unitary(parsed_qasm.circuit), cirq.unitary(expected_circuit))
+    assert parsed_qasm.regs.qubits == {'q': 2}
+    # Bug in qiskit ? 
+    # cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_non_bit_type_in_measurement() -> None:
+    qasm = """OPENQASM 3.0;
+     qubit q;
+     angle a;
+     a = measure q;
+    """
+    parser = Qasm3Parser()
+    with pytest.raises(QasmException, match=f"Illegal use of `angle` type register for measurement results at line 4"):
+        parser.parse(qasm)
+
+
+def test_qubits() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qubit[2] q;
+     bit[2] b;
+
+     x q[0];
+
+     b[0] = measure q[0];
+     reset q[0];
+    """
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit([cirq.X.on(q0), cirq.measure(q0, key='b_0'), cirq.reset(q0)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+
+def test_scalar_qubit() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qubit q;
+     bit b;
+     x q;
+     b = measure q;
+     reset q;
+    """
+    parser = Qasm3Parser()
+
+    q0 = cirq.NamedQubit('q_0')
+
+    expected_circuit = Circuit([cirq.X.on(q0), cirq.measure(q0, key='b_0'), cirq.reset(q0)])
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 1}
+
+
+def test_control_modifier() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     ctrl @ x q[0], q[1];
+    """
+    # The outer circuit should then translate to this
+    q_0, q_1 = cirq.NamedQubit.range(2, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        cirq.ControlledOperation(sub_operation=cirq.X(q_1), controls=[q_0]),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    assert parsed_qasm.circuit == expected
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_control_modifier_with_params() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     ctrl @ rx(0.1) q[0], q[1];
+    """
+    # The outer circuit should then translate to this
+    q_0, q_1 = cirq.NamedQubit.range(2, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        cirq.ControlledOperation(sub_operation=cirq.rx(0.1).on(q_1), controls=[q_0]),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    assert parsed_qasm.circuit == expected
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_many_control_modifier() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[3];
+     ctrl @ ctrl @ x q[0], q[1], q[2];
+    """
+    # The outer circuit should then translate to this
+    q_0, q_1, q_2 = cirq.NamedQubit.range(3, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        cirq.ControlledOperation(sub_operation=cirq.X(q_2), controls=[q_0, q_1]),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    assert parsed_qasm.circuit == expected
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_multi_control_modifier() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[3];
+     ctrl(2) @ x q[0], q[1], q[2];
+    """
+    # The outer circuit should then translate to this
+    q_0, q_1, q_2 = cirq.NamedQubit.range(3, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        cirq.ControlledOperation(sub_operation=cirq.X(q_2), controls=[q_0, q_1]),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    assert parsed_qasm.circuit == expected
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+
+
+def test_multi_control_modifier_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[3];
+     ctrl(2.1) @ x q[0], q[1], q[2];
+    """
+    with pytest.raises(QasmException, match=r'.*control qubits .* integer .* line 4'):
+        Qasm3Parser().parse(qasm)
+
+
+def test_custom_gate() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     gate g q0, q1 {
+        x q0;
+        y q0;
+        z q1;
+     }
+     g q[0], q[1];
+     g q[1], q[0];
+    """
+
+    # The gate definition should translate to this
+    q0 = cirq.NamedQubit('q0_0')
+    q1 = cirq.NamedQubit('q1_0')
+    g = cirq.FrozenCircuit(cirq.X(q0), cirq.Y(q0), cirq.Z(q1))
+
+    # The outer circuit should then translate to this
+    q_0, q_1 = cirq.NamedQubit.range(2, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        cirq.CircuitOperation(g, qubit_map={q0: q_0, q1: q_1}),
+        cirq.CircuitOperation(g, qubit_map={q0: q_1, q1: q_0}),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    parsed_qasm_decomposed = cirq.Circuit(cirq.decompose(parsed_qasm.circuit, preserve_structure=True))
+    assert parsed_qasm_decomposed == expected
+
+    # Sanity check that this unrolls to a valid circuit
+    unrolled_expected = cirq.Circuit(
+        cirq.X(q_0), cirq.Y(q_0), cirq.Z(q_1), cirq.X(q_1), cirq.Y(q_1), cirq.Z(q_0)
+    )
+    unrolled = cirq.align_left(cirq.unroll_circuit_op(parsed_qasm_decomposed, tags_to_check=None))
+    assert unrolled == unrolled_expected
+
+    # Sanity check that these have the same unitaries as the QASM.
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(unrolled))
+
+
+def test_custom_gate_parameterized() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     gate g(p0, p1) q0, q1 {
+        rx(p0) q0;
+        ry(p0+p1) q0;
+        rz(p1) q1;
+     }
+     g(1,2) q[0], q[1];
+     g(0,4) q[1], q[0];
+    """
+
+    # The gate definition should translate to this
+    p0, p1 = sympy.symbols('p0, p1')
+    q0 = cirq.NamedQubit('q0_0')
+    q1 = cirq.NamedQubit('q1_0')
+    g = cirq.FrozenCircuit(
+        cirq.Rx(rads=p0).on(q0), cirq.Ry(rads=p0 + p1).on(q0), cirq.Rz(rads=p1).on(q1)
+    )
+
+    # The outer circuit should then translate to this
+    q_0, q_1 = cirq.NamedQubit.range(2, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        cirq.CircuitOperation(g, qubit_map={q0: q_0, q1: q_1}, param_resolver={'p0': 1, 'p1': 2}),
+        cirq.CircuitOperation(g, qubit_map={q0: q_1, q1: q_0}, param_resolver={'p0': 0, 'p1': 4}),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    parsed_qasm_decomposed = cirq.Circuit(cirq.decompose(parsed_qasm.circuit, preserve_structure=True))
+    assert parsed_qasm_decomposed == expected
+
+    # Sanity check that this unrolls to a valid circuit
+    unrolled_expected = cirq.Circuit(
+        cirq.Rx(rads=1).on(q_0),
+        cirq.Ry(rads=3).on(q_0),
+        cirq.Rz(rads=2).on(q_1),
+        cirq.Rx(rads=0).on(q_1),
+        cirq.Ry(rads=4).on(q_1),
+        cirq.Rz(rads=4).on(q_0),
+    )
+    unrolled = cirq.align_left(cirq.unroll_circuit_op(parsed_qasm_decomposed, tags_to_check=None))
+    assert unrolled == unrolled_expected
+
+    # Sanity check that these have the same unitaries as the QASM.
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(unrolled))
+
+
+def test_custom_gate_broadcast() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[3];
+     gate g q0 {
+        x q0;
+        y q0;
+        z q0;
+     }
+     g q; // broadcast to all qubits in register
+    """
+
+    # The gate definition should translate to this
+    q0 = cirq.NamedQubit('q0_0')
+    g = cirq.FrozenCircuit(cirq.X(q0), cirq.Y(q0), cirq.Z(q0))
+
+    # The outer circuit should then translate to this
+    q_0, q_1, q_2 = cirq.NamedQubit.range(3, prefix='q_')  # The outer qreg array
+    expected = cirq.Circuit(
+        # It is broadcast to all qubits in the qreg
+        cirq.CircuitOperation(g, qubit_map={q0: q_0}),
+        cirq.CircuitOperation(g, qubit_map={q0: q_1}),
+        cirq.CircuitOperation(g, qubit_map={q0: q_2}),
+    )
+
+    # Verify
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    parsed_qasm_decomposed = cirq.Circuit(cirq.decompose(parsed_qasm.circuit, preserve_structure=True))
+    assert parsed_qasm_decomposed == expected
+
+    # Sanity check that this unrolls to a valid circuit
+    unrolled_expected = cirq.Circuit(
+        cirq.X(q_0),
+        cirq.Y(q_0),
+        cirq.Z(q_0),
+        cirq.X(q_1),
+        cirq.Y(q_1),
+        cirq.Z(q_1),
+        cirq.X(q_2),
+        cirq.Y(q_2),
+        cirq.Z(q_2),
+    )
+    unrolled = cirq.align_left(cirq.unroll_circuit_op(parsed_qasm_decomposed, tags_to_check=None))
+    assert unrolled == unrolled_expected
+
+    # Sanity check that these have the same unitaries as the QASM.
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(unrolled))
+
+
+def test_qubit_in_non_global_scope_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { qubit[1] q; }
+     g q
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Qubits cannot be declared in non global scope at line 4",
+        qiskit_err='', # Qiskit bug errors but with no message?
+    )
+
+
+def test_old_style_qubit_in_non_global_scope_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { qreg q[1]; }
+     g q
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Qubits cannot be declared in non global scope at line 4",
+        qiskit_err='', # Qiskit bug errors but with no message?
+    )
+
+
+def test_custom_gate_undefined_qubit_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { x q1; }
+     g q
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Undefined register 'q1' at line 4",
+        qiskit_err='', # Qiskit bug?
+    )
+
+
+def test_custom_gate_qubit_scope_closure_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { x q; }
+     g q
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Undefined register 'q' at line 4",
+        qiskit_err='', # Qiskit bug?
+    )
+
+
+def test_custom_gate_qubit_index_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { x q0[0]; }
+     g q;
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Cannot index into qubit while defining a custom gate at line 4",
+        qiskit_err="4,19: only indexing (qu)bit arrays is supported, not \'qubit\'",
+    )
+
+
+def test_custom_gate_qreg_count_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[2];
+     gate g q0 { x q0; }
+     g q[0], q[1];
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="g only takes 1 arg(s) (qubits and/or registers), got: 2, at line 5",
+        qiskit_err="The amount of qubit(2)/clbit(0) arguments does not match the gate expectation (1).",
+    )
+
+
+def test_custom_gate_missing_param_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g(p) q0 { rx(p) q0; }
+     g q;
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Wrong number of params for 'g' at line 5",
+        qiskit_err="incorrect number of parameters in call. Expecting  1, got 0.",
+    )
+
+
+def test_custom_gate_extra_param_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { x q0; }
+     g(3) q;
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Wrong number of params for 'g' at line 5",
+        qiskit_err="incorrect number of parameters in call. Expecting  0, got 1.",
+    )
+
+
+def test_custom_gate_undefined_param_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     gate g q0 { rx(p) q0; }
+     g q;
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Undefined parameter 'p' in line 4",
+        qiskit_err="4,20: required an angle-like value",
+    )
+
+
+def test_custom_gate_not_in_global_scope_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     gate g q0 { gate a q1 { x q1;} }
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Custom gates cannot be defined in non global scope at line 3",
+        qiskit_err="L3:C17: gate definitions must be global",
+    )
+
+
+def test_top_level_param_error() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qreg q[1];
+     rx(p) q;
+    """
+    _test_parse_exception(
+        qasm,
+        cirq_err="Undefined parameter 'p' in line 4",
+        qiskit_err="4,8: required an angle-like value",
+    )
+
+
+def _test_parse_exception(qasm: str, cirq_err: str, qiskit_err: str | None):
+    parser = Qasm3Parser()
+    with pytest.raises(QasmException, match=re.escape(cirq_err)):
+        parser.parse(qasm)
+    pytest.importorskip("qiskit.qasm3")
+    import qiskit.qasm3
+
+    if qiskit_err is None:
+        qiskit.qasm3.loads(qasm)
+        return
+    with pytest.raises(Exception, match=re.escape(qiskit_err)):
+        qiskit.qasm3.loads(qasm)
+
+
+def test_nested_custom_gate_has_keyword_in_name() -> None:
+    qasm = """OPENQASM 3.0;
+     include "stdgates.inc";
+     qubit[1] q;
+     gate gateGate qb { x qb; }
+     gate qregGate() qa { gateGate qa; }
+     qregGate q;
+    """
+    qb = cirq.NamedQubit('qb_0')
+    inner = cirq.FrozenCircuit(cirq.X(qb))
+    qa = cirq.NamedQubit('qa_0')
+    middle = cirq.FrozenCircuit(cirq.CircuitOperation(inner, qubit_map={qb: qa}))
+    q_0 = cirq.NamedQubit('q_0')
+    expected = cirq.Circuit(cirq.CircuitOperation(middle, qubit_map={qa: q_0}))
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    parsed_qasm_decompose = cirq.Circuit(cirq.decompose(parsed_qasm.circuit, preserve_structure=True))
+    assert parsed_qasm_decompose == expected
+
+
+def test_crx_gate() -> None:
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qreg q[2];
+    crx(pi/7) q[0],q[1];
+    """
+    parser = Qasm3Parser()
+
+    q0, q1 = cirq.NamedQubit('q_0'), cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq.ControlledGate(cirq.rx(np.pi / 7)).on(q0, q1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_cry_gate() -> None:
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qreg q[2];
+    cry(pi/7) q[0],q[1];
+    """
+    parser = Qasm3Parser()
+
+    q0, q1 = cirq.NamedQubit('q_0'), cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq.ControlledGate(cirq.ry(np.pi / 7)).on(q0, q1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+def test_crz_gate() -> None:
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qreg q[2];
+    crz(pi/7) q[0],q[1];
+    """
+    parser = Qasm3Parser()
+
+    q0, q1 = cirq.NamedQubit('q_0'), cirq.NamedQubit('q_1')
+
+    expected_circuit = Circuit()
+    expected_circuit.append(cirq.ControlledGate(cirq.rz(np.pi / 7)).on(q0, q1))
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.std_gates_included
+
+    ct.assert_same_circuits(parsed_qasm.circuit, expected_circuit)
+    assert parsed_qasm.regs.qubits == {'q': 2}
+
+    cq.assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, cirq.unitary(expected_circuit))
+
+
+@pytest.mark.parametrize(
+    "qasm_gate,cirq_gate,num_params,num_args",
+    [
+        (name, stmt.cirq_gate, stmt.num_params, stmt.num_args)
+        for name, stmt in Qasm3Parser.std_gates.items()
+    ],
+)
+@pytest.mark.parametrize(
+    "theta,theta_str", [(np.pi / 4, "pi/4"), (np.pi / 2, "pi/2"), (np.pi, "pi")]
+)
+def test_all_qelib_gates_unitary_equivalence(
+    qasm_gate, cirq_gate, num_params, num_args, theta, theta_str
+):
+    thetas = [theta] * num_params
+    params_str = f"({','.join(theta_str for _ in range(num_params))})" if num_params else ""
+    qubit_names, qubits = [], []
+    for i in range(num_args):
+        qubit_names.append(f"q[{i}]")
+        qubits.append(cirq.NamedQubit(f"q_{i}"))
+    qasm = f"""
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qreg q[{num_args}];
+        {qasm_gate}{params_str} {','.join(qubit_names)};
+    """
+
+    parser = Qasm3Parser()
+    parsed_qasm = parser.parse(qasm)
+    if num_params:
+        gate = cirq_gate(thetas)
+    else:
+        gate = cirq_gate
+    expected = Circuit()
+    expected.append(gate.on(*qubits))
+    imported = list(parsed_qasm.circuit.all_operations())[0].gate
+    U_native = cirq.unitary(gate)
+    U_import = cirq.unitary(imported)
+    assert np.allclose(U_import, U_native, atol=1e-8)
+    assert parsed_qasm.regs.qubits == {'q': num_args}

--- a/cirq-core/cirq/contrib/qasm_import/qasm.py
+++ b/cirq-core/cirq/contrib/qasm_import/qasm.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cirq.contrib.qasm_import._parser import QasmParser
+from cirq.contrib.qasm_import._parser3 import Qasm3Parser
 
 if TYPE_CHECKING:
     import cirq
@@ -33,3 +34,16 @@ def circuit_from_qasm(qasm: str) -> cirq.Circuit:
     """
 
     return QasmParser().parse(qasm).circuit
+
+
+def circuit_from_qasm3(qasm: str) -> cirq.Circuit:
+    """Parses an OpenQASM 3.0 string to `cirq.Circuit`.
+
+    Args:
+        qasm: The OpenQASM string
+
+    Returns:
+        The parsed circuit
+    """
+
+    return Qasm3Parser().parse(qasm).circuit

--- a/cirq-core/cirq/testing/consistent_qasm.py
+++ b/cirq-core/cirq/testing/consistent_qasm.py
@@ -124,6 +124,24 @@ def assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, unitary) -> None:  #
     lin_alg_utils.assert_allclose_up_to_global_phase(unitary, qiskit_unitary, rtol=1e-8, atol=1e-8)
 
 
+def assert_qiskit_parsed_qasm3_consistent_with_unitary(qasm, unitary) -> None:  # pragma: no cover
+    try:
+        # We don't want to require qiskit as a dependency but
+        # if Qiskit is installed, test QASM output against it.
+        import qiskit
+        import qiskit.qasm3
+    except ImportError:
+        return
+
+    num_qubits = int(np.log2(len(unitary)))
+    qc = qiskit.qasm3.loads(qasm)
+    qc.remove_final_measurements()  # no measurements allowed
+    qiskit_unitary = qiskit.quantum_info.Operator(qc).data
+    qiskit_unitary = _reorder_indices_of_matrix(qiskit_unitary, list(reversed(range(num_qubits))))
+
+    lin_alg_utils.assert_allclose_up_to_global_phase(unitary, qiskit_unitary, rtol=1e-8, atol=1e-8)
+
+
 def _indent(*content: str) -> str:
     return '    ' + '\n'.join(content).replace('\n', '\n    ')
 


### PR DESCRIPTION
Added a parser for more of the qasm3 specification including:
- gphase gates
- ctrl gate modifiers
- parameterised gates

Other qasm3 parts of the qasm3 specification have been left out for now