### PR TITLE
Document Circuit insert behavior for explicit moments

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1816,7 +1816,15 @@ class Circuit(AbstractCircuit):
                 circuit. You can also pass in operations, lists of operations,
                 or generally anything meeting the `cirq.OP_TREE` contract.
                 Non-moment entries will be inserted according to the specified
-                insertion strategy.
+                insertion strategy. When `contents` contains individual operations, 
+                they are packed according to `strategy`. This packing treats repeated 
+                measurement keys, and measurement keys that are also used as classical
+                control keys, as conflicts that may require separate moments. By contrast,
+                explicit `cirq.Moment` objects are inserted intact. This allows expert 
+                users to construct moments with repeated measurement keys or 
+                measurement-vs-control-key overlap when they intentionally need that 
+                structure. Non-expert users should usually prefer distinct keys, or a 
+                single multi-qubit measurement such as `cirq.measure(q0, q1, key='m')`.
             strategy: When initializing the circuit with operations and moments
                 from `contents`, this determines how the operations are packed
                 together. This option does not affect later insertions into the
@@ -2259,8 +2267,13 @@ class Circuit(AbstractCircuit):
         """Inserts operations into the circuit.
 
         Operations are inserted into the moment specified by the index and
-        'InsertStrategy'.
-        Moments within the operation tree are inserted intact.
+        'InsertStrategy'. Moments within the operation tree are inserted intact.
+
+        Individual operations are packed according to `strategy`. During this
+        packing, repeated measurement keys and measurement-vs-control-key overlap
+        are treated as conflicts and may require separate moments. To intentionally
+        insert operations with such overlapping keys in the same moment, pass an
+        explicit `cirq.Moment`.
 
         Args:
             index: The index to insert all the operations at.
@@ -2597,7 +2610,12 @@ class Circuit(AbstractCircuit):
     ) -> None:
         """Appends operations onto the end of the circuit.
 
-        Moments within the operation tree are appended intact.
+        Moments within the operation tree are appended intact. Individual
+        operations are packed according to `strategy`. During this packing,
+        repeated measurement keys and measurement-vs-control-key overlap are
+        treated as conflicts and may require separate moments. To intentionally
+        append operations with such overlapping keys in the same moment, pass an
+        explicit `cirq.Moment`.
 
         Args:
             moment_or_operation_tree: The moment or operation tree to append.

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -194,7 +194,93 @@ def test_append_single() -> None:
         [cirq.Moment(cirq.H(cirq.NamedQubit('a'))), cirq.Moment(cirq.H(cirq.NamedQubit('a')))]
     )
 
+@pytest.mark.parametrize('method_name', ['append', 'insert'])
+def test_adding_operations_with_same_measurement_key_splits_moments(method_name) -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op0 = cirq.measure(q0, key='m')
+    op1 = cirq.measure(q1, key='m')
 
+    circuit = cirq.Circuit()
+    if method_name == 'append':
+        circuit.append([op0, op1])
+    else:
+        circuit.insert(0, [op0, op1])
+
+    assert circuit == cirq.Circuit(
+        cirq.Moment(op0),
+        cirq.Moment(op1),
+    )
+
+
+@pytest.mark.parametrize('method_name', ['append', 'insert'])
+def test_adding_moment_with_same_measurement_key_preserves_moment(method_name) -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op0 = cirq.measure(q0, key='m')
+    op1 = cirq.measure(q1, key='m')
+    moment = cirq.Moment(op0, op1)
+
+    circuit = cirq.Circuit()
+    if method_name == 'append':
+        circuit.append(moment)
+    else:
+        circuit.insert(0, moment)
+
+    assert circuit == cirq.Circuit(moment)
+
+
+@pytest.mark.parametrize('method_name', ['append', 'insert'])
+def test_adding_measurement_and_control_operation_splits_moments(method_name) -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    measure_op = cirq.measure(q0, key='m')
+    controlled_op = cirq.X(q1).with_classical_controls('m')
+
+    circuit = cirq.Circuit()
+    if method_name == 'append':
+        circuit.append([measure_op, controlled_op])
+    else:
+        circuit.insert(0, [measure_op, controlled_op])
+
+    assert circuit == cirq.Circuit(
+        cirq.Moment(measure_op),
+        cirq.Moment(controlled_op),
+    )
+
+
+@pytest.mark.parametrize('method_name', ['append', 'insert'])
+def test_adding_moment_with_measurement_and_control_key_preserves_moment(method_name) -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    measure_op = cirq.measure(q0, key='m')
+    controlled_op = cirq.X(q1).with_classical_controls('m')
+    moment = cirq.Moment(measure_op, controlled_op)
+
+    circuit = cirq.Circuit()
+    if method_name == 'append':
+        circuit.append(moment)
+    else:
+        circuit.insert(0, moment)
+
+    assert circuit == cirq.Circuit(moment)
+
+
+def test_circuit_init_with_operations_splits_overlapping_measurement_keys() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op0 = cirq.measure(q0, key='m')
+    op1 = cirq.measure(q1, key='m')
+
+    assert cirq.Circuit([op0, op1]) == cirq.Circuit(
+        cirq.Moment(op0),
+        cirq.Moment(op1),
+    )
+
+
+def test_circuit_init_with_moment_preserves_overlapping_measurement_keys() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    moment = cirq.Moment(
+        cirq.measure(q0, key='m'),
+        cirq.measure(q1, key='m'),
+    )
+
+    assert cirq.Circuit(moment) == cirq.Circuit(moment)
 def test_append_control_key() -> None:
     q0, q1, q2 = cirq.LineQubit.range(3)
     c = cirq.Circuit()

--- a/docs/build/circuits.ipynb
+++ b/docs/build/circuits.ipynb
@@ -297,6 +297,29 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Measurement and classical-control keys\n",
+    "\n",
+    "`Circuit.append`, `Circuit.insert`, and the `Circuit` initializer treat individual\n",
+    "operations differently from explicit `Moment` objects.\n",
+    "\n",
+    "When you pass individual operations, Cirq packs them according to the requested\n",
+    "`InsertStrategy`. During this packing, repeated measurement keys and\n",
+    "measurement-vs-control-key overlap are treated as conflicts, so Cirq may place the\n",
+    "operations in separate moments.\n",
+    "\n",
+    "When you pass an explicit `cirq.Moment`, Cirq inserts or appends that moment intact.\n",
+    "This is useful for expert workflows that intentionally require overlapping measurement\n",
+    "keys in the same moment, but most users should avoid overlapping keys. Prefer distinct\n",
+    "measurement keys, or use a single multi-qubit measurement such as:\n",
+    "\n",
+    "```python\n",
+    "cirq.measure(q0, q1, key=\"m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "2t7qgbPkAwCx"
    },


### PR DESCRIPTION
Fixes #8132.

This PR documents the difference between adding individual operations and adding explicit `Moment` objects via `Circuit.__init__`, `Circuit.insert`, and `Circuit.append`.

Summary:
- Clarifies that individual operations are packed according to insertion strategy.
- Clarifies that repeated measurement keys and measurement-vs-control-key overlap are treated as conflicts during packing.
- Clarifies that explicit `Moment` objects are inserted/appended intact.
- Adds regression tests for repeated measurement keys and measurement-vs-control-key overlap.
- Updates the circuit-building notebook documentation.

Tests:
- `python -m pytest cirq-core/cirq/circuits/circuit_test.py -k "measurement_key or control_key or moment"`
- `python -m pytest cirq-core/cirq/circuits/circuit_test.py`