### PR TITLE
Return frozenset instead of set from cached methods

### DIFF
--- a/cirq-core/cirq/circuits/frozen_circuit.py
+++ b/cirq-core/cirq/circuits/frozen_circuit.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Hashable, Iterable, Iterator, Sequence, Set
+from collections.abc import Hashable, Iterable, Iterator, Sequence
 from functools import cached_property
 from types import NotImplementedType
 from typing import TYPE_CHECKING
@@ -173,8 +173,8 @@ class FrozenCircuit(AbstractCircuit, protocols.SerializableByKey):
         return super()._is_parameterized_()
 
     @_compat.cached_method
-    def _parameter_names_(self) -> Set[str]:
-        return super()._parameter_names_()
+    def _parameter_names_(self) -> frozenset[str]:
+        return frozenset(super()._parameter_names_())
 
     def _measurement_key_names_(self) -> frozenset[str]:
         return self.all_measurement_key_names()

--- a/cirq-core/cirq/circuits/moment.py
+++ b/cirq-core/cirq/circuits/moment.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence, Set
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from functools import cached_property
 from types import NotImplementedType
 from typing import Any, cast, overload, Self, TYPE_CHECKING
@@ -293,8 +293,8 @@ class Moment:
         return any(protocols.is_parameterized(op) for op in self)
 
     @_compat.cached_method()
-    def _parameter_names_(self) -> Set[str]:
-        return {name for op in self for name in protocols.parameter_names(op)}
+    def _parameter_names_(self) -> frozenset[str]:
+        return frozenset().union(*(protocols.parameter_names(op) for op in self))
 
     def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> cirq.Moment:
         changed = False

--- a/cirq-core/cirq/ops/if_op.py
+++ b/cirq-core/cirq/ops/if_op.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence, Set
+from collections.abc import Mapping, Sequence
 from types import NotImplementedType
 from typing import Any, TYPE_CHECKING
 
@@ -170,12 +170,10 @@ class If(raw_types.Operation):
         ) or protocols.is_parameterized(self._sub_operation)
 
     @_compat.cached_method
-    def _parameter_names_(self) -> Set[str]:
-        names: set[str] = set()
-        for c in self._conditions:
-            names.update(protocols.parameter_names(c))
-        names.update(protocols.parameter_names(self._sub_operation))
-        return names
+    def _parameter_names_(self) -> frozenset[str]:
+        return frozenset(protocols.parameter_names(self._sub_operation)).union(
+            *(protocols.parameter_names(c) for c in self._conditions)
+        )
 
     def _resolve_parameters_(self, resolver: cirq.ParamResolver, recursive: bool) -> If:
         new_conditions = [

--- a/cirq-core/cirq/ops/raw_types.py
+++ b/cirq-core/cirq/ops/raw_types.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import abc
 import functools
-from collections.abc import Callable, Collection, Hashable, Iterable, Mapping, Sequence, Set
+from collections.abc import Callable, Collection, Hashable, Iterable, Mapping, Sequence
 from types import NotImplementedType
 from typing import Any, cast, overload, TYPE_CHECKING
 
@@ -901,9 +901,10 @@ class TaggedOperation(Operation):
         return NotImplemented
 
     @cached_method
-    def _parameter_names_(self) -> Set[str]:
-        tag_params = {name for tag in self.tags for name in protocols.parameter_names(tag)}
-        return protocols.parameter_names(self.sub_operation) | tag_params
+    def _parameter_names_(self) -> frozenset[str]:
+        return frozenset(protocols.parameter_names(self.sub_operation)).union(
+            *(protocols.parameter_names(tag) for tag in self.tags)
+        )
 
     def _resolve_parameters_(
         self, resolver: cirq.ParamResolver, recursive: bool
@@ -1016,8 +1017,8 @@ class _InverseCompositeGate(Gate):
         return protocols.is_parameterized(self._original)
 
     @cached_method
-    def _parameter_names_(self) -> Set[str]:
-        return protocols.parameter_names(self._original)
+    def _parameter_names_(self) -> frozenset[str]:
+        return frozenset(protocols.parameter_names(self._original))
 
     def _resolve_parameters_(
         self, resolver: cirq.ParamResolver, recursive: bool


### PR DESCRIPTION
Prevent accidental mutation of the cached return value.
