### PR TITLE
Fix #7941: Add __hash__ to UniformSuperpositionGate to prevent TypeError

### DIFF
--- a/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
+++ b/cirq-core/cirq/neutral_atoms/convert_to_neutral_atom_gates_test.py
@@ -49,3 +49,10 @@ def test_gateset(op: cirq.Operation, expected: bool) -> None:
     assert cirq.is_native_neutral_atom_op(op) == expected
     if op.gate is not None:
         assert cirq.is_native_neutral_atom_gate(op.gate) == expected
+
+
+def test_is_native_neutral_atom_gate_unhashable_gate() -> None:
+    # Regression test for https://github.com/quantumlib/Cirq/issues/7941
+    # UniformSuperpositionGate previously raised TypeError due to missing __hash__
+    gate = cirq.UniformSuperpositionGate(m_value=3, num_qubits=2)
+    assert cirq.is_native_neutral_atom_gate(gate) is False

--- a/cirq-core/cirq/ops/uniform_superposition_gate.py
+++ b/cirq-core/cirq/ops/uniform_superposition_gate.py
@@ -113,6 +113,9 @@ class UniformSuperpositionGate(raw_types.Gate):
             return (self._m_value == other._m_value) and (self._num_qubits == other._num_qubits)
         return False
 
+    def __hash__(self) -> int:
+        return hash((self._m_value, self._num_qubits))
+
     def __repr__(self) -> str:
         return f'UniformSuperpositionGate(m_value={self._m_value}, num_qubits={self._num_qubits})'
 

--- a/cirq-core/cirq/ops/uniform_superposition_gate_test.py
+++ b/cirq-core/cirq/ops/uniform_superposition_gate_test.py
@@ -95,3 +95,12 @@ def test_eq(m: int, n: int) -> None:
     assert a.__eq__(b)
     assert not (a.__eq__(c))
     assert not (a.__eq__(d))
+
+
+def test_hash() -> None:
+    a = cirq.UniformSuperpositionGate(5, 3)
+    b = cirq.UniformSuperpositionGate(5, 3)
+    c = cirq.UniformSuperpositionGate(6, 3)
+    assert hash(a) == hash(b)
+    assert hash(a) != hash(c)
+    assert {a, b} == {a}  # usable in sets


### PR DESCRIPTION
## Summary

Fixes #7941.

`UniformSuperpositionGate` defined `__eq__` but not `__hash__`, making instances unhashable. This caused `is_native_neutral_atom_gate` to crash with `TypeError` when checking gates against the native gate set (which uses `in` on a frozenset).

## Changes

- Added `__hash__` to `UniformSuperpositionGate` using `(m_value, num_qubits)` tuple
- Added hash consistency test in `uniform_superposition_gate_test.py`
- Added regression test in `convert_to_neutral_atom_gates_test.py` reproducing the original crash

## Test Plan

- New test `test_hash` verifies equal gates hash equal and different gates hash different
- New test `test_is_native_neutral_atom_gate_unhashable_gate` reproduces the original TypeError and verifies it returns False instead of crashing

---

> This PR was created with AI assistance using [Claude Code](https://claude.ai/code).
> The implementation was reviewed for correctness before submission.
> If anything needs adjustment, please leave a review comment and I'll address it promptly.