### PR TITLE
Skip cirq pre-release if PR has ci/no-release label

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -35,15 +35,15 @@ jobs:
           envsubst < dev_tools/packaging/pypirc_template > $HOME/.pypirc
       - name: Build and publish
         run: |
-          CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
-          if [[ "${CIRQ_PRE_RELEASE_VERSION}" != *.dev* ]]; then
-            echo "Not a dev version"
-            exit 1
-          fi
           if ${{ contains(github.event.pull_request.labels.*.name, 'ci/no-release') }}; then
             echo "The PR has ci/no-release label - skipping the release"
             echo "### Skipped release due to ci/no-release label"  >> ${GITHUB_STEP_SUMMARY}
             exit 0
+          fi
+          CIRQ_PRE_RELEASE_VERSION=$(dev_tools/packaging/generate-dev-version-id.sh)
+          if [[ "${CIRQ_PRE_RELEASE_VERSION}" != *.dev* ]]; then
+            echo "Not a dev version"
+            exit 1
           fi
           echo "Building wheels for the dev version '${CIRQ_PRE_RELEASE_VERSION}'"
           THIS_DATE_EPOCH=$(git log -1 --pretty="%ct")


### PR DESCRIPTION
Intended for code formatting or trivial typos that do not warrant
creating a new Cirq pre-release on PyPI.
