### PR TITLE
Iterate over moments in `AbstractCircuit.{_is_parameterized_, _parameter_names_}`

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1329,12 +1329,12 @@ class AbstractCircuit(abc.ABC):
         return diagram
 
     def _is_parameterized_(self) -> bool:
-        return any(protocols.is_parameterized(moment) for moment in self.moments) or any(
+        return any(protocols.is_parameterized(moment) for moment in self) or any(
             protocols.is_parameterized(tag) for tag in self.tags
         )
 
     def _parameter_names_(self) -> Set[str]:
-        op_params = {name for m in self.moments for name in protocols.parameter_names(m)}
+        op_params = {name for moment in self for name in protocols.parameter_names(moment)}
         tag_params = {name for tag in self.tags for name in protocols.parameter_names(tag)}
         return op_params | tag_params
 

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -1329,12 +1329,12 @@ class AbstractCircuit(abc.ABC):
         return diagram
 
     def _is_parameterized_(self) -> bool:
-        return any(protocols.is_parameterized(op) for op in self.all_operations()) or any(
+        return any(protocols.is_parameterized(moment) for moment in self.moments) or any(
             protocols.is_parameterized(tag) for tag in self.tags
         )
 
     def _parameter_names_(self) -> Set[str]:
-        op_params = {name for op in self.all_operations() for name in protocols.parameter_names(op)}
+        op_params = {name for m in self.moments for name in protocols.parameter_names(m)}
         tag_params = {name for tag in self.tags for name in protocols.parameter_names(tag)}
         return op_params | tag_params
 


### PR DESCRIPTION
Moments cache these methods, so this makes sure we hit those caches instead of iterating over all operations again.