### PR TITLE
Add CircuitFunction

### DIFF
--- a/cirq-core/cirq/__init__.py
+++ b/cirq-core/cirq/__init__.py
@@ -68,6 +68,7 @@ from cirq.circuits import (
     AbstractCircuit as AbstractCircuit,
     Alignment as Alignment,
     Circuit as Circuit,
+    CircuitFunction as CircuitFunction,
     CircuitOperation as CircuitOperation,
     FrozenCircuit as FrozenCircuit,
     InsertStrategy as InsertStrategy,

--- a/cirq-core/cirq/circuits/__init__.py
+++ b/cirq-core/cirq/circuits/__init__.py
@@ -22,6 +22,7 @@ from cirq.circuits.circuit import (
     Alignment as Alignment,
     Circuit as Circuit,
 )
+from cirq.circuits.circuit_function import CircuitFunction as CircuitFunction
 from cirq.circuits.circuit_operation import CircuitOperation as CircuitOperation
 from cirq.circuits.frozen_circuit import FrozenCircuit as FrozenCircuit
 from cirq.circuits.insert_strategy import InsertStrategy as InsertStrategy

--- a/cirq-core/cirq/circuits/circuit_function.py
+++ b/cirq-core/cirq/circuits/circuit_function.py
@@ -1,0 +1,145 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A named quantum circuit template with symbolic parameters."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence, Set
+from typing import Any, TYPE_CHECKING
+
+import sympy
+
+from cirq import _compat, protocols, value
+from cirq.circuits.circuit import AbstractCircuit
+
+if TYPE_CHECKING:
+    import cirq
+    from cirq.circuits.frozen_circuit import FrozenCircuit
+
+
+@value.value_equality
+class CircuitFunction:
+    """A function that maps from a given set of parameters to a circuit.
+
+    Note: This is an experimental class designed as part of a prototype
+       for Cirq 2.0. The interface for this class is subject to change
+       between versions.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        circuit: cirq.AbstractCircuit,
+        function_params: Sequence[sympy.Symbol] | None = None,
+    ) -> None:
+        """Initializes a CircuitFunction.
+
+        Args:
+            name: The name of the function.
+            circuit: The circuit body. If mutable, it will be frozen.
+            function_params: Optional ordered sequence of parameters to the
+                `CircuitFunction`. If None, defaults to all symbols in `circuit`.
+
+        Raises:
+            TypeError: If `name` is not a str, `circuit` is not an `AbstractCircuit`,
+                or any item in `function_params` is not a `sympy.Symbol`.
+            ValueError: If `name` is empty.
+        """
+        if not isinstance(name, str):
+            raise TypeError(f"Function name must be a string, got: {type(name)!r}.")
+        if not name:
+            raise ValueError("Function name must be a non-empty string.")
+
+        if not isinstance(circuit, AbstractCircuit):
+            raise TypeError(f"Expected circuit of type AbstractCircuit, got: {type(circuit)!r}.")
+
+        self._name = name
+        self._circuit = circuit.freeze()
+        self._qubits = self._circuit.all_qubits()
+
+        if function_params is None:
+            circuit_symbols = protocols.parameter_symbols(self._circuit)
+            self._function_params = tuple(sorted(circuit_symbols, key=lambda s: s.name))
+        else:
+            self._function_params = tuple(function_params)
+            if not all(isinstance(p, sympy.Symbol) for p in self._function_params):
+                raise TypeError("All parameters must be sympy Symbols.")
+            if len(set(self._function_params)) != len(self._function_params):
+                raise ValueError("CircuitFunctions may not have duplicate parameters.")
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def circuit(self) -> FrozenCircuit:
+        return self._circuit
+
+    @property
+    def function_params(self) -> tuple[sympy.Symbol, ...]:
+        return self._function_params
+
+    @property
+    def qubits(self) -> frozenset[cirq.Qid]:
+        return self._qubits
+
+    def _value_equality_values_(self) -> Any:
+        return (self._name, self._circuit, self._function_params)
+
+    def _is_parameterized_(self) -> bool:
+        """Returns true if the circuit includes non-function parameters."""
+        return bool(self._parameter_names_())
+
+    def _parameter_names_(self) -> Set[str]:
+        """Returns names of the non-function parameters."""
+        circuit_parameters = protocols.parameter_names(self._circuit)
+        return circuit_parameters - {p.name for p in self._function_params}
+
+    def _json_dict_(self) -> dict[str, Any]:
+        return protocols.obj_to_dict_helper(self, ['name', 'circuit', 'function_params'])
+
+    @classmethod
+    def _from_json_dict_(
+        cls,
+        name: str,
+        circuit: cirq.FrozenCircuit,
+        function_params: Sequence[sympy.Symbol],
+        **kwargs,
+    ) -> CircuitFunction:
+        return cls(name=name, circuit=circuit, function_params=function_params)
+
+    def __call__(self, *call_params: cirq.TParamVal) -> cirq.AbstractCircuit:
+        """Call the circuit function with given parameters values."""
+        if len(call_params) != len(self.function_params):
+            raise TypeError(
+                f"CircuitFunction {self.name} called with the wrong number of parameters."
+            )
+
+        param_dict = dict(zip(self._function_params, call_params))
+        return protocols.resolve_parameters(self._circuit, param_dict)
+
+    def __repr__(self) -> str:
+        param_items = ", ".join(_compat.proper_repr(p) for p in self._function_params)
+        return (
+            f"cirq.CircuitFunction("
+            f"name={self._name!r}, "
+            f"circuit={self._circuit!r}, "
+            f"function_params=[{param_items}]"
+            f")"
+        )
+
+    def __str__(self) -> str:
+        params_str = ", ".join(str(p) for p in self._function_params)
+        return f"{self._name}({params_str})"

--- a/cirq-core/cirq/circuits/circuit_function_test.py
+++ b/cirq-core/cirq/circuits/circuit_function_test.py
@@ -1,0 +1,179 @@
+# Copyright 2026 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import sympy
+
+import cirq
+
+
+def test_construction_unparameterized() -> None:
+    q = cirq.q(0)
+    c = cirq.Circuit(cirq.X(q))
+    cf = cirq.CircuitFunction("test_function", c)
+    assert cf.name == "test_function"
+    assert cf.circuit == c.freeze()
+    assert cf.function_params == ()
+    assert cirq.parameter_names(cf) == set()
+    assert not cirq.is_parameterized(cf)
+    assert cf.qubits == frozenset((q,))
+
+    # expose nonfunctional parameter
+    theta = sympy.Symbol('theta')
+    cf = cirq.CircuitFunction("test_function", c, function_params=[theta])
+    assert cf.function_params == (theta,)
+    assert cirq.parameter_names(cf) == set()
+    assert not cirq.is_parameterized(cf)
+
+
+def test_construction_basic() -> None:
+    # parameter exposed
+    q = cirq.q(0)
+    theta = sympy.Symbol('theta')
+    c = cirq.Circuit(cirq.X(q) ** theta)
+    cf = cirq.CircuitFunction("test_function", c, function_params=[theta])
+    assert cf.name == "test_function"
+    assert cf.circuit == c.freeze()
+    assert cf.function_params == (theta,)
+    assert cirq.parameter_names(cf) == set()
+    assert not cirq.is_parameterized(cf)
+    assert cf.qubits == frozenset((q,))
+
+    cf = cirq.CircuitFunction("test_function", c)
+    assert cf.function_params == (theta,)
+
+    # parameter not exposed
+    cf = cirq.CircuitFunction("test_function", c, function_params=[])
+    assert cf.function_params == ()
+    assert cirq.parameter_names(cf) == {theta.name}
+    assert cirq.is_parameterized(cf)
+
+    with pytest.raises(TypeError, match='Function name must be a string'):
+        _ = cirq.CircuitFunction(10, c)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match='Function name must be a non-empty string'):
+        _ = cirq.CircuitFunction("", c)
+
+    with pytest.raises(TypeError, match='Expected circuit of type AbstractCircuit'):
+        _ = cirq.CircuitFunction("test_function", 5)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match='All parameters must be sympy Symbols.'):
+        _ = cirq.CircuitFunction("test_function", c, function_params=[5])
+
+    with pytest.raises(ValueError, match='CircuitFunctions may not have duplicate parameters.'):
+        _ = cirq.CircuitFunction("test_function", c, function_params=[theta, theta])
+
+
+def test_construction_vqid() -> None:
+    # parameter exposed, vqid not exposed
+    x = sympy.Symbol('x')
+    q = cirq.VariableLineQid(x)
+    theta = sympy.Symbol('theta')
+    c = cirq.Circuit(cirq.X(q) ** theta)
+    cf = cirq.CircuitFunction("test_function", c, function_params=[theta])
+    assert cf.name == "test_function"
+    assert cf.circuit == c.freeze()
+    assert cf.function_params == (theta,)
+    assert cirq.parameter_names(cf) == {x.name}
+    assert cirq.is_parameterized(cf)
+    assert cf.qubits == frozenset((q,))
+
+    # parameter exposed, vqid exposed
+    cf = cirq.CircuitFunction("test_function", c, function_params=[theta, x])
+    assert cf.function_params == (theta, x)
+    assert cirq.parameter_names(cf) == set()
+    assert not cirq.is_parameterized(cf)
+
+    cf = cirq.CircuitFunction("test_function", c)
+    assert cf.function_params == (theta, x)
+
+    # parameter not exposed, vqid exposed
+    cf = cirq.CircuitFunction("test_function", c, function_params=[x])
+    assert cf.function_params == (x,)
+    assert cirq.parameter_names(cf) == {theta.name}
+    assert cirq.is_parameterized(cf)
+
+    # parameter not exposed, vqid not exposed
+    cf = cirq.CircuitFunction("test_function", c, function_params=[])
+    assert cf.function_params == ()
+    assert cirq.parameter_names(cf) == {theta.name, x.name}
+    assert cirq.is_parameterized(cf)
+
+
+def test_repr() -> None:
+    x = sympy.Symbol('x')
+    qx = cirq.VariableLineQid(x)
+    q0 = cirq.q(0)
+    theta = sympy.Symbol('theta')
+    cx = cirq.Circuit(cirq.X(qx) ** theta)
+    c0 = cirq.Circuit(cirq.X(q0) ** theta)
+    cirq.testing.assert_equivalent_repr(
+        cirq.CircuitFunction("test_function", c0, function_params=[theta])
+    )
+    cirq.testing.assert_equivalent_repr(
+        cirq.CircuitFunction("test_function", cx, function_params=[])
+    )
+    cirq.testing.assert_equivalent_repr(
+        cirq.CircuitFunction("test_function", cx, function_params=[theta])
+    )
+    cirq.testing.assert_equivalent_repr(
+        cirq.CircuitFunction("test_function", cx, function_params=[theta, x])
+    )
+
+
+def test_str() -> None:
+    x = sympy.Symbol('x')
+    qx = cirq.VariableLineQid(x)
+    theta = sympy.Symbol('theta')
+    cx = cirq.Circuit(cirq.X(qx) ** theta)
+    assert str(cirq.CircuitFunction("test_function", cx, function_params=[])) == "test_function()"
+    assert (
+        str(cirq.CircuitFunction("test_function", cx, function_params=[theta]))
+        == "test_function(theta)"
+    )
+    assert str(cirq.CircuitFunction("test_function", cx)) == "test_function(theta, x)"
+
+
+def test_eq() -> None:
+    x = sympy.Symbol('x')
+    qx = cirq.VariableLineQid(x)
+    theta = sympy.Symbol('theta')
+    cx = cirq.Circuit(cirq.X(qx) ** theta)
+
+    eq = cirq.testing.EqualsTester()
+    eq.add_equality_group(
+        cirq.CircuitFunction("test_function", cx),
+        cirq.CircuitFunction("test_function", cx, function_params=[theta, x]),
+    )
+    eq.add_equality_group(cirq.CircuitFunction("test_function2", cx))
+    eq.add_equality_group(
+        cirq.CircuitFunction("test_function", cx, function_params=[]),
+        cirq.CircuitFunction("test_function", cx.freeze(), function_params=[]),
+    )
+
+
+def test_call() -> None:
+    x = sympy.Symbol('x')
+    qx = cirq.VariableLineQid(x)
+    theta = sympy.Symbol('theta')
+    cx = cirq.Circuit(cirq.X(qx) ** theta)
+    cf = cirq.CircuitFunction("test_function", cx, function_params=[x, theta])
+
+    ref_circuit = cirq.Circuit(cirq.X(cirq.q(2)) ** 3).freeze()
+    assert cf(2, 3) == ref_circuit
+
+    with pytest.raises(
+        TypeError, match="CircuitFunction test_function called with the wrong number of parameters"
+    ):
+        _ = cf(2)

--- a/cirq-core/cirq/json_resolver_cache.py
+++ b/cirq-core/cirq/json_resolver_cache.py
@@ -115,6 +115,7 @@ def _class_resolver_dictionary() -> dict[str, ObjectFactory]:
         'CCYPowGate': cirq.CCYPowGate,
         'CCZPowGate': cirq.CCZPowGate,
         'Circuit': cirq.Circuit,
+        'CircuitFunction': cirq.CircuitFunction,
         'CircuitOperation': cirq.CircuitOperation,
         'ClassicallyControlledOperation': cirq.ClassicallyControlledOperation,
         'ClassicalDataDictionaryStore': cirq.ClassicalDataDictionaryStore,

--- a/cirq-core/cirq/protocols/json_test_data/CircuitFunction.json
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitFunction.json
@@ -1,0 +1,49 @@
+{
+  "cirq_type": "CircuitFunction",
+  "name": "test_func",
+  "circuit": {
+    "cirq_type": "VAL",
+    "key": 0,
+    "val": {
+      "cirq_type": "FrozenCircuit",
+      "moments": [
+        {
+          "cirq_type": "Moment",
+          "operations": [
+            {
+              "cirq_type": "GateOperation",
+              "gate": {
+                "cirq_type": "XPowGate",
+                "exponent": {
+                  "cirq_type": "sympy.Symbol",
+                  "name": "theta"
+                },
+                "global_shift": 0.0
+              },
+              "qubits": [
+                {
+                  "cirq_type": "VariableLineQid",
+                  "x": {
+                    "cirq_type": "sympy.Symbol",
+                    "name": "qx"
+                  },
+                  "dimension": 2
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "function_params": [
+    {
+      "cirq_type": "sympy.Symbol",
+      "name": "qx"
+    },
+    {
+      "cirq_type": "sympy.Symbol",
+      "name": "theta"
+    }
+  ]
+}

--- a/cirq-core/cirq/protocols/json_test_data/CircuitFunction.repr
+++ b/cirq-core/cirq/protocols/json_test_data/CircuitFunction.repr
@@ -1,0 +1,9 @@
+cirq.CircuitFunction(
+    name='test_func',
+    circuit=cirq.FrozenCircuit([
+        cirq.Moment(
+            (cirq.X**sympy.Symbol('theta')).on(cirq.VariableLineQid(sympy.Symbol('qx'), dimension=2)),
+        ),
+    ]),
+    function_params=[sympy.Symbol('qx'), sympy.Symbol('theta')],
+)


### PR DESCRIPTION
This adds `CircuitFunction`, which maps from a set of parameters to a
circuit.`CircuitFunction` will be used by the planned `CallFunction`
operation in a future PR. This is an experimental Cirq 2.0 feature.