### PR TITLE
pytest - parametrize tests using collection containers only

### DIFF
--- a/benchmarks/circuit_construction_perf.py
+++ b/benchmarks/circuit_construction_perf.py
@@ -156,7 +156,7 @@ class TestXOnAllQubitsCircuit:
     group = "circuit_operations"
 
     @pytest.mark.parametrize(
-        ["qubit_count", "depth"], itertools.product([1, 10, 100, 1000], [1, 10, 100, 1000])
+        ["qubit_count", "depth"], list(itertools.product([1, 10, 100, 1000], [1, 10, 100, 1000]))
     )
     @pytest.mark.benchmark(group=group)
     def test_circuit_construction(self, benchmark, qubit_count: int, depth: int) -> None:

--- a/benchmarks/parameter_resolution_perf.py
+++ b/benchmarks/parameter_resolution_perf.py
@@ -23,7 +23,8 @@ import cirq
 
 
 @pytest.mark.parametrize(
-    ["num_qubits", "num_scan_points"], itertools.product([50, 100, 150, 200], [20, 40, 60, 80, 100])
+    ["num_qubits", "num_scan_points"],
+    list(itertools.product([50, 100, 150, 200], [20, 40, 60, 80, 100])),
 )
 @pytest.mark.benchmark(group="parameter_resolution")
 def test_parameter_resolution(benchmark, num_qubits: int, num_scan_points: int) -> None:

--- a/benchmarks/randomized_benchmarking_perf.py
+++ b/benchmarks/randomized_benchmarking_perf.py
@@ -67,7 +67,8 @@ class TestSingleQubitRandomizedBenchmarking:
         return op_grid
 
     @pytest.mark.parametrize(
-        ["depth", "num_qubits", "num_circuits"], itertools.product(depth, num_qubits, num_circuits)
+        ["depth", "num_qubits", "num_circuits"],
+        list(itertools.product(depth, num_qubits, num_circuits)),
     )
     @pytest.mark.benchmark(group=group)
     def test_rb_op_grid_generation(
@@ -82,7 +83,8 @@ class TestSingleQubitRandomizedBenchmarking:
         benchmark(_f)
 
     @pytest.mark.parametrize(
-        ["depth", "num_qubits", "num_circuits"], itertools.product(depth, num_qubits, num_circuits)
+        ["depth", "num_qubits", "num_circuits"],
+        list(itertools.product(depth, num_qubits, num_circuits)),
     )
     @pytest.mark.benchmark(group=group)
     def test_rb_circuit_construction(

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -2684,8 +2684,8 @@ def density_operator_basis(n_qubits: int) -> Iterator[np.ndarray]:
 
 @pytest.mark.parametrize(
     'circuit, initial_state',
-    itertools.chain(
-        itertools.product(
+    [
+        *itertools.product(
             [
                 cirq.Circuit(cirq.I(q0)),
                 cirq.Circuit(cirq.X(q0)),
@@ -2696,7 +2696,7 @@ def density_operator_basis(n_qubits: int) -> Iterator[np.ndarray]:
             ],
             density_operator_basis(n_qubits=1),
         ),
-        itertools.product(
+        *itertools.product(
             [
                 cirq.Circuit(cirq.H(q0), cirq.CNOT(q0, q1)),
                 cirq.Circuit(cirq.depolarize(0.2).on(q0), cirq.CNOT(q0, q1)),
@@ -2709,7 +2709,7 @@ def density_operator_basis(n_qubits: int) -> Iterator[np.ndarray]:
             ],
             density_operator_basis(n_qubits=2),
         ),
-        itertools.product(
+        *itertools.product(
             [
                 cirq.Circuit(
                     cirq.depolarize(0.1, n_qubits=2).on(q0, q1),
@@ -2721,7 +2721,7 @@ def density_operator_basis(n_qubits: int) -> Iterator[np.ndarray]:
             ],
             density_operator_basis(n_qubits=3),
         ),
-    ),
+    ],
 )
 def test_compare_circuits_superoperator_to_simulation(circuit, initial_state) -> None:
     """Compares action of circuit superoperator and circuit simulation."""

--- a/cirq-core/cirq/contrib/acquaintance/bipartite_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/bipartite_test.py
@@ -204,7 +204,7 @@ circuit_diagrams = {
 
 
 @pytest.mark.parametrize(
-    'subgraph,part_size', itertools.product(cca.BipartiteGraphType, range(1, 5))
+    'subgraph,part_size', list(itertools.product(cca.BipartiteGraphType, range(1, 5)))
 )
 def test_circuit_diagrams(part_size, subgraph) -> None:
     qubits = cirq.LineQubit.range(2 * part_size)
@@ -258,7 +258,7 @@ def test_bipartite_swap_network_acquaintance_size() -> None:
 
 
 @pytest.mark.parametrize(
-    'subgraph,part_size', itertools.product(cca.BipartiteGraphType, range(1, 3))
+    'subgraph,part_size', list(itertools.product(cca.BipartiteGraphType, range(1, 3)))
 )
 def test_repr(subgraph, part_size) -> None:
     gate = cca.BipartiteSwapNetworkGate(subgraph, part_size)
@@ -269,7 +269,7 @@ def test_repr(subgraph, part_size) -> None:
 
 
 @pytest.mark.parametrize(
-    'subgraph,part_size', itertools.product(cca.BipartiteGraphType, range(1, 6))
+    'subgraph,part_size', list(itertools.product(cca.BipartiteGraphType, range(1, 6)))
 )
 def test_decomposition_permutation_consistency(part_size, subgraph) -> None:
     gate = cca.BipartiteSwapNetworkGate(subgraph, part_size)

--- a/cirq-core/cirq/contrib/acquaintance/inspection_utils_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/inspection_utils_test.py
@@ -23,7 +23,7 @@ import cirq.contrib.acquaintance as cca
 import cirq.contrib.acquaintance.inspection_utils as inspection_utils
 
 
-@pytest.mark.parametrize('n_qubits, acquaintance_size', product(range(2, 6), range(2, 5)))
+@pytest.mark.parametrize('n_qubits, acquaintance_size', list(product(range(2, 6), range(2, 5))))
 def test_get_logical_acquaintance_opportunities(n_qubits, acquaintance_size) -> None:
     qubits = cirq.LineQubit.range(n_qubits)
     acquaintance_strategy = cca.complete_acquaintance_strategy(qubits, acquaintance_size)

--- a/cirq-core/cirq/contrib/acquaintance/permutation_test.py
+++ b/cirq-core/cirq/contrib/acquaintance/permutation_test.py
@@ -104,10 +104,10 @@ def test_get_logical_operations() -> None:
 
 @pytest.mark.parametrize(
     'n_elements,n_permuted',
-    (
+    [
         (n_elements, random.randint(0, n_elements))
         for n_elements in (random.randint(5, 20) for _ in range(20))
-    ),
+    ],
 )
 def test_linear_permutation_gate(n_elements, n_permuted) -> None:
     qubits = cirq.LineQubit.range(n_elements)
@@ -156,10 +156,10 @@ def random_permutation_equality_groups(
             fingerprints.add(fingerprint)
 
 
-@pytest.mark.parametrize('permutation_sets', [random_permutation_equality_groups(5, 3, 10, 0.5)])
-def test_linear_permutation_gate_equality(permutation_sets) -> None:
+def test_linear_permutation_gate_equality() -> None:
     swap_gates = [cirq.SWAP, cirq.CNOT]
     equals_tester = ct.EqualsTester()
+    permutation_sets = random_permutation_equality_groups(5, 3, 10, 0.5)
     for swap_gate in swap_gates:
         for permutation_set in permutation_sets:
             equals_tester.add_equality_group(

--- a/cirq-core/cirq/contrib/circuitdag/circuit_dag_test.py
+++ b/cirq-core/cirq/contrib/circuitdag/circuit_dag_test.py
@@ -229,7 +229,7 @@ def _get_circuits_and_is_blockers():
     ]
     not_on_edge = lambda op: len(op.qubits) > 1 and set(op.qubits) not in edges
     is_blockers = [lambda op: False, not_on_edge]
-    return itertools.product(circuits, is_blockers)
+    return list(itertools.product(circuits, is_blockers))
 
 
 @pytest.mark.parametrize('circuit, is_blocker', _get_circuits_and_is_blockers())

--- a/cirq-core/cirq/experiments/fidelity_estimation_test.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation_test.py
@@ -60,13 +60,15 @@ def make_random_quantum_circuit(qubits: Sequence[cirq.Qid], depth: int) -> cirq.
 
 @pytest.mark.parametrize(
     'depolarization, estimator',
-    itertools.product(
-        (0.0, 0.2, 0.7, 1.0),
-        (
-            cirq.hog_score_xeb_fidelity_from_probabilities,
-            cirq.linear_xeb_fidelity_from_probabilities,
-            cirq.log_xeb_fidelity_from_probabilities,
-        ),
+    list(
+        itertools.product(
+            (0.0, 0.2, 0.7, 1.0),
+            (
+                cirq.hog_score_xeb_fidelity_from_probabilities,
+                cirq.linear_xeb_fidelity_from_probabilities,
+                cirq.log_xeb_fidelity_from_probabilities,
+            ),
+        )
     ),
 )
 def test_xeb_fidelity(depolarization, estimator) -> None:

--- a/cirq-core/cirq/experiments/z_phase_calibration_test.py
+++ b/cirq-core/cirq/experiments/z_phase_calibration_test.py
@@ -69,8 +69,8 @@ def _create_tests(n, with_options: bool = False):
                 }
             )
 
-        return zip(angles, error, options)
-    return zip(angles, error)
+        return list(zip(angles, error, options))
+    return list(zip(angles, error))
 
 
 def _trace_distance(A, B):

--- a/cirq-core/cirq/linalg/operator_spaces_test.py
+++ b/cirq-core/cirq/linalg/operator_spaces_test.py
@@ -123,7 +123,9 @@ def test_kron_bases_consistency(basis1, basis2) -> None:
         assert np.all(basis1[name] == basis2[name])
 
 
-@pytest.mark.parametrize('basis,repeat', itertools.product((PAULI_BASIS, STANDARD_BASIS), range(5)))
+@pytest.mark.parametrize(
+    'basis,repeat', list(itertools.product((PAULI_BASIS, STANDARD_BASIS), range(5)))
+)
 def test_kron_bases_repeat_validation_checks(basis, repeat) -> None:
     product_basis = cirq.kron_bases(basis, repeat=repeat)
     assert len(product_basis) == 4**repeat
@@ -195,7 +197,7 @@ def test_hilbert_schmidt_inner_product_values(m1, m2, expected_value) -> None:
 
 @pytest.mark.parametrize(
     'm,basis',
-    itertools.product((I, X, Y, Z, H, SQRT_X, SQRT_Y, SQRT_Z), (PAULI_BASIS, STANDARD_BASIS)),
+    list(itertools.product((I, X, Y, Z, H, SQRT_X, SQRT_Y, SQRT_Z), (PAULI_BASIS, STANDARD_BASIS))),
 )
 def test_expand_matrix_in_orthogonal_basis(m, basis) -> None:
     expansion = cirq.expand_matrix_in_orthogonal_basis(m, basis)
@@ -231,7 +233,7 @@ def test_matrix_from_basis_coefficients(expansion) -> None:
 
 @pytest.mark.parametrize(
     'm1,basis',
-    (
+    list(
         itertools.product(
             (I, X, Y, Z, H, SQRT_X, SQRT_Y, SQRT_Z, E00, E01, E10, E11),
             (PAULI_BASIS, STANDARD_BASIS),
@@ -248,57 +250,59 @@ def test_expand_is_inverse_of_reconstruct(m1, basis) -> None:
 
 @pytest.mark.parametrize(
     'coefficients,exponent',
-    itertools.product(
-        (
-            (0, 0, 0, 0),
-            (-1, 0, 0, 0),
-            (0.5, 0, 0, 0),
-            (0.5j, 0, 0, 0),
-            (1, 0, 0, 0),
-            (2, 0, 0, 0),
-            (0, -1, 0, 0),
-            (0, 0.5, 0, 0),
-            (0, 0.5j, 0, 0),
-            (0, 1, 0, 0),
-            (0, 2, 0, 0),
-            (0, 0, -1, 0),
-            (0, 0, 0.5, 0),
-            (0, 0, 0.5j, 0),
-            (0, 0, 1, 0),
-            (0, 0, 2, 0),
-            (0, 0, 0, -1),
-            (0, 0, 0, 0.5),
-            (0, 0, 0, 0.5j),
-            (0, 0, 0, 1),
-            (0, 0, 0, 2),
-            (0, -1, 0, -1),
-            (0, 1, 0, 1j),
-            (0, 0.5, 0, 0.5),
-            (0, 0.5j, 0, 0.5j),
-            (0, 0.5, 0, 0.5j),
-            (0, 1, 0, 1),
-            (0, 2, 0, 2),
-            (0, 0.5, 0.5, 0.5),
-            (0, 1, 1, 1),
-            (0, 1.1j, 0.5 - 0.4j, 0.9),
-            (0.7j, 1.1j, 0.5 - 0.4j, 0.9),
-            (0.25, 0.25, 0.25, 0.25),
-            (0.25j, 0.25j, 0.25j, 0.25j),
-            (0.4, 0, 0.5, 0),
-            (1, 2, 3, 4),
-            (-1, -2, -3, -4),
-            (-1, -2, 3, 4),
-            (1j, 2j, 3j, 4j),
-            (1j, 2j, 3, 4),
-            (sympy.Symbol('i'), sympy.Symbol('x'), sympy.Symbol('y'), sympy.Symbol('z')),
+    list(
+        itertools.product(
             (
-                sympy.Symbol('i') * 1j,
-                -sympy.Symbol('x'),
-                -sympy.Symbol('y') * 1j,
-                sympy.Symbol('z'),
+                (0, 0, 0, 0),
+                (-1, 0, 0, 0),
+                (0.5, 0, 0, 0),
+                (0.5j, 0, 0, 0),
+                (1, 0, 0, 0),
+                (2, 0, 0, 0),
+                (0, -1, 0, 0),
+                (0, 0.5, 0, 0),
+                (0, 0.5j, 0, 0),
+                (0, 1, 0, 0),
+                (0, 2, 0, 0),
+                (0, 0, -1, 0),
+                (0, 0, 0.5, 0),
+                (0, 0, 0.5j, 0),
+                (0, 0, 1, 0),
+                (0, 0, 2, 0),
+                (0, 0, 0, -1),
+                (0, 0, 0, 0.5),
+                (0, 0, 0, 0.5j),
+                (0, 0, 0, 1),
+                (0, 0, 0, 2),
+                (0, -1, 0, -1),
+                (0, 1, 0, 1j),
+                (0, 0.5, 0, 0.5),
+                (0, 0.5j, 0, 0.5j),
+                (0, 0.5, 0, 0.5j),
+                (0, 1, 0, 1),
+                (0, 2, 0, 2),
+                (0, 0.5, 0.5, 0.5),
+                (0, 1, 1, 1),
+                (0, 1.1j, 0.5 - 0.4j, 0.9),
+                (0.7j, 1.1j, 0.5 - 0.4j, 0.9),
+                (0.25, 0.25, 0.25, 0.25),
+                (0.25j, 0.25j, 0.25j, 0.25j),
+                (0.4, 0, 0.5, 0),
+                (1, 2, 3, 4),
+                (-1, -2, -3, -4),
+                (-1, -2, 3, 4),
+                (1j, 2j, 3j, 4j),
+                (1j, 2j, 3, 4),
+                (sympy.Symbol('i'), sympy.Symbol('x'), sympy.Symbol('y'), sympy.Symbol('z')),
+                (
+                    sympy.Symbol('i') * 1j,
+                    -sympy.Symbol('x'),
+                    -sympy.Symbol('y') * 1j,
+                    sympy.Symbol('z'),
+                ),
             ),
-        ),
-        (0, 1, 2, 3, 4, 5, 100, 101),
+            (0, 1, 2, 3, 4, 5, 100, 101),
+        )
     ),
 )
 def test_pow_pauli_combination(coefficients, exponent) -> None:

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -51,11 +51,12 @@ def _all_rotations():
     yield from itertools.product(_paulis, _bools)
 
 
-def _all_rotation_pairs():
-    for px, flip_x, pz, flip_z in itertools.product(_paulis, _bools, _paulis, _bools):
-        if px == pz:
-            continue
-        yield (px, flip_x), (pz, flip_z)
+def _all_rotation_pairs() -> list[tuple[tuple[cirq.Pauli, bool], tuple[cirq.Pauli, bool]]]:
+    return [
+        ((px, flip_x), (pz, flip_z))
+        for px, flip_x, pz, flip_z in itertools.product(_paulis, _bools, _paulis, _bools)
+        if px != pz
+    ]
 
 
 @functools.lru_cache()
@@ -66,7 +67,7 @@ def _all_clifford_gates() -> tuple[cirq.SingleQubitCliffordGate, ...]:
     )
 
 
-@pytest.mark.parametrize('pauli,flip_x,flip_z', itertools.product(_paulis, _bools, _bools))
+@pytest.mark.parametrize('pauli,flip_x,flip_z', list(itertools.product(_paulis, _bools, _bools)))
 def test_init_value_error(pauli, flip_x, flip_z) -> None:
     with pytest.raises(ValueError):
         cirq.SingleQubitCliffordGate.from_xz_map((pauli, flip_x), (pauli, flip_z))
@@ -89,11 +90,11 @@ def test_dense_pauli_string() -> None:
 
 @pytest.mark.parametrize(
     'trans1,trans2,from1',
-    (
+    [
         (trans1, trans2, from1)
         for trans1, trans2, from1 in itertools.product(_all_rotations(), _all_rotations(), _paulis)
         if trans1[0] != trans2[0]
-    ),
+    ],
 )
 def test_init_from_double_map_vs_kwargs(trans1, trans2, from1) -> None:
     from2 = cirq.Pauli.by_relative_index(from1, 1)
@@ -110,10 +111,7 @@ def test_init_from_double_map_vs_kwargs(trans1, trans2, from1) -> None:
     _assert_no_collision(gate_map)
 
 
-@pytest.mark.parametrize(
-    'trans1,from1',
-    ((trans1, from1) for trans1, from1 in itertools.product(_all_rotations(), _paulis)),
-)
+@pytest.mark.parametrize('trans1,from1', list(itertools.product(_all_rotations(), _paulis)))
 def test_init_from_double_invalid(trans1, from1) -> None:
     from2 = cirq.Pauli.by_relative_index(from1, 1)
     # Test throws on invalid arguments
@@ -121,7 +119,7 @@ def test_init_from_double_invalid(trans1, from1) -> None:
         cirq.SingleQubitCliffordGate.from_double_map({from1: trans1, from2: trans1})
 
 
-@pytest.mark.parametrize('trans,frm', itertools.product(_all_rotations(), _paulis))
+@pytest.mark.parametrize('trans,frm', list(itertools.product(_all_rotations(), _paulis)))
 def test_init_from_single_map_vs_kwargs(trans, frm) -> None:
     from_str = str(frm).lower() + '_to'
     gate_kw = cirq.SingleQubitCliffordGate.from_single_map(**{from_str: trans})
@@ -131,11 +129,11 @@ def test_init_from_single_map_vs_kwargs(trans, frm) -> None:
 
 @pytest.mark.parametrize(
     'trans,frm',
-    (
+    [
         (trans, frm)
         for trans, frm in itertools.product(_all_rotations(), _paulis)
         if trans[0] != frm
-    ),
+    ],
 )
 def test_init_90rot_from_single(trans, frm) -> None:
     gate = cirq.SingleQubitCliffordGate.from_single_map({frm: trans})
@@ -156,11 +154,11 @@ def test_init_90rot_from_single(trans, frm) -> None:
 
 @pytest.mark.parametrize(
     'trans,frm',
-    (
+    [
         (trans, frm)
         for trans, frm in itertools.product(_all_rotations(), _paulis)
         if trans[0] == frm and trans[1]
-    ),
+    ],
 )
 def test_init_180rot_from_single(trans, frm) -> None:
     gate = cirq.SingleQubitCliffordGate.from_single_map({frm: trans})
@@ -175,11 +173,11 @@ def test_init_180rot_from_single(trans, frm) -> None:
 
 @pytest.mark.parametrize(
     'trans,frm',
-    (
+    [
         (trans, frm)
         for trans, frm in itertools.product(_all_rotations(), _paulis)
         if trans[0] == frm and not trans[1]
-    ),
+    ],
 )
 def test_init_ident_from_single(trans, frm) -> None:
     gate = cirq.SingleQubitCliffordGate.from_single_map({frm: trans})
@@ -455,7 +453,7 @@ def test_commutes_notimplemented_type() -> None:
     assert cirq.commutes(cirq.CliffordGate.X, 'X', default='default') == 'default'
 
 
-@pytest.mark.parametrize('gate,other', itertools.combinations(_all_clifford_gates(), r=2))
+@pytest.mark.parametrize('gate,other', list(itertools.combinations(_all_clifford_gates(), r=2)))
 def test_commutes_single_qubit_gate(gate, other) -> None:
     q0 = cirq.NamedQubit('q0')
     gate_op = gate(q0)
@@ -478,7 +476,7 @@ def test_parses_single_qubit_gate(gate) -> None:
 
 @pytest.mark.parametrize(
     'gate,pauli,half_turns',
-    itertools.product(_all_clifford_gates(), _paulis, (1.0, 0.25, 0.5, -0.5)),
+    list(itertools.product(_all_clifford_gates(), _paulis, (1.0, 0.25, 0.5, -0.5))),
 )
 def test_commutes_pauli(gate, pauli, half_turns) -> None:
     pauli_gate = pauli if half_turns == 1 else pauli**half_turns

--- a/cirq-core/cirq/ops/identity_test.py
+++ b/cirq-core/cirq/ops/identity_test.py
@@ -164,7 +164,7 @@ def test_pauli_expansion_notimplemented() -> None:
 
 
 @pytest.mark.parametrize(
-    'gate_type, num_qubits', itertools.product((cirq.IdentityGate,), range(1, 5))
+    'gate_type, num_qubits', list(itertools.product((cirq.IdentityGate,), range(1, 5)))
 )
 def test_consistent_protocols(gate_type, num_qubits) -> None:
     gate = gate_type(num_qubits=num_qubits)

--- a/cirq-core/cirq/ops/pauli_interaction_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_interaction_gate_test.py
@@ -26,11 +26,13 @@ _bools = (False, True)
 _paulis = (cirq.X, cirq.Y, cirq.Z)
 
 
-def _all_interaction_gates(exponents=(1,)):
-    for pauli0, invert0, pauli1, invert1, e in itertools.product(
-        _paulis, _bools, _paulis, _bools, exponents
-    ):
-        yield cirq.PauliInteractionGate(pauli0, invert0, pauli1, invert1, exponent=e)
+def _all_interaction_gates(exponents=(1,)) -> list[cirq.PauliInteractionGate]:
+    return [
+        cirq.PauliInteractionGate(pauli0, invert0, pauli1, invert1, exponent=e)
+        for pauli0, invert0, pauli1, invert1, e in itertools.product(
+            _paulis, _bools, _paulis, _bools, exponents
+        )
+    ]
 
 
 @pytest.mark.parametrize('gate', _all_interaction_gates())

--- a/cirq-core/cirq/ops/pauli_string_phasor_test.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor_test.py
@@ -350,10 +350,12 @@ def test_manual_default_decompose() -> None:
 
 @pytest.mark.parametrize(
     'paulis,phase_exponent_negative,sign',
-    itertools.product(
-        itertools.product((cirq.X, cirq.Y, cirq.Z, None), repeat=3),
-        (0, 0.1, 0.5, 1, -0.25),
-        (+1, -1),
+    list(
+        itertools.product(
+            itertools.product((cirq.X, cirq.Y, cirq.Z, None), repeat=3),
+            (0, 0.1, 0.5, 1, -0.25),
+            (+1, -1),
+        )
     ),
 )
 def test_default_decompose(paulis, phase_exponent_negative: float, sign: int) -> None:

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import itertools
 import math
-from collections.abc import Iterator
 
 import numpy as np
 import pytest
@@ -30,33 +29,36 @@ def _make_qubits(n) -> list[cirq.NamedQubit]:
     return [cirq.NamedQubit(f'q{i}') for i in range(n)]
 
 
-def _sample_qubit_pauli_maps() -> Iterator[dict[cirq.NamedQubit, cirq.Pauli]]:
+def _sample_qubit_pauli_maps() -> list[dict[cirq.NamedQubit, cirq.Pauli]]:
     """All combinations of having a Pauli or nothing on 3 qubits.
     Yields 64 qubit pauli maps
     """
     qubits = _make_qubits(3)
     paulis_or_none = (None, cirq.X, cirq.Y, cirq.Z)
-    for paulis in itertools.product(paulis_or_none, repeat=len(qubits)):
-        yield {qubit: pauli for qubit, pauli in zip(qubits, paulis) if pauli is not None}
+    return [
+        {qubit: pauli for qubit, pauli in zip(qubits, paulis) if pauli is not None}
+        for paulis in itertools.product(paulis_or_none, repeat=len(qubits))
+    ]
 
 
-def _small_sample_qubit_pauli_maps() -> Iterator[dict[cirq.NamedQubit, cirq.Pauli]]:
+def _small_sample_qubit_pauli_maps() -> list[dict[cirq.NamedQubit, cirq.Pauli]]:
     """A few representative samples of qubit maps.
 
     Only tests 10 combinations of Paulis to speed up testing.
     """
     qubits = _make_qubits(3)
-    yield {}
-    yield {qubits[0]: cirq.X}
-    yield {qubits[1]: cirq.X}
-    yield {qubits[2]: cirq.X}
-    yield {qubits[1]: cirq.Z}
-
-    yield {qubits[0]: cirq.Y, qubits[1]: cirq.Z}
-    yield {qubits[1]: cirq.Z, qubits[2]: cirq.X}
-    yield {qubits[0]: cirq.X, qubits[1]: cirq.X, qubits[2]: cirq.X}
-    yield {qubits[0]: cirq.X, qubits[1]: cirq.Y, qubits[2]: cirq.Z}
-    yield {qubits[0]: cirq.Z, qubits[1]: cirq.X, qubits[2]: cirq.Y}
+    return [
+        {},
+        {qubits[0]: cirq.X},
+        {qubits[1]: cirq.X},
+        {qubits[2]: cirq.X},
+        {qubits[1]: cirq.Z},
+        {qubits[0]: cirq.Y, qubits[1]: cirq.Z},
+        {qubits[1]: cirq.Z, qubits[2]: cirq.X},
+        {qubits[0]: cirq.X, qubits[1]: cirq.X, qubits[2]: cirq.X},
+        {qubits[0]: cirq.X, qubits[1]: cirq.Y, qubits[2]: cirq.Z},
+        {qubits[0]: cirq.Z, qubits[1]: cirq.X, qubits[2]: cirq.Y},
+    ]
 
 
 def assert_conjugation(

--- a/cirq-core/cirq/ops/phased_x_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_gate_test.py
@@ -255,7 +255,7 @@ def test_phase_by() -> None:
 
 
 @pytest.mark.parametrize(
-    'exponent,phase_exponent', itertools.product(np.arange(-2.5, 2.75, 0.25), repeat=2)
+    'exponent,phase_exponent', list(itertools.product(np.arange(-2.5, 2.75, 0.25), repeat=2))
 )
 def test_exponent_consistency(exponent, phase_exponent) -> None:
     """Verifies that instances of PhasedX gate expose consistent exponents."""

--- a/cirq-core/cirq/ops/phased_x_z_gate_test.py
+++ b/cirq-core/cirq/ops/phased_x_z_gate_test.py
@@ -248,7 +248,7 @@ def test_from_matrix_close_unitary(unitary: np.ndarray) -> None:
 
 @pytest.mark.parametrize(
     ['x_exponent', 'z_exponent', 'axis_phase_exponent'],
-    itertools.product([-0.5, 0.0, 0.5, 1.0], repeat=3),
+    list(itertools.product([-0.5, 0.0, 0.5, 1.0], repeat=3)),
 )
 def test_exact_unitary_at_half_integers(
     x_exponent: float, z_exponent: float, axis_phase_exponent: float

--- a/cirq-core/cirq/sim/classical_simulator_test.py
+++ b/cirq-core/cirq/sim/classical_simulator_test.py
@@ -125,7 +125,7 @@ def test_CCCX(initial_state) -> None:
     np.testing.assert_equal(results, final_state)
 
 
-@pytest.mark.parametrize('initial_state', product([0, 1], repeat=3))
+@pytest.mark.parametrize('initial_state', list(product([0, 1], repeat=3)))
 @pytest.mark.parametrize('cswap', [cirq.CSWAP, cirq.SWAP.controlled()], ids=str)
 def test_controlled_swap(cswap: cirq.Gate, initial_state: tuple[int, int, int]) -> None:
     qubits = cirq.LineQubit.range(3)

--- a/cirq-core/cirq/sim/density_matrix_simulator_test.py
+++ b/cirq-core/cirq/sim/density_matrix_simulator_test.py
@@ -533,9 +533,11 @@ def test_reset_one_qubit_does_not_affect_partial_trace_of_other_qubits(
 
 @pytest.mark.parametrize(
     'dtype,circuit',
-    itertools.product(
-        [np.complex64, np.complex128],
-        [cirq.testing.random_circuit(cirq.LineQubit.range(4), 5, 0.9) for _ in range(20)],
+    list(
+        itertools.product(
+            [np.complex64, np.complex128],
+            [cirq.testing.random_circuit(cirq.LineQubit.range(4), 5, 0.9) for _ in range(20)],
+        )
     ),
 )
 def test_simulate_compare_to_state_vector_simulator(

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -409,7 +409,7 @@ def test_simulate_mixtures(dtype: type[np.complexfloating], split: bool) -> None
 
 
 @pytest.mark.parametrize(
-    'dtype, split', itertools.product([np.complex64, np.complex128], [True, False])
+    'dtype, split', list(itertools.product([np.complex64, np.complex128], [True, False]))
 )
 def test_simulate_qudit_mixtures(dtype: type[np.complexfloating], split: bool) -> None:
     q0 = cirq.LineQid(0, 3)

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -73,7 +73,7 @@ def _cases_for_random_circuit():
 
 
 @pytest.mark.parametrize(
-    'n_qubits,n_moments,op_density,gate_domain,pass_qubits', _cases_for_random_circuit()
+    'n_qubits,n_moments,op_density,gate_domain,pass_qubits', list(_cases_for_random_circuit())
 )
 def test_random_circuit(
     n_qubits: int | Sequence[cirq.Qid],

--- a/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/cphase_to_fsim_test.py
@@ -91,9 +91,11 @@ def test_decomposition_to_sycamore_gate(exponent) -> None:
 
 @pytest.mark.parametrize(
     'theta, phi',
-    itertools.product(
-        (-2.4 * np.pi, -np.pi / 11, np.pi / 9, np.pi / 2, 1.4 * np.pi),
-        (-1.4 * np.pi, -np.pi / 9, np.pi / 11, np.pi / 2, 2.4 * np.pi),
+    list(
+        itertools.product(
+            (-2.4 * np.pi, -np.pi / 11, np.pi / 9, np.pi / 2, 1.4 * np.pi),
+            (-1.4 * np.pi, -np.pi / 9, np.pi / 11, np.pi / 2, 2.4 * np.pi),
+        )
     ),
 )
 def test_valid_cphase_exponents(theta, phi) -> None:
@@ -127,9 +129,11 @@ def complement_intervals(intervals: Sequence[tuple[float, float]]) -> Sequence[t
 
 @pytest.mark.parametrize(
     'theta, phi',
-    itertools.product(
-        (-2.3 * np.pi, -np.pi / 7, np.pi / 5, 1.8 * np.pi),
-        (-1.7 * np.pi, -np.pi / 5, np.pi / 7, 2.5 * np.pi),
+    list(
+        itertools.product(
+            (-2.3 * np.pi, -np.pi / 7, np.pi / 5, 1.8 * np.pi),
+            (-1.7 * np.pi, -np.pi / 5, np.pi / 7, 2.5 * np.pi),
+        )
     ),
 )
 def test_invalid_cphase_exponents(theta, phi) -> None:

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_fsim_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_to_fsim_test.py
@@ -97,7 +97,9 @@ def test_decompose_xx_yy_into_two_fsims_ignoring_single_qubit_ops_fail() -> None
         )
 
 
-@pytest.mark.parametrize('obj,fsim_gate', itertools.product(UNITARY_OBJS, FEASIBLE_FSIM_GATES))
+@pytest.mark.parametrize(
+    'obj,fsim_gate', list(itertools.product(UNITARY_OBJS, FEASIBLE_FSIM_GATES))
+)
 def test_decompose_two_qubit_interaction_into_four_fsim_gates_equivalence(
     obj: Any, fsim_gate: cirq.FSimGate
 ) -> None:

--- a/dev_tools/snippets_test.py
+++ b/dev_tools/snippets_test.py
@@ -57,7 +57,6 @@ from __future__ import annotations
 import inspect
 import pathlib
 import re
-from collections.abc import Iterator
 from re import Pattern
 from typing import Any
 
@@ -84,10 +83,8 @@ def test_can_run_readme_code_snippets():
     assert_file_has_working_code_snippets(readme_path, assume_import=False)
 
 
-def find_docs_code_snippets_paths() -> Iterator[str]:
-    for filename in DOCS_FOLDER.rglob('*.md'):
-        path = filename.relative_to(DOCS_FOLDER).as_posix()
-        yield path
+def find_docs_code_snippets_paths() -> list[str]:
+    return [filename.relative_to(DOCS_FOLDER).as_posix() for filename in DOCS_FOLDER.rglob('*.md')]
 
 
 @pytest.mark.parametrize('path', find_docs_code_snippets_paths())

--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -272,9 +272,11 @@ def test_example_shor_find_factor_with_composite_n_and_quantum_order_finder(n) -
 
 @pytest.mark.parametrize(
     'n, order_finder',
-    itertools.product(
-        (2, 3, 5, 11, 101, 127, 907),
-        (examples.shor.naive_order_finder, examples.shor.quantum_order_finder),
+    list(
+        itertools.product(
+            (2, 3, 5, 11, 101, 127, 907),
+            (examples.shor.naive_order_finder, examples.shor.quantum_order_finder),
+        )
     ),
 )
 def test_example_shor_find_factor_with_prime_n(n, order_finder) -> None:


### PR DESCRIPTION
Replace deprecated non-collection iterables in `@pytest.mark.parametrize`.
Address deprecation warning `PytestRemovedIn10Warning`.

Ref: https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
