### PR TITLE
Disable local Google Cloud credentials in cirq-google tests

### DIFF
--- a/cirq-google/cirq_google/conftest.py
+++ b/cirq-google/cirq_google/conftest.py
@@ -33,8 +33,8 @@ def closefigures():
 def disable_local_gcloud_credentials(tmp_path_factory):
     """Ensure tests cannot authenticate to cloud servers with user credentials.
 
-    Disable credentials set either through environment variable GOOGLE_APPLICATION_CREDENTIALS
-    or via configuration files if user ran `gcloud auth application-default login`
+    Disable credentials set either through the GOOGLE_APPLICATION_CREDENTIALS environment variable
+    or via configuration files after running `gcloud auth application-default login`
 
     For more details see `google.auth.default`.
     """

--- a/cirq-google/cirq_google/conftest.py
+++ b/cirq-google/cirq_google/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from unittest import mock
 
 import matplotlib.pyplot as plt
 import pytest
@@ -26,3 +27,11 @@ def pytest_configure(config):
 def closefigures():
     yield
     plt.close('all')
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_local_gcloud_credentials(tmp_path_factory):
+    # Ensure tests cannot authenticate to production servers with user credentials
+    empty_dir = tmp_path_factory.mktemp("empty_gcloud_config-cirq_google", numbered=False)
+    with mock.patch.dict(os.environ, {"CLOUDSDK_CONFIG": str(empty_dir)}):
+        yield

--- a/cirq-google/cirq_google/conftest.py
+++ b/cirq-google/cirq_google/conftest.py
@@ -31,7 +31,17 @@ def closefigures():
 
 @pytest.fixture(scope="session", autouse=True)
 def disable_local_gcloud_credentials(tmp_path_factory):
-    # Ensure tests cannot authenticate to production servers with user credentials
+    """Ensure tests cannot authenticate to cloud servers with user credentials.
+
+    Disable credentials set either through environment variable GOOGLE_APPLICATION_CREDENTIALS
+    or via configuration files if user ran `gcloud auth application-default login`
+
+    For more details see `google.auth.default`.
+    """
     empty_dir = tmp_path_factory.mktemp("empty_gcloud_config-cirq_google", numbered=False)
-    with mock.patch.dict(os.environ, {"CLOUDSDK_CONFIG": str(empty_dir)}):
+    scrubbed_environ = {
+        **{k: v for k, v in os.environ.items() if k != "GOOGLE_APPLICATION_CREDENTIALS"},
+        "CLOUDSDK_CONFIG": str(empty_dir),
+    }
+    with mock.patch.dict(os.environ, scrubbed_environ, clear=True):
         yield

--- a/dev_tools/conftest.py
+++ b/dev_tools/conftest.py
@@ -35,7 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 @pytest.fixture(scope="session", autouse=True)
 def disable_local_gcloud_credentials(tmp_path_factory):
     # Ensure tests cannot authenticate to production servers with user credentials
-    empty_dir = tmp_path_factory.mktemp("empty_gcloud_config", numbered=False)
+    empty_dir = tmp_path_factory.mktemp("empty_gcloud_config-dev_tools", numbered=False)
     with mock.patch.dict(os.environ, {"CLOUDSDK_CONFIG": str(empty_dir)}):
         yield
 

--- a/dev_tools/conftest.py
+++ b/dev_tools/conftest.py
@@ -34,9 +34,19 @@ _LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session", autouse=True)
 def disable_local_gcloud_credentials(tmp_path_factory):
-    # Ensure tests cannot authenticate to production servers with user credentials
+    """Ensure tests cannot authenticate to cloud servers with user credentials.
+
+    Disable credentials set either through the GOOGLE_APPLICATION_CREDENTIALS environment variable
+    or via configuration files after running `gcloud auth application-default login`
+
+    For more details see `google.auth.default`.
+    """
     empty_dir = tmp_path_factory.mktemp("empty_gcloud_config-dev_tools", numbered=False)
-    with mock.patch.dict(os.environ, {"CLOUDSDK_CONFIG": str(empty_dir)}):
+    scrubbed_environ = {
+        **{k: v for k, v in os.environ.items() if k != "GOOGLE_APPLICATION_CREDENTIALS"},
+        "CLOUDSDK_CONFIG": str(empty_dir),
+    }
+    with mock.patch.dict(os.environ, scrubbed_environ, clear=True):
         yield
 
 


### PR DESCRIPTION
Prevent `cirq_google.engine` tests from connecting to the actual
services with local user credentials.  Tell gcloud to use empty
configuration directory instead of user configuration and also
unset `GOOGLE_APPLICATION_CREDENTIALS` from the environment.

Ref: https://google-auth.readthedocs.io/en/latest/reference/google.auth.html

May resolve b/511678310
