### PR TITLE
Optimize `cached_method` for no args

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -65,10 +65,6 @@ def with_debug(value: bool) -> Iterator[None]:
         __cirq_debug__.reset(token)
 
 
-# Sentinel used by wrapped_no_args below when method has not yet been cached.
-_NOT_FOUND = object()
-
-
 TFunc = TypeVar('TFunc', bound=Callable)
 
 

--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -103,11 +103,12 @@ def cached_method(method: TFunc | None = None, *, maxsize: int = 128) -> Any:
 
             @functools.wraps(func)
             def wrapped_no_args(self):
-                result = getattr(self, cache_name, _NOT_FOUND)
-                if result is _NOT_FOUND:
+                try:
+                    return getattr(self, cache_name)
+                except AttributeError:
                     result = func(self)
                     object.__setattr__(self, cache_name, result)
-                return result
+                    return result
 
             return wrapped_no_args
 


### PR DESCRIPTION
This saves 17ns (28%) on each cache hit. In some internal benchmarks we have over 100M cache hits, so this adds up to a measurable amount of time.