### PR TITLE
Prevent script injection through Circuit3D rendered circuit data

### DIFF
--- a/cirq-web/cirq_web/circuits/circuit.py
+++ b/cirq-web/cirq_web/circuits/circuit.py
@@ -86,8 +86,12 @@ class Circuit3D(widget.Widget):
                 symbol = self._build_3D_symbol(item, moment_id)
                 args.append(symbol.to_typescript())
 
-        argument_str = ','.join(str(item) for item in args)
-        return f'[{argument_str}]'
+        # Serialize as HTML-safe JSON before this is interpolated verbatim into the
+        # inline ``<script>`` produced by ``get_client_code``. The previous
+        # ``','.join(str(item) ...)`` emitted Python ``repr`` literals, letting
+        # attacker-influenced diagram text (e.g. a gate's ``wire_symbols``) break out
+        # of the script context to inject markup or script (CWE-79).
+        return widget._to_html_safe_json(args)
 
     def _build_3D_symbol(self, operation, moment) -> Operation3DSymbol:
         symbol_info = resolve_operation(operation, self._resolvers)

--- a/cirq-web/cirq_web/circuits/circuit_test.py
+++ b/cirq-web/cirq_web/circuits/circuit_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 import cirq
@@ -55,7 +57,7 @@ def test_circuit_client_code(qubit) -> None:
         <button id="camera-toggle">Toggle Camera Type</button>
         <script>
         let viz_{stripped_id} = createGridCircuit(
-            {str(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
+            {json.dumps(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
         );
 
         document.getElementById("camera-reset").addEventListener('click', ()  => {{
@@ -85,3 +87,36 @@ def test_circuit_default_bundle_name() -> None:
     circuit = cirq_web.Circuit3D(cirq.Circuit(moment))
 
     assert circuit.get_widget_bundle_name() == 'circuit.bundle.js'
+
+
+class _UntrustedSymbolGate(cirq.testing.SingleQubitGate):
+    """A gate whose circuit-diagram symbol carries an HTML/JS injection payload."""
+
+    def _circuit_diagram_info_(self, args) -> cirq.CircuitDiagramInfo:
+        return cirq.CircuitDiagramInfo(
+            wire_symbols=("</script><img src=x onerror=alert(document.domain)>",)
+        )
+
+
+def test_circuit_client_code_escapes_untrusted_symbols() -> None:
+    # Diagram symbols are attacker-controllable (a custom gate's `_circuit_diagram_info_`),
+    # and a circuit may originate from an untrusted source, e.g. `cirq.read_json`. Such a
+    # symbol must not be able to break out of the inline <script> that renders the circuit
+    # (CWE-79).
+    qubit = cirq.GridQubit(0, 0)
+    circuit = cirq_web.Circuit3D(cirq.Circuit(_UntrustedSymbolGate().on(qubit)))
+
+    client_code = circuit.get_client_code()
+
+    payload = "</script><img src=x onerror=alert(document.domain)>"
+    # The injected markup must never reach the HTML tokenizer: the payload must not
+    # appear, no "</script>" should come from the data (only the one legitimate closing
+    # tag of the template remains), and the breakout sequence must be absent.
+    assert payload not in client_code
+    assert client_code.count("</script>") == 1
+    assert "</script><img" not in client_code
+    # The dangerous characters survive only in their escaped, inert form.
+    assert "\\u003c/script\\u003e" in client_code
+    # The escaped payload still round-trips back to the original data.
+    decoded = json.loads(circuit._serialize_circuit())
+    assert decoded[0]['wire_symbols'] == [payload]

--- a/cirq-web/cirq_web/widget.py
+++ b/cirq-web/cirq_web/widget.py
@@ -14,12 +14,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import uuid
 import webbrowser
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import cirq_web
 
@@ -120,3 +122,39 @@ def _to_script_tag(bundle_filename: str) -> str:
     bundle_file_path = _DIST_PATH.joinpath(bundle_filename)
     bundle_file_contents = bundle_file_path.read_text(encoding='utf-8')
     return f'<script>{bundle_file_contents}</script>'
+
+
+# Characters that are significant to the HTML tokenizer (or illegal inside a
+# JavaScript string literal) and therefore must not appear unescaped in data
+# interpolated into an inline ``<script>`` block. ``json.dumps`` does not escape
+# any of these, so e.g. a value containing ``</script>`` would otherwise close
+# the script element at the HTML level and let attacker-influenced data inject
+# arbitrary markup or script (CWE-79). U+2028 and U+2029 are valid in JSON but
+# terminate a JavaScript string literal.
+_HTML_SCRIPT_ESCAPES = {
+    ord('<'): '\\u003c',
+    ord('>'): '\\u003e',
+    ord('&'): '\\u0026',
+    0x2028: '\\u2028',
+    0x2029: '\\u2029',
+}
+
+
+def _to_html_safe_json(value: Any) -> str:
+    r"""Serializes ``value`` to JSON that is safe to embed inside an HTML ``<script>``.
+
+    The result is valid JSON (and therefore a valid JavaScript literal) in which the
+    characters that are significant to the HTML tokenizer (``<``, ``>``, ``&``) and the
+    JavaScript line separators (U+2028, U+2029) are replaced with equivalent ``\uXXXX``
+    escapes. This keeps attacker-influenced data (such as a gate's circuit-diagram
+    symbols) from breaking out of the surrounding ``<script>`` element to inject markup
+    or script (CWE-79), while remaining byte-for-byte equivalent for benign payloads.
+
+    Args:
+        value: A JSON-serializable object to embed in client-side code. Values that are
+            not natively JSON-serializable are coerced with ``str`` (and then escaped).
+
+    Returns:
+        The escaped JSON string.
+    """
+    return json.dumps(value, default=str).translate(_HTML_SCRIPT_ESCAPES)

--- a/cirq-web/cirq_web/widget_test.py
+++ b/cirq-web/cirq_web/widget_test.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from unittest import mock
 
 import cirq_web
+from cirq_web import widget
 
 
 class FakeWidget(cirq_web.Widget):
@@ -75,3 +77,31 @@ def test_generate_html_file_with_browser(tmpdir) -> None:
         This is the test client code.
         """
     assert remove_whitespace(expected) == remove_whitespace(actual)
+
+
+def test_to_html_safe_json_escapes_html_significant_characters() -> None:
+    value = {"label": "</script><script>alert(1)</script>", "amp": "a & b", "ok": "X^2"}
+    out = widget._to_html_safe_json(value)
+
+    # None of the characters significant to the HTML tokenizer survive unescaped, so the
+    # result can never close the surrounding <script> element or open new markup.
+    assert "<" not in out
+    assert ">" not in out
+    assert "&" not in out
+    assert "</script>" not in out
+    assert "\\u003c" in out and "\\u003e" in out and "\\u0026" in out
+    # The escaped JSON still decodes back to the original value.
+    assert json.loads(out) == value
+
+
+def test_to_html_safe_json_escapes_js_line_separators() -> None:
+    # U+2028/U+2029 are valid in JSON but terminate a JavaScript string literal.
+    out = widget._to_html_safe_json("a\u2028b\u2029c")
+    assert "\u2028" not in out
+    assert "\u2029" not in out
+    assert json.loads(out) == "a\u2028b\u2029c"
+
+
+def test_to_html_safe_json_preserves_benign_payload() -> None:
+    value = [{"wire_symbols": ["H"], "location_info": [{"row": 0, "col": 0}]}]
+    assert widget._to_html_safe_json(value) == json.dumps(value)


### PR DESCRIPTION
Circuit3D was embedding serialized circuit data directly into an inline script block. Since wire symbols can come from user-controlled circuit metadata, specially crafted values could break out of the script context when the generated HTML is rendered.

This change introduces a safe JSON serialization path for data embedded in scripts and adds regression tests to verify that malicious payloads are properly escaped while preserving existing rendering behavior.
