### PR TITLE
Update `.github/CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,24 +26,24 @@ cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomol
 # docs maintainers
 #####################################################
 
-docs/**/*.* @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/**/*.* @quantumlib/cirq-maintainers @vtomole
 
 ###################################################################
 # vendor docs maintainers: vendor maintainers + + @rmlarose
 ###################################################################
 
-docs/google/**/*.* @wcourtney @rmlarose @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
-docs/tutorials/google/**/*.* @wcourtney @rmlarose @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+docs/tutorials/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
 
-docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @rmlarose @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
+docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 
-docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomole
 
-docs/hardware/pasqal/**/*.* @HGSilveri @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
 docs/hardware/azure-quantum/**/*.* @guenp @anpaz @quantumlib/cirq-maintainers @vtomole
 
 #############################################################
 # qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw
 #############################################################
-docs/noise/qcvv/**/*.* @mrwojtek @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 # GitHub CODEOWNERS file for Cirq.
+# To view the members of a team, construct a URL of this form:
+# https://github.com/orgs/quantumlib/teams/[TEAM_NAME]/members
 
 #### Overall Cirq maintainers ####
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,40 +1,38 @@
-################################################################################
 # GitHub CODEOWNERS file for Cirq.
 #
 # Reminders:
 #  * People listed here must have write permissions for the repo.
 #  * Earlier pattern rules should be broader, later ones more specific.
-################################################################################
 
 # Overall Cirq maintainers.
 
-* @quantumlib/cirq-maintainers @vtomole
+* @quantumlib/cirq-maintainers
 
 
 # Cirq docs maintainers.
 
-docs/**/*.* @quantumlib/cirq-maintainers @vtomole
-docs/tutorials/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
-docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
+docs/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-contributors
+docs/tutorials/google/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-contributors @wcourtney @verult @hoisinberg
+docs/noise/qcvv/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-contributors @mrwojtek
 
 
 # Hardware module maintainers.
 
-cirq-aqt/**/*.*          @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
-docs/hardware/aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
+cirq-aqt/**/*.*          @quantumlib/cirq-maintainers @quantumlib/cirq-aqt-contributors
+docs/hardware/aqt/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-aqt-contributors
 
-cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
-docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+cirq-google/**/*.* @quantumlib/cirq-maintainers @wcourtney @verult @hoisinberg
+docs/google/**/*.* @quantumlib/cirq-maintainers @wcourtney @verult @hoisinberg
 
-cirq-ionq/**/*.*          @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
-docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
+cirq-ionq/**/*.*          @quantumlib/cirq-maintainers @quantumlib/cirq-ionq-contributors
+docs/hardware/ionq/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-ionq-contributors
 
-cirq-pasqal/**/*.*          @HGSilveri @quantumlib/cirq-maintainers @vtomole
-docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
+cirq-pasqal/**/*.*          @quantumlib/cirq-maintainers @quantumlib/cirq-pasqal-contributors
+docs/hardware/pasqal/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-pasqal-contributors
 
-docs/hardware/azure-quantum/**/*.* @ScottCarda-MS @billti @quantumlib/cirq-maintainers @vtomole
+docs/hardware/azure-quantum/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-azure-contributors
 
 
 # Experiments maintainers.
 
-cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
+cirq-core/cirq/experiments/**/*.* @quantumlib/cirq-maintainers @mrwojtek

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,27 +23,27 @@ cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
 
 #####################################################
-# docs maintainers: maintainers + @aasfaw + @rmlarose
+# docs maintainers
 #####################################################
 
-docs/**/*.* @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/**/*.* @rmlarose @quantumlib/cirq-maintainers @vtomole
 
 ###################################################################
-# vendor docs maintainers: vendor maintainers + @aasfaw + @rmlarose
+# vendor docs maintainers: vendor maintainers + + @rmlarose
 ###################################################################
 
-docs/google/**/*.* @wcourtney @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
-docs/tutorials/google/**/*.* @wcourtney @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+docs/google/**/*.* @wcourtney @rmlarose @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+docs/tutorials/google/**/*.* @wcourtney @rmlarose @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
 
-docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @aasfaw @rmlarose @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
+docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @rmlarose @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 
-docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @rmlarose @quantumlib/cirq-maintainers @vtomole
 
-docs/hardware/pasqal/**/*.* @HGSilveri @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/hardware/pasqal/**/*.* @HGSilveri @rmlarose @quantumlib/cirq-maintainers @vtomole
 
-docs/hardware/azure-quantum/**/*.* @guenp @anpaz @aasfaw @quantumlib/cirq-maintainers @vtomole
+docs/hardware/azure-quantum/**/*.* @guenp @anpaz @quantumlib/cirq-maintainers @vtomole
 
 #############################################################
 # qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw
 #############################################################
-docs/noise/qcvv/**/*.* @mrwojtek @aasfaw @rmlarose @quantumlib/cirq-maintainers @vtomole
+docs/noise/qcvv/**/*.* @mrwojtek @rmlarose @quantumlib/cirq-maintainers @vtomole

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoi
 
 cirq-ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 
-cirq-aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomole
+cirq-aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
 
 cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
@@ -37,11 +37,11 @@ docs/tutorials/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @v
 
 docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 
-docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainers @vtomole
+docs/hardware/aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
 
 docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
-docs/hardware/azure-quantum/**/*.* @ScottCarda-MS @billti @anpaz @quantumlib/cirq-maintainers @vtomole
+docs/hardware/azure-quantum/**/*.* @ScottCarda-MS @billti @quantumlib/cirq-maintainers @vtomole
 
 #############################################################
 # qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 ####################
-# cirq maintainers
+# Cirq maintainers
 ####################
 
 * @quantumlib/cirq-maintainers @vtomole
 
 ####################
-# vendor maintainers
+# Vendor maintainers
 ####################
 
 cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
@@ -23,13 +23,13 @@ cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
 
 #####################################################
-# docs maintainers
+# Cirq docs maintainers
 #####################################################
 
 docs/**/*.* @quantumlib/cirq-maintainers @vtomole
 
 ###################################################################
-# vendor docs maintainers: vendor maintainers + + @rmlarose
+# Vendor docs maintainers
 ###################################################################
 
 docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
@@ -46,4 +46,5 @@ docs/hardware/azure-quantum/**/*.* @ScottCarda-MS @billti @anpaz @quantumlib/cir
 #############################################################
 # qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw
 #############################################################
+
 docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@ docs/hardware/aqt/**/*.* @ma5x @pschindler @alfrisch @quantumlib/cirq-maintainer
 
 docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
-docs/hardware/azure-quantum/**/*.* @guenp @anpaz @quantumlib/cirq-maintainers @vtomole
+docs/hardware/azure-quantum/**/*.* @ScottCarda-MS @billti @anpaz @quantumlib/cirq-maintainers @vtomole
 
 #############################################################
 # qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,22 @@
 # GitHub CODEOWNERS file for Cirq.
-#
-# Reminders:
-#  * People listed here must have write permissions for the repo.
-#  * Earlier pattern rules should be broader, later ones more specific.
 
-# Overall Cirq maintainers.
+#### Overall Cirq maintainers ####
 
 * @quantumlib/cirq-maintainers
 
-
-# Cirq docs maintainers.
+#### Cirq docs maintainers ####
 
 docs/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-contributors
 docs/tutorials/google/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-contributors @wcourtney @verult @hoisinberg
 docs/noise/qcvv/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-contributors @mrwojtek
 
-
-# Hardware module maintainers.
-
-cirq-aqt/**/*.*          @quantumlib/cirq-maintainers @quantumlib/cirq-aqt-contributors
-docs/hardware/aqt/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-aqt-contributors
+#### Hardware module maintainers ####
 
 cirq-google/**/*.* @quantumlib/cirq-maintainers @wcourtney @verult @hoisinberg
 docs/google/**/*.* @quantumlib/cirq-maintainers @wcourtney @verult @hoisinberg
+
+cirq-aqt/**/*.*          @quantumlib/cirq-maintainers @quantumlib/cirq-aqt-contributors
+docs/hardware/aqt/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-aqt-contributors
 
 cirq-ionq/**/*.*          @quantumlib/cirq-maintainers @quantumlib/cirq-ionq-contributors
 docs/hardware/ionq/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-ionq-contributors
@@ -32,7 +26,6 @@ docs/hardware/pasqal/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-pasqal
 
 docs/hardware/azure-quantum/**/*.* @quantumlib/cirq-maintainers @quantumlib/cirq-azure-contributors
 
-
-# Experiments maintainers.
+#### Experiments maintainers ####
 
 cirq-core/cirq/experiments/**/*.* @quantumlib/cirq-maintainers @mrwojtek

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,50 +1,40 @@
-####################
-# Cirq maintainers
-####################
+################################################################################
+# GitHub CODEOWNERS file for Cirq.
+#
+# Reminders:
+#  * People listed here must have write permissions for the repo.
+#  * Earlier pattern rules should be broader, later ones more specific.
+################################################################################
+
+# Overall Cirq maintainers.
 
 * @quantumlib/cirq-maintainers @vtomole
 
-####################
-# Vendor maintainers
-####################
 
-cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
-
-cirq-ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
-
-cirq-aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
-
-cirq-pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
-
-################################################
-# qcvv maintainers @mrwojtek + cirq maintainers
-################################################
-
-cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
-
-#####################################################
-# Cirq docs maintainers
-#####################################################
+# Cirq docs maintainers.
 
 docs/**/*.* @quantumlib/cirq-maintainers @vtomole
-
-###################################################################
-# Vendor docs maintainers
-###################################################################
-
-docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
 docs/tutorials/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
 
+
+# Hardware module maintainers.
+
+cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
+
+cirq-ionq/**/*.*          @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 
+cirq-aqt/**/*.*          @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
 docs/hardware/aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
 
+cirq-pasqal/**/*.*          @HGSilveri @quantumlib/cirq-maintainers @vtomole
 docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole
 
 docs/hardware/azure-quantum/**/*.* @ScottCarda-MS @billti @quantumlib/cirq-maintainers @vtomole
 
-#############################################################
-# qcvv docs maintainers: docs maintainers + mrwojtek + aasfaw
-#############################################################
 
-docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
+# Experiments maintainers.
+
+cirq-core/cirq/experiments/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,14 +20,14 @@ docs/noise/qcvv/**/*.* @mrwojtek @quantumlib/cirq-maintainers @vtomole
 
 # Hardware module maintainers.
 
+cirq-aqt/**/*.*          @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
+docs/hardware/aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
+
 cirq-google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
 docs/google/**/*.* @wcourtney @quantumlib/cirq-maintainers @vtomole @verult @hoisinberg
 
 cirq-ionq/**/*.*          @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
 docs/hardware/ionq/**/*.* @dabacon @ColemanCollins @nakardo @gmauricio @Cynocracy @quantumlib/cirq-maintainers @vtomole @splch
-
-cirq-aqt/**/*.*          @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
-docs/hardware/aqt/**/*.* @ma5x @pschindler @quantumlib/cirq-maintainers @vtomole
 
 cirq-pasqal/**/*.*          @HGSilveri @quantumlib/cirq-maintainers @vtomole
 docs/hardware/pasqal/**/*.* @HGSilveri @quantumlib/cirq-maintainers @vtomole

--- a/dev_tools/codeowners_test.py
+++ b/dev_tools/codeowners_test.py
@@ -21,27 +21,29 @@ import pytest
 
 CIRQ_MAINTAINERS = ('TEAM', "@quantumlib/cirq-maintainers")
 
-BASE_MAINTAINERS = {CIRQ_MAINTAINERS, ('USERNAME', "@vtomole")}
+BASE_MAINTAINERS = {CIRQ_MAINTAINERS}
 
-DOCS_MAINTAINERS = BASE_MAINTAINERS.union({('USERNAME', '@aasfaw'), ('USERNAME', '@rmlarose')})
+DOCS_MAINTAINERS = BASE_MAINTAINERS.union({('TEAM', "@quantumlib/cirq-contributors")})
 
 GOOGLE_TEAM = {('USERNAME', "@wcourtney"), ('USERNAME', "@verult"), ("USERNAME", "@hoisinberg")}
 
 GOOGLE_MAINTAINERS = BASE_MAINTAINERS.union(GOOGLE_TEAM)
 
-IONQ_TEAM = {
-    ('USERNAME', u)
-    for u in ["@dabacon", "@ColemanCollins", "@nakardo", "@gmauricio", "@Cynocracy", "@splch"]
-}
+IONQ_TEAM = {('TEAM', "@quantumlib/cirq-ionq-contributors")}
+
 IONQ_MAINTAINERS = BASE_MAINTAINERS.union(IONQ_TEAM)
 
-PASQAL_TEAM = {('USERNAME', u) for u in ["@HGSilveri"]}
+PASQAL_TEAM = {('TEAM', "@quantumlib/cirq-pasqal-contributors")}
 
 PASQAL_MAINTAINERS = BASE_MAINTAINERS.union(PASQAL_TEAM)
 
-AQT_TEAM = {('USERNAME', u) for u in ["@ma5x", "@pschindler", "@alfrisch"]}
+AQT_TEAM = {('TEAM', "@quantumlib/cirq-aqt-contributors")}
 
 AQT_MAINTAINERS = BASE_MAINTAINERS.union(AQT_TEAM)
+
+AZURE_TEAM = {('TEAM', "@quantumlib/cirq-azure-contributors")}
+
+AZURE_MAINTAINERS = BASE_MAINTAINERS.union(AZURE_TEAM)
 
 QCVV_TEAM = {('USERNAME', "@mrwojtek")}
 
@@ -62,23 +64,25 @@ QCVV_MAINTAINERS = BASE_MAINTAINERS.union(QCVV_TEAM)
         # aqt
         ("cirq-aqt/cirq_aqt/__init__.py", AQT_MAINTAINERS),
         ("cirq-aqt/setup.py", AQT_MAINTAINERS),
-        ("docs/hardware/aqt/access.md", AQT_MAINTAINERS.union(DOCS_MAINTAINERS)),
-        ("docs/hardware/aqt/getting_started.ipynb", AQT_MAINTAINERS.union(DOCS_MAINTAINERS)),
+        ("docs/hardware/aqt/access.md", AQT_MAINTAINERS),
+        ("docs/hardware/aqt/getting_started.ipynb", AQT_MAINTAINERS),
         # pasqal
         ("cirq-pasqal/cirq_pasqal/__init__.py", PASQAL_MAINTAINERS),
         ("cirq-pasqal/setup.py", PASQAL_MAINTAINERS),
-        ("docs/hardware/pasqal/access.md", PASQAL_MAINTAINERS.union(DOCS_MAINTAINERS)),
-        ("docs/hardware/pasqal/getting_started.ipynb", PASQAL_MAINTAINERS.union(DOCS_MAINTAINERS)),
+        ("docs/hardware/pasqal/access.md", PASQAL_MAINTAINERS),
+        ("docs/hardware/pasqal/getting_started.ipynb", PASQAL_MAINTAINERS),
         # ionq
         ("cirq-ionq/cirq_ionq/__init__.py", IONQ_MAINTAINERS),
         ("cirq-ionq/setup.py", IONQ_MAINTAINERS),
-        ("docs/hardware/ionq/access.md", IONQ_MAINTAINERS.union(DOCS_MAINTAINERS)),
-        ("docs/hardware/ionq/getting_started.ipynb", IONQ_MAINTAINERS.union(DOCS_MAINTAINERS)),
+        ("docs/hardware/ionq/access.md", IONQ_MAINTAINERS),
+        ("docs/hardware/ionq/getting_started.ipynb", IONQ_MAINTAINERS),
         # google
         ("cirq-google/cirq_google/__init__.py", GOOGLE_MAINTAINERS),
         ("cirq-google/setup.py", GOOGLE_MAINTAINERS),
-        ("docs/google/access.md", GOOGLE_MAINTAINERS.union(DOCS_MAINTAINERS)),
+        ("docs/google/access.md", GOOGLE_MAINTAINERS),
         ("docs/tutorials/google/start.ipynb", GOOGLE_MAINTAINERS.union(DOCS_MAINTAINERS)),
+        # azure-quantum
+        ("docs/hardware/azure-quantum/access.md", AZURE_MAINTAINERS),
     ],
 )
 def test_codeowners(filepath, expected) -> None:


### PR DESCRIPTION
This PR replaces closed PR#7514. It fixes issue #7031 by updating `.github/CODEOWNERS`. Summary of main changes:

- Prefer the use of teams instead of individual user names for most cases. This will allow us to adjust permissions via GitHub team controls; in addition, it will let us use GitHub team features such as code review assignments.

- Use newly-created subteams of "Cirq Contributors" for the vendor modules.

- Adjust default ownership assignments to reflect activity in recent years and best-guesses about appropriateness for different roles.

- Add changes discussed in the [comments on a previous PR](https://github.com/quantumlib/Cirq/pull/7514#pullrequestreview-3353628770). 

- Reorganize the file in an effort to make it more readable and maintainable. For example, the hardware interface modules were previously split based on code versus docs; they are now grouped by the interface modules, so that it's obvious there are two parts to each one.

(Note to reviewers: the new teams were created today, and not all members have accepted invitations yet. Beware that the team listings will look incomplete due to this.)

Fixes #7031
