### PR TITLE
For development install cirq-packages in an editable mode

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -45,7 +45,7 @@ jobs:
             -r dev_tools/requirements/deps/pytest.txt \
             -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest check
-        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
+        run: check/pytest -n auto --enable-slow-tests
   windows:
     if: github.repository_owner == 'quantumlib'
     name: Pytest Windows
@@ -71,7 +71,7 @@ jobs:
             -r dev_tools/requirements/deps/pytest.txt `
             -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest Windows
-        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
+        run: check/pytest -n auto --enable-slow-tests
         shell: bash
   macos:
     if: github.repository_owner == 'quantumlib'
@@ -99,4 +99,4 @@ jobs:
             -r dev_tools/requirements/deps/pytest.txt \
             -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest check
-        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
+        run: check/pytest -n auto --enable-slow-tests

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
-  # FIXME - remove this before PR submission
-  pull_request:
-    branches:
-      - main
 
   # Allow manual invocation.
   workflow_dispatch:

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -37,6 +37,10 @@ jobs:
           cache-dependency-path: |
             **/requirements.txt
             dev_tools/requirements/**/*.txt
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
           pip install --upgrade "cirq~=1.0.dev" "cirq-core[contrib]~=1.0.dev"
@@ -71,7 +75,7 @@ jobs:
             -r dev_tools/requirements/deps/pytest.txt `
             -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest Windows
-        run: check/pytest -n auto --enable-slow-tests
+        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
         shell: bash
   macos:
     if: github.repository_owner == 'quantumlib'
@@ -99,4 +103,4 @@ jobs:
             -r dev_tools/requirements/deps/pytest.txt \
             -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest check
-        run: check/pytest -n auto --enable-slow-tests
+        run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
+  # FIXME - remove this before PR submission
+  pull_request:
+    branches:
+      - main
 
   # Allow manual invocation.
   workflow_dispatch:

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -35,11 +35,11 @@ jobs:
             dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
-          pip install --upgrade cirq~=1.0.dev &&
-            pip install \
-              -r dev_tools/requirements/deps/pylint.txt \
-              -r dev_tools/requirements/deps/pytest.txt \
-              -r dev_tools/requirements/deps/notebook.txt
+          pip install --upgrade "cirq~=1.0.dev" "cirq-core[contrib]~=1.0.dev"
+          pip install \
+            -r dev_tools/requirements/deps/pylint.txt \
+            -r dev_tools/requirements/deps/pytest.txt \
+            -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest check
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
   windows:
@@ -61,10 +61,11 @@ jobs:
             dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
-          pip install --upgrade cirq~=1.0.dev &&
-            pip install -r dev_tools/requirements/deps/pylint.txt &&
-            pip install -r dev_tools/requirements/deps/pytest.txt &&
-            pip install -r dev_tools/requirements/deps/notebook.txt
+          pip install --upgrade "cirq~=1.0.dev" "cirq-core[contrib]~=1.0.dev"
+          pip install `
+            -r dev_tools/requirements/deps/pylint.txt `
+            -r dev_tools/requirements/deps/pytest.txt `
+            -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest Windows
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests
         shell: bash
@@ -88,10 +89,10 @@ jobs:
             dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
-          pip install --upgrade cirq~=1.0.dev &&
-            pip install \
-              -r dev_tools/requirements/deps/pylint.txt \
-              -r dev_tools/requirements/deps/pytest.txt \
-              -r dev_tools/requirements/deps/notebook.txt
+          pip install --upgrade "cirq~=1.0.dev" "cirq-core[contrib]~=1.0.dev"
+          pip install \
+            -r dev_tools/requirements/deps/pylint.txt \
+            -r dev_tools/requirements/deps/pytest.txt \
+            -r dev_tools/requirements/deps/notebook.txt
       - name: Pytest check
         run: check/pytest -n auto --ignore=cirq-core/cirq/contrib --enable-slow-tests

--- a/dev_tools/requirements/deps/cirq-all-no-contrib.txt
+++ b/dev_tools/requirements/deps/cirq-all-no-contrib.txt
@@ -1,8 +1,9 @@
-# captures all the modules
+# install all cirq sub-packages in editable mode
 
--r ../../../cirq-aqt/requirements.txt
--r ../../../cirq-core/requirements.txt
--r ../../../cirq-google/requirements.txt
--r ../../../cirq-ionq/requirements.txt
--r ../../../cirq-pasqal/requirements.txt
--r ../../../cirq-web/requirements.txt
+# paths are relative to the pip run directory
+-e ./cirq-aqt
+-e ./cirq-core
+-e ./cirq-google
+-e ./cirq-ionq
+-e ./cirq-pasqal
+-e ./cirq-web

--- a/dev_tools/requirements/deps/notebook.txt
+++ b/dev_tools/requirements/deps/notebook.txt
@@ -7,8 +7,5 @@ ipykernel~=7.1
 # for executing notebooks in tests
 papermill~=2.6
 
-# for notebooks that do `pip install cirq-core[contrib]`
--r ../../../cirq-core/cirq/contrib/requirements.txt
-
 # assumed to be part of colab
 seaborn~=0.12


### PR DESCRIPTION
This satisfies stimcirq requirement on cirq-core without duplicate
installation of cirq-core.  In addition, the python virtual environment
gets to find all modules without having to source `dev_tools/pypath`.

Also remove contrib requirements from `deps/notebook.txt` so that
they do not get transitively included in `no-contrib.env.txt`.
Instead, install `cirq-core[contrib]` explicitly in the CI job
to satisfy notebooks that need the contrib packages.
    
Resolves #7891
Follow-up to #6444
