### PR TITLE
CI - use shallow repo clone for build_protos and shellcheck jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,6 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
       - name: Run shellcheck
         run: check/shellcheck
   yamllint:
@@ -260,8 +258,6 @@ jobs:
     steps:
       - name: Check out source repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
       - name: Set up Python environment
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
The Cirq git history is not used in `Build protos` and
`Shell check` jobs.  They can do with the default shallow clone.
