### PR TITLE
Allow optional device_graph in random grid circuit generation

### DIFF
--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
@@ -539,6 +539,7 @@ def random_rotations_between_grid_interaction_layers_circuit(
     qubits: Iterable[cirq.GridQubit],
     depth: int,
     *,  # forces keyword arguments
+    device_graph: nx.Graph | None = None,
     two_qubit_op_factory: Callable[
         [cirq.GridQubit, cirq.GridQubit, np.random.RandomState], cirq.OP_TREE
     ] = lambda a, b, _: ops.CZPowGate()(a, b),
@@ -566,6 +567,9 @@ def random_rotations_between_grid_interaction_layers_circuit(
     Args:
         qubits: The qubits to use.
         depth: The number of cycles.
+        device_graph: A graph whose edges specify the available two-qubit interactions. Only edges
+            between qubits in `qubits` are considered. If omitted, all pairs of adjacent grid
+            qubits are used.
         two_qubit_op_factory: A callable that returns a two-qubit operation.
             These operations will be generated with calls of the form
             `two_qubit_op_factory(q0, q1, prng)`, where `prng` is the
@@ -584,7 +588,15 @@ def random_rotations_between_grid_interaction_layers_circuit(
     """
     prng = value.parse_random_state(seed)
     qubits = list(qubits)
-    coupled_qubit_pairs = _coupled_qubit_pairs(qubits)
+    if device_graph is None:
+        coupled_qubit_pairs = _coupled_qubit_pairs(qubits)
+    else:
+        qubit_set = set(qubits)
+        coupled_qubit_pairs = sorted(
+            tuple(sorted((a, b)))
+            for a, b in device_graph.edges
+            if a in qubit_set and b in qubit_set
+        )
 
     circuit = circuits.Circuit()
     previous_single_qubit_layer = circuits.Moment()

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation.py
@@ -593,9 +593,11 @@ def random_rotations_between_grid_interaction_layers_circuit(
     else:
         qubit_set = set(qubits)
         coupled_qubit_pairs = sorted(
-            tuple(sorted((a, b)))
-            for a, b in device_graph.edges
-            if a in qubit_set and b in qubit_set
+            {
+                tuple(sorted((a, b)))
+                for a, b in device_graph.edges
+                if a in qubit_set and b in qubit_set and a != b
+            }
         )
 
     circuit = circuits.Circuit()

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -402,6 +402,25 @@ def test_random_rotations_between_grid_interaction_layers(
     )
 
 
+def test_random_rotations_between_grid_interaction_layers_respects_device_graph() -> None:
+    qubits = cirq.GridQubit.rect(2, 2)
+    q00, q01, q10, q11 = qubits
+    device_graph = nx.Graph([(q10, q00), (q11, q10), (q11, q01)])
+
+    circuit = random_rotations_between_grid_interaction_layers_circuit(
+        qubits,
+        depth=len(cirq.experiments.GRID_STAGGERED_PATTERN),
+        device_graph=device_graph,
+        two_qubit_op_factory=lambda a, b, _: cirq.CNOT(a, b),
+        single_qubit_gates=(cirq.X,),
+        add_final_single_qubit_layer=False,
+        seed=1234,
+    )
+
+    actual_pairs = {op.qubits for op in circuit.all_operations() if cirq.num_qubits(op) == 2}
+    assert actual_pairs == {tuple(sorted(pair)) for pair in device_graph.edges}
+
+
 def test_grid_interaction_layer_repr() -> None:
     layer = GridInteractionLayer(col_offset=0, vertical=True, stagger=False)
     assert repr(layer) == (

--- a/cirq-core/cirq/experiments/random_quantum_circuit_generation_test.py
+++ b/cirq-core/cirq/experiments/random_quantum_circuit_generation_test.py
@@ -421,6 +421,37 @@ def test_random_rotations_between_grid_interaction_layers_respects_device_graph(
     assert actual_pairs == {tuple(sorted(pair)) for pair in device_graph.edges}
 
 
+def test_random_rotations_between_grid_interaction_layers_dedupes_device_graph_edges() -> None:
+    qubits = cirq.GridQubit.rect(2, 2)
+    q00, q01, q10, q11 = qubits
+    # DiGraph reverse edges and self-loops should collapse to unique undirected pairs
+    # with self-loops skipped.
+    device_graph = nx.DiGraph(
+        [
+            (q10, q00),
+            (q00, q10),  # reverse duplicate
+            (q11, q10),
+            (q11, q01),
+            (q00, q00),  # self-loop
+            (q11, q11),  # self-loop
+        ]
+    )
+    expected_pairs = {(q00, q10), (q10, q11), (q01, q11)}
+
+    circuit = random_rotations_between_grid_interaction_layers_circuit(
+        qubits,
+        depth=len(cirq.experiments.GRID_STAGGERED_PATTERN),
+        device_graph=device_graph,
+        two_qubit_op_factory=lambda a, b, _: cirq.CNOT(a, b),
+        single_qubit_gates=(cirq.X,),
+        add_final_single_qubit_layer=False,
+        seed=1234,
+    )
+
+    actual_pairs = {op.qubits for op in circuit.all_operations() if cirq.num_qubits(op) == 2}
+    assert actual_pairs == expected_pairs
+
+
 def test_grid_interaction_layer_repr() -> None:
     layer = GridInteractionLayer(col_offset=0, vertical=True, stagger=False)
     assert repr(layer) == (


### PR DESCRIPTION
Fixes #3342.

Adds an optional keyword-only `device_graph` to `random_rotations_between_grid_interaction_layers_circuit`. When supplied, two-qubit interactions are limited to graph edges between the requested qubits; undirected edges are canonically ordered for directional gate factories. Omitting it preserves the existing grid-adjacency behavior.

A regression test covers a non-complete 2×2 graph with a directional two-qubit gate factory.

## AI Tools Usage Disclosure

OpenAI Codex was used during development and review of this change. I reviewed the submitted code and tests, verified the behavior, and take responsibility for the contribution.