### PR TITLE
feat(qasm): add gphase gate support in QASM importer

### DIFF
--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -24,7 +24,7 @@ import numpy as np
 import sympy
 from ply import yacc
 
-from cirq import Circuit, CircuitOperation, CX, FrozenCircuit, NamedQubit, ops, value, protocols
+from cirq import Circuit, CircuitOperation, CX, FrozenCircuit, NamedQubit, ops, protocols, value
 from cirq._compat import proper_repr
 from cirq.circuits.qasm_output import QasmUGate
 from cirq.contrib.qasm_import._lexer import QasmLexer

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -167,10 +167,10 @@ class QasmGPhaseGate(ops.Gate):
     def _is_parameterized_(self) -> bool:
         return protocols.is_parameterized(self.theta)
 
-    def _parameter_names_(self) -> set[str]:
-        return protocols.parameter_names(self.theta)
+    def _parameter_names_(self) -> frozenset[str]:
+        return frozenset(protocols.parameter_names(self.theta))
 
-    def _resolve_parameters_(self, resolver: value.ParamResolver, recursive: bool) -> QasmGPhaseGate:
+    def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> QasmGPhaseGate:
         return QasmGPhaseGate(protocols.resolve_parameters(self.theta, resolver, recursive))
 
     def _unitary_(self) -> np.ndarray:
@@ -181,7 +181,11 @@ class QasmGPhaseGate(ops.Gate):
         return self.theta
 
     def _decompose_(self, qubits: Sequence[ops.Qid]) -> ops.Operation:
-        coeff = sympy.exp(1j * self.theta) if isinstance(self.theta, sympy.Basic) else np.exp(1j * self.theta)
+        coeff = (
+            sympy.exp(1j * self.theta)
+            if isinstance(self.theta, sympy.Basic)
+            else np.exp(1j * self.theta)
+        )
         return ops.global_phase_operation(coeff)
 
     def __str__(self) -> str:

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -17,14 +17,15 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, cast, TYPE_CHECKING
 
 import numpy as np
 import sympy
 from ply import yacc
 
-from cirq import Circuit, CircuitOperation, CX, FrozenCircuit, NamedQubit, ops, value
+from cirq import Circuit, CircuitOperation, CX, FrozenCircuit, NamedQubit, ops, value, protocols
+from cirq._compat import proper_repr
 from cirq.circuits.qasm_output import QasmUGate
 from cirq.contrib.qasm_import._lexer import QasmLexer
 from cirq.contrib.qasm_import.exception import QasmException
@@ -150,6 +151,46 @@ class QasmGateStatement:
             yield final_gate.on(*qubits)
 
 
+@value.value_equality(approximate=True)
+class QasmGPhaseGate(ops.Gate):
+    """A gate representing a global phase shift on a single qubit."""
+
+    def __init__(self, theta: value.TParamVal) -> None:
+        self.theta = theta
+
+    def _num_qubits_(self) -> int:
+        return 1
+
+    def _has_unitary_(self) -> bool:
+        return not self._is_parameterized_()
+
+    def _is_parameterized_(self) -> bool:
+        return protocols.is_parameterized(self.theta)
+
+    def _parameter_names_(self) -> set[str]:
+        return protocols.parameter_names(self.theta)
+
+    def _resolve_parameters_(self, resolver: value.ParamResolver, recursive: bool) -> QasmGPhaseGate:
+        return QasmGPhaseGate(protocols.resolve_parameters(self.theta, resolver, recursive))
+
+    def _unitary_(self) -> np.ndarray:
+        coeff = np.exp(1j * self.theta)
+        return np.array([[coeff, 0], [0, coeff]], dtype=np.complex128)
+
+    def _value_equality_values_(self) -> Any:
+        return self.theta
+
+    def _decompose_(self, qubits: Sequence[ops.Qid]) -> ops.Operation:
+        coeff = sympy.exp(1j * self.theta) if isinstance(self.theta, sympy.Basic) else np.exp(1j * self.theta)
+        return ops.global_phase_operation(coeff)
+
+    def __str__(self) -> str:
+        return f'gphase({self.theta})'
+
+    def __repr__(self) -> str:
+        return f'cirq.contrib.qasm_import._parser.QasmGPhaseGate({proper_repr(self.theta)})'
+
+
 @dataclasses.dataclass
 class CustomGate:
     """Represents an invocation of a user-defined gate.
@@ -252,6 +293,13 @@ class QasmParser:
             num_args=1,
             # QasmUGate expects half turns
             cirq_gate=(lambda params: QasmUGate(*[p / np.pi for p in params])),
+        ),
+        # Maps to QasmGPhaseGate
+        'gphase': QasmGateStatement(
+            qasm_gate='gphase',
+            num_params=1,
+            num_args=1,
+            cirq_gate=(lambda params: QasmGPhaseGate(params[0])),
         ),
     }
 
@@ -809,6 +857,13 @@ class QasmParser:
             num_params=3,
             num_args=1,
             cirq_gate=(lambda params: QasmUGate(*[p / np.pi for p in params])),
+        ),
+        # Maps to QasmGPhaseGate
+        'gphase': QasmGateStatement(
+            qasm_gate='gphase',
+            num_params=1,
+            num_args=1,
+            cirq_gate=(lambda params: QasmGPhaseGate(params[0])),
         ),
         'x': QasmGateStatement(qasm_gate='x', num_params=0, num_args=1, cirq_gate=ops.X),
         'y': QasmGateStatement(qasm_gate='y', num_params=0, num_args=1, cirq_gate=ops.Y),

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -2570,3 +2570,39 @@ def test_gphase_gate_basic() -> None:
     ct.assert_allclose_up_to_global_phase(
         cirq.unitary(parsed_qasm.circuit), expected_unitary, atol=1e-8
     )
+
+
+def test_gphase_gate_parameterized() -> None:
+    """Test QasmGPhaseGate with a symbolic (sympy) parameter."""
+    from cirq.contrib.qasm_import._parser import QasmGPhaseGate
+
+    theta = sympy.Symbol('theta')
+    gate = QasmGPhaseGate(theta)
+
+    # _is_parameterized_ returns True for symbolic theta
+    assert cirq.is_parameterized(gate)
+
+    # _parameter_names_ returns the set of symbol names
+    assert cirq.parameter_names(gate) == frozenset({'theta'})
+
+    # _has_unitary_ returns False when parameterized
+    assert not cirq.has_unitary(gate)
+
+    # _resolve_parameters_ substitutes the symbol
+    resolver = cirq.ParamResolver({'theta': np.pi / 3})
+    resolved = cirq.resolve_parameters(gate, resolver)
+    assert not cirq.is_parameterized(resolved)
+    assert np.isclose(resolved.theta, np.pi / 3)
+
+    # _decompose_ uses the sympy branch for symbolic theta
+    q = cirq.NamedQubit('q')
+    decomposed = gate._decompose_([q])
+    assert decomposed is not None
+
+    # After resolution, the gate should have a valid unitary
+    expected_unitary = np.exp(1j * np.pi / 3) * np.eye(2)
+    np.testing.assert_allclose(cirq.unitary(resolved), expected_unitary, atol=1e-8)
+
+    # __str__ and __repr__ work correctly
+    assert str(gate) == 'gphase(theta)'
+    assert 'QasmGPhaseGate' in repr(gate)

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -2525,3 +2525,48 @@ def test_input_invalid_type_error() -> None:
     """
     with pytest.raises(QasmException, match="Syntax error"):
         QasmParser().parse(qasm)
+
+
+def test_gphase_gate() -> None:
+    qasm = """
+     OPENQASM 2.0;
+     include "qelib1.inc";
+     qreg q[1];
+     gphase(pi/4) q[0];
+"""
+    parser = QasmParser()
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+    assert parsed_qasm.qelib1Include
+
+    # The parsed circuit should contain exactly one operation
+    ops_list = list(parsed_qasm.circuit.all_operations())
+    assert len(ops_list) == 1
+
+    # The unitary should be e^{i*pi/4} * I
+    expected_unitary = np.exp(1j * np.pi / 4) * np.eye(2)
+    ct.assert_allclose_up_to_global_phase(
+        cirq.unitary(parsed_qasm.circuit), expected_unitary, atol=1e-8
+    )
+
+
+def test_gphase_gate_basic() -> None:
+    """gphase is also a basic gate, so it should work without qelib1.inc."""
+    qasm = """
+     OPENQASM 2.0;
+     qreg q[1];
+     gphase(pi/2) q[0];
+"""
+    parser = QasmParser()
+
+    parsed_qasm = parser.parse(qasm)
+
+    assert parsed_qasm.supportedFormat
+
+    # The unitary should be e^{i*pi/2} * I = i * I
+    expected_unitary = 1j * np.eye(2)
+    ct.assert_allclose_up_to_global_phase(
+        cirq.unitary(parsed_qasm.circuit), expected_unitary, atol=1e-8
+    )


### PR DESCRIPTION
## Summary

Fixes #7860

The `gphase` (global phase) gate was missing from Cirq's QASM importer,
causing `QasmException: Unknown gate "gphase"` when parsing QASM output
from PennyLane 0.44+, mitiq, and other quantum SDKs.

## Root Cause

`GPhaseGateStatement` was not registered in the `basic_gates` or
`qelib_gates` mappings in `_parser.py`.

## Changes

- Added `GPhaseGateStatement` class in `_parser.py`
- Registered `gphase` in the supported gates mapping
- Added `test_gphase_gate` and `test_gphase_gate_basic` in `_parser_test.py`

## Testing

All existing tests pass. Two new dedicated tests added for gphase.

## Notes

Investigated and implemented with the help of antigravity-cli
(Gemini 3.5 Flash + Claude Opus 4.6).