### PR TITLE
Ensure CircuitOperations and controlled operations are validated agai…

### DIFF
--- a/cirq-google/cirq_google/devices/grid_device.py
+++ b/cirq-google/cirq_google/devices/grid_device.py
@@ -771,7 +771,17 @@ class GridDevice(cirq.Device):
         for operation in operations:
             op_qubits = operation.qubits
             if (
-                isinstance(operation, cirq.Gate) or isinstance(operation.gate, cirq.Gate)
+                isinstance(operation, cirq.Gate)
+                or isinstance(operation.gate, cirq.Gate)
+                or isinstance(
+                    operation.untagged,
+                    (
+                        cirq.CircuitOperation,
+                        cirq.ClassicallyControlledOperation,
+                        cirq.ControlledOperation,
+                    ),
+                )
+                or bool(operation.classical_controls)
             ) and operation not in gateset:
                 raise ValueError(f'Operation {operation} contains a gate which is not supported.')
 

--- a/cirq-google/cirq_google/devices/grid_device_test.py
+++ b/cirq-google/cirq_google/devices/grid_device_test.py
@@ -516,6 +516,29 @@ def test_grid_device_validate_operations_negative():
             cirq.testing.DoesNotSupportSerializationGate()(device_info.grid_qubits[0])
         )
 
+    # Nested circuit with unsupported gate
+    q01 = device_info.grid_qubits[1]
+    nested_unsupported = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.CNOT(q00, q01)))
+    with pytest.raises(ValueError, match='gate which is not supported'):
+        device.validate_operation(nested_unsupported)
+    with pytest.raises(ValueError, match='gate which is not supported'):
+        device.validate_circuit(cirq.Circuit(nested_unsupported))
+
+    # Nested circuit with supported gate passes validation
+    nested_supported = cirq.CircuitOperation(cirq.FrozenCircuit(cirq.CZ(q00, q01), cirq.X(q00)))
+    device.validate_operation(nested_supported)
+    device.validate_circuit(cirq.Circuit(nested_supported))
+
+    # Supported gate with unsupported classical controls
+    with pytest.raises(ValueError, match='gate which is not supported'):
+        device.validate_operation(cirq.X(q00).with_classical_controls('m'))
+    with pytest.raises(ValueError, match='gate which is not supported'):
+        device.validate_circuit(cirq.Circuit(cirq.X(q00).with_classical_controls('m')))
+
+    # Unsupported gate with classical controls
+    with pytest.raises(ValueError, match='gate which is not supported'):
+        device.validate_operation(cirq.CNOT(q00, q01).with_classical_controls('m'))
+
     class CustomNonGateOp(cirq.Operation):
         def __init__(self, qubits):
             self._qubits = tuple(qubits)


### PR DESCRIPTION
PR #8265 restricted gateset validation to operations subclassing Gate or with operation.gate. However, CircuitOperation, ClassicallyControlledOperation, and other controlled operations have `op.gate == None` and were unintentionally bypassing gateset validation in GridDevice.

This updates GridDevice._validate_operations to check CircuitOperation, ClassicallyControlledOperation, ControlledOperation, and operations with classical controls against the gateset, while still allowing non-gate metadata annotations to bypass gateset validation.