### PR TITLE
Add pytest-benchmark to development requirements

### DIFF
--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -2,6 +2,7 @@
 
 pytest
 pytest-asyncio
+pytest-benchmark
 pytest-cov
 pytest-randomly
 coverage~=7.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ ignore_missing_imports = true
 
 
 [tool.pytest.ini_options]
+addopts = ["--benchmark-disable"]
 filterwarnings = [
     "ignore:Matplotlib is currently using agg:UserWarning",
     "ignore:FigureCanvasAgg is non-interactive.*cannot be shown:UserWarning",


### PR DESCRIPTION
Disable execution of benchmarks by default.

Related to #7796
