### PR TITLE
Replace noninclusive dummy and sanity language (#8103)

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_sampler_test.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler_test.py
@@ -339,7 +339,7 @@ def test_aqt_sampler_submits_jobs_correctly() -> None:
 def test_measurement_not_at_end_is_not_allowed() -> None:
     legacy_json = json.dumps([["R", 1.0, 0.0, [0]], ["Meas"], ["MS", 0.5, [0, 1]]])
 
-    sampler = AQTSampler("default", "dummy_resource", "test")
+    sampler = AQTSampler("default", "mock_resource", "test")
     with pytest.raises(ValueError):
         sampler._send_json(json_str=legacy_json, id_str="test")
 
@@ -347,7 +347,7 @@ def test_measurement_not_at_end_is_not_allowed() -> None:
 def test_multiple_measurements_are_not_allowed() -> None:
     legacy_json = json.dumps([["R", 1.0, 0.0, [0]], ["Meas"], ["Meas"]])
 
-    sampler = AQTSampler("default", "dummy_resource", "test")
+    sampler = AQTSampler("default", "mock_resource", "test")
     with pytest.raises(ValueError):
         sampler._send_json(json_str=legacy_json, id_str="test")
 
@@ -355,7 +355,7 @@ def test_multiple_measurements_are_not_allowed() -> None:
 def test_unknown_gate_in_json() -> None:
     legacy_json = json.dumps([["A", 1.0, 0.0, [0]], ["Meas"]])
 
-    sampler = AQTSampler("default", "dummy_resource", "test")
+    sampler = AQTSampler("default", "mock_resource", "test")
     with pytest.raises(
         ValueError, match=r"Got unknown gate on operation: \['A', 1\.0, 0\.0, \[0\]\]\."
     ):

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -73,16 +73,14 @@ def test_error_not_starting_with_format(qasm: str) -> None:
 def test_comments() -> None:
     parser = QasmParser()
 
-    parsed_qasm = parser.parse(
-        """
+    parsed_qasm = parser.parse("""
     //this is the format
     OPENQASM 2.0;
     // this is some other comment
     include "qelib1.inc";
     // and something at the end of the file
     // multiline
-    """
-    )
+    """)
 
     assert parsed_qasm.supportedFormat
     assert parsed_qasm.qelib1Include
@@ -763,8 +761,7 @@ def test_measurement_bounds() -> None:
 
 
 def test_reset() -> None:
-    qasm = textwrap.dedent(
-        """\
+    qasm = textwrap.dedent("""\
         OPENQASM 2.0;
         include "qelib1.inc";
         qreg q[1];
@@ -772,8 +769,7 @@ def test_reset() -> None:
         x q[0];
         reset q[0];
         measure q[0] -> c[0];
-        """
-    )
+        """)
 
     parser = QasmParser()
 

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -73,14 +73,16 @@ def test_error_not_starting_with_format(qasm: str) -> None:
 def test_comments() -> None:
     parser = QasmParser()
 
-    parsed_qasm = parser.parse("""
+    parsed_qasm = parser.parse(
+        """
     //this is the format
     OPENQASM 2.0;
     // this is some other comment
     include "qelib1.inc";
     // and something at the end of the file
     // multiline
-    """)
+    """
+    )
 
     assert parsed_qasm.supportedFormat
     assert parsed_qasm.qelib1Include
@@ -761,7 +763,8 @@ def test_measurement_bounds() -> None:
 
 
 def test_reset() -> None:
-    qasm = textwrap.dedent("""\
+    qasm = textwrap.dedent(
+        """\
         OPENQASM 2.0;
         include "qelib1.inc";
         qreg q[1];
@@ -769,7 +772,8 @@ def test_reset() -> None:
         x q[0];
         reset q[0];
         measure q[0] -> c[0];
-        """)
+        """
+    )
 
     parser = QasmParser()
 
@@ -1973,14 +1977,14 @@ def test_custom_gate() -> None:
     parsed_qasm = parser.parse(qasm)
     assert parsed_qasm.circuit == expected
 
-    # Sanity check that this unrolls to a valid circuit
+    # Check that this unrolls to a valid circuit
     unrolled_expected = cirq.Circuit(
         cirq.X(q_0), cirq.Y(q_0), cirq.Z(q_1), cirq.X(q_1), cirq.Y(q_1), cirq.Z(q_0)
     )
     unrolled = cirq.align_left(cirq.unroll_circuit_op(parsed_qasm.circuit, tags_to_check=None))
     assert unrolled == unrolled_expected
 
-    # Sanity check that these have the same unitaries as the QASM.
+    # Check that these have the same unitaries as the QASM.
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(unrolled))
 
@@ -2017,7 +2021,7 @@ def test_custom_gate_parameterized() -> None:
     parsed_qasm = parser.parse(qasm)
     assert parsed_qasm.circuit == expected
 
-    # Sanity check that this unrolls to a valid circuit
+    # Check that this unrolls to a valid circuit
     unrolled_expected = cirq.Circuit(
         cirq.Rx(rads=1).on(q_0),
         cirq.Ry(rads=6).on(q_0),
@@ -2029,7 +2033,7 @@ def test_custom_gate_parameterized() -> None:
     unrolled = cirq.align_left(cirq.unroll_circuit_op(parsed_qasm.circuit, tags_to_check=None))
     assert unrolled == unrolled_expected
 
-    # Sanity check that these have the same unitaries as the QASM.
+    # Check that these have the same unitaries as the QASM.
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(unrolled))
 
@@ -2064,7 +2068,7 @@ def test_custom_gate_broadcast() -> None:
     parsed_qasm = parser.parse(qasm)
     assert parsed_qasm.circuit == expected
 
-    # Sanity check that this unrolls to a valid circuit
+    # Check that this unrolls to a valid circuit
     unrolled_expected = cirq.Circuit(
         cirq.X(q_0),
         cirq.Y(q_0),
@@ -2079,7 +2083,7 @@ def test_custom_gate_broadcast() -> None:
     unrolled = cirq.align_left(cirq.unroll_circuit_op(parsed_qasm.circuit, tags_to_check=None))
     assert unrolled == unrolled_expected
 
-    # Sanity check that these have the same unitaries as the QASM.
+    # Check that these have the same unitaries as the QASM.
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(parsed_qasm.circuit))
     cq.assert_qiskit_parsed_qasm_consistent_with_unitary(qasm, cirq.unitary(unrolled))
 

--- a/cirq-core/cirq/linalg/operator_spaces_test.py
+++ b/cirq-core/cirq/linalg/operator_spaces_test.py
@@ -124,7 +124,7 @@ def test_kron_bases_consistency(basis1, basis2) -> None:
 
 
 @pytest.mark.parametrize('basis,repeat', itertools.product((PAULI_BASIS, STANDARD_BASIS), range(5)))
-def test_kron_bases_repeat_sanity_checks(basis, repeat) -> None:
+def test_kron_bases_repeat_validation_checks(basis, repeat) -> None:
     product_basis = cirq.kron_bases(basis, repeat=repeat)
     assert len(product_basis) == 4**repeat
     for name1, matrix1 in product_basis.items():

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -114,7 +114,7 @@ def _pad_tableau(
     clifford_tableau: qis.CliffordTableau, num_qubits_after_padding: int, axes: list[int]
 ) -> qis.CliffordTableau:
     """Roughly, this function copies self.tableau into the "identity" matrix."""
-    # Sanity check
+    # Validate inputs
     if len(set(axes)) != clifford_tableau.n:
         raise ValueError(
             "Input axes of padding should match with the number of qubits in the input tableau."

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -1466,7 +1466,7 @@ def test_decompose_with_extracted_phases(gate_type: type, exponent: cirq.TParamV
         assert isinstance(gate1, cirq.GlobalPhaseGate)
         assert gate1.coefficient == 1j ** (2 * exponent * test_shift)
 
-    # Sanity check that the decomposition is equivalent to the original.
+    # Check that the decomposition is equivalent to the original.
     decomposed_circuit = cirq.Circuit(decomposed)
     if cirq.is_parameterized(exponent):
         resolver = {'s': -1.234}  # arbitrary

--- a/cirq-core/cirq/ops/controlled_gate_test.py
+++ b/cirq-core/cirq/ops/controlled_gate_test.py
@@ -829,7 +829,7 @@ def test_controlled_phase_extracted_before_decomposition(gate_type, test_shift) 
     np.testing.assert_approx_equal(z.exponent, test_shift)
     assert z.global_shift == 0
 
-    # Sanity check that the decomposition is equivalent
+    # Check that the decomposition is equivalent
     np.testing.assert_allclose(
         cirq.unitary(cirq.Circuit(shifted_decomposition)), cirq.unitary(shifted_op), atol=1e-10
     )

--- a/cirq-core/cirq/protocols/decompose_protocol_test.py
+++ b/cirq-core/cirq/protocols/decompose_protocol_test.py
@@ -480,10 +480,10 @@ def test_handling_of_none_vs_notimplemented_return_values() -> None:
     assert result == [op]
 
     op = TestOp()
-    result = cirq.decompose_once(op, default='dummy')
+    result = cirq.decompose_once(op, default='placeholder')
     assert op.called_decompose_with_context, 'Should always call _decompose_with_context_'
     assert not op.called_decompose, 'Should not fall back to _decompose_'
-    assert result == 'dummy'
+    assert result == 'placeholder'
 
     op = TestOp()
     op.return_value = NotImplemented
@@ -494,7 +494,7 @@ def test_handling_of_none_vs_notimplemented_return_values() -> None:
 
     op = TestOp()
     op.return_value = NotImplemented
-    result = cirq.decompose_once(op, default='dummy')
+    result = cirq.decompose_once(op, default='placeholder')
     assert op.called_decompose_with_context, 'Should always call _decompose_with_context_'
     assert op.called_decompose, 'Should fall back to _decompose_'
-    assert result == 'dummy'
+    assert result == 'placeholder'

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -768,7 +768,7 @@ class StepResult(Generic[TSimulatorState], metaclass=abc.ABCMeta):
                 operations from `measurement_ops`.
         """
 
-        # Sanity checks.
+        # Validate measurement operations.
         for op in measurement_ops:
             gate = op.gate
             if not isinstance(gate, ops.MeasurementGate):

--- a/cirq-ionq/cirq_ionq/sampler_test.py
+++ b/cirq-ionq/cirq_ionq/sampler_test.py
@@ -169,7 +169,7 @@ def test_sampler_run_sweep_batched_job_results():
     job = ionq.Job(client=mock_service, job_dict=job_dict)
     mock_service.create_job.return_value = job
 
-    # Create dummy results
+    # Create mock results
     result1 = ionq.QPUResult(counts={0: 4}, num_qubits=1, measurement_dict={'a': [0]})
     result2 = ionq.QPUResult(counts={1: 4}, num_qubits=1, measurement_dict={'a': [0]})
 

--- a/cirq-web/cirq_web/src/bloch_sphere/bloch_sphere_test.ts
+++ b/cirq-web/cirq_web/src/bloch_sphere/bloch_sphere_test.ts
@@ -59,7 +59,7 @@ describe('BlochSphere (with empty constructor)', () => {
     const children = scene.children;
     expect(children.length).toBe(1);
     expect(children[0].type).toBe('Group');
-    // Sanity check to make sure it works as BlochSphere
+    // Check that the child is a BlochSphere instance
     expect(children[0] instanceof BlochSphere).toBe(true);
   });
 

--- a/dev_tools/modules_test_data/mod1/setup.py
+++ b/dev_tools/modules_test_data/mod1/setup.py
@@ -15,7 +15,7 @@ with open('requirements.txt', encoding='utf-8') as file:
 
 pack1_packages = ['pack1'] + ['pack1.' + package for package in find_packages(where='pack1')]
 
-# Sanity check
+# Verify version is set
 assert __version__, 'Version string cannot be empty'
 
 setup(

--- a/release.md
+++ b/release.md
@@ -211,7 +211,7 @@ Test PyPI will fail:
 ```
 
 Once this runs, you can create a virtual environment to perform
-manual verification as a sanity check and to check version number and
+manual verification as a quick check and to verify the version number and
 any high-risk features that have changed this release.
 
 ```bash


### PR DESCRIPTION
Comment and test-only edits per Khronos guidance and @mhucka review. Also renames dummy_resource to mock_resource in aqt_sampler_test and applies black to _parser_test.py.