### PR TITLE
Replace `check/mypy` with `check/typecheck`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: pip install -r dev_tools/requirements/deps/format.txt
       - name: Format
         run: check/format-incremental
-  mypy:
+  typecheck:
     if: github.repository_owner == 'quantumlib'
     name: Type check
     runs-on: ubuntu-22.04
@@ -84,7 +84,7 @@ jobs:
       - name: Install mypy
         run: pip install -r dev_tools/requirements/mypy.env.txt
       - name: Type check
-        run: FORCE_COLOR=1 check/mypy
+        run: FORCE_COLOR=1 check/typecheck
   changed_files:
     if: github.repository_owner == 'quantumlib'
     name: Changed files test

--- a/check/all
+++ b/check/all
@@ -107,7 +107,7 @@ else
     run check/pytest-and-incremental-coverage "${base_rev[@]}"
 fi
 
-run check/mypy
+run check/typecheck
 
 # Make the only-changed mode fast.  Skip check/doctest which rarely fails,
 # but takes most run time in that mode.

--- a/check/all
+++ b/check/all
@@ -60,6 +60,7 @@ for arg in "$@"; do
         --apply-format-changes)
             echo "Warning: option '--apply-format-changes' is deprecated." \
                 "Please use '--fix' instead." >&2
+            echo "Warning: The '--apply-format-changes' will be removed in cirq v1.8." >&2
             echo >&2
             extra_format_args=( --apply )
             ;;

--- a/check/shellcheck
+++ b/check/shellcheck
@@ -44,10 +44,10 @@ required_shell_scripts=(
     check/all
     check/doctest
     check/format-incremental
-    check/typecheck
     check/nbformat
     check/pylint
     check/pytest
+    check/typecheck
     dev_tools/pypath
 )
 

--- a/check/shellcheck
+++ b/check/shellcheck
@@ -44,7 +44,7 @@ required_shell_scripts=(
     check/all
     check/doctest
     check/format-incremental
-    check/mypy
+    check/typecheck
     check/nbformat
     check/pylint
     check/pytest

--- a/check/typecheck
+++ b/check/typecheck
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 
 ################################################################################
-# Runs mypy on the repository.
+# Runs type checking on the repository using the mypy tool.
 #
 # Usage:
-#     check/mypy [--flags]
+#     check/typecheck [flags-for-mypy]
 ################################################################################
-
-echo "Warning: 'check/mypy' is deprecated." \
-    "Please use 'check/typecheck' instead." >&2
-echo "Warning: 'check/mypy' will be removed in cirq v1.8." >&2
-echo >&2
 
 # Get the working directory to the repo root.
 thisdir=$(dirname "${BASH_SOURCE[0]:?}") || exit $?

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -217,7 +217,7 @@ set the Python path and configuration arguments for you and cover more use cases
     - Type checking:
 
         ```bash
-        ./check/mypy [flags-for-mypy]
+        ./check/typecheck [flags-for-mypy]
         ```
 
     - Miscellaneous checks:


### PR DESCRIPTION
Keep the `check/mypy` script around with a deprecation warning
so that developers have time to adjust.

Also add deprecation deadline for an old option in `check/all`.

Related to #8182
