### PR TITLE
Fix ordering in Engine.run_batch

### DIFF
--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -158,11 +158,11 @@ class ProcessorSampler(cirq.Sampler):
             final_results = []
             for batch_res, batch_progs in zip(all_batch_results, program_batches):
                 num_progs = len(batch_progs)
+                num_sweeps = len(batch_res) // num_progs
                 for j in range(num_progs):
-                    # Engine returns results grouped by sweep then by program.
-                    # e.g. (S1, P1), (S1, P2), (S2, P1), (S2, P2)
-                    # So P1's results are at indices 0, 2, ...
-                    final_results.append(batch_res[j::num_progs])
+                    # Engine returns results grouped by program then by sweep.
+                    # e.g. (P1, S1), (P1, S2), (P2, S1), (P2, S2)
+                    final_results.append(batch_res[j * num_sweeps : (j + 1) * num_sweeps])
             return final_results
 
         prog_values = list(programs.values()) if isinstance(programs, Mapping) else list(programs)

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -159,6 +159,11 @@ class ProcessorSampler(cirq.Sampler):
             for batch_res, batch_progs in zip(all_batch_results, program_batches):
                 num_progs = len(batch_progs)
                 num_sweeps = len(batch_res) // num_progs
+                if len(batch_res) % num_progs != 0:
+                    raise ValueError(
+                        f"Engine returned {len(batch_res)} results, "
+                        f"which is not divisible by {num_progs} programs."
+                    )
                 for j in range(num_progs):
                     # Engine returns results grouped by program then by sweep.
                     # e.g. (P1, S1), (P1, S2), (P2, S1), (P2, S2)

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -208,7 +208,7 @@ def test_run_batch_ordering():
     sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
 
     a = cirq.LineQubit(0)
-    circuit1 = cirq.Circuit(cirq.X(a), cirq.measure(a, key='m'))
+    circuit1 = cirq.Circuit(cirq.X(a), cirq.X(a), cirq.measure(a, key='m'))
     circuit2 = cirq.Circuit(cirq.Y(a), cirq.measure(a, key='m'))
 
     # 2 sweep points

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -223,10 +223,10 @@ def test_run_batch_ordering():
         params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job'
     )
     r1_s2 = cg.EngineResult(
-        params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job'
+        params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[0]])}, job_id='job'
     )
     r2_s1 = cg.EngineResult(
-        params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job'
+        params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[1]])}, job_id='job'
     )
     r2_s2 = cg.EngineResult(
         params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job'

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -220,10 +220,18 @@ def test_run_batch_ordering():
     # P1_S1, P1_S2, P2_S1, P2_S2
     import numpy as np
 
-    r1_s1 = cg.EngineResult(params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job')
-    r1_s2 = cg.EngineResult(params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job')
-    r2_s1 = cg.EngineResult(params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job')
-    r2_s2 = cg.EngineResult(params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job')
+    r1_s1 = cg.EngineResult(
+        params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job'
+    )
+    r1_s2 = cg.EngineResult(
+        params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job'
+    )
+    r2_s1 = cg.EngineResult(
+        params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job'
+    )
+    r2_s2 = cg.EngineResult(
+        params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job'
+    )
 
     results_grouped = [r1_s1, r1_s2, r2_s1, r2_s2]
     mock_job.results_async.return_value = results_grouped

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -410,6 +410,7 @@ def test_processor_sampler_with_invalid_configuration_throws(run_name, device_co
             processor=processor, run_name=run_name, device_config_name=device_config_name
         )
 
+
 @duet.sync
 async def test_run_batch_error_divisible():
     processor = mock.create_autospec(AbstractProcessor, instance=True)

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from unittest import mock
 
 import duet
+import numpy as np
 import pytest
 
 import cirq
@@ -218,8 +219,6 @@ def test_run_batch_ordering():
 
     # Engine returns results grouped by program:
     # P1_S1, P1_S2, P2_S1, P2_S2
-    import numpy as np
-
     r1_s1 = cg.EngineResult(
         params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job'
     )
@@ -410,3 +409,23 @@ def test_processor_sampler_with_invalid_configuration_throws(run_name, device_co
         cg.ProcessorSampler(
             processor=processor, run_name=run_name, device_config_name=device_config_name
         )
+
+@duet.sync
+async def test_run_batch_error_divisible():
+    processor = mock.create_autospec(AbstractProcessor, instance=True)
+    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.X(a))
+    circuit2 = cirq.Circuit(cirq.Y(a))
+
+    job = mock.create_autospec(EngineJob, instance=True)
+    # Return 3 results for 2 programs. 3 % 2 != 0.
+    job.results_async.return_value = [mock.Mock()] * 3
+
+    processor.run_sweep_async.return_value = job
+
+    with pytest.raises(
+        ValueError, match="Engine returned 3 results, which is not divisible by 2 programs."
+    ):
+        await sampler.run_batch_async([circuit1, circuit2], [{}, {}], 5)

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -202,6 +202,42 @@ def test_run_batch_with_jobs_per_batch():
     )
 
 
+def test_run_batch_ordering():
+    processor = mock.create_autospec(AbstractProcessor, instance=True)
+    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+
+    a = cirq.LineQubit(0)
+    circuit1 = cirq.Circuit(cirq.X(a), cirq.measure(a, key='m'))
+    circuit2 = cirq.Circuit(cirq.Y(a), cirq.measure(a, key='m'))
+
+    # 2 sweep points
+    sweep = cirq.Points('v', [0, 1])
+
+    # Mock job and results
+    mock_job = mock.AsyncMock(EngineJob)
+
+    # Engine returns results grouped by program:
+    # P1_S1, P1_S2, P2_S1, P2_S2
+    import numpy as np
+
+    r1_s1 = cg.EngineResult(params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job')
+    r1_s2 = cg.EngineResult(params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job')
+    r2_s1 = cg.EngineResult(params=cirq.ParamResolver({'v': 0}), measurements={'m': np.array([[0]])}, job_id='job')
+    r2_s2 = cg.EngineResult(params=cirq.ParamResolver({'v': 1}), measurements={'m': np.array([[1]])}, job_id='job')
+
+    results_grouped = [r1_s1, r1_s2, r2_s1, r2_s2]
+    mock_job.results_async.return_value = results_grouped
+    processor.run_sweep_async.return_value = mock_job
+
+    # Run batch
+    results = sampler.run_batch([circuit1, circuit2], [sweep, sweep], repetitions=1)
+
+    # results[0] should be for circuit1: [r1_s1, r1_s2]
+    # results[1] should be for circuit2: [r2_s1, r2_s2]
+    assert results[0] == [r1_s1, r1_s2]
+    assert results[1] == [r2_s1, r2_s2]
+
+
 @pytest.mark.parametrize('use_mapping', [True, False])
 def test_run_batch_with_jobs_per_batch_and_params(use_mapping: bool):
     processor = mock.create_autospec(AbstractProcessor, instance=True)

--- a/cirq-google/cirq_google/engine/simulated_local_job.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job.py
@@ -33,11 +33,9 @@ from cirq_google.engine.local_simulation_type import LocalSimulationType
 def _flatten_results(batch_results: Sequence[Sequence[EngineResult]]) -> list[EngineResult]:
     if not batch_results:
         return []
-    # Engine returns results grouped by sweep then by program.
-    # batch_results is currently grouped by program then by sweep.
-    return [
-        batch_results[i][j] for j in range(len(batch_results[0])) for i in range(len(batch_results))
-    ]
+    # Engine returns results grouped by program then by sweep.
+    # batch_results is already grouped by program then by sweep.
+    return [res for batch in batch_results for res in batch]
 
 
 def _to_engine_results(

--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -135,3 +135,27 @@ def test_run_async():
     )
     _ = job.results()
     assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS
+
+
+def test_run_batch():
+    program = ParentProgram(
+        [
+            cirq.Circuit(cirq.X(Q) ** sympy.Symbol('t'), cirq.measure(Q, key='m')),
+            cirq.Circuit(cirq.Z(Q) ** sympy.Symbol('t'), cirq.measure(Q, key='m')),
+        ],
+        None,
+    )
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=100,
+        sweeps=[cirq.Points(key='t', points=[0, 1]), cirq.Points(key='t', points=[0, 1])],
+    )
+    assert job.execution_status() == quantum.ExecutionStatus.State.READY
+    results = job.results()
+    assert np.all(results[0].measurements['m'] == 0)
+    assert np.all(results[1].measurements['m'] == 1)
+    assert np.all(results[2].measurements['m'] == 0)
+    assert np.all(results[3].measurements['m'] == 0)
+    assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS


### PR DESCRIPTION
- ProcessorSampler incorrectly reconstructs the results from Quantum Engine. It incorrectly assumes that the engine returns results interleaved by sweep point (e.g., S1_P1, S1_P2, S2_P1, S2_P2), when the engine actually returns them grouped by program (e.g., P1_S1, P1_S2, P2_S1, P2_S2).
- This causes the results to be returned incorrectly if jobs_per_batch>1.