### PR TITLE
Fix #8307: Mypy type errors in Python 3.12

### DIFF
--- a/cirq-core/cirq/experiments/readout_confusion_matrix.py
+++ b/cirq-core/cirq/experiments/readout_confusion_matrix.py
@@ -34,10 +34,13 @@ if TYPE_CHECKING:
 class TensoredConfusionMatrices:
     """Store and use confusion matrices for readout error mitigation on sets of qubits.
 
-    The confusion matrix (CM) for one qubit is:
+    In Cirq's convention, a confusion matrix (CM) is structured such that rows index the prepared
+    (true) computational basis states, and columns index the observed (measured) outcomes. Each row
+    forms a normalized probability distribution summing to 1. The confusion matrix (CM) for one
+    qubit is:
 
-        [ Pr(0|0) Pr(0|1) ]
-        [ Pr(1|0) Pr(1|1) ]
+        ⎡ Pr(0|0) Pr(1|0) ⎤
+        ⎣ Pr(0|1) Pr(1|1) ⎦
 
     where Pr(i | j) = Probability of observing state "i" given state "j" was prepared.
 

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -1356,6 +1356,7 @@ def test_zpow_dim_4() -> None:
     svs = [
         step.state_vector(copy=True) for step in sim.simulate_moment_steps(circuit, initial_state=0)
     ]
+    # Use a different variable to avoid a type check error.
     expected_dim4 = np.asarray([[1, 0, 0, 0]] * 8)
     assert np.allclose((svs), expected_dim4)
 

--- a/cirq-core/cirq/ops/common_gates_test.py
+++ b/cirq-core/cirq/ops/common_gates_test.py
@@ -1356,8 +1356,8 @@ def test_zpow_dim_4() -> None:
     svs = [
         step.state_vector(copy=True) for step in sim.simulate_moment_steps(circuit, initial_state=0)
     ]
-    expected = np.asarray([[1, 0, 0, 0]] * 8)
-    assert np.allclose((svs), expected)
+    expected_dim4 = np.asarray([[1, 0, 0, 0]] * 8)
+    assert np.allclose((svs), expected_dim4)
 
     svs = [
         step.state_vector(copy=True) for step in sim.simulate_moment_steps(circuit, initial_state=1)

--- a/cirq-core/cirq/ops/linear_combinations_test.py
+++ b/cirq-core/cirq/ops/linear_combinations_test.py
@@ -1339,6 +1339,7 @@ def test_expectation_from_state_vector_invalid_input() -> None:
     with pytest.raises(ValueError, match='normalized'):
         psum.expectation_from_state_vector(np.arange(16, dtype=np.complex64), q_map_2)
 
+    # Use a different variable to avoid a type check error.
     wf_16 = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16))
     with pytest.raises(ValueError, match='shape'):
         psum.expectation_from_state_vector(wf_16.reshape((16, 1)), q_map_2)

--- a/cirq-core/cirq/ops/linear_combinations_test.py
+++ b/cirq-core/cirq/ops/linear_combinations_test.py
@@ -1339,11 +1339,11 @@ def test_expectation_from_state_vector_invalid_input() -> None:
     with pytest.raises(ValueError, match='normalized'):
         psum.expectation_from_state_vector(np.arange(16, dtype=np.complex64), q_map_2)
 
-    wf = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16))
+    wf_16 = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16))
     with pytest.raises(ValueError, match='shape'):
-        psum.expectation_from_state_vector(wf.reshape((16, 1)), q_map_2)
+        psum.expectation_from_state_vector(wf_16.reshape((16, 1)), q_map_2)
     with pytest.raises(ValueError, match='shape'):
-        psum.expectation_from_state_vector(wf.reshape((4, 4, 1)), q_map_2)
+        psum.expectation_from_state_vector(wf_16.reshape((4, 4, 1)), q_map_2)
 
 
 def test_expectation_from_state_vector_check_preconditions() -> None:

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -974,11 +974,11 @@ def test_expectation_from_state_vector_invalid_input() -> None:
     rho_or_wf = 0.5 * np.ones((2, 2), dtype=np.complex64)
     _ = ps.expectation_from_state_vector(rho_or_wf, q_map)
 
-    wf = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16))
+    wf_16 = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16))
     with pytest.raises(ValueError, match='shape'):
-        ps.expectation_from_state_vector(wf.reshape((16, 1)), q_map_2)
+        ps.expectation_from_state_vector(wf_16.reshape((16, 1)), q_map_2)
     with pytest.raises(ValueError, match='shape'):
-        ps.expectation_from_state_vector(wf.reshape((4, 4, 1)), q_map_2)
+        ps.expectation_from_state_vector(wf_16.reshape((4, 4, 1)), q_map_2)
 
 
 def test_expectation_from_state_vector_check_preconditions() -> None:

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -223,8 +224,8 @@ def _validate_num_qubits(density_matrix: np.ndarray) -> int:
     """
     shape = density_matrix.shape
     half_index = len(shape) // 2
-    row_size = np.prod(shape[:half_index]).item() if shape else 0
-    col_size = np.prod(shape[half_index:]).item() if shape else 0
+    row_size = math.prod(shape[:half_index]) if shape else 0
+    col_size = math.prod(shape[half_index:]) if shape else 0
     if row_size != col_size:
         raise ValueError(f'Matrix was not square. Shape was {shape}')
     if row_size & (row_size - 1):

--- a/cirq-core/cirq/sim/density_matrix_utils.py
+++ b/cirq-core/cirq/sim/density_matrix_utils.py
@@ -16,8 +16,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 import math
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/quantum_shannon_decomposition.py
@@ -326,7 +326,9 @@ def _nth_gray(n: int) -> int:
 
 
 def _multiplexed_cossin(
-    cossin_qubits: Sequence[cirq.Qid], angles: list[float], rot_func: Callable = ops.ry
+    cossin_qubits: Sequence[cirq.Qid],
+    angles: Sequence[float] | np.ndarray,
+    rot_func: Callable = ops.ry,
 ) -> Iterator[cirq.Operation]:
     """Performs a multiplexed rotation over all qubits in this unitary matrix,
 

--- a/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge.py
+++ b/cirq-core/cirq/transformers/gauge_compiling/iswap_gauge.py
@@ -41,7 +41,7 @@ class RZRotation(Gauge):
     def weight(self) -> float:
         return 2.0
 
-    def _rz(self, theta, sgn: int) -> ConstantGauge:
+    def _rz(self, theta, sgn: int | np.integer) -> ConstantGauge:
         """Returns an ISWAP Gauge composed of Rz rotations.
 
         0: ───Rz(theta)──────iSwap───Rz(sgn*theta)───

--- a/cirq-core/cirq/transformers/randomized_measurements.py
+++ b/cirq-core/cirq/transformers/randomized_measurements.py
@@ -148,7 +148,7 @@ def _single_qubit_clifford(rng: np.random.Generator) -> cirq.Gate:
     """
 
     # there are 24 distinct single-qubit Clifford gates
-    clifford_idx = rng.choice(np.arange(24))
+    clifford_idx = int(rng.choice(24))
 
     return SingleQubitCliffordGate.to_phased_xz_gate(
         SingleQubitCliffordGate.all_single_qubit_cliffords[clifford_idx]


### PR DESCRIPTION
This updates a small number of type hints so that the result passes `check/typecheck` with both NumPy 2.4.x and 2.5.x. (See issue #8307 for motivation.)