### PR TITLE
Only check cirq.Gate's against the device's gateset.

### DIFF
--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -770,7 +770,9 @@ class GridDevice(cirq.Device):
         qubits = self._metadata.qubit_set
         for operation in operations:
             op_qubits = operation.qubits
-            if operation not in gateset:
+            if (
+                isinstance(operation, cirq.Gate) or isinstance(operation.gate, cirq.Gate)
+            ) and operation not in gateset:
                 raise ValueError(f'Operation {operation} contains a gate which is not supported.')
 
             for q in op_qubits:

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -516,6 +516,47 @@ def test_grid_device_validate_operations_negative():
             cirq.testing.DoesNotSupportSerializationGate()(device_info.grid_qubits[0])
         )
 
+    class CustomNonGateOp(cirq.Operation):
+        def __init__(self, qubits):
+            self._qubits = tuple(qubits)
+
+        @property
+        def qubits(self):
+            return self._qubits
+
+        def with_qubits(self, *new_qubits):
+            return CustomNonGateOp(new_qubits)
+
+    # Non-gate operation on valid qubits passes validation without gateset check
+    device.validate_operation(CustomNonGateOp([device_info.grid_qubits[0]]))
+    device.validate_operation(
+        CustomNonGateOp([device_info.grid_qubits[0], device_info.grid_qubits[1]])
+    )
+
+    # Non-gate operation on invalid qubits or invalid pair still fails
+    with pytest.raises(ValueError, match='Qubit not on device'):
+        device.validate_operation(CustomNonGateOp([bad_qubit]))
+    with pytest.raises(ValueError, match='Qubit pair is not valid'):
+        device.validate_operation(CustomNonGateOp([q00, q10]))
+
+    class CustomGateOp(cirq.Operation, cirq.Gate):
+        def __init__(self, qubits):
+            self._qubits = tuple(qubits)
+
+        @property
+        def qubits(self):
+            return self._qubits
+
+        def with_qubits(self, *new_qubits):
+            return CustomGateOp(new_qubits)
+
+        def num_qubits(self) -> int:
+            return len(self._qubits)
+
+    # Operation subclassing Gate is checked against gateset and fails if not in gateset
+    with pytest.raises(ValueError, match='gate which is not supported'):
+        device.validate_operation(CustomGateOp([device_info.grid_qubits[0]]))
+
 
 def test_grid_device_validate_operation_coupler_for_horizontal_couplings():
     """Tests coupler device on a device spec that only

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -525,7 +525,7 @@ def test_grid_device_validate_operations_negative():
             return self._qubits
 
         def with_qubits(self, *new_qubits):
-            return CustomNonGateOp(new_qubits)
+            raise NotImplementedError
 
     # Non-gate operation on valid qubits passes validation without gateset check
     device.validate_operation(CustomNonGateOp([device_info.grid_qubits[0]]))
@@ -539,7 +539,7 @@ def test_grid_device_validate_operations_negative():
     with pytest.raises(ValueError, match='Qubit pair is not valid'):
         device.validate_operation(CustomNonGateOp([q00, q10]))
 
-    class CustomGateOp(cirq.Operation, cirq.Gate):
+    class CustomGateOp(cirq.Operation, cirq.Gate):  # type: ignore[misc]
         def __init__(self, qubits):
             self._qubits = tuple(qubits)
 
@@ -548,10 +548,7 @@ def test_grid_device_validate_operations_negative():
             return self._qubits
 
         def with_qubits(self, *new_qubits):
-            return CustomGateOp(new_qubits)
-
-        def num_qubits(self) -> int:
-            return len(self._qubits)
+            raise NotImplementedError
 
     # Operation subclassing Gate is checked against gateset and fails if not in gateset
     with pytest.raises(ValueError, match='gate which is not supported'):


### PR DESCRIPTION
We should only validate against a grid device's gateset if the `cirq.Operation` subclasses `cirq.Gate`. This will allow us to use `stimcirq.DetAnnotation`s and other annotations in circuits for execution on hardware. 