### PR TITLE
Add texlive-latex-extra to required system packages

### DIFF
--- a/.github/workflows/ci-monitoring.yml
+++ b/.github/workflows/ci-monitoring.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install latexmk texlive-latex-base texlive-latex-extra
+          sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
           pip install --upgrade setuptools wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install latexmk texlive-latex-base texlive-latex-extra
+          sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install changed files test dependencies
         run: dev_tools/conf/pip-install-minimal-for-pytest-changed-files.sh
       - name: Changed files test
@@ -215,7 +215,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install latexmk texlive-latex-base texlive-latex-extra
+          sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
           pip install --upgrade setuptools wheel
@@ -279,7 +279,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install latexmk texlive-latex-base texlive-latex-extra
+          sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
           pip install --upgrade setuptools wheel

--- a/apt-system-requirements.txt
+++ b/apt-system-requirements.txt
@@ -1,3 +1,3 @@
-texlive-latex-base
 latexmk
 python3-tk
+texlive-latex-extra


### PR DESCRIPTION
Provide LaTeX packages used by circuit rendering functions
in cirq.contrib.  Also use apt-system-requirements.txt as
the SOT for packages to be installed for CI tests.

Fixes #8013
