### PR TITLE
add some documentation and tests on changes to `Circuit.append`, `Circuit.insert`

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1815,8 +1815,8 @@ class Circuit(AbstractCircuit):
             contents: The initial list of moments and operations defining the
                 circuit. You can also pass in operations, lists of operations,
                 or generally anything meeting the `cirq.OP_TREE` contract.
-                Non-moment entries will be inserted according to the specified
-                insertion strategy.
+                Non-moment entries will be appended according to the specified
+                insertion strategy; see `Circuit.append` for specific mechanics.
             strategy: When initializing the circuit with operations and moments
                 from `contents`, this determines how the operations are packed
                 together. This option does not affect later insertions into the
@@ -2258,9 +2258,16 @@ class Circuit(AbstractCircuit):
     ) -> int:
         """Inserts operations into the circuit.
 
-        Operations are inserted into the moment specified by the index and
-        'InsertStrategy'.
-        Moments within the operation tree are inserted intact.
+        Moments within the operation tree are inserted intact. Operations are
+        inserted into the moment specified by the index and 'InsertStrategy'.
+        Operations affecting similar qubits are separated into different moments
+        according to the insertion strategy.
+        
+        Measurements with the same keys are discouraged and will be separated
+        into different moments; prefer multi-qubit measurements. Controlled
+        operations and measurements with the same key will also be separated.
+        Special use cases requiring these operations to be in the same moment
+        should insert them as a moment.
 
         Args:
             index: The index to insert all the operations at.
@@ -2597,7 +2604,15 @@ class Circuit(AbstractCircuit):
     ) -> None:
         """Appends operations onto the end of the circuit.
 
-        Moments within the operation tree are appended intact.
+        Moments within the operation tree are appended intact. Operations
+        affecting similar qubits are separated into different moments according
+        to the insertion strategy.
+        
+        Measurements with the same keys are discouraged and will be separated
+        into different moments; prefer multi-qubit measurements. Controlled
+        operations and measurements with the same key will also be separated.
+        Special use cases requiring these operations to be in the same moment
+        should append them as a moment.
 
         Args:
             moment_or_operation_tree: The moment or operation tree to append.

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -2262,7 +2262,7 @@ class Circuit(AbstractCircuit):
         inserted into the moment specified by the index and 'InsertStrategy'.
         Operations affecting similar qubits are separated into different moments
         according to the insertion strategy.
-        
+
         Measurements with the same keys are discouraged and will be separated
         into different moments; prefer multi-qubit measurements. Controlled
         operations and measurements with the same key will also be separated.
@@ -2607,7 +2607,7 @@ class Circuit(AbstractCircuit):
         Moments within the operation tree are appended intact. Operations
         affecting similar qubits are separated into different moments according
         to the insertion strategy.
-        
+
         Measurements with the same keys are discouraged and will be separated
         into different moments; prefer multi-qubit measurements. Controlled
         operations and measurements with the same key will also be separated.

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -5162,12 +5162,10 @@ def test_insert_in_existing_moment_measurement_control_key_conflict() -> None:
 def test_insert_moment_with_same_measurement_control_keys() -> None:
     c1 = cirq.Circuit()
     c1.insert(0, cirq.Moment(cirq.measure(q0, key="k"), cirq.measure(q1, key="k")))
-    assert c1 == cirq.Circuit(
-        cirq.Moment(cirq.measure(q0, key="k"), cirq.measure(q1, key="k")),
-    )
+    assert c1 == cirq.Circuit(cirq.Moment(cirq.measure(q0, key="k"), cirq.measure(q1, key="k")))
 
     c2 = cirq.Circuit()
     c2.insert(0, cirq.Moment(cirq.measure(q0, key="k"), cirq.X(q1).with_classical_controls("k")))
     assert c2 == cirq.Circuit(
-        cirq.Moment(cirq.measure(q0, key="k"), cirq.X(q1).with_classical_controls("k")),
+        cirq.Moment(cirq.measure(q0, key="k"), cirq.X(q1).with_classical_controls("k"))
     )

--- a/cirq-core/cirq/circuits/circuit_test.py
+++ b/cirq-core/cirq/circuits/circuit_test.py
@@ -5157,3 +5157,17 @@ def test_insert_in_existing_moment_measurement_control_key_conflict() -> None:
     assert c == cirq.Circuit(
         cirq.Moment(cirq.X(q1).with_classical_controls("k")), cirq.Moment(cirq.measure(q0, key="k"))
     )
+
+
+def test_insert_moment_with_same_measurement_control_keys() -> None:
+    c1 = cirq.Circuit()
+    c1.insert(0, cirq.Moment(cirq.measure(q0, key="k"), cirq.measure(q1, key="k")))
+    assert c1 == cirq.Circuit(
+        cirq.Moment(cirq.measure(q0, key="k"), cirq.measure(q1, key="k")),
+    )
+
+    c2 = cirq.Circuit()
+    c2.insert(0, cirq.Moment(cirq.measure(q0, key="k"), cirq.X(q1).with_classical_controls("k")))
+    assert c2 == cirq.Circuit(
+        cirq.Moment(cirq.measure(q0, key="k"), cirq.X(q1).with_classical_controls("k")),
+    )

--- a/cirq-core/cirq/circuits/moment_test.py
+++ b/cirq-core/cirq/circuits/moment_test.py
@@ -1002,3 +1002,24 @@ def test_moment_with_tags() -> None:
     # Test that tags are retained if the Moment is unchanged.
     assert moment.with_operations().tags == (tag_obj,)
     assert moment.without_operations_touching([q1]).tags == (tag_obj,)
+
+
+def test_moment_with_same_measurement_keys() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+
+    m = cirq.Moment(cirq.measure(q0, key="k"), cirq.measure(q1, key="k"))
+    assert len(m) == 2
+    assert cirq.measurement_key_names(m[q0]) == {"k"}
+    assert cirq.measurement_key_names(m[q1]) == {"k"}
+    assert cirq.measurement_key_names(m) == {"k"}
+
+
+def test_moment_with_same_measurement_control_keys() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+
+    m = cirq.Moment(cirq.measure(q0, key="k"), cirq.X(q1).with_classical_controls("k"))
+    assert len(m) == 2
+    assert cirq.measurement_key_names(m[q0]) == {"k"}
+    assert cirq.control_keys(m[q1]) == {"k"}
+    assert cirq.measurement_key_names(m) == {"k"}
+    assert cirq.control_keys(m) == {"k"}


### PR DESCRIPTION
this PR makes the following changes:
* adds some documentation to `circuits/circuit.py` about the mechanics of `append` and `insert` on 
measurements and controlled operations.
* adds a couple tests to `circuits/circuit_test.py` and `circuits/moment_test.py` to outline the new behavior of insert and append.
  * it appears some tests were already introduced in https://github.com/quantumlib/Cirq/pull/7823 on adding measurements and controlled operations into circuits. one test I think is missing is ensuring moments created with similar-keyed operations stay as a single moment.

this should address 2/3 of the asks from #8132 .