### PR TITLE
Fix API docstring math and ASCII rendering

### DIFF
--- a/cirq-core/cirq/ops/uniform_superposition_gate.py
+++ b/cirq-core/cirq/ops/uniform_superposition_gate.py
@@ -30,9 +30,13 @@ if TYPE_CHECKING:
 
 @value.value_equality
 class UniformSuperpositionGate(raw_types.Gate):
-    r"""Creates a uniform superposition state on the states $[0, M)$
-    The gate creates the state $\frac{1}{\sqrt{M}}\sum_{j=0}^{M-1}\ket{j}$
-    (where $1\leq M \leq 2^n$), using n qubits, according to the Shukla-Vedula algorithm [SV24].
+    r"""Creates a uniform superposition state on the states $[0, M)$.
+
+    The gate creates the state
+    $$\frac{1}{\sqrt{M}}\sum_{j=0}^{M-1}|j\rangle$$
+    (where $1 \leq M \leq 2^n$), using n qubits, according to the
+    Shukla-Vedula algorithm [SV24].
+
     References:
         [SV24]
         [An efficient quantum algorithm for preparation of uniform quantum superposition

--- a/cirq-core/cirq/ops/uniform_superposition_gate.py
+++ b/cirq-core/cirq/ops/uniform_superposition_gate.py
@@ -33,7 +33,9 @@ class UniformSuperpositionGate(raw_types.Gate):
     r"""Creates a uniform superposition state on the states $[0, M)$.
 
     The gate creates the state
-    $$\frac{1}{\sqrt{M}}\sum_{j=0}^{M-1}|j\rangle$$
+    $$
+    \frac{1}{\sqrt{M}}\sum_{j=0}^{M-1}|j\rangle
+    $$
     (where $1 \leq M \leq 2^n$), using n qubits, according to the
     Shukla-Vedula algorithm [SV24].
 

--- a/cirq-core/cirq/vis/histogram.py
+++ b/cirq-core/cirq/vis/histogram.py
@@ -41,17 +41,17 @@ def integrated_histogram(
     Suppose the input is a list of gate fidelities. The x-axis of the plot will
     be gate fidelity, and the y-axis will be the probability that a random gate
     fidelity from the list is less than the x-value. It will look something like
-    this
+    this:
 
-    1.0
-    |              |
-    |           ___|
-    |           |
-    |       ____|
-    |      |
-    |      |
-    |_____|_______________
-    0.0
+        1.0
+        |              |
+        |           ___|
+        |           |
+        |       ____|
+        |      |
+        |      |
+        |_____|_______________
+        0.0
 
     Another way of saying this is that we assume the probability distribution
     function (pdf) of gate fidelities is a set of equally weighted delta


### PR DESCRIPTION
Replace nonstandard `\ket` with `|j\rangle` so the UniformSuperpositionGate formula renders correctly, and indent the integrated_histogram ASCII sketch as a Markdown code block so it does not collapse to one line in the docs.

Fixes #8212
Fixes #8211