### PR TITLE
Rename deprecated `target_version`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 fast = true
 line-length = 100
-target_version = ['py311', 'py312', 'py313', 'py314']
+target-version = ['py311', 'py312', 'py313', 'py314']
 skip-string-normalization = true
 skip-magic-trailing-comma = true
 extend-exclude = ".*_pb2[.]py[i]?"


### PR DESCRIPTION
The Black property `target_version` in pyproject.toml should be `target-version` (with a hyphen). Though Black seems to take the other form, the official JSON schema for use with `validate-pyproject` ([introduced with Black version 24.2.0](https://black.readthedocs.io/en/latest/change_log.html#id79)) causes the presence of `target_version` to produce an error.