### PR TITLE
ruff - enable the UP045 (non-pep604-annotation-optional) rule

### DIFF
--- a/cirq-core/cirq/experiments/qubit_characterizations.py
+++ b/cirq-core/cirq/experiments/qubit_characterizations.py
@@ -18,7 +18,7 @@ import dataclasses
 import functools
 import itertools
 from collections.abc import Iterator, Mapping, Sequence
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 import attrs
 import numpy as np
@@ -76,7 +76,7 @@ class RandomizedBenchMarkResult:
         self,
         num_cliffords: Sequence[int],
         ground_state_probabilities: Sequence[float],
-        ground_state_probabilities_std: Optional[Sequence[float]] | None = None,
+        ground_state_probabilities_std: Sequence[float] | None = None,
     ):
         """Inits RandomizedBenchMarkResult.
 

--- a/cirq-core/cirq/testing/deprecation.py
+++ b/cirq-core/cirq/testing/deprecation.py
@@ -41,7 +41,7 @@ def assert_deprecated(*msgs: str, deadline: str, count: int | None = 1) -> Itera
     from cirq.testing import assert_logs
 
     orig_exist = ALLOW_DEPRECATION_IN_TEST in os.environ
-    orig_value = os.environ.get(ALLOW_DEPRECATION_IN_TEST, None)
+    orig_value = os.environ.get(ALLOW_DEPRECATION_IN_TEST, '')
     os.environ[ALLOW_DEPRECATION_IN_TEST] = 'True'
     try:
         with assert_logs(
@@ -50,8 +50,6 @@ def assert_deprecated(*msgs: str, deadline: str, count: int | None = 1) -> Itera
             yield
     finally:
         if orig_exist:
-            # mypy can't resolve that orig_exist ensures that orig_value
-            # of type Optional[str] can't be None
-            os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value  # type: ignore[assignment]
+            os.environ[ALLOW_DEPRECATION_IN_TEST] = orig_value
         else:
             del os.environ[ALLOW_DEPRECATION_IN_TEST]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ select = [
     "UP034",  # extraneous-parentheses
     "UP035",  # deprecated-import
     "UP037",  # quoted-annotation
+    "UP045",  # non-pep604-annotation-optional
     "W605",  # invalid-escape-sequence, pylint anomalous-backslash-in-string
 ]
 


### PR DESCRIPTION
And fix one instance of a leftover `Optional` annotation.

Ref: https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional
