### PR TITLE
Reapply "Keep TLS certificate verification on in PasqalSampler requests (#8209)"

### DIFF
--- a/cirq-pasqal/cirq_pasqal/pasqal_sampler.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_sampler.py
@@ -68,7 +68,7 @@ class PasqalSampler(cirq.work.Sampler):
 
         url = f'{self.remote_host}/get-result/{task_id}'
         while True:
-            response = requests.get(url, headers=self._authorization_header, verify=False)
+            response = requests.get(url, headers=self._authorization_header)
             response.raise_for_status()
 
             result = response.text
@@ -90,7 +90,6 @@ class PasqalSampler(cirq.work.Sampler):
         simulate_url = f'{self.remote_host}/simulate/no-noise/submit'
         submit_response = requests.post(
             simulate_url,
-            verify=False,
             headers={"Repetitions": str(repetitions), **self._authorization_header},
             data=serialization_str,
         )

--- a/cirq-pasqal/cirq_pasqal/pasqal_sampler_test.py
+++ b/cirq-pasqal/cirq_pasqal/pasqal_sampler_test.py
@@ -107,3 +107,8 @@ def test_run_sweep(mock_post, mock_get):
     assert cirq.read_json(json_text=submitted_json) == ex_circuit_odd
     assert mock_post.call_count == 2
     assert data[1] == ex_circuit_odd
+
+    # The access token rides in the Authorization header of every request below,
+    # so none of them may turn off TLS certificate verification.
+    for call in [*mock_post.call_args_list, *mock_get.call_args_list]:
+        assert call[1].get('verify', True) is not False


### PR DESCRIPTION
Roll forward #8209 - we have confirmation this change is good per
https://github.com/quantumlib/Cirq/pull/8209#issuecomment-5191646803

This reverts commit 9e53613b0ca8e65fbbbb2c8157a0a5e07e497707.
