### PR TITLE
Add cirq.If classical condition operator

### DIFF
--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -72,7 +72,7 @@ fi
 source dev_tools/pypath || exit $?
 
 # Run tests while producing coverage files.
-check/pytest --cov "${PYTEST_ARGS[@]}"
+check/pytest --cov=cirq "${PYTEST_ARGS[@]}"
 pytest_result=$?
 
 

--- a/check/pytest-and-incremental-coverage
+++ b/check/pytest-and-incremental-coverage
@@ -72,7 +72,7 @@ fi
 source dev_tools/pypath || exit $?
 
 # Run tests while producing coverage files.
-check/pytest --cov=cirq "${PYTEST_ARGS[@]}"
+check/pytest --cov "${PYTEST_ARGS[@]}"
 pytest_result=$?
 
 

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -240,6 +240,7 @@ from cirq.ops import (
     I as I,
     identity_each as identity_each,
     IdentityGate as IdentityGate,
+    If as If,
     InterchangeableQubitsGate as InterchangeableQubitsGate,
     ISWAP as ISWAP,
     ISwapPowGate as ISwapPowGate,

--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -150,6 +150,7 @@ def _class_resolver_dictionary() -> dict[str, ObjectFactory]:
         'HPowGate': cirq.HPowGate,
         'ISwapPowGate': cirq.ISwapPowGate,
         'IdentityGate': cirq.IdentityGate,
+        'If': cirq.If,
         'InitObsSetting': cirq.work.InitObsSetting,
         'InsertionNoiseModel': InsertionNoiseModel,
         '_InverseCompositeGate': raw_types._InverseCompositeGate,

--- a/cirq-core/cirq/ops/__init__.py
+++ b/cirq-core/cirq/ops/__init__.py
@@ -108,6 +108,8 @@ from cirq.ops.gateset import GateFamily as GateFamily, Gateset as Gateset
 
 from cirq.ops.identity import I as I, identity_each as identity_each, IdentityGate as IdentityGate
 
+from cirq.ops.if_op import If as If
+
 from cirq.ops.global_phase_op import (
     GlobalPhaseGate as GlobalPhaseGate,
     global_phase_operation as global_phase_operation,

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -1,0 +1,276 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence, Set
+from typing import Any, TYPE_CHECKING
+
+import sympy
+
+from cirq import protocols, value
+from cirq.ops import classically_controlled_operation, raw_types
+
+if TYPE_CHECKING:
+    import cirq
+
+
+@value.value_equality
+class If(raw_types.Operation):
+    """An operation that conditionally executes a sub-operation based on classical conditions.
+
+    This operation decomposes into a `cirq.ClassicallyControlledOperation`.
+    """
+
+    def __init__(
+        self,
+        condition: str
+        | cirq.MeasurementKey
+        | cirq.Condition
+        | sympy.Basic
+        | Sequence[str | cirq.MeasurementKey | cirq.Condition | sympy.Basic],
+        sub_operation: cirq.Operation | cirq.OP_TREE,
+        *more_operations: cirq.Operation | cirq.OP_TREE,
+    ):
+        """Initializes the `If` operation.
+
+        Args:
+            condition: The condition(s) under which `sub_operation` should be applied.
+                Can be a measurement key, string, condition object, sympy expression, or a
+                sequence of these conditions.
+            sub_operation: The operation (or tree of operations) to run when `condition` is satisfied.
+            *more_operations: Additional operations to run when `condition` is satisfied. If provided,
+                `sub_operation` and `more_operations` are combined into a `cirq.CircuitOperation`.
+
+        Raises:
+            ValueError: If `condition` sequence is empty, or if the sub-operation contains
+                measurement keys.
+            TypeError: If an unrecognized condition type is provided.
+        """
+        if isinstance(condition, (str, value.MeasurementKey, value.Condition, sympy.Basic)):
+            raw_conditions: Sequence[Any] = (condition,)
+        elif isinstance(condition, Sequence):
+            raw_conditions = condition
+        else:
+            raise TypeError(f"Unrecognized condition type: {type(condition)}")
+
+        conds: list[cirq.Condition] = []
+        for c in raw_conditions:
+            if isinstance(c, str):
+                c = value.MeasurementKey.parse_serialized(c)
+            if isinstance(c, value.MeasurementKey):
+                c = value.KeyCondition(c)
+            if isinstance(c, sympy.Basic):
+                c = value.SympyCondition(c)
+            if not isinstance(c, value.Condition):
+                raise TypeError(f"Unrecognized condition type: {type(c)}")
+            conds.append(c)
+
+        if not conds:
+            raise ValueError("At least one condition must be provided.")
+        conds_tuple = tuple(conds)
+
+        if not more_operations and isinstance(sub_operation, raw_types.Operation):
+            if isinstance(sub_operation, If):
+                self._conditions: tuple[cirq.Condition, ...] = (
+                    conds_tuple + sub_operation.conditions
+                )
+                self._sub_operation: cirq.Operation = sub_operation.sub_operation
+            elif isinstance(
+                sub_operation, classically_controlled_operation.ClassicallyControlledOperation
+            ):
+                self._conditions = conds_tuple + sub_operation._conditions
+                self._sub_operation = sub_operation._sub_operation
+            else:
+                self._conditions = conds_tuple
+                self._sub_operation = sub_operation
+        else:
+            # Inline import to prevent circular dependency.
+            from cirq.circuits import circuit, circuit_operation
+
+            if more_operations:
+                c = circuit.Circuit(sub_operation, *more_operations)
+            else:
+                c = circuit.Circuit(sub_operation)
+            self._conditions = conds_tuple
+            self._sub_operation = circuit_operation.CircuitOperation(c.freeze())
+
+        if protocols.measurement_key_objs(self._sub_operation):
+            raise ValueError(
+                f'Cannot conditionally run operations with measurements: {self._sub_operation}'
+            )
+
+    @property
+    def conditions(self) -> tuple[cirq.Condition, ...]:
+        """All conditions that must be satisfied for the sub-operation to run."""
+        return self._conditions
+
+    @property
+    def condition(self) -> cirq.Condition:
+        """The condition that must be satisfied for the sub-operation to run.
+
+        Raises:
+            ValueError: If there are multiple conditions on this operation.
+        """
+        if len(self._conditions) != 1:
+            raise ValueError(
+                f'Operation has multiple conditions: {self._conditions}. '
+                'Use `conditions` property instead.'
+            )
+        return self._conditions[0]
+
+    @property
+    def sub_operation(self) -> cirq.Operation:
+        """The operation that is conditionally executed."""
+        return self._sub_operation
+
+    @property
+    def classical_controls(self) -> frozenset[cirq.Condition]:
+        return frozenset(self._conditions).union(self._sub_operation.classical_controls)
+
+    def without_classical_controls(self) -> cirq.Operation:
+        return self._sub_operation.without_classical_controls()
+
+    @property
+    def qubits(self) -> tuple[cirq.Qid, ...]:
+        return self._sub_operation.qubits
+
+    def with_qubits(self, *new_qubits: cirq.Qid) -> cirq.Operation:
+        return If(self._conditions, self._sub_operation.with_qubits(*new_qubits))
+
+    def _decompose_with_context_(
+        self, *, context: cirq.DecompositionContext | None = None
+    ) -> cirq.OP_TREE:
+        return self._sub_operation.with_classical_controls(*self._conditions)
+
+    def _decompose_(self) -> cirq.OP_TREE:
+        return self._sub_operation.with_classical_controls(*self._conditions)
+
+    def _value_equality_values_(self) -> Any:
+        return self._conditions, self._sub_operation
+
+    def __str__(self) -> str:
+        if len(self._conditions) == 1:
+            return f'If({self._conditions[0]}, {self._sub_operation})'
+        keys = ', '.join(str(c) for c in self._conditions)
+        return f'If(({keys}), {self._sub_operation})'
+
+    def __repr__(self) -> str:
+        if len(self._conditions) == 1:
+            return f'cirq.If({self._conditions[0]!r}, {self._sub_operation!r})'
+        return f'cirq.If({list(self._conditions)!r}, {self._sub_operation!r})'
+
+    def _is_parameterized_(self) -> bool:
+        return any(
+            protocols.is_parameterized(c) for c in self._conditions
+        ) or protocols.is_parameterized(self._sub_operation)
+
+    def _parameter_names_(self) -> Set[str]:
+        names: set[str] = set()
+        for c in self._conditions:
+            names.update(protocols.parameter_names(c))
+        names.update(protocols.parameter_names(self._sub_operation))
+        return names
+
+    def _resolve_parameters_(
+        self, resolver: cirq.ParamResolver, recursive: bool
+    ) -> If:
+        new_conditions = [
+            protocols.resolve_parameters(c, resolver, recursive) for c in self._conditions
+        ]
+        new_sub_op = protocols.resolve_parameters(self._sub_operation, resolver, recursive)
+        return If(new_conditions, new_sub_op)
+
+    def _circuit_diagram_info_(
+        self, args: cirq.CircuitDiagramInfoArgs
+    ) -> protocols.CircuitDiagramInfo | None:
+        sub_args = protocols.CircuitDiagramInfoArgs(
+            known_qubit_count=args.known_qubit_count,
+            known_qubits=args.known_qubits,
+            use_unicode_characters=args.use_unicode_characters,
+            precision=args.precision,
+            label_map=args.label_map,
+        )
+        sub_info = protocols.circuit_diagram_info(self._sub_operation, sub_args, None)
+        if sub_info is None:
+            return NotImplemented  # pragma: no cover
+        control_label_count = 0
+        if args.label_map is not None:
+            control_label_count = len({k for c in self._conditions for k in c.keys})
+        wire_symbols = sub_info.wire_symbols + ('^',) * control_label_count
+        if control_label_count == 0 or any(
+            not isinstance(c, value.KeyCondition) for c in self._conditions
+        ):
+            if len(self._conditions) == 1:
+                cond_str = str(self._conditions[0])
+            else:
+                cond_str = ', '.join(str(c) for c in self._conditions)
+            wire_symbols = (f'{wire_symbols[0]}(If={cond_str})', *wire_symbols[1:])
+        exp_index = sub_info.exponent_qubit_index
+        if exp_index is None:
+            exp_index = len(sub_info.wire_symbols) - 1
+        return protocols.CircuitDiagramInfo(
+            wire_symbols=wire_symbols, exponent=sub_info.exponent, exponent_qubit_index=exp_index
+        )
+
+    def _json_dict_(self) -> dict[str, Any]:
+        return {'condition': list(self._conditions), 'sub_operation': self._sub_operation}
+
+    def _act_on_(self, sim_state: cirq.SimulationStateBase) -> bool:
+        if all(c.resolve(sim_state.classical_data) for c in self._conditions):
+            protocols.act_on(self._sub_operation, sim_state)
+        return True
+
+    def _with_measurement_key_mapping_(self, key_map: Mapping[str, str]) -> If:
+        conditions = [protocols.with_measurement_key_mapping(c, key_map) for c in self._conditions]
+        sub_operation = protocols.with_measurement_key_mapping(self._sub_operation, key_map)
+        sub_operation = self._sub_operation if sub_operation is NotImplemented else sub_operation
+        return If(conditions, sub_operation)
+
+    def _with_key_path_prefix_(self, prefix: tuple[str, ...]) -> If:
+        conditions = [protocols.with_key_path_prefix(c, prefix) for c in self._conditions]
+        sub_operation = protocols.with_key_path_prefix(self._sub_operation, prefix)
+        sub_operation = self._sub_operation if sub_operation is NotImplemented else sub_operation
+        return If(conditions, sub_operation)
+
+    def _with_rescoped_keys_(
+        self, path: tuple[str, ...], bindable_keys: frozenset[cirq.MeasurementKey]
+    ) -> If:
+        conds = [protocols.with_rescoped_keys(c, path, bindable_keys) for c in self._conditions]
+        sub_operation = protocols.with_rescoped_keys(self._sub_operation, path, bindable_keys)
+        return If(conds, sub_operation)
+
+    def _control_keys_(self) -> frozenset[cirq.MeasurementKey]:
+        local_keys: frozenset[cirq.MeasurementKey] = frozenset(
+            k for condition in self._conditions for k in condition.keys
+        )
+        return local_keys.union(protocols.control_keys(self._sub_operation))
+
+    def _qasm_(
+        self, *, args: cirq.QasmArgs | None = None, qubits: Sequence[cirq.Qid] | None = None
+    ) -> str | None:
+        if args is None:
+            from cirq.protocols.qasm import QasmArgs
+
+            args = QasmArgs()
+        args.validate_version('2.0', '3.0')
+        if args.version == "2.0" and len(self._conditions) > 1:
+            raise ValueError(
+                'QASM 2.0 does not support multiple conditions. Consider exporting with QASM 3.0.'
+            )
+        subop_qasm = protocols.qasm(self._sub_operation, args=args, qubits=qubits, default=None)
+        if subop_qasm is None:
+            return None
+        condition_qasm = " && ".join(protocols.qasm(c, args=args) for c in self._conditions)
+        return f'if ({condition_qasm}) {subop_qasm}'

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -15,11 +15,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence, Set
+from types import NotImplementedType
 from typing import Any, TYPE_CHECKING
 
 import sympy
 
-from cirq import protocols, value
+from cirq import _compat, protocols, value
 from cirq.ops import classically_controlled_operation, raw_types
 
 if TYPE_CHECKING:
@@ -112,10 +113,6 @@ class If(raw_types.Operation):
                 f'Cannot conditionally run operations with measurements: {self._sub_operation}'
             )
 
-        # Cached parameters
-        self._is_parameterized = None
-        self._parameter_names: set[str] | None = None
-
     @property
     def conditions(self) -> tuple[cirq.Condition, ...]:
         """All conditions that must be satisfied for the sub-operation to run."""
@@ -162,20 +159,19 @@ class If(raw_types.Operation):
             return f'cirq.If({self._conditions[0]!r}, {self._sub_operation!r})'
         return f'cirq.If({list(self._conditions)!r}, {self._sub_operation!r})'
 
+    @_compat.cached_method
     def _is_parameterized_(self) -> bool:
-        if self._is_parameterized is None:
-            self._is_parameterized = any(
-                protocols.is_parameterized(c) for c in self._conditions
-            ) or protocols.is_parameterized(self._sub_operation)
-        return self._is_parameterized
+        return any(
+            protocols.is_parameterized(c) for c in self._conditions
+        ) or protocols.is_parameterized(self._sub_operation)
 
+    @_compat.cached_method
     def _parameter_names_(self) -> Set[str]:
-        if self._parameter_names is None:
-            self._parameter_names = set()
-            for c in self._conditions:
-                self._parameter_names.update(protocols.parameter_names(c))
-            self._parameter_names.update(protocols.parameter_names(self._sub_operation))
-        return self._parameter_names
+        names: set[str] = set()
+        for c in self._conditions:
+            names.update(protocols.parameter_names(c))
+        names.update(protocols.parameter_names(self._sub_operation))
+        return names
 
     def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> If:
         new_conditions = [

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -1,0 +1,276 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence, Set
+from typing import Any, Self, TYPE_CHECKING
+
+import sympy
+
+from cirq import protocols, value
+from cirq.ops import classically_controlled_operation, raw_types
+
+if TYPE_CHECKING:
+    import cirq
+
+
+@value.value_equality
+class If(raw_types.Operation):
+    """An operation that conditionally executes a sub-operation based on classical conditions.
+
+    This operation decomposes into a `cirq.ClassicallyControlledOperation`.
+    """
+
+    def __init__(
+        self,
+        condition: (
+            str
+            | cirq.MeasurementKey
+            | cirq.Condition
+            | sympy.Basic
+            | Sequence[str | cirq.MeasurementKey | cirq.Condition | sympy.Basic]
+        ),
+        sub_operation: cirq.Operation | cirq.OP_TREE,
+        *more_operations: cirq.Operation | cirq.OP_TREE,
+    ):
+        """Initializes the `If` operation.
+
+        Args:
+            condition: The condition(s) under which `sub_operation` should be applied.
+                Can be a measurement key, string, condition object, sympy expression, or a
+                sequence of these conditions.
+            sub_operation: The operation (or tree of operations) to run when `condition` is satisfied.
+            *more_operations: Additional operations to run when `condition` is satisfied. If provided,
+                `sub_operation` and `more_operations` are combined into a `cirq.CircuitOperation`.
+
+        Raises:
+            ValueError: If `condition` sequence is empty, or if the sub-operation contains
+                measurement keys.
+            TypeError: If an unrecognized condition type is provided.
+        """
+        if isinstance(condition, (str, value.MeasurementKey, value.Condition, sympy.Basic)):
+            raw_conditions: Sequence[Any] = (condition,)
+        elif isinstance(condition, Sequence):
+            raw_conditions = condition
+        else:
+            raise TypeError(f"Unrecognized condition type: {type(condition)}")
+
+        conds: list[cirq.Condition] = []
+        for c in raw_conditions:
+            if isinstance(c, str):
+                c = value.MeasurementKey.parse_serialized(c)
+            if isinstance(c, value.MeasurementKey):
+                c = value.KeyCondition(c)
+            if isinstance(c, sympy.Basic):
+                c = value.SympyCondition(c)
+            if not isinstance(c, value.Condition):
+                raise TypeError(f"Unrecognized condition type: {type(c)}")
+            conds.append(c)
+
+        if not conds:
+            raise ValueError("At least one condition must be provided.")
+        conds_tuple = tuple(conds)
+
+        if not more_operations and isinstance(sub_operation, raw_types.Operation):
+            if isinstance(sub_operation, If):
+                self._conditions: tuple[cirq.Condition, ...] = (
+                    conds_tuple + sub_operation.conditions
+                )
+                self._sub_operation: cirq.Operation = sub_operation.sub_operation
+            elif isinstance(
+                sub_operation, classically_controlled_operation.ClassicallyControlledOperation
+            ):
+                self._conditions = conds_tuple + sub_operation._conditions
+                self._sub_operation = sub_operation._sub_operation
+            else:
+                self._conditions = conds_tuple
+                self._sub_operation = sub_operation
+        else:
+            # Inline import to prevent circular dependency.
+            from cirq.circuits import circuit, circuit_operation
+
+            if more_operations:
+                c = circuit.Circuit(sub_operation, *more_operations)
+            else:
+                c = circuit.Circuit(sub_operation)
+            self._conditions = conds_tuple
+            self._sub_operation = circuit_operation.CircuitOperation(c.freeze())
+
+        if protocols.measurement_key_objs(self._sub_operation):
+            raise ValueError(
+                f'Cannot conditionally run operations with measurements: {self._sub_operation}'
+            )
+
+    @property
+    def conditions(self) -> tuple[cirq.Condition, ...]:
+        """All conditions that must be satisfied for the sub-operation to run."""
+        return self._conditions
+
+    @property
+    def condition(self) -> cirq.Condition:
+        """The condition that must be satisfied for the sub-operation to run.
+
+        Raises:
+            ValueError: If there are multiple conditions on this operation.
+        """
+        if len(self._conditions) != 1:
+            raise ValueError(
+                f'Operation has multiple conditions: {self._conditions}. '
+                'Use `conditions` property instead.'
+            )
+        return self._conditions[0]
+
+    @property
+    def sub_operation(self) -> cirq.Operation:
+        """The operation that is conditionally executed."""
+        return self._sub_operation
+
+    @property
+    def classical_controls(self) -> frozenset[cirq.Condition]:
+        return frozenset(self._conditions).union(self._sub_operation.classical_controls)
+
+    def without_classical_controls(self) -> cirq.Operation:
+        return self._sub_operation.without_classical_controls()
+
+    @property
+    def qubits(self) -> tuple[cirq.Qid, ...]:
+        return self._sub_operation.qubits
+
+    def with_qubits(self, *new_qubits: cirq.Qid) -> Self:
+        return If(self._conditions, self._sub_operation.with_qubits(*new_qubits))
+
+    def _decompose_with_context_(
+        self, *, context: cirq.DecompositionContext | None = None
+    ) -> cirq.OP_TREE:
+        return self._sub_operation.with_classical_controls(*self._conditions)
+
+    def _decompose_(self) -> cirq.OP_TREE:
+        return self._sub_operation.with_classical_controls(*self._conditions)
+
+    def _value_equality_values_(self) -> Any:
+        return self._conditions, self._sub_operation
+
+    def __str__(self) -> str:
+        if len(self._conditions) == 1:
+            return f'If({self._conditions[0]}, {self._sub_operation})'
+        keys = ', '.join(str(c) for c in self._conditions)
+        return f'If(({keys}), {self._sub_operation})'
+
+    def __repr__(self) -> str:
+        if len(self._conditions) == 1:
+            return f'cirq.If({self._conditions[0]!r}, {self._sub_operation!r})'
+        return f'cirq.If({list(self._conditions)!r}, {self._sub_operation!r})'
+
+    def _is_parameterized_(self) -> bool:
+        return any(
+            protocols.is_parameterized(c) for c in self._conditions
+        ) or protocols.is_parameterized(self._sub_operation)
+
+    def _parameter_names_(self) -> Set[str]:
+        names: set[str] = set()
+        for c in self._conditions:
+            names.update(protocols.parameter_names(c))
+        names.update(protocols.parameter_names(self._sub_operation))
+        return names
+
+    def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> If:
+        new_conditions = [
+            protocols.resolve_parameters(c, resolver, recursive) for c in self._conditions
+        ]
+        new_sub_op = protocols.resolve_parameters(self._sub_operation, resolver, recursive)
+        return If(new_conditions, new_sub_op)
+
+    def _circuit_diagram_info_(
+        self, args: cirq.CircuitDiagramInfoArgs
+    ) -> protocols.CircuitDiagramInfo | None:
+        sub_args = protocols.CircuitDiagramInfoArgs(
+            known_qubit_count=args.known_qubit_count,
+            known_qubits=args.known_qubits,
+            use_unicode_characters=args.use_unicode_characters,
+            precision=args.precision,
+            label_map=args.label_map,
+        )
+        sub_info = protocols.circuit_diagram_info(self._sub_operation, sub_args, None)
+        if sub_info is None:
+            return NotImplemented  # pragma: no cover
+        control_label_count = 0
+        if args.label_map is not None:
+            control_label_count = len({k for c in self._conditions for k in c.keys})
+        wire_symbols = sub_info.wire_symbols + ('^',) * control_label_count
+        if control_label_count == 0 or any(
+            not isinstance(c, value.KeyCondition) for c in self._conditions
+        ):
+            if len(self._conditions) == 1:
+                cond_str = str(self._conditions[0])
+            else:
+                cond_str = ', '.join(str(c) for c in self._conditions)
+            wire_symbols = (f'{wire_symbols[0]}(If={cond_str})', *wire_symbols[1:])
+        exp_index = sub_info.exponent_qubit_index
+        if exp_index is None:
+            exp_index = len(sub_info.wire_symbols) - 1
+        return protocols.CircuitDiagramInfo(
+            wire_symbols=wire_symbols, exponent=sub_info.exponent, exponent_qubit_index=exp_index
+        )
+
+    def _json_dict_(self) -> dict[str, Any]:
+        return {'condition': list(self._conditions), 'sub_operation': self._sub_operation}
+
+    def _act_on_(self, sim_state: cirq.SimulationStateBase) -> bool:
+        if all(c.resolve(sim_state.classical_data) for c in self._conditions):
+            protocols.act_on(self._sub_operation, sim_state)
+        return True
+
+    def _with_measurement_key_mapping_(self, key_map: Mapping[str, str]) -> If:
+        conditions = [protocols.with_measurement_key_mapping(c, key_map) for c in self._conditions]
+        sub_operation = protocols.with_measurement_key_mapping(self._sub_operation, key_map)
+        sub_operation = self._sub_operation if sub_operation is NotImplemented else sub_operation
+        return If(conditions, sub_operation)
+
+    def _with_key_path_prefix_(self, prefix: tuple[str, ...]) -> If:
+        conditions = [protocols.with_key_path_prefix(c, prefix) for c in self._conditions]
+        sub_operation = protocols.with_key_path_prefix(self._sub_operation, prefix)
+        sub_operation = self._sub_operation if sub_operation is NotImplemented else sub_operation
+        return If(conditions, sub_operation)
+
+    def _with_rescoped_keys_(
+        self, path: tuple[str, ...], bindable_keys: frozenset[cirq.MeasurementKey]
+    ) -> If:
+        conds = [protocols.with_rescoped_keys(c, path, bindable_keys) for c in self._conditions]
+        sub_operation = protocols.with_rescoped_keys(self._sub_operation, path, bindable_keys)
+        return If(conds, sub_operation)
+
+    def _control_keys_(self) -> frozenset[cirq.MeasurementKey]:
+        local_keys: frozenset[cirq.MeasurementKey] = frozenset(
+            k for condition in self._conditions for k in condition.keys
+        )
+        return local_keys.union(protocols.control_keys(self._sub_operation))
+
+    def _qasm_(
+        self, *, args: cirq.QasmArgs | None = None, qubits: Sequence[cirq.Qid] | None = None
+    ) -> str | None:
+        if args is None:
+            from cirq.protocols.qasm import QasmArgs
+
+            args = QasmArgs()
+        args.validate_version('2.0', '3.0')
+        if args.version == "2.0" and len(self._conditions) > 1:
+            raise ValueError(
+                'QASM 2.0 does not support multiple conditions. Consider exporting with QASM 3.0.'
+            )
+        subop_qasm = protocols.qasm(self._sub_operation, args=args, qubits=qubits, default=None)
+        if subop_qasm is None:
+            return None
+        condition_qasm = " && ".join(protocols.qasm(c, args=args) for c in self._conditions)
+        return f'if ({condition_qasm}) {subop_qasm}'

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -85,7 +85,7 @@ class If(raw_types.Operation):
             raise ValueError("At least one condition must be provided.")
         conds_tuple = tuple(conds)
 
-        if not more_operations and isinstance(sub_operation, raw_types.Operation):
+        if more_operations or not isinstance(sub_operation, raw_types.Operation):
             if isinstance(sub_operation, If):
                 self._conditions: tuple[cirq.Condition, ...] = (
                     conds_tuple + sub_operation.conditions
@@ -101,38 +101,25 @@ class If(raw_types.Operation):
                 self._sub_operation = sub_operation
         else:
             # Inline import to prevent circular dependency.
-            from cirq.circuits import circuit, circuit_operation
+            from cirq.circuits import Circuit, CircuitOperation
 
-            if more_operations:
-                c = circuit.Circuit(sub_operation, *more_operations)
-            else:
-                c = circuit.Circuit(sub_operation)
+            c = Circuit(sub_operation, *more_operations)
             self._conditions = conds_tuple
-            self._sub_operation = circuit_operation.CircuitOperation(c.freeze())
+            self._sub_operation = CircuitOperation(c.freeze())
 
         if protocols.measurement_key_objs(self._sub_operation):
             raise ValueError(
                 f'Cannot conditionally run operations with measurements: {self._sub_operation}'
             )
 
+        # Cached parameters
+        self._is_parameterized = None
+        self._parameter_names: set[str] | None = None
+
     @property
     def conditions(self) -> tuple[cirq.Condition, ...]:
         """All conditions that must be satisfied for the sub-operation to run."""
         return self._conditions
-
-    @property
-    def condition(self) -> cirq.Condition:
-        """The condition that must be satisfied for the sub-operation to run.
-
-        Raises:
-            ValueError: If there are multiple conditions on this operation.
-        """
-        if len(self._conditions) != 1:
-            raise ValueError(
-                f'Operation has multiple conditions: {self._conditions}. '
-                'Use `conditions` property instead.'
-            )
-        return self._conditions[0]
 
     @property
     def sub_operation(self) -> cirq.Operation:
@@ -168,7 +155,7 @@ class If(raw_types.Operation):
         if len(self._conditions) == 1:
             return f'If({self._conditions[0]}, {self._sub_operation})'
         keys = ', '.join(str(c) for c in self._conditions)
-        return f'If(({keys}), {self._sub_operation})'
+        return f'If([{keys}], {self._sub_operation})'
 
     def __repr__(self) -> str:
         if len(self._conditions) == 1:
@@ -176,16 +163,19 @@ class If(raw_types.Operation):
         return f'cirq.If({list(self._conditions)!r}, {self._sub_operation!r})'
 
     def _is_parameterized_(self) -> bool:
-        return any(
-            protocols.is_parameterized(c) for c in self._conditions
-        ) or protocols.is_parameterized(self._sub_operation)
+        if self._is_parameterized is None:
+            self._is_parameterized = any(
+                protocols.is_parameterized(c) for c in self._conditions
+            ) or protocols.is_parameterized(self._sub_operation)
+        return self._is_parameterized
 
     def _parameter_names_(self) -> Set[str]:
-        names: set[str] = set()
-        for c in self._conditions:
-            names.update(protocols.parameter_names(c))
-        names.update(protocols.parameter_names(self._sub_operation))
-        return names
+        if self._parameter_names is None:
+            self._parameter_names = set()
+            for c in self._conditions:
+                self._parameter_names.update(protocols.parameter_names(c))
+            self._parameter_names.update(protocols.parameter_names(self._sub_operation))
+        return self._parameter_names
 
     def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> If:
         new_conditions = [
@@ -196,7 +186,7 @@ class If(raw_types.Operation):
 
     def _circuit_diagram_info_(
         self, args: cirq.CircuitDiagramInfoArgs
-    ) -> protocols.CircuitDiagramInfo | None:
+    ) -> protocols.CircuitDiagramInfo | NotImplementedType:
         sub_args = protocols.CircuitDiagramInfoArgs(
             known_qubit_count=args.known_qubit_count,
             known_qubits=args.known_qubits,

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -48,16 +48,18 @@ class If(raw_types.Operation):
         """Initializes the `If` operation.
 
         Args:
-            condition: The condition(s) under which `sub_operation` should be applied.
-                Can be a measurement key, string, condition object, sympy expression, or a
-                sequence of these conditions.
-            sub_operation: The operation (or tree of operations) to run when `condition` is satisfied.
-            *more_operations: Additional operations to run when `condition` is satisfied. If provided,
-                `sub_operation` and `more_operations` are combined into a `cirq.CircuitOperation`.
+            condition: The condition(s) under which `sub_operation` should be
+                applied.  Can be a measurement key, string, condition object,
+                sympy expression, or a sequence of these conditions.
+            sub_operation: The operation (or tree of operations) to run when
+                `condition` is satisfied.
+            *more_operations: Additional operations to run when `condition`
+                is satisfied. If provided, `sub_operation` and `more_operations`
+                are combined into a `cirq.CircuitOperation`.
 
         Raises:
-            ValueError: If `condition` sequence is empty, or if the sub-operation contains
-                measurement keys.
+            ValueError: If `condition` sequence is empty,
+                or if the sub-operation contains measurement keys.
             TypeError: If an unrecognized condition type is provided.
         """
         if isinstance(condition, (str, value.MeasurementKey, value.Condition, sympy.Basic)):

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -85,7 +85,7 @@ class If(raw_types.Operation):
             raise ValueError("At least one condition must be provided.")
         conds_tuple = tuple(conds)
 
-        if more_operations or not isinstance(sub_operation, raw_types.Operation):
+        if not more_operations and isinstance(sub_operation, raw_types.Operation):
             if isinstance(sub_operation, If):
                 self._conditions: tuple[cirq.Condition, ...] = (
                     conds_tuple + sub_operation.conditions

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence, Set
-from typing import Any, Self, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import sympy
 
@@ -148,7 +148,7 @@ class If(raw_types.Operation):
     def qubits(self) -> tuple[cirq.Qid, ...]:
         return self._sub_operation.qubits
 
-    def with_qubits(self, *new_qubits: cirq.Qid) -> Self:
+    def with_qubits(self, *new_qubits: cirq.Qid) -> If:
         return If(self._conditions, self._sub_operation.with_qubits(*new_qubits))
 
     def _decompose_with_context_(

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -86,7 +86,17 @@ class If(raw_types.Operation):
             raise ValueError("At least one condition must be provided.")
         conds_tuple = tuple(conds)
 
-        if not more_operations and isinstance(sub_operation, raw_types.Operation):
+        if more_operations or not isinstance(sub_operation, Operation):
+            # Multiple operations: wrap in a CircuitOperation
+
+            # Inline import to prevent circular dependency.
+            from cirq.circuits import Circuit, CircuitOperation
+
+            c = Circuit(sub_operation, *more_operations)
+            self._conditions = conds_tuple
+            self._sub_operation = CircuitOperation(c.freeze())
+        else:
+            # Single operation
             if isinstance(sub_operation, If):
                 self._conditions: tuple[cirq.Condition, ...] = (
                     conds_tuple + sub_operation.conditions
@@ -100,13 +110,6 @@ class If(raw_types.Operation):
             else:
                 self._conditions = conds_tuple
                 self._sub_operation = sub_operation
-        else:
-            # Inline import to prevent circular dependency.
-            from cirq.circuits import Circuit, CircuitOperation
-
-            c = Circuit(sub_operation, *more_operations)
-            self._conditions = conds_tuple
-            self._sub_operation = CircuitOperation(c.freeze())
 
         if protocols.measurement_key_objs(self._sub_operation):
             raise ValueError(

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -93,15 +93,13 @@ class If(raw_types.Operation):
             from cirq.circuits import Circuit, CircuitOperation
 
             c = Circuit(sub_operation, *more_operations)
-            self._conditions = conds_tuple
-            self._sub_operation = CircuitOperation(c.freeze())
+            self._conditions: tuple[cirq.Condition, ...] = conds_tuple
+            self._sub_operation: cirq.Operation = CircuitOperation(c.freeze())
         else:
             # Single operation
             if isinstance(sub_operation, If):
-                self._conditions: tuple[cirq.Condition, ...] = (
-                    conds_tuple + sub_operation.conditions
-                )
-                self._sub_operation: cirq.Operation = sub_operation.sub_operation
+                self._conditions = conds_tuple + sub_operation.conditions
+                self._sub_operation = sub_operation.sub_operation
             elif isinstance(
                 sub_operation, classically_controlled_operation.ClassicallyControlledOperation
             ):

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -86,7 +86,7 @@ class If(raw_types.Operation):
             raise ValueError("At least one condition must be provided.")
         conds_tuple = tuple(conds)
 
-        if more_operations or not isinstance(sub_operation, Operation):
+        if more_operations or not isinstance(sub_operation, raw_types.Operation):
             # Multiple operations: wrap in a CircuitOperation
 
             # Inline import to prevent circular dependency.

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -134,7 +134,7 @@ def test_str_and_repr() -> None:
     op1 = cirq.If('m', cirq.X(q))
     assert str(op1) == 'If(m, X(q(0)))'
     assert repr(op1) == (
-        "cirq.If(cirq.KeyCondition(cirq.MeasurementKey(name='m')), " "cirq.X(cirq.LineQubit(0)))"
+        "cirq.If(cirq.KeyCondition(cirq.MeasurementKey(name='m')), cirq.X(cirq.LineQubit(0)))"
     )
     assert eval(repr(op1)) == op1
 

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -1,0 +1,303 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import sympy
+
+import cirq
+
+
+def test_init() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('m', cirq.X(q))
+    assert op.condition == cirq.KeyCondition(cirq.MeasurementKey('m'))
+    assert op.conditions == (cirq.KeyCondition(cirq.MeasurementKey('m')),)
+    assert op.sub_operation == cirq.X(q)
+    assert op.qubits == (q,)
+    assert op.classical_controls == frozenset([cirq.KeyCondition(cirq.MeasurementKey('m'))])
+    assert op.without_classical_controls() == cirq.X(q)
+
+
+def test_init_condition_types() -> None:
+    q = cirq.LineQubit(0)
+    key = cirq.MeasurementKey('k')
+    cond = cirq.KeyCondition(key)
+    sym = sympy.Symbol('s')
+
+    assert cirq.If(key, cirq.X(q)).condition == cond
+    assert cirq.If(cond, cirq.X(q)).condition == cond
+    assert cirq.If(sym, cirq.X(q)).condition == cirq.SympyCondition(sym)
+
+
+def test_init_multiple_conditions() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If(['a', 'b'], cirq.X(q))
+    assert op.conditions == (
+        cirq.KeyCondition(cirq.MeasurementKey('a')),
+        cirq.KeyCondition(cirq.MeasurementKey('b')),
+    )
+    with pytest.raises(ValueError, match='Operation has multiple conditions'):
+        _ = op.condition
+
+
+def test_init_multiple_operations() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.If('m', cirq.X(q0), cirq.Y(q1))
+    assert isinstance(op.sub_operation, cirq.CircuitOperation)
+    assert op.sub_operation.circuit == cirq.Circuit(cirq.X(q0), cirq.Y(q1))
+    assert op.qubits == (q0, q1)
+
+    op_list = cirq.If('m', [cirq.X(q0), cirq.Y(q1)])
+    assert isinstance(op_list.sub_operation, cirq.CircuitOperation)
+    assert op_list.sub_operation.circuit == cirq.Circuit(cirq.X(q0), cirq.Y(q1))
+
+
+def test_init_squash_nested_if() -> None:
+    q = cirq.LineQubit(0)
+    inner = cirq.If('a', cirq.X(q))
+    outer = cirq.If('b', inner)
+    assert outer.conditions == (
+        cirq.KeyCondition(cirq.MeasurementKey('b')),
+        cirq.KeyCondition(cirq.MeasurementKey('a')),
+    )
+    assert outer.sub_operation == cirq.X(q)
+
+    cco = cirq.ClassicallyControlledOperation(cirq.X(q), ['a'])
+    outer_cco = cirq.If('b', cco)
+    assert outer_cco.conditions == (
+        cirq.KeyCondition(cirq.MeasurementKey('b')),
+        cirq.KeyCondition(cirq.MeasurementKey('a')),
+    )
+    assert outer_cco.sub_operation == cirq.X(q)
+
+
+def test_init_errors() -> None:
+    q = cirq.LineQubit(0)
+    with pytest.raises(TypeError, match='Unrecognized condition type'):
+        _ = cirq.If(123, cirq.X(q))
+
+    with pytest.raises(TypeError, match='Unrecognized condition type'):
+        _ = cirq.If(['a', 123], cirq.X(q))
+
+    with pytest.raises(ValueError, match='At least one condition must be provided'):
+        _ = cirq.If([], cirq.X(q))
+
+    with pytest.raises(ValueError, match='Cannot conditionally run operations with measurements'):
+        _ = cirq.If('m', cirq.measure(q, key='out'))
+
+
+def test_with_qubits() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.If('m', cirq.X(q0))
+    new_op = op.with_qubits(q1)
+    assert new_op == cirq.If('m', cirq.X(q1))
+
+
+def test_decomposition() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('m', cirq.X(q))
+    decomposed = cirq.decompose_once(op)
+    expected = [cirq.ClassicallyControlledOperation(cirq.X(q), ['m'])]
+    assert decomposed == expected
+    assert op._decompose_() == expected[0]
+
+    circuit = cirq.Circuit(cirq.measure(q, key='m'), op)
+    full_decomposed = cirq.Circuit(cirq.decompose(circuit))
+    assert full_decomposed == cirq.Circuit(
+        cirq.measure(q, key='m'), cirq.X(q).with_classical_controls('m')
+    )
+
+
+def test_value_equality() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(cirq.If('a', cirq.X(q0)), cirq.If(cirq.MeasurementKey('a'), cirq.X(q0)))
+    eq.add_equality_group(cirq.If('b', cirq.X(q0)))
+    eq.add_equality_group(cirq.If('a', cirq.X(q1)))
+    eq.add_equality_group(cirq.If(['a', 'b'], cirq.X(q0)))
+
+
+def test_str_and_repr() -> None:
+    q = cirq.LineQubit(0)
+    op1 = cirq.If('m', cirq.X(q))
+    assert str(op1) == 'If(m, X(q(0)))'
+    assert repr(op1) == "cirq.If(cirq.KeyCondition(cirq.MeasurementKey(name='m')), cirq.X(cirq.LineQubit(0)))"
+    assert eval(repr(op1)) == op1
+
+    op2 = cirq.If(['a', 'b'], cirq.X(q))
+    assert str(op2) == 'If((a, b), X(q(0)))'
+    assert (
+        repr(op2)
+        == "cirq.If([cirq.KeyCondition(cirq.MeasurementKey(name='a')), cirq.KeyCondition(cirq.MeasurementKey(name='b'))], cirq.X(cirq.LineQubit(0)))"
+    )
+    assert eval(repr(op2)) == op2
+
+
+def test_parameterized_and_resolve() -> None:
+    q = cirq.LineQubit(0)
+    sym = sympy.Symbol('theta')
+    cond_sym = sympy.Symbol('cond')
+
+    op = cirq.If(cond_sym, cirq.Rx(rads=sym).on(q))
+    assert cirq.is_parameterized(op)
+    assert cirq.parameter_names(op) == {'theta'}
+
+    resolved = cirq.resolve_parameters(op, cirq.ParamResolver({'theta': np.pi, 'cond': 1}))
+    assert not cirq.is_parameterized(resolved)
+    assert resolved == cirq.If(cond_sym, cirq.Rx(rads=np.pi).on(q))
+
+
+def test_diagram() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───M───────
+      ║
+1: ───╫───X───
+      ║   ║
+a: ═══@═══^═══
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_diagram_multiple_conditions() -> None:
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(
+        cirq.measure(q0, key='a'), cirq.measure(q1, key='b'), cirq.If(['a', 'b'], cirq.X(q2))
+    )
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+      ┌──┐
+0: ────M─────────
+       ║
+1: ────╫M────────
+       ║║
+2: ────╫╫────X───
+       ║║    ║
+a: ════@╬════^═══
+        ║    ║
+b: ═════@════^═══
+      └──┘
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_diagram_sympy_condition() -> None:
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.If(sympy.Symbol('s'), cirq.X(q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───X(If=s)───
+      ║
+s: ═══^═════════
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_simulation() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    # If q0 measured as 1, flip q1.
+    circuit = cirq.Circuit(cirq.X(q0), cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
+    sim = cirq.Simulator()
+    res = sim.simulate(circuit)
+    assert res.measurements['a'] == [1]
+    # Since 'a' is 1, X(q1) ran, so final state vector should have both q0 and q1 in |1>.
+    expected_state = np.zeros(4, dtype=np.complex64)
+    expected_state[3] = 1.0
+    np.testing.assert_allclose(res.state_vector(), expected_state, atol=1e-6)
+
+    # Now if q0 measured as 0, do not flip q1.
+    circuit_zero = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
+    res_zero = sim.simulate(circuit_zero)
+    assert res_zero.measurements['a'] == [0]
+    expected_state_zero = np.zeros(4, dtype=np.complex64)
+    expected_state_zero[0] = 1.0
+    np.testing.assert_allclose(res_zero.state_vector(), expected_state_zero, atol=1e-6)
+
+
+def test_key_mappings_and_scoping() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('a', cirq.X(q))
+
+    mapped = cirq.with_measurement_key_mapping(op, {'a': 'b'})
+    assert mapped == cirq.If('b', cirq.X(q))
+
+    prefixed = cirq.with_key_path_prefix(op, ('path',))
+    assert prefixed == cirq.If('path:a', cirq.X(q))
+
+    rescoped = cirq.with_rescoped_keys(
+        op, ('scope',), frozenset([cirq.MeasurementKey.parse_serialized('scope:a')])
+    )
+    assert rescoped == cirq.If('scope:a', cirq.X(q))
+
+    assert cirq.control_keys(op) == frozenset([cirq.MeasurementKey('a')])
+
+
+def test_qasm() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.If('a', cirq.X(q1))
+    circuit = cirq.Circuit(cirq.measure(q0, key='a'), op)
+    qasm_str = cirq.qasm(circuit)
+    assert 'if (m_a==1) cx q[1];' in qasm_str or 'if (m_a==1) x q[1];' in qasm_str
+
+    op_multi = cirq.If(['a', 'b'], cirq.X(q1))
+    with pytest.raises(ValueError, match='QASM 2.0 does not support multiple conditions'):
+        _ = cirq.qasm(op_multi)
+
+
+def test_json_serialization() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('m', cirq.X(q))
+    cirq.testing.assert_json_roundtrip_works(op)
+    op_multi = cirq.If(['a', 'b'], cirq.X(q))
+    cirq.testing.assert_json_roundtrip_works(op_multi)
+
+
+def test_diagram_multiple_sympy_conditions() -> None:
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.If([sympy.Symbol('s'), sympy.Symbol('t')], cirq.X(q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───X(If=s, t)───
+      ║
+s: ═══^════════════
+      ║
+t: ═══^════════════
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_qasm_sub_op_no_qasm() -> None:
+    class NoQasmOp(cirq.Operation):
+        @property
+        def qubits(self):
+            return (cirq.LineQubit(0),)
+
+        def with_qubits(self, *new_qubits):
+            return self
+
+    op = cirq.If('a', NoQasmOp())
+    assert op.qubits == (cirq.LineQubit(0),)
+    assert op.with_qubits(cirq.LineQubit(1)).sub_operation == op.sub_operation
+    assert cirq.qasm(op, default=None) is None

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -287,10 +287,10 @@ def test_qasm_sub_op_no_qasm() -> None:
     class NoQasmOp(cirq.Operation):
         @property
         def qubits(self):
-            return (cirq.LineQubit(0),)
+            return (cirq.LineQubit(0),)  # pragma: nocover
 
         def with_qubits(self, *new_qubits):
-            return self
+            return self  # pragma: nocover
 
     op = cirq.If('a', NoQasmOp())
     assert cirq.qasm(op, default=None) is None

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -22,7 +22,6 @@ import cirq
 def test_init() -> None:
     q = cirq.LineQubit(0)
     op = cirq.If('m', cirq.X(q))
-    assert op.condition == cirq.KeyCondition(cirq.MeasurementKey('m'))
     assert op.conditions == (cirq.KeyCondition(cirq.MeasurementKey('m')),)
     assert op.sub_operation == cirq.X(q)
     assert op.qubits == (q,)
@@ -36,9 +35,9 @@ def test_init_condition_types() -> None:
     cond = cirq.KeyCondition(key)
     sym = sympy.Symbol('s')
 
-    assert cirq.If(key, cirq.X(q)).condition == cond
-    assert cirq.If(cond, cirq.X(q)).condition == cond
-    assert cirq.If(sym, cirq.X(q)).condition == cirq.SympyCondition(sym)
+    assert cirq.If(key, cirq.X(q)).conditions == (cond,)
+    assert cirq.If(cond, cirq.X(q)).conditions == (cond,)
+    assert cirq.If(sym, cirq.X(q)).conditions == (cirq.SympyCondition(sym),)
 
 
 def test_init_multiple_conditions() -> None:
@@ -48,8 +47,6 @@ def test_init_multiple_conditions() -> None:
         cirq.KeyCondition(cirq.MeasurementKey('a')),
         cirq.KeyCondition(cirq.MeasurementKey('b')),
     )
-    with pytest.raises(ValueError, match='Operation has multiple conditions'):
-        _ = op.condition
 
 
 def test_init_multiple_operations() -> None:
@@ -139,7 +136,7 @@ def test_str_and_repr() -> None:
     assert eval(repr(op1)) == op1
 
     op2 = cirq.If(['a', 'b'], cirq.X(q))
-    assert str(op2) == 'If((a, b), X(q(0)))'
+    assert str(op2) == 'If([a, b], X(q(0)))'
     assert repr(op2) == (
         "cirq.If([cirq.KeyCondition(cirq.MeasurementKey(name='a')), "
         "cirq.KeyCondition(cirq.MeasurementKey(name='b'))], cirq.X(cirq.LineQubit(0)))"
@@ -280,6 +277,10 @@ def test_qasm() -> None:
     op_multi = cirq.If(['a', 'b'], cirq.X(q1))
     with pytest.raises(ValueError, match='QASM 2.0 does not support multiple conditions'):
         _ = cirq.qasm(op_multi)
+
+    circuit_multi = cirq.Circuit(cirq.measure(q0, key='a'), cirq.measure(q0, key='b'), op_multi)
+    qasm_str_3 = cirq.qasm(circuit_multi, args=cirq.QasmArgs(version='3.0'))
+    assert 'if (m_a!=0 && m_b!=0) x q[1];' in qasm_str_3
 
 
 def test_qasm_sub_op_no_qasm() -> None:

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -133,17 +133,16 @@ def test_str_and_repr() -> None:
     q = cirq.LineQubit(0)
     op1 = cirq.If('m', cirq.X(q))
     assert str(op1) == 'If(m, X(q(0)))'
-    assert (
-        repr(op1)
-        == "cirq.If(cirq.KeyCondition(cirq.MeasurementKey(name='m')), cirq.X(cirq.LineQubit(0)))"
+    assert repr(op1) == (
+        "cirq.If(cirq.KeyCondition(cirq.MeasurementKey(name='m')), " "cirq.X(cirq.LineQubit(0)))"
     )
     assert eval(repr(op1)) == op1
 
     op2 = cirq.If(['a', 'b'], cirq.X(q))
     assert str(op2) == 'If((a, b), X(q(0)))'
-    assert (
-        repr(op2)
-        == "cirq.If([cirq.KeyCondition(cirq.MeasurementKey(name='a')), cirq.KeyCondition(cirq.MeasurementKey(name='b'))], cirq.X(cirq.LineQubit(0)))"
+    assert repr(op2) == (
+        "cirq.If([cirq.KeyCondition(cirq.MeasurementKey(name='a')), "
+        "cirq.KeyCondition(cirq.MeasurementKey(name='b'))], cirq.X(cirq.LineQubit(0)))"
     )
     assert eval(repr(op2)) == op2
 

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -1,0 +1,306 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import sympy
+
+import cirq
+
+
+def test_init() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('m', cirq.X(q))
+    assert op.condition == cirq.KeyCondition(cirq.MeasurementKey('m'))
+    assert op.conditions == (cirq.KeyCondition(cirq.MeasurementKey('m')),)
+    assert op.sub_operation == cirq.X(q)
+    assert op.qubits == (q,)
+    assert op.classical_controls == frozenset([cirq.KeyCondition(cirq.MeasurementKey('m'))])
+    assert op.without_classical_controls() == cirq.X(q)
+
+
+def test_init_condition_types() -> None:
+    q = cirq.LineQubit(0)
+    key = cirq.MeasurementKey('k')
+    cond = cirq.KeyCondition(key)
+    sym = sympy.Symbol('s')
+
+    assert cirq.If(key, cirq.X(q)).condition == cond
+    assert cirq.If(cond, cirq.X(q)).condition == cond
+    assert cirq.If(sym, cirq.X(q)).condition == cirq.SympyCondition(sym)
+
+
+def test_init_multiple_conditions() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If(['a', 'b'], cirq.X(q))
+    assert op.conditions == (
+        cirq.KeyCondition(cirq.MeasurementKey('a')),
+        cirq.KeyCondition(cirq.MeasurementKey('b')),
+    )
+    with pytest.raises(ValueError, match='Operation has multiple conditions'):
+        _ = op.condition
+
+
+def test_init_multiple_operations() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.If('m', cirq.X(q0), cirq.Y(q1))
+    assert isinstance(op.sub_operation, cirq.CircuitOperation)
+    assert op.sub_operation.circuit == cirq.Circuit(cirq.X(q0), cirq.Y(q1))
+    assert op.qubits == (q0, q1)
+
+    op_list = cirq.If('m', [cirq.X(q0), cirq.Y(q1)])
+    assert isinstance(op_list.sub_operation, cirq.CircuitOperation)
+    assert op_list.sub_operation.circuit == cirq.Circuit(cirq.X(q0), cirq.Y(q1))
+
+
+def test_init_squash_nested_if() -> None:
+    q = cirq.LineQubit(0)
+    inner = cirq.If('a', cirq.X(q))
+    outer = cirq.If('b', inner)
+    assert outer.conditions == (
+        cirq.KeyCondition(cirq.MeasurementKey('b')),
+        cirq.KeyCondition(cirq.MeasurementKey('a')),
+    )
+    assert outer.sub_operation == cirq.X(q)
+
+    cco = cirq.ClassicallyControlledOperation(cirq.X(q), ['a'])
+    outer_cco = cirq.If('b', cco)
+    assert outer_cco.conditions == (
+        cirq.KeyCondition(cirq.MeasurementKey('b')),
+        cirq.KeyCondition(cirq.MeasurementKey('a')),
+    )
+    assert outer_cco.sub_operation == cirq.X(q)
+
+
+def test_init_errors() -> None:
+    q = cirq.LineQubit(0)
+    with pytest.raises(TypeError, match='Unrecognized condition type'):
+        _ = cirq.If(123, cirq.X(q))
+
+    with pytest.raises(TypeError, match='Unrecognized condition type'):
+        _ = cirq.If(['a', 123], cirq.X(q))
+
+    with pytest.raises(ValueError, match='At least one condition must be provided'):
+        _ = cirq.If([], cirq.X(q))
+
+    with pytest.raises(ValueError, match='Cannot conditionally run operations with measurements'):
+        _ = cirq.If('m', cirq.measure(q, key='out'))
+
+
+def test_with_qubits() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.If('m', cirq.X(q0))
+    new_op = op.with_qubits(q1)
+    assert new_op == cirq.If('m', cirq.X(q1))
+
+
+def test_decomposition() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('m', cirq.X(q))
+    decomposed = cirq.decompose_once(op)
+    expected = [cirq.ClassicallyControlledOperation(cirq.X(q), ['m'])]
+    assert decomposed == expected
+    assert op._decompose_() == expected[0]
+
+    circuit = cirq.Circuit(cirq.measure(q, key='m'), op)
+    full_decomposed = cirq.Circuit(cirq.decompose(circuit))
+    assert full_decomposed == cirq.Circuit(
+        cirq.measure(q, key='m'), cirq.X(q).with_classical_controls('m')
+    )
+
+
+def test_value_equality() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(cirq.If('a', cirq.X(q0)), cirq.If(cirq.MeasurementKey('a'), cirq.X(q0)))
+    eq.add_equality_group(cirq.If('b', cirq.X(q0)))
+    eq.add_equality_group(cirq.If('a', cirq.X(q1)))
+    eq.add_equality_group(cirq.If(['a', 'b'], cirq.X(q0)))
+
+
+def test_str_and_repr() -> None:
+    q = cirq.LineQubit(0)
+    op1 = cirq.If('m', cirq.X(q))
+    assert str(op1) == 'If(m, X(q(0)))'
+    assert (
+        repr(op1)
+        == "cirq.If(cirq.KeyCondition(cirq.MeasurementKey(name='m')), cirq.X(cirq.LineQubit(0)))"
+    )
+    assert eval(repr(op1)) == op1
+
+    op2 = cirq.If(['a', 'b'], cirq.X(q))
+    assert str(op2) == 'If((a, b), X(q(0)))'
+    assert (
+        repr(op2)
+        == "cirq.If([cirq.KeyCondition(cirq.MeasurementKey(name='a')), cirq.KeyCondition(cirq.MeasurementKey(name='b'))], cirq.X(cirq.LineQubit(0)))"
+    )
+    assert eval(repr(op2)) == op2
+
+
+def test_parameterized_and_resolve() -> None:
+    q = cirq.LineQubit(0)
+    sym = sympy.Symbol('theta')
+    cond_sym = sympy.Symbol('cond')
+
+    op = cirq.If(cond_sym, cirq.Rx(rads=sym).on(q))
+    assert cirq.is_parameterized(op)
+    assert cirq.parameter_names(op) == {'theta'}
+
+    resolved = cirq.resolve_parameters(op, cirq.ParamResolver({'theta': np.pi, 'cond': 1}))
+    assert not cirq.is_parameterized(resolved)
+    assert resolved == cirq.If(cond_sym, cirq.Rx(rads=np.pi).on(q))
+
+
+def test_diagram() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───M───────
+      ║
+1: ───╫───X───
+      ║   ║
+a: ═══@═══^═══
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_diagram_multiple_conditions() -> None:
+    q0, q1, q2 = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(
+        cirq.measure(q0, key='a'), cirq.measure(q1, key='b'), cirq.If(['a', 'b'], cirq.X(q2))
+    )
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+      ┌──┐
+0: ────M─────────
+       ║
+1: ────╫M────────
+       ║║
+2: ────╫╫────X───
+       ║║    ║
+a: ════@╬════^═══
+        ║    ║
+b: ═════@════^═══
+      └──┘
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_diagram_sympy_condition() -> None:
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.If(sympy.Symbol('s'), cirq.X(q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───X(If=s)───
+      ║
+s: ═══^═════════
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_simulation() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    # If q0 measured as 1, flip q1.
+    circuit = cirq.Circuit(cirq.X(q0), cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
+    sim = cirq.Simulator()
+    res = sim.simulate(circuit)
+    assert res.measurements['a'] == [1]
+    # Since 'a' is 1, X(q1) ran, so final state vector should have both q0 and q1 in |1>.
+    expected_state = np.zeros(4, dtype=np.complex64)
+    expected_state[3] = 1.0
+    np.testing.assert_allclose(res.state_vector(), expected_state, atol=1e-6)
+
+    # Now if q0 measured as 0, do not flip q1.
+    circuit_zero = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
+    res_zero = sim.simulate(circuit_zero)
+    assert res_zero.measurements['a'] == [0]
+    expected_state_zero = np.zeros(4, dtype=np.complex64)
+    expected_state_zero[0] = 1.0
+    np.testing.assert_allclose(res_zero.state_vector(), expected_state_zero, atol=1e-6)
+
+
+def test_key_mappings_and_scoping() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('a', cirq.X(q))
+
+    mapped = cirq.with_measurement_key_mapping(op, {'a': 'b'})
+    assert mapped == cirq.If('b', cirq.X(q))
+
+    prefixed = cirq.with_key_path_prefix(op, ('path',))
+    assert prefixed == cirq.If('path:a', cirq.X(q))
+
+    rescoped = cirq.with_rescoped_keys(
+        op, ('scope',), frozenset([cirq.MeasurementKey.parse_serialized('scope:a')])
+    )
+    assert rescoped == cirq.If('scope:a', cirq.X(q))
+
+    assert cirq.control_keys(op) == frozenset([cirq.MeasurementKey('a')])
+
+
+def test_qasm() -> None:
+    q0, q1 = cirq.LineQubit.range(2)
+    op = cirq.If('a', cirq.X(q1))
+    circuit = cirq.Circuit(cirq.measure(q0, key='a'), op)
+    qasm_str = cirq.qasm(circuit)
+    assert 'if (m_a==1) cx q[1];' in qasm_str or 'if (m_a==1) x q[1];' in qasm_str
+
+    op_multi = cirq.If(['a', 'b'], cirq.X(q1))
+    with pytest.raises(ValueError, match='QASM 2.0 does not support multiple conditions'):
+        _ = cirq.qasm(op_multi)
+
+
+def test_json_serialization() -> None:
+    q = cirq.LineQubit(0)
+    op = cirq.If('m', cirq.X(q))
+    cirq.testing.assert_json_roundtrip_works(op)
+    op_multi = cirq.If(['a', 'b'], cirq.X(q))
+    cirq.testing.assert_json_roundtrip_works(op_multi)
+
+
+def test_diagram_multiple_sympy_conditions() -> None:
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.If([sympy.Symbol('s'), sympy.Symbol('t')], cirq.X(q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───X(If=s, t)───
+      ║
+s: ═══^════════════
+      ║
+t: ═══^════════════
+""",
+        use_unicode_characters=True,
+    )
+
+
+def test_qasm_sub_op_no_qasm() -> None:
+    class NoQasmOp(cirq.Operation):
+        @property
+        def qubits(self):
+            return (cirq.LineQubit(0),)
+
+        def with_qubits(self, *new_qubits):
+            return self
+
+    op = cirq.If('a', NoQasmOp())
+    assert op.qubits == (cirq.LineQubit(0),)
+    assert op.with_qubits(cirq.LineQubit(1)).sub_operation == op.sub_operation
+    assert cirq.qasm(op, default=None) is None

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -215,6 +215,22 @@ s: ═══^═════════
     )
 
 
+def test_diagram_multiple_sympy_conditions() -> None:
+    q = cirq.LineQubit(0)
+    circuit = cirq.Circuit(cirq.If([sympy.Symbol('s'), sympy.Symbol('t')], cirq.X(q)))
+    cirq.testing.assert_has_diagram(
+        circuit,
+        """
+0: ───X(If=s, t)───
+      ║
+s: ═══^════════════
+      ║
+t: ═══^════════════
+""",
+        use_unicode_characters=True,
+    )
+
+
 def test_simulation() -> None:
     q0, q1 = cirq.LineQubit.range(2)
     # If q0 measured as 1, flip q1.
@@ -225,7 +241,7 @@ def test_simulation() -> None:
     # Since 'a' is 1, X(q1) ran, so final state vector should have both q0 and q1 in |1>.
     expected_state = np.zeros(4, dtype=np.complex64)
     expected_state[3] = 1.0
-    np.testing.assert_allclose(res.state_vector(), expected_state, atol=1e-6)
+    np.testing.assert_equal(res.state_vector(), expected_state)
 
     # Now if q0 measured as 0, do not flip q1.
     circuit_zero = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
@@ -233,7 +249,7 @@ def test_simulation() -> None:
     assert res_zero.measurements['a'] == [0]
     expected_state_zero = np.zeros(4, dtype=np.complex64)
     expected_state_zero[0] = 1.0
-    np.testing.assert_allclose(res_zero.state_vector(), expected_state_zero, atol=1e-6)
+    np.testing.assert_equal(res_zero.state_vector(), expected_state_zero)
 
 
 def test_key_mappings_and_scoping() -> None:
@@ -259,35 +275,11 @@ def test_qasm() -> None:
     op = cirq.If('a', cirq.X(q1))
     circuit = cirq.Circuit(cirq.measure(q0, key='a'), op)
     qasm_str = cirq.qasm(circuit)
-    assert 'if (m_a==1) cx q[1];' in qasm_str or 'if (m_a==1) x q[1];' in qasm_str
+    assert 'if (m_a==1) x q[1];' in qasm_str
 
     op_multi = cirq.If(['a', 'b'], cirq.X(q1))
     with pytest.raises(ValueError, match='QASM 2.0 does not support multiple conditions'):
         _ = cirq.qasm(op_multi)
-
-
-def test_json_serialization() -> None:
-    q = cirq.LineQubit(0)
-    op = cirq.If('m', cirq.X(q))
-    cirq.testing.assert_json_roundtrip_works(op)
-    op_multi = cirq.If(['a', 'b'], cirq.X(q))
-    cirq.testing.assert_json_roundtrip_works(op_multi)
-
-
-def test_diagram_multiple_sympy_conditions() -> None:
-    q = cirq.LineQubit(0)
-    circuit = cirq.Circuit(cirq.If([sympy.Symbol('s'), sympy.Symbol('t')], cirq.X(q)))
-    cirq.testing.assert_has_diagram(
-        circuit,
-        """
-0: ───X(If=s, t)───
-      ║
-s: ═══^════════════
-      ║
-t: ═══^════════════
-""",
-        use_unicode_characters=True,
-    )
 
 
 def test_qasm_sub_op_no_qasm() -> None:
@@ -300,6 +292,4 @@ def test_qasm_sub_op_no_qasm() -> None:
             return self
 
     op = cirq.If('a', NoQasmOp())
-    assert op.qubits == (cirq.LineQubit(0),)
-    assert op.with_qubits(cirq.LineQubit(1)).sub_operation == op.sub_operation
     assert cirq.qasm(op, default=None) is None

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -236,7 +236,7 @@ def test_simulation() -> None:
     res = sim.simulate(circuit)
     assert res.measurements['a'] == [1]
     # Since 'a' is 1, X(q1) ran, so final state vector should have both q0 and q1 in |1>.
-    np.testing.assert_equal(res.state_vector(), [0, 0, 1, 0])
+    np.testing.assert_equal(res.state_vector(), [0, 0, 0, 1])
 
     # Now if q0 measured as 0, do not flip q1.
     circuit_zero = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -236,7 +236,7 @@ def test_simulation() -> None:
     res = sim.simulate(circuit)
     assert res.measurements['a'] == [1]
     # Since 'a' is 1, X(q1) ran, so final state vector should have both q0 and q1 in |1>.
-    np.testing.assert_equal(res_zero.state_vector(), [0, 0, 1, 0])
+    np.testing.assert_equal(res.state_vector(), [0, 0, 1, 0])
 
     # Now if q0 measured as 0, do not flip q1.
     circuit_zero = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))

--- a/cirq-core/cirq/ops/if_op_test.py
+++ b/cirq-core/cirq/ops/if_op_test.py
@@ -236,17 +236,13 @@ def test_simulation() -> None:
     res = sim.simulate(circuit)
     assert res.measurements['a'] == [1]
     # Since 'a' is 1, X(q1) ran, so final state vector should have both q0 and q1 in |1>.
-    expected_state = np.zeros(4, dtype=np.complex64)
-    expected_state[3] = 1.0
-    np.testing.assert_equal(res.state_vector(), expected_state)
+    np.testing.assert_equal(res_zero.state_vector(), [0, 0, 1, 0])
 
     # Now if q0 measured as 0, do not flip q1.
     circuit_zero = cirq.Circuit(cirq.measure(q0, key='a'), cirq.If('a', cirq.X(q1)))
     res_zero = sim.simulate(circuit_zero)
     assert res_zero.measurements['a'] == [0]
-    expected_state_zero = np.zeros(4, dtype=np.complex64)
-    expected_state_zero[0] = 1.0
-    np.testing.assert_equal(res_zero.state_vector(), expected_state_zero)
+    np.testing.assert_equal(res_zero.state_vector(), [1, 0, 0, 0])
 
 
 def test_key_mappings_and_scoping() -> None:

--- a/cirq-core/cirq/protocols/json_test_data/If.json
+++ b/cirq-core/cirq/protocols/json_test_data/If.json
@@ -1,0 +1,35 @@
+{
+  "cirq_type": "If",
+  "condition": [
+    {
+      "cirq_type": "KeyCondition",
+      "index": -1,
+      "key": {
+        "cirq_type": "MeasurementKey",
+        "name": "a",
+        "path": []
+      }
+    },
+    {
+      "cirq_type": "KeyCondition",
+      "index": -1,
+      "key": {
+        "cirq_type": "MeasurementKey",
+        "name": "b",
+        "path": []
+      }
+    }
+  ],
+  "sub_operation": {
+    "cirq_type": "SingleQubitPauliStringGateOperation",
+    "pauli": {
+      "cirq_type": "_PauliY",
+      "exponent": 1.0,
+      "global_shift": 0.0
+    },
+    "qubit": {
+      "cirq_type": "NamedQubit",
+      "name": "target"
+    }
+  }
+}

--- a/cirq-core/cirq/protocols/json_test_data/If.repr
+++ b/cirq-core/cirq/protocols/json_test_data/If.repr
@@ -1,0 +1,1 @@
+cirq.If([cirq.KeyCondition(cirq.MeasurementKey(name='a')), cirq.KeyCondition(cirq.MeasurementKey(name='b'))], cirq.Y(cirq.NamedQubit('target')))


### PR DESCRIPTION
- This will be an easier way to write classically conditioned statements than using CircuitOperations with classically_conditioned_on()
- This introduces a new operation cirq.If that represents a classically controlled operation based on either measurement results or on a sympy expression.  Hopefully, this will be more user-friendly than the current options.

Examples include:

- cirq.If(['a', 'b'], cirq.X(q))
- cirq.If('m', cirq.X(q0), cirq.Y(q1))
- cirq.If(sympy.Symbol('s'), cirq.X(q))
