### PR TITLE
Small clean ups in the tests

### DIFF
--- a/cirq-core/cirq/circuits/text_diagram_drawer_test.py
+++ b/cirq-core/cirq/circuits/text_diagram_drawer_test.py
@@ -316,8 +316,6 @@ AB
 
     d.force_vertical_padding_after(0, 0)
     with pytest.raises(ValueError):
-        print(d.vertical_padding)
-        print(dd.vertical_padding)
         TextDiagramDrawer.hstack((d, dd))
 
     dd.force_vertical_padding_after(0, 0)

--- a/cirq-core/cirq/ops/clifford_gate_test.py
+++ b/cirq-core/cirq/ops/clifford_gate_test.py
@@ -997,7 +997,6 @@ def test_cxswap_czswap() -> None:
 
     # cirq unitary for CNOT then SWAP (big endian)
     cxswap_expected = np.asarray([[1, 0, 0, 0], [0, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]])
-    print(cirq.unitary(cirq.CXSWAP))
     assert np.allclose(cirq.unitary(cirq.CXSWAP), cxswap_expected)
 
     czswap_expected = np.asarray([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, -1]])

--- a/cirq-core/cirq/study/sweeps_test.py
+++ b/cirq-core/cirq/study/sweeps_test.py
@@ -324,17 +324,10 @@ def test_equality() -> None:
 
 
 def test_repr() -> None:
+    cirq.testing.assert_equivalent_repr(cirq.study.sweeps.Product(cirq.UnitSweep))
+    cirq.testing.assert_equivalent_repr(cirq.study.sweeps.Zip(cirq.UnitSweep))
     cirq.testing.assert_equivalent_repr(
-        cirq.study.sweeps.Product(cirq.UnitSweep),
-        setup_code='import cirq\nfrom collections import OrderedDict',
-    )
-    cirq.testing.assert_equivalent_repr(
-        cirq.study.sweeps.Zip(cirq.UnitSweep),
-        setup_code='import cirq\nfrom collections import OrderedDict',
-    )
-    cirq.testing.assert_equivalent_repr(
-        cirq.ListSweep(cirq.Linspace('a', start=0, stop=3, length=4)),
-        setup_code='import cirq\nfrom collections import OrderedDict',
+        cirq.ListSweep(cirq.Linspace('a', start=0, stop=3, length=4))
     )
     cirq.testing.assert_equivalent_repr(cirq.Points('zero&pi', [0, 3.14159]))
     cirq.testing.assert_equivalent_repr(cirq.Linspace('I/10', 0, 1, 10))

--- a/cirq-google/cirq_google/devices/google_noise_properties_test.py
+++ b/cirq-google/cirq_google/devices/google_noise_properties_test.py
@@ -80,9 +80,7 @@ def sample_noise_properties(
 def test_consistent_repr():
     q0, q1 = cirq.LineQubit.range(2)
     test_props = sample_noise_properties([q0, q1], [(q0, q1), (q1, q0)])
-    cirq.testing.assert_equivalent_repr(
-        test_props, setup_code="import cirq, cirq_google\nimport numpy as np"
-    )
+    cirq.testing.assert_equivalent_repr(test_props, setup_code="import cirq, cirq_google")
 
 
 def test_equals():

--- a/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
+++ b/cirq-google/cirq_google/experimental/ops/coupler_pulse_test.py
@@ -27,7 +27,7 @@ def test_consistent_protocols():
     )
     cirq.testing.assert_implements_consistent_protocols(
         gate,
-        setup_code='import cirq\nimport numpy as np\nimport sympy\nimport cirq_google',
+        setup_code='import cirq\nimport cirq_google',
         qubit_count=2,
         ignore_decompose_to_default_gateset=True,
     )

--- a/cirq-google/cirq_google/ops/no_sync_tag_test.py
+++ b/cirq-google/cirq_google/ops/no_sync_tag_test.py
@@ -56,14 +56,12 @@ def test_invalid_args() -> None:
 def test_str_repr() -> None:
     assert str(cirq_google.NoSyncTag()) == 'NoSyncTag()'
     assert repr(cirq_google.NoSyncTag()) == 'cirq_google.NoSyncTag()'
-    cirq.testing.assert_equivalent_repr(
-        cirq_google.NoSyncTag(), setup_code='import cirq\nimport cirq_google\n'
-    )
+    cirq.testing.assert_equivalent_repr(cirq_google.NoSyncTag(), setup_code='import cirq_google')
 
     tag = cirq_google.NoSyncTag(reverse=2, forward=1)
     assert str(tag) == 'NoSyncTag(reverse=2, forward=1)'
     assert repr(tag) == 'cirq_google.NoSyncTag(reverse=2, forward=1)'
-    cirq.testing.assert_equivalent_repr(tag, setup_code='import cirq\nimport cirq_google\n')
+    cirq.testing.assert_equivalent_repr(tag, setup_code='import cirq_google')
 
     tag_bool = cirq_google.NoSyncTag(remove_all_syncs_before=True, remove_all_syncs_after=True)
     assert str(tag_bool) == 'NoSyncTag(remove_all_syncs_before=True, remove_all_syncs_after=True)'
@@ -71,7 +69,7 @@ def test_str_repr() -> None:
         repr(tag_bool)
         == 'cirq_google.NoSyncTag(remove_all_syncs_before=True, remove_all_syncs_after=True)'
     )
-    cirq.testing.assert_equivalent_repr(tag_bool, setup_code='import cirq\nimport cirq_google\n')
+    cirq.testing.assert_equivalent_repr(tag_bool, setup_code='import cirq_google')
 
 
 def test_proto() -> None:

--- a/cirq-google/cirq_google/ops/sycamore_gate_test.py
+++ b/cirq-google/cirq_google/ops/sycamore_gate_test.py
@@ -32,7 +32,7 @@ import cirq_google as cg
 def test_consistent_protocols(gate_type, qubit_count):
     cirq.testing.assert_implements_consistent_protocols(
         gate_type,
-        setup_code='import cirq\nimport numpy as np\nimport sympy\nimport cirq_google',
+        setup_code='import cirq\nimport sympy\nimport cirq_google',
         qubit_count=qubit_count,
     )
 

--- a/cirq-google/cirq_google/ops/willow_gate_test.py
+++ b/cirq-google/cirq_google/ops/willow_gate_test.py
@@ -22,9 +22,7 @@ import cirq_google as cg
 
 def test_consistent_protocols():
     cirq.testing.assert_implements_consistent_protocols(
-        cg.WILLOW,
-        setup_code='import cirq\nimport numpy as np\nimport sympy\nimport cirq_google',
-        qubit_count=2,
+        cg.WILLOW, setup_code='import cirq\nimport sympy\nimport cirq_google', qubit_count=2
     )
 
 

--- a/cirq-google/cirq_google/study/finite_random_variable_test.py
+++ b/cirq-google/cirq_google/study/finite_random_variable_test.py
@@ -141,7 +141,7 @@ def test_repr():
         key=KEY, distribution=DIST, seed=SEED, length=LENGTH, metadata={'data': 1}
     )
     # cirq.testing.assert_equivalent_repr evaluates the repr and checks equality
-    cirq.testing.assert_equivalent_repr(sweep, setup_code='import sympy\nimport cirq_google')
+    cirq.testing.assert_equivalent_repr(sweep, setup_code='import cirq_google')
 
 
 def test_json_serialization():

--- a/cirq-google/cirq_google/study/finite_random_variable_test.py
+++ b/cirq-google/cirq_google/study/finite_random_variable_test.py
@@ -140,7 +140,6 @@ def test_repr():
     sweep = cirq_google.study.FiniteRandomVariable(
         key=KEY, distribution=DIST, seed=SEED, length=LENGTH, metadata={'data': 1}
     )
-    print(repr(sweep))
     # cirq.testing.assert_equivalent_repr evaluates the repr and checks equality
     cirq.testing.assert_equivalent_repr(sweep, setup_code='import sympy\nimport cirq_google')
 


### PR DESCRIPTION
Remove unnecessary imports from `setup_code` statements for
`assert_equivalent_repr` and `assert_implements_consistent_protocols`.
Also remove a few leftover debugging print-outs.

No change in the effective code.