### PR TITLE
Replace inplace assignment of NumPy array shape

### DIFF
--- a/cirq-core/cirq/ops/arithmetic_operation.py
+++ b/cirq-core/cirq/ops/arithmetic_operation.py
@@ -225,7 +225,7 @@ class ArithmeticGate(Gate, metaclass=abc.ABCMeta):
             dst[tuple(outputs)] = src[tuple(inputs)]
 
         # In case the reshaped arrays were copies instead of views.
-        dst.shape = transposed_args.available_buffer.shape
+        dst = dst.reshape(transposed_args.available_buffer.shape, copy=False)
         transposed_args.target_tensor[...] = dst
 
         return args.target_tensor

--- a/cirq-core/cirq/protocols/apply_channel_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_channel_protocol_test.py
@@ -181,8 +181,8 @@ def test_apply_channel_channel_fallback_one_qubit_random_on_two_qubits() -> None
 
         expected = 0.5 * rho + 0.5 * np.dot(np.dot(full_u, rho), np.conjugate(np.transpose(full_u)))
 
-        rho.shape = (2, 2, 2, 2)
-        expected.shape = (2, 2, 2, 2)
+        rho = np.reshape(rho, (2, 2, 2, 2))
+        expected = np.reshape(expected, (2, 2, 2, 2))
 
         class HasChannel:
             def _kraus_(self):
@@ -202,8 +202,8 @@ def test_apply_channel_channel_fallback_two_qubit_random() -> None:
 
         expected = 0.5 * rho + 0.5 * np.dot(np.dot(u, rho), np.conjugate(np.transpose(u)))
 
-        rho.shape = (2, 2, 2, 2)
-        expected.shape = (2, 2, 2, 2)
+        rho = np.reshape(rho, (2, 2, 2, 2))
+        expected = np.reshape(expected, (2, 2, 2, 2))
 
         class HasChannel:
             def _kraus_(self):

--- a/cirq-core/cirq/protocols/apply_mixture_protocol_test.py
+++ b/cirq-core/cirq/protocols/apply_mixture_protocol_test.py
@@ -213,8 +213,8 @@ def test_apply_mixture_fallback_two_qubit_random() -> None:
 
         expected = 0.5 * rho + 0.5 * np.dot(np.dot(u, rho), np.conjugate(np.transpose(u)))
 
-        rho.shape = (2, 2, 2, 2)
-        expected.shape = (2, 2, 2, 2)
+        rho = np.reshape(rho, (2, 2, 2, 2))
+        expected = np.reshape(expected, (2, 2, 2, 2))
 
         class HasMixture:
             def _mixture_(self):

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -1089,6 +1089,7 @@ def eye_tensor(half_shape: tuple[int, ...], *, dtype: DTypeLike) -> np.ndarray:
     Returns:
         The created numpy array with shape `half_shape + half_shape`.
     """
-    identity = np.eye(np.prod(half_shape, dtype=np.int64).item(), dtype=dtype)
-    identity.shape = half_shape * 2
+    identity = np.eye(np.prod(half_shape, dtype=np.int64).item(), dtype=dtype).reshape(
+        half_shape * 2, copy=False
+    )
     return identity

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -159,9 +159,6 @@ def measure_density_matrix(
 
     prng = value.parse_random_state(seed)
 
-    # Cache initial shape.
-    initial_shape = density_matrix.shape
-
     # Calculate the measurement probabilities and then make the measurement.
     probs = _probs(density_matrix, indices, qid_shape)
     result = prng.choice(len(probs), p=probs)
@@ -176,12 +173,10 @@ def measure_density_matrix(
     # Remove ellipses from last element of
     mask[result_slice * 2] = False
 
-    # Potentially reshape to tensor, and then set masked values to 0.
-    arrout.shape = qid_shape * 2
-    arrout[mask] = 0
+    # Reshape to a tensor inplace to set the masked values to 0.
+    arrout.reshape(qid_shape * 2, copy=False)[mask] = 0
 
-    # Restore original shape (if necessary) and renormalize.
-    arrout.shape = initial_shape
+    # Renormalize.
     arrout /= probs[result]
 
     return measurement_bits, arrout

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -287,9 +287,6 @@ def measure_state_vector(
 
     prng = value.parse_random_state(seed)
 
-    # Cache initial shape.
-    initial_shape = state_vector.shape
-
     # Calculate the measurement probabilities and then make the measurement.
     probs = (state_vector * state_vector.conj()).real
     probs = simulation_utils.state_probabilities_by_indices(probs, indices, shape)
@@ -314,12 +311,10 @@ def measure_state_vector(
         np.copyto(dst=out, src=state_vector)
     # Final else: if out is state then state will be modified in place.
 
-    # Potentially reshape to tensor, and then set masked values to 0.
-    out.shape = shape
-    out[mask] = 0
+    # Reshape to a tensor inplace to set the masked values to 0.
+    out.reshape(shape, copy=False)[mask] = 0
 
-    # Restore original shape (if necessary) and renormalize.
-    out.shape = initial_shape
+    # Renormalize.
     out /= np.sqrt(probs[result])
 
     assert out is not None


### PR DESCRIPTION
Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
Here we replace such instances with `np.reshape()`.

This fixes failure of the CI job "Pytest Windows (3.13)" due to
unexpected deprecation warnings.
