### PR TITLE
Escape xml characters in all svg text instructions

### DIFF
--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -243,7 +243,10 @@ def tdd_to_svg(
 
         v_text = fixup_text(v.text)
         t += _rect(boxx, boxy, boxwidth, boxheight)
-        t += _text(x, y, v_text, fontsize=14 if len(v_text) > 1 else 18)
+        fontsize = 14 if v.text and '\n' not in v.text else 18
+        # FIXME - remove assertion before merge
+        assert fontsize == 14 if len(v_text) > 1 else 18
+        t += _text(x, y, v_text, fontsize=fontsize)
 
     t += '</svg>'
     return t

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -57,7 +57,7 @@ def _text(x: float, y: float, text: str, fontsize: int = 14):
     return (
         f'<text x="{x}" y="{y}" dominant-baseline="middle" '
         f'text-anchor="middle" font-size="{fontsize}px" '
-        f'font-family="{FONT}">{text}</text>'
+        f'font-family="{FONT}">{fixup_text(text)}</text>'
     )
 
 
@@ -241,12 +241,11 @@ def tdd_to_svg(
         if v.text == '':
             continue
 
-        v_text = fixup_text(v.text)
         t += _rect(boxx, boxy, boxwidth, boxheight)
         fontsize = 14 if v.text and '\n' not in v.text else 18
         # FIXME - remove assertion before merge
-        assert fontsize == 14 if len(v_text) > 1 else 18
-        t += _text(x, y, v_text, fontsize=fontsize)
+        assert fontsize == 14 if len(fixup_text(v.text)) > 1 else 18
+        t += _text(x, y, v.text, fontsize=fontsize)
 
     t += '</svg>'
     return t

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -243,8 +243,6 @@ def tdd_to_svg(
 
         t += _rect(boxx, boxy, boxwidth, boxheight)
         fontsize = 14 if v.text and '\n' not in v.text else 18
-        # FIXME - remove assertion before merge
-        assert fontsize == 14 if len(fixup_text(v.text)) > 1 else 18
         t += _text(x, y, v.text, fontsize=fontsize)
 
     t += '</svg>'

--- a/cirq-core/cirq/contrib/svg/svg.py
+++ b/cirq-core/cirq/contrib/svg/svg.py
@@ -242,7 +242,7 @@ def tdd_to_svg(
             continue
 
         t += _rect(boxx, boxy, boxwidth, boxheight)
-        fontsize = 14 if v.text and '\n' not in v.text else 18
+        fontsize = 14 if len(v.text) > 1 and '\n' not in v.text else 18
         t += _text(x, y, v.text, fontsize=fontsize)
 
     t += '</svg>'

--- a/cirq-core/cirq/contrib/svg/svg_test.py
+++ b/cirq-core/cirq/contrib/svg/svg_test.py
@@ -90,3 +90,10 @@ def test_gate_with_less_greater_str(symbol, svg_symbol) -> None:
 
     _ = IPython.display.SVG(svg)
     assert svg_symbol in svg
+
+
+def test_named_qubit_name_is_quoted():
+    q = cirq.NamedQubit("<a, &b, >c, some name")
+    svg_circuit = SVGCircuit(cirq.Circuit(cirq.I(q)))
+    svg = svg_circuit._repr_svg_()
+    assert "&lt;a, &amp;b, &gt;c, some name" in svg


### PR DESCRIPTION
In particular escape such characters when rendering NamedQubit.
