### PR TITLE
Add note that PauliSum does not preserve gate order of summed PauliStrings

### DIFF
--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -360,7 +360,8 @@ class PauliSum:
 
     Under the hood, this class is backed by a LinearDict with coefficient-less
     PauliStrings as keys. PauliStrings are reconstructed on-the-fly during
-    iteration.
+    iteration.  Note the ordering of Pauli gates and qubits in such reconstructed
+    strings may differ from the order in PauliStrings that were combined in PauliSum.
 
     PauliSums can be constructed explicitly:
 


### PR DESCRIPTION
Resolves #6630
