### PR TITLE
Use stable Cirq in demo notebooks after cirq release

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -47,10 +47,7 @@ from dev_tools.notebooks import filter_notebooks, list_all_notebooks, REPO_ROOT,
 # by the notebooks in question when adding notebooks to this list.
 # For more information, please see the section "Lifecycle" in docs/dev/notebooks.md.
 
-NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = [
-    # needs https://github.com/quantumlib/Cirq/pull/7972
-    'docs/hardware/pasqal/getting_started.ipynb'
-]
+NOTEBOOKS_DEPENDING_ON_UNRELEASED_FEATURES: list[str] = []
 
 # By default all notebooks should be tested, however, this list contains exceptions to the rule
 # please always add a reason for skipping.

--- a/docs/hardware/pasqal/getting_started.ipynb
+++ b/docs/hardware/pasqal/getting_started.ipynb
@@ -63,17 +63,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "98bffd06e567"
-   },
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Note: this notebook relies on unreleased Cirq features. If you want to try these features, make sure you install cirq via `pip install --upgrade cirq~=1.0.dev`."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -85,7 +74,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --upgrade --quiet cirq~=1.0.dev\n",
+    "    !pip install --quiet cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "import cirq_pasqal\n",


### PR DESCRIPTION
Development features were released with cirq-1.7.0.
Notebooks that need them can use stable Cirq.

Ref: https://github.com/quantumlib/Cirq/blob/main/docs/dev/notebooks.md#lifecycle
