### PR TITLE
Make DD more stable

### DIFF
--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -334,8 +334,9 @@ class PhasedXZGate(raw_types.Gate):
         )
         return result
 
-    def canonical_clifford(self) -> PhasedXZGate | None:
-        """Returns the exact Clifford gate if this gate's exponents are all within small round-off errors.  Returns None otherwise."""
+    def canonical_clifford(self, atol: float = 1e-8) -> PhasedXZGate | None:
+        """Returns the exact Clifford gate if this gate's exponents are all within small errors."""
+
         if not self._has_stabilizer_effect_(tol=atol):
             return None
 

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -343,6 +343,8 @@ class PhasedXZGate(raw_types.Gate):
         z = round(self._z_exponent, 2)
         a = round(self._axis_phase_exponent, 2)
         x, z, a = _canonical_xza_mod_2(x, z, a)
+        if x == self._x_exponent and z == self._z_exponent and a == self._axis_phase_exponent:
+            return self
         return PhasedXZGate(x_exponent=x, z_exponent=z, axis_phase_exponent=a)
 
 

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -18,7 +18,7 @@ import functools
 import math
 import numbers
 from collections.abc import Iterator, Sequence, Set
-from typing import Any, Final, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 import sympy

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -334,8 +334,8 @@ class PhasedXZGate(raw_types.Gate):
         )
         return result
 
-    def nearest_clifford(self, atol: float = 1e-8) -> PhasedXZGate | None:
-        """Returns the nearest clifford if it is within `atol` or None otherwise."""
+    def canonical_clifford(self) -> PhasedXZGate | None:
+        """Returns the exact Clifford gate if this gate's exponents are all within small round-off errors.  Returns None otherwise."""
         if not self._has_stabilizer_effect_(tol=atol):
             return None
 

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -18,7 +18,7 @@ import functools
 import math
 import numbers
 from collections.abc import Iterator, Sequence, Set
-from typing import Any, TYPE_CHECKING
+from typing import Any, Final, TYPE_CHECKING
 
 import numpy as np
 import sympy
@@ -323,9 +323,10 @@ class PhasedXZGate(raw_types.Gate):
             self, ['axis_phase_exponent', 'x_exponent', 'z_exponent']
         )
 
-    def _has_stabilizer_effect_(self, *, tol: float = 1e-8) -> bool:
+    def _has_stabilizer_effect_(self) -> bool:
         if not self._has_unitary_():
             return False
+        tol: Final = 1e-8
         result = (
             abs((x := round(self._x_exponent, 2)) - self._x_exponent) <= tol
             and abs((z := round(self._z_exponent, 2)) - self._z_exponent) <= tol
@@ -334,10 +335,10 @@ class PhasedXZGate(raw_types.Gate):
         )
         return result
 
-    def canonical_clifford(self, atol: float = 1e-8) -> PhasedXZGate | None:
+    def canonical_clifford(self) -> PhasedXZGate | None:
         """Returns the exact Clifford gate if this gate's exponents are all within small errors."""
 
-        if not self._has_stabilizer_effect_(tol=atol):
+        if not self._has_stabilizer_effect_():
             return None
 
         x = round(self._x_exponent, 2)

--- a/cirq-core/cirq/ops/phased_x_z_gate.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate.py
@@ -323,10 +323,9 @@ class PhasedXZGate(raw_types.Gate):
             self, ['axis_phase_exponent', 'x_exponent', 'z_exponent']
         )
 
-    def _has_stabilizer_effect_(self) -> bool:
+    def _has_stabilizer_effect_(self, *, tol: float = 1e-8) -> bool:
         if not self._has_unitary_():
             return False
-        tol: Final = 1e-8
         result = (
             abs((x := round(self._x_exponent, 2)) - self._x_exponent) <= tol
             and abs((z := round(self._z_exponent, 2)) - self._z_exponent) <= tol
@@ -334,6 +333,17 @@ class PhasedXZGate(raw_types.Gate):
             and _canonical_xza_mod_2(x, z, a) in _clifford_as_phasedzx_params()
         )
         return result
+
+    def nearest_clifford(self, atol: float = 1e-8) -> PhasedXZGate | None:
+        """Returns the nearest clifford if it is within `atol` or None otherwise."""
+        if not self._has_stabilizer_effect_(tol=atol):
+            return None
+
+        x = round(self._x_exponent, 2)
+        z = round(self._z_exponent, 2)
+        a = round(self._axis_phase_exponent, 2)
+        x, z, a = _canonical_xza_mod_2(x, z, a)
+        return PhasedXZGate(x_exponent=x, z_exponent=z, axis_phase_exponent=a)
 
 
 def _canonical_xza_mod_2(

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -405,18 +405,18 @@ def test_canonical_xza_mod_2_matches_canonical(x: float, z: float, a: float) -> 
 @pytest.mark.parametrize(
     'gate', [g.to_phased_xz_gate() for g in cirq.SingleQubitCliffordGate.all_single_qubit_cliffords]
 )
-def test_nearest_clifford_for_real_cliffords(gate):
-    assert gate.nearest_clifford() == gate
+def test_canonical_clifford_for_real_cliffords(gate):
+    assert gate.canonical_clifford() == gate
     eps = 1e-10
     gate1 = cirq.PhasedXZGate(
         x_exponent=gate.x_exponent + eps,
         z_exponent=gate.z_exponent - eps,
         axis_phase_exponent=gate.axis_phase_exponent + eps,
     )
-    assert gate1.nearest_clifford() == gate
+    assert gate1.canonical_clifford() == gate
 
 
 @pytest.mark.parametrize(['x', 'z', 'a'], np.random.uniform(-3, 3, (100, 3)), ids=range(100))
-def test_nearest_clifford_for_non_cliffords(x, z, a):
+def test_canonical_clifford_for_non_cliffords(x, z, a):
     gate = cirq.PhasedXZGate(x_exponent=x, z_exponent=z, axis_phase_exponent=a)
-    assert gate.nearest_clifford() is None
+    assert gate.canonical_clifford() is None

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -400,3 +400,16 @@ def test_canonical_xza_mod_2_matches_canonical(x: float, z: float, a: float) -> 
     xzab_expected = (gateb.x_exponent % 2, gateb.z_exponent % 2, gateb.axis_phase_exponent % 2)
     xzab_actual = cirq.ops.phased_x_z_gate._canonical_xza_mod_2(xb, zb, ab)
     assert xzab_actual == xzab_expected
+
+
+@pytest.mark.parametrize(
+    'gate', [g.to_phased_xz_gate() for g in cirq.SingleQubitCliffordGate.all_single_qubit_cliffords]
+)
+def test_nearest_clifford_for_real_cliffords(gate):
+    assert gate.nearest_clifford() == gate
+
+
+@pytest.mark.parametrize(['x', 'z', 'a'], np.random.uniform(-3, 3, (100, 3)), ids=range(100))
+def test_nearest_clifford_for_non_cliffords(x, z, a):
+    gate = cirq.PhasedXZGate(x_exponent=x, z_exponent=z, axis_phase_exponent=a)._canonical()
+    assert gate.nearest_clifford() is None

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -418,5 +418,5 @@ def test_nearest_clifford_for_real_cliffords(gate):
 
 @pytest.mark.parametrize(['x', 'z', 'a'], np.random.uniform(-3, 3, (100, 3)), ids=range(100))
 def test_nearest_clifford_for_non_cliffords(x, z, a):
-    gate = cirq.PhasedXZGate(x_exponent=x, z_exponent=z, axis_phase_exponent=a)._canonical()
+    gate = cirq.PhasedXZGate(x_exponent=x, z_exponent=z, axis_phase_exponent=a)
     assert gate.nearest_clifford() is None

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -407,6 +407,13 @@ def test_canonical_xza_mod_2_matches_canonical(x: float, z: float, a: float) -> 
 )
 def test_nearest_clifford_for_real_cliffords(gate):
     assert gate.nearest_clifford() == gate
+    eps = 1e-10
+    gate1 = cirq.PhasedXZGate(
+        x_exponent=gate.x_exponent + eps,
+        z_exponent=gate.z_exponent - eps,
+        axis_phase_exponent=gate.axis_phase_exponent + eps,
+    )
+    assert gate1.nearest_clifford() == gate
 
 
 @pytest.mark.parametrize(['x', 'z', 'a'], np.random.uniform(-3, 3, (100, 3)), ids=range(100))

--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -379,8 +379,10 @@ def add_dynamical_decoupling(
 
 
 def _as_clifford(op: ops.Operation) -> ops.Operation:
-    gate = op.gate
-    if not isinstance(gate, ops.PhasedXZGate):
-        return op
-    gate = cast(ops.PhasedXZGate, gate.nearest_clifford())
-    return gate(*op.qubits)
+def _as_clifford(op: ops.Operation) -> ops.Operation:
+    if isinstance(op.gate, ops.PhasedXZGate):
+        gate_clifford = op.gate.nearest_clifford()
+        assert gate_clifford is not None
+        if gate_clifford is not op.gate:
+            return gate_clifford(*op.qubits)
+    return op

--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -367,11 +367,22 @@ def add_dynamical_decoupling(
                 updated_moment_ops.add(new_op_at_q)
 
         updated_moment = Moment(updated_moment_ops)
-        clifford_ops = [op for op in updated_moment if _is_clifford_op(op)]
-        pulled_through = pulled_through.after(clifford_ops)
+        pulled_through = pulled_through.after(
+            [_as_clifford(op) for op in updated_moment if _is_clifford_op(op)]
+        )
         transformed_moments.append(updated_moment)
 
     if len(pulled_through) > 0:
         raise RuntimeError("Expect empty remaining Paulis after the dd insertion.")
 
     return Circuit.from_moments(*transformed_moments)
+
+
+def _as_clifford(op: ops.Operation) -> ops.Operation:
+    gate = op.gate
+    if not isinstance(gate, ops.PhasedXZGate):
+        return op
+    gate = gate.nearest_clifford()
+    if gate is None:
+        raise ValueError(f'{op=} is not clifford')
+    return gate(*op.qubits)

--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from enum import Enum
 from functools import reduce
 from itertools import cycle
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 import numpy as np
 from attrs import frozen
@@ -382,7 +382,5 @@ def _as_clifford(op: ops.Operation) -> ops.Operation:
     gate = op.gate
     if not isinstance(gate, ops.PhasedXZGate):
         return op
-    gate = gate.nearest_clifford()
-    if gate is None:
-        raise ValueError(f'{op=} is not clifford')
+    gate = cast(ops.PhasedXZGate, gate.nearest_clifford())
     return gate(*op.qubits)

--- a/cirq-core/cirq/transformers/dynamical_decoupling.py
+++ b/cirq-core/cirq/transformers/dynamical_decoupling.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from enum import Enum
 from functools import reduce
 from itertools import cycle
-from typing import cast, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import frozen
@@ -379,9 +379,8 @@ def add_dynamical_decoupling(
 
 
 def _as_clifford(op: ops.Operation) -> ops.Operation:
-def _as_clifford(op: ops.Operation) -> ops.Operation:
     if isinstance(op.gate, ops.PhasedXZGate):
-        gate_clifford = op.gate.nearest_clifford()
+        gate_clifford = op.gate.canonical_clifford()
         assert gate_clifford is not None
         if gate_clifford is not op.gate:
             return gate_clifford(*op.qubits)


### PR DESCRIPTION
Avoid error in `add_dynamical_decoupling` when `PhasedXZGate` differs
from a Clifford gate by small numerical round-off.