### PR TITLE
CI - enable ci-daily tests with Python 3.14 on Mac OS X

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -79,8 +79,7 @@ jobs:
     name: Pytest MacOS
     strategy:
       matrix:
-        # TODO: quantumlib/qsim#1017 - enable '3.14' when qsimcirq has binary wheel
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     runs-on: macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Recent release of qsimcirq-0.22.1 provides binaries for Python 3.14,
https://pypi.org/project/qsimcirq/0.22.1

This reverts commit 7eba335bbf2b1b5be89819b750d171c55f4fa6bd (#7912).
