### PR TITLE
Improve the check/all testing script

### DIFF
--- a/check/all
+++ b/check/all
@@ -31,7 +31,6 @@ die() {
     exit "$1"
 }
 
-
 # Get the working directory to the repo root -----------------------------------
 
 thisdir=$(dirname "${BASH_SOURCE[0]:?}")


### PR DESCRIPTION
* include the `ruff check` linter check
* add option `--fix` to apply corrections from both `ruff` and `black`
* add option `--changed` as a shorter alias for `--only-changed-files`
* support `-h, --help` to show usage info
* improve parsing of the BASE_REV revision argument
* skip check/doctest in the only-changed-files mode to make it fast
* rewrite in a similar way as in quantumlib/OpenFermion,
  ref: https://github.com/quantumlib/OpenFermion/pull/1146

Follow-up to #7951
