### PR TITLE
Fix the ci-daily job

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
-  # FIXME - remove this before PR submission
-  pull_request:
-    branches:
-      - main
 
   # Allow manual invocation.
   workflow_dispatch:

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     # Checks out main by default.
     - cron: '0 0 * * *'
+  # FIXME - remove this before PR submission
+  pull_request:
+    branches:
+      - main
 
   # Allow manual invocation.
   workflow_dispatch:

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -66,10 +66,11 @@ jobs:
       - name: Install requirements
         run: |
           pip install --upgrade "cirq~=1.0.dev" "cirq-core[contrib]~=1.0.dev"
-          pip install `
-            -r dev_tools/requirements/deps/pylint.txt `
-            -r dev_tools/requirements/deps/pytest.txt `
+          pip install \
+            -r dev_tools/requirements/deps/pylint.txt \
+            -r dev_tools/requirements/deps/pytest.txt \
             -r dev_tools/requirements/deps/notebook.txt
+        shell: bash
       - name: Pytest Windows
         run: check/pytest -n logical --ignore=cirq-core/cirq/contrib --enable-slow-tests
         shell: bash

--- a/.github/workflows/ci-monitoring.yml
+++ b/.github/workflows/ci-monitoring.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
-          pip install --upgrade setuptools wheel
+          pip install --upgrade setuptools
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Pytest check
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,6 @@ jobs:
         shell: bash
       - name: Pytest Windows
         run: |
-          source dev_tools/pypath
           check/pytest -n logical --durations=20 --ignore=cirq-core/cirq/contrib
         shell: bash
   macos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
-          pip install --upgrade setuptools wheel
+          pip install --upgrade setuptools
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Pytest check
         run: check/pytest -n logical --durations=20
@@ -282,7 +282,7 @@ jobs:
           sudo apt-get install $(cat apt-system-requirements.txt)
       - name: Install requirements
         run: |
-          pip install --upgrade setuptools wheel
+          pip install --upgrade setuptools
           pip install --upgrade --upgrade-strategy eager -r dev_tools/requirements/dev.env.txt
       - name: Coverage check
         run: check/pytest-and-incremental-coverage -n logical
@@ -316,7 +316,7 @@ jobs:
             dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
-          pip install --upgrade setuptools wheel
+          pip install --upgrade setuptools
           pip install --upgrade --upgrade-strategy eager \
             -r dev_tools/requirements/pytest-minimal.env.txt \
             qiskit-aer~=0.17.0 stimcirq
@@ -353,7 +353,7 @@ jobs:
             dev_tools/requirements/**/*.txt
       - name: Install requirements
         run: |
-          pip install --upgrade setuptools wheel
+          pip install --upgrade setuptools
           pip install --upgrade --upgrade-strategy eager \
             -r dev_tools/requirements/pytest-minimal.env.txt \
             qiskit-aer~=0.17.0 stimcirq

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -44,7 +44,7 @@ jobs:
         if: steps.check-labels.outputs.has_no_release != 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade setuptools wheel twine
+          pip install --upgrade setuptools twine
       - name: Create PyPI config file
         if: steps.check-labels.outputs.has_no_release != 'true'
         env:

--- a/dev_tools/cloned_env_test.py
+++ b/dev_tools/cloned_env_test.py
@@ -44,5 +44,5 @@ def test_isolated_env_cloning(cloned_env, param) -> None:
     assert {"name": "flynt", "version": "0.64"} in packages
     package_names = {p['name'] for p in packages}
     assert package_names.issuperset({"astor", "flynt", "pip"})
-    assert package_names.issubset({"astor", "flynt", "pip", "setuptools", "wheel"})
+    assert package_names.issubset({"astor", "flynt", "pip", "setuptools"})
     shutil.rmtree(env)

--- a/dev_tools/requirements/deps/packaging.txt
+++ b/dev_tools/requirements/deps/packaging.txt
@@ -3,7 +3,6 @@ virtualenv
 
 # for creating packages
 setuptools>=70
-wheel
 
 # for uploading packages to pypi
 twine

--- a/dev_tools/requirements/deps/packaging.txt
+++ b/dev_tools/requirements/deps/packaging.txt
@@ -1,6 +1,3 @@
-# for testing packaging in isolation
-virtualenv
-
 # for creating packages
 setuptools>=70
 

--- a/dev_tools/requirements/deps/pytest.txt
+++ b/dev_tools/requirements/deps/pytest.txt
@@ -14,6 +14,9 @@ filelock~=3.1
 # codeowners test dependency
 codeowners; platform_system != "Windows"
 
+# for resolving module metadata
+setuptools>=70
+
 # for creating isolated environments
 virtualenv~=21.1
 virtualenv-clone


### PR DESCRIPTION
* Add `setuptools` dependency to pytest.txt as it is imported
  in `dev_tools.modules` and associated tests

* Cleanup dependencies in packaging.txt
  - `virtualenv` is not needed for packaging test
  - `wheel` is not needed for tests nor to run `pip wheel`

* Use `bash` in ci-daily Pytest Windows so we have
  uniform command syntax on all platform

* Also drop unnecessary sourcing of `dev_tools/pypath`

Fixes #8156