### PR TITLE
Run pip-install without output suppression in colab notebooks

### DIFF
--- a/docs/start/intro.ipynb
+++ b/docs/start/intro.ipynb
@@ -97,7 +97,7 @@
     "    import cirq\n",
     "except ImportError:\n",
     "    print(\"installing cirq...\")\n",
-    "    !pip install --quiet cirq\n",
+    "    !pip install cirq\n",
     "    print(\"installed cirq.\")\n",
     "    import cirq\n",
     "\n",


### PR DESCRIPTION
Run standard pip-install without the `--quiet` option so that Colab
can detect an upgrade of pre-loaded modules (numpy) and suggest
session restart.

Part 1 - change only the intro notebook to verify it renders correctly
at https://quantumai.google/cirq/start/intro.

Related to b/538201381
