### PR TITLE
Fix return order in the docstring of two_qubit_matrix_to_diagonal_and_cz_operations

### DIFF
--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_cz.py
@@ -110,7 +110,7 @@ def two_qubit_matrix_to_diagonal_and_cz_operations(
         clean_operations: Enables optimizing resulting operation list by
             merging operations and ejecting phased Paulis and Z operations.
     Returns:
-        tuple(ops,D): operations `ops`, and the diagonal `D`
+        A tuple `(D, ops)` where `D` is the diagonal matrix and `ops` the list of operations.
     """
     if predicates.is_diagonal(mat, atol=atol):
         return mat, []


### PR DESCRIPTION
Thanks to @guillembrasco-sudo for finding this.
