### PR TITLE
Add multiply method to LineQid and GridQid

### DIFF
--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -153,16 +153,14 @@ class _BaseGridQid(ops.Qid):
                     f"Got {self.dimension} and {other.dimension}"
                 )
             return self._with_row_col(row=self._row + other._row, col=self._col + other._col)
-        if not (
-            isinstance(other, (tuple, np.ndarray))
-            and len(other) == 2
-            and all(isinstance(x, (int, np.integer)) for x in other)
-        ):
-            raise TypeError(
-                'Can only add integer tuples of length 2 to '
-                f'{type(self).__name__}. Instead was {other}'
-            )
-        return self._with_row_col(row=self._row + other[0], col=self._col + other[1])
+        if isinstance(other, (tuple, np.ndarray)):
+            if not (len(other) == 2 and all(isinstance(x, (int, np.integer)) for x in other)):
+                raise TypeError(
+                    'Can only add integer tuples of length 2 to '
+                    f'{type(self).__name__}. Instead was {other}'
+                )
+            return self._with_row_col(row=self._row + other[0], col=self._col + other[1])
+        return NotImplemented
 
     def __sub__(self, other: tuple[int, int] | Self) -> Self:
         if isinstance(other, _BaseGridQid):
@@ -172,22 +170,42 @@ class _BaseGridQid(ops.Qid):
                     f"Got {self.dimension} and {other.dimension}"
                 )
             return self._with_row_col(row=self._row - other._row, col=self._col - other._col)
-        if not (
-            isinstance(other, (tuple, np.ndarray))
-            and len(other) == 2
-            and all(isinstance(x, (int, np.integer)) for x in other)
-        ):
-            raise TypeError(
-                "Can only subtract integer tuples of length 2 to "
-                f"{type(self).__name__}. Instead was {other}"
-            )
-        return self._with_row_col(row=self._row - other[0], col=self._col - other[1])
+        if isinstance(other, (tuple, np.ndarray)):
+            if not (len(other) == 2 and all(isinstance(x, (int, np.integer)) for x in other)):
+                raise TypeError(
+                    "Can only subtract integer tuples of length 2 from "
+                    f"{type(self).__name__}. Instead was {other}"
+                )
+            return self._with_row_col(row=self._row - other[0], col=self._col - other[1])
+        return NotImplemented
+
+    def __mul__(self, other: tuple[int, int] | int | Self) -> Self:
+        if isinstance(other, _BaseGridQid):
+            if self.dimension != other.dimension:
+                raise TypeError(
+                    "Can only multiply GridQids with identical dimension. "
+                    f"Got {self.dimension} and {other.dimension}"
+                )
+            return self._with_row_col(row=self._row * other._row, col=self._col * other._col)
+        if isinstance(other, int):
+            return self._with_row_col(row=self._row * other, col=self._col * other)
+        if isinstance(other, (tuple, np.ndarray)):
+            if not (len(other) == 2 and all(isinstance(x, (int, np.integer)) for x in other)):
+                raise TypeError(
+                    f'Can only multiply {type(self).__name__} by integers, integer '
+                    f'tuples of length 2, and {type(self).__name__}. Instead was {other}'
+                )
+            return self._with_row_col(row=self._row * other[0], col=self._col * other[1])
+        return NotImplemented
 
     def __radd__(self, other: tuple[int, int]) -> Self:
-        return self + other
+        return self.__add__(other)
 
     def __rsub__(self, other: tuple[int, int]) -> Self:
-        return -self + other
+        return (-self).__add__(other)
+
+    def __rmul__(self, other: tuple[int, int] | int) -> Self:
+        return self.__mul__(other)
 
     def __neg__(self) -> Self:
         return self._with_row_col(row=-self._row, col=-self._col)

--- a/cirq-core/cirq/devices/grid_qubit_test.py
+++ b/cirq-core/cirq/devices/grid_qubit_test.py
@@ -313,7 +313,7 @@ def test_addition_subtraction_numpy_array(dtype) -> None:
 
 def test_unsupported_add() -> None:
     # ruff: disable[RUF005]
-    with pytest.raises(TypeError, match='1'):
+    with pytest.raises(TypeError, match='unsupported operand type'):
         _ = cirq.GridQubit(1, 1) + 1  # type: ignore[operator]
     with pytest.raises(TypeError, match='(1,)'):
         _ = cirq.GridQubit(1, 1) + (1,)  # type: ignore[operator]
@@ -322,8 +322,10 @@ def test_unsupported_add() -> None:
     with pytest.raises(TypeError, match='(1, 2.0)'):
         _ = cirq.GridQubit(1, 1) + (1, 2.0)  # type: ignore[operator]
 
-    with pytest.raises(TypeError, match='1'):
+    with pytest.raises(TypeError, match='unsupported operand type'):
         _ = cirq.GridQubit(1, 1) - 1  # type: ignore[operator]
+    with pytest.raises(TypeError, match='(1,)'):
+        _ = cirq.GridQubit(1, 1) - (1,)  # type: ignore[operator]
 
     with pytest.raises(TypeError, match='[1., 2.]'):
         _ = cirq.GridQubit(1, 1) + np.array([1.0, 2.0])
@@ -332,20 +334,81 @@ def test_unsupported_add() -> None:
 
 
 def test_addition_subtraction_type_error() -> None:
-    with pytest.raises(TypeError, match="bort"):
+    with pytest.raises(TypeError, match="unsupported operand type"):
         _ = cirq.GridQubit(5, 3) + "bort"  # type: ignore[operator]
-    with pytest.raises(TypeError, match="bort"):
+    with pytest.raises(TypeError, match="unsupported operand type"):
         _ = cirq.GridQubit(5, 3) - "bort"  # type: ignore[operator]
 
-    with pytest.raises(TypeError, match="bort"):
+    with pytest.raises(TypeError, match="unsupported operand type"):
         _ = cirq.GridQid(5, 3, dimension=3) + "bort"  # type: ignore[operator]
-    with pytest.raises(TypeError, match="bort"):
+    with pytest.raises(TypeError, match="unsupported operand type"):
         _ = cirq.GridQid(5, 3, dimension=3) - "bort"  # type: ignore[operator]
 
     with pytest.raises(TypeError, match="Can only add GridQids with identical dimension."):
         _ = cirq.GridQid(5, 3, dimension=3) + cirq.GridQid(3, 5, dimension=4)
     with pytest.raises(TypeError, match="Can only subtract GridQids with identical dimension."):
         _ = cirq.GridQid(5, 3, dimension=3) - cirq.GridQid(3, 5, dimension=4)
+
+
+def test_multiplication() -> None:
+    # GridQubits
+    assert cirq.GridQubit(1, 2) * (3, 4) == cirq.GridQubit(3, 8)
+    assert cirq.GridQubit(1, 2) * (0, 0) == cirq.GridQubit(0, 0)
+    assert cirq.GridQubit(1, 2) * cirq.GridQubit(-3, 4) == cirq.GridQubit(-3, 8)
+
+    assert cirq.GridQubit(1, 2) * 3 == cirq.GridQubit(3, 6)
+    assert 3 * cirq.GridQubit(1, 2) == cirq.GridQubit(3, 6)
+
+    # GridQids
+    assert cirq.GridQid(5, 4, dimension=3) * (2, 3) == cirq.GridQid(10, 12, dimension=3)
+    assert cirq.GridQid(1, 2, dimension=3) * (0, 0) == cirq.GridQid(0, 0, dimension=3)
+    assert cirq.GridQid(2, 6, dimension=3) * cirq.GridQid(3, -2, dimension=3) == cirq.GridQid(
+        6, -12, dimension=3
+    )
+
+    assert (1, 5) * cirq.GridQid(3, 4, dimension=3) == cirq.GridQid(3, 20, dimension=3)
+
+    assert 2 * cirq.GridQid(3, 4, dimension=3) == cirq.GridQid(6, 8, dimension=3)
+    assert cirq.GridQid(3, 4, dimension=3) * 2 == cirq.GridQid(6, 8, dimension=3)
+
+
+@pytest.mark.parametrize('dtype', (np.int8, np.int16, np.int32, np.int64, int))
+def test_multiplication_numpy_array(dtype) -> None:
+    assert cirq.GridQubit(1, 2) * np.array([1, 2], dtype=dtype) == cirq.GridQubit(1, 4)
+    assert cirq.GridQubit(1, 2) * np.array([0, 0], dtype=dtype) == cirq.GridQubit(0, 0)
+    assert cirq.GridQubit(1, 2) * np.array([-1, 0], dtype=dtype) == cirq.GridQubit(-1, 0)
+
+    assert cirq.GridQid(1, 2, dimension=3) * np.array([-1, 0], dtype=dtype) == cirq.GridQid(
+        -1, 0, dimension=3
+    )
+    assert cirq.GridQid(1, 2, dimension=3) * np.array([3, 4], dtype=dtype) == cirq.GridQid(
+        3, 8, dimension=3
+    )
+
+
+def test_unsupported_multiplication() -> None:
+    with pytest.raises(TypeError, match='(1,)'):
+        _ = cirq.GridQubit(1, 1) * (1,)  # type: ignore[operator]
+    with pytest.raises(TypeError, match='(1, 2, 3)'):
+        _ = cirq.GridQubit(1, 1) * (1, 2, 3)  # type: ignore[operator]
+    with pytest.raises(TypeError, match='(1, 2.0)'):
+        _ = cirq.GridQubit(1, 1) * (1, 2.0)  # type: ignore[operator]
+
+    with pytest.raises(TypeError, match='[1., 2.]'):
+        _ = cirq.GridQubit(1, 1) * np.array([1.0, 2.0])
+    with pytest.raises(TypeError, match='[1, 2, 3]'):
+        _ = cirq.GridQubit(1, 1) * np.array([1, 2, 3], dtype=int)
+
+
+def test_multiplication_type_error() -> None:
+    with pytest.raises(TypeError, match="can't multiply"):
+        _ = cirq.GridQubit(5, 3) * "bort"  # type: ignore[operator]
+
+    with pytest.raises(TypeError, match="can't multiply"):
+        _ = cirq.GridQid(5, 3, dimension=3) * "bort"  # type: ignore[operator]
+
+    with pytest.raises(TypeError, match="Can only multiply GridQids with identical dimension."):
+        _ = cirq.GridQid(5, 3, dimension=3) * cirq.GridQid(3, 5, dimension=4)
 
 
 def test_neg() -> None:

--- a/cirq-core/cirq/devices/line_qubit.py
+++ b/cirq-core/cirq/devices/line_qubit.py
@@ -130,9 +130,10 @@ class _BaseLineQid(ops.Qid):
                     f"Got {self._dimension} and {other._dimension}"
                 )
             return self._with_x(x=self._x + other._x)
-        if not isinstance(other, int):
-            raise TypeError(f"Can only add ints and {type(self).__name__}. Instead was {other}")
-        return self._with_x(self._x + other)
+        if isinstance(other, int):
+            return self._with_x(self._x + other)
+
+        return NotImplemented
 
     def __sub__(self, other: int | Self) -> Self:
         if isinstance(other, _BaseLineQid):
@@ -142,20 +143,37 @@ class _BaseLineQid(ops.Qid):
                     f"Got {self._dimension} and {other._dimension}"
                 )
             return self._with_x(x=self._x - other._x)
-        if not isinstance(other, int):
-            raise TypeError(
-                f"Can only subtract ints and {type(self).__name__}. Instead was {other}"
-            )
-        return self._with_x(self._x - other)
+        if isinstance(other, int):
+            return self._with_x(self._x - other)
+
+        return NotImplemented
+
+    def __mul__(self, other: int | Self) -> Self:
+        if isinstance(other, _BaseLineQid):
+            if self._dimension != other._dimension:
+                raise TypeError(
+                    'Can only multiply LineQids with identical dimension. '
+                    f'Got {self._dimension} and {other._dimension}'
+                )
+            return self._with_x(x=self._x * other._x)
+        if isinstance(other, int):
+            return self._with_x(self._x * other)
+
+        return NotImplemented
 
     def __radd__(self, other: int) -> Self:
-        return self + other
+        return self.__add__(other)
 
     def __rsub__(self, other: int) -> Self:
-        return -self + other
+        if isinstance(other, int):
+            return self._with_x(other - self._x)
+        return NotImplemented
 
     def __neg__(self) -> Self:
         return self._with_x(-self._x)
+
+    def __rmul__(self, other: int) -> Self:
+        return self.__mul__(other)
 
     def __complex__(self) -> complex:
         return complex(self._x)

--- a/cirq-core/cirq/devices/line_qubit_test.py
+++ b/cirq-core/cirq/devices/line_qubit_test.py
@@ -202,14 +202,14 @@ def test_addition_subtraction() -> None:
 
 
 def test_addition_subtraction_type_error() -> None:
-    with pytest.raises(TypeError, match='dave'):
+    with pytest.raises(TypeError, match='unsupported operand type'):
         _ = cirq.LineQubit(1) + 'dave'  # type: ignore[operator]
-    with pytest.raises(TypeError, match='dave'):
+    with pytest.raises(TypeError, match='unsupported operand type'):
         _ = cirq.LineQubit(1) - 'dave'  # type: ignore[operator]
 
-    with pytest.raises(TypeError, match='dave'):
+    with pytest.raises(TypeError, match='unsupported operand type'):
         _ = cirq.LineQid(1, 3) + 'dave'  # type: ignore[operator]
-    with pytest.raises(TypeError, match='dave'):
+    with pytest.raises(TypeError, match='unsupported operand type'):
         _ = cirq.LineQid(1, 3) - 'dave'  # type: ignore[operator]
 
     with pytest.raises(TypeError, match="Can only add LineQids with identical dimension."):
@@ -217,6 +217,29 @@ def test_addition_subtraction_type_error() -> None:
 
     with pytest.raises(TypeError, match="Can only subtract LineQids with identical dimension."):
         _ = cirq.LineQid(5, dimension=3) - cirq.LineQid(3, dimension=4)
+
+
+def test_multiplication() -> None:
+    assert cirq.LineQubit(3) * 2 == cirq.LineQubit(6)
+    assert 2 * cirq.LineQubit(4) == cirq.LineQubit(8)
+
+    assert cirq.LineQid(2, 3) * 4 == cirq.LineQid(8, 3)
+    assert 4 * cirq.LineQid(2, 3) == cirq.LineQid(8, 3)
+
+    assert cirq.LineQid(3, dimension=3) * cirq.LineQid(4, dimension=3) == cirq.LineQid(
+        12, dimension=3
+    )
+
+
+def test_multiplication_type_error() -> None:
+    with pytest.raises(TypeError, match='can\'t multiply'):
+        _ = cirq.LineQubit(1) * 'dave'  # type: ignore[operator]
+
+    with pytest.raises(TypeError, match='can\'t multiply'):
+        _ = cirq.LineQid(1, 3) * 'dave'  # type: ignore[operator]
+
+    with pytest.raises(TypeError, match="Can only multiply LineQids with identical dimension."):
+        _ = cirq.LineQid(5, dimension=3) * cirq.LineQid(3, dimension=4)
 
 
 def test_neg() -> None:

--- a/cirq-core/cirq/study/resolver.py
+++ b/cirq-core/cirq/study/resolver.py
@@ -175,6 +175,8 @@ class ParamResolver:
         # we wouldn't need the following block.
         if isinstance(value, sympy.Float):
             return float(value)
+        if isinstance(value, sympy.Integer):
+            return int(value)
         if isinstance(value, sympy.Add):
             summation = self.value_of(value.args[0], recursive)
             for addend in value.args[1:]:
@@ -213,6 +215,8 @@ class ParamResolver:
                 # Technically, this should not return complex, but changing
                 # type signature to complex would cause many cascading issues
                 return complex(v)
+            elif v.is_integer:
+                return int(v)
             else:
                 return float(v)
 


### PR DESCRIPTION
Adds the `__mul__` method to LineQid and GridQid which supports multiplying by 
another LineQid/GridQid or an integer. The `__add__` and `__sub__` methods are also
changed to return NotImplemented to adhere with PEP guidelines. This is 
prefactoring needed for the addition of VariableQid.