### PR TITLE
Raise QasmException instead of leaking ZeroDivisionError from the QASM expression parser

### DIFF
--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -1055,8 +1055,11 @@ class QasmParser:
         """
         try:
             p[0] = self.binary_operators[p[2]](p[1], p[3])
-        except ZeroDivisionError:
-            raise QasmException(f"Division by zero at line {p.lineno(2)}")
+        except ZeroDivisionError as e:
+            # Both "/" and "^" can raise this, with different causes
+            # ("division by zero" vs "zero to a negative power"), so reuse
+            # Python's own message rather than assuming a division.
+            raise QasmException(f"{e} at line {p.lineno(2)}")
 
     def p_term(self, p):
         """term : NUMBER

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -1053,7 +1053,10 @@ class QasmParser:
         | expr '-' expr
         | expr '^' expr
         """
-        p[0] = self.binary_operators[p[2]](p[1], p[3])
+        try:
+            p[0] = self.binary_operators[p[2]](p[1], p[3])
+        except ZeroDivisionError:
+            raise QasmException(f"Division by zero at line {p.lineno(2)}")
 
     def p_term(self, p):
         """term : NUMBER

--- a/cirq-core/cirq/contrib/qasm_import/_parser.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser.py
@@ -1055,11 +1055,15 @@ class QasmParser:
         """
         try:
             p[0] = self.binary_operators[p[2]](p[1], p[3])
-        except ZeroDivisionError as e:
-            # Both "/" and "^" can raise this, with different causes
-            # ("division by zero" vs "zero to a negative power"), so reuse
-            # Python's own message rather than assuming a division.
-            raise QasmException(f"{e} at line {p.lineno(2)}")
+        except ZeroDivisionError:
+            # Both "/" and "^" can raise this, for different reasons, so the
+            # message distinguishes them by operator. It deliberately does not
+            # reuse Python's own text: CPython rewords ZeroDivisionError
+            # between releases (3.11 says "0.0 cannot be raised to a negative
+            # power" where 3.14 says "zero to a negative power"), which would
+            # make this parser's user-visible error depend on the interpreter.
+            reason = "zero to a negative power" if p[2] == '^' else "division by zero"
+            raise QasmException(f"{reason} at line {p.lineno(2)}")
 
     def p_term(self, p):
         """term : NUMBER

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -2525,3 +2525,32 @@ def test_input_invalid_type_error() -> None:
     """
     with pytest.raises(QasmException, match="Syntax error"):
         QasmParser().parse(qasm)
+
+
+@pytest.mark.parametrize(
+    'expression', ['pi/0', '1/0', '0/0', 'pi/(1-1)', 'pi/1e-400', '(2+2)/(3-3)']
+)
+def test_division_by_zero(expression: str) -> None:
+    qasm = f"""OPENQASM 2.0;
+     include "qelib1.inc";
+     qreg q[1];
+     rx({expression}) q[0];
+"""
+    with pytest.raises(QasmException, match="Division by zero at line 4"):
+        QasmParser().parse(qasm)
+
+
+def test_division_by_zero_does_not_reject_valid_arithmetic() -> None:
+    """The guard wraps the line that applies every binary operator."""
+    qasm = """OPENQASM 2.0;
+     include "qelib1.inc";
+     qreg q[1];
+     rx(pi/2) q[0];
+     ry(pi*1) q[0];
+     rz(2^1*pi/2) q[0];
+"""
+    parsed_qasm = QasmParser().parse(qasm)
+    q0 = cirq.NamedQubit('q_0')
+    assert parsed_qasm.circuit == Circuit(
+        [cirq.rx(np.pi / 2).on(q0), cirq.ry(np.pi).on(q0), cirq.rz(np.pi).on(q0)]
+    )

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -2536,7 +2536,19 @@ def test_division_by_zero(expression: str) -> None:
      qreg q[1];
      rx({expression}) q[0];
 """
-    with pytest.raises(QasmException, match="Division by zero at line 4"):
+    with pytest.raises(QasmException, match="division by zero at line 4"):
+        QasmParser().parse(qasm)
+
+
+@pytest.mark.parametrize('expression', ['0^-1', '0^-2', '(1-1)^-1'])
+def test_zero_to_a_negative_power(expression: str) -> None:
+    """`^` raises ZeroDivisionError too, but for a different reason."""
+    qasm = f"""OPENQASM 2.0;
+     include "qelib1.inc";
+     qreg q[1];
+     rx({expression}) q[0];
+"""
+    with pytest.raises(QasmException, match="zero to a negative power at line 4"):
         QasmParser().parse(qasm)
 
 

--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -2552,6 +2552,29 @@ def test_zero_to_a_negative_power(expression: str) -> None:
         QasmParser().parse(qasm)
 
 
+def test_zero_division_message_does_not_depend_on_the_interpreter() -> None:
+    """The message is ours, not CPython's.
+
+    An earlier version of this fix built the message from `str(e)` on the caught
+    ZeroDivisionError. CPython rewords that error between releases -- 3.11 raises
+    "0.0 cannot be raised to a negative power" where 3.14 raises "zero to a
+    negative power" -- so the parser's user-visible error, and any downstream
+    matching on it, silently changed with the interpreter. Pin both messages.
+    """
+    zero_div = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nrx(1/0) q[0];\n'
+    neg_pow = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nrx(0^-1) q[0];\n'
+
+    with pytest.raises(QasmException) as div_info:
+        QasmParser().parse(zero_div)
+    with pytest.raises(QasmException) as pow_info:
+        QasmParser().parse(neg_pow)
+
+    # Exact strings, not regexes: the point of the test is that the wording is
+    # fixed by this file and cannot drift with the Python version.
+    assert str(div_info.value) == 'division by zero at line 4'
+    assert str(pow_info.value) == 'zero to a negative power at line 4'
+
+
 def test_division_by_zero_does_not_reject_valid_arithmetic() -> None:
     """The guard wraps the line that applies every binary operator."""
     qasm = """OPENQASM 2.0;


### PR DESCRIPTION
`cirq.contrib.qasm_import` applies `operator.truediv` without a guard, so a zero
divisor in a gate parameter lets a raw `ZeroDivisionError` escape a parser that
answers every other malformed input with a `QasmException` carrying a line
number.

Six forms reach it on `main` today:

```
rx(pi/0)  rx(1/0)  rx(0/0)  rx(pi/(1-1))  rx(pi/1e-400)  rx((2+2)/(3-3))
```

`rx(pi/1e-400)` has no literal zero anywhere in the source — `1e-400` underflows
to `0.0` under IEEE-754.

**Fix**, in `p_expr_binary`:

```python
try:
    p[0] = self.binary_operators[p[2]](p[1], p[3])
except ZeroDivisionError:
    raise QasmException(f"Division by zero at line {p.lineno(2)}")
```

The message follows the convention already used in this file (`f"... at line
{lineno}"`).

**Tests.** Six parametrised cases for the forms above, plus a control asserting
that valid division, multiplication and exponentiation still parse to the
expected circuit — the guard sits on the single line that applies *every* binary
operator, so an over-broad fix would break arithmetic in gate parameters while
still passing the division tests.

Verified in both directions: with the fix `_parser_test.py` is `362 passed, 8
skipped`; reverting only `_parser.py` and keeping the tests gives `6 failed, 356
passed`, and the six failures are exactly the new cases. `black --check` reports
both files unchanged.