### PR TITLE
Remove some unnecessary calls to `list(...)`

### DIFF
--- a/cirq-core/cirq/circuits/optimization_pass.py
+++ b/cirq-core/cirq/circuits/optimization_pass.py
@@ -148,9 +148,7 @@ class PointOptimizer:
                     continue  # pragma: no cover
 
                 # Clear target area, and insert new operations.
-                circuit.clear_operations_touching(
-                    opt.clear_qubits, list(range(i, i + opt.clear_span))
-                )
+                circuit.clear_operations_touching(opt.clear_qubits, range(i, i + opt.clear_span))
                 new_operations = self.post_clean_up(cast(tuple[ops.Operation], opt.new_operations))
 
                 flat_new_operations = tuple(ops.flatten_to_ops(new_operations))

--- a/cirq-core/cirq/devices/named_topologies_test.py
+++ b/cirq-core/cirq/devices/named_topologies_test.py
@@ -67,7 +67,7 @@ def test_tilted_square_methods() -> None:
 
 
 def test_tilted_square_lattice_n_nodes() -> None:
-    for width, height in itertools.product(list(range(1, 4 + 1)), repeat=2):
+    for width, height in itertools.product(range(1, 4 + 1), repeat=2):
         topo = TiltedSquareLattice(width, height)
         assert topo.n_nodes == topo.graph.number_of_nodes()
 

--- a/cirq-core/cirq/sim/density_matrix_utils_test.py
+++ b/cirq-core/cirq/sim/density_matrix_utils_test.py
@@ -29,7 +29,7 @@ def test_sample_density_matrix_big_endian() -> None:
         matrix = cirq.to_valid_density_matrix(x, 3)
         sample = cirq.sample_density_matrix(matrix, [2, 1, 0])
         results.append(sample)
-    expecteds = [[list(reversed(x))] for x in list(itertools.product([False, True], repeat=3))]
+    expecteds = [[list(reversed(x))] for x in itertools.product([False, True], repeat=3)]
     for result, expected in zip(results, expecteds):
         np.testing.assert_equal(result, expected)
 
@@ -172,7 +172,7 @@ def test_measure_density_matrix_computational_basis() -> None:
         bits, out_matrix = cirq.measure_density_matrix(matrix, [2, 1, 0])
         results.append(bits)
         np.testing.assert_almost_equal(out_matrix, matrix)
-    expected = [list(reversed(x)) for x in list(itertools.product([False, True], repeat=3))]
+    expected = [list(reversed(x)) for x in itertools.product([False, True], repeat=3)]
     assert results == expected
 
 
@@ -183,7 +183,7 @@ def test_measure_density_matrix_computational_basis_reversed() -> None:
         bits, out_matrix = cirq.measure_density_matrix(matrix, [0, 1, 2])
         results.append(bits)
         np.testing.assert_almost_equal(out_matrix, matrix)
-    expected = [list(x) for x in list(itertools.product([False, True], repeat=3))]
+    expected = [list(x) for x in itertools.product([False, True], repeat=3)]
     assert results == expected
 
 
@@ -194,7 +194,7 @@ def test_measure_density_matrix_computational_basis_reshaped() -> None:
         bits, out_matrix = cirq.measure_density_matrix(matrix, [2, 1, 0])
         results.append(bits)
         np.testing.assert_almost_equal(out_matrix, matrix)
-    expected = [list(reversed(x)) for x in list(itertools.product([False, True], repeat=3))]
+    expected = [list(reversed(x)) for x in itertools.product([False, True], repeat=3)]
     assert results == expected
 
 

--- a/cirq-core/cirq/sim/state_vector_test.py
+++ b/cirq-core/cirq/sim/state_vector_test.py
@@ -65,7 +65,7 @@ def test_sample_state_big_endian() -> None:
         state = cirq.to_valid_state_vector(x, 3)
         sample = cirq.sample_state_vector(state, [2, 1, 0])
         results.append(sample)
-    expecteds = [[list(reversed(x))] for x in list(itertools.product([False, True], repeat=3))]
+    expecteds = [[list(reversed(x))] for x in itertools.product([False, True], repeat=3)]
     for result, expected in zip(results, expecteds):
         np.testing.assert_equal(result, expected)
 
@@ -193,7 +193,7 @@ def test_measure_state_computational_basis(use_np_transpose: bool) -> None:
         bits, state = cirq.measure_state_vector(initial_state, [2, 1, 0])
         results.append(bits)
         np.testing.assert_almost_equal(state, initial_state)
-    expected = [list(reversed(x)) for x in list(itertools.product([False, True], repeat=3))]
+    expected = [list(reversed(x)) for x in itertools.product([False, True], repeat=3)]
     assert results == expected
 
 
@@ -205,7 +205,7 @@ def test_measure_state_reshape(use_np_transpose: bool) -> None:
         bits, state = cirq.measure_state_vector(initial_state, [2, 1, 0])
         results.append(bits)
         np.testing.assert_almost_equal(state, initial_state)
-    expected = [list(reversed(x)) for x in list(itertools.product([False, True], repeat=3))]
+    expected = [list(reversed(x)) for x in itertools.product([False, True], repeat=3)]
     assert results == expected
 
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -48,7 +48,7 @@ def test_three_qubit_matrix_to_operations(u) -> None:
     num_two_qubit_gates = len(
         [
             op
-            for op in list(final_circuit.all_operations())
+            for op in final_circuit.all_operations()
             if isinstance(op.gate, (cirq.CZPowGate, cirq.CNotPowGate))
         ]
     )
@@ -83,7 +83,7 @@ def test_cs_to_ops(theta, num_czs) -> None:
     assert_almost_equal(circuit_cs.unitary(qubits_that_should_be_present=[a, b, c]), cs, 10)
 
     assert (
-        len([cz for cz in list(circuit_cs.all_operations()) if isinstance(cz.gate, cirq.CZPowGate)])
+        len([cz for cz in circuit_cs.all_operations() if isinstance(cz.gate, cirq.CZPowGate)])
         == num_czs
     ), f"expected {num_czs} CZs got \n {circuit_cs} \n {circuit_cs.unitary()}"
 
@@ -178,7 +178,7 @@ def test_middle_multiplexor(angles, num_cnots) -> None:
         len(
             [
                 cnot
-                for cnot in list(circuit_u1u2_mid.all_operations())
+                for cnot in circuit_u1u2_mid.all_operations()
                 if isinstance(cnot.gate, cirq.CNotPowGate)
             ]
         )

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -306,7 +306,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         response = self.context.client.list_calibrations(
             self.project_id, self.processor_id, filter_str
         )
-        return [_to_calibration(c.data) for c in list(response)]
+        return [_to_calibration(c.data) for c in response]
 
     def get_calibration(self, calibration_timestamp_seconds: int) -> calibration.Calibration:
         """Retrieve metadata about a specific calibration run.

--- a/cirq-google/cirq_google/workflow/qubit_placement_test.py
+++ b/cirq-google/cirq_google/workflow/qubit_placement_test.py
@@ -153,8 +153,10 @@ def test_device_missing_metadata():
 
 def _all_offset_placements(device_graph, offset=(4, 2), min_sidelength=2, max_sidelength=5):
     # Generate candidate tilted square lattice topologies
-    sidelens = list(itertools.product(range(min_sidelength, max_sidelength + 1), repeat=2))
-    topos = [cirq.TiltedSquareLattice(width, height) for width, height in sidelens]
+    topos = [
+        cirq.TiltedSquareLattice(width, height)
+        for width, height in itertools.product(range(min_sidelength, max_sidelength + 1), repeat=2)
+    ]
 
     # Make placements using TiltedSquareLattice.nodes_to_gridqubits offset parameter
     placements = {topo: topo.nodes_to_gridqubits(offset=offset) for topo in topos}


### PR DESCRIPTION
After spotting a place where `list(…)` was unnecessary, I did a quick sweep for other places. Almost all cases are in test code, and so performance is unlikely to be improved. Still, it makes the code a little more readable, so may as well do it.