### PR TITLE
Add LZSResetViaResonator Gate to Cirq-google

### DIFF
--- a/cirq-google/cirq_google/__init__.py
+++ b/cirq-google/cirq_google/__init__.py
@@ -61,6 +61,7 @@ from cirq_google.ops import (
     FSimViaModelTag as FSimViaModelTag,
     InternalGate as InternalGate,
     InternalTag as InternalTag,
+    LZSResetViaResonator as LZSResetViaResonator,
     MultilevelResetViaResonator as MultilevelResetViaResonator,
     PhysicalZTag as PhysicalZTag,
     SYC as SYC,

--- a/cirq-google/cirq_google/json_resolver_cache.py
+++ b/cirq-google/cirq_google/json_resolver_cache.py
@@ -59,6 +59,7 @@ def _class_resolver_dictionary() -> dict[str, ObjectFactory]:
         'SycamoreGate': cirq_google.SycamoreGate,
         'WaitGateWithUnit': cirq_google.WaitGateWithUnit,
         'WillowGate': cirq_google.WillowGate,
+        'LZSResetViaResonator': cirq_google.LZSResetViaResonator,
         'MultilevelResetViaResonator': cirq_google.MultilevelResetViaResonator,
         # cirq_google.GateTabulation has been removed and replaced by cirq.TwoQubitGateTabulation.
         'GateTabulation': TwoQubitGateTabulation,

--- a/cirq-google/cirq_google/json_test_data/LZSResetViaResonator.json
+++ b/cirq-google/cirq_google/json_test_data/LZSResetViaResonator.json
@@ -1,0 +1,3 @@
+{
+  "cirq_type": "LZSResetViaResonator"
+}

--- a/cirq-google/cirq_google/json_test_data/LZSResetViaResonator.repr
+++ b/cirq-google/cirq_google/json_test_data/LZSResetViaResonator.repr
@@ -1,0 +1,1 @@
+cirq_google.LZSResetViaResonator()

--- a/cirq-google/cirq_google/ops/__init__.py
+++ b/cirq-google/cirq_google/ops/__init__.py
@@ -46,6 +46,8 @@ from cirq_google.ops.wait_gate import WaitGateWithUnit as WaitGateWithUnit
 
 from cirq_google.ops.willow_gate import WillowGate as WillowGate, WILLOW as WILLOW
 
+from cirq_google.ops.lzs_reset import LZSResetViaResonator as LZSResetViaResonator
+
 from cirq_google.ops.multi_level_reset import (
     MultilevelResetViaResonator as MultilevelResetViaResonator,
 )

--- a/cirq-google/cirq_google/ops/lzs_reset.py
+++ b/cirq-google/cirq_google/ops/lzs_reset.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import cirq
+from cirq_google.ops.internal_gate import InternalGate
+
+
+class LZSResetViaResonator(InternalGate):
+    """Qubit reset via LZS swap with resonator.
+
+    This is a specialized type of reset that uses a dual-passage
+    LZS (Landau-Zener-Stückelberg) trajectory to utilize interference
+    to actively reset a qubit.
+    """
+
+    def __init__(self, gate_name=None, gate_module=None, num_qubits=1, **kwargs):
+        super().__init__(gate_name="LZSResetViaResonator", num_qubits=1)
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
+        return ["[R (LZS)]"]
+
+    def is_reset_gate(self) -> bool:
+        return True
+
+    def _decompose_(self, qubits):
+        return cirq.reset_each(*qubits)
+
+    def _json_dict_(self):
+        return {}
+
+    def __repr__(self) -> str:
+        return 'cirq_google.LZSResetViaResonator()'

--- a/cirq-google/cirq_google/ops/lzs_reset_test.py
+++ b/cirq-google/cirq_google/ops/lzs_reset_test.py
@@ -1,0 +1,79 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import cirq
+import cirq_google as cg
+from cirq_google.ops.lzs_reset import LZSResetViaResonator
+
+
+def test_lzs_reset_properties():
+    gate = LZSResetViaResonator()
+    assert cirq.num_qubits(gate) == 1
+    assert gate.is_reset_gate()
+    assert not cirq.has_unitary(gate)
+
+
+def test_circuit_diagram():
+    q = cirq.GridQubit(0, 0)
+    op = LZSResetViaResonator()(q)
+    circuit = cirq.Circuit(op)
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+(0, 0): ───[R (LZS)]───
+""",
+    )
+
+
+def test_decomposition():
+    q = cirq.GridQubit(0, 0)
+    op = LZSResetViaResonator()(q)
+    decomp = cirq.decompose(op)
+    assert decomp == [cirq.ResetChannel()(q)]
+
+
+def test_serialization_round_trip():
+    q = cirq.GridQubit(0, 0)
+    gate = LZSResetViaResonator()
+    op = gate(q)
+    circuit = cirq.Circuit(op)
+
+    # Serialize
+    proto = cg.CIRCUIT_SERIALIZER.serialize(circuit)
+
+    # Verify proto structure
+    op_protos = [c.operation_value for c in proto.constants if c.HasField('operation_value')]
+    assert len(op_protos) == 1
+    op_proto = op_protos[0]
+
+    assert op_proto.WhichOneof('gate_value') == 'internalgate'
+    internal_gate_proto = op_proto.internalgate
+    assert internal_gate_proto.name == "LZSResetViaResonator"
+    assert internal_gate_proto.num_qubits == 1
+
+    # Deserialize
+    deserialized_circuit = cg.CIRCUIT_SERIALIZER.deserialize(proto)
+
+    # Verify matching
+    assert deserialized_circuit == circuit
+
+    # Verify exact class
+    deserialized_op = next(iter(deserialized_circuit.all_operations()))
+    assert isinstance(deserialized_op.gate, LZSResetViaResonator)
+
+
+def test_repr():
+    gate = LZSResetViaResonator()
+    assert repr(gate) == 'cirq_google.LZSResetViaResonator()'

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -926,7 +926,7 @@ class CircuitSerializer(serializer.Serializer):
                 case "LZSResetViaResonator":
                     gate: cirq.Gate = LZSResetViaResonator()
                 case "MultilevelResetViaResonator":
-                    gate: cirq.Gate = MultilevelResetViaResonator()
+                    gate = MultilevelResetViaResonator()
                 case _:
                     gate = arg_func_langs.internal_gate_from_proto(msg)
             op = gate(*qubits)

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -35,6 +35,7 @@ from cirq_google.ops import (
     FSimViaModelTag,
     InternalGate,
     InternalTag,
+    LZSResetViaResonator,
     MultilevelResetViaResonator,
     PhysicalZTag,
     SycamoreGate,
@@ -922,6 +923,8 @@ class CircuitSerializer(serializer.Serializer):
             msg = operation_proto.internalgate
             match str(msg.name):
                 # Add new custom cirq_google gates here:
+                case "LZSResetViaResonator":
+                    gate: cirq.Gate = LZSResetViaResonator()
                 case "MultilevelResetViaResonator":
                     gate: cirq.Gate = MultilevelResetViaResonator()
                 case _:


### PR DESCRIPTION
- This gate is needed for QEC experiment and allows resets with circuits with many rounds of measure
and reset.