### PR TITLE
Mark slow benchmarks to shorten overall runtime

### DIFF
--- a/benchmarks/serialization_perf.py
+++ b/benchmarks/serialization_perf.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterable
+
 import pytest
 
 import cirq
@@ -30,6 +32,16 @@ PARAMETERS = (
 )
 
 
+def _mark_slow(parameters: Iterable[tuple], slow_parameters: set[tuple]) -> list[tuple]:
+    parameter_list = list(parameters)
+    if not slow_parameters.issubset(parameter_list):
+        raise ValueError("Unmatched values in slow_parameters")
+    return [
+        (pytest.param(*p, marks=pytest.mark.slow) if p in slow_parameters else p)
+        for p in parameter_list
+    ]
+
+
 def _make_circuit(num_qubits: int, num_moments: int) -> cirq.Circuit:
     qubits = cirq.LineQubit.range(num_qubits)
     one_q_x_moment = cirq.Moment(cirq.X(q) for q in qubits[::2])
@@ -46,7 +58,7 @@ def _make_circuit(num_qubits: int, num_moments: int) -> cirq.Circuit:
 
 @pytest.mark.parametrize(
     ["num_qubits", "num_moments", "_expected_gzip_size"],
-    PARAMETERS,
+    _mark_slow(PARAMETERS, {(500, 4000, 5918482), (1000, 1000, 2853094), (1000, 4000, 11412197)}),
     ids=[f"{nq}-{nm}" for nq, nm, _ in PARAMETERS],
 )
 @pytest.mark.benchmark(group="serialization")
@@ -60,7 +72,7 @@ def test_json_serialization(
 
 @pytest.mark.parametrize(
     ["num_qubits", "num_moments", "expected_gzip_size"],
-    PARAMETERS,
+    _mark_slow(PARAMETERS, {(500, 4000, 5918482), (1000, 1000, 2853094), (1000, 4000, 11412197)}),
     ids=[f"{nq}-{nm}" for nq, nm, _ in PARAMETERS],
 )
 @pytest.mark.benchmark(group="serialization")

--- a/benchmarks/transformers/routing_perf.py
+++ b/benchmarks/transformers/routing_perf.py
@@ -15,6 +15,7 @@
 """Performance tests for circuit qubit routing."""
 
 import itertools
+from collections.abc import Iterable
 from typing import Final
 
 import pytest
@@ -22,8 +23,31 @@ import pytest
 import cirq
 
 
+def _mark_slow(parameters: Iterable[tuple], slow_parameters: set[tuple]) -> list[tuple]:
+    parameter_list = list(parameters)
+    if not slow_parameters.issubset(parameter_list):
+        raise ValueError("Unmatched values in slow_parameters")
+    return [
+        (pytest.param(*p, marks=pytest.mark.slow) if p in slow_parameters else p)
+        for p in parameter_list
+    ]
+
+
 @pytest.mark.parametrize(
-    ["qubits", "depth"], itertools.product([10, 25, 50, 75, 100], [10, 50, 100, 250, 500, 1000])
+    ["qubits", "depth"],
+    _mark_slow(
+        itertools.product([10, 25, 50, 75, 100], [10, 50, 100, 250, 500, 1000]),
+        {
+            (50, 1000),
+            (75, 250),
+            (75, 500),
+            (75, 1000),
+            (100, 100),
+            (100, 250),
+            (100, 500),
+            (100, 1000),
+        },
+    ),
 )
 @pytest.mark.benchmark(group="circuit_routing", max_time=10)
 def test_circuit_routing(benchmark, qubits: int, depth: int) -> None:

--- a/benchmarks/transformers/transformer_primitives_perf.py
+++ b/benchmarks/transformers/transformer_primitives_perf.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterable
+
 import pytest
 
 import cirq
@@ -30,6 +32,16 @@ PARAMETERS = (
 )
 
 
+def _mark_slow(parameters: Iterable[tuple], slow_parameters: set[tuple]) -> list[tuple]:
+    parameter_list = list(parameters)
+    if not slow_parameters.issubset(parameter_list):
+        raise ValueError("Unmatched values in slow_parameters")
+    return [
+        (pytest.param(*p, marks=pytest.mark.slow) if p in slow_parameters else p)
+        for p in parameter_list
+    ]
+
+
 def _make_circuit(num_qubits: int, num_moments: int) -> cirq.Circuit:
     qubits = cirq.LineQubit.range(num_qubits)
     one_q_x_moment = cirq.Moment(cirq.X(q) for q in qubits[::2])
@@ -42,7 +54,9 @@ def _make_circuit(num_qubits: int, num_moments: int) -> cirq.Circuit:
     return circuit
 
 
-@pytest.mark.parametrize(["num_qubits", "num_moments"], PARAMETERS)
+@pytest.mark.parametrize(
+    ["num_qubits", "num_moments"], _mark_slow(PARAMETERS, {(1000, 4000), (500, 4000)})
+)
 @pytest.mark.benchmark(group="transformer_primitives")
 def test_map_moments(benchmark, num_qubits: int, num_moments: int) -> None:
     circuit = _make_circuit(num_qubits, num_moments)
@@ -58,7 +72,7 @@ def test_map_moments(benchmark, num_qubits: int, num_moments: int) -> None:
     benchmark(cirq.map_moments, circuit=circuit, map_func=map_func)
 
 
-@pytest.mark.parametrize(["num_qubits", "num_moments"], PARAMETERS)
+@pytest.mark.parametrize(["num_qubits", "num_moments"], _mark_slow(PARAMETERS, {(1000, 4000)}))
 @pytest.mark.benchmark(group="transformer_primitives")
 def test_map_operations_apply_tag(benchmark, num_qubits: int, num_moments: int) -> None:
     circuit = _make_circuit(num_qubits, num_moments)
@@ -69,7 +83,10 @@ def test_map_operations_apply_tag(benchmark, num_qubits: int, num_moments: int) 
     benchmark(cirq.map_operations, circuit=circuit, map_func=map_func)
 
 
-@pytest.mark.parametrize(["num_qubits", "num_moments"], PARAMETERS)
+@pytest.mark.parametrize(
+    ["num_qubits", "num_moments"],
+    _mark_slow(PARAMETERS, {(100, 4000), (500, 1000), (500, 4000), (1000, 1000), (1000, 4000)}),
+)
 @pytest.mark.benchmark(group="transformer_primitives")
 def test_map_operations_to_optree(benchmark, num_qubits: int, num_moments: int) -> None:
     circuit = _make_circuit(num_qubits, num_moments)
@@ -80,7 +97,7 @@ def test_map_operations_to_optree(benchmark, num_qubits: int, num_moments: int) 
     benchmark(cirq.map_operations, circuit=circuit, map_func=map_func)
 
 
-@pytest.mark.parametrize(["num_qubits", "num_moments"], PARAMETERS)
+@pytest.mark.parametrize(["num_qubits", "num_moments"], _mark_slow(PARAMETERS, {(1000, 4000)}))
 @pytest.mark.benchmark(group="transformer_primitives")
 def test_map_operations_to_optree_and_unroll(benchmark, num_qubits: int, num_moments: int) -> None:
     circuit = _make_circuit(num_qubits, num_moments)


### PR DESCRIPTION
Apply slow test marker to expensive benchmarks to fit the
overall runtime to ~30 minutes on cloud Linux box.

Partially implements #7796
