### PR TITLE
Add multi-circuit capability to EngineJob.get_circuit

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -159,6 +159,19 @@ class AbstractJob(abc.ABC):
         one was captured, else None."""
 
     @abc.abstractmethod
+    def get_circuit(self, program_num: int | None = None) -> cirq.Circuit:
+        """Returns the cirq Circuit for the job.
+
+        Args:
+            program_num: if this is a multi-circuit job, the index of the circuit
+                to return.  This argument is zero-indexed. Negative values
+                indexing from the end of the list.
+
+        Returns:
+            The job's cirq Circuit.
+        """
+
+    @abc.abstractmethod
     def cancel(self) -> bool | None:
         """Cancel the job."""
 

--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -165,7 +165,7 @@ class AbstractJob(abc.ABC):
         Args:
             program_num: if this is a multi-circuit job, the index of the circuit
                 to return.  This argument is zero-indexed. Negative values
-                indexing from the end of the list.
+                index from the end of the list.  Ignored if not multi-circuit.
 
         Returns:
             The job's cirq Circuit.

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -81,7 +81,7 @@ class MockJob(AbstractJob):
         pass
 
     def get_circuit(self, program_num: int | None = None) -> cirq.Circuit:
-        pass
+        return cirq.Circuit()
 
     def cancel(self) -> None:
         pass

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -80,6 +80,9 @@ class MockJob(AbstractJob):
     def get_calibration(self):
         pass
 
+    def get_circuit(self, program_num: int | None = None) -> cirq.Circuit:
+        pass
+
     def cancel(self) -> None:
         pass
 
@@ -117,3 +120,9 @@ def test_instantiation_and_iteration():
     assert result.measurements['a'][0] == 4
     with pytest.raises(StopIteration):
         next(iterator)
+
+
+def test_get_circuit():
+    job = MockJob()
+    job.get_circuit()
+    job.get_circuit(1)

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -124,5 +124,5 @@ def test_instantiation_and_iteration():
 
 def test_get_circuit():
     job = MockJob()
-    job.get_circuit()
-    job.get_circuit(1)
+    assert job.get_circuit() == cirq.Circuit()
+    assert job.get_circuit(1) == cirq.Circuit()

--- a/cirq-google/cirq_google/engine/abstract_local_job.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job.py
@@ -174,3 +174,16 @@ class AbstractLocalJob(AbstractJob):
         """Returns the recorded calibration at the time when the job was created,
         from the parent Engine object."""
         return self.get_processor().get_latest_calibration(int(self._create_time.timestamp()))
+
+    def get_circuit(self, program_num: int | None = None) -> cirq.Circuit:
+        """Returns the cirq Circuit for the job.
+
+        Args:
+            program_num: if this is a multi-circuit job, the index of the circuit
+                to return.  This argument is zero-indexed. Negative values
+                indexing from the end of the list.
+
+        Returns:
+            The job's cirq Circuit.
+        """
+        return self.program().get_circuit(program_num)

--- a/cirq-google/cirq_google/engine/abstract_local_job.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job.py
@@ -181,7 +181,7 @@ class AbstractLocalJob(AbstractJob):
         Args:
             program_num: if this is a multi-circuit job, the index of the circuit
                 to return.  This argument is zero-indexed. Negative values
-                indexing from the end of the list.
+                index from the end of the list.  Ignored if not multi-circuit.
 
         Returns:
             The job's cirq Circuit.

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -24,6 +24,7 @@ from unittest import mock
 import cirq
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_local_job import AbstractLocalJob
+from cirq_google.engine.engine_program import EngineProgram
 
 if TYPE_CHECKING:
     from cirq_google.engine.engine_result import EngineResult
@@ -106,7 +107,10 @@ def test_get_circuit():
         repetitions=100,
         sweeps=[],
     )
-    job.get_circuit()
+
+    circuit = cirq.Circuit()
+    mock_program.get_circuit.return_value = circuit
+    assert job.get_circuit() == circuit
     mock_program.get_circuit.assert_called_with(None)
-    job.get_circuit(1)
+    assert job.get_circuit(1) == circuit
     mock_program.get_circuit.assert_called_with(1)

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -24,7 +24,6 @@ from unittest import mock
 import cirq
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_local_job import AbstractLocalJob
-from cirq_google.engine.engine_program import EngineProgram
 
 if TYPE_CHECKING:
     from cirq_google.engine.engine_result import EngineResult

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import datetime
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
+from unittest import mock
 
 import cirq
 from cirq_google.cloud import quantum
@@ -94,3 +95,18 @@ def test_create_update_time():
     job._update_time = update_time
     assert job.create_time() == create_time
     assert job.update_time() == update_time
+
+
+def test_get_circuit():
+    mock_program = mock.Mock()
+    job = NothingJob(
+        job_id='test',
+        processor_id='pot_of_gold',
+        parent_program=mock_program,
+        repetitions=100,
+        sweeps=[],
+    )
+    job.get_circuit()
+    mock_program.get_circuit.assert_called_with(None)
+    job.get_circuit(1)
+    mock_program.get_circuit.assert_called_with(1)

--- a/cirq-google/cirq_google/engine/abstract_local_program.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program.py
@@ -195,14 +195,14 @@ class AbstractLocalProgram(AbstractProgram):
         supported if the program was created with the V2 protos.
 
         Args:
-            program_num: if this is a batch program, the index of the circuit in
-                the batch.  This argument is zero-indexed. Negative values
+            program_num: if this is a multi-circuit program, the index of the circuit
+                to return.  This argument is zero-indexed. Negative values
                 indexing from the end of the list.
 
         Returns:
             The program's cirq Circuit.
         """
-        if program_num:
+        if program_num is not None:
             return self._circuits[program_num]
         return self._circuits[0]
 

--- a/cirq-google/cirq_google/engine/abstract_program.py
+++ b/cirq-google/cirq_google/engine/abstract_program.py
@@ -158,9 +158,14 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_circuit(self) -> cirq.Circuit:
+    def get_circuit(self, program_num: int | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the program. This is only
         supported if the program was created with the V2 protos.
+
+        Args:
+            program_num: if this is a multi-circuit program, the index of the circuit
+                to return.  This argument is zero-indexed. Negative values
+                indexing from the end of the list.
 
         Returns:
             The program's cirq Circuit.

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -258,6 +258,21 @@ class EngineJob(abstract_job.AbstractJob):
         metrics = v2.metrics_pb2.MetricsSnapshot.FromString(response.data.value)
         return calibration.Calibration(metrics)
 
+    async def get_circuit_async(self, program_num: int | None = None) -> cirq.Circuit:
+        """Returns the cirq Circuit for the Quantum Engine job.
+
+        Args:
+            program_num: if this is a multi-circuit job, the index of the circuit
+                to return.  This argument is zero-indexed. Negative values
+                indexing from the end of the list.
+
+        Returns:
+            The job's cirq Circuit.
+        """
+        return await self.program().get_circuit_async(program_num)
+
+    get_circuit = duet.sync(get_circuit_async)
+
     def cancel(self) -> None:
         """Cancel the job."""
         self.context.client.cancel_job(self.project_id, self.program_id, self.job_id)

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -569,9 +569,9 @@ def test_get_circuit():
         cg.EngineProgram, 'get_circuit_async', new_callable=mock.AsyncMock
     ) as get_circuit_async:
         get_circuit_async.return_value = circuit
-        assert job.get_circuit() == circuit
+        assert job.get_circuit() is circuit
         get_circuit_async.assert_called_with(None)
-        assert job.get_circuit(1) == circuit
+        assert job.get_circuit(1) is circuit
         get_circuit_async.assert_called_with(1)
 
 
@@ -583,5 +583,5 @@ async def test_get_circuit_async():
         cg.EngineProgram, 'get_circuit_async', new_callable=mock.AsyncMock
     ) as get_circuit_async:
         get_circuit_async.return_value = circuit
-        assert await job.get_circuit_async(1) == circuit
+        assert await job.get_circuit_async(1) is circuit
         get_circuit_async.assert_called_with(1)

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -560,3 +560,28 @@ def test_timeout(get_job):
 def test_str():
     job = cg.EngineJob('a', 'b', 'steve', EngineContext())
     assert str(job) == 'EngineJob(project_id=\'a\', program_id=\'b\', job_id=\'steve\')'
+
+
+def test_get_circuit():
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+    circuit = cirq.Circuit()
+    with mock.patch.object(
+        cg.EngineProgram, 'get_circuit_async', new_callable=mock.AsyncMock
+    ) as get_circuit_async:
+        get_circuit_async.return_value = circuit
+        assert job.get_circuit() == circuit
+        get_circuit_async.assert_called_with(None)
+        assert job.get_circuit(1) == circuit
+        get_circuit_async.assert_called_with(1)
+
+
+@duet.sync
+async def test_get_circuit_async():
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+    circuit = cirq.Circuit()
+    with mock.patch.object(
+        cg.EngineProgram, 'get_circuit_async', new_callable=mock.AsyncMock
+    ) as get_circuit_async:
+        get_circuit_async.return_value = circuit
+        assert await job.get_circuit_async(1) == circuit
+        get_circuit_async.assert_called_with(1)

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 import duet
 
@@ -419,7 +419,7 @@ def _deserialize_program(code: any_pb2.Any, program_num: int | None = None) -> c
     if program is not None:
         serializer = circuit_serializer.CIRCUIT_SERIALIZER
         if program_num is not None:
-            return serializer.deserialize_multi_program(program)[program_num][2]
+            return cast(cirq.Circuit, serializer.deserialize_multi_program(program)[program_num][2])
         return serializer.deserialize(program)
 
     raise ValueError(f'unsupported program type: {code_type}')

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -352,9 +352,14 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     remove_labels = duet.sync(remove_labels_async)
 
-    async def get_circuit_async(self) -> cirq.Circuit:
+    async def get_circuit_async(self, program_num: int | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the Quantum Engine program. This is only
         supported if the program was created with the V2 protos.
+
+        Args:
+            program_num: if this is a multi-circuit program, the index of the circuit
+                to return.  This argument is zero-indexed. Negative values
+                indexing from the end of the list.
 
         Returns:
             The program's cirq Circuit.
@@ -365,7 +370,7 @@ class EngineProgram(abstract_program.AbstractProgram):
             self._program = await self.context.client.get_program_async(
                 self.project_id, self.program_id, True
             )
-        return _deserialize_program(self._program.code)
+        return _deserialize_program(self._program.code, program_num)
 
     get_circuit = duet.sync(get_circuit_async)
 
@@ -402,7 +407,7 @@ class EngineProgram(abstract_program.AbstractProgram):
         return f'EngineProgram(project_id=\'{self.project_id}\', program_id=\'{self.program_id}\')'
 
 
-def _deserialize_program(code: any_pb2.Any) -> cirq.Circuit:
+def _deserialize_program(code: any_pb2.Any, program_num: int | None = None) -> cirq.Circuit:
     import cirq_google.engine.engine as engine_base
 
     code_type = code.type_url[len(engine_base.TYPE_PREFIX) :]
@@ -412,6 +417,9 @@ def _deserialize_program(code: any_pb2.Any) -> cirq.Circuit:
     elif code_type == 'cirq.google.api.v2.Program' or code_type == 'cirq.api.google.v2.Program':
         program = v2.program_pb2.Program.FromString(code.value)
     if program is not None:
-        return circuit_serializer.CIRCUIT_SERIALIZER.deserialize(program)
+        serializer = circuit_serializer.CIRCUIT_SERIALIZER
+        if program_num is not None:
+            return serializer.deserialize_multi_program(program)[program_num][2]
+        return serializer.deserialize(program)
 
     raise ValueError(f'unsupported program type: {code_type}')

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -314,6 +314,41 @@ def test_get_circuit_v2(get_program_async, include_empty_program: bool) -> None:
     )
     get_program_async.assert_called_once_with('a', 'b', True)
 
+    with mock.patch(
+        'cirq_google.serialization.circuit_serializer.CIRCUIT_SERIALIZER.deserialize_multi_program'
+    ) as deserialize_multi_program:
+        deserialize_multi_program.return_value = [('key0', (), circuit), ('key1', (), circuit)]
+        assert program.get_circuit(program_num=1) == circuit
+        deserialize_multi_program.assert_called_once()
+
+
+@duet.sync
+async def test_get_circuit_async():
+    context = EngineContext()
+    program = cg.EngineProgram('a', 'b', context)
+    circuit = cirq.Circuit()
+    with mock.patch.object(
+        context.client, 'get_program_async', new_callable=mock.AsyncMock
+    ) as get_program_async:
+        get_program_async.return_value = quantum.QuantumProgram(code=_PROGRAM_V2)
+        with mock.patch(
+            'cirq_google.engine.engine_program._deserialize_program'
+        ) as deserialize_program:
+            deserialize_program.return_value = circuit
+            assert await program.get_circuit_async(1) == circuit
+            deserialize_program.assert_called_once_with(mock.ANY, 1)
+
+
+def test_deserialize_program():
+    code = util.pack_any(v2.program_pb2.Program())
+    with mock.patch(
+        'cirq_google.serialization.circuit_serializer.CIRCUIT_SERIALIZER'
+    ) as mock_serializer:
+        cg.engine.engine_program._deserialize_program(code)
+        mock_serializer.deserialize.assert_called_once()
+        cg.engine.engine_program._deserialize_program(code, program_num=1)
+        mock_serializer.deserialize_multi_program.assert_called_once()
+
 
 @pytest.fixture(scope='module', autouse=True)
 def mock_grpc_client():

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -319,7 +319,7 @@ def test_get_circuit_v2(get_program_async, include_empty_program: bool) -> None:
         'cirq_google.serialization.circuit_serializer.CIRCUIT_SERIALIZER.deserialize_multi_program'
     ) as deserialize_multi_program:
         deserialize_multi_program.return_value = [('key0', (), circuit), ('key1', (), circuit)]
-        assert program.get_circuit(program_num=1) == circuit
+        assert program.get_circuit(program_num=1) is circuit
         deserialize_multi_program.assert_called_once()
 
 

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import datetime
 from unittest import mock
 
+import duet
 import numpy as np
 import pytest
 from google.protobuf import any_pb2, timestamp_pb2


### PR DESCRIPTION
- Updates AbstractJob and AbstractProgram to allow an optional circuit index.  For multi-circuit, this will index into the keyed_circuit proto.
- Updates EngineJob and EngineProgram to support the implementation.
- AbstractLocalJob to allow a fake/mock to support local simulator and tests.