### PR TITLE
Change serialization of MLS and LZS reset to be resetgate

### DIFF
--- a/cirq-google/cirq_google/ops/lzs_reset.py
+++ b/cirq-google/cirq_google/ops/lzs_reset.py
@@ -25,14 +25,14 @@ class LZSResetViaResonator(cirq.Gate):
     to actively reset a qubit.
     """
 
-    def __init__(self, num_qubits=1, **kwargs):
-        self.num_qubits = num_qubits
+    def __init__(self, num_qubits: int = 1, **kwargs):
+        self._num_qubits = num_qubits
 
     def _num_qubits_(self) -> int:
-        return self.num_qubits
+        return self._num_qubits
 
     def _value_equality_values_(self):
-        return (self.num_qubits,)
+        return (self._num_qubits,)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
         return ["[R (LZS)]"]

--- a/cirq-google/cirq_google/ops/lzs_reset.py
+++ b/cirq-google/cirq_google/ops/lzs_reset.py
@@ -14,10 +14,10 @@
 
 
 import cirq
-from cirq_google.ops.internal_gate import InternalGate
 
 
-class LZSResetViaResonator(InternalGate):
+@cirq.value_equality
+class LZSResetViaResonator(cirq.Gate):
     """Qubit reset via LZS swap with resonator.
 
     This is a specialized type of reset that uses a dual-passage
@@ -25,8 +25,14 @@ class LZSResetViaResonator(InternalGate):
     to actively reset a qubit.
     """
 
-    def __init__(self, gate_name=None, gate_module=None, num_qubits=1, **kwargs):
-        super().__init__(gate_name="LZSResetViaResonator", num_qubits=1)
+    def __init__(self, num_qubits=1, **kwargs):
+        self.num_qubits = num_qubits
+
+    def _num_qubits_(self) -> int:
+        return self.num_qubits
+
+    def _value_equality_values_(self):
+        return (self.num_qubits,)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
         return ["[R (LZS)]"]

--- a/cirq-google/cirq_google/ops/lzs_reset_test.py
+++ b/cirq-google/cirq_google/ops/lzs_reset_test.py
@@ -58,10 +58,9 @@ def test_serialization_round_trip():
     assert len(op_protos) == 1
     op_proto = op_protos[0]
 
-    assert op_proto.WhichOneof('gate_value') == 'internalgate'
-    internal_gate_proto = op_proto.internalgate
-    assert internal_gate_proto.name == "LZSResetViaResonator"
-    assert internal_gate_proto.num_qubits == 1
+    assert op_proto.WhichOneof('gate_value') == 'resetgate'
+    gate_proto = op_proto.resetgate
+    assert gate_proto.reset_type == "LZSResetViaResonator"
 
     # Deserialize
     deserialized_circuit = cg.CIRCUIT_SERIALIZER.deserialize(proto)

--- a/cirq-google/cirq_google/ops/multi_level_reset.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset.py
@@ -26,14 +26,14 @@ class MultilevelResetViaResonator(cirq.Gate):
     rounds of measurement and reset.
     """
 
-    def __init__(self, num_qubits=1, **kwargs):
-        self.num_qubits = num_qubits
+    def __init__(self, num_qubits: int = 1, **kwargs):
+        self._num_qubits = num_qubits
 
     def _num_qubits_(self) -> int:
-        return self.num_qubits
+        return self._num_qubits
 
     def _value_equality_values_(self):
-        return (self.num_qubits,)
+        return (self._num_qubits,)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
         return ["[R (ML)]"]

--- a/cirq-google/cirq_google/ops/multi_level_reset.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset.py
@@ -14,10 +14,10 @@
 
 
 import cirq
-from cirq_google.ops.internal_gate import InternalGate
 
 
-class MultilevelResetViaResonator(InternalGate):
+@cirq.value_equality
+class MultilevelResetViaResonator(cirq.Gate):
     """Multilevel qubit reset with resonator.
 
     This is a specialized type of reset that can be used to clear out
@@ -26,8 +26,14 @@ class MultilevelResetViaResonator(InternalGate):
     rounds of measurement and reset.
     """
 
-    def __init__(self, gate_name=None, gate_module=None, num_qubits=1, **kwargs):
-        super().__init__(gate_name="MultilevelResetViaResonator", num_qubits=1)
+    def __init__(self, num_qubits=1, **kwargs):
+        self.num_qubits = num_qubits
+
+    def _num_qubits_(self) -> int:
+        return self.num_qubits
+
+    def _value_equality_values_(self):
+        return (self.num_qubits,)
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> list[str]:
         return ["[R (ML)]"]

--- a/cirq-google/cirq_google/ops/multi_level_reset_test.py
+++ b/cirq-google/cirq_google/ops/multi_level_reset_test.py
@@ -58,10 +58,9 @@ def test_serialization_round_trip():
     assert len(op_protos) == 1
     op_proto = op_protos[0]
 
-    assert op_proto.WhichOneof('gate_value') == 'internalgate'
-    internal_gate_proto = op_proto.internalgate
-    assert internal_gate_proto.name == "MultilevelResetViaResonator"
-    assert internal_gate_proto.num_qubits == 1
+    assert op_proto.WhichOneof('gate_value') == 'resetgate'
+    gate_proto = op_proto.resetgate
+    assert gate_proto.reset_type == "MultilevelResetViaResonator"
 
     # Deserialize
     deserialized_circuit = cg.CIRCUIT_SERIALIZER.deserialize(proto)

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -395,6 +395,8 @@ class CircuitSerializer(serializer.Serializer):
             )
         elif isinstance(gate, cirq.ResetChannel):
             arg_func_langs.arg_to_proto(gate.dimension, out=msg.resetgate.arguments['dimension'])
+        elif isinstance(gate, (MultilevelResetViaResonator, LZSResetViaResonator)):
+            msg.resetgate.reset_type = type(gate).__name__
         elif isinstance(gate, CouplerPulse):
             arg_func_langs.float_arg_to_proto(
                 gate.hold_time.total_picos(), out=msg.couplerpulsegate.hold_time_ps
@@ -919,14 +921,22 @@ class CircuitSerializer(serializer.Serializer):
             if not isinstance(dimensions, int):
                 # This should always be int, if serialized from cirq.
                 raise ValueError(f"dimensions {dimensions} for ResetChannel must be an integer!")
-            op = cirq.ResetChannel(dimension=dimensions)(*qubits)
+            match operation_proto.resetgate.reset_type:
+                case "LZSResetViaResonator":
+                    op = LZSResetViaResonator()(*qubits)
+                case "MultilevelResetViaResonator":
+                    op = MultilevelResetViaResonator()(*qubits)
+                case _:
+                    op = cirq.ResetChannel(dimension=dimensions)(*qubits)
         elif which_gate_type == 'internalgate':
             msg = operation_proto.internalgate
             match str(msg.name):
                 # Add new custom cirq_google gates here:
                 case "LZSResetViaResonator":
+                    # Can be removed once resetgate deployed (about 9/2026)
                     gate: cirq.Gate = LZSResetViaResonator()
                 case "MultilevelResetViaResonator":
+                    # Can be removed once resetgate deployed (about 9/2026)
                     gate = MultilevelResetViaResonator()
                 case "LeakageISWAPPhaseMatched":
                     gate = LeakageISWAP(phase_matched=True)


### PR DESCRIPTION
- This changes the serialization of LZS and MLR reset operations to use the resetgate oneof rather than internalgate.
- This allows us to match serialization of internal versions of these gates and is a more accurate representation of what these gates do.
- This keep deserialization of internalgate for temporary backwards compatibility.