### PR TITLE
Produce Correct Rotation on PauliSumExponential with Identity Inputs

### DIFF
--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -319,7 +319,7 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
 
         return pauli_string.PauliString(
             coefficient=self.coefficient,
-            qubit_pauli_map={q: PAULI_GATES[p] for q, p in zip(qubits, self.pauli_mask) if p},
+            qubit_pauli_map={q: PAULI_GATES[p] for q, p in zip(qubits, self.pauli_mask)},
         )
 
     def __str__(self) -> str:

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -35,7 +35,7 @@ from cirq.value.linear_dict import _format_terms
 if TYPE_CHECKING:
     import cirq
 
-UnitPauliStringT = frozenset[tuple[raw_types.Qid, pauli_gates.Pauli]]
+UnitPauliStringT = frozenset[tuple[raw_types.Qid, pauli_gates.Pauli | identity.I ]]
 PauliSumLike = Union[
     complex, PauliString, 'PauliSum', pauli_string.SingleQubitPauliStringGateOperation
 ]

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -35,7 +35,7 @@ from cirq.value.linear_dict import _format_terms
 if TYPE_CHECKING:
     import cirq
 
-UnitPauliStringT = frozenset[tuple[raw_types.Qid, pauli_gates.Pauli | identity.IdentityGate ]]
+UnitPauliStringT = frozenset[tuple[raw_types.Qid, pauli_gates.Pauli | identity.IdentityGate]]
 PauliSumLike = Union[
     complex, PauliString, 'PauliSum', pauli_string.SingleQubitPauliStringGateOperation
 ]
@@ -336,7 +336,7 @@ def _is_linear_dict_of_unit_pauli_string(linear_dict: value.LinearDict[UnitPauli
         for qid, pauli in k:
             if not isinstance(qid, raw_types.Qid):
                 return False
-            if not isinstance(pauli, pauli_gates.Pauli) and not pauli == identity.I:
+            if not isinstance(pauli, pauli_gates.Pauli) and pauli != identity.I:
                 return False
 
     return True
@@ -468,7 +468,10 @@ class PauliSum:
             terms = [terms]
         termdict: defaultdict[UnitPauliStringT, value.Scalar] = defaultdict(lambda: 0)
         for pstring in terms:
-            key = frozenset(list(pstring._qubit_pauli_map.items()) + [(qubit, identity.I) for qubit in pstring.identity_qubits])
+            key = frozenset(
+                list(pstring._qubit_pauli_map.items())
+                + [(qubit, identity.I) for qubit in pstring.identity_qubits]
+            )
             termdict[key] += pstring.coefficient
         return cls(linear_dict=value.LinearDict(termdict))
 

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -336,7 +336,7 @@ def _is_linear_dict_of_unit_pauli_string(linear_dict: value.LinearDict[UnitPauli
         for qid, pauli in k:
             if not isinstance(qid, raw_types.Qid):
                 return False
-            if not isinstance(pauli, pauli_gates.Pauli):
+            if not isinstance(pauli, pauli_gates.Pauli) and not pauli == identity.I:
                 return False
 
     return True
@@ -468,7 +468,7 @@ class PauliSum:
             terms = [terms]
         termdict: defaultdict[UnitPauliStringT, value.Scalar] = defaultdict(lambda: 0)
         for pstring in terms:
-            key = frozenset(pstring._qubit_pauli_map.items())
+            key = frozenset(list(pstring._qubit_pauli_map.items()) + [(qubit, identity.I) for qubit in pstring.identity_qubits])
             termdict[key] += pstring.coefficient
         return cls(linear_dict=value.LinearDict(termdict))
 

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -35,7 +35,7 @@ from cirq.value.linear_dict import _format_terms
 if TYPE_CHECKING:
     import cirq
 
-UnitPauliStringT = frozenset[tuple[raw_types.Qid, pauli_gates.Pauli | identity.I ]]
+UnitPauliStringT = frozenset[tuple[raw_types.Qid, pauli_gates.Pauli | identity.IdentityGate ]]
 PauliSumLike = Union[
     complex, PauliString, 'PauliSum', pauli_string.SingleQubitPauliStringGateOperation
 ]

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -154,7 +154,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
     def __init__(
         self,
         *contents: cirq.PAULI_STRING_LIKE,
-        qubit_pauli_map: dict[TKey, cirq.Pauli] | dict[TKey, cirq.Pauli | cirq.IdentityGate] | None = None,
+        qubit_pauli_map: Mapping[TKey, cirq.Pauli | cirq.IdentityGate] | None = None,
         coefficient: cirq.TParamValComplex = 1,
     ):
         """Initializes a new `PauliString` operation.
@@ -166,9 +166,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
                 values is given, they are each individually converted and then
                 multiplied from left to right in order.
             qubit_pauli_map: Initial dictionary mapping qubits to pauli
-                operations. Defaults to the empty dictionary. Note that, unlike
-                dictionaries passed to contents, this dictionary must not
-                contain any identity gate values. Further note that this
+                operations. Defaults to the empty dictionary. Note that this
                 argument specifies values that are logically *before* factors
                 specified in `contents`; `contents` are *right* multiplied onto
                 the values in this dictionary.
@@ -178,7 +176,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
             TypeError: If the `qubit_pauli_map` has values that are not Paulis.
         """
         self._qubit_pauli_map: dict[TKey, cirq.Pauli] = {}
-        # Maintain a list of identity qubits. 
+        # Maintain a list of identity qubits.
         # Historically this class retains only qubits with Pauli operations applied
         # to them. However, downstream calculations (e.g. applying exponentiation, etc.)
         # relies on knowledge of where identity qubits are placed as well. To maintain
@@ -338,7 +336,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
     def qubits(self) -> tuple[TKey, ...]:
         """Returns a tuple of qubits on which this pauli string acts."""
         return tuple(self.keys())
-    
+
     @property
     def identity_qubits(self) -> tuple[cirq.Qid, ...]:
         """Returns a tuple of qubits that this pauli string is applying I on."""

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -177,12 +177,17 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         Raises:
             TypeError: If the `qubit_pauli_map` has values that are not Paulis.
         """
+        self._qubit_pauli_map: dict[TKey, cirq.Pauli] = {}
+        self._identity_qubits: Sequence[cirq.Qid] = []
         if _compat.__cirq_debug__.get() and qubit_pauli_map is not None:
-            for v in qubit_pauli_map.values():
-                if not isinstance(v, pauli_gates.Pauli):
-                    raise TypeError(f'{v} is not a Pauli')
+            for k, v in qubit_pauli_map.items():
+                if isinstance(v, pauli_gates.Pauli):
+                    self._qubit_pauli_map[k] = v
+                elif v == identity.I:
+                    self._identity_qubits.append(k)
+                else:
+                    raise TypeError(f'{v} is not a Pauli or identity')
 
-        self._qubit_pauli_map: dict[TKey, cirq.Pauli] = qubit_pauli_map or {}
         self._coefficient: cirq.TParamValComplex | sympy.Expr = (
             coefficient if isinstance(coefficient, sympy.Expr) else complex(coefficient)
         )
@@ -328,6 +333,11 @@ class PauliString(raw_types.Operation, Generic[TKey]):
     def qubits(self) -> tuple[TKey, ...]:
         """Returns a tuple of qubits on which this pauli string acts."""
         return tuple(self.keys())
+    
+    @property
+    def identity_qubits(self) -> tuple[cirq.Qid, ...]:
+        """Returns a tuple of qubits that this pauli string is applying I on."""
+        return tuple(self._identity_qubits)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
         if not len(self._qubit_pauli_map):

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -178,6 +178,11 @@ class PauliString(raw_types.Operation, Generic[TKey]):
             TypeError: If the `qubit_pauli_map` has values that are not Paulis.
         """
         self._qubit_pauli_map: dict[TKey, cirq.Pauli] = {}
+        # Maintain a list of identity qubits. 
+        # Historically this class retains only qubits with Pauli operations applied
+        # to them. However, downstream calculations (e.g. applying exponentiation, etc.)
+        # relies on knowledge of where identity qubits are placed as well. To maintain
+        # existing behavior, track identity qubits under a separate field.
         self._identity_qubits: Sequence[cirq.Qid] = []
         if _compat.__cirq_debug__.get() and qubit_pauli_map is not None:
             for k, v in qubit_pauli_map.items():

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -154,7 +154,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
     def __init__(
         self,
         *contents: cirq.PAULI_STRING_LIKE,
-        qubit_pauli_map: dict[TKey, cirq.Pauli | cirq.IdentityGate] | None = None,
+        qubit_pauli_map: dict[TKey, cirq.Pauli] | dict[TKey, cirq.Pauli | cirq.IdentityGate] | None = None,
         coefficient: cirq.TParamValComplex = 1,
     ):
         """Initializes a new `PauliString` operation.

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -154,7 +154,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
     def __init__(
         self,
         *contents: cirq.PAULI_STRING_LIKE,
-        qubit_pauli_map: dict[TKey, cirq.Pauli] | None = None,
+        qubit_pauli_map: dict[TKey, cirq.Pauli | cirq.IdentityGate] | None = None,
         coefficient: cirq.TParamValComplex = 1,
     ):
         """Initializes a new `PauliString` operation.

--- a/cirq-core/cirq/ops/pauli_sum_exponential.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential.py
@@ -124,7 +124,7 @@ class PauliSumExponential:
             # e^{i \theta P_n} = I \cos{(\theta)} + i P_n \sin{(\theta)}
             # in the context of the qubits involved in the PauliSum.
             pauli_string_qubits = set(pauli_string.qubits)
-            pauli_string_unitary = np.ones(1.0)
+            pauli_string_unitary = np.ones(1, dtype=float)
             for qubit in sorted(qubits):
                 if qubit in pauli_string_qubits:
                     pauli_string_unitary = np.kron(

--- a/cirq-core/cirq/ops/pauli_sum_exponential.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential.py
@@ -108,9 +108,35 @@ class PauliSumExponential:
         """
         if protocols.is_parameterized(self._exponent):
             raise ValueError("Exponent should not parameterized.")
-        ret = np.ones(1)
-        for pauli_string_exp in self:
-            ret = np.kron(ret, protocols.unitary(pauli_string_exp))
+        
+        # Retrieve all qubits that are involved in producing the PauliSum used by
+        # this class, including identity qubits. These qubits will be used to
+        # compute the appropriate total size of the final unitary.
+        qubits = set()
+        for pauli_string in self._pauli_sum:
+            qubits.update(pauli_string.qubits)
+            qubits.update(pauli_string.identity_qubits)
+        
+        # Calculate the identity e^{i \theta \sum P} = \prod e^{i \theta P_n}
+        ret = np.eye(2 ** len(qubits))
+        for pauli_string in self._pauli_sum:
+            # For each e^{i \theta P_n}, compute its value using the identity
+            # e^{i \theta P_n} = I \cos{(\theta)} + i P_n \sin{(\theta)}
+            # in the context of the qubits involved in the PauliSum.
+            pauli_string_qubits = set(pauli_string.qubits)
+            pauli_string_unitary = np.ones(1)
+            for qubit in sorted(qubits):
+                if qubit in pauli_string_qubits:
+                    pauli_string_unitary = np.kron(
+                        pauli_string_unitary, protocols.unitary(pauli_string[qubit]))
+                else:
+                    pauli_string_unitary = np.kron(
+                        pauli_string_unitary, np.eye(2))
+            theta = pauli_string.coefficient * self._multiplier
+            theta *= self._exponent
+            cos_term = np.cos(theta) * np.eye(2 ** len(qubits))
+            sin_term = np.sin(theta) * 1j * pauli_string_unitary
+            ret = ret @ (cos_term + sin_term)
         return ret
 
     @_compat.cached_method

--- a/cirq-core/cirq/ops/pauli_sum_exponential.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential.py
@@ -108,7 +108,7 @@ class PauliSumExponential:
         """
         if protocols.is_parameterized(self._exponent):
             raise ValueError("Exponent should not parameterized.")
-        
+
         # Retrieve all qubits that are involved in producing the PauliSum used by
         # this class, including identity qubits. These qubits will be used to
         # compute the appropriate total size of the final unitary.
@@ -116,7 +116,7 @@ class PauliSumExponential:
         for pauli_string in self._pauli_sum:
             qubits.update(pauli_string.qubits)
             qubits.update(pauli_string.identity_qubits)
-        
+
         # Calculate the identity e^{i \theta \sum P} = \prod e^{i \theta P_n}
         ret = np.eye(2 ** len(qubits))
         for pauli_string in self._pauli_sum:
@@ -128,10 +128,10 @@ class PauliSumExponential:
             for qubit in sorted(qubits):
                 if qubit in pauli_string_qubits:
                     pauli_string_unitary = np.kron(
-                        pauli_string_unitary, protocols.unitary(pauli_string[qubit]))
+                        pauli_string_unitary, protocols.unitary(pauli_string[qubit])
+                    )
                 else:
-                    pauli_string_unitary = np.kron(
-                        pauli_string_unitary, np.eye(2))
+                    pauli_string_unitary = np.kron(pauli_string_unitary, np.eye(2))
             theta = pauli_string.coefficient * self._multiplier
             theta *= self._exponent
             cos_term = np.cos(theta) * np.eye(2 ** len(qubits))

--- a/cirq-core/cirq/ops/pauli_sum_exponential.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential.py
@@ -124,7 +124,7 @@ class PauliSumExponential:
             # e^{i \theta P_n} = I \cos{(\theta)} + i P_n \sin{(\theta)}
             # in the context of the qubits involved in the PauliSum.
             pauli_string_qubits = set(pauli_string.qubits)
-            pauli_string_unitary = np.ones(1)
+            pauli_string_unitary = np.ones(1.0)
             for qubit in sorted(qubits):
                 if qubit in pauli_string_qubits:
                     pauli_string_unitary = np.kron(

--- a/cirq-core/cirq/ops/pauli_sum_exponential_test.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential_test.py
@@ -33,6 +33,7 @@ def test_raises_for_non_hermitian_pauli() -> None:
     with pytest.raises(ValueError, match='Hermitian'):
         cirq.PauliSumExponential(cirq.X(q0) + 1j * cirq.Z(q1), np.pi / 2)
 
+
 @pytest.mark.parametrize(
     'psum_exp, expected_qubits',
     (
@@ -103,17 +104,18 @@ def test_pauli_sum_exponential_parameterized_matrix_raises() -> None:
         ),
         (
             cirq.PauliSumExponential(cirq.DensePauliString('XI')(q0, q1), exponent=np.pi / 4),
-            np.array([[1, 0, 1j, 0], [0, 1, 0, 1j], [1j, 0, 1, 0], [0, 1j, 0, 1]]) / (2 ** 0.5),
+            np.array([[1, 0, 1j, 0], [0, 1, 0, 1j], [1j, 0, 1, 0], [0, 1j, 0, 1]]) / (2**0.5),
         ),
         (
             cirq.PauliSumExponential(cirq.DensePauliString('IY')(q0, q1), exponent=3 * np.pi / 4),
-            np.array([[-1, 1, 0, 0], [-1, -1, 0, 0], [0, 0, -1, 1], [0, 0, -1, -1]]) / (2 ** 0.5),
+            np.array([[-1, 1, 0, 0], [-1, -1, 0, 0], [0, 0, -1, 1], [0, 0, -1, -1]]) / (2**0.5),
         ),
     ),
 )
 def test_pauli_sum_exponential_has_correct_unitary(psum_exp, expected_unitary) -> None:
     assert cirq.has_unitary(psum_exp)
     assert np.allclose(cirq.unitary(psum_exp), expected_unitary)
+
 
 @pytest.mark.parametrize(
     'psum_exp, power, expected_psum',

--- a/cirq-core/cirq/ops/pauli_sum_exponential_test.py
+++ b/cirq-core/cirq/ops/pauli_sum_exponential_test.py
@@ -33,7 +33,6 @@ def test_raises_for_non_hermitian_pauli() -> None:
     with pytest.raises(ValueError, match='Hermitian'):
         cirq.PauliSumExponential(cirq.X(q0) + 1j * cirq.Z(q1), np.pi / 2)
 
-
 @pytest.mark.parametrize(
     'psum_exp, expected_qubits',
     (
@@ -102,12 +101,19 @@ def test_pauli_sum_exponential_parameterized_matrix_raises() -> None:
             cirq.PauliSumExponential(2j * cirq.X(q0) + 3j * cirq.Z(q1), np.pi / 2),
             np.array([[1j, 0, 0, 0], [0, -1j, 0, 0], [0, 0, 1j, 0], [0, 0, 0, -1j]]),
         ),
+        (
+            cirq.PauliSumExponential(cirq.DensePauliString('XI')(q0, q1), exponent=np.pi / 4),
+            np.array([[1, 0, 1j, 0], [0, 1, 0, 1j], [1j, 0, 1, 0], [0, 1j, 0, 1]]) / (2 ** 0.5),
+        ),
+        (
+            cirq.PauliSumExponential(cirq.DensePauliString('IY')(q0, q1), exponent=3 * np.pi / 4),
+            np.array([[-1, 1, 0, 0], [-1, -1, 0, 0], [0, 0, -1, 1], [0, 0, -1, -1]]) / (2 ** 0.5),
+        ),
     ),
 )
 def test_pauli_sum_exponential_has_correct_unitary(psum_exp, expected_unitary) -> None:
     assert cirq.has_unitary(psum_exp)
     assert np.allclose(cirq.unitary(psum_exp), expected_unitary)
-
 
 @pytest.mark.parametrize(
     'psum_exp, power, expected_psum',


### PR DESCRIPTION
this PR allows `cirq.PauliSumExponential` to produce proper unitaries with PauliStrings containing `I` operations.

concretely, the following changes are made:
  * `PauliString` does not support remembering qubits with `I` operations. this is documented in its docstring. this PR adds support for maintaining these qubits in `PauliString` for any computation that requires them to be present.
  * `PauliSum` is also updated to ensure `I` operations of its constituent `PauliString` are not dropped.
  * `PauliSumExponential` calculates its unitaries based off `PauliStringPhasor` objects, however `PauliStringPhasor` calculates its unitaries based off operations produced by its `_decompose_` function. it is unclear to me how to insert identity operations into this process, so instead, this PR calculates the `PauliSumExponential` unitary based on its own formula:
    1. calculate the final unitary size $\lvert U \rvert$ by taking all referenced qubits from its constituent PauliStrings 
    2. split its representation into $e^{i\theta \sum P_i} = \prod e^{i\theta P_i}$
    3. use Euler's formula to compute $e^{i\theta P_i} = I\cos{\theta} + iP_i\sin{\theta}$ with properly sized $I$ and $P_i$ based on (i).

I am concerned this PR might produce some further confusion for clients as to how `PauliString` works given that this update changes its behavior to track identity operations now, but separately from its main qubit map. consultation from the Cirq team would be appreciated :) 

edit: I see there is also https://github.com/quantumlib/Cirq/pull/8170, if they decide a separate class would be the way to go to fix #6598 

Fixes #6598 