### PR TITLE
Fix detection of ci/no-release label in a push event

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -35,8 +35,10 @@ jobs:
           envsubst < dev_tools/packaging/pypirc_template > $HOME/.pypirc
       - name: Build and publish
         run: |
-          if gh pr list --state=merged --search="${GITHUB_SHA}" --label=ci/no-release \
-            --json=mergeCommit --jq=".[].mergeCommit.oid" | grep -q "${GITHUB_SHA}";
+          pr_number=$(git log -1 --pretty="%s" | sed -n -E "s/.*[(]#([0-9]+)[)]$/\1/p")
+          if (( pr_number )) &&
+            gh pr view --json=labels --jq=".labels[].name" "${pr_number}" |
+            grep -q -x ci/no-release;
           then
             echo "The PR has a ci/no-release label - skipping the release"
             echo "### Skipped release due to ci/no-release label"  >> ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
Problem: `gh pr list --state=merged` may not find the pull request
due to race condition at its push event time.

Solution: Extract pull request number from the commit subject and
look up its labels directly.

Follow-up to #7917
