### PR TITLE
Fix overly broad permission in ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   quick_test:


### PR DESCRIPTION
- Apparently, a new tool called zizmor is having an error because the read permissions can be further reduced.