### PR TITLE
Support non-uniform repetitions in batch jobs

### DIFF
--- a/cirq-google/cirq_google/api/v2/sweeps.py
+++ b/cirq-google/cirq_google/api/v2/sweeps.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import gzip
 import numbers
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, cast, TYPE_CHECKING
 
 import sympy
@@ -418,7 +418,7 @@ def sweepable_to_proto(
 
 def run_context_to_proto(
     sweepable: cirq.Sweepable,
-    repetitions: int,
+    repetitions: int | Sequence[int],
     *,
     out: run_context_pb2.RunContext | None = None,
     compress_proto: bool = False,
@@ -428,7 +428,8 @@ def run_context_to_proto(
 
     Args:
         sweepable: The sweepable to include in the run context.
-        repetitions: The number of repetitions for the run context.
+        repetitions: The number of repetitions for the run context. Can be a single
+            integer or a sequence of integers (for non-uniform repetitions in batch).
         out: Optional message to be populated. If not given, a new message will
             be created.
         compress_proto: If set to `True` the function will gzip the proto and
@@ -444,7 +445,26 @@ def run_context_to_proto(
     if compress_proto:
         uncompressed_wrapper = out
         out = run_context_pb2.RunContext()
-    sweepable_to_proto(sweepable, repetitions, out=out, use_float64=use_float64)
+
+    sweeps_list = cirq.to_sweeps(sweepable)
+    if isinstance(repetitions, Sequence) and not isinstance(repetitions, str):
+        if len(sweeps_list) == 1 and len(repetitions) > 1:
+            sweeps_list = sweeps_list * len(repetitions)
+        if len(sweeps_list) != len(repetitions):
+            raise ValueError(
+                f"Length of sweeps ({len(sweeps_list)}) and "
+                f"repetitions ({len(repetitions)}) must match."
+            )
+        for s, r in zip(sweeps_list, repetitions):
+            sweep_proto = out.parameter_sweeps.add()
+            sweep_proto.repetitions = r
+            sweep_to_proto(s, out=sweep_proto.sweep, use_float64=use_float64)
+    else:
+        for s in sweeps_list:
+            sweep_proto = out.parameter_sweeps.add()
+            sweep_proto.repetitions = repetitions
+            sweep_to_proto(s, out=sweep_proto.sweep, use_float64=use_float64)
+
     if compress_proto:
         raw_bytes = out.SerializeToString()
         uncompressed_wrapper.compressed_run_context = gzip.compress(raw_bytes)

--- a/cirq-google/cirq_google/api/v2/sweeps_test.py
+++ b/cirq-google/cirq_google/api/v2/sweeps_test.py
@@ -513,3 +513,37 @@ def test_run_context_to_proto_sweepable(sweepable: cirq.Sweepable, use_resolver:
 def test_invalid_sweepable_raises() -> None:
     with pytest.raises(TypeError):
         _ = v2.run_context_to_proto(cirq.X, 1000, compress_proto=False)  # type: ignore[arg-type]
+
+
+def test_run_context_to_proto_sequence_repetitions() -> None:
+    # Case 1: len(sweeps) == 1, len(reps) > 1
+    sweep = cirq.UnitSweep
+    reps = [10, 20, 30]
+    out = v2.run_context_to_proto(sweep, reps)
+    assert len(out.parameter_sweeps) == 3
+    for i, r in enumerate(reps):
+        assert out.parameter_sweeps[i].repetitions == r
+        assert v2.sweep_from_proto(out.parameter_sweeps[i].sweep) == sweep
+
+    # Case 2: len(sweeps) > 1, len(reps) > 1, matching lengths
+    sweeps_list = [cirq.Linspace('a', 0, 1, 5), cirq.Linspace('b', 0, 1, 5)]
+    reps = [10, 20]
+    out = v2.run_context_to_proto(sweeps_list, reps)
+    assert len(out.parameter_sweeps) == 2
+    for i, r in enumerate(reps):
+        assert out.parameter_sweeps[i].repetitions == r
+        assert v2.sweep_from_proto(out.parameter_sweeps[i].sweep) == sweeps_list[i]
+
+    # Case 3: len(sweeps) > 1, len(reps) > 1, non-matching lengths
+    sweeps_list = [cirq.Linspace('a', 0, 1, 5), cirq.Linspace('b', 0, 1, 5)]
+    reps = [10, 20, 30]
+    with pytest.raises(ValueError, match="Length of sweeps.*and repetitions.*must match"):
+        _ = v2.run_context_to_proto(sweeps_list, reps)
+
+    # Case 4: len(sweeps) == 1, len(reps) == 1
+    sweep = cirq.UnitSweep
+    reps = [10]
+    out = v2.run_context_to_proto(sweep, reps)
+    assert len(out.parameter_sweeps) == 1
+    assert out.parameter_sweeps[0].repetitions == 10
+    assert v2.sweep_from_proto(out.parameter_sweeps[0].sweep) == sweep

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -255,7 +255,7 @@ class EngineJob(abstract_job.AbstractJob):
                 )
             # Mapped sweeps in a batch job
             try:
-                return (reps, [sweeps[circuit_num]])
+                return (reps[circuit_num], [sweeps[circuit_num]])
             except IndexError:
                 raise IndexError(
                     f"Index {circuit_num} out of range for sweeps of size {len(sweeps)}."
@@ -264,7 +264,9 @@ class EngineJob(abstract_job.AbstractJob):
         # Not a batch job
         if not is_batch and circuit_num and circuit_num != -1:
             raise IndexError(f"Job is not a batch job, cannot index {circuit_num}")
-        return (reps, sweeps)
+        if not reps:
+            raise ValueError("No repetitions found in run context.")
+        return (reps[0], sweeps)
 
     def get_processor(self) -> engine_processor.EngineProcessor | None:
         """Returns the EngineProcessor for the processor the job is/was run on,
@@ -402,7 +404,7 @@ class EngineJob(abstract_job.AbstractJob):
         )
 
 
-def _deserialize_run_context(run_context: any_pb2.Any) -> tuple[int, list[cirq.Sweep]]:
+def _deserialize_run_context(run_context: any_pb2.Any) -> tuple[list[int], list[cirq.Sweep]]:
     import cirq_google.engine.engine as engine_base
 
     run_context_type = run_context.type_url[len(engine_base.TYPE_PREFIX) :]
@@ -416,7 +418,7 @@ def _deserialize_run_context(run_context: any_pb2.Any) -> tuple[int, list[cirq.S
         or run_context_type == 'cirq.api.google.v2.RunContext'
     ):
         v2_run_context = v2.run_context_pb2.RunContext.FromString(run_context.value)
-        return v2_run_context.parameter_sweeps[0].repetitions, [
+        return [s.repetitions for s in v2_run_context.parameter_sweeps], [
             v2.sweep_from_proto(s.sweep) for s in v2_run_context.parameter_sweeps
         ]
     raise ValueError(f'unsupported run_context type: {run_context_type}')

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -385,6 +385,42 @@ def test_get_repetitions_and_sweeps(get_job, get_program):
         _ = job_batch_mapped.get_repetitions_and_sweeps(2)
 
 
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_program_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_async')
+def test_get_repetitions_and_sweeps_non_uniform(get_job, get_program):
+    get_program.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2)
+    get_job.return_value = quantum.QuantumJob(
+        run_context=util.pack_any(
+            v2.run_context_pb2.RunContext(
+                parameter_sweeps=[
+                    v2.run_context_pb2.ParameterSweep(repetitions=10),
+                    v2.run_context_pb2.ParameterSweep(
+                        repetitions=20,
+                        sweep=v2.run_context_pb2.Sweep(
+                            single_sweep=v2.run_context_pb2.SingleSweep(
+                                parameter_key='t',
+                                points=v2.run_context_pb2.Points(points_double=[1.0, 2.0]),
+                            )
+                        ),
+                    ),
+                ]
+            )
+        )
+    )
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+
+    with pytest.raises(ValueError, match="mapped sweeps"):
+        _ = job.get_repetitions_and_sweeps()
+
+    reps0, sweeps0 = job.get_repetitions_and_sweeps(0)
+    assert reps0 == 10
+    assert sweeps0 == [cirq.UnitSweep]
+
+    reps1, sweeps1 = job.get_repetitions_and_sweeps(1)
+    assert reps1 == 20
+    assert sweeps1 == [cirq.Points('t', [1.0, 2.0])]
+
+
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_async')
 def test_get_repetitions_and_sweeps_v1(get_job):
     job = cg.EngineJob('a', 'b', 'steve', EngineContext())
@@ -407,6 +443,18 @@ def test_get_repetitions_and_sweeps_unsupported(get_job):
     )
     with pytest.raises(ValueError, match='unsupported run_context type: unknown.proto'):
         job.get_repetitions_and_sweeps()
+
+
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_program_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_async')
+def test_get_repetitions_and_sweeps_no_repetitions(get_job, get_program):
+    get_program.return_value = quantum.QuantumProgram(code=_PROGRAM_V2)
+    get_job.return_value = quantum.QuantumJob(
+        run_context=util.pack_any(v2.run_context_pb2.RunContext(parameter_sweeps=[]))
+    )
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+    with pytest.raises(ValueError, match="No repetitions found in run context."):
+        _ = job.get_repetitions_and_sweeps()
 
 
 def test_get_processor():
@@ -569,6 +617,55 @@ sweep_results: [{
     )
 )
 
+RESULTS_NON_UNIFORM = quantum.QuantumResult(
+    result=util.pack_any(
+        Merge(
+            """
+sweep_results: [{
+        repetitions: 10,
+        parameterized_results: [{
+            params: {
+                assignments: {
+                    key: 'a'
+                    value: 1
+                }
+            },
+            measurement_results: {
+                key: 'q'
+                qubit_measurement_results: [{
+                  qubit: {
+                    id: '1_1'
+                  }
+                  results: "\\000\\000"
+                }]
+            }
+        }]
+    }, {
+        repetitions: 20,
+        parameterized_results: [{
+            params: {
+                assignments: {
+                    key: 'a'
+                    value: 2
+                }
+            },
+            measurement_results: {
+                key: 'q'
+                qubit_measurement_results: [{
+                  qubit: {
+                    id: '1_1'
+                  }
+                  results: "\\000\\000\\000"
+                }]
+            }
+        }]
+    }]
+""",
+            v2.result_pb2.Result(),
+        )
+    )
+)
+
 
 UPDATE_TIME = datetime.datetime.now(tz=datetime.timezone.utc)
 
@@ -587,6 +684,24 @@ def test_results(get_job_results):
     assert str(data[0]) == 'q=0110'
     assert str(data[1]) == 'q=1010'
     get_job_results.assert_called_once_with('a', 'b', 'steve')
+
+
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')
+def test_results_non_uniform(get_job_results):
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(state=quantum.ExecutionStatus.State.SUCCESS),
+        update_time=UPDATE_TIME,
+    )
+    get_job_results.return_value = RESULTS_NON_UNIFORM
+
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+    data = job.results()
+    assert len(data) == 2
+    assert len(data[0].measurements['q']) == 10
+    assert len(data[1].measurements['q']) == 20
+    # Verify they are correct EngineResult
+    assert data[0].job_id == 'steve'
+    assert data[1].job_id == 'steve'
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')

--- a/cirq-google/cirq_google/engine/engine_validator.py
+++ b/cirq-google/cirq_google/engine/engine_validator.py
@@ -77,7 +77,7 @@ def _verify_measurements(circuits):
 def validate_program(
     circuits: Sequence[cirq.AbstractCircuit],
     sweeps: Sequence[cirq.Sweepable],
-    repetitions: int,
+    repetitions: int | Sequence[int],
     serializer: Serializer,
     max_size: int = MAX_MESSAGE_SIZE,
 ) -> None:
@@ -114,10 +114,10 @@ def create_program_validator(max_size: int = MAX_MESSAGE_SIZE) -> PROGRAM_VALIDA
     def _validator(
         circuits: Sequence[cirq.AbstractCircuit],
         sweeps: Sequence[cirq.Sweepable],
-        repetitions: int,
+        repetitions: int | Sequence[int],
         serializer: Serializer,
-    ):
-        return validate_program(circuits, sweeps, repetitions, serializer, max_size)
+    ) -> None:
+        validate_program(circuits, sweeps, repetitions, serializer, max_size)
 
     return _validator
 

--- a/cirq-google/cirq_google/engine/engine_validator.py
+++ b/cirq-google/cirq_google/engine/engine_validator.py
@@ -30,7 +30,8 @@ MAX_MOMENTS = 10000
 MAX_TOTAL_REPETITIONS = 5_000_000
 
 PROGRAM_VALIDATOR_TYPE = Callable[
-    [Sequence[cirq.AbstractCircuit], Sequence[cirq.Sweepable], int, 'Serializer'], None
+    [Sequence[cirq.AbstractCircuit], Sequence[cirq.Sweepable], int | Sequence[int], 'Serializer'],
+    None,
 ]
 
 

--- a/cirq-google/cirq_google/engine/simulated_local_job.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job.py
@@ -130,6 +130,8 @@ class SimulatedLocalJob(AbstractLocalJob):
             programs = parent.get_circuits()
             if len(sweeps) == 1 and len(programs) > 1:
                 sweeps = sweeps * len(programs)
+            elif len(programs) == 1 and len(sweeps) > 1:
+                programs = programs * len(sweeps)
             batch_results = self._sampler.run_batch(
                 programs=programs, params_list=cast(list[cirq.Sweepable], sweeps), repetitions=reps
             )

--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -159,3 +159,28 @@ def test_run_batch():
     assert np.all(results[2].measurements['m'] == 0)
     assert np.all(results[3].measurements['m'] == 0)
     assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS
+
+
+def test_run_batch_non_uniform_repetitions():
+    program = ParentProgram(
+        [
+            cirq.Circuit(cirq.X(Q), cirq.measure(Q, key='m')),
+            cirq.Circuit(cirq.Y(Q), cirq.measure(Q, key='m')),
+        ],
+        None,
+    )
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=[10, 20],
+        sweeps=[cirq.UnitSweep, cirq.UnitSweep],
+    )
+    assert job.execution_status() == quantum.ExecutionStatus.State.READY
+    results = job.results()
+    assert len(results) == 2
+    assert len(results[0].measurements['m']) == 10
+    assert len(results[1].measurements['m']) == 20
+    assert np.all(results[0].measurements['m'] == 1)
+    assert np.all(results[1].measurements['m'] == 1)
+    assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -208,7 +208,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
         program_id: str | None = None,
         job_id: str | None = None,
         params: cirq.Sweepable = None,
-        repetitions: int = 1,
+        repetitions: int | Sequence[int] = 1,
         program_description: str | None = None,
         program_labels: dict[str, str] | None = None,
         job_description: str | None = None,
@@ -227,7 +227,12 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             programs = list(program.values())
         else:
             programs = list(program)
-        self._program_validator(programs, [params], repetitions, CIRCUIT_SERIALIZER)
+
+        sweeps_list = cirq.to_sweeps(params)
+        is_mapped = len(programs) > 1 and len(sweeps_list) == len(programs)
+        sweeps_to_use = sweeps_list if is_mapped else [params]
+
+        self._program_validator(programs, sweeps_to_use, repetitions, CIRCUIT_SERIALIZER)
         self._programs[program_id] = SimulatedLocalProgram(
             program_id=program_id,
             simulation_type=self._simulation_type,
@@ -240,7 +245,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             processor_id=self.processor_id,
             parent_program=self._programs[program_id],
             repetitions=repetitions,
-            sweeps=[params],
+            sweeps=sweeps_to_use,
             sampler=self._sampler,
             simulation_type=self._simulation_type,
         )

--- a/cirq-google/cirq_google/engine/simulated_local_processor.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor.py
@@ -229,8 +229,7 @@ class SimulatedLocalProcessor(AbstractLocalProcessor):
             programs = list(program)
 
         sweeps_list = cirq.to_sweeps(params)
-        is_mapped = len(programs) > 1 and len(sweeps_list) == len(programs)
-        sweeps_to_use = sweeps_list if is_mapped else [params]
+        sweeps_to_use = sweeps_list
 
         self._program_validator(programs, sweeps_to_use, repetitions, CIRCUIT_SERIALIZER)
         self._programs[program_id] = SimulatedLocalProgram(

--- a/cirq-google/cirq_google/engine/simulated_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor_test.py
@@ -269,3 +269,30 @@ def test_simulated_local_processor_mapped_sweeps():
     # P1 S1_1: u=1 -> Y^1 = Y -> measurements should be 1
     assert np.all(results[2].measurements['m'] == 0)
     assert np.all(results[3].measurements['m'] == 1)
+
+
+def test_simulated_local_processor_multiple_sweeps_single_circuit():
+    Q = cirq.GridQubit(2, 2)
+    circuit = cirq.Circuit(cirq.X(Q) ** sympy.Symbol('t'), cirq.measure(Q, key='m'))
+
+    processor = SimulatedLocalProcessor(processor_id='test_processor')
+
+    sweeps = [cirq.Points(key='t', points=[0, 1]), cirq.Points(key='t', points=[1, 0])]
+
+    job = processor.run_sweep(
+        program=circuit, params=sweeps, repetitions=10, device_config_name='test_config'
+    )
+
+    results = job.results()
+    assert len(results) == 4
+
+    reps, job_sweeps = job.get_repetitions_and_sweeps()
+    assert reps == 10
+    assert len(job_sweeps) == 2
+    assert job_sweeps[0] == sweeps[0]
+    assert job_sweeps[1] == sweeps[1]
+
+    assert np.all(results[0].measurements['m'] == 0)
+    assert np.all(results[1].measurements['m'] == 1)
+    assert np.all(results[2].measurements['m'] == 1)
+    assert np.all(results[3].measurements['m'] == 0)

--- a/cirq-google/cirq_google/engine/simulated_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_processor_test.py
@@ -222,3 +222,50 @@ def test_simulated_local_processor_run_sweep_multi():
 
     # Sequence (else block)
     processor.run_sweep([circuit], params={}, repetitions=1)
+
+
+def test_simulated_local_processor_mapped_sweeps():
+    Q = cirq.GridQubit(2, 2)
+    # Circuit 0 uses symbol 't', Circuit 1 uses symbol 'u'
+    circuit0 = cirq.Circuit(cirq.X(Q) ** sympy.Symbol('t'), cirq.measure(Q, key='m'))
+    circuit1 = cirq.Circuit(cirq.Y(Q) ** sympy.Symbol('u'), cirq.measure(Q, key='m'))
+
+    processor = SimulatedLocalProcessor(processor_id='test_processor')
+
+    sweeps = [cirq.Points(key='t', points=[0, 1]), cirq.Points(key='u', points=[0, 1])]
+
+    # We want to run:
+    # - circuit0 with sweep over 't' (10 reps)
+    # - circuit1 with sweep over 'u' (20 reps)
+
+    job = processor.run_sweep(
+        program=[circuit0, circuit1],
+        params=sweeps,
+        repetitions=[10, 20],
+        device_config_name='test_config',
+    )
+
+    results = job.results()
+    assert len(results) == 4  # 2 circuits * 2 sweep points each = 4 results
+
+    # Engine returns results grouped by program then by sweep.
+    # e.g. (P0, S0_0), (P0, S0_1), (P1, S1_0), (P1, S1_1)
+
+    # P0 (circuit0, has 't') was run with 10 reps.
+    assert len(results[0].measurements['m']) == 10
+    assert len(results[1].measurements['m']) == 10
+
+    # P1 (circuit1, has 'u') was run with 20 reps.
+    assert len(results[2].measurements['m']) == 20
+    assert len(results[3].measurements['m']) == 20
+
+    # Verify values to ensure correct sweeps were mapped
+    # P0 S0_0: t=0 -> X^0 = I -> measurements should be 0
+    # P0 S0_1: t=1 -> X^1 = X -> measurements should be 1
+    assert np.all(results[0].measurements['m'] == 0)
+    assert np.all(results[1].measurements['m'] == 1)
+
+    # P1 S1_0: u=0 -> Y^0 = I -> measurements should be 0
+    # P1 S1_1: u=1 -> Y^1 = Y -> measurements should be 1
+    assert np.all(results[2].measurements['m'] == 0)
+    assert np.all(results[3].measurements['m'] == 1)


### PR DESCRIPTION
  This CL adds support for running batch jobs with different repetitions for
  different circuits in the batch. This is supported across the v2
  serialization API, the Engine client, and the local simulated processor.

  This updates function signatures to accept Sequence[int] where
necessary, and retrieves the proper repetitions if multiple repetitions are provided.  Updated  _deserialize_run_context  to extract and return a list of repetitions (one per parameter sweep) instead of a single integer.