### PR TITLE
Downgrade the minimum numpy version to numpy-2.0

### DIFF
--- a/cirq-core/cirq/ops/arithmetic_operation.py
+++ b/cirq-core/cirq/ops/arithmetic_operation.py
@@ -225,7 +225,7 @@ class ArithmeticGate(Gate, metaclass=abc.ABCMeta):
             dst[tuple(outputs)] = src[tuple(inputs)]
 
         # In case the reshaped arrays were copies instead of views.
-        dst = dst.reshape(transposed_args.available_buffer.shape, copy=False)
+        dst = dst.reshape(transposed_args.available_buffer.shape)
         transposed_args.target_tensor[...] = dst
 
         return args.target_tensor

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -1090,6 +1090,6 @@ def eye_tensor(half_shape: tuple[int, ...], *, dtype: DTypeLike) -> np.ndarray:
         The created numpy array with shape `half_shape + half_shape`.
     """
     identity = np.eye(np.prod(half_shape, dtype=np.int64).item(), dtype=dtype).reshape(
-        half_shape * 2, copy=False
+        half_shape * 2
     )
     return identity

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -174,7 +174,7 @@ def measure_density_matrix(
     mask[result_slice * 2] = False
 
     # Reshape to a tensor inplace to set the masked values to 0.
-    arrout.reshape(qid_shape * 2, copy=False)[mask] = 0
+    arrout.reshape(qid_shape * 2)[mask] = 0
 
     # Renormalize.
     arrout /= probs[result]

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -312,7 +312,7 @@ def measure_state_vector(
     # Final else: if out is state then state will be modified in place.
 
     # Reshape to a tensor inplace to set the masked values to 0.
-    out.reshape(shape, copy=False)[mask] = 0
+    out.reshape(shape)[mask] = 0
 
     # Renormalize.
     out /= np.sqrt(probs[result])

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -4,7 +4,11 @@ attrs>=21.3.0
 duet>=0.2.8
 matplotlib~=3.9
 networkx~=3.4
-numpy~=2.1
+
+# Keep the minimum version compatible with the one installed in Colab runtime
+# per https://research.google.com/colaboratory/runtime-version-faq.html
+numpy~=2.0
+
 pandas>=2.3,<3.1.0.dev
 scipy~=1.15
 sympy


### PR DESCRIPTION
Make numpy requirement compatible with the numpy pre-installed
and pre-loaded in Colab sessions.  This should preserve the
existing numpy installation after `pip install cirq` in a Colab
avoiding mismatch between in-memory and installed NumPy versions.

Also remove the `copy` argument from `np.reshape` calls which
was only introduced in numpy-2.1.

Fixes b/538201381
