### PR TITLE
Deduplicate shared preamble in expectation-value sweeps

### DIFF
--- a/cirq-core/cirq/sim/density_matrix_simulator.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator.py
@@ -200,7 +200,6 @@ class DensityMatrixSimulator(
             params=params, measurements=measurements, final_simulator_state=final_simulator_state
         )
 
-    # TODO(#4209): Deduplicate with identical code in sparse_simulator.
     def simulate_expectation_values_sweep(
         self,
         program: cirq.AbstractCircuit,
@@ -210,18 +209,10 @@ class DensityMatrixSimulator(
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> list[list[float]]:
-        if not permit_terminal_measurements and program.are_any_measurements_terminal():
-            raise ValueError(
-                'Provided circuit has terminal measurements, which may '
-                'skew expectation values. If this is intentional, set '
-                'permit_terminal_measurements=True.'
-            )
+        qubit_order, qmap, pslist = self._qubit_map_and_pauli_sums(
+            program, observables, qubit_order, permit_terminal_measurements
+        )
         swept_evs = []
-        qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)
-        qmap = {q: i for i, q in enumerate(qubit_order.order_for(program.all_qubits()))}
-        if not isinstance(observables, list):
-            observables = [observables]
-        pslist = [ops.PauliSum.wrap(pslike) for pslike in observables]
         for param_resolver in study.to_resolvers(params):
             result = self.simulate(
                 program, param_resolver, qubit_order=qubit_order, initial_state=initial_state

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -439,6 +439,48 @@ class SimulatesExpectationValues(metaclass=value.ABCMetaImplementAnyOneOf):
         """
         raise NotImplementedError
 
+    def _qubit_map_and_pauli_sums(
+        self,
+        program: cirq.AbstractCircuit,
+        observables: cirq.PauliSumLike | list[cirq.PauliSumLike],
+        qubit_order: cirq.QubitOrderOrList,
+        permit_terminal_measurements: bool,
+    ) -> tuple[cirq.QubitOrder, dict[cirq.Qid, int], list[cirq.PauliSum]]:
+        """Validates inputs and builds the data shared by expectation-value sweeps.
+
+        Runs the common preamble for `simulate_expectation_values_sweep` and
+        `simulate_expectation_values_sweep_iter` implementations: it rejects
+        terminal measurements (unless permitted), resolves the qubit order, and
+        wraps the observables as `cirq.PauliSum`s.
+
+        Args:
+            program: The circuit whose qubits define the ordering.
+            observables: An observable or list of observables.
+            qubit_order: Determines the canonical ordering of the qubits.
+            permit_terminal_measurements: If False, raises when `program` ends
+                with measurement(s).
+
+        Returns:
+            A tuple of the resolved `cirq.QubitOrder`, the qubit-to-index map, and
+            the observables wrapped as a list of `cirq.PauliSum`.
+
+        Raises:
+            ValueError: If `program` has terminal measurement(s) and
+                `permit_terminal_measurements` is False.
+        """
+        if not permit_terminal_measurements and program.are_any_measurements_terminal():
+            raise ValueError(
+                'Provided circuit has terminal measurements, which may '
+                'skew expectation values. If this is intentional, set '
+                'permit_terminal_measurements=True.'
+            )
+        qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)
+        qmap = {q: i for i, q in enumerate(qubit_order.order_for(program.all_qubits()))}
+        if not isinstance(observables, list):
+            observables = [observables]
+        pslist = [ops.PauliSum.wrap(pslike) for pslike in observables]
+        return qubit_order, qmap, pslist
+
 
 class SimulatesFinalState(
     Generic[TSimulationTrialResult], metaclass=value.ABCMetaImplementAnyOneOf

--- a/cirq-core/cirq/sim/sparse_simulator.py
+++ b/cirq-core/cirq/sim/sparse_simulator.py
@@ -199,17 +199,9 @@ class Simulator(
         initial_state: Any = None,
         permit_terminal_measurements: bool = False,
     ) -> Iterator[list[float]]:
-        if not permit_terminal_measurements and program.are_any_measurements_terminal():
-            raise ValueError(
-                'Provided circuit has terminal measurements, which may '
-                'skew expectation values. If this is intentional, set '
-                'permit_terminal_measurements=True.'
-            )
-        qubit_order = ops.QubitOrder.as_qubit_order(qubit_order)
-        qmap = {q: i for i, q in enumerate(qubit_order.order_for(program.all_qubits()))}
-        if not isinstance(observables, list):
-            observables = [observables]
-        pslist = [ops.PauliSum.wrap(pslike) for pslike in observables]
+        qubit_order, qmap, pslist = self._qubit_map_and_pauli_sums(
+            program, observables, qubit_order, permit_terminal_measurements
+        )
         yield from (
             [obs.expectation_from_state_vector(result.final_state_vector, qmap) for obs in pslist]
             for result in self.simulate_sweep_iter(


### PR DESCRIPTION
Fixes #4209.

## What

`DensityMatrixSimulator.simulate_expectation_values_sweep` and
`Simulator.simulate_expectation_values_sweep_iter` began with an identical preamble
(the one flagged by the `# TODO(#4209)` comment): reject terminal measurements unless
permitted, resolve the qubit order, build the qubit→index map, and wrap the observables
as `cirq.PauliSum`s.

This factors that preamble into a protected helper `_qubit_map_and_pauli_sums` on
`SimulatesExpectationValues` (the base both simulators already inherit) and removes the
`# TODO(#4209)` marker.

## Design context

Only the preamble is shared; the two methods' bodies are intentionally left as they are.
The base class documents "Prefer overriding `simulate_expectation_values_sweep_iter`", and
the sparse `Simulator` deliberately stays a lazy generator that streams over
`simulate_sweep_iter` and uses `expectation_from_state_vector`, while
`DensityMatrixSimulator` is eager and uses `expectation_from_density_matrix`. Collapsing the
two into one method would regress the sparse path's streaming behavior, so the helper covers
only the common setup. The helper returns the already-resolved `QubitOrder` so the qubit map
and the downstream `simulate(...)` call use the same ordering — no behavior change.

No public API change (the helper is protected); no serialization changes.

## Scope / non-goals

- Does not change the eager-vs-lazy structure of either method.
- Does not touch the other `Simulates*` interfaces or the Clifford/MPS simulators (they
  don't override these methods).
- No new public symbols.

## Test

No new behavior is introduced, so the existing expectation-value tests act as the regression
net — `density_matrix_simulator_test.py`, `sparse_simulator_test.py`, and `simulator_test.py`
all pass (473 tests), and they already cover the numeric expectation values, the
terminal-measurement `ValueError`, and the `permit_terminal_measurements` flag, which
exercise every line of the new helper.
