### PR TITLE
Add support for getting mapped circuits

### DIFF
--- a/cirq-google/cirq_google/engine/abstract_job.py
+++ b/cirq-google/cirq_google/engine/abstract_job.py
@@ -165,13 +165,14 @@ class AbstractJob(abc.ABC):
         """Returns the configuration used for the job, if available, else None."""
 
     @abc.abstractmethod
-    def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:
+    def get_circuit(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the job.
 
         Args:
-            circuit_num: if this is a multi-circuit job, the index of the circuit
-                to return.  This argument is zero-indexed. Negative values
-                index from the end of the list.  Ignored if not multi-circuit.
+            circuit_num: if this is a multi-circuit job, the index or key of the circuit
+                to return. For integer indices, this argument is zero-indexed with negative
+                values indexing from the end of the list. For string keys, this looks up
+                the circuit by its key in a mapped program. Ignored if not multi-circuit.
 
         Returns:
             The job's cirq Circuit.

--- a/cirq-google/cirq_google/engine/abstract_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_job_test.py
@@ -95,7 +95,7 @@ class MockJob(AbstractJob):
     def get_config(self):
         pass
 
-    def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:
+    def get_circuit(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         return cirq.Circuit()
 
     def cancel(self) -> None:
@@ -144,6 +144,7 @@ def test_get_circuit():
     job = MockJob()
     assert job.get_circuit() == cirq.Circuit()
     assert job.get_circuit(1) == cirq.Circuit()
+    assert job.get_circuit('c1') == cirq.Circuit()
 
 
 def test_batched_results():

--- a/cirq-google/cirq_google/engine/abstract_local_job.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job.py
@@ -190,13 +190,14 @@ class AbstractLocalJob(AbstractJob):
         if available, else None."""
         return self.engine().get_processor(self._processor_id)
 
-    def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:
+    def get_circuit(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the job.
 
         Args:
-            circuit_num: if this is a multi-circuit job, the index of the circuit
-                to return.  This argument is zero-indexed. Negative values
-                index from the end of the list.  Ignored if not multi-circuit.
+            circuit_num: if this is a multi-circuit job, the index or key of the circuit
+                to return. For integer indices, this argument is zero-indexed with negative
+                values indexing from the end of the list. For string keys, this looks up
+                the circuit by its key in a mapped program. Ignored if not multi-circuit.
 
         Returns:
             The job's cirq Circuit.

--- a/cirq-google/cirq_google/engine/abstract_local_job_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_job_test.py
@@ -156,6 +156,8 @@ def test_get_circuit():
     mock_program.get_circuit.assert_called_with(None)
     assert job.get_circuit(1) == circuit
     mock_program.get_circuit.assert_called_with(1)
+    assert job.get_circuit('c1') == circuit
+    mock_program.get_circuit.assert_called_with('c1')
 
 
 def test_get_config():

--- a/cirq-google/cirq_google/engine/abstract_local_program.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program.py
@@ -56,6 +56,8 @@ class AbstractLocalProgram(AbstractProgram):
         self._engine = engine
         self._jobs: dict[str, AbstractLocalJob] = {}
         if isinstance(circuits, Mapping):
+            if any(not key for key in circuits.keys()):
+                raise ValueError("Empty key provided in program.")
             self._batch_keys: list[str] | None = list(circuits.keys())
             self._circuits: list[cirq.Circuit] = list(circuits.values())
         else:
@@ -211,14 +213,15 @@ class AbstractLocalProgram(AbstractProgram):
             del self._labels[key]
         return self
 
-    def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:
+    def get_circuit(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the program. This is only
         supported if the program was created with the V2 protos.
 
         Args:
-            circuit_num: if this is a multi-circuit program, the index of the circuit
-                to return.  This argument is zero-indexed. Negative values
-                indexing from the end of the list.
+            circuit_num: if this is a multi-circuit program, the index or key of the circuit
+                to return. For integer indices, this argument is zero-indexed with negative
+                values indexing from the end of the list. For string keys, this looks up
+                the circuit by its key in a mapped program.
 
         Returns:
             The program's cirq Circuit.
@@ -231,6 +234,10 @@ class AbstractLocalProgram(AbstractProgram):
                     "or use `get_circuits()` to get all of them."
                 )
             return self._circuits[0]
+        if isinstance(circuit_num, str):
+            if self._batch_keys is not None and circuit_num in self._batch_keys:
+                return self._circuits[self._batch_keys.index(circuit_num)]
+            raise KeyError(f"Circuit key '{circuit_num}' not found in program.")
         try:
             return self._circuits[circuit_num]
         except IndexError:
@@ -238,9 +245,11 @@ class AbstractLocalProgram(AbstractProgram):
                 f"Index {circuit_num} out of range for batch program of size {len(self._circuits)}."
             )
 
-    def get_circuits(self) -> list[cirq.Circuit]:
+    def get_circuits(self) -> list[cirq.Circuit] | dict[str, cirq.Circuit]:
         """Returns all the cirq Circuits for the program."""
-        return self._circuits
+        if self._batch_keys is not None:
+            return dict(zip(self._batch_keys, self._circuits))
+        return self._circuits.copy()
 
     def is_batch(self) -> bool:
         """Returns True if the program is a batch program."""

--- a/cirq-google/cirq_google/engine/abstract_local_program.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program.py
@@ -56,6 +56,8 @@ class AbstractLocalProgram(AbstractProgram):
         self._engine = engine
         self._jobs: dict[str, AbstractLocalJob] = {}
         if isinstance(circuits, Mapping):
+            if batch_keys is not None:
+                raise ValueError("batch_keys is not used if a circuit mapping is provided.")
             if any(not key for key in circuits.keys()):
                 raise ValueError("Empty key provided in program.")
             self._batch_keys: list[str] | None = list(circuits.keys())
@@ -235,9 +237,12 @@ class AbstractLocalProgram(AbstractProgram):
                 )
             return self._circuits[0]
         if isinstance(circuit_num, str):
-            if self._batch_keys is not None and circuit_num in self._batch_keys:
+            if self._batch_keys is None:
+                raise KeyError("Program has no keys.")
+            try:
                 return self._circuits[self._batch_keys.index(circuit_num)]
-            raise KeyError(f"Circuit key '{circuit_num}' not found in program.")
+            except ValueError:
+                raise KeyError(f"Circuit key '{circuit_num}' not found in program.")
         try:
             return self._circuits[circuit_num]
         except IndexError:

--- a/cirq-google/cirq_google/engine/abstract_local_program.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program.py
@@ -237,12 +237,9 @@ class AbstractLocalProgram(AbstractProgram):
                 )
             return self._circuits[0]
         if isinstance(circuit_num, str):
-            if self._batch_keys is None:
-                raise KeyError("Program has no keys.")
-            try:
+            if self._batch_keys is not None and circuit_num in self._batch_keys:
                 return self._circuits[self._batch_keys.index(circuit_num)]
-            except ValueError:
-                raise KeyError(f"Circuit key '{circuit_num}' not found in program.")
+            raise KeyError(f"Circuit key '{circuit_num}' not found in program.")
         try:
             return self._circuits[circuit_num]
         except IndexError:
@@ -250,11 +247,24 @@ class AbstractLocalProgram(AbstractProgram):
                 f"Index {circuit_num} out of range for batch program of size {len(self._circuits)}."
             )
 
-    def get_circuits(self) -> list[cirq.Circuit] | dict[str, cirq.Circuit]:
+    def get_circuits(self) -> list[cirq.Circuit]:
         """Returns all the cirq Circuits for the program."""
-        if self._batch_keys is not None:
-            return dict(zip(self._batch_keys, self._circuits))
         return self._circuits.copy()
+
+    def get_mapped_circuits(self) -> dict[str, cirq.Circuit]:
+        """Returns all the cirq Circuits for a mapped program batch.
+
+        Returns:
+            A dictionary mapping circuit keys to cirq Circuits.
+
+        Raises:
+            ValueError: If called for a non-batch program or if keys were not specified.
+        """
+        if not self.is_batch():
+            raise ValueError("get_mapped_circuits called for a non-batch program.")
+        if self._batch_keys is None or any(not k for k in self._batch_keys):
+            raise ValueError("get_mapped_circuits called for a batch program without circuit keys.")
+        return dict(zip(self._batch_keys, self._circuits))
 
     def is_batch(self) -> bool:
         """Returns True if the program is a batch program."""

--- a/cirq-google/cirq_google/engine/abstract_local_program.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program.py
@@ -58,7 +58,7 @@ class AbstractLocalProgram(AbstractProgram):
         if isinstance(circuits, Mapping):
             if batch_keys is not None:
                 raise ValueError("batch_keys is not used if a circuit mapping is provided.")
-            if any(not key for key in circuits.keys()):
+            if not all(circuits.keys()):
                 raise ValueError("Empty key provided in program.")
             self._batch_keys: list[str] | None = list(circuits.keys())
             self._circuits: list[cirq.Circuit] = list(circuits.values())
@@ -227,6 +227,11 @@ class AbstractLocalProgram(AbstractProgram):
 
         Returns:
             The program's cirq Circuit.
+
+        Raises:
+            ValueError: If called with an int for a non-batch program.
+            KeyError: If called with a string that is not in a mapping.
+            IndexError: If called with an int larger than the size of the batch.
         """
         if circuit_num is None:
             if self.is_batch():

--- a/cirq-google/cirq_google/engine/abstract_local_program_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program_test.py
@@ -53,6 +53,9 @@ def test_init():
     with pytest.raises(ValueError, match='Empty key provided in program.'):
         _ = NothingProgram([circuit1, circuit2], None, batch_keys=['a', ''])
 
+    with pytest.raises(ValueError, match='batch_keys is not used'):
+        _ = NothingProgram({'a': circuit1, 'b': circuit2}, None, batch_keys=['a', ''])
+
 
 def test_jobs():
     program = NothingProgram([cirq.Circuit()], None)
@@ -221,12 +224,12 @@ def test_circuit():
 
     # Non-batch single circuit raises KeyError for string key
     program = NothingProgram([circuit1], None)
-    with pytest.raises(KeyError, match="Circuit key 'a' not found in program."):
+    with pytest.raises(KeyError, match="Program has no keys."):
         _ = program.get_circuit('a')
 
     # Unkeyed multi circuit raises KeyError for string key
     program = NothingProgram([circuit1, circuit2], None)
-    with pytest.raises(KeyError, match="Circuit key 'a' not found in program."):
+    with pytest.raises(KeyError, match="Program has no keys."):
         _ = program.get_circuit('a')
 
     # Empty key in mapping raises ValueError

--- a/cirq-google/cirq_google/engine/abstract_local_program_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program_test.py
@@ -196,7 +196,8 @@ def test_circuit():
     assert program.get_circuit(0) == circuit1
     assert program.get_circuit(1) == circuit2
     assert program.get_circuit(-1) == circuit2
-    assert program.get_circuits() == {'a': circuit1, 'b': circuit2}
+    assert program.get_circuits() == [circuit1, circuit2]
+    assert program.get_mapped_circuits() == {'a': circuit1, 'b': circuit2}
     with pytest.raises(KeyError, match="Circuit key 'c' not found in program."):
         _ = program.get_circuit('c')
     with pytest.raises(IndexError):
@@ -208,7 +209,8 @@ def test_circuit():
     assert program.get_circuit('y') == circuit2
     assert program.get_circuit(0) == circuit1
     assert program.get_circuit(1) == circuit2
-    assert program.get_circuits() == {'x': circuit1, 'y': circuit2}
+    assert program.get_circuits() == [circuit1, circuit2]
+    assert program.get_mapped_circuits() == {'x': circuit1, 'y': circuit2}
 
     # Dict mapping single-circuit
     program = NothingProgram({'only': circuit1}, None)
@@ -216,21 +218,28 @@ def test_circuit():
     assert program.batch_size() == 1
     assert program.get_circuit('only') == circuit1
     assert program.get_circuit(0) == circuit1
-    assert program.get_circuits() == {'only': circuit1}
+    assert program.get_circuits() == [circuit1]
+    assert program.get_mapped_circuits() == {'only': circuit1}
     with pytest.raises(ValueError, match="batch program containing 1 circuits"):
         _ = program.get_circuit()
     with pytest.raises(KeyError, match="Circuit key 'other' not found in program."):
         _ = program.get_circuit('other')
 
-    # Non-batch single circuit raises KeyError for string key
+    # Non-batch single circuit raises KeyError for string key and ValueError for get_mapped_circuits
     program = NothingProgram([circuit1], None)
-    with pytest.raises(KeyError, match="Program has no keys."):
+    with pytest.raises(KeyError, match="Circuit key 'a' not found in program."):
         _ = program.get_circuit('a')
+    with pytest.raises(ValueError, match="get_mapped_circuits called for a non-batch program"):
+        _ = program.get_mapped_circuits()
 
-    # Unkeyed multi circuit raises KeyError for string key
+    # Unkeyed multi circuit raises KeyError for string key and ValueError for get_mapped_circuits
     program = NothingProgram([circuit1, circuit2], None)
-    with pytest.raises(KeyError, match="Program has no keys."):
+    with pytest.raises(KeyError, match="Circuit key 'a' not found in program."):
         _ = program.get_circuit('a')
+    with pytest.raises(
+        ValueError, match="get_mapped_circuits called for a batch program without circuit keys"
+    ):
+        _ = program.get_mapped_circuits()
 
     # Empty key in mapping raises ValueError
     with pytest.raises(ValueError, match="Empty key provided in program."):

--- a/cirq-google/cirq_google/engine/abstract_local_program_test.py
+++ b/cirq-google/cirq_google/engine/abstract_local_program_test.py
@@ -184,6 +184,55 @@ def test_circuit():
     with pytest.raises(IndexError):
         _ = program.get_circuit(2)
 
+    # Mapped circuits (dict)
+    program = NothingProgram({'a': circuit1, 'b': circuit2}, None)
+    assert program.is_batch()
+    assert program.batch_size() == 2
+    assert program.get_circuit('a') == circuit1
+    assert program.get_circuit('b') == circuit2
+    assert program.get_circuit(0) == circuit1
+    assert program.get_circuit(1) == circuit2
+    assert program.get_circuit(-1) == circuit2
+    assert program.get_circuits() == {'a': circuit1, 'b': circuit2}
+    with pytest.raises(KeyError, match="Circuit key 'c' not found in program."):
+        _ = program.get_circuit('c')
+    with pytest.raises(IndexError):
+        _ = program.get_circuit(2)
+
+    # Mapped circuits with explicit batch keys
+    program = NothingProgram([circuit1, circuit2], None, batch_keys=['x', 'y'])
+    assert program.get_circuit('x') == circuit1
+    assert program.get_circuit('y') == circuit2
+    assert program.get_circuit(0) == circuit1
+    assert program.get_circuit(1) == circuit2
+    assert program.get_circuits() == {'x': circuit1, 'y': circuit2}
+
+    # Dict mapping single-circuit
+    program = NothingProgram({'only': circuit1}, None)
+    assert program.is_batch()
+    assert program.batch_size() == 1
+    assert program.get_circuit('only') == circuit1
+    assert program.get_circuit(0) == circuit1
+    assert program.get_circuits() == {'only': circuit1}
+    with pytest.raises(ValueError, match="batch program containing 1 circuits"):
+        _ = program.get_circuit()
+    with pytest.raises(KeyError, match="Circuit key 'other' not found in program."):
+        _ = program.get_circuit('other')
+
+    # Non-batch single circuit raises KeyError for string key
+    program = NothingProgram([circuit1], None)
+    with pytest.raises(KeyError, match="Circuit key 'a' not found in program."):
+        _ = program.get_circuit('a')
+
+    # Unkeyed multi circuit raises KeyError for string key
+    program = NothingProgram([circuit1, circuit2], None)
+    with pytest.raises(KeyError, match="Circuit key 'a' not found in program."):
+        _ = program.get_circuit('a')
+
+    # Empty key in mapping raises ValueError
+    with pytest.raises(ValueError, match="Empty key provided in program."):
+        _ = NothingProgram({'': circuit1}, None)
+
 
 def test_batch_keys():
     circuit1 = cirq.Circuit(cirq.X(cirq.LineQubit(1)))

--- a/cirq-google/cirq_google/engine/abstract_program.py
+++ b/cirq-google/cirq_google/engine/abstract_program.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import abc
 import datetime
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -158,25 +158,26 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_circuit(self, circuit_num: int | None = None) -> cirq.Circuit:
+    def get_circuit(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the program. This is only
         supported if the program was created with the V2 protos.
 
         Args:
-            circuit_num: if this is a multi-circuit program, the index of the circuit
-                to return.  This argument is zero-indexed. Negative values
-                indexing from the end of the list.
+            circuit_num: if this is a multi-circuit program, the index or key of the
+                circuit to return. For integer indices, this argument is zero-indexed
+                with negative values indexing from the end of the list. For string keys,
+                this looks up the circuit by its key in a mapped program.
 
         Returns:
             The program's cirq Circuit.
         """
 
     @abc.abstractmethod
-    def get_circuits(self) -> Sequence[cirq.Circuit]:
+    def get_circuits(self) -> Sequence[cirq.Circuit] | Mapping[str, cirq.Circuit]:
         """Returns all the cirq Circuits for the program.
 
         Returns:
-            A list of the program's cirq Circuits.
+            A list or a dict of the program's cirq Circuits.
         """
 
     @abc.abstractmethod

--- a/cirq-google/cirq_google/engine/abstract_program.py
+++ b/cirq-google/cirq_google/engine/abstract_program.py
@@ -173,11 +173,22 @@ class AbstractProgram(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_circuits(self) -> Sequence[cirq.Circuit] | Mapping[str, cirq.Circuit]:
+    def get_circuits(self) -> Sequence[cirq.Circuit]:
         """Returns all the cirq Circuits for the program.
 
         Returns:
-            A list or a dict of the program's cirq Circuits.
+            A list of the program's cirq Circuits.
+        """
+
+    @abc.abstractmethod
+    def get_mapped_circuits(self) -> Mapping[str, cirq.Circuit]:
+        """Returns all the cirq Circuits for a mapped program batch.
+
+        Returns:
+            A dictionary mapping circuit keys to cirq Circuits.
+
+        Raises:
+            ValueError: If called for a non-batch program or if keys were not specified.
         """
 
     @abc.abstractmethod

--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -476,7 +476,7 @@ class Engine(abstract_engine.AbstractEngine):
 
         Args:
             program: The circuit or circuits to execute. Can either be a single
-                circuit or a list of circuits. Mappings are not currently supported.
+                circuit, a sequence of circuits, or a mapping from string keys to circuits.
             program_id: A user-provided identifier for the program. This must be
                 unique within the Google Cloud project being used. If this
                 parameter is not provided, a random id of the format

--- a/cirq-google/cirq_google/engine/engine_job.py
+++ b/cirq-google/cirq_google/engine/engine_job.py
@@ -337,13 +337,14 @@ class EngineJob(abstract_job.AbstractJob):
             config_name=device_config_key.config_alias,
         )
 
-    async def get_circuit_async(self, circuit_num: int | None = None) -> cirq.Circuit:
+    async def get_circuit_async(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the Quantum Engine job.
 
         Args:
-            circuit_num: if this is a multi-circuit job, the index of the circuit
-                to return.  This argument is zero-indexed. Negative values
-                indexing from the end of the list.
+            circuit_num: if this is a multi-circuit job, the index or key of the circuit
+                to return.  For integer indices, this argument is zero-indexed with negative
+                values indexing from the end of the list. For string keys, this looks up
+                the circuit by its key in a mapped program.
 
         Returns:
             The job's cirq Circuit.

--- a/cirq-google/cirq_google/engine/engine_job_test.py
+++ b/cirq-google/cirq_google/engine/engine_job_test.py
@@ -940,6 +940,8 @@ def test_get_circuit():
         get_circuit_async.assert_called_with(None)
         assert job.get_circuit(1) is circuit
         get_circuit_async.assert_called_with(1)
+        assert job.get_circuit('c1') is circuit
+        get_circuit_async.assert_called_with('c1')
 
 
 @duet.sync
@@ -952,6 +954,8 @@ async def test_get_circuit_async():
         get_circuit_async.return_value = circuit
         assert await job.get_circuit_async(1) is circuit
         get_circuit_async.assert_called_with(1)
+        assert await job.get_circuit_async('c1') is circuit
+        get_circuit_async.assert_called_with('c1')
 
 
 @mock.patch('cirq_google.engine.engine_program.EngineProgram.is_batch_async')

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -502,9 +502,7 @@ def _deserialize_to_proto(code: any_pb2.Any) -> v2.program_pb2.Program:
     raise ValueError(f'unsupported program type: {code_type}')
 
 
-def _deserialize_program(
-    code: any_pb2.Any, circuit_num: int | str | None = None
-) -> cirq.Circuit:
+def _deserialize_program(code: any_pb2.Any, circuit_num: int | str | None = None) -> cirq.Circuit:
     program = _deserialize_to_proto(code)
     serializer = circuit_serializer.CIRCUIT_SERIALIZER
     if circuit_num is not None:

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -527,11 +527,11 @@ def _deserialize_program(code: any_pb2.Any, circuit_num: int | str | None = None
         deserialized = serializer.deserialize_multi_program(program)
         if isinstance(circuit_num, str):
             if not circuit_num:
-                raise KeyError(f"Empty circuit key not found in batch program {program}.")
+                raise KeyError("Empty circuit key not found in batch program.")
             for key, _, circuit in deserialized:
                 if key == circuit_num:
                     return cast(cirq.Circuit, circuit)
-            raise KeyError(f"Circuit key '{circuit_num}' not found in batch program {program}.")
+            raise KeyError(f"Circuit key '{circuit_num}' not found in batch program")
         try:
             return cast(cirq.Circuit, deserialized[circuit_num][2])
         except IndexError:

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -369,14 +369,15 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     is_batch = duet.sync(is_batch_async)
 
-    async def get_circuit_async(self, circuit_num: int | None = None) -> cirq.Circuit:
+    async def get_circuit_async(self, circuit_num: int | str | None = None) -> cirq.Circuit:
         """Returns the cirq Circuit for the Quantum Engine program. This is only
         supported if the program was created with the V2 protos.
 
         Args:
-            circuit_num: if this is a multi-circuit program, the index of the circuit
-                to return.  This argument is zero-indexed. Negative values
-                indexing from the end of the list.
+            circuit_num: if this is a multi-circuit program, the index or key of the circuit
+                to return.  For integer indices, this argument is zero-indexed with negative
+                values indexing from the end of the list. For string keys, this looks up
+                the circuit by its key in a mapped program.
 
         Returns:
             The program's cirq Circuit.
@@ -395,6 +396,11 @@ class EngineProgram(abstract_program.AbstractProgram):
             return circuit_serializer.CIRCUIT_SERIALIZER.deserialize(proto)
 
         if not is_batch:
+            if isinstance(circuit_num, str):
+                raise KeyError(
+                    f"Program {self.program_id} is not a batch program, "
+                    f"cannot index '{circuit_num}'"
+                )
             if circuit_num != 0 and circuit_num != -1:
                 raise IndexError(
                     f"Program {self.program_id} is not a batch program, cannot index {circuit_num}"
@@ -402,6 +408,15 @@ class EngineProgram(abstract_program.AbstractProgram):
             return circuit_serializer.CIRCUIT_SERIALIZER.deserialize(proto)
 
         deserialized = circuit_serializer.CIRCUIT_SERIALIZER.deserialize_multi_program(proto)
+        if isinstance(circuit_num, str):
+            if circuit_num:
+                for key, _, circuit in deserialized:
+                    if key == circuit_num:
+                        return cast(cirq.Circuit, circuit)
+            raise KeyError(
+                f"Circuit key '{circuit_num}' not found in batch program {self.program_id}."
+            )
+
         try:
             return cast(cirq.Circuit, deserialized[circuit_num][2])
         except IndexError:
@@ -412,7 +427,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     get_circuit = duet.sync(get_circuit_async)
 
-    async def get_circuits_async(self) -> list[cirq.Circuit]:
+    async def get_circuits_async(self) -> list[cirq.Circuit] | dict[str, cirq.Circuit]:
         """Returns all the cirq Circuits for the Quantum Engine program."""
         proto = await self._get_proto_async()
         serializer = circuit_serializer.CIRCUIT_SERIALIZER
@@ -420,6 +435,8 @@ class EngineProgram(abstract_program.AbstractProgram):
             return [serializer.deserialize(proto)]
 
         deserialized = serializer.deserialize_multi_program(proto)
+        if all(kc.key for kc in proto.keyed_circuits) and len(proto.keyed_circuits) > 0:
+            return {triple[0]: cast(cirq.Circuit, triple[2]) for triple in deserialized}
         return [cast(cirq.Circuit, triple[2]) for triple in deserialized]
 
     get_circuits = duet.sync(get_circuits_async)
@@ -485,12 +502,21 @@ def _deserialize_to_proto(code: any_pb2.Any) -> v2.program_pb2.Program:
     raise ValueError(f'unsupported program type: {code_type}')
 
 
-def _deserialize_program(code: any_pb2.Any, circuit_num: int | None = None) -> cirq.Circuit:
+def _deserialize_program(
+    code: any_pb2.Any, circuit_num: int | str | None = None
+) -> cirq.Circuit:
     program = _deserialize_to_proto(code)
     serializer = circuit_serializer.CIRCUIT_SERIALIZER
     if circuit_num is not None:
+        deserialized = serializer.deserialize_multi_program(program)
+        if isinstance(circuit_num, str):
+            if circuit_num:
+                for key, _, circuit in deserialized:
+                    if key == circuit_num:
+                        return cast(cirq.Circuit, circuit)
+            raise KeyError(f"Circuit key '{circuit_num}' not found.")
         try:
-            return cast(cirq.Circuit, serializer.deserialize_multi_program(program)[circuit_num][2])
+            return cast(cirq.Circuit, deserialized[circuit_num][2])
         except IndexError:
             raise IndexError(f"Index {circuit_num} out of range for batch program.")
     return serializer.deserialize(program)

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -427,7 +427,7 @@ class EngineProgram(abstract_program.AbstractProgram):
 
     get_circuit = duet.sync(get_circuit_async)
 
-    async def get_circuits_async(self) -> list[cirq.Circuit] | dict[str, cirq.Circuit]:
+    async def get_circuits_async(self) -> list[cirq.Circuit]:
         """Returns all the cirq Circuits for the Quantum Engine program."""
         proto = await self._get_proto_async()
         serializer = circuit_serializer.CIRCUIT_SERIALIZER
@@ -435,11 +435,29 @@ class EngineProgram(abstract_program.AbstractProgram):
             return [serializer.deserialize(proto)]
 
         deserialized = serializer.deserialize_multi_program(proto)
-        if all(kc.key for kc in proto.keyed_circuits) and len(proto.keyed_circuits) > 0:
-            return {triple[0]: cast(cirq.Circuit, triple[2]) for triple in deserialized}
         return [cast(cirq.Circuit, triple[2]) for triple in deserialized]
 
     get_circuits = duet.sync(get_circuits_async)
+
+    async def get_mapped_circuits_async(self) -> dict[str, cirq.Circuit]:
+        """Returns all the cirq Circuits for a mapped batch program.
+
+        Returns:
+            A dictionary mapping circuit keys to cirq Circuits.
+
+        Raises:
+            ValueError: if the program is not a batch program or does not have circuit keys.
+        """
+        if not await self.is_batch_async():
+            raise ValueError(f"Program {self.program_id} is not a batch program.")
+        proto = await self._get_proto_async()
+        if not all(kc.key for kc in proto.keyed_circuits) or len(proto.keyed_circuits) == 0:
+            raise ValueError(f"Program {self.program_id} does not have circuit keys.")
+        serializer = circuit_serializer.CIRCUIT_SERIALIZER
+        deserialized = serializer.deserialize_multi_program(proto)
+        return {triple[0]: cast(cirq.Circuit, triple[2]) for triple in deserialized}
+
+    get_mapped_circuits = duet.sync(get_mapped_circuits_async)
 
     async def batch_size_async(self) -> int:
         """Returns the number of programs in a batch program.

--- a/cirq-google/cirq_google/engine/engine_program.py
+++ b/cirq-google/cirq_google/engine/engine_program.py
@@ -508,11 +508,12 @@ def _deserialize_program(code: any_pb2.Any, circuit_num: int | str | None = None
     if circuit_num is not None:
         deserialized = serializer.deserialize_multi_program(program)
         if isinstance(circuit_num, str):
-            if circuit_num:
-                for key, _, circuit in deserialized:
-                    if key == circuit_num:
-                        return cast(cirq.Circuit, circuit)
-            raise KeyError(f"Circuit key '{circuit_num}' not found.")
+            if not circuit_num:
+                raise KeyError(f"Empty circuit key not found in batch program {program}.")
+            for key, _, circuit in deserialized:
+                if key == circuit_num:
+                    return cast(cirq.Circuit, circuit)
+            raise KeyError(f"Circuit key '{circuit_num}' not found in batch program {program}.")
         try:
             return cast(cirq.Circuit, deserialized[circuit_num][2])
         except IndexError:

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -135,6 +135,58 @@ constants {
     )
 )
 
+_BATCH_PROGRAM_V2_UNKEYED = util.pack_any(
+    Merge(
+        """language {
+  gate_set: "v2_5"
+  arg_function_language: "exp"
+}
+keyed_circuits {
+  circuit {
+    scheduling_strategy: MOMENT_BY_MOMENT
+    moments {
+      operations {
+        qubit_constant_index: 0
+        phasedxpowgate {
+          phase_exponent {
+            float_value: 0.0
+          }
+          exponent {
+            float_value: 0.5
+          }
+        }
+      }
+    }
+  }
+}
+keyed_circuits {
+  circuit {
+    scheduling_strategy: MOMENT_BY_MOMENT
+    moments {
+      operations {
+        qubit_constant_index: 0
+        phasedxpowgate {
+          phase_exponent {
+            float_value: 0.0
+          }
+          exponent {
+            float_value: 0.5
+          }
+        }
+      }
+    }
+  }
+}
+constants {
+  qubit {
+    id: "5_2"
+  }
+}
+""",
+        v2.program_pb2.Program(),
+    )
+)
+
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.create_job_async')
 def test_run_sweeps_delegation(create_job_async):
@@ -379,7 +431,10 @@ def test_get_circuit_v2(get_program_async, include_empty_program: bool) -> None:
     ) as deserialize_multi_program:
         deserialize_multi_program.return_value = [('key0', (), circuit), ('key1', (), circuit)]
         assert program_batch.get_circuit(circuit_num=1) is circuit
-        deserialize_multi_program.assert_called_once()
+        assert program_batch.get_circuit('key1') is circuit
+        assert program_batch.get_circuit('key0') is circuit
+        with pytest.raises(KeyError, match="not found"):
+            program_batch.get_circuit('key2')
 
 
 @duet.sync
@@ -404,6 +459,10 @@ async def test_get_circuit_async():
         get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2)
         c = await program_batch.get_circuit_async(1)
         cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(c, circuit)
+        c_str = await program_batch.get_circuit_async('c2')
+        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(c_str, circuit)
+        with pytest.raises(KeyError, match="not found"):
+            await program_batch.get_circuit_async('c3')
 
 
 def test_deserialize_program():
@@ -416,11 +475,17 @@ def test_deserialize_program():
         cg.engine.engine_program._deserialize_program(code, circuit_num=1)
         mock_serializer.deserialize_multi_program.assert_called_once()
 
+    c = cg.engine.engine_program._deserialize_program(_BATCH_PROGRAM_V2, circuit_num='c1')
+    assert isinstance(c, cirq.Circuit)
+
 
 def test_deserialize_program_errors():
     # Index out of range
     with pytest.raises(IndexError, match="Index 2 out of range"):
         cg.engine.engine_program._deserialize_program(_BATCH_PROGRAM_V2, circuit_num=2)
+    # Key not found
+    with pytest.raises(KeyError, match="Circuit key 'c3' not found"):
+        cg.engine.engine_program._deserialize_program(_BATCH_PROGRAM_V2, circuit_num='c3')
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -490,21 +555,38 @@ def test_get_circuits(get_program_async):
     program = cg.EngineProgram('a', 'b', EngineContext())
     get_program_async.return_value = quantum.QuantumProgram(code=_PROGRAM_V2)
     circuits = program.get_circuits()
+    assert isinstance(circuits, list)
     assert len(circuits) == 1
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(circuits[0], circuit)
 
-    # Batch program
+    # Batch program without keys (list)
+    program_batch_unkeyed = cg.EngineProgram('a', 'b', EngineContext())
+    get_program_async.reset_mock()
+    get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2_UNKEYED)
+    circuits_unkeyed = program_batch_unkeyed.get_circuits()
+    assert isinstance(circuits_unkeyed, list)
+    assert len(circuits_unkeyed) == 2
+    expected_circuit = cirq.Circuit(cirq.X(cirq.GridQubit(5, 2)) ** 0.5)
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        circuits_unkeyed[0], expected_circuit
+    )
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        circuits_unkeyed[1], expected_circuit
+    )
+
+    # Batch program with keys (dict)
     program_batch = cg.EngineProgram('a', 'b', EngineContext())
     get_program_async.reset_mock()
     get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2)
-    circuits = program_batch.get_circuits()
-    assert len(circuits) == 2
-    expected_circuit = cirq.Circuit(cirq.X(cirq.GridQubit(5, 2)) ** 0.5)
+    circuits_dict = program_batch.get_circuits()
+    assert isinstance(circuits_dict, dict)
+    assert len(circuits_dict) == 2
+    assert list(circuits_dict.keys()) == ['c1', 'c2']
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-        circuits[0], expected_circuit
+        circuits_dict['c1'], expected_circuit
     )
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
-        circuits[1], expected_circuit
+        circuits_dict['c2'], expected_circuit
     )
 
 
@@ -520,6 +602,10 @@ def test_get_circuit_error_cases(get_program_async):
     with pytest.raises(IndexError, match="Index 2 out of range"):
         _ = program_batch.get_circuit(2)
 
+    # Batch program, key not found
+    with pytest.raises(KeyError, match="not found"):
+        _ = program_batch.get_circuit('nonexistent')
+
     # Single circuit program, indexing not allowed (except 0 and -1)
     program_single = cg.EngineProgram('a', 'b', EngineContext())
     get_program_async.reset_mock()
@@ -529,6 +615,8 @@ def test_get_circuit_error_cases(get_program_async):
     assert program_single.get_circuit(-1) is not None
     with pytest.raises(IndexError, match="is not a batch program, cannot index 1"):
         _ = program_single.get_circuit(1)
+    with pytest.raises(KeyError, match="is not a batch program"):
+        _ = program_single.get_circuit('key')
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_program_async')

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -484,8 +484,11 @@ def test_deserialize_program_errors():
     with pytest.raises(IndexError, match="Index 2 out of range"):
         cg.engine.engine_program._deserialize_program(_BATCH_PROGRAM_V2, circuit_num=2)
     # Key not found
-    with pytest.raises(KeyError, match="Circuit key 'c3' not found"):
+    with pytest.raises(KeyError, match="c3.* not found in batch program"):
         cg.engine.engine_program._deserialize_program(_BATCH_PROGRAM_V2, circuit_num='c3')
+    # Empty key
+    with pytest.raises(KeyError, match="Empty circuit key not found in batch program"):
+        cg.engine.engine_program._deserialize_program(_BATCH_PROGRAM_V2, circuit_num='')
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/cirq-google/cirq_google/engine/engine_program_test.py
+++ b/cirq-google/cirq_google/engine/engine_program_test.py
@@ -465,6 +465,25 @@ async def test_get_circuit_async():
             await program_batch.get_circuit_async('c3')
 
 
+@duet.sync
+async def test_get_mapped_circuits_async():
+    context = EngineContext()
+    circuit = cirq.Circuit(cirq.X(cirq.GridQubit(5, 2)) ** 0.5)
+
+    program_batch = cg.EngineProgram('a', 'b', context)
+    with mock.patch.object(
+        context.client, 'get_program_async', new_callable=mock.AsyncMock
+    ) as get_program_async:
+        get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2)
+        circuits = await program_batch.get_mapped_circuits_async()
+        assert isinstance(circuits, dict)
+        assert len(circuits) == 2
+        assert list(circuits.keys()) == ['c1', 'c2']
+        cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+            circuits['c1'], circuit
+        )
+
+
 def test_deserialize_program():
     code = util.pack_any(v2.program_pb2.Program())
     with mock.patch(
@@ -577,11 +596,29 @@ def test_get_circuits(get_program_async):
         circuits_unkeyed[1], expected_circuit
     )
 
-    # Batch program with keys (dict)
+    # Batch program with keys (list)
     program_batch = cg.EngineProgram('a', 'b', EngineContext())
     get_program_async.reset_mock()
     get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2)
-    circuits_dict = program_batch.get_circuits()
+    circuits_list = program_batch.get_circuits()
+    assert isinstance(circuits_list, list)
+    assert len(circuits_list) == 2
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        circuits_list[0], expected_circuit
+    )
+    cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
+        circuits_list[1], expected_circuit
+    )
+
+
+@mock.patch('cirq_google.engine.engine_client.EngineClient.get_program_async')
+def test_get_mapped_circuits(get_program_async):
+    expected_circuit = cirq.Circuit(cirq.X(cirq.GridQubit(5, 2)) ** 0.5)
+
+    # Batch program with keys (dict)
+    program_batch = cg.EngineProgram('a', 'b', EngineContext())
+    get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2)
+    circuits_dict = program_batch.get_mapped_circuits()
     assert isinstance(circuits_dict, dict)
     assert len(circuits_dict) == 2
     assert list(circuits_dict.keys()) == ['c1', 'c2']
@@ -591,6 +628,20 @@ def test_get_circuits(get_program_async):
     cirq.testing.assert_circuits_with_terminal_measurements_are_equivalent(
         circuits_dict['c2'], expected_circuit
     )
+
+    # Single circuit program (raises ValueError)
+    program_single = cg.EngineProgram('a', 'b', EngineContext())
+    get_program_async.reset_mock()
+    get_program_async.return_value = quantum.QuantumProgram(code=_PROGRAM_V2)
+    with pytest.raises(ValueError, match="not a batch program"):
+        _ = program_single.get_mapped_circuits()
+
+    # Batch program without keys (raises ValueError)
+    program_unkeyed = cg.EngineProgram('a', 'b', EngineContext())
+    get_program_async.reset_mock()
+    get_program_async.return_value = quantum.QuantumProgram(code=_BATCH_PROGRAM_V2_UNKEYED)
+    with pytest.raises(ValueError, match="does not have circuit keys"):
+        _ = program_unkeyed.get_mapped_circuits()
 
 
 @mock.patch('cirq_google.engine.engine_client.EngineClient.get_program_async')

--- a/cirq-google/cirq_google/engine/simulated_local_job.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job.py
@@ -18,7 +18,7 @@ and a provided sampler to execute circuits."""
 from __future__ import annotations
 
 import concurrent.futures
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import cast
 
 import duet
@@ -128,8 +128,6 @@ class SimulatedLocalJob(AbstractLocalJob):
         try:
             self._state = quantum.ExecutionStatus.State.RUNNING
             programs = parent.get_circuits()
-            if isinstance(programs, Mapping):
-                programs = list(programs.values())
             if len(sweeps) == 1 and len(programs) > 1:
                 sweeps = sweeps * len(programs)
             elif len(programs) == 1 and len(sweeps) > 1:

--- a/cirq-google/cirq_google/engine/simulated_local_job.py
+++ b/cirq-google/cirq_google/engine/simulated_local_job.py
@@ -18,7 +18,7 @@ and a provided sampler to execute circuits."""
 from __future__ import annotations
 
 import concurrent.futures
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import cast
 
 import duet
@@ -128,6 +128,8 @@ class SimulatedLocalJob(AbstractLocalJob):
         try:
             self._state = quantum.ExecutionStatus.State.RUNNING
             programs = parent.get_circuits()
+            if isinstance(programs, Mapping):
+                programs = list(programs.values())
             if len(sweeps) == 1 and len(programs) > 1:
                 sweeps = sweeps * len(programs)
             elif len(programs) == 1 and len(sweeps) > 1:


### PR DESCRIPTION
- When specifying a mapping of circuits to quantum engine, this PR adds support get get_circuit() and circuits() to allow the retrieval of the circuits in a dictionary format.