### PR TITLE
All multi-circuit programs to be batched in the same request in Engine.

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_processor.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import abc
 import datetime
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 import duet
@@ -126,7 +127,11 @@ class AbstractProcessor(abc.ABC):
     @abc.abstractmethod
     async def run_sweep_async(
         self,
-        program: cirq.AbstractCircuit,
+        program: (
+            cirq.AbstractCircuit
+            | Sequence[cirq.AbstractCircuit]
+            | Mapping[str, cirq.AbstractCircuit]
+        ),
         *,
         device_config_name: str,
         run_name: str = "",

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -29,6 +29,7 @@ import datetime
 import enum
 import random
 import string
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, TypeVar
 
 import duet
@@ -46,7 +47,7 @@ from cirq_google.engine import (
     processor_config,
     util,
 )
-from cirq_google.serialization import CIRCUIT_SERIALIZER, Serializer
+from cirq_google.serialization import CIRCUIT_SERIALIZER, CircuitSerializer
 
 if TYPE_CHECKING:
     from google.protobuf import any_pb2
@@ -87,7 +88,7 @@ class EngineContext:
         verbose: bool | None = None,
         client: engine_client.EngineClient | None = None,
         timeout: int | None = None,
-        serializer: Serializer = CIRCUIT_SERIALIZER,
+        serializer: CircuitSerializer = CIRCUIT_SERIALIZER,
         # TODO(#5996) Remove enable_streaming once the feature is stable.
         enable_streaming: bool = True,
         compress_run_context: bool = False,
@@ -144,6 +145,22 @@ class EngineContext:
         if self.proto_version != ProtoVersion.V2:
             raise ValueError(f'invalid program proto version: {self.proto_version}')
         return util.pack_any(self.serializer.serialize(program))
+
+    def _serialize_multi_program(
+        self, programs: Sequence[cirq.AbstractCircuit] | Mapping[str, cirq.AbstractCircuit]
+    ) -> any_pb2.Any:
+        if isinstance(programs, Mapping):
+            if any(not isinstance(value, cirq.AbstractCircuit) for value in programs.values()):
+                raise TypeError(f'Unrecognized program type: {type(programs)}')
+        if isinstance(programs, Sequence):
+            if any(not isinstance(value, cirq.AbstractCircuit) for value in programs):
+                raise TypeError(f'Unrecognized program type: {type(programs)}')
+        else:
+            raise TypeError(f'Unrecognized program type: {type(programs)}')
+
+        if self.proto_version != ProtoVersion.V2:
+            raise ValueError(f'invalid program proto version: {self.proto_version}')
+        return util.pack_any(self.serializer.serialize_multi_program(programs))
 
     def _serialize_run_context(self, sweeps: cirq.Sweepable, repetitions: int) -> any_pb2.Any:
         if self.proto_version != ProtoVersion.V2:
@@ -306,7 +323,11 @@ class Engine(abstract_engine.AbstractEngine):
 
     async def run_sweep_async(
         self,
-        program: cirq.AbstractCircuit,
+        program: (
+            cirq.AbstractCircuit
+            | Sequence[cirq.AbstractCircuit]
+            | Mapping[str, cirq.AbstractCircuit]
+        ),
         processor_id: str,
         program_id: str | None = None,
         job_id: str | None = None,
@@ -329,6 +350,8 @@ class Engine(abstract_engine.AbstractEngine):
         Args:
             program: The Circuit to execute. If a circuit is
                 provided, a moment by moment schedule will be used.
+                A list or mapping of programs can also be provided.
+                These will be executed as KeyedCircuits.
             program_id: A user-provided identifier for the program. This must
                 be unique within the Google Cloud project being used. If this
                 parameter is not provided, a random id of the format
@@ -375,12 +398,17 @@ class Engine(abstract_engine.AbstractEngine):
                 job_id = _make_random_id('job-')
             run_context = self.context._serialize_run_context(params, repetitions)
 
+            if isinstance(program, cirq.AbstractCircuit):
+                code = self.context._serialize_program(program)
+            else:
+                code = self.context._serialize_multi_program(program)
+
             job_result_future = self.context.client.run_job_over_stream(
                 project_id=self.project_id,
                 program_id=str(program_id),
                 program_description=program_description,
                 program_labels=program_labels,
-                code=self.context._serialize_program(program),
+                code=code,
                 job_id=str(job_id),
                 run_context=run_context,
                 job_description=job_description,
@@ -417,7 +445,11 @@ class Engine(abstract_engine.AbstractEngine):
 
     async def create_program_async(
         self,
-        program: cirq.AbstractCircuit,
+        program: (
+            cirq.AbstractCircuit
+            | Sequence[cirq.AbstractCircuit]
+            | Mapping[str, cirq.AbstractCircuit]
+        ),
         program_id: str | None = None,
         description: str | None = None,
         labels: dict[str, str] | None = None,
@@ -443,12 +475,13 @@ class Engine(abstract_engine.AbstractEngine):
         if not program_id:
             program_id = _make_random_id('prog-')
 
+        if isinstance(program, cirq.AbstractCircuit):
+            code = self.context._serialize_program(program)
+        else:
+            code = self.context._serialize_multi_program(program)
+
         new_program_id, new_program = await self.context.client.create_program_async(
-            self.project_id,
-            program_id,
-            code=self.context._serialize_program(program),
-            description=description,
-            labels=labels,
+            self.project_id, program_id, code=code, description=description, labels=labels
         )
 
         return engine_program.EngineProgram(

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -152,7 +152,7 @@ class EngineContext:
         if isinstance(programs, Mapping):
             if any(not isinstance(value, cirq.AbstractCircuit) for value in programs.values()):
                 raise TypeError(f'Unrecognized program type: {type(programs)}')
-        if isinstance(programs, Sequence):
+        elif isinstance(programs, Sequence):
             if any(not isinstance(value, cirq.AbstractCircuit) for value in programs):
                 raise TypeError(f'Unrecognized program type: {type(programs)}')
         else:

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import datetime
+from collections.abc import Mapping, Sequence
 from typing import Any, TYPE_CHECKING
 
 from cirq import _compat
@@ -155,7 +156,11 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
 
     async def run_sweep_async(
         self,
-        program: cirq.AbstractCircuit,
+        program: (
+            cirq.AbstractCircuit
+            | Sequence[cirq.AbstractCircuit]
+            | Mapping[str, cirq.AbstractCircuit]
+        ),
         *,
         device_config_name: str,
         run_name: str = "",
@@ -177,6 +182,8 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         Args:
             program: The Circuit to execute. If a circuit is
                 provided, a moment by moment schedule will be used.
+                A list or mapping of circuits can also be provided.  If so,
+                it will be executed as a KeyedCircuit.
             run_name: A unique identifier representing an automation run for the
                 processor. An Automation Run contains a collection of device
                 configurations for the processor.

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -1151,3 +1151,43 @@ def test_list_processor_configs_from_snapshot(list_processor_configs_async):
         ('test_config_1', processor_id, '', snapshot.id),
         ('test_config_2', processor_id, '', snapshot.id),
     ]
+
+
+def test_engine_context_serialize_multi_program_errors():
+    context = EngineContext()
+
+    # Mapping with non-circuits
+    with pytest.raises(TypeError, match='Unrecognized program type'):
+        context._serialize_multi_program({'a': 'not a circuit'})
+
+    # Sequence with non-circuits
+    with pytest.raises(TypeError, match='Unrecognized program type'):
+        context._serialize_multi_program(['not a circuit'])
+
+    # Invalid type
+    with pytest.raises(TypeError, match='Unrecognized program type'):
+        context._serialize_multi_program(123)
+
+    # invalid proto version
+    # Note: ProtoVersion.V1 is blocked in __init__, but UNDEFINED is not.
+    context.proto_version = cg.engine.engine.ProtoVersion.UNDEFINED
+    with pytest.raises(ValueError, match='invalid program proto version'):
+        context._serialize_multi_program([_CIRCUIT])
+
+
+def test_engine_context_serialize_multi_program_success():
+    context = EngineContext()
+    # success
+    # This should not raise
+    context._serialize_multi_program([_CIRCUIT])
+    context._serialize_multi_program({'a': _CIRCUIT})
+
+
+@mock.patch('cirq_google.engine.engine_client.EngineClient', autospec=True)
+def test_engine_create_program_multi(client_mock):
+    client_mock().create_program_async.return_value = ('prog', quantum.QuantumProgram())
+    engine = cg.Engine(project_id='proj')
+
+    # program is not AbstractCircuit (it's a list)
+    engine.create_program([_CIRCUIT], 'prog')
+    client_mock().create_program_async.assert_called_once()

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -114,7 +114,7 @@ class ProcessorSampler(cirq.Sampler):
             params_list, repetitions = self._normalize_batch_args(
                 prog_values, params_list, repetitions
             )
-            # Batch programs that have the same number of repetitions.
+            # Batch programs that have the same number of repetitions and same sweep.
             program_batches = []
             params_list_batches = []
             repetition_batches = []
@@ -122,27 +122,36 @@ class ProcessorSampler(cirq.Sampler):
             i = 0
             while i < len(prog_values):
                 batch_reps = repetitions[i]
+                batch_sweep = params_list[i]
                 batch_programs = {prog_keys[i]: prog_values[i]} if prog_keys else [prog_values[i]]
-                batch_params = [params_list[i]]
                 i += 1
                 while (
                     i < len(prog_values)
                     and len(batch_programs) < self._jobs_per_batch
                     and repetitions[i] == batch_reps
+                    and params_list[i] == batch_sweep
                 ):
                     if isinstance(batch_programs, dict):
                         batch_programs[prog_keys[i]] = prog_values[i]
                     else:
                         batch_programs.append(prog_values[i])
-                    batch_params.append(params_list[i])
                     i += 1
                 program_batches.append(batch_programs)
-                params_list_batches.append(batch_params)
+                params_list_batches.append(batch_sweep)
                 repetition_batches.append(batch_reps)
 
-            return await duet.pstarmap_async(
+            all_batch_results = await duet.pstarmap_async(
                 self.run_sweep_async, zip(program_batches, params_list_batches, repetition_batches)
             )
+            final_results = []
+            for batch_res, batch_progs in zip(all_batch_results, program_batches):
+                num_progs = len(batch_progs)
+                for j in range(num_progs):
+                    # Engine returns results grouped by sweep then by program.
+                    # e.g. (S1, P1), (S1, P2), (S2, P1), (S2, P2)
+                    # So P1's results are at indices 0, 2, ...
+                    final_results.append(batch_res[j::num_progs])
+            return final_results
 
         prog_values = list(programs.values()) if isinstance(programs, Mapping) else list(programs)
         return cast(

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -105,27 +105,24 @@ class ProcessorSampler(cirq.Sampler):
         repetitions: int | Sequence[int] = 1,
     ) -> Sequence[Sequence[cg.EngineResult]]:
         if self._jobs_per_batch > 1:
+            # Treat programs as a sequence for iteration, but keep keys if it's a mapping
+            prog_keys = list(programs.keys()) if isinstance(programs, Mapping) else []
+            prog_values = (
+                list(programs.values()) if isinstance(programs, Mapping) else list(programs)
+            )
+
             params_list, repetitions = self._normalize_batch_args(
-                programs, params_list, repetitions
+                prog_values, params_list, repetitions
             )
             # Batch programs that have the same number of repetitions.
             program_batches = []
             params_list_batches = []
             repetition_batches = []
 
-            # Treat programs as a sequence for iteration, but keep keys if it's a mapping
-            prog_keys = list(programs.keys()) if isinstance(programs, Mapping) else None
-            prog_values = (
-                list(programs.values()) if isinstance(programs, Mapping) else list(programs)
-            )
-
             i = 0
             while i < len(prog_values):
                 batch_reps = repetitions[i]
-                if prog_keys is not None:
-                    batch_programs = {prog_keys[i]: prog_values[i]}
-                else:
-                    batch_programs = [prog_values[i]]
+                batch_programs = {prog_keys[i]: prog_values[i]} if prog_keys else [prog_values[i]]
                 batch_params = [params_list[i]]
                 i += 1
                 while (
@@ -133,7 +130,7 @@ class ProcessorSampler(cirq.Sampler):
                     and len(batch_programs) < self._jobs_per_batch
                     and repetitions[i] == batch_reps
                 ):
-                    if prog_keys is not None:
+                    if isinstance(batch_programs, dict):
                         batch_programs[prog_keys[i]] = prog_values[i]
                     else:
                         batch_programs.append(prog_values[i])

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -100,7 +100,7 @@ class ProcessorSampler(cirq.Sampler):
 
     async def run_batch_async(
         self,
-        programs: Sequence[cirq.AbstractCircuit],
+        programs: Sequence[cirq.AbstractCircuit] | Mapping[str, cirq.AbstractCircuit],
         params_list: Sequence[cirq.Sweepable] | None = None,
         repetitions: int | Sequence[int] = 1,
     ) -> Sequence[Sequence[cg.EngineResult]]:
@@ -113,18 +113,30 @@ class ProcessorSampler(cirq.Sampler):
             params_list_batches = []
             repetition_batches = []
 
+            # Treat programs as a sequence for iteration, but keep keys if it's a mapping
+            prog_keys = list(programs.keys()) if isinstance(programs, Mapping) else None
+            prog_values = (
+                list(programs.values()) if isinstance(programs, Mapping) else list(programs)
+            )
+
             i = 0
-            while i < len(programs):
+            while i < len(prog_values):
                 batch_reps = repetitions[i]
-                batch_programs = [programs[i]]
+                if prog_keys is not None:
+                    batch_programs = {prog_keys[i]: prog_values[i]}
+                else:
+                    batch_programs = [prog_values[i]]
                 batch_params = [params_list[i]]
                 i += 1
                 while (
-                    i < len(programs)
+                    i < len(prog_values)
                     and len(batch_programs) < self._jobs_per_batch
                     and repetitions[i] == batch_reps
                 ):
-                    batch_programs.append(programs[i])
+                    if prog_keys is not None:
+                        batch_programs[prog_keys[i]] = prog_values[i]
+                    else:
+                        batch_programs.append(prog_values[i])
                     batch_params.append(params_list[i])
                     i += 1
                 program_batches.append(batch_programs)
@@ -135,9 +147,10 @@ class ProcessorSampler(cirq.Sampler):
                 self.run_sweep_async, zip(program_batches, params_list_batches, repetition_batches)
             )
 
+        prog_values = list(programs.values()) if isinstance(programs, Mapping) else list(programs)
         return cast(
             Sequence[Sequence['cg.EngineResult']],
-            await super().run_batch_async(programs, params_list, repetitions),
+            await super().run_batch_async(prog_values, params_list, repetitions),
         )
 
     run_batch = duet.sync(run_batch_async)

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import cast, TYPE_CHECKING
 
 import duet
@@ -36,6 +36,7 @@ class ProcessorSampler(cirq.Sampler):
         snapshot_id: str = "",
         device_config_name: str = "",
         max_concurrent_jobs: int = 100,
+        jobs_per_batch: int = 1,
     ):
         """Inits ProcessorSampler.
 
@@ -56,6 +57,9 @@ class ProcessorSampler(cirq.Sampler):
                 concurrently to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
+            jobs_per_batch:  If set to greater than 1, this will batch multiple
+                circuits within the same API call when calling run_batch() or
+                run_batch_async() up to a maximum of `jobs_per_batch`.
 
         Raises:
             ValueError: If  only one of `run_name` and `device_config_name` are specified.
@@ -68,9 +72,17 @@ class ProcessorSampler(cirq.Sampler):
         self._snapshot_id = snapshot_id
         self._device_config_name = device_config_name
         self._concurrent_job_limiter = duet.Limiter(max_concurrent_jobs)
+        self._jobs_per_batch = jobs_per_batch
 
     async def run_sweep_async(
-        self, program: cirq.AbstractCircuit, params: cirq.Sweepable, repetitions: int = 1
+        self,
+        program: (
+            cirq.AbstractCircuit
+            | Sequence[cirq.AbstractCircuit]
+            | Mapping[str, cirq.AbstractCircuit]
+        ),
+        params: cirq.Sweepable | Sequence[cirq.Sweepable],
+        repetitions: int = 1,
     ) -> Sequence[cg.EngineResult]:
         async with self._concurrent_job_limiter:
             job = await self._processor.run_sweep_async(
@@ -92,6 +104,37 @@ class ProcessorSampler(cirq.Sampler):
         params_list: Sequence[cirq.Sweepable] | None = None,
         repetitions: int | Sequence[int] = 1,
     ) -> Sequence[Sequence[cg.EngineResult]]:
+        if self._jobs_per_batch > 1:
+            params_list, repetitions = self._normalize_batch_args(
+                programs, params_list, repetitions
+            )
+            # Batch programs that have the same number of repetitions.
+            program_batches = []
+            params_list_batches = []
+            repetition_batches = []
+
+            i = 0
+            while i < len(programs):
+                batch_reps = repetitions[i]
+                batch_programs = [programs[i]]
+                batch_params = [params_list[i]]
+                i += 1
+                while (
+                    i < len(programs)
+                    and len(batch_programs) < self._jobs_per_batch
+                    and repetitions[i] == batch_reps
+                ):
+                    batch_programs.append(programs[i])
+                    batch_params.append(params_list[i])
+                    i += 1
+                program_batches.append(batch_programs)
+                params_list_batches.append(batch_params)
+                repetition_batches.append(batch_reps)
+
+            return await duet.pstarmap_async(
+                self.run_sweep_async, zip(program_batches, params_list_batches, repetition_batches)
+            )
+
         return cast(
             Sequence[Sequence['cg.EngineResult']],
             await super().run_batch_async(programs, params_list, repetitions),

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -83,7 +83,7 @@ class ProcessorSampler(cirq.Sampler):
         params: cirq.Sweepable | Sequence[cirq.Sweepable],
         repetitions: int = 1,
     ) -> Sequence[cg.EngineResult]:
-        await self._run_sweep_async(program, params, repetitions)
+        return await self._run_sweep_async(program, params, repetitions)
 
     run_sweep = duet.sync(run_sweep_async)
 

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -60,6 +60,9 @@ class ProcessorSampler(cirq.Sampler):
             jobs_per_batch:  If set to greater than 1, this will batch multiple
                 circuits within the same API call when calling run_batch() or
                 run_batch_async() up to a maximum of `jobs_per_batch`.
+                Note that actual hardware execution order is not guaranteed
+                if jobs_per_batch > 1. (For instance, the hardware may run
+                all circuits for the first sweep point, then the second point, etc).
 
         Raises:
             ValueError: If  only one of `run_name` and `device_config_name` are specified.
@@ -76,6 +79,16 @@ class ProcessorSampler(cirq.Sampler):
 
     async def run_sweep_async(
         self,
+        program: cirq.AbstractCircuit,
+        params: cirq.Sweepable | Sequence[cirq.Sweepable],
+        repetitions: int = 1,
+    ) -> Sequence[cg.EngineResult]:
+        await self._run_sweep_async(program, params, repetitions)
+
+    run_sweep = duet.sync(run_sweep_async)
+
+    async def _run_sweep_async(
+        self,
         program: (
             cirq.AbstractCircuit
             | Sequence[cirq.AbstractCircuit]
@@ -84,6 +97,7 @@ class ProcessorSampler(cirq.Sampler):
         params: cirq.Sweepable | Sequence[cirq.Sweepable],
         repetitions: int = 1,
     ) -> Sequence[cg.EngineResult]:
+        """Internal helper to run sweeps or batches."""
         async with self._concurrent_job_limiter:
             job = await self._processor.run_sweep_async(
                 program=program,
@@ -95,8 +109,6 @@ class ProcessorSampler(cirq.Sampler):
             )
 
             return await job.results_async()
-
-    run_sweep = duet.sync(run_sweep_async)
 
     async def run_batch_async(
         self,

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -202,7 +202,8 @@ def test_run_batch_with_jobs_per_batch():
     )
 
 
-def test_run_batch_with_jobs_per_batch_and_params():
+@pytest.mark.parametrize('use_mapping', [True, False])
+def test_run_batch_with_jobs_per_batch_and_params(use_mapping: bool):
     processor = mock.create_autospec(AbstractProcessor, instance=True)
     sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
     a = cirq.LineQubit(0)
@@ -211,10 +212,12 @@ def test_run_batch_with_jobs_per_batch_and_params():
     params1 = [cirq.ParamResolver({'t': 1})]
     params2 = [cirq.ParamResolver({'t': 2})]
 
-    sampler.run_batch([circuit1, circuit2], [params1, params2], repetitions=5)
+    batch = {'a': circuit1, 'b': circuit2} if use_mapping else [circuit1, circuit2]
+
+    sampler.run_batch(batch, [params1, params2], repetitions=5)
 
     processor.run_sweep_async.assert_called_once_with(
-        program=[circuit1, circuit2],
+        program=batch,
         params=[params1, params2],
         repetitions=5,
         run_name='',

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -186,7 +186,7 @@ def test_run_batch_with_jobs_per_batch():
     assert processor.run_sweep_async.call_count == 2
     processor.run_sweep_async.assert_any_call(
         program=[circuit1, circuit2],
-        params=[None, None],
+        params=None,
         repetitions=5,
         run_name='',
         snapshot_id='',
@@ -194,7 +194,7 @@ def test_run_batch_with_jobs_per_batch():
     )
     processor.run_sweep_async.assert_any_call(
         program=[circuit3],
-        params=[None],
+        params=None,
         repetitions=5,
         run_name='',
         snapshot_id='',
@@ -210,15 +210,44 @@ def test_run_batch_with_jobs_per_batch_and_params(use_mapping: bool):
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
     params1 = [cirq.ParamResolver({'t': 1})]
-    params2 = [cirq.ParamResolver({'t': 2})]
 
     batch = {'a': circuit1, 'b': circuit2} if use_mapping else [circuit1, circuit2]
 
-    sampler.run_batch(batch, [params1, params2], repetitions=5)
+    sampler.run_batch(batch, [params1, params1], repetitions=5)
 
     processor.run_sweep_async.assert_called_once_with(
         program=batch,
-        params=[params1, params2],
+        params=params1,
+        repetitions=5,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+
+
+def test_run_batch_with_jobs_per_batch_different_params():
+    processor = mock.create_autospec(AbstractProcessor, instance=True)
+    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.X(a))
+    circuit2 = cirq.Circuit(cirq.Y(a))
+    params1 = [cirq.ParamResolver({'t': 1})]
+    params2 = [cirq.ParamResolver({'t': 2})]
+
+    sampler.run_batch([circuit1, circuit2], [params1, params2], repetitions=5)
+
+    assert processor.run_sweep_async.call_count == 2
+    processor.run_sweep_async.assert_any_call(
+        program=[circuit1],
+        params=params1,
+        repetitions=5,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+    processor.run_sweep_async.assert_any_call(
+        program=[circuit2],
+        params=params2,
         repetitions=5,
         run_name='',
         snapshot_id='',
@@ -238,7 +267,7 @@ def test_run_batch_with_jobs_per_batch_different_repetitions():
     assert processor.run_sweep_async.call_count == 2
     processor.run_sweep_async.assert_any_call(
         program=[circuit1],
-        params=[None],
+        params=None,
         repetitions=5,
         run_name='',
         snapshot_id='',
@@ -246,7 +275,7 @@ def test_run_batch_with_jobs_per_batch_different_repetitions():
     )
     processor.run_sweep_async.assert_any_call(
         program=[circuit2],
-        params=[None],
+        params=None,
         repetitions=10,
         run_name='',
         snapshot_id='',

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -173,6 +173,84 @@ def test_run_batch_differing_repetitions():
     )
 
 
+def test_run_batch_with_jobs_per_batch():
+    processor = mock.create_autospec(AbstractProcessor, instance=True)
+    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.X(a))
+    circuit2 = cirq.Circuit(cirq.Y(a))
+    circuit3 = cirq.Circuit(cirq.Z(a))
+
+    sampler.run_batch([circuit1, circuit2, circuit3], repetitions=5)
+
+    assert processor.run_sweep_async.call_count == 2
+    processor.run_sweep_async.assert_any_call(
+        program=[circuit1, circuit2],
+        params=[None, None],
+        repetitions=5,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+    processor.run_sweep_async.assert_any_call(
+        program=[circuit3],
+        params=[None],
+        repetitions=5,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+
+
+def test_run_batch_with_jobs_per_batch_and_params():
+    processor = mock.create_autospec(AbstractProcessor, instance=True)
+    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.X(a))
+    circuit2 = cirq.Circuit(cirq.Y(a))
+    params1 = [cirq.ParamResolver({'t': 1})]
+    params2 = [cirq.ParamResolver({'t': 2})]
+
+    sampler.run_batch([circuit1, circuit2], [params1, params2], repetitions=5)
+
+    processor.run_sweep_async.assert_called_once_with(
+        program=[circuit1, circuit2],
+        params=[params1, params2],
+        repetitions=5,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+
+
+def test_run_batch_with_jobs_per_batch_different_repetitions():
+    processor = mock.create_autospec(AbstractProcessor, instance=True)
+    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.X(a))
+    circuit2 = cirq.Circuit(cirq.Y(a))
+
+    sampler.run_batch([circuit1, circuit2], repetitions=[5, 10])
+
+    assert processor.run_sweep_async.call_count == 2
+    processor.run_sweep_async.assert_any_call(
+        program=[circuit1],
+        params=[None],
+        repetitions=5,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+    processor.run_sweep_async.assert_any_call(
+        program=[circuit2],
+        params=[None],
+        repetitions=10,
+        run_name='',
+        snapshot_id='',
+        device_config_name='',
+    )
+
+
 @duet.sync
 async def test_sampler_with_full_job_queue_blocks():
     processor = mock.create_autospec(AbstractProcessor, instance=True)

--- a/cirq-google/cirq_google/engine/simulated_local_job.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job.py
@@ -31,7 +31,13 @@ from cirq_google.engine.local_simulation_type import LocalSimulationType
 
 
 def _flatten_results(batch_results: Sequence[Sequence[EngineResult]]) -> list[EngineResult]:
-    return [result for batch in batch_results for result in batch]
+    if not batch_results:
+        return []
+    # Engine returns results grouped by sweep then by program.
+    # batch_results is currently grouped by program then by sweep.
+    return [
+        batch_results[i][j] for j in range(len(batch_results[0])) for i in range(len(batch_results))
+    ]
 
 
 def _to_engine_results(
@@ -124,6 +130,8 @@ class SimulatedLocalJob(AbstractLocalJob):
         try:
             self._state = quantum.ExecutionStatus.State.RUNNING
             programs = [parent.get_circuit(n) for n in range(batch_size)]
+            if len(sweeps) == 1 and len(programs) > 1:
+                sweeps = sweeps * len(programs)
             batch_results = self._sampler.run_batch(
                 programs=programs, params_list=cast(list[cirq.Sweepable], sweeps), repetitions=reps
             )

--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -24,7 +24,7 @@ import cirq
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_local_program import AbstractLocalProgram
 from cirq_google.engine.local_simulation_type import LocalSimulationType
-from cirq_google.engine.simulated_local_job import SimulatedLocalJob
+from cirq_google.engine.simulated_local_job import SimulatedLocalJob, _flatten_results
 
 Q = cirq.GridQubit(2, 2)
 
@@ -35,6 +35,10 @@ class ParentProgram(AbstractLocalProgram):
 
     def delete_job(self, program_id: str) -> None:
         pass
+
+
+def test_flatten_results_empty():
+    assert _flatten_results([]) == []
 
 
 def test_run():
@@ -51,6 +55,28 @@ def test_run():
     results = job.results()
     assert np.all(results[0].measurements['m'] == 1)
     assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS
+
+
+def test_run_multi_program_single_sweep():
+    # Covers line 134: sweeps = sweeps * len(programs)
+    program = ParentProgram(
+        [
+            cirq.Circuit(cirq.X(Q), cirq.measure(Q, key='m')),
+            cirq.Circuit(cirq.I(Q), cirq.measure(Q, key='m')),
+        ],
+        None,
+    )
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=10,
+        sweeps=[{}],
+    )
+    results = job.results()
+    assert len(results) == 2
+    assert np.all(results[0].measurements['m'] == 1)
+    assert np.all(results[1].measurements['m'] == 0)
 
 
 def test_run_sweep():

--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -24,7 +24,7 @@ import cirq
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_local_program import AbstractLocalProgram
 from cirq_google.engine.local_simulation_type import LocalSimulationType
-from cirq_google.engine.simulated_local_job import SimulatedLocalJob, _flatten_results
+from cirq_google.engine.simulated_local_job import _flatten_results, SimulatedLocalJob
 
 Q = cirq.GridQubit(2, 2)
 
@@ -67,11 +67,7 @@ def test_run_multi_program_single_sweep():
         None,
     )
     job = SimulatedLocalJob(
-        job_id='test_job',
-        processor_id='test1',
-        parent_program=program,
-        repetitions=10,
-        sweeps=[{}],
+        job_id='test_job', processor_id='test1', parent_program=program, repetitions=10, sweeps=[{}]
     )
     results = job.results()
     assert len(results) == 2

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import datetime
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 import cirq
@@ -198,7 +199,11 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
 
     async def run_sweep_async(
         self,
-        program: cirq.AbstractCircuit,
+        program: (
+            cirq.AbstractCircuit
+            | Sequence[cirq.AbstractCircuit]
+            | Mapping[str, cirq.AbstractCircuit]
+        ),
         *,
         program_id: str | None = None,
         job_id: str | None = None,
@@ -216,11 +221,17 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             program_id = self._create_id(id_type='program')
         if job_id is None:
             job_id = self._create_id(id_type='job')
-        self._program_validator([program], [params], repetitions, CIRCUIT_SERIALIZER)
+        if isinstance(program, cirq.AbstractCircuit):
+            programs = [program]
+        elif isinstance(program, Mapping):
+            programs = list(program.values())
+        else:
+            programs = list(program)
+        self._program_validator(programs, [params], repetitions, CIRCUIT_SERIALIZER)
         self._programs[program_id] = SimulatedLocalProgram(
             program_id=program_id,
             simulation_type=self._simulation_type,
-            circuits=[program],
+            circuits=programs,
             processor=self,
             engine=self.engine(),
         )

--- a/cirq-google/cirq_google/engine/simulated_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor_test.py
@@ -211,3 +211,14 @@ def test_device_specification():
     device_spec.valid_qubits.append('q0_1')
     proc = SimulatedLocalProcessor(processor_id='test_proc', device_specification=device_spec)
     assert proc.get_device_specification() == device_spec
+
+
+def test_simulated_local_processor_run_sweep_multi():
+    processor = SimulatedLocalProcessor(processor_id='test_proc')
+    circuit = cirq.Circuit(cirq.measure(cirq.GridQubit(0, 0), key='m'))
+
+    # Mapping
+    processor.run_sweep({'a': circuit}, params={}, repetitions=1)
+
+    # Sequence (else block)
+    processor.run_sweep([circuit], params={}, repetitions=1)


### PR DESCRIPTION
- Allow the client to accept a jobs_per_batch which batches multiple circuits within the same request.
- Adjusts the signature of the functions accordingly to match that this could include a mapping or sequence of circuits.

See internal bug: b/500927996