### PR TITLE
Deprecate the cirq-web sub-package

### DIFF
--- a/cirq-web/README.md
+++ b/cirq-web/README.md
@@ -1,4 +1,12 @@
 <div align="center">
+
+| ⚠️ WARNING |
+|:----------:|
+| cirq-web is deprecated.  For more details or to provide feedback see https://github.com/quantumlib/Cirq/issues/8168 |
+
+</div>
+
+<div align="center">
 <img width="200px" alt="Cirq logo"
 src="https://raw.githubusercontent.com/quantumlib/Cirq/refs/heads/main/docs/images/Cirq_logo_color.svg">
 </div>

--- a/cirq-web/cirq_web/bloch_sphere/bloch_sphere.py
+++ b/cirq-web/cirq_web/bloch_sphere/bloch_sphere.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 import cirq
 from cirq_web import widget
+from cirq_web.deprecation import deprecated_cirq_web_class
 
 
+@deprecated_cirq_web_class
 class BlochSphere(widget.Widget):
     def __init__(self, sphere_radius: int = 5, state_vector: cirq.STATE_VECTOR_LIKE | None = None):
         """Initializes a BlochSphere.

--- a/cirq-web/cirq_web/bloch_sphere/bloch_sphere_test.py
+++ b/cirq-web/cirq_web/bloch_sphere/bloch_sphere_test.py
@@ -21,25 +21,30 @@ import pytest
 
 import cirq
 import cirq_web
+from cirq_web.deprecation import assert_deprecated_cirq_web_warning
 
 
+@assert_deprecated_cirq_web_warning
 def test_init_bloch_sphere_type() -> None:
     bloch_sphere = cirq_web.BlochSphere(state_vector=[1 / math.sqrt(2), 1 / math.sqrt(2)])
     assert isinstance(bloch_sphere, cirq_web.BlochSphere)
 
 
+@assert_deprecated_cirq_web_warning
 @pytest.mark.parametrize('sphere_radius', [5, 0.2, 100])
 def test_valid_bloch_sphere_radius(sphere_radius) -> None:
     bloch_sphere = cirq_web.BlochSphere(sphere_radius, [1 / math.sqrt(2), 1 / math.sqrt(2)])
     assert sphere_radius == bloch_sphere.sphere_radius
 
 
+@assert_deprecated_cirq_web_warning
 @pytest.mark.parametrize('sphere_radius', [0, -1])
 def test_invalid_bloch_sphere_radius(sphere_radius) -> None:
     with pytest.raises(ValueError):
         cirq_web.BlochSphere(sphere_radius=sphere_radius)
 
 
+@assert_deprecated_cirq_web_warning
 def test_valid_bloch_sphere_vector() -> None:
     state_vector = np.array([1 / math.sqrt(2), 1 / math.sqrt(2)])
     bloch_sphere = cirq_web.BlochSphere(state_vector=state_vector)
@@ -47,11 +52,13 @@ def test_valid_bloch_sphere_vector() -> None:
     assert np.array_equal(bloch_vector, bloch_sphere.bloch_vector)
 
 
+@assert_deprecated_cirq_web_warning
 def test_no_state_vector_given() -> None:
     with pytest.raises(ValueError):
         cirq_web.BlochSphere()
 
 
+@assert_deprecated_cirq_web_warning
 def test_bloch_sphere_default_client_code() -> None:
     bloch_sphere = cirq_web.BlochSphere(state_vector=[1 / math.sqrt(2), 1 / math.sqrt(2)])
 
@@ -65,6 +72,7 @@ def test_bloch_sphere_default_client_code() -> None:
     assert expected_client_code == bloch_sphere.get_client_code()
 
 
+@assert_deprecated_cirq_web_warning
 def test_bloch_sphere_default_client_code_comp_basis() -> None:
     bloch_sphere = cirq_web.BlochSphere(state_vector=1)
 
@@ -78,6 +86,7 @@ def test_bloch_sphere_default_client_code_comp_basis() -> None:
     assert expected_client_code == bloch_sphere.get_client_code()
 
 
+@assert_deprecated_cirq_web_warning
 def test_bloch_sphere_default_bundle_name() -> None:
     state_vector = cirq.to_valid_state_vector([math.sqrt(2) / 2, math.sqrt(2) / 2])
     bloch_sphere = cirq_web.BlochSphere(state_vector=state_vector)

--- a/cirq-web/cirq_web/circuits/circuit.py
+++ b/cirq-web/cirq_web/circuits/circuit.py
@@ -25,8 +25,10 @@ from cirq_web.circuits.symbols import (
     resolve_operation,
     SymbolResolver,
 )
+from cirq_web.deprecation import deprecated_cirq_web_class
 
 
+@deprecated_cirq_web_class
 class Circuit3D(widget.Widget):
     """Takes cirq.Circuit objects and displays them in 3D."""
 

--- a/cirq-web/cirq_web/circuits/circuit_test.py
+++ b/cirq-web/cirq_web/circuits/circuit_test.py
@@ -20,12 +20,14 @@ import pytest
 
 import cirq
 import cirq_web
+from cirq_web.deprecation import assert_deprecated_cirq_web_warning
 
 
 def strip_ws(string):
     return "".join(string.split())
 
 
+@assert_deprecated_cirq_web_warning
 def test_circuit_init_type() -> None:
     qubits = [cirq.GridQubit(x, y) for x in range(2) for y in range(2)]
     moment = cirq.Moment(cirq.H(qubits[0]))
@@ -35,6 +37,7 @@ def test_circuit_init_type() -> None:
     assert isinstance(circuit3d, cirq_web.Circuit3D)
 
 
+@assert_deprecated_cirq_web_warning
 @pytest.mark.parametrize('qubit', [cirq.GridQubit(0, 0), cirq.LineQubit(0)])
 def test_circuit_client_code(qubit) -> None:
     moment = cirq.Moment(cirq.H(qubit))
@@ -90,6 +93,7 @@ def test_circuit_client_code(qubit) -> None:
     assert strip_ws(circuit.get_client_code()) == strip_ws(expected_client_code)
 
 
+@assert_deprecated_cirq_web_warning
 def test_circuit_client_code_unsupported_qubit_type() -> None:
     moment = cirq.Moment(cirq.H(cirq.NamedQubit('q0')))
     circuit = cirq_web.Circuit3D(cirq.Circuit(moment))
@@ -98,6 +102,7 @@ def test_circuit_client_code_unsupported_qubit_type() -> None:
         circuit.get_client_code()
 
 
+@assert_deprecated_cirq_web_warning
 def test_circuit_client_code_escapes_wire_symbols() -> None:
     key = "</script><img src=x onerror=alert(1)>"
     circuit = cirq_web.Circuit3D(cirq.Circuit(cirq.measure(cirq.LineQubit(0), key=key)))
@@ -109,6 +114,7 @@ def test_circuit_client_code_escapes_wire_symbols() -> None:
     assert client_code.count('</script>') == 1
 
 
+@assert_deprecated_cirq_web_warning
 def test_circuit_default_bundle_name() -> None:
     qubits = [cirq.GridQubit(x, y) for x in range(2) for y in range(2)]
     moment = cirq.Moment(cirq.H(qubits[0]))

--- a/cirq-web/cirq_web/circuits/symbols.py
+++ b/cirq-web/cirq_web/circuits/symbols.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import abc
 import dataclasses
+import os
 from collections.abc import Iterable
 
 import cirq
+from cirq._compat import ALLOW_DEPRECATION_IN_TEST
 from cirq.protocols.circuit_diagram_info_protocol import CircuitDiagramInfoArgs
 from cirq_web.deprecation import deprecated_cirq_web_class, deprecated_cirq_web_function
 
@@ -103,7 +105,16 @@ class DefaultResolver(SymbolResolver):
         return symbol_info
 
 
+# This module may be imported during test discovery.
+# Allow call to the deprecated DefaultResolver below.
+_SAVE_ENVIRON = {k: os.environ[k] for k in [ALLOW_DEPRECATION_IN_TEST] if k in os.environ}
+os.environ[ALLOW_DEPRECATION_IN_TEST] = "True"
+
 DEFAULT_SYMBOL_RESOLVERS: Iterable[SymbolResolver] = (DefaultResolver(),)
+
+# restore os.environ as before and clean up extra variable
+del os.environ[ALLOW_DEPRECATION_IN_TEST]
+os.environ.update(_SAVE_ENVIRON)
 
 
 @deprecated_cirq_web_function

--- a/cirq-web/cirq_web/circuits/symbols.py
+++ b/cirq-web/cirq_web/circuits/symbols.py
@@ -23,8 +23,10 @@ from collections.abc import Iterable
 
 import cirq
 from cirq.protocols.circuit_diagram_info_protocol import CircuitDiagramInfoArgs
+from cirq_web.deprecation import deprecated_cirq_web_class, deprecated_cirq_web_function
 
 
+@deprecated_cirq_web_class
 @dataclasses.dataclass
 class SymbolInfo:
     """Organizes information about a symbol."""
@@ -59,6 +61,7 @@ class SymbolResolver(metaclass=abc.ABCMeta):
         """Converts cirq.Operation objects into SymbolInfo objects for serialization."""
 
 
+@deprecated_cirq_web_class
 class DefaultResolver(SymbolResolver):
     """Default symbol resolver implementation. Takes information
     from circuit_diagram_info, if unavailable, returns information representing
@@ -103,6 +106,7 @@ class DefaultResolver(SymbolResolver):
 DEFAULT_SYMBOL_RESOLVERS: Iterable[SymbolResolver] = (DefaultResolver(),)
 
 
+@deprecated_cirq_web_function
 def resolve_operation(operation: cirq.Operation, resolvers: Iterable[SymbolResolver]) -> SymbolInfo:
     """Builds a SymbolInfo object based off of a designated operation
     and list of resolvers. The latest resolver takes precedent.
@@ -126,6 +130,7 @@ def resolve_operation(operation: cirq.Operation, resolvers: Iterable[SymbolResol
     return symbol_info
 
 
+@deprecated_cirq_web_class
 class Operation3DSymbol:
     def __init__(self, wire_symbols, location_info, color_info, moment):
         """Gathers symbol information from an operation and builds an

--- a/cirq-web/cirq_web/circuits/symbols.py
+++ b/cirq-web/cirq_web/circuits/symbols.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import os
+import warnings
 from collections.abc import Iterable
 
 import cirq
@@ -110,11 +111,19 @@ class DefaultResolver(SymbolResolver):
 _SAVE_ENVIRON = {k: os.environ[k] for k in [ALLOW_DEPRECATION_IN_TEST] if k in os.environ}
 os.environ[ALLOW_DEPRECATION_IN_TEST] = "True"
 
-DEFAULT_SYMBOL_RESOLVERS: Iterable[SymbolResolver] = (DefaultResolver(),)
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message="(.|\n)*cirq-web is deprecated.",
+        category=DeprecationWarning,
+        module=__name__,
+    )
+    DEFAULT_SYMBOL_RESOLVERS: Iterable[SymbolResolver] = (DefaultResolver(),)
 
 # restore os.environ as before and clean up extra variable
 del os.environ[ALLOW_DEPRECATION_IN_TEST]
 os.environ.update(_SAVE_ENVIRON)
+del _SAVE_ENVIRON
 
 
 @deprecated_cirq_web_function

--- a/cirq-web/cirq_web/circuits/symbols_test.py
+++ b/cirq-web/cirq_web/circuits/symbols_test.py
@@ -18,6 +18,7 @@ import pytest
 
 import cirq
 import cirq_web
+from cirq_web.deprecation import assert_deprecated_cirq_web_warning
 
 
 class MockGateNoDiagramInfo(cirq.testing.SingleQubitGate):
@@ -30,6 +31,7 @@ class MockGateUnimplementedDiagramInfo(cirq.testing.SingleQubitGate):
         return NotImplemented
 
 
+@assert_deprecated_cirq_web_warning
 def test_Operation3DSymbol_basic() -> None:
     wire_symbols = ['X']
     location_info = [{'row': 0, 'col': 0}]
@@ -50,6 +52,7 @@ def test_Operation3DSymbol_basic() -> None:
     assert actual == expected
 
 
+@assert_deprecated_cirq_web_warning
 def test_resolve_operation_hadamard() -> None:
     mock_qubit = cirq.NamedQubit('mock')
     operation = cirq.H(mock_qubit)
@@ -64,6 +67,7 @@ def test_resolve_operation_hadamard() -> None:
     assert symbol_info.colors == expected_colors
 
 
+@assert_deprecated_cirq_web_warning
 def test_resolve_operation_x_pow() -> None:
     mock_qubit = cirq.NamedQubit('mock')
     operation = cirq.X(mock_qubit) ** 0.5
@@ -78,6 +82,7 @@ def test_resolve_operation_x_pow() -> None:
     assert symbol_info.colors == expected_colors
 
 
+@assert_deprecated_cirq_web_warning
 @pytest.mark.parametrize('custom_gate', [MockGateNoDiagramInfo, MockGateUnimplementedDiagramInfo])
 def test_resolve_operation_invalid_diagram_info(custom_gate) -> None:
     mock_qubit = cirq.NamedQubit('mock')
@@ -94,6 +99,7 @@ def test_resolve_operation_invalid_diagram_info(custom_gate) -> None:
     assert symbol_info.colors == expected_colors
 
 
+@assert_deprecated_cirq_web_warning
 def test_unresolvable_operation_() -> None:
     mock_qubit = cirq.NamedQubit('mock')
     operation = cirq.X(mock_qubit)

--- a/cirq-web/cirq_web/deprecation.py
+++ b/cirq-web/cirq_web/deprecation.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from collections.abc import Callable
+
+from cirq._compat import deprecated, deprecated_class
+from cirq.testing.deprecation import assert_deprecated
+
+_DEPRECATION_DEADLINE = "v1.9"
+_DEPRECATION_FIX_MSG = (
+    "cirq-web is deprecated.  For more details or to provide feedback see "
+    "https://github.com/quantumlib/Cirq/issues/8168"
+)
+
+
+def deprecated_cirq_web_class(cls: type) -> Callable[[type], type]:
+    """Decorator to mark a class in cirq-web deprecated."""
+    return deprecated_class(deadline=_DEPRECATION_DEADLINE, fix=_DEPRECATION_FIX_MSG)(cls)
+
+
+def deprecated_cirq_web_function(func: Callable) -> Callable:
+    """Decorator to mark a function in cirq-web deprecated."""
+    return deprecated(deadline=_DEPRECATION_DEADLINE, fix=_DEPRECATION_FIX_MSG)(func)
+
+
+def assert_deprecated_cirq_web_warning(func: Callable) -> Callable:
+    """Decorator to allow deprecated cirq-web code in tests and to verify it emits warnings."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with assert_deprecated(_DEPRECATION_FIX_MSG, deadline=_DEPRECATION_DEADLINE, count=None):
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/cirq-web/cirq_web/widget.py
+++ b/cirq-web/cirq_web/widget.py
@@ -22,17 +22,20 @@ from enum import Enum
 from pathlib import Path
 
 import cirq_web
+from cirq_web.deprecation import deprecated_cirq_web_class
 
 # Resolve the path so the bundle file can be accessed properly
 _DIST_PATH = Path(cirq_web.__file__).parents[1] / "cirq_web" / "dist"
 
 
+@deprecated_cirq_web_class
 class Env(Enum):
     JUPYTER = 1
     COLAB = 2
     OTHER = 3
 
 
+@deprecated_cirq_web_class
 class Widget(ABC):
     """Abstract class for all widgets."""
 

--- a/cirq-web/cirq_web/widget_test.py
+++ b/cirq-web/cirq_web/widget_test.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from unittest import mock
 
 import cirq_web
+from cirq_web.deprecation import assert_deprecated_cirq_web_warning
 
 
 class FakeWidget(cirq_web.Widget):
@@ -36,6 +37,7 @@ def remove_whitespace(string: str) -> str:
     return "".join(string.split())
 
 
+@assert_deprecated_cirq_web_warning
 def test_repr_html(tmpdir) -> None:
     # # Reset the path so the files are accessible
     cirq_web.widget._DIST_PATH = Path(tmpdir) / "dir"
@@ -55,6 +57,7 @@ def test_repr_html(tmpdir) -> None:
     assert remove_whitespace(expected) == remove_whitespace(actual)
 
 
+@assert_deprecated_cirq_web_warning
 @mock.patch.dict(os.environ, {"BROWSER": "true"})
 def test_generate_html_file_with_browser(tmpdir) -> None:
     # # Reset the path so the files are accessible


### PR DESCRIPTION
- Add deprecation warnings to public functions and classes in cirq-web
- Adjust tests to ensure they can proceed with deprecation warnings and
  that warnings are raised as expected
- Add deprecation notice to the cirq-web README

Partially implements #8168
