### PR TITLE
Add quantum engine batched_results()

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -192,6 +192,16 @@ class AbstractJob(abc.ABC):
 
     results = duet.sync(results_async)
 
+    @abc.abstractmethod
+    async def batched_results_async(self) -> Sequence[Sequence[EngineResult]]:
+        """Returns the job results split by program/circuit in the batch.
+
+        Instead of flattening results into a single list, this will return a Sequence[EngineResult]
+        for each circuit in the batch.
+        """
+
+    batched_results = duet.sync(batched_results_async)
+
     def __iter__(self) -> Iterator[cirq.Result]:
         yield from self.results()
 

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -92,6 +92,9 @@ class MockJob(AbstractJob):
     async def results_async(self):
         return [cirq.ResultDict(params={}, measurements={'a': np.asarray([t])}) for t in range(5)]
 
+    async def batched_results_async(self):
+        return [[r] for r in await self.results_async()]
+
 
 def test_instantiation_and_iteration():
     job = MockJob()
@@ -126,3 +129,12 @@ def test_get_circuit():
     job = MockJob()
     assert job.get_circuit() == cirq.Circuit()
     assert job.get_circuit(1) == cirq.Circuit()
+
+
+def test_batched_results():
+    job = MockJob()
+    batched = job.batched_results()
+    assert len(batched) == 5
+    for count, r_list in enumerate(batched):
+        assert len(r_list) == 1
+        assert r_list[0].measurements['a'][0] == count

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -53,6 +53,9 @@ class NothingJob(AbstractLocalJob):
     async def results_async(self) -> Sequence[EngineResult]:
         return []  # pragma: no cover
 
+    async def batched_results_async(self) -> Sequence[Sequence[EngineResult]]:
+        return []  # pragma: no cover
+
 
 def test_description_and_labels():
     job = NothingJob(

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -332,10 +332,24 @@ class EngineJob(abstract_job.AbstractJob):
                 or result_type == 'cirq.api.google.v2.Result'
             ):
                 v2_parsed_result = v2.result_pb2.Result.FromString(result.value)
-                self._results = self._get_job_results_v2(v2_parsed_result)
+                self._batched_results = self._get_batched_job_results_v2(v2_parsed_result)
+                self._results = _flatten(self._batched_results)
             else:
                 raise ValueError(f'invalid result proto version: {result_type}')
         return self._results
+
+    async def batched_results_async(self) -> Sequence[Sequence[EngineResult]]:
+        """Returns the job results split by program/circuit in the batch.
+
+        Instead of flattening results into a single list, this will return a Sequence[EngineResult]
+        for each circuit in the batch.
+        """
+        if not self.program().is_batch():
+            raise ValueError('batched_results called for a non-batch program.')
+        await self.results_async()
+        if self._batched_results is None:
+            raise ValueError('batched_results was not populated for this batch job.')
+        return self._batched_results
 
     async def _await_result_async(self) -> quantum.QuantumResult:
         if self._job_result_future is not None:
@@ -395,6 +409,16 @@ class EngineJob(abstract_job.AbstractJob):
             EngineResult.from_result(result, job_id=job_id)
             for sweep_result in sweep_results
             for result in sweep_result
+        ]
+
+    def _get_batched_job_results_v2(
+        self, result: v2.result_pb2.Result
+    ) -> Sequence[Sequence[EngineResult]]:
+        sweep_results = v2.results_from_proto(result)
+        job_id = self.id()
+        return [
+            [EngineResult.from_result(r, job_id=job_id) for r in sweep_result]
+            for sweep_result in sweep_results
         ]
 
     def __str__(self) -> str:

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -851,3 +851,56 @@ async def test_get_circuit_async():
         get_circuit_async.return_value = circuit
         assert await job.get_circuit_async(1) is circuit
         get_circuit_async.assert_called_with(1)
+
+
+@mock.patch('cirq_google.engine.engine_program.EngineProgram.is_batch_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')
+def test_batched_results_non_batch_job_raises(get_job_results, mock_is_batch):
+    mock_is_batch.return_value = False
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(state=quantum.ExecutionStatus.State.SUCCESS),
+        update_time=UPDATE_TIME,
+    )
+    get_job_results.return_value = RESULTS
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+    with pytest.raises(ValueError, match='batched_results called for a non-batch program'):
+        _ = job.batched_results()
+
+
+@mock.patch('cirq_google.engine.engine_program.EngineProgram.is_batch_async')
+@mock.patch('cirq_google.engine.engine_program.EngineProgram.batch_size_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')
+def test_batched_results_batch_job(get_job_results, mock_batch_size, mock_is_batch):
+    mock_is_batch.return_value = True
+    mock_batch_size.return_value = 2
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(state=quantum.ExecutionStatus.State.SUCCESS),
+        update_time=UPDATE_TIME,
+    )
+    get_job_results.return_value = RESULTS_NON_UNIFORM
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+
+    batched = job.batched_results()
+    assert len(batched) == 2
+    assert len(batched[0]) == 1
+    assert len(batched[1]) == 1
+    assert len(batched[0][0].measurements['q']) == 10
+    assert len(batched[1][0].measurements['q']) == 20
+    assert batched[0][0].job_id == 'steve'
+    assert batched[1][0].job_id == 'steve'
+
+
+@mock.patch('cirq_google.engine.engine_program.EngineProgram.is_batch_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_results_async')
+def test_batched_results_batch_job_v1_raises(get_job_results, mock_is_batch):
+    mock_is_batch.return_value = True
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(state=quantum.ExecutionStatus.State.SUCCESS),
+        update_time=UPDATE_TIME,
+    )
+    v1_result = quantum.QuantumResult(result=util.pack_any(v1.program_pb2.Result()))
+    get_job_results.return_value = v1_result
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+
+    with pytest.raises(ValueError, match='batched_results was not populated for this batch job'):
+        _ = job.batched_results()

--- a/cirq-google/cirq_google/engine/simulated_local_job.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job.py
@@ -151,4 +151,19 @@ class SimulatedLocalJob(AbstractLocalJob):
         elif self._type == LocalSimulationType.ASYNCHRONOUS:
             return _flatten_results(await self._future)
         else:
-            raise ValueError('Unsupported simulation type {self._type}')
+            raise ValueError(f'Unsupported simulation type {self._type}')
+
+    async def batched_results_async(self) -> Sequence[Sequence[EngineResult]]:
+        """Returns the job results split by program/circuit in the batch.
+
+        Instead of flattening results into a single list, this will return a Sequence[EngineResult]
+        for each circuit in the batch.
+        """
+        if not self.program().is_batch():
+            raise ValueError('batched_results called for a non-batch program.')
+        if self._type == LocalSimulationType.SYNCHRONOUS:
+            return self._execute_results()
+        elif self._type == LocalSimulationType.ASYNCHRONOUS:
+            return await self._future
+        else:
+            raise ValueError(f'Unsupported simulation type {self._type}')

--- a/cirq-google/cirq_google/engine/simulated_local_job_test.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job_test.py
@@ -184,3 +184,90 @@ def test_run_batch_non_uniform_repetitions():
     assert np.all(results[0].measurements['m'] == 1)
     assert np.all(results[1].measurements['m'] == 1)
     assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS
+
+
+def test_batched_results_non_batch_job_raises():
+    program = ParentProgram([cirq.Circuit(cirq.X(Q), cirq.measure(Q, key='m'))], None)
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=10,
+        sweeps=[cirq.UnitSweep],
+    )
+    with pytest.raises(ValueError, match='batched_results called for a non-batch program'):
+        _ = job.batched_results()
+
+
+def test_batched_results_batch_job():
+    program = ParentProgram(
+        [
+            cirq.Circuit(cirq.X(Q) ** sympy.Symbol('t'), cirq.measure(Q, key='m')),
+            cirq.Circuit(cirq.Z(Q) ** sympy.Symbol('t'), cirq.measure(Q, key='m')),
+        ],
+        None,
+    )
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=100,
+        sweeps=[cirq.Points(key='t', points=[0, 1]), cirq.Points(key='t', points=[0, 1])],
+    )
+    assert job.execution_status() == quantum.ExecutionStatus.State.READY
+    batched = job.batched_results()
+    assert len(batched) == 2
+    assert len(batched[0]) == 2
+    assert len(batched[1]) == 2
+    assert np.all(batched[0][0].measurements['m'] == 0)
+    assert np.all(batched[0][1].measurements['m'] == 1)
+    assert np.all(batched[1][0].measurements['m'] == 0)
+    assert np.all(batched[1][1].measurements['m'] == 0)
+    assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS
+
+
+def test_batched_results_batch_job_async():
+    program = ParentProgram(
+        [
+            cirq.Circuit(cirq.X(Q), cirq.measure(Q, key='m')),
+            cirq.Circuit(cirq.Y(Q), cirq.measure(Q, key='m')),
+        ],
+        None,
+    )
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=[10, 20],
+        sweeps=[cirq.UnitSweep, cirq.UnitSweep],
+        simulation_type=LocalSimulationType.ASYNCHRONOUS,
+    )
+    batched = job.batched_results()
+    assert len(batched) == 2
+    assert len(batched[0]) == 1
+    assert len(batched[1]) == 1
+    assert len(batched[0][0].measurements['m']) == 10
+    assert len(batched[1][0].measurements['m']) == 20
+    assert np.all(batched[0][0].measurements['m'] == 1)
+    assert np.all(batched[1][0].measurements['m'] == 1)
+    assert job.execution_status() == quantum.ExecutionStatus.State.SUCCESS
+
+
+def test_batched_results_unsupported_type():
+    program = ParentProgram(
+        [
+            cirq.Circuit(cirq.X(Q), cirq.measure(Q, key='m')),
+            cirq.Circuit(cirq.Y(Q), cirq.measure(Q, key='m')),
+        ],
+        None,
+    )
+    job = SimulatedLocalJob(
+        job_id='test_job',
+        processor_id='test1',
+        parent_program=program,
+        repetitions=10,
+        sweeps=[cirq.UnitSweep, cirq.UnitSweep],
+        simulation_type=LocalSimulationType.ASYNCHRONOUS_WITH_DELAY,
+    )
+    with pytest.raises(ValueError, match='Unsupported simulation type'):
+        _ = job.batched_results()


### PR DESCRIPTION
- This adds a new function analogous to results() that returns results according to the batch.
- Normal results() call returns all results in a flat list
- For batches, this is confusing, and the order is not clear.
- This function organizes the results into a list of lists organized by the execution of the (batched) circuits.