### PR TITLE
Flush deprecations for the 1.7.0 release

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_local_processor.py
+++ b/cirq-google/cirq_google/engine/abstract_local_processor.py
@@ -16,11 +16,10 @@ from __future__ import annotations
 
 import abc
 import datetime
-from typing import Any, overload, TYPE_CHECKING
+from typing import overload, TYPE_CHECKING
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from cirq import _compat
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_processor import AbstractProcessor
 
@@ -46,13 +45,6 @@ def _to_timestamp(union_time: None | datetime.datetime | datetime.timedelta) -> 
     elif isinstance(union_time, datetime.datetime):
         return int(union_time.timestamp())
     return None
-
-
-def _fix_deprecated_allowlisted_users_args(
-    args: tuple[Any, ...], kwargs: dict[str, Any]
-) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    kwargs['allowlisted_users'] = kwargs.pop('whitelisted_users')
-    return args, kwargs
 
 
 class AbstractLocalProcessor(AbstractProcessor):
@@ -242,13 +234,6 @@ class AbstractLocalProcessor(AbstractProcessor):
             return False
         return True
 
-    @_compat.deprecated_parameter(
-        deadline='v1.7',
-        fix='Change whitelisted_users to allowlisted_users.',
-        parameter_desc='whitelisted_users',
-        match=lambda args, kwargs: 'whitelisted_users' in kwargs,
-        rewrite=_fix_deprecated_allowlisted_users_args,
-    )
     def create_reservation(
         self,
         start_time: datetime.datetime,
@@ -296,13 +281,6 @@ class AbstractLocalProcessor(AbstractProcessor):
         else:
             return None
 
-    @_compat.deprecated_parameter(
-        deadline='v1.7',
-        fix='Change whitelisted_users to allowlisted_users.',
-        parameter_desc='whitelisted_users',
-        match=lambda args, kwargs: 'whitelisted_users' in kwargs,
-        rewrite=_fix_deprecated_allowlisted_users_args,
-    )
     def update_reservation(
         self,
         reservation_id: str,

--- a/cirq-google/cirq_google/engine/abstract_local_processor_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_processor_test.py
@@ -19,7 +19,6 @@ import datetime
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
-import cirq
 from cirq_google.cloud import quantum
 from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
 
@@ -123,16 +122,6 @@ def test_reservations():
 
     with pytest.raises(ValueError, match='does not exist'):
         p.update_reservation(reservation_id='invalid', allowlisted_users=users)
-
-    day = datetime.timedelta(hours=24)
-    with cirq.testing.assert_deprecated('Change whitelisted_users', deadline='v1.7'):
-        _ = p.create_reservation(
-            start_time=start_reservation + day,
-            end_time=end_reservation + day,
-            whitelisted_users=users,
-        )
-    with cirq.testing.assert_deprecated('Change whitelisted_users', deadline='v1.7'):
-        p.update_reservation(reservation_id=reservation.name, whitelisted_users=users)
 
 
 def test_list_reservations():

--- a/cirq-google/cirq_google/engine/engine_client.py
+++ b/cirq-google/cirq_google/engine/engine_client.py
@@ -19,7 +19,7 @@ import sys
 import warnings
 from collections.abc import AsyncIterable, Awaitable, Callable
 from functools import cached_property
-from typing import Any, TypeVar
+from typing import TypeVar
 
 import duet
 import proto
@@ -27,7 +27,6 @@ from google.api_core.exceptions import GoogleAPICallError, NotFound
 from google.protobuf import any_pb2, field_mask_pb2
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from cirq import _compat
 from cirq_google.cloud import quantum
 from cirq_google.engine import stream_manager
 from cirq_google.engine.asyncio_executor import AsyncioExecutor
@@ -40,13 +39,6 @@ from cirq_google.engine.processor_config import (
 
 _M = TypeVar('_M', bound=proto.Message)
 _R = TypeVar('_R')
-
-
-def _fix_deprecated_allowlisted_users_args(
-    args: tuple[Any, ...], kwargs: dict[str, Any]
-) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    kwargs['allowlisted_users'] = kwargs.pop('whitelisted_users')
-    return args, kwargs
 
 
 class EngineException(Exception):
@@ -965,13 +957,6 @@ class EngineClient:
 
     get_current_calibration = duet.sync(get_current_calibration_async)
 
-    @_compat.deprecated_parameter(
-        deadline='v1.7',
-        fix='Change whitelisted_users to allowlisted_users.',
-        parameter_desc='whitelisted_users',
-        match=lambda args, kwargs: 'whitelisted_users' in kwargs,
-        rewrite=_fix_deprecated_allowlisted_users_args,
-    )
     async def create_reservation_async(
         self,
         project_id: str,
@@ -1004,7 +989,7 @@ class EngineClient:
         )
         return await self._send_request_async(self.grpc_client.create_quantum_reservation, request)
 
-    create_reservation = duet.sync(create_reservation_async)  # type: ignore[misc]
+    create_reservation = duet.sync(create_reservation_async)
 
     async def cancel_reservation_async(
         self, project_id: str, processor_id: str, reservation_id: str
@@ -1110,13 +1095,6 @@ class EngineClient:
 
     list_reservations = duet.sync(list_reservations_async)
 
-    @_compat.deprecated_parameter(
-        deadline='v1.7',
-        fix='Change whitelisted_users to allowlisted_users.',
-        parameter_desc='whitelisted_users',
-        match=lambda args, kwargs: 'whitelisted_users' in kwargs,
-        rewrite=_fix_deprecated_allowlisted_users_args,
-    )
     async def update_reservation_async(
         self,
         project_id: str,
@@ -1167,7 +1145,7 @@ class EngineClient:
         )
         return await self._send_request_async(self.grpc_client.update_quantum_reservation, request)
 
-    update_reservation = duet.sync(update_reservation_async)  # type: ignore[misc]
+    update_reservation = duet.sync(update_reservation_async)
 
     async def list_time_slots_async(
         self, project_id: str, processor_id: str, filter_str: str = ''

--- a/cirq-google/cirq_google/engine/engine_client_test.py
+++ b/cirq-google/cirq_google/engine/engine_client_test.py
@@ -27,7 +27,6 @@ from google.protobuf import any_pb2
 from google.protobuf.field_mask_pb2 import FieldMask
 from google.protobuf.timestamp_pb2 import Timestamp
 
-import cirq.testing
 import cirq_google.engine.stream_manager as engine_stream_manager
 from cirq_google.cloud import quantum
 from cirq_google.engine.engine_client import EngineClient, EngineException
@@ -1620,10 +1619,6 @@ def test_create_reservation(client_constructor, default_engine_client):
             parent='projects/proj/processors/processor0', quantum_reservation=result
         )
     )
-    with cirq.testing.assert_deprecated('Change whitelisted_users', deadline='v1.7'):
-        _ = default_engine_client.create_reservation(
-            'proj', 'processor0', start, end, whitelisted_users=users
-        )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)
@@ -1758,15 +1753,6 @@ def test_update_reservation(client_constructor, default_engine_client):
             update_mask=FieldMask(paths=['start_time', 'end_time', 'allowlisted_users']),
         )
     )
-    with cirq.testing.assert_deprecated('Change whitelisted_users', deadline='v1.7'):
-        _ = default_engine_client.update_reservation(
-            'proj',
-            'processor0',
-            'papar-party-44',
-            start=datetime.datetime.fromtimestamp(1000001000),
-            end=datetime.datetime.fromtimestamp(1000002000),
-            whitelisted_users=['jeff@google.com'],
-        )
 
 
 @mock.patch.object(quantum, 'QuantumEngineServiceAsyncClient', autospec=True)

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping, Sequence
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
-from cirq import _compat
 from cirq_google.api import v2
 from cirq_google.devices import grid_device
 from cirq_google.engine import (
@@ -47,13 +46,6 @@ def _date_to_timestamp(union_time: datetime.datetime | datetime.date | int | Non
     elif isinstance(union_time, datetime.date):
         return int(datetime.datetime.combine(union_time, datetime.datetime.min.time()).timestamp())
     return None
-
-
-def _fix_deprecated_allowlisted_users_args(
-    args: tuple[Any, ...], kwargs: dict[str, Any]
-) -> tuple[tuple[Any, ...], dict[str, Any]]:
-    kwargs['allowlisted_users'] = kwargs.pop('whitelisted_users')
-    return args, kwargs
 
 
 class EngineProcessor(abstract_processor.AbstractProcessor):
@@ -343,13 +335,6 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         else:
             return None
 
-    @_compat.deprecated_parameter(
-        deadline='v1.7',
-        fix='Change whitelisted_users to allowlisted_users.',
-        parameter_desc='whitelisted_users',
-        match=lambda args, kwargs: 'whitelisted_users' in kwargs,
-        rewrite=_fix_deprecated_allowlisted_users_args,
-    )
     def create_reservation(
         self,
         start_time: datetime.datetime,
@@ -418,13 +403,6 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             self.project_id, self.processor_id, reservation_id
         )
 
-    @_compat.deprecated_parameter(
-        deadline='v1.7',
-        fix='Change whitelisted_users to allowlisted_users.',
-        parameter_desc='whitelisted_users',
-        match=lambda args, kwargs: 'whitelisted_users' in kwargs,
-        rewrite=_fix_deprecated_allowlisted_users_args,
-    )
     def update_reservation(
         self,
         reservation_id: str,

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -525,12 +525,6 @@ def test_create_reservation(create_reservation):
         datetime.datetime.fromtimestamp(1000003600),
         ['dstrain@google.com'],
     )
-    with cirq.testing.assert_deprecated('Change whitelisted_users', deadline='v1.7'):
-        _ = processor.create_reservation(
-            datetime.datetime.fromtimestamp(1000000000),
-            datetime.datetime.fromtimestamp(1000003600),
-            whitelisted_users=['dstrain@google.com'],
-        )
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.delete_reservation_async')
@@ -679,10 +673,6 @@ def test_update_reservation(update_reservation):
     update_reservation.assert_called_once_with(
         'proj', 'p0', 'rid', start=start, end=end, allowlisted_users=['dstrain@google.com']
     )
-    with cirq.testing.assert_deprecated('Change whitelisted_users', deadline='v1.7'):
-        _ = processor.update_reservation(
-            'rid', start, end, whitelisted_users=['dstrain@google.com']
-        )
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.list_reservations_async')


### PR DESCRIPTION
Remove deprecated objects with the `v1.7` deadline.

Ref: https://github.com/quantumlib/Cirq/blob/main/release.md#before-you-release-flush-the-deprecation-backlog
