### PR TITLE
Fix patching of `CIRQ_TESTING` environment variable

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -264,7 +264,7 @@ def _warn_or_error(msg):
             f"During testing using Cirq deprecated functionality is not allowed: {msg}"
             f"Update to non-deprecated functionality, or alternatively, you can quiet "
             f"this error by removing the CIRQ_TESTING environment variable "
-            f"temporarily with `@mock.patch.dict(os.environ, clear='CIRQ_TESTING')`.\n"
+            f"temporarily with `@mock.patch.dict(os.environ, {{'CIRQ_TESTING': 'false'}})`.\n"
             f"In case the usage of deprecated cirq is intentional, use "
             f"`with cirq.testing.assert_deprecated(...):` around this line:\n"
             f"{filename}:{line_number}: in {function_name}\n"
@@ -589,7 +589,7 @@ _warned: set[str] = set()
 
 
 def _called_from_test() -> bool:
-    return 'CIRQ_TESTING' in os.environ
+    return os.environ.get("CIRQ_TESTING", "").lower() == "true"
 
 
 def _should_dedupe_module_deprecation() -> bool:

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -204,7 +204,7 @@ Q0, Q1, Q2, Q3, Q4 = QUBITS
 # during test setup deprecated submodules are inspected and trigger the
 # deprecation error in testing. It is cleaner to just turn it off than to assert
 # deprecation for each submodule.
-@mock.patch.dict(os.environ, clear='CIRQ_TESTING')
+@mock.patch.dict(os.environ, {'CIRQ_TESTING': 'false'})
 def test_shouldnt_be_serialized_no_superfluous(mod_spec: ModuleJsonTestSpec) -> None:
     # everything in the list should be ignored for a reason
     names = set(mod_spec.get_all_names())
@@ -220,7 +220,7 @@ def test_shouldnt_be_serialized_no_superfluous(mod_spec: ModuleJsonTestSpec) -> 
 # during test setup deprecated submodules are inspected and trigger the
 # deprecation error in testing. It is cleaner to just turn it off than to assert
 # deprecation for each submodule.
-@mock.patch.dict(os.environ, clear='CIRQ_TESTING')
+@mock.patch.dict(os.environ, {'CIRQ_TESTING': 'false'})
 def test_not_yet_serializable_no_superfluous(mod_spec: ModuleJsonTestSpec) -> None:
     # everything in the list should be ignored for a reason
     names = set(mod_spec.get_all_names())
@@ -425,7 +425,7 @@ def test_serializable_by_key() -> None:
 # during test setup deprecated submodules are inspected and trigger the
 # deprecation error in testing. It is cleaner to just turn it off than to assert
 # deprecation for each submodule.
-@mock.patch.dict(os.environ, clear='CIRQ_TESTING')
+@mock.patch.dict(os.environ, {'CIRQ_TESTING': 'false'})
 def _list_public_classes_for_tested_modules():
     # to remove DeprecationWarning noise during test collection
     with warnings.catch_warnings():


### PR DESCRIPTION
Problem: The suggested `mock.patch.dict(os.environ, clear='CIRQ_TESTING')`
empties the environment, because `clear` is a boolean flag.

Solution: Require `os.environ["CIRQ_TESTING"] == "true"` to mark up active
test session.  This allows `mock.patch.dict` to change CIRQ_TESTING value
to "false" instead of having to remove it from the environment.
