### PR TITLE
Fix several broken links in Markdown files

### DIFF
--- a/cirq-core/cirq/protocols/json_test_data/README.md
+++ b/cirq-core/cirq/protocols/json_test_data/README.md
@@ -2,4 +2,4 @@
 
 This folder contains test data for Cirq's JSON serialization functionality. For
 more information, please see
-[`docs/dev/serialization.md`](/docs/dev/serialization.md).
+[`docs/dev/serialization.md`](../../../../docs/dev/serialization.md).

--- a/cirq-ionq/README.md
+++ b/cirq-ionq/README.md
@@ -2,7 +2,7 @@
 <img width="190px" alt="Cirq logo"
 src="https://raw.githubusercontent.com/quantumlib/Cirq/refs/heads/main/docs/images/Cirq_logo_color.svg"
 ><img width="50px" height="0" alt=""><img width="200px" alt="IonQ logo"
-src="https://ionq.com/images/ionq-logo-dark.svg">
+src="https://upload.wikimedia.org/wikipedia/commons/d/d4/IonQ_corp_logo.svg">
 </div>
 
 # cirq-ionq

--- a/dev_tools/triage-party/README.md
+++ b/dev_tools/triage-party/README.md
@@ -58,7 +58,7 @@ Kubernetes.
 Please refer to the official [Triage Party documentation] for details on the available configuration
 options.
 
-[Triage Party documentation]: https://github.com/google/triage-party/blob/main/docs/config.md
+[Triage Party documentation]: https://github.com/google/triage-party/blob/master/docs/config.md
 
 ### 2. Static Resources & Theming (CSS & Favicon)
 

--- a/docs/build/ecosystem.md
+++ b/docs/build/ecosystem.md
@@ -47,7 +47,7 @@ The following document provides an ecosystem overview of various open-source too
 |--- |--- |
 |[Alpine Quantum Technologies](https://quantumai.google/cirq/hardware/aqt/getting_started)|Trapped ions|
 |[IonQ](https://quantumai.google/cirq/hardware/ionq/getting_started)|Trapped ions|
-|[IQM](https://iqm-finland.github.io/cirq-on-iqm/)|Superconducting qubits|
+|[IQM](https://docs.iqm.tech/iqm-client/user_guide_cirq.html)|Superconducting qubits|
 |[Microsoft Azure Quantum](https://quantumai.google/cirq/hardware/azure-quantum/getting_started_ionq)|Trapped ions (Honeywell and IonQ)|
 |[Pasqal](https://quantumai.google/cirq/hardware/pasqal/getting_started)|Neutral atoms|
 

--- a/docs/build/ecosystem.md
+++ b/docs/build/ecosystem.md
@@ -52,7 +52,7 @@ The following document provides an ecosystem overview of various open-source too
 |[Pasqal](https://quantumai.google/cirq/hardware/pasqal/getting_started)|Neutral atoms|
 
 For more information for vendors about integrating with Cirq,
-see our [RFC page](../dev/rfc_process.md#new_hardware_integrations).
+see our [RFC page](../dev/rfc_process.md#new-hardware-integrations).
 
 ## High performance quantum circuit simulators
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -10,5 +10,5 @@ When using our projects, please cite them according to the following guide:
 | Qualtran | https://github.com/quantumlib/qualtran#how-to-cite-qualtran |
 | ReCirq | https://github.com/quantumlib/ReCirq#how-to-cite-recirq |
 | Stim | https://github.com/quantumlib/stim#how-cite-stim |
-| TensorFlow Quantum | https://github.com/tensorflow/quantum#references|
-| Tesseract Decoder | https://github.com/quantumlib/tesseract-decoder#citation|
+| TensorFlow Quantum | https://github.com/tensorflow/quantum#references |
+| Tesseract Decoder | https://github.com/quantumlib/tesseract-decoder#citation |

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -28,7 +28,7 @@ Note that if you are using PyCharm, you might have to use the command Restart & 
 1. Fork the Cirq repo (Fork button in upper right corner of
 [repo page](https://github.com/quantumlib/Cirq)).
 Forking creates a new GitHub repo at the location
-https://github.com/USERNAME/cirq where `USERNAME` is
+`https://github.com/USERNAME/cirq` where `USERNAME` is
 your GitHub id.
 1. Clone the fork you created to your local machine at the directory
 where you would like to store your local copy of the code, and `cd` into the newly created directory.

--- a/docs/dev/triage.md
+++ b/docs/dev/triage.md
@@ -1,6 +1,6 @@
 # Cirq Triage
 
-Original RFC: [bit.do/cirq-triage](https://bit.do/cirq-triage)
+Original RFC: [goo.gle/cirq-rfc-triage](https://goo.gle/cirq-rfc-triage)
 
 ## **Objective**
 
@@ -14,7 +14,7 @@ The goals for this document are as follows:
 
 [Triage Party](https://github.com/google/triage-party) is a stateless web app to optimize issue and PR triage for large open-source projects using the GitHub API.
 
-Our deployed version is here (a static IP, domain request is in progress): [http://bit.do/cirq-triage-party](http://bit.do/cirq-triage-party)
+Our deployed version is here (a static IP, domain request is in progress): [goo.gle/cirq-triage-party](http://goo.gle/cirq-triage-party)
 
 [GitHub Actions](https://github.com/features/actions) is GitHub's workflow automation platform. We use it for continuous integration testing as well as for stale issue handling later described here.
 

--- a/docs/dev/triage.md
+++ b/docs/dev/triage.md
@@ -14,7 +14,7 @@ The goals for this document are as follows:
 
 [Triage Party](https://github.com/google/triage-party) is a stateless web app to optimize issue and PR triage for large open-source projects using the GitHub API.
 
-Our deployed version is here (a static IP, domain request is in progress): [goo.gle/cirq-triage-party](http://goo.gle/cirq-triage-party)
+Our deployed version is here (a static IP, domain request is in progress): [goo.gle/cirq-triage-party](https://goo.gle/cirq-triage-party)
 
 [GitHub Actions](https://github.com/features/actions) is GitHub's workflow automation platform. We use it for continuous integration testing as well as for stale issue handling later described here.
 

--- a/docs/dev/versions.md
+++ b/docs/dev/versions.md
@@ -22,8 +22,7 @@ the following:
     *   Similarly, symbols in vendor packages, like [cirq-google](https://quantumai.google/reference/python/cirq_google/all_symbols), [cirq-aqt](https://quantumai.google/reference/python/cirq_aqt/all_symbols) are also not covered by the compatibility guarantee.
     *   If a symbol is available through the `cirq` Python module or its submodules, but is not documented, then it is **not** considered part of the public API.
 
-<a name="what-is-not-covered"></a>
-## What is _not_ covered
+## What is not covered
 * **Experimental APIs**: To facilitate development, we exempt some API symbols clearly marked as experimental from the compatibility guarantees. In particular, the following are not covered by any compatibility guarantees:
     *   any symbol in the `cirq.contrib` module or its submodules.
     *   any symbol whose name contains `experimental` or `Experimental`; or

--- a/docs/dev/versions.md
+++ b/docs/dev/versions.md
@@ -22,6 +22,7 @@ the following:
     *   Similarly, symbols in vendor packages, like [cirq-google](https://quantumai.google/reference/python/cirq_google/all_symbols), [cirq-aqt](https://quantumai.google/reference/python/cirq_aqt/all_symbols) are also not covered by the compatibility guarantee.
     *   If a symbol is available through the `cirq` Python module or its submodules, but is not documented, then it is **not** considered part of the public API.
 
+<a name="what-is-not-covered"></a>
 ## What is _not_ covered
 * **Experimental APIs**: To facilitate development, we exempt some API symbols clearly marked as experimental from the compatibility guarantees. In particular, the following are not covered by any compatibility guarantees:
     *   any symbol in the `cirq.contrib` module or its submodules.

--- a/docs/hardware/pasqal/access.md
+++ b/docs/hardware/pasqal/access.md
@@ -1,7 +1,7 @@
 # Access and Authentication
 
 Pasqal's API is not yet open for public access. In case you're interested, contact
-us through our [website](https://pasqal.io/contact/) to request access.
+us through our [website](https://www.pasqal.com/contact-us/) to request access.
 
 ## API Access
 


### PR DESCRIPTION
This PR simply replaces some broken hyperlinks in a small number of Markdown files.