### PR TITLE
Avoid non-string keys in serialized JSON

### DIFF
--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -152,8 +152,6 @@ def obj_to_dict_helper(obj: Any, attribute_names: Iterable[str]) -> dict[str, An
     d = {}
     for attr_name in attribute_names:
         d[attr_name] = getattr(obj, attr_name)
-        if isinstance(d[attr_name], dict):
-            assert all(isinstance(k, str) for k in d[attr_name].keys())
     return d
 
 

--- a/cirq-core/cirq/protocols/json_serialization.py
+++ b/cirq-core/cirq/protocols/json_serialization.py
@@ -152,6 +152,8 @@ def obj_to_dict_helper(obj: Any, attribute_names: Iterable[str]) -> dict[str, An
     d = {}
     for attr_name in attribute_names:
         d[attr_name] = getattr(obj, attr_name)
+        if isinstance(d[attr_name], dict):
+            assert all(isinstance(k, str) for k in d[attr_name].keys())
     return d
 
 

--- a/cirq-google/cirq_google/study/finite_random_variable.py
+++ b/cirq-google/cirq_google/study/finite_random_variable.py
@@ -121,17 +121,21 @@ class FiniteRandomVariable(SingleSweep):
         cls,
         *,
         key: cirq.TParamKey,
-        distribution: dict[str, float],
+        distribution: list[tuple[float, float]],
         seed: int,
         length: int,
         metadata: Any | None = None,
         **kwargs,
     ) -> 'FiniteRandomVariable':
-        # Convert json keys to floats
-        fixed_distribution = {float(key): distribution[key] for key in distribution}
         return cls(
-            key=key, distribution=fixed_distribution, seed=seed, length=length, metadata=metadata
+            key=key, distribution=dict(distribution), seed=seed, length=length, metadata=metadata
         )
 
     def _json_dict_(self) -> dict[str, Any]:
-        return cirq.obj_to_dict_helper(self, ["key", "distribution", "seed", "length", "metadata"])
+        return {
+            "key": self.key,
+            "distribution": list(self.distribution.items()),
+            "seed": self.seed,
+            "length": self.length,
+            "metadata": self.metadata,
+        }

--- a/cirq-google/cirq_google/workflow/quantum_runtime.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime.py
@@ -103,7 +103,9 @@ class RuntimeInfo:
     def _json_dict_(self) -> dict[str, Any]:
         d = {
             'execution_index': self.execution_index,
-            'qubit_placement': self.qubit_placement and list(self.qubit_placement.items()),
+            'qubit_placement': (
+                list(self.qubit_placement.items()) if self.qubit_placement is not None else None
+            ),
             'timings_s': list(self.timings_s.items()),
         }
         return d

--- a/cirq-google/cirq_google/workflow/quantum_runtime.py
+++ b/cirq-google/cirq_google/workflow/quantum_runtime.py
@@ -101,10 +101,11 @@ class RuntimeInfo:
         return 'cirq.google'
 
     def _json_dict_(self) -> dict[str, Any]:
-        d = dataclass_json_dict(self)
-        if d['qubit_placement']:
-            d['qubit_placement'] = list(d['qubit_placement'].items())
-        d['timings_s'] = list(d['timings_s'].items())
+        d = {
+            'execution_index': self.execution_index,
+            'qubit_placement': self.qubit_placement and list(self.qubit_placement.items()),
+            'timings_s': list(self.timings_s.items()),
+        }
         return d
 
     @classmethod


### PR DESCRIPTION
Dictionaries in JSON must have string keys.  The stock `json.dumps`
implicitly converts `int`, `float`, `bool` and `None` keys to `str`.
`orjson.dumps` by default fails for non-string keys.

Here we address a couple of non-string-keys dictionaries to
express them as lists of items in JSON serialization, and
thus make them work with `orjson.dumps`.

Note: This changes the JSON expression for `FiniteRandomVariable`
which should be acceptable as that class is experimental.

Ref: https://docs.python.org/3.14/library/json.html#json.dumps

Towards b/484463959
