### PR TITLE
Address mypy complaint showing for typedunits-0.0.2

### DIFF
--- a/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit.py
+++ b/cirq-google/cirq_google/experimental/analog_experiments/generic_analog_circuit.py
@@ -198,7 +198,7 @@ class AnalogSimulationCircuitBuilder:
         """
 
         # resolve the idles
-        idle_freq_map_resolved = (
+        idle_freq_map_resolved: dict[cirq.Qid, tu.Value] = (
             dict.fromkeys(self.trajectory.qubits, 0 * tu.GHz)
             if idle_freq_map is None
             else idle_freq_map


### PR DESCRIPTION
For some reason the argument of `get_full_trajectory_with_resolved_idles`
needs an extra typing hint to be recognized as a compatible type.
