### PR TITLE
Regenerate quantum engine client

### DIFF
--- a/cirq-google/cirq_google/cloud/quantum/__init__.py
+++ b/cirq-google/cirq_google/cloud/quantum/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+
 from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service.client import (
     QuantumEngineServiceClient,
 )
@@ -22,6 +24,8 @@ from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service.async_cl
 
 from cirq_google.cloud.quantum_v1alpha1.types.engine import CancelQuantumJobRequest
 from cirq_google.cloud.quantum_v1alpha1.types.engine import CancelQuantumReservationRequest
+from cirq_google.cloud.quantum_v1alpha1.types.engine import CompileQecProgramRequest
+from cirq_google.cloud.quantum_v1alpha1.types.engine import CompileQecProgramResponse
 from cirq_google.cloud.quantum_v1alpha1.types.engine import CreateQuantumJobRequest
 from cirq_google.cloud.quantum_v1alpha1.types.engine import CreateQuantumProgramAndJobRequest
 from cirq_google.cloud.quantum_v1alpha1.types.engine import CreateQuantumProgramRequest
@@ -42,6 +46,12 @@ from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumJobEvents
 from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumJobEventsResponse
 from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumJobsRequest
 from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumJobsResponse
+from cirq_google.cloud.quantum_v1alpha1.types.engine import (
+    ListQuantumProcessorAutomationRunHistoryRequest,
+)
+from cirq_google.cloud.quantum_v1alpha1.types.engine import (
+    ListQuantumProcessorAutomationRunHistoryResponse,
+)
 from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumProcessorConfigsRequest
 from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumProcessorConfigsResponse
 from cirq_google.cloud.quantum_v1alpha1.types.engine import ListQuantumProcessorsRequest
@@ -69,10 +79,12 @@ from cirq_google.cloud.quantum_v1alpha1.types.quantum import ExecutionStatus
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import GcsLocation
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import InlineData
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import OutputConfig
+from cirq_google.cloud.quantum_v1alpha1.types.quantum import QecRecipe
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumCalibration
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumJob
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumJobEvent
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumProcessor
+from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumProcessorAutomationRunHistory
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumProcessorConfig
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumProgram
 from cirq_google.cloud.quantum_v1alpha1.types.quantum import QuantumReservation
@@ -87,6 +99,8 @@ __all__ = (
     'QuantumEngineServiceAsyncClient',
     'CancelQuantumJobRequest',
     'CancelQuantumReservationRequest',
+    'CompileQecProgramRequest',
+    'CompileQecProgramResponse',
     'CreateQuantumJobRequest',
     'CreateQuantumProgramAndJobRequest',
     'CreateQuantumProgramRequest',
@@ -107,6 +121,8 @@ __all__ = (
     'ListQuantumJobEventsResponse',
     'ListQuantumJobsRequest',
     'ListQuantumJobsResponse',
+    'ListQuantumProcessorAutomationRunHistoryRequest',
+    'ListQuantumProcessorAutomationRunHistoryResponse',
     'ListQuantumProcessorConfigsRequest',
     'ListQuantumProcessorConfigsResponse',
     'ListQuantumProcessorsRequest',
@@ -134,10 +150,12 @@ __all__ = (
     'GcsLocation',
     'InlineData',
     'OutputConfig',
+    'QecRecipe',
     'QuantumCalibration',
     'QuantumJob',
     'QuantumJobEvent',
     'QuantumProcessor',
+    'QuantumProcessorAutomationRunHistory',
     'QuantumProcessorConfig',
     'QuantumProgram',
     'QuantumReservation',

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/__init__.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+
+import google.api_core as api_core
+import sys
+
+
+from importlib import metadata
+
+
 from .services.quantum_engine_service import QuantumEngineServiceClient
 from .services.quantum_engine_service import QuantumEngineServiceAsyncClient
 
 from .types.engine import CancelQuantumJobRequest
 from .types.engine import CancelQuantumReservationRequest
+from .types.engine import CompileQecProgramRequest
+from .types.engine import CompileQecProgramResponse
 from .types.engine import CreateQuantumJobRequest
 from .types.engine import CreateQuantumProgramAndJobRequest
 from .types.engine import CreateQuantumProgramRequest
@@ -38,6 +49,8 @@ from .types.engine import ListQuantumJobEventsRequest
 from .types.engine import ListQuantumJobEventsResponse
 from .types.engine import ListQuantumJobsRequest
 from .types.engine import ListQuantumJobsResponse
+from .types.engine import ListQuantumProcessorAutomationRunHistoryRequest
+from .types.engine import ListQuantumProcessorAutomationRunHistoryResponse
 from .types.engine import ListQuantumProcessorConfigsRequest
 from .types.engine import ListQuantumProcessorConfigsResponse
 from .types.engine import ListQuantumProcessorsRequest
@@ -65,10 +78,12 @@ from .types.quantum import ExecutionStatus
 from .types.quantum import GcsLocation
 from .types.quantum import InlineData
 from .types.quantum import OutputConfig
+from .types.quantum import QecRecipe
 from .types.quantum import QuantumCalibration
 from .types.quantum import QuantumJob
 from .types.quantum import QuantumJobEvent
 from .types.quantum import QuantumProcessor
+from .types.quantum import QuantumProcessorAutomationRunHistory
 from .types.quantum import QuantumProcessorConfig
 from .types.quantum import QuantumProgram
 from .types.quantum import QuantumReservation
@@ -78,10 +93,95 @@ from .types.quantum import QuantumResult
 from .types.quantum import QuantumTimeSlot
 from .types.quantum import SchedulingConfig
 
+if hasattr(api_core, "check_python_version") and hasattr(
+    api_core, "check_dependency_versions"
+):  # pragma: NO COVER
+    api_core.check_python_version("cirq_google.cloud.quantum_v1alpha1")  # type: ignore
+    api_core.check_dependency_versions("cirq_google.cloud.quantum_v1alpha1")  # type: ignore
+else:  # pragma: NO COVER
+    # An older version of api_core is installed which does not define the
+    # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+
+        _py_version_str = sys.version.split()[0]
+        _package_label = "cirq_google.cloud.quantum_v1alpha1"
+        if sys.version_info < (3, 10):
+            warnings.warn(
+                "You are using a non-supported Python version "
+                + f"({_py_version_str}).  Google will not post any further "
+                + f"updates to {_package_label} supporting this Python version. "
+                + "Please upgrade to the latest Python version, or at "
+                + f"least to Python 3.10, and then update {_package_label}.",
+                FutureWarning,
+            )
+
+        def parse_version_to_tuple(version_string: str):
+            """Safely converts a semantic version string to a comparable tuple of integers.
+            Example: "6.33.5" -> (6, 33, 5)
+            Ignores non-numeric parts and handles common version formats.
+            Args:
+                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
+            Returns:
+                Tuple of integers for the parsed version string.
+            """
+            parts = []
+            for part in version_string.split("."):
+                try:
+                    parts.append(int(part))
+                except ValueError:
+                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
+                    # This is a simplification compared to 'packaging.parse_version', but sufficient
+                    # for comparing strictly numeric semantic versions.
+                    break
+            return tuple(parts)
+
+        def _get_version(dependency_name):
+            try:
+                version_string: str = metadata.version(dependency_name)
+                parsed_version = parse_version_to_tuple(version_string)
+                return (parsed_version, version_string)
+            except Exception:
+                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
+                # or errors during parse_version_to_tuple
+                return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "6.33.5"
+        _next_supported_version_tuple = (6, 33, 5)
+        _recommendation = " (we recommend 7.x)"
+        _version_used, _version_used_string = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(
+                f"Package {_package_label} depends on "
+                + f"{_dependency_package}, currently installed at version "
+                + f"{_version_used_string}. Future updates to "
+                + f"{_package_label} will require {_dependency_package} at "
+                + f"version {_next_supported_version} or higher{_recommendation}."
+                + " Please ensure "
+                + "that either (a) your Python environment doesn't pin the "
+                + f"version of {_dependency_package}, so that updates to "
+                + f"{_package_label} can require the higher version, or "
+                + "(b) you manually update your Python environment to use at "
+                + f"least version {_next_supported_version} of "
+                + f"{_dependency_package}.",
+                FutureWarning,
+            )
+    except Exception:
+        warnings.warn(
+            "Could not determine the version of Python "
+            + "currently being used. To continue receiving "
+            + "updates for {_package_label}, ensure you are "
+            + "using a supported version of Python; see "
+            + "https://devguide.python.org/versions/"
+        )
+
 __all__ = (
     'QuantumEngineServiceAsyncClient',
     'CancelQuantumJobRequest',
     'CancelQuantumReservationRequest',
+    'CompileQecProgramRequest',
+    'CompileQecProgramResponse',
     'CreateQuantumJobRequest',
     'CreateQuantumProgramAndJobRequest',
     'CreateQuantumProgramRequest',
@@ -107,6 +207,8 @@ __all__ = (
     'ListQuantumJobEventsResponse',
     'ListQuantumJobsRequest',
     'ListQuantumJobsResponse',
+    'ListQuantumProcessorAutomationRunHistoryRequest',
+    'ListQuantumProcessorAutomationRunHistoryResponse',
     'ListQuantumProcessorConfigsRequest',
     'ListQuantumProcessorConfigsResponse',
     'ListQuantumProcessorsRequest',
@@ -122,11 +224,13 @@ __all__ = (
     'ListQuantumTimeSlotsRequest',
     'ListQuantumTimeSlotsResponse',
     'OutputConfig',
+    'QecRecipe',
     'QuantumCalibration',
     'QuantumEngineServiceClient',
     'QuantumJob',
     'QuantumJobEvent',
     'QuantumProcessor',
+    'QuantumProcessorAutomationRunHistory',
     'QuantumProcessorConfig',
     'QuantumProgram',
     'QuantumReservation',

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/gapic_metadata.json
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/gapic_metadata.json
@@ -20,6 +20,11 @@
                 "cancel_quantum_reservation"
               ]
             },
+            "CompileQecProgram": {
+              "methods": [
+                "compile_qec_program"
+              ]
+            },
             "CreateQuantumJob": {
               "methods": [
                 "create_quantum_job"
@@ -98,6 +103,11 @@
             "ListQuantumJobs": {
               "methods": [
                 "list_quantum_jobs"
+              ]
+            },
+            "ListQuantumProcessorAutomationRunHistory": {
+              "methods": [
+                "list_quantum_processor_automation_run_history"
               ]
             },
             "ListQuantumProcessorConfigs": {
@@ -175,6 +185,11 @@
                 "cancel_quantum_reservation"
               ]
             },
+            "CompileQecProgram": {
+              "methods": [
+                "compile_qec_program"
+              ]
+            },
             "CreateQuantumJob": {
               "methods": [
                 "create_quantum_job"
@@ -253,6 +268,11 @@
             "ListQuantumJobs": {
               "methods": [
                 "list_quantum_jobs"
+              ]
+            },
+            "ListQuantumProcessorAutomationRunHistory": {
+              "methods": [
+                "list_quantum_processor_automation_run_history"
               ]
             },
             "ListQuantumProcessorConfigs": {
@@ -330,6 +350,11 @@
                 "cancel_quantum_reservation"
               ]
             },
+            "CompileQecProgram": {
+              "methods": [
+                "compile_qec_program"
+              ]
+            },
             "CreateQuantumJob": {
               "methods": [
                 "create_quantum_job"
@@ -408,6 +433,11 @@
             "ListQuantumJobs": {
               "methods": [
                 "list_quantum_jobs"
+              ]
+            },
+            "ListQuantumProcessorAutomationRunHistory": {
+              "methods": [
+                "list_quantum_processor_automation_run_history"
               ]
             },
             "ListQuantumProcessorConfigs": {

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/__init__.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/__init__.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/async_client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,16 +38,17 @@ from google.api_core.client_options import ClientOptions
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.oauth2 import service_account  # type: ignore
 
+import cirq_google
+
 try:
     OptionalRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
-from google.protobuf import any_pb2  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import timestamp_pb2  # type: ignore
+import google.protobuf.any_pb2 as any_pb2  # type: ignore
+import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
+import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 
-import cirq_google
 from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service import pagers
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 
@@ -125,7 +126,8 @@ class QuantumEngineServiceAsyncClient:
         Returns:
             QuantumEngineServiceAsyncClient: The constructed client.
         """
-        return QuantumEngineServiceClient.from_service_account_info.__func__(QuantumEngineServiceAsyncClient, info, *args, **kwargs)  # type: ignore
+        sa_info_func = QuantumEngineServiceClient.from_service_account_info.__func__  # type: ignore
+        return sa_info_func(QuantumEngineServiceAsyncClient, info, *args, **kwargs)
 
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
@@ -141,7 +143,8 @@ class QuantumEngineServiceAsyncClient:
         Returns:
             QuantumEngineServiceAsyncClient: The constructed client.
         """
-        return QuantumEngineServiceClient.from_service_account_file.__func__(QuantumEngineServiceAsyncClient, filename, *args, **kwargs)  # type: ignore
+        sa_file_func = QuantumEngineServiceClient.from_service_account_file.__func__  # type: ignore
+        return sa_file_func(QuantumEngineServiceAsyncClient, filename, *args, **kwargs)
 
     from_service_account_json = from_service_account_file
 
@@ -189,7 +192,7 @@ class QuantumEngineServiceAsyncClient:
         return self._client.transport
 
     @property
-    def api_endpoint(self):
+    def api_endpoint(self) -> str:
         """Return the API endpoint used by the client instance.
 
         Returns:
@@ -671,6 +674,82 @@ class QuantumEngineServiceAsyncClient:
         rpc = self._client._transport._wrapped_methods[
             self._client._transport.update_quantum_program
         ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+        )
+
+        # Validate the universe domain.
+        self._client._validate_universe_domain()
+
+        # Send the request.
+        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata)
+
+        # Done; return the response.
+        return response
+
+    async def compile_qec_program(
+        self,
+        request: Optional[Union[engine.CompileQecProgramRequest, dict]] = None,
+        *,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> engine.CompileQecProgramResponse:
+        r"""-
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import quantum_v1alpha1
+
+            async def sample_compile_qec_program():
+                # Create a client
+                client = quantum_v1alpha1.QuantumEngineServiceAsyncClient()
+
+                # Initialize request argument(s)
+                request = quantum_v1alpha1.CompileQecProgramRequest(
+                    stim_circuit="stim_circuit_value",
+                )
+
+                # Make the request
+                response = await client.compile_qec_program(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Optional[Union[cirq_google.cloud.quantum_v1alpha1.types.CompileQecProgramRequest, dict]]):
+                The request object. -
+            retry (google.api_core.retry_async.AsyncRetry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            cirq_google.cloud.quantum_v1alpha1.types.CompileQecProgramResponse:
+                -
+        """
+        # Create or coerce a protobuf request object.
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(request, engine.CompileQecProgramRequest):
+            request = engine.CompileQecProgramRequest(request)
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._client._transport._wrapped_methods[self._client._transport.compile_qec_program]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1678,6 +1757,123 @@ class QuantumEngineServiceAsyncClient:
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
         response = pagers.ListQuantumProcessorConfigsAsyncPager(
+            method=rpc,
+            request=request,
+            response=response,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
+    async def list_quantum_processor_automation_run_history(
+        self,
+        request: Optional[
+            Union[engine.ListQuantumProcessorAutomationRunHistoryRequest, dict]
+        ] = None,
+        *,
+        parent: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> pagers.ListQuantumProcessorAutomationRunHistoryAsyncPager:
+        r"""-
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import quantum_v1alpha1
+
+            async def sample_list_quantum_processor_automation_run_history():
+                # Create a client
+                client = quantum_v1alpha1.QuantumEngineServiceAsyncClient()
+
+                # Initialize request argument(s)
+                request = quantum_v1alpha1.ListQuantumProcessorAutomationRunHistoryRequest(
+                )
+
+                # Make the request
+                page_result = client.list_quantum_processor_automation_run_history(request=request)
+
+                # Handle the response
+                async for response in page_result:
+                    print(response)
+
+        Args:
+            request (Optional[Union[cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryRequest, dict]]):
+                The request object. -
+            parent (:class:`str`):
+                -
+                This corresponds to the ``parent`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry_async.AsyncRetry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service.pagers.ListQuantumProcessorAutomationRunHistoryAsyncPager:
+                -
+
+                Iterating over this object will yield
+                results and resolve additional pages
+                automatically.
+
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [parent]
+        has_flattened_params = len([param for param in flattened_params if param is not None]) > 0
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(request, engine.ListQuantumProcessorAutomationRunHistoryRequest):
+            request = engine.ListQuantumProcessorAutomationRunHistoryRequest(request)
+
+        # If we have keyword arguments corresponding to fields on the
+        # request, apply these.
+        if parent is not None:
+            request.parent = parent
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._client._transport._wrapped_methods[
+            self._client._transport.list_quantum_processor_automation_run_history
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("parent", request.parent),)),
+        )
+
+        # Validate the universe domain.
+        self._client._validate_universe_domain()
+
+        # Send the request.
+        response = await rpc(request, retry=retry, timeout=timeout, metadata=metadata)
+
+        # This method is paged; wrap the response in a pager, which provides
+        # an `__aiter__` convenience method.
+        response = pagers.ListQuantumProcessorAutomationRunHistoryAsyncPager(
             method=rpc,
             request=request,
             response=response,

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ from google.auth.transport import mtls  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
 from google.oauth2 import service_account  # type: ignore
 
+import cirq_google
+
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
@@ -63,11 +65,10 @@ except ImportError:  # pragma: NO COVER
 
 _LOGGER = std_logging.getLogger(__name__)
 
-from google.protobuf import any_pb2  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import timestamp_pb2  # type: ignore
+import google.protobuf.any_pb2 as any_pb2  # type: ignore
+import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
+import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 
-import cirq_google
 from cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service import pagers
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
 
@@ -115,7 +116,7 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
     """-"""
 
     @staticmethod
-    def _get_default_mtls_endpoint(api_endpoint):
+    def _get_default_mtls_endpoint(api_endpoint) -> Optional[str]:
         """Converts api endpoint to mTLS endpoint.
 
         Convert "*.sandbox.googleapis.com" and "*.googleapis.com" to
@@ -123,7 +124,7 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         Args:
             api_endpoint (Optional[str]): the api endpoint to convert.
         Returns:
-            str: converted mTLS api endpoint.
+            Optional[str]: converted mTLS api endpoint.
         """
         if not api_endpoint:
             return api_endpoint
@@ -133,6 +134,10 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         )
 
         m = mtls_endpoint_re.match(api_endpoint)
+        if m is None:
+            # Could not parse api_endpoint; return as-is.
+            return api_endpoint
+
         name, mtls, sandbox, googledomain = m.groups()
         if mtls or not googledomain:
             return api_endpoint
@@ -148,6 +153,32 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
 
     _DEFAULT_ENDPOINT_TEMPLATE = "quantum.{UNIVERSE_DOMAIN}"
     _DEFAULT_UNIVERSE = "googleapis.com"
+
+    @staticmethod
+    def _use_client_cert_effective():
+        """Returns whether client certificate should be used for mTLS if the
+        google-auth version supports should_use_client_cert automatic mTLS enablement.
+
+        Alternatively, read from the GOOGLE_API_USE_CLIENT_CERTIFICATE env var.
+
+        Returns:
+            bool: whether client certificate should be used for mTLS
+        Raises:
+            ValueError: (If using a version of google-auth without should_use_client_cert and
+            GOOGLE_API_USE_CLIENT_CERTIFICATE is set to an unexpected value.)
+        """
+        # check if google-auth version supports should_use_client_cert for automatic mTLS enablement
+        if hasattr(mtls, "should_use_client_cert"):  # pragma: NO COVER
+            return mtls.should_use_client_cert()
+        else:  # pragma: NO COVER
+            # if unsupported, fallback to reading from env var
+            use_client_cert_str = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false").lower()
+            if use_client_cert_str not in ("true", "false"):
+                raise ValueError(
+                    "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be"
+                    " either `true` or `false`"
+                )
+            return use_client_cert_str == "true"
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
@@ -370,12 +401,8 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         )
         if client_options is None:
             client_options = client_options_lib.ClientOptions()
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")
+        use_client_cert = QuantumEngineServiceClient._use_client_cert_effective()
         use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto")
-        if use_client_cert not in ("true", "false"):
-            raise ValueError(
-                "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
-            )
         if use_mtls_endpoint not in ("auto", "never", "always"):
             raise MutualTLSChannelError(
                 "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
@@ -383,7 +410,7 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
 
         # Figure out the client cert source to use.
         client_cert_source = None
-        if use_client_cert == "true":
+        if use_client_cert:
             if client_options.client_cert_source:
                 client_cert_source = client_options.client_cert_source
             elif mtls.has_default_client_cert_source():
@@ -413,18 +440,14 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
             google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
                 is not any of ["auto", "never", "always"].
         """
-        use_client_cert = os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false").lower()
+        use_client_cert = QuantumEngineServiceClient._use_client_cert_effective()
         use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
         universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_client_cert not in ("true", "false"):
-            raise ValueError(
-                "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
-            )
         if use_mtls_endpoint not in ("auto", "never", "always"):
             raise MutualTLSChannelError(
                 "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
             )
-        return use_client_cert == "true", use_mtls_endpoint, universe_domain_env
+        return use_client_cert, use_mtls_endpoint, universe_domain_env
 
     @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
@@ -446,7 +469,9 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         return client_cert_source
 
     @staticmethod
-    def _get_api_endpoint(api_override, client_cert_source, universe_domain, use_mtls_endpoint):
+    def _get_api_endpoint(
+        api_override, client_cert_source, universe_domain, use_mtls_endpoint
+    ) -> str:
         """Return the API endpoint used by the client.
 
         Args:
@@ -535,7 +560,7 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
             error._details.append(json.dumps(cred_info))
 
     @property
-    def api_endpoint(self):
+    def api_endpoint(self) -> str:
         """Return the API endpoint used by the client instance.
 
         Returns:
@@ -629,7 +654,7 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         self._universe_domain = QuantumEngineServiceClient._get_universe_domain(
             universe_domain_opt, self._universe_domain_env
         )
-        self._api_endpoint = None  # updated below, depending on `transport`
+        self._api_endpoint: str = ""  # updated below, depending on `transport`
 
         # Initialize the universe domain validation.
         self._is_universe_domain_valid = False
@@ -1083,6 +1108,82 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
         rpc = self._transport._wrapped_methods[self._transport.update_quantum_program]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+        )
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata)
+
+        # Done; return the response.
+        return response
+
+    def compile_qec_program(
+        self,
+        request: Optional[Union[engine.CompileQecProgramRequest, dict]] = None,
+        *,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> engine.CompileQecProgramResponse:
+        r"""-
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import quantum_v1alpha1
+
+            def sample_compile_qec_program():
+                # Create a client
+                client = quantum_v1alpha1.QuantumEngineServiceClient()
+
+                # Initialize request argument(s)
+                request = quantum_v1alpha1.CompileQecProgramRequest(
+                    stim_circuit="stim_circuit_value",
+                )
+
+                # Make the request
+                response = client.compile_qec_program(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Union[cirq_google.cloud.quantum_v1alpha1.types.CompileQecProgramRequest, dict]):
+                The request object. -
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            cirq_google.cloud.quantum_v1alpha1.types.CompileQecProgramResponse:
+                -
+        """
+        # Create or coerce a protobuf request object.
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(request, engine.CompileQecProgramRequest):
+            request = engine.CompileQecProgramRequest(request)
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[self._transport.compile_qec_program]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2078,6 +2179,122 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
         response = pagers.ListQuantumProcessorConfigsPager(
+            method=rpc,
+            request=request,
+            response=response,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
+    def list_quantum_processor_automation_run_history(
+        self,
+        request: Optional[
+            Union[engine.ListQuantumProcessorAutomationRunHistoryRequest, dict]
+        ] = None,
+        *,
+        parent: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> pagers.ListQuantumProcessorAutomationRunHistoryPager:
+        r"""-
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import quantum_v1alpha1
+
+            def sample_list_quantum_processor_automation_run_history():
+                # Create a client
+                client = quantum_v1alpha1.QuantumEngineServiceClient()
+
+                # Initialize request argument(s)
+                request = quantum_v1alpha1.ListQuantumProcessorAutomationRunHistoryRequest(
+                )
+
+                # Make the request
+                page_result = client.list_quantum_processor_automation_run_history(request=request)
+
+                # Handle the response
+                for response in page_result:
+                    print(response)
+
+        Args:
+            request (Union[cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryRequest, dict]):
+                The request object. -
+            parent (str):
+                -
+                This corresponds to the ``parent`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            cirq_google.cloud.quantum_v1alpha1.services.quantum_engine_service.pagers.ListQuantumProcessorAutomationRunHistoryPager:
+                -
+
+                Iterating over this object will yield
+                results and resolve additional pages
+                automatically.
+
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [parent]
+        has_flattened_params = len([param for param in flattened_params if param is not None]) > 0
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                'If the `request` argument is set, then none of '
+                'the individual field arguments should be set.'
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(request, engine.ListQuantumProcessorAutomationRunHistoryRequest):
+            request = engine.ListQuantumProcessorAutomationRunHistoryRequest(request)
+            # If we have keyword arguments corresponding to fields on the
+            # request, apply these.
+            if parent is not None:
+                request.parent = parent
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[
+            self._transport.list_quantum_processor_automation_run_history
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("parent", request.parent),)),
+        )
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata)
+
+        # This method is paged; wrap the response in a pager, which provides
+        # an `__iter__` convenience method.
+        response = pagers.ListQuantumProcessorAutomationRunHistoryPager(
             method=rpc,
             request=request,
             response=response,

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/pagers.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -779,6 +779,156 @@ class ListQuantumProcessorConfigsAsyncPager:
         async def async_generator():
             async for page in self.pages:
                 for response in page.quantum_processor_configs:
+                    yield response
+
+        return async_generator()
+
+    def __repr__(self) -> str:
+        return '{0}<{1!r}>'.format(self.__class__.__name__, self._response)
+
+
+class ListQuantumProcessorAutomationRunHistoryPager:
+    """A pager for iterating through ``list_quantum_processor_automation_run_history`` requests.
+
+    This class thinly wraps an initial
+    :class:`cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryResponse` object, and
+    provides an ``__iter__`` method to iterate through its
+    ``run_history`` field.
+
+    If there are more pages, the ``__iter__`` method will make additional
+    ``ListQuantumProcessorAutomationRunHistory`` requests and continue to iterate
+    through the ``run_history`` field on the
+    corresponding responses.
+
+    All the usual :class:`cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryResponse`
+    attributes are available on the pager. If multiple requests are made, only
+    the most recent response is retained, and thus used for attribute lookup.
+    """
+
+    def __init__(
+        self,
+        method: Callable[..., engine.ListQuantumProcessorAutomationRunHistoryResponse],
+        request: engine.ListQuantumProcessorAutomationRunHistoryRequest,
+        response: engine.ListQuantumProcessorAutomationRunHistoryResponse,
+        *,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ):
+        """Instantiate the pager.
+
+        Args:
+            method (Callable): The method that was originally called, and
+                which instantiated this pager.
+            request (cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryRequest):
+                The initial request object.
+            response (cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryResponse):
+                The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+        """
+        self._method = method
+        self._request = engine.ListQuantumProcessorAutomationRunHistoryRequest(request)
+        self._response = response
+        self._retry = retry
+        self._timeout = timeout
+        self._metadata = metadata
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._response, name)
+
+    @property
+    def pages(self) -> Iterator[engine.ListQuantumProcessorAutomationRunHistoryResponse]:
+        yield self._response
+        while self._response.next_page_token:
+            self._request.page_token = self._response.next_page_token
+            self._response = self._method(
+                self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata
+            )
+            yield self._response
+
+    def __iter__(self) -> Iterator[quantum.QuantumProcessorAutomationRunHistory]:
+        for page in self.pages:
+            yield from page.run_history
+
+    def __repr__(self) -> str:
+        return '{0}<{1!r}>'.format(self.__class__.__name__, self._response)
+
+
+class ListQuantumProcessorAutomationRunHistoryAsyncPager:
+    """A pager for iterating through ``list_quantum_processor_automation_run_history`` requests.
+
+    This class thinly wraps an initial
+    :class:`cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryResponse` object, and
+    provides an ``__aiter__`` method to iterate through its
+    ``run_history`` field.
+
+    If there are more pages, the ``__aiter__`` method will make additional
+    ``ListQuantumProcessorAutomationRunHistory`` requests and continue to iterate
+    through the ``run_history`` field on the
+    corresponding responses.
+
+    All the usual :class:`cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryResponse`
+    attributes are available on the pager. If multiple requests are made, only
+    the most recent response is retained, and thus used for attribute lookup.
+    """
+
+    def __init__(
+        self,
+        method: Callable[..., Awaitable[engine.ListQuantumProcessorAutomationRunHistoryResponse]],
+        request: engine.ListQuantumProcessorAutomationRunHistoryRequest,
+        response: engine.ListQuantumProcessorAutomationRunHistoryResponse,
+        *,
+        retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ):
+        """Instantiates the pager.
+
+        Args:
+            method (Callable): The method that was originally called, and
+                which instantiated this pager.
+            request (cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryRequest):
+                The initial request object.
+            response (cirq_google.cloud.quantum_v1alpha1.types.ListQuantumProcessorAutomationRunHistoryResponse):
+                The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+        """
+        self._method = method
+        self._request = engine.ListQuantumProcessorAutomationRunHistoryRequest(request)
+        self._response = response
+        self._retry = retry
+        self._timeout = timeout
+        self._metadata = metadata
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._response, name)
+
+    @property
+    async def pages(self) -> AsyncIterator[engine.ListQuantumProcessorAutomationRunHistoryResponse]:
+        yield self._response
+        while self._response.next_page_token:
+            self._request.page_token = self._response.next_page_token
+            self._response = await self._method(
+                self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata
+            )
+            yield self._response
+
+    def __aiter__(self) -> AsyncIterator[quantum.QuantumProcessorAutomationRunHistory]:
+        async def async_generator():
+            async for page in self.pages:
+                for response in page.run_history:
                     yield response
 
         return async_generator()

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/README.rst
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/README.rst
@@ -2,8 +2,9 @@
 transport inheritance structure
 _______________________________
 
-`QuantumEngineServiceTransport` is the ABC for all transports.
-- public child `QuantumEngineServiceGrpcTransport` for sync gRPC transport (defined in `grpc.py`).
-- public child `QuantumEngineServiceGrpcAsyncIOTransport` for async gRPC transport (defined in `grpc_asyncio.py`).
-- private child `_BaseQuantumEngineServiceRestTransport` for base REST transport with inner classes `_BaseMETHOD` (defined in `rest_base.py`).
-- public child `QuantumEngineServiceRestTransport` for sync REST transport with inner classes `METHOD` derived from the parent's corresponding `_BaseMETHOD` classes (defined in `rest.py`).
+``QuantumEngineServiceTransport`` is the ABC for all transports.
+
+- public child ``QuantumEngineServiceGrpcTransport`` for sync gRPC transport (defined in ``grpc.py``).
+- public child ``QuantumEngineServiceGrpcAsyncIOTransport`` for async gRPC transport (defined in ``grpc_asyncio.py``).
+- private child ``_BaseQuantumEngineServiceRestTransport`` for base REST transport with inner classes ``_BaseMETHOD`` (defined in ``rest_base.py``).
+- public child ``QuantumEngineServiceRestTransport`` for sync REST transport with inner classes ``METHOD`` derived from the parent's corresponding ``_BaseMETHOD`` classes (defined in ``rest.py``).

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/__init__.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/base.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@ from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import google.api_core
 import google.auth  # type: ignore
 import google.protobuf
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import exceptions as core_exceptions, gapic_v1, retry as retries
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.oauth2 import service_account  # type: ignore
-from google.protobuf import empty_pb2  # type: ignore
 
 import cirq_google
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
@@ -63,9 +63,10 @@ class QuantumEngineServiceTransport(abc.ABC):
                 credentials identify the application to the service; if none
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
-            credentials_file (Optional[str]): A file with credentials that can
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
-                This argument is mutually exclusive with credentials.
+                This argument is mutually exclusive with credentials. This argument will be
+                removed in the next major version of this library.
             scopes (Optional[Sequence[str]]): A list of scopes.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
@@ -76,9 +77,11 @@ class QuantumEngineServiceTransport(abc.ABC):
                 your own client library.
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
         """
-
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -94,10 +97,15 @@ class QuantumEngineServiceTransport(abc.ABC):
 
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
-                credentials_file, **scopes_kwargs, quota_project_id=quota_project_id
+                credentials_file,
+                scopes=scopes,
+                quota_project_id=quota_project_id,
+                default_scopes=self.AUTH_SCOPES,
             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(
+                scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES
+            )
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)
@@ -117,6 +125,8 @@ class QuantumEngineServiceTransport(abc.ABC):
         if ':' not in host:
             host += ':443'
         self._host = host
+
+        self._wrapped_methods: Dict[Callable, Callable] = {}
 
     @property
     def host(self):
@@ -139,6 +149,9 @@ class QuantumEngineServiceTransport(abc.ABC):
             ),
             self.update_quantum_program: gapic_v1.method.wrap_method(
                 self.update_quantum_program, default_timeout=60.0, client_info=client_info
+            ),
+            self.compile_qec_program: gapic_v1.method.wrap_method(
+                self.compile_qec_program, default_timeout=None, client_info=client_info
             ),
             self.create_quantum_job: gapic_v1.method.wrap_method(
                 self.create_quantum_job, default_timeout=60.0, client_info=client_info
@@ -175,6 +188,11 @@ class QuantumEngineServiceTransport(abc.ABC):
             ),
             self.list_quantum_processor_configs: gapic_v1.method.wrap_method(
                 self.list_quantum_processor_configs, default_timeout=None, client_info=client_info
+            ),
+            self.list_quantum_processor_automation_run_history: gapic_v1.method.wrap_method(
+                self.list_quantum_processor_automation_run_history,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.list_quantum_calibrations: gapic_v1.method.wrap_method(
                 self.list_quantum_calibrations, default_timeout=60.0, client_info=client_info
@@ -269,6 +287,15 @@ class QuantumEngineServiceTransport(abc.ABC):
     ) -> Callable[
         [engine.UpdateQuantumProgramRequest],
         Union[quantum.QuantumProgram, Awaitable[quantum.QuantumProgram]],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def compile_qec_program(
+        self,
+    ) -> Callable[
+        [engine.CompileQecProgramRequest],
+        Union[engine.CompileQecProgramResponse, Awaitable[engine.CompileQecProgramResponse]],
     ]:
         raise NotImplementedError()
 
@@ -376,6 +403,18 @@ class QuantumEngineServiceTransport(abc.ABC):
         Union[
             engine.ListQuantumProcessorConfigsResponse,
             Awaitable[engine.ListQuantumProcessorConfigsResponse],
+        ],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def list_quantum_processor_automation_run_history(
+        self,
+    ) -> Callable[
+        [engine.ListQuantumProcessorAutomationRunHistoryRequest],
+        Union[
+            engine.ListQuantumProcessorAutomationRunHistoryResponse,
+            Awaitable[engine.ListQuantumProcessorAutomationRunHistoryResponse],
         ],
     ]:
         raise NotImplementedError()

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 import google.auth  # type: ignore
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.message
 import grpc  # type: ignore
 import proto  # type: ignore
 from google.api_core import gapic_v1, grpc_helpers
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-from google.protobuf import empty_pb2  # type: ignore
 from google.protobuf.json_format import MessageToJson
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
@@ -53,7 +53,7 @@ class _LoggingClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # pragma: NO
             elif isinstance(request, google.protobuf.message.Message):
                 request_payload = MessageToJson(request)
             else:
-                request_payload = f"{type(request).__name__}: {pickle.dumps(request)}"
+                request_payload = f"{type(request).__name__}: {pickle.dumps(request)!r}"
 
             request_metadata = {
                 key: value.decode("utf-8") if isinstance(value, bytes) else value
@@ -86,7 +86,7 @@ class _LoggingClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # pragma: NO
             elif isinstance(result, google.protobuf.message.Message):
                 response_payload = MessageToJson(result)
             else:
-                response_payload = f"{type(result).__name__}: {pickle.dumps(result)}"
+                response_payload = f"{type(result).__name__}: {pickle.dumps(result)!r}"
             grpc_response = {"payload": response_payload, "metadata": metadata, "status": "OK"}
             _LOGGER.debug(
                 f"Received response for {client_call_details.method}.",
@@ -143,9 +143,10 @@ class QuantumEngineServiceGrpcTransport(QuantumEngineServiceTransport):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
                 This argument is ignored if a ``channel`` instance is provided.
-            credentials_file (Optional[str]): A file with credentials that can
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
                 This argument is ignored if a ``channel`` instance is provided.
+                This argument will be removed in the next major version of this library.
             scopes (Optional(Sequence[str])): A list of scopes. This argument is
                 ignored if a ``channel`` instance is provided.
             channel (Optional[Union[grpc.Channel, Callable[..., grpc.Channel]]]):
@@ -176,6 +177,10 @@ class QuantumEngineServiceGrpcTransport(QuantumEngineServiceTransport):
                 your own client library.
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
 
         Raises:
           google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
@@ -276,9 +281,10 @@ class QuantumEngineServiceGrpcTransport(QuantumEngineServiceTransport):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
-            credentials_file (Optional[str]): A file with credentials that can
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
-                This argument is mutually exclusive with credentials.
+                This argument is mutually exclusive with credentials.  This argument will be
+                removed in the next major version of this library.
             scopes (Optional[Sequence[str]]): A optional list of scopes needed for this
                 service. These are only used when credentials are not specified and
                 are passed to :func:`google.auth.default`.
@@ -439,6 +445,32 @@ class QuantumEngineServiceGrpcTransport(QuantumEngineServiceTransport):
                 response_deserializer=quantum.QuantumProgram.deserialize,
             )
         return self._stubs['update_quantum_program']
+
+    @property
+    def compile_qec_program(
+        self,
+    ) -> Callable[[engine.CompileQecProgramRequest], engine.CompileQecProgramResponse]:
+        r"""Return a callable for the compile qec program method over gRPC.
+
+        -
+
+        Returns:
+            Callable[[~.CompileQecProgramRequest],
+                    ~.CompileQecProgramResponse]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if 'compile_qec_program' not in self._stubs:
+            self._stubs['compile_qec_program'] = self._logged_channel.unary_unary(
+                '/google.cloud.quantum.v1alpha1.QuantumEngineService/CompileQecProgram',
+                request_serializer=engine.CompileQecProgramRequest.serialize,
+                response_deserializer=engine.CompileQecProgramResponse.deserialize,
+            )
+        return self._stubs['compile_qec_program']
 
     @property
     def create_quantum_job(self) -> Callable[[engine.CreateQuantumJobRequest], quantum.QuantumJob]:
@@ -743,6 +775,38 @@ class QuantumEngineServiceGrpcTransport(QuantumEngineServiceTransport):
                 response_deserializer=engine.ListQuantumProcessorConfigsResponse.deserialize,
             )
         return self._stubs['list_quantum_processor_configs']
+
+    @property
+    def list_quantum_processor_automation_run_history(
+        self,
+    ) -> Callable[
+        [engine.ListQuantumProcessorAutomationRunHistoryRequest],
+        engine.ListQuantumProcessorAutomationRunHistoryResponse,
+    ]:
+        r"""Return a callable for the list quantum processor
+        automation run history method over gRPC.
+
+        -
+
+        Returns:
+            Callable[[~.ListQuantumProcessorAutomationRunHistoryRequest],
+                    ~.ListQuantumProcessorAutomationRunHistoryResponse]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if 'list_quantum_processor_automation_run_history' not in self._stubs:
+            self._stubs['list_quantum_processor_automation_run_history'] = (
+                self._logged_channel.unary_unary(
+                    '/google.cloud.quantum.v1alpha1.QuantumEngineService/ListQuantumProcessorAutomationRunHistory',
+                    request_serializer=engine.ListQuantumProcessorAutomationRunHistoryRequest.serialize,
+                    response_deserializer=engine.ListQuantumProcessorAutomationRunHistoryResponse.deserialize,
+                )
+            )
+        return self._stubs['list_quantum_processor_automation_run_history']
 
     @property
     def list_quantum_calibrations(

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc_asyncio.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import pickle
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.message
 import grpc  # type: ignore
 import proto  # type: ignore
@@ -31,7 +32,6 @@ from google.api_core import (
 )
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-from google.protobuf import empty_pb2  # type: ignore
 from google.protobuf.json_format import MessageToJson
 from grpc.experimental import aio  # type: ignore
 
@@ -60,7 +60,7 @@ class _LoggingClientAIOInterceptor(grpc.aio.UnaryUnaryClientInterceptor):  # pra
             elif isinstance(request, google.protobuf.message.Message):
                 request_payload = MessageToJson(request)
             else:
-                request_payload = f"{type(request).__name__}: {pickle.dumps(request)}"
+                request_payload = f"{type(request).__name__}: {pickle.dumps(request)!r}"
 
             request_metadata = {
                 key: value.decode("utf-8") if isinstance(value, bytes) else value
@@ -93,7 +93,7 @@ class _LoggingClientAIOInterceptor(grpc.aio.UnaryUnaryClientInterceptor):  # pra
             elif isinstance(result, google.protobuf.message.Message):
                 response_payload = MessageToJson(result)
             else:
-                response_payload = f"{type(result).__name__}: {pickle.dumps(result)}"
+                response_payload = f"{type(result).__name__}: {pickle.dumps(result)!r}"
             grpc_response = {"payload": response_payload, "metadata": metadata, "status": "OK"}
             _LOGGER.debug(
                 f"Received response to rpc {client_call_details.method}.",
@@ -141,8 +141,9 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
                 credentials identify this application to the service. If
                 none are specified, the client will attempt to ascertain
                 the credentials from the environment.
-            credentials_file (Optional[str]): A file with credentials that can
-                be loaded with :func:`google.auth.load_credentials_from_file`.
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`. This argument will be
+                removed in the next major version of this library.
             scopes (Optional[Sequence[str]]): A optional list of scopes needed for this
                 service. These are only used when credentials are not specified and
                 are passed to :func:`google.auth.default`.
@@ -193,9 +194,10 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
                 This argument is ignored if a ``channel`` instance is provided.
-            credentials_file (Optional[str]): A file with credentials that can
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
                 This argument is ignored if a ``channel`` instance is provided.
+                This argument will be removed in the next major version of this library.
             scopes (Optional[Sequence[str]]): A optional list of scopes needed for this
                 service. These are only used when credentials are not specified and
                 are passed to :func:`google.auth.default`.
@@ -227,6 +229,10 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
                 your own client library.
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
 
         Raises:
             google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
@@ -456,6 +462,32 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
                 response_deserializer=quantum.QuantumProgram.deserialize,
             )
         return self._stubs['update_quantum_program']
+
+    @property
+    def compile_qec_program(
+        self,
+    ) -> Callable[[engine.CompileQecProgramRequest], Awaitable[engine.CompileQecProgramResponse]]:
+        r"""Return a callable for the compile qec program method over gRPC.
+
+        -
+
+        Returns:
+            Callable[[~.CompileQecProgramRequest],
+                    Awaitable[~.CompileQecProgramResponse]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if 'compile_qec_program' not in self._stubs:
+            self._stubs['compile_qec_program'] = self._logged_channel.unary_unary(
+                '/google.cloud.quantum.v1alpha1.QuantumEngineService/CompileQecProgram',
+                request_serializer=engine.CompileQecProgramRequest.serialize,
+                response_deserializer=engine.CompileQecProgramResponse.deserialize,
+            )
+        return self._stubs['compile_qec_program']
 
     @property
     def create_quantum_job(
@@ -777,6 +809,38 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
                 response_deserializer=engine.ListQuantumProcessorConfigsResponse.deserialize,
             )
         return self._stubs['list_quantum_processor_configs']
+
+    @property
+    def list_quantum_processor_automation_run_history(
+        self,
+    ) -> Callable[
+        [engine.ListQuantumProcessorAutomationRunHistoryRequest],
+        Awaitable[engine.ListQuantumProcessorAutomationRunHistoryResponse],
+    ]:
+        r"""Return a callable for the list quantum processor
+        automation run history method over gRPC.
+
+        -
+
+        Returns:
+            Callable[[~.ListQuantumProcessorAutomationRunHistoryRequest],
+                    Awaitable[~.ListQuantumProcessorAutomationRunHistoryResponse]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if 'list_quantum_processor_automation_run_history' not in self._stubs:
+            self._stubs['list_quantum_processor_automation_run_history'] = (
+                self._logged_channel.unary_unary(
+                    '/google.cloud.quantum.v1alpha1.QuantumEngineService/ListQuantumProcessorAutomationRunHistory',
+                    request_serializer=engine.ListQuantumProcessorAutomationRunHistoryRequest.serialize,
+                    response_deserializer=engine.ListQuantumProcessorAutomationRunHistoryResponse.deserialize,
+                )
+            )
+        return self._stubs['list_quantum_processor_automation_run_history']
 
     @property
     def list_quantum_calibrations(
@@ -1152,6 +1216,9 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
             self.update_quantum_program: self._wrap_method(
                 self.update_quantum_program, default_timeout=60.0, client_info=client_info
             ),
+            self.compile_qec_program: self._wrap_method(
+                self.compile_qec_program, default_timeout=None, client_info=client_info
+            ),
             self.create_quantum_job: self._wrap_method(
                 self.create_quantum_job, default_timeout=60.0, client_info=client_info
             ),
@@ -1187,6 +1254,11 @@ class QuantumEngineServiceGrpcAsyncIOTransport(QuantumEngineServiceTransport):
             ),
             self.list_quantum_processor_configs: self._wrap_method(
                 self.list_quantum_processor_configs, default_timeout=None, client_info=client_info
+            ),
+            self.list_quantum_processor_automation_run_history: self._wrap_method(
+                self.list_quantum_processor_automation_run_history,
+                default_timeout=None,
+                client_info=client_info,
             ),
             self.list_quantum_calibrations: self._wrap_method(
                 self.list_quantum_calibrations, default_timeout=60.0, client_info=client_info

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/rest.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import google.protobuf
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import (
     exceptions as core_exceptions,
     gapic_v1,
@@ -29,7 +30,6 @@ from google.api_core import (
 )
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
-from google.protobuf import empty_pb2  # type: ignore
 from google.protobuf import json_format
 from requests import __version__ as requests_version
 
@@ -86,6 +86,14 @@ class QuantumEngineServiceRestInterceptor:
                 return request, metadata
 
             def post_cancel_quantum_reservation(self, response):
+                logging.log(f"Received response: {response}")
+                return response
+
+            def pre_compile_qec_program(self, request, metadata):
+                logging.log(f"Received request: {request}")
+                return request, metadata
+
+            def post_compile_qec_program(self, response):
                 logging.log(f"Received response: {response}")
                 return response
 
@@ -202,6 +210,14 @@ class QuantumEngineServiceRestInterceptor:
                 return request, metadata
 
             def post_list_quantum_jobs(self, response):
+                logging.log(f"Received response: {response}")
+                return response
+
+            def pre_list_quantum_processor_automation_run_history(self, request, metadata):
+                logging.log(f"Received request: {request}")
+                return request, metadata
+
+            def post_list_quantum_processor_automation_run_history(self, response):
                 logging.log(f"Received response: {response}")
                 return response
 
@@ -354,6 +370,52 @@ class QuantumEngineServiceRestInterceptor:
         `post_cancel_quantum_reservation` interceptor. The (possibly modified) response returned by
         `post_cancel_quantum_reservation` will be passed to
         `post_cancel_quantum_reservation_with_metadata`.
+        """
+        return response, metadata
+
+    def pre_compile_qec_program(
+        self,
+        request: engine.CompileQecProgramRequest,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[engine.CompileQecProgramRequest, Sequence[Tuple[str, Union[str, bytes]]]]:
+        """Pre-rpc interceptor for compile_qec_program
+
+        Override in a subclass to manipulate the request or metadata
+        before they are sent to the QuantumEngineService server.
+        """
+        return request, metadata
+
+    def post_compile_qec_program(
+        self, response: engine.CompileQecProgramResponse
+    ) -> engine.CompileQecProgramResponse:
+        """Post-rpc interceptor for compile_qec_program
+
+        DEPRECATED. Please use the `post_compile_qec_program_with_metadata`
+        interceptor instead.
+
+        Override in a subclass to read or manipulate the response
+        after it is returned by the QuantumEngineService server but before
+        it is returned to user code. This `post_compile_qec_program` interceptor runs
+        before the `post_compile_qec_program_with_metadata` interceptor.
+        """
+        return response
+
+    def post_compile_qec_program_with_metadata(
+        self,
+        response: engine.CompileQecProgramResponse,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[engine.CompileQecProgramResponse, Sequence[Tuple[str, Union[str, bytes]]]]:
+        """Post-rpc interceptor for compile_qec_program
+
+        Override in a subclass to read or manipulate the response or metadata after it
+        is returned by the QuantumEngineService server but before it is returned to user code.
+
+        We recommend only using this `post_compile_qec_program_with_metadata`
+        interceptor in new development instead of the `post_compile_qec_program` interceptor.
+        When both interceptors are used, this `post_compile_qec_program_with_metadata` interceptor runs after the
+        `post_compile_qec_program` interceptor. The (possibly modified) response returned by
+        `post_compile_qec_program` will be passed to
+        `post_compile_qec_program_with_metadata`.
         """
         return response, metadata
 
@@ -971,6 +1033,58 @@ class QuantumEngineServiceRestInterceptor:
         """
         return response, metadata
 
+    def pre_list_quantum_processor_automation_run_history(
+        self,
+        request: engine.ListQuantumProcessorAutomationRunHistoryRequest,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        engine.ListQuantumProcessorAutomationRunHistoryRequest,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Pre-rpc interceptor for list_quantum_processor_automation_run_history
+
+        Override in a subclass to manipulate the request or metadata
+        before they are sent to the QuantumEngineService server.
+        """
+        return request, metadata
+
+    def post_list_quantum_processor_automation_run_history(
+        self, response: engine.ListQuantumProcessorAutomationRunHistoryResponse
+    ) -> engine.ListQuantumProcessorAutomationRunHistoryResponse:
+        """Post-rpc interceptor for list_quantum_processor_automation_run_history
+
+        DEPRECATED. Please use the `post_list_quantum_processor_automation_run_history_with_metadata`
+        interceptor instead.
+
+        Override in a subclass to read or manipulate the response
+        after it is returned by the QuantumEngineService server but before
+        it is returned to user code. This `post_list_quantum_processor_automation_run_history` interceptor runs
+        before the `post_list_quantum_processor_automation_run_history_with_metadata` interceptor.
+        """
+        return response
+
+    def post_list_quantum_processor_automation_run_history_with_metadata(
+        self,
+        response: engine.ListQuantumProcessorAutomationRunHistoryResponse,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        engine.ListQuantumProcessorAutomationRunHistoryResponse,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Post-rpc interceptor for list_quantum_processor_automation_run_history
+
+        Override in a subclass to read or manipulate the response or metadata after it
+        is returned by the QuantumEngineService server but before it is returned to user code.
+
+        We recommend only using this `post_list_quantum_processor_automation_run_history_with_metadata`
+        interceptor in new development instead of the `post_list_quantum_processor_automation_run_history` interceptor.
+        When both interceptors are used, this `post_list_quantum_processor_automation_run_history_with_metadata` interceptor runs after the
+        `post_list_quantum_processor_automation_run_history` interceptor. The (possibly modified) response returned by
+        `post_list_quantum_processor_automation_run_history` will be passed to
+        `post_list_quantum_processor_automation_run_history_with_metadata`.
+        """
+        return response, metadata
+
     def pre_list_quantum_processor_configs(
         self,
         request: engine.ListQuantumProcessorConfigsRequest,
@@ -1525,9 +1639,10 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                 are specified, the client will attempt to ascertain the
                 credentials from the environment.
 
-            credentials_file (Optional[str]): A file with credentials that can
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
-                This argument is ignored if ``channel`` is provided.
+                This argument is ignored if ``channel`` is provided. This argument will be
+                removed in the next major version of this library.
             scopes (Optional(Sequence[str])): A list of scopes. This argument is
                 ignored if ``channel`` is provided.
             client_cert_source_for_mtls (Callable[[], Tuple[bytes, bytes]]): Client
@@ -1545,6 +1660,12 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
             url_scheme: the protocol scheme for the API endpoint.  Normally
                 "https", but for testing or local servers,
                 "http" can be specified.
+            interceptor (Optional[QuantumEngineServiceRestInterceptor]): Interceptor used
+                to manipulate requests, request metadata, and responses.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
         """
         # Run the base constructor
         # TODO(yon-mg): resolve other ctor params i.e. scopes, quota, etc.
@@ -1636,7 +1757,7 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                 request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
                 method = transcoded_request['method']
                 try:
-                    request_payload = json_format.MessageToJson(request)
+                    request_payload = type(request).to_json(request)
                 except:
                     request_payload = None
                 http_request = {
@@ -1794,6 +1915,139 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                     extra={
                         "serviceName": "google.cloud.quantum.v1alpha1.QuantumEngineService",
                         "rpcName": "CancelQuantumReservation",
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
+                    },
+                )
+            return resp
+
+    class _CompileQecProgram(
+        _BaseQuantumEngineServiceRestTransport._BaseCompileQecProgram, QuantumEngineServiceRestStub
+    ):
+        def __hash__(self):
+            return hash("QuantumEngineServiceRestTransport.CompileQecProgram")
+
+        @staticmethod
+        def _get_response(
+            host, metadata, query_params, session, timeout, transcoded_request, body=None
+        ):
+
+            uri = transcoded_request['uri']
+            method = transcoded_request['method']
+            headers = dict(metadata)
+            headers['Content-Type'] = 'application/json'
+            response = getattr(session, method)(
+                "{host}{uri}".format(host=host, uri=uri),
+                timeout=timeout,
+                headers=headers,
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                data=body,
+            )
+            return response
+
+        def __call__(
+            self,
+            request: engine.CompileQecProgramRequest,
+            *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Optional[float] = None,
+            metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ) -> engine.CompileQecProgramResponse:
+            r"""Call the compile qec program method over HTTP.
+
+            Args:
+                request (~.engine.CompileQecProgramRequest):
+                    The request object. -
+                retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                    should be retried.
+                timeout (float): The timeout for this request.
+                metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                    sent along with the request as metadata. Normally, each value must be of type `str`,
+                    but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                    be of type `bytes`.
+
+            Returns:
+                ~.engine.CompileQecProgramResponse:
+                    -
+            """
+
+            http_options = (
+                _BaseQuantumEngineServiceRestTransport._BaseCompileQecProgram._get_http_options()
+            )
+
+            request, metadata = self._interceptor.pre_compile_qec_program(request, metadata)
+            transcoded_request = _BaseQuantumEngineServiceRestTransport._BaseCompileQecProgram._get_transcoded_request(
+                http_options, request
+            )
+
+            body = _BaseQuantumEngineServiceRestTransport._BaseCompileQecProgram._get_request_body_json(
+                transcoded_request
+            )
+
+            # Jsonify the query params
+            query_params = _BaseQuantumEngineServiceRestTransport._BaseCompileQecProgram._get_query_params_json(
+                transcoded_request
+            )
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                try:
+                    request_payload = type(request).to_json(request)
+                except:
+                    request_payload = None
+                http_request = {
+                    "payload": request_payload,
+                    "requestMethod": method,
+                    "requestUrl": request_url,
+                    "headers": dict(metadata),
+                }
+                _LOGGER.debug(
+                    f"Sending request for cirq_google.cloud.quantum_v1alpha1.QuantumEngineServiceClient.CompileQecProgram",
+                    extra={
+                        "serviceName": "google.cloud.quantum.v1alpha1.QuantumEngineService",
+                        "rpcName": "CompileQecProgram",
+                        "httpRequest": http_request,
+                        "metadata": http_request["headers"],
+                    },
+                )
+
+            # Send the request
+            response = QuantumEngineServiceRestTransport._CompileQecProgram._get_response(
+                self._host, metadata, query_params, self._session, timeout, transcoded_request, body
+            )
+
+            # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+            # subclass.
+            if response.status_code >= 400:
+                raise core_exceptions.from_http_response(response)
+
+            # Return the response
+            resp = engine.CompileQecProgramResponse()
+            pb_resp = engine.CompileQecProgramResponse.pb(resp)
+
+            json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
+            resp = self._interceptor.post_compile_qec_program(resp)
+            response_metadata = [(k, str(v)) for k, v in response.headers.items()]
+            resp, _ = self._interceptor.post_compile_qec_program_with_metadata(
+                resp, response_metadata
+            )
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                try:
+                    response_payload = engine.CompileQecProgramResponse.to_json(response)
+                except:
+                    response_payload = None
+                http_response = {
+                    "payload": response_payload,
+                    "headers": dict(response.headers),
+                    "status": response.status_code,
+                }
+                _LOGGER.debug(
+                    "Received response for cirq_google.cloud.quantum_v1alpha1.QuantumEngineServiceClient.compile_qec_program",
+                    extra={
+                        "serviceName": "google.cloud.quantum.v1alpha1.QuantumEngineService",
+                        "rpcName": "CompileQecProgram",
                         "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
@@ -2271,7 +2525,7 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                 request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
                 method = transcoded_request['method']
                 try:
-                    request_payload = json_format.MessageToJson(request)
+                    request_payload = type(request).to_json(request)
                 except:
                     request_payload = None
                 http_request = {
@@ -2364,7 +2618,7 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                 request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
                 method = transcoded_request['method']
                 try:
-                    request_payload = json_format.MessageToJson(request)
+                    request_payload = type(request).to_json(request)
                 except:
                     request_payload = None
                 http_request = {
@@ -2458,7 +2712,7 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                 request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
                 method = transcoded_request['method']
                 try:
-                    request_payload = json_format.MessageToJson(request)
+                    request_payload = type(request).to_json(request)
                 except:
                     request_payload = None
                 http_request = {
@@ -3778,6 +4032,144 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
                     extra={
                         "serviceName": "google.cloud.quantum.v1alpha1.QuantumEngineService",
                         "rpcName": "ListQuantumJobs",
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
+                    },
+                )
+            return resp
+
+    class _ListQuantumProcessorAutomationRunHistory(
+        _BaseQuantumEngineServiceRestTransport._BaseListQuantumProcessorAutomationRunHistory,
+        QuantumEngineServiceRestStub,
+    ):
+        def __hash__(self):
+            return hash(
+                "QuantumEngineServiceRestTransport.ListQuantumProcessorAutomationRunHistory"
+            )
+
+        @staticmethod
+        def _get_response(
+            host, metadata, query_params, session, timeout, transcoded_request, body=None
+        ):
+
+            uri = transcoded_request['uri']
+            method = transcoded_request['method']
+            headers = dict(metadata)
+            headers['Content-Type'] = 'application/json'
+            response = getattr(session, method)(
+                "{host}{uri}".format(host=host, uri=uri),
+                timeout=timeout,
+                headers=headers,
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
+            )
+            return response
+
+        def __call__(
+            self,
+            request: engine.ListQuantumProcessorAutomationRunHistoryRequest,
+            *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Optional[float] = None,
+            metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ) -> engine.ListQuantumProcessorAutomationRunHistoryResponse:
+            r"""Call the list quantum processor
+            automation run history method over HTTP.
+
+                Args:
+                    request (~.engine.ListQuantumProcessorAutomationRunHistoryRequest):
+                        The request object. -
+                    retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                        should be retried.
+                    timeout (float): The timeout for this request.
+                    metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                        sent along with the request as metadata. Normally, each value must be of type `str`,
+                        but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                        be of type `bytes`.
+
+                Returns:
+                    ~.engine.ListQuantumProcessorAutomationRunHistoryResponse:
+                        -
+            """
+
+            http_options = (
+                _BaseQuantumEngineServiceRestTransport._BaseListQuantumProcessorAutomationRunHistory._get_http_options()
+            )
+
+            request, metadata = self._interceptor.pre_list_quantum_processor_automation_run_history(
+                request, metadata
+            )
+            transcoded_request = _BaseQuantumEngineServiceRestTransport._BaseListQuantumProcessorAutomationRunHistory._get_transcoded_request(
+                http_options, request
+            )
+
+            # Jsonify the query params
+            query_params = _BaseQuantumEngineServiceRestTransport._BaseListQuantumProcessorAutomationRunHistory._get_query_params_json(
+                transcoded_request
+            )
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                try:
+                    request_payload = type(request).to_json(request)
+                except:
+                    request_payload = None
+                http_request = {
+                    "payload": request_payload,
+                    "requestMethod": method,
+                    "requestUrl": request_url,
+                    "headers": dict(metadata),
+                }
+                _LOGGER.debug(
+                    f"Sending request for cirq_google.cloud.quantum_v1alpha1.QuantumEngineServiceClient.ListQuantumProcessorAutomationRunHistory",
+                    extra={
+                        "serviceName": "google.cloud.quantum.v1alpha1.QuantumEngineService",
+                        "rpcName": "ListQuantumProcessorAutomationRunHistory",
+                        "httpRequest": http_request,
+                        "metadata": http_request["headers"],
+                    },
+                )
+
+            # Send the request
+            response = QuantumEngineServiceRestTransport._ListQuantumProcessorAutomationRunHistory._get_response(
+                self._host, metadata, query_params, self._session, timeout, transcoded_request
+            )
+
+            # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+            # subclass.
+            if response.status_code >= 400:
+                raise core_exceptions.from_http_response(response)
+
+            # Return the response
+            resp = engine.ListQuantumProcessorAutomationRunHistoryResponse()
+            pb_resp = engine.ListQuantumProcessorAutomationRunHistoryResponse.pb(resp)
+
+            json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
+            resp = self._interceptor.post_list_quantum_processor_automation_run_history(resp)
+            response_metadata = [(k, str(v)) for k, v in response.headers.items()]
+            resp, _ = (
+                self._interceptor.post_list_quantum_processor_automation_run_history_with_metadata(
+                    resp, response_metadata
+                )
+            )
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                try:
+                    response_payload = (
+                        engine.ListQuantumProcessorAutomationRunHistoryResponse.to_json(response)
+                    )
+                except:
+                    response_payload = None
+                http_response = {
+                    "payload": response_payload,
+                    "headers": dict(response.headers),
+                    "status": response.status_code,
+                }
+                _LOGGER.debug(
+                    "Received response for cirq_google.cloud.quantum_v1alpha1.QuantumEngineServiceClient.list_quantum_processor_automation_run_history",
+                    extra={
+                        "serviceName": "google.cloud.quantum.v1alpha1.QuantumEngineService",
+                        "rpcName": "ListQuantumProcessorAutomationRunHistory",
                         "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
@@ -5286,6 +5678,14 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
         return self._CancelQuantumReservation(self._session, self._host, self._interceptor)  # type: ignore
 
     @property
+    def compile_qec_program(
+        self,
+    ) -> Callable[[engine.CompileQecProgramRequest], engine.CompileQecProgramResponse]:
+        # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
+        # In C++ this would require a dynamic_cast
+        return self._CompileQecProgram(self._session, self._host, self._interceptor)  # type: ignore
+
+    @property
     def create_quantum_job(self) -> Callable[[engine.CreateQuantumJobRequest], quantum.QuantumJob]:
         # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
         # In C++ this would require a dynamic_cast
@@ -5406,6 +5806,17 @@ class QuantumEngineServiceRestTransport(_BaseQuantumEngineServiceRestTransport):
         # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
         # In C++ this would require a dynamic_cast
         return self._ListQuantumJobs(self._session, self._host, self._interceptor)  # type: ignore
+
+    @property
+    def list_quantum_processor_automation_run_history(
+        self,
+    ) -> Callable[
+        [engine.ListQuantumProcessorAutomationRunHistoryRequest],
+        engine.ListQuantumProcessorAutomationRunHistoryResponse,
+    ]:
+        # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
+        # In C++ this would require a dynamic_cast
+        return self._ListQuantumProcessorAutomationRunHistory(self._session, self._host, self._interceptor)  # type: ignore
 
     @property
     def list_quantum_processor_configs(

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/rest_base.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ import json  # type: ignore
 import re
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import gapic_v1, path_template
-from google.protobuf import empty_pb2  # type: ignore
 from google.protobuf import json_format
 
 from cirq_google.cloud.quantum_v1alpha1.types import engine, quantum
@@ -145,6 +145,47 @@ class _BaseQuantumEngineServiceRestTransport(QuantumEngineServiceTransport):
         @staticmethod
         def _get_transcoded_request(http_options, request):
             pb_request = engine.CancelQuantumReservationRequest.pb(request)
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+        @staticmethod
+        def _get_request_body_json(transcoded_request):
+            # Jsonify the request body
+
+            body = json_format.MessageToJson(
+                transcoded_request['body'], use_integers_for_enums=True
+            )
+            return body
+
+        @staticmethod
+        def _get_query_params_json(transcoded_request):
+            query_params = json.loads(
+                json_format.MessageToJson(
+                    transcoded_request['query_params'], use_integers_for_enums=True
+                )
+            )
+
+            query_params["$alt"] = "json;enum-encoding=int"
+            return query_params
+
+    class _BaseCompileQecProgram:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+
+        @staticmethod
+        def _get_http_options():
+            http_options: List[Dict[str, str]] = [
+                {
+                    'method': 'post',
+                    'uri': '/v1alpha1/{name=projects/*}/programs:compileQecProgram',
+                    'body': '*',
+                }
+            ]
+            return http_options
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            pb_request = engine.CompileQecProgramRequest.pb(request)
             transcoded_request = path_template.transcode(http_options, pb_request)
             return transcoded_request
 
@@ -680,6 +721,37 @@ class _BaseQuantumEngineServiceRestTransport(QuantumEngineServiceTransport):
             query_params["$alt"] = "json;enum-encoding=int"
             return query_params
 
+    class _BaseListQuantumProcessorAutomationRunHistory:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+
+        @staticmethod
+        def _get_http_options():
+            http_options: List[Dict[str, str]] = [
+                {
+                    'method': 'get',
+                    'uri': '/v1alpha1/{parent=projects/*/processors/*/configAutomationRuns/*}/history',
+                }
+            ]
+            return http_options
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            pb_request = engine.ListQuantumProcessorAutomationRunHistoryRequest.pb(request)
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+        @staticmethod
+        def _get_query_params_json(transcoded_request):
+            query_params = json.loads(
+                json_format.MessageToJson(
+                    transcoded_request['query_params'], use_integers_for_enums=True
+                )
+            )
+
+            query_params["$alt"] = "json;enum-encoding=int"
+            return query_params
+
     class _BaseListQuantumProcessorConfigs:
         def __hash__(self):  # pragma: NO COVER
             return NotImplementedError("__hash__ must be implemented.")
@@ -699,11 +771,11 @@ class _BaseQuantumEngineServiceRestTransport(QuantumEngineServiceTransport):
             http_options: List[Dict[str, str]] = [
                 {
                     'method': 'get',
-                    'uri': '/v1alpha1/{parent=projects/*/processors/*/configSnapshots/*/configs}',
+                    'uri': '/v1alpha1/{parent=projects/*/processors/*/configSnapshots/*}/configs',
                 },
                 {
                     'method': 'get',
-                    'uri': '/v1alpha1/{parent=projects/*/processors/*/configAutomationRuns/*/configs}',
+                    'uri': '/v1alpha1/{parent=projects/*/processors/*/configAutomationRuns/*}/configs',
                 },
             ]
             return http_options

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/__init__.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 from .engine import (
     CancelQuantumJobRequest,
     CancelQuantumReservationRequest,
+    CompileQecProgramRequest,
+    CompileQecProgramResponse,
     CreateQuantumJobRequest,
     CreateQuantumProgramAndJobRequest,
     CreateQuantumProgramRequest,
@@ -36,6 +38,8 @@ from .engine import (
     ListQuantumJobEventsResponse,
     ListQuantumJobsRequest,
     ListQuantumJobsResponse,
+    ListQuantumProcessorAutomationRunHistoryRequest,
+    ListQuantumProcessorAutomationRunHistoryResponse,
     ListQuantumProcessorConfigsRequest,
     ListQuantumProcessorConfigsResponse,
     ListQuantumProcessorsRequest,
@@ -65,10 +69,12 @@ from .quantum import (
     GcsLocation,
     InlineData,
     OutputConfig,
+    QecRecipe,
     QuantumCalibration,
     QuantumJob,
     QuantumJobEvent,
     QuantumProcessor,
+    QuantumProcessorAutomationRunHistory,
     QuantumProcessorConfig,
     QuantumProgram,
     QuantumReservation,
@@ -82,6 +88,8 @@ from .quantum import (
 __all__ = (
     'CancelQuantumJobRequest',
     'CancelQuantumReservationRequest',
+    'CompileQecProgramRequest',
+    'CompileQecProgramResponse',
     'CreateQuantumJobRequest',
     'CreateQuantumProgramAndJobRequest',
     'CreateQuantumProgramRequest',
@@ -102,6 +110,8 @@ __all__ = (
     'ListQuantumJobEventsResponse',
     'ListQuantumJobsRequest',
     'ListQuantumJobsResponse',
+    'ListQuantumProcessorAutomationRunHistoryRequest',
+    'ListQuantumProcessorAutomationRunHistoryResponse',
     'ListQuantumProcessorConfigsRequest',
     'ListQuantumProcessorConfigsResponse',
     'ListQuantumProcessorsRequest',
@@ -129,10 +139,12 @@ __all__ = (
     'GcsLocation',
     'InlineData',
     'OutputConfig',
+    'QecRecipe',
     'QuantumCalibration',
     'QuantumJob',
     'QuantumJobEvent',
     'QuantumProcessor',
+    'QuantumProcessorAutomationRunHistory',
     'QuantumProcessorConfig',
     'QuantumProgram',
     'QuantumReservation',

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/engine.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/engine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 from typing import MutableMapping, MutableSequence
 
+import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
+import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import proto  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import field_mask_pb2  # type: ignore
 
 from cirq_google.cloud.quantum_v1alpha1.types import quantum
 
@@ -48,6 +48,8 @@ __protobuf__ = proto.module(
         'GetQuantumProcessorConfigRequest',
         'ListQuantumProcessorConfigsRequest',
         'ListQuantumProcessorConfigsResponse',
+        'ListQuantumProcessorAutomationRunHistoryRequest',
+        'ListQuantumProcessorAutomationRunHistoryResponse',
         'ListQuantumCalibrationsRequest',
         'ListQuantumCalibrationsResponse',
         'GetQuantumCalibrationRequest',
@@ -69,6 +71,8 @@ __protobuf__ = proto.module(
         'ListQuantumReservationBudgetsResponse',
         'ListQuantumTimeSlotsRequest',
         'ListQuantumTimeSlotsResponse',
+        'CompileQecProgramRequest',
+        'CompileQecProgramResponse',
     },
 )
 
@@ -113,17 +117,20 @@ class ListQuantumJobsRequest(proto.Message):
         parent (str):
             -
         page_size (int):
-            -
+            Optional. -
         page_token (str):
-            -
+            Optional. -
         filter (str):
-            -
+            Optional. -
+        order_by (str):
+            Optional. -
     """
 
     parent: str = proto.Field(proto.STRING, number=1)
     page_size: int = proto.Field(proto.INT32, number=2)
     page_token: str = proto.Field(proto.STRING, number=3)
     filter: str = proto.Field(proto.STRING, number=4)
+    order_by: str = proto.Field(proto.STRING, number=5)
 
 
 class ListQuantumJobsResponse(proto.Message):
@@ -440,6 +447,45 @@ class ListQuantumProcessorConfigsResponse(proto.Message):
 
     quantum_processor_configs: MutableSequence[quantum.QuantumProcessorConfig] = (
         proto.RepeatedField(proto.MESSAGE, number=1, message=quantum.QuantumProcessorConfig)
+    )
+    next_page_token: str = proto.Field(proto.STRING, number=2)
+
+
+class ListQuantumProcessorAutomationRunHistoryRequest(proto.Message):
+    r"""-
+
+    Attributes:
+        parent (str):
+            -
+        page_size (int):
+            -
+        page_token (str):
+            -
+    """
+
+    parent: str = proto.Field(proto.STRING, number=1)
+    page_size: int = proto.Field(proto.INT32, number=2)
+    page_token: str = proto.Field(proto.STRING, number=3)
+
+
+class ListQuantumProcessorAutomationRunHistoryResponse(proto.Message):
+    r"""-
+
+    Attributes:
+        run_history (MutableSequence[cirq_google.cloud.quantum_v1alpha1.types.QuantumProcessorAutomationRunHistory]):
+            -
+        next_page_token (str):
+            -
+    """
+
+    @property
+    def raw_page(self):
+        return self
+
+    run_history: MutableSequence[quantum.QuantumProcessorAutomationRunHistory] = (
+        proto.RepeatedField(
+            proto.MESSAGE, number=1, message=quantum.QuantumProcessorAutomationRunHistory
+        )
     )
     next_page_token: str = proto.Field(proto.STRING, number=2)
 
@@ -917,6 +963,48 @@ class ListQuantumTimeSlotsResponse(proto.Message):
         proto.MESSAGE, number=1, message=quantum.QuantumTimeSlot
     )
     next_page_token: str = proto.Field(proto.STRING, number=2)
+
+
+class CompileQecProgramRequest(proto.Message):
+    r"""-
+
+    .. _oneof: https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields
+
+    Attributes:
+        name (str):
+            -
+        stim_circuit (str):
+            -
+
+            This field is a member of `oneof`_ ``circuit``.
+        recipe (cirq_google.cloud.quantum_v1alpha1.types.QecRecipe):
+            -
+        processor_id (str):
+            -
+        device_config_selector (cirq_google.cloud.quantum_v1alpha1.types.DeviceConfigSelector):
+            -
+    """
+
+    name: str = proto.Field(proto.STRING, number=1)
+    stim_circuit: str = proto.Field(proto.STRING, number=2, oneof='circuit')
+    recipe: quantum.QecRecipe = proto.Field(proto.MESSAGE, number=3, message=quantum.QecRecipe)
+    processor_id: str = proto.Field(proto.STRING, number=4)
+    device_config_selector: quantum.DeviceConfigSelector = proto.Field(
+        proto.MESSAGE, number=5, message=quantum.DeviceConfigSelector
+    )
+
+
+class CompileQecProgramResponse(proto.Message):
+    r"""-
+
+    Attributes:
+        program (cirq_google.cloud.quantum_v1alpha1.types.QuantumProgram):
+            -
+    """
+
+    program: quantum.QuantumProgram = proto.Field(
+        proto.MESSAGE, number=1, message=quantum.QuantumProgram
+    )
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/quantum.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/types/quantum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ from __future__ import annotations
 
 from typing import MutableMapping, MutableSequence
 
+import google.protobuf.any_pb2 as any_pb2  # type: ignore
+import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
+import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
+import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import proto  # type: ignore
-from google.protobuf import any_pb2  # type: ignore
-from google.protobuf import duration_pb2  # type: ignore
-from google.protobuf import field_mask_pb2  # type: ignore
-from google.protobuf import timestamp_pb2  # type: ignore
 
 __protobuf__ = proto.module(
     package='google.cloud.quantum.v1alpha1',
@@ -44,6 +44,8 @@ __protobuf__ = proto.module(
         'QuantumReservationBudget',
         'QuantumTimeSlot',
         'QuantumReservation',
+        'QuantumProcessorAutomationRunHistory',
+        'QecRecipe',
     },
 )
 
@@ -60,7 +62,7 @@ class QuantumProgram(proto.Message):
 
     Attributes:
         name (str):
-            -
+            Identifier. -
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             -
         update_time (google.protobuf.timestamp_pb2.Timestamp):
@@ -114,11 +116,11 @@ class QuantumJob(proto.Message):
 
     Attributes:
         name (str):
-            -
+            Identifier. -
         create_time (google.protobuf.timestamp_pb2.Timestamp):
-            -
+            Output only. -
         update_time (google.protobuf.timestamp_pb2.Timestamp):
-            -
+            Output only. -
         labels (MutableMapping[str, str]):
             -
         label_fingerprint (str):
@@ -130,7 +132,7 @@ class QuantumJob(proto.Message):
         output_config (cirq_google.cloud.quantum_v1alpha1.types.OutputConfig):
             -
         execution_status (cirq_google.cloud.quantum_v1alpha1.types.ExecutionStatus):
-            -
+            Output only. -
         gcs_run_context_location (cirq_google.cloud.quantum_v1alpha1.types.GcsLocation):
             -
 
@@ -141,7 +143,21 @@ class QuantumJob(proto.Message):
             This field is a member of `oneof`_ ``run_context_location``.
         run_context (google.protobuf.any_pb2.Any):
             -
+        execute_circuit (cirq_google.cloud.quantum_v1alpha1.types.QuantumJob.ExecuteCircuitAction):
+            Optional. -
+
+            This field is a member of `oneof`_ ``action``.
+        calibrate_circuit (cirq_google.cloud.quantum_v1alpha1.types.QuantumJob.CalibrateCircuitAction):
+            Optional. -
+
+            This field is a member of `oneof`_ ``action``.
     """
+
+    class ExecuteCircuitAction(proto.Message):
+        r"""-"""
+
+    class CalibrateCircuitAction(proto.Message):
+        r"""-"""
 
     name: str = proto.Field(proto.STRING, number=1)
     create_time: timestamp_pb2.Timestamp = proto.Field(
@@ -167,6 +183,12 @@ class QuantumJob(proto.Message):
         proto.MESSAGE, number=12, oneof='run_context_location', message='InlineData'
     )
     run_context: any_pb2.Any = proto.Field(proto.MESSAGE, number=11, message=any_pb2.Any)
+    execute_circuit: ExecuteCircuitAction = proto.Field(
+        proto.MESSAGE, number=13, oneof='action', message=ExecuteCircuitAction
+    )
+    calibrate_circuit: CalibrateCircuitAction = proto.Field(
+        proto.MESSAGE, number=14, oneof='action', message=CalibrateCircuitAction
+    )
 
 
 class SchedulingConfig(proto.Message):
@@ -223,6 +245,8 @@ class ExecutionStatus(proto.Message):
         failure (cirq_google.cloud.quantum_v1alpha1.types.ExecutionStatus.Failure):
             -
         timing (cirq_google.cloud.quantum_v1alpha1.types.ExecutionStatus.Timing):
+            -
+        device_config_key (cirq_google.cloud.quantum_v1alpha1.types.DeviceConfigKey):
             -
     """
 
@@ -340,6 +364,9 @@ class ExecutionStatus(proto.Message):
     calibration_name: str = proto.Field(proto.STRING, number=4)
     failure: Failure = proto.Field(proto.MESSAGE, number=5, message=Failure)
     timing: Timing = proto.Field(proto.MESSAGE, number=6, message=Timing)
+    device_config_key: 'DeviceConfigKey' = proto.Field(
+        proto.MESSAGE, number=7, message='DeviceConfigKey'
+    )
 
 
 class DeviceConfigSelector(proto.Message):
@@ -819,6 +846,38 @@ class QuantumReservation(proto.Message):
         proto.MESSAGE, number=4, message=timestamp_pb2.Timestamp
     )
     allowlisted_users: MutableSequence[str] = proto.RepeatedField(proto.STRING, number=5)
+
+
+class QuantumProcessorAutomationRunHistory(proto.Message):
+    r"""-
+
+    Attributes:
+        snapshot_id (str):
+            -
+        timestamp (google.protobuf.timestamp_pb2.Timestamp):
+            -
+        configs (MutableSequence[cirq_google.cloud.quantum_v1alpha1.types.QuantumProcessorConfig]):
+            -
+    """
+
+    snapshot_id: str = proto.Field(proto.STRING, number=1)
+    timestamp: timestamp_pb2.Timestamp = proto.Field(
+        proto.MESSAGE, number=2, message=timestamp_pb2.Timestamp
+    )
+    configs: MutableSequence['QuantumProcessorConfig'] = proto.RepeatedField(
+        proto.MESSAGE, number=3, message='QuantumProcessorConfig'
+    )
+
+
+class QecRecipe(proto.Message):
+    r"""-
+
+    Attributes:
+        desired_algorithms (MutableSequence[str]):
+            -
+    """
+
+    desired_algorithms: MutableSequence[str] = proto.RepeatedField(proto.STRING, number=1)
 
 
 __all__ = tuple(sorted(__protobuf__.manifest))


### PR DESCRIPTION
Contains changes for the following Quantum Engine RPCs and their associated request/response protos:

- ListQuantumProcessorAutomationRunHistory (new)
- CompileQecProgram (new)
- ListQuantumJobs (modified)

Also contains changes corresponding to new fields in the QuantumJob proto.