### PR TITLE
Escape circuit data before inlining it in the Circuit3D script tag

### DIFF
--- a/cirq-web/cirq_web/circuits/circuit.py
+++ b/cirq-web/cirq_web/circuits/circuit.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable
 
 import cirq
@@ -86,8 +87,7 @@ class Circuit3D(widget.Widget):
                 symbol = self._build_3D_symbol(item, moment_id)
                 args.append(symbol.to_typescript())
 
-        argument_str = ','.join(str(item) for item in args)
-        return f'[{argument_str}]'
+        return _to_script_literal(args)
 
     def _build_3D_symbol(self, operation, moment) -> Operation3DSymbol:
         symbol_info = resolve_operation(operation, self._resolvers)
@@ -100,3 +100,15 @@ class Circuit3D(widget.Widget):
             else:
                 raise ValueError('Unsupported qubit type')
         return Operation3DSymbol(symbol_info.labels, location_info, symbol_info.colors, moment)
+
+
+def _to_script_literal(value) -> str:
+    """Encodes a value as a JS literal that is safe to inline in an HTML script element.
+
+    Wire symbols come from the circuit itself (a measurement key, for example), so a circuit
+    read with `cirq.read_json` can carry `</script>` or a quote into the widget markup and take
+    over the page it is rendered in. JSON is a subset of JS, and escaping the characters that
+    are meaningful to the HTML parser keeps the literal inside the script element.
+    """
+    # ensure_ascii in json.dumps also covers the U+2028/U+2029 line terminators.
+    return json.dumps(value).replace('<', '\\u003c').replace('>', '\\u003e').replace('&', '\\u0026')

--- a/cirq-web/cirq_web/circuits/circuit_test.py
+++ b/cirq-web/cirq_web/circuits/circuit_test.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 import cirq
@@ -55,7 +57,7 @@ def test_circuit_client_code(qubit) -> None:
         <button id="camera-toggle">Toggle Camera Type</button>
         <script>
         let viz_{stripped_id} = createGridCircuit(
-            {str(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
+            {json.dumps(circuit_obj)}, {str(moments)}, "{circuit.id}", {circuit.padding_factor}
         );
 
         document.getElementById("camera-reset").addEventListener('click', ()  => {{
@@ -77,6 +79,17 @@ def test_circuit_client_code_unsupported_qubit_type() -> None:
 
     with pytest.raises(ValueError, match='Unsupported qubit type'):
         circuit.get_client_code()
+
+
+def test_circuit_client_code_escapes_wire_symbols() -> None:
+    key = "</script><img src=x onerror=alert(1)>"
+    circuit = cirq_web.Circuit3D(cirq.Circuit(cirq.measure(cirq.LineQubit(0), key=key)))
+
+    client_code = circuit.get_client_code()
+
+    assert '</script><img' not in client_code
+    assert '\\u003c/script\\u003e' in client_code
+    assert client_code.count('</script>') == 1
 
 
 def test_circuit_default_bundle_name() -> None:


### PR DESCRIPTION
`Circuit3D.get_client_code` pastes the serialized circuit straight into a `<script>` block, and the serialization was Python `repr`, so nothing in it is escaped for HTML.

- wire symbols carry circuit data: a measurement key lands verbatim inside `M('...')`
- a circuit from `cirq.read_json` with key `</script><img src=x onerror=alert(1)>` closes the script element and the rest renders as markup, in a notebook via `_repr_html_` and in the page from `generate_html_file`
- switched to `json.dumps` with `<`, `>` and `&` escaped, which is still a valid JS literal for `createGridCircuit` and cannot leave the script element
- `cirq.contrib.svg.fixup_text` and `Circuit._repr_html_` already do the equivalent, this brings the 3D widget in line

Existing client-code test updated for the JSON form, plus one regression test for the breakout.