### PR TITLE
Fix docstring of GoogleNoiseProperties.with_params

### DIFF
--- a/cirq-core/cirq/testing/equals_tester.py
+++ b/cirq-core/cirq/testing/equals_tester.py
@@ -102,7 +102,7 @@ class EqualsTester:
         or will be added.
 
         Args:
-          *group_items: The items making up the equivalence group.
+            *group_items: The items making up the equivalence group.
 
         Raises:
             AssertionError: Items within the group are not equal to each other,

--- a/cirq-core/cirq/testing/order_tester.py
+++ b/cirq-core/cirq/testing/order_tester.py
@@ -88,7 +88,7 @@ class OrderTester:
         which are supposed to be equal to each other within that group.
 
         Args:
-          *items: The sequence of strictly ascending items.
+            *items: The sequence of strictly ascending items.
 
         Raises:
             AssertionError: Items are not ascending either

--- a/cirq-core/cirq/transformers/analytical_decompositions/single_qubit_decompositions.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/single_qubit_decompositions.py
@@ -126,7 +126,7 @@ def single_qubit_op_to_framed_phase_form(mat: np.ndarray) -> tuple[np.ndarray, c
     rotations into controlled-Z operations bordered by single-qubit operations.
 
     Args:
-      mat:  The qubit operation as a 2x2 unitary matrix.
+        mat: The qubit operation as a 2x2 unitary matrix.
 
     Returns:
         A 2x2 unitary U, the complex relative phase factor r, and the complex

--- a/cirq-core/cirq/transformers/routing/route_circuit_cqc.py
+++ b/cirq-core/cirq/transformers/routing/route_circuit_cqc.py
@@ -368,14 +368,14 @@ class RouteCQC:
         timestep.
 
         Args:
-          two_qubit_ops: the circuit's two-qubit gates factored into timesteps as defined by the
-            paper.
-          single_qubit_ops: the circuit's single-qubit gates factored into timesteps as defined by
-            the paper.
-          lookahead_radius: the maximum number of times the cost function can be iterated for
-            convergence.
-        tag_inserted_swaps: whether or not a RoutingSwapTag should be attached to inserted swap
-            operations.
+            two_qubit_ops: the circuit's two-qubit gates factored into timesteps as defined by the
+                paper.
+            single_qubit_ops: the circuit's single-qubit gates factored into timesteps as defined
+                by the paper.
+            lookahead_radius: the maximum number of times the cost function can be iterated for
+                convergence.
+            tag_inserted_swaps: whether or not a RoutingSwapTag should be attached to inserted swap
+                operations.
 
         Returns:
             A list of lists corresponding to timesteps of the routed circuit and

--- a/cirq-google/cirq_google/devices/google_noise_properties.py
+++ b/cirq-google/cirq_google/devices/google_noise_properties.py
@@ -126,20 +126,18 @@ class GoogleNoiseProperties(devices.SuperconductingQubitsNoiseProperties):
         the same as those used in the constructor.
 
         Args:
-        gate_times_ns: float or dict[type[`cirq.Gate`], float].
-        t1_ns: float or dict[`cirq.Qid`, float].
-        tphi_ns: float or dict[`cirq.Qid`, float].
-        readout_errors: Sequence or dict[`cirq.Qid`, Sequence]. Converted to
-            list[float] if not provided in that format.
-        gate_pauli_errors: float or dict[`cirq.OpIdentifier`, float].
-            Dict key can also be type[`cirq.Gate`]; this will apply the given
-            error to all placements of that gate that appear in the original
-            object.
-        fsim_errors: `cirq.PhasedFSimGate` or dict[`cirq.OpIdentifier`,
-            `cirq.PhasedFSimGate`] Dict key can also be type[`cirq.Gate`]; this
-            will apply the given error to all placements of that gate that
-            appear in the original object.
-
+            gate_times_ns: float or dict[type[`cirq.Gate`], float].
+            t1_ns: float or dict[`cirq.Qid`, float].
+            tphi_ns: float or dict[`cirq.Qid`, float].
+            readout_errors: Sequence[float] or dict[`cirq.Qid`, Sequence[float]].
+                Converted to list[float] if not provided in that format.
+            gate_pauli_errors: float or dict[`cirq.OpIdentifier`, float].
+                Dict key can also be type[`cirq.Gate`]; this will apply the given
+                error to all placements of that gate that appear in the original
+                object.
+            fsim_errors: `cirq.PhasedFSimGate` or dict[`cirq.OpIdentifier`, `cirq.PhasedFSimGate`].
+                Dict key can also be type[`cirq.Gate`]; this will apply the given error
+                to all placements of that gate that appear in the original object.
         """
         replace_args: dict[str, Any] = {}
         if gate_times_ns is not None:


### PR DESCRIPTION
Fix item indentation in the `Args:` section.  This corrects
rendering of the `with_params` arguments table at
https://quantumai.google/reference/python/cirq_google/devices/GoogleNoiseProperties#with_params

Also correct few more docstrings with inconsistent indentation.

No change in the effective code.
