### PR TITLE
merge_single_qubit_gates_to_phxz shouldn't return ops.I

### DIFF
--- a/cirq-core/cirq/transformers/merge_single_qubit_gates.py
+++ b/cirq-core/cirq/transformers/merge_single_qubit_gates.py
@@ -106,7 +106,9 @@ def merge_single_qubit_gates_to_phxz(
         u = protocols.unitary(circuit_op)
         if protocols.num_qubits(circuit_op) == 0:
             return ops.GlobalPhaseGate(u[0, 0]).on()
-        gate = single_qubit_decompositions.single_qubit_matrix_to_phxz(u, atol) or ops.I
+        gate = single_qubit_decompositions.single_qubit_matrix_to_phxz(u, atol) or ops.PhasedXZGate(
+            axis_phase_exponent=0, x_exponent=0.0, z_exponent=0.0
+        )
         phxz_op = gate.on(circuit_op.qubits[0])
         return phxz_op.with_tags(*merge_tags_fn(circuit_op)) if merge_tags_fn else phxz_op
 


### PR DESCRIPTION
return `PhasedXZGate(0, 0, 0)` instead of `I` since callers expect the returned gates to be of type PhasedXZGate