### PR TITLE
Deflake notebook_test when run in parallel

### DIFF
--- a/dev_tools/conftest.py
+++ b/dev_tools/conftest.py
@@ -134,6 +134,5 @@ def papermill_scheduler(
 ) -> Callable[[], tuple[float, float]]:
     queuefile = tmp_path_factory.getbasetemp().parent.joinpath("papermill_scheduler_queue.tmp")
     worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0"))
-    worker_name = os.environ.get("PYTEST_XDIST_WORKER", "unspecified")
     interval = 1.0 if worker_count > 1 else 0.0
-    return create_parallel_scheduler(queuefile, worker_name, interval)
+    return create_parallel_scheduler(queuefile, interval)

--- a/dev_tools/conftest.py
+++ b/dev_tools/conftest.py
@@ -20,6 +20,7 @@ import shutil
 import sys
 import tempfile
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from unittest import mock
 
@@ -28,6 +29,7 @@ from filelock import FileLock
 
 from dev_tools import shell_tools
 from dev_tools.env_tools import create_virtual_env
+from dev_tools.notebooks.utils import create_parallel_scheduler
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,3 +126,14 @@ def cloned_env(testrun_uid, worker_id):
             raise
 
     return base_env_creator
+
+
+@pytest.fixture(scope="session")
+def papermill_scheduler(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Callable[[], tuple[float, float]]:
+    queuefile = tmp_path_factory.getbasetemp().parent.joinpath("papermill_scheduler_queue.tmp")
+    worker_count = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0"))
+    worker_name = os.environ.get("PYTEST_XDIST_WORKER", "unspecified")
+    interval = 1.0 if worker_count > 1 else 0.0
+    return create_parallel_scheduler(queuefile, worker_name, interval)

--- a/dev_tools/notebooks/__init__.py
+++ b/dev_tools/notebooks/__init__.py
@@ -17,4 +17,5 @@ from dev_tools.notebooks.utils import (
     filter_notebooks as filter_notebooks,
     list_all_notebooks as list_all_notebooks,
     rewrite_notebook as rewrite_notebook,
+    sleep_once_if_parallel as sleep_once_if_parallel,
 )

--- a/dev_tools/notebooks/__init__.py
+++ b/dev_tools/notebooks/__init__.py
@@ -17,5 +17,4 @@ from dev_tools.notebooks.utils import (
     filter_notebooks as filter_notebooks,
     list_all_notebooks as list_all_notebooks,
     rewrite_notebook as rewrite_notebook,
-    sleep_once_if_parallel as sleep_once_if_parallel,
 )

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -31,6 +31,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import time
 import warnings
 
 import pytest
@@ -135,7 +136,7 @@ def _partitioned_test_cases(notebooks):
     return [(f"partition-{i%n_partitions}", notebook) for i, notebook in enumerate(notebooks)]
 
 
-def _rewrite_and_run_notebook(notebook_path, cloned_env):
+def _rewrite_and_run_notebook(notebook_path, cloned_env, papermill_scheduler):
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, REPO_ROOT))
     out_path = f"out/{notebook_rel_dir}/{notebook_file[:-6]}.out.ipynb"
@@ -154,6 +155,8 @@ def _rewrite_and_run_notebook(notebook_path, cloned_env):
         pip list
         papermill "{rewritten_notebook_path}" "{REPO_ROOT/out_path}"
     """
+    wait_time = papermill_scheduler()[1]
+    time.sleep(wait_time)
     result = shell_tools.run(
         cmd,
         log_run_to_stderr=False,
@@ -189,7 +192,9 @@ def _rewrite_and_run_notebook(notebook_path, cloned_env):
     "partition, notebook_path",
     _partitioned_test_cases(filter_notebooks(_list_changed_notebooks(), SKIP_NOTEBOOKS)),
 )
-def test_changed_notebooks_against_released_cirq(partition, notebook_path, cloned_env) -> None:
+def test_changed_notebooks_against_released_cirq(
+    partition, notebook_path, cloned_env, papermill_scheduler
+) -> None:
     """Tests changed notebooks in isolated virtual environments.
 
     In order to speed up the execution of these tests an auxiliary file may be supplied which
@@ -201,7 +206,7 @@ def test_changed_notebooks_against_released_cirq(partition, notebook_path, clone
     regular expression, it is considered best practice to not use complicated regular expressions.
     Lines in this file that do not have `->` are ignored.
     """
-    _rewrite_and_run_notebook(notebook_path, cloned_env)
+    _rewrite_and_run_notebook(notebook_path, cloned_env, papermill_scheduler)
 
 
 @pytest.mark.weekly
@@ -209,13 +214,15 @@ def test_changed_notebooks_against_released_cirq(partition, notebook_path, clone
     "partition, notebook_path",
     _partitioned_test_cases(filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS)),
 )
-def test_all_notebooks_against_released_cirq(partition, notebook_path, cloned_env) -> None:
+def test_all_notebooks_against_released_cirq(
+    partition, notebook_path, cloned_env, papermill_scheduler
+) -> None:
     """Tests all notebooks in isolated virtual environments.
 
     See `test_changed_notebooks_against_released_cirq` for more details on
     notebooks execution.
     """
-    _rewrite_and_run_notebook(notebook_path, cloned_env)
+    _rewrite_and_run_notebook(notebook_path, cloned_env, papermill_scheduler)
 
 
 @pytest.mark.parametrize("notebook_path", NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES)

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -36,13 +36,7 @@ import warnings
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import (
-    filter_notebooks,
-    list_all_notebooks,
-    REPO_ROOT,
-    rewrite_notebook,
-    sleep_once_if_parallel,
-)
+from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT, rewrite_notebook
 
 # The notebooks in the following list rely on features that are not yet released.
 # They are excluded from isolated notebook tests in this file; however, they are still tested
@@ -141,7 +135,6 @@ def _partitioned_test_cases(notebooks):
     return [(f"partition-{i%n_partitions}", notebook) for i, notebook in enumerate(notebooks)]
 
 
-@sleep_once_if_parallel
 def _rewrite_and_run_notebook(notebook_path, cloned_env):
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, REPO_ROOT))

--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -36,7 +36,13 @@ import warnings
 import pytest
 
 from dev_tools import shell_tools
-from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT, rewrite_notebook
+from dev_tools.notebooks import (
+    filter_notebooks,
+    list_all_notebooks,
+    REPO_ROOT,
+    rewrite_notebook,
+    sleep_once_if_parallel,
+)
 
 # The notebooks in the following list rely on features that are not yet released.
 # They are excluded from isolated notebook tests in this file; however, they are still tested
@@ -135,6 +141,7 @@ def _partitioned_test_cases(notebooks):
     return [(f"partition-{i%n_partitions}", notebook) for i, notebook in enumerate(notebooks)]
 
 
+@sleep_once_if_parallel
 def _rewrite_and_run_notebook(notebook_path, cloned_env):
     notebook_file = os.path.basename(notebook_path)
     notebook_rel_dir = os.path.dirname(os.path.relpath(notebook_path, REPO_ROOT))

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,20 +24,13 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import tempfile
-import time
 from collections.abc import Iterator
 
 import pytest
 
 from dev_tools import shell_tools
 from dev_tools.modules import list_modules
-from dev_tools.notebooks import (
-    filter_notebooks,
-    list_all_notebooks,
-    REPO_ROOT,
-    rewrite_notebook,
-    sleep_once_if_parallel,
-)
+from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT, rewrite_notebook
 from dev_tools.test_utils import only_on_posix
 
 SKIP_NOTEBOOKS = [
@@ -54,24 +47,6 @@ SKIP_NOTEBOOKS = [
     'docs/tutorials/google/spin_echoes.ipynb',
     'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
 ]
-
-
-def _short_sleep_if_parallel() -> None:
-    """Avoid race condition when several workers start jupyter kernel simultaneously.
-
-    Perform short random sleep for the first call on a parallel pytest worker.
-    """
-    global _short_sleep_done
-    seconds = (
-        0.0
-        if _short_sleep_done or int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0")) <= 1
-        else (time.monotonic_ns() % 1000) / 1000.0
-    )
-    time.sleep(seconds)
-    _short_sleep_done = True
-
-
-_short_sleep_done = False
 
 
 @pytest.fixture
@@ -123,7 +98,6 @@ def env_with_temporary_pip_target() -> Iterator[dict[str, str]]:
 @pytest.mark.slow
 @only_on_posix
 @pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
-@sleep_once_if_parallel
 def test_notebooks_against_cirq_head(
     notebook_path, require_packages_not_changed, env_with_temporary_pip_target
 ) -> None:
@@ -148,7 +122,6 @@ def test_notebooks_against_cirq_head(
     assert os.path.isdir(env_with_temporary_pip_target["CLOUDSDK_CONFIG"])
 
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
-    _short_sleep_if_parallel()
     result = shell_tools.run(
         cmd,
         log_run_to_stderr=False,

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import tempfile
+import textwrap
 import time
+import warnings
 from collections.abc import Iterator
 
 import pytest
@@ -149,3 +151,21 @@ def test_skip_notebooks_has_valid_patterns() -> None:
     """Verify patterns in SKIP_NOTEBOOKS are all valid."""
     patterns_without_match = [g for g in SKIP_NOTEBOOKS if not any(REPO_ROOT.glob(g))]
     assert patterns_without_match == []
+
+
+def test_papermill_scheduler_is_still_needed() -> None:
+    # reminder to revisit the papermill_scheduler hack when papermill releases new version
+    needed_for_papermill_version = (2, 7)
+    pmdist = importlib.metadata.distribution("papermill")
+    actual_papermill_version = tuple(int(v) for v in pmdist.version.split(".")[:2])
+    msg = f"""
+        Please check if papermill_scheduler fixture can be removed for papermill-{pmdist.version}.
+        If so the following pytest run will pass without errors (repeat several times)
+
+          check/pytest -n8 -m slow dev_tools/notebooks/notebook_test.py
+
+        If you get "Kernel died before replying to kernel_info" error, continue using the
+        `papermill_scheduler` fixture and adjust the `needed_for_papermill_version` value.
+    """
+    if actual_papermill_version > needed_for_papermill_version:
+        warnings.warn(textwrap.dedent(msg), DeprecationWarning)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,13 +24,20 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import tempfile
+import time
 from collections.abc import Iterator
 
 import pytest
 
 from dev_tools import shell_tools
 from dev_tools.modules import list_modules
-from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT, rewrite_notebook
+from dev_tools.notebooks import (
+    filter_notebooks,
+    list_all_notebooks,
+    REPO_ROOT,
+    rewrite_notebook,
+    sleep_once_if_parallel,
+)
 from dev_tools.test_utils import only_on_posix
 
 SKIP_NOTEBOOKS = [
@@ -47,6 +54,24 @@ SKIP_NOTEBOOKS = [
     'docs/tutorials/google/spin_echoes.ipynb',
     'docs/tutorials/google/visualizing_calibration_metrics.ipynb',
 ]
+
+
+def _short_sleep_if_parallel() -> None:
+    """Avoid race condition when several workers start jupyter kernel simultaneously.
+
+    Perform short random sleep for the first call on a parallel pytest worker.
+    """
+    global _short_sleep_done
+    seconds = (
+        0.0
+        if _short_sleep_done or int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "0")) <= 1
+        else (time.monotonic_ns() % 1000) / 1000.0
+    )
+    time.sleep(seconds)
+    _short_sleep_done = True
+
+
+_short_sleep_done = False
 
 
 @pytest.fixture
@@ -98,6 +123,7 @@ def env_with_temporary_pip_target() -> Iterator[dict[str, str]]:
 @pytest.mark.slow
 @only_on_posix
 @pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
+@sleep_once_if_parallel
 def test_notebooks_against_cirq_head(
     notebook_path, require_packages_not_changed, env_with_temporary_pip_target
 ) -> None:
@@ -122,6 +148,7 @@ def test_notebooks_against_cirq_head(
     assert os.path.isdir(env_with_temporary_pip_target["CLOUDSDK_CONFIG"])
 
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
+    _short_sleep_if_parallel()
     result = shell_tools.run(
         cmd,
         log_run_to_stderr=False,

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -122,9 +122,9 @@ def test_notebooks_against_cirq_head(
     # ensure papermill will have CLOUDSDK_CONFIG set per dev_tools/conftest.py
     assert os.path.isdir(env_with_temporary_pip_target["CLOUDSDK_CONFIG"])
 
-    _, wait_time = papermill_scheduler()
-    time.sleep(wait_time)
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
+    wait_time = papermill_scheduler()[1]
+    time.sleep(wait_time)
     result = shell_tools.run(
         cmd,
         log_run_to_stderr=False,

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -156,7 +156,10 @@ def test_skip_notebooks_has_valid_patterns() -> None:
 def test_papermill_scheduler_is_still_needed() -> None:
     # reminder to revisit the papermill_scheduler hack when papermill releases new version
     needed_for_papermill_version = (2, 7)
-    pmdist = importlib.metadata.distribution("papermill")
+    try:
+        pmdist = importlib.metadata.distribution("papermill")
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("papermill is not installed")
     actual_papermill_version = tuple(int(v) for v in pmdist.version.split(".")[:2])
     msg = f"""
         Please check if papermill_scheduler fixture can be removed for papermill-{pmdist.version}.

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import tempfile
+import time
 from collections.abc import Iterator
 
 import pytest
@@ -99,7 +100,7 @@ def env_with_temporary_pip_target() -> Iterator[dict[str, str]]:
 @only_on_posix
 @pytest.mark.parametrize("notebook_path", filter_notebooks(list_all_notebooks(), SKIP_NOTEBOOKS))
 def test_notebooks_against_cirq_head(
-    notebook_path, require_packages_not_changed, env_with_temporary_pip_target
+    notebook_path, require_packages_not_changed, env_with_temporary_pip_target, papermill_scheduler
 ) -> None:
     """Test that jupyter notebooks execute.
 
@@ -121,6 +122,8 @@ def test_notebooks_against_cirq_head(
     # ensure papermill will have CLOUDSDK_CONFIG set per dev_tools/conftest.py
     assert os.path.isdir(env_with_temporary_pip_target["CLOUDSDK_CONFIG"])
 
+    _, wait_time = papermill_scheduler()
+    time.sleep(wait_time)
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
     result = shell_tools.run(
         cmd,

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -19,6 +19,8 @@ import pathlib
 import re
 import subprocess
 import tempfile
+import time
+from collections.abc import Callable
 from logging import warning
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
@@ -119,3 +121,51 @@ def rewrite_notebook(notebook_path: str) -> str:
         new_file.writelines(lines)
 
     return new_file.name
+
+
+def create_parallel_scheduler(
+    queuefile: pathlib.Path, worker_name: str, interval: float
+) -> Callable[[], tuple[float, float]]:
+    """Create callable which generates epoch time for events separated by interval seconds.
+
+    The scheduler is synchronized over parallel Python processes provided each
+    of them uses a unique `worker_name` and the same `queuefile`.
+
+    Args:
+        queuefile: The shared file used to determine the next event time.
+            The file is appended to at each use of the returned scheduler
+            and should be empty or non-existent at the time of the first use.
+        worker_name: The unique name for associating the created scheduler
+            with its `queuefile` data.  Each parallel process should use
+            a unique `worker_name` when sharing the same `queuefile`.
+        interval: The minimum delay in seconds between successive events.
+
+    Returns:
+        The scheduler as a zero-argument callable object.  At each call the scheduler
+        returns a tuple of (event_time, wait_time), where `event_time` is the epoch
+        time for the next event and `wait_time` is the time in seconds left to that time.
+    """
+    pos = 0
+    event_time = 0.0
+
+    def schedule() -> tuple[float, float]:
+        """Return time for the next event as a tuple of (event_time, wait_time)."""
+        nonlocal pos
+        nonlocal event_time
+        record = f"{time.time()} {worker_name}\n"
+        with queuefile.open("a") as fp:
+            fp.write(record)
+        with queuefile.open("r") as fp:
+            fp.seek(pos)
+            for line in fp:
+                pos += len(line)
+                t = float(line.split(maxsplit=1)[0])
+                event_time = max(t, event_time + interval)
+                if line == record:
+                    break
+            else:
+                raise OSError(f"Cannot find sentinel line {record!r} in {queuefile}")
+        wait_time = max(event_time - time.time(), 0.0)
+        return event_time, wait_time
+
+    return schedule

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -14,12 +14,16 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import pathlib
 import re
 import subprocess
 import tempfile
+import time
+from collections.abc import Callable
 from logging import warning
+from typing import ParamSpec, TypeVar
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 
@@ -119,3 +123,29 @@ def rewrite_notebook(notebook_path: str) -> str:
         new_file.writelines(lines)
 
     return new_file.name
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def sleep_once_if_parallel(testfunc: Callable[P, R]) -> Callable[P, R]:
+    """Decorator to insert incremental sleep to the first call of a test in a parallel pytest run.
+
+    Avoid race condition when several workers start jupyter kernel simultaneously by
+    perform a short random sleep at the first call of the decorated test function.
+    """
+    is_first_call = True
+
+    @functools.wraps(testfunc)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        nonlocal is_first_call
+        mx = re.search(r"\d+$", os.environ.get("PYTEST_XDIST_WORKER", ""))
+        worker_index = int(mx.group()) if mx else 0
+        seconds = 1.0 * worker_index
+        if is_first_call and seconds:
+            time.sleep(seconds)
+        is_first_call = False
+        return testfunc(*args, **kwargs)
+
+    return wrapped

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -20,6 +20,7 @@ import re
 import subprocess
 import tempfile
 import time
+import uuid
 from collections.abc import Callable
 from logging import warning
 
@@ -124,21 +125,20 @@ def rewrite_notebook(notebook_path: str) -> str:
 
 
 def create_parallel_scheduler(
-    queuefile: pathlib.Path, worker_name: str, interval: float
+    queuefile: pathlib.Path, interval: float
 ) -> Callable[[], tuple[float, float]]:
     """Create callable which generates epoch time for events separated by interval seconds.
 
-    The scheduler is synchronized over parallel Python processes provided each
-    of them uses a unique `worker_name` and the same `queuefile`.
+    The scheduler is synchronized over parallel Python processes provided
+    all of them use the same `queuefile`.
 
     Args:
         queuefile: The shared file used to determine the next event time.
             The file is appended to at each use of the returned scheduler
-            and should be empty or non-existent at the time of the first use.
-        worker_name: The unique name for associating the created scheduler
-            with its `queuefile` data.  Each parallel process should use
-            a unique `worker_name` when sharing the same `queuefile`.
+            and should be empty or non-existent at the time of its first use.
         interval: The minimum delay in seconds between successive events.
+            When zero or negative, the scheduler produces immediate time
+            without using the `queuefile`.
 
     Returns:
         The scheduler as a zero-argument callable object.  At each call the scheduler
@@ -147,12 +147,16 @@ def create_parallel_scheduler(
     """
     pos = 0
     event_time = 0.0
+    this_scheduler_uid = f"{uuid.uuid4()}"[-12:]
 
-    def schedule() -> tuple[float, float]:
+    if interval <= 0:
+        return lambda: (time.time(), 0.0)
+
+    def scheduler() -> tuple[float, float]:
         """Return time for the next event as a tuple of (event_time, wait_time)."""
         nonlocal pos
         nonlocal event_time
-        record = f"{time.time()} {worker_name}\n"
+        record = f"{time.time()} {this_scheduler_uid}\n"
         with queuefile.open("a") as fp:
             fp.write(record)
         with queuefile.open("r") as fp:
@@ -168,4 +172,4 @@ def create_parallel_scheduler(
         wait_time = max(event_time - time.time(), 0.0)
         return event_time, wait_time
 
-    return schedule
+    return scheduler

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -156,10 +156,10 @@ def create_parallel_scheduler(
         """Return time for the next event as a tuple of (event_time, wait_time)."""
         nonlocal pos
         nonlocal event_time
-        record = f"{time.time()} {this_scheduler_uid}\n"
-        with queuefile.open("a") as fp:
+        record = f"{time.time()} {this_scheduler_uid}\n".encode()
+        with queuefile.open("ab") as fp:
             fp.write(record)
-        with queuefile.open("r") as fp:
+        with queuefile.open("rb") as fp:
             fp.seek(pos)
             for line in fp:
                 pos += len(line)

--- a/dev_tools/notebooks/utils.py
+++ b/dev_tools/notebooks/utils.py
@@ -14,16 +14,12 @@
 
 from __future__ import annotations
 
-import functools
 import os
 import pathlib
 import re
 import subprocess
 import tempfile
-import time
-from collections.abc import Callable
 from logging import warning
-from typing import ParamSpec, TypeVar
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 
@@ -123,29 +119,3 @@ def rewrite_notebook(notebook_path: str) -> str:
         new_file.writelines(lines)
 
     return new_file.name
-
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-def sleep_once_if_parallel(testfunc: Callable[P, R]) -> Callable[P, R]:
-    """Decorator to insert incremental sleep to the first call of a test in a parallel pytest run.
-
-    Avoid race condition when several workers start jupyter kernel simultaneously by
-    perform a short random sleep at the first call of the decorated test function.
-    """
-    is_first_call = True
-
-    @functools.wraps(testfunc)
-    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
-        nonlocal is_first_call
-        mx = re.search(r"\d+$", os.environ.get("PYTEST_XDIST_WORKER", ""))
-        worker_index = int(mx.group()) if mx else 0
-        seconds = 1.0 * worker_index
-        if is_first_call and seconds:
-            time.sleep(seconds)
-        is_first_call = False
-        return testfunc(*args, **kwargs)
-
-    return wrapped

--- a/dev_tools/notebooks/utils_test.py
+++ b/dev_tools/notebooks/utils_test.py
@@ -102,3 +102,24 @@ def test_rewrite_notebook_unused_patterns() -> None:
         _ = dt.rewrite_notebook(ipynb_path)
 
     shutil.rmtree(directory)
+
+
+def test_create_parallel_scheduler_with_100ms_interval(tmp_path: pathlib.Path) -> None:
+    queuefile = tmp_path / "queuefile.tmp"
+    scheduler = dt.utils.create_parallel_scheduler(queuefile, 0.1)
+    event_time_0, wait_time_0 = scheduler()
+    event_time_1, wait_time_1 = scheduler()
+    assert wait_time_0 == 0.0
+    assert event_time_1 >= 0.1 + event_time_0
+    assert 0 < wait_time_1 <= 0.1
+
+
+def test_create_parallel_scheduler_with_zero_interval(tmp_path: pathlib.Path) -> None:
+    queuefile = tmp_path / "queuefile.tmp"
+    assert not queuefile.exists()
+    scheduler = dt.utils.create_parallel_scheduler(queuefile, 0)
+    event_time_0, wait_time_0 = scheduler()
+    event_time_1, wait_time_1 = scheduler()
+    assert wait_time_0 == wait_time_1 == 0.0
+    assert event_time_0 <= event_time_1
+    assert not queuefile.exists()


### PR DESCRIPTION
Problem: In a parallel pytest session several papermill jobs may start
jupyter kernels simultaneously resulting in a race condition when looking
for free local ports.  This shows as test failure with
"Kernel died before replying to kernel_info" error.

Solution: Introduce 1 second delay between consecutive starts of parallel
papermill jobs.  For future papermill versions show a reminder to check
if the delay is still needed.

Verification: The following run has a flaky failure before this fix

```
for i in {1..8}; do
    check/pytest -n8 -m slow dev_tools/notebooks/notebook_test.py || break
done
```
