### PR TITLE
CI - automatically convert new dependabot PRs to draft

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -75,3 +75,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: ./dev_tools/ci/size-labeler.sh
+
+  label-dependabot-pr:
+    if: >-
+      github.repository_owner == 'quantumlib' &&
+      (github.event.action == 'opened' || github.event_name == 'workflow_dispatch') &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    name: Convert dependabot PR to draft
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    steps:
+      - name: Convert to draft and attach the on-hold label
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PULL_REQUEST_URL: ${{github.event.pull_request.html_url}}
+        run: |
+          gh pr ready "${PULL_REQUEST_URL}" --undo
+          gh pr edit "${PULL_REQUEST_URL}" --add-label status/on-hold


### PR DESCRIPTION
dependabot PRs are processed once a month.  In a meantime they
should be in a draft mode and have the "status/on-hold" label.
Here we automate this for new dependabot PRs.

The workflow can be also started manually for testing -
provided the target PR is from dependabot.
