### PR TITLE
Replace temporary sets in inner loops if possible

### DIFF
--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -591,12 +591,9 @@ class Moment:
                 raise KeyError("Moment doesn't act on given qubit")
             return self._qubit_to_op[key]
         elif isinstance(key, Iterable):
-            qubits_to_keep = frozenset(key)
-            ops_to_keep = []
-            for q in qubits_to_keep:
-                if q in self._qubit_to_op:
-                    ops_to_keep.append(self._qubit_to_op[q])
-            return Moment(frozenset(ops_to_keep))
+            ops_to_keep = frozenset(op for q in key if (op := self._qubit_to_op.get(q)) is not None)
+            # preserve the order of operations
+            return Moment.from_ops(*(op for op in self if op in ops_to_keep))
 
     def to_text_diagram(
         self: cirq.Moment,

--- a/cirq-core/cirq/contrib/circuitdag/circuit_dag.py
+++ b/cirq-core/cirq/contrib/circuitdag/circuit_dag.py
@@ -52,8 +52,8 @@ class Unique(Generic[T]):
 
 
 def _disjoint_qubits(op1: cirq.Operation, op2: cirq.Operation) -> bool:
-    """Returns true only if the operations have qubits in common."""
-    return not set(op1.qubits) & set(op2.qubits)
+    """Returns true only if the operations have no qubits in common."""
+    return set(op1.qubits).isdisjoint(op2.qubits)
 
 
 class CircuitDag(networkx.DiGraph):

--- a/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
+++ b/cirq-core/cirq/contrib/paulistring/clifford_optimize.py
@@ -75,7 +75,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit, atol: float = 1e-8) ->
         num_passed_over = 0
         for i in range(start_i + 1, len(all_ops)):
             op = all_ops[i]
-            if not set(op.qubits) & set(modified_op.qubits):
+            if set(op.qubits).isdisjoint(modified_op.qubits):
                 # No qubits in common
                 continue
             cont_cond = continue_condition(op, modified_op, i == start_i + 1)
@@ -120,7 +120,7 @@ def clifford_optimized_circuit(circuit: circuits.Circuit, atol: float = 1e-8) ->
             part_cliff_gate = ops.SingleQubitCliffordGate.from_quarter_turns(pauli, quarter_turns)
 
             other_op = all_ops[merge_i] if merge_i < len(all_ops) else None
-            if other_op is not None and qubit not in set(other_op.qubits):
+            if other_op is not None and qubit not in other_op.qubits:
                 other_op = None
 
             if isinstance(other_op, ops.GateOperation) and isinstance(
@@ -160,9 +160,10 @@ def clifford_optimized_circuit(circuit: circuits.Circuit, atol: float = 1e-8) ->
 
     def try_merge_cz(cz_op: ops.GateOperation, start_i: int) -> int:
         """Returns the number of operations removed at or before start_i."""
+        cz_op_qubits = frozenset(cz_op.qubits)
         for i in reversed(range(start_i)):
             op = all_ops[i]
-            if not set(cz_op.qubits) & set(op.qubits):
+            if cz_op_qubits.isdisjoint(op.qubits):
                 # Don't share qubits
                 # Keep looking
                 continue

--- a/cirq-core/cirq/contrib/paulistring/recombine.py
+++ b/cirq-core/cirq/contrib/paulistring/recombine.py
@@ -39,7 +39,7 @@ def _sorted_best_string_placements(
         node_max = (string_op, 0, possible_node)
 
         for i, out_op in enumerate(output_ops):
-            if not set(out_op.qubits) & set(string_op.qubits):
+            if set(out_op.qubits).isdisjoint(string_op.qubits):
                 # Skip if operations don't share qubits
                 continue
             if isinstance(out_op, ops.PauliStringPhasor) and protocols.commutes(

--- a/cirq-core/cirq/contrib/routing/greedy.py
+++ b/cirq-core/cirq/contrib/routing/greedy.py
@@ -97,10 +97,9 @@ class _GreedyRouter:
         max_search_radius: int = 1,
         max_num_empty_steps: int = 5,
         initial_mapping: dict[ops.Qid, ops.Qid] | None = None,
-        can_reorder: Callable[[ops.Operation, ops.Operation], bool] = lambda op1, op2: not set(
+        can_reorder: Callable[[ops.Operation, ops.Operation], bool] = lambda op1, op2: set(
             op1.qubits
-        )
-        & set(op2.qubits),
+        ).isdisjoint(op2.qubits),
         random_state: cirq.RANDOM_STATE_OR_SEED_LIKE = None,
     ):
 

--- a/cirq-core/cirq/contrib/routing/utils.py
+++ b/cirq-core/cirq/contrib/routing/utils.py
@@ -52,7 +52,7 @@ def ops_are_consistent_with_device_graph(
     ops: Iterable[ops.Operation], device_graph: nx.Graph
 ) -> bool:
     for op in ops:
-        if not set(op.qubits).issubset(device_graph):
+        if any(q not in device_graph for q in op.qubits):
             return False
         if len(op.qubits) >= 2 and not device_graph.has_edge(*op.qubits):
             return False
@@ -64,7 +64,7 @@ def is_valid_routing(
     swap_network: SwapNetwork,
     *,
     equals: BINARY_OP_PREDICATE = operator.eq,
-    can_reorder: BINARY_OP_PREDICATE = lambda op1, op2: not set(op1.qubits) & set(op2.qubits),
+    can_reorder: BINARY_OP_PREDICATE = lambda op1, op2: set(op1.qubits).isdisjoint(op2.qubits),
 ) -> bool:
     """Determines whether a swap network is consistent with a given circuit.
 

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -112,7 +112,7 @@ class ClassicallyControlledOperation(raw_types.Operation):
 
     @property
     def classical_controls(self) -> frozenset[cirq.Condition]:
-        return frozenset().union(self._conditions, self._sub_operation.classical_controls)
+        return self._sub_operation.classical_controls.union(self._conditions)
 
     def without_classical_controls(self) -> cirq.Operation:
         return self._sub_operation.without_classical_controls()

--- a/cirq-core/cirq/ops/classically_controlled_operation.py
+++ b/cirq-core/cirq/ops/classically_controlled_operation.py
@@ -112,7 +112,7 @@ class ClassicallyControlledOperation(raw_types.Operation):
 
     @property
     def classical_controls(self) -> frozenset[cirq.Condition]:
-        return frozenset(self._conditions).union(self._sub_operation.classical_controls)
+        return frozenset().union(self._conditions, self._sub_operation.classical_controls)
 
     def without_classical_controls(self) -> cirq.Operation:
         return self._sub_operation.without_classical_controls()

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -129,7 +129,7 @@ class If(raw_types.Operation):
 
     @property
     def classical_controls(self) -> frozenset[cirq.Condition]:
-        return frozenset().union(self._conditions, self._sub_operation.classical_controls)
+        return self._sub_operation.classical_controls.union(self._conditions)
 
     def without_classical_controls(self) -> cirq.Operation:
         return self._sub_operation.without_classical_controls()

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -129,7 +129,7 @@ class If(raw_types.Operation):
 
     @property
     def classical_controls(self) -> frozenset[cirq.Condition]:
-        return frozenset(self._conditions).union(self._sub_operation.classical_controls)
+        return frozenset().union(self._conditions, self._sub_operation.classical_controls)
 
     def without_classical_controls(self) -> cirq.Operation:
         return self._sub_operation.without_classical_controls()

--- a/cirq-core/cirq/ops/linear_combinations.py
+++ b/cirq-core/cirq/ops/linear_combinations.py
@@ -226,8 +226,7 @@ class LinearCombinationOfOperations(value.LinearDict[raw_types.Operation]):
         """Returns qubits acted on self."""
         if not self:
             return ()
-        qubit_sets = [set(op.qubits) for op in self.keys()]
-        all_qubits = set.union(*qubit_sets)
+        all_qubits = set().union(*(op.qubits for op in self.keys()))
         return tuple(sorted(all_qubits))
 
     def __pow__(self, exponent: int) -> LinearCombinationOfOperations:

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -1013,7 +1013,11 @@ class PauliString(raw_types.Operation, Generic[TKey]):
             conjugated = _calc_conjugation(ps, op)
             # The pauli string on the remaining qubits
             remain: PauliString = PauliString(
-                *(pauli(q) for q in all_qubits - set(op.qubits) if (pauli := ps.get(q)) is not None)
+                *(
+                    pauli(q)
+                    for q in all_qubits.difference(op.qubits)
+                    if (pauli := ps.get(q)) is not None
+                )
             )
             ps = remain * conjugated
         return ps

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -972,12 +972,15 @@ def split_into_matching_protocol_then_general(
         matching_part = []
         general_part = []
         for op in moment:
-            qs = set(op.qubits)
             keys = protocols.measurement_keys_touched(op)
-            if predicate(op) and qs.isdisjoint(blocked_qubits) and keys.isdisjoint(blocked_keys):
+            if (
+                predicate(op)
+                and blocked_qubits.isdisjoint(op.qubits)
+                and keys.isdisjoint(blocked_keys)
+            ):
                 matching_part.append(op)
             else:
-                blocked_qubits |= qs
+                blocked_qubits.update(op.qubits)
                 blocked_keys |= keys
                 general_part.append(op)
         if matching_part:

--- a/cirq-core/cirq/transformers/align.py
+++ b/cirq-core/cirq/transformers/align.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import dataclasses
 from typing import TYPE_CHECKING
 
-from cirq import circuits, ops
+from cirq import circuits
 from cirq.transformers import transformer_api, transformer_primitives
 
 if TYPE_CHECKING:
@@ -44,13 +44,12 @@ def align_left(
     """
     if context is None:
         context = transformer_api.TransformerContext()
+    tags_to_ignore_set = frozenset(context.tags_to_ignore)
 
     ret = circuits.Circuit()
     for i, moment in enumerate(circuit):
         for op in moment:
-            if isinstance(op, ops.TaggedOperation) and set(op.tags).intersection(
-                context.tags_to_ignore
-            ):
+            if not tags_to_ignore_set.isdisjoint(op.tags):
                 ret.append([circuits.Moment()] * (i + 1 - len(ret)))
                 ret[i] = ret[i].with_operation(op)
             else:

--- a/cirq-core/cirq/transformers/eject_phased_paulis.py
+++ b/cirq-core/cirq/transformers/eject_phased_paulis.py
@@ -60,11 +60,11 @@ def eject_phased_paulis(
           Copy of the transformed input circuit.
     """
     held_w_phases: dict[ops.Qid, value.TParamVal] = {}
-    tags_to_ignore = set(context.tags_to_ignore) if context else set()
+    tags_to_ignore = frozenset(context.tags_to_ignore) if context else frozenset()
 
     def map_func(op: cirq.Operation, _: int) -> cirq.OP_TREE:
         # Dump if `op` marked with a no compile tag.
-        if set(op.tags) & tags_to_ignore:
+        if not tags_to_ignore.isdisjoint(op.tags):
             return [_dump_held(op.qubits, held_w_phases, atol), op]
 
         # Collect, phase, and merge Ws.

--- a/cirq-core/cirq/transformers/eject_z.py
+++ b/cirq-core/cirq/transformers/eject_z.py
@@ -74,7 +74,7 @@ def eject_z(
     """
     # Tracks qubit phases (in half turns; multiply by pi to get radians).
     qubit_phase: dict[ops.Qid, float] = defaultdict(lambda: 0)
-    tags_to_ignore = set(context.tags_to_ignore) if context else set()
+    tags_to_ignore = frozenset(context.tags_to_ignore) if context else frozenset()
     phased_xz_replacements: dict[tuple[int, ops.Operation], ops.PhasedXZGate] = {}
     last_phased_xz_op: dict[ops.Qid, tuple[int, ops.Operation] | None] = defaultdict(lambda: None)
 
@@ -91,7 +91,7 @@ def eject_z(
     def map_func(op: cirq.Operation, moment_index: int) -> cirq.OP_TREE:
         last_phased_xz_op.update(dict.fromkeys(op.qubits))
 
-        if tags_to_ignore & set(op.tags):
+        if not tags_to_ignore.isdisjoint(op.tags):
             # Op marked with no-compile, dump phases and do not cross.
             return [dump_tracked_phase(op.qubits), op]
 

--- a/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/gauge_compiling.py
@@ -226,6 +226,7 @@ class GaugeTransformer:
         rng = np.random.default_rng() if prng is None else prng
         if context is None:
             context = transformer_api.TransformerContext(deep=False)
+        tags_to_ignore_set = frozenset(context.tags_to_ignore)
         if context.deep:
             raise ValueError('GaugeTransformer cannot be used with deep=True')
         new_moments = []
@@ -236,9 +237,7 @@ class GaugeTransformer:
             right.clear()
             center: list[ops.Operation] = []
             for op in moment:
-                if isinstance(op, ops.TaggedOperation) and set(op.tags).intersection(
-                    context.tags_to_ignore
-                ):
+                if not tags_to_ignore_set.isdisjoint(op.tags):
                     center.append(op)
                     continue
                 if op.gate is not None and len(op.qubits) == 2 and op in self.target:
@@ -279,6 +278,7 @@ class GaugeTransformer:
             context = transformer_api.TransformerContext(deep=False)
         if context.deep:
             raise ValueError('GaugeTransformer cannot be used with deep=True')
+        tags_to_ignore_set = frozenset(context.tags_to_ignore)
         new_moments: list[list[ops.Operation]] = []  # Store parameterized circuits.
         phxz_sid = itertools.count()
         two_qubit_gate_sid = itertools.count()
@@ -305,9 +305,7 @@ class GaugeTransformer:
             left_moment: list[ops.Operation] = []
             right_moment: list[ops.Operation] = []
             for op in moment:
-                if isinstance(op, ops.TaggedOperation) and set(op.tags).intersection(
-                    context.tags_to_ignore
-                ):
+                if not tags_to_ignore_set.isdisjoint(op.tags):
                     center_moment.append(op)
                     continue
                 if op.gate is not None and op in self.target:
@@ -362,9 +360,7 @@ class GaugeTransformer:
         for _ in range(N):
             for moment_id, moment in enumerate(circuit):
                 for op in moment:
-                    if isinstance(op, ops.TaggedOperation) and set(op.tags).intersection(
-                        context.tags_to_ignore
-                    ):
+                    if not tags_to_ignore_set.isdisjoint(op.tags):
                         continue
                     if op.gate is not None and len(op.qubits) == 2 and op in self.target:
                         gauge = self.gauge_selector(rng).sample(op.gate, rng)

--- a/cirq-core/cirq/transformers/gauge_compiling/multi_moment_gauge_compiling.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/multi_moment_gauge_compiling.py
@@ -85,17 +85,16 @@ class MultiMomentGaugeTransformer(abc.ABC):
         A moment is a target moment if it contains at least one target op and
         all its operations are supported by this transformer.
         """
+        tags_to_ignore_set = frozenset(context.tags_to_ignore) if context else frozenset()
+
         # skip the moment if the moment is tagged to be ignored
-        if context and set(moment.tags).intersection(context.tags_to_ignore):
+        if not tags_to_ignore_set.isdisjoint(moment.tags):
             return False
 
         has_target_gates: bool = False
         for op in moment:
-            if (
-                context
-                and isinstance(op, ops.TaggedOperation)
-                and set(op.tags).intersection(context.tags_to_ignore)
-            ):  # skip the moment if the op is tagged to be ignored
+            # skip the moment if the op is tagged to be ignored
+            if not tags_to_ignore_set.isdisjoint(op.tags):
                 return False
             if op.gate:
                 if op in self.target:

--- a/cirq-core/cirq/transformers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates.py
@@ -316,8 +316,7 @@ def merge_single_qubit_gates_to_phxz_symbolized(
             merge_tags_fn=lambda circuit_op: (
                 [symbolized_single_tag]
                 if any(
-                    symbolized_single_tag in set(op.tags)
-                    for op in circuit_op.circuit.all_operations()
+                    symbolized_single_tag in op.tags for op in circuit_op.circuit.all_operations()
                 )
                 else []
             ),

--- a/cirq-core/cirq/transformers/optimize_for_target_gateset.py
+++ b/cirq-core/cirq/transformers/optimize_for_target_gateset.py
@@ -71,12 +71,14 @@ def _decompose_operations_to_target_gateset(
         ValueError: If any input operation fails to convert and `ignore_failures` is False.
     """
 
+    tags_to_decompose_set = frozenset(tags_to_decompose)
+
     def map_func(op: cirq.Operation, moment_index: int):
         if (
             context
             and context.deep
             and isinstance(op.untagged, circuits.CircuitOperation)
-            and set(op.tags).isdisjoint(tags_to_decompose)
+            and tags_to_decompose_set.isdisjoint(op.tags)
         ):
             return op
         return dp.decompose(

--- a/cirq-core/cirq/transformers/symbolize.py
+++ b/cirq-core/cirq/transformers/symbolize.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import attrs
@@ -75,26 +74,29 @@ def symbolize_single_qubit_gates_by_indexed_tags(
         Copy of the transformed input circuit.
     """
 
+    symbolize_tag_pattern = re.compile(f"{re.escape(symbolize_tag.prefix)}_(\\d+)")
+
     def _map_func(op: cirq.Operation, _):
         """Maps an op with tag `{tag_prefix}_i` to a symbolized `PhasedXZGate(xi,zi,ai)`."""
-        tags: set[Hashable] = set(op.tags)
         tag_id: None | int = None
-        for tag in tags:
-            if re.fullmatch(f"{symbolize_tag.prefix}_\\d+", str(tag)):
+        tag_index_to_drop = len(op.tags)
+        for idx, tag in enumerate(op.tags):
+            if match := symbolize_tag_pattern.fullmatch(str(tag)):
                 if tag_id is None:
-                    tag_id = int(str(tag).rsplit("_", maxsplit=-1)[-1])
+                    tag_id = int(match.group(1))
+                    tag_index_to_drop = idx
                 else:
                     raise ValueError(f"Multiple tags are prefixed with {symbolize_tag.prefix}.")
         if tag_id is None:
             return op
-        tags.remove(f"{symbolize_tag.prefix}_{tag_id}")
         phxz_params = {
             "x_exponent": sympy.Symbol(f"x{tag_id}"),
             "z_exponent": sympy.Symbol(f"z{tag_id}"),
             "axis_phase_exponent": sympy.Symbol(f"a{tag_id}"),
         }
 
-        return ops.PhasedXZGate(**phxz_params).on(*op.qubits).with_tags(*tags)
+        new_tags = (*op.tags[:tag_index_to_drop], *op.tags[tag_index_to_drop + 1 :])
+        return ops.PhasedXZGate(**phxz_params).on(*op.qubits).with_tags(*new_tags)
 
     return transformer_primitives.map_operations(
         circuit.freeze(),

--- a/cirq-core/cirq/transformers/synchronize_terminal_measurements.py
+++ b/cirq-core/cirq/transformers/synchronize_terminal_measurements.py
@@ -85,10 +85,11 @@ def synchronize_terminal_measurements(
     """
     if context is None:
         context = transformer_api.TransformerContext()
+    tags_to_ignore_set = frozenset(context.tags_to_ignore)
     terminal_measurements = [
         (i, op)
         for i, op in find_terminal_measurements(circuit)
-        if set(op.tags).isdisjoint(context.tags_to_ignore)
+        if tags_to_ignore_set.isdisjoint(op.tags)
     ]
     ret = circuit.unfreeze(copy=True)
     if not terminal_measurements:

--- a/cirq-core/cirq/transformers/tag_transformers.py
+++ b/cirq-core/cirq/transformers/tag_transformers.py
@@ -48,13 +48,10 @@ def index_tags(
     tag_iter_by_tags = {tag: itertools.count(start=0, step=1) for tag in target_tags}
 
     def _map_func(op: cirq.Operation, _) -> cirq.OP_TREE:
-        tag_set = set(op.tags)
-        nonlocal tag_iter_by_tags
-        for tag in target_tags.intersection(op.tags):
-            tag_set.remove(tag)
-            tag_set.add(f"{tag}_{next(tag_iter_by_tags[tag])}")
-
-        return op.untagged.with_tags(*tag_set)
+        new_tags = (
+            f"{tag}_{next(tag_iter_by_tags[tag])}" if tag in target_tags else tag for tag in op.tags
+        )
+        return op.untagged.with_tags(*new_tags)
 
     return transformer_primitives.map_operations(
         circuit, _map_func, deep=context.deep if context else False

--- a/cirq-core/cirq/transformers/transformer_api.py
+++ b/cirq-core/cirq/transformers/transformer_api.py
@@ -393,12 +393,13 @@ def _run_transformer_on_circuit(
 ) -> cirq.AbstractCircuit:
     mutable_circuit = None
     if extracted_context and extracted_context.deep and add_deep_support:
+        tags_to_ignore_set = frozenset(extracted_context.tags_to_ignore)
         batch_replace = []
         for i, op in circuit.findall_operations(
             lambda o: isinstance(o.untagged, circuits.CircuitOperation)
         ):
             op_untagged = cast(circuits.CircuitOperation, op.untagged)
-            if not set(op.tags).isdisjoint(extracted_context.tags_to_ignore):
+            if not tags_to_ignore_set.isdisjoint(op.tags):
                 continue
             op_untagged = op_untagged.replace(
                 circuit=_run_transformer_on_circuit(

--- a/cirq-core/cirq/transformers/transformer_primitives.py
+++ b/cirq-core/cirq/transformers/transformer_primitives.py
@@ -1014,7 +1014,7 @@ def toggle_tags(circuit: CIRCUIT_TYPE, tags: Sequence[Hashable], *, deep: bool =
         return (
             op
             if deep and isinstance(op, circuits.CircuitOperation)
-            else op.untagged.with_tags(*(set(op.tags) ^ tags_to_xor))
+            else op.untagged.with_tags(*tags_to_xor.symmetric_difference(op.tags))
         )
 
     return map_operations(circuit, map_func, deep=deep)

--- a/cirq-ionq/cirq_ionq/ionq_devices.py
+++ b/cirq-ionq/cirq_ionq/ionq_devices.py
@@ -68,7 +68,7 @@ class IonQAPIDevice(cirq.Device):
             )
         if not self.is_api_gate(operation):
             raise ValueError(f'IonQAPIDevice has unsupported gate {operation.gate}.')
-        if not set(operation.qubits).intersection(self.metadata.qubit_set):
+        if self.metadata.qubit_set.isdisjoint(operation.qubits):
             raise ValueError(f'Operation with qubits not on the device. Qubits: {operation.qubits}')
 
     def is_api_gate(self, operation: cirq.Operation) -> bool:


### PR DESCRIPTION
Avoid creating temporary sets just to evaluate set intersection.
Use `set.isdisjoint` instead.

No change in code function.

Towards b/452757715
