### PR TITLE
Convert attribute docstrings to conventional docstrings

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_device.py
+++ b/cirq-aqt/cirq_aqt/aqt_device.py
@@ -41,19 +41,19 @@ gate_dict = {'X': cirq.X, 'Y': cirq.Y, 'Z': cirq.Z, 'MS': cirq.XX, 'R': cirq.Pha
 
 
 class OperationString(Enum):
-    """String representations of operations supported by AQT resources."""
+    """String representations of operations supported by AQT resources.
+
+    Attributes:
+        MS: Cirq: XXPowGate, AQT: RXX gate.
+        Z: Cirq: ZPowGate, AQT: RZ gate.
+        R: Cirq: PhasedXPowGate, AQT: R gate.
+        MEASURE: Measurement gate.
+    """
 
     MS = "MS"
-    """Cirq: XXPowGate, AQT: RXX gate."""
-
     Z = "Z"
-    """Cirq: ZPowGate, AQT: RZ gate."""
-
     R = "R"
-    """Cirq: PhasedXPowGate, AQT: R gate."""
-
     MEASURE = "Meas"
-    """Measurement gate."""
 
 
 def get_op_string(op_obj: cirq.Operation) -> str:

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -39,12 +39,18 @@ class Qasm:
     def __init__(
         self, supported_format: bool, qelib1_include: bool, qregs: dict, cregs: dict, c: Circuit
     ):
-        # defines whether the Quantum Experience standard header
-        # is present or not
+        """Initializes Qasm.
+
+        Attributes:
+            qelib1Include: defines whether the Quantum Experience standard header
+                is present or not.
+            supportedFormat: defines if it has a supported format or not.
+            qregs: quantum registers.
+            cregs: classical registers.
+            circuit: circuit.
+        """
         self.qelib1Include = qelib1_include
-        # defines if it has a supported format or not
         self.supportedFormat = supported_format
-        # circuit
         self.qregs = qregs
         self.cregs = cregs
         self.circuit = c
@@ -176,22 +182,26 @@ class QasmParser:
     """
 
     def __init__(self) -> None:
+        """Initializes the Qasm parser.
+
+        Attributes:
+            gate_set: The gates available to use in the circuit, including those from
+                libraries, and user-defined ones.
+            in_custom_gate_scope: This is set to True when the parser is in the middle
+                of parsing a custom gate definition.
+            custom_gate_scoped_params: The params declared within the current custom
+                gate definition. Empty if not in custom gate scope.
+            custom_gate_scoped_qubits: The qubits declared within the current custom
+                gate definition. Empty if not in custom gate scope.
+        """
         self.parser = yacc.yacc(module=self, debug=False, write_tables=False)
         self.circuit = Circuit()
         self.qregs: dict[str, int] = {}
         self.cregs: dict[str, int] = {}
         self.gate_set: dict[str, CustomGate | QasmGateStatement] = {**self.basic_gates}
-        """The gates available to use in the circuit, including those from libraries, and
-         user-defined ones."""
         self.in_custom_gate_scope = False
-        """This is set to True when the parser is in the middle of parsing a custom gate
-         definition."""
         self.custom_gate_scoped_params: set[str] = set()
-        """The params declared within the current custom gate definition. Empty if not in
-         custom gate scope."""
         self.custom_gate_scoped_qubits: dict[str, ops.Qid] = {}
-        """The qubits declared within the current custom gate definition. Empty if not in
-         custom gate scope."""
         self.qelibinc = False
         self.lexer = QasmLexer()
         self.supported_format = False

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -37,16 +37,16 @@ class NamedTopology(metaclass=abc.ABCMeta):
     "Named topologies" provide a mapping from a simple dataclass to a unique graph for categories
     of relevant topologies. Relevant topologies may be hardware dependant, but common topologies
     are linear (1D) and rectangular grid topologies.
+
+    Attributes:
+        name: A name that uniquely identifies this topology.
+        n_nodes: The number of nodes in the topology.
+        graph: A networkx graph representation of the topology.
     """
 
     name: str = NotImplemented
-    """A name that uniquely identifies this topology."""
-
     n_nodes: int = NotImplemented
-    """The number of nodes in the topology."""
-
     graph: nx.Graph = NotImplemented
-    """A networkx graph representation of the topology."""
 
 
 _GRIDLIKE_NODE = Union['cirq.GridQubit', tuple[int, int]]

--- a/cirq-google/cirq_google/workflow/quantum_executable.py
+++ b/cirq-google/cirq_google/workflow/quantum_executable.py
@@ -30,10 +30,12 @@ class ExecutableSpec(metaclass=abc.ABCMeta):
     """Specification metadata about an executable.
 
     Subclasses should add problem-specific fields.
+
+    Attributes:
+        executable_family: A unique name to group executables.
     """
 
     executable_family: str = NotImplemented
-    """A unique name to group executables."""
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
A few places such as the `__init__()` method of QasmParser contained embedded strings. These were presumably meant as attribute docstrings. Such "floating" string literals placed immediately after an attribute assignment are sometimes meant to document instance variables. However, wWhile they look like docstrings, they are technically just string literals that the Python interpreter ignores at runtime. They are not assigned to any `__doc__` attribute.

We do not follow this convention in Cirq, so I converted them to Google-style attribute descriptions in the class-level docstring.