### PR TITLE
CI - provide token for GitHub CLI used in the release workflow

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           envsubst < dev_tools/packaging/pypirc_template > $HOME/.pypirc
       - name: Build and publish
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           pr_number=$(git log -1 --pretty="%s" | sed -n -E "s/.*[(]#([0-9]+)[)]$/\1/p")
           if (( pr_number )) &&


### PR DESCRIPTION
This is required for querying the repo on GitHub.

Follow-up to #7927
