### PR TITLE
Make program.run() return an EngineJob so it's consistent with program.run_sweep()

### DIFF
--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -147,7 +147,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         repetitions: int = 1,
         description: str | None = None,
         labels: dict[str, str] | None = None,
-    ) -> cirq.Result:
+    ) -> engine_job.EngineJob:
         """Runs the supplied Circuit via Quantum Engine.
 
         Args:
@@ -171,7 +171,8 @@ class EngineProgram(abstract_program.AbstractProgram):
             labels: Optional set of labels to set on the job.
 
         Returns:
-            A single Result for this run.
+            An EngineJob. If this is iterated over it returns a list containing a single
+            TrialResult
 
         Raises:
             ValueError: If a processor id hasn't been specified to run the job
@@ -179,7 +180,7 @@ class EngineProgram(abstract_program.AbstractProgram):
             ValueError: If either `run_name` and `device_config_name` are set but
                 `processor_id` is empty.
         """
-        job = await self.run_sweep_async(
+        return await self.run_sweep_async(
             job_id=job_id,
             params=[param_resolver],
             repetitions=repetitions,
@@ -190,8 +191,6 @@ class EngineProgram(abstract_program.AbstractProgram):
             snapshot_id=snapshot_id,
             device_config_name=device_config_name,
         )
-        results = await job.results_async()
-        return results[0]
 
     run = duet.sync(run_async)
 

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -172,7 +172,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
         Returns:
             An EngineJob. If this is iterated over it returns a list containing a single
-            TrialResult
+            EngineResult
 
         Raises:
             ValueError: If a processor id hasn't been specified to run the job

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -171,8 +171,7 @@ class EngineProgram(abstract_program.AbstractProgram):
             labels: Optional set of labels to set on the job.
 
         Returns:
-            An EngineJob. If this is iterated over it returns a list containing a single
-            EngineResult
+            An EngineJob. If this is iterated over it yields one EngineResult.
 
         Raises:
             ValueError: If a processor id hasn't been specified to run the job

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime
 from unittest import mock
 
+import duet
 import numpy as np
 import pytest
 from google.protobuf import any_pb2, timestamp_pb2
@@ -98,7 +99,8 @@ def test_run_sweeps_delegation(create_job_async):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')
 @mock.patch('cirq_google.engine.engine_client.EngineClient.create_job_async')
-def test_run_delegation(create_job_async, get_results_async):
+@duet.sync
+async def test_run_delegation(create_job_async, get_results_async):
     dt = datetime.datetime.now(tz=datetime.timezone.utc)
     create_job_async.return_value = (
         'steve',
@@ -139,7 +141,7 @@ def test_run_delegation(create_job_async, get_results_async):
 
     program = cg.EngineProgram('a', 'b', EngineContext())
     param_resolver = cirq.ParamResolver({})
-    results = program.run(
+    job = program.run(
         job_id='steve',
         repetitions=10,
         param_resolver=param_resolver,
@@ -148,7 +150,10 @@ def test_run_delegation(create_job_async, get_results_async):
         device_config_name="config",
     )
 
-    assert results == cg.EngineResult(
+    results = await job.results_async()
+    result = results[0]
+
+    assert result == cg.EngineResult(
         params=cirq.ParamResolver({'a': 1.0}),
         measurements={'q': np.array([[False], [True], [True], [False]], dtype=bool)},
         job_id='steve',

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import datetime
 from unittest import mock
 
-import duet
 import numpy as np
 import pytest
 from google.protobuf import any_pb2, timestamp_pb2
@@ -99,8 +98,7 @@ def test_run_sweeps_delegation(create_job_async):
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')
 @mock.patch('cirq_google.engine.engine_client.EngineClient.create_job_async')
-@duet.sync
-async def test_run_delegation(create_job_async, get_results_async):
+def test_run_delegation(create_job_async, get_results_async):
     dt = datetime.datetime.now(tz=datetime.timezone.utc)
     create_job_async.return_value = (
         'steve',
@@ -150,7 +148,7 @@ async def test_run_delegation(create_job_async, get_results_async):
         device_config_name="config",
     )
 
-    results = await job.results_async()
+    results = job.results()
     result = results[0]
 
     assert result == cg.EngineResult(

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -148,8 +148,7 @@ def test_run_delegation(create_job_async, get_results_async):
         device_config_name="config",
     )
 
-    results = job.results()
-    result = results[0]
+    (result,) = job
 
     assert result == cg.EngineResult(
         params=cirq.ParamResolver({'a': 1.0}),

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -612,7 +612,7 @@ def test_run_multiple_times(client):
         param_resolver=cirq.ParamResolver({'a': 1}),
         run_name="run",
         device_config_name="config_alias",
-    )
+    ).results()
     run_context = v2.run_context_pb2.RunContext()
     client().create_job_async.call_args[1]['run_context'].Unpack(run_context)
     sweeps1 = run_context.parameter_sweeps


### PR DESCRIPTION
Internal request by @eliottrosenberg to have program.run() return an EngineJob, rather than having the function wait for the EngineJob to complete before returning.

This interface makes it consistent with existing program.run_sweep()

Fixes b/495930398
