### PR TITLE
Drop unnecessary normalization in StateVectorTrialResult.final_state_vector

### DIFF
--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -18,9 +18,7 @@ from __future__ import annotations
 
 import abc
 import itertools
-import warnings
 from collections.abc import Iterator, Sequence
-from functools import cached_property
 from typing import Any, Generic, TYPE_CHECKING, TypeVar
 
 import numpy as np
@@ -128,22 +126,9 @@ class StateVectorTrialResult(
             qubit_map=final_simulator_state.qubit_map,
         )
 
-    @cached_property
+    @property
     def final_state_vector(self) -> np.ndarray:
-        ret = self._get_merged_sim_state().target_tensor.reshape(-1)
-        norm = np.linalg.norm(ret)
-        if abs(norm - 1) > np.sqrt(np.finfo(ret.dtype).eps):
-            warnings.warn(
-                f"final state vector's {norm=} is too far from 1,"
-                f" {abs(norm-1)} > {np.sqrt(np.finfo(ret.dtype).eps)}."
-                "skipping renormalization"
-            )
-            return ret
-        # normalize only if doing so improves the round-off on total probability
-        ret_norm = ret / norm
-        round_off_change = abs(np.vdot(ret_norm, ret_norm) - 1) - abs(np.vdot(ret, ret) - 1)
-        result = ret_norm if round_off_change < 0 else ret
-        return result
+        return self._get_merged_sim_state().target_tensor.reshape(-1)
 
     def state_vector(self, copy: bool = False) -> np.ndarray:
         """Return the state vector at the end of the computation.


### PR DESCRIPTION
The normalization in `StateVectorTrialResult.final_state_vector` was
introduced in #6522 to fix poorly normalized state vector per example
in #6402.  It turns out the imperfect normalization does not happen
for numpy-2.0 so it is not needed anymore.

This saves memory since a possibly huge state vector is not normalized
by a copy.  The `@cached_property` decorator is also removed, because
the `final_state_vector` property returns a view of already cached data.

Related:

- #6556 - reverted here
- #6522 - reverted here
- https://github.com/quantumlib/qsim/issues/893 - has
  OOM partially fixed here
