### PR TITLE
Allow Unrecognized gates to pass through creation of a GridDevice

### DIFF
--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -691,8 +691,9 @@ class GridDevice(cirq.Device):
                 }
                 if len(durations_for_rep) > 1:
                     raise ValueError(
-                        'Multiple gate families in the following list exist in the gate duration dict, and '
-                        f'they are expected to have the same duration value: {gate_rep.supported_gates}'
+                        'Multiple gate families in the following list exist in the gate duration dict, '
+                        'and they are expected to have the same duration value: '
+                        f'{gate_rep.supported_gates}'
                     )
 
                 all_gates.extend(gate_rep.supported_gates)

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -691,8 +691,8 @@ class GridDevice(cirq.Device):
                 }
                 if len(durations_for_rep) > 1:
                     raise ValueError(
-                        'Multiple gate families in the following list exist in the gate duration dict, '
-                        'and they are expected to have the same duration value: '
+                        'Multiple gate families in the following list exist in the gate duration '
+                        'dict, and they are expected to have the same duration value: '
                         f'{gate_rep.supported_gates}'
                     )
 

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -697,7 +697,11 @@ class GridDevice(cirq.Device):
 
                 all_gates.extend(gate_rep.supported_gates)
                 if gate_durations is not None:
-                    dur = next(iter(durations_for_rep)) if durations_for_rep else cirq.Duration(picos=0)
+                    dur = (
+                        next(iter(durations_for_rep))
+                        if durations_for_rep
+                        else cirq.Duration(picos=0)
+                    )
                     for gf in gate_rep.supported_gates:
                         all_gate_durations[gf] = dur
 

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -664,19 +664,51 @@ class GridDevice(cirq.Device):
             ValueError: If all_qubits is provided and is not a superset
                 of all the qubits found in qubit_pairs.
         """
+        if gate_durations is not None:
+            if not set(gate_durations.keys()).issubset(gateset.gates):
+                raise ValueError(
+                    "Some gate_durations keys are not found in gateset."
+                    f" gate_durations={gate_durations}"
+                    f" gateset.gates={gateset.gates}"
+                )
+
+        all_gates: list[GateOrFamily] = []
+        all_gate_durations: dict[cirq.GateFamily, cirq.Duration] = {}
+        _gate_durations = gate_durations or {}
+
+        for gate_family in gateset.gates:
+            gate_rep = next(
+                (gr for gr in _GATES for gf in gr.supported_gates if gf == gate_family), None
+            )
+            if gate_rep is None:
+                all_gates.append(gate_family)
+                if gate_family in _gate_durations:
+                    all_gate_durations[gate_family] = _gate_durations[gate_family]
+            else:
+                durations_for_rep = {
+                    _gate_durations[gf] for gf in gate_rep.supported_gates if gf in _gate_durations
+                }
+                if len(durations_for_rep) > 1:
+                    raise ValueError(
+                        'Multiple gate families in the following list exist in the gate duration dict, and '
+                        f'they are expected to have the same duration value: {gate_rep.supported_gates}'
+                    )
+
+                all_gates.extend(gate_rep.supported_gates)
+                if durations_for_rep:
+                    dur = next(iter(durations_for_rep))
+                    for gf in gate_rep.supported_gates:
+                        all_gate_durations[gf] = dur
+
+        expanded_gateset = cirq.Gateset(*all_gates)
         metadata = cirq.GridDeviceMetadata(
             qubit_pairs=qubit_pairs,
-            gateset=gateset,
-            gate_durations=gate_durations,
+            gateset=expanded_gateset,
+            gate_durations=all_gate_durations if gate_durations is not None else None,
             all_qubits=all_qubits,
+            compilation_target_gatesets=_build_compilation_target_gatesets(expanded_gateset),
         )
-        incomplete_device = GridDevice(metadata)
-        # incomplete_device may have incomplete gateset and gate durations information, as described
-        # in the docstring.
-        # To generate the full gateset and gate durations, we rely on the device deserialization
-        # logic by first serializing then deserializing the fake device, to ensure that the
-        # resulting device is consistent with one that is deserialized from DeviceSpecification.
-        return GridDevice.from_proto(incomplete_device.to_proto())
+        return GridDevice(metadata)
 
     @property
     def metadata(self) -> cirq.GridDeviceMetadata:

--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -298,8 +298,9 @@ def _serialize_gateset_and_gate_durations(
         }
         if len(gate_durations_picos) > 1:
             raise ValueError(
-                'Multiple gate families in the following list exist in the gate duration dict, and '
-                f'they are expected to have the same duration value: {gate_rep.supported_gates}'
+                'Multiple gate families in the following list exist in the gate duration dict, '
+                'and they are expected to have the same duration value: '
+                f'{gate_rep.supported_gates}'
             )
         elif len(gate_durations_picos) == 1:
             gate_spec.gate_duration_picos = gate_durations_picos.pop()
@@ -695,8 +696,8 @@ class GridDevice(cirq.Device):
                     )
 
                 all_gates.extend(gate_rep.supported_gates)
-                if durations_for_rep:
-                    dur = next(iter(durations_for_rep))
+                if gate_durations is not None:
+                    dur = next(iter(durations_for_rep)) if durations_for_rep else cirq.Duration(picos=0)
                     for gf in gate_rep.supported_gates:
                         all_gate_durations[gf] = dur
 

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -706,12 +706,6 @@ def test_device_from_device_information_equals_device_from_proto():
             None,
         ),
         (
-            'Unrecognized gate',
-            [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
-            cirq.Gateset(cirq.H),
-            None,
-        ),
-        (
             'Some gate_durations keys are not found in gateset',
             [(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
             cirq.Gateset(cirq.CZ),
@@ -733,6 +727,18 @@ def test_from_device_information_invalid_input(error_match, qubit_pairs, gateset
         grid_device.GridDevice._from_device_information(
             qubit_pairs=qubit_pairs, gateset=gateset, gate_durations=gate_durations
         )
+
+
+def test_from_device_information_unrecognized_gate():
+    gateset = cirq.Gateset(cirq.H)
+    gate_durations = {cirq.GateFamily(cirq.H): cirq.Duration(picos=1_000)}
+    device = grid_device.GridDevice._from_device_information(
+        qubit_pairs=[(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
+        gateset=gateset,
+        gate_durations=gate_durations,
+    )
+    assert cirq.GateFamily(cirq.H) in device.metadata.gateset.gates
+    assert device.metadata.gate_durations == {cirq.GateFamily(cirq.H): cirq.Duration(picos=1_000)}
 
 
 def test_from_device_information_fsim_gate_family():

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -866,3 +866,17 @@ def test_qubit_attributes_unlisted_qubit():
 
     with pytest.raises(ValueError, match="is not in valid_qubits"):
         _ = cirq_google.GridDevice.from_proto(spec)
+
+
+def test_to_proto_invalid_gate_durations():
+    metadata = cirq.GridDeviceMetadata(
+        qubit_pairs=[(cirq.GridQubit(0, 0), cirq.GridQubit(0, 1))],
+        gateset=cirq.Gateset(cirq.PhasedXZGate, cirq.XPowGate),
+        gate_durations={
+            cirq.GateFamily(cirq.PhasedXZGate): cirq.Duration(picos=1_000),
+            cirq.GateFamily(cirq.XPowGate): cirq.Duration(picos=2_000),
+        },
+    )
+    device = cirq_google.GridDevice(metadata)
+    with pytest.raises(ValueError, match="Multiple gate families"):
+        device.to_proto()


### PR DESCRIPTION
- Previously, the creation of a GridDevice would serialize to a proto and back (what?) in order to add missing gate representations to the gateset (like if you had PhasedXPowGate but not XPowGate).
- This changes the code to directly use GateRepresentations to add these missing values.
- This allows unrecognized gates that don't exist in the list of public gate representations to be ignored and kept in the Gateset.