### PR TITLE
ruff - enable and fix TC004 (runtime-import-in-type-checking-block)

### DIFF
--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -43,7 +43,6 @@ from typing import Any, cast, overload, Self, TYPE_CHECKING, TypeVar, Union
 import networkx
 import numpy as np
 
-import cirq._version
 from cirq import _compat, devices, ops, protocols, qis
 from cirq._doc import document
 from cirq.circuits._bucket_priority_queue import BucketPriorityQueue
@@ -52,7 +51,6 @@ from cirq.circuits.insert_strategy import InsertStrategy
 from cirq.circuits.moment import Moment
 from cirq.circuits.qasm_output import QasmOutput
 from cirq.circuits.text_diagram_drawer import TextDiagramDrawer
-from cirq.protocols import circuit_diagram_info_protocol
 
 if TYPE_CHECKING:
     import cirq
@@ -236,7 +234,7 @@ class AbstractCircuit(abc.ABC):
             return NotImplemented
         return other is self or (
             self.tags == other.tags
-            and cirq.protocols.approx_eq(tuple(self.moments), tuple(other.moments), atol=atol)
+            and protocols.approx_eq(tuple(self.moments), tuple(other.moments), atol=atol)
         )
 
     def __ne__(self, other) -> bool:
@@ -1306,7 +1304,7 @@ class AbstractCircuit(abc.ABC):
             diagram.write(0, i, name)
         first_annotation_row = max(label_map.values(), default=0) + 1
 
-        if any(isinstance(op.gate, cirq.GlobalPhaseGate) for op in self.all_operations()):
+        if any(isinstance(op.gate, ops.GlobalPhaseGate) for op in self.all_operations()):
             diagram.write(0, max(label_map.values(), default=0) + 1, 'global phase:')
             first_annotation_row += 1
 
@@ -1391,8 +1389,10 @@ class AbstractCircuit(abc.ABC):
             version:  Version of OpenQASM to render as output.  Defaults
                 to OpenQASM 2.0.  For OpenQASM 3.0, set this to '3.0'.
         """
+        from cirq import __version__
+
         if header is None:
-            header = f'Generated from Cirq v{cirq._version.__version__}'
+            header = f'Generated from Cirq v{__version__}'
         qubits = ops.QubitOrder.as_qubit_order(qubit_order).order_for(self.all_qubits())
         return QasmOutput(
             operations=self.all_operations(),
@@ -1513,13 +1513,13 @@ class AbstractCircuit(abc.ABC):
         if isinstance(align, str):
             align = Alignment[align.upper()]
 
-        result = cirq.Circuit(tags=circuits[0].tags if circuits else ())
+        result = Circuit(tags=circuits[0].tags if circuits else ())
         for k in range(n):
             try:
                 if align == Alignment.LEFT:
-                    moment = cirq.Moment(c[k] for c in circuits if k < len(c))
+                    moment = Moment(c[k] for c in circuits if k < len(c))
                 else:
-                    moment = cirq.Moment(c[len(c) - n + k] for c in circuits if len(c) - n + k >= 0)
+                    moment = Moment(c[len(c) - n + k] for c in circuits if len(c) - n + k >= 0)
                 result.append(moment)
             except ValueError as ex:
                 raise ValueError(
@@ -1572,7 +1572,7 @@ class AbstractCircuit(abc.ABC):
 
         # Allocate a buffer large enough to append and prepend all the circuits.
         pad_len = sum(len(c) for c in circuits) - n_acc
-        buffer: MutableSequence[cirq.Moment] = [cirq.Moment()] * (pad_len * 2 + n_acc)
+        buffer: MutableSequence[cirq.Moment] = [Moment()] * (pad_len * 2 + n_acc)
 
         # Put the initial circuit in the center of the buffer.
         offset = pad_len
@@ -1582,7 +1582,7 @@ class AbstractCircuit(abc.ABC):
         for k in range(1, len(circuits)):
             offset, n_acc = _concat_ragged_helper(offset, n_acc, buffer, circuits[k].moments, align)
 
-        return cirq.Circuit(buffer[offset : offset + n_acc], tags=circuits[0].tags)
+        return Circuit(buffer[offset : offset + n_acc], tags=circuits[0].tags)
 
     def get_independent_qubit_sets(self) -> list[set[cirq.Qid]]:
         """Divide circuit's qubits into independent qubit sets.
@@ -2046,12 +2046,12 @@ class Circuit(AbstractCircuit):
             return NotImplemented
         inv_moments = []
         for moment in self[::-1]:
-            inv_moment = cirq.inverse(moment, default=NotImplemented)
+            inv_moment = protocols.inverse(moment, default=NotImplemented)
             if inv_moment is NotImplemented:
                 return NotImplemented
             inv_moments.append(inv_moment)
 
-        return cirq.Circuit(inv_moments, tags=self.tags)
+        return Circuit(inv_moments, tags=self.tags)
 
     __hash__ = None  # type: ignore[assignment]
 
@@ -2314,7 +2314,7 @@ class Circuit(AbstractCircuit):
                 and not all(
                     (strategy is InsertStrategy.EARLIEST and self._can_add_op_at(k, op))
                     or (k > 0 and self._can_add_op_at(k - 1, op))
-                    for op in cast(list[cirq.Operation], batch)
+                    for op in cast(list[ops.Operation], batch)
                 )
             ):
                 self._moments.insert(k, Moment())
@@ -2774,7 +2774,7 @@ def _draw_moment_in_diagram(
     transpose: bool,
 ):
     if get_circuit_diagram_info is None:
-        get_circuit_diagram_info = circuit_diagram_info_protocol._op_info_with_fallback
+        get_circuit_diagram_info = protocols.circuit_diagram_info_protocol._op_info_with_fallback
     x0 = out_diagram.width()
 
     non_global_ops = [op for op in moment.operations if op.qubits]
@@ -3045,7 +3045,7 @@ def _group_into_moment_compatible(inputs: Sequence[_MOMENT_OR_OP]) -> Iterator[l
     batch_measurement_keys: set[cirq.MeasurementKey] = set()
     batch_control_keys: set[cirq.MeasurementKey] = set()
     for mop in inputs:
-        if isinstance(mop, cirq.Moment):
+        if isinstance(mop, Moment):
             if batch:
                 yield batch
                 batch = []

--- a/cirq-core/cirq/circuits/circuit.py
+++ b/cirq-core/cirq/circuits/circuit.py
@@ -861,8 +861,6 @@ class AbstractCircuit(abc.ABC):
             given predicate are terminal. Also checks within any CircuitGates
             the circuit may contain.
         """
-        from cirq.circuits import CircuitOperation
-
         if not all(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)
@@ -906,8 +904,6 @@ class AbstractCircuit(abc.ABC):
             given predicate are terminal. Also checks within any CircuitGates
             the circuit may contain.
         """
-        from cirq.circuits import CircuitOperation
-
         if any(
             self.next_moment_operating_on(op.qubits, i + 1) is None
             for (i, op) in self.findall_operations(predicate)

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -1003,7 +1003,7 @@ class _InverseCompositeGate(Gate):
         )
 
     def _has_unitary_(self):
-        from cirq import devices, protocols
+        from cirq import devices
 
         qubits = devices.LineQid.for_gate(self)
         return all(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,7 @@ select = [
     "TC001",  # typing-only-first-party-import
     "TC002",  # typing-only-third-party-import
     # "TC003",  # typing-only-standard-library-import
+    "TC004",  # runtime-import-in-type-checking-block
     "TID251",  # banned-api
     "UP004",  # useless-object-inheritance
     "UP006",  # non-pep585-annotation


### PR DESCRIPTION
Clean up references to `cirq.Something` when `cirq` should be
imported only for type checking.

Also clean up a few unnecessary local imports which repeated
imports done at the module level.