### PR TITLE
Fix indentation of args and raises docstring items

### DIFF
--- a/cirq-aqt/cirq_aqt/aqt_sampler.py
+++ b/cirq-aqt/cirq_aqt/aqt_sampler.py
@@ -414,7 +414,7 @@ class AQTSampler(cirq.Sampler):
 
         Args:
             program: The circuit to simulate.
-            Should be generated using AQTSampler.generate_circuit_from_list
+                Should be generated using `AQTSampler.generate_circuit_from_list`.
             params: Parameters to run with the program.
             repetitions: The number of repetitions to simulate.
 

--- a/cirq-core/cirq/contrib/bayesian_network/bayesian_network_gate.py
+++ b/cirq-core/cirq/contrib/bayesian_network/bayesian_network_gate.py
@@ -143,7 +143,7 @@ class BayesianNetworkGate(raw_types.Gate):
 
         Raises:
             ValueError: If the probabilities are not in [0, 1], or an incorrect number of
-            probability is specified, or if the parameter names are no passed as a tuple.
+                probability is specified, or if the parameter names are no passed as a tuple.
         """
         for _, init_prob in init_probs:
             if init_prob is None:

--- a/cirq-core/cirq/contrib/circuitdag/circuit_dag.py
+++ b/cirq-core/cirq/contrib/circuitdag/circuit_dag.py
@@ -190,8 +190,7 @@ class CircuitDag(networkx.DiGraph):
         """Finds all nodes before blocking ones.
 
         Args:
-            is_blocker: The predicate that indicates whether or not an
-            operation is blocking.
+            is_blocker: The predicate that indicates whether or not an operation is blocking.
         """
         remaining_dag = self.copy()
 

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -275,12 +275,12 @@ class CommonCliffordGates(metaclass=CommonCliffordGateMetaClass):
 
         Args:
             tableau: A CliffordTableau to define the effect of Clifford Gate applying on
-            the stabilizer state or Pauli group. The meaning of tableau here is
-                    To  X   Z    sign
-            from  X  [ X_x Z_x | r_x ]
-            from  Z  [ X_z Z_z | r_z ]
-            Each row in the Clifford tableau indicates how the transformation of original
-            Pauli gates to the new gates after applying this Clifford Gate.
+                the stabilizer state or Pauli group. The meaning of tableau here is
+                        To  X   Z    sign
+                from  X  [ X_x Z_x | r_x ]
+                from  Z  [ X_z Z_z | r_z ]
+                Each row in the Clifford tableau indicates how the transformation of original
+                Pauli gates to the new gates after applying this Clifford Gate.
 
         Returns:
             A CliffordGate instance, which has the transformation defined by
@@ -288,7 +288,7 @@ class CommonCliffordGates(metaclass=CommonCliffordGateMetaClass):
 
         Raises:
             ValueError: When input tableau is wrong type or the tableau does not
-            satisfy the symplectic property.
+                satisfy the symplectic property.
         """
         if not isinstance(tableau, qis.CliffordTableau):
             raise ValueError('Input argument has to be a CliffordTableau instance.')

--- a/cirq-core/cirq/protocols/commutes_protocol.py
+++ b/cirq-core/cirq/protocols/commutes_protocol.py
@@ -124,7 +124,7 @@ def commutes(
 
     Raises:
         TypeError: The commutativity of `v1` and `v2` is indeterminate, or could
-        not be determined, and the `default` argument was not specified.
+            not be determined, and the `default` argument was not specified.
     """
     atol = float(atol)
 

--- a/cirq-core/cirq/qis/quantum_state_representation.py
+++ b/cirq-core/cirq/qis/quantum_state_representation.py
@@ -30,10 +30,11 @@ class QuantumStateRepresentation(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def copy(self, deep_copy_buffers: bool = True) -> Self:
         """Creates a copy of the object.
+
         Args:
             deep_copy_buffers: If True, buffers will also be deep-copied.
-            Otherwise the copy will share a reference to the original object's
-            buffers.
+                Otherwise the copy will share a reference to the original object's buffers.
+
         Returns:
             A copied instance.
         """

--- a/cirq-core/cirq/sim/simulation_state.py
+++ b/cirq-core/cirq/sim/simulation_state.py
@@ -146,8 +146,7 @@ class SimulationState(SimulationStateBase, Generic[TState], metaclass=abc.ABCMet
 
         Args:
             deep_copy_buffers: If True, buffers will also be deep-copied.
-            Otherwise the copy will share a reference to the original object's
-            buffers.
+                Otherwise the copy will share a reference to the original object's buffers.
 
         Returns:
             A copied instance.

--- a/cirq-core/cirq/sim/simulation_state_base.py
+++ b/cirq-core/cirq/sim/simulation_state_base.py
@@ -105,8 +105,7 @@ class SimulationStateBase(Generic[TSimulationState], metaclass=abc.ABCMeta):
 
         Args:
             deep_copy_buffers: If True, buffers will also be deep-copied.
-            Otherwise the copy will share a reference to the original object's
-            buffers.
+                Otherwise the copy will share a reference to the original object's buffers.
 
         Returns:
             A copied instance.

--- a/cirq-core/cirq/sim/state_vector.py
+++ b/cirq-core/cirq/sim/state_vector.py
@@ -88,10 +88,10 @@ class StateVectorMixin:
 
         Args:
             copy: If True, the returned state vector will be a copy of that
-            stored by the object. This is potentially expensive for large
-            state vectors, but prevents mutation of the object state, e.g. for
-            operating on intermediate states of a circuit.
-            Defaults to False.
+                stored by the object. This is potentially expensive for large
+                state vectors, but prevents mutation of the object state, e.g.,
+                for operating on intermediate states of a circuit.
+                Defaults to False.
         """
         raise NotImplementedError()
 

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -158,10 +158,10 @@ class StateVectorTrialResult(
 
         Args:
             copy: If True, the returned state vector will be a copy of that
-            stored by the object. This is potentially expensive for large
-            state vectors, but prevents mutation of the object state, e.g. for
-            operating on intermediate states of a circuit.
-            Defaults to False.
+                stored by the object. This is potentially expensive for large
+                state vectors, but prevents mutation of the object state, e.g.,
+                for operating on intermediate states of a circuit.
+                Defaults to False.
         """
         return self.final_state_vector.copy() if copy else self.final_state_vector
 

--- a/cirq-core/cirq/study/flatten_expressions.py
+++ b/cirq-core/cirq/study/flatten_expressions.py
@@ -52,7 +52,7 @@ def flatten(val: Any) -> tuple[Any, ExpressionMap]:
 
     Args:
         val: The value to copy and substitute parameter expressions with
-        flattened symbols.
+            flattened symbols.
 
     Returns:
         The tuple (new value, expression map) where new value and expression map
@@ -136,7 +136,7 @@ def flatten_with_sweep(
 
     Args:
         val: The value to copy and substitute parameter expressions with
-        flattened symbols.
+            flattened symbols.
         sweep: A sweep over parameters used by `val`.
 
     Returns:
@@ -171,7 +171,7 @@ def flatten_with_params(
 
     Args:
         val: The value to copy and substitute parameter expressions with
-        flattened symbols.
+            flattened symbols.
         params: A dictionary or `ParamResolver` where the keys are
             `sympy.Symbol`s used by `val` and the values are numbers.
 

--- a/cirq-core/cirq/transformers/transformer_api.py
+++ b/cirq-core/cirq/transformers/transformer_api.py
@@ -154,7 +154,7 @@ class TransformerLogger:
 
         Args:
             level: The logging level to filter the logs with. The method shows all logs with a
-            `LogLevel` >= `level`.
+                `LogLevel` >= `level`.
         """
 
         def print_log(log: _LoggerNode, pad=''):

--- a/cirq-core/cirq/work/sampler.py
+++ b/cirq-core/cirq/work/sampler.py
@@ -421,7 +421,7 @@ class Sampler(metaclass=value.ABCMetaImplementAnyOneOf):
 
         Raises:
             ValueError: if the qid_shape of different instances of the same measurement
-            key disagree.
+                key disagree.
         """
         qid_shapes: dict[str, tuple[int, ...]] = {}
         num_instances: dict[str, int] = collections.Counter()

--- a/cirq-core/cirq/work/zeros_sampler.py
+++ b/cirq-core/cirq/work/zeros_sampler.py
@@ -53,7 +53,7 @@ class ZerosSampler(work.Sampler, metaclass=abc.ABCMeta):
 
         Raises:
             ValueError: circuit is not valid for the sampler, due to invalid
-            repeated keys or incompatibility with the sampler's device.
+                repeated keys or incompatibility with the sampler's device.
         """
         if self.device:
             self.device.validate_circuit(program)

--- a/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
+++ b/cirq-google/cirq_google/cloud/quantum_v1alpha1/services/quantum_engine_service/client.py
@@ -163,9 +163,10 @@ class QuantumEngineServiceClient(metaclass=QuantumEngineServiceClientMeta):
 
         Returns:
             bool: whether client certificate should be used for mTLS
+
         Raises:
             ValueError: (If using a version of google-auth without should_use_client_cert and
-            GOOGLE_API_USE_CLIENT_CERTIFICATE is set to an unexpected value.)
+                GOOGLE_API_USE_CLIENT_CERTIFICATE is set to an unexpected value.)
         """
         # check if google-auth version supports should_use_client_cert for automatic mTLS enablement
         if hasattr(mtls, "should_use_client_cert"):  # pragma: NO COVER

--- a/cirq-ionq/cirq_ionq/service.py
+++ b/cirq-ionq/cirq_ionq/service.py
@@ -405,7 +405,7 @@ class Service:
 
         Args:
             job_id: The UUID of the job. Jobs are assigned these numbers by the
-            server during the creation of the job.
+                server during the creation of the job.
 
         Returns:
             A `cirq_ionq.IonQJob` which can be queried for status or results.

--- a/cirq-web/cirq_web/circuits/symbols.py
+++ b/cirq-web/cirq_web/circuits/symbols.py
@@ -158,15 +158,15 @@ class Operation3DSymbol:
 
         Args:
             wire_symbols: a list of symbols taken from circuit_diagram_info()
-            that will be used to represent the operation in the 3D circuit.
+                that will be used to represent the operation in the 3D circuit.
 
             location_info: A list of coordinates for each wire_symbol. The
-            index of the coordinate tuple in the location_info list must
-            correspond with the index of the symbol in the wire_symbols list.
+                index of the coordinate tuple in the location_info list must
+                correspond with the index of the symbol in the wire_symbols list.
 
             color_info: a list representing the desired color of the symbol(s).
-            These will also correspond to index of the symbol in the
-            wire_symbols list.
+                These will also correspond to index of the symbol in the
+                wire_symbols list.
 
             moment: the moment where the symbol should be.
         """

--- a/cirq-web/cirq_web/widget.py
+++ b/cirq-web/cirq_web/widget.py
@@ -76,7 +76,7 @@ class Widget(ABC):
 
         Args:
             output_directory: the directory in which the output file will be
-            generated. The default is the current directory ('./')
+                generated. The default is the current directory ('./')
 
             file_name: the name of the output file. Default is 'bloch_sphere'
 

--- a/dev_tools/modules.py
+++ b/dev_tools/modules.py
@@ -88,12 +88,14 @@ def list_modules(
 
     Args:
         include_parent: if true, a setup.py is expected in `search_dir`, and the corresponding
-        module will be included.
+            module will be included.
         search_dir: the search directory for modules, by default the repo root.
+
     Returns:
-          a list of `Module`s that were found, where each module `m` is initialized with `m.root`
-           relative to `search_dir`, `m.raw_setup` contains the dictionary equivalent to the
-           keyword args passed to the `setuptools.setup` method in setup.py
+        a list of `Module`s that were found, where each module `m` is initialized with `m.root`
+        relative to `search_dir`, `m.raw_setup` contains the dictionary equivalent to the
+        keyword args passed to the `setuptools.setup` method in setup.py
+
     Raises:
         ValueError: if include_parent=True but there is no setup.py in `search_dir`.
     """


### PR DESCRIPTION
When description of an argument or possible exception does not
fit in a single docstring line, the next line should be indented.

No change in the effective code.
