### PR TITLE
CI - simplify condition for label-dependabot-pr workflow

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -79,7 +79,7 @@ jobs:
   label-dependabot-pr:
     if: >-
       github.repository_owner == 'quantumlib' &&
-      (github.event.action == 'opened' || github.event_name == 'workflow_dispatch') &&
+      github.event.action == 'opened' &&
       github.event.pull_request.user.login == 'dependabot[bot]'
     name: Convert dependabot PR to draft
     runs-on: ubuntu-slim


### PR DESCRIPTION
The if-condition for running the workflow could not possibly match
for manual workflow_dispatch.  Remove check for workflow_dispatch
completely as it is not worth fixing at this time.

Follow-up to #8043
