### PR TITLE
Add cirq.is_circuit_operation to detect tagged CircuitOperations.

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_target_gateset.py
+++ b/cirq-aqt/cirq_aqt/aqt_target_gateset.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 import numpy as np
 
@@ -49,11 +49,10 @@ class AQTTargetGateset(cirq.TwoQubitCompilationTargetGateset):
     def _decompose_single_qubit_operation(self, op: cirq.Operation, _: int) -> DecomposeResult:
         # unwrap tagged and circuit operations to get the actual operation
         opu = op.untagged
-        opu = (
-            next(opu.circuit.all_operations()).untagged
-            if isinstance(opu, cirq.CircuitOperation) and len(opu.circuit) == 1
-            else opu
-        )
+        if cirq.is_circuit_operation(opu):
+            circuit_op = cast(cirq.CircuitOperation, opu)
+            if len(circuit_op.circuit) == 1:
+                opu = next(circuit_op.circuit.all_operations()).untagged
         if isinstance(opu.gate, cirq.HPowGate) and opu.gate.exponent == 1:
             return [cirq.rx(np.pi).on(opu.qubits[0]), cirq.ry(-1 * np.pi / 2).on(opu.qubits[0])]
         if cirq.has_unitary(opu):

--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -71,6 +71,7 @@ from cirq.circuits import (
     CircuitOperation as CircuitOperation,
     FrozenCircuit as FrozenCircuit,
     InsertStrategy as InsertStrategy,
+    is_circuit_operation as is_circuit_operation,
     Moment as Moment,
     PointOptimizationSummary as PointOptimizationSummary,
     PointOptimizer as PointOptimizer,

--- a/cirq-core/cirq/circuits/__init__.py
+++ b/cirq-core/cirq/circuits/__init__.py
@@ -22,7 +22,10 @@ from cirq.circuits.circuit import (
     Alignment as Alignment,
     Circuit as Circuit,
 )
-from cirq.circuits.circuit_operation import CircuitOperation as CircuitOperation
+from cirq.circuits.circuit_operation import (
+    CircuitOperation as CircuitOperation,
+    is_circuit_operation as is_circuit_operation,
+)
 from cirq.circuits.frozen_circuit import FrozenCircuit as FrozenCircuit
 from cirq.circuits.insert_strategy import InsertStrategy as InsertStrategy
 

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -47,7 +47,7 @@ import cirq._version
 from cirq import _compat, devices, ops, protocols, qis
 from cirq._doc import document
 from cirq.circuits._bucket_priority_queue import BucketPriorityQueue
-from cirq.circuits.circuit_operation import CircuitOperation
+from cirq.circuits.circuit_operation import CircuitOperation, is_circuit_operation
 from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.circuits.moment import Moment
 from cirq.circuits.qasm_output import QasmOutput
@@ -863,12 +863,10 @@ class AbstractCircuit(abc.ABC):
             given predicate are terminal. Also checks within any CircuitGates
             the circuit may contain.
         """
-        from cirq.circuits import CircuitOperation
-
         if not all(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
-            if not isinstance(op.untagged, CircuitOperation)
+            if not is_circuit_operation(op)
         ):
             return False
 
@@ -908,12 +906,10 @@ class AbstractCircuit(abc.ABC):
             given predicate are terminal. Also checks within any CircuitGates
             the circuit may contain.
         """
-        from cirq.circuits import CircuitOperation
-
         if any(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
-            if not isinstance(op.untagged, CircuitOperation)
+            if not is_circuit_operation(op)
         ):
             return True
 
@@ -2719,8 +2715,8 @@ def _get_moment_annotations(moment: cirq.Moment) -> Iterator[cirq.Operation]:
         op = op.untagged
         if isinstance(op.gate, ops.GlobalPhaseGate):
             continue
-        if isinstance(op, CircuitOperation):
-            for m in op.circuit:
+        if is_circuit_operation(op):
+            for m in cast(CircuitOperation, op).circuit:
                 yield from _get_moment_annotations(m)
         else:
             yield op
@@ -2862,8 +2858,9 @@ def _draw_moment_in_diagram(
 def _get_global_phase_and_tags_for_op(op: cirq.Operation) -> tuple[complex | None, list[Any]]:
     if isinstance(op.gate, ops.GlobalPhaseGate):
         return complex(op.gate.coefficient), list(op.tags)
-    elif isinstance(op.untagged, CircuitOperation):
-        op_phase, op_tags = _get_global_phase_and_tags_for_ops(op.untagged.circuit.all_operations())
+    elif is_circuit_operation(op):
+        op_untagged = cast(CircuitOperation, op.untagged)
+        op_phase, op_tags = _get_global_phase_and_tags_for_ops(op_untagged.circuit.all_operations())
         return op_phase, list(op.tags) + op_tags
     return None, []
 

--- a/cirq-core/cirq/circuits/circuit_operation.py
+++ b/cirq-core/cirq/circuits/circuit_operation.py
@@ -850,3 +850,23 @@ class CircuitOperation(ops.Operation):
         return resolved.replace(
             repetitions=resolver.value_of(cast('cirq.TParamVal', self.repetitions), recursive)
         )
+
+
+def is_circuit_operation(val: Any) -> bool:
+    """Returns whether the value is a CircuitOperation, ignoring tags.
+
+    Tags wrap an operation in ``cirq.TaggedOperation``, so
+    ``isinstance(val, CircuitOperation)`` is False when a CircuitOperation has
+    tags. This helper uses ``val.untagged`` when present (as on
+    ``cirq.Operation``), matching the usual Cirq pattern
+    ``isinstance(op.untagged, cirq.CircuitOperation)``.
+
+    Args:
+        val: The value to check.
+
+    Returns:
+        True if ``val`` is a CircuitOperation, or a TaggedOperation whose
+        underlying operation is a CircuitOperation.
+    """
+    untagged = getattr(val, 'untagged', val)
+    return isinstance(untagged, CircuitOperation)

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -788,6 +788,26 @@ def test_nonterminal_in_subcircuit() -> None:
     assert not c.are_any_measurements_terminal()
 
 
+def test_is_circuit_operation() -> None:
+    q = cirq.LineQubit(0)
+    circuit_op = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q)))
+    tagged = circuit_op.with_tags('t')
+    multi_tagged = circuit_op.with_tags('a', 'b')
+    gate_op = cirq.X(q)
+    tagged_gate = gate_op.with_tags('t')
+
+    assert cirq.is_circuit_operation(circuit_op)
+    assert cirq.is_circuit_operation(tagged)
+    assert cirq.is_circuit_operation(multi_tagged)
+    assert not cirq.is_circuit_operation(gate_op)
+    assert not cirq.is_circuit_operation(tagged_gate)
+    assert not cirq.is_circuit_operation(None)
+    assert not cirq.is_circuit_operation(object())
+    # Matches the documented isinstance gap for tagged CircuitOperations.
+    assert not isinstance(tagged, cirq.CircuitOperation)
+    assert isinstance(tagged.untagged, cirq.CircuitOperation)
+
+
 def test_decompose_applies_maps() -> None:
     a, b, c = cirq.LineQubit.range(3)
     exp = sympy.Symbol('exp')

--- a/cirq-core/cirq/circuits/circuit_operation_test.py
+++ b/cirq-core/cirq/circuits/circuit_operation_test.py
@@ -791,21 +791,21 @@ def test_nonterminal_in_subcircuit() -> None:
 def test_is_circuit_operation() -> None:
     q = cirq.LineQubit(0)
     circuit_op = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q)))
-    tagged = circuit_op.with_tags('t')
-    multi_tagged = circuit_op.with_tags('a', 'b')
+    tagged_circuit_op = circuit_op.with_tags('t')
+    multi_tagged_circuit_op = circuit_op.with_tags('a', 'b')
     gate_op = cirq.X(q)
     tagged_gate = gate_op.with_tags('t')
 
     assert cirq.is_circuit_operation(circuit_op)
-    assert cirq.is_circuit_operation(tagged)
-    assert cirq.is_circuit_operation(multi_tagged)
+    assert cirq.is_circuit_operation(tagged_circuit_op)
+    assert cirq.is_circuit_operation(multi_tagged_circuit_op)
     assert not cirq.is_circuit_operation(gate_op)
     assert not cirq.is_circuit_operation(tagged_gate)
     assert not cirq.is_circuit_operation(None)
     assert not cirq.is_circuit_operation(object())
     # Matches the documented isinstance gap for tagged CircuitOperations.
-    assert not isinstance(tagged, cirq.CircuitOperation)
-    assert isinstance(tagged.untagged, cirq.CircuitOperation)
+    assert not isinstance(tagged_circuit_op, cirq.CircuitOperation)
+    assert isinstance(tagged_circuit_op.untagged, cirq.CircuitOperation)
 
 
 def test_decompose_applies_maps() -> None:

--- a/cirq-core/cirq/protocols/decompose_protocol.py
+++ b/cirq-core/cirq/protocols/decompose_protocol.py
@@ -20,7 +20,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from types import NotImplementedType
-from typing import Any, overload, Protocol, TYPE_CHECKING, TypeVar, Union
+from typing import Any, cast, overload, Protocol, TYPE_CHECKING, TypeVar, Union
 
 from cirq import devices, ops
 from cirq._doc import doc_private
@@ -173,11 +173,12 @@ class _DecomposeArgs:
 
 
 def _decompose_dfs(item: Any, args: _DecomposeArgs) -> Iterator[cirq.Operation]:
-    from cirq.circuits import CircuitOperation, FrozenCircuit
+    from cirq.circuits import CircuitOperation, FrozenCircuit, is_circuit_operation
 
     if isinstance(item, ops.Operation):
         item_untagged = item.untagged
-        if args.preserve_structure and isinstance(item_untagged, CircuitOperation):
+        if args.preserve_structure and is_circuit_operation(item):
+            item_untagged = cast(CircuitOperation, item_untagged)
             new_fc = FrozenCircuit(_decompose_dfs(item_untagged.circuit, args))
             yield item_untagged.replace(circuit=new_fc).with_tags(*item.tags)
             return

--- a/cirq-core/cirq/transformers/expand_composite.py
+++ b/cirq-core/cirq/transformers/expand_composite.py
@@ -52,7 +52,7 @@ def expand_composite(
     """
 
     def map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
-        if context and context.deep and isinstance(op.untagged, circuits.CircuitOperation):
+        if context and context.deep and circuits.is_circuit_operation(op):
             return op
         return protocols.decompose(op, keep=no_decomp, on_stuck_raise=None)
 

--- a/cirq-core/cirq/transformers/merge_k_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_k_qubit_gates.py
@@ -38,11 +38,8 @@ def _rewrite_merged_k_qubit_unitaries(
 
     def map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
         op_untagged = op.untagged
-        if (
-            deep
-            and isinstance(op_untagged, circuits.CircuitOperation)
-            and merged_circuit_op_tag not in op.tags
-        ):
+        if deep and circuits.is_circuit_operation(op) and merged_circuit_op_tag not in op.tags:
+            op_untagged = cast(circuits.CircuitOperation, op_untagged)
             return op_untagged.replace(
                 circuit=_rewrite_merged_k_qubit_unitaries(
                     op_untagged.circuit,

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -75,7 +75,7 @@ def _decompose_operations_to_target_gateset(
         if (
             context
             and context.deep
-            and isinstance(op.untagged, circuits.CircuitOperation)
+            and circuits.is_circuit_operation(op)
             and set(op.tags).isdisjoint(tags_to_decompose)
         ):
             return op

--- a/cirq-core/cirq/transformers/qubit_management_transformers.py
+++ b/cirq-core/cirq/transformers/qubit_management_transformers.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from cirq import circuits, ops
 
@@ -110,9 +110,10 @@ def map_clean_and_borrowable_qubits(
 
         # Handle CircuitOperation recursively, sharing the same QubitManager
         # to ensure globally unique qubit allocation across all nesting levels.
-        if isinstance(op.untagged, circuits.CircuitOperation):
-            inner_circuit = map_clean_and_borrowable_qubits(op.untagged.circuit, qm=qm)
-            op = op.untagged.replace(circuit=inner_circuit.freeze()).with_tags(*op.tags)
+        if circuits.is_circuit_operation(op):
+            op_untagged = cast(circuits.CircuitOperation, op.untagged)
+            inner_circuit = map_clean_and_borrowable_qubits(op_untagged.circuit, qm=qm)
+            op = op_untagged.replace(circuit=inner_circuit.freeze()).with_tags(*op.tags)
 
         for q in sorted(to_free):
             is_managed_qubit = allocated_map[q] not in all_qubits

--- a/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
+++ b/cirq-core/cirq/transformers/target_gatesets/compilation_target_gateset.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Hashable
-from typing import TYPE_CHECKING
+from typing import cast, TYPE_CHECKING
 
 from cirq import circuits, ops, protocols, transformers
 from cirq.transformers import merge_k_qubit_gates, merge_single_qubit_gates
@@ -235,9 +235,8 @@ class TwoQubitCompilationTargetGateset(CompilationTargetGateset):
         new_optree = [*ops.flatten_to_ops_or_moments(new_optree)]
         op_untagged = op.untagged
         old_optree = (
-            [*op_untagged.circuit]
-            if isinstance(op_untagged, circuits.CircuitOperation)
-            and self._intermediate_result_tag in op.tags
+            [*cast(circuits.CircuitOperation, op_untagged).circuit]
+            if circuits.is_circuit_operation(op) and self._intermediate_result_tag in op.tags
             else [op]
         )
         old_2q_gate_count = sum(1 for o in ops.flatten_to_ops(old_optree) if len(o.qubits) == 2)

--- a/cirq-core/cirq/transformers/transformer_api.py
+++ b/cirq-core/cirq/transformers/transformer_api.py
@@ -394,9 +394,7 @@ def _run_transformer_on_circuit(
     mutable_circuit = None
     if extracted_context and extracted_context.deep and add_deep_support:
         batch_replace = []
-        for i, op in circuit.findall_operations(
-            lambda o: isinstance(o.untagged, circuits.CircuitOperation)
-        ):
+        for i, op in circuit.findall_operations(circuits.is_circuit_operation):
             op_untagged = cast(circuits.CircuitOperation, op.untagged)
             if not set(op.tags).isdisjoint(extracted_context.tags_to_ignore):
                 continue

--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -110,9 +110,7 @@ def map_moments(
     mutable_circuit = circuit.unfreeze(copy=False)
     if deep:
         batch_replace = []
-        for i, op in circuit.findall_operations(
-            lambda o: isinstance(o.untagged, circuits.CircuitOperation)
-        ):
+        for i, op in circuit.findall_operations(circuits.is_circuit_operation):
             if set(op.tags).intersection(tags_to_ignore):
                 continue
             op_untagged = cast(circuits.CircuitOperation, op.untagged)
@@ -187,10 +185,11 @@ def _map_operations_impl(
     def apply_map_func(op: cirq.Operation, idx: int) -> list[cirq.Operation]:
         if tags_to_ignore_set.intersection(op.tags):
             return [op]
-        if deep and isinstance(op.untagged, circuits.CircuitOperation):
-            op = op.untagged.replace(
+        if deep and circuits.is_circuit_operation(op):
+            op_untagged = cast(circuits.CircuitOperation, op.untagged)
+            op = op_untagged.replace(
                 circuit=_map_operations_impl(
-                    op.untagged.circuit,
+                    op_untagged.circuit,
                     map_func,
                     deep=deep,
                     raise_if_add_qubits=raise_if_add_qubits,
@@ -488,10 +487,10 @@ def _merge_operations_impl(
         for op in sorted(current_moment.operations, key=lambda op: op.qubits):
             if (
                 deep
-                and isinstance(op.untagged, circuits.CircuitOperation)
+                and circuits.is_circuit_operation(op)
                 and tags_to_ignore_set.isdisjoint(op.tags)
             ):
-                op_untagged = op.untagged
+                op_untagged = cast(circuits.CircuitOperation, op.untagged)
                 merged_op = op_untagged.replace(
                     circuit=_merge_operations_impl(
                         op_untagged.circuit,
@@ -731,17 +730,16 @@ def merge_moments(
     if not circuit:
         return circuit
     if deep:
-        circuit = map_operations(
-            circuit,
-            lambda op, _: (
-                op.untagged.replace(
-                    circuit=merge_moments(op.untagged.circuit, merge_func, deep=deep)
-                ).with_tags(*op.tags)
-                if isinstance(op.untagged, circuits.CircuitOperation)
-                else op
-            ),
-            tags_to_ignore=tags_to_ignore,
-        )
+
+        def _map_nested_circuit_op(op: cirq.Operation, _: int) -> cirq.Operation:
+            if not circuits.is_circuit_operation(op):
+                return op
+            op_untagged = cast(circuits.CircuitOperation, op.untagged)
+            return op_untagged.replace(
+                circuit=merge_moments(op_untagged.circuit, merge_func, deep=deep)
+            ).with_tags(*op.tags)
+
+        circuit = map_operations(circuit, _map_nested_circuit_op, tags_to_ignore=tags_to_ignore)
     merged_moments: list[circuits.Moment] = [circuit[0]]
     for current_moment in circuit[1:]:
         merged_moment = merge_func(merged_moments[-1], current_moment)
@@ -782,19 +780,18 @@ def merge_moments_batch(
     if not circuit:
         return circuit
     if deep:
-        circuit = map_operations(
-            circuit,
-            lambda op, _: (
-                op.untagged.replace(
-                    circuit=merge_moments_batch(
-                        op.untagged.circuit, merge_func, tags_to_ignore=tags_to_ignore, deep=deep
-                    )
-                ).with_tags(*op.tags)
-                if isinstance(op.untagged, circuits.CircuitOperation)
-                else op
-            ),
-            tags_to_ignore=tags_to_ignore,
-        )
+
+        def _map_nested_circuit_op(op: cirq.Operation, _: int) -> cirq.Operation:
+            if not circuits.is_circuit_operation(op):
+                return op
+            op_untagged = cast(circuits.CircuitOperation, op.untagged)
+            return op_untagged.replace(
+                circuit=merge_moments_batch(
+                    op_untagged.circuit, merge_func, tags_to_ignore=tags_to_ignore, deep=deep
+                )
+            ).with_tags(*op.tags)
+
+        circuit = map_operations(circuit, _map_nested_circuit_op, tags_to_ignore=tags_to_ignore)
 
     merged_moments: list[circuits.Moment] = []
     moments_to_merge: Sequence[circuits.Moment] = circuit.moments
@@ -832,7 +829,8 @@ def unroll_circuit_op(
         to_zip: list[cirq.AbstractCircuit] = []
         for op in m:
             op_untagged = op.untagged
-            if isinstance(op_untagged, circuits.CircuitOperation):
+            if circuits.is_circuit_operation(op):
+                op_untagged = cast(circuits.CircuitOperation, op_untagged)
                 if deep:
                     op_untagged = op_untagged.replace(
                         circuit=unroll_circuit_op(
@@ -876,9 +874,7 @@ def unroll_circuit_op_greedy_earliest(
     batch_replace = []
     batch_remove = []
     batch_insert = []
-    for i, op in circuit.findall_operations(
-        lambda o: isinstance(o.untagged, circuits.CircuitOperation)
-    ):
+    for i, op in circuit.findall_operations(circuits.is_circuit_operation):
         op_untagged = cast(circuits.CircuitOperation, op.untagged)
         if deep:
             op_untagged = op_untagged.replace(
@@ -926,11 +922,11 @@ def unroll_circuit_op_greedy_frontier(
     while idx < len(unrolled_circuit):
         for op in unrolled_circuit[idx].operations:
             # Don't touch stuff inserted by unrolling previous circuit ops.
-            if not isinstance(op.untagged, circuits.CircuitOperation):
+            if not circuits.is_circuit_operation(op):
                 continue
             if any(frontier[q] > idx for q in op.qubits):
                 continue
-            op_untagged = op.untagged
+            op_untagged = cast(circuits.CircuitOperation, op.untagged)
             if deep:
                 op_untagged = op_untagged.replace(
                     circuit=unroll_circuit_op_greedy_frontier(

--- a/cirq-google/cirq_google/serialization/circuit_serializer.py
+++ b/cirq-google/cirq_google/serialization/circuit_serializer.py
@@ -251,9 +251,9 @@ class CircuitSerializer(serializer.Serializer):
             moment_proto = v2.program_pb2.Moment()
 
             for op in moment:
-                if isinstance(op.untagged, cirq.CircuitOperation) or (
+                if cirq.is_circuit_operation(op) or (
                     isinstance(op.untagged, cirq.ClassicallyControlledOperation)
-                    and isinstance(op.untagged.without_classical_controls(), cirq.CircuitOperation)
+                    and cirq.is_circuit_operation(op.untagged.without_classical_controls())
                 ):
                     op_pb = moment_proto.circuit_operations.add()
                     self._serialize_circuit_op(

--- a/cirq-google/cirq_google/serialization/op_serializer.py
+++ b/cirq-google/cirq_google/serialization/op_serializer.py
@@ -69,7 +69,7 @@ class CircuitOpSerializer(OpSerializer):
     """Describes how to serialize CircuitOperations."""
 
     def can_serialize_operation(self, op: cirq.Operation):
-        return isinstance(op.untagged, cirq.CircuitOperation)
+        return cirq.is_circuit_operation(op)
 
     def to_proto(
         self,

--- a/cirq-google/cirq_google/transformers/analytical_decompositions/two_qubit_to_sycamore.py
+++ b/cirq-google/cirq_google/transformers/analytical_decompositions/two_qubit_to_sycamore.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import itertools
 import math
 from collections.abc import Iterator
+from typing import cast
 
 import numpy as np
 
@@ -118,8 +119,10 @@ def known_2q_op_to_sycamore_operations(op: cirq.Operation) -> cirq.OP_TREE | Non
 
     q0, q1 = op.qubits
 
-    if isinstance(op.untagged, cirq.CircuitOperation):
-        flattened_gates = [o.gate for o in cirq.decompose_once(op.untagged)]
+    if cirq.is_circuit_operation(op):
+        flattened_gates = [
+            o.gate for o in cirq.decompose_once(cast(cirq.CircuitOperation, op.untagged))
+        ]
         if len(flattened_gates) != 2:
             return None
         for g1, g2 in itertools.permutations(flattened_gates):


### PR DESCRIPTION
Adds `cirq.is_circuit_operation` so tagged `CircuitOperation`s are detected via `.untagged` (plain `isinstance` misses `TaggedOperation` wrappers).

Closes #6570