### PR TITLE
Make parallel_xeb.parallel_two_qubit_xeb reproducible w/r to randomly_seed

### DIFF
--- a/cirq-core/cirq/experiments/benchmarking/parallel_xeb.py
+++ b/cirq-core/cirq/experiments/benchmarking/parallel_xeb.py
@@ -579,9 +579,8 @@ def parallel_xeb_workflow(
     Raises:
         ValueError: If qubits are not specified and the sampler has no device.
     """
-    if rng is None:
-        rng = np.random.default_rng()
-    rs = np.random.RandomState(rng.integers(0, 10**9))
+    seed = np.random.randint(0, 10**9) if rng is None else rng.integers(0, 10**9)
+    rs = np.random.RandomState(seed)
 
     pairs = _extract_pairs(sampler, target, qubits, pairs)
     graph = nx.Graph(pairs)


### PR DESCRIPTION
The `test_parallel_two_qubit_xeb_with_device` has flaky failures, e.g.,
https://github.com/quantumlib/Cirq/actions/runs/23392166114.

Here we make it use default RandomState which depends on the
`randomly_seed` value from pytest-randomly so that failed
test runs can be reproduced.
