### PR TITLE
Fix detection of the ci/no-release label in a push event

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,4 +1,4 @@
-name: Pre-release cirq to PyPi
+name: Pre-release cirq to PyPI
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   push_to_pypi:
     if: github.repository == 'quantumlib/Cirq'
-    name: Push to PyPi
+    name: Push to PyPI
     runs-on: ubuntu-22.04
     env:
       NAME: dev-release
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade setuptools wheel twine
-      - name: Create PYPI config file
+      - name: Create PyPI config file
         env:
           CIRQ_PYPI_TOKEN: ${{ secrets.CIRQ_PYPI_TOKEN }}
           CIRQ_TEST_PYPI_TOKEN: ${{ secrets.CIRQ_TEST_PYPI_TOKEN }}
@@ -38,7 +38,7 @@ jobs:
           if gh pr list --state=merged --search="${GITHUB_SHA}" --label=ci/no-release \
             --json=mergeCommit --jq=".[].mergeCommit.oid" | grep -q "${GITHUB_SHA}";
           then
-            echo "The PR has ci/no-release label - skipping the release"
+            echo "The PR has a ci/no-release label - skipping the release"
             echo "### Skipped release due to ci/no-release label"  >> ${GITHUB_STEP_SUMMARY}
             exit 0
           fi


### PR DESCRIPTION
The release-main workflow is triggered by "push" event which
does not carry `github.event.pull_request.labels`.
Here we use the GitHub CLI instead to lookup the PR from commit and
check if it has the "ci/no-release" label.
Note `gh pr list --search=COMMIT` may give several matches hence
the extra check with `grep "${GITHUB_SHA}"`.

Follow-up to #7915
