### PR TITLE
Use identity to check for singleton values

### DIFF
--- a/cirq-core/cirq/circuits/text_diagram_drawer_test.py
+++ b/cirq-core/cirq/circuits/text_diagram_drawer_test.py
@@ -384,7 +384,7 @@ AB D
 
 
 def test_drawer_eq() -> None:
-    assert TextDiagramDrawer().__eq__(23) == NotImplemented
+    assert TextDiagramDrawer().__eq__(23) is NotImplemented
 
     eq = ct.EqualsTester()
 

--- a/cirq-core/cirq/ops/identity_test.py
+++ b/cirq-core/cirq/ops/identity_test.py
@@ -160,7 +160,7 @@ def test_identity_pow() -> None:
 
 
 def test_pauli_expansion_notimplemented() -> None:
-    assert cirq.IdentityGate(1, (3,))._pauli_expansion_() == NotImplemented
+    assert cirq.IdentityGate(1, (3,))._pauli_expansion_() is NotImplemented
 
 
 @pytest.mark.parametrize(

--- a/cirq-core/cirq/ops/parallel_gate.py
+++ b/cirq-core/cirq/ops/parallel_gate.py
@@ -125,7 +125,7 @@ class ParallelGate(raw_types.Gate):
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> cirq.CircuitDiagramInfo:
         diagram_info = protocols.circuit_diagram_info(self.sub_gate, args, NotImplemented)
-        if diagram_info == NotImplemented:
+        if diagram_info is NotImplemented:
             return diagram_info
 
         # Include symbols for every qubit instead of just one.

--- a/cirq-core/cirq/ops/two_qubit_diagonal_gate.py
+++ b/cirq-core/cirq/ops/two_qubit_diagonal_gate.py
@@ -128,7 +128,7 @@ class TwoQubitDiagonalGate(raw_types.Gate):
         angles = []
         for angle in self._diag_angles_radians:
             mulAngle = protocols.mul(angle, exponent, NotImplemented)
-            if mulAngle == NotImplemented:
+            if mulAngle is NotImplemented:
                 return NotImplemented
             angles.append(mulAngle)
         return TwoQubitDiagonalGate(angles)

--- a/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
+++ b/cirq-core/cirq/sim/clifford/stabilizer_simulation_state_test.py
@@ -43,7 +43,7 @@ def test_apply_gate() -> None:
     state.apply_x.assert_called_with(1, 2.0, 1.3)
 
     state.reset_mock()
-    assert args._strat_apply_gate(cirq.X**1.4, [q0]) == NotImplemented
+    assert args._strat_apply_gate(cirq.X**1.4, [q0]) is NotImplemented
     state.apply_x.assert_not_called()
 
     state.reset_mock()
@@ -87,7 +87,7 @@ def test_apply_gate() -> None:
     state.apply_cx.assert_has_calls([mock.call(0, 1), mock.call(1, 0, 2.0, 1.3), mock.call(0, 1)])
 
     state.reset_mock()
-    assert args._strat_apply_gate(cirq.BitFlipChannel(0.5), [q0]) == NotImplemented
+    assert args._strat_apply_gate(cirq.BitFlipChannel(0.5), [q0]) is NotImplemented
     state.apply_x.assert_not_called()
 
 

--- a/cirq-google/cirq_google/study/symbol_util.py
+++ b/cirq-google/cirq_google/study/symbol_util.py
@@ -26,17 +26,17 @@ import cirq
 # follows more on the t-unit + symbol instead of float + symbol style.
 ValueOrSymbol: TypeAlias = tu.Value | sympy.Basic
 
-# A sentile for not finding the key in resolver.
-NOT_FOUND = "__NOT_FOUND__"
+# A sentinel to mark keys that are not present in the resolver dictionary.
+_NOT_FOUND = object()
 
 
 def direct_symbol_replacement(x, resolver: cirq.ParamResolver):
     """A shortcut for value resolution to avoid tu.unit compare with float issue."""
     if isinstance(x, sympy.Symbol):
-        value = resolver.param_dict.get(x.name, NOT_FOUND)
-        if value == NOT_FOUND:
-            value = resolver.param_dict.get(x, NOT_FOUND)
-        if value != NOT_FOUND:
+        value = resolver.param_dict.get(x.name, _NOT_FOUND)
+        if value is _NOT_FOUND:
+            value = resolver.param_dict.get(x, _NOT_FOUND)
+        if value is not _NOT_FOUND:
             return value
         return x  # pragma: no cover
     return x

--- a/cirq-ionq/cirq_ionq/ionq_native_target_gateset_test.py
+++ b/cirq-ionq/cirq_ionq/ionq_native_target_gateset_test.py
@@ -64,7 +64,7 @@ def test_AriaNativeGateset_decompose_two_qubit_operation():
     result = gateset._decompose_two_qubit_operation(
         cirq.MeasurementGate(num_qubits=1, key='key'), "blank"
     )
-    assert result == NotImplemented
+    assert result is NotImplemented
 
 
 # test _decompose_two_qubit_operation on non unitary argument
@@ -73,7 +73,7 @@ def test_ForteNativeGateset_decompose_two_qubit_operation():
     result = gateset._decompose_two_qubit_operation(
         cirq.MeasurementGate(num_qubits=1, key='key'), "blank"
     )
-    assert result == NotImplemented
+    assert result is NotImplemented
 
 
 # test CCZ_gate not working with 2 qubits


### PR DESCRIPTION
Replace singleton equality check with identity as equality may be
slower if compared object has its own `__eq__` method.

Also use unique object for a sentinel in `cirq_google.study.symbol_util`
so that any string value is possible in symbol resolution.

No change in the effective code.
