### PR TITLE
escape circuit symbol text in cirq-web script output

### DIFF
--- a/cirq-web/cirq_web/circuits/circuit.py
+++ b/cirq-web/cirq_web/circuits/circuit.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable
 
 import cirq
@@ -86,8 +87,7 @@ class Circuit3D(widget.Widget):
                 symbol = self._build_3D_symbol(item, moment_id)
                 args.append(symbol.to_typescript())
 
-        argument_str = ','.join(str(item) for item in args)
-        return f'[{argument_str}]'
+        return _to_script_safe_json(args)
 
     def _build_3D_symbol(self, operation, moment) -> Operation3DSymbol:
         symbol_info = resolve_operation(operation, self._resolvers)
@@ -100,3 +100,21 @@ class Circuit3D(widget.Widget):
             else:
                 raise ValueError('Unsupported qubit type')
         return Operation3DSymbol(symbol_info.labels, location_info, symbol_info.colors, moment)
+
+
+def _to_script_safe_json(value) -> str:
+    """Serializes a value to JSON that is safe to embed inside an HTML <script> tag.
+
+    The serialized circuit is interpolated directly into a <script> block, so symbol
+    text taken from gate diagrams (which may originate from an untrusted circuit) must
+    not be able to close the tag or break out of the JS string. Emitting real JSON and
+    escaping the HTML-significant characters keeps the payload inert.
+    """
+    serialized = json.dumps(value)
+    return (
+        serialized.replace('<', '\\u003c')
+        .replace('>', '\\u003e')
+        .replace('&', '\\u0026')
+        .replace('\u2028', '\\u2028')
+        .replace('\u2029', '\\u2029')
+    )

--- a/cirq-web/cirq_web/circuits/circuit_test.py
+++ b/cirq-web/cirq_web/circuits/circuit_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 import cirq
@@ -55,7 +57,7 @@ def test_circuit_client_code(qubit) -> None:
         <button id="camera-toggle">Toggle Camera Type</button>
         <script>
         let viz_{stripped_id} = createGridCircuit(
-            {str(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
+            {json.dumps(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
         );
 
         document.getElementById("camera-reset").addEventListener('click', ()  => {{
@@ -77,6 +79,21 @@ def test_circuit_client_code_unsupported_qubit_type() -> None:
 
     with pytest.raises(ValueError, match='Unsupported qubit type'):
         circuit.get_client_code()
+
+
+def test_circuit_client_code_escapes_script_breakout() -> None:
+    class _EvilGate(cirq.Gate):
+        def _num_qubits_(self):
+            return 1
+
+        def _circuit_diagram_info_(self, args):
+            return cirq.CircuitDiagramInfo(wire_symbols=['</script><script>x</script>'])
+
+    circuit = cirq_web.Circuit3D(cirq.Circuit(_EvilGate().on(cirq.LineQubit(0))))
+    client_code = circuit.get_client_code()
+
+    assert '</script><script>' not in client_code
+    assert '\\u003c/script\\u003e' in client_code
 
 
 def test_circuit_default_bundle_name() -> None:


### PR DESCRIPTION
Circuit3D builds the client HTML by interpolating the serialized circuit directly into a <script> block, and _serialize_circuit emitted that string with Python repr, so gate diagram symbol text was never escaped.

- a wire symbol containing </script> or a quote breaks out of the script tag, injecting arbitrary HTML/JS when the widget is shown in a notebook or written via generate_html_file
- symbol text comes from circuit_diagram_info, so a circuit loaded from an untrusted source carries the payload
- the repr output also was not valid JSON, it relied on JS tolerating single quotes

Serialize with json.dumps and escape <, >, &, U+2028, U+2029 so the data stays inert inside the script tag. Same idea as the recent svg text escaping.