### PR TITLE
Count iterator items without throw-away list

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -792,7 +792,7 @@ class AbstractCircuit(abc.ABC):
 
     def findall_operations(
         self, predicate: Callable[[cirq.Operation], bool]
-    ) -> Iterable[tuple[int, cirq.Operation]]:
+    ) -> Iterator[tuple[int, cirq.Operation]]:
         """Find the locations of all operations that satisfy a given condition.
 
         This returns an iterator of (index, operation) tuples where each
@@ -813,7 +813,7 @@ class AbstractCircuit(abc.ABC):
 
     def findall_operations_with_gate_type(
         self, gate_type: type[_TGate]
-    ) -> Iterable[tuple[int, cirq.GateOperation, _TGate]]:
+    ) -> Iterator[tuple[int, cirq.GateOperation, _TGate]]:
         """Find the locations of all gate operations of a given type.
 
         Args:
@@ -2989,14 +2989,14 @@ _TKey = TypeVar('_TKey')
 @overload
 def _group_until_different(
     items: Iterable[_TIn], key: Callable[[_TIn], _TKey]
-) -> Iterable[tuple[_TKey, list[_TIn]]]:
+) -> Iterator[tuple[_TKey, list[_TIn]]]:
     pass
 
 
 @overload
 def _group_until_different(
     items: Iterable[_TIn], key: Callable[[_TIn], _TKey], val: Callable[[_TIn], _TOut]
-) -> Iterable[tuple[_TKey, list[_TOut]]]:
+) -> Iterator[tuple[_TKey, list[_TOut]]]:
     pass
 
 

--- a/cirq-core/cirq/contrib/acquaintance/permutation.py
+++ b/cirq-core/cirq/contrib/acquaintance/permutation.py
@@ -243,7 +243,7 @@ def update_mapping(mapping: dict[ops.Qid, LogicalIndex], operations: cirq.OP_TRE
 
 def get_logical_operations(
     operations: cirq.OP_TREE, initial_mapping: dict[ops.Qid, ops.Qid]
-) -> Iterable[cirq.Operation]:
+) -> Iterator[cirq.Operation]:
     """Gets the logical operations specified by the physical operations and
     initial mapping.
 

--- a/cirq-core/cirq/contrib/acquaintance/topological_sort.py
+++ b/cirq-core/cirq/contrib/acquaintance/topological_sort.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import operator
 import random
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any, cast, TYPE_CHECKING
 
 from cirq import ops
@@ -73,7 +73,7 @@ def is_topologically_sorted(
     return not bool(frontier)
 
 
-def random_topological_sort(dag: networkx.DiGraph) -> Iterable[Any]:
+def random_topological_sort(dag: networkx.DiGraph) -> Iterator[Any]:
     remaining_dag = dag.copy()
     frontier = [node for node in remaining_dag.nodes() if not remaining_dag.pred[node]]
     while frontier:

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import operator
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterator
 from typing import Any, cast, TYPE_CHECKING
 
 import numpy as np
@@ -137,7 +137,7 @@ class QasmGateStatement:
 
     def on(
         self, params: list[value.TParamVal], args: list[list[ops.Qid]], lineno: int
-    ) -> Iterable[ops.Operation]:
+    ) -> Iterator[ops.Operation]:
         self._validate_args(args, lineno)
         self._validate_params(params, lineno)
 
@@ -166,7 +166,7 @@ class CustomGate:
 
     def on(
         self, params: list[value.TParamVal], args: list[list[ops.Qid]], lineno: int
-    ) -> Iterable[ops.Operation]:
+    ) -> Iterator[ops.Operation]:
         if len(params) != len(self.params):
             raise QasmException(f"Wrong number of params for '{self.name}' at line {lineno}")
         if len(args) != len(self.qubits):

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume_test.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume_test.py
@@ -176,22 +176,15 @@ def test_compile_circuit_replaces_swaps() -> None:
 
     # Assert that there were some swaps in the result
     compiler_mock.assert_called_with(compilation_result.circuit)
-    assert (
-        len(
-            list(compilation_result.circuit.findall_operations_with_gate_type(cirq.ops.SwapPowGate))
-        )
-        > 0
-    )
+    assert list(compilation_result.circuit.findall_operations_with_gate_type(cirq.ops.SwapPowGate))
     # Assert that there were not SwapPermutations in the result.
     assert (
-        len(
-            list(
-                compilation_result.circuit.findall_operations_with_gate_type(
-                    cirq.contrib.acquaintance.SwapPermutationGate
-                )
+        list(
+            compilation_result.circuit.findall_operations_with_gate_type(
+                cirq.contrib.acquaintance.SwapPermutationGate
             )
         )
-        == 0
+        == []
     )
 
 

--- a/cirq-core/cirq/contrib/quirk/export_to_quirk.py
+++ b/cirq-core/cirq/contrib/quirk/export_to_quirk.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import urllib.parse
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any, cast
 
 from cirq import circuits, devices, ops, protocols
@@ -43,7 +43,7 @@ def _try_convert_to_quirk_gate(op: ops.Operation, prefer_unknown_gate_to_failure
 
 def _to_quirk_cols(
     op: ops.Operation, prefer_unknown_gate_to_failure: bool
-) -> Iterable[tuple[list[Any], bool]]:
+) -> Iterator[tuple[list[Any], bool]]:
     gate = _try_convert_to_quirk_gate(op, prefer_unknown_gate_to_failure)
     qubits = cast(Iterable[devices.LineQubit], op.qubits)
 

--- a/cirq-core/cirq/contrib/routing/router.py
+++ b/cirq-core/cirq/contrib/routing/router.py
@@ -57,7 +57,7 @@ def route_circuit(
     if any(protocols.num_qubits(op) > 2 for op in circuit.all_operations()):
         raise ValueError('Can only route circuits with operations that act on at most 2 qubits.')
 
-    if len(list(circuit.all_qubits())) > device_graph.number_of_nodes():
+    if len(circuit.all_qubits()) > device_graph.number_of_nodes():
         raise ValueError('Number of logical qubits is greater than number of physical qubits.')
 
     if not (algo_name is None or router is None):

--- a/cirq-core/cirq/devices/named_topologies.py
+++ b/cirq-core/cirq/devices/named_topologies.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import abc
 import warnings
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING, Union
 
@@ -54,7 +54,7 @@ _GRIDLIKE_NODE = Union['cirq.GridQubit', tuple[int, int]]
 
 def _node_and_coordinates(
     nodes: Iterable[_GRIDLIKE_NODE],
-) -> Iterable[tuple[_GRIDLIKE_NODE, tuple[int, int]]]:
+) -> Iterator[tuple[_GRIDLIKE_NODE, tuple[int, int]]]:
     """Yield tuples whose first element is the input node and the second is guaranteed to be a tuple
     of two integers. The input node can be a tuple of ints or a GridQubit."""
     for node in nodes:

--- a/cirq-core/cirq/experiments/qubit_characterizations_test.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations_test.py
@@ -75,30 +75,26 @@ def test_single_qubit_cliffords() -> None:
 
     # Check that XZ decomposition has at most one X gate per clifford.
     for gates in cliffords.c1_in_xz:
-        num_i = len([gate for gate in gates if gate == cirq.ops.SingleQubitCliffordGate.I])
-        num_x = len(
-            [
-                gate
-                for gate in gates
-                if gate
-                in (
-                    cirq.ops.SingleQubitCliffordGate.X,
-                    cirq.ops.SingleQubitCliffordGate.X_sqrt,
-                    cirq.ops.SingleQubitCliffordGate.X_nsqrt,
-                )
-            ]
+        num_i = sum(1 for gate in gates if gate == cirq.ops.SingleQubitCliffordGate.I)
+        num_x = sum(
+            1
+            for gate in gates
+            if gate
+            in (
+                cirq.ops.SingleQubitCliffordGate.X,
+                cirq.ops.SingleQubitCliffordGate.X_sqrt,
+                cirq.ops.SingleQubitCliffordGate.X_nsqrt,
+            )
         )
-        num_z = len(
-            [
-                gate
-                for gate in gates
-                if gate
-                in (
-                    cirq.ops.SingleQubitCliffordGate.Z,
-                    cirq.ops.SingleQubitCliffordGate.Z_sqrt,
-                    cirq.ops.SingleQubitCliffordGate.Z_nsqrt,
-                )
-            ]
+        num_z = sum(
+            1
+            for gate in gates
+            if gate
+            in (
+                cirq.ops.SingleQubitCliffordGate.Z,
+                cirq.ops.SingleQubitCliffordGate.Z_sqrt,
+                cirq.ops.SingleQubitCliffordGate.Z_nsqrt,
+            )
         )
         assert num_x + num_z + num_i == len(gates)
         assert num_x <= 1

--- a/cirq-core/cirq/experiments/single_qubit_readout_calibration.py
+++ b/cirq-core/cirq/experiments/single_qubit_readout_calibration.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import dataclasses
 import time
-from collections.abc import Iterable
+from collections.abc import Collection
 from typing import Any, cast, TYPE_CHECKING
 
 import matplotlib.pyplot as plt
@@ -213,7 +213,7 @@ class SingleQubitReadoutCalibrationResult:
 
 
 def estimate_single_qubit_readout_errors(
-    sampler: cirq.Sampler, *, qubits: Iterable[cirq.Qid], repetitions: int = 1000
+    sampler: cirq.Sampler, *, qubits: Collection[cirq.Qid], repetitions: int = 1000
 ) -> SingleQubitReadoutCalibrationResult:
     """Estimate single-qubit readout error.
 
@@ -234,7 +234,7 @@ def estimate_single_qubit_readout_errors(
         the probabilities. Also stores a timestamp indicating the time when
         data was finished being collected from the sampler.
     """
-    num_qubits = len(list(qubits))
+    num_qubits = len(qubits)
     return estimate_parallel_single_qubit_readout_errors(
         sampler=sampler,
         qubits=qubits,
@@ -247,7 +247,7 @@ def estimate_single_qubit_readout_errors(
 def estimate_parallel_single_qubit_readout_errors(
     sampler: cirq.Sampler,
     *,
-    qubits: Iterable[cirq.Qid],
+    qubits: Collection[cirq.Qid],
     trials: int = 20,
     repetitions: int = 1000,
     trials_per_batch: int | None = None,

--- a/cirq-core/cirq/experiments/xeb_fitting.py
+++ b/cirq-core/cirq/experiments/xeb_fitting.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterator, Sequence
 from concurrent import futures
 from typing import Any, TYPE_CHECKING
 
@@ -296,7 +296,7 @@ class XEBPhasedFSimCharacterizationOptions(XEBCharacterizationOptions):
     gamma_default: float | None = None
     phi_default: float | None = None
 
-    def _iter_angles(self) -> Iterable[tuple[bool, float | None, sympy.Symbol]]:
+    def _iter_angles(self) -> Iterator[tuple[bool, float | None, sympy.Symbol]]:
         yield from (
             (self.characterize_theta, self.theta_default, THETA_SYMBOL),
             (self.characterize_zeta, self.zeta_default, ZETA_SYMBOL),
@@ -305,7 +305,7 @@ class XEBPhasedFSimCharacterizationOptions(XEBCharacterizationOptions):
             (self.characterize_phi, self.phi_default, PHI_SYMBOL),
         )
 
-    def _iter_angles_for_characterization(self) -> Iterable[tuple[float | None, sympy.Symbol]]:
+    def _iter_angles_for_characterization(self) -> Iterator[tuple[float | None, sympy.Symbol]]:
         yield from (
             (default, symbol)
             for characterize, default, symbol in self._iter_angles()

--- a/cirq-core/cirq/linalg/decompositions_test.py
+++ b/cirq-core/cirq/linalg/decompositions_test.py
@@ -733,7 +733,7 @@ def test_kak_decompose(unitary: np.ndarray) -> None:
     circuit = cirq.Circuit(kak._decompose_(cirq.LineQubit.range(2)))
     np.testing.assert_allclose(cirq.unitary(circuit), unitary, atol=1e-6)
     assert len(circuit) == 5
-    assert len(list(circuit.all_operations())) == 8
+    assert sum(1 for _ in circuit.all_operations()) == 8
 
 
 @cirq.testing.retry_once_with_later_random_values

--- a/cirq-core/cirq/ops/pauli_string_phasor.py
+++ b/cirq-core/cirq/ops/pauli_string_phasor.py
@@ -452,7 +452,7 @@ class PauliStringPhasorGate(raw_types.Gate):
 
 def xor_nonlocal_decompose(
     qubits: Iterable[raw_types.Qid], onto_qubit: cirq.Qid
-) -> Iterable[raw_types.Operation]:
+) -> Iterator[raw_types.Operation]:
     """Decomposition ignores connectivity."""
     for qubit in qubits:
         if qubit != onto_qubit:

--- a/cirq-core/cirq/ops/three_qubit_gates_test.py
+++ b/cirq-core/cirq/ops/three_qubit_gates_test.py
@@ -256,8 +256,8 @@ def test_identity_multiplication() -> None:
 )
 def test_decomposition_cost(op: cirq.Operation, max_two_cost: int) -> None:
     ops = tuple(cirq.flatten_op_tree(cirq.decompose(op)))
-    two_cost = len([e for e in ops if len(e.qubits) == 2])
-    over_cost = len([e for e in ops if len(e.qubits) > 2])
+    two_cost = sum(1 for e in ops if len(e.qubits) == 2)
+    over_cost = sum(1 for e in ops if len(e.qubits) > 2)
     assert over_cost == 0
     assert two_cost == max_two_cost
 

--- a/cirq-core/cirq/qis/channels_test.py
+++ b/cirq-core/cirq/qis/channels_test.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterator, Sequence
 
 import numpy as np
 import pytest
@@ -37,7 +37,7 @@ def apply_kraus_operators(kraus_operators: Sequence[np.ndarray], rho: np.ndarray
     return out
 
 
-def generate_standard_operator_basis(d_out: int, d_in: int) -> Iterable[np.ndarray]:
+def generate_standard_operator_basis(d_out: int, d_in: int) -> Iterator[np.ndarray]:
     for i in range(d_out):
         for j in range(d_in):
             e_ij = np.zeros((d_out, d_in))

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import abc
+import itertools
 import warnings
 from collections.abc import Iterator, Sequence
 from functools import cached_property
@@ -191,7 +192,8 @@ class StateVectorTrialResult(
             shape = final.shape
             size = np.prod(shape, dtype=np.int64)
             final = final.reshape(size)
-            if sum(1 for e in final if abs(e) > 0.001) < 16:
+            iter_from_16th = itertools.islice((e for e in final if abs(e) > 0.001), 15, None)
+            if next(iter_from_16th, None) is None:
                 state_vector = qis.dirac_notation(final, 3, qid_shape(substate.qubits))
             else:
                 state_vector = str(final)

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -191,7 +191,7 @@ class StateVectorTrialResult(
             shape = final.shape
             size = np.prod(shape, dtype=np.int64)
             final = final.reshape(size)
-            if len([1 for e in final if abs(e) > 0.001]) < 16:
+            if sum(1 for e in final if abs(e) > 0.001) < 16:
                 state_vector = qis.dirac_notation(final, 3, qid_shape(substate.qubits))
             else:
                 state_vector = str(final)

--- a/cirq-core/cirq/testing/random_circuit_test.py
+++ b/cirq-core/cirq/testing/random_circuit_test.py
@@ -137,8 +137,8 @@ def test_random_circuit_reproducible_between_runs() -> None:
 
 
 def test_random_two_qubit_circuit_with_czs() -> None:
-    num_czs = lambda circuit: len(
-        [o for o in circuit.all_operations() if isinstance(o.gate, cirq.CZPowGate)]
+    num_czs = lambda circuit: sum(
+        1 for o in circuit.all_operations() if isinstance(o.gate, cirq.CZPowGate)
     )
 
     c = cirq.testing.random_two_qubit_circuit_with_czs()

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -21,7 +21,7 @@ https://arxiv.org/abs/quant-ph/0406176
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import cast, TYPE_CHECKING
 
 import attrs
@@ -49,7 +49,7 @@ class _TwoQubitGate:
 
 def quantum_shannon_decomposition(
     qubits: Sequence[cirq.Qid], u: np.ndarray, atol: float = 1e-8
-) -> Iterable[cirq.Operation]:
+) -> Iterator[cirq.Operation]:
     """Decomposes n-qubit unitary 1-q, 2-q and GlobalPhase gates, preserving global phase.
 
     The gates used are CX/YPow/ZPow/CNOT/GlobalPhase/CZ/PhasedXZGate/PhasedXPowGate.
@@ -149,7 +149,7 @@ def quantum_shannon_decomposition(
     yield from cast(Iterable[ops.Operation], ops.flatten_op_tree(shannon_decomp))
 
 
-def _recursive_decomposition(qubits: Sequence[cirq.Qid], u: np.ndarray) -> Iterable[cirq.Operation]:
+def _recursive_decomposition(qubits: Sequence[cirq.Qid], u: np.ndarray) -> Iterator[cirq.Operation]:
     """Recursive step in the quantum shannon decomposition.
 
     Decomposes n-qubit unitary into generic 2-qubit gates, CNOT, CZ and 1-qubit gates.
@@ -226,7 +226,7 @@ def _global_phase_difference(u: np.ndarray, ops: list[cirq.Operation]) -> float:
     return np.angle(u[i, j]) - np.angle(new_unitary[i, j])
 
 
-def _single_qubit_decomposition(qubit: cirq.Qid, u: np.ndarray) -> Iterable[cirq.Operation]:
+def _single_qubit_decomposition(qubit: cirq.Qid, u: np.ndarray) -> Iterator[cirq.Operation]:
     """Decomposes single-qubit gate, and returns list of operations, keeping phase invariant.
 
     Args:
@@ -271,7 +271,7 @@ def _single_qubit_decomposition(qubit: cirq.Qid, u: np.ndarray) -> Iterable[cirq
 
 def _msb_demuxer(
     demux_qubits: Sequence[cirq.Qid], u1: np.ndarray, u2: np.ndarray
-) -> Iterable[cirq.Operation]:
+) -> Iterator[cirq.Operation]:
     """Demultiplexes a unitary matrix that is multiplexed in its most-significant-qubit.
 
     Decomposition structure:
@@ -337,7 +337,7 @@ def _nth_gray(n: int) -> int:
 
 def _multiplexed_cossin(
     cossin_qubits: Sequence[cirq.Qid], angles: list[float], rot_func: Callable = ops.ry
-) -> Iterable[cirq.Operation]:
+) -> Iterator[cirq.Operation]:
     """Performs a multiplexed rotation over all qubits in this unitary matrix,
 
     Uses ry and rz multiplexing for quantum shannon decomposition

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition_test.py
@@ -165,7 +165,7 @@ def test_cliffords(gate, num_ops) -> None:
     desired_unitary = cirq.unitary(gate)
     shannon_circuit = cirq.Circuit(quantum_shannon_decomposition((cirq.q(0),), desired_unitary))
     new_unitary = cirq.unitary(shannon_circuit)
-    assert len([*shannon_circuit.all_operations()]) == num_ops
+    assert sum(1 for _ in shannon_circuit.all_operations()) == num_ops
     if num_ops:
         np.testing.assert_allclose(new_unitary, desired_unitary)
 

--- a/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/three_qubit_decomposition_test.py
@@ -45,12 +45,10 @@ def test_three_qubit_matrix_to_operations(u) -> None:
     final_circuit = cirq.Circuit(operations)
     final_unitary = final_circuit.unitary(qubits_that_should_be_present=[a, b, c])
     cirq.testing.assert_allclose_up_to_global_phase(u, final_unitary, atol=1e-9)
-    num_two_qubit_gates = len(
-        [
-            op
-            for op in final_circuit.all_operations()
-            if isinstance(op.gate, (cirq.CZPowGate, cirq.CNotPowGate))
-        ]
+    num_two_qubit_gates = sum(
+        1
+        for op in final_circuit.all_operations()
+        if isinstance(op.gate, (cirq.CZPowGate, cirq.CNotPowGate))
     )
     assert num_two_qubit_gates <= 20, f"expected at most 20 CZ/CNOTs got {num_two_qubit_gates}"
 
@@ -83,7 +81,7 @@ def test_cs_to_ops(theta, num_czs) -> None:
     assert_almost_equal(circuit_cs.unitary(qubits_that_should_be_present=[a, b, c]), cs, 10)
 
     assert (
-        len([cz for cz in circuit_cs.all_operations() if isinstance(cz.gate, cirq.CZPowGate)])
+        sum(1 for cz in circuit_cs.all_operations() if isinstance(cz.gate, cirq.CZPowGate))
         == num_czs
     ), f"expected {num_czs} CZs got \n {circuit_cs} \n {circuit_cs.unitary()}"
 
@@ -175,12 +173,10 @@ def test_middle_multiplexor(angles, num_cnots) -> None:
         mid, circuit_u1u2_mid.unitary(qubits_that_should_be_present=[a, b, c])
     )
     assert (
-        len(
-            [
-                cnot
-                for cnot in circuit_u1u2_mid.all_operations()
-                if isinstance(cnot.gate, cirq.CNotPowGate)
-            ]
+        sum(
+            1
+            for cnot in circuit_u1u2_mid.all_operations()
+            if isinstance(cnot.gate, cirq.CNotPowGate)
         )
         == num_cnots
     ), f"expected {num_cnots} CNOTs got \n {circuit_u1u2_mid} \n {circuit_u1u2_mid.unitary()}"

--- a/cirq-core/cirq/transformers/measurement_transformers.py
+++ b/cirq-core/cirq/transformers/measurement_transformers.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import itertools
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any, cast, TYPE_CHECKING
 
 import numpy as np
@@ -172,7 +172,7 @@ def defer_measurements(
 def _all_possible_datastore_states(
     keys: Iterable[tuple[cirq.MeasurementKey, int]],
     measurement_qubits: dict[cirq.MeasurementKey, list[tuple[cirq.Qid, ...]]],
-) -> Iterable[cirq.ClassicalDataStoreReader]:
+) -> Iterator[cirq.ClassicalDataStoreReader]:
     """The Cartesian product of all possible DataStore states for the given keys."""
     # First we get the list of all possible values. So if we have a key mapped to qubits of shape
     # (2, 2) and a key mapped to a qutrit, the possible measurement values are:

--- a/cirq-core/cirq/transformers/routing/route_circuit_cqc_test.py
+++ b/cirq-core/cirq/transformers/routing/route_circuit_cqc_test.py
@@ -275,9 +275,7 @@ def test_empty_circuit() -> None:
     empty_circuit_routed = router(empty_circuit)
 
     device.validate_circuit(empty_circuit_routed)
-    assert len(list(empty_circuit.all_operations())) == len(
-        list(empty_circuit_routed.all_operations())
-    )
+    assert 0 == len(empty_circuit_routed)
 
 
 def test_directed_device_with_tag_inserted_swaps() -> None:

--- a/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/cz_gateset_test.py
@@ -170,7 +170,7 @@ def test_optimizes_single_iswap() -> None:
     c = cirq.Circuit(cirq.ISWAP(a, b))
     assert_optimization_not_broken(c)
     c = cirq.optimize_for_target_gateset(c, gateset=cirq.CZTargetGateset(), ignore_failures=False)
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 2
 
 
 def test_optimizes_tagged_partial_cz() -> None:
@@ -179,7 +179,7 @@ def test_optimizes_tagged_partial_cz() -> None:
     assert_optimization_not_broken(c)
     c = cirq.optimize_for_target_gateset(c, gateset=cirq.CZTargetGateset(), ignore_failures=False)
     assert (
-        len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
+        sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 2
     ), 'It should take 2 CZ gates to decompose a CZ**0.5 gate'
 
 

--- a/cirq-core/cirq/transformers/target_gatesets/sqrt_iswap_gateset_test.py
+++ b/cirq-core/cirq/transformers/target_gatesets/sqrt_iswap_gateset_test.py
@@ -305,7 +305,7 @@ def test_optimizes_single_iswap() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 2
 
 
 def test_optimizes_single_inv_sqrt_iswap() -> None:
@@ -315,7 +315,7 @@ def test_optimizes_single_inv_sqrt_iswap() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 1
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 1
 
 
 def test_optimizes_single_iswap_require0() -> None:
@@ -325,7 +325,7 @@ def test_optimizes_single_iswap_require0() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(required_sqrt_iswap_count=0), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 0
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 0
 
 
 def test_optimizes_single_iswap_require0_raises() -> None:
@@ -346,7 +346,7 @@ def test_optimizes_single_iswap_require1() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(required_sqrt_iswap_count=1), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 1
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 1
 
 
 def test_optimizes_single_iswap_require1_raises() -> None:
@@ -367,7 +367,7 @@ def test_optimizes_single_iswap_require2() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(required_sqrt_iswap_count=2), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 2
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 2
 
 
 def test_optimizes_single_iswap_require2_raises() -> None:
@@ -388,7 +388,7 @@ def test_optimizes_single_iswap_require3() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(required_sqrt_iswap_count=3), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 3
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 3
 
 
 def test_optimizes_single_inv_sqrt_iswap_require3() -> None:
@@ -398,4 +398,4 @@ def test_optimizes_single_inv_sqrt_iswap_require3() -> None:
     c = cirq.optimize_for_target_gateset(
         c, gateset=cirq.SqrtIswapTargetGateset(required_sqrt_iswap_count=3), ignore_failures=False
     )
-    assert len([1 for op in c.all_operations() if len(op.qubits) == 2]) == 3
+    assert sum(1 for op in c.all_operations() if len(op.qubits) == 2) == 3

--- a/cirq-core/cirq/transformers/transformer_primitives_test.py
+++ b/cirq-core/cirq/transformers/transformer_primitives_test.py
@@ -897,7 +897,7 @@ def test_merge_operations_complexity(op_density):
 
         wrapped_merge_func.num_function_calls = 0
         _ = cirq.merge_operations(circuit, wrapped_merge_func)
-        total_operations = len([*circuit.all_operations()])
+        total_operations = sum(1 for _ in circuit.all_operations())
         assert wrapped_merge_func.num_function_calls <= 2 * total_operations
 
 

--- a/cirq-core/cirq/value/angle.py
+++ b/cirq-core/cirq/value/angle.py
@@ -47,7 +47,7 @@ def chosen_angle_to_half_turns(
         ValueError: If more than one of `half_turn`, `rads`, or `degs` is given.
     """
 
-    if len([1 for e in [half_turns, rads, degs] if e is not None]) > 1:
+    if sum(1 for e in [half_turns, rads, degs] if e is not None) > 1:
         raise ValueError('Redundant angle specification. Use ONE of half_turns, rads, or degs.')
 
     if rads is not None:

--- a/cirq-core/cirq/value/linear_dict.py
+++ b/cirq-core/cirq/value/linear_dict.py
@@ -220,7 +220,7 @@ class LinearDict(Generic[TVector], MutableMapping[TVector, 'cirq.TParamValComple
         return snapshot._terms.__iter__()
 
     def __len__(self) -> int:
-        return len([v for v, c in self._terms.items() if c != 0])
+        return sum(1 for c in self._terms.values() if c != 0)
 
     def __iadd__(self, other: Self) -> Self:
         for vector, other_coefficient in other.items():

--- a/cirq-core/cirq/work/observable_measurement_data.py
+++ b/cirq-core/cirq/work/observable_measurement_data.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterator, Mapping
 from typing import Any, TYPE_CHECKING
 
 import numpy as np
@@ -298,7 +298,7 @@ class BitstringAccumulator:
         return len(self.bitstrings)
 
     @property
-    def results(self) -> Iterable[ObservableMeasuredResult]:
+    def results(self) -> Iterator[ObservableMeasuredResult]:
         """Yield individual setting results as `ObservableMeasuredResult`
         objects."""
         for setting in self._simul_settings:

--- a/cirq-google/cirq_google/engine/engine_validator.py
+++ b/cirq-google/cirq_google/engine/engine_validator.py
@@ -53,9 +53,9 @@ def _verify_reps(
     total_reps = 0
     for idx, sweep in enumerate(sweeps):
         if not isinstance(repetitions, int):
-            total_reps += len(list(cirq.to_resolvers(sweep))) * repetitions[idx]
+            total_reps += sum(1 for _ in cirq.to_resolvers(sweep)) * repetitions[idx]
         else:
-            total_reps += len(list(cirq.to_resolvers(sweep))) * repetitions
+            total_reps += sum(1 for _ in cirq.to_resolvers(sweep)) * repetitions
     if total_reps > max_repetitions:
         raise RuntimeError(
             'No requested processors currently support the number of requested total repetitions.'

--- a/cirq-google/cirq_google/engine/runtime_estimator.py
+++ b/cirq-google/cirq_google/engine/runtime_estimator.py
@@ -157,7 +157,7 @@ def estimate_run_sweep_time(
     """
     width = len(program.all_qubits())
     depth = len(program)
-    sweeps = len(list(cirq.to_resolvers(params)))
+    sweeps = sum(1 for _ in cirq.to_resolvers(params))
     return _estimate_run_time_seconds(width, depth, sweeps, repetitions, latency)
 
 
@@ -199,7 +199,7 @@ def estimate_run_batch_time(
             current_width = width
         total_depth += len(program)
         num_circuits += 1
-        total_sweeps += len(list(cirq.to_resolvers(params_list[idx])))
+        total_sweeps += sum(1 for _ in cirq.to_resolvers(params_list[idx]))
     if num_circuits > 0:
         total_time += _estimate_run_time_seconds(
             width, total_depth // num_circuits, total_sweeps, repetitions, 0.0

--- a/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
+++ b/cirq-google/cirq_google/transformers/target_gatesets/sycamore_gateset_test.py
@@ -160,7 +160,9 @@ def test_sycamore_gateset_compiles_swap_zz():
     compiled_circuit2 = cirq.optimize_for_target_gateset(circuit2, gateset=gateset)
     cirq.testing.assert_same_circuits(compiled_circuit1, compiled_circuit2)
     assert (
-        len(list(compiled_circuit1.findall_operations_with_gate_type(cirq_google.SycamoreGate)))
+        sum(
+            1 for _ in compiled_circuit1.findall_operations_with_gate_type(cirq_google.SycamoreGate)
+        )
         == 3
     )
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(

--- a/dev_tools/env_tools.py
+++ b/dev_tools/env_tools.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from typing import cast, TYPE_CHECKING
 
 from dev_tools import git_env_tools, shell_tools
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from dev_tools.github_repository import GithubRepository
 
 
-def get_unhidden_ungenerated_python_files(directory: str) -> Iterable[str]:
+def get_unhidden_ungenerated_python_files(directory: str) -> Iterator[str]:
     """Iterates through relevant python files within the given directory.
 
     Args:

--- a/examples/bell_inequality.py
+++ b/examples/bell_inequality.py
@@ -85,7 +85,7 @@ def main():
     x = np.array(result.measurements['x'][:, 0])
     y = np.array(result.measurements['y'][:, 0])
     outcomes = a ^ b == x & y
-    win_percent = sum(1 for e in outcomes if e) * 100 / repetitions
+    win_percent = np.count_nonzero(outcomes) * 100 / repetitions
 
     # Print data.
     print()

--- a/examples/bell_inequality.py
+++ b/examples/bell_inequality.py
@@ -85,7 +85,7 @@ def main():
     x = np.array(result.measurements['x'][:, 0])
     y = np.array(result.measurements['y'][:, 0])
     outcomes = a ^ b == x & y
-    win_percent = len([e for e in outcomes if e]) * 100 / repetitions
+    win_percent = sum(1 for e in outcomes if e) * 100 / repetitions
 
     # Print data.
     print()


### PR DESCRIPTION
Replace `len(list(ii))` with `sum(1 for _ in ii)`.

Also refine return-type annotations for generator functions.
Specifically, these return `Iterator` rather than an `Iterable`.
