### PR TITLE
Add jobs_per_batch to `get_sampler`

### DIFF
--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -689,7 +689,7 @@ class Engine(abstract_engine.AbstractEngine):
                 run_batch_async() up to a maximum of `jobs_per_batch`.
                 Note that actual hardware execution order is not guaranteed
                 if jobs_per_batch > 1. (For instance, the hardware may run
-                all circuits for the first sweep point, then the second point, etc).
+                all circuits for the first sweep point, then the second point, etc.).
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -670,6 +670,7 @@ class Engine(abstract_engine.AbstractEngine):
         device_config_name: str | None = None,
         device_config_revision: processor_config.DeviceConfigRevision | None = None,
         max_concurrent_jobs: int = 100,
+        jobs_per_batch: int = 1,
     ) -> cirq_google.ProcessorSampler:
         """Returns a sampler backed by the engine.
 
@@ -683,6 +684,12 @@ class Engine(abstract_engine.AbstractEngine):
                 concurrently to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
+            jobs_per_batch:  If set to greater than 1, this will batch multiple
+                circuits within the same API call when calling run_batch() or
+                run_batch_async() up to a maximum of `jobs_per_batch`.
+                Note that actual hardware execution order is not guaranteed
+                if jobs_per_batch > 1. (For instance, the hardware may run
+                all circuits for the first sweep point, then the second point, etc).
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`
@@ -703,6 +710,7 @@ class Engine(abstract_engine.AbstractEngine):
             device_config_name=device_config_name,
             device_config_revision=device_config_revision,
             max_concurrent_jobs=max_concurrent_jobs,
+            jobs_per_batch=jobs_per_batch,
         )
 
     async def get_processor_config_async(

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -97,6 +97,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         device_config_name: str | None = None,
         device_config_revision: processor_config.DeviceConfigRevision | None = None,
         max_concurrent_jobs: int = 100,
+        jobs_per_batch: int = 1,
     ) -> cg.engine.ProcessorSampler:
         """Returns the default sampler backed by the engine.
 
@@ -109,6 +110,12 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 simultaneously to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
+            jobs_per_batch:  If set to greater than 1, this will batch multiple
+                circuits within the same API call when calling run_batch() or
+                run_batch_async() up to a maximum of `jobs_per_batch`.
+                Note that actual hardware execution order is not guaranteed
+                if jobs_per_batch > 1. (For instance, the hardware may run
+                all circuits for the first sweep point, then the second point, etc).
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`
@@ -131,6 +138,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 snapshot_id=device_config_revision.id,
                 device_config_name=device_config_name,
                 max_concurrent_jobs=max_concurrent_jobs,
+                jobs_per_batch=jobs_per_batch,
             )
         if isinstance(device_config_revision, processor_config.Run):
             return processor_sampler.ProcessorSampler(
@@ -138,6 +146,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 run_name=device_config_revision.id,
                 device_config_name=device_config_name,
                 max_concurrent_jobs=max_concurrent_jobs,
+                jobs_per_batch=jobs_per_batch,
             )
 
         return processor_sampler.ProcessorSampler(
@@ -145,6 +154,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             run_name=processor.default_device_config_key.run,
             device_config_name=device_config_name,
             max_concurrent_jobs=max_concurrent_jobs,
+            jobs_per_batch=jobs_per_batch,
         )
 
     async def run_sweep_async(

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -115,7 +115,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 run_batch_async() up to a maximum of `jobs_per_batch`.
                 Note that actual hardware execution order is not guaranteed
                 if jobs_per_batch > 1. (For instance, the hardware may run
-                all circuits for the first sweep point, then the second point, etc).
+                all circuits for the first sweep point, then the second point, etc.).
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -378,6 +378,60 @@ def test_get_sampler_from_run_name_with_defaults() -> None:
     assert sampler.device_config_name == default_config_alias
 
 
+def test_get_sampler_initializes_jobs_per_batch() -> None:
+    processor = cg.EngineProcessor(
+        'a',
+        'p',
+        EngineContext(),
+        _processor=quantum.QuantumProcessor(
+            default_device_config_key=quantum.DeviceConfigKey(
+                run="run", config_alias="config_alias"
+            )
+        ),
+    )
+    sampler_default = processor.get_sampler()
+    assert sampler_default._jobs_per_batch == 1
+
+    jobs_per_batch = 5
+    sampler = processor.get_sampler(jobs_per_batch=jobs_per_batch)
+    assert sampler._jobs_per_batch == jobs_per_batch
+
+
+def test_get_sampler_initializes_jobs_per_batch_with_snapshot() -> None:
+    processor = cg.EngineProcessor(
+        'a',
+        'p',
+        EngineContext(),
+        _processor=quantum.QuantumProcessor(
+            default_device_config_key=quantum.DeviceConfigKey(
+                config_alias="config_alias", snapshot_id="snap"
+            )
+        ),
+    )
+    snapshot = Snapshot(id='test_snapshot')
+    jobs_per_batch = 5
+    sampler = processor.get_sampler(device_config_revision=snapshot, jobs_per_batch=jobs_per_batch)
+    assert sampler._jobs_per_batch == jobs_per_batch
+
+
+def test_get_sampler_initializes_jobs_per_batch_with_run() -> None:
+    processor = cg.EngineProcessor(
+        'a',
+        'p',
+        EngineContext(),
+        _processor=quantum.QuantumProcessor(
+            default_device_config_key=quantum.DeviceConfigKey(
+                run="run", config_alias="config_alias"
+            )
+        ),
+    )
+    run = Run(id='test_run')
+    jobs_per_batch = 5
+    sampler = processor.get_sampler(device_config_revision=run, jobs_per_batch=jobs_per_batch)
+    assert sampler._jobs_per_batch == jobs_per_batch
+
+
+
 def test_get_sampler_from_snapshot_id() -> None:
     default_snapshot_id = 'default_snap'
     processor = cg.EngineProcessor(

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -431,7 +431,6 @@ def test_get_sampler_initializes_jobs_per_batch_with_run() -> None:
     assert sampler._jobs_per_batch == jobs_per_batch
 
 
-
 def test_get_sampler_from_snapshot_id() -> None:
     default_snapshot_id = 'default_snap'
     processor = cg.EngineProcessor(

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -924,7 +924,6 @@ def test_get_sampler_initializes_jobs_per_batch():
     assert sampler._jobs_per_batch == jobs_per_batch
 
 
-
 def test_get_sampler_from_run_name():
     processor_id = 'test_processor_id'
     run = Run(id="test_run_name")

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -914,6 +914,17 @@ def test_get_sampler_initializes_max_concurrent_jobs():
     assert sampler.max_concurrent_jobs == max_concurrent_jobs
 
 
+def test_get_sampler_initializes_jobs_per_batch():
+    engine = cg.Engine(project_id='proj')
+    sampler_default = engine.get_sampler(processor_id='tmp')
+    assert sampler_default._jobs_per_batch == 1
+
+    jobs_per_batch = 5
+    sampler = engine.get_sampler(processor_id='tmp', jobs_per_batch=jobs_per_batch)
+    assert sampler._jobs_per_batch == jobs_per_batch
+
+
+
 def test_get_sampler_from_run_name():
     processor_id = 'test_processor_id'
     run = Run(id="test_run_name")

--- a/cirq-google/cirq_google/engine/processor_config.py
+++ b/cirq-google/cirq_google/engine/processor_config.py
@@ -129,7 +129,9 @@ class ProcessorConfig:
         parts = self._quantum_processor_config.name.split('/')
         return parts[-1]
 
-    def sampler(self, max_concurrent_jobs: int = 100) -> processor_sampler.ProcessorSampler:
+    def sampler(
+        self, max_concurrent_jobs: int = 100, jobs_per_batch: int = 1
+    ) -> processor_sampler.ProcessorSampler:
         """Returns the sampler backed by this config.
 
         Args:
@@ -137,6 +139,12 @@ class ProcessorConfig:
                 simultaneously to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
+            jobs_per_batch:  If set to greater than 1, this will batch multiple
+                circuits within the same API call when calling run_batch() or
+                run_batch_async() up to a maximum of `jobs_per_batch`.
+                Note that actual hardware execution order is not guaranteed
+                if jobs_per_batch > 1. (For instance, the hardware may run
+                all circuits for the first sweep point, then the second point, etc).
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`)
@@ -149,6 +157,7 @@ class ProcessorConfig:
             snapshot_id=self.snapshot_id,
             device_config_name=self.config_name,
             max_concurrent_jobs=max_concurrent_jobs,
+            jobs_per_batch=jobs_per_batch,
         )
 
     def __repr__(self) -> str:

--- a/cirq-google/cirq_google/engine/processor_config.py
+++ b/cirq-google/cirq_google/engine/processor_config.py
@@ -144,7 +144,7 @@ class ProcessorConfig:
                 run_batch_async() up to a maximum of `jobs_per_batch`.
                 Note that actual hardware execution order is not guaranteed
                 if jobs_per_batch > 1. (For instance, the hardware may run
-                all circuits for the first sweep point, then the second point, etc).
+                all circuits for the first sweep point, then the second point, etc.).
 
         Returns:
             A `cirq.Sampler` instance (specifically a `engine_sampler.ProcessorSampler`)

--- a/cirq-google/cirq_google/engine/processor_config_test.py
+++ b/cirq-google/cirq_google/engine/processor_config_test.py
@@ -167,6 +167,20 @@ def test_sampler():
     assert sampler.run_name == run.id
     assert sampler.snapshot_id == _SNAPSHOT_ID
     assert sampler.device_config_name == _CONFIG_NAME
+    assert sampler._jobs_per_batch == 1
+
+
+def test_sampler_initializes_jobs_per_batch():
+    run = Run(id='test_run_name')
+    config = cg.engine.ProcessorConfig(
+        processor=None,
+        quantum_processor_config=_VALID_QUANTUM_PROCESSOR_CONFIG,
+        device_config_revision=run,
+    )
+    jobs_per_batch = 5
+    sampler = config.sampler(jobs_per_batch=jobs_per_batch)
+
+    assert sampler._jobs_per_batch == jobs_per_batch
 
 
 def test_validate_device_config_revision():

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -62,7 +62,7 @@ class ProcessorSampler(cirq.Sampler):
                 run_batch_async() up to a maximum of `jobs_per_batch`.
                 Note that actual hardware execution order is not guaranteed
                 if jobs_per_batch > 1. (For instance, the hardware may run
-                all circuits for the first sweep point, then the second point, etc).
+                all circuits for the first sweep point, then the second point, etc.).
 
         Raises:
             ValueError: If  only one of `run_name` and `device_config_name` are specified.


### PR DESCRIPTION
The argument `jobs_per_batch` was recently added to `ProcessorSampler`. This adds it to the `get_sampler` methods.