### PR TITLE
Rename jobs_per_batch to circuits_per_job

### DIFF
--- a/cirq-google/cirq_google/engine/engine.py
+++ b/cirq-google/cirq_google/engine/engine.py
@@ -670,7 +670,7 @@ class Engine(abstract_engine.AbstractEngine):
         device_config_name: str | None = None,
         device_config_revision: processor_config.DeviceConfigRevision | None = None,
         max_concurrent_jobs: int = 100,
-        jobs_per_batch: int = 1,
+        circuits_per_job: int = 1,
     ) -> cirq_google.ProcessorSampler:
         """Returns a sampler backed by the engine.
 
@@ -684,11 +684,11 @@ class Engine(abstract_engine.AbstractEngine):
                 concurrently to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
-            jobs_per_batch:  If set to greater than 1, this will batch multiple
+            circuits_per_job:  If set to greater than 1, this will batch multiple
                 circuits within the same API call when calling run_batch() or
-                run_batch_async() up to a maximum of `jobs_per_batch`.
+                run_batch_async() up to a maximum of `circuits_per_job`.
                 Note that actual hardware execution order is not guaranteed
-                if jobs_per_batch > 1. (For instance, the hardware may run
+                if circuits_per_job > 1. (For instance, the hardware may run
                 all circuits for the first sweep point, then the second point, etc.).
 
         Returns:
@@ -710,7 +710,7 @@ class Engine(abstract_engine.AbstractEngine):
             device_config_name=device_config_name,
             device_config_revision=device_config_revision,
             max_concurrent_jobs=max_concurrent_jobs,
-            jobs_per_batch=jobs_per_batch,
+            circuits_per_job=circuits_per_job,
         )
 
     async def get_processor_config_async(

--- a/cirq-google/cirq_google/engine/engine_processor.py
+++ b/cirq-google/cirq_google/engine/engine_processor.py
@@ -80,7 +80,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
         device_config_name: str | None = None,
         device_config_revision: processor_config.DeviceConfigRevision | None = None,
         max_concurrent_jobs: int = 100,
-        jobs_per_batch: int = 1,
+        circuits_per_job: int = 1,
     ) -> cg.engine.ProcessorSampler:
         """Returns the default sampler backed by the engine.
 
@@ -93,11 +93,11 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 simultaneously to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
-            jobs_per_batch:  If set to greater than 1, this will batch multiple
+            circuits_per_job:  If set to greater than 1, this will batch multiple
                 circuits within the same API call when calling run_batch() or
-                run_batch_async() up to a maximum of `jobs_per_batch`.
+                run_batch_async() up to a maximum of `circuits_per_job`.
                 Note that actual hardware execution order is not guaranteed
-                if jobs_per_batch > 1. (For instance, the hardware may run
+                if circuits_per_job > 1. (For instance, the hardware may run
                 all circuits for the first sweep point, then the second point, etc.).
 
         Returns:
@@ -121,7 +121,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 snapshot_id=device_config_revision.id,
                 device_config_name=device_config_name,
                 max_concurrent_jobs=max_concurrent_jobs,
-                jobs_per_batch=jobs_per_batch,
+                circuits_per_job=circuits_per_job,
             )
         if isinstance(device_config_revision, processor_config.Run):
             return processor_sampler.ProcessorSampler(
@@ -129,7 +129,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
                 run_name=device_config_revision.id,
                 device_config_name=device_config_name,
                 max_concurrent_jobs=max_concurrent_jobs,
-                jobs_per_batch=jobs_per_batch,
+                circuits_per_job=circuits_per_job,
             )
 
         return processor_sampler.ProcessorSampler(
@@ -137,7 +137,7 @@ class EngineProcessor(abstract_processor.AbstractProcessor):
             run_name=processor.default_device_config_key.run,
             device_config_name=device_config_name,
             max_concurrent_jobs=max_concurrent_jobs,
-            jobs_per_batch=jobs_per_batch,
+            circuits_per_job=circuits_per_job,
         )
 
     async def run_sweep_async(

--- a/cirq-google/cirq_google/engine/engine_processor_test.py
+++ b/cirq-google/cirq_google/engine/engine_processor_test.py
@@ -378,7 +378,7 @@ def test_get_sampler_from_run_name_with_defaults() -> None:
     assert sampler.device_config_name == default_config_alias
 
 
-def test_get_sampler_initializes_jobs_per_batch() -> None:
+def test_get_sampler_initializes_circuits_per_job() -> None:
     processor = cg.EngineProcessor(
         'a',
         'p',
@@ -390,14 +390,16 @@ def test_get_sampler_initializes_jobs_per_batch() -> None:
         ),
     )
     sampler_default = processor.get_sampler()
-    assert sampler_default._jobs_per_batch == 1
+    assert sampler_default._circuits_per_job == 1
+    assert sampler_default.circuits_per_job == 1
 
-    jobs_per_batch = 5
-    sampler = processor.get_sampler(jobs_per_batch=jobs_per_batch)
-    assert sampler._jobs_per_batch == jobs_per_batch
+    circuits_per_job = 5
+    sampler = processor.get_sampler(circuits_per_job=circuits_per_job)
+    assert sampler._circuits_per_job == circuits_per_job
+    assert sampler.circuits_per_job == circuits_per_job
 
 
-def test_get_sampler_initializes_jobs_per_batch_with_snapshot() -> None:
+def test_get_sampler_initializes_circuits_per_job_with_snapshot() -> None:
     processor = cg.EngineProcessor(
         'a',
         'p',
@@ -409,12 +411,15 @@ def test_get_sampler_initializes_jobs_per_batch_with_snapshot() -> None:
         ),
     )
     snapshot = Snapshot(id='test_snapshot')
-    jobs_per_batch = 5
-    sampler = processor.get_sampler(device_config_revision=snapshot, jobs_per_batch=jobs_per_batch)
-    assert sampler._jobs_per_batch == jobs_per_batch
+    circuits_per_job = 5
+    sampler = processor.get_sampler(
+        device_config_revision=snapshot, circuits_per_job=circuits_per_job
+    )
+    assert sampler._circuits_per_job == circuits_per_job
+    assert sampler.circuits_per_job == circuits_per_job
 
 
-def test_get_sampler_initializes_jobs_per_batch_with_run() -> None:
+def test_get_sampler_initializes_circuits_per_job_with_run() -> None:
     processor = cg.EngineProcessor(
         'a',
         'p',
@@ -426,9 +431,10 @@ def test_get_sampler_initializes_jobs_per_batch_with_run() -> None:
         ),
     )
     run = Run(id='test_run')
-    jobs_per_batch = 5
-    sampler = processor.get_sampler(device_config_revision=run, jobs_per_batch=jobs_per_batch)
-    assert sampler._jobs_per_batch == jobs_per_batch
+    circuits_per_job = 5
+    sampler = processor.get_sampler(device_config_revision=run, circuits_per_job=circuits_per_job)
+    assert sampler._circuits_per_job == circuits_per_job
+    assert sampler.circuits_per_job == circuits_per_job
 
 
 def test_get_sampler_from_snapshot_id() -> None:

--- a/cirq-google/cirq_google/engine/engine_test.py
+++ b/cirq-google/cirq_google/engine/engine_test.py
@@ -914,14 +914,16 @@ def test_get_sampler_initializes_max_concurrent_jobs():
     assert sampler.max_concurrent_jobs == max_concurrent_jobs
 
 
-def test_get_sampler_initializes_jobs_per_batch():
+def test_get_sampler_initializes_circuits_per_job():
     engine = cg.Engine(project_id='proj')
     sampler_default = engine.get_sampler(processor_id='tmp')
-    assert sampler_default._jobs_per_batch == 1
+    assert sampler_default._circuits_per_job == 1
+    assert sampler_default.circuits_per_job == 1
 
-    jobs_per_batch = 5
-    sampler = engine.get_sampler(processor_id='tmp', jobs_per_batch=jobs_per_batch)
-    assert sampler._jobs_per_batch == jobs_per_batch
+    circuits_per_job = 5
+    sampler = engine.get_sampler(processor_id='tmp', circuits_per_job=circuits_per_job)
+    assert sampler._circuits_per_job == circuits_per_job
+    assert sampler.circuits_per_job == circuits_per_job
 
 
 def test_get_sampler_from_run_name():

--- a/cirq-google/cirq_google/engine/processor_config.py
+++ b/cirq-google/cirq_google/engine/processor_config.py
@@ -130,7 +130,7 @@ class ProcessorConfig:
         return parts[-1]
 
     def sampler(
-        self, max_concurrent_jobs: int = 100, jobs_per_batch: int = 1
+        self, max_concurrent_jobs: int = 100, circuits_per_job: int = 1
     ) -> processor_sampler.ProcessorSampler:
         """Returns the sampler backed by this config.
 
@@ -139,11 +139,11 @@ class ProcessorConfig:
                 simultaneously to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
-            jobs_per_batch:  If set to greater than 1, this will batch multiple
+            circuits_per_job:  If set to greater than 1, this will batch multiple
                 circuits within the same API call when calling run_batch() or
-                run_batch_async() up to a maximum of `jobs_per_batch`.
+                run_batch_async() up to a maximum of `circuits_per_job`.
                 Note that actual hardware execution order is not guaranteed
-                if jobs_per_batch > 1. (For instance, the hardware may run
+                if circuits_per_job > 1. (For instance, the hardware may run
                 all circuits for the first sweep point, then the second point, etc.).
 
         Returns:
@@ -157,7 +157,7 @@ class ProcessorConfig:
             snapshot_id=self.snapshot_id,
             device_config_name=self.config_name,
             max_concurrent_jobs=max_concurrent_jobs,
-            jobs_per_batch=jobs_per_batch,
+            circuits_per_job=circuits_per_job,
         )
 
     def __repr__(self) -> str:

--- a/cirq-google/cirq_google/engine/processor_config_test.py
+++ b/cirq-google/cirq_google/engine/processor_config_test.py
@@ -167,20 +167,22 @@ def test_sampler():
     assert sampler.run_name == run.id
     assert sampler.snapshot_id == _SNAPSHOT_ID
     assert sampler.device_config_name == _CONFIG_NAME
-    assert sampler._jobs_per_batch == 1
+    assert sampler._circuits_per_job == 1
+    assert sampler.circuits_per_job == 1
 
 
-def test_sampler_initializes_jobs_per_batch():
+def test_sampler_initializes_circuits_per_job():
     run = Run(id='test_run_name')
     config = cg.engine.ProcessorConfig(
         processor=None,
         quantum_processor_config=_VALID_QUANTUM_PROCESSOR_CONFIG,
         device_config_revision=run,
     )
-    jobs_per_batch = 5
-    sampler = config.sampler(jobs_per_batch=jobs_per_batch)
+    circuits_per_job = 5
+    sampler = config.sampler(circuits_per_job=circuits_per_job)
 
-    assert sampler._jobs_per_batch == jobs_per_batch
+    assert sampler._circuits_per_job == circuits_per_job
+    assert sampler.circuits_per_job == circuits_per_job
 
 
 def test_validate_device_config_revision():

--- a/cirq-google/cirq_google/engine/processor_sampler.py
+++ b/cirq-google/cirq_google/engine/processor_sampler.py
@@ -36,7 +36,7 @@ class ProcessorSampler(cirq.Sampler):
         snapshot_id: str = "",
         device_config_name: str = "",
         max_concurrent_jobs: int = 100,
-        jobs_per_batch: int = 1,
+        circuits_per_job: int = 1,
     ):
         """Inits ProcessorSampler.
 
@@ -57,11 +57,11 @@ class ProcessorSampler(cirq.Sampler):
                 concurrently to the Engine. This client-side throttle can be
                 used to proactively reduce load to the backends and avoid quota
                 violations when pipelining circuit executions.
-            jobs_per_batch:  If set to greater than 1, this will batch multiple
+            circuits_per_job:  If set to greater than 1, this will batch multiple
                 circuits within the same API call when calling run_batch() or
-                run_batch_async() up to a maximum of `jobs_per_batch`.
+                run_batch_async() up to a maximum of `circuits_per_job`.
                 Note that actual hardware execution order is not guaranteed
-                if jobs_per_batch > 1. (For instance, the hardware may run
+                if circuits_per_job > 1. (For instance, the hardware may run
                 all circuits for the first sweep point, then the second point, etc.).
 
         Raises:
@@ -75,7 +75,7 @@ class ProcessorSampler(cirq.Sampler):
         self._snapshot_id = snapshot_id
         self._device_config_name = device_config_name
         self._concurrent_job_limiter = duet.Limiter(max_concurrent_jobs)
-        self._jobs_per_batch = jobs_per_batch
+        self._circuits_per_job = circuits_per_job
 
     async def run_sweep_async(
         self,
@@ -116,7 +116,7 @@ class ProcessorSampler(cirq.Sampler):
         params_list: Sequence[cirq.Sweepable] | None = None,
         repetitions: int | Sequence[int] = 1,
     ) -> Sequence[Sequence[cg.EngineResult]]:
-        if self._jobs_per_batch > 1:
+        if self._circuits_per_job > 1:
             # Treat programs as a sequence for iteration, but keep keys if it's a mapping
             prog_keys = list(programs.keys()) if isinstance(programs, Mapping) else []
             prog_values = (
@@ -139,7 +139,7 @@ class ProcessorSampler(cirq.Sampler):
                 i += 1
                 while (
                     i < len(prog_values)
-                    and len(batch_programs) < self._jobs_per_batch
+                    and len(batch_programs) < self._circuits_per_job
                     and repetitions[i] == batch_reps
                     and params_list[i] == batch_sweep
                 ):
@@ -198,3 +198,7 @@ class ProcessorSampler(cirq.Sampler):
     def max_concurrent_jobs(self) -> int:
         assert self._concurrent_job_limiter.capacity is not None
         return self._concurrent_job_limiter.capacity
+
+    @property
+    def circuits_per_job(self) -> int:
+        return self._circuits_per_job

--- a/cirq-google/cirq_google/engine/processor_sampler_test.py
+++ b/cirq-google/cirq_google/engine/processor_sampler_test.py
@@ -174,9 +174,9 @@ def test_run_batch_differing_repetitions():
     )
 
 
-def test_run_batch_with_jobs_per_batch():
+def test_run_batch_with_circuits_per_job():
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=2)
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -205,7 +205,7 @@ def test_run_batch_with_jobs_per_batch():
 
 def test_run_batch_ordering():
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=2)
 
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a), cirq.X(a), cirq.measure(a, key='m'))
@@ -246,9 +246,9 @@ def test_run_batch_ordering():
 
 
 @pytest.mark.parametrize('use_mapping', [True, False])
-def test_run_batch_with_jobs_per_batch_and_params(use_mapping: bool):
+def test_run_batch_with_circuits_per_job_and_params(use_mapping: bool):
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=2)
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -268,9 +268,9 @@ def test_run_batch_with_jobs_per_batch_and_params(use_mapping: bool):
     )
 
 
-def test_run_batch_with_jobs_per_batch_different_params():
+def test_run_batch_with_circuits_per_job_different_params():
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=2)
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -298,9 +298,9 @@ def test_run_batch_with_jobs_per_batch_different_params():
     )
 
 
-def test_run_batch_with_jobs_per_batch_different_repetitions():
+def test_run_batch_with_circuits_per_job_different_repetitions():
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=2)
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))
     circuit2 = cirq.Circuit(cirq.Y(a))
@@ -384,8 +384,9 @@ async def test_sampler_with_full_job_queue_unblocks_when_available():
 
 def test_processor_sampler_processor_property():
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=3)
     assert sampler.processor is processor
+    assert sampler.circuits_per_job == 3
 
 
 def test_with_local_processor():
@@ -414,7 +415,7 @@ def test_processor_sampler_with_invalid_configuration_throws(run_name, device_co
 @duet.sync
 async def test_run_batch_error_divisible():
     processor = mock.create_autospec(AbstractProcessor, instance=True)
-    sampler = cg.ProcessorSampler(processor=processor, jobs_per_batch=2)
+    sampler = cg.ProcessorSampler(processor=processor, circuits_per_job=2)
 
     a = cirq.LineQubit(0)
     circuit1 = cirq.Circuit(cirq.X(a))

--- a/docs/google/best_practices.ipynb
+++ b/docs/google/best_practices.ipynb
@@ -337,8 +337,8 @@
     "of your program so that more repetitions are completed per second.\n",
     "\n",
     "By default, `run_batch` will create one job per circuit. It is also possible to\n",
-    "pack multiple circuits into a job by specifying `jobs_per_batch` when loading the\n",
-    "sampler using [`cirq_google.engine.ProcessorSampler(..., jobs_per_batch=...)`](https://quantumai.google/reference/python/cirq_google/engine/ProcessorSampler)."
+    "pack multiple circuits into a job by specifying `circuits_per_job` when loading the\n",
+    "sampler using [`cirq_google.engine.ProcessorSampler(..., circuits_per_job=...)`](https://quantumai.google/reference/python/cirq_google/engine/ProcessorSampler)."
    ]
   },
   {


### PR DESCRIPTION
- Renames jobs_per_batch to circuits_per_job to more accurately represent that we are sending N circuits to the engine per job/program.
- This new attribute is not yet being widely used by clients and can be directly renamed.
