### PR TITLE
Prefer module-level import of builtin modules

### DIFF
--- a/cirq-core/cirq/_compat_test.py
+++ b/cirq-core/cirq/_compat_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import collections
 import dataclasses
 import importlib.metadata
+import importlib.util
 import inspect
 import logging
 import multiprocessing
@@ -518,9 +519,6 @@ def _new_module_in_different_parent():
 
 def _find_spec_deprecated_multiple_times():
     """to ensure the idempotency of the aliasing loader change"""
-    # sets up the DeprecationFinders
-    import importlib.util
-
     # first import, the loader is the regular loader on the spec
     assert importlib.util.find_spec('cirq.testing._compat_test_data.fake_a')
     # second import it might be the aliasing loader already
@@ -709,8 +707,6 @@ def test_deprecated_module(outdated_method, deprecation_messages):
 
 def _test_deprecated_module_inner(outdated_method, deprecation_messages):
     # ensure that both packages are initialized exactly once
-    import cirq
-
     with cirq.testing.assert_logs(
         'init:compat_test_data',
         'init:module_a',

--- a/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
+++ b/cirq-core/cirq/contrib/paulistring/pauli_string_measurement_with_readout_mitigation_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import itertools
 import random
 from collections.abc import Sequence
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -864,9 +865,6 @@ def test_postselection_symmetry_validation_and_logic() -> None:
 @pytest.mark.parametrize("use_sweep", [False, True])
 def test_sampler_receives_correct_circuits(use_sweep: bool) -> None:
     """Test that the sampler receives circuits with correct measurement qubits."""
-
-    from unittest.mock import MagicMock
-
     from cirq.study.result import ResultDict
 
     qubits = cirq.LineQubit.range(5)
@@ -876,7 +874,7 @@ def test_sampler_receives_correct_circuits(use_sweep: bool) -> None:
 
     # Test standard Pauli String without Symmetries
     circuits_to_pauli = {circuit: [pauli_str]}
-    mock_sampler = MagicMock()
+    mock_sampler = mock.MagicMock()
 
     mock_res = ResultDict(params=cirq.ParamResolver({}), measurements={"result": np.zeros((1, 3))})
     mock_sampler.run_batch.return_value = [[mock_res]]
@@ -909,7 +907,7 @@ def test_sampler_receives_correct_circuits(use_sweep: bool) -> None:
         postselection_symmetries=[(cirq.PauliString(cirq.Z(sym_qubit)), 1)],
     )
 
-    mock_sampler_sym = MagicMock()
+    mock_sampler_sym = mock.MagicMock()
     mock_res_sym = ResultDict(
         params=cirq.ParamResolver({}), measurements={"result": np.zeros((1, 4))}
     )

--- a/cirq-core/cirq/testing/json.py
+++ b/cirq-core/cirq/testing/json.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import dataclasses
+import importlib.util
 import inspect
 import io
 import pathlib
@@ -132,8 +133,6 @@ class ModuleJsonTestSpec:
 
 
 def spec_for(module_name: str) -> ModuleJsonTestSpec:
-    import importlib.util
-
     if importlib.util.find_spec(module_name) is None:
         raise ModuleNotFoundError(f"{module_name} not found")
 


### PR DESCRIPTION
Also remove redundant import of `cirq` when imported by `cirq.testing`.
