### PR TITLE
Allow cirq-web installation with later cirq-core releases

### DIFF
--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -31,7 +31,7 @@ long_description = pathlib.Path('README.md').read_text(encoding='utf-8')
 # Read in requirements
 with open('requirements.txt', encoding='utf-8') as file:
     requirements = [r.strip() for r in file]
-requirements += [f'cirq-core=={__version__}']
+requirements += [f'cirq-core>={__version__},<2.0dev']
 
 packs = ['cirq_web'] + ['cirq_web.' + package for package in find_packages(where='cirq_web')]
 

--- a/cirq-web/setup.py
+++ b/cirq-web/setup.py
@@ -31,7 +31,7 @@ long_description = pathlib.Path('README.md').read_text(encoding='utf-8')
 # Read in requirements
 with open('requirements.txt', encoding='utf-8') as file:
     requirements = [r.strip() for r in file]
-requirements += [f'cirq-core>={__version__},<2.0dev']
+requirements += [f'cirq-core>={__version__},<2.0.dev']
 
 packs = ['cirq_web'] + ['cirq_web.' + package for package in find_packages(where='cirq_web')]
 

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -38,7 +38,7 @@ def test_isolated_packages(cloned_env, module, tmp_path) -> None:
     if module.name != "cirq-core":
         assert f'cirq-core=={module.version}' in module.install_requires or (
             module.name == "cirq-web"
-            and f"cirq-core>={module.version},<2.0dev" in module.install_requires
+            and f"cirq-core>={module.version},<2.0.dev" in module.install_requires
         )
 
     env = cloned_env("isolated_packages", *PACKAGES)

--- a/dev_tools/packaging/isolated_packages_test.py
+++ b/dev_tools/packaging/isolated_packages_test.py
@@ -35,10 +35,13 @@ PACKAGES = ["-r", "dev_tools/requirements/isolated-base.env.txt"]
 @mock.patch.dict(os.environ, {"PYTHONPATH": ""})
 @pytest.mark.parametrize('module', list_modules(), ids=[m.name for m in list_modules()])
 def test_isolated_packages(cloned_env, module, tmp_path) -> None:
-    env = cloned_env("isolated_packages", *PACKAGES)
-
     if module.name != "cirq-core":
-        assert f'cirq-core=={module.version}' in module.install_requires
+        assert f'cirq-core=={module.version}' in module.install_requires or (
+            module.name == "cirq-web"
+            and f"cirq-core>={module.version},<2.0dev" in module.install_requires
+        )
+
+    env = cloned_env("isolated_packages", *PACKAGES)
 
     # Create per-worker copy of cirq-core sources so that parallel builds
     # of cirq-core wheel do not conflict.


### PR DESCRIPTION
Loosen equal-version requirement for cirq-core as a dependency
of cirq-web.  This enables installation of the upcoming last
release of cirq-web with subsequent releases of cirq-core.

Towards #8168
