### PR TITLE
Add workflow for labeling issues

### DIFF
--- a/.github/workflows/issue-labeler.yaml
+++ b/.github/workflows/issue-labeler.yaml
@@ -49,7 +49,7 @@ jobs:
         env:
           GH_TOKEN: '${{secrets.GITHUB_TOKEN}}'
           SHELLOPTS: ${{inputs.debug && 'xtrace' || '' }}
+          ISSUE_NUMBER: ${{inputs.issue-number || github.event.issue.number}}
         run: |
-          gh issue edit "${{inputs.issue-number || github.event.issue.number}}" \
-            --repo "${{github.repository}}" \
+          gh issue edit "${ISSUE_NUMBER}" --repo "${{github.repository}}" \
             --add-label "triage/discuss"


### PR DESCRIPTION
This introduces a workflow to help with triaging issues. This initial version adds `triage/discuss` to new issues so that we don't have to remember to do it before the biweekly Cirq Cynqs. In the future, we may think of other labels to add, perhaps with the help of actions such as [auto-label](https://github.com/marketplace/actions/auto-label) and [Advanced Issue Labeler](https://github.com/marketplace/actions/advanced-issue-labeler).