### PR TITLE
CI - adjust permission for the label-dependabot-pr job

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      issues: write
+      contents: write
       pull-requests: write
     steps:
       - name: Convert to draft and attach the on-hold label


### PR DESCRIPTION
Conversion to the draft state requires `contents-write`.
The `issues-write` permission was redundant.

Follow-up to #8066
