### PR TITLE
Neutralize untrusted circuit-derived strings in QASM and Quantikz exp…

### DIFF
--- a/cirq-core/cirq/circuits/qasm_output.py
+++ b/cirq-core/cirq/circuits/qasm_output.py
@@ -252,7 +252,7 @@ class QasmOutput:
             else:
                 meas_id = f'm{meas_i}'
                 meas_i += 1
-                meas_comments[key] = ' '.join(key.split('\n'))
+                meas_comments[key] = self._escape_comment(key)
             meas_key_id_map[key] = meas_id
         return meas_key_id_map, meas_comments
 
@@ -286,6 +286,22 @@ class QasmOutput:
     def is_valid_qasm_id(self, id_str: str) -> bool:
         """Test if id_str is a valid id in QASM grammar."""
         return self.valid_id_re.match(id_str) is not None
+
+    @staticmethod
+    def _escape_comment(text: str) -> str:
+        r"""Collapses line breaks so untrusted text stays within a single comment.
+
+        Qubit names and measurement keys are free-form strings that may be
+        attacker-controlled (for example, they survive JSON serialization). They
+        are emitted into ``//`` comments in the generated QASM. A ``//`` comment
+        is terminated by a line break, so an embedded line break would let such a
+        string break out of the comment and inject arbitrary QASM statements
+        (CWE-94 / CWE-150). Collapsing every line-break character -- ``\n``,
+        ``\r``, ``\r\n`` and the Unicode line/paragraph separators recognized by
+        ``str.splitlines`` -- to a single space keeps the text confined to its
+        comment.
+        """
+        return ' '.join(text.splitlines())
 
     def save(self, path: str | bytes | int) -> None:
         """Write QASM output to a file specified by path."""
@@ -338,7 +354,8 @@ class QasmOutput:
         # Register definitions
         # Qubit registers
 
-        output(f"// Qubits: [{', '.join(map(str, self.qubits))}]\n")
+        qubit_list = ', '.join(self._escape_comment(str(qubit)) for qubit in self.qubits)
+        output(f"// Qubits: [{qubit_list}]\n")
         if len(self.qubits) > 0:
             if self.args.version == '2.0':
                 output(f'qreg q[{len(self.qubits)}];\n')

--- a/cirq-core/cirq/circuits/qasm_output_test.py
+++ b/cirq-core/cirq/circuits/qasm_output_test.py
@@ -664,3 +664,52 @@ m_c[0] = measure q[0];
 m_c[0] = measure q[0];
 m_c[1] = measure q[1];
 """
+
+
+def test_escape_comment_collapses_all_line_breaks() -> None:
+    """The comment escaper collapses every kind of line break to a space."""
+    escape = cirq.QasmOutput._escape_comment
+    assert escape('a\nb\rc\r\nd e f') == 'a b c d e f'
+    assert escape('plain text') == 'plain text'
+    assert escape('') == ''
+
+
+def test_qubit_name_newline_cannot_break_out_of_comment() -> None:
+    """A newline in a qubit name must not inject QASM via the `// Qubits` comment.
+
+    The qubit register itself is emitted as the indexed ``q[i]``, but the qubit's
+    string representation is echoed into the ``// Qubits: [...]`` comment. Without
+    neutralization, a crafted name closes the comment and injects statements.
+    """
+    evil = cirq.NamedQubit('q0\nx q[0];\n//')
+    qasm = str(cirq.QasmOutput((), (evil,), precision=5))
+    lines = qasm.splitlines()
+
+    # The payload is preserved, but only inside the single `// Qubits` comment.
+    qubits_comment = [line for line in lines if line.startswith('// Qubits:')]
+    assert len(qubits_comment) == 1
+    assert 'x q[0];' in qubits_comment[0]
+    # ... and never as a bare, executable statement line.
+    assert 'x q[0];' not in [line.strip() for line in lines]
+
+
+def test_measurement_key_newline_cannot_break_out_of_comment() -> None:
+    """A line break in a measurement key must stay within its `// Measurement` comment."""
+    q = cirq.LineQubit(0)
+    # The '?' makes `m_<key>` an invalid QASM id, so the raw key is emitted as a
+    # comment; the embedded carriage return must not start a new QASM line.
+    circuit = cirq.Circuit(cirq.measure(q, key='k?\rcreg evil[1];'))
+    lines = circuit.to_qasm().splitlines()
+
+    # No injected creg: the only creg is the sanitized measurement register.
+    cregs = [line for line in lines if line.strip().startswith('creg ')]
+    assert cregs == ['creg m0[1];  // Measurement: k? creg evil[1];']
+    assert 'creg evil[1];' not in [line.strip() for line in lines]
+
+
+def test_legitimate_qubit_names_and_keys_unchanged() -> None:
+    """Escaping must not regress ordinary qubit names or measurement keys."""
+    q = cirq.NamedQubit('alice')
+    qasm = cirq.Circuit(cirq.measure(q, key='x?')).to_qasm()
+    assert '// Qubits: [alice]' in qasm
+    assert 'creg m0[1];  // Measurement: x?' in qasm

--- a/cirq-core/cirq/contrib/quantikz/circuit_to_latex_quantikz.py
+++ b/cirq-core/cirq/contrib/quantikz/circuit_to_latex_quantikz.py
@@ -62,6 +62,7 @@ Example:
 from __future__ import annotations
 
 import math
+import re
 import warnings
 from typing import Any
 
@@ -154,6 +155,27 @@ _PARAMETERIZED_GATE_BASE_NAMES: dict[type[ops.Gate], str] = {
     ops.PhasedXZGate: "PhasedXZ",
     ops.FSimGate: "FSim",
 }
+
+# Mapping of LaTeX special characters to escape sequences that render the
+# character literally. The replacements are valid in both text and math mode,
+# so they are safe to insert inside ``\meter{...}`` arguments as well as inside
+# ``$...$`` wire labels. ``\`` is included so that attacker-supplied control
+# sequences cannot survive escaping; because the substitution below is a single
+# left-to-right pass, the braces introduced by ``\textbackslash{}`` (and the
+# other ``\text...{}`` forms) are not themselves re-escaped.
+_LATEX_SPECIAL_CHARS = {
+    "\\": r"\textbackslash{}",
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\textasciicircum{}",
+}
+_LATEX_SPECIAL_RE = re.compile("|".join(re.escape(char) for char in _LATEX_SPECIAL_CHARS))
 
 
 # =============================================================================
@@ -273,6 +295,34 @@ class CircuitToQuantikz:
             label = label.replace("_", r"\_")
         return label
 
+    @staticmethod
+    def _escape_latex_text(text: str) -> str:
+        r"""Escapes arbitrary text so that LaTeX renders it literally.
+
+        Cirq circuits carry attacker-influenceable free-form strings such as
+        measurement keys (set via ``cirq.measure(..., key=...)``) and
+        named-qubit labels. These values are embedded verbatim into the
+        generated ``.tex`` document, which ``render_circuit`` then compiles with
+        ``pdflatex``. Unlike gate labels -- whose math content is intentionally
+        allowed to contain LaTeX (e.g. ``\alpha``) -- these strings have no such
+        meaning and must be neutralised. If their LaTeX special characters are
+        left intact, a crafted value can break out of its surrounding command
+        argument and inject arbitrary LaTeX, for example ``\input{/etc/passwd}``
+        to read a file into the rendered image, or (when shell-escape is
+        enabled) ``\write18{...}`` to run a shell command.
+
+        Every LaTeX special character is replaced with an escape sequence that
+        is valid in both text and math mode, so the result is safe to embed in
+        either context.
+
+        Args:
+            text: The raw, untrusted string to escape.
+
+        Returns:
+            The escaped string, safe to embed in the generated LaTeX document.
+        """
+        return _LATEX_SPECIAL_RE.sub(lambda m: _LATEX_SPECIAL_CHARS[m.group()], text)
+
     def _get_wire_label(self, qubit: ops.Qid, index: int) -> str:
         r"""Generates the LaTeX string for a qubit wire label.
 
@@ -288,7 +338,7 @@ class CircuitToQuantikz:
             f"q_{{{index}}}"
             if self.wire_labels == "q"
             else (
-                str(index) if self.wire_labels == "index" else str(self._escape_string(str(qubit)))
+                str(index) if self.wire_labels == "index" else self._escape_latex_text(str(qubit))
             )
         )
         return f"${lbl}$"
@@ -510,7 +560,7 @@ class CircuitToQuantikz:
 
         # Apply special Quantikz commands for specific gate types
         if isinstance(gate, ops.MeasurementGate):
-            lbl = gate.key.replace("_", r"\_") if gate.key else ""
+            lbl = self._escape_latex_text(gate.key) if gate.key else ""
             for idx, q1 in enumerate(q_indices):
                 if idx == 0:
                     output[q1] = f"\\meter{final_style_tikz}{{{lbl}}}"

--- a/cirq-core/cirq/contrib/quantikz/circuit_to_latex_quantikz_test.py
+++ b/cirq-core/cirq/contrib/quantikz/circuit_to_latex_quantikz_test.py
@@ -251,3 +251,56 @@ def test_classical_control() -> None:
     converter = CircuitToQuantikz(circuit)
     latex_code = converter.generate_latex_document()
     assert "\\vcw" in latex_code
+
+
+def test_escape_latex_text_neutralizes_special_characters():
+    """The escaper replaces every LaTeX special character with a literal form."""
+    assert CircuitToQuantikz._escape_latex_text(r"\&%$#_{}~^") == (
+        r"\textbackslash{}\&\%\$\#\_\{\}\textasciitilde{}\textasciicircum{}"
+    )
+    # Ordinary text must pass through without over-escaping.
+    assert CircuitToQuantikz._escape_latex_text("alice") == "alice"
+    assert CircuitToQuantikz._escape_latex_text("result_0") == r"result\_0"
+    assert CircuitToQuantikz._escape_latex_text("") == ""
+
+
+def test_measurement_key_is_latex_escaped():
+    r"""Untrusted measurement keys must not inject raw LaTeX (CWE-94 / CWE-150).
+
+    A measurement key is free-form user/data-supplied text that is embedded into
+    the generated document and later compiled by ``pdflatex``. A crafted key
+    must not be able to break out of the ``\meter{...}`` argument and inject a
+    command such as ``\input`` (file disclosure) or ``\write18`` (RCE under
+    shell-escape).
+    """
+    q = cirq.LineQubit(0)
+    malicious_key = r"a}{\input{/etc/passwd}"
+    circuit = cirq.Circuit(cirq.measure(q, key=malicious_key))
+    latex_code = CircuitToQuantikz(circuit).generate_latex_document()
+
+    # The raw payload (and its brace break-out / control sequence) must be gone.
+    assert malicious_key not in latex_code
+    assert r"\input{/etc/passwd}" not in latex_code
+    assert "}{" not in latex_code
+    # The dangerous characters are present only in escaped form.
+    assert r"\textbackslash{}input" in latex_code
+
+
+def test_named_qubit_label_is_latex_escaped():
+    """Untrusted qubit names must not inject raw LaTeX into wire labels."""
+    q = cirq.NamedQubit(r"\input{/etc/passwd}")
+    circuit = cirq.Circuit(cirq.H(q))
+    latex_code = CircuitToQuantikz(circuit, wire_labels="qid").generate_latex_document()
+
+    assert r"\input{/etc/passwd}" not in latex_code
+    assert r"\lstick{$\textbackslash{}input\{/etc/passwd\}$}" in latex_code
+
+
+def test_legitimate_keys_and_labels_are_unchanged():
+    """Escaping must not regress rendering of ordinary keys and qubit labels."""
+    q = cirq.NamedQubit("alice")
+    circuit = cirq.Circuit(cirq.H(q), cirq.measure(q, key="result"))
+    latex_code = CircuitToQuantikz(circuit, wire_labels="qid").generate_latex_document()
+
+    assert r"\lstick{$alice$}" in latex_code
+    assert r"\meter[style={fill=gray!20}]{result}" in latex_code


### PR DESCRIPTION
This change improves the reliability of Cirq's export paths by safely handling circuit-defined names and labels when generating QASM and Quantikz output. 

User-provided strings are now normalized before being written into exported files, preventing formatting issues and keeping generated output well-formed.

 The patch also adds regression tests to cover these scenarios and confirm expected behavior. All affected test suites and code quality checks passed successfully after the update.
