### PR TITLE
Add PauliRotation gate for dense Pauli string exponentials

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -276,6 +276,8 @@ from cirq.ops import (
     PauliStringPhasor as PauliStringPhasor,
     PauliStringPhasorGate as PauliStringPhasorGate,
     PauliSum as PauliSum,
+    PauliRotation as PauliRotation,
+    PauliRotationGate as PauliRotationGate,
     PauliSumExponential as PauliSumExponential,
     PauliSumLike as PauliSumLike,
     phase_damp as phase_damp,

--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -183,6 +183,8 @@ def _class_resolver_dictionary() -> dict[str, ObjectFactory]:
         'ParallelGateFamily': cirq.ParallelGateFamily,
         'PauliInteractionGate': cirq.PauliInteractionGate,
         'PauliMeasurementGate': cirq.PauliMeasurementGate,
+        'PauliRotation': cirq.PauliRotation,
+        'PauliRotationGate': cirq.PauliRotationGate,
         'PauliString': cirq.PauliString,
         'PauliStringPhasor': cirq.PauliStringPhasor,
         'PauliStringPhasorGate': cirq.PauliStringPhasorGate,

--- a/cirq-core/cirq/ops/__init__.py
+++ b/cirq-core/cirq/ops/__init__.py
@@ -126,7 +126,10 @@ from cirq.ops.linear_combinations import (
 from cirq.ops.mixed_unitary_channel import MixedUnitaryChannel as MixedUnitaryChannel
 
 from cirq.ops.pauli_sum_exponential import PauliSumExponential as PauliSumExponential
-from cirq.ops.pauli_rotation import PauliRotation as PauliRotation, PauliRotationGate as PauliRotationGate
+from cirq.ops.pauli_rotation import (
+    PauliRotation as PauliRotation,
+    PauliRotationGate as PauliRotationGate,
+)
 
 from cirq.ops.pauli_measurement_gate import PauliMeasurementGate as PauliMeasurementGate
 

--- a/cirq-core/cirq/ops/__init__.py
+++ b/cirq-core/cirq/ops/__init__.py
@@ -126,6 +126,7 @@ from cirq.ops.linear_combinations import (
 from cirq.ops.mixed_unitary_channel import MixedUnitaryChannel as MixedUnitaryChannel
 
 from cirq.ops.pauli_sum_exponential import PauliSumExponential as PauliSumExponential
+from cirq.ops.pauli_rotation import PauliRotation as PauliRotation, PauliRotationGate as PauliRotationGate
 
 from cirq.ops.pauli_measurement_gate import PauliMeasurementGate as PauliMeasurementGate
 

--- a/cirq-core/cirq/ops/pauli_rotation.py
+++ b/cirq-core/cirq/ops/pauli_rotation.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Sequence, Set
 from types import NotImplementedType
 from typing import TYPE_CHECKING
 
@@ -40,9 +40,7 @@ class PauliRotationGate(raw_types.Gate):
         self, dense_pauli_string: dps.DensePauliString, *, exponent: cirq.TParamVal
     ) -> None:
         if dense_pauli_string.coefficient != 1:
-            raise ValueError(
-                'PauliRotationGate requires a unit Pauli string with coefficient 1.'
-            )
+            raise ValueError('PauliRotationGate requires a unit Pauli string with coefficient 1.')
         self._dense_pauli_string = dense_pauli_string
         self._exponent = exponent
 
@@ -63,7 +61,7 @@ class PauliRotationGate(raw_types.Gate):
     def _is_parameterized_(self) -> bool:
         return protocols.is_parameterized(self._exponent)
 
-    def _parameter_names_(self) -> tuple[str, ...]:
+    def _parameter_names_(self) -> Set[str]:
         return protocols.parameter_names(self._exponent)
 
     def _resolve_parameters_(
@@ -90,9 +88,7 @@ class PauliRotationGate(raw_types.Gate):
         # full Hilbert space (e.g. X⊗I rather than a single-qubit X).
         pauli_op = self._dense_pauli_string.on(*qubits)
         pauli_string = (
-            pauli_op.gate
-            if isinstance(pauli_op, gate_operation.GateOperation)
-            else pauli_op
+            pauli_op.gate if isinstance(pauli_op, gate_operation.GateOperation) else pauli_op
         )
         return [
             pauli_string_phasor.PauliStringPhasor(
@@ -109,11 +105,11 @@ class PauliRotationGate(raw_types.Gate):
     def __pow__(self, power: int) -> PauliRotationGate:
         return PauliRotationGate(self._dense_pauli_string, exponent=self._exponent * power)
 
+    def _json_dict_(self):
+        return protocols.obj_to_dict_helper(self, ['dense_pauli_string', 'exponent'])
+
     def __repr__(self) -> str:
-        return (
-            f'cirq.PauliRotationGate({self._dense_pauli_string!r}, '
-            f'exponent={self._exponent!r})'
-        )
+        return f'cirq.PauliRotationGate({self._dense_pauli_string!r}, exponent={self._exponent!r})'
 
 
 @value.value_equality(approximate=True)
@@ -158,9 +154,14 @@ class PauliRotation(gate_operation.GateOperation):
         return self.gate, self.qubits
 
     def __pow__(self, power: int) -> PauliRotation:
-        return PauliRotation(
-            self.dense_pauli_string, self.qubits, exponent=self.exponent * power
-        )
+        return PauliRotation(self.dense_pauli_string, self.qubits, exponent=self.exponent * power)
+
+    def _json_dict_(self):
+        return protocols.obj_to_dict_helper(self, ['dense_pauli_string', 'qubits', 'exponent'])
+
+    @classmethod
+    def _from_json_dict_(cls, dense_pauli_string, qubits, exponent, **kwargs):
+        return PauliRotation(pauli_string=dense_pauli_string, qubits=qubits, exponent=exponent)
 
     def __repr__(self) -> str:
         return (

--- a/cirq-core/cirq/ops/pauli_rotation.py
+++ b/cirq-core/cirq/ops/pauli_rotation.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from types import NotImplementedType
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from cirq import protocols, value
+from cirq.ops import dense_pauli_string as dps, gate_operation, pauli_string_phasor, raw_types
+
+if TYPE_CHECKING:
+    import cirq
+
+
+@value.value_equality(approximate=True)
+class PauliRotationGate(raw_types.Gate):
+    r"""A gate representing :math:`e^{i \theta P}` for a Pauli string :math:`P`.
+
+    The Pauli string is specified as a `cirq.DensePauliString`, which preserves
+    identity factors (unlike `cirq.PauliString`). For a unit Pauli operator
+    :math:`P`, the unitary is :math:`\cos(\theta) I + i \sin(\theta) P`.
+    """
+
+    def __init__(
+        self, dense_pauli_string: dps.DensePauliString, *, exponent: cirq.TParamVal
+    ) -> None:
+        if dense_pauli_string.coefficient != 1:
+            raise ValueError(
+                'PauliRotationGate requires a unit Pauli string with coefficient 1.'
+            )
+        self._dense_pauli_string = dense_pauli_string
+        self._exponent = exponent
+
+    @property
+    def dense_pauli_string(self) -> dps.DensePauliString:
+        return self._dense_pauli_string
+
+    @property
+    def exponent(self) -> cirq.TParamVal:
+        return self._exponent
+
+    def _value_equality_values_(self):
+        return self._dense_pauli_string, self._exponent
+
+    def num_qubits(self) -> int:
+        return len(self._dense_pauli_string.pauli_mask)
+
+    def _is_parameterized_(self) -> bool:
+        return protocols.is_parameterized(self._exponent)
+
+    def _parameter_names_(self) -> tuple[str, ...]:
+        return protocols.parameter_names(self._exponent)
+
+    def _resolve_parameters_(
+        self, resolver: cirq.ParamResolver, recursive: bool
+    ) -> PauliRotationGate:
+        return PauliRotationGate(
+            self._dense_pauli_string,
+            exponent=protocols.resolve_parameters(self._exponent, resolver, recursive),
+        )
+
+    def _unitary_(self) -> np.ndarray | NotImplementedType:
+        if protocols.is_parameterized(self._exponent):
+            return NotImplemented
+        pauli_unitary = protocols.unitary(self._dense_pauli_string)
+        cos_theta = np.cos(self._exponent)
+        sin_theta = np.sin(self._exponent)
+        identity = np.eye(pauli_unitary.shape[0], dtype=complex)
+        return cos_theta * identity + 1j * sin_theta * pauli_unitary
+
+    def _decompose_(self, qubits: Sequence[cirq.Qid]) -> cirq.OP_TREE:
+        if protocols.is_parameterized(self._exponent):
+            return NotImplemented
+        pauli_string_gate = self._dense_pauli_string.on(*qubits)
+        if isinstance(pauli_string_gate, gate_operation.GateOperation):
+            pauli_string = pauli_string_gate.gate
+        else:
+            pauli_string = pauli_string_gate
+        return [
+            pauli_string_phasor.PauliStringPhasor(
+                pauli_string,
+                qubits=qubits,
+                exponent_pos=self._exponent / np.pi,
+                exponent_neg=-self._exponent / np.pi,
+            )
+        ]
+
+    def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> str:
+        return f'PR({self._dense_pauli_string},{self._exponent})'
+
+    def __pow__(self, power: int) -> PauliRotationGate:
+        return PauliRotationGate(self._dense_pauli_string, exponent=self._exponent * power)
+
+    def __repr__(self) -> str:
+        return (
+            f'cirq.PauliRotationGate({self._dense_pauli_string!r}, '
+            f'exponent={self._exponent!r})'
+        )
+
+
+@value.value_equality(approximate=True)
+class PauliRotation(gate_operation.GateOperation):
+    r"""An operation representing :math:`e^{i \theta P}` for a Pauli string :math:`P`."""
+
+    def __init__(
+        self,
+        pauli_string: dps.DensePauliString | str,
+        qubits: Sequence[cirq.Qid],
+        *,
+        exponent: cirq.TParamVal,
+    ) -> None:
+        if isinstance(pauli_string, str):
+            dense_pauli_string = dps.DensePauliString(pauli_string)
+        else:
+            dense_pauli_string = pauli_string
+        if len(dense_pauli_string.pauli_mask) != len(qubits):
+            raise ValueError(
+                'Pauli string length must match number of qubits. '
+                f'Got {len(dense_pauli_string.pauli_mask)} Paulis and {len(qubits)} qubits.'
+            )
+        gate = PauliRotationGate(dense_pauli_string, exponent=exponent)
+        super().__init__(gate, qubits)
+
+    @property
+    def gate(self) -> PauliRotationGate:
+        return super().gate  # type: ignore[return-value]
+
+    @property
+    def exponent(self) -> cirq.TParamVal:
+        return self.gate.exponent
+
+    @property
+    def dense_pauli_string(self) -> dps.DensePauliString:
+        return self.gate.dense_pauli_string
+
+    def _value_equality_values_(self):
+        return self.gate, self.qubits
+
+    def __pow__(self, power: int) -> PauliRotation:
+        return PauliRotation(
+            self.dense_pauli_string, self.qubits, exponent=self.exponent * power
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f'cirq.PauliRotation({self.dense_pauli_string!r}, '
+            f'{self.qubits!r}, exponent={self.exponent!r})'
+        )

--- a/cirq-core/cirq/ops/pauli_rotation.py
+++ b/cirq-core/cirq/ops/pauli_rotation.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The Cirq Developers
+# Copyright 2025 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,11 +86,14 @@ class PauliRotationGate(raw_types.Gate):
     def _decompose_(self, qubits: Sequence[cirq.Qid]) -> cirq.OP_TREE:
         if protocols.is_parameterized(self._exponent):
             return NotImplemented
-        pauli_string_gate = self._dense_pauli_string.on(*qubits)
-        if isinstance(pauli_string_gate, gate_operation.GateOperation):
-            pauli_string = pauli_string_gate.gate
-        else:
-            pauli_string = pauli_string_gate
+        # Pass explicit qubits so PauliStringPhasor keeps identity factors in the
+        # full Hilbert space (e.g. X⊗I rather than a single-qubit X).
+        pauli_op = self._dense_pauli_string.on(*qubits)
+        pauli_string = (
+            pauli_op.gate
+            if isinstance(pauli_op, gate_operation.GateOperation)
+            else pauli_op
+        )
         return [
             pauli_string_phasor.PauliStringPhasor(
                 pauli_string,
@@ -115,7 +118,10 @@ class PauliRotationGate(raw_types.Gate):
 
 @value.value_equality(approximate=True)
 class PauliRotation(gate_operation.GateOperation):
-    r"""An operation representing :math:`e^{i \theta P}` for a Pauli string :math:`P`."""
+    r"""An operation representing :math:`e^{i \theta P}` for a Pauli string :math:`P`.
+
+    Accepts a `cirq.DensePauliString` label or string such as ``'XI'``.
+    """
 
     def __init__(
         self,

--- a/cirq-core/cirq/ops/pauli_rotation_test.py
+++ b/cirq-core/cirq/ops/pauli_rotation_test.py
@@ -18,7 +18,6 @@ import sympy
 
 import cirq
 
-
 _ATOL = 1e-8
 
 
@@ -45,15 +44,11 @@ def _expected_pauli_rotation_unitary(pauli_label: str, exponent: float) -> np.nd
         ('XYZ', np.pi / 9),
     ],
 )
-def test_pauli_rotation_unitary_matches_analytic_formula(
-    pauli_label: str, exponent: float
-) -> None:
+def test_pauli_rotation_unitary_matches_analytic_formula(pauli_label: str, exponent: float) -> None:
     qubits = cirq.LineQubit.range(len(pauli_label))
     op = cirq.PauliRotation(pauli_label, qubits, exponent=exponent)
     expected = _expected_pauli_rotation_unitary(pauli_label, exponent)
-    cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(op), expected, atol=_ATOL
-    )
+    cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(op), expected, atol=_ATOL)
 
 
 def test_pauli_rotation_differs_from_pauli_sum_exponential() -> None:
@@ -61,9 +56,7 @@ def test_pauli_rotation_differs_from_pauli_sum_exponential() -> None:
     theta = np.pi / 4
     rotation = cirq.unitary(cirq.PauliRotation('XI', [q0, q1], exponent=theta))
     wrong = cirq.unitary(
-        cirq.PauliSumExponential(
-            cirq.DensePauliString('XI')(*[q0, q1]), exponent=theta
-        )
+        cirq.PauliSumExponential(cirq.DensePauliString('XI')(*[q0, q1]), exponent=theta)
     )
     assert rotation.shape == (4, 4)
     assert wrong.shape == (2, 2)
@@ -71,12 +64,9 @@ def test_pauli_rotation_differs_from_pauli_sum_exponential() -> None:
 
 
 @pytest.mark.parametrize(
-    'pauli_label,exponent',
-    [('X', np.pi / 5), ('YZ', np.pi / 6), ('XY', np.pi / 8)],
+    'pauli_label,exponent', [('X', np.pi / 5), ('YZ', np.pi / 6), ('XY', np.pi / 8)]
 )
-def test_pauli_rotation_decomposition_matches_unitary(
-    pauli_label: str, exponent: float
-) -> None:
+def test_pauli_rotation_decomposition_matches_unitary(pauli_label: str, exponent: float) -> None:
     qubits = cirq.LineQubit.range(len(pauli_label))
     op = cirq.PauliRotation(pauli_label, qubits, exponent=exponent)
     decomposed = cirq.Circuit(cirq.decompose(op))
@@ -87,9 +77,7 @@ def test_pauli_rotation_decomposition_matches_unitary(
 
 def test_pauli_rotation_repr_roundtrip() -> None:
     q0, q1 = cirq.LineQubit.range(2)
-    cirq.testing.assert_equivalent_repr(
-        cirq.PauliRotation('XI', [q0, q1], exponent=np.pi / 4)
-    )
+    cirq.testing.assert_equivalent_repr(cirq.PauliRotation('XI', [q0, q1], exponent=np.pi / 4))
     cirq.testing.assert_equivalent_repr(
         cirq.PauliRotationGate(cirq.DensePauliString('XI'), exponent=np.pi / 4)
     )
@@ -116,6 +104,49 @@ def test_pauli_rotation_parameter_resolution() -> None:
     assert resolved_op.gate.exponent == resolved_angle
 
     expected = _expected_pauli_rotation_unitary('XI', resolved_angle)
-    cirq.testing.assert_allclose_up_to_global_phase(
-        cirq.unitary(resolved_op), expected, atol=_ATOL
-    )
+    cirq.testing.assert_allclose_up_to_global_phase(cirq.unitary(resolved_op), expected, atol=_ATOL)
+
+
+def test_pauli_rotation_gate_rejects_non_unit_coefficient() -> None:
+    dps = cirq.DensePauliString('X') * 2
+    with pytest.raises(ValueError, match='unit Pauli string'):
+        cirq.PauliRotationGate(dps, exponent=0.1)
+
+
+def test_pauli_rotation_rejects_qubit_mismatch() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    with pytest.raises(ValueError, match='must match'):
+        cirq.PauliRotation('X', [q0, q1], exponent=0.1)
+
+
+def test_pauli_rotation_gate_unitary_not_implemented_when_parameterized() -> None:
+    theta = sympy.Symbol('theta')
+    gate = cirq.PauliRotationGate(cirq.DensePauliString('X'), exponent=theta)
+    assert cirq.unitary(gate, default=None) is None
+
+
+def test_pauli_rotation_gate_decompose_not_implemented_when_parameterized() -> None:
+    theta = sympy.Symbol('theta')
+    gate = cirq.PauliRotationGate(cirq.DensePauliString('X'), exponent=theta)
+    result = gate._decompose_((cirq.LineQubit(0),))
+    assert result is NotImplemented
+
+
+def test_pauli_rotation_gate_circuit_diagram_info() -> None:
+    gate = cirq.PauliRotationGate(cirq.DensePauliString('X'), exponent=0.5)
+    info = gate._circuit_diagram_info_(cirq.CircuitDiagramInfoArgs.UNINFORMED_DEFAULT)
+    assert 'PR(' in str(info)
+
+
+def test_pauli_rotation_gate_pow() -> None:
+    gate = cirq.PauliRotationGate(cirq.DensePauliString('X'), exponent=np.pi / 4)
+    doubled = gate**2
+    assert doubled == cirq.PauliRotationGate(cirq.DensePauliString('X'), exponent=np.pi / 2)
+
+
+def test_pauli_rotation_pow() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.PauliRotation('XI', [q0, q1], exponent=np.pi / 4)
+    doubled = op**2
+    expected = cirq.PauliRotation('XI', [q0, q1], exponent=np.pi / 2)
+    assert doubled == expected

--- a/cirq-core/cirq/ops/pauli_rotation_test.py
+++ b/cirq-core/cirq/ops/pauli_rotation_test.py
@@ -1,0 +1,122 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import sympy
+
+import cirq
+
+
+_ATOL = 1e-8
+
+
+def _expected_pauli_rotation_unitary(
+    pauli_label: str, exponent: float
+) -> np.ndarray:
+    pauli = cirq.unitary(cirq.DensePauliString(pauli_label))
+    cos_theta = np.cos(exponent)
+    sin_theta = np.sin(exponent)
+    identity = np.eye(pauli.shape[0], dtype=complex)
+    return cos_theta * identity + 1j * sin_theta * pauli
+
+
+@pytest.mark.parametrize(
+    'pauli_label,exponent',
+    [
+        ('X', 0.0),
+        ('X', np.pi / 7),
+        ('Y', np.pi / 3),
+        ('Z', -np.pi / 5),
+        ('XI', np.pi / 4),
+        ('IX', np.pi / 6),
+        ('XY', np.pi / 8),
+        ('ZZ', np.pi / 2),
+        ('XYZ', np.pi / 9),
+    ],
+)
+def test_pauli_rotation_unitary_matches_analytic_formula(
+    pauli_label: str, exponent: float
+) -> None:
+    qubits = cirq.LineQubit.range(len(pauli_label))
+    op = cirq.PauliRotation(pauli_label, qubits, exponent=exponent)
+    expected = _expected_pauli_rotation_unitary(pauli_label, exponent)
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(op), expected, atol=_ATOL
+    )
+
+
+def test_pauli_rotation_differs_from_pauli_sum_exponential() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    theta = np.pi / 4
+    rotation = cirq.unitary(cirq.PauliRotation('XI', [q0, q1], exponent=theta))
+    wrong = cirq.unitary(
+        cirq.PauliSumExponential(
+            cirq.DensePauliString('XI')(*[q0, q1]), exponent=theta
+        )
+    )
+    assert rotation.shape == (4, 4)
+    assert wrong.shape == (2, 2)
+    assert not np.allclose(rotation[:2, :2], wrong)
+
+
+@pytest.mark.parametrize(
+    'pauli_label,exponent',
+    [('X', np.pi / 5), ('YZ', np.pi / 6), ('XY', np.pi / 8)],
+)
+def test_pauli_rotation_decomposition_matches_unitary(
+    pauli_label: str, exponent: float
+) -> None:
+    qubits = cirq.LineQubit.range(len(pauli_label))
+    op = cirq.PauliRotation(pauli_label, qubits, exponent=exponent)
+    decomposed = cirq.Circuit(cirq.decompose(op))
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(op), cirq.unitary(decomposed), atol=_ATOL
+    )
+
+
+def test_pauli_rotation_repr_roundtrip() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    cirq.testing.assert_equivalent_repr(
+        cirq.PauliRotation('XI', [q0, q1], exponent=np.pi / 4)
+    )
+    cirq.testing.assert_equivalent_repr(
+        cirq.PauliRotationGate(cirq.DensePauliString('XI'), exponent=np.pi / 4)
+    )
+
+
+def test_pauli_rotation_parameter_resolution() -> None:
+    theta = sympy.Symbol('theta')
+    q0, q1 = cirq.LineQubit.range(2)
+    gate = cirq.PauliRotationGate(cirq.DensePauliString('XI'), exponent=theta)
+    op = cirq.PauliRotation('XI', [q0, q1], exponent=theta)
+
+    assert cirq.is_parameterized(gate)
+    assert cirq.is_parameterized(op)
+    assert 'theta' in gate._parameter_names_()
+
+    resolved_angle = np.pi / 11
+    resolver = cirq.ParamResolver({'theta': resolved_angle})
+    resolved_gate = cirq.resolve_parameters(gate, resolver)
+    resolved_op = cirq.resolve_parameters(op, resolver)
+
+    assert not cirq.is_parameterized(resolved_gate)
+    assert not cirq.is_parameterized(resolved_op)
+    assert resolved_gate.exponent == resolved_angle
+    assert resolved_op.gate.exponent == resolved_angle
+
+    expected = _expected_pauli_rotation_unitary('XI', resolved_angle)
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq.unitary(resolved_op), expected, atol=_ATOL
+    )

--- a/cirq-core/cirq/ops/pauli_rotation_test.py
+++ b/cirq-core/cirq/ops/pauli_rotation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2026 The Cirq Developers
+# Copyright 2025 The Cirq Developers
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,9 +22,8 @@ import cirq
 _ATOL = 1e-8
 
 
-def _expected_pauli_rotation_unitary(
-    pauli_label: str, exponent: float
-) -> np.ndarray:
+def _expected_pauli_rotation_unitary(pauli_label: str, exponent: float) -> np.ndarray:
+    """Reference unitary for U = cos(theta)I + i sin(theta) P."""
     pauli = cirq.unitary(cirq.DensePauliString(pauli_label))
     cos_theta = np.cos(exponent)
     sin_theta = np.sin(exponent)

--- a/cirq-core/cirq/protocols/json_test_data/PauliRotation.json
+++ b/cirq-core/cirq/protocols/json_test_data/PauliRotation.json
@@ -1,0 +1,26 @@
+{
+  "cirq_type": "PauliRotation",
+  "dense_pauli_string": {
+    "cirq_type": "DensePauliString",
+    "pauli_mask": [
+      1,
+      0
+    ],
+    "coefficient": {
+      "cirq_type": "complex",
+      "real": 1.0,
+      "imag": 0.0
+    }
+  },
+  "qubits": [
+    {
+      "cirq_type": "LineQubit",
+      "x": 0
+    },
+    {
+      "cirq_type": "LineQubit",
+      "x": 1
+    }
+  ],
+  "exponent": 0.7853981633974483
+}

--- a/cirq-core/cirq/protocols/json_test_data/PauliRotation.repr
+++ b/cirq-core/cirq/protocols/json_test_data/PauliRotation.repr
@@ -1,0 +1,1 @@
+cirq.PauliRotation(cirq.DensePauliString('XI', coefficient=(1+0j)), (cirq.LineQubit(0), cirq.LineQubit(1)), exponent=0.7853981633974483)

--- a/cirq-core/cirq/protocols/json_test_data/PauliRotationGate.json
+++ b/cirq-core/cirq/protocols/json_test_data/PauliRotationGate.json
@@ -1,0 +1,16 @@
+{
+  "cirq_type": "PauliRotationGate",
+  "dense_pauli_string": {
+    "cirq_type": "DensePauliString",
+    "pauli_mask": [
+      1,
+      0
+    ],
+    "coefficient": {
+      "cirq_type": "complex",
+      "real": 1.0,
+      "imag": 0.0
+    }
+  },
+  "exponent": 0.7853981633974483
+}

--- a/cirq-core/cirq/protocols/json_test_data/PauliRotationGate.repr
+++ b/cirq-core/cirq/protocols/json_test_data/PauliRotationGate.repr
@@ -1,0 +1,1 @@
+cirq.PauliRotationGate(cirq.DensePauliString('XI', coefficient=(1+0j)), exponent=0.7853981633974483)


### PR DESCRIPTION
## Summary
Adds `PauliRotation` / `PauliRotationGate` using `DensePauliString` so identity factors are preserved (e.g. `XI` stays two-qubit).

Implements `U = cos(θ)I + i sin(θ)P` and decomposes via `PauliStringPhasor` with explicit `qubits`.

Closes #6598

## Tests
`pytest cirq/ops/pauli_rotation_test.py` — 15 tests.

AI disclosure: Cursor IDE was used only to read/search the codebase and help debug the issue. All code in this PR was written and reviewed by me.