### PR TITLE
Fix circuit reversal when searching for shortest stratified_circuit in reverse

### DIFF
--- a/cirq-core/cirq/transformers/align.py
+++ b/cirq-core/cirq/transformers/align.py
@@ -20,7 +20,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 from cirq import circuits, ops
-from cirq.transformers import transformer_api
+from cirq.transformers import transformer_api, transformer_primitives
 
 if TYPE_CHECKING:
     import cirq
@@ -79,11 +79,6 @@ def align_right(
     # Reverse the circuit, align left, and reverse again. Note each moment also has to have its ops
     # reversed internally, to avoid edge conditions where non-commuting but can-be-in-same-moment
     # ops (measurements and classical controls, particularly) could end up getting swapped.
-    backwards = []
-    for moment in circuit[::-1]:
-        backwards.append(circuits.Moment(reversed(moment.operations)))
-    aligned_backwards = align_left(circuits.Circuit(backwards), context=context)
-    forwards = []
-    for moment in aligned_backwards[::-1]:
-        forwards.append(circuits.Moment(reversed(moment.operations)))
-    return circuits.Circuit(forwards)
+    backwards = transformer_primitives.reverse_circuit(circuit)
+    aligned_backwards = align_left(backwards, context=context)
+    return transformer_primitives.reverse_circuit(aligned_backwards)

--- a/cirq-core/cirq/transformers/stratify.py
+++ b/cirq-core/cirq/transformers/stratify.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Union
 
 from cirq import _import, circuits, ops, protocols
-from cirq.transformers import transformer_api
+from cirq.transformers import transformer_api, transformer_primitives
 
 drop_empty_moments = _import.LazyLoader('drop_empty_moments', globals(), 'cirq.transformers')
 
@@ -70,7 +70,7 @@ def stratified_circuit(
     # Try the algorithm with each permutation of the classifiers.
     smallest_depth = protocols.num_qubits(circuit) * len(circuit) + 1
     shortest_stratified_circuit = circuits.Circuit()
-    reversed_circuit = circuit[::-1]
+    reversed_circuit = transformer_primitives.reverse_circuit(circuit)
     for ordered_classifiers in itertools.permutations(classifiers):
         solution = _stratify_circuit(
             circuit,
@@ -88,9 +88,9 @@ def stratified_circuit(
             reversed_circuit,
             classifiers=ordered_classifiers,
             context=context or transformer_api.TransformerContext(),
-        )[::-1]
+        )
         if len(solution) < smallest_depth:
-            shortest_stratified_circuit = solution
+            shortest_stratified_circuit = transformer_primitives.reverse_circuit(solution)
             smallest_depth = len(solution)
 
     return shortest_stratified_circuit

--- a/cirq-core/cirq/transformers/stratify_test.py
+++ b/cirq-core/cirq/transformers/stratify_test.py
@@ -277,13 +277,13 @@ def test_stratify_respects_no_compile_operations():
 
 def test_does_not_move_ccos_behind_measurement():
     q = cirq.LineQubit.range(3)
-    c_orig = cirq.Circuit(
+    c_orig_1 = cirq.Circuit(
         cirq.measure(q[0], key='m'),
         cirq.X(q[1]).with_classical_controls('m'),
         cirq.Moment(cirq.X.on_each(q[1], q[2])),
     )
     cirq.testing.assert_has_diagram(
-        c_orig,
+        c_orig_1,
         '''
 0: ───M───────────
       ║
@@ -294,11 +294,11 @@ def test_does_not_move_ccos_behind_measurement():
 m: ═══@═══^═══════
 ''',
     )
-    c_out = cirq.stratified_circuit(
-        c_orig, categories=[cirq.GateOperation, cirq.ClassicallyControlledOperation]
+    c_out_1 = cirq.stratified_circuit(
+        c_orig_1, categories=[cirq.GateOperation, cirq.ClassicallyControlledOperation]
     )
     cirq.testing.assert_has_diagram(
-        c_out,
+        c_out_1,
         '''
       ┌──┐
 0: ────M─────────────
@@ -309,6 +309,37 @@ m: ═══@═══^═══════
        ║     ║
 m: ════@═════^═══════
       └──┘
+''',
+    )
+    c_orig_2 = cirq.Circuit(
+        cirq.measure(q[0], key='m'),
+        cirq.X(q[1]).with_classical_controls("m"),
+        cirq.X(q[0]).with_classical_controls("m"),
+        cirq.X(q[1]),
+    )
+    cirq.testing.assert_has_diagram(
+        c_orig_2,
+        '''
+          ┌──┐
+0: ───M─────X────────
+      ║     ║
+1: ───╫────X╫────X───
+      ║    ║║
+m: ═══@════^^════════
+          └──┘
+''',
+    )
+    c_out_2 = cirq.stratified_circuit(c_orig_2)
+    cirq.testing.assert_has_diagram(
+        c_out_2,
+        '''
+          ┌──┐
+0: ───M─────X────────
+      ║     ║
+1: ───╫────X╫────X───
+      ║    ║║
+m: ═══@════^^════════
+          └──┘
 ''',
     )
 

--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -41,7 +41,7 @@ MAPPED_CIRCUIT_OP_TAG = '<mapped_circuit_op>'
 
 
 def _to_target_circuit_type(
-    circuit: circuits.AbstractCircuit, target_circuit: CIRCUIT_TYPE
+    circuit: cirq.AbstractCircuit, target_circuit: CIRCUIT_TYPE
 ) -> CIRCUIT_TYPE:
     return cast(
         CIRCUIT_TYPE,
@@ -923,3 +923,26 @@ def toggle_tags(circuit: CIRCUIT_TYPE, tags: Sequence[Hashable], *, deep: bool =
         )
 
     return map_operations(circuit, map_func, deep=deep)
+
+
+def reverse_circuit(circuit: cirq.AbstractCircuit) -> cirq.Circuit:
+    """Return a mutable copy of the circuit with moments and operations reversed.
+
+    This creates a circuit with reversed iteration order in `circuit.all_operations()`.
+    A second call restores back the initial input circuit (as a mutable copy).
+
+    Args:
+        circuit: The input circuit to be reversed.
+
+    Returns:
+        A mutable circuit with a reversed order of moments and operations.
+    """
+    moments = [
+        (
+            circuits.Moment.from_ops(*reversed(m.operations), tags=m.tags)
+            if len(m.operations) > 1
+            else m
+        )
+        for m in circuit
+    ]
+    return circuits.Circuit._from_moments(reversed(moments), tags=circuit.tags)

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -19,7 +19,7 @@ from collections.abc import Iterator
 import pytest
 
 import cirq
-from cirq.transformers.transformer_primitives import MAPPED_CIRCUIT_OP_TAG
+from cirq.transformers.transformer_primitives import MAPPED_CIRCUIT_OP_TAG, reverse_circuit
 
 
 def test_map_operations_can_write_new_gates_inline():
@@ -1061,3 +1061,19 @@ def test_merge_3q_unitaries_to_circuit_op_prefer_to_merge_into_earlier_op():
 5: ───H[ignore]────────────────────────#3───────────────────────────────────────────@────────────────────────────
 ''',  # noqa: E501
     )
+
+
+def test_reverse_circuit_has_reversed_all_operations() -> None:
+    q = cirq.LineQubit.range(3)
+    c_orig = cirq.Circuit(
+        cirq.Moment(cirq.H(q[0])).with_tags("H"),
+        cirq.Moment(cirq.X(q[0]), cirq.Y(q[1]), cirq.Z(q[2])).with_tags("XYZ"),
+        cirq.Moment(cirq.measure(q[1]), cirq.measure(q[2])).with_tags("M1M2"),
+    ).with_tags("circuit")
+    all_operations_orig = list(c_orig.all_operations())
+    c_reversed = reverse_circuit(c_orig)
+    assert c_reversed.tags == ("circuit",)
+    assert [len(m) for m in c_reversed] == [2, 3, 1]
+    assert [m.tags for m in c_reversed] == [("M1M2",), ("XYZ",), ("H",)]
+    assert list(c_reversed.all_operations()) == all_operations_orig[::-1]
+    cirq.testing.assert_same_circuits(reverse_circuit(c_reversed), c_orig)


### PR DESCRIPTION
Make sure `cirq.stratified_circuit` has an exactly reversed operation order
when checking the stratification in reverse.  This avoids incorrect ordering
of classically-controlled and measurement operations.

Also add a transformers helper function `reverse_circuit` to
`transformer_primitives` and reuse it in the `cirq.align_right`
transformer which needs a reversed circuit too.

Related to #6899
Fixes #7474
