### PR TITLE
Tell pylint to ignore files in package build directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ asyncio_default_fixture_loop_scope = "function"
 fail-on = ["I"]
 ignore-long-lines = "^(.*#\\w*pylint: disable.*|\\s*(# )?[<\\[\\(]?https?://\\S+[>\\]\\)]?)$"
 ignore-paths=[
+    "cirq-[^/]*/build/",
     "cirq-google/cirq_google/cloud/",
     "cirq-web/cirq_web/node_modules/",
 ]


### PR DESCRIPTION
Problem: Building cirq-core, cirq-google, etc.  produces `build`
directories with a duplicate sources that do not match
pylint `ignore-paths`.

Solution: Ignore any package build directories first.
