### PR TITLE
Prevent script-context XSS in Circuit3D serialization

### DIFF
--- a/cirq-web/cirq_web/circuits/circuit.py
+++ b/cirq-web/cirq_web/circuits/circuit.py
@@ -79,15 +79,19 @@ class Circuit3D(widget.Widget):
         return 'circuit.bundle.js'
 
     def _serialize_circuit(self) -> str:
-        args = []
+        symbols = []
         moments = self.circuit.moments
         for moment_id, moment in enumerate(moments):
             for item in moment:
                 symbol = self._build_3D_symbol(item, moment_id)
-                args.append(symbol.to_typescript())
+                symbols.append(symbol.to_typescript())
 
-        argument_str = ','.join(str(item) for item in args)
-        return f'[{argument_str}]'
+        # Use a JSON serializer with contextual HTML escaping rather than `str()` on
+        # Python dicts. Besides producing valid JavaScript (e.g. for booleans/None),
+        # this ensures attacker-controlled gate labels cannot break out of the
+        # surrounding `<script>` element and inject markup (XSS). See `cirq.read_json`
+        # as an untrusted source of circuits that may be visualized here.
+        return widget.to_script_safe_json(symbols)
 
     def _build_3D_symbol(self, operation, moment) -> Operation3DSymbol:
         symbol_info = resolve_operation(operation, self._resolvers)

--- a/cirq-web/cirq_web/circuits/circuit_test.py
+++ b/cirq-web/cirq_web/circuits/circuit_test.py
@@ -46,6 +46,7 @@ def test_circuit_client_code(qubit) -> None:
             'moment': 0,
         }
     ]
+    serialized_circuit = cirq_web.widget.to_script_safe_json(circuit_obj)
 
     moments = 1
     stripped_id = circuit.id.replace('-', '')
@@ -55,7 +56,7 @@ def test_circuit_client_code(qubit) -> None:
         <button id="camera-toggle">Toggle Camera Type</button>
         <script>
         let viz_{stripped_id} = createGridCircuit(
-            {str(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
+            {serialized_circuit}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
         );
 
         document.getElementById("camera-reset").addEventListener('click', ()  => {{
@@ -69,6 +70,33 @@ def test_circuit_client_code(qubit) -> None:
         """
 
     assert strip_ws(circuit.get_client_code()) == strip_ws(expected_client_code)
+
+
+class _MaliciousLabelGate(cirq.Gate):
+    """A single-qubit gate whose circuit-diagram label contains HTML markup.
+
+    This models a gate label coming from an untrusted source (e.g. a circuit
+    deserialized via `cirq.read_json` or shared in a notebook).
+    """
+
+    def _num_qubits_(self) -> int:
+        return 1
+
+    def _circuit_diagram_info_(self, args) -> cirq.CircuitDiagramInfo:
+        return cirq.CircuitDiagramInfo(wire_symbols=["</script><script>alert('xss')</script>"])
+
+
+def test_circuit_client_code_escapes_malicious_labels() -> None:
+    # Regression test: an attacker-controlled wire symbol must not be able to break
+    # out of the surrounding <script> element and inject executable markup (XSS).
+    circuit = cirq_web.Circuit3D(cirq.Circuit(_MaliciousLabelGate().on(cirq.LineQubit(0))))
+
+    client_code = circuit.get_client_code()
+
+    # The literal closing tag / injected element must not appear verbatim.
+    assert "</script><script>" not in client_code
+    # The data is preserved, but encoded so the HTML parser treats it as inert text.
+    assert "\\u003c/script\\u003e\\u003cscript\\u003e" in client_code
 
 
 def test_circuit_client_code_unsupported_qubit_type() -> None:

--- a/cirq-web/cirq_web/widget.py
+++ b/cirq-web/cirq_web/widget.py
@@ -14,17 +14,56 @@
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
 import webbrowser
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import cirq_web
 
 # Resolve the path so the bundle file can be accessed properly
 _DIST_PATH = Path(cirq_web.__file__).parents[1] / "cirq_web" / "dist"
+
+# Characters that are unsafe to emit verbatim inside an HTML ``<script>`` element.
+# ``<`` / ``>`` are escaped so that a substring such as ``</script>`` in the
+# serialized data cannot terminate the enclosing script element, ``&`` is escaped
+# to avoid HTML entity decoding, and U+2028 / U+2029 are escaped because they are
+# valid JSON but illegal as raw characters in a JavaScript string literal. Escaping
+# them as ``\uXXXX`` keeps the decoded JavaScript value identical while making the
+# serialized text inert to the HTML parser.
+_HTML_SCRIPT_ESCAPES = {
+    ord('<'): '\\u003c',
+    ord('>'): '\\u003e',
+    ord('&'): '\\u0026',
+    0x2028: '\\u2028',
+    0x2029: '\\u2029',
+}
+
+
+def to_script_safe_json(value: Any) -> str:
+    """Serializes a value to JSON that is safe to embed inside an HTML ``<script>`` tag.
+
+    `json.dumps` alone is not sufficient: it does not escape ``<``, ``>`` or ``&``,
+    so a string such as ``"</script>"`` originating from untrusted data (for example
+    a gate label in a circuit loaded via `cirq.read_json`) would close the surrounding
+    ``<script>`` element and allow arbitrary HTML/JavaScript injection (XSS) when the
+    widget is displayed in a notebook or exported to a standalone HTML file.
+
+    This applies contextual output encoding on top of `json.dumps`, escaping the
+    HTML-significant characters as Unicode escapes. The decoded JavaScript value is
+    unchanged, but the serialized text can no longer break out of the script context.
+
+    Args:
+        value: Any JSON-serializable value.
+
+    Returns:
+        A JSON string safe for direct inclusion within an HTML ``<script>`` element.
+    """
+    return json.dumps(value).translate(_HTML_SCRIPT_ESCAPES)
 
 
 class Env(Enum):

--- a/cirq-web/cirq_web/widget_test.py
+++ b/cirq-web/cirq_web/widget_test.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from unittest import mock
 
 import cirq_web
+from cirq_web.widget import to_script_safe_json
 
 
 class FakeWidget(cirq_web.Widget):
@@ -53,6 +55,32 @@ def test_repr_html(tmpdir) -> None:
         """
 
     assert remove_whitespace(expected) == remove_whitespace(actual)
+
+
+def test_to_script_safe_json_escapes_html_characters() -> None:
+    payload = {'label': "</script><script>alert('xss')</script>", 'amp': 'a & b'}
+    encoded = to_script_safe_json(payload)
+
+    # None of the HTML-significant characters survive verbatim ...
+    assert '<' not in encoded
+    assert '>' not in encoded
+    assert '&' not in encoded
+    # ... and the closing-tag breakout in particular is neutralized.
+    assert '</script>' not in encoded
+    # The value still round-trips back to the original data.
+    assert json.loads(encoded) == payload
+
+
+def test_to_script_safe_json_escapes_line_separators() -> None:
+    # U+2028 / U+2029 are valid JSON but illegal raw in a JS string literal.
+    line_sep, para_sep = chr(0x2028), chr(0x2029)
+    original = f"a{line_sep}b{para_sep}c"
+    encoded = to_script_safe_json(original)
+    assert line_sep not in encoded
+    assert para_sep not in encoded
+    assert '\\u2028' in encoded
+    assert '\\u2029' in encoded
+    assert json.loads(encoded) == original
 
 
 @mock.patch.dict(os.environ, {"BROWSER": "true"})


### PR DESCRIPTION
# Prevent Script-Context XSS in Circuit3D Serialization

## Summary

This patch fixes a stored Cross-Site Scripting (XSS) vulnerability in the `cirq-web` Circuit3D visualization component.

Previously, circuit data was converted using Python's `str()` representation and embedded directly into an HTML `<script>` block. Since gate labels and wire symbols may originate from untrusted circuit data, a specially crafted label containing HTML or JavaScript could break out of the script context and execute arbitrary code when rendered.

This patch introduces safe JSON serialization with contextual escaping to ensure that circuit metadata is safely embedded into HTML script blocks.

## Security Issue

### Vulnerability Type

* CWE-79: Improper Neutralization of Input During Web Page Generation (Cross-site Scripting)

### Affected Component

* `cirq-web`
* `Circuit3D` visualization serialization

### Impact

An attacker-controlled gate label such as:

```python
"</script><script>alert('xss')</script>"
```

could previously be embedded directly into generated HTML, allowing script injection when the visualization was rendered in a browser or notebook environment.

## Changes Made

### Safe Script Serialization

Added a dedicated helper function to serialize circuit data as JSON while escaping HTML-sensitive characters:

* `<` → `\u003c`
* `>` → `\u003e`
* `&` → `\u0026`
* `U+2028` → `\u2028`
* `U+2029` → `\u2029`

This prevents malicious content from breaking out of the surrounding `<script>` element.

### Circuit3D Serialization Update

Replaced direct use of Python string representations with the new safe JSON serializer when generating client-side visualization data.

### Regression Tests

Added tests to verify:

* HTML-sensitive characters are escaped correctly.
* Unicode line separators are safely encoded.
* Malicious gate labels cannot inject JavaScript.
* Serialized data continues to round-trip correctly.

## Files Modified

### `cirq-web/cirq_web/widget.py`

* Added script-safe JSON serialization helper.
* Added contextual escaping for HTML script contexts.

### `cirq-web/cirq_web/circuits/circuit.py`

* Updated circuit serialization to use safe JSON encoding.
* Added documentation explaining the security rationale.

### `cirq-web/cirq_web/widget_test.py`

* Added unit tests for escaping behavior.
* Added round-trip validation tests.

### `cirq-web/cirq_web/circuits/circuit_test.py`

* Added XSS regression test.
* Updated serialization expectations.

## Validation

### Functional Verification

Verified that malicious labels no longer produce executable HTML:

**Before:**

```html
</script><script>alert('xss')</script>
```

**After:**

```html
\u003c/script\u003e\u003cscript\u003ealert('xss')
```

The payload remains intact as data but is no longer interpreted as HTML or JavaScript.

## Build & Test Results

### Ruff

```text
All checks passed
```

### Black

```text
All done! ✨
4 files would be left unchanged.
```

### Mypy

```text
Success: no issues found
```

### cirq-web Test Suite

```text
28 passed, 1 warning
```

### Targeted Regression Tests

```text
10 passed, 1 warning
```

## Result

This patch implements contextual output encoding for Circuit3D visualization data, preventing script-context XSS while preserving existing functionality and maintaining full test compatibility.
