### PR TITLE
Improve fixup order in `check/all --fix`

### DIFF
--- a/check/all
+++ b/check/all
@@ -91,8 +91,8 @@ run() {
 }
 
 run check/misc
-run ruff check "${extra_ruff_args[@]}"
 run check/format-incremental "${base_rev[@]}" "${extra_format_args[@]}"
+run ruff check "${extra_ruff_args[@]}"
 
 if (( only_changed )); then
     run check/pylint-changed-files "${base_rev[@]}"


### PR DESCRIPTION
Problem: In `check/all --fix` the `ruff check` may flag long lines
before they get wrapped by format-incremental.  The process
then returns error status for code that was all fixed up.

Solution: Fix code formatting before running `ruff check`.
