### PR TITLE
CI - ensure concurrency group name is unique

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - checks_requested
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 # Declare default permissions as read only.


### PR DESCRIPTION
In GitHub Actions the concurrency group name is effective for
all workflows in the project.  Here we prepend workflow name
to the concurrency group for the "Continuous Integration"
so it cannot accidentally conflict with other workflows.

Ref: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
