### PR TITLE
Micro optimization to Moment initialization.

### DIFF
--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -101,7 +101,7 @@ class Moment:
 
         # An internal dictionary to support efficient operation access by qubit.
         self._qubit_to_op: dict[cirq.Qid, cirq.Operation] = {}
-        for op in self.operations:
+        for op in self._operations:
             for q in op.qubits:
                 # Check that operations don't overlap.
                 if q in self._qubit_to_op:


### PR DESCRIPTION
- Change to a local reference speeds Moment creation by about 5%.
- Not much, but it is a common operation.