### PR TITLE
Micro optimization: avoid recompiling regex in `incremental_coverage.py`

### DIFF
--- a/dev_tools/incremental_coverage.py
+++ b/dev_tools/incremental_coverage.py
@@ -281,9 +281,7 @@ def is_applicable_python_file(rel_path: str) -> bool:
     Returns:
         Whether to include the file.
     """
-    return rel_path.endswith('.py') and not any(
-        pat.search(rel_path) for pat in IGNORED_FILE_RE
-    )
+    return rel_path.endswith('.py') and not any(pat.search(rel_path) for pat in IGNORED_FILE_RE)
 
 
 def check_for_uncovered_lines(env: env_tools.PreparedEnv) -> int:


### PR DESCRIPTION
The function `determine_ignored_lines()` in `dev_tools/incremental_coverage.py` compiled a regex. Compiling regex inside a function that is potentially called multiple times adds unnecessary overhead. This PR pre-compiles some regex patterns at the module level in `dev_tools/incremental_coverage.py` to avoid redundant compilation.

In simple wall-clock timings on a linux VM, running `dev_tools/pytest-and-incremental-coverage`, I get an average of about 10% time improvement over the unmodified version of the file.

(Full disclosure: this was largely the work of Jules, which I've experimenting with.)