### PR TITLE
Deprecate paths to create Moments with duplicate or overlapping measurement keys

### DIFF
--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -112,6 +112,13 @@ class Moment:
         self._control_keys: frozenset[cirq.MeasurementKey] | None = None
         self._tags = tags
 
+        # Check for the presence of duplicate measurement keys or incompatible arrangements
+        # of measurement and control keys, then throw relevant warnings.
+        if _compat.__cirq_debug__.get():
+            _ = self._measurement_key_objs_()
+            _ = self._control_keys_()
+            self._validate_measurement_and_control_keys_arrangement()
+
     @classmethod
     def from_ops(cls, *ops: cirq.Operation, tags: tuple[Hashable, ...] = ()) -> cirq.Moment:
         """Construct a Moment from the given operations.
@@ -226,6 +233,7 @@ class Moment:
             protocols.measurement_key_objs(operation)
         )
         m._control_keys = self._control_keys_().union(protocols.control_keys(operation))
+        m._validate_measurement_and_control_keys_arrangement()
 
         return m
 
@@ -266,6 +274,7 @@ class Moment:
         m._control_keys = self._control_keys_().union(
             itertools.chain(*(protocols.control_keys(op) for op in flattened_contents))
         )
+        m._validate_measurement_and_control_keys_arrangement()
 
         return m
 
@@ -327,9 +336,17 @@ class Moment:
 
     def _measurement_key_objs_(self) -> frozenset[cirq.MeasurementKey]:
         if self._measurement_key_objs is None:
-            self._measurement_key_objs = frozenset(
-                key for op in self.operations for key in protocols.measurement_key_objs(op)
-            )
+            # Discourage duplicate measurement keys for ops in the same Moment
+            all_keys = [key for op in self.operations for key in protocols.measurement_key_objs(op)]
+            unique_keys = frozenset(all_keys)
+            if len(all_keys) != len(unique_keys):
+                _compat._warn_or_error(
+                    f'Moment was created with duplicate measurement keys '
+                    f'but support for this is deprecated.\n'
+                    f'It will be removed in cirq v1.8.\n'
+                    f'Measurement keys: {all_keys}\n'
+                )
+            self._measurement_key_objs = unique_keys
         return self._measurement_key_objs
 
     def _control_keys_(self) -> frozenset[cirq.MeasurementKey]:
@@ -338,6 +355,17 @@ class Moment:
                 k for op in self.operations for k in protocols.control_keys(op)
             )
         return self._control_keys
+
+    def _validate_measurement_and_control_keys_arrangement(self):
+        if self._measurement_key_objs and self._control_keys:
+            if not self._measurement_key_objs.isdisjoint(self._control_keys):
+                _compat._warn_or_error(
+                    f'Moment was created with overlapping measurement and control keys '
+                    f'but support for this is deprecated.\n'
+                    f'It will be removed in cirq v1.8.\n'
+                    f'Measurement keys: {self._measurement_key_objs}\n'
+                    f'Control keys: {self._control_keys}\n'
+                )
 
     def _sorted_operations_(self) -> tuple[cirq.Operation, ...]:
         if self._sorted_operations is None:

--- a/cirq-core/cirq/circuits/moment_test.py
+++ b/cirq-core/cirq/circuits/moment_test.py
@@ -410,9 +410,59 @@ def test_measurement_keys() -> None:
     assert cirq.is_measurement(m2)
 
 
+def test_duplicate_measurement_keys_deprecated() -> None:
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+    with cirq.testing.assert_deprecated(
+        'Moment was created with duplicate measurement keys', deadline='v1.8', count=2
+    ):
+        _ = cirq.Moment(cirq.M(a, key='k'), cirq.M(b, key='k'))
+        _ = cirq.Moment.from_ops(cirq.M(a, key='k'), cirq.M(b, key='k'))
+
+
+def test_overlapping_measurement_and_control_keys_deprecated() -> None:
+    a = cirq.NamedQubit('a')
+    b = cirq.NamedQubit('b')
+
+    # First add a classical control key foo, then an overlapping measurement key foo
+    with cirq.testing.assert_deprecated(
+        'Moment was created with overlapping measurement and control keys', deadline='v1.8'
+    ):
+        m = cirq.Moment(cirq.X(a).with_classical_controls('foo'))
+        assert m._control_keys == {cirq.MeasurementKey(name='foo')}
+        _ = m.with_operation(cirq.M(b, key='foo'))
+
+    # Do the same thing, but exercise the multiple operations path
+    with cirq.testing.assert_deprecated(
+        'Moment was created with overlapping measurement and control keys', deadline='v1.8'
+    ):
+        m = cirq.Moment(cirq.X(a).with_classical_controls('foo'))
+        assert m._control_keys == {cirq.MeasurementKey(name='foo')}
+        _ = m.with_operations(cirq.M(b, key='foo'))
+
+    # Now reverse the order: add measurement key first, then classical control key
+    with cirq.testing.assert_deprecated(
+        'Moment was created with overlapping measurement and control keys', deadline='v1.8'
+    ):
+        m = cirq.Moment(cirq.M(b, key='foo'))
+        assert m._measurement_key_objs == {cirq.MeasurementKey(name='foo')}
+        _ = m.with_operation(cirq.X(a).with_classical_controls('foo'))
+
+    # Multiple operations
+    with cirq.testing.assert_deprecated(
+        'Moment was created with overlapping measurement and control keys', deadline='v1.8'
+    ):
+        m = cirq.Moment(cirq.M(b, key='foo'))
+        assert m._measurement_key_objs == {cirq.MeasurementKey(name='foo')}
+        _ = m.with_operations(cirq.X(a).with_classical_controls('foo'))
+
+
 def test_measurement_key_objs_caching() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
-    m = cirq.Moment(cirq.measure(q0, key='foo'))
+    # Debugging mode stores more state than normal.
+    # Focus this test on normal mode.
+    with cirq.with_debug(False):
+        m = cirq.Moment(cirq.measure(q0, key='foo'))
     assert m._measurement_key_objs is None
     key_objs = cirq.measurement_key_objs(m)
     assert m._measurement_key_objs == key_objs
@@ -435,7 +485,10 @@ def test_measurement_key_objs_caching() -> None:
 
 def test_control_keys_caching() -> None:
     q0, q1, q2, q3 = cirq.LineQubit.range(4)
-    m = cirq.Moment(cirq.X(q0).with_classical_controls('foo'))
+    # Debugging mode stores more state than normal.
+    # Focus this test on normal mode.
+    with cirq.with_debug(False):
+        m = cirq.Moment(cirq.X(q0).with_classical_controls('foo'))
     assert m._control_keys is None
     keys = cirq.control_keys(m)
     assert m._control_keys == keys

--- a/cirq-core/cirq/devices/noise_properties.py
+++ b/cirq-core/cirq/devices/noise_properties.py
@@ -88,8 +88,12 @@ class NoiseModelFromNoiseProperties(devices.NoiseModel):
                     continue
                 m_key = protocols.measurement_key_obj(op)
                 multi_measurements[m_key] = op
-                for q in op.qubits:
-                    split_measure_ops.append(ops.measure(q, key=m_key))
+                for i, q in enumerate(op.qubits):
+                    # Ensure unique keys for the new single-qubit measurements.
+                    # Restore them to the original form when combined later.
+                    split_measure_ops.append(
+                        ops.measure(q, key=m_key.replace(path=(*m_key.path, str(i))))
+                    )
             split_measure_moments.append(circuits.Moment(split_measure_ops))
 
         # Append PHYSICAL_GATE_TAG to non-virtual ops in the input circuit,
@@ -126,7 +130,8 @@ class NoiseModelFromNoiseProperties(devices.NoiseModel):
                 if not protocols.is_measurement(op):
                     combined_measure_ops.append(op)
                     continue
-                restore_keys.add(protocols.measurement_key_obj(op))
+                m_key = protocols.measurement_key_obj(op)
+                restore_keys.add(m_key.replace(path=m_key.path[:-1]))
             for key in restore_keys:
                 combined_measure_ops.append(multi_measurements[key])
             final_moments.append(circuits.Moment(combined_measure_ops))


### PR DESCRIPTION
Fixes https://github.com/quantumlib/Cirq/issues/8097. 