### PR TITLE
Add a `get_config()` method to `EngineJob`

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     import cirq_google.engine.abstract_processor as abstract_processor
     import cirq_google.engine.abstract_program as abstract_program
     import cirq_google.engine.calibration as calibration
+    import cirq_google.engine.processor_config as processor_config
     from cirq_google.engine.engine_result import EngineResult
 
 
@@ -164,6 +165,10 @@ class AbstractJob(abc.ABC):
     def get_calibration(self) -> calibration.Calibration | None:
         """Returns the recorded calibration at the time when the job was run, if
         one was captured, else None."""
+
+    @abc.abstractmethod
+    def get_config(self) -> processor_config.ProcessorConfig | None:
+        """Returns the configuration used for the job, if available, else None."""
 
     @abc.abstractmethod
     def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -80,6 +80,9 @@ class MockJob(AbstractJob):
     def get_calibration(self):
         pass
 
+    def get_config(self):
+        pass
+
     def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:
         return cirq.Circuit()
 

--- a/cirq-google/cirq_google/engine/abstract_local_job.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job.py
@@ -25,6 +25,7 @@ from cirq_google.engine.abstract_job import AbstractJob
 if TYPE_CHECKING:
     import cirq
     import cirq_google.engine.calibration as calibration
+    import cirq_google.engine.processor_config as processor_config
     from cirq_google.engine.abstract_local_engine import AbstractLocalEngine
     from cirq_google.engine.abstract_local_processor import AbstractLocalProcessor
     from cirq_google.engine.abstract_local_program import AbstractLocalProgram
@@ -33,22 +34,22 @@ if TYPE_CHECKING:
 class AbstractLocalJob(AbstractJob):
     """A job that handles labels and descriptions locally in-memory.
 
-        This class is designed to make writing custom AbstractJob objects
-        that function in-memory easier.  This class will handle basic functionality
-        expected to be common across all local implementations.
+    This class is designed to make writing custom AbstractJob objects
+    that function in-memory easier.  This class will handle basic functionality
+    expected to be common across all local implementations.
 
-        Implementors of this class should write the following functions:
-          - Status functions: execution_status, failure
-          - Action functions: cancel, delete
-          - Result functions: results, batched_results, calibration_results
-    `
-        Attributes:
-          processor_ids: A string list of processor ids that this job can be run on.
-          processor_id: If provided, the processor id that the job was run on.
-              If not provided, assumed to be the first element of processor_ids
-          parent_program: Program containing this job
-          repetitions: number of repetitions for each parameter set
-          sweeps: list of Sweeps that this job should iterate through.
+    Implementors of this class should write the following functions:
+      - Status functions: execution_status, failure
+      - Action functions: cancel, delete
+      - Result functions: results, batched_results, calibration_results
+
+    Attributes:
+      processor_ids: A string list of processor ids that this job can be run on.
+      processor_id: If provided, the processor id that the job was run on.
+          If not provided, assumed to be the first element of processor_ids
+      parent_program: Program containing this job
+      repetitions: number of repetitions for each parameter set
+      sweeps: list of Sweeps that this job should iterate through.
     """
 
     def __init__(
@@ -59,6 +60,7 @@ class AbstractLocalJob(AbstractJob):
         repetitions: int,
         sweeps: list[cirq.Sweep],
         processor_id: str = '',
+        processor_config: processor_config.ProcessorConfig | None = None,
     ):
         self._id = job_id
         self._processor_id = processor_id
@@ -69,6 +71,7 @@ class AbstractLocalJob(AbstractJob):
         self._update_time = datetime.datetime.now()
         self._description = ''
         self._labels: dict[str, str] = {}
+        self._processor_config = processor_config
 
     def engine(self) -> AbstractLocalEngine:
         """Returns the parent program's `AbstractEngine` object."""
@@ -205,3 +208,7 @@ class AbstractLocalJob(AbstractJob):
             The job's cirq Circuit.
         """
         return self.program().get_circuit(circuit_num)
+
+    def get_config(self) -> processor_config.ProcessorConfig | None:
+        """Returns the configuration used for the job, if available, else None."""
+        return self._processor_config

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -156,3 +156,16 @@ def test_get_circuit():
     mock_program.get_circuit.assert_called_with(None)
     assert job.get_circuit(1) == circuit
     mock_program.get_circuit.assert_called_with(1)
+
+
+def test_get_config():
+    mock_config = mock.Mock()
+    job = NothingJob(
+        job_id='test',
+        processor_id='pot_of_gold',
+        parent_program=None,
+        repetitions=100,
+        sweeps=[],
+        processor_config=mock_config,
+    )
+    assert job.get_config() == mock_config

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import warnings
 from collections.abc import Awaitable, Callable, Sequence
 from http import HTTPStatus
 from typing import TYPE_CHECKING
@@ -26,7 +27,7 @@ import duet
 import cirq
 from cirq_google.api import v1, v2
 from cirq_google.cloud import quantum
-from cirq_google.engine import abstract_job, calibration, engine_client
+from cirq_google.engine import abstract_job, calibration, engine_client, processor_config
 from cirq_google.engine.engine_result import EngineResult
 from cirq_google.engine.stream_manager import StreamError
 
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 
     import cirq_google.engine.engine as engine_base
     from cirq_google.engine.engine import engine_processor, engine_program
+
 
 TERMINAL_STATES = [
     quantum.ExecutionStatus.State.SUCCESS,
@@ -292,6 +294,59 @@ class EngineJob(abstract_job.AbstractJob):
         response = self.context.client.get_calibration(*ids)
         metrics = v2.metrics_pb2.MetricsSnapshot.FromString(response.data.value)
         return calibration.Calibration(metrics)
+
+    def get_config(self) -> processor_config.ProcessorConfig | None:
+        """Returns the configuration used for the job.
+
+        Returns None if the job is not in a terminal state (SUCCESS, FAILURE, CANCELLED).
+
+        Raises:
+            ValueError: If device_config_key is not set in the job execution status
+                or if the processor name cannot be determined.
+        """
+        job = self._inner_job()
+        status = job.execution_status
+        if status.state not in TERMINAL_STATES:
+            warnings.warn(
+                f"Job {self.job_id} is in non-terminal state {status.state.name}, "
+                "returning None for config."
+            )
+            return None
+
+        device_config_key = status.device_config_key
+
+        if not device_config_key:
+            raise ValueError(
+                "device_config_key is not set in job execution status "
+                f"(state: {status.state.name})."
+            )
+
+        if not device_config_key.config_alias or not (
+            device_config_key.snapshot_id or device_config_key.run
+        ):
+            raise ValueError(
+                f"device_config_key {device_config_key} in job execution status "
+                f"(state: {status.state.name}) must have both `config_alias` "
+                "and either `snapshot_id` or `run` set."
+            )
+
+        if status.processor_name:
+            processor_id = engine_client._ids_from_processor_name(status.processor_name)[1]
+        else:
+            raise ValueError("Processor name is not set in job status.")
+
+        if device_config_key.snapshot_id:
+            device_config_revision: processor_config.DeviceConfigRevision = (
+                processor_config.Snapshot(device_config_key.snapshot_id)
+            )
+        else:
+            device_config_revision = processor_config.Run(device_config_key.run)
+
+        return self.engine().get_processor_config(
+            processor_id=processor_id,
+            device_config_revision=device_config_revision,
+            config_name=device_config_key.config_alias,
+        )
 
     async def get_circuit_async(self, circuit_num: int | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the Quantum Engine job.

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -558,6 +558,120 @@ def test_get_calibration_no_calibration(get_job):
     get_job.assert_called_once()
 
 
+def test_get_config_not_set():
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(state=quantum.ExecutionStatus.State.SUCCESS)
+    )
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+    with pytest.raises(ValueError, match="device_config_key is not set.*state: SUCCESS"):
+        _ = job.get_config()
+
+
+def test_get_config_non_terminal():
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(state=quantum.ExecutionStatus.State.RUNNING)
+    )
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+    with pytest.warns(UserWarning, match="RUNNING"):
+        assert job.get_config() is None
+
+
+@pytest.mark.parametrize(
+    "key_kwargs", [{"config_alias": "alias1"}, {"run": "run1"}, {"snapshot_id": "snapshot1"}]
+)
+def test_get_config_incomplete(key_kwargs):
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(
+            state=quantum.ExecutionStatus.State.SUCCESS,
+            device_config_key=quantum.DeviceConfigKey(**key_kwargs),
+        )
+    )
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+    with pytest.raises(
+        ValueError, match="must have both `config_alias` and either `snapshot_id` or `run` set"
+    ):
+        _ = job.get_config()
+
+
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_quantum_processor_config_async')
+def test_get_config_success(get_quantum_processor_config, get_job):
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(
+            state=quantum.ExecutionStatus.State.SUCCESS,
+            processor_name='projects/a/processors/p',
+            device_config_key=quantum.DeviceConfigKey(run='run1', config_alias='alias1'),
+        )
+    )
+
+    get_job.return_value = qjob
+
+    mock_config = quantum.QuantumProcessorConfig(
+        name='projects/a/processors/p/configSnapshots/snapshot1/configs/alias1'
+    )
+    get_quantum_processor_config.return_value = mock_config
+
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+    config = job.get_config()
+
+    assert config is not None
+    assert config._quantum_processor_config == mock_config
+    get_job.assert_called_once()
+    get_quantum_processor_config.assert_called_once_with(
+        project_id='a',
+        processor_id='p',
+        device_config_revision=cg.Run('run1'),
+        config_name='alias1',
+    )
+
+
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_job_async')
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_quantum_processor_config_async')
+def test_get_config_snapshot_success(get_quantum_processor_config, get_job):
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(
+            state=quantum.ExecutionStatus.State.SUCCESS,
+            processor_name='projects/a/processors/p',
+            device_config_key=quantum.DeviceConfigKey(
+                snapshot_id='snapshot1', config_alias='alias1'
+            ),
+        )
+    )
+    get_job.return_value = qjob
+
+    mock_config = quantum.QuantumProcessorConfig(
+        name='projects/a/processors/p/configSnapshots/snapshot1/configs/alias1'
+    )
+    get_quantum_processor_config.return_value = mock_config
+
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext())
+    config = job.get_config()
+
+    assert config is not None
+    assert config._quantum_processor_config == mock_config
+    get_job.assert_called_once()
+    get_quantum_processor_config.assert_called_once_with(
+        project_id='a',
+        processor_id='p',
+        device_config_revision=cg.Snapshot('snapshot1'),
+        config_name='alias1',
+    )
+
+
+def test_get_config_no_processor_name():
+    qjob = quantum.QuantumJob(
+        execution_status=quantum.ExecutionStatus(
+            state=quantum.ExecutionStatus.State.SUCCESS,
+            device_config_key=quantum.DeviceConfigKey(
+                snapshot_id='snapshot1', config_alias='alias1'
+            ),
+        )
+    )
+    job = cg.EngineJob('a', 'b', 'steve', EngineContext(), _job=qjob)
+    with pytest.raises(ValueError, match="Processor name is not set in job status."):
+        _ = job.get_config()
+
+
 @mock.patch('cirq_google.engine.engine_client.EngineClient.cancel_job_async')
 def test_cancel(cancel_job):
     job = cg.EngineJob('a', 'b', 'steve', EngineContext())


### PR DESCRIPTION
Allow users to see the specific configuration, that an EngineJob ran on