### PR TITLE
Allow testing of notebooks that use `cirq_web`

### DIFF
--- a/dev_tools/notebooks/isolated_notebook_test.py
+++ b/dev_tools/notebooks/isolated_notebook_test.py
@@ -142,11 +142,18 @@ def _rewrite_and_run_notebook(notebook_path, cloned_env, papermill_scheduler):
     # ensure papermill will have CLOUDSDK_CONFIG set per dev_tools/conftest.py
     env = {'CLOUDSDK_CONFIG': os.environ['CLOUDSDK_CONFIG'], 'PIP_CONFIG_FILE': '/dev/null'}
     assert os.path.isdir(env["CLOUDSDK_CONFIG"])
-    notebook_env = cloned_env("isolated_notebook_tests", *PACKAGES)
 
-    notebook_file = os.path.basename(notebook_path)
+    # allow testing of notebooks that import deprecated cirq_web
+    notebooks_that_use_cirq_web = (
+        "circuit_example.ipynb",
+        "qvm_stabilizer_example.ipynb",
+        "bloch_sphere_example.ipynb",
+    )
+    if notebook_file in notebooks_that_use_cirq_web:
+        env["ALLOW_DEPRECATION_IN_TEST"] = "True"
 
     rewritten_notebook_path = rewrite_notebook(notebook_path)
+    notebook_env = cloned_env("isolated_notebook_tests", *PACKAGES)
 
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
     cmd = f"""

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -131,9 +131,7 @@ def test_notebooks_against_cirq_head(
         "bloch_sphere_example.ipynb",
     )
     if notebook_file in notebooks_that_use_cirq_web:
-        env_with_temporary_pip_target = {
-            "ALLOW_DEPRECATION_IN_TEST": "True",
-            **env_with_temporary_pip_target,
+        env_with_temporary_pip_target["ALLOW_DEPRECATION_IN_TEST"] = "True"
         }
 
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -124,6 +124,18 @@ def test_notebooks_against_cirq_head(
     # ensure papermill will have CLOUDSDK_CONFIG set per dev_tools/conftest.py
     assert os.path.isdir(env_with_temporary_pip_target["CLOUDSDK_CONFIG"])
 
+    # allow testing of notebooks that import deprecated cirq_web
+    notebooks_that_use_cirq_web = (
+        "circuit_example.ipynb",
+        "qvm_stabilizer_example.ipynb",
+        "bloch_sphere_example.ipynb",
+    )
+    if notebook_file in notebooks_that_use_cirq_web:
+        env_with_temporary_pip_target = {
+            "ALLOW_DEPRECATION_IN_TEST": "True",
+            **env_with_temporary_pip_target,
+        }
+
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
     wait_time = papermill_scheduler()[1]
     time.sleep(wait_time)

--- a/dev_tools/notebooks/notebook_test.py
+++ b/dev_tools/notebooks/notebook_test.py
@@ -132,7 +132,6 @@ def test_notebooks_against_cirq_head(
     )
     if notebook_file in notebooks_that_use_cirq_web:
         env_with_temporary_pip_target["ALLOW_DEPRECATION_IN_TEST"] = "True"
-        }
 
     REPO_ROOT.joinpath("out", notebook_rel_dir).mkdir(parents=True, exist_ok=True)
     wait_time = papermill_scheduler()[1]


### PR DESCRIPTION
Problem: When notebooks are tested in a pytest session,
use of the deprecated `cirq_web` makes them fail.

Solution: Allow use of deprecated Cirq code in notebooks that
need `cirq_web`.

Note that `isolated_notebook_test.py` tests notebooks against the
released cirq so the modification there preempts failures for
the next Cirq release (with cirq-web deprecation).
