### PR TITLE
Fix flaky EngineProcessor time filter tests

### DIFF
--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -568,11 +568,15 @@ def _to_calibration(calibration_any: any_pb2.Any) -> calibration.Calibration:
     return calibration.Calibration(metrics)
 
 
+def _now() -> datetime.datetime:
+    return datetime.datetime.now()
+
+
 def _to_date_time_filters(
     from_time: None | datetime.datetime | datetime.timedelta,
     to_time: None | datetime.datetime | datetime.timedelta,
 ) -> list[str]:
-    now = datetime.datetime.now()
+    now = _now()
 
     if from_time is None:
         start_time = None

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -568,15 +568,11 @@ def _to_calibration(calibration_any: any_pb2.Any) -> calibration.Calibration:
     return calibration.Calibration(metrics)
 
 
-def _now() -> datetime.datetime:
-    return datetime.datetime.now()
-
-
 def _to_date_time_filters(
     from_time: None | datetime.datetime | datetime.timedelta,
     to_time: None | datetime.datetime | datetime.timedelta,
 ) -> list[str]:
-    now = _now()
+    now = datetime.datetime.now()
 
     if from_time is None:
         start_time = None

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -782,7 +782,7 @@ def test_get_schedule_filter_by_time_slot(list_time_slots):
     )
 
 
-# @mock.patch('datetime.datetime', _FrozenDateTime)
+@mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_time_slots_async')
 def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.return_value = []
@@ -826,7 +826,7 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.assert_called_with('proj', 'p0', f'start_time < {utc_ts}')
 
 
-# @mock.patch('datetime.datetime', _FrozenDateTime)
+@mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_reservations_async')
 def test_list_reservations_time_filter_behavior(list_reservations):
     list_reservations.return_value = []

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import datetime
+import functools
 from unittest import mock
 
 import duet
@@ -192,6 +193,17 @@ _METRIC_SNAPSHOT = v2.metrics_pb2.MetricsSnapshot(
         ),
     ],
 )
+
+
+class _FrozenDateTime(datetime.datetime):
+    """Frozen datetime for testing time related behavior."""
+
+    _stock_datetime = datetime.datetime
+
+    @classmethod
+    @functools.cache
+    def now(cls, tz=None):
+        return cls._stock_datetime.now(tz)
 
 
 class FakeEngineContext(EngineContext):
@@ -769,17 +781,16 @@ def test_get_schedule_filter_by_time_slot(list_time_slots):
     )
 
 
-@mock.patch('cirq_google.engine.engine_processor._now')
+@mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_time_slots_async')
-def test_get_schedule_time_filter_behavior(list_time_slots, mock_now):
-    fixed_now = datetime.datetime(2026, 4, 1)
+def test_get_schedule_time_filter_behavior(list_time_slots):
+    _FrozenDateTime.now.cache_clear()
+    fixed_now = _FrozenDateTime.now()
 
-    mock_now.return_value = fixed_now
+    now = int(fixed_now.timestamp())
     list_time_slots.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
-    now = int((fixed_now).timestamp())
     in_two_weeks = int((fixed_now + datetime.timedelta(weeks=2)).timestamp())
-
     processor.get_schedule()
     list_time_slots.assert_called_with(
         'proj', 'p0', f'start_time < {in_two_weeks} AND end_time > {now}'
@@ -815,15 +826,15 @@ def test_get_schedule_time_filter_behavior(list_time_slots, mock_now):
     list_time_slots.assert_called_with('proj', 'p0', f'start_time < {utc_ts}')
 
 
-@mock.patch('cirq_google.engine.engine_processor._now')
+@mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_reservations_async')
-def test_list_reservations_time_filter_behavior(list_reservations, mock_now):
-    fixed_now = datetime.datetime(2026, 4, 1)
+def test_list_reservations_time_filter_behavior(list_reservations):
+    _FrozenDateTime.now.cache_clear()
+    fixed_now = _FrozenDateTime.now()
 
-    mock_now.return_value = fixed_now
+    now = int(fixed_now.timestamp())
     list_reservations.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
-    now = int((fixed_now).timestamp())
     in_two_weeks = int((fixed_now + datetime.timedelta(weeks=2)).timestamp())
     processor.list_reservations()
     list_reservations.assert_called_with(

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -769,13 +769,17 @@ def test_get_schedule_filter_by_time_slot(list_time_slots):
     )
 
 
+@mock.patch('cirq_google.engine.engine_processor._now')
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_time_slots_async')
-def test_get_schedule_time_filter_behavior(list_time_slots):
+def test_get_schedule_time_filter_behavior(list_time_slots, mock_now):
+    fixed_now = datetime.datetime(2026, 4, 1)
+
+    mock_now.return_value = fixed_now
     list_time_slots.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
+    now = int((fixed_now).timestamp())
+    in_two_weeks = int((fixed_now + datetime.timedelta(weeks=2)).timestamp())
 
-    now = int(datetime.datetime.now().timestamp())
-    in_two_weeks = int((datetime.datetime.now() + datetime.timedelta(weeks=2)).timestamp())
     processor.get_schedule()
     list_time_slots.assert_called_with(
         'proj', 'p0', f'start_time < {in_two_weeks} AND end_time > {now}'
@@ -811,13 +815,16 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.assert_called_with('proj', 'p0', f'start_time < {utc_ts}')
 
 
+@mock.patch('cirq_google.engine.engine_processor._now')
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_reservations_async')
-def test_list_reservations_time_filter_behavior(list_reservations):
+def test_list_reservations_time_filter_behavior(list_reservations, mock_now):
+    fixed_now = datetime.datetime(2026, 4, 1)
+
+    mock_now.return_value = fixed_now
     list_reservations.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
-
-    now = int(datetime.datetime.now().timestamp())
-    in_two_weeks = int((datetime.datetime.now() + datetime.timedelta(weeks=2)).timestamp())
+    now = int((fixed_now).timestamp())
+    in_two_weeks = int((fixed_now + datetime.timedelta(weeks=2)).timestamp())
     processor.list_reservations()
     list_reservations.assert_called_with(
         'proj', 'p0', f'start_time < {in_two_weeks} AND end_time > {now}'

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import datetime
 import functools
-import time
 from unittest import mock
 
 import duet
@@ -804,7 +803,6 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
     processor.get_schedule(from_time=None, to_time=None)
     list_time_slots.assert_called_with('proj', 'p0', '')
 
-    time.sleep(1)
     processor.get_schedule(from_time=datetime.timedelta(0), to_time=None)
     list_time_slots.assert_called_with('proj', 'p0', f'end_time > {now}')
 
@@ -833,7 +831,6 @@ def test_list_reservations_time_filter_behavior(list_reservations):
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
 
     now = int(datetime.datetime.now().timestamp())
-    time.sleep(1)
     in_two_weeks = int((datetime.datetime.now() + datetime.timedelta(weeks=2)).timestamp())
     processor.list_reservations()
     list_reservations.assert_called_with(

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import datetime
 import functools
+import time
 from unittest import mock
 
 import duet
@@ -781,7 +782,7 @@ def test_get_schedule_filter_by_time_slot(list_time_slots):
     )
 
 
-@mock.patch('datetime.datetime', _FrozenDateTime)
+# @mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_time_slots_async')
 def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.return_value = []
@@ -803,6 +804,7 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
     processor.get_schedule(from_time=None, to_time=None)
     list_time_slots.assert_called_with('proj', 'p0', '')
 
+    time.sleep(1)
     processor.get_schedule(from_time=datetime.timedelta(0), to_time=None)
     list_time_slots.assert_called_with('proj', 'p0', f'end_time > {now}')
 
@@ -824,13 +826,14 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
     list_time_slots.assert_called_with('proj', 'p0', f'start_time < {utc_ts}')
 
 
-@mock.patch('datetime.datetime', _FrozenDateTime)
+# @mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_reservations_async')
 def test_list_reservations_time_filter_behavior(list_reservations):
     list_reservations.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
 
     now = int(datetime.datetime.now().timestamp())
+    time.sleep(1)
     in_two_weeks = int((datetime.datetime.now() + datetime.timedelta(weeks=2)).timestamp())
     processor.list_reservations()
     list_reservations.assert_called_with(

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -784,13 +784,11 @@ def test_get_schedule_filter_by_time_slot(list_time_slots):
 @mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_time_slots_async')
 def test_get_schedule_time_filter_behavior(list_time_slots):
-    _FrozenDateTime.now.cache_clear()
-    fixed_now = _FrozenDateTime.now()
-
-    now = int(fixed_now.timestamp())
     list_time_slots.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
-    in_two_weeks = int((fixed_now + datetime.timedelta(weeks=2)).timestamp())
+
+    now = int(datetime.datetime.now().timestamp())
+    in_two_weeks = int((datetime.datetime.now() + datetime.timedelta(weeks=2)).timestamp())
     processor.get_schedule()
     list_time_slots.assert_called_with(
         'proj', 'p0', f'start_time < {in_two_weeks} AND end_time > {now}'
@@ -829,13 +827,11 @@ def test_get_schedule_time_filter_behavior(list_time_slots):
 @mock.patch('datetime.datetime', _FrozenDateTime)
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_reservations_async')
 def test_list_reservations_time_filter_behavior(list_reservations):
-    _FrozenDateTime.now.cache_clear()
-    fixed_now = _FrozenDateTime.now()
-
-    now = int(fixed_now.timestamp())
     list_reservations.return_value = []
     processor = cg.EngineProcessor('proj', 'p0', EngineContext())
-    in_two_weeks = int((fixed_now + datetime.timedelta(weeks=2)).timestamp())
+
+    now = int(datetime.datetime.now().timestamp())
+    in_two_weeks = int((datetime.datetime.now() + datetime.timedelta(weeks=2)).timestamp())
     processor.list_reservations()
     list_reservations.assert_called_with(
         'proj', 'p0', f'start_time < {in_two_weeks} AND end_time > {now}'


### PR DESCRIPTION
This fix addresses the flaky tests in engine_processor_test.py as explained in #7851.
The tests are fixed by mocking the `datetime.datetime` class with a subclass
`_FrozenDateTime` to make `datetime.datetime.now()` return a constant.

I reproduced the issue by adding `import time; time.sleep(1)` to both `test_get_schedule_time_filter_behavior` and `test_list_reservations_time_filter_behavior` and confirmed that the fix works for both cases (though I removed the sleeps for this pr).

Fixes #7851