### PR TITLE
Limit # threads used by libraries during parallel pytest runs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
+import os
+
 import pytest
+
+_NO_OPTION = object()
 
 
 def pytest_addoption(parser):
@@ -42,3 +47,112 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         for k in skip_keywords.intersection(item.keywords):
             item.add_marker(skip_marks[k])
+
+
+def resolve_cpu_count(
+    process_cpus: int | None = None,
+    affinity_count: int | None = None,
+    total_cpus: int | None = None,
+) -> int:
+    """Return the number of available CPUs based on a hierarchy of sources."""
+    if process_cpus is not None and process_cpus >= 1:
+        return process_cpus
+    if affinity_count is not None and affinity_count >= 1:
+        return affinity_count
+    if total_cpus is not None and total_cpus >= 1:
+        return total_cpus
+    return 1
+
+
+def get_available_cpu_count() -> int:
+    """Return the number of CPU cores available to the current process.
+
+    This function respects active CPU limits such as process affinity and
+    container limits.
+    """
+    process_cpus = getattr(os, "process_cpu_count", lambda: None)()
+
+    affinity_count = None
+    if hasattr(os, "sched_getaffinity"):
+        try:
+            affinity_count = len(os.sched_getaffinity(0))
+        except OSError:
+            pass
+
+    total_cpus = os.cpu_count()
+    return resolve_cpu_count(process_cpus, affinity_count, total_cpus)
+
+
+def compute_thread_limit(
+    num_processes: int | str | None,
+    available_cpus: int,
+    env: collections.abc.Mapping[str, str] = os.environ,
+) -> str | None:
+    """Return a thread limit value, as a string."""
+    # If not using xdist or have only a single worker, do not set limits.
+    if num_processes in (None, _NO_OPTION, 0, 1, "1"):
+        return None
+
+    if str(num_processes) in ("auto", "logical"):
+        auto_cap = env.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
+        try:
+            workers = int(auto_cap) if auto_cap else available_cpus
+        except (ValueError, TypeError):
+            workers = available_cpus
+    else:
+        try:
+            workers = int(num_processes)
+        except (ValueError, TypeError):
+            return None
+
+    if workers <= 1:
+        return None
+
+    threads_per_worker = max(1, available_cpus // workers)
+    return str(threads_per_worker)
+
+
+# Environment variables used to limit the number of threads spawned by pytest-xdist workers.
+THREAD_ENV_VARS = (
+    "BLIS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMBA_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+)
+
+
+def _config_set_thread_limits(
+    config, env: collections.abc.MutableMapping[str, str] = os.environ, cpu_count: int | None = None
+) -> None:
+    """Limit number of threads to prevent oversubscription with pytest-xdist.
+
+    This only influences parallelism in some core numerical libraries used in
+    packages such as NumPy by setting certain environment variables. When
+    pytest runs as many workers as CPUs, limiting the number of threads used by
+    the libraries greatly improves overall test performance. Without the limit,
+    numerical operations in some tests spawn as many parallel threads as CPUs,
+    overwhelming host resources when pytest runs the tests in parallel.
+    """
+    cpus = cpu_count if cpu_count is not None else get_available_cpu_count()
+    try:
+        numprocesses = config.getoption("numprocesses")
+    except (AttributeError, ValueError):
+        numprocesses = None
+
+    limit = compute_thread_limit(numprocesses, available_cpus=cpus, env=env)
+    if limit is not None:
+        for var in THREAD_ENV_VARS:
+            env[var] = limit
+
+
+def pytest_configure(
+    config, env: collections.abc.MutableMapping[str, str] = os.environ, cpu_count: int | None = None
+) -> None:
+    """Configure pytest environment settings, especially for pytest-xdist."""
+    # Worker processes in pytest-xdist inherit environment variables from the controller
+    # process, so thread limits only need to be initialized once before workers launch.
+    if hasattr(config, "workerinput"):
+        return
+    _config_set_thread_limits(config, env=env, cpu_count=cpu_count)

--- a/conftest_test.py
+++ b/conftest_test.py
@@ -1,0 +1,96 @@
+# Copyright 2025 The Cirq Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+import conftest
+
+
+class _FakeConfig:
+    """Minimal stand-in for pytest `Config`."""
+
+    def __init__(self, numprocesses=conftest._NO_OPTION, workerinput: dict | None = None) -> None:
+        self.numprocesses = numprocesses
+        if workerinput is not None:
+            self.workerinput = workerinput
+
+    def getoption(self, name: str):
+        if name == "numprocesses" and self.numprocesses is not conftest._NO_OPTION:
+            return self.numprocesses
+        raise ValueError(f"no option named {name!r}")
+
+
+def test_get_available_cpu_count_live() -> None:
+    assert conftest.get_available_cpu_count() >= 1
+
+
+@pytest.mark.parametrize(
+    "process_cpus,affinity_count,total_cpus,expected",
+    [
+        (3, 2, 64, 3),  # process_cpu_count() takes highest precedence.
+        (None, 4, 64, 4),  # Affinity takes second precedence.
+        (None, None, 12, 12),  # Total cpu_count used if no affinity.
+        (None, None, None, 1),  # Fallback to 1 if nothing reported.
+        (0, 0, 0, 1),  # Invalid/zero counts fallback to 1.
+    ],
+)
+def test_resolve_cpu_count(process_cpus, affinity_count, total_cpus, expected):
+    assert conftest.resolve_cpu_count(process_cpus, affinity_count, total_cpus) == expected
+
+
+@pytest.mark.parametrize(
+    "numprocesses,available_cpus,env,expected_limit",
+    [
+        (4, 8, {}, "2"),  # 8 CPUs with 4 workers = 2 threads.
+        ("4", 8, {}, "2"),  # String input support.
+        (16, 8, {}, "1"),  # More workers than CPUs -> 1 thread minimum.
+        ("auto", 8, {}, "1"),  # "auto" defaults to 1 worker per CPU (8/8 = 1).
+        ("logical", 8, {}, "1"),
+        ("auto", 8, {"PYTEST_XDIST_AUTO_NUM_WORKERS": "2"}, "4"),  # Respects auto cap (8/2 = 4).
+        ("auto", 8, {"PYTEST_XDIST_AUTO_NUM_WORKERS": "invalid"}, "1"),
+        (None, 8, {}, None),  # Single worker/disabled -> no limit.
+        (1, 8, {}, None),
+        ("1", 8, {}, None),
+        ("not-a-number", 8, {}, None),
+    ],
+)
+def test_compute_thread_limit(numprocesses, available_cpus, env, expected_limit):
+    assert conftest.compute_thread_limit(numprocesses, available_cpus, env) == expected_limit
+
+
+def test_config_set_thread_limits():
+    fake_env: dict[str, str] = {}
+    conftest._config_set_thread_limits(_FakeConfig(4), env=fake_env, cpu_count=8)
+    assert fake_env == dict.fromkeys(conftest.THREAD_ENV_VARS, "2")
+
+
+def test_pytest_configure_sets_thread_limits():
+    fake_env: dict[str, str] = {}
+    conftest.pytest_configure(_FakeConfig(2), env=fake_env, cpu_count=8)
+    assert fake_env == dict.fromkeys(conftest.THREAD_ENV_VARS, "4")
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        _FakeConfig(2, workerinput={}),  # Worker process skips setting limits.
+        _FakeConfig(),  # xdist not present or option missing.
+    ],
+)
+def test_pytest_configure_skips_thread_limits(config):
+    fake_env: dict[str, str] = {}
+    conftest.pytest_configure(config, env=fake_env, cpu_count=8)
+    assert fake_env == {}


### PR DESCRIPTION
Some of the core numerical libraries used by NumPy, SciPy, and other Python packages may use multithreading internally in their C++ cores. The problem is, they are not aware of the overall number of processes spawned by parallel pytest execution (via pytest-xdist). This results in some tests causing CPU resource contention on the host system.

This PR adds code to `conftest.py` that is executed in the pytest-xdist controller process before workers are started. It sets certain environment variables affecting the number of threads that some common numerical libraries will use. It caps the value to a low number calculated based on the number of CPUs and workers requested.

This results in a `check/pytest` speed increase of 20-30%.

Manually-performed pytest timings (mean of 10 runs for each number), in Python 3.11 on an otherwise lightly-loaded 64-core x86_64 Linux system:

`check/pytest -n 64`:

* Before: ~134 sec
* After: ~110 sec

`check/pytest -n 32`:

* Before: ~126 sec
* After: ~95 sec

`check/pytest -n 16`:

* Before: ~132 sec
* After: ~101 sec

`check/pytest -n 8`:

* Before: ~142 sec
* After: ~118 sec

`check/pytest -n 2`:

* Before: ~304 sec
* After: ~293 sec

`check/pytest -n 1`:

* Before: ~579 sec
* After: ~558 sec

The implementation respects `PYTEST_XDIST_AUTO_NUM_WORKERS` if it is set.

This work was partly assisted by Google Gemini 3.8 Flash.