### PR TITLE
Add support for confusion map to PauliMeasurementGate

### DIFF
--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -45,7 +45,7 @@ def measure_single_paulistring(
             If none provided, it defaults to a comma-separated list of
             `str(qubit)` for each of the target qubits.
         confusion_matrix: A 2x2 numpy array representing the confusion matrix
-            for the measurement qubit.
+            for the measured observable.
 
     Returns:
         An operation measuring the pauli observable.

--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -35,7 +35,7 @@ def _default_measurement_key(qubits: Iterable[raw_types.Qid]) -> str:
 def measure_single_paulistring(
     pauli_observable: pauli_string.PauliString,
     key: str | cirq.MeasurementKey | None = None,
-    confusion_map: dict[tuple[int, ...], np.ndarray] | None = None,
+    confusion_matrix: np.ndarray | None = None,
 ) -> raw_types.Operation:
     """Returns a single PauliMeasurementGate which measures the pauli observable
 
@@ -44,10 +44,8 @@ def measure_single_paulistring(
         key: Optional `str` or `cirq.MeasurementKey` that gate should use.
             If none provided, it defaults to a comma-separated list of
             `str(qubit)` for each of the target qubits.
-        confusion_map: A map of qubit index sets (using indices in the
-            operation generated from this gate) to the 2D confusion matrix
-            for those qubits. Since PauliMeasurementGate has only a single
-            measurement outcome, the only valid index is 0.
+        confusion_matrix: A 2x2 numpy array representing the confusion matrix
+            for the measurement qubit.
 
     Returns:
         An operation measuring the pauli observable.
@@ -68,7 +66,9 @@ def measure_single_paulistring(
     if key is None:
         key = _default_measurement_key(pauli_observable)
     return PauliMeasurementGate(
-        pauli_observable.dense(list(pauli_observable.keys())), key, confusion_map=confusion_map
+        pauli_observable.dense(list(pauli_observable.keys())),
+        key,
+        confusion_matrix=confusion_matrix,
     ).on(*pauli_observable.keys())
 
 

--- a/cirq-core/cirq/ops/measure_util.py
+++ b/cirq-core/cirq/ops/measure_util.py
@@ -33,7 +33,9 @@ def _default_measurement_key(qubits: Iterable[raw_types.Qid]) -> str:
 
 
 def measure_single_paulistring(
-    pauli_observable: pauli_string.PauliString, key: str | cirq.MeasurementKey | None = None
+    pauli_observable: pauli_string.PauliString,
+    key: str | cirq.MeasurementKey | None = None,
+    confusion_map: dict[tuple[int, ...], np.ndarray] | None = None,
 ) -> raw_types.Operation:
     """Returns a single PauliMeasurementGate which measures the pauli observable
 
@@ -42,6 +44,10 @@ def measure_single_paulistring(
         key: Optional `str` or `cirq.MeasurementKey` that gate should use.
             If none provided, it defaults to a comma-separated list of
             `str(qubit)` for each of the target qubits.
+        confusion_map: A map of qubit index sets (using indices in the
+            operation generated from this gate) to the 2D confusion matrix
+            for those qubits. Since PauliMeasurementGate has only a single
+            measurement outcome, the only valid index is 0.
 
     Returns:
         An operation measuring the pauli observable.
@@ -61,9 +67,9 @@ def measure_single_paulistring(
 
     if key is None:
         key = _default_measurement_key(pauli_observable)
-    return PauliMeasurementGate(pauli_observable.dense(list(pauli_observable.keys())), key).on(
-        *pauli_observable.keys()
-    )
+    return PauliMeasurementGate(
+        pauli_observable.dense(list(pauli_observable.keys())), key, confusion_map=confusion_map
+    ).on(*pauli_observable.keys())
 
 
 def measure_paulistring_terms(

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -98,6 +98,12 @@ def test_measure_single_paulistring() -> None:
         ps.values(), key='a'
     ).on(*ps.keys())
 
+    # Test with confusion map
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    assert cirq.measure_single_paulistring(
+        ps, key='a', confusion_map=cmap
+    ) == cirq.PauliMeasurementGate(ps.values(), key='a', confusion_map=cmap).on(*ps.keys())
+
     # Test with negative coefficient
     ps_neg = -cirq.Y(cirq.LineQubit(0)) * cirq.Y(cirq.LineQubit(1))
     assert cirq.measure_single_paulistring(ps_neg, key='1').gate == cirq.PauliMeasurementGate(

--- a/cirq-core/cirq/ops/measure_util_test.py
+++ b/cirq-core/cirq/ops/measure_util_test.py
@@ -98,11 +98,11 @@ def test_measure_single_paulistring() -> None:
         ps.values(), key='a'
     ).on(*ps.keys())
 
-    # Test with confusion map
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    # Test with confusion matrix
+    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
     assert cirq.measure_single_paulistring(
-        ps, key='a', confusion_map=cmap
-    ) == cirq.PauliMeasurementGate(ps.values(), key='a', confusion_map=cmap).on(*ps.keys())
+        ps, key='a', confusion_matrix=cmat
+    ) == cirq.PauliMeasurementGate(ps.values(), key='a', confusion_matrix=cmat).on(*ps.keys())
 
     # Test with negative coefficient
     ps_neg = -cirq.Y(cirq.LineQubit(0)) * cirq.Y(cirq.LineQubit(1))

--- a/cirq-core/cirq/ops/pauli_measurement_gate.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import Any, cast, TYPE_CHECKING
 
+import numpy as np
+
 from cirq import protocols, value
 from cirq.ops import (
     dense_pauli_string as dps,
@@ -43,6 +45,7 @@ class PauliMeasurementGate(raw_types.Gate):
         self,
         observable: cirq.BaseDensePauliString | Iterable[cirq.Pauli],
         key: str | cirq.MeasurementKey = '',
+        confusion_map: dict[tuple[int, ...], np.ndarray] | None = None,
     ) -> None:
         """Inits PauliMeasurementGate.
 
@@ -52,6 +55,9 @@ class PauliMeasurementGate(raw_types.Gate):
                 If you wish to measure pauli observables with coefficient -1,
                 then pass a `cirq.DensePauliString` as observable.
             key: The string key of the measurement.
+            confusion_map: A map of qubit index sets (using indices in the
+                operation generated from this gate) to the 2D confusion matrix
+                for those qubits. Indices not included use the identity.
 
         Raises:
             ValueError: If the observable is empty.
@@ -74,6 +80,9 @@ class PauliMeasurementGate(raw_types.Gate):
         self._mkey = (
             key if isinstance(key, value.MeasurementKey) else value.MeasurementKey(name=key)
         )
+        self._confusion_map = confusion_map or {}
+        if any(x >= len(self._observable) for idx in self._confusion_map for x in idx):
+            raise ValueError('Confusion matrices have index out of bounds.')
 
     @property
     def key(self) -> str:
@@ -82,6 +91,10 @@ class PauliMeasurementGate(raw_types.Gate):
     @property
     def mkey(self) -> cirq.MeasurementKey:
         return self._mkey
+
+    @property
+    def confusion_map(self) -> dict[tuple[int, ...], np.ndarray]:
+        return self._confusion_map
 
     def _qid_shape_(self) -> tuple[int, ...]:
         return (2,) * len(self._observable)
@@ -93,7 +106,7 @@ class PauliMeasurementGate(raw_types.Gate):
         """Creates a pauli measurement gate with a new key but otherwise identical."""
         if key == self.key:
             return self
-        return PauliMeasurementGate(self._observable, key=key)
+        return PauliMeasurementGate(self._observable, key=key, confusion_map=self.confusion_map)
 
     def _with_key_path_(self, path: tuple[str, ...]) -> PauliMeasurementGate:
         return self.with_key(self.mkey._with_key_path_(path))
@@ -119,7 +132,7 @@ class PauliMeasurementGate(raw_types.Gate):
             else dps.DensePauliString(observable)
         ) == self._observable:
             return self
-        return PauliMeasurementGate(observable, key=self.key)
+        return PauliMeasurementGate(observable, key=self.key, confusion_map=self.confusion_map)
 
     def _is_measurement_(self) -> bool:
         return True

--- a/cirq-core/cirq/ops/pauli_measurement_gate.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate.py
@@ -59,7 +59,7 @@ class PauliMeasurementGate(raw_types.Gate):
                 for the measurement qubit.
 
         Raises:
-            ValueError: If the observable is empty
+            ValueError: If the observable is empty.
         """
         if not observable:
             raise ValueError(f'Pauli observable {observable} is empty.')
@@ -154,13 +154,16 @@ class PauliMeasurementGate(raw_types.Gate):
         any_qubit = qubits[0]
         to_z_ops = op_tree.freeze_op_tree(self._observable.on(*qubits).to_z_basis_ops())
         xor_decomp = tuple(pauli_string_phasor.xor_nonlocal_decompose(qubits, any_qubit))
-        cmap: dict[tuple[int, ...], np.ndarray] | None = None
+        confusion_map: dict[tuple[int, ...], np.ndarray] | None = None
         if self.confusion_matrix is not None:
-            cmap = {(0,): self.confusion_matrix}
+            confusion_map = {(0,): self.confusion_matrix}
         yield to_z_ops
         yield xor_decomp
         yield measurement_gate.MeasurementGate(
-            1, self.mkey, invert_mask=(self._observable.coefficient != 1,), confusion_map=cmap
+            1,
+            self.mkey,
+            invert_mask=(self._observable.coefficient != 1,),
+            confusion_map=confusion_map,
         ).on(any_qubit)
         yield protocols.inverse(xor_decomp)
         yield protocols.inverse(to_z_ops)
@@ -198,11 +201,7 @@ class PauliMeasurementGate(raw_types.Gate):
         return f'cirq.PauliMeasurementGate({", ".join(args)})'
 
     def _value_equality_values_(self) -> Any:
-        hashable_mat = (
-            None
-            if self.confusion_matrix is None
-            else tuple(v for _, v in np.ndenumerate(self.confusion_matrix))
-        )
+        hashable_mat = None if self.confusion_matrix is None else tuple(self.confusion_matrix.flat)
         return self.key, self._observable, hashable_mat
 
     def _json_dict_(self) -> dict[str, Any]:

--- a/cirq-core/cirq/ops/pauli_measurement_gate.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate.py
@@ -45,7 +45,7 @@ class PauliMeasurementGate(raw_types.Gate):
         self,
         observable: cirq.BaseDensePauliString | Iterable[cirq.Pauli],
         key: str | cirq.MeasurementKey = '',
-        confusion_map: dict[tuple[int, ...], np.ndarray] | None = None,
+        confusion_matrix: np.ndarray | None = None,
     ) -> None:
         """Inits PauliMeasurementGate.
 
@@ -55,14 +55,11 @@ class PauliMeasurementGate(raw_types.Gate):
                 If you wish to measure pauli observables with coefficient -1,
                 then pass a `cirq.DensePauliString` as observable.
             key: The string key of the measurement.
-            confusion_map: A map of qubit index sets (using indices in the
-                operation generated from this gate) to the 2D confusion matrix
-                for those qubits. Since PauliMeasurementGate has only a single
-                measurement outcome, the only valid index is 0.
+            confusion_matrix: A 2x2 numpy array representing the confusion matrix
+                for the measurement qubit.
 
         Raises:
-            ValueError: If the observable is empty, or if confusion_map has
-                indices greater than or equal to 1.
+            ValueError: If the observable is empty
         """
         if not observable:
             raise ValueError(f'Pauli observable {observable} is empty.')
@@ -82,9 +79,7 @@ class PauliMeasurementGate(raw_types.Gate):
         self._mkey = (
             key if isinstance(key, value.MeasurementKey) else value.MeasurementKey(name=key)
         )
-        self._confusion_map = confusion_map or {}
-        if any(x >= 1 for idx in self._confusion_map for x in idx):
-            raise ValueError('Confusion matrices have index out of bounds.')
+        self._confusion_matrix = confusion_matrix
 
     @property
     def key(self) -> str:
@@ -95,8 +90,8 @@ class PauliMeasurementGate(raw_types.Gate):
         return self._mkey
 
     @property
-    def confusion_map(self) -> dict[tuple[int, ...], np.ndarray]:
-        return self._confusion_map
+    def confusion_matrix(self) -> np.ndarray | None:
+        return self._confusion_matrix
 
     def _qid_shape_(self) -> tuple[int, ...]:
         return (2,) * len(self._observable)
@@ -108,7 +103,9 @@ class PauliMeasurementGate(raw_types.Gate):
         """Creates a pauli measurement gate with a new key but otherwise identical."""
         if key == self.key:
             return self
-        return PauliMeasurementGate(self._observable, key=key, confusion_map=self.confusion_map)
+        return PauliMeasurementGate(
+            self._observable, key=key, confusion_matrix=self.confusion_matrix
+        )
 
     def _with_key_path_(self, path: tuple[str, ...]) -> PauliMeasurementGate:
         return self.with_key(self.mkey._with_key_path_(path))
@@ -134,7 +131,9 @@ class PauliMeasurementGate(raw_types.Gate):
             else dps.DensePauliString(observable)
         ) == self._observable:
             return self
-        return PauliMeasurementGate(observable, key=self.key, confusion_map=self.confusion_map)
+        return PauliMeasurementGate(
+            observable, key=self.key, confusion_matrix=self.confusion_matrix
+        )
 
     def _is_measurement_(self) -> bool:
         return True
@@ -155,13 +154,13 @@ class PauliMeasurementGate(raw_types.Gate):
         any_qubit = qubits[0]
         to_z_ops = op_tree.freeze_op_tree(self._observable.on(*qubits).to_z_basis_ops())
         xor_decomp = tuple(pauli_string_phasor.xor_nonlocal_decompose(qubits, any_qubit))
+        cmap: dict[tuple[int, ...], np.ndarray] | None = None
+        if self.confusion_matrix is not None:
+            cmap = {(0,): self.confusion_matrix}
         yield to_z_ops
         yield xor_decomp
         yield measurement_gate.MeasurementGate(
-            1,
-            self.mkey,
-            invert_mask=(self._observable.coefficient != 1,),
-            confusion_map=self.confusion_map,
+            1, self.mkey, invert_mask=(self._observable.coefficient != 1,), confusion_map=cmap
         ).on(any_qubit)
         yield protocols.inverse(xor_decomp)
         yield protocols.inverse(to_z_ops)
@@ -187,44 +186,39 @@ class PauliMeasurementGate(raw_types.Gate):
         args = [repr(self._observable.on(*qubits))]
         if self.key != _default_measurement_key(qubits):
             args.append(f'key={self.mkey!r}')
-        if self.confusion_map:
-            proper_map_str = ', '.join(
-                f"{k!r}: {_compat.proper_repr(v)}" for k, v in self.confusion_map.items()
-            )
-            args.append(f'confusion_map={{{proper_map_str}}}')
+        if self.confusion_matrix is not None:
+            args.append(f'confusion_matrix={_compat.proper_repr(self.confusion_matrix)}')
         arg_list = ', '.join(args)
         return f'cirq.measure_single_paulistring({arg_list})'
 
     def __repr__(self) -> str:
         args = [f'{self._observable!r}', f'{self.mkey!r}']
-        if self.confusion_map:
-            proper_map_str = ', '.join(
-                f"{k!r}: {_compat.proper_repr(v)}" for k, v in self.confusion_map.items()
-            )
-            args.append(f'confusion_map={{{proper_map_str}}}')
+        if self.confusion_matrix is not None:
+            args.append(f'confusion_matrix={_compat.proper_repr(self.confusion_matrix)}')
         return f'cirq.PauliMeasurementGate({", ".join(args)})'
 
     def _value_equality_values_(self) -> Any:
-        hashable_cmap = frozenset(
-            (idxs, tuple(v for _, v in np.ndenumerate(cmap)))
-            for idxs, cmap in self._confusion_map.items()
+        hashable_mat = (
+            None
+            if self.confusion_matrix is None
+            else tuple(v for _, v in np.ndenumerate(self.confusion_matrix))
         )
-        return self.key, self._observable, hashable_cmap
+        return self.key, self._observable, hashable_mat
 
     def _json_dict_(self) -> dict[str, Any]:
         res: dict[str, Any] = {'observable': self._observable, 'key': self.key}
-        if self.confusion_map:
-            res['confusion_map'] = [(k, v.tolist()) for k, v in self.confusion_map.items()]
+        if self.confusion_matrix is not None:
+            res['confusion_matrix'] = self.confusion_matrix.tolist()
         return res
 
     @classmethod
     def _from_json_dict_(
-        cls, observable, key, confusion_map=None, **kwargs
+        cls, observable, key, confusion_matrix=None, **kwargs
     ) -> PauliMeasurementGate:
         return cls(
             observable=observable,
             key=value.MeasurementKey.parse_serialized(key),
-            confusion_map=({tuple(k): np.array(v) for k, v in confusion_map or []}),
+            confusion_matrix=None if confusion_matrix is None else np.array(confusion_matrix),
         )
 
 

--- a/cirq-core/cirq/ops/pauli_measurement_gate.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate.py
@@ -19,7 +19,7 @@ from typing import Any, cast, TYPE_CHECKING
 
 import numpy as np
 
-from cirq import protocols, value
+from cirq import _compat, protocols, value
 from cirq.ops import (
     dense_pauli_string as dps,
     measurement_gate,
@@ -57,10 +57,12 @@ class PauliMeasurementGate(raw_types.Gate):
             key: The string key of the measurement.
             confusion_map: A map of qubit index sets (using indices in the
                 operation generated from this gate) to the 2D confusion matrix
-                for those qubits. Indices not included use the identity.
+                for those qubits. Since PauliMeasurementGate has only a single
+                measurement outcome, the only valid index is 0.
 
         Raises:
-            ValueError: If the observable is empty.
+            ValueError: If the observable is empty, or if confusion_map has
+                indices greater than or equal to 1.
         """
         if not observable:
             raise ValueError(f'Pauli observable {observable} is empty.')
@@ -81,7 +83,7 @@ class PauliMeasurementGate(raw_types.Gate):
             key if isinstance(key, value.MeasurementKey) else value.MeasurementKey(name=key)
         )
         self._confusion_map = confusion_map or {}
-        if any(x >= len(self._observable) for idx in self._confusion_map for x in idx):
+        if any(x >= 1 for idx in self._confusion_map for x in idx):
             raise ValueError('Confusion matrices have index out of bounds.')
 
     @property
@@ -156,7 +158,10 @@ class PauliMeasurementGate(raw_types.Gate):
         yield to_z_ops
         yield xor_decomp
         yield measurement_gate.MeasurementGate(
-            1, self.mkey, invert_mask=(self._observable.coefficient != 1,)
+            1,
+            self.mkey,
+            invert_mask=(self._observable.coefficient != 1,),
+            confusion_map=self.confusion_map,
         ).on(any_qubit)
         yield protocols.inverse(xor_decomp)
         yield protocols.inverse(to_z_ops)
@@ -182,21 +187,45 @@ class PauliMeasurementGate(raw_types.Gate):
         args = [repr(self._observable.on(*qubits))]
         if self.key != _default_measurement_key(qubits):
             args.append(f'key={self.mkey!r}')
+        if self.confusion_map:
+            proper_map_str = ', '.join(
+                f"{k!r}: {_compat.proper_repr(v)}" for k, v in self.confusion_map.items()
+            )
+            args.append(f'confusion_map={{{proper_map_str}}}')
         arg_list = ', '.join(args)
         return f'cirq.measure_single_paulistring({arg_list})'
 
     def __repr__(self) -> str:
-        return f'cirq.PauliMeasurementGate({self._observable!r}, {self.mkey!r})'
+        args = [f'{self._observable!r}', f'{self.mkey!r}']
+        if self.confusion_map:
+            proper_map_str = ', '.join(
+                f"{k!r}: {_compat.proper_repr(v)}" for k, v in self.confusion_map.items()
+            )
+            args.append(f'confusion_map={{{proper_map_str}}}')
+        return f'cirq.PauliMeasurementGate({", ".join(args)})'
 
     def _value_equality_values_(self) -> Any:
-        return self.key, self._observable
+        hashable_cmap = frozenset(
+            (idxs, tuple(v for _, v in np.ndenumerate(cmap)))
+            for idxs, cmap in self._confusion_map.items()
+        )
+        return self.key, self._observable, hashable_cmap
 
     def _json_dict_(self) -> dict[str, Any]:
-        return {'observable': self._observable, 'key': self.key}
+        res: dict[str, Any] = {'observable': self._observable, 'key': self.key}
+        if self.confusion_map:
+            res['confusion_map'] = [(k, v.tolist()) for k, v in self.confusion_map.items()]
+        return res
 
     @classmethod
-    def _from_json_dict_(cls, observable, key, **kwargs) -> PauliMeasurementGate:
-        return cls(observable=observable, key=value.MeasurementKey.parse_serialized(key))
+    def _from_json_dict_(
+        cls, observable, key, confusion_map=None, **kwargs
+    ) -> PauliMeasurementGate:
+        return cls(
+            observable=observable,
+            key=value.MeasurementKey.parse_serialized(key),
+            confusion_map=({tuple(k): np.array(v) for k, v in confusion_map or []}),
+        )
 
 
 def _default_measurement_key(qubits: Iterable[raw_types.Qid]) -> str:

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -229,15 +229,6 @@ def test_confusion_matrix_decomposition() -> None:
     assert np.array_equal(meas_op.gate.confusion_map[(0,)], cmat)
 
 
-def test_confusion_matrix_serialization() -> None:
-    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
-    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_matrix=cmat)
-    serialized = cirq.read_json(json_text=cirq.to_json(gate))
-    assert serialized == gate
-    assert serialized.confusion_matrix is not None
-    assert np.array_equal(serialized.confusion_matrix, cmat)
-
-
 def test_confusion_matrix_simulation() -> None:
     # one qubit
     cmat = np.array([[0.0, 1.0], [1.0, 0.0]])

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -239,11 +239,32 @@ def test_confusion_matrix_serialization() -> None:
 
 
 def test_confusion_matrix_simulation() -> None:
-    # 100% chance to flip the output
+    # one qubit
     cmat = np.array([[0.0, 1.0], [1.0, 0.0]])
     q = cirq.LineQubit(0)
-
-    # Normally measures 0. With confusion map, should measure 1.
     c = cirq.Circuit(cirq.PauliMeasurementGate([cirq.Z], key='out', confusion_matrix=cmat).on(q))
     sim_results = cirq.Simulator().sample(c, repetitions=10)['out']
     assert sim_results.all() == 1
+
+    # two qubits
+    q0, q1 = cirq.LineQubit.range(2)
+    c = cirq.Circuit(
+        cirq.PauliMeasurementGate([cirq.Z, cirq.Z], key='out', confusion_matrix=cmat).on(q0, q1)
+    )
+    sim_results = cirq.Simulator().sample(c, repetitions=10)['out']
+    assert sim_results.all() == 1
+
+
+def test_confusion_matrix_mixed_simulation() -> None:
+    # 90% chance of 0->0, 10% chance of 0->1
+    # 40% chance of 1->0, 60% chance of 1->1
+    cmat = np.array([[0.9, 0.1], [0.4, 0.6]])
+    q = cirq.LineQubit(0)
+
+    # should be 50/50 0 vs 1
+    c0 = cirq.Circuit(cirq.PauliMeasurementGate([cirq.X], key='out', confusion_matrix=cmat).on(q))
+    sim_results0 = cirq.Simulator(seed=1234).sample(c0, repetitions=1000)['out']
+
+    # Expect zero: 0.5 (prob 0) * 0.9 (prob no flip) + 0.5 (prob 1) * 0.4 (prob flip) = 0.65
+    # Expect one: 0.5 (prob 0) * 0.1 (prob flip) + 0.5 (prob 1) * 0.6 (prob no flip) = 0.35
+    np.testing.assert_allclose(np.mean(sim_results0), 0.35, atol=0.03)

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 import cirq
@@ -32,6 +33,13 @@ def test_eval_repr(key) -> None:
     cirq.testing.assert_equivalent_repr(op)
     assert cirq.is_measurement(op)
     assert cirq.measurement_key_name(op) == str(key)
+
+    # Test with confusion map
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    gate_with_cmap = cirq.PauliMeasurementGate([cirq.X], key, confusion_map=cmap)
+    cirq.testing.assert_equivalent_repr(gate_with_cmap)
+    op_with_cmap = gate_with_cmap.on(cirq.GridQubit(0, 1))
+    cirq.testing.assert_equivalent_repr(op_with_cmap)
 
 
 @pytest.mark.parametrize('observable', [[cirq.X], [cirq.Y, cirq.Z], cirq.DensePauliString('XYZ')])
@@ -151,6 +159,15 @@ def test_op_repr() -> None:
         "key=cirq.MeasurementKey(name='out'))"
     )
 
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    assert (
+        repr(cirq.measure_single_paulistring(ps, key='out', confusion_map=cmap))
+        == "cirq.measure_single_paulistring(((1+0j)*cirq.X(cirq.LineQubit(0))"
+        "*cirq.Y(cirq.LineQubit(1))*cirq.Z(cirq.LineQubit(2))), "
+        "key=cirq.MeasurementKey(name='out'), "
+        "confusion_map={(0,): np.array([[0.8, 0.2], [0.1, 0.9]], dtype=np.dtype('float64'))})"
+    )
+
 
 def test_bad_observable_raises() -> None:
     with pytest.raises(ValueError, match='Pauli observable .* is empty'):
@@ -190,3 +207,51 @@ def test_pauli_measurement_gate_samples(rot, obs, out) -> None:
     q = cirq.NamedQubit("q")
     c = cirq.Circuit(rot(q), cirq.PauliMeasurementGate(obs, key='out').on(q))
     assert cirq.Simulator().sample(c)['out'][0] == out
+
+
+def test_confusion_map_validation() -> None:
+    # Valid indices (only 0 is allowed)
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_map=cmap)
+    assert gate.confusion_map == cmap
+
+    # Invalid indices (out of bounds)
+    with pytest.raises(ValueError, match='Confusion matrices have index out of bounds'):
+        _ = cirq.PauliMeasurementGate(
+            [cirq.X], key='a', confusion_map={(1,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+        )
+
+
+def test_confusion_map_decomposition() -> None:
+    q = cirq.LineQubit(0)
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_map=cmap)
+    decomposed = cirq.decompose_once(gate.on(q))
+
+    # Check that it decomposes to a MeasurementGate with the same confusion map
+    meas_op = next(op for op in decomposed if isinstance(op.gate, cirq.MeasurementGate))
+    assert isinstance(meas_op.gate, cirq.MeasurementGate)
+    assert meas_op.gate.confusion_map.keys() == cmap.keys()
+    for k in cmap:
+        assert np.array_equal(meas_op.gate.confusion_map[k], cmap[k])
+
+
+def test_confusion_map_serialization() -> None:
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_map=cmap)
+    serialized = cirq.read_json(json_text=cirq.to_json(gate))
+    assert serialized == gate
+    assert serialized.confusion_map.keys() == cmap.keys()
+    for k in cmap:
+        assert np.array_equal(serialized.confusion_map[k], cmap[k])
+
+
+def test_confusion_map_simulation() -> None:
+    # 100% chance to flip the output
+    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.0, 1.0], [1.0, 0.0]])}
+    q = cirq.LineQubit(0)
+
+    # Normally measures 0. With confusion map, should measure 1.
+    c = cirq.Circuit(cirq.PauliMeasurementGate([cirq.Z], key='out', confusion_map=cmap).on(q))
+    sim_results = cirq.Simulator().sample(c, repetitions=10)['out']
+    assert sim_results.all() == 1

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -34,12 +34,12 @@ def test_eval_repr(key) -> None:
     assert cirq.is_measurement(op)
     assert cirq.measurement_key_name(op) == str(key)
 
-    # Test with confusion map
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
-    gate_with_cmap = cirq.PauliMeasurementGate([cirq.X], key, confusion_map=cmap)
-    cirq.testing.assert_equivalent_repr(gate_with_cmap)
-    op_with_cmap = gate_with_cmap.on(cirq.GridQubit(0, 1))
-    cirq.testing.assert_equivalent_repr(op_with_cmap)
+    # Test with confusion matrix
+    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
+    gate_with_cmat = cirq.PauliMeasurementGate([cirq.X], key, confusion_matrix=cmat)
+    cirq.testing.assert_equivalent_repr(gate_with_cmat)
+    op_with_cmat = gate_with_cmat.on(cirq.GridQubit(0, 1))
+    cirq.testing.assert_equivalent_repr(op_with_cmat)
 
 
 @pytest.mark.parametrize('observable', [[cirq.X], [cirq.Y, cirq.Z], cirq.DensePauliString('XYZ')])
@@ -159,13 +159,13 @@ def test_op_repr() -> None:
         "key=cirq.MeasurementKey(name='out'))"
     )
 
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
+    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
     assert (
-        repr(cirq.measure_single_paulistring(ps, key='out', confusion_map=cmap))
+        repr(cirq.measure_single_paulistring(ps, key='out', confusion_matrix=cmat))
         == "cirq.measure_single_paulistring(((1+0j)*cirq.X(cirq.LineQubit(0))"
         "*cirq.Y(cirq.LineQubit(1))*cirq.Z(cirq.LineQubit(2))), "
         "key=cirq.MeasurementKey(name='out'), "
-        "confusion_map={(0,): np.array([[0.8, 0.2], [0.1, 0.9]], dtype=np.dtype('float64'))})"
+        "confusion_matrix=np.array([[0.8, 0.2], [0.1, 0.9]], dtype=np.dtype('float64')))"
     )
 
 
@@ -209,49 +209,41 @@ def test_pauli_measurement_gate_samples(rot, obs, out) -> None:
     assert cirq.Simulator().sample(c)['out'][0] == out
 
 
-def test_confusion_map_validation() -> None:
-    # Valid indices (only 0 is allowed)
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
-    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_map=cmap)
-    assert gate.confusion_map == cmap
-
-    # Invalid indices (out of bounds)
-    with pytest.raises(ValueError, match='Confusion matrices have index out of bounds'):
-        _ = cirq.PauliMeasurementGate(
-            [cirq.X], key='a', confusion_map={(1,): np.array([[0.8, 0.2], [0.1, 0.9]])}
-        )
+def test_confusion_matrix_validation() -> None:
+    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
+    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_matrix=cmat)
+    assert gate.confusion_matrix is not None
+    assert np.array_equal(gate.confusion_matrix, cmat)
 
 
-def test_confusion_map_decomposition() -> None:
+def test_confusion_matrix_decomposition() -> None:
     q = cirq.LineQubit(0)
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
-    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_map=cmap)
+    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
+    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_matrix=cmat)
     decomposed = cirq.decompose_once(gate.on(q))
 
     # Check that it decomposes to a MeasurementGate with the same confusion map
     meas_op = next(op for op in decomposed if isinstance(op.gate, cirq.MeasurementGate))
     assert isinstance(meas_op.gate, cirq.MeasurementGate)
-    assert meas_op.gate.confusion_map.keys() == cmap.keys()
-    for k in cmap:
-        assert np.array_equal(meas_op.gate.confusion_map[k], cmap[k])
+    assert list(meas_op.gate.confusion_map.keys()) == [(0,)]
+    assert np.array_equal(meas_op.gate.confusion_map[(0,)], cmat)
 
 
-def test_confusion_map_serialization() -> None:
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.8, 0.2], [0.1, 0.9]])}
-    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_map=cmap)
+def test_confusion_matrix_serialization() -> None:
+    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
+    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_matrix=cmat)
     serialized = cirq.read_json(json_text=cirq.to_json(gate))
     assert serialized == gate
-    assert serialized.confusion_map.keys() == cmap.keys()
-    for k in cmap:
-        assert np.array_equal(serialized.confusion_map[k], cmap[k])
+    assert serialized.confusion_matrix is not None
+    assert np.array_equal(serialized.confusion_matrix, cmat)
 
 
-def test_confusion_map_simulation() -> None:
+def test_confusion_matrix_simulation() -> None:
     # 100% chance to flip the output
-    cmap: dict[tuple[int, ...], np.ndarray] = {(0,): np.array([[0.0, 1.0], [1.0, 0.0]])}
+    cmat = np.array([[0.0, 1.0], [1.0, 0.0]])
     q = cirq.LineQubit(0)
 
     # Normally measures 0. With confusion map, should measure 1.
-    c = cirq.Circuit(cirq.PauliMeasurementGate([cirq.Z], key='out', confusion_map=cmap).on(q))
+    c = cirq.Circuit(cirq.PauliMeasurementGate([cirq.Z], key='out', confusion_matrix=cmat).on(q))
     sim_results = cirq.Simulator().sample(c, repetitions=10)['out']
     assert sim_results.all() == 1

--- a/cirq-core/cirq/ops/pauli_measurement_gate_test.py
+++ b/cirq-core/cirq/ops/pauli_measurement_gate_test.py
@@ -209,13 +209,6 @@ def test_pauli_measurement_gate_samples(rot, obs, out) -> None:
     assert cirq.Simulator().sample(c)['out'][0] == out
 
 
-def test_confusion_matrix_validation() -> None:
-    cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
-    gate = cirq.PauliMeasurementGate([cirq.X], key='a', confusion_matrix=cmat)
-    assert gate.confusion_matrix is not None
-    assert np.array_equal(gate.confusion_matrix, cmat)
-
-
 def test_confusion_matrix_decomposition() -> None:
     q = cirq.LineQubit(0)
     cmat = np.array([[0.8, 0.2], [0.1, 0.9]])
@@ -235,7 +228,7 @@ def test_confusion_matrix_simulation() -> None:
     q = cirq.LineQubit(0)
     c = cirq.Circuit(cirq.PauliMeasurementGate([cirq.Z], key='out', confusion_matrix=cmat).on(q))
     sim_results = cirq.Simulator().sample(c, repetitions=10)['out']
-    assert sim_results.all() == 1
+    assert sim_results.all()
 
     # two qubits
     q0, q1 = cirq.LineQubit.range(2)
@@ -243,7 +236,7 @@ def test_confusion_matrix_simulation() -> None:
         cirq.PauliMeasurementGate([cirq.Z, cirq.Z], key='out', confusion_matrix=cmat).on(q0, q1)
     )
     sim_results = cirq.Simulator().sample(c, repetitions=10)['out']
-    assert sim_results.all() == 1
+    assert sim_results.all()
 
 
 def test_confusion_matrix_mixed_simulation() -> None:

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.json
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.json
@@ -49,5 +49,26 @@
       }
     },
     "key": "key"
+  },
+  {
+    "cirq_type": "PauliMeasurementGate",
+    "observable": {
+      "cirq_type": "DensePauliString",
+      "pauli_mask": [
+        1,
+        2,
+        3
+      ],
+      "coefficient": {
+        "cirq_type": "complex",
+        "real": 1.0,
+        "imag": 0.0
+      }
+    },
+    "key": "key",
+    "confusion_matrix": [
+      [0.8, 0.2],
+      [0.1, 0.9]
+    ]
   }
 ]

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr
@@ -4,4 +4,3 @@
     cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ", coefficient=-1), cirq.MeasurementKey(name='key')),
     cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ"), cirq.MeasurementKey(name='key'), confusion_matrix=np.array([[0.8, 0.2], [0.1, 0.9]])),
 ]
-

--- a/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr
+++ b/cirq-core/cirq/protocols/json_test_data/PauliMeasurementGate.repr
@@ -2,5 +2,6 @@
     cirq.PauliMeasurementGate((cirq.X, cirq.Y, cirq.Z), cirq.MeasurementKey(name='key')),
     cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ"), cirq.MeasurementKey(path=('p', 'q'), name='key')),
     cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ", coefficient=-1), cirq.MeasurementKey(name='key')),
+    cirq.PauliMeasurementGate(cirq.DensePauliString("XYZ"), cirq.MeasurementKey(name='key'), confusion_matrix=np.array([[0.8, 0.2], [0.1, 0.9]])),
 ]
 


### PR DESCRIPTION
Closes #5571, building off a previous PR #7373. 

This adds support for a confusion matrix to `PauliMeasurementGate`.
It also updates `measure_single_paulistring()` to accept a confusion matrix.