### PR TITLE
CI - add missing permissions to the label-dependabot-pr job

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -84,6 +84,9 @@ jobs:
     name: Convert dependabot PR to draft
     runs-on: ubuntu-slim
     timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Convert to draft and attach the on-hold label
         env:


### PR DESCRIPTION
Write permissions are required for modifying dependabot PRs.
