### PR TITLE
Clean up AI fluff introduced to qasm parser tests

### DIFF
--- a/cirq-core/cirq/contrib/qasm_import/_parser_test.py
+++ b/cirq-core/cirq/contrib/qasm_import/_parser_test.py
@@ -2527,65 +2527,24 @@ def test_input_invalid_type_error() -> None:
         QasmParser().parse(qasm)
 
 
-@pytest.mark.parametrize(
-    'expression', ['pi/0', '1/0', '0/0', 'pi/(1-1)', 'pi/1e-400', '(2+2)/(3-3)']
-)
+@pytest.mark.parametrize('expression', ['pi/0', '1/0', 'pi/(1-1)'])
 def test_division_by_zero(expression: str) -> None:
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
      rx({expression}) q[0];
-"""
-    with pytest.raises(QasmException, match="division by zero at line 4"):
+    """
+    with pytest.raises(QasmException, match="^division by zero at line 4$"):
         QasmParser().parse(qasm)
 
 
-@pytest.mark.parametrize('expression', ['0^-1', '0^-2', '(1-1)^-1'])
+@pytest.mark.parametrize('expression', ['0^-1', '(1-1)^-1'])
 def test_zero_to_a_negative_power(expression: str) -> None:
     """`^` raises ZeroDivisionError too, but for a different reason."""
     qasm = f"""OPENQASM 2.0;
      include "qelib1.inc";
      qreg q[1];
      rx({expression}) q[0];
-"""
-    with pytest.raises(QasmException, match="zero to a negative power at line 4"):
-        QasmParser().parse(qasm)
-
-
-def test_zero_division_message_does_not_depend_on_the_interpreter() -> None:
-    """The message is ours, not CPython's.
-
-    An earlier version of this fix built the message from `str(e)` on the caught
-    ZeroDivisionError. CPython rewords that error between releases -- 3.11 raises
-    "0.0 cannot be raised to a negative power" where 3.14 raises "zero to a
-    negative power" -- so the parser's user-visible error, and any downstream
-    matching on it, silently changed with the interpreter. Pin both messages.
     """
-    zero_div = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nrx(1/0) q[0];\n'
-    neg_pow = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nrx(0^-1) q[0];\n'
-
-    with pytest.raises(QasmException) as div_info:
-        QasmParser().parse(zero_div)
-    with pytest.raises(QasmException) as pow_info:
-        QasmParser().parse(neg_pow)
-
-    # Exact strings, not regexes: the point of the test is that the wording is
-    # fixed by this file and cannot drift with the Python version.
-    assert str(div_info.value) == 'division by zero at line 4'
-    assert str(pow_info.value) == 'zero to a negative power at line 4'
-
-
-def test_division_by_zero_does_not_reject_valid_arithmetic() -> None:
-    """The guard wraps the line that applies every binary operator."""
-    qasm = """OPENQASM 2.0;
-     include "qelib1.inc";
-     qreg q[1];
-     rx(pi/2) q[0];
-     ry(pi*1) q[0];
-     rz(2^1*pi/2) q[0];
-"""
-    parsed_qasm = QasmParser().parse(qasm)
-    q0 = cirq.NamedQubit('q_0')
-    assert parsed_qasm.circuit == Circuit(
-        [cirq.rx(np.pi / 2).on(q0), cirq.ry(np.pi).on(q0), cirq.rz(np.pi).on(q0)]
-    )
+    with pytest.raises(QasmException, match="^zero to a negative power at line 4$"):
+        QasmParser().parse(qasm)


### PR DESCRIPTION
- prune repetitive parameters.  Drop testing with 1e-400 in
  case it gets handled differently in the future.

- drop `test_zero_division_message_does_not_depend_on_the_interpreter`
  which duplicated previous checks of QasmException wording.
  Tighten regular expressions in pytest.raises instead.

- drop `test_division_by_zero_does_not_reject_valid_arithmetic`
  Already tested in `test_expressions`.

Follow up to #8306
