### PR TITLE
Update Scientific Python dependencies per NEP-29 and SPEC-0

### DIFF
--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -253,7 +253,7 @@ def test_tomography_plot_raises_for_incorrect_number_of_axes() -> None:
     result = single_qubit_state_tomography(simulator, qubit, circuit, 1000)
     with pytest.raises(TypeError):  # ax is not a list[plt.Axes]
         ax = plt.subplot()
-        result.plot(ax)  # type: ignore[arg-type]
+        result.plot(ax)
     with pytest.raises(ValueError):
         _, axes = plt.subplots(1, 3)
         result.plot(axes)

--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -100,6 +100,21 @@ def t1_decay(
         if name not in tab:
             tab.insert(col_index, name, [0] * tab.shape[0])
 
+    # validate that pandas-3 version will produce the same DataFrame
+    tab0 = tab
+
+    # Cross tabulate into a delay_ns, false_count, true_count table.
+    tab = pd.crosstab(
+        results.delay_ns.reset_index(drop=True), results.output.reset_index(drop=True)
+    )
+    tab.rename_axis(None, axis="columns", inplace=True)
+    tab = tab.rename(columns={0: 'false_count', 1: 'true_count'}).reset_index()
+    for col_index, name in [(1, 'false_count'), (2, 'true_count')]:
+        if name not in tab:
+            tab.insert(col_index, name, [0] * tab.shape[0])
+
+    assert tab.equals(tab0)
+
     return T1DecayResult(tab)
 
 

--- a/cirq-core/cirq/experiments/t1_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t1_decay_experiment.py
@@ -93,17 +93,6 @@ def t1_decay(
     results = sampler.sample(circuit, params=sweep, repetitions=repetitions)
 
     # Cross tabulate into a delay_ns, false_count, true_count table.
-    tab = pd.crosstab(results.delay_ns, results.output)
-    tab.rename_axis(None, axis="columns", inplace=True)
-    tab = tab.rename(columns={0: 'false_count', 1: 'true_count'}).reset_index()
-    for col_index, name in [(1, 'false_count'), (2, 'true_count')]:
-        if name not in tab:
-            tab.insert(col_index, name, [0] * tab.shape[0])
-
-    # validate that pandas-3 version will produce the same DataFrame
-    tab0 = tab
-
-    # Cross tabulate into a delay_ns, false_count, true_count table.
     tab = pd.crosstab(
         results.delay_ns.reset_index(drop=True), results.output.reset_index(drop=True)
     )
@@ -112,8 +101,6 @@ def t1_decay(
     for col_index, name in [(1, 'false_count'), (2, 'true_count')]:
         if name not in tab:
             tab.insert(col_index, name, [0] * tab.shape[0])
-
-    assert tab.equals(tab0)
 
     return T1DecayResult(tab)
 

--- a/cirq-core/cirq/experiments/t2_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment.py
@@ -226,15 +226,6 @@ def t2_decay(
 def _create_tabulation(measurements: pd.DataFrame) -> pd.DataFrame:
     """Returns a sum of 0 and 1 results per index from a list of measurements."""
     if 'num_pulses' in measurements.columns:
-        cols = [measurements.delay_ns, measurements.num_pulses]
-    else:
-        cols = [measurements.delay_ns]
-    tabulation = pd.crosstab(cols, measurements.output).reset_index()
-
-    # validate that pandas-3 version will produce the same DataFrame
-    tabulation0 = tabulation
-
-    if 'num_pulses' in measurements.columns:
         cols = [
             measurements.delay_ns.reset_index(drop=True),
             measurements.num_pulses.reset_index(drop=True),
@@ -242,9 +233,6 @@ def _create_tabulation(measurements: pd.DataFrame) -> pd.DataFrame:
     else:
         cols = [measurements.delay_ns.reset_index(drop=True)]
     tabulation = pd.crosstab(cols, measurements.output.reset_index(drop=True)).reset_index()
-
-    assert tabulation.equals(tabulation0)
-
     # If all measurements are 1 or 0, fill in the missing column with all zeros.
     for col_index, name in [(1, 0), (2, 1)]:
         if name not in tabulation:

--- a/cirq-core/cirq/experiments/t2_decay_experiment.py
+++ b/cirq-core/cirq/experiments/t2_decay_experiment.py
@@ -230,6 +230,21 @@ def _create_tabulation(measurements: pd.DataFrame) -> pd.DataFrame:
     else:
         cols = [measurements.delay_ns]
     tabulation = pd.crosstab(cols, measurements.output).reset_index()
+
+    # validate that pandas-3 version will produce the same DataFrame
+    tabulation0 = tabulation
+
+    if 'num_pulses' in measurements.columns:
+        cols = [
+            measurements.delay_ns.reset_index(drop=True),
+            measurements.num_pulses.reset_index(drop=True),
+        ]
+    else:
+        cols = [measurements.delay_ns.reset_index(drop=True)]
+    tabulation = pd.crosstab(cols, measurements.output.reset_index(drop=True)).reset_index()
+
+    assert tabulation.equals(tabulation0)
+
     # If all measurements are 1 or 0, fill in the missing column with all zeros.
     for col_index, name in [(1, 0), (2, 1)]:
         if name not in tabulation:

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -4,8 +4,8 @@ attrs>=21.3.0
 duet>=0.2.8
 matplotlib~=3.9
 networkx~=3.4
-numpy~=2.0
-pandas~=2.3
-scipy~=1.14
+numpy~=2.1
+pandas>=2.3,<3.1.0.dev
+scipy~=1.15
 sympy
 tqdm>=4.12

--- a/dev_tools/requirements/deps/ipython.txt
+++ b/dev_tools/requirements/deps/ipython.txt
@@ -1,1 +1,1 @@
-ipython>=8.24,<10.0dev
+ipython>=8.26,<10.0dev

--- a/docs/start/intro.ipynb
+++ b/docs/start/intro.ipynb
@@ -2114,7 +2114,7 @@
     ")\n",
     "\n",
     "# You can test with the following plot\n",
-    "# pandas.crosstab(results.theta, results.q).plot()"
+    "# pandas.crosstab(results.theta, results.q.values, colnames=[\"q\"]).plot()"
    ]
   },
   {
@@ -2135,7 +2135,7 @@
     "results = cirq.Simulator().sample(\n",
     "    program=parameterized_circuit, params=param_resolvers, repetitions=repetitions\n",
     ")\n",
-    "pandas.crosstab(results.theta, results.q).plot()"
+    "pandas.crosstab(results.theta, results.q.values, colnames=[\"q\"]).plot()"
    ]
   },
   {


### PR DESCRIPTION
Update Scientific Python dependencies per NEP-29 and SPEC-0

* drop numpy-2.0 per NEP-29 and SPEC-0
* drop scipy-1.14 per SPEC-0
* allow pandas-3.0 per SPEC-0 and adjust `pandas.crosstab`
  calls to work with both pandas-2 and pandas-3
* drop ipython-8.25 per SPEC-0

Keep Python 3.11 to preserve its support in upcoming cirq-1.7.0.
Keep matplotlib-3.9 to have compatibility with 2 minor releases.

Refs:

* https://numpy.org/neps/nep-0029-deprecation_policy.html
* https://scientific-python.org/specs/spec-0000

Resolves #8059
Resolves b/500500986
