### PR TITLE
Remove obsolete code for handling quimb-1.2

### DIFF
--- a/cirq-core/cirq/contrib/quimb/state_vector.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Sequence
 from typing import cast, TYPE_CHECKING
 
@@ -13,21 +12,6 @@ import cirq
 
 if TYPE_CHECKING:
     import numpy as np
-
-
-def _get_quimb_version():
-    """Returns the quimb version and parsed (major,minor) numbers if possible.
-    Returns:
-        a tuple of ((major, minor), version string)
-    """
-    version = quimb.__version__
-    try:
-        return tuple(int(x) for x in version.split('.')), version
-    except ValueError:
-        return (0, 0), version
-
-
-QUIMB_VERSION = _get_quimb_version()
 
 
 def circuit_to_tensors(
@@ -163,15 +147,7 @@ def tensor_expectation_value(
         for q in qubits
     ]
     tn = qtn.TensorNetwork(tensors + end_bras)
-    if QUIMB_VERSION[0] < (1, 3):
-        warnings.warn(  # pragma: no cover
-            f'quimb version {QUIMB_VERSION[1]} detected. Please use '
-            f'quimb>=1.3 for optimal performance in '
-            '`tensor_expectation_value`. '
-            'See https://github.com/quantumlib/Cirq/issues/3263'
-        )
-    else:
-        tn.rank_simplify(inplace=True)
+    tn.rank_simplify(inplace=True)
     path_info = tn.contract(get='path-info')
     ram_gb = path_info.largest_intermediate * 128 / 8 / 1024 / 1024 / 1024
     if ram_gb > max_ram_gb:

--- a/cirq-core/cirq/contrib/quimb/state_vector_test.py
+++ b/cirq-core/cirq/contrib/quimb/state_vector_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import functools
 import operator
-from unittest import mock
 
 import numpy as np
 import pytest
@@ -157,9 +156,3 @@ def test_too_much_ram() -> None:
         ccq.tensor_expectation_value(circuit=circuit, pauli_string=op)
 
     assert e.match(r'.*too much RAM!.*')
-
-
-def test_get_quimb_version_unparseable() -> None:
-    pytest.importorskip('quimb')
-    with mock.patch('quimb.__version__', 'unknown'):
-        assert ccq.state_vector._get_quimb_version() == ((0, 0), 'unknown')

--- a/cirq-core/cirq/contrib/requirements.txt
+++ b/cirq-core/cirq/contrib/requirements.txt
@@ -4,5 +4,5 @@ ply>=3.6
 pylatex~=1.4
 
 # quimb
-quimb>=1.8
+quimb~=1.8
 opt_einsum


### PR DESCRIPTION
quimb is already required to be version 1.8 or later.
Clean up unnecessary parsing of quimb version.
Since we are at it let us pin the major quimb version too.

Follow-up to #7987
