### PR TITLE
Fix ci-daily run on windows-2022

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
-  # FIXME - remove this before PR submission
-  pull_request:
-    branches:
-      - main
 
   # Allow manual invocation.
   workflow_dispatch:

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
+  # FIXME - remove this before PR submission
+  pull_request:
+    branches:
+      - main
 
   # Allow manual invocation.
   workflow_dispatch:

--- a/cirq-core/cirq/linalg/transformations_test.py
+++ b/cirq-core/cirq/linalg/transformations_test.py
@@ -390,25 +390,28 @@ def test_sub_state_vector() -> None:
     )
 
     # Reject factoring for very tight tolerance.
+    imperfect_state = state * np.random.normal(1.0, 1e-6, state.shape)
     assert (
-        cirq.sub_state_vector(state, [0, 1], default=_DEFAULT_ARRAY, atol=1e-16) is _DEFAULT_ARRAY
-    )
-    assert (
-        cirq.sub_state_vector(state, [2, 3, 4], default=_DEFAULT_ARRAY, atol=1e-16)
+        cirq.sub_state_vector(imperfect_state, [0, 1], default=_DEFAULT_ARRAY, atol=1e-16)
         is _DEFAULT_ARRAY
     )
     assert (
-        cirq.sub_state_vector(state, [5, 6, 7, 8], default=_DEFAULT_ARRAY, atol=1e-16)
+        cirq.sub_state_vector(imperfect_state, [2, 3, 4], default=_DEFAULT_ARRAY, atol=1e-16)
+        is _DEFAULT_ARRAY
+    )
+    assert (
+        cirq.sub_state_vector(imperfect_state, [5, 6, 7, 8], default=_DEFAULT_ARRAY, atol=1e-16)
         is _DEFAULT_ARRAY
     )
 
     # Ensure None can be passed as the `default` argument
-    assert cirq.sub_state_vector(state, [0, 1], default=None, atol=1e-16) is None
+    assert cirq.sub_state_vector(imperfect_state, [0, 1], default=None, atol=1e-16) is None
 
     # Permit invalid factoring for loose tolerance.
     for q1 in range(9):
         assert (
-            cirq.sub_state_vector(state, [q1], default=_DEFAULT_ARRAY, atol=1) is not _DEFAULT_ARRAY
+            cirq.sub_state_vector(imperfect_state, [q1], default=_DEFAULT_ARRAY, atol=1)
+            is not _DEFAULT_ARRAY
         )
 
 


### PR DESCRIPTION
Problem: The `atol` used in a test of `sub_state_vector` cannot simulate
low precision when the largest eigenvalue equals 1.

Solution: Test with `imperfect_state` with a small artificial errors.

