### PR TITLE
Adds MultilevelResetViaResonator gate to cirq_google

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -61,6 +61,7 @@ from cirq_google.ops import (
     FSimViaModelTag as FSimViaModelTag,
     InternalGate as InternalGate,
     InternalTag as InternalTag,
+    MultilevelResetViaResonator as MultilevelResetViaResonator,
     PhysicalZTag as PhysicalZTag,
     SYC as SYC,
     SycamoreGate as SycamoreGate,

--- a/cirq-google/cirq_google/json_resolver_cache.py
+++ b/cirq-google/cirq_google/json_resolver_cache.py
@@ -59,6 +59,7 @@ def _class_resolver_dictionary() -> dict[str, ObjectFactory]:
         'SycamoreGate': cirq_google.SycamoreGate,
         'WaitGateWithUnit': cirq_google.WaitGateWithUnit,
         'WillowGate': cirq_google.WillowGate,
+        'MultilevelResetViaResonator': cirq_google.MultilevelResetViaResonator,
         # cirq_google.GateTabulation has been removed and replaced by cirq.TwoQubitGateTabulation.
         'GateTabulation': TwoQubitGateTabulation,
         'PhysicalZTag': cirq_google.PhysicalZTag,

--- a/cirq-google/cirq_google/json_test_data/MultilevelResetViaResonator.json
+++ b/cirq-google/cirq_google/json_test_data/MultilevelResetViaResonator.json
@@ -1,0 +1,3 @@
+{
+  "cirq_type": "MultilevelResetViaResonator"
+}

--- a/cirq-google/cirq_google/json_test_data/MultilevelResetViaResonator.repr
+++ b/cirq-google/cirq_google/json_test_data/MultilevelResetViaResonator.repr
@@ -1,0 +1,1 @@
+cirq_google.MultilevelResetViaResonator()

--- a/cirq-google/cirq_google/ops/__init__.py
+++ b/cirq-google/cirq_google/ops/__init__.py
@@ -45,3 +45,7 @@ from cirq_google.ops.dynamical_decoupling_tag import (
 from cirq_google.ops.wait_gate import WaitGateWithUnit as WaitGateWithUnit
 
 from cirq_google.ops.willow_gate import WillowGate as WillowGate, WILLOW as WILLOW
+
+from cirq_google.ops.multi_level_reset import (
+    MultilevelResetViaResonator as MultilevelResetViaResonator,
+)

--- a/cirq-google/cirq_google/ops/internal_gate.py
+++ b/cirq-google/cirq_google/ops/internal_gate.py
@@ -35,7 +35,7 @@ class InternalGate(ops.Gate):
     def __init__(
         self,
         gate_name: str,
-        gate_module: str = None,
+        gate_module: str | None = None,
         num_qubits: int = 1,
         custom_args: Mapping[str, program_pb2.CustomArg] | None = None,
         **kwargs,

--- a/cirq-google/cirq_google/ops/internal_gate.py
+++ b/cirq-google/cirq_google/ops/internal_gate.py
@@ -35,7 +35,7 @@ class InternalGate(ops.Gate):
     def __init__(
         self,
         gate_name: str,
-        gate_module: str,
+        gate_module: str = None,
         num_qubits: int = 1,
         custom_args: Mapping[str, program_pb2.CustomArg] | None = None,
         **kwargs,
@@ -44,7 +44,8 @@ class InternalGate(ops.Gate):
 
         Arguments:
             gate_name: Gate class name.
-            gate_module: The module of the gate.
+            gate_module: The module of the gate. If not specified, the engine
+                will attempt to infer the module.
             num_qubits: Number of qubits that the gate acts on.
             custom_args: A mapping from argument name to `CustomArg`.
                 This is to support argument that require special processing.

--- a/cirq-google/cirq_google/ops/multi_level_reset.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
 
 import cirq
 from cirq_google.ops.internal_gate import InternalGate

--- a/cirq-google/cirq_google/ops/multi_level_reset.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset.py
@@ -1,0 +1,50 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+import cirq
+from cirq_google.ops.internal_gate import InternalGate
+
+
+class MultilevelResetViaResonator(InternalGate):
+    """Multilevel qubit reset with resonator.
+
+    This is a specialized type of reset that can be used to clear out
+    excited levels by utilizing the attached resonator.  Useful in
+    performing Quantum Error Correction experiments that require multiple
+    rounds of measurement and reset.
+    """
+
+    def __init__(self, gate_name=None, gate_module=None, num_qubits=1, **kwargs):
+        super().__init__(
+            gate_name="MultilevelResetViaResonator",
+            gate_module="pyle.cirqtools.pyle_gates",
+            num_qubits=1,
+        )
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
+        return ["[R (ML)]"]
+
+    def is_reset_gate(self) -> bool:
+        return True
+
+    def _decompose_(self, qubits):
+        return cirq.reset_each(*qubits)
+
+    def _json_dict_(self):
+        return {}
+
+    def __repr__(self) -> str:
+        return 'cirq_google.MultilevelResetViaResonator()'

--- a/cirq-google/cirq_google/ops/multi_level_reset.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset.py
@@ -27,11 +27,7 @@ class MultilevelResetViaResonator(InternalGate):
     """
 
     def __init__(self, gate_name=None, gate_module=None, num_qubits=1, **kwargs):
-        super().__init__(
-            gate_name="MultilevelResetViaResonator",
-            gate_module="pyle.cirqtools.pyle_gates",
-            num_qubits=1,
-        )
+        super().__init__(gate_name="MultilevelResetViaResonator", num_qubits=1)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
         return ["[R (ML)]"]

--- a/cirq-google/cirq_google/ops/multi_level_reset_test.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset_test.py
@@ -1,0 +1,85 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import stimcirq
+
+import cirq
+import cirq_google as cg
+from cirq_google.ops.multi_level_reset import MultilevelResetViaResonator
+
+
+def test_multi_level_reset_properties():
+    gate = MultilevelResetViaResonator()
+    assert cirq.num_qubits(gate) == 1
+    assert gate.is_reset_gate()
+    assert not cirq.has_unitary(gate)
+
+
+def test_circuit_diagram():
+    q = cirq.GridQubit(0, 0)
+    op = MultilevelResetViaResonator()(q)
+    circuit = cirq.Circuit(op)
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+(0, 0): ───[R (ML)]───
+""",
+    )
+
+
+def test_decomposition():
+    q = cirq.GridQubit(0, 0)
+    op = MultilevelResetViaResonator()(q)
+    decomp = cirq.decompose(op)
+    assert decomp == [cirq.ResetChannel()(q)]
+
+
+def test_serialization_round_trip():
+    q = cirq.GridQubit(0, 0)
+    gate = MultilevelResetViaResonator()
+    op = gate(q)
+    circuit = cirq.Circuit(op)
+
+    # Serialize
+    proto = cg.CIRCUIT_SERIALIZER.serialize(circuit)
+
+    # Verify proto structure
+    op_protos = [c.operation_value for c in proto.constants if c.HasField('operation_value')]
+    assert len(op_protos) == 1
+    op_proto = op_protos[0]
+
+    assert op_proto.WhichOneof('gate_value') == 'internalgate'
+    internal_gate_proto = op_proto.internalgate
+    assert internal_gate_proto.name == "MultilevelResetViaResonator"
+    assert internal_gate_proto.module == "pyle.cirqtools.pyle_gates"
+    assert internal_gate_proto.num_qubits == 1
+
+    # Deserialize
+    deserialized_circuit = cg.CIRCUIT_SERIALIZER.deserialize(proto)
+
+    # Verify matching
+    assert deserialized_circuit == circuit
+
+    # Verify exact class
+    deserialized_op = list(deserialized_circuit.all_operations())[0]
+    assert isinstance(deserialized_op.gate, MultilevelResetViaResonator)
+
+
+def test_repr():
+    gate = MultilevelResetViaResonator()
+    assert repr(gate) == 'cirq_google.MultilevelResetViaResonator()'
+    import cirq_google
+
+    assert eval(repr(gate)) == gate

--- a/cirq-google/cirq_google/ops/multi_level_reset_test.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset_test.py
@@ -61,7 +61,6 @@ def test_serialization_round_trip():
     assert op_proto.WhichOneof('gate_value') == 'internalgate'
     internal_gate_proto = op_proto.internalgate
     assert internal_gate_proto.name == "MultilevelResetViaResonator"
-    assert internal_gate_proto.module == "pyle.cirqtools.pyle_gates"
     assert internal_gate_proto.num_qubits == 1
 
     # Deserialize

--- a/cirq-google/cirq_google/ops/multi_level_reset_test.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset_test.py
@@ -78,5 +78,3 @@ def test_serialization_round_trip():
 def test_repr():
     gate = MultilevelResetViaResonator()
     assert repr(gate) == 'cirq_google.MultilevelResetViaResonator()'
-
-    assert eval(repr(gate)) == gate

--- a/cirq-google/cirq_google/ops/multi_level_reset_test.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-import stimcirq
 
 import cirq
 import cirq_google as cg
@@ -73,13 +71,12 @@ def test_serialization_round_trip():
     assert deserialized_circuit == circuit
 
     # Verify exact class
-    deserialized_op = list(deserialized_circuit.all_operations())[0]
+    deserialized_op = next(iter(deserialized_circuit.all_operations()))
     assert isinstance(deserialized_op.gate, MultilevelResetViaResonator)
 
 
 def test_repr():
     gate = MultilevelResetViaResonator()
     assert repr(gate) == 'cirq_google.MultilevelResetViaResonator()'
-    import cirq_google
 
     assert eval(repr(gate)) == gate

--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -526,7 +526,8 @@ def internal_gate_arg_to_proto(
     """
     msg = v2.program_pb2.InternalGate() if out is None else out
     msg.name = value.gate_name
-    msg.module = value.gate_module
+    if value.gate_module:
+        msg.module = value.gate_module
     msg.num_qubits = value.num_qubits()
 
     for k, v in value.gate_args.items():

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -22,6 +22,7 @@ import warnings
 from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import Any
 
+import attrs
 import sympy
 
 import cirq
@@ -35,6 +36,7 @@ from cirq_google.ops import (
     FSimViaModelTag,
     InternalGate,
     InternalTag,
+    MultilevelResetViaResonator,
     PhysicalZTag,
     SycamoreGate,
     TwoPulseFSimTag,
@@ -919,7 +921,13 @@ class CircuitSerializer(serializer.Serializer):
             op = cirq.ResetChannel(dimension=dimensions)(*qubits)
         elif which_gate_type == 'internalgate':
             msg = operation_proto.internalgate
-            op = arg_func_langs.internal_gate_from_proto(msg)(*qubits)
+            match str(msg.name):
+                # Add new custom cirq_google gates here:
+                case "MultilevelResetViaResonator":
+                    gate = MultilevelResetViaResonator()
+                case _:
+                    gate = arg_func_langs.internal_gate_from_proto(msg)
+            op = gate(*qubits)
         elif which_gate_type == 'couplerpulsegate':
             gate = CouplerPulse(
                 hold_time=cirq.Duration(

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -22,7 +22,6 @@ import warnings
 from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import Any
 
-import attrs
 import sympy
 
 import cirq
@@ -924,7 +923,7 @@ class CircuitSerializer(serializer.Serializer):
             match str(msg.name):
                 # Add new custom cirq_google gates here:
                 case "MultilevelResetViaResonator":
-                    gate = MultilevelResetViaResonator()
+                    gate: cirq.Gate = MultilevelResetViaResonator()
                 case _:
                     gate = arg_func_langs.internal_gate_from_proto(msg)
             op = gate(*qubits)


### PR DESCRIPTION
- This gate will perform a reset by using the resonator.
- This gate will be used for QEC experiments where there are multiple rounds of measure and reset.